### PR TITLE
refactor: reduce parameter count in high-arity constructor and initializer functions

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -188,10 +188,17 @@ func buildWebServer(
 		return nil, fmt.Errorf("initializing settings: %w", err)
 	}
 
-	apiSrv, bus, err := buildAPIServer(ctx, db, sysLogger,
-		agentStore, chatStore, integrationStore, integrationRegistry,
-		mcpRegistry, localToolsMCP, settingsMgr,
-	)
+	apiSrv, bus, err := buildAPIServer(ctx, appDeps{
+		db:                  db,
+		logger:              sysLogger,
+		agentStore:          agentStore,
+		chatStore:           chatStore,
+		integrationStore:    integrationStore,
+		integrationRegistry: integrationRegistry,
+		mcpRegistry:         mcpRegistry,
+		localToolsMCP:       localToolsMCP,
+		settingsMgr:         settingsMgr,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -206,47 +213,57 @@ func buildWebServer(
 	return srv, nil
 }
 
+// appDeps bundles the stores, registries, and configuration needed to wire up
+// the API server and task scheduler. It replaces the long parameter lists of
+// buildAPIServer and initTaskScheduler.
+type appDeps struct {
+	db                  *sql.DB
+	logger              *slog.Logger
+	agentStore          storage.AgentStore
+	chatStore           storage.ChatStore
+	integrationStore    storage.IntegrationStore
+	integrationRegistry *integrations.IntegrationRegistry
+	mcpRegistry         *config.MCPRegistry
+	localToolsMCP       *tools.LocalMCPConfig
+	settingsMgr         *config.SettingsManager
+}
+
 // buildAPIServer wires all services and returns the api.Server and the event bus.
-func buildAPIServer(
-	ctx context.Context,
-	db *sql.DB,
-	sysLogger *slog.Logger,
-	agentStore storage.AgentStore,
-	chatStore storage.ChatStore,
-	integrationStore storage.IntegrationStore,
-	integrationRegistry *integrations.IntegrationRegistry,
-	mcpRegistry *config.MCPRegistry,
-	localToolsMCP *tools.LocalMCPConfig,
-	settingsMgr *config.SettingsManager,
-) (*api.Server, eventbus.EventBus, error) {
-	notifStore, bus := setupNotifications(db, settingsMgr, sysLogger)
+func buildAPIServer(ctx context.Context, deps appDeps) (*api.Server, eventbus.EventBus, error) {
+	notifStore, bus := setupNotifications(deps.db, deps.settingsMgr, deps.logger)
 
-	agentSvc := service.NewAgentService(agentStore, sysLogger)
+	agentSvc := service.NewAgentService(deps.agentStore, deps.logger)
 	chatSvc := service.NewChatService(
-		chatStore, agentStore, mcpRegistry, localToolsMCP,
-		integrationRegistry, settingsMgr, sysLogger,
+		deps.chatStore, deps.agentStore, deps.mcpRegistry, deps.localToolsMCP,
+		deps.integrationRegistry, deps.settingsMgr, deps.logger,
 	)
-	integrationSvc := service.NewIntegrationService(integrationStore, integrationRegistry, sysLogger, ctx)
-	notificationSvc := service.NewNotificationService(settingsMgr, notifStore)
+	integrationSvc := service.NewIntegrationService(deps.integrationStore, deps.integrationRegistry, deps.logger, ctx)
+	notificationSvc := service.NewNotificationService(deps.settingsMgr, notifStore)
 
-	taskStore := storage.NewSQLiteTaskStore(db)
+	taskStore := storage.NewSQLiteTaskStore(deps.db)
 
-	taskScheduler, err := initTaskScheduler(ctx, taskStore, chatStore, agentStore,
-		mcpRegistry, localToolsMCP, integrationRegistry, settingsMgr, sysLogger, bus)
+	taskScheduler, err := initTaskScheduler(ctx, deps, taskStore, bus)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	taskSvc := service.NewTaskService(taskStore, taskScheduler, sysLogger)
-	profileSvc := service.NewClaudeSettingsProfileService(sysLogger)
+	taskSvc := service.NewTaskService(taskStore, taskScheduler, deps.logger)
+	profileSvc := service.NewClaudeSettingsProfileService(deps.logger)
 
-	sessionCache := claudesessions.NewCache(db, sysLogger)
+	sessionCache := claudesessions.NewCache(deps.db, deps.logger)
 	sessionCache.StartBackgroundScan()
 
-	apiSrv := api.New(
-		agentSvc, chatSvc, integrationSvc, notificationSvc, taskSvc, profileSvc,
-		settingsMgr, sysLogger, sessionCache,
-	)
+	apiSrv := api.New(api.ServerConfig{
+		AgentSvc:        agentSvc,
+		ChatSvc:         chatSvc,
+		IntegrationSvc:  integrationSvc,
+		NotificationSvc: notificationSvc,
+		TaskSvc:         taskSvc,
+		ProfileSvc:      profileSvc,
+		SettingsMgr:     deps.settingsMgr,
+		Logger:          deps.logger,
+		SessionCache:    sessionCache,
+	})
 	return apiSrv, bus, nil
 }
 
@@ -294,29 +311,25 @@ func loadNotificationSettingsFromJSON(raw string) (*notification.NotificationSet
 }
 
 func initTaskScheduler(
-	ctx context.Context,
-	taskStore storage.TaskStore, chatStore storage.ChatStore, agentStore storage.AgentStore,
-	mcpRegistry *config.MCPRegistry, localMCP *tools.LocalMCPConfig,
-	integrationRegistry *integrations.IntegrationRegistry,
-	settingsMgr *config.SettingsManager, sysLogger *slog.Logger,
+	ctx context.Context, deps appDeps, taskStore storage.TaskStore,
 	eventPublisher scheduler.EventPublisher,
 ) (*scheduler.Scheduler, error) {
 	taskScheduler, err := scheduler.New(scheduler.Config{
 		TaskStore:           taskStore,
-		ChatStore:           chatStore,
-		AgentStore:          agentStore,
-		MCPRegistry:         mcpRegistry,
-		LocalMCP:            localMCP,
-		IntegrationRegistry: integrationRegistry,
-		SettingsManager:     settingsMgr,
-		Logger:              sysLogger,
+		ChatStore:           deps.chatStore,
+		AgentStore:          deps.agentStore,
+		MCPRegistry:         deps.mcpRegistry,
+		LocalMCP:            deps.localToolsMCP,
+		IntegrationRegistry: deps.integrationRegistry,
+		SettingsManager:     deps.settingsMgr,
+		Logger:              deps.logger,
 		EventPublisher:      eventPublisher,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("creating task scheduler: %w", err)
 	}
 	if startErr := taskScheduler.Start(ctx); startErr != nil {
-		sysLogger.Warn("failed to start task scheduler", "error", startErr)
+		deps.logger.Warn("failed to start task scheduler", "error", startErr)
 	}
 	return taskScheduler, nil
 }

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -11,7 +11,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Roboto:wght@400;500&family=Open+Sans:wght@400;600&family=Lato:wght@400;700&family=Merriweather:wght@400;700&family=JetBrains+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
-    <script type="module" crossorigin src="/assets/index-BkjW-lK7.js"></script>
+    <script type="module" crossorigin src="/assets/index-B_ZkeqXg.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-Bl8Cdcns.css">
   </head>
   <body>

--- a/frontend/src/components/TaskForm.tsx
+++ b/frontend/src/components/TaskForm.tsx
@@ -153,8 +153,11 @@ export default function TaskForm({ initialData, isEdit }: TaskFormProps) {
           {/* Left: Prompt */}
           <div className="space-y-4">
             <div>
-              <label className={labelClass}>Prompt</label>
+              <label htmlFor="task-prompt" className={labelClass}>
+                Prompt
+              </label>
               <textarea
+                id="task-prompt"
                 value={prompt}
                 onChange={e => setPrompt(e.target.value)}
                 rows={16}
@@ -173,8 +176,11 @@ export default function TaskForm({ initialData, isEdit }: TaskFormProps) {
                 Basic
               </h3>
               <div>
-                <label className={labelClass}>Name</label>
+                <label htmlFor="task-name" className={labelClass}>
+                  Name
+                </label>
                 <input
+                  id="task-name"
                   type="text"
                   value={name}
                   onChange={e => setName(e.target.value)}
@@ -184,8 +190,11 @@ export default function TaskForm({ initialData, isEdit }: TaskFormProps) {
                 />
               </div>
               <div>
-                <label className={labelClass}>Description</label>
+                <label htmlFor="task-description" className={labelClass}>
+                  Description
+                </label>
                 <input
+                  id="task-description"
                   type="text"
                   value={description}
                   onChange={e => setDescription(e.target.value)}
@@ -194,8 +203,11 @@ export default function TaskForm({ initialData, isEdit }: TaskFormProps) {
                 />
               </div>
               <div>
-                <label className={labelClass}>Agent (optional)</label>
+                <label htmlFor="task-agent" className={labelClass}>
+                  Agent (optional)
+                </label>
                 <select
+                  id="task-agent"
                   value={agentSlug}
                   onChange={e => setAgentSlug(e.target.value)}
                   className={selectClass}
@@ -209,8 +221,11 @@ export default function TaskForm({ initialData, isEdit }: TaskFormProps) {
                 </select>
               </div>
               <div>
-                <label className={labelClass}>Model (optional)</label>
+                <label htmlFor="task-model" className={labelClass}>
+                  Model (optional)
+                </label>
                 <select
+                  id="task-model"
                   value={model}
                   onChange={e => setModel(e.target.value)}
                   className={selectClass}
@@ -231,8 +246,11 @@ export default function TaskForm({ initialData, isEdit }: TaskFormProps) {
                 Schedule
               </h3>
               <div>
-                <label className={labelClass}>Type</label>
+                <label htmlFor="task-schedule-type" className={labelClass}>
+                  Type
+                </label>
                 <select
+                  id="task-schedule-type"
                   value={scheduleType}
                   onChange={e => {
                     setScheduleType(e.target.value as ScheduleType)
@@ -255,8 +273,11 @@ export default function TaskForm({ initialData, isEdit }: TaskFormProps) {
 
               {scheduleType === 'one_off' && (
                 <div>
-                  <label className={labelClass}>Run at</label>
+                  <label htmlFor="task-run-at" className={labelClass}>
+                    Run at
+                  </label>
                   <input
+                    id="task-run-at"
                     type="datetime-local"
                     value={
                       scheduleConfig.run_at ? toLocalDatetimeString(scheduleConfig.run_at) : ''
@@ -277,8 +298,11 @@ export default function TaskForm({ initialData, isEdit }: TaskFormProps) {
                 <div className="space-y-2">
                   <div className="grid grid-cols-3 gap-2">
                     <div>
-                      <label className={labelClass}>Minutes</label>
+                      <label htmlFor="task-interval-minutes" className={labelClass}>
+                        Minutes
+                      </label>
                       <input
+                        id="task-interval-minutes"
                         type="number"
                         min={0}
                         value={scheduleConfig.every_minutes ?? ''}
@@ -293,8 +317,11 @@ export default function TaskForm({ initialData, isEdit }: TaskFormProps) {
                       />
                     </div>
                     <div>
-                      <label className={labelClass}>Hours</label>
+                      <label htmlFor="task-interval-hours" className={labelClass}>
+                        Hours
+                      </label>
                       <input
+                        id="task-interval-hours"
                         type="number"
                         min={0}
                         value={scheduleConfig.every_hours ?? ''}
@@ -309,8 +336,11 @@ export default function TaskForm({ initialData, isEdit }: TaskFormProps) {
                       />
                     </div>
                     <div>
-                      <label className={labelClass}>Days</label>
+                      <label htmlFor="task-interval-days" className={labelClass}>
+                        Days
+                      </label>
                       <input
+                        id="task-interval-days"
                         type="number"
                         min={0}
                         value={scheduleConfig.every_days ?? ''}
@@ -327,8 +357,11 @@ export default function TaskForm({ initialData, isEdit }: TaskFormProps) {
                   </div>
                   {(scheduleConfig.every_days ?? 0) > 0 && (
                     <div>
-                      <label className={labelClass}>At time (HH:MM)</label>
+                      <label htmlFor="task-at-time" className={labelClass}>
+                        At time (HH:MM)
+                      </label>
                       <input
+                        id="task-at-time"
                         type="time"
                         value={scheduleConfig.at_time ?? ''}
                         onChange={e =>
@@ -343,8 +376,11 @@ export default function TaskForm({ initialData, isEdit }: TaskFormProps) {
 
               {scheduleType === 'cron' && (
                 <div>
-                  <label className={labelClass}>Cron expression</label>
+                  <label htmlFor="task-cron-expression" className={labelClass}>
+                    Cron expression
+                  </label>
                   <input
+                    id="task-cron-expression"
                     type="text"
                     value={scheduleConfig.expression ?? ''}
                     onChange={e =>
@@ -379,8 +415,11 @@ export default function TaskForm({ initialData, isEdit }: TaskFormProps) {
               {stopConditionsOpen && (
                 <div className="space-y-3">
                   <div>
-                    <label className={labelClass}>Stop after N runs (0 = unlimited)</label>
+                    <label htmlFor="task-stop-after-count" className={labelClass}>
+                      Stop after N runs (0 = unlimited)
+                    </label>
                     <input
+                      id="task-stop-after-count"
                       type="number"
                       min={0}
                       value={stopAfterCount}
@@ -389,8 +428,11 @@ export default function TaskForm({ initialData, isEdit }: TaskFormProps) {
                     />
                   </div>
                   <div>
-                    <label className={labelClass}>Stop after date (optional)</label>
+                    <label htmlFor="task-stop-after-time" className={labelClass}>
+                      Stop after date (optional)
+                    </label>
                     <input
+                      id="task-stop-after-time"
                       type="datetime-local"
                       value={stopAfterTime ? toLocalDatetimeString(stopAfterTime) : ''}
                       onChange={e =>
@@ -423,8 +465,11 @@ export default function TaskForm({ initialData, isEdit }: TaskFormProps) {
               {advancedOpen && (
                 <div className="space-y-3">
                   <div>
-                    <label className={labelClass}>Working directory</label>
+                    <label htmlFor="task-working-directory" className={labelClass}>
+                      Working directory
+                    </label>
                     <input
+                      id="task-working-directory"
                       type="text"
                       value={workingDirectory}
                       onChange={e => setWorkingDirectory(e.target.value)}
@@ -433,8 +478,11 @@ export default function TaskForm({ initialData, isEdit }: TaskFormProps) {
                     />
                   </div>
                   <div>
-                    <label className={labelClass}>Timeout (minutes, 1-240)</label>
+                    <label htmlFor="task-timeout" className={labelClass}>
+                      Timeout (minutes, 1-240)
+                    </label>
                     <input
+                      id="task-timeout"
                       type="number"
                       min={1}
                       max={240}

--- a/frontend/src/pages/IntegrationSlackPage.tsx
+++ b/frontend/src/pages/IntegrationSlackPage.tsx
@@ -241,10 +241,13 @@ export default function IntegrationSlackPage() {
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-2">
+                <span
+                  id="slack-auth-method-label"
+                  className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-2"
+                >
                   Authentication method
-                </label>
-                <div className="flex gap-3">
+                </span>
+                <div className="flex gap-3" role="group" aria-labelledby="slack-auth-method-label">
                   <button
                     onClick={() => setAuthMode('bot_token')}
                     className={`flex-1 rounded-md border px-3 py-2.5 text-sm text-left transition-colors cursor-pointer ${

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -48,7 +48,14 @@ func newHarness(t *testing.T) *testHarness {
 	require.NoError(t, err)
 
 	logger := slog.Default()
-	srv := api.New(agentSvc, chatSvc, integrationSvc, notificationSvc, nil, nil, mgr, logger, nil)
+	srv := api.New(api.ServerConfig{
+		AgentSvc:        agentSvc,
+		ChatSvc:         chatSvc,
+		IntegrationSvc:  integrationSvc,
+		NotificationSvc: notificationSvc,
+		SettingsMgr:     mgr,
+		Logger:          logger,
+	})
 
 	r := chi.NewRouter()
 	srv.Mount(r)

--- a/internal/api/chats.go
+++ b/internal/api/chats.go
@@ -202,6 +202,19 @@ type streamState struct {
 	pendingInput  json.RawMessage
 }
 
+// eventProcessor captures the shared context for processing agent events during
+// a single SSE stream. It replaces the long parameter lists of consumeAgentEvents,
+// processAgentEvent, and handlePendingUserInput.
+type eventProcessor struct {
+	server       *Server
+	r            *http.Request
+	id           string
+	agentSession *claude.Session
+	flusher      http.Flusher
+	w            http.ResponseWriter
+	chs          sendMessageChannels
+}
+
 func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 
@@ -247,7 +260,16 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 		close(chs.questionCh)
 	}()
 
-	state := s.consumeAgentEvents(r, id, agentSession, flusher, w, chs)
+	ep := &eventProcessor{
+		server:       s,
+		r:            r,
+		id:           id,
+		agentSession: agentSession,
+		flusher:      flusher,
+		w:            w,
+		chs:          chs,
+	}
+	state := ep.consumeAgentEvents()
 
 	if isFirstMessage {
 		chatSession.Title = truncateTitle(req.Content, 60)
@@ -353,12 +375,9 @@ func (s *Server) handleBeginMessageError(w http.ResponseWriter, id string, err e
 	s.writeError(w, http.StatusInternalServerError, "failed to start message")
 }
 
-func (s *Server) consumeAgentEvents(
-	r *http.Request, id string, agentSession *claude.Session,
-	flusher http.Flusher, w http.ResponseWriter, chs sendMessageChannels,
-) streamState {
+func (ep *eventProcessor) consumeAgentEvents() streamState {
 	var state streamState
-	eventsCh := agentSession.Events()
+	eventsCh := ep.agentSession.Events()
 
 	for {
 		select {
@@ -367,37 +386,32 @@ func (s *Server) consumeAgentEvents(
 				return state
 			}
 			if len(event.Raw) > 0 {
-				sendSSERaw(w, flusher, string(event.Type), event.Raw)
+				sendSSERaw(ep.w, ep.flusher, string(event.Type), event.Raw)
 			}
-			done := s.processAgentEvent(r, id, event, agentSession, flusher, w, chs, &state)
-			if done {
+			if ep.processAgentEvent(event, &state) {
 				return state
 			}
 
-		case qInput := <-chs.questionCh:
+		case qInput := <-ep.chs.questionCh:
 			state.pendingInput = nil
-			s.sendSSEEvent(w, flusher, "user_input_required", map[string]any{"input": qInput})
+			ep.server.sendSSEEvent(ep.w, ep.flusher, "user_input_required", map[string]any{"input": qInput})
 
-		case pr := <-chs.permissionReqCh:
-			s.sendSSEEvent(w, flusher, "permission_request", pr)
+		case pr := <-ep.chs.permissionReqCh:
+			ep.server.sendSSEEvent(ep.w, ep.flusher, "permission_request", pr)
 
-		case <-r.Context().Done():
+		case <-ep.r.Context().Done():
 			return state
 		}
 	}
 }
 
-func (s *Server) processAgentEvent(
-	r *http.Request, id string, event claude.Event,
-	agentSession *claude.Session, flusher http.Flusher, w http.ResponseWriter,
-	chs sendMessageChannels, state *streamState,
-) bool {
+func (ep *eventProcessor) processAgentEvent(event claude.Event, state *streamState) bool {
 	switch event.Type {
 	case claude.TypeAssistant:
 		state.blocks = appendAssistantBlocks(state.blocks, event.Raw)
 		if input := extractAskUserQuestionInput(event.Raw); input != nil {
 			state.pendingInput = input
-			s.logger.Info("AskUserQuestion detected in stream", "session_id", id)
+			ep.server.logger.Info("AskUserQuestion detected in stream", "session_id", ep.id)
 		}
 
 	case claude.TypeResult:
@@ -418,30 +432,26 @@ func (s *Server) processAgentEvent(
 		if state.pendingInput == nil {
 			return true // final result
 		}
-		return s.handlePendingUserInput(r, id, agentSession, flusher, w, chs, state)
+		return ep.handlePendingUserInput(state)
 	}
 	return false
 }
 
-func (s *Server) handlePendingUserInput(
-	r *http.Request, id string, agentSession *claude.Session,
-	flusher http.Flusher, w http.ResponseWriter, chs sendMessageChannels,
-	state *streamState,
-) bool {
-	s.logger.Info("sending user_input_required, waiting for answer", "session_id", id)
-	s.sendSSEEvent(w, flusher, "user_input_required", map[string]any{"input": state.pendingInput})
+func (ep *eventProcessor) handlePendingUserInput(state *streamState) bool {
+	ep.server.logger.Info("sending user_input_required, waiting for answer", "session_id", ep.id)
+	ep.server.sendSSEEvent(ep.w, ep.flusher, "user_input_required", map[string]any{"input": state.pendingInput})
 	state.pendingInput = nil
 
 	select {
-	case answer := <-chs.inputCh:
-		s.logger.Info("received user answer, resuming session", "session_id", id)
-		if err := agentSession.Send(answer); err != nil {
-			s.logger.Error("inject answer failed", "session_id", id, "error", err)
+	case answer := <-ep.chs.inputCh:
+		ep.server.logger.Info("received user answer, resuming session", "session_id", ep.id)
+		if err := ep.agentSession.Send(answer); err != nil {
+			ep.server.logger.Error("inject answer failed", "session_id", ep.id, "error", err)
 			return true
 		}
 		state.assistantText = ""
 		return false // continue event loop
-	case <-r.Context().Done():
+	case <-ep.r.Context().Done():
 		return true
 	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -29,6 +29,19 @@ const (
 	routeJobHistoryByID  = routeJobHistoryBase + "/{id}"
 )
 
+// ServerConfig bundles all dependencies needed to construct an API Server.
+type ServerConfig struct {
+	AgentSvc        service.AgentService
+	ChatSvc         service.ChatService
+	IntegrationSvc  service.IntegrationService
+	NotificationSvc service.NotificationService
+	TaskSvc         service.TaskService
+	ProfileSvc      service.ClaudeSettingsProfileService
+	SettingsMgr     *config.SettingsManager
+	Logger          *slog.Logger
+	SessionCache    *claudesessions.Cache
+}
+
 // Server holds all dependencies for the REST API handlers.
 type Server struct {
 	agentSvc           service.AgentService
@@ -44,28 +57,21 @@ type Server struct {
 }
 
 // New creates a new API Server backed by the provided services.
-func New(
-	agentSvc service.AgentService,
-	chatSvc service.ChatService,
-	integrationSvc service.IntegrationService,
-	notificationSvc service.NotificationService,
-	taskSvc service.TaskService,
-	profileSvc service.ClaudeSettingsProfileService,
-	settingsMgr *config.SettingsManager,
-	logger *slog.Logger,
-	sessionCache *claudesessions.Cache,
-) *Server {
+func New(cfg ServerConfig) *Server {
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
 	return &Server{
-		agentSvc:           agentSvc,
-		chatSvc:            chatSvc,
-		integrationSvc:     integrationSvc,
-		notificationSvc:    notificationSvc,
-		taskSvc:            taskSvc,
-		profileSvc:         profileSvc,
-		settingsMgr:        settingsMgr,
-		logger:             logger,
+		agentSvc:           cfg.AgentSvc,
+		chatSvc:            cfg.ChatSvc,
+		integrationSvc:     cfg.IntegrationSvc,
+		notificationSvc:    cfg.NotificationSvc,
+		taskSvc:            cfg.TaskSvc,
+		profileSvc:         cfg.ProfileSvc,
+		settingsMgr:        cfg.SettingsMgr,
+		logger:             cfg.Logger,
 		liveSessions:       newLiveSessionStore(),
-		claudeSessionCache: sessionCache,
+		claudeSessionCache: cfg.SessionCache,
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes SonarQube rule Go:S107 violations — functions with more than 7 parameters. Introduces config/options structs to replace long parameter lists with no behavioral changes.

- **`cmd/web.go`**: introduce `appDeps` struct; `buildAPIServer` drops from 10 → 1 struct param + ctx; `initTaskScheduler` drops from 10 → 3 params (ctx + struct + taskStore); `ctx` passed explicitly per Go conventions (not stored in struct)
- **`internal/api/server.go`**: introduce `ServerConfig` struct; `api.New()` drops from 9 → 1 param; add nil Logger guard to prevent nil-pointer panics
- **`internal/api/chats.go`**: extract `eventProcessor` struct; `processAgentEvent` drops from 8 → 2 params; related SSE methods converted to `eventProcessor` receivers
- **`internal/api/api_test.go`**: update test to use new `ServerConfig` struct
- **`frontend/src/components/TaskForm.tsx`**: fix label/htmlFor associations (accessibility)
- **`frontend/src/pages/IntegrationSlackPage.tsx`**: improve radio group accessibility with `aria-labelledby` pattern

## Test plan

- [x] `make test` — all tests pass
- [x] `make lint` — 0 golangci-lint issues
- [x] Pre-commit hooks pass (ESLint, Prettier, TypeScript, build)
- [x] No behavioral changes introduced

Closes #64