### PR TITLE
fix: clear stale SDK session ID on streaming error

### DIFF
--- a/internal/api/chats.go
+++ b/internal/api/chats.go
@@ -401,11 +401,15 @@ func (s *Server) processAgentEvent(
 		if event.Result == nil {
 			return false
 		}
-		state.sdkSessionID = event.Result.SessionID
 		state.tokens.add(event.Result)
 		if event.Result.IsError {
+			// Clear the stale SDK session ID so the next attempt starts a fresh
+			// session instead of endlessly retrying a session that no longer exists
+			// (e.g. "No conversation found with session ID: ...").
+			state.sdkSessionID = ""
 			return true
 		}
+		state.sdkSessionID = event.Result.SessionID
 		state.assistantText = event.Result.Result
 
 		if state.pendingInput == nil {


### PR DESCRIPTION
## Summary

- Fixes a bug where sending a second message in a chat would permanently fail with **\"No conversation found with session ID: ...\"**

## Root Cause

When the Claude Code subprocess returns an error result (`IsError: true`), `processAgentEvent` was capturing `event.Result.SessionID` into `state.sdkSessionID` **before** checking for the error. This meant `CommitMessage` wrote the same stale/invalid session ID back to the database on every failure. Every subsequent message in that chat then tried to `--resume` the same dead session, looping forever.

## Fix

Move the `state.sdkSessionID = event.Result.SessionID` assignment to after the `IsError` check, and leave `state.sdkSessionID` empty (`""`) on error. `CommitMessage` then clears `SDKSession` in the DB, so the next message starts a fresh session without `--resume`.

```go
// Before
state.sdkSessionID = event.Result.SessionID
state.tokens.add(event.Result)
if event.Result.IsError {
    return true
}

// After
state.tokens.add(event.Result)
if event.Result.IsError {
    state.sdkSessionID = "" // cleared → CommitMessage wipes DB field
    return true
}
state.sdkSessionID = event.Result.SessionID
```

## Test plan

- [ ] Start a new chat, send a first message — works normally
- [ ] Trigger the error (e.g. use a session ID that no longer exists on disk) — second message shows the SDK error once, but clears the stale ID
- [ ] Send another message in the same chat — starts fresh, succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)