### PR TITLE
Update documentation and context files

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Agents are specialized assistants with a custom system prompt, model, and set of
 5. Select which tools the agent can use.
 6. Click **Save**.
 
-Agents are stored as YAML files in `~/.agento/agents/`. You can also create or edit them directly:
+Agents are stored in the SQLite database at `~/.agento/agento.db`. Legacy YAML files in `~/.agento/agents/` are auto-migrated on first startup. You can also define agents as YAML files:
 
 ```yaml
 name: My Assistant

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,12 +1,12 @@
 # Agents
 
-An agent is a YAML file stored in `~/.agento/agents/`. It defines the model, system prompt, and tools the agent can use.
+An agent defines the model, system prompt, and tools it can use. Agents are stored in the SQLite database at `~/.agento/agento.db`. You can create and manage agents from the UI, or define them as YAML files in `~/.agento/agents/` (auto-migrated to SQLite on first startup).
 
 ---
 
 ## Create an agent
 
-Create a file in `~/.agento/agents/` with a `.yaml` extension. The file name becomes the agent's slug if you don't set one explicitly.
+The recommended way is through the UI (see "Manage agents from the UI" below). You can also create a YAML file in `~/.agento/agents/` — it will be imported into the database on next startup.
 
 **Example: `~/.agento/agents/support.yaml`**
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -89,9 +89,11 @@ agento/
 │   ├── build/        # Build-time version variables
 │   ├── config/       # AppConfig, AgentConfig, MCP config
 │   ├── server/       # HTTP server wiring
-│   ├── service/      # Business logic (AgentService, ChatService)
-│   ├── storage/      # File-system persistence
-│   └── tools/        # Local MCP tool server
+│   ├── claudesessions/ # Claude session scanner and analytics
+│   ├── integrations/   # Integration registry + Google MCP servers
+│   ├── service/        # Business logic (AgentService, ChatService)
+│   ├── storage/        # SQLite persistence (~/.agento/agento.db)
+│   └── tools/          # Local MCP tool server
 ├── docs/             # Documentation
 ├── .goreleaser.yaml  # Release configuration
 └── Makefile

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -23,12 +23,11 @@ Enable the APIs your agents will use:
 ### Creating an Integration
 
 1. Open Agento and go to **Integrations** in the sidebar
-2. Click **New Integration**
-3. Select **Google** as the provider
-4. Enter a name, your Client ID, and Client Secret
-5. Enable the services you want (Calendar, Gmail, Drive) and select tools per service
-6. Click **Save** — a Google sign-in window opens
-7. Complete the OAuth flow — you'll see "Connected" when done
+2. Click the **Google** card to start setup
+3. Enter a name, your Client ID, and Client Secret
+4. Enable the services you want (Calendar, Gmail, Drive) and select tools per service
+5. Click **Save** — a Google sign-in window opens
+6. Complete the OAuth flow — you'll see "Connected" when done
 
 ### Available Tools
 


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: Fix env vars (PORT default 8990, AGENTO_DATA_DIR, API key now optional), update storage description to SQLite, add `internal/integrations/` and `internal/claudesessions/` packages, update agent config for SQLite and new fields
- **README.md**: Update agents storage to mention SQLite with auto-migration
- **docs/agents.md**: Reflect SQLite as primary storage, recommend UI-first workflow
- **docs/development.md**: Update project layout tree with SQLite, new packages
- **docs/integrations.md**: Update setup flow for provider-specific routes (`/integrations/google`)

## Test plan
- [x] Review each doc for accuracy against current codebase
- [x] Verify no broken links or outdated references

🤖 Generated with [Claude Code](https://claude.com/claude-code)