### PR TITLE
fix(frontend): associate labels with form controls for accessibility (#66)

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -11,7 +11,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Roboto:wght@400;500&family=Open+Sans:wght@400;600&family=Lato:wght@400;700&family=Merriweather:wght@400;700&family=JetBrains+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
-    <script type="module" crossorigin src="/assets/index-BBrbBY7s.js"></script>
+    <script type="module" crossorigin src="/assets/index-BBdS6LpB.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-Bl8Cdcns.css">
   </head>
   <body>

--- a/frontend/src/components/TaskForm.tsx
+++ b/frontend/src/components/TaskForm.tsx
@@ -496,6 +496,7 @@ export default function TaskForm({ initialData, isEdit }: TaskFormProps) {
                       type="button"
                       role="switch"
                       aria-checked={saveOutput}
+                      aria-labelledby="task-save-output-label"
                       onClick={() => setSaveOutput(v => !v)}
                       className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus:outline-none focus:ring-2 focus:ring-zinc-400 dark:focus:ring-zinc-500 ${
                         saveOutput ? 'bg-zinc-900 dark:bg-zinc-100' : 'bg-zinc-200 dark:bg-zinc-700'
@@ -508,7 +509,10 @@ export default function TaskForm({ initialData, isEdit }: TaskFormProps) {
                       />
                     </button>
                     <div>
-                      <p className="text-xs font-medium text-zinc-700 dark:text-zinc-300">
+                      <p
+                        id="task-save-output-label"
+                        className="text-xs font-medium text-zinc-700 dark:text-zinc-300"
+                      >
                         Save output
                       </p>
                       <p className="text-xs text-zinc-400 dark:text-zinc-500 mt-0.5">


### PR DESCRIPTION
## Summary

- Add `htmlFor`/`id` pairs to all 16 form labels in `TaskForm.tsx`, resolving SonarQube's `jsx-a11y/label-has-associated-control` violations
- Replace `<label>` with `<span id="...">` + `role="group" aria-labelledby="..."` for the Slack "Authentication method" button group (a `<label>` cannot label a non-labelable element)
- Add `aria-labelledby` to the "Save output" toggle switch (`role="switch"`) so screen readers can announce it correctly

## Test plan

- [ ] `npm run lint` passes with 0 jsx-a11y errors in `TaskForm.tsx` and `IntegrationSlackPage.tsx`
- [ ] `npm run typecheck` passes
- [ ] `npm run build` succeeds
- [ ] All form fields remain visually and functionally unchanged
- [ ] Screen reader correctly announces label/control associations (manual check)

Fixes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)