### PR TITLE
feat: appearance settings — dark mode, font size, font family

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,12 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Agento</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Roboto:wght@400;500&family=Open+Sans:wght@400;600&family=Lato:wght@400;700&family=Merriweather:wght@400;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/AppearanceTab.tsx
+++ b/frontend/src/components/AppearanceTab.tsx
@@ -1,0 +1,159 @@
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useAppearance, FONT_OPTIONS } from '@/contexts/ThemeContext'
+import { settingsApi } from '@/lib/api'
+
+export default function AppearanceTab() {
+  const { appearance, setAppearance } = useAppearance()
+  const [saving, setSaving] = useState(false)
+  const [toast, setToast] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const showToast = (msg: string) => {
+    setToast(msg)
+    setTimeout(() => setToast(null), 3000)
+  }
+
+  const handleDarkMode = (enabled: boolean) => {
+    setAppearance({ ...appearance, darkMode: enabled })
+  }
+
+  const handleFontSize = (size: number) => {
+    setAppearance({ ...appearance, fontSize: size })
+  }
+
+  const handleFontFamily = (family: string) => {
+    setAppearance({ ...appearance, fontFamily: family })
+  }
+
+  const handleSave = async () => {
+    setSaving(true)
+    setError(null)
+    try {
+      const current = await settingsApi.get()
+      await settingsApi.update({
+        ...current.settings,
+        appearance_dark_mode: appearance.darkMode,
+        appearance_font_size: appearance.fontSize,
+        appearance_font_family: appearance.fontFamily,
+      })
+      showToast('Appearance saved')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save appearance')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const previewFontCss =
+    FONT_OPTIONS.find(f => f.value === appearance.fontFamily)?.css ?? FONT_OPTIONS[0].css
+
+  return (
+    <div className="max-w-md flex flex-col gap-6">
+      <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 mb-0">Appearance</h2>
+
+      {/* Dark Mode */}
+      <div className="flex flex-col gap-1.5">
+        <Label className="text-sm font-medium text-zinc-700 dark:text-zinc-300">Dark Mode</Label>
+        <div className="flex items-center gap-3">
+          <button
+            role="switch"
+            aria-checked={appearance.darkMode}
+            onClick={() => handleDarkMode(!appearance.darkMode)}
+            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-zinc-500 ${
+              appearance.darkMode ? 'bg-zinc-800' : 'bg-zinc-300'
+            }`}
+          >
+            <span
+              className={`inline-block h-4 w-4 rounded-full bg-white shadow transition-transform ${
+                appearance.darkMode ? 'translate-x-6' : 'translate-x-1'
+              }`}
+            />
+          </button>
+          <span className="text-sm text-zinc-600 dark:text-zinc-400">
+            {appearance.darkMode ? 'Enabled' : 'Disabled'}
+          </span>
+        </div>
+      </div>
+
+      {/* Font Size */}
+      <div className="flex flex-col gap-1.5">
+        <Label className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+          Font Size: {appearance.fontSize}px
+        </Label>
+        <input
+          type="range"
+          min={12}
+          max={24}
+          step={1}
+          value={appearance.fontSize}
+          onChange={e => handleFontSize(Number(e.target.value))}
+          className="w-full h-2 bg-zinc-200 dark:bg-zinc-700 rounded-lg appearance-none cursor-pointer accent-zinc-800 dark:accent-zinc-300"
+        />
+        <div className="flex justify-between text-xs text-zinc-400">
+          <span>12px</span>
+          <span>24px</span>
+        </div>
+      </div>
+
+      {/* Font Family */}
+      <div className="flex flex-col gap-1.5">
+        <Label className="text-sm font-medium text-zinc-700 dark:text-zinc-300">Font Family</Label>
+        <Select value={appearance.fontFamily} onValueChange={handleFontFamily}>
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="Select a font" />
+          </SelectTrigger>
+          <SelectContent>
+            {FONT_OPTIONS.map(f => (
+              <SelectItem key={f.value} value={f.value}>
+                {f.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Live Preview */}
+      <div
+        className="rounded-md border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800/50 p-4"
+        style={{ fontFamily: previewFontCss, fontSize: `${appearance.fontSize}px` }}
+      >
+        <p className="font-semibold text-zinc-900 dark:text-zinc-100 mb-1">Preview</p>
+        <p className="text-zinc-600 dark:text-zinc-400">
+          The quick brown fox jumps over the lazy dog. 0123456789
+        </p>
+        <p className="text-zinc-500 dark:text-zinc-500 text-[0.85em] mt-1">
+          AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz
+        </p>
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      <Button
+        className="bg-zinc-900 hover:bg-zinc-800 text-white dark:bg-zinc-100 dark:hover:bg-zinc-200 dark:text-zinc-900 w-full sm:w-auto"
+        onClick={() => void handleSave()}
+        disabled={saving}
+      >
+        {saving ? 'Saving…' : 'Save Appearance Settings'}
+      </Button>
+
+      {toast && (
+        <div className="fixed bottom-4 right-4 z-50 rounded-md bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 px-4 py-2 text-sm shadow-lg">
+          {toast}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -26,23 +26,23 @@ export default function Layout() {
   const [mobileOpen, setMobileOpen] = useState(false)
 
   return (
-    <div className="flex h-screen w-screen overflow-hidden bg-white">
+    <div className="flex h-screen w-screen overflow-hidden bg-white dark:bg-zinc-950">
       <Sidebar mobileOpen={mobileOpen} onMobileClose={() => setMobileOpen(false)} />
 
       <div className="flex flex-1 flex-col overflow-hidden">
         {/* Mobile top bar */}
-        <header className="flex items-center gap-3 border-b border-zinc-200 px-4 h-14 shrink-0 md:hidden">
+        <header className="flex items-center gap-3 border-b border-zinc-200 dark:border-zinc-700/50 px-4 h-14 shrink-0 md:hidden">
           <button
             onClick={() => setMobileOpen(true)}
-            className="h-8 w-8 flex items-center justify-center rounded-md text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 transition-colors cursor-pointer"
+            className="h-8 w-8 flex items-center justify-center rounded-md text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors cursor-pointer"
           >
             <Menu className="h-5 w-5" />
           </button>
           <AgentoLogo />
-          <span className="text-sm font-semibold text-zinc-900">Agento</span>
+          <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Agento</span>
         </header>
 
-        <main className="flex flex-1 flex-col overflow-hidden bg-white">
+        <main className="flex flex-1 flex-col overflow-hidden bg-white dark:bg-zinc-950">
           <Outlet />
         </main>
       </div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -68,18 +68,20 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
       {/* Logo */}
       <div
         className={cn(
-          'flex items-center border-b border-zinc-200 h-14 shrink-0',
+          'flex items-center border-b border-zinc-200 dark:border-zinc-700/50 h-14 shrink-0',
           !isMobile && collapsed ? 'justify-center px-0' : 'gap-2.5 px-5',
         )}
       >
         <AgentoLogo size={28} />
         {(isMobile || !collapsed) && (
-          <span className="text-sm font-semibold tracking-wide text-zinc-900">Agento</span>
+          <span className="text-sm font-semibold tracking-wide text-zinc-900 dark:text-zinc-100">
+            Agento
+          </span>
         )}
         {isMobile && (
           <button
             onClick={onMobileClose}
-            className="ml-auto h-8 w-8 flex items-center justify-center rounded-md text-zinc-400 hover:text-zinc-700 hover:bg-zinc-200 transition-colors cursor-pointer"
+            className="ml-auto h-8 w-8 flex items-center justify-center rounded-md text-zinc-400 dark:text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-200 hover:bg-zinc-200 dark:hover:bg-zinc-700 transition-colors cursor-pointer"
           >
             <X className="h-4 w-4" />
           </button>
@@ -92,7 +94,7 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
           <Tooltip content="New Chat">
             <button
               onClick={() => navigate('/chats?new=1')}
-              className="flex h-9 w-9 items-center justify-center rounded-md bg-zinc-200 text-zinc-700 hover:bg-zinc-300 hover:text-zinc-900 transition-colors mx-auto cursor-pointer"
+              className="flex h-9 w-9 items-center justify-center rounded-md bg-zinc-200 dark:bg-zinc-700 text-zinc-700 dark:text-zinc-200 hover:bg-zinc-300 dark:hover:bg-zinc-600 hover:text-zinc-900 dark:hover:text-white transition-colors mx-auto cursor-pointer"
             >
               <Plus className="h-4 w-4" />
             </button>
@@ -103,7 +105,7 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
               navigate('/chats?new=1')
               onMobileClose?.()
             }}
-            className="flex w-full items-center gap-2 rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-700 hover:bg-zinc-100 hover:text-zinc-900 transition-colors cursor-pointer"
+            className="flex w-full items-center gap-2 rounded-md border border-zinc-300 dark:border-zinc-600 bg-white dark:bg-zinc-800 px-3 py-1.5 text-sm text-zinc-700 dark:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-700 hover:text-zinc-900 dark:hover:text-white transition-colors cursor-pointer"
           >
             <Plus className="h-3.5 w-3.5 shrink-0" />
             <span>New Chat</span>
@@ -123,8 +125,8 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
                     cn(
                       'flex h-9 w-9 items-center justify-center rounded-md transition-colors mx-auto',
                       isActive
-                        ? 'bg-zinc-900 text-white'
-                        : 'text-zinc-500 hover:bg-zinc-200 hover:text-zinc-900',
+                        ? 'bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900'
+                        : 'text-zinc-500 dark:text-zinc-400 hover:bg-zinc-200 dark:hover:bg-zinc-700 hover:text-zinc-900 dark:hover:text-zinc-100',
                     )
                   }
                 >
@@ -140,8 +142,8 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
                   cn(
                     'flex items-center gap-2.5 rounded-md px-3 py-2 text-sm transition-colors',
                     isActive
-                      ? 'bg-zinc-900 text-white'
-                      : 'text-zinc-600 hover:bg-zinc-200 hover:text-zinc-900',
+                      ? 'bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900'
+                      : 'text-zinc-600 dark:text-zinc-400 hover:bg-zinc-200 dark:hover:bg-zinc-700 hover:text-zinc-900 dark:hover:text-zinc-100',
                   )
                 }
               >
@@ -156,7 +158,10 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
       {/* Settings link + Collapse toggle — desktop only */}
       {!isMobile && (
         <div
-          className={cn('border-t border-zinc-200 py-2 shrink-0', collapsed ? 'px-2.5' : 'px-2')}
+          className={cn(
+            'border-t border-zinc-200 dark:border-zinc-700/50 py-2 shrink-0',
+            collapsed ? 'px-2.5' : 'px-2',
+          )}
         >
           {/* Settings link */}
           {collapsed ? (
@@ -168,8 +173,8 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
                   cn(
                     'flex h-9 w-9 items-center justify-center rounded-md transition-colors mx-auto mb-1',
                     isActive
-                      ? 'bg-zinc-900 text-white'
-                      : 'text-zinc-400 hover:bg-zinc-200 hover:text-zinc-700',
+                      ? 'bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900'
+                      : 'text-zinc-400 dark:text-zinc-500 hover:bg-zinc-200 dark:hover:bg-zinc-700 hover:text-zinc-700 dark:hover:text-zinc-200',
                   )
                 }
               >
@@ -182,8 +187,9 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
               onClick={handleNavClick}
               className={({ isActive }) =>
                 cn(
-                  'flex items-center rounded-md text-zinc-400 hover:text-zinc-700 hover:bg-zinc-200 transition-colors h-8 w-full px-3 gap-2 mb-1',
-                  isActive && 'bg-zinc-900 text-white hover:bg-zinc-900 hover:text-white',
+                  'flex items-center rounded-md text-zinc-400 dark:text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-200 hover:bg-zinc-200 dark:hover:bg-zinc-700 transition-colors h-8 w-full px-3 gap-2 mb-1',
+                  isActive &&
+                    'bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 hover:bg-zinc-900 dark:hover:bg-zinc-100 hover:text-white dark:hover:text-zinc-900',
                 )
               }
             >
@@ -196,7 +202,7 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
           <button
             onClick={() => setCollapsed(c => !c)}
             className={cn(
-              'flex items-center rounded-md text-zinc-400 hover:text-zinc-700 hover:bg-zinc-200 transition-colors h-8 cursor-pointer',
+              'flex items-center rounded-md text-zinc-400 dark:text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-200 hover:bg-zinc-200 dark:hover:bg-zinc-700 transition-colors h-8 cursor-pointer',
               collapsed ? 'w-9 justify-center mx-auto' : 'w-full px-3 gap-2',
             )}
           >
@@ -219,7 +225,7 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
       {/* Desktop sidebar */}
       <aside
         className={cn(
-          'hidden md:flex h-full flex-col bg-zinc-50 text-zinc-900 border-r border-zinc-200 transition-[width] duration-200 ease-in-out shrink-0',
+          'hidden md:flex h-full flex-col bg-zinc-50 dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 border-r border-zinc-200 dark:border-zinc-700/50 transition-[width] duration-200 ease-in-out shrink-0',
           collapsed ? 'w-[64px]' : 'w-[272px]',
         )}
       >
@@ -232,7 +238,7 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
           {/* Backdrop */}
           <div className="fixed inset-0 z-40 bg-black/40 md:hidden" onClick={onMobileClose} />
           {/* Drawer */}
-          <aside className="fixed inset-y-0 left-0 z-50 flex w-72 flex-col bg-zinc-50 text-zinc-900 border-r border-zinc-200 md:hidden">
+          <aside className="fixed inset-y-0 left-0 z-50 flex w-72 flex-col bg-zinc-50 dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 border-r border-zinc-200 dark:border-zinc-700/50 md:hidden">
             {sidebarContent(true)}
           </aside>
         </>

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -1,0 +1,122 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+import type { ReactNode } from 'react'
+
+export interface AppearanceSettings {
+  darkMode: boolean
+  fontSize: number
+  fontFamily: string
+}
+
+const STORAGE_KEY = 'agento-appearance'
+
+const DEFAULTS: AppearanceSettings = {
+  darkMode: false,
+  fontSize: 15,
+  fontFamily: 'system',
+}
+
+export const FONT_OPTIONS = [
+  {
+    value: 'system',
+    label: 'System Default',
+    css: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif",
+  },
+  { value: 'inter', label: 'Inter', css: "'Inter', sans-serif" },
+  { value: 'roboto', label: 'Roboto', css: "'Roboto', sans-serif" },
+  { value: 'open-sans', label: 'Open Sans', css: "'Open Sans', sans-serif" },
+  { value: 'lato', label: 'Lato', css: "'Lato', sans-serif" },
+  { value: 'merriweather', label: 'Merriweather', css: "'Merriweather', serif" },
+  { value: 'jetbrains-mono', label: 'JetBrains Mono', css: "'JetBrains Mono', monospace" },
+]
+
+function loadFromStorage(): AppearanceSettings {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (raw) {
+      const p = JSON.parse(raw) as Partial<AppearanceSettings>
+      return {
+        darkMode: typeof p.darkMode === 'boolean' ? p.darkMode : DEFAULTS.darkMode,
+        fontSize:
+          p.fontSize && p.fontSize >= 12 && p.fontSize <= 24 ? p.fontSize : DEFAULTS.fontSize,
+        fontFamily:
+          p.fontFamily && FONT_OPTIONS.some(f => f.value === p.fontFamily)
+            ? p.fontFamily
+            : DEFAULTS.fontFamily,
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return { ...DEFAULTS }
+}
+
+function saveToStorage(settings: AppearanceSettings) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings))
+  } catch {
+    // ignore
+  }
+}
+
+function applyToDom(settings: AppearanceSettings) {
+  const root = document.documentElement
+  if (settings.darkMode) {
+    root.classList.add('dark')
+  } else {
+    root.classList.remove('dark')
+  }
+  // Set font-size on html so rem-based Tailwind classes (text-sm, text-xs, etc.) scale with it
+  root.style.fontSize = `${settings.fontSize}px`
+  const fontOption = FONT_OPTIONS.find(f => f.value === settings.fontFamily)
+  root.style.fontFamily = fontOption?.css ?? FONT_OPTIONS[0].css
+}
+
+interface ThemeContextValue {
+  appearance: AppearanceSettings
+  setAppearance: (settings: AppearanceSettings) => void
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null)
+
+interface AppearanceProviderProps {
+  children: ReactNode
+  serverSettings?: Partial<AppearanceSettings>
+}
+
+export function AppearanceProvider({ children, serverSettings }: AppearanceProviderProps) {
+  const [appearance, setAppearanceState] = useState<AppearanceSettings>(() => {
+    const local = loadFromStorage()
+    return local
+  })
+
+  // On mount, apply DOM immediately from localStorage
+  useEffect(() => {
+    applyToDom(appearance)
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // When server settings arrive, merge them (server wins, then update localStorage)
+  useEffect(() => {
+    if (!serverSettings || Object.keys(serverSettings).length === 0) return
+    const merged = { ...appearance, ...serverSettings }
+    saveToStorage(merged)
+    applyToDom(merged)
+    setAppearanceState(merged)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [serverSettings?.darkMode, serverSettings?.fontSize, serverSettings?.fontFamily])
+
+  const setAppearance = (settings: AppearanceSettings) => {
+    applyToDom(settings)
+    saveToStorage(settings)
+    setAppearanceState(settings)
+  }
+
+  return (
+    <ThemeContext.Provider value={{ appearance, setAppearance }}>{children}</ThemeContext.Provider>
+  )
+}
+
+export function useAppearance(): ThemeContextValue {
+  const ctx = useContext(ThemeContext)
+  if (!ctx) throw new Error('useAppearance must be used inside AppearanceProvider')
+  return ctx
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,8 @@
 @import 'tailwindcss';
 
+/* Enable class-based dark mode: `dark:` variants activate when html has .dark class */
+@custom-variant dark (&:where(.dark, .dark *));
+
 @theme {
   --color-border: hsl(0 0% 89%);
   --color-input: hsl(0 0% 89%);
@@ -23,6 +26,29 @@
   --radius: 0.5rem;
 }
 
+/* Dark mode variable overrides */
+html.dark {
+  --color-background: hsl(0 0% 10%);
+  --color-foreground: hsl(0 0% 94%);
+  --color-card: hsl(0 0% 13%);
+  --color-card-foreground: hsl(0 0% 94%);
+  --color-border: hsl(0 0% 22%);
+  --color-input: hsl(0 0% 22%);
+  --color-ring: hsl(0 0% 45%);
+  --color-muted: hsl(0 0% 18%);
+  --color-muted-foreground: hsl(0 0% 63%);
+  --color-secondary: hsl(0 0% 18%);
+  --color-secondary-foreground: hsl(0 0% 94%);
+  --color-accent: hsl(0 0% 18%);
+  --color-accent-foreground: hsl(0 0% 94%);
+  --color-primary: hsl(0 0% 94%);
+  --color-primary-foreground: hsl(0 0% 10%);
+  --color-popover: hsl(0 0% 13%);
+  --color-popover-foreground: hsl(0 0% 94%);
+  --color-destructive: hsl(0 65% 55%);
+  --color-destructive-foreground: hsl(0 0% 98%);
+}
+
 * {
   border-color: var(--color-border);
 }
@@ -30,8 +56,6 @@
 body {
   background-color: var(--color-background);
   color: var(--color-foreground);
-  font-family:
-    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
 }
 
@@ -90,7 +114,7 @@ body {
   list-style-type: decimal;
 }
 .prose code {
-  background: hsl(0 0% 94%);
+  background: var(--color-muted);
   padding: 0.1em 0.3em;
   border-radius: 3px;
   font-size: 0.875em;
@@ -107,6 +131,9 @@ body {
   overflow-y: hidden;
   max-width: 100%;
   margin-bottom: 0.75rem;
+}
+html.dark .prose pre {
+  background: hsl(0 0% 6%);
 }
 .prose pre code {
   word-break: normal;
@@ -134,17 +161,17 @@ body {
   background: hsl(0 0% 62%);
 }
 .prose blockquote {
-  border-left: 3px solid hsl(0 0% 89%);
+  border-left: 3px solid var(--color-border);
   padding-left: 1rem;
-  color: hsl(0 0% 45%);
+  color: var(--color-muted-foreground);
   margin-bottom: 0.75rem;
 }
 .prose a {
-  color: hsl(0 0% 9%);
+  color: var(--color-foreground);
   text-decoration: underline;
 }
 .prose hr {
-  border-color: hsl(0 0% 89%);
+  border-color: var(--color-border);
   margin: 1rem 0;
 }
 .prose table {
@@ -155,10 +182,10 @@ body {
 }
 .prose th,
 .prose td {
-  border: 1px solid hsl(0 0% 89%);
+  border: 1px solid var(--color-border);
   padding: 0.375rem 0.75rem;
 }
 .prose th {
-  background: hsl(0 0% 94%);
+  background: var(--color-muted);
   font-weight: 600;
 }

--- a/frontend/src/pages/ChatSessionPage.tsx
+++ b/frontend/src/pages/ChatSessionPage.tsx
@@ -259,19 +259,19 @@ export default function ChatSessionPage() {
   return (
     <div className="flex flex-col h-full min-w-0 overflow-hidden">
       {/* Header */}
-      <div className="flex items-center gap-3 border-b border-zinc-100 px-3 sm:px-4 py-3 shrink-0">
+      <div className="flex items-center gap-3 border-b border-zinc-100 dark:border-zinc-700/50 px-3 sm:px-4 py-3 shrink-0">
         <button
           onClick={() => navigate('/chats')}
-          className="h-7 w-7 flex items-center justify-center rounded-md text-zinc-400 hover:text-zinc-700 hover:bg-zinc-100 transition-colors"
+          className="h-7 w-7 flex items-center justify-center rounded-md text-zinc-400 dark:text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
         >
           <ArrowLeft className="h-4 w-4" />
         </button>
         <div className="flex-1 min-w-0">
-          <h2 className="text-sm font-semibold text-zinc-900 truncate">
+          <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 truncate">
             {detail?.session.title ?? 'Chat'}
           </h2>
         </div>
-        <span className="text-xs text-zinc-400 shrink-0 font-mono">
+        <span className="text-xs text-zinc-400 dark:text-zinc-500 shrink-0 font-mono">
           {agentLabel ?? 'Direct chat'}
         </span>
       </div>
@@ -356,7 +356,7 @@ export default function ChatSessionPage() {
 
           {/* Streaming: system status (tool execution in progress) */}
           {streaming && systemStatus && (
-            <div className="flex items-center gap-2 pl-10 text-xs text-zinc-400">
+            <div className="flex items-center gap-2 pl-10 text-xs text-zinc-400 dark:text-zinc-500">
               <Loader2 className="h-3 w-3 animate-spin shrink-0" />
               {systemStatus}
             </div>
@@ -365,10 +365,10 @@ export default function ChatSessionPage() {
           {/* Streaming: assistant response */}
           {streaming && streamingText && (
             <div className="flex gap-3">
-              <div className="flex h-7 w-7 items-center justify-center rounded-full bg-zinc-900 text-white shrink-0 mt-0.5 text-xs font-bold">
+              <div className="flex h-7 w-7 items-center justify-center rounded-full bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 shrink-0 mt-0.5 text-xs font-bold">
                 {agentLabel ? agentLabel[0].toUpperCase() : 'C'}
               </div>
-              <div className="bg-zinc-50 border border-zinc-100 rounded-2xl rounded-tl-sm px-4 py-3 text-sm max-w-[90%] sm:max-w-[82%] overflow-x-auto min-w-0">
+              <div className="bg-zinc-50 dark:bg-zinc-800/60 border border-zinc-100 dark:border-zinc-700 rounded-2xl rounded-tl-sm px-4 py-3 text-sm max-w-[90%] sm:max-w-[82%] overflow-x-auto min-w-0">
                 <div className="prose prose-sm max-w-none">
                   <ReactMarkdown remarkPlugins={[remarkGfm]}>{streamingText}</ReactMarkdown>
                 </div>
@@ -405,7 +405,7 @@ export default function ChatSessionPage() {
       </div>
 
       {/* Input */}
-      <div className="border-t border-zinc-100 px-3 py-3 sm:px-6 shrink-0 bg-white">
+      <div className="border-t border-zinc-100 dark:border-zinc-700/50 px-3 py-3 sm:px-6 shrink-0 bg-white dark:bg-zinc-950">
         <div className="flex gap-2 max-w-4xl mx-auto">
           <Textarea
             value={input}
@@ -431,8 +431,8 @@ export default function ChatSessionPage() {
               className={cn(
                 'flex h-9 w-9 items-center justify-center rounded-md shrink-0 self-end transition-colors',
                 input.trim()
-                  ? 'bg-zinc-900 text-white hover:bg-zinc-700'
-                  : 'bg-zinc-100 text-zinc-400 cursor-not-allowed',
+                  ? 'bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 hover:bg-zinc-700 dark:hover:bg-zinc-300'
+                  : 'bg-zinc-100 dark:bg-zinc-800 text-zinc-400 dark:text-zinc-600 cursor-not-allowed',
               )}
             >
               <Send className="h-4 w-4" />
@@ -484,11 +484,11 @@ function MessageBubble({ message }: { message: ChatMessage }) {
 
   return (
     <div className="flex gap-3">
-      <div className="flex h-7 w-7 items-center justify-center rounded-full bg-zinc-900 text-white shrink-0 mt-0.5 text-xs font-bold">
+      <div className="flex h-7 w-7 items-center justify-center rounded-full bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 shrink-0 mt-0.5 text-xs font-bold">
         C
       </div>
-      <div className="bg-zinc-50 border border-zinc-100 rounded-2xl rounded-tl-sm px-4 py-3 text-sm max-w-[90%] sm:max-w-[82%] overflow-x-auto min-w-0">
-        <div className="prose prose-sm max-w-none">
+      <div className="bg-zinc-50 dark:bg-zinc-800/60 border border-zinc-100 dark:border-zinc-700 rounded-2xl rounded-tl-sm px-4 py-3 text-sm max-w-[90%] sm:max-w-[82%] overflow-x-auto min-w-0">
+        <div className="prose prose-sm max-w-none dark:text-zinc-200">
           <ReactMarkdown remarkPlugins={[remarkGfm]}>{message.content}</ReactMarkdown>
         </div>
       </div>
@@ -501,19 +501,19 @@ function ThinkingBlock({ text }: { text: string }) {
 
   return (
     <div className="flex gap-3">
-      <div className="flex h-7 w-7 items-center justify-center rounded-full bg-zinc-100 text-zinc-500 shrink-0 mt-0.5 text-xs">
+      <div className="flex h-7 w-7 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400 shrink-0 mt-0.5 text-xs">
         ✦
       </div>
       <div className="flex-1 max-w-[82%]">
         <button
           onClick={() => setExpanded(e => !e)}
-          className="flex items-center gap-1.5 text-xs text-zinc-400 hover:text-zinc-600 transition-colors mb-1"
+          className="flex items-center gap-1.5 text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors mb-1"
         >
           {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
           Thinking
         </button>
         {expanded && (
-          <div className="rounded-lg border border-zinc-100 bg-zinc-50 px-3 py-2 text-xs text-zinc-500 font-mono whitespace-pre-wrap leading-relaxed">
+          <div className="rounded-lg border border-zinc-100 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800/60 px-3 py-2 text-xs text-zinc-500 dark:text-zinc-400 font-mono whitespace-pre-wrap leading-relaxed">
             {text}
           </div>
         )}
@@ -577,13 +577,13 @@ function ToolCallCard({
 
   return (
     <div className="flex gap-3">
-      <div className="flex h-7 w-7 items-center justify-center rounded-full bg-zinc-100 text-zinc-500 shrink-0 mt-0.5">
+      <div className="flex h-7 w-7 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400 shrink-0 mt-0.5">
         <Terminal className="h-3.5 w-3.5" />
       </div>
       <div className="flex-1 min-w-0 max-w-[82%]">
         <button
           onClick={() => setExpanded(e => !e)}
-          className="flex w-full items-center gap-1.5 text-xs text-zinc-400 hover:text-zinc-600 transition-colors mb-1 min-w-0"
+          className="flex w-full items-center gap-1.5 text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors mb-1 min-w-0"
         >
           {expanded ? (
             <ChevronDown className="h-3 w-3 shrink-0" />
@@ -591,10 +591,14 @@ function ToolCallCard({
             <ChevronRight className="h-3 w-3 shrink-0" />
           )}
           <span className="font-mono font-medium shrink-0">{name}</span>
-          {summary && <span className="font-mono text-zinc-400 truncate min-w-0">({summary})</span>}
+          {summary && (
+            <span className="font-mono text-zinc-400 dark:text-zinc-500 truncate min-w-0">
+              ({summary})
+            </span>
+          )}
         </button>
         {expanded && block.input !== undefined && (
-          <div className="rounded-lg border border-zinc-100 bg-zinc-50 px-3 py-2 text-xs text-zinc-500 font-mono whitespace-pre-wrap leading-relaxed overflow-x-auto max-h-48">
+          <div className="rounded-lg border border-zinc-100 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800/60 px-3 py-2 text-xs text-zinc-500 dark:text-zinc-400 font-mono whitespace-pre-wrap leading-relaxed overflow-x-auto max-h-48">
             {JSON.stringify(block.input, null, 2)}
           </div>
         )}
@@ -662,20 +666,25 @@ function AskUserQuestionCard({
 
   return (
     <div className="flex gap-3">
-      <div className="flex h-7 w-7 items-center justify-center rounded-full bg-zinc-100 text-zinc-500 shrink-0 mt-0.5">
+      <div className="flex h-7 w-7 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400 shrink-0 mt-0.5">
         <MessageSquare className="h-3.5 w-3.5" />
       </div>
       <div className="flex-1 min-w-0 max-w-[82%] space-y-3">
         {questions.map((q, i) => {
           const otherSelected = (selections[i] ?? []).includes(OTHER_LABEL)
           return (
-            <div key={i} className="rounded-lg border border-zinc-200 bg-white p-3">
+            <div
+              key={i}
+              className="rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800/60 p-3"
+            >
               {q.header && (
-                <div className="text-[10px] font-semibold uppercase tracking-wider text-zinc-400 mb-1">
+                <div className="text-[10px] font-semibold uppercase tracking-wider text-zinc-400 dark:text-zinc-500 mb-1">
                   {q.header}
                 </div>
               )}
-              <div className="text-sm font-medium text-zinc-800 mb-2">{q.question}</div>
+              <div className="text-sm font-medium text-zinc-800 dark:text-zinc-200 mb-2">
+                {q.question}
+              </div>
               <div className="flex flex-wrap gap-1.5">
                 {q.options.map((opt, j) => {
                   const selected = (selections[i] ?? []).includes(opt.label)
@@ -690,8 +699,8 @@ function AskUserQuestionCard({
                           ? 'cursor-pointer hover:border-zinc-400'
                           : 'cursor-default',
                         selected
-                          ? 'border-zinc-900 bg-zinc-900 text-white'
-                          : 'border-zinc-200 bg-zinc-50 text-zinc-700',
+                          ? 'border-zinc-900 dark:border-zinc-100 bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900'
+                          : 'border-zinc-200 dark:border-zinc-600 bg-zinc-50 dark:bg-zinc-700/50 text-zinc-700 dark:text-zinc-300',
                       )}
                     >
                       <span className="font-medium">{opt.label}</span>
@@ -714,8 +723,8 @@ function AskUserQuestionCard({
                       ? 'cursor-pointer hover:border-zinc-400'
                       : 'cursor-default',
                     otherSelected
-                      ? 'border-zinc-900 bg-zinc-900 text-white'
-                      : 'border-zinc-200 bg-zinc-50 text-zinc-700',
+                      ? 'border-zinc-900 dark:border-zinc-100 bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900'
+                      : 'border-zinc-200 dark:border-zinc-600 bg-zinc-50 dark:bg-zinc-700/50 text-zinc-700 dark:text-zinc-300',
                   )}
                 >
                   <span className="font-medium">Other</span>
@@ -732,11 +741,13 @@ function AskUserQuestionCard({
                     if (e.key === 'Enter' && hasSelections) handleSubmit()
                   }}
                   placeholder="Type your answer…"
-                  className="mt-2 w-full rounded-md border border-zinc-200 bg-zinc-50 px-2.5 py-1.5 text-xs text-zinc-800 placeholder:text-zinc-400 focus:border-zinc-900 focus:outline-none"
+                  className="mt-2 w-full rounded-md border border-zinc-200 dark:border-zinc-600 bg-zinc-50 dark:bg-zinc-700/50 px-2.5 py-1.5 text-xs text-zinc-800 dark:text-zinc-200 placeholder:text-zinc-400 dark:placeholder:text-zinc-500 focus:border-zinc-900 dark:focus:border-zinc-400 focus:outline-none"
                 />
               )}
               {q.multiSelect && !submitted && (
-                <div className="mt-2 text-[10px] text-zinc-400">Multiple selections allowed</div>
+                <div className="mt-2 text-[10px] text-zinc-400 dark:text-zinc-500">
+                  Multiple selections allowed
+                </div>
               )}
             </div>
           )
@@ -749,14 +760,16 @@ function AskUserQuestionCard({
             className={cn(
               'rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
               hasSelections
-                ? 'bg-zinc-900 text-white hover:bg-zinc-700'
-                : 'bg-zinc-100 text-zinc-400 cursor-not-allowed',
+                ? 'bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 hover:bg-zinc-700 dark:hover:bg-zinc-300'
+                : 'bg-zinc-100 dark:bg-zinc-800 text-zinc-400 dark:text-zinc-600 cursor-not-allowed',
             )}
           >
             Send answers
           </button>
         )}
-        {submitted && <div className="text-[10px] text-zinc-400">Answers sent</div>}
+        {submitted && (
+          <div className="text-[10px] text-zinc-400 dark:text-zinc-500">Answers sent</div>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/pages/ChatsPage.tsx
+++ b/frontend/src/pages/ChatsPage.tsx
@@ -185,10 +185,10 @@ export default function ChatsPage() {
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
-      <div className="flex items-center justify-between border-b border-zinc-100 px-4 sm:px-6 py-4 shrink-0">
+      <div className="flex items-center justify-between border-b border-zinc-100 dark:border-zinc-700/50 px-4 sm:px-6 py-4 shrink-0">
         <div>
-          <h1 className="text-base font-semibold text-zinc-900">Chats</h1>
-          <p className="text-xs text-zinc-500 mt-0.5">
+          <h1 className="text-base font-semibold text-zinc-900 dark:text-zinc-100">Chats</h1>
+          <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">
             {sessions.length} conversation{sessions.length !== 1 ? 's' : ''}
           </p>
         </div>
@@ -204,14 +204,14 @@ export default function ChatsPage() {
 
       {/* Filters */}
       {sessions.length > 0 && (
-        <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2 sm:gap-3 px-4 sm:px-6 py-3 border-b border-zinc-100 shrink-0">
+        <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2 sm:gap-3 px-4 sm:px-6 py-3 border-b border-zinc-100 dark:border-zinc-700/50 shrink-0">
           <div className="relative flex-1 sm:max-w-xs">
-            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-zinc-400" />
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-zinc-400 dark:text-zinc-500" />
             <input
               value={search}
               onChange={e => setSearch(e.target.value)}
               placeholder="Search conversations…"
-              className="w-full rounded-md border border-zinc-200 bg-white pl-8 pr-3 py-1.5 text-sm placeholder:text-zinc-400 focus:outline-none focus:ring-1 focus:ring-zinc-900 focus:border-zinc-900"
+              className="w-full rounded-md border border-zinc-200 dark:border-zinc-600 bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 pl-8 pr-3 py-1.5 text-sm placeholder:text-zinc-400 dark:placeholder:text-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-900 dark:focus:ring-zinc-400 focus:border-zinc-900 dark:focus:border-zinc-400"
             />
           </div>
           {agents.length > 1 && (
@@ -263,7 +263,7 @@ export default function ChatsPage() {
             <p className="text-sm text-zinc-400">No conversations match your filters.</p>
           </div>
         ) : (
-          <div className="divide-y divide-zinc-100">
+          <div className="divide-y divide-zinc-100 dark:divide-zinc-700/50">
             {filtered.map(session => (
               <ChatRow
                 key={session.id}
@@ -441,37 +441,41 @@ function ChatRow({
 }) {
   return (
     <div
-      className="flex items-center gap-3 px-4 sm:px-6 py-3.5 hover:bg-zinc-50 cursor-pointer group transition-colors"
+      className="flex items-center gap-3 px-4 sm:px-6 py-3.5 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 cursor-pointer group transition-colors"
       onClick={onClick}
     >
-      <div className="flex h-8 w-8 items-center justify-center rounded-full bg-zinc-100 text-zinc-500 shrink-0">
+      <div className="flex h-8 w-8 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400 shrink-0">
         <MessageSquare className="h-3.5 w-3.5" />
       </div>
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium text-zinc-900 truncate">{truncate(session.title, 70)}</p>
+        <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100 truncate">
+          {truncate(session.title, 70)}
+        </p>
         <div className="flex items-center gap-2 mt-0.5">
           {agentName ? (
             <Badge
               variant="secondary"
-              className="text-xs py-0 h-4 bg-zinc-100 text-zinc-600 hover:bg-zinc-100 border-0 font-normal"
+              className="text-xs py-0 h-4 bg-zinc-100 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-700 border-0 font-normal"
             >
               {agentName}
             </Badge>
           ) : (
             <Badge
               variant="secondary"
-              className="text-xs py-0 h-4 bg-zinc-50 text-zinc-400 hover:bg-zinc-50 border-0 font-normal"
+              className="text-xs py-0 h-4 bg-zinc-50 dark:bg-zinc-800 text-zinc-400 dark:text-zinc-500 hover:bg-zinc-50 dark:hover:bg-zinc-800 border-0 font-normal"
             >
               Direct chat
             </Badge>
           )}
-          <span className="text-xs text-zinc-400">{formatRelativeTime(session.updated_at)}</span>
+          <span className="text-xs text-zinc-400 dark:text-zinc-500">
+            {formatRelativeTime(session.updated_at)}
+          </span>
         </div>
       </div>
       <AlertDialog>
         <AlertDialogTrigger asChild>
           <button
-            className="opacity-0 group-hover:opacity-100 h-7 w-7 flex items-center justify-center rounded-md text-zinc-400 hover:text-red-500 hover:bg-red-50 transition-all shrink-0"
+            className="opacity-0 group-hover:opacity-100 h-7 w-7 flex items-center justify-center rounded-md text-zinc-400 dark:text-zinc-500 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-950/30 transition-all shrink-0"
             onClick={e => e.stopPropagation()}
           >
             <Trash2 className="h-3.5 w-3.5" />

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -13,11 +13,12 @@ import {
 import { Tooltip } from '@/components/ui/tooltip'
 import FilesystemBrowserModal from '@/components/FilesystemBrowserModal'
 import ClaudeSettingsTab from '@/components/ClaudeSettingsTab'
+import AppearanceTab from '@/components/AppearanceTab'
 import { settingsApi } from '@/lib/api'
 import type { SettingsResponse } from '@/types'
 import { MODELS } from '@/types'
 
-type Tab = 'general' | 'claude'
+type Tab = 'general' | 'claude' | 'appearance'
 
 export default function SettingsPage() {
   const [activeTab, setActiveTab] = useState<Tab>('general')
@@ -86,18 +87,18 @@ export default function SettingsPage() {
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
-      <div className="border-b border-zinc-100 px-4 sm:px-6 py-4 shrink-0">
-        <h1 className="text-base font-semibold text-zinc-900">Settings</h1>
+      <div className="border-b border-zinc-100 dark:border-zinc-700/50 px-4 sm:px-6 py-4 shrink-0">
+        <h1 className="text-base font-semibold text-zinc-900 dark:text-zinc-100">Settings</h1>
       </div>
 
       <div className="flex flex-1 overflow-hidden">
         {/* Left tab sidebar */}
-        <nav className="w-44 shrink-0 border-r border-zinc-100 py-3 px-2 flex flex-col gap-1">
+        <nav className="w-44 shrink-0 border-r border-zinc-100 dark:border-zinc-700/50 py-3 px-2 flex flex-col gap-1">
           <button
             className={`flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors ${
               activeTab === 'general'
-                ? 'bg-zinc-900 text-white'
-                : 'text-zinc-600 hover:bg-zinc-100 hover:text-zinc-900'
+                ? 'bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900'
+                : 'text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 hover:text-zinc-900 dark:hover:text-zinc-100'
             }`}
             onClick={() => setActiveTab('general')}
           >
@@ -106,12 +107,22 @@ export default function SettingsPage() {
           <button
             className={`flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors ${
               activeTab === 'claude'
-                ? 'bg-zinc-900 text-white'
-                : 'text-zinc-600 hover:bg-zinc-100 hover:text-zinc-900'
+                ? 'bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900'
+                : 'text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 hover:text-zinc-900 dark:hover:text-zinc-100'
             }`}
             onClick={() => setActiveTab('claude')}
           >
             Claude Settings
+          </button>
+          <button
+            className={`flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors ${
+              activeTab === 'appearance'
+                ? 'bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900'
+                : 'text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 hover:text-zinc-900 dark:hover:text-zinc-100'
+            }`}
+            onClick={() => setActiveTab('appearance')}
+          >
+            Appearance
           </button>
         </nav>
 
@@ -119,12 +130,16 @@ export default function SettingsPage() {
         <div className="flex-1 overflow-y-auto px-6 py-6">
           {activeTab === 'general' && (
             <>
-              <h2 className="text-sm font-semibold text-zinc-900 mb-6">General Settings</h2>
+              <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 mb-6">
+                General Settings
+              </h2>
 
               <div className="max-w-md flex flex-col gap-6">
                 {/* Working Directory */}
                 <div className="flex flex-col gap-1.5">
-                  <Label className="text-sm font-medium text-zinc-700">Working Directory</Label>
+                  <Label className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                    Working Directory
+                  </Label>
                   <div className="flex gap-2">
                     <Input
                       value={workingDir}
@@ -150,7 +165,9 @@ export default function SettingsPage() {
 
                 {/* Default Model */}
                 <div className="flex flex-col gap-1.5">
-                  <Label className="text-sm font-medium text-zinc-700">Default Model</Label>
+                  <Label className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                    Default Model
+                  </Label>
                   {modelLocked ? (
                     <div className="flex items-center gap-2">
                       <Input value={model} disabled className="flex-1 font-mono text-sm" />
@@ -191,6 +208,8 @@ export default function SettingsPage() {
           )}
 
           {activeTab === 'claude' && <ClaudeSettingsTab />}
+
+          {activeTab === 'appearance' && <AppearanceTab />}
         </div>
       </div>
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -30,6 +30,9 @@ export interface UserSettings {
   default_working_dir: string
   default_model: string
   onboarding_complete: boolean
+  appearance_dark_mode?: boolean
+  appearance_font_size?: number
+  appearance_font_family?: string
 }
 
 export interface SettingsResponse {

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -15,9 +15,12 @@ const (
 
 // UserSettings holds persisted user preferences.
 type UserSettings struct {
-	DefaultWorkingDir  string `json:"default_working_dir"`
-	DefaultModel       string `json:"default_model"`
-	OnboardingComplete bool   `json:"onboarding_complete"`
+	DefaultWorkingDir    string `json:"default_working_dir"`
+	DefaultModel         string `json:"default_model"`
+	OnboardingComplete   bool   `json:"onboarding_complete"`
+	AppearanceDarkMode   bool   `json:"appearance_dark_mode"`
+	AppearanceFontSize   int    `json:"appearance_font_size"`
+	AppearanceFontFamily string `json:"appearance_font_family"`
 }
 
 // SettingsManager loads and saves user settings to disk, and exposes which


### PR DESCRIPTION
## Summary

- **Dark mode** toggle that applies globally via `html.dark` class — configured Tailwind v4 `@custom-variant` so all `dark:` utilities activate on class toggle; added `dark:` variants to every component (Layout, Sidebar, SettingsPage, ChatsPage, ChatSessionPage including MessageBubble, ThinkingBlock, ToolCallCard, AskUserQuestionCard)
- **Font size** slider (12–24px) — sets `html` font-size directly so all `rem`-based Tailwind classes (`text-sm`, `text-xs`, etc.) scale proportionally across the entire app
- **Font family** picker — curated list of 7 fonts (Inter, Roboto, Open Sans, Lato, Merriweather, JetBrains Mono, System Default) loaded via Google Fonts
- **Persistence** — preferences saved to `localStorage` on every change (no flash on reload) and explicitly synced to backend on "Save Appearance Settings"; server values merged on load with zero-value Go defaults sanitized so they don't override valid localStorage state
- New `AppearanceProvider` / `useAppearance()` context wraps the whole app; new `AppearanceTab` component with live preview panel added to Settings page

## Test plan

- [ ] Toggle dark mode → entire app (sidebar, chats list, chat conversation, settings) goes dark
- [ ] Drag font size slider → all text in the app scales proportionally
- [ ] Change font family → font updates globally including live preview
- [ ] Refresh page → preferences restore from localStorage with no flash
- [ ] Click "Save Appearance Settings" → `GET /api/settings` returns the saved appearance fields
- [ ] Set preferences, clear localStorage manually, reload → server settings restore them