### PR TITLE
Add task scheduler with background job execution

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -11,8 +11,8 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Roboto:wght@400;500&family=Open+Sans:wght@400;600&family=Lato:wght@400;700&family=Merriweather:wght@400;700&family=JetBrains+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
-    <script type="module" crossorigin src="/assets/index-v6kW7wNK.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-DFywDP5B.css">
+    <script type="module" crossorigin src="/assets/index-BC4isaio.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-DzCbz7po.css">
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,10 @@ import GeneralUsagePage from '@/pages/GeneralUsagePage'
 import IntegrationsPage from '@/pages/IntegrationsPage'
 import IntegrationGooglePage from '@/pages/IntegrationGooglePage'
 import IntegrationDetailPage from '@/pages/IntegrationDetailPage'
+import TasksPage from '@/pages/TasksPage'
+import TaskCreatePage from '@/pages/TaskCreatePage'
+import TaskEditPage from '@/pages/TaskEditPage'
+import JobHistoriesPage from '@/pages/JobHistoriesPage'
 import OnboardingWizard from '@/components/OnboardingWizard'
 import { AppearanceProvider } from '@/contexts/ThemeContext'
 import { settingsApi } from '@/lib/api'
@@ -83,6 +87,10 @@ export default function App() {
             <Route path="integrations" element={<IntegrationsPage />} />
             <Route path="integrations/google" element={<IntegrationGooglePage />} />
             <Route path="integrations/:id" element={<IntegrationDetailPage />} />
+            <Route path="tasks" element={<TasksPage />} />
+            <Route path="tasks/new" element={<TaskCreatePage />} />
+            <Route path="tasks/:id/edit" element={<TaskEditPage />} />
+            <Route path="job-history" element={<JobHistoriesPage />} />
             <Route path="settings" element={<SettingsPage />} />
           </Route>
         </Routes>

--- a/frontend/src/components/AgentForm.tsx
+++ b/frontend/src/components/AgentForm.tsx
@@ -115,7 +115,7 @@ export default function AgentForm({ agent, isEdit = false }: AgentFormProps) {
   const [slug, setSlug] = useState(agent?.slug ?? '')
   const [slugTouched, setSlugTouched] = useState(isEdit)
   const [description, setDescription] = useState(agent?.description ?? '')
-  const [model, setModel] = useState(agent?.model ?? 'eu.anthropic.claude-sonnet-4-5-20250929-v1:0')
+  const [model, setModel] = useState(agent?.model ?? '')
   const [thinking, setThinking] = useState<Agent['thinking']>(agent?.thinking ?? 'adaptive')
   const [permissionMode, setPermissionMode] = useState<Agent['permission_mode']>(
     agent?.permission_mode ?? 'default',
@@ -298,11 +298,15 @@ export default function AgentForm({ agent, isEdit = false }: AgentFormProps) {
       <CollapsibleSection title="Model & Behavior">
         <div className="space-y-1.5">
           <Label>Model</Label>
-          <Select value={model} onValueChange={setModel}>
+          <Select
+            value={model || '__default__'}
+            onValueChange={v => setModel(v === '__default__' ? '' : v)}
+          >
             <SelectTrigger>
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
+              <SelectItem value="__default__">Default (from settings)</SelectItem>
               {MODELS.map(m => (
                 <SelectItem key={m.value} value={m.value}>
                   {m.label}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -12,6 +12,8 @@ import {
   History,
   BarChart2,
   LayoutDashboard,
+  CalendarClock,
+  ClipboardList,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Tooltip } from '@/components/ui/tooltip'
@@ -70,6 +72,11 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
     { to: '/chats', icon: MessageSquare, label: 'Chats' },
     { to: '/agents', icon: Bot, label: 'Agents' },
     { to: '/integrations', icon: Plug, label: 'Integrations' },
+  ]
+
+  const taskNavItems = [
+    { to: '/tasks', icon: CalendarClock, label: 'Manage Tasks' },
+    { to: '/job-history', icon: ClipboardList, label: 'Job History' },
   ]
 
   const claudeNavItems = [{ to: '/claude-sessions', icon: History, label: 'Claude Sessions' }]
@@ -173,6 +180,56 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
               </NavLink>
             ),
           )}
+        </div>
+
+        {/* Tasks section */}
+        <div className="mt-4">
+          {(!collapsed || isMobile) && (
+            <p className="px-3 mb-1 text-[10px] font-semibold uppercase tracking-widest text-zinc-400 dark:text-zinc-500 select-none">
+              Tasks
+            </p>
+          )}
+          {!isMobile && collapsed && (
+            <div className="mx-2 mb-2 border-t border-zinc-200 dark:border-zinc-700/50" />
+          )}
+          <div className="space-y-0.5">
+            {taskNavItems.map(({ to, icon: Icon, label }) =>
+              !isMobile && collapsed ? (
+                <Tooltip key={to} content={label}>
+                  <NavLink
+                    to={to}
+                    className={({ isActive }) =>
+                      cn(
+                        'flex h-9 w-9 items-center justify-center rounded-md transition-colors mx-auto',
+                        isActive
+                          ? 'bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900'
+                          : 'text-zinc-500 dark:text-zinc-400 hover:bg-zinc-200 dark:hover:bg-zinc-700 hover:text-zinc-900 dark:hover:text-zinc-100',
+                      )
+                    }
+                  >
+                    <Icon className="h-4 w-4" />
+                  </NavLink>
+                </Tooltip>
+              ) : (
+                <NavLink
+                  key={to}
+                  to={to}
+                  onClick={handleNavClick}
+                  className={({ isActive }) =>
+                    cn(
+                      'flex items-center gap-2.5 rounded-md px-3 py-2 text-sm transition-colors',
+                      isActive
+                        ? 'bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900'
+                        : 'text-zinc-600 dark:text-zinc-400 hover:bg-zinc-200 dark:hover:bg-zinc-700 hover:text-zinc-900 dark:hover:text-zinc-100',
+                    )
+                  }
+                >
+                  <Icon className="h-4 w-4 shrink-0" />
+                  <span>{label}</span>
+                </NavLink>
+              ),
+            )}
+          </div>
         </div>
 
         {/* Claude Usage section */}

--- a/frontend/src/components/TaskForm.tsx
+++ b/frontend/src/components/TaskForm.tsx
@@ -1,0 +1,389 @@
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { agentsApi, tasksApi } from '@/lib/api'
+import type { Agent, ScheduledTask, ScheduleType, ScheduleConfig } from '@/types'
+import { MODELS } from '@/types'
+import { Button } from '@/components/ui/button'
+
+/** Convert an ISO/UTC string to a `YYYY-MM-DDTHH:MM` value in the user's local timezone. */
+function toLocalDatetimeString(iso: string): string {
+  const d = new Date(iso)
+  if (isNaN(d.getTime())) return ''
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+interface TaskFormProps {
+  readonly initialData?: ScheduledTask
+  readonly isEdit?: boolean
+}
+
+export default function TaskForm({ initialData, isEdit }: TaskFormProps) {
+  const navigate = useNavigate()
+  const [agents, setAgents] = useState<Agent[]>([])
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const [name, setName] = useState(initialData?.name ?? '')
+  const [description, setDescription] = useState(initialData?.description ?? '')
+  const [prompt, setPrompt] = useState(initialData?.prompt ?? '')
+  const [agentSlug, setAgentSlug] = useState(initialData?.agent_slug ?? '')
+  const [model, setModel] = useState(initialData?.model ?? '')
+  const [workingDirectory, setWorkingDirectory] = useState(initialData?.working_directory ?? '')
+  const [timeoutMinutes, setTimeoutMinutes] = useState(initialData?.timeout_minutes ?? 30)
+  const [scheduleType, setScheduleType] = useState<ScheduleType>(
+    initialData?.schedule_type ?? 'one_off',
+  )
+  const [scheduleConfig, setScheduleConfig] = useState<ScheduleConfig>(
+    initialData?.schedule_config ?? {},
+  )
+  const [stopAfterCount, setStopAfterCount] = useState(initialData?.stop_after_count ?? 0)
+  const [stopAfterTime, setStopAfterTime] = useState(initialData?.stop_after_time ?? '')
+
+  useEffect(() => {
+    agentsApi
+      .list()
+      .then(setAgents)
+      .catch(() => {})
+  }, [])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setSaving(true)
+    setError(null)
+
+    const data: Partial<ScheduledTask> = {
+      name,
+      description,
+      prompt,
+      agent_slug: agentSlug,
+      model,
+      working_directory: workingDirectory,
+      timeout_minutes: timeoutMinutes,
+      schedule_type: scheduleType,
+      schedule_config: scheduleConfig,
+      stop_after_count: stopAfterCount,
+      stop_after_time: stopAfterTime || undefined,
+    }
+
+    try {
+      if (isEdit && initialData) {
+        await tasksApi.update(initialData.id, data)
+      } else {
+        await tasksApi.create(data)
+      }
+      navigate('/tasks')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save task')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const selectClass =
+    'w-full rounded-md border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 text-sm text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-zinc-400 dark:focus:ring-zinc-500'
+  const inputClass = selectClass
+  const labelClass = 'block text-xs font-medium text-zinc-700 dark:text-zinc-300 mb-1'
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col h-full">
+      <div className="flex items-center justify-between border-b border-zinc-100 dark:border-zinc-800 px-4 sm:px-6 py-4 shrink-0">
+        <div>
+          <h1 className="text-base font-semibold text-zinc-900 dark:text-zinc-100">
+            {isEdit ? 'Edit Task' : 'New Scheduled Task'}
+          </h1>
+        </div>
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => navigate('/tasks')}
+            className="text-xs h-8"
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            size="sm"
+            disabled={saving}
+            className="gap-1.5 bg-zinc-900 hover:bg-zinc-800 dark:bg-zinc-100 dark:hover:bg-zinc-200 dark:text-zinc-900 text-white text-xs h-8"
+          >
+            {saving ? 'Saving…' : isEdit ? 'Update Task' : 'Create Task'}
+          </Button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mx-6 mt-3 rounded-md border border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-900/20 px-4 py-2.5 text-sm text-red-700 dark:text-red-400">
+          {error}
+        </div>
+      )}
+
+      <div className="flex-1 overflow-y-auto p-4 sm:p-6">
+        <div className="grid grid-cols-1 lg:grid-cols-[3fr_2fr] gap-6 max-w-6xl">
+          {/* Left: Prompt */}
+          <div className="space-y-4">
+            <div>
+              <label className={labelClass}>Prompt</label>
+              <textarea
+                value={prompt}
+                onChange={e => setPrompt(e.target.value)}
+                rows={16}
+                placeholder="Enter the prompt to send to the agent. You can use {{current_date}} and {{current_time}} variables."
+                className={`${inputClass} resize-y font-mono text-xs leading-relaxed`}
+                required
+              />
+            </div>
+          </div>
+
+          {/* Right: Config */}
+          <div className="space-y-5">
+            {/* Basic */}
+            <section className="space-y-3">
+              <h3 className="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">
+                Basic
+              </h3>
+              <div>
+                <label className={labelClass}>Name</label>
+                <input
+                  type="text"
+                  value={name}
+                  onChange={e => setName(e.target.value)}
+                  placeholder="My scheduled task"
+                  className={inputClass}
+                  required
+                />
+              </div>
+              <div>
+                <label className={labelClass}>Description</label>
+                <input
+                  type="text"
+                  value={description}
+                  onChange={e => setDescription(e.target.value)}
+                  placeholder="Optional description"
+                  className={inputClass}
+                />
+              </div>
+              <div>
+                <label className={labelClass}>Agent (optional)</label>
+                <select
+                  value={agentSlug}
+                  onChange={e => setAgentSlug(e.target.value)}
+                  className={selectClass}
+                >
+                  <option value="">No agent (direct chat)</option>
+                  {agents.map(a => (
+                    <option key={a.slug} value={a.slug}>
+                      {a.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className={labelClass}>Model (optional)</label>
+                <select
+                  value={model}
+                  onChange={e => setModel(e.target.value)}
+                  className={selectClass}
+                >
+                  <option value="">Default</option>
+                  {MODELS.map(m => (
+                    <option key={m.value} value={m.value}>
+                      {m.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </section>
+
+            {/* Schedule */}
+            <section className="space-y-3">
+              <h3 className="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">
+                Schedule
+              </h3>
+              <div>
+                <label className={labelClass}>Type</label>
+                <select
+                  value={scheduleType}
+                  onChange={e => {
+                    setScheduleType(e.target.value as ScheduleType)
+                    setScheduleConfig({})
+                  }}
+                  className={selectClass}
+                >
+                  <option value="one_off">One-off</option>
+                  <option value="interval">Interval</option>
+                  <option value="cron">Cron</option>
+                </select>
+              </div>
+
+              {scheduleType === 'one_off' && (
+                <div>
+                  <label className={labelClass}>Run at</label>
+                  <input
+                    type="datetime-local"
+                    value={
+                      scheduleConfig.run_at ? toLocalDatetimeString(scheduleConfig.run_at) : ''
+                    }
+                    onChange={e =>
+                      setScheduleConfig({
+                        ...scheduleConfig,
+                        run_at: e.target.value ? new Date(e.target.value).toISOString() : '',
+                      })
+                    }
+                    className={inputClass}
+                    required
+                  />
+                </div>
+              )}
+
+              {scheduleType === 'interval' && (
+                <div className="space-y-2">
+                  <div className="grid grid-cols-3 gap-2">
+                    <div>
+                      <label className={labelClass}>Minutes</label>
+                      <input
+                        type="number"
+                        min={0}
+                        value={scheduleConfig.every_minutes ?? ''}
+                        onChange={e =>
+                          setScheduleConfig({
+                            ...scheduleConfig,
+                            every_minutes: Number(e.target.value) || undefined,
+                          })
+                        }
+                        placeholder="0"
+                        className={inputClass}
+                      />
+                    </div>
+                    <div>
+                      <label className={labelClass}>Hours</label>
+                      <input
+                        type="number"
+                        min={0}
+                        value={scheduleConfig.every_hours ?? ''}
+                        onChange={e =>
+                          setScheduleConfig({
+                            ...scheduleConfig,
+                            every_hours: Number(e.target.value) || undefined,
+                          })
+                        }
+                        placeholder="0"
+                        className={inputClass}
+                      />
+                    </div>
+                    <div>
+                      <label className={labelClass}>Days</label>
+                      <input
+                        type="number"
+                        min={0}
+                        value={scheduleConfig.every_days ?? ''}
+                        onChange={e =>
+                          setScheduleConfig({
+                            ...scheduleConfig,
+                            every_days: Number(e.target.value) || undefined,
+                          })
+                        }
+                        placeholder="0"
+                        className={inputClass}
+                      />
+                    </div>
+                  </div>
+                  {(scheduleConfig.every_days ?? 0) > 0 && (
+                    <div>
+                      <label className={labelClass}>At time (HH:MM)</label>
+                      <input
+                        type="time"
+                        value={scheduleConfig.at_time ?? ''}
+                        onChange={e =>
+                          setScheduleConfig({ ...scheduleConfig, at_time: e.target.value })
+                        }
+                        className={inputClass}
+                      />
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {scheduleType === 'cron' && (
+                <div>
+                  <label className={labelClass}>Cron expression</label>
+                  <input
+                    type="text"
+                    value={scheduleConfig.expression ?? ''}
+                    onChange={e =>
+                      setScheduleConfig({ ...scheduleConfig, expression: e.target.value })
+                    }
+                    placeholder="0 */2 * * *"
+                    className={`${inputClass} font-mono`}
+                    required
+                  />
+                  <p className="text-xs text-zinc-400 dark:text-zinc-500 mt-1">
+                    Standard 5-field cron expression
+                  </p>
+                </div>
+              )}
+            </section>
+
+            {/* Stop Conditions */}
+            <section className="space-y-3">
+              <h3 className="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">
+                Stop Conditions
+              </h3>
+              <div>
+                <label className={labelClass}>Stop after N runs (0 = unlimited)</label>
+                <input
+                  type="number"
+                  min={0}
+                  value={stopAfterCount}
+                  onChange={e => setStopAfterCount(Number(e.target.value))}
+                  className={inputClass}
+                />
+              </div>
+              <div>
+                <label className={labelClass}>Stop after date (optional)</label>
+                <input
+                  type="datetime-local"
+                  value={stopAfterTime ? toLocalDatetimeString(stopAfterTime) : ''}
+                  onChange={e =>
+                    setStopAfterTime(e.target.value ? new Date(e.target.value).toISOString() : '')
+                  }
+                  className={inputClass}
+                />
+              </div>
+            </section>
+
+            {/* Advanced */}
+            <section className="space-y-3">
+              <h3 className="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">
+                Advanced
+              </h3>
+              <div>
+                <label className={labelClass}>Working directory</label>
+                <input
+                  type="text"
+                  value={workingDirectory}
+                  onChange={e => setWorkingDirectory(e.target.value)}
+                  placeholder="/path/to/project"
+                  className={inputClass}
+                />
+              </div>
+              <div>
+                <label className={labelClass}>Timeout (minutes, 1-240)</label>
+                <input
+                  type="number"
+                  min={1}
+                  max={240}
+                  value={timeoutMinutes}
+                  onChange={e => setTimeoutMinutes(Number(e.target.value))}
+                  className={inputClass}
+                />
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+    </form>
+  )
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -21,6 +21,8 @@ import type {
   Integration,
   GoogleCredentials,
   AvailableTool,
+  ScheduledTask,
+  JobHistoryEntry,
 } from '../types'
 
 const BASE = '/api'
@@ -363,6 +365,50 @@ export const integrationsApi = {
     request<{ authenticated: boolean }>(`/integrations/${id}/auth/status`),
 
   availableTools: () => request<AvailableTool[]>('/integrations/available-tools'),
+}
+
+// ── Scheduled Tasks ──────────────────────────────────────────────────────────
+
+export const tasksApi = {
+  list: () => request<ScheduledTask[]>('/tasks'),
+
+  get: (id: string) => request<ScheduledTask>(`/tasks/${id}`),
+
+  create: (data: Partial<ScheduledTask>) =>
+    request<ScheduledTask>('/tasks', { method: 'POST', body: JSON.stringify(data) }),
+
+  update: (id: string, data: Partial<ScheduledTask>) =>
+    request<ScheduledTask>(`/tasks/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
+
+  delete: (id: string) =>
+    fetch(`${BASE}/tasks/${id}`, { method: 'DELETE' }).then(res => {
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    }),
+
+  pause: (id: string) => request<ScheduledTask>(`/tasks/${id}/pause`, { method: 'POST' }),
+
+  resume: (id: string) => request<ScheduledTask>(`/tasks/${id}/resume`, { method: 'POST' }),
+
+  jobHistory: (id: string, limit?: number) => {
+    const params = new URLSearchParams()
+    if (limit) params.set('limit', String(limit))
+    const query = params.toString()
+    const suffix = query ? `?${query}` : ''
+    return request<JobHistoryEntry[]>(`/tasks/${id}/job-history${suffix}`)
+  },
+}
+
+export const jobHistoryApi = {
+  list: (limit?: number, offset?: number) => {
+    const params = new URLSearchParams()
+    if (limit) params.set('limit', String(limit))
+    if (offset) params.set('offset', String(offset))
+    const query = params.toString()
+    const suffix = query ? `?${query}` : ''
+    return request<JobHistoryEntry[]>(`/job-history${suffix}`)
+  },
+
+  get: (id: string) => request<JobHistoryEntry>(`/job-history/${id}`),
 }
 
 // ── Analytics ─────────────────────────────────────────────────────────────────

--- a/frontend/src/pages/AgentsPage.tsx
+++ b/frontend/src/pages/AgentsPage.tsx
@@ -17,9 +17,8 @@ import {
 import { Plus, Pencil, Trash2, Bot } from 'lucide-react'
 
 function shortModel(model: string): string {
-  // eu.anthropic.claude-X → claude-X, claude-sonnet-4-6 → sonnet-4-6
-  const m = model.replace(/^.*anthropic\./i, '').replace(/^claude-/, '')
-  return m.length > 28 ? m.slice(0, 28) + '…' : m
+  if (!model) return 'default'
+  return model
 }
 
 export default function AgentsPage() {

--- a/frontend/src/pages/JobHistoriesPage.tsx
+++ b/frontend/src/pages/JobHistoriesPage.tsx
@@ -1,0 +1,276 @@
+import { useState, useEffect, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { jobHistoryApi } from '@/lib/api'
+import type { JobHistoryEntry } from '@/types'
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { ClipboardList, ExternalLink } from 'lucide-react'
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  const sec = ms / 1000
+  if (sec < 60) return `${sec.toFixed(1)}s`
+  const min = sec / 60
+  return `${min.toFixed(1)}m`
+}
+
+function JobStatusBadge({ status }: Readonly<{ status: string }>) {
+  const colors: Record<string, string> = {
+    success: 'bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+    failed: 'bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+    running: 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  }
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${colors[status] ?? 'bg-zinc-100 text-zinc-500'}`}
+    >
+      {status}
+    </span>
+  )
+}
+
+function DetailRow({ label, children }: Readonly<{ label: string; children: React.ReactNode }>) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <dt className="text-xs font-medium text-zinc-500 dark:text-zinc-400">{label}</dt>
+      <dd className="text-sm text-zinc-900 dark:text-zinc-100">{children}</dd>
+    </div>
+  )
+}
+
+const PAGE_SIZE = 50
+
+export default function JobHistoriesPage() {
+  const navigate = useNavigate()
+  const [entries, setEntries] = useState<JobHistoryEntry[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [offset, setOffset] = useState(0)
+  const [hasMore, setHasMore] = useState(true)
+  const [selected, setSelected] = useState<JobHistoryEntry | null>(null)
+
+  const load = useCallback(async (currentOffset: number) => {
+    try {
+      setLoading(true)
+      const data = await jobHistoryApi.list(PAGE_SIZE, currentOffset)
+      if (currentOffset === 0) {
+        setEntries(data)
+      } else {
+        setEntries(prev => [...prev, ...data])
+      }
+      setHasMore(data.length === PAGE_SIZE)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load job history')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    load(0)
+  }, [load])
+
+  const loadMore = () => {
+    const newOffset = offset + PAGE_SIZE
+    setOffset(newOffset)
+    load(newOffset)
+  }
+
+  if (loading && entries.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="text-sm text-zinc-400 dark:text-zinc-500">Loading job history…</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center justify-between border-b border-zinc-100 dark:border-zinc-800 px-4 sm:px-6 py-4 shrink-0">
+        <div>
+          <h1 className="text-base font-semibold text-zinc-900 dark:text-zinc-100">Job History</h1>
+          <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">
+            {entries.length} entr{entries.length === 1 ? 'y' : 'ies'}
+          </p>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mx-6 mt-3 rounded-md border border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-900/20 px-4 py-2.5 text-sm text-red-700 dark:text-red-400">
+          {error}
+        </div>
+      )}
+
+      <div className="flex-1 overflow-y-auto">
+        {entries.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-20 text-center">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800 mb-4">
+              <ClipboardList className="h-5 w-5 text-zinc-400 dark:text-zinc-500" />
+            </div>
+            <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 mb-1">
+              No job history
+            </h2>
+            <p className="text-xs text-zinc-500 dark:text-zinc-400 max-w-xs">
+              Job executions will appear here once scheduled tasks start running.
+            </p>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-zinc-100 dark:border-zinc-800 text-xs text-zinc-500 dark:text-zinc-400">
+                  <th className="text-left px-4 py-2.5 font-medium">Task</th>
+                  <th className="text-left px-4 py-2.5 font-medium">Status</th>
+                  <th className="text-left px-4 py-2.5 font-medium">Started</th>
+                  <th className="text-left px-4 py-2.5 font-medium">Duration</th>
+                  <th className="text-left px-4 py-2.5 font-medium">Tokens</th>
+                </tr>
+              </thead>
+              <tbody>
+                {entries.map(entry => (
+                  <tr
+                    key={entry.id}
+                    onClick={() => setSelected(entry)}
+                    className="border-b border-zinc-50 dark:border-zinc-800/50 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors cursor-pointer"
+                  >
+                    <td className="px-4 py-2.5">
+                      <div className="font-medium text-zinc-900 dark:text-zinc-100 text-xs">
+                        {entry.task_name}
+                      </div>
+                      {entry.agent_slug && (
+                        <div className="text-xs text-zinc-400 dark:text-zinc-500 font-mono">
+                          {entry.agent_slug}
+                        </div>
+                      )}
+                    </td>
+                    <td className="px-4 py-2.5">
+                      <JobStatusBadge status={entry.status} />
+                    </td>
+                    <td className="px-4 py-2.5 text-xs text-zinc-500 dark:text-zinc-400 whitespace-nowrap">
+                      {new Date(entry.started_at).toLocaleString()}
+                    </td>
+                    <td className="px-4 py-2.5 text-xs text-zinc-500 dark:text-zinc-400 font-mono">
+                      {entry.duration_ms > 0 ? formatDuration(entry.duration_ms) : '-'}
+                    </td>
+                    <td className="px-4 py-2.5 text-xs text-zinc-500 dark:text-zinc-400 font-mono">
+                      {entry.total_input_tokens + entry.total_output_tokens > 0
+                        ? `${(entry.total_input_tokens + entry.total_output_tokens).toLocaleString()}`
+                        : '-'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+
+            {hasMore && (
+              <div className="flex justify-center py-4">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={loadMore}
+                  disabled={loading}
+                  className="text-xs"
+                >
+                  {loading ? 'Loading…' : 'Load more'}
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Detail dialog */}
+      <Dialog
+        open={selected !== null}
+        onOpenChange={open => {
+          if (!open) setSelected(null)
+        }}
+      >
+        <DialogContent className="max-w-lg">
+          {selected && (
+            <>
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2">
+                  {selected.task_name}
+                  <JobStatusBadge status={selected.status} />
+                </DialogTitle>
+              </DialogHeader>
+
+              <dl className="grid grid-cols-2 gap-x-4 gap-y-3 mt-2">
+                <DetailRow label="Started">
+                  {new Date(selected.started_at).toLocaleString()}
+                </DetailRow>
+                <DetailRow label="Duration">
+                  {selected.duration_ms > 0 ? formatDuration(selected.duration_ms) : '-'}
+                </DetailRow>
+                {selected.agent_slug && (
+                  <DetailRow label="Agent">
+                    <span className="font-mono">{selected.agent_slug}</span>
+                  </DetailRow>
+                )}
+                {selected.model && (
+                  <DetailRow label="Model">
+                    <span className="font-mono">{selected.model}</span>
+                  </DetailRow>
+                )}
+                <DetailRow label="Input tokens">
+                  {selected.total_input_tokens.toLocaleString()}
+                </DetailRow>
+                <DetailRow label="Output tokens">
+                  {selected.total_output_tokens.toLocaleString()}
+                </DetailRow>
+                {(selected.total_cache_read_tokens > 0 ||
+                  selected.total_cache_creation_tokens > 0) && (
+                  <>
+                    <DetailRow label="Cache read">
+                      {selected.total_cache_read_tokens.toLocaleString()}
+                    </DetailRow>
+                    <DetailRow label="Cache creation">
+                      {selected.total_cache_creation_tokens.toLocaleString()}
+                    </DetailRow>
+                  </>
+                )}
+              </dl>
+
+              {selected.prompt_preview && (
+                <div className="mt-3">
+                  <p className="text-xs font-medium text-zinc-500 dark:text-zinc-400 mb-1">
+                    Prompt
+                  </p>
+                  <p className="text-sm text-zinc-700 dark:text-zinc-300 bg-zinc-50 dark:bg-zinc-800 rounded-md px-3 py-2 whitespace-pre-wrap break-words">
+                    {selected.prompt_preview}
+                  </p>
+                </div>
+              )}
+
+              {selected.error_message && (
+                <div className="mt-3">
+                  <p className="text-xs font-medium text-red-500 dark:text-red-400 mb-1">Error</p>
+                  <p className="text-sm text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md px-3 py-2 whitespace-pre-wrap break-words">
+                    {selected.error_message}
+                  </p>
+                </div>
+              )}
+
+              {selected.chat_session_id && (
+                <div className="mt-4 pt-3 border-t border-zinc-100 dark:border-zinc-800">
+                  <Button
+                    size="sm"
+                    onClick={() => {
+                      setSelected(null)
+                      navigate(`/chats/${selected.chat_session_id}`)
+                    }}
+                    className="gap-1.5 bg-zinc-900 hover:bg-zinc-800 dark:bg-zinc-100 dark:hover:bg-zinc-200 dark:text-zinc-900 text-white text-xs h-8"
+                  >
+                    <ExternalLink className="h-3.5 w-3.5" />
+                    View Chat Session
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/frontend/src/pages/TaskCreatePage.tsx
+++ b/frontend/src/pages/TaskCreatePage.tsx
@@ -1,0 +1,5 @@
+import TaskForm from '@/components/TaskForm'
+
+export default function TaskCreatePage() {
+  return <TaskForm />
+}

--- a/frontend/src/pages/TaskEditPage.tsx
+++ b/frontend/src/pages/TaskEditPage.tsx
@@ -1,0 +1,39 @@
+import { useState, useEffect } from 'react'
+import { useParams } from 'react-router-dom'
+import { tasksApi } from '@/lib/api'
+import type { ScheduledTask } from '@/types'
+import TaskForm from '@/components/TaskForm'
+
+export default function TaskEditPage() {
+  const { id } = useParams<{ id: string }>()
+  const [task, setTask] = useState<ScheduledTask | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!id) return
+    tasksApi
+      .get(id)
+      .then(setTask)
+      .catch(err => setError(err instanceof Error ? err.message : 'Failed to load task'))
+      .finally(() => setLoading(false))
+  }, [id])
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="text-sm text-zinc-400 dark:text-zinc-500">Loading task…</div>
+      </div>
+    )
+  }
+
+  if (error || !task) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="text-sm text-red-500">{error ?? 'Task not found'}</div>
+      </div>
+    )
+  }
+
+  return <TaskForm initialData={task} isEdit />
+}

--- a/frontend/src/pages/TasksPage.tsx
+++ b/frontend/src/pages/TasksPage.tsx
@@ -1,0 +1,277 @@
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { tasksApi } from '@/lib/api'
+import type { ScheduledTask } from '@/types'
+import { Button } from '@/components/ui/button'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+import { Plus, CalendarClock, Pencil, Trash2, Pause, Play } from 'lucide-react'
+
+function formatSchedule(task: ScheduledTask): string {
+  const cfg = task.schedule_config
+  switch (task.schedule_type) {
+    case 'one_off':
+      return cfg.run_at ? `Once at ${new Date(cfg.run_at).toLocaleString()}` : 'One-off'
+    case 'interval':
+      if (cfg.every_minutes) return `Every ${cfg.every_minutes} min`
+      if (cfg.every_hours) return `Every ${cfg.every_hours} hr`
+      if (cfg.every_days)
+        return `Every ${cfg.every_days} day${cfg.every_days > 1 ? 's' : ''}${cfg.at_time ? ` at ${cfg.at_time}` : ''}`
+      return 'Interval'
+    case 'cron':
+      return cfg.expression || 'Cron'
+    default:
+      return task.schedule_type
+  }
+}
+
+function StatusBadge({ status }: Readonly<{ status: string }>) {
+  const isActive = status === 'active'
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+        isActive
+          ? 'bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+          : 'bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400'
+      }`}
+    >
+      {isActive ? 'Active' : 'Paused'}
+    </span>
+  )
+}
+
+function RunStatusBadge({ status }: Readonly<{ status: string }>) {
+  if (!status) return null
+  const colors: Record<string, string> = {
+    success: 'bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+    failed: 'bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+    running: 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  }
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${colors[status] ?? 'bg-zinc-100 text-zinc-500'}`}
+    >
+      {status}
+    </span>
+  )
+}
+
+export default function TasksPage() {
+  const navigate = useNavigate()
+  const [tasks, setTasks] = useState<ScheduledTask[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const loadTasks = async () => {
+    try {
+      const data = await tasksApi.list()
+      setTasks(data)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load tasks')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadTasks()
+  }, [])
+
+  const handleDelete = async (id: string) => {
+    try {
+      await tasksApi.delete(id)
+      setTasks(prev => prev.filter(t => t.id !== id))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete task')
+    }
+  }
+
+  const handleTogglePause = async (task: ScheduledTask) => {
+    try {
+      const updated =
+        task.status === 'active' ? await tasksApi.pause(task.id) : await tasksApi.resume(task.id)
+      setTasks(prev => prev.map(t => (t.id === task.id ? updated : t)))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update task')
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="text-sm text-zinc-400 dark:text-zinc-500">Loading tasks…</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center justify-between border-b border-zinc-100 dark:border-zinc-800 px-4 sm:px-6 py-4 shrink-0">
+        <div>
+          <h1 className="text-base font-semibold text-zinc-900 dark:text-zinc-100">
+            Scheduled Tasks
+          </h1>
+          <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">
+            {tasks.length} task{tasks.length === 1 ? '' : 's'}
+          </p>
+        </div>
+        <Button
+          onClick={() => navigate('/tasks/new')}
+          size="sm"
+          className="gap-1.5 bg-zinc-900 hover:bg-zinc-800 dark:bg-zinc-100 dark:hover:bg-zinc-200 dark:text-zinc-900 text-white text-xs h-8"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          New Task
+        </Button>
+      </div>
+
+      {error && (
+        <div className="mx-6 mt-3 rounded-md border border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-900/20 px-4 py-2.5 text-sm text-red-700 dark:text-red-400">
+          {error}
+        </div>
+      )}
+
+      <div className="flex-1 overflow-y-auto p-4 sm:p-6">
+        {tasks.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-20 text-center">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800 mb-4">
+              <CalendarClock className="h-5 w-5 text-zinc-400 dark:text-zinc-500" />
+            </div>
+            <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 mb-1">
+              No scheduled tasks
+            </h2>
+            <p className="text-xs text-zinc-500 dark:text-zinc-400 mb-4 max-w-xs">
+              Schedule agent tasks to run automatically — one-time or recurring.
+            </p>
+            <Button
+              onClick={() => navigate('/tasks/new')}
+              size="sm"
+              className="gap-1.5 bg-zinc-900 hover:bg-zinc-800 dark:bg-zinc-100 dark:hover:bg-zinc-200 dark:text-zinc-900 text-white text-xs h-8"
+            >
+              <Plus className="h-3.5 w-3.5" />
+              Create your first task
+            </Button>
+          </div>
+        ) : (
+          <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 xl:grid-cols-3">
+            {tasks.map(task => (
+              <TaskCard
+                key={task.id}
+                task={task}
+                onEdit={() => navigate(`/tasks/${task.id}/edit`)}
+                onDelete={() => handleDelete(task.id)}
+                onTogglePause={() => handleTogglePause(task)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function TaskCard({
+  task,
+  onEdit,
+  onDelete,
+  onTogglePause,
+}: Readonly<{
+  task: ScheduledTask
+  onEdit: () => void
+  onDelete: () => void
+  onTogglePause: () => void
+}>) {
+  return (
+    <div className="flex flex-col rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 p-4 hover:border-zinc-300 dark:hover:border-zinc-600 transition-colors">
+      <div className="flex items-start gap-3 mb-3">
+        <div className="flex h-8 w-8 items-center justify-center rounded-md bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 shrink-0">
+          <CalendarClock className="h-4 w-4" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <h3 className="font-semibold text-sm text-zinc-900 dark:text-zinc-100 truncate">
+            {task.name}
+          </h3>
+          <p className="text-xs text-zinc-400 dark:text-zinc-500 font-mono">
+            {formatSchedule(task)}
+          </p>
+        </div>
+        <StatusBadge status={task.status} />
+      </div>
+
+      {task.description && (
+        <p className="text-xs text-zinc-500 dark:text-zinc-400 mb-3 line-clamp-2 flex-1 leading-relaxed">
+          {task.description}
+        </p>
+      )}
+
+      <div className="flex flex-wrap gap-2 mb-3 text-xs text-zinc-500 dark:text-zinc-400">
+        {task.agent_slug && (
+          <span className="inline-flex items-center rounded-md bg-zinc-100 dark:bg-zinc-800 px-2 py-0.5 font-mono">
+            {task.agent_slug}
+          </span>
+        )}
+        <span>Runs: {task.run_count}</span>
+        {task.last_run_at && <span>Last: {new Date(task.last_run_at).toLocaleString()}</span>}
+        {task.last_run_status && <RunStatusBadge status={task.last_run_status} />}
+      </div>
+
+      <div className="flex items-center gap-1 pt-2 border-t border-zinc-100 dark:border-zinc-800">
+        <button
+          onClick={onTogglePause}
+          className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
+        >
+          {task.status === 'active' ? (
+            <>
+              <Pause className="h-3 w-3" /> Pause
+            </>
+          ) : (
+            <>
+              <Play className="h-3 w-3" /> Resume
+            </>
+          )}
+        </button>
+        <button
+          onClick={onEdit}
+          className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
+        >
+          <Pencil className="h-3 w-3" />
+          Edit
+        </button>
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <button className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs text-zinc-400 dark:text-zinc-500 hover:bg-red-50 dark:hover:bg-red-900/20 hover:text-red-600 dark:hover:text-red-400 transition-colors">
+              <Trash2 className="h-3 w-3" />
+              Delete
+            </button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete task?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This will permanently delete <strong>{task.name}</strong> and all its job history.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={onDelete}
+                className="bg-red-600 text-white hover:bg-red-700"
+              >
+                Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -115,11 +115,9 @@ export interface ChatDetail {
 }
 
 export const MODELS = [
-  { value: 'eu.anthropic.claude-sonnet-4-5-20250929-v1:0', label: 'Claude Sonnet 4.5 (EU)' },
-  { value: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
-  { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
-  { value: 'claude-haiku-4-5', label: 'Claude Haiku 4.5' },
-  { value: 'claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5 (2025-10)' },
+  { value: 'sonnet', label: 'Sonnet' },
+  { value: 'opus', label: 'Opus' },
+  { value: 'haiku', label: 'Haiku' },
 ]
 
 // ── Raw SDK streaming event types ─────────────────────────────────────────────
@@ -480,6 +478,63 @@ export interface ClaudeTodo {
 export interface ClaudeSessionDetail extends ClaudeSessionSummary {
   messages: ClaudeMessage[]
   todos: ClaudeTodo[]
+}
+
+// ── Scheduled Tasks ──────────────────────────────────────────────────────────
+
+export type ScheduleType = 'one_off' | 'interval' | 'cron'
+export type TaskStatus = 'active' | 'paused'
+export type JobStatus = 'running' | 'success' | 'failed'
+
+export interface ScheduleConfig {
+  run_at?: string
+  every_minutes?: number
+  every_hours?: number
+  every_days?: number
+  at_time?: string
+  expression?: string
+}
+
+export interface ScheduledTask {
+  id: string
+  name: string
+  description: string
+  prompt: string
+  agent_slug: string
+  working_directory: string
+  model: string
+  settings_profile_id: string
+  timeout_minutes: number
+  schedule_type: ScheduleType
+  schedule_config: ScheduleConfig
+  stop_after_count: number
+  stop_after_time?: string
+  status: TaskStatus
+  run_count: number
+  last_run_at?: string
+  last_run_status: string
+  next_run_at?: string
+  created_at: string
+  updated_at: string
+}
+
+export interface JobHistoryEntry {
+  id: string
+  task_id: string
+  task_name: string
+  agent_slug: string
+  status: JobStatus
+  started_at: string
+  finished_at?: string
+  duration_ms: number
+  chat_session_id: string
+  model: string
+  prompt_preview: string
+  error_message: string
+  total_input_tokens: number
+  total_output_tokens: number
+  total_cache_creation_tokens: number
+  total_cache_read_tokens: number
 }
 
 // ── Analytics ─────────────────────────────────────────────────────────────────

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/creativeprojects/go-selfupdate v1.5.2
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-chi/cors v1.2.2
+	github.com/go-co-op/gocron/v2 v2.19.1
 	github.com/google/uuid v1.6.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/modelcontextprotocol/go-sdk v1.3.1
@@ -50,6 +51,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/hashicorp/go-version v1.8.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
@@ -57,6 +59,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.3 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
 github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
 github.com/go-chi/cors v1.2.2 h1:Jmey33TE+b+rB7fT8MUy1u0I4L+NARQlK6LhzKPSyQE=
 github.com/go-chi/cors v1.2.2/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
+github.com/go-co-op/gocron/v2 v2.19.1 h1:B4iLeA0NB/2iO3EKQ7NfKn5KsQgZfjb2fkvoZJU3yBI=
+github.com/go-co-op/gocron/v2 v2.19.1/go.mod h1:5lEiCKk1oVJV39Zg7/YG10OnaVrDAV5GGR6O0663k6U=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=
 github.com/go-fed/httpsig v1.1.0/go.mod h1:RCMrTZvN1bJYtofsG4rd5NaO5obxQ5xBkdiS7xsT7bM=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -83,6 +85,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
+github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -110,6 +114,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qq
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -149,6 +155,8 @@ go.opentelemetry.io/otel/sdk/metric v1.39.0 h1:cXMVVFVgsIf2YL6QkRF4Urbr/aMInf+2W
 go.opentelemetry.io/otel/sdk/metric v1.39.0/go.mod h1:xq9HEVH7qeX69/JnwEfp6fVq5wosJsY1mt4lLfYdVew=
 go.opentelemetry.io/otel/trace v1.39.0 h1:2d2vfpEDmCJ5zVYz7ijaJdOF59xLomrvj7bjt6/qCJI=
 go.opentelemetry.io/otel/trace v1.39.0/go.mod h1:88w4/PnZSazkGzz/w84VHpQafiU4EtqqlVdxWy+rNOA=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -46,7 +46,7 @@ func newHarness(t *testing.T) *testHarness {
 	require.NoError(t, err)
 
 	logger := slog.Default()
-	srv := api.New(agentSvc, chatSvc, integrationSvc, mgr, logger, nil)
+	srv := api.New(agentSvc, chatSvc, integrationSvc, nil, mgr, logger, nil, nil)
 
 	r := chi.NewRouter()
 	srv.Mount(r)

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -1,0 +1,189 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/shaharia-lab/agento/internal/storage"
+)
+
+// handleListTasks returns all scheduled tasks.
+func (s *Server) handleListTasks(w http.ResponseWriter, r *http.Request) {
+	tasks, err := s.taskSvc.ListTasks(r.Context())
+	if err != nil {
+		httpErr(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, tasks)
+}
+
+// handleCreateTask creates a new scheduled task.
+func (s *Server) handleCreateTask(w http.ResponseWriter, r *http.Request) {
+	var task storage.ScheduledTask
+	if err := json.NewDecoder(r.Body).Decode(&task); err != nil {
+		writeError(w, http.StatusBadRequest, errInvalidJSONBody)
+		return
+	}
+
+	created, err := s.taskSvc.CreateTask(r.Context(), &task)
+	if err != nil {
+		httpErr(w, err)
+		return
+	}
+
+	// Schedule the task if the scheduler is available.
+	if s.scheduler != nil && created.Status == storage.TaskStatusActive {
+		if schedErr := s.scheduler.ScheduleTask(created); schedErr != nil {
+			s.logger.Warn("failed to schedule newly created task",
+				"task_id", created.ID, "error", schedErr)
+		}
+	}
+
+	writeJSON(w, http.StatusCreated, created)
+}
+
+// handleGetTask returns a single task by ID.
+func (s *Server) handleGetTask(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	task, err := s.taskSvc.GetTask(r.Context(), id)
+	if err != nil {
+		httpErr(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, task)
+}
+
+// handleUpdateTask updates an existing task.
+func (s *Server) handleUpdateTask(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var task storage.ScheduledTask
+	if err := json.NewDecoder(r.Body).Decode(&task); err != nil {
+		writeError(w, http.StatusBadRequest, errInvalidJSONBody)
+		return
+	}
+
+	updated, err := s.taskSvc.UpdateTask(r.Context(), id, &task)
+	if err != nil {
+		httpErr(w, err)
+		return
+	}
+
+	// Reschedule the task.
+	if s.scheduler != nil {
+		s.scheduler.UnscheduleTask(id)
+		if updated.Status == storage.TaskStatusActive {
+			if schedErr := s.scheduler.ScheduleTask(updated); schedErr != nil {
+				s.logger.Warn("failed to reschedule updated task",
+					"task_id", id, "error", schedErr)
+			}
+		}
+	}
+
+	writeJSON(w, http.StatusOK, updated)
+}
+
+// handleDeleteTask deletes a task and its job history.
+func (s *Server) handleDeleteTask(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	// Unschedule first.
+	if s.scheduler != nil {
+		s.scheduler.UnscheduleTask(id)
+	}
+
+	if err := s.taskSvc.DeleteTask(r.Context(), id); err != nil {
+		httpErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handlePauseTask pauses a scheduled task.
+func (s *Server) handlePauseTask(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	task, err := s.taskSvc.PauseTask(r.Context(), id)
+	if err != nil {
+		httpErr(w, err)
+		return
+	}
+
+	if s.scheduler != nil {
+		s.scheduler.UnscheduleTask(id)
+	}
+
+	writeJSON(w, http.StatusOK, task)
+}
+
+// handleResumeTask resumes a paused task.
+func (s *Server) handleResumeTask(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	task, err := s.taskSvc.ResumeTask(r.Context(), id)
+	if err != nil {
+		httpErr(w, err)
+		return
+	}
+
+	if s.scheduler != nil {
+		if schedErr := s.scheduler.ScheduleTask(task); schedErr != nil {
+			s.logger.Warn("failed to schedule resumed task",
+				"task_id", id, "error", schedErr)
+		}
+	}
+
+	writeJSON(w, http.StatusOK, task)
+}
+
+// handleListTaskJobHistory returns job history for a specific task.
+func (s *Server) handleListTaskJobHistory(w http.ResponseWriter, r *http.Request) {
+	taskID := chi.URLParam(r, "id")
+	limit := parseQueryInt(r, "limit", 50)
+
+	history, err := s.taskSvc.ListJobHistory(r.Context(), taskID, limit)
+	if err != nil {
+		httpErr(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, history)
+}
+
+// handleListAllJobHistory returns all job history entries with pagination.
+func (s *Server) handleListAllJobHistory(w http.ResponseWriter, r *http.Request) {
+	limit := parseQueryInt(r, "limit", 50)
+	offset := parseQueryInt(r, "offset", 0)
+
+	history, err := s.taskSvc.ListAllJobHistory(r.Context(), limit, offset)
+	if err != nil {
+		httpErr(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, history)
+}
+
+// handleGetJobHistory returns a single job history entry.
+func (s *Server) handleGetJobHistory(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	jh, err := s.taskSvc.GetJobHistory(r.Context(), id)
+	if err != nil {
+		httpErr(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, jh)
+}
+
+func parseQueryInt(r *http.Request, key string, defaultVal int) int {
+	s := r.URL.Query().Get(key)
+	if s == "" {
+		return defaultVal
+	}
+	v, err := strconv.Atoi(s)
+	if err != nil || v < 0 {
+		return defaultVal
+	}
+	return v
+}

--- a/internal/config/app_config.go
+++ b/internal/config/app_config.go
@@ -60,7 +60,7 @@ func Load() (*AppConfig, error) {
 		if c.AnthropicDefaultSonnetModel != "" {
 			c.DefaultModel = c.AnthropicDefaultSonnetModel
 		} else {
-			c.DefaultModel = "eu.anthropic.claude-sonnet-4-5-20250929-v1:0"
+			c.DefaultModel = "sonnet"
 		}
 	}
 

--- a/internal/config/app_config_test.go
+++ b/internal/config/app_config_test.go
@@ -64,7 +64,7 @@ func TestLoad(t *testing.T) {
 	assert.Equal(t, "debug", cfg.LogLevel)
 	assert.Equal(t, 9090, cfg.Port)
 	// DefaultModel should be the built-in default
-	assert.Equal(t, "eu.anthropic.claude-sonnet-4-5-20250929-v1:0", cfg.DefaultModel)
+	assert.Equal(t, "sonnet", cfg.DefaultModel)
 }
 
 func TestLoad_DefaultModel_Priority(t *testing.T) {
@@ -90,7 +90,7 @@ func TestLoad_DefaultModel_Priority(t *testing.T) {
 			name:          "built-in default when neither env var set",
 			defaultModel:  "",
 			sonnetModel:   "",
-			expectedModel: "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
+			expectedModel: "sonnet",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 )
 
-const defaultModel = "eu.anthropic.claude-sonnet-4-5-20250929-v1:0"
+const defaultModel = "sonnet"
 
 // DefaultWorkingDir returns the default working directory for agent sessions,
 // located under the user's home directory (~/.agento/work) to avoid using

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -29,7 +29,7 @@ func TestNewSettingsManager(t *testing.T) {
 			cfg:           &config.AppConfig{},
 			wantSettings: func(t *testing.T, s config.UserSettings) {
 				assert.Equal(t, config.DefaultWorkingDir(), s.DefaultWorkingDir)
-				assert.Equal(t, "eu.anthropic.claude-sonnet-4-5-20250929-v1:0", s.DefaultModel)
+				assert.Equal(t, "sonnet", s.DefaultModel)
 			},
 			wantModelEnv: false,
 			wantLocked:   map[string]string{},
@@ -134,7 +134,7 @@ func TestNewSettingsManager(t *testing.T) {
 			cfg:           &config.AppConfig{DefaultModel: "from-config"},
 			wantSettings: func(t *testing.T, s config.UserSettings) {
 				// Model not locked, so store value (default) is used
-				assert.Equal(t, "eu.anthropic.claude-sonnet-4-5-20250929-v1:0", s.DefaultModel)
+				assert.Equal(t, "sonnet", s.DefaultModel)
 			},
 			wantModelEnv: false,
 			wantLocked:   map[string]string{},

--- a/internal/scheduler/executor.go
+++ b/internal/scheduler/executor.go
@@ -1,0 +1,307 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/shaharia-lab/agento/internal/agent"
+	"github.com/shaharia-lab/agento/internal/config"
+	"github.com/shaharia-lab/agento/internal/storage"
+)
+
+// executeTask runs a single task execution with concurrency limiting.
+func (s *Scheduler) executeTask(taskID string) {
+	// Acquire semaphore.
+	s.semaphore <- struct{}{}
+	defer func() { <-s.semaphore }()
+
+	task, err := s.cfg.TaskStore.GetTask(taskID)
+	if err != nil {
+		s.logger.Error("failed to load task for execution",
+			"task_id", taskID, "error", err)
+		return
+	}
+	if task == nil || task.Status != storage.TaskStatusActive {
+		return
+	}
+
+	if s.shouldAutoPause(task) {
+		return
+	}
+
+	s.logger.Info("executing task",
+		"task_id", task.ID, "task_name", task.Name,
+		"run_count", task.RunCount+1)
+
+	s.runTask(task)
+}
+
+// shouldAutoPause checks stop conditions and pauses the task if met.
+func (s *Scheduler) shouldAutoPause(task *storage.ScheduledTask) bool {
+	if task.StopAfterCount > 0 && task.RunCount >= task.StopAfterCount {
+		s.autoPause(task, "stop_after_count reached")
+		return true
+	}
+	if task.StopAfterTime != nil && time.Now().After(*task.StopAfterTime) {
+		s.autoPause(task, "stop_after_time reached")
+		return true
+	}
+	return false
+}
+
+// runTask performs the core task execution: prompt interpolation, session
+// creation, agent invocation, and result recording.
+func (s *Scheduler) runTask(task *storage.ScheduledTask) {
+	startedAt := time.Now().UTC()
+
+	prompt, err := agent.Interpolate(task.Prompt, nil)
+	if err != nil {
+		s.logger.Error("failed to interpolate prompt",
+			"task_id", task.ID, "error", err)
+		s.recordFailedRun(task, startedAt, "",
+			fmt.Sprintf("prompt interpolation: %v", err))
+		return
+	}
+
+	chatSession, err := s.createTaskSession(task)
+	if err != nil {
+		s.logger.Error("failed to create chat session",
+			"task_id", task.ID, "error", err)
+		s.recordFailedRun(task, startedAt, "",
+			fmt.Sprintf("create session: %v", err))
+		return
+	}
+
+	jh := s.createInitialJobHistory(task, startedAt, chatSession.ID, prompt)
+
+	agentCfg, err := s.resolveAgentConfig(task)
+	if err != nil {
+		s.logger.Error("failed to resolve agent config",
+			"task_id", task.ID, "error", err)
+		s.finishJobHistory(jh, startedAt, storage.JobStatusFailed,
+			fmt.Sprintf("resolve agent: %v", err), agent.UsageStats{})
+		s.updateTaskAfterRun(task, startedAt, "failed")
+		return
+	}
+
+	opts := s.buildRunOptions(task)
+
+	timeout := time.Duration(task.TimeoutMinutes) * time.Minute
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	result, err := agent.RunAgent(ctx, agentCfg, prompt, opts)
+	if err != nil {
+		s.logger.Error("task execution failed",
+			"task_id", task.ID, "error", err)
+		s.finishJobHistory(jh, startedAt, storage.JobStatusFailed,
+			err.Error(), agent.UsageStats{})
+		s.updateTaskAfterRun(task, startedAt, "failed")
+		return
+	}
+
+	s.saveSessionResults(chatSession, result, prompt, startedAt)
+	s.finishJobHistory(
+		jh, startedAt, storage.JobStatusSuccess, "", result.Usage,
+	)
+	s.updateTaskAfterRun(task, startedAt, "success")
+
+	s.logger.Info("task execution completed",
+		"task_id", task.ID, "task_name", task.Name,
+		"session_id", chatSession.ID, "run_count", task.RunCount+1)
+}
+
+// createTaskSession creates a chat session for the task execution.
+func (s *Scheduler) createTaskSession(
+	task *storage.ScheduledTask,
+) (*storage.ChatSession, error) {
+	chatSession, err := s.cfg.ChatStore.CreateSession(
+		task.AgentSlug, task.WorkingDirectory,
+		task.Model, task.SettingsProfileID,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	chatSession.Title = "[Task] " + task.Name
+	if updateErr := s.cfg.ChatStore.UpdateSession(chatSession); updateErr != nil {
+		s.logger.Warn("failed to update session title", "error", updateErr)
+	}
+	return chatSession, nil
+}
+
+// createInitialJobHistory creates and persists an initial job history record.
+func (s *Scheduler) createInitialJobHistory(
+	task *storage.ScheduledTask, startedAt time.Time,
+	chatSessionID, prompt string,
+) *storage.JobHistory {
+	promptPreview := prompt
+	if len(promptPreview) > 200 {
+		promptPreview = promptPreview[:200] + "..."
+	}
+	jh := &storage.JobHistory{
+		TaskID:        task.ID,
+		TaskName:      task.Name,
+		AgentSlug:     task.AgentSlug,
+		Status:        storage.JobStatusRunning,
+		StartedAt:     startedAt,
+		ChatSessionID: chatSessionID,
+		Model:         task.Model,
+		PromptPreview: promptPreview,
+	}
+	if err := s.cfg.TaskStore.CreateJobHistory(jh); err != nil {
+		s.logger.Error("failed to create job history",
+			"task_id", task.ID, "error", err)
+	}
+	return jh
+}
+
+// buildRunOptions constructs the agent RunOptions for a task.
+func (s *Scheduler) buildRunOptions(task *storage.ScheduledTask) agent.RunOptions {
+	opts := agent.RunOptions{
+		LocalToolsMCP:       s.cfg.LocalMCP,
+		MCPRegistry:         s.cfg.MCPRegistry,
+		IntegrationRegistry: s.cfg.IntegrationRegistry,
+	}
+
+	if task.SettingsProfileID != "" {
+		filePath, err := config.LoadProfileFilePath(task.SettingsProfileID)
+		if err != nil {
+			s.logger.Warn("failed to resolve settings profile", "error", err)
+		} else {
+			opts.SettingsFilePath = filePath
+		}
+	}
+	return opts
+}
+
+// saveSessionResults updates the chat session with agent results and stores messages.
+func (s *Scheduler) saveSessionResults(
+	chatSession *storage.ChatSession, result *agent.AgentResult,
+	prompt string, startedAt time.Time,
+) {
+	chatSession.SDKSession = result.SessionID
+	chatSession.TotalInputTokens = result.Usage.InputTokens
+	chatSession.TotalOutputTokens = result.Usage.OutputTokens
+	chatSession.TotalCacheCreationTokens = result.Usage.CacheCreationInputTokens
+	chatSession.TotalCacheReadTokens = result.Usage.CacheReadInputTokens
+	chatSession.UpdatedAt = time.Now().UTC()
+	if updateErr := s.cfg.ChatStore.UpdateSession(chatSession); updateErr != nil {
+		s.logger.Warn("failed to update chat session after execution",
+			"error", updateErr)
+	}
+
+	if result.Answer != "" {
+		msg := storage.ChatMessage{
+			Role:      "user",
+			Content:   prompt,
+			Timestamp: startedAt,
+		}
+		if appendErr := s.cfg.ChatStore.AppendMessage(chatSession.ID, msg); appendErr != nil {
+			s.logger.Warn("failed to store user message", "error", appendErr)
+		}
+
+		assistantMsg := storage.ChatMessage{
+			Role:      "assistant",
+			Content:   result.Answer,
+			Timestamp: time.Now().UTC(),
+		}
+		if appendErr := s.cfg.ChatStore.AppendMessage(chatSession.ID, assistantMsg); appendErr != nil {
+			s.logger.Warn("failed to store assistant message", "error", appendErr)
+		}
+	}
+}
+
+func (s *Scheduler) resolveAgentConfig(task *storage.ScheduledTask) (*config.AgentConfig, error) {
+	if task.AgentSlug != "" {
+		agentCfg, err := s.cfg.AgentStore.Get(task.AgentSlug)
+		if err != nil {
+			return nil, fmt.Errorf("loading agent %q: %w", task.AgentSlug, err)
+		}
+		if agentCfg == nil {
+			return nil, fmt.Errorf("agent %q not found", task.AgentSlug)
+		}
+		return agentCfg, nil
+	}
+
+	// Synthesize minimal config — use the user's configured default model from settings.
+	model := task.Model
+	if model == "" && s.cfg.SettingsManager != nil {
+		model = s.cfg.SettingsManager.Get().DefaultModel
+	}
+	return &config.AgentConfig{
+		Model:    model,
+		Thinking: "adaptive",
+	}, nil
+}
+
+func (s *Scheduler) finishJobHistory(
+	jh *storage.JobHistory, startedAt time.Time,
+	status storage.JobStatus, errMsg string, usage agent.UsageStats,
+) {
+	now := time.Now().UTC()
+	jh.Status = status
+	jh.FinishedAt = &now
+	jh.DurationMS = now.Sub(startedAt).Milliseconds()
+	jh.ErrorMessage = errMsg
+	jh.TotalInputTokens = usage.InputTokens
+	jh.TotalOutputTokens = usage.OutputTokens
+	jh.TotalCacheCreationTokens = usage.CacheCreationInputTokens
+	jh.TotalCacheReadTokens = usage.CacheReadInputTokens
+
+	if err := s.cfg.TaskStore.UpdateJobHistory(jh); err != nil {
+		s.logger.Error("failed to update job history", "job_id", jh.ID, "error", err)
+	}
+}
+
+func (s *Scheduler) updateTaskAfterRun(task *storage.ScheduledTask, ranAt time.Time, status string) {
+	task.RunCount++
+	task.LastRunAt = &ranAt
+	task.LastRunStatus = status
+
+	// Auto-pause one-off tasks after execution.
+	if task.ScheduleType == storage.ScheduleOneOff {
+		task.Status = storage.TaskStatusPaused
+		s.UnscheduleTask(task.ID)
+	}
+
+	// Check if stop conditions are now met.
+	if task.StopAfterCount > 0 && task.RunCount >= task.StopAfterCount {
+		task.Status = storage.TaskStatusPaused
+		s.UnscheduleTask(task.ID)
+	}
+
+	if err := s.cfg.TaskStore.UpdateTask(task); err != nil {
+		s.logger.Error("failed to update task after run", "task_id", task.ID, "error", err)
+	}
+}
+
+func (s *Scheduler) recordFailedRun(task *storage.ScheduledTask, startedAt time.Time, chatSessionID, errMsg string) {
+	jh := &storage.JobHistory{
+		TaskID:        task.ID,
+		TaskName:      task.Name,
+		AgentSlug:     task.AgentSlug,
+		Status:        storage.JobStatusFailed,
+		StartedAt:     startedAt,
+		ChatSessionID: chatSessionID,
+		ErrorMessage:  errMsg,
+	}
+	now := time.Now().UTC()
+	jh.FinishedAt = &now
+	jh.DurationMS = now.Sub(startedAt).Milliseconds()
+
+	if err := s.cfg.TaskStore.CreateJobHistory(jh); err != nil {
+		s.logger.Error("failed to create failed job history", "task_id", task.ID, "error", err)
+	}
+	s.updateTaskAfterRun(task, startedAt, "failed")
+}
+
+func (s *Scheduler) autoPause(task *storage.ScheduledTask, reason string) {
+	s.logger.Info("auto-pausing task", "task_id", task.ID, "reason", reason)
+	task.Status = storage.TaskStatusPaused
+	if err := s.cfg.TaskStore.UpdateTask(task); err != nil {
+		s.logger.Error("failed to auto-pause task", "task_id", task.ID, "error", err)
+	}
+	s.UnscheduleTask(task.ID)
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1,0 +1,208 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-co-op/gocron/v2"
+	"github.com/google/uuid"
+
+	"github.com/shaharia-lab/agento/internal/config"
+	"github.com/shaharia-lab/agento/internal/integrations"
+	"github.com/shaharia-lab/agento/internal/storage"
+	"github.com/shaharia-lab/agento/internal/tools"
+)
+
+// Config holds the scheduler configuration.
+type Config struct {
+	TaskStore           storage.TaskStore
+	ChatStore           storage.ChatStore
+	AgentStore          storage.AgentStore
+	MCPRegistry         *config.MCPRegistry
+	LocalMCP            *tools.LocalMCPConfig
+	IntegrationRegistry *integrations.IntegrationRegistry
+	SettingsManager     *config.SettingsManager
+	Logger              *slog.Logger
+	MaxConcurrency      int
+}
+
+// Scheduler manages scheduled task execution using gocron.
+type Scheduler struct {
+	cron      gocron.Scheduler
+	cfg       Config
+	jobs      map[string]uuid.UUID // taskID → gocron job UUID
+	mu        sync.Mutex
+	semaphore chan struct{}
+	logger    *slog.Logger
+}
+
+// New creates a new Scheduler.
+func New(cfg Config) (*Scheduler, error) {
+	cron, err := gocron.NewScheduler()
+	if err != nil {
+		return nil, fmt.Errorf("creating gocron scheduler: %w", err)
+	}
+
+	maxConc := cfg.MaxConcurrency
+	if maxConc <= 0 {
+		maxConc = 3
+	}
+
+	return &Scheduler{
+		cron:      cron,
+		cfg:       cfg,
+		jobs:      make(map[string]uuid.UUID),
+		semaphore: make(chan struct{}, maxConc),
+		logger:    cfg.Logger,
+	}, nil
+}
+
+// Start loads active tasks from the database, schedules them, and starts the gocron scheduler.
+func (s *Scheduler) Start(_ context.Context) error {
+	tasks, err := s.cfg.TaskStore.ListTasks()
+	if err != nil {
+		return fmt.Errorf("loading tasks: %w", err)
+	}
+
+	for _, task := range tasks {
+		if task.Status != storage.TaskStatusActive {
+			continue
+		}
+		if err := s.ScheduleTask(task); err != nil {
+			s.logger.Warn("failed to schedule task on startup",
+				"task_id", task.ID, "task_name", task.Name, "error", err)
+		}
+	}
+
+	s.cron.Start()
+	s.logger.Info("task scheduler started", "active_tasks", len(s.jobs))
+	return nil
+}
+
+// Stop shuts down the gocron scheduler.
+func (s *Scheduler) Stop() error {
+	return s.cron.Shutdown()
+}
+
+// ScheduleTask adds or replaces a task's schedule in gocron.
+func (s *Scheduler) ScheduleTask(task *storage.ScheduledTask) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Remove existing job if any.
+	if jobID, ok := s.jobs[task.ID]; ok {
+		if err := s.cron.RemoveJob(jobID); err != nil {
+			s.logger.Warn("failed to remove existing job", "task_id", task.ID, "error", err)
+		}
+		delete(s.jobs, task.ID)
+	}
+
+	jobDef, err := s.buildJobDefinition(task)
+	if err != nil {
+		return fmt.Errorf("building job definition for task %q: %w", task.ID, err)
+	}
+
+	taskID := task.ID
+	job, err := s.cron.NewJob(jobDef, gocron.NewTask(func() {
+		s.executeTask(taskID)
+	}))
+	if err != nil {
+		return fmt.Errorf("scheduling task %q: %w", task.ID, err)
+	}
+
+	s.jobs[task.ID] = job.ID()
+	s.logger.Info("task scheduled", "task_id", task.ID, "task_name", task.Name,
+		"schedule_type", task.ScheduleType)
+	return nil
+}
+
+// UnscheduleTask removes a task from the gocron scheduler.
+func (s *Scheduler) UnscheduleTask(taskID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if jobID, ok := s.jobs[taskID]; ok {
+		if err := s.cron.RemoveJob(jobID); err != nil {
+			s.logger.Warn("failed to remove job", "task_id", taskID, "error", err)
+		}
+		delete(s.jobs, taskID)
+		s.logger.Info("task unscheduled", "task_id", taskID)
+	}
+}
+
+// buildJobDefinition converts a ScheduledTask's schedule config into a gocron JobDefinition.
+func (s *Scheduler) buildJobDefinition(task *storage.ScheduledTask) (gocron.JobDefinition, error) {
+	cfg := task.ScheduleConfig
+
+	switch task.ScheduleType {
+	case storage.ScheduleOneOff:
+		runAt, err := time.Parse(time.RFC3339, cfg.RunAt)
+		if err != nil {
+			return nil, fmt.Errorf("parsing run_at time: %w", err)
+		}
+		return gocron.OneTimeJob(gocron.OneTimeJobStartDateTime(runAt)), nil
+
+	case storage.ScheduleInterval:
+		return s.buildIntervalJob(cfg)
+
+	case storage.ScheduleCron:
+		return gocron.CronJob(cfg.Expression, false), nil
+
+	default:
+		return nil, fmt.Errorf("unknown schedule type: %s", task.ScheduleType)
+	}
+}
+
+// buildIntervalJob creates a gocron job for interval-based schedules.
+func (s *Scheduler) buildIntervalJob(cfg storage.ScheduleConfig) (gocron.JobDefinition, error) {
+	if cfg.EveryMinutes > 0 {
+		return gocron.DurationJob(time.Duration(cfg.EveryMinutes) * time.Minute), nil
+	}
+	if cfg.EveryHours > 0 {
+		return gocron.DurationJob(time.Duration(cfg.EveryHours) * time.Hour), nil
+	}
+	if cfg.EveryDays > 0 {
+		if cfg.AtTime != "" {
+			if def, err := s.buildDailyAtTimeJob(cfg); err == nil {
+				return def, nil
+			}
+		}
+		return gocron.DurationJob(time.Duration(cfg.EveryDays) * 24 * time.Hour), nil
+	}
+	return nil, fmt.Errorf("invalid interval config")
+}
+
+// buildDailyAtTimeJob parses an "HH:MM" at_time string and returns a DailyJob definition.
+func (s *Scheduler) buildDailyAtTimeJob(cfg storage.ScheduleConfig) (gocron.JobDefinition, error) {
+	parts := strings.Split(cfg.AtTime, ":")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid at_time format: %s", cfg.AtTime)
+	}
+	hour, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("parsing hour from at_time: %w", err)
+	}
+	minute, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("parsing minute from at_time: %w", err)
+	}
+	if hour < 0 || hour > 23 || minute < 0 || minute > 59 {
+		return nil, fmt.Errorf("at_time values out of range: %d:%d", hour, minute)
+	}
+	if cfg.EveryDays < 0 {
+		return nil, fmt.Errorf("every_days must be positive, got %d", cfg.EveryDays)
+	}
+	return gocron.DailyJob(
+		uint(cfg.EveryDays), //nolint:gosec // bounds checked above
+		gocron.NewAtTimes(gocron.NewAtTime(
+			uint(hour),   //nolint:gosec // bounds checked above
+			uint(minute), //nolint:gosec // bounds checked above
+			0,
+		)),
+	), nil
+}

--- a/internal/service/chat_service.go
+++ b/internal/service/chat_service.go
@@ -68,19 +68,18 @@ type chatService struct {
 	mcpRegistry         *config.MCPRegistry
 	localMCP            *tools.LocalMCPConfig
 	integrationRegistry *integrations.IntegrationRegistry
-	defaultModel        string
+	settingsMgr         *config.SettingsManager
 	logger              *slog.Logger
 }
 
 // NewChatService constructs a ChatService backed by the provided repositories.
-// defaultModel is used for no-agent (direct) chat sessions.
 func NewChatService(
 	chatRepo storage.ChatStore,
 	agentRepo storage.AgentStore,
 	mcpRegistry *config.MCPRegistry,
 	localMCP *tools.LocalMCPConfig,
 	integrationRegistry *integrations.IntegrationRegistry,
-	defaultModel string,
+	settingsMgr *config.SettingsManager,
 	logger *slog.Logger,
 ) ChatService {
 	return &chatService{
@@ -89,7 +88,7 @@ func NewChatService(
 		mcpRegistry:         mcpRegistry,
 		localMCP:            localMCP,
 		integrationRegistry: integrationRegistry,
-		defaultModel:        defaultModel,
+		settingsMgr:         settingsMgr,
 		logger:              logger,
 	}
 }
@@ -213,8 +212,8 @@ func (s *chatService) resolveAgentConfig(session *storage.ChatSession) (*config.
 	}
 
 	model := session.Model
-	if model == "" {
-		model = s.defaultModel
+	if model == "" && s.settingsMgr != nil {
+		model = s.settingsMgr.Get().DefaultModel
 	}
 	return &config.AgentConfig{
 		Model:    model,

--- a/internal/service/chat_service_test.go
+++ b/internal/service/chat_service_test.go
@@ -22,7 +22,7 @@ import (
 // integrationRegistry) are left nil.
 func newTestService(chatRepo *mocks.MockChatStore, agentRepo *mocks.MockAgentStore) ChatService {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	return NewChatService(chatRepo, agentRepo, nil, nil, nil, "claude-sonnet-4-20250514", logger)
+	return NewChatService(chatRepo, agentRepo, nil, nil, nil, nil, logger)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/service/mocks/mock_task_service.go
+++ b/internal/service/mocks/mock_task_service.go
@@ -1,0 +1,101 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/shaharia-lab/agento/internal/storage"
+)
+
+// MockTaskService is a mock implementation of service.TaskService.
+type MockTaskService struct {
+	mock.Mock
+}
+
+//nolint:revive
+func (m *MockTaskService) ListTasks(ctx context.Context) ([]*storage.ScheduledTask, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*storage.ScheduledTask), args.Error(1)
+}
+
+//nolint:revive
+func (m *MockTaskService) GetTask(ctx context.Context, id string) (*storage.ScheduledTask, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*storage.ScheduledTask), args.Error(1)
+}
+
+//nolint:revive
+func (m *MockTaskService) CreateTask(ctx context.Context, task *storage.ScheduledTask) (*storage.ScheduledTask, error) {
+	args := m.Called(ctx, task)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*storage.ScheduledTask), args.Error(1)
+}
+
+//nolint:revive
+func (m *MockTaskService) UpdateTask(ctx context.Context, id string, task *storage.ScheduledTask) (*storage.ScheduledTask, error) {
+	args := m.Called(ctx, id, task)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*storage.ScheduledTask), args.Error(1)
+}
+
+//nolint:revive
+func (m *MockTaskService) DeleteTask(ctx context.Context, id string) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+//nolint:revive
+func (m *MockTaskService) PauseTask(ctx context.Context, id string) (*storage.ScheduledTask, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*storage.ScheduledTask), args.Error(1)
+}
+
+//nolint:revive
+func (m *MockTaskService) ResumeTask(ctx context.Context, id string) (*storage.ScheduledTask, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*storage.ScheduledTask), args.Error(1)
+}
+
+//nolint:revive
+func (m *MockTaskService) ListJobHistory(ctx context.Context, taskID string, limit int) ([]*storage.JobHistory, error) {
+	args := m.Called(ctx, taskID, limit)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*storage.JobHistory), args.Error(1)
+}
+
+//nolint:revive
+func (m *MockTaskService) ListAllJobHistory(ctx context.Context, limit, offset int) ([]*storage.JobHistory, error) {
+	args := m.Called(ctx, limit, offset)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*storage.JobHistory), args.Error(1)
+}
+
+//nolint:revive
+func (m *MockTaskService) GetJobHistory(ctx context.Context, id string) (*storage.JobHistory, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*storage.JobHistory), args.Error(1)
+}

--- a/internal/service/task_service.go
+++ b/internal/service/task_service.go
@@ -1,0 +1,241 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/shaharia-lab/agento/internal/storage"
+)
+
+// TaskService defines the business logic interface for managing scheduled tasks.
+type TaskService interface {
+	ListTasks(ctx context.Context) ([]*storage.ScheduledTask, error)
+	GetTask(ctx context.Context, id string) (*storage.ScheduledTask, error)
+	CreateTask(ctx context.Context, task *storage.ScheduledTask) (*storage.ScheduledTask, error)
+	UpdateTask(ctx context.Context, id string, task *storage.ScheduledTask) (*storage.ScheduledTask, error)
+	DeleteTask(ctx context.Context, id string) error
+	PauseTask(ctx context.Context, id string) (*storage.ScheduledTask, error)
+	ResumeTask(ctx context.Context, id string) (*storage.ScheduledTask, error)
+	ListJobHistory(ctx context.Context, taskID string, limit int) ([]*storage.JobHistory, error)
+	ListAllJobHistory(ctx context.Context, limit, offset int) ([]*storage.JobHistory, error)
+	GetJobHistory(ctx context.Context, id string) (*storage.JobHistory, error)
+}
+
+type taskService struct {
+	repo   storage.TaskStore
+	logger *slog.Logger
+}
+
+// NewTaskService returns a new TaskService backed by the given TaskStore.
+func NewTaskService(repo storage.TaskStore, logger *slog.Logger) TaskService {
+	return &taskService{repo: repo, logger: logger}
+}
+
+func (s *taskService) ListTasks(_ context.Context) ([]*storage.ScheduledTask, error) {
+	tasks, err := s.repo.ListTasks()
+	if err != nil {
+		return nil, fmt.Errorf("listing tasks: %w", err)
+	}
+	return tasks, nil
+}
+
+func (s *taskService) GetTask(_ context.Context, id string) (*storage.ScheduledTask, error) {
+	task, err := s.repo.GetTask(id)
+	if err != nil {
+		return nil, fmt.Errorf("getting task %q: %w", id, err)
+	}
+	if task == nil {
+		return nil, &NotFoundError{Resource: "task", ID: id}
+	}
+	return task, nil
+}
+
+func (s *taskService) CreateTask(_ context.Context, task *storage.ScheduledTask) (*storage.ScheduledTask, error) {
+	if err := validateTask(task); err != nil {
+		return nil, err
+	}
+
+	if task.Status == "" {
+		task.Status = storage.TaskStatusActive
+	}
+	if task.TimeoutMinutes == 0 {
+		task.TimeoutMinutes = 30
+	}
+
+	if err := s.repo.CreateTask(task); err != nil {
+		return nil, fmt.Errorf("creating task: %w", err)
+	}
+
+	s.logger.Info("task created", "id", task.ID, "name", task.Name)
+	return task, nil
+}
+
+func (s *taskService) UpdateTask(
+	_ context.Context, id string, task *storage.ScheduledTask,
+) (*storage.ScheduledTask, error) {
+	existing, err := s.repo.GetTask(id)
+	if err != nil {
+		return nil, fmt.Errorf("looking up task: %w", err)
+	}
+	if existing == nil {
+		return nil, &NotFoundError{Resource: "task", ID: id}
+	}
+
+	task.ID = id
+	task.RunCount = existing.RunCount
+	task.LastRunAt = existing.LastRunAt
+	task.LastRunStatus = existing.LastRunStatus
+	task.CreatedAt = existing.CreatedAt
+
+	if err := validateTask(task); err != nil {
+		return nil, err
+	}
+
+	if task.TimeoutMinutes == 0 {
+		task.TimeoutMinutes = 30
+	}
+
+	if err := s.repo.UpdateTask(task); err != nil {
+		return nil, fmt.Errorf("updating task: %w", err)
+	}
+
+	s.logger.Info("task updated", "id", id, "name", task.Name)
+	return task, nil
+}
+
+func (s *taskService) DeleteTask(_ context.Context, id string) error {
+	existing, err := s.repo.GetTask(id)
+	if err != nil {
+		return fmt.Errorf("looking up task: %w", err)
+	}
+	if existing == nil {
+		return &NotFoundError{Resource: "task", ID: id}
+	}
+
+	if err := s.repo.DeleteTask(id); err != nil {
+		return fmt.Errorf("deleting task %q: %w", id, err)
+	}
+	s.logger.Info("task deleted", "id", id)
+	return nil
+}
+
+func (s *taskService) PauseTask(_ context.Context, id string) (*storage.ScheduledTask, error) {
+	task, err := s.repo.GetTask(id)
+	if err != nil {
+		return nil, fmt.Errorf("looking up task: %w", err)
+	}
+	if task == nil {
+		return nil, &NotFoundError{Resource: "task", ID: id}
+	}
+
+	task.Status = storage.TaskStatusPaused
+	if err := s.repo.UpdateTask(task); err != nil {
+		return nil, fmt.Errorf("pausing task: %w", err)
+	}
+
+	s.logger.Info("task paused", "id", id)
+	return task, nil
+}
+
+func (s *taskService) ResumeTask(_ context.Context, id string) (*storage.ScheduledTask, error) {
+	task, err := s.repo.GetTask(id)
+	if err != nil {
+		return nil, fmt.Errorf("looking up task: %w", err)
+	}
+	if task == nil {
+		return nil, &NotFoundError{Resource: "task", ID: id}
+	}
+
+	task.Status = storage.TaskStatusActive
+	task.RunCount = 0
+	task.LastRunAt = nil
+	task.LastRunStatus = ""
+	if err := s.repo.UpdateTask(task); err != nil {
+		return nil, fmt.Errorf("resuming task: %w", err)
+	}
+
+	s.logger.Info("task resumed", "id", id)
+	return task, nil
+}
+
+func (s *taskService) ListJobHistory(_ context.Context, taskID string, limit int) ([]*storage.JobHistory, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	history, err := s.repo.ListJobHistory(taskID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("listing job history: %w", err)
+	}
+	return history, nil
+}
+
+func (s *taskService) ListAllJobHistory(_ context.Context, limit, offset int) ([]*storage.JobHistory, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	history, err := s.repo.ListAllJobHistory(limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("listing all job history: %w", err)
+	}
+	return history, nil
+}
+
+func (s *taskService) GetJobHistory(_ context.Context, id string) (*storage.JobHistory, error) {
+	jh, err := s.repo.GetJobHistory(id)
+	if err != nil {
+		return nil, fmt.Errorf("getting job history %q: %w", id, err)
+	}
+	if jh == nil {
+		return nil, &NotFoundError{Resource: "job_history", ID: id}
+	}
+	return jh, nil
+}
+
+func validateTask(task *storage.ScheduledTask) error {
+	if task.Name == "" {
+		return &ValidationError{Field: "name", Message: "name is required"}
+	}
+	if task.Prompt == "" {
+		return &ValidationError{Field: "prompt", Message: "prompt is required"}
+	}
+	if task.TimeoutMinutes < 0 || task.TimeoutMinutes > 240 {
+		return &ValidationError{Field: "timeout_minutes", Message: "timeout must be between 1 and 240 minutes"}
+	}
+
+	switch task.ScheduleType {
+	case storage.ScheduleOneOff, storage.ScheduleInterval, storage.ScheduleCron:
+		// valid
+	case "":
+		task.ScheduleType = storage.ScheduleOneOff
+	default:
+		return &ValidationError{Field: "schedule_type", Message: "must be one_off, interval, or cron"}
+	}
+
+	return validateScheduleConfig(task)
+}
+
+func validateScheduleConfig(task *storage.ScheduledTask) error {
+	cfg := task.ScheduleConfig
+	switch task.ScheduleType {
+	case storage.ScheduleOneOff:
+		if cfg.RunAt == "" {
+			return &ValidationError{Field: "schedule_config.run_at", Message: "run_at is required for one_off schedules"}
+		}
+	case storage.ScheduleInterval:
+		if cfg.EveryMinutes == 0 && cfg.EveryHours == 0 && cfg.EveryDays == 0 {
+			return &ValidationError{
+				Field:   "schedule_config",
+				Message: "at least one of every_minutes, every_hours, or every_days is required for interval schedules",
+			}
+		}
+	case storage.ScheduleCron:
+		if cfg.Expression == "" {
+			return &ValidationError{Field: "schedule_config.expression", Message: "expression is required for cron schedules"}
+		}
+	}
+	return nil
+}

--- a/internal/service/task_service_test.go
+++ b/internal/service/task_service_test.go
@@ -1,0 +1,469 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shaharia-lab/agento/internal/storage"
+	"github.com/shaharia-lab/agento/internal/storage/mocks"
+)
+
+func newTestTaskService(repo *mocks.MockTaskStore) TaskService {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return NewTaskService(repo, logger)
+}
+
+// ---------------------------------------------------------------------------
+// ListTasks
+// ---------------------------------------------------------------------------
+
+func TestListTasks(t *testing.T) {
+	tasks := []*storage.ScheduledTask{
+		{ID: "t1", Name: "Task 1"},
+		{ID: "t2", Name: "Task 2"},
+	}
+
+	repo := new(mocks.MockTaskStore)
+	repo.On("ListTasks").Return(tasks, nil)
+
+	svc := newTestTaskService(repo)
+	result, err := svc.ListTasks(context.Background())
+
+	require.NoError(t, err)
+	assert.Len(t, result, 2)
+	repo.AssertExpectations(t)
+}
+
+func TestListTasks_Error(t *testing.T) {
+	repo := new(mocks.MockTaskStore)
+	repo.On("ListTasks").Return(nil, errors.New("db error"))
+
+	svc := newTestTaskService(repo)
+	_, err := svc.ListTasks(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "listing tasks")
+	repo.AssertExpectations(t)
+}
+
+// ---------------------------------------------------------------------------
+// GetTask
+// ---------------------------------------------------------------------------
+
+func TestGetTask(t *testing.T) {
+	task := &storage.ScheduledTask{ID: "t1", Name: "Task 1"}
+
+	repo := new(mocks.MockTaskStore)
+	repo.On("GetTask", "t1").Return(task, nil)
+
+	svc := newTestTaskService(repo)
+	result, err := svc.GetTask(context.Background(), "t1")
+
+	require.NoError(t, err)
+	assert.Equal(t, "Task 1", result.Name)
+	repo.AssertExpectations(t)
+}
+
+func TestGetTask_NotFound(t *testing.T) {
+	repo := new(mocks.MockTaskStore)
+	repo.On("GetTask", "missing").Return(nil, nil)
+
+	svc := newTestTaskService(repo)
+	_, err := svc.GetTask(context.Background(), "missing")
+
+	require.Error(t, err)
+	var notFound *NotFoundError
+	assert.True(t, errors.As(err, &notFound))
+	repo.AssertExpectations(t)
+}
+
+// ---------------------------------------------------------------------------
+// CreateTask
+// ---------------------------------------------------------------------------
+
+func TestCreateTask(t *testing.T) {
+	repo := new(mocks.MockTaskStore)
+	repo.On("CreateTask", mock.AnythingOfType("*storage.ScheduledTask")).Return(nil)
+
+	svc := newTestTaskService(repo)
+	task := &storage.ScheduledTask{
+		Name:         "New Task",
+		Prompt:       "Do something",
+		ScheduleType: storage.ScheduleOneOff,
+		ScheduleConfig: storage.ScheduleConfig{
+			RunAt: "2026-03-01T10:00:00Z",
+		},
+	}
+	result, err := svc.CreateTask(context.Background(), task)
+
+	require.NoError(t, err)
+	assert.Equal(t, storage.TaskStatusActive, result.Status)
+	assert.Equal(t, 30, result.TimeoutMinutes)
+	repo.AssertExpectations(t)
+}
+
+func TestCreateTask_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		task    *storage.ScheduledTask
+		wantErr string
+	}{
+		{
+			name:    "missing name",
+			task:    &storage.ScheduledTask{Prompt: "p", ScheduleType: storage.ScheduleOneOff, ScheduleConfig: storage.ScheduleConfig{RunAt: "t"}},
+			wantErr: "name",
+		},
+		{
+			name:    "missing prompt",
+			task:    &storage.ScheduledTask{Name: "n", ScheduleType: storage.ScheduleOneOff, ScheduleConfig: storage.ScheduleConfig{RunAt: "t"}},
+			wantErr: "prompt",
+		},
+		{
+			name:    "invalid schedule type",
+			task:    &storage.ScheduledTask{Name: "n", Prompt: "p", ScheduleType: "bogus"},
+			wantErr: "schedule_type",
+		},
+		{
+			name:    "one_off missing run_at",
+			task:    &storage.ScheduledTask{Name: "n", Prompt: "p", ScheduleType: storage.ScheduleOneOff},
+			wantErr: "run_at",
+		},
+		{
+			name:    "interval missing duration",
+			task:    &storage.ScheduledTask{Name: "n", Prompt: "p", ScheduleType: storage.ScheduleInterval},
+			wantErr: "schedule_config",
+		},
+		{
+			name:    "cron missing expression",
+			task:    &storage.ScheduledTask{Name: "n", Prompt: "p", ScheduleType: storage.ScheduleCron},
+			wantErr: "expression",
+		},
+		{
+			name:    "timeout too high",
+			task:    &storage.ScheduledTask{Name: "n", Prompt: "p", ScheduleType: storage.ScheduleOneOff, ScheduleConfig: storage.ScheduleConfig{RunAt: "t"}, TimeoutMinutes: 300},
+			wantErr: "timeout",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := new(mocks.MockTaskStore)
+			svc := newTestTaskService(repo)
+
+			_, err := svc.CreateTask(context.Background(), tt.task)
+
+			require.Error(t, err)
+			var ve *ValidationError
+			assert.True(t, errors.As(err, &ve), "expected ValidationError")
+			assert.Contains(t, ve.Field, tt.wantErr)
+			repo.AssertExpectations(t)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UpdateTask
+// ---------------------------------------------------------------------------
+
+func TestUpdateTask(t *testing.T) {
+	now := time.Now().UTC()
+	existing := &storage.ScheduledTask{
+		ID:            "t1",
+		Name:          "Old Name",
+		Prompt:        "old prompt",
+		RunCount:      5,
+		LastRunAt:     &now,
+		LastRunStatus: "success",
+		CreatedAt:     now,
+		ScheduleType:  storage.ScheduleOneOff,
+		ScheduleConfig: storage.ScheduleConfig{
+			RunAt: "2026-01-01T00:00:00Z",
+		},
+	}
+
+	repo := new(mocks.MockTaskStore)
+	repo.On("GetTask", "t1").Return(existing, nil)
+	repo.On("UpdateTask", mock.MatchedBy(func(t *storage.ScheduledTask) bool {
+		// Preserves run metadata from existing task
+		return t.RunCount == 5 && t.LastRunStatus == "success" && t.CreatedAt.Equal(now)
+	})).Return(nil)
+
+	svc := newTestTaskService(repo)
+	updated := &storage.ScheduledTask{
+		Name:         "New Name",
+		Prompt:       "new prompt",
+		ScheduleType: storage.ScheduleOneOff,
+		ScheduleConfig: storage.ScheduleConfig{
+			RunAt: "2026-06-01T00:00:00Z",
+		},
+	}
+	result, err := svc.UpdateTask(context.Background(), "t1", updated)
+
+	require.NoError(t, err)
+	assert.Equal(t, "t1", result.ID)
+	assert.Equal(t, 5, result.RunCount)
+	repo.AssertExpectations(t)
+}
+
+func TestUpdateTask_NotFound(t *testing.T) {
+	repo := new(mocks.MockTaskStore)
+	repo.On("GetTask", "missing").Return(nil, nil)
+
+	svc := newTestTaskService(repo)
+	_, err := svc.UpdateTask(context.Background(), "missing", &storage.ScheduledTask{Name: "x", Prompt: "p"})
+
+	require.Error(t, err)
+	var notFound *NotFoundError
+	assert.True(t, errors.As(err, &notFound))
+	repo.AssertExpectations(t)
+}
+
+// ---------------------------------------------------------------------------
+// DeleteTask
+// ---------------------------------------------------------------------------
+
+func TestDeleteTask(t *testing.T) {
+	repo := new(mocks.MockTaskStore)
+	repo.On("GetTask", "t1").Return(&storage.ScheduledTask{ID: "t1"}, nil)
+	repo.On("DeleteTask", "t1").Return(nil)
+
+	svc := newTestTaskService(repo)
+	err := svc.DeleteTask(context.Background(), "t1")
+
+	require.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestDeleteTask_NotFound(t *testing.T) {
+	repo := new(mocks.MockTaskStore)
+	repo.On("GetTask", "missing").Return(nil, nil)
+
+	svc := newTestTaskService(repo)
+	err := svc.DeleteTask(context.Background(), "missing")
+
+	require.Error(t, err)
+	var notFound *NotFoundError
+	assert.True(t, errors.As(err, &notFound))
+	repo.AssertExpectations(t)
+}
+
+// ---------------------------------------------------------------------------
+// PauseTask
+// ---------------------------------------------------------------------------
+
+func TestPauseTask(t *testing.T) {
+	repo := new(mocks.MockTaskStore)
+	repo.On("GetTask", "t1").Return(&storage.ScheduledTask{ID: "t1", Status: storage.TaskStatusActive}, nil)
+	repo.On("UpdateTask", mock.MatchedBy(func(task *storage.ScheduledTask) bool {
+		return task.Status == storage.TaskStatusPaused
+	})).Return(nil)
+
+	svc := newTestTaskService(repo)
+	result, err := svc.PauseTask(context.Background(), "t1")
+
+	require.NoError(t, err)
+	assert.Equal(t, storage.TaskStatusPaused, result.Status)
+	repo.AssertExpectations(t)
+}
+
+func TestPauseTask_NotFound(t *testing.T) {
+	repo := new(mocks.MockTaskStore)
+	repo.On("GetTask", "missing").Return(nil, nil)
+
+	svc := newTestTaskService(repo)
+	_, err := svc.PauseTask(context.Background(), "missing")
+
+	require.Error(t, err)
+	var notFound *NotFoundError
+	assert.True(t, errors.As(err, &notFound))
+}
+
+// ---------------------------------------------------------------------------
+// ResumeTask
+// ---------------------------------------------------------------------------
+
+func TestResumeTask(t *testing.T) {
+	now := time.Now().UTC()
+	repo := new(mocks.MockTaskStore)
+	repo.On("GetTask", "t1").Return(&storage.ScheduledTask{
+		ID:            "t1",
+		Status:        storage.TaskStatusPaused,
+		RunCount:      3,
+		LastRunAt:     &now,
+		LastRunStatus: "failed",
+	}, nil)
+	repo.On("UpdateTask", mock.MatchedBy(func(task *storage.ScheduledTask) bool {
+		return task.Status == storage.TaskStatusActive &&
+			task.RunCount == 0 &&
+			task.LastRunAt == nil &&
+			task.LastRunStatus == ""
+	})).Return(nil)
+
+	svc := newTestTaskService(repo)
+	result, err := svc.ResumeTask(context.Background(), "t1")
+
+	require.NoError(t, err)
+	assert.Equal(t, storage.TaskStatusActive, result.Status)
+	assert.Equal(t, 0, result.RunCount, "run count should be reset on resume")
+	assert.Nil(t, result.LastRunAt, "last_run_at should be cleared on resume")
+	assert.Empty(t, result.LastRunStatus, "last_run_status should be cleared on resume")
+	repo.AssertExpectations(t)
+}
+
+func TestResumeTask_NotFound(t *testing.T) {
+	repo := new(mocks.MockTaskStore)
+	repo.On("GetTask", "missing").Return(nil, nil)
+
+	svc := newTestTaskService(repo)
+	_, err := svc.ResumeTask(context.Background(), "missing")
+
+	require.Error(t, err)
+	var notFound *NotFoundError
+	assert.True(t, errors.As(err, &notFound))
+}
+
+func TestResumeTask_StoreError(t *testing.T) {
+	repo := new(mocks.MockTaskStore)
+	repo.On("GetTask", "t1").Return(&storage.ScheduledTask{
+		ID:     "t1",
+		Status: storage.TaskStatusPaused,
+	}, nil)
+	repo.On("UpdateTask", mock.Anything).Return(errors.New("db write error"))
+
+	svc := newTestTaskService(repo)
+	_, err := svc.ResumeTask(context.Background(), "t1")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resuming task")
+	repo.AssertExpectations(t)
+}
+
+// ---------------------------------------------------------------------------
+// ListJobHistory
+// ---------------------------------------------------------------------------
+
+func TestListJobHistory(t *testing.T) {
+	history := []*storage.JobHistory{
+		{ID: "j1", TaskID: "t1"},
+	}
+
+	repo := new(mocks.MockTaskStore)
+	repo.On("ListJobHistory", "t1", 50).Return(history, nil)
+
+	svc := newTestTaskService(repo)
+	result, err := svc.ListJobHistory(context.Background(), "t1", 0)
+
+	require.NoError(t, err)
+	assert.Len(t, result, 1)
+	repo.AssertExpectations(t)
+}
+
+func TestListAllJobHistory(t *testing.T) {
+	history := []*storage.JobHistory{{ID: "j1"}, {ID: "j2"}}
+
+	repo := new(mocks.MockTaskStore)
+	repo.On("ListAllJobHistory", 50, 0).Return(history, nil)
+
+	svc := newTestTaskService(repo)
+	result, err := svc.ListAllJobHistory(context.Background(), 0, -1)
+
+	require.NoError(t, err)
+	assert.Len(t, result, 2)
+	repo.AssertExpectations(t)
+}
+
+// ---------------------------------------------------------------------------
+// GetJobHistory
+// ---------------------------------------------------------------------------
+
+func TestGetJobHistory(t *testing.T) {
+	jh := &storage.JobHistory{ID: "j1", TaskName: "Test"}
+
+	repo := new(mocks.MockTaskStore)
+	repo.On("GetJobHistory", "j1").Return(jh, nil)
+
+	svc := newTestTaskService(repo)
+	result, err := svc.GetJobHistory(context.Background(), "j1")
+
+	require.NoError(t, err)
+	assert.Equal(t, "Test", result.TaskName)
+	repo.AssertExpectations(t)
+}
+
+func TestGetJobHistory_NotFound(t *testing.T) {
+	repo := new(mocks.MockTaskStore)
+	repo.On("GetJobHistory", "missing").Return(nil, nil)
+
+	svc := newTestTaskService(repo)
+	_, err := svc.GetJobHistory(context.Background(), "missing")
+
+	require.Error(t, err)
+	var notFound *NotFoundError
+	assert.True(t, errors.As(err, &notFound))
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+func TestValidateTask_EmptyScheduleTypeDefaultsToOneOff(t *testing.T) {
+	repo := new(mocks.MockTaskStore)
+	repo.On("CreateTask", mock.MatchedBy(func(task *storage.ScheduledTask) bool {
+		return task.ScheduleType == storage.ScheduleOneOff
+	})).Return(nil)
+
+	svc := newTestTaskService(repo)
+	task := &storage.ScheduledTask{
+		Name:           "Test",
+		Prompt:         "Do something",
+		ScheduleType:   "", // empty
+		ScheduleConfig: storage.ScheduleConfig{RunAt: "2026-03-01T10:00:00Z"},
+	}
+	_, err := svc.CreateTask(context.Background(), task)
+
+	require.NoError(t, err)
+	assert.Equal(t, storage.ScheduleOneOff, task.ScheduleType)
+	repo.AssertExpectations(t)
+}
+
+func TestCreateTask_ValidIntervalSchedule(t *testing.T) {
+	repo := new(mocks.MockTaskStore)
+	repo.On("CreateTask", mock.Anything).Return(nil)
+
+	svc := newTestTaskService(repo)
+	task := &storage.ScheduledTask{
+		Name:           "Interval Task",
+		Prompt:         "Run periodically",
+		ScheduleType:   storage.ScheduleInterval,
+		ScheduleConfig: storage.ScheduleConfig{EveryMinutes: 30},
+	}
+	_, err := svc.CreateTask(context.Background(), task)
+
+	require.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestCreateTask_ValidCronSchedule(t *testing.T) {
+	repo := new(mocks.MockTaskStore)
+	repo.On("CreateTask", mock.Anything).Return(nil)
+
+	svc := newTestTaskService(repo)
+	task := &storage.ScheduledTask{
+		Name:           "Cron Task",
+		Prompt:         "Run on schedule",
+		ScheduleType:   storage.ScheduleCron,
+		ScheduleConfig: storage.ScheduleConfig{Expression: "0 */2 * * *"},
+	}
+	_, err := svc.CreateTask(context.Background(), task)
+
+	require.NoError(t, err)
+	repo.AssertExpectations(t)
+}

--- a/internal/storage/mocks/mock_task_store.go
+++ b/internal/storage/mocks/mock_task_store.go
@@ -1,0 +1,87 @@
+package mocks
+
+import (
+	"github.com/stretchr/testify/mock"
+
+	"github.com/shaharia-lab/agento/internal/storage"
+)
+
+// MockTaskStore is a mock implementation of storage.TaskStore.
+type MockTaskStore struct {
+	mock.Mock
+}
+
+//nolint:revive
+func (m *MockTaskStore) ListTasks() ([]*storage.ScheduledTask, error) {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*storage.ScheduledTask), args.Error(1)
+}
+
+//nolint:revive
+func (m *MockTaskStore) GetTask(id string) (*storage.ScheduledTask, error) {
+	args := m.Called(id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*storage.ScheduledTask), args.Error(1)
+}
+
+//nolint:revive
+func (m *MockTaskStore) CreateTask(task *storage.ScheduledTask) error {
+	args := m.Called(task)
+	return args.Error(0)
+}
+
+//nolint:revive
+func (m *MockTaskStore) UpdateTask(task *storage.ScheduledTask) error {
+	args := m.Called(task)
+	return args.Error(0)
+}
+
+//nolint:revive
+func (m *MockTaskStore) DeleteTask(id string) error {
+	args := m.Called(id)
+	return args.Error(0)
+}
+
+//nolint:revive
+func (m *MockTaskStore) ListJobHistory(taskID string, limit int) ([]*storage.JobHistory, error) {
+	args := m.Called(taskID, limit)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*storage.JobHistory), args.Error(1)
+}
+
+//nolint:revive
+func (m *MockTaskStore) ListAllJobHistory(limit, offset int) ([]*storage.JobHistory, error) {
+	args := m.Called(limit, offset)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*storage.JobHistory), args.Error(1)
+}
+
+//nolint:revive
+func (m *MockTaskStore) GetJobHistory(id string) (*storage.JobHistory, error) {
+	args := m.Called(id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*storage.JobHistory), args.Error(1)
+}
+
+//nolint:revive
+func (m *MockTaskStore) CreateJobHistory(jh *storage.JobHistory) error {
+	args := m.Called(jh)
+	return args.Error(0)
+}
+
+//nolint:revive
+func (m *MockTaskStore) UpdateJobHistory(jh *storage.JobHistory) error {
+	args := m.Called(jh)
+	return args.Error(0)
+}

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -115,6 +115,56 @@ CREATE TABLE claude_cache_metadata (
 );
 `,
 	},
+	{
+		version: 3,
+		sql: `
+CREATE TABLE scheduled_tasks (
+    id                  TEXT PRIMARY KEY,
+    name                TEXT NOT NULL,
+    description         TEXT NOT NULL DEFAULT '',
+    prompt              TEXT NOT NULL,
+    agent_slug          TEXT NOT NULL DEFAULT '',
+    working_directory   TEXT NOT NULL DEFAULT '',
+    model               TEXT NOT NULL DEFAULT '',
+    settings_profile_id TEXT NOT NULL DEFAULT '',
+    timeout_minutes     INTEGER NOT NULL DEFAULT 30,
+    schedule_type       TEXT NOT NULL DEFAULT 'one_off',
+    schedule_config     TEXT NOT NULL DEFAULT '{}',
+    stop_after_count    INTEGER NOT NULL DEFAULT 0,
+    stop_after_time     DATETIME,
+    status              TEXT NOT NULL DEFAULT 'active',
+    run_count           INTEGER NOT NULL DEFAULT 0,
+    last_run_at         DATETIME,
+    last_run_status     TEXT NOT NULL DEFAULT '',
+    next_run_at         DATETIME,
+    created_at          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_scheduled_tasks_status ON scheduled_tasks(status);
+CREATE INDEX idx_scheduled_tasks_next_run ON scheduled_tasks(next_run_at);
+
+CREATE TABLE job_history (
+    id                          TEXT PRIMARY KEY,
+    task_id                     TEXT NOT NULL REFERENCES scheduled_tasks(id) ON DELETE CASCADE,
+    task_name                   TEXT NOT NULL,
+    agent_slug                  TEXT NOT NULL DEFAULT '',
+    status                      TEXT NOT NULL DEFAULT 'running',
+    started_at                  DATETIME NOT NULL,
+    finished_at                 DATETIME,
+    duration_ms                 INTEGER NOT NULL DEFAULT 0,
+    chat_session_id             TEXT NOT NULL DEFAULT '',
+    model                       TEXT NOT NULL DEFAULT '',
+    prompt_preview              TEXT NOT NULL DEFAULT '',
+    error_message               TEXT NOT NULL DEFAULT '',
+    total_input_tokens          INTEGER NOT NULL DEFAULT 0,
+    total_output_tokens         INTEGER NOT NULL DEFAULT 0,
+    total_cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+    total_cache_read_tokens     INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX idx_job_history_task ON job_history(task_id, started_at DESC);
+CREATE INDEX idx_job_history_started ON job_history(started_at DESC);
+`,
+	},
 }
 
 // NewSQLiteDB opens (or creates) a SQLite database at dbPath, configures

--- a/internal/storage/sqlite_task_store.go
+++ b/internal/storage/sqlite_task_store.go
@@ -1,0 +1,362 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// SQLiteTaskStore implements TaskStore backed by a SQLite database.
+type SQLiteTaskStore struct {
+	db *sql.DB
+}
+
+// NewSQLiteTaskStore returns a new SQLiteTaskStore.
+func NewSQLiteTaskStore(db *sql.DB) *SQLiteTaskStore {
+	return &SQLiteTaskStore{db: db}
+}
+
+// ListTasks returns all scheduled tasks ordered by creation time descending.
+func (s *SQLiteTaskStore) ListTasks() ([]*ScheduledTask, error) {
+	ctx := context.Background()
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, name, description, prompt, agent_slug, working_directory, model,
+		       settings_profile_id, timeout_minutes, schedule_type, schedule_config,
+		       stop_after_count, stop_after_time, status, run_count, last_run_at,
+		       last_run_status, next_run_at, created_at, updated_at
+		FROM scheduled_tasks
+		ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("listing tasks: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	tasks := make([]*ScheduledTask, 0)
+	for rows.Next() {
+		t, err := scanScheduledTask(rows)
+		if err != nil {
+			return nil, err
+		}
+		tasks = append(tasks, t)
+	}
+	return tasks, rows.Err()
+}
+
+// GetTask returns a scheduled task by ID, or nil if not found.
+func (s *SQLiteTaskStore) GetTask(id string) (*ScheduledTask, error) {
+	ctx := context.Background()
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, name, description, prompt, agent_slug, working_directory, model,
+		       settings_profile_id, timeout_minutes, schedule_type, schedule_config,
+		       stop_after_count, stop_after_time, status, run_count, last_run_at,
+		       last_run_status, next_run_at, created_at, updated_at
+		FROM scheduled_tasks WHERE id = ?`, id)
+
+	t := &ScheduledTask{}
+	var configJSON string
+	var stopAfterTime sql.NullTime
+	var lastRunAt sql.NullTime
+	var nextRunAt sql.NullTime
+
+	err := row.Scan(
+		&t.ID, &t.Name, &t.Description, &t.Prompt, &t.AgentSlug,
+		&t.WorkingDirectory, &t.Model, &t.SettingsProfileID, &t.TimeoutMinutes,
+		&t.ScheduleType, &configJSON, &t.StopAfterCount, &stopAfterTime,
+		&t.Status, &t.RunCount, &lastRunAt, &t.LastRunStatus, &nextRunAt,
+		&t.CreatedAt, &t.UpdatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("getting task %q: %w", id, err)
+	}
+
+	if err := json.Unmarshal([]byte(configJSON), &t.ScheduleConfig); err != nil {
+		return nil, fmt.Errorf("unmarshaling schedule config for task %q: %w", id, err)
+	}
+	if stopAfterTime.Valid {
+		t.StopAfterTime = &stopAfterTime.Time
+	}
+	if lastRunAt.Valid {
+		t.LastRunAt = &lastRunAt.Time
+	}
+	if nextRunAt.Valid {
+		t.NextRunAt = &nextRunAt.Time
+	}
+	return t, nil
+}
+
+// CreateTask inserts a new scheduled task.
+func (s *SQLiteTaskStore) CreateTask(task *ScheduledTask) error {
+	if task.ID == "" {
+		task.ID = uuid.New().String()
+	}
+	now := time.Now().UTC()
+	task.CreatedAt = now
+	task.UpdatedAt = now
+
+	configJSON, err := task.MarshalScheduleConfig()
+	if err != nil {
+		return fmt.Errorf("marshaling schedule config: %w", err)
+	}
+
+	ctx := context.Background()
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO scheduled_tasks
+			(id, name, description, prompt, agent_slug, working_directory, model,
+			 settings_profile_id, timeout_minutes, schedule_type, schedule_config,
+			 stop_after_count, stop_after_time, status, run_count, last_run_at,
+			 last_run_status, next_run_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		task.ID, task.Name, task.Description, task.Prompt, task.AgentSlug,
+		task.WorkingDirectory, task.Model, task.SettingsProfileID, task.TimeoutMinutes,
+		task.ScheduleType, configJSON, task.StopAfterCount, task.StopAfterTime,
+		task.Status, task.RunCount, task.LastRunAt, task.LastRunStatus, task.NextRunAt,
+		task.CreatedAt, task.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("creating task: %w", err)
+	}
+	return nil
+}
+
+// UpdateTask updates an existing scheduled task.
+func (s *SQLiteTaskStore) UpdateTask(task *ScheduledTask) error {
+	task.UpdatedAt = time.Now().UTC()
+
+	configJSON, err := task.MarshalScheduleConfig()
+	if err != nil {
+		return fmt.Errorf("marshaling schedule config: %w", err)
+	}
+
+	ctx := context.Background()
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE scheduled_tasks SET
+			name = ?, description = ?, prompt = ?, agent_slug = ?,
+			working_directory = ?, model = ?, settings_profile_id = ?,
+			timeout_minutes = ?, schedule_type = ?, schedule_config = ?,
+			stop_after_count = ?, stop_after_time = ?, status = ?,
+			run_count = ?, last_run_at = ?, last_run_status = ?,
+			next_run_at = ?, updated_at = ?
+		WHERE id = ?`,
+		task.Name, task.Description, task.Prompt, task.AgentSlug,
+		task.WorkingDirectory, task.Model, task.SettingsProfileID,
+		task.TimeoutMinutes, task.ScheduleType, configJSON,
+		task.StopAfterCount, task.StopAfterTime, task.Status,
+		task.RunCount, task.LastRunAt, task.LastRunStatus,
+		task.NextRunAt, task.UpdatedAt, task.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("updating task %q: %w", task.ID, err)
+	}
+	n, rowErr := res.RowsAffected()
+	if rowErr != nil {
+		return fmt.Errorf("checking rows affected for task %q: %w", task.ID, rowErr)
+	}
+	if n == 0 {
+		return fmt.Errorf("task %q not found", task.ID)
+	}
+	return nil
+}
+
+// DeleteTask deletes a scheduled task and its job history (via CASCADE).
+func (s *SQLiteTaskStore) DeleteTask(id string) error {
+	ctx := context.Background()
+	res, err := s.db.ExecContext(ctx, "DELETE FROM scheduled_tasks WHERE id = ?", id)
+	if err != nil {
+		return fmt.Errorf("deleting task %q: %w", id, err)
+	}
+	n, rowErr := res.RowsAffected()
+	if rowErr != nil {
+		return fmt.Errorf("checking rows affected for task %q: %w", id, rowErr)
+	}
+	if n == 0 {
+		return fmt.Errorf("task %q not found", id)
+	}
+	return nil
+}
+
+// ListJobHistory returns job history entries for a specific task.
+func (s *SQLiteTaskStore) ListJobHistory(taskID string, limit int) ([]*JobHistory, error) {
+	ctx := context.Background()
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, task_id, task_name, agent_slug, status, started_at, finished_at,
+		       duration_ms, chat_session_id, model, prompt_preview, error_message,
+		       total_input_tokens, total_output_tokens,
+		       total_cache_creation_tokens, total_cache_read_tokens
+		FROM job_history
+		WHERE task_id = ?
+		ORDER BY started_at DESC
+		LIMIT ?`, taskID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("listing job history for task %q: %w", taskID, err)
+	}
+	defer rows.Close() //nolint:errcheck
+	return scanJobHistoryRows(rows)
+}
+
+// ListAllJobHistory returns all job history entries with pagination.
+func (s *SQLiteTaskStore) ListAllJobHistory(limit, offset int) ([]*JobHistory, error) {
+	ctx := context.Background()
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, task_id, task_name, agent_slug, status, started_at, finished_at,
+		       duration_ms, chat_session_id, model, prompt_preview, error_message,
+		       total_input_tokens, total_output_tokens,
+		       total_cache_creation_tokens, total_cache_read_tokens
+		FROM job_history
+		ORDER BY started_at DESC
+		LIMIT ? OFFSET ?`, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("listing all job history: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+	return scanJobHistoryRows(rows)
+}
+
+// GetJobHistory returns a single job history entry by ID, or nil if not found.
+func (s *SQLiteTaskStore) GetJobHistory(id string) (*JobHistory, error) {
+	ctx := context.Background()
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, task_id, task_name, agent_slug, status, started_at, finished_at,
+		       duration_ms, chat_session_id, model, prompt_preview, error_message,
+		       total_input_tokens, total_output_tokens,
+		       total_cache_creation_tokens, total_cache_read_tokens
+		FROM job_history WHERE id = ?`, id)
+
+	jh, err := scanJobHistoryRow(row)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("getting job history %q: %w", id, err)
+	}
+	return jh, nil
+}
+
+// CreateJobHistory inserts a new job history record.
+func (s *SQLiteTaskStore) CreateJobHistory(jh *JobHistory) error {
+	if jh.ID == "" {
+		jh.ID = uuid.New().String()
+	}
+
+	ctx := context.Background()
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO job_history
+			(id, task_id, task_name, agent_slug, status, started_at, finished_at,
+			 duration_ms, chat_session_id, model, prompt_preview, error_message,
+			 total_input_tokens, total_output_tokens,
+			 total_cache_creation_tokens, total_cache_read_tokens)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		jh.ID, jh.TaskID, jh.TaskName, jh.AgentSlug, jh.Status,
+		jh.StartedAt, jh.FinishedAt, jh.DurationMS, jh.ChatSessionID,
+		jh.Model, jh.PromptPreview, jh.ErrorMessage,
+		jh.TotalInputTokens, jh.TotalOutputTokens,
+		jh.TotalCacheCreationTokens, jh.TotalCacheReadTokens,
+	)
+	if err != nil {
+		return fmt.Errorf("creating job history: %w", err)
+	}
+	return nil
+}
+
+// UpdateJobHistory updates an existing job history record.
+func (s *SQLiteTaskStore) UpdateJobHistory(jh *JobHistory) error {
+	ctx := context.Background()
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE job_history SET
+			status = ?, finished_at = ?, duration_ms = ?, chat_session_id = ?,
+			error_message = ?, total_input_tokens = ?, total_output_tokens = ?,
+			total_cache_creation_tokens = ?, total_cache_read_tokens = ?
+		WHERE id = ?`,
+		jh.Status, jh.FinishedAt, jh.DurationMS, jh.ChatSessionID,
+		jh.ErrorMessage, jh.TotalInputTokens, jh.TotalOutputTokens,
+		jh.TotalCacheCreationTokens, jh.TotalCacheReadTokens, jh.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("updating job history %q: %w", jh.ID, err)
+	}
+	return nil
+}
+
+// scanScheduledTask scans a scheduled task from a row set.
+func scanScheduledTask(rows *sql.Rows) (*ScheduledTask, error) {
+	t := &ScheduledTask{}
+	var configJSON string
+	var stopAfterTime sql.NullTime
+	var lastRunAt sql.NullTime
+	var nextRunAt sql.NullTime
+
+	err := rows.Scan(
+		&t.ID, &t.Name, &t.Description, &t.Prompt, &t.AgentSlug,
+		&t.WorkingDirectory, &t.Model, &t.SettingsProfileID, &t.TimeoutMinutes,
+		&t.ScheduleType, &configJSON, &t.StopAfterCount, &stopAfterTime,
+		&t.Status, &t.RunCount, &lastRunAt, &t.LastRunStatus, &nextRunAt,
+		&t.CreatedAt, &t.UpdatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("scanning task: %w", err)
+	}
+
+	if err := json.Unmarshal([]byte(configJSON), &t.ScheduleConfig); err != nil {
+		return nil, fmt.Errorf("unmarshaling schedule config: %w", err)
+	}
+	if stopAfterTime.Valid {
+		t.StopAfterTime = &stopAfterTime.Time
+	}
+	if lastRunAt.Valid {
+		t.LastRunAt = &lastRunAt.Time
+	}
+	if nextRunAt.Valid {
+		t.NextRunAt = &nextRunAt.Time
+	}
+	return t, nil
+}
+
+// scanJobHistoryRows scans multiple job history rows.
+func scanJobHistoryRows(rows *sql.Rows) ([]*JobHistory, error) {
+	results := make([]*JobHistory, 0)
+	for rows.Next() {
+		jh := &JobHistory{}
+		var finishedAt sql.NullTime
+		err := rows.Scan(
+			&jh.ID, &jh.TaskID, &jh.TaskName, &jh.AgentSlug, &jh.Status,
+			&jh.StartedAt, &finishedAt, &jh.DurationMS, &jh.ChatSessionID,
+			&jh.Model, &jh.PromptPreview, &jh.ErrorMessage,
+			&jh.TotalInputTokens, &jh.TotalOutputTokens,
+			&jh.TotalCacheCreationTokens, &jh.TotalCacheReadTokens,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("scanning job history: %w", err)
+		}
+		if finishedAt.Valid {
+			jh.FinishedAt = &finishedAt.Time
+		}
+		results = append(results, jh)
+	}
+	return results, rows.Err()
+}
+
+// scanJobHistoryRow scans a single job history row.
+func scanJobHistoryRow(row *sql.Row) (*JobHistory, error) {
+	jh := &JobHistory{}
+	var finishedAt sql.NullTime
+	err := row.Scan(
+		&jh.ID, &jh.TaskID, &jh.TaskName, &jh.AgentSlug, &jh.Status,
+		&jh.StartedAt, &finishedAt, &jh.DurationMS, &jh.ChatSessionID,
+		&jh.Model, &jh.PromptPreview, &jh.ErrorMessage,
+		&jh.TotalInputTokens, &jh.TotalOutputTokens,
+		&jh.TotalCacheCreationTokens, &jh.TotalCacheReadTokens,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if finishedAt.Valid {
+		jh.FinishedAt = &finishedAt.Time
+	}
+	return jh, nil
+}

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -44,8 +44,8 @@ func TestNewSQLiteDB_MigrationVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("querying version: %v", err)
 	}
-	if version != 2 {
-		t.Errorf("expected version 2, got %d", version)
+	if version != 3 {
+		t.Errorf("expected version 3, got %d", version)
 	}
 }
 

--- a/internal/storage/task_store.go
+++ b/internal/storage/task_store.go
@@ -1,0 +1,116 @@
+package storage
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// ScheduleType defines the kind of schedule for a task.
+type ScheduleType string
+
+// Schedule type constants for task scheduling.
+const (
+	ScheduleOneOff   ScheduleType = "one_off"
+	ScheduleInterval ScheduleType = "interval"
+	ScheduleCron     ScheduleType = "cron"
+)
+
+// TaskStatus defines the lifecycle state of a scheduled task.
+type TaskStatus string
+
+// Task status constants for lifecycle management.
+const (
+	TaskStatusActive TaskStatus = "active"
+	TaskStatusPaused TaskStatus = "paused"
+)
+
+// JobStatus defines the outcome of a single job execution.
+type JobStatus string
+
+// Job status constants for execution outcomes.
+const (
+	JobStatusRunning JobStatus = "running"
+	JobStatusSuccess JobStatus = "success"
+	JobStatusFailed  JobStatus = "failed"
+)
+
+// ScheduleConfig holds the schedule-type-specific configuration as JSON.
+type ScheduleConfig struct {
+	// One-off
+	RunAt string `json:"run_at,omitempty"`
+	// Interval
+	EveryMinutes int    `json:"every_minutes,omitempty"`
+	EveryHours   int    `json:"every_hours,omitempty"`
+	EveryDays    int    `json:"every_days,omitempty"`
+	AtTime       string `json:"at_time,omitempty"` // HH:MM for daily intervals
+	// Cron
+	Expression string `json:"expression,omitempty"`
+}
+
+// ScheduledTask represents a task that can be run on a schedule.
+type ScheduledTask struct {
+	ID                string         `json:"id"`
+	Name              string         `json:"name"`
+	Description       string         `json:"description"`
+	Prompt            string         `json:"prompt"`
+	AgentSlug         string         `json:"agent_slug"`
+	WorkingDirectory  string         `json:"working_directory"`
+	Model             string         `json:"model"`
+	SettingsProfileID string         `json:"settings_profile_id"`
+	TimeoutMinutes    int            `json:"timeout_minutes"`
+	ScheduleType      ScheduleType   `json:"schedule_type"`
+	ScheduleConfig    ScheduleConfig `json:"schedule_config"`
+	StopAfterCount    int            `json:"stop_after_count"`
+	StopAfterTime     *time.Time     `json:"stop_after_time,omitempty"`
+	Status            TaskStatus     `json:"status"`
+	RunCount          int            `json:"run_count"`
+	LastRunAt         *time.Time     `json:"last_run_at,omitempty"`
+	LastRunStatus     string         `json:"last_run_status"`
+	NextRunAt         *time.Time     `json:"next_run_at,omitempty"`
+	CreatedAt         time.Time      `json:"created_at"`
+	UpdatedAt         time.Time      `json:"updated_at"`
+}
+
+// MarshalScheduleConfig returns the JSON encoding of the schedule config.
+func (t *ScheduledTask) MarshalScheduleConfig() (string, error) {
+	b, err := json.Marshal(t.ScheduleConfig)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// JobHistory records the result of a single task execution.
+type JobHistory struct {
+	ID                       string     `json:"id"`
+	TaskID                   string     `json:"task_id"`
+	TaskName                 string     `json:"task_name"`
+	AgentSlug                string     `json:"agent_slug"`
+	Status                   JobStatus  `json:"status"`
+	StartedAt                time.Time  `json:"started_at"`
+	FinishedAt               *time.Time `json:"finished_at,omitempty"`
+	DurationMS               int64      `json:"duration_ms"`
+	ChatSessionID            string     `json:"chat_session_id"`
+	Model                    string     `json:"model"`
+	PromptPreview            string     `json:"prompt_preview"`
+	ErrorMessage             string     `json:"error_message"`
+	TotalInputTokens         int        `json:"total_input_tokens"`
+	TotalOutputTokens        int        `json:"total_output_tokens"`
+	TotalCacheCreationTokens int        `json:"total_cache_creation_tokens"`
+	TotalCacheReadTokens     int        `json:"total_cache_read_tokens"`
+}
+
+// TaskStore defines the persistence interface for scheduled tasks and job history.
+type TaskStore interface {
+	ListTasks() ([]*ScheduledTask, error)
+	GetTask(id string) (*ScheduledTask, error)
+	CreateTask(task *ScheduledTask) error
+	UpdateTask(task *ScheduledTask) error
+	DeleteTask(id string) error
+
+	ListJobHistory(taskID string, limit int) ([]*JobHistory, error)
+	ListAllJobHistory(limit, offset int) ([]*JobHistory, error)
+	GetJobHistory(id string) (*JobHistory, error)
+	CreateJobHistory(jh *JobHistory) error
+	UpdateJobHistory(jh *JobHistory) error
+}


### PR DESCRIPTION
## Summary

- Complete task scheduling system: one-time, interval, and cron-based schedules for agent tasks
- Background job executor using `go-co-op/gocron/v2` with concurrency semaphore, running tasks via `agent.RunAgent()`
- Full management UI: task CRUD, pause/resume (resets run counter), job history with detail dialog
- Model resolution refactored: removed all hardcoded model IDs, SettingsManager is now the single source of truth, dropdowns use abstract `sonnet`/`opus`/`haiku` names that Claude CLI resolves
- Proper local timezone handling for datetime pickers (UTC conversions happen behind the scenes)
- 22 unit tests for TaskService with mocks

## Changes

**New files:**
- `internal/storage/task_store.go` — types, interfaces
- `internal/storage/sqlite_task_store.go` — SQLite implementation
- `internal/service/task_service.go` — business logic with validation
- `internal/scheduler/scheduler.go` — gocron wrapper
- `internal/scheduler/executor.go` — task execution engine
- `internal/api/tasks.go` — 11 REST endpoints
- `frontend/src/pages/TasksPage.tsx`, `TaskCreatePage.tsx`, `TaskEditPage.tsx`, `JobHistoriesPage.tsx`
- `frontend/src/components/TaskForm.tsx`
- Test and mock files

**Modified files:**
- `internal/storage/sqlite.go` — migration v3
- `internal/service/chat_service.go` — uses SettingsManager instead of hardcoded model string
- `internal/config/settings.go`, `app_config.go` — default model changed to `sonnet`
- `internal/api/server.go`, `cmd/web.go` — wiring
- `frontend/src/types.ts` — MODELS simplified to sonnet/opus/haiku
- `frontend/src/components/AgentForm.tsx` — "Default (from settings)" option added

## Test plan

- [x] `make test` — all existing + 22 new tests pass
- [x] `npm run typecheck && npm run lint` — clean
- [x] golangci-lint — all hooks pass
- [ ] Create a one-off task via UI, verify it executes at scheduled time
- [ ] Create a recurring task (interval), verify multiple executions, pause, verify no more runs
- [ ] Verify job history shows entries with session links
- [ ] Verify stop conditions work (stop after N runs)
- [ ] Verify resume resets run counter

🤖 Generated with [Claude Code](https://claude.com/claude-code)