### PR TITLE
Redesign agent form with two-column layout

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -115,3 +115,16 @@ Tool calls made by the agent are shown inline in the conversation. If the agent 
 ## Manage agents from the UI
 
 You can create, edit, and delete agents from the **Agents** section in the UI without editing YAML files by hand. Changes take effect immediately.
+
+### Creating or editing an agent in the UI
+
+Go to **Agents → New Agent** (or click **Edit** on an existing agent). The form has two areas:
+
+- **System Prompt** (left side on desktop, first tab on mobile) — A full-height editor where you write the agent's instructions. Line numbers are shown for reference. Use `{{current_date}}` and `{{current_time}}` as placeholders.
+- **Configuration** (right side on desktop, second tab on mobile) — Collapsible sections for all other settings:
+  - **Basic Info** — Name, slug, and description.
+  - **Model & Behavior** — Model selection, thinking mode, and permission mode.
+  - **Built-in Tools** — Select which built-in tools the agent can use. Leave all unchecked to allow all.
+  - **Integration Tools** — If you have connected integrations (e.g. Google), their tools appear here for selection.
+
+Click **Create Agent** or **Update Agent** to save.

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -11,8 +11,8 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Roboto:wght@400;500&family=Open+Sans:wght@400;600&family=Lato:wght@400;700&family=Merriweather:wght@400;700&family=JetBrains+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
-    <script type="module" crossorigin src="/assets/index-CeUL0tzz.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-DFywDP5B.css">
+    <script type="module" crossorigin src="/assets/index-BbDrzq4v.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-Bqyb8ppS.css">
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/pages/AgentCreatePage.tsx
+++ b/frontend/src/pages/AgentCreatePage.tsx
@@ -9,7 +9,7 @@ export default function AgentCreatePage() {
           Define a new AI agent with a custom system prompt and capabilities.
         </p>
       </div>
-      <div className="flex-1 overflow-y-auto p-4 sm:p-6">
+      <div className="flex-1 flex flex-col min-h-0 p-4 sm:p-6">
         <AgentForm />
       </div>
     </div>

--- a/frontend/src/pages/AgentEditPage.tsx
+++ b/frontend/src/pages/AgentEditPage.tsx
@@ -41,7 +41,7 @@ export default function AgentEditPage() {
         <h1 className="text-lg font-semibold">Edit Agent</h1>
         <p className="text-sm text-muted-foreground font-mono">{agent.slug}</p>
       </div>
-      <div className="flex-1 overflow-y-auto p-4 sm:p-6">
+      <div className="flex-1 flex flex-col min-h-0 p-4 sm:p-6">
         <AgentForm agent={agent} isEdit />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Restructure the agent create/edit form into a two-column layout: system prompt editor on the left (~60%), collapsible config sections on the right (~40%)
- Add line-number gutter and full-height monospace editor for system prompts
- Switch to a tabbed layout on mobile/tablet screens (<1024px)
- Update `docs/agents.md` with UI form documentation for end users

## Test plan
- [ ] Desktop (1024px+): verify two-column layout with system prompt on left, config sections on right
- [ ] Collapse/expand each config section (Basic Info expanded by default, others collapsed)
- [ ] Resize browser below 1024px: verify tabbed layout with "System Prompt" and "Configuration" tabs
- [ ] Create a new agent — all fields save correctly
- [ ] Edit an existing agent — all fields populate and update correctly
- [ ] Line numbers update as you type in the system prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)