### PR TITLE
feat: save task output to job history with opt-in toggle

### DIFF
--- a/frontend/src/components/TaskForm.tsx
+++ b/frontend/src/components/TaskForm.tsx
@@ -39,6 +39,7 @@ export default function TaskForm({ initialData, isEdit }: TaskFormProps) {
   )
   const [stopAfterCount, setStopAfterCount] = useState(initialData?.stop_after_count ?? 0)
   const [stopAfterTime, setStopAfterTime] = useState(initialData?.stop_after_time ?? '')
+  const [saveOutput, setSaveOutput] = useState(initialData?.save_output ?? false)
 
   useEffect(() => {
     agentsApi
@@ -64,6 +65,7 @@ export default function TaskForm({ initialData, isEdit }: TaskFormProps) {
       schedule_config: scheduleConfig,
       stop_after_count: stopAfterCount,
       stop_after_time: stopAfterTime || undefined,
+      save_output: saveOutput,
     }
 
     try {
@@ -379,6 +381,31 @@ export default function TaskForm({ initialData, isEdit }: TaskFormProps) {
                   onChange={e => setTimeoutMinutes(Number(e.target.value))}
                   className={inputClass}
                 />
+              </div>
+              <div className="flex items-start gap-3 pt-1">
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={saveOutput}
+                  onClick={() => setSaveOutput(v => !v)}
+                  className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus:outline-none focus:ring-2 focus:ring-zinc-400 dark:focus:ring-zinc-500 ${
+                    saveOutput ? 'bg-zinc-900 dark:bg-zinc-100' : 'bg-zinc-200 dark:bg-zinc-700'
+                  }`}
+                >
+                  <span
+                    className={`pointer-events-none inline-block h-4 w-4 rounded-full bg-white dark:bg-zinc-900 shadow transition-transform ${
+                      saveOutput ? 'translate-x-4' : 'translate-x-0'
+                    }`}
+                  />
+                </button>
+                <div>
+                  <p className="text-xs font-medium text-zinc-700 dark:text-zinc-300">
+                    Save output
+                  </p>
+                  <p className="text-xs text-zinc-400 dark:text-zinc-500 mt-0.5">
+                    Store the AI response in job history
+                  </p>
+                </div>
               </div>
             </section>
           </div>

--- a/frontend/src/pages/JobHistoriesPage.tsx
+++ b/frontend/src/pages/JobHistoriesPage.tsx
@@ -186,74 +186,89 @@ export default function JobHistoriesPage() {
           if (!open) setSelected(null)
         }}
       >
-        <DialogContent className="max-w-lg">
+        <DialogContent className="max-w-lg max-h-[80vh] flex flex-col overflow-hidden">
           {selected && (
             <>
-              <DialogHeader>
+              <DialogHeader className="shrink-0">
                 <DialogTitle className="flex items-center gap-2">
                   {selected.task_name}
                   <JobStatusBadge status={selected.status} />
                 </DialogTitle>
               </DialogHeader>
 
-              <dl className="grid grid-cols-2 gap-x-4 gap-y-3 mt-2">
-                <DetailRow label="Started">
-                  {new Date(selected.started_at).toLocaleString()}
-                </DetailRow>
-                <DetailRow label="Duration">
-                  {selected.duration_ms > 0 ? formatDuration(selected.duration_ms) : '-'}
-                </DetailRow>
-                {selected.agent_slug && (
-                  <DetailRow label="Agent">
-                    <span className="font-mono">{selected.agent_slug}</span>
+              <div className="overflow-y-auto flex-1 pr-1">
+                <dl className="grid grid-cols-2 gap-x-4 gap-y-3 mt-2">
+                  <DetailRow label="Started">
+                    {new Date(selected.started_at).toLocaleString()}
                   </DetailRow>
-                )}
-                {selected.model && (
-                  <DetailRow label="Model">
-                    <span className="font-mono">{selected.model}</span>
+                  <DetailRow label="Duration">
+                    {selected.duration_ms > 0 ? formatDuration(selected.duration_ms) : '-'}
                   </DetailRow>
-                )}
-                <DetailRow label="Input tokens">
-                  {selected.total_input_tokens.toLocaleString()}
-                </DetailRow>
-                <DetailRow label="Output tokens">
-                  {selected.total_output_tokens.toLocaleString()}
-                </DetailRow>
-                {(selected.total_cache_read_tokens > 0 ||
-                  selected.total_cache_creation_tokens > 0) && (
-                  <>
-                    <DetailRow label="Cache read">
-                      {selected.total_cache_read_tokens.toLocaleString()}
+                  {selected.agent_slug && (
+                    <DetailRow label="Agent">
+                      <span className="font-mono">{selected.agent_slug}</span>
                     </DetailRow>
-                    <DetailRow label="Cache creation">
-                      {selected.total_cache_creation_tokens.toLocaleString()}
+                  )}
+                  {selected.model && (
+                    <DetailRow label="Model">
+                      <span className="font-mono">{selected.model}</span>
                     </DetailRow>
-                  </>
+                  )}
+                  <DetailRow label="Input tokens">
+                    {selected.total_input_tokens.toLocaleString()}
+                  </DetailRow>
+                  <DetailRow label="Output tokens">
+                    {selected.total_output_tokens.toLocaleString()}
+                  </DetailRow>
+                  {(selected.total_cache_read_tokens > 0 ||
+                    selected.total_cache_creation_tokens > 0) && (
+                    <>
+                      <DetailRow label="Cache read">
+                        {selected.total_cache_read_tokens.toLocaleString()}
+                      </DetailRow>
+                      <DetailRow label="Cache creation">
+                        {selected.total_cache_creation_tokens.toLocaleString()}
+                      </DetailRow>
+                    </>
+                  )}
+                </dl>
+
+                {selected.prompt_preview && (
+                  <div className="mt-3">
+                    <p className="text-xs font-medium text-zinc-500 dark:text-zinc-400 mb-1">
+                      Prompt
+                    </p>
+                    <p className="text-sm text-zinc-700 dark:text-zinc-300 bg-zinc-50 dark:bg-zinc-800 rounded-md px-3 py-2 whitespace-pre-wrap break-words">
+                      {selected.prompt_preview}
+                    </p>
+                  </div>
                 )}
-              </dl>
 
-              {selected.prompt_preview && (
-                <div className="mt-3">
-                  <p className="text-xs font-medium text-zinc-500 dark:text-zinc-400 mb-1">
-                    Prompt
-                  </p>
-                  <p className="text-sm text-zinc-700 dark:text-zinc-300 bg-zinc-50 dark:bg-zinc-800 rounded-md px-3 py-2 whitespace-pre-wrap break-words">
-                    {selected.prompt_preview}
-                  </p>
-                </div>
-              )}
+                {selected.response_text && (
+                  <div className="mt-3">
+                    <p className="text-xs font-medium text-zinc-500 dark:text-zinc-400 mb-1">
+                      Output
+                    </p>
+                    <div className="max-h-64 overflow-y-auto rounded-md bg-zinc-50 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700">
+                      <p className="text-sm text-zinc-700 dark:text-zinc-300 px-3 py-2 whitespace-pre-wrap break-words">
+                        {selected.response_text}
+                      </p>
+                    </div>
+                  </div>
+                )}
 
-              {selected.error_message && (
-                <div className="mt-3">
-                  <p className="text-xs font-medium text-red-500 dark:text-red-400 mb-1">Error</p>
-                  <p className="text-sm text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md px-3 py-2 whitespace-pre-wrap break-words">
-                    {selected.error_message}
-                  </p>
-                </div>
-              )}
+                {selected.error_message && (
+                  <div className="mt-3">
+                    <p className="text-xs font-medium text-red-500 dark:text-red-400 mb-1">Error</p>
+                    <p className="text-sm text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md px-3 py-2 whitespace-pre-wrap break-words">
+                      {selected.error_message}
+                    </p>
+                  </div>
+                )}
+              </div>
 
               {selected.chat_session_id && (
-                <div className="mt-4 pt-3 border-t border-zinc-100 dark:border-zinc-800">
+                <div className="mt-4 pt-3 border-t border-zinc-100 dark:border-zinc-800 shrink-0">
                   <Button
                     size="sm"
                     onClick={() => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -575,6 +575,7 @@ export interface ScheduledTask {
   schedule_config: ScheduleConfig
   stop_after_count: number
   stop_after_time?: string
+  save_output: boolean
   status: TaskStatus
   run_count: number
   last_run_at?: string
@@ -601,6 +602,7 @@ export interface JobHistoryEntry {
   total_output_tokens: number
   total_cache_creation_tokens: number
   total_cache_read_tokens: number
+  response_text: string
 }
 
 // ── Analytics ─────────────────────────────────────────────────────────────────

--- a/internal/scheduler/executor.go
+++ b/internal/scheduler/executor.go
@@ -95,7 +95,7 @@ func (s *Scheduler) runTask(task *storage.ScheduledTask) {
 		s.logger.Error("failed to resolve agent config",
 			"task_id", task.ID, "error", err)
 		s.finishJobHistory(jh, startedAt, storage.JobStatusFailed,
-			errMsg, agent.UsageStats{})
+			errMsg, agent.UsageStats{}, "")
 		s.updateTaskAfterRun(task, startedAt, "failed")
 		s.publishTaskFailed(task, errMsg)
 		return
@@ -112,15 +112,19 @@ func (s *Scheduler) runTask(task *storage.ScheduledTask) {
 		s.logger.Error("task execution failed",
 			"task_id", task.ID, "error", err)
 		s.finishJobHistory(jh, startedAt, storage.JobStatusFailed,
-			err.Error(), agent.UsageStats{})
+			err.Error(), agent.UsageStats{}, "")
 		s.updateTaskAfterRun(task, startedAt, "failed")
 		s.publishTaskFailed(task, err.Error())
 		return
 	}
 
 	s.saveSessionResults(chatSession, result, prompt, startedAt)
+	responseText := ""
+	if task.SaveOutput {
+		responseText = result.Answer
+	}
 	s.finishJobHistory(
-		jh, startedAt, storage.JobStatusSuccess, "", result.Usage,
+		jh, startedAt, storage.JobStatusSuccess, "", result.Usage, responseText,
 	)
 	s.updateTaskAfterRun(task, startedAt, "success")
 	s.publishTaskFinished(task, jh, chatSession.ID)
@@ -257,12 +261,14 @@ func (s *Scheduler) resolveAgentConfig(task *storage.ScheduledTask) (*config.Age
 func (s *Scheduler) finishJobHistory(
 	jh *storage.JobHistory, startedAt time.Time,
 	status storage.JobStatus, errMsg string, usage agent.UsageStats,
+	responseText string,
 ) {
 	now := time.Now().UTC()
 	jh.Status = status
 	jh.FinishedAt = &now
 	jh.DurationMS = now.Sub(startedAt).Milliseconds()
 	jh.ErrorMessage = errMsg
+	jh.ResponseText = responseText
 	jh.TotalInputTokens = usage.InputTokens
 	jh.TotalOutputTokens = usage.OutputTokens
 	jh.TotalCacheCreationTokens = usage.CacheCreationInputTokens

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -184,6 +184,14 @@ CREATE TABLE notification_log (
 CREATE INDEX idx_notification_log_created ON notification_log(created_at DESC);
 `,
 	},
+	{
+		version: 5,
+		sql:     `ALTER TABLE job_history ADD COLUMN response_text TEXT NOT NULL DEFAULT '';`,
+	},
+	{
+		version: 6,
+		sql:     `ALTER TABLE scheduled_tasks ADD COLUMN save_output INTEGER NOT NULL DEFAULT 0;`,
+	},
 }
 
 // NewSQLiteDB opens (or creates) a SQLite database at dbPath, configures

--- a/internal/storage/sqlite_task_store.go
+++ b/internal/storage/sqlite_task_store.go
@@ -26,7 +26,7 @@ func (s *SQLiteTaskStore) ListTasks() ([]*ScheduledTask, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, name, description, prompt, agent_slug, working_directory, model,
 		       settings_profile_id, timeout_minutes, schedule_type, schedule_config,
-		       stop_after_count, stop_after_time, status, run_count, last_run_at,
+		       stop_after_count, stop_after_time, save_output, status, run_count, last_run_at,
 		       last_run_status, next_run_at, created_at, updated_at
 		FROM scheduled_tasks
 		ORDER BY created_at DESC`)
@@ -52,7 +52,7 @@ func (s *SQLiteTaskStore) GetTask(id string) (*ScheduledTask, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, name, description, prompt, agent_slug, working_directory, model,
 		       settings_profile_id, timeout_minutes, schedule_type, schedule_config,
-		       stop_after_count, stop_after_time, status, run_count, last_run_at,
+		       stop_after_count, stop_after_time, save_output, status, run_count, last_run_at,
 		       last_run_status, next_run_at, created_at, updated_at
 		FROM scheduled_tasks WHERE id = ?`, id)
 
@@ -65,7 +65,7 @@ func (s *SQLiteTaskStore) GetTask(id string) (*ScheduledTask, error) {
 	err := row.Scan(
 		&t.ID, &t.Name, &t.Description, &t.Prompt, &t.AgentSlug,
 		&t.WorkingDirectory, &t.Model, &t.SettingsProfileID, &t.TimeoutMinutes,
-		&t.ScheduleType, &configJSON, &t.StopAfterCount, &stopAfterTime,
+		&t.ScheduleType, &configJSON, &t.StopAfterCount, &stopAfterTime, &t.SaveOutput,
 		&t.Status, &t.RunCount, &lastRunAt, &t.LastRunStatus, &nextRunAt,
 		&t.CreatedAt, &t.UpdatedAt,
 	)
@@ -110,12 +110,12 @@ func (s *SQLiteTaskStore) CreateTask(task *ScheduledTask) error {
 		INSERT INTO scheduled_tasks
 			(id, name, description, prompt, agent_slug, working_directory, model,
 			 settings_profile_id, timeout_minutes, schedule_type, schedule_config,
-			 stop_after_count, stop_after_time, status, run_count, last_run_at,
+			 stop_after_count, stop_after_time, save_output, status, run_count, last_run_at,
 			 last_run_status, next_run_at, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		task.ID, task.Name, task.Description, task.Prompt, task.AgentSlug,
 		task.WorkingDirectory, task.Model, task.SettingsProfileID, task.TimeoutMinutes,
-		task.ScheduleType, configJSON, task.StopAfterCount, task.StopAfterTime,
+		task.ScheduleType, configJSON, task.StopAfterCount, task.StopAfterTime, task.SaveOutput,
 		task.Status, task.RunCount, task.LastRunAt, task.LastRunStatus, task.NextRunAt,
 		task.CreatedAt, task.UpdatedAt,
 	)
@@ -140,14 +140,14 @@ func (s *SQLiteTaskStore) UpdateTask(task *ScheduledTask) error {
 			name = ?, description = ?, prompt = ?, agent_slug = ?,
 			working_directory = ?, model = ?, settings_profile_id = ?,
 			timeout_minutes = ?, schedule_type = ?, schedule_config = ?,
-			stop_after_count = ?, stop_after_time = ?, status = ?,
+			stop_after_count = ?, stop_after_time = ?, save_output = ?, status = ?,
 			run_count = ?, last_run_at = ?, last_run_status = ?,
 			next_run_at = ?, updated_at = ?
 		WHERE id = ?`,
 		task.Name, task.Description, task.Prompt, task.AgentSlug,
 		task.WorkingDirectory, task.Model, task.SettingsProfileID,
 		task.TimeoutMinutes, task.ScheduleType, configJSON,
-		task.StopAfterCount, task.StopAfterTime, task.Status,
+		task.StopAfterCount, task.StopAfterTime, task.SaveOutput, task.Status,
 		task.RunCount, task.LastRunAt, task.LastRunStatus,
 		task.NextRunAt, task.UpdatedAt, task.ID,
 	)
@@ -188,7 +188,7 @@ func (s *SQLiteTaskStore) ListJobHistory(taskID string, limit int) ([]*JobHistor
 		SELECT id, task_id, task_name, agent_slug, status, started_at, finished_at,
 		       duration_ms, chat_session_id, model, prompt_preview, error_message,
 		       total_input_tokens, total_output_tokens,
-		       total_cache_creation_tokens, total_cache_read_tokens
+		       total_cache_creation_tokens, total_cache_read_tokens, response_text
 		FROM job_history
 		WHERE task_id = ?
 		ORDER BY started_at DESC
@@ -207,7 +207,7 @@ func (s *SQLiteTaskStore) ListAllJobHistory(limit, offset int) ([]*JobHistory, e
 		SELECT id, task_id, task_name, agent_slug, status, started_at, finished_at,
 		       duration_ms, chat_session_id, model, prompt_preview, error_message,
 		       total_input_tokens, total_output_tokens,
-		       total_cache_creation_tokens, total_cache_read_tokens
+		       total_cache_creation_tokens, total_cache_read_tokens, response_text
 		FROM job_history
 		ORDER BY started_at DESC
 		LIMIT ? OFFSET ?`, limit, offset)
@@ -225,7 +225,7 @@ func (s *SQLiteTaskStore) GetJobHistory(id string) (*JobHistory, error) {
 		SELECT id, task_id, task_name, agent_slug, status, started_at, finished_at,
 		       duration_ms, chat_session_id, model, prompt_preview, error_message,
 		       total_input_tokens, total_output_tokens,
-		       total_cache_creation_tokens, total_cache_read_tokens
+		       total_cache_creation_tokens, total_cache_read_tokens, response_text
 		FROM job_history WHERE id = ?`, id)
 
 	jh, err := scanJobHistoryRow(row)
@@ -250,13 +250,13 @@ func (s *SQLiteTaskStore) CreateJobHistory(jh *JobHistory) error {
 			(id, task_id, task_name, agent_slug, status, started_at, finished_at,
 			 duration_ms, chat_session_id, model, prompt_preview, error_message,
 			 total_input_tokens, total_output_tokens,
-			 total_cache_creation_tokens, total_cache_read_tokens)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			 total_cache_creation_tokens, total_cache_read_tokens, response_text)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		jh.ID, jh.TaskID, jh.TaskName, jh.AgentSlug, jh.Status,
 		jh.StartedAt, jh.FinishedAt, jh.DurationMS, jh.ChatSessionID,
 		jh.Model, jh.PromptPreview, jh.ErrorMessage,
 		jh.TotalInputTokens, jh.TotalOutputTokens,
-		jh.TotalCacheCreationTokens, jh.TotalCacheReadTokens,
+		jh.TotalCacheCreationTokens, jh.TotalCacheReadTokens, jh.ResponseText,
 	)
 	if err != nil {
 		return fmt.Errorf("creating job history: %w", err)
@@ -271,11 +271,13 @@ func (s *SQLiteTaskStore) UpdateJobHistory(jh *JobHistory) error {
 		UPDATE job_history SET
 			status = ?, finished_at = ?, duration_ms = ?, chat_session_id = ?,
 			error_message = ?, total_input_tokens = ?, total_output_tokens = ?,
-			total_cache_creation_tokens = ?, total_cache_read_tokens = ?
+			total_cache_creation_tokens = ?, total_cache_read_tokens = ?,
+			response_text = ?
 		WHERE id = ?`,
 		jh.Status, jh.FinishedAt, jh.DurationMS, jh.ChatSessionID,
 		jh.ErrorMessage, jh.TotalInputTokens, jh.TotalOutputTokens,
-		jh.TotalCacheCreationTokens, jh.TotalCacheReadTokens, jh.ID,
+		jh.TotalCacheCreationTokens, jh.TotalCacheReadTokens,
+		jh.ResponseText, jh.ID,
 	)
 	if err != nil {
 		return fmt.Errorf("updating job history %q: %w", jh.ID, err)
@@ -294,7 +296,7 @@ func scanScheduledTask(rows *sql.Rows) (*ScheduledTask, error) {
 	err := rows.Scan(
 		&t.ID, &t.Name, &t.Description, &t.Prompt, &t.AgentSlug,
 		&t.WorkingDirectory, &t.Model, &t.SettingsProfileID, &t.TimeoutMinutes,
-		&t.ScheduleType, &configJSON, &t.StopAfterCount, &stopAfterTime,
+		&t.ScheduleType, &configJSON, &t.StopAfterCount, &stopAfterTime, &t.SaveOutput,
 		&t.Status, &t.RunCount, &lastRunAt, &t.LastRunStatus, &nextRunAt,
 		&t.CreatedAt, &t.UpdatedAt,
 	)
@@ -329,6 +331,7 @@ func scanJobHistoryRows(rows *sql.Rows) ([]*JobHistory, error) {
 			&jh.Model, &jh.PromptPreview, &jh.ErrorMessage,
 			&jh.TotalInputTokens, &jh.TotalOutputTokens,
 			&jh.TotalCacheCreationTokens, &jh.TotalCacheReadTokens,
+			&jh.ResponseText,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scanning job history: %w", err)
@@ -351,6 +354,7 @@ func scanJobHistoryRow(row *sql.Row) (*JobHistory, error) {
 		&jh.Model, &jh.PromptPreview, &jh.ErrorMessage,
 		&jh.TotalInputTokens, &jh.TotalOutputTokens,
 		&jh.TotalCacheCreationTokens, &jh.TotalCacheReadTokens,
+		&jh.ResponseText,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -44,8 +44,8 @@ func TestNewSQLiteDB_MigrationVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("querying version: %v", err)
 	}
-	if version != 4 {
-		t.Errorf("expected version 4, got %d", version)
+	if version != 6 {
+		t.Errorf("expected version 6, got %d", version)
 	}
 }
 

--- a/internal/storage/task_store.go
+++ b/internal/storage/task_store.go
@@ -62,6 +62,7 @@ type ScheduledTask struct {
 	ScheduleConfig    ScheduleConfig `json:"schedule_config"`
 	StopAfterCount    int            `json:"stop_after_count"`
 	StopAfterTime     *time.Time     `json:"stop_after_time,omitempty"`
+	SaveOutput        bool           `json:"save_output"`
 	Status            TaskStatus     `json:"status"`
 	RunCount          int            `json:"run_count"`
 	LastRunAt         *time.Time     `json:"last_run_at,omitempty"`
@@ -98,6 +99,7 @@ type JobHistory struct {
 	TotalOutputTokens        int        `json:"total_output_tokens"`
 	TotalCacheCreationTokens int        `json:"total_cache_creation_tokens"`
 	TotalCacheReadTokens     int        `json:"total_cache_read_tokens"`
+	ResponseText             string     `json:"response_text"`
 }
 
 // TaskStore defines the persistence interface for scheduled tasks and job history.


### PR DESCRIPTION
## Summary

- Adds two DB migrations: `response_text` on `job_history` (v5) and `save_output` on `scheduled_tasks` (v6)
- Task executor only persists the AI response when `save_output` is enabled on the task (default: off)
- Job history detail popup now shows a scrollable **Output** section when response text is present
- Task create/edit form has a new toggle in the **Advanced** section to enable output saving

## Test plan

- [x] Create a task with "Save output" toggled **off** → run it → confirm `response_text` is empty in job history popup
- [x] Create a task with "Save output" toggled **on** → run it → confirm the Output section appears in the job history popup with the full AI response
- [x] Verify existing tasks and job history records are unaffected (migration adds columns with safe defaults)
- [x] Edit an existing task and toggle save output on/off — confirm it persists correctly