### PR TITLE
feat: Claude Sessions viewer, token usage tracking, and continue session

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -11,8 +11,8 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Roboto:wght@400;500&family=Open+Sans:wght@400;600&family=Lato:wght@400;700&family=Merriweather:wght@400;700&family=JetBrains+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
-    <script type="module" crossorigin src="/assets/index-CFmSOkp5.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-qeKty1mT.css">
+    <script type="module" crossorigin src="/assets/index-nCEm0NI1.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-D8Hm_q2Y.css">
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,8 @@ import AgentEditPage from '@/pages/AgentEditPage'
 import ChatsPage from '@/pages/ChatsPage'
 import ChatSessionPage from '@/pages/ChatSessionPage'
 import SettingsPage from '@/pages/SettingsPage'
+import ClaudeSessionsPage from '@/pages/ClaudeSessionsPage'
+import ClaudeSessionDetailPage from '@/pages/ClaudeSessionDetailPage'
 import OnboardingWizard from '@/components/OnboardingWizard'
 import { AppearanceProvider } from '@/contexts/ThemeContext'
 import { settingsApi } from '@/lib/api'
@@ -69,6 +71,8 @@ export default function App() {
             <Route path="agents" element={<AgentsPage />} />
             <Route path="agents/new" element={<AgentCreatePage />} />
             <Route path="agents/:slug/edit" element={<AgentEditPage />} />
+            <Route path="claude-sessions" element={<ClaudeSessionsPage />} />
+            <Route path="claude-sessions/:id" element={<ClaudeSessionDetailPage />} />
             <Route path="settings" element={<SettingsPage />} />
           </Route>
         </Routes>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,6 +1,15 @@
 import { useState, useEffect } from 'react'
 import { NavLink, useNavigate } from 'react-router-dom'
-import { MessageSquare, Bot, Plus, PanelLeftClose, PanelLeftOpen, X, Settings } from 'lucide-react'
+import {
+  MessageSquare,
+  Bot,
+  Plus,
+  PanelLeftClose,
+  PanelLeftOpen,
+  X,
+  Settings,
+  History,
+} from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Tooltip } from '@/components/ui/tooltip'
 
@@ -56,6 +65,7 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
 
   const navItems = [
     { to: '/chats', icon: MessageSquare, label: 'Chats' },
+    { to: '/claude-sessions', icon: History, label: 'Claude Sessions' },
     { to: '/agents', icon: Bot, label: 'Agents' },
   ]
 

--- a/frontend/src/pages/ChatsPage.tsx
+++ b/frontend/src/pages/ChatsPage.tsx
@@ -36,7 +36,7 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog'
 import FilesystemBrowserModal from '@/components/FilesystemBrowserModal'
-import { Plus, MessageSquare, Trash2, Search, Send, FolderOpen, Lock } from 'lucide-react'
+import { Plus, MessageSquare, Trash2, Search, Send, FolderOpen, Lock, Zap } from 'lucide-react'
 
 export default function ChatsPage() {
   const navigate = useNavigate()
@@ -428,6 +428,13 @@ export default function ChatsPage() {
   )
 }
 
