### PR TITLE
fix: rename folder to directory in goreleaser homebrew config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -74,7 +74,7 @@ brews:
     homepage: "https://github.com/shaharia-lab/agento"
     description: "Agento — AI Agents Platform"
     license: "MIT"
-    folder: Formula
+    directory: Formula
     test: |
       system "#{bin}/agento", "--version"
     install: |


### PR DESCRIPTION
## Summary
- GoReleaser v2 renamed the `folder` field to `directory` in the `brews` configuration
- This was causing the snapshot build to fail with: `line 77: field folder not found in type config.Homebrew`

## Test plan
- [ ] Snapshot build workflow passes after merge
- [ ] Release workflow triggers GoReleaser successfully on tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)