+function formatTokens(n: number | undefined): string {
+  if (!n) return '—'
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  return String(n)
+}
+
 function ChatRow({
   session,
   agentName,
@@ -439,6 +446,8 @@ function ChatRow({
   onClick: () => void
   onDelete: () => void
 }) {
+  const hasTokens = (session.total_input_tokens ?? 0) > 0 || (session.total_output_tokens ?? 0) > 0
+
   return (
     <div
       className="flex items-center gap-3 px-4 sm:px-6 py-3.5 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 cursor-pointer group transition-colors"
@@ -451,7 +460,7 @@ function ChatRow({
         <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100 truncate">
           {truncate(session.title, 70)}
         </p>
-        <div className="flex items-center gap-2 mt-0.5">
+        <div className="flex items-center gap-2 mt-0.5 flex-wrap">
           {agentName ? (
             <Badge
               variant="secondary"
@@ -470,6 +479,13 @@ function ChatRow({
           <span className="text-xs text-zinc-400 dark:text-zinc-500">
             {formatRelativeTime(session.updated_at)}
           </span>
+          {hasTokens && (
+            <span className="flex items-center gap-0.5 text-xs text-zinc-400 dark:text-zinc-500">
+              <Zap className="h-2.5 w-2.5" />
+              {formatTokens(session.total_input_tokens)}↑&nbsp;
+              {formatTokens(session.total_output_tokens)}↓
+            </span>
+          )}
         </div>
       </div>
       <AlertDialog>

--- a/frontend/src/pages/ClaudeSessionDetailPage.tsx
+++ b/frontend/src/pages/ClaudeSessionDetailPage.tsx
@@ -1,0 +1,461 @@
+import { useState, useEffect, useCallback } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { claudeSessionsApi } from '@/lib/api'
+import type { ClaudeSessionDetail, ClaudeMessage, ClaudeNormalizedBlock, ClaudeTodo } from '@/types'
+import { formatRelativeTime } from '@/lib/utils'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  ArrowLeft,
+  ChevronDown,
+  ChevronRight,
+  GitBranch,
+  Folder,
+  Cpu,
+  Zap,
+  CheckCircle2,
+  Circle,
+  Clock,
+  Play,
+  Loader2,
+} from 'lucide-react'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function formatTokens(n: number): string {
+  if (!n) return '—'
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  return String(n)
+}
+
+function shortPath(path: string): string {
+  return path.replace(/^\/home\/[^/]+\//, '~/')
+}
+
+function todoIcon(status: string) {
+  if (status === 'completed')
+    return <CheckCircle2 className="h-3.5 w-3.5 text-green-500 shrink-0" />
+  if (status === 'in_progress')
+    return <Clock className="h-3.5 w-3.5 text-yellow-500 shrink-0 animate-pulse" />
+  return <Circle className="h-3.5 w-3.5 text-zinc-400 shrink-0" />
+}
+
+// ── Block renderer ────────────────────────────────────────────────────────────
+
+function ThinkingBlock({ text }: { text: string }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div className="rounded-md border border-purple-200 dark:border-purple-900/50 bg-purple-50 dark:bg-purple-950/20 text-xs overflow-hidden">
+      <button
+        className="flex w-full items-center gap-1.5 px-3 py-1.5 text-purple-700 dark:text-purple-400 hover:bg-purple-100 dark:hover:bg-purple-900/30 transition-colors text-left"
+        onClick={() => setOpen(o => !o)}
+      >
+        {open ? (
+          <ChevronDown className="h-3 w-3 shrink-0" />
+        ) : (
+          <ChevronRight className="h-3 w-3 shrink-0" />
+        )}
+        <Cpu className="h-3 w-3 shrink-0" />
+        <span>Thinking</span>
+      </button>
+      {open && (
+        <pre className="px-3 pb-2 text-purple-800 dark:text-purple-300 whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed border-t border-purple-200 dark:border-purple-900/50">
+          {text}
+        </pre>
+      )}
+    </div>
+  )
+}
+
+function ToolUseBlock({ block }: { block: ClaudeNormalizedBlock }) {
+  const [open, setOpen] = useState(false)
+  const toolName = block.name ?? 'unknown'
+  const inputStr = block.input ? JSON.stringify(block.input, null, 2) : ''
+
+  // Extract a short summary from the input for common tools.
+  let summary = ''
+  if (block.input) {
+    const inp = block.input as Record<string, unknown>
+    if (toolName === 'Read' || toolName === 'Write' || toolName === 'Edit') {
+      summary = String(inp.file_path ?? inp.filePath ?? '')
+    } else if (toolName === 'Bash') {
+      summary = String(inp.command ?? '').slice(0, 60)
+    } else if (toolName === 'Glob' || toolName === 'Grep') {
+      summary = String(inp.pattern ?? inp.query ?? '')
+    } else if (toolName === 'WebFetch' || toolName === 'WebSearch') {
+      summary = String(inp.url ?? inp.query ?? '')
+    } else if (toolName === 'Task') {
+      summary = String(inp.description ?? '').slice(0, 60)
+    }
+  }
+
+  return (
+    <div className="rounded-md border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800/50 text-xs overflow-hidden">
+      <button
+        className="flex w-full items-center gap-1.5 px-3 py-1.5 text-zinc-600 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-700/50 transition-colors text-left"
+        onClick={() => setOpen(o => !o)}
+      >
+        {open ? (
+          <ChevronDown className="h-3 w-3 shrink-0" />
+        ) : (
+          <ChevronRight className="h-3 w-3 shrink-0" />
+        )}
+        <Badge
+          variant="secondary"
+          className="text-[10px] py-0 h-3.5 bg-zinc-200 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-300 border-0 font-mono px-1"
+        >
+          {toolName}
+        </Badge>
+        {summary && (
+          <span className="text-zinc-500 dark:text-zinc-400 font-mono truncate">{summary}</span>
+        )}
+      </button>
+      {open && inputStr && (
+        <pre className="px-3 pb-2 text-zinc-600 dark:text-zinc-400 whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed border-t border-zinc-200 dark:border-zinc-700">
+          {inputStr}
+        </pre>
+      )}
+    </div>
+  )
+}
+
+function MessageBlocks({ blocks }: { blocks: ClaudeNormalizedBlock[] }) {
+  return (
+    <div className="flex flex-col gap-2">
+      {blocks.map((b, i) => {
+        if (b.type === 'thinking') {
+          return <ThinkingBlock key={i} text={b.text ?? ''} />
+        }
+        if (b.type === 'text') {
+          return (
+            <p
+              key={i}
+              className="text-sm text-zinc-800 dark:text-zinc-200 whitespace-pre-wrap leading-relaxed"
+            >
+              {b.text}
+            </p>
+          )
+        }
+        if (b.type === 'tool_use') {
+          return <ToolUseBlock key={i} block={b} />
+        }
+        return null
+      })}
+    </div>
+  )
+}
+
+// ── Progress children ─────────────────────────────────────────────────────────
+
+function ProgressChildren({ children }: { children: ClaudeMessage[] }) {
+  const [open, setOpen] = useState(false)
+  if (!children || children.length === 0) return null
+  return (
+    <div className="mt-2">
+      <button
+        className="flex items-center gap-1 text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-400 transition-colors"
+        onClick={() => setOpen(o => !o)}
+      >
+        {open ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+        {children.length} sub-agent event{children.length !== 1 ? 's' : ''}
+      </button>
+      {open && (
+        <div className="mt-1 pl-3 border-l border-zinc-200 dark:border-zinc-700 flex flex-col gap-0.5">
+          {children.map(c => (
+            <div key={c.uuid} className="text-xs text-zinc-400 dark:text-zinc-500 font-mono">
+              {new Date(c.timestamp).toLocaleTimeString()}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Message components ────────────────────────────────────────────────────────
+
+function UserMessage({ msg }: { msg: ClaudeMessage }) {
+  return (
+    <div className="flex gap-3">
+      <div className="flex h-7 w-7 items-center justify-center rounded-full bg-zinc-200 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-300 shrink-0 text-xs font-semibold mt-0.5">
+        U
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm text-zinc-800 dark:text-zinc-200 whitespace-pre-wrap leading-relaxed">
+          {msg.content}
+        </p>
+        <span className="text-xs text-zinc-400 dark:text-zinc-500 mt-0.5 block">
+          {formatRelativeTime(msg.timestamp)}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+function AssistantMessage({ msg }: { msg: ClaudeMessage }) {
+  const hasBlocks = (msg.blocks ?? []).length > 0
+  const hasChildren = (msg.children ?? []).length > 0
+
+  return (
+    <div className="flex gap-3">
+      <div className="flex h-7 w-7 items-center justify-center rounded-full bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 shrink-0 text-xs font-semibold mt-0.5">
+        A
+      </div>
+      <div className="flex-1 min-w-0">
+        {hasBlocks ? (
+          <MessageBlocks blocks={msg.blocks!} />
+        ) : (
+          <p className="text-sm text-zinc-400 dark:text-zinc-500 italic">No text content</p>
+        )}
+        {hasChildren && <ProgressChildren children={msg.children!} />}
+        <div className="flex items-center gap-3 mt-1">
+          <span className="text-xs text-zinc-400 dark:text-zinc-500">
+            {formatRelativeTime(msg.timestamp)}
+          </span>
+          {msg.usage && (
+            <span className="flex items-center gap-0.5 text-xs text-zinc-400 dark:text-zinc-500">
+              <Zap className="h-2.5 w-2.5" />
+              {formatTokens(msg.usage.input_tokens)}↑&nbsp;{formatTokens(msg.usage.output_tokens)}↓
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Todos ─────────────────────────────────────────────────────────────────────
+
+function TodosSection({ todos }: { todos: ClaudeTodo[] }) {
+  const [open, setOpen] = useState(false)
+  if (!todos || todos.length === 0) return null
+
+  const completed = todos.filter(t => t.status === 'completed').length
+
+  return (
+    <div className="rounded-md border border-zinc-200 dark:border-zinc-700 overflow-hidden">
+      <button
+        className="flex w-full items-center gap-2 px-4 py-2.5 bg-zinc-50 dark:bg-zinc-800/50 hover:bg-zinc-100 dark:hover:bg-zinc-700/50 transition-colors text-left"
+        onClick={() => setOpen(o => !o)}
+      >
+        {open ? (
+          <ChevronDown className="h-3.5 w-3.5 text-zinc-400" />
+        ) : (
+          <ChevronRight className="h-3.5 w-3.5 text-zinc-400" />
+        )}
+        <span className="text-xs font-medium text-zinc-700 dark:text-zinc-300">Todos</span>
+        <span className="text-xs text-zinc-400 dark:text-zinc-500">
+          {completed}/{todos.length} completed
+        </span>
+      </button>
+      {open && (
+        <div className="divide-y divide-zinc-100 dark:divide-zinc-700/50">
+          {todos.map((todo, i) => (
+            <div key={i} className="flex items-start gap-2 px-4 py-2">
+              {todoIcon(todo.status)}
+              <span
+                className={`text-xs leading-relaxed ${
+                  todo.status === 'completed'
+                    ? 'text-zinc-400 dark:text-zinc-500 line-through'
+                    : 'text-zinc-700 dark:text-zinc-300'
+                }`}
+              >
+                {todo.content}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Main page ─────────────────────────────────────────────────────────────────
+
+export default function ClaudeSessionDetailPage() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const [detail, setDetail] = useState<ClaudeSessionDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [continuing, setContinuing] = useState(false)
+
+  const load = useCallback(async () => {
+    if (!id) return
+    try {
+      const d = await claudeSessionsApi.get(id)
+      setDetail(d)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load session')
+    } finally {
+      setLoading(false)
+    }
+  }, [id])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const handleContinue = async () => {
+    if (!id || continuing) return
+    setContinuing(true)
+    try {
+      const { chat_id } = await claudeSessionsApi.continue(id)
+      navigate(`/chats/${chat_id}`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to continue session')
+      setContinuing(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="text-sm text-zinc-400">Loading session…</div>
+      </div>
+    )
+  }
+
+  if (error || !detail) {
+    return (
+      <div className="flex flex-col h-full">
+        <div className="px-4 sm:px-6 py-4 border-b border-zinc-100 dark:border-zinc-700/50">
+          <button
+            onClick={() => navigate('/claude-sessions')}
+            className="flex items-center gap-1.5 text-xs text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" />
+            Back to Sessions
+          </button>
+        </div>
+        <div className="flex flex-col items-center justify-center flex-1 text-center">
+          <p className="text-sm text-zinc-500">{error ?? 'Session not found.'}</p>
+        </div>
+      </div>
+    )
+  }
+
+  const totalTokens = (detail.usage?.input_tokens ?? 0) + (detail.usage?.output_tokens ?? 0)
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="border-b border-zinc-100 dark:border-zinc-700/50 px-4 sm:px-6 py-4 shrink-0">
+        <button
+          onClick={() => navigate('/claude-sessions')}
+          className="flex items-center gap-1.5 text-xs text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors mb-3"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Back to Sessions
+        </button>
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex-1 min-w-0">
+            <p className="text-base font-semibold text-zinc-900 dark:text-zinc-100 truncate">
+              {detail.preview || 'Session ' + (id ?? '').slice(0, 8)}
+            </p>
+            {/* Session meta */}
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1.5">
+              {detail.cwd && (
+                <span className="flex items-center gap-1 text-xs text-zinc-500 dark:text-zinc-400">
+                  <Folder className="h-3 w-3" />
+                  <span className="font-mono">{shortPath(detail.cwd)}</span>
+                </span>
+              )}
+              {detail.git_branch && (
+                <span className="flex items-center gap-1 text-xs text-zinc-500 dark:text-zinc-400">
+                  <GitBranch className="h-3 w-3" />
+                  <span className="font-mono">{detail.git_branch}</span>
+                </span>
+              )}
+              {detail.model && (
+                <Badge
+                  variant="secondary"
+                  className="text-xs py-0 h-4 bg-zinc-100 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-300 border-0 font-mono font-normal"
+                >
+                  {detail.model}
+                </Badge>
+              )}
+              <span className="text-xs text-zinc-400 dark:text-zinc-500 font-mono">
+                {(id ?? '').slice(0, 8)}…
+              </span>
+            </div>
+          </div>
+          <Button
+            size="sm"
+            className="gap-1.5 bg-zinc-900 hover:bg-zinc-800 text-white text-xs h-8 shrink-0"
+            onClick={() => void handleContinue()}
+            disabled={continuing}
+          >
+            {continuing ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Play className="h-3.5 w-3.5" />
+            )}
+            {continuing ? 'Opening…' : 'Continue'}
+          </Button>
+        </div>
+      </div>
+
+      {/* Token usage banner */}
+      {totalTokens > 0 && (
+        <div className="flex items-center gap-4 px-4 sm:px-6 py-2 border-b border-zinc-100 dark:border-zinc-700/50 bg-zinc-50 dark:bg-zinc-900/50 shrink-0">
+          <Zap className="h-3.5 w-3.5 text-zinc-400 shrink-0" />
+          <div className="flex items-center gap-4 text-xs text-zinc-500 dark:text-zinc-400">
+            <span>
+              <span className="font-medium text-zinc-700 dark:text-zinc-300">
+                {formatTokens(detail.usage.input_tokens)}
+              </span>{' '}
+              input
+            </span>
+            <span>
+              <span className="font-medium text-zinc-700 dark:text-zinc-300">
+                {formatTokens(detail.usage.output_tokens)}
+              </span>{' '}
+              output
+            </span>
+            {detail.usage.cache_creation_tokens > 0 && (
+              <span>
+                <span className="font-medium text-zinc-700 dark:text-zinc-300">
+                  {formatTokens(detail.usage.cache_creation_tokens)}
+                </span>{' '}
+                cache write
+              </span>
+            )}
+            {detail.usage.cache_read_tokens > 0 && (
+              <span>
+                <span className="font-medium text-zinc-700 dark:text-zinc-300">
+                  {formatTokens(detail.usage.cache_read_tokens)}
+                </span>{' '}
+                cache read
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Body */}
+      <div className="flex-1 overflow-y-auto px-4 sm:px-6 py-4 flex flex-col gap-4">
+        {/* Todos */}
+        {detail.todos && detail.todos.length > 0 && <TodosSection todos={detail.todos} />}
+
+        {/* Conversation */}
+        {detail.messages.length === 0 ? (
+          <p className="text-sm text-zinc-400 text-center py-8">No messages in this session.</p>
+        ) : (
+          <div className="flex flex-col gap-5">
+            {detail.messages.map(msg => {
+              if (msg.role === 'user') {
+                return <UserMessage key={msg.uuid} msg={msg} />
+              }
+              if (msg.role === 'assistant') {
+                return <AssistantMessage key={msg.uuid} msg={msg} />
+              }
+              return null
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -24,6 +24,11 @@ export interface ChatSession {
   model: string
   created_at: string
   updated_at: string
+  /** Cumulative token usage across all turns. Zero when not yet populated. */
+  total_input_tokens?: number
+  total_output_tokens?: number
+  total_cache_creation_tokens?: number
+  total_cache_read_tokens?: number
 }
 
 export interface UserSettings {
@@ -382,3 +387,64 @@ export const BUILT_IN_TOOLS = [
   'Task',
   'current_time',
 ]
+
+// ── Claude Code sessions (~/.claude) ─────────────────────────────────────────
+
+export interface ClaudeTokenUsage {
+  input_tokens: number
+  output_tokens: number
+  cache_creation_tokens: number
+  cache_read_tokens: number
+}
+
+export interface ClaudeProject {
+  encoded_name: string
+  decoded_path: string
+  session_count: number
+}
+
+export interface ClaudeSessionSummary {
+  session_id: string
+  project_path: string
+  preview: string
+  start_time: string
+  last_activity: string
+  message_count: number
+  usage: ClaudeTokenUsage
+  git_branch?: string
+  model?: string
+  cwd?: string
+}
+
+export interface ClaudeNormalizedBlock {
+  type: 'thinking' | 'text' | 'tool_use'
+  text?: string
+  id?: string
+  name?: string
+  input?: Record<string, unknown>
+}
+
+export interface ClaudeMessage {
+  uuid: string
+  parent_uuid?: string
+  type: 'user' | 'assistant' | 'progress'
+  timestamp: string
+  role?: string
+  content?: string
+  blocks?: ClaudeNormalizedBlock[]
+  usage?: ClaudeTokenUsage
+  git_branch?: string
+  is_sidechain?: boolean
+  children?: ClaudeMessage[]
+}
+
+export interface ClaudeTodo {
+  content: string
+  status: 'completed' | 'in_progress' | 'pending'
+  active_form?: string
+}
+
+export interface ClaudeSessionDetail extends ClaudeSessionSummary {
+  messages: ClaudeMessage[]
+  todos: ClaudeTodo[]
+}

--- a/internal/api/chats.go
+++ b/internal/api/chats.go
@@ -14,6 +14,33 @@ import (
 	"github.com/shaharia-lab/agento/internal/storage"
 )
 
+// tokenAccumulator accumulates token usage across multiple TypeResult events (multi-turn).
+type tokenAccumulator struct {
+	InputTokens              int
+	OutputTokens             int
+	CacheCreationInputTokens int
+	CacheReadInputTokens     int
+}
+
+func (t *tokenAccumulator) add(r *claude.Result) {
+	if r == nil {
+		return
+	}
+	t.InputTokens += r.Usage.InputTokens
+	t.OutputTokens += r.Usage.OutputTokens
+	t.CacheCreationInputTokens += r.Usage.CacheCreationInputTokens
+	t.CacheReadInputTokens += r.Usage.CacheReadInputTokens
+}
+
+func (t *tokenAccumulator) toUsageStats() agent.UsageStats {
+	return agent.UsageStats{
+		InputTokens:              t.InputTokens,
+		OutputTokens:             t.OutputTokens,
+		CacheCreationInputTokens: t.CacheCreationInputTokens,
+		CacheReadInputTokens:     t.CacheReadInputTokens,
+	}
+}
+
 // assistantEventRaw is used to parse content blocks out of a raw "assistant" SSE event.
 type assistantEventRaw struct {
 	Message struct {
@@ -204,6 +231,9 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 	// blocks accumulates ordered content blocks (thinking/text/tool_use) across
 	// all assistant events so they can be persisted and re-rendered after reload.
 	var blocks []storage.MessageBlock
+	// tokens accumulates usage across all TypeResult events (multi-turn sessions
+	// may emit more than one).
+	var tokens tokenAccumulator
 	// pendingInput holds the AskUserQuestion tool input from the most recent
 	// TypeAssistant event; non-nil means the agent asked the user something and
 	// we need to pause and collect the answer before the conversation can continue.
@@ -256,6 +286,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 					continue
 				}
 				sdkSessionID = event.Result.SessionID
+				tokens.add(event.Result)
 				if event.Result.IsError {
 					return
 				}
@@ -312,7 +343,7 @@ done:
 		chatSession.Title = title
 	}
 
-	if err := s.chatSvc.CommitMessage(r.Context(), chatSession, assistantText, sdkSessionID, isFirstMessage, blocks); err != nil {
+	if err := s.chatSvc.CommitMessage(r.Context(), chatSession, assistantText, sdkSessionID, isFirstMessage, blocks, tokens.toUsageStats()); err != nil {
 		s.logger.Error("commit message failed", "session_id", id, "error", err)
 	}
 }

--- a/internal/api/claude_sessions.go
+++ b/internal/api/claude_sessions.go
@@ -1,0 +1,125 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/shaharia-lab/agento/internal/claudesessions"
+)
+
+// handleListClaudeSessions returns all Claude Code sessions with optional filtering.
+// Query params:
+//   - project: filter by decoded project path (exact match)
+//   - q: search by session ID prefix or preview text (case-insensitive substring)
+func (s *Server) handleListClaudeSessions(w http.ResponseWriter, r *http.Request) {
+	sessions := s.claudeSessionCache.List()
+
+	project := r.URL.Query().Get("project")
+	if project != "" {
+		var filtered []claudesessions.ClaudeSessionSummary
+		for _, sess := range sessions {
+			if sess.ProjectPath == project {
+				filtered = append(filtered, sess)
+			}
+		}
+		sessions = filtered
+	}
+
+	q := strings.ToLower(r.URL.Query().Get("q"))
+	if q != "" {
+		var filtered []claudesessions.ClaudeSessionSummary
+		for _, sess := range sessions {
+			if strings.Contains(strings.ToLower(sess.SessionID), q) ||
+				strings.Contains(strings.ToLower(sess.Preview), q) {
+				filtered = append(filtered, sess)
+			}
+		}
+		sessions = filtered
+	}
+
+	if sessions == nil {
+		sessions = []claudesessions.ClaudeSessionSummary{}
+	}
+	writeJSON(w, http.StatusOK, sessions)
+}
+
+// handleListClaudeProjects returns all distinct project directories containing sessions.
+func (s *Server) handleListClaudeProjects(w http.ResponseWriter, r *http.Request) {
+	projects, err := claudesessions.ListProjects()
+	if err != nil {
+		s.logger.Error("list claude projects failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to list projects")
+		return
+	}
+	if projects == nil {
+		projects = []claudesessions.ClaudeProject{}
+	}
+	writeJSON(w, http.StatusOK, projects)
+}
+
+// handleGetClaudeSession returns the full detail of a single Claude Code session
+// including all messages, token usage, and todos.
+func (s *Server) handleGetClaudeSession(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	detail, err := claudesessions.GetSessionDetail(id)
+	if err != nil {
+		s.logger.Error("get claude session failed", "session_id", id, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to get session")
+		return
+	}
+	if detail == nil {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, detail)
+}
+
+// handleRefreshClaudeSessionCache invalidates the in-memory session cache.
+// The next call to List() will trigger a fresh scan.
+func (s *Server) handleRefreshClaudeSessionCache(w http.ResponseWriter, _ *http.Request) {
+	s.claudeSessionCache.Invalidate()
+	// Trigger rescan in background so the next list request gets fresh data.
+	go func() { s.claudeSessionCache.List() }()
+	w.WriteHeader(http.StatusAccepted)
+}
+
+// handleContinueClaudeSession creates a new Agento chat session that inherits the
+// given Claude Code session ID so the SDK can resume the existing conversation.
+func (s *Server) handleContinueClaudeSession(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	// Look up the session to get its working directory and model.
+	detail, err := claudesessions.GetSessionDetail(id)
+	if err != nil {
+		s.logger.Error("continue claude session: lookup failed", "session_id", id, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to look up session")
+		return
+	}
+	if detail == nil {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+
+	// Create a new Agento chat session with no agent slug, inheriting the session's cwd.
+	chatSession, err := s.chatSvc.CreateSession(r.Context(), "", detail.CWD, detail.Model, "")
+	if err != nil {
+		s.logger.Error("continue claude session: create chat failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to create chat session")
+		return
+	}
+
+	// Link the new Agento chat to the original Claude Code session so the SDK
+	// picks up the conversation history when the first message is sent.
+	chatSession.SDKSession = id
+	if err := s.chatSvc.UpdateSession(r.Context(), chatSession); err != nil {
+		s.logger.Error("continue claude session: update session failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to link session")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]string{
+		"chat_id": chatSession.ID,
+	})
+}

--- a/internal/claudesessions/cache.go
+++ b/internal/claudesessions/cache.go
@@ -1,0 +1,84 @@
+package claudesessions
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+)
+
+const defaultCacheTTL = 5 * time.Minute
+
+// Cache is an in-memory cache of Claude Code session summaries with TTL-based invalidation.
+// It is safe for concurrent use.
+type Cache struct {
+	mu        sync.RWMutex
+	sessions  []ClaudeSessionSummary
+	expiresAt time.Time
+	ttl       time.Duration
+	logger    *slog.Logger
+}
+
+// NewCache creates a new Cache with the default TTL.
+func NewCache(logger *slog.Logger) *Cache {
+	return &Cache{
+		ttl:    defaultCacheTTL,
+		logger: logger,
+	}
+}
+
+// StartBackgroundScan starts the initial scan of ~/.claude/projects/ in a background
+// goroutine so the server starts immediately while the cache is being populated.
+func (c *Cache) StartBackgroundScan() {
+	go func() {
+		c.logger.Info("claude sessions: starting background scan")
+		sessions, err := ScanAllSessions()
+		if err != nil {
+			c.logger.Warn("claude sessions: background scan failed", "error", err)
+			return
+		}
+		c.mu.Lock()
+		c.sessions = sessions
+		c.expiresAt = time.Now().Add(c.ttl)
+		c.mu.Unlock()
+		c.logger.Info("claude sessions: scan complete", "count", len(sessions))
+	}()
+}
+
+// List returns all cached session summaries. If the cache has expired or is empty,
+// a synchronous rescan is performed before returning.
+func (c *Cache) List() []ClaudeSessionSummary {
+	c.mu.RLock()
+	if c.sessions != nil && time.Now().Before(c.expiresAt) {
+		sessions := c.sessions
+		c.mu.RUnlock()
+		return sessions
+	}
+	c.mu.RUnlock()
+
+	// Cache expired or not yet populated — rescan synchronously.
+	sessions, err := ScanAllSessions()
+	if err != nil {
+		c.logger.Warn("claude sessions: refresh scan failed", "error", err)
+		// Return stale data if available rather than an error.
+		c.mu.RLock()
+		stale := c.sessions
+		c.mu.RUnlock()
+		if stale != nil {
+			return stale
+		}
+		return []ClaudeSessionSummary{}
+	}
+
+	c.mu.Lock()
+	c.sessions = sessions
+	c.expiresAt = time.Now().Add(c.ttl)
+	c.mu.Unlock()
+	return sessions
+}
+
+// Invalidate clears the cache expiry so the next List() call triggers a rescan.
+func (c *Cache) Invalidate() {
+	c.mu.Lock()
+	c.expiresAt = time.Time{}
+	c.mu.Unlock()
+}

--- a/internal/claudesessions/scanner.go
+++ b/internal/claudesessions/scanner.go
@@ -1,0 +1,457 @@
+package claudesessions
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+const previewMaxRunes = 120
+
+// rawEvent is the raw JSON structure of a single line in a Claude Code session JSONL file.
+type rawEvent struct {
+	Type        string      `json:"type"`
+	UUID        string      `json:"uuid"`
+	ParentUUID  string      `json:"parentUuid"`
+	SessionID   string      `json:"sessionId"`
+	Timestamp   time.Time   `json:"timestamp"`
+	CWD         string      `json:"cwd"`
+	Version     string      `json:"version"`
+	GitBranch   string      `json:"gitBranch"`
+	IsSidechain bool        `json:"isSidechain"`
+	Message     *rawMessage `json:"message,omitempty"`
+}
+
+type rawMessage struct {
+	Role    string          `json:"role"`
+	Model   string          `json:"model,omitempty"`
+	Content json.RawMessage `json:"content"` // string or array of content blocks
+	Usage   *rawUsage       `json:"usage,omitempty"`
+}
+
+type rawUsage struct {
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+}
+
+type rawContentBlock struct {
+	Type     string          `json:"type"`
+	Text     string          `json:"text,omitempty"`
+	Thinking string          `json:"thinking,omitempty"`
+	ID       string          `json:"id,omitempty"`
+	Name     string          `json:"name,omitempty"`
+	Input    json.RawMessage `json:"input,omitempty"`
+}
+
+// ClaudeHome returns the path to the user's ~/.claude directory.
+func ClaudeHome() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join("/root", ".claude")
+	}
+	return filepath.Join(home, ".claude")
+}
+
+// DecodeProjectPath converts an encoded Claude Code directory name to the original path.
+// Claude Code encodes paths by replacing '/' separators with '-' and prepending '-'.
+// e.g. "-home-user-Projects-foo" → "/home/user/Projects/foo"
+//
+// Note: this encoding is ambiguous when directory names contain hyphens, but it
+// matches what Claude Code itself uses, so decoded paths may differ in that edge case.
+func DecodeProjectPath(encoded string) string {
+	trimmed := strings.TrimPrefix(encoded, "-")
+	return "/" + strings.ReplaceAll(trimmed, "-", "/")
+}
+
+// ListProjects returns all projects found in ~/.claude/projects/.
+func ListProjects() ([]ClaudeProject, error) {
+	projectsDir := filepath.Join(ClaudeHome(), "projects")
+	entries, err := os.ReadDir(projectsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	projects := make([]ClaudeProject, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		files, _ := os.ReadDir(filepath.Join(projectsDir, e.Name()))
+		count := 0
+		for _, f := range files {
+			if !f.IsDir() && strings.HasSuffix(f.Name(), ".jsonl") {
+				count++
+			}
+		}
+		projects = append(projects, ClaudeProject{
+			EncodedName:  e.Name(),
+			DecodedPath:  DecodeProjectPath(e.Name()),
+			SessionCount: count,
+		})
+	}
+	sort.Slice(projects, func(i, j int) bool {
+		return projects[i].DecodedPath < projects[j].DecodedPath
+	})
+	return projects, nil
+}
+
+// ScanAllSessions scans all project directories and returns summaries for all sessions.
+// Sessions are sorted by last activity, most recent first.
+func ScanAllSessions() ([]ClaudeSessionSummary, error) {
+	projectsDir := filepath.Join(ClaudeHome(), "projects")
+	entries, err := os.ReadDir(projectsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var sessions []ClaudeSessionSummary
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		projectPath := DecodeProjectPath(e.Name())
+		files, err := os.ReadDir(filepath.Join(projectsDir, e.Name()))
+		if err != nil {
+			continue
+		}
+		for _, f := range files {
+			if f.IsDir() || !strings.HasSuffix(f.Name(), ".jsonl") {
+				continue
+			}
+			sessionID := strings.TrimSuffix(f.Name(), ".jsonl")
+			filePath := filepath.Join(projectsDir, e.Name(), f.Name())
+			summary, err := readSessionSummary(sessionID, projectPath, filePath)
+			if err != nil || summary == nil {
+				continue
+			}
+			sessions = append(sessions, *summary)
+		}
+	}
+
+	sort.Slice(sessions, func(i, j int) bool {
+		return sessions[i].LastActivity.After(sessions[j].LastActivity)
+	})
+	return sessions, nil
+}
+
+// readSessionSummary reads a session JSONL file and extracts lightweight metadata.
+func readSessionSummary(sessionID, projectPath, filePath string) (*ClaudeSessionSummary, error) {
+	f, err := os.Open(filePath) //nolint:gosec
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	summary := &ClaudeSessionSummary{
+		SessionID:   sessionID,
+		ProjectPath: projectPath,
+	}
+
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 4*1024*1024), 4*1024*1024)
+
+	for sc.Scan() {
+		var ev rawEvent
+		if err := json.Unmarshal(sc.Bytes(), &ev); err != nil {
+			continue
+		}
+		if ev.Type == "file-history-snapshot" {
+			continue
+		}
+
+		ts := ev.Timestamp
+		if !ts.IsZero() {
+			if summary.StartTime.IsZero() || ts.Before(summary.StartTime) {
+				summary.StartTime = ts
+			}
+			if ts.After(summary.LastActivity) {
+				summary.LastActivity = ts
+			}
+		}
+
+		if summary.CWD == "" && ev.CWD != "" {
+			summary.CWD = ev.CWD
+		}
+		if summary.GitBranch == "" && ev.GitBranch != "" {
+			summary.GitBranch = ev.GitBranch
+		}
+
+		switch ev.Type {
+		case "user":
+			if ev.IsSidechain {
+				continue
+			}
+			summary.MessageCount++
+			if summary.Preview == "" && ev.Message != nil {
+				summary.Preview = truncateRunes(extractTextContent(ev.Message.Content), previewMaxRunes)
+			}
+
+		case "assistant":
+			summary.MessageCount++
+			if ev.Message != nil {
+				if summary.Model == "" && ev.Message.Model != "" {
+					summary.Model = ev.Message.Model
+				}
+				if ev.Message.Usage != nil {
+					summary.Usage.InputTokens += ev.Message.Usage.InputTokens
+					summary.Usage.OutputTokens += ev.Message.Usage.OutputTokens
+					summary.Usage.CacheCreationTokens += ev.Message.Usage.CacheCreationInputTokens
+					summary.Usage.CacheReadTokens += ev.Message.Usage.CacheReadInputTokens
+				}
+			}
+		}
+	}
+
+	if summary.StartTime.IsZero() {
+		return nil, nil // empty or unreadable file
+	}
+	return summary, sc.Err()
+}
+
+// GetSessionDetail reads the full session JSONL and builds the complete message list.
+// Returns nil if the session is not found.
+func GetSessionDetail(sessionID string) (*ClaudeSessionDetail, error) {
+	projectsDir := filepath.Join(ClaudeHome(), "projects")
+	entries, _ := os.ReadDir(projectsDir)
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		filePath := filepath.Join(projectsDir, e.Name(), sessionID+".jsonl")
+		if _, err := os.Stat(filePath); err == nil {
+			projectPath := DecodeProjectPath(e.Name())
+			return readSessionDetail(sessionID, projectPath, filePath)
+		}
+	}
+	return nil, nil
+}
+
+// readSessionDetail reads a session JSONL file and builds the full detail including
+// message tree with progress events nested under their parent assistant turns.
+func readSessionDetail(sessionID, projectPath, filePath string) (*ClaudeSessionDetail, error) {
+	f, err := os.Open(filePath) //nolint:gosec
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	detail := &ClaudeSessionDetail{}
+	detail.SessionID = sessionID
+	detail.ProjectPath = projectPath
+
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 4*1024*1024), 4*1024*1024)
+
+	var topLevel []ClaudeMessage
+	progressByParentUUID := make(map[string][]ClaudeMessage)
+
+	for sc.Scan() {
+		var ev rawEvent
+		if err := json.Unmarshal(sc.Bytes(), &ev); err != nil {
+			continue
+		}
+		if ev.Type == "file-history-snapshot" {
+			continue
+		}
+
+		ts := ev.Timestamp
+		if !ts.IsZero() {
+			if detail.StartTime.IsZero() || ts.Before(detail.StartTime) {
+				detail.StartTime = ts
+			}
+			if ts.After(detail.LastActivity) {
+				detail.LastActivity = ts
+			}
+		}
+
+		if detail.CWD == "" && ev.CWD != "" {
+			detail.CWD = ev.CWD
+		}
+		if detail.GitBranch == "" && ev.GitBranch != "" {
+			detail.GitBranch = ev.GitBranch
+		}
+
+		switch ev.Type {
+		case "user":
+			if ev.IsSidechain {
+				continue
+			}
+			content := ""
+			if ev.Message != nil {
+				content = extractTextContent(ev.Message.Content)
+			}
+			msg := ClaudeMessage{
+				UUID:       ev.UUID,
+				ParentUUID: ev.ParentUUID,
+				Type:       "user",
+				Timestamp:  ev.Timestamp,
+				Role:       "user",
+				Content:    content,
+				GitBranch:  ev.GitBranch,
+			}
+			detail.MessageCount++
+			topLevel = append(topLevel, msg)
+
+		case "assistant":
+			msg := ClaudeMessage{
+				UUID:       ev.UUID,
+				ParentUUID: ev.ParentUUID,
+				Type:       "assistant",
+				Timestamp:  ev.Timestamp,
+				Role:       "assistant",
+				GitBranch:  ev.GitBranch,
+			}
+			if ev.Message != nil {
+				if detail.Model == "" && ev.Message.Model != "" {
+					detail.Model = ev.Message.Model
+				}
+				if ev.Message.Usage != nil {
+					u := TokenUsage{
+						InputTokens:         ev.Message.Usage.InputTokens,
+						OutputTokens:        ev.Message.Usage.OutputTokens,
+						CacheCreationTokens: ev.Message.Usage.CacheCreationInputTokens,
+						CacheReadTokens:     ev.Message.Usage.CacheReadInputTokens,
+					}
+					msg.Usage = &u
+					detail.Usage.InputTokens += u.InputTokens
+					detail.Usage.OutputTokens += u.OutputTokens
+					detail.Usage.CacheCreationTokens += u.CacheCreationTokens
+					detail.Usage.CacheReadTokens += u.CacheReadTokens
+				}
+				// Parse and normalize content blocks.
+				var blocks []rawContentBlock
+				if err := json.Unmarshal(ev.Message.Content, &blocks); err == nil {
+					for _, b := range blocks {
+						if nb := normalizeBlock(b); nb.Type != "" {
+							msg.Blocks = append(msg.Blocks, nb)
+						}
+					}
+				}
+			}
+			detail.MessageCount++
+			topLevel = append(topLevel, msg)
+
+		case "progress":
+			// Group progress events under their parent by UUID. We key on
+			// ParentUUID which is the UUID of the assistant message that
+			// spawned this sub-agent call.
+			if ev.ParentUUID == "" {
+				continue
+			}
+			progressByParentUUID[ev.ParentUUID] = append(progressByParentUUID[ev.ParentUUID], ClaudeMessage{
+				UUID:        ev.UUID,
+				ParentUUID:  ev.ParentUUID,
+				Type:        "progress",
+				Timestamp:   ev.Timestamp,
+				IsSidechain: ev.IsSidechain,
+			})
+		}
+	}
+
+	// Attach collected progress children to their parent top-level messages.
+	for i := range topLevel {
+		if children, ok := progressByParentUUID[topLevel[i].UUID]; ok {
+			topLevel[i].Children = children
+		}
+	}
+
+	detail.Messages = topLevel
+	if detail.Messages == nil {
+		detail.Messages = []ClaudeMessage{}
+	}
+
+	detail.Todos = loadTodos(sessionID)
+	if detail.Todos == nil {
+		detail.Todos = []ClaudeTodo{}
+	}
+
+	// Derive preview from first user message.
+	for _, msg := range detail.Messages {
+		if msg.Role == "user" && msg.Content != "" {
+			detail.Preview = truncateRunes(msg.Content, previewMaxRunes)
+			break
+		}
+	}
+
+	return detail, sc.Err()
+}
+
+// normalizeBlock converts a raw Claude Code content block to Agento's NormalizedBlock format.
+// Thinking blocks use the "text" field to match Agento's stored MessageBlock format.
+func normalizeBlock(b rawContentBlock) NormalizedBlock {
+	switch b.Type {
+	case "thinking":
+		return NormalizedBlock{Type: "thinking", Text: b.Thinking}
+	case "text":
+		return NormalizedBlock{Type: "text", Text: b.Text}
+	case "tool_use":
+		return NormalizedBlock{Type: "tool_use", ID: b.ID, Name: b.Name, Input: b.Input}
+	default:
+		return NormalizedBlock{} // unknown type — skip
+	}
+}
+
+// extractTextContent extracts plain text from a Claude Code message content field,
+// which may be either a JSON string or an array of content blocks.
+func extractTextContent(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	// Try plain string first.
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	// Try array of content blocks; concatenate text blocks.
+	var blocks []rawContentBlock
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		return ""
+	}
+	var sb strings.Builder
+	for _, b := range blocks {
+		if b.Type == "text" && b.Text != "" {
+			if sb.Len() > 0 {
+				sb.WriteString("\n")
+			}
+			sb.WriteString(b.Text)
+		}
+	}
+	return sb.String()
+}
+
+// loadTodos reads the session's todo list from ~/.claude/todos/{id}-agent-{id}.json.
+func loadTodos(sessionID string) []ClaudeTodo {
+	todoPath := filepath.Join(ClaudeHome(), "todos",
+		sessionID+"-agent-"+sessionID+".json")
+	data, err := os.ReadFile(todoPath) //nolint:gosec
+	if err != nil {
+		return nil
+	}
+	var todos []ClaudeTodo
+	if err := json.Unmarshal(data, &todos); err != nil {
+		return nil
+	}
+	return todos
+}
+
+// truncateRunes truncates s to at most maxRunes Unicode code points, appending "…" if truncated.
+func truncateRunes(s string, maxRunes int) string {
+	if utf8.RuneCountInString(s) <= maxRunes {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:maxRunes]) + "…"
+}

--- a/internal/claudesessions/types.go
+++ b/internal/claudesessions/types.go
@@ -1,0 +1,75 @@
+package claudesessions
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// TokenUsage represents API token consumption for a session or message turn.
+type TokenUsage struct {
+	InputTokens         int `json:"input_tokens"`
+	OutputTokens        int `json:"output_tokens"`
+	CacheCreationTokens int `json:"cache_creation_tokens"`
+	CacheReadTokens     int `json:"cache_read_tokens"`
+}
+
+// ClaudeProject represents a project directory containing Claude Code sessions.
+type ClaudeProject struct {
+	EncodedName  string `json:"encoded_name"`
+	DecodedPath  string `json:"decoded_path"`
+	SessionCount int    `json:"session_count"`
+}
+
+// ClaudeSessionSummary contains lightweight metadata for list views.
+type ClaudeSessionSummary struct {
+	SessionID    string     `json:"session_id"`
+	ProjectPath  string     `json:"project_path"`
+	Preview      string     `json:"preview"` // first user message text, truncated
+	StartTime    time.Time  `json:"start_time"`
+	LastActivity time.Time  `json:"last_activity"`
+	MessageCount int        `json:"message_count"` // user + assistant top-level messages
+	Usage        TokenUsage `json:"usage"`
+	GitBranch    string     `json:"git_branch,omitempty"`
+	Model        string     `json:"model,omitempty"`
+	CWD          string     `json:"cwd,omitempty"`
+}
+
+// ClaudeSessionDetail extends the summary with full message history and todos.
+type ClaudeSessionDetail struct {
+	ClaudeSessionSummary
+	Messages []ClaudeMessage `json:"messages"`
+	Todos    []ClaudeTodo    `json:"todos"`
+}
+
+// ClaudeMessage represents a single conversation turn (user or assistant).
+type ClaudeMessage struct {
+	UUID        string            `json:"uuid"`
+	ParentUUID  string            `json:"parent_uuid,omitempty"`
+	Type        string            `json:"type"` // "user" | "assistant" | "progress"
+	Timestamp   time.Time         `json:"timestamp"`
+	Role        string            `json:"role,omitempty"`
+	Content     string            `json:"content,omitempty"` // plain text for user messages
+	Blocks      []NormalizedBlock `json:"blocks,omitempty"`  // for assistant messages
+	Usage       *TokenUsage       `json:"usage,omitempty"`
+	GitBranch   string            `json:"git_branch,omitempty"`
+	IsSidechain bool              `json:"is_sidechain,omitempty"`
+	// Children holds progress/sub-agent events nested under this message.
+	Children []ClaudeMessage `json:"children,omitempty"`
+}
+
+// NormalizedBlock is a content block normalized to Agento's rendering format.
+// Thinking blocks use the "text" field (matching Agento's stored format).
+type NormalizedBlock struct {
+	Type  string          `json:"type"`            // "thinking" | "text" | "tool_use"
+	Text  string          `json:"text,omitempty"`  // for "thinking" and "text"
+	ID    string          `json:"id,omitempty"`    // for "tool_use"
+	Name  string          `json:"name,omitempty"`  // for "tool_use"
+	Input json.RawMessage `json:"input,omitempty"` // for "tool_use"
+}
+
+// ClaudeTodo represents a task item from the session's todo list.
+type ClaudeTodo struct {
+	Content    string `json:"content"`
+	Status     string `json:"status"`                // "completed" | "in_progress" | "pending"
+	ActiveForm string `json:"active_form,omitempty"` // present-continuous description
+}

--- a/internal/storage/chat_store.go
+++ b/internal/storage/chat_store.go
@@ -23,6 +23,11 @@ type ChatSession struct {
 	SettingsProfileID string    `json:"settings_profile_id,omitempty"`
 	CreatedAt         time.Time `json:"created_at"`
 	UpdatedAt         time.Time `json:"updated_at"`
+	// Cumulative token usage across all turns in this session.
+	TotalInputTokens         int `json:"total_input_tokens,omitempty"`
+	TotalOutputTokens        int `json:"total_output_tokens,omitempty"`
+	TotalCacheCreationTokens int `json:"total_cache_creation_tokens,omitempty"`
+	TotalCacheReadTokens     int `json:"total_cache_read_tokens,omitempty"`
 }
 
 // MessageBlock represents a single ordered content block within an assistant message.
@@ -80,6 +85,11 @@ type jsonlRecord struct {
 	SettingsProfileID string    `json:"settings_profile_id,omitempty"`
 	CreatedAt         time.Time `json:"created_at,omitempty"`
 	UpdatedAt         time.Time `json:"updated_at,omitempty"`
+	// cumulative token usage (session records only)
+	TotalInputTokens         int `json:"total_input_tokens,omitempty"`
+	TotalOutputTokens        int `json:"total_output_tokens,omitempty"`
+	TotalCacheCreationTokens int `json:"total_cache_creation_tokens,omitempty"`
+	TotalCacheReadTokens     int `json:"total_cache_read_tokens,omitempty"`
 	// message fields
 	Role      string          `json:"role,omitempty"`
 	Content   string          `json:"content,omitempty"`
@@ -155,15 +165,19 @@ func (s *FSChatStore) GetSession(id string) (*ChatSession, error) {
 		return nil, fmt.Errorf("invalid session file: first record type is %q", rec.Type)
 	}
 	return &ChatSession{
-		ID:                rec.ID,
-		Title:             rec.Title,
-		AgentSlug:         rec.AgentSlug,
-		SDKSession:        rec.SDKSession,
-		WorkingDir:        rec.WorkingDir,
-		Model:             rec.Model,
-		SettingsProfileID: rec.SettingsProfileID,
-		CreatedAt:         rec.CreatedAt,
-		UpdatedAt:         rec.UpdatedAt,
+		ID:                       rec.ID,
+		Title:                    rec.Title,
+		AgentSlug:                rec.AgentSlug,
+		SDKSession:               rec.SDKSession,
+		WorkingDir:               rec.WorkingDir,
+		Model:                    rec.Model,
+		SettingsProfileID:        rec.SettingsProfileID,
+		CreatedAt:                rec.CreatedAt,
+		UpdatedAt:                rec.UpdatedAt,
+		TotalInputTokens:         rec.TotalInputTokens,
+		TotalOutputTokens:        rec.TotalOutputTokens,
+		TotalCacheCreationTokens: rec.TotalCacheCreationTokens,
+		TotalCacheReadTokens:     rec.TotalCacheReadTokens,
 	}, nil
 }
 
@@ -194,15 +208,19 @@ func (s *FSChatStore) GetSessionWithMessages(id string) (*ChatSession, []ChatMes
 			first = false
 			if rec.Type == "session" {
 				session = &ChatSession{
-					ID:                rec.ID,
-					Title:             rec.Title,
-					AgentSlug:         rec.AgentSlug,
-					SDKSession:        rec.SDKSession,
-					WorkingDir:        rec.WorkingDir,
-					Model:             rec.Model,
-					SettingsProfileID: rec.SettingsProfileID,
-					CreatedAt:         rec.CreatedAt,
-					UpdatedAt:         rec.UpdatedAt,
+					ID:                       rec.ID,
+					Title:                    rec.Title,
+					AgentSlug:                rec.AgentSlug,
+					SDKSession:               rec.SDKSession,
+					WorkingDir:               rec.WorkingDir,
+					Model:                    rec.Model,
+					SettingsProfileID:        rec.SettingsProfileID,
+					CreatedAt:                rec.CreatedAt,
+					UpdatedAt:                rec.UpdatedAt,
+					TotalInputTokens:         rec.TotalInputTokens,
+					TotalOutputTokens:        rec.TotalOutputTokens,
+					TotalCacheCreationTokens: rec.TotalCacheCreationTokens,
+					TotalCacheReadTokens:     rec.TotalCacheReadTokens,
 				}
 			}
 			continue
@@ -310,16 +328,20 @@ func (s *FSChatStore) UpdateSession(session *ChatSession) error {
 	}
 
 	rec := jsonlRecord{
-		Type:              "session",
-		ID:                session.ID,
-		Title:             session.Title,
-		AgentSlug:         session.AgentSlug,
-		SDKSession:        session.SDKSession,
-		WorkingDir:        session.WorkingDir,
-		Model:             session.Model,
-		SettingsProfileID: session.SettingsProfileID,
-		CreatedAt:         session.CreatedAt,
-		UpdatedAt:         session.UpdatedAt,
+		Type:                     "session",
+		ID:                       session.ID,
+		Title:                    session.Title,
+		AgentSlug:                session.AgentSlug,
+		SDKSession:               session.SDKSession,
+		WorkingDir:               session.WorkingDir,
+		Model:                    session.Model,
+		SettingsProfileID:        session.SettingsProfileID,
+		CreatedAt:                session.CreatedAt,
+		UpdatedAt:                session.UpdatedAt,
+		TotalInputTokens:         session.TotalInputTokens,
+		TotalOutputTokens:        session.TotalOutputTokens,
+		TotalCacheCreationTokens: session.TotalCacheCreationTokens,
+		TotalCacheReadTokens:     session.TotalCacheReadTokens,
 	}
 	firstLine, err := json.Marshal(rec)
 	if err != nil {


### PR DESCRIPTION
## Summary

- **Claude Sessions page**: Browse all Claude Code CLI sessions from `~/.claude/projects/` in a new UI page. Sessions are listed flat by date with project, git branch, message count, and token usage. Filter by project or search by session ID / message content.
- **Session detail view**: Click any session to see the full conversation — user and assistant turns with collapsible thinking blocks, tool calls (with input preview), and sub-agent events. Token usage banner and todo list from the session are shown at the top.
- **Continue Session**: A "Continue" button creates a new Agento chat that inherits the Claude Code session ID, so the SDK resumes the existing conversation seamlessly.
- **Token usage in Agento chats**: `ChatSession` now tracks cumulative input/output/cache token totals. Tokens are accumulated from every `TypeResult` SDK event (multi-turn sessions sum correctly). Token counts appear in the Chats list next to each session.

## New files

| File | Purpose |
|---|---|
| `internal/claudesessions/types.go` | Go types for Claude Code sessions, messages, todos |
| `internal/claudesessions/scanner.go` | JSONL scanner, project path decoder, token aggregation |
| `internal/claudesessions/cache.go` | In-memory cache with 5-min TTL, background scan on startup |
| `internal/api/claude_sessions.go` | 5 API handlers (list, projects, get, refresh, continue) |
| `frontend/src/pages/ClaudeSessionsPage.tsx` | Session list page with filtering |
| `frontend/src/pages/ClaudeSessionDetailPage.tsx` | Full session viewer with message rendering |

## Modified files

- `internal/storage/chat_store.go` — adds 4 token fields to `ChatSession`
- `internal/service/chat_service.go` — updates `CommitMessage` to accept/persist token usage; adds `UpdateSession`
- `internal/api/chats.go` — accumulates token counts from `TypeResult` events
- `internal/api/server.go` — wires `claudeSessionCache`, registers new routes
- `cmd/web.go` — initialises session cache, starts background scan
- `frontend/src/types.ts` — token fields on `ChatSession`; new Claude session types
- `frontend/src/lib/api.ts` — `claudeSessionsApi`
- `frontend/src/App.tsx` — new routes for `/claude-sessions` and `/claude-sessions/:id`
- `frontend/src/components/Sidebar.tsx` — "Claude Sessions" nav item
- `frontend/src/pages/ChatsPage.tsx` — shows token counts in session list rows

## Test plan

- [ ] Start server; confirm background scan log message appears
- [ ] Navigate to Claude Sessions — sessions should load from `~/.claude/projects/`
- [ ] Filter by project, search by session ID prefix
- [ ] Click a session — verify messages, todos, token usage render correctly
- [ ] Expand a thinking block; expand tool calls; verify collapsible sub-agent events
- [ ] Click "Continue" on a session — should navigate to `/chats/<id>` ready to type
- [ ] Send a message in an Agento chat; check the Chats list shows token counts afterward
- [ ] Click "Refresh" on Claude Sessions page — cache invalidates and rescans

🤖 Generated with [Claude Code](https://claude.com/claude-code)