### PR TITLE
Add bidirectional messaging platform support with Telegram adapter

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -31,6 +31,8 @@ import (
 	slackintegration "github.com/shaharia-lab/agento/internal/integrations/slack"
 	telegramintegration "github.com/shaharia-lab/agento/internal/integrations/telegram"
 	"github.com/shaharia-lab/agento/internal/logger"
+	"github.com/shaharia-lab/agento/internal/messaging"
+	telegrammessaging "github.com/shaharia-lab/agento/internal/messaging/telegram"
 	"github.com/shaharia-lab/agento/internal/notification"
 	"github.com/shaharia-lab/agento/internal/scheduler"
 	"github.com/shaharia-lab/agento/internal/server"
@@ -247,7 +249,56 @@ func buildAPIServer(
 		agentSvc, chatSvc, integrationSvc, notificationSvc, taskSvc, profileSvc,
 		settingsMgr, sysLogger, sessionCache,
 	)
+
+	// Wire up the bidirectional messaging system.
+	mappingStore := storage.NewSQLiteConversationMappingStore(db)
+	dispatcher := messaging.NewDispatcher(chatSvc, mappingStore, sysLogger)
+	msgManager := messaging.NewManager(dispatcher, sysLogger)
+	msgManager.RegisterFactory("telegram", telegrammessaging.NewFactory(sysLogger))
+	apiSrv.SetMessagingManager(msgManager)
+
+	// Start messaging adapters for enabled integrations that support bidirectional chat.
+	startMessagingAdapters(ctx, integrationStore, msgManager, sysLogger)
+
 	return apiSrv, bus, nil
+}
+
+// startMessagingAdapters scans existing integrations and starts messaging
+// platform adapters for those that support bidirectional messaging.
+func startMessagingAdapters(
+	ctx context.Context,
+	store storage.IntegrationStore,
+	mgr *messaging.Manager,
+	logger *slog.Logger,
+) {
+	cfgs, err := store.List()
+	if err != nil {
+		logger.Warn("failed to list integrations for messaging adapters", "error", err)
+		return
+	}
+
+	for _, cfg := range cfgs {
+		if !cfg.Enabled || !cfg.IsAuthenticated() {
+			continue
+		}
+		// Only start messaging adapters for platforms that support bidirectional chat.
+		switch cfg.Type {
+		case "telegram":
+			var creds config.TelegramCredentials
+			if parseErr := cfg.ParseCredentials(&creds); parseErr != nil {
+				logger.Warn("failed to parse telegram credentials for messaging", "id", cfg.ID, "error", parseErr)
+				continue
+			}
+			if startErr := mgr.StartPlatform(ctx, "telegram", cfg.ID, map[string]string{
+				"bot_token": creds.BotToken,
+			}); startErr != nil {
+				logger.Warn("failed to start telegram messaging adapter", "id", cfg.ID, "error", startErr)
+			}
+		// Future platforms (slack, etc.) will be added here.
+		default:
+			continue
+		}
+	}
 }
 
 // setupNotifications creates the notification store, event bus, and wires the

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/shaharia-lab/agento/internal/claudesessions"
 	"github.com/shaharia-lab/agento/internal/config"
+	"github.com/shaharia-lab/agento/internal/messaging"
 	"github.com/shaharia-lab/agento/internal/service"
 )
 
@@ -41,6 +42,7 @@ type Server struct {
 	logger             *slog.Logger
 	liveSessions       *liveSessionStore
 	claudeSessionCache *claudesessions.Cache
+	messagingManager   *messaging.Manager
 }
 
 // New creates a new API Server backed by the provided services.
@@ -111,6 +113,9 @@ func (s *Server) Mount(r chi.Router) {
 
 	// Filesystem, integrations, tasks, job history
 	s.mountExtensionRoutes(r)
+
+	// Bidirectional messaging webhooks (Telegram, Slack, …)
+	s.mountWebhookRoutes(r)
 
 	// Build info
 	r.Get("/version", s.handleVersion)

--- a/internal/api/webhooks.go
+++ b/internal/api/webhooks.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/shaharia-lab/agento/internal/messaging"
+)
+
+// mountWebhookRoutes registers the generic webhook endpoint used by
+// bidirectional messaging integrations (Telegram, Slack, etc.).
+func (s *Server) mountWebhookRoutes(r chi.Router) {
+	if s.messagingManager == nil {
+		return
+	}
+	r.Post("/webhooks/{platform_type}/{integration_id}", s.handleWebhook)
+}
+
+// handleWebhook delegates an inbound webhook to the correct messaging platform adapter.
+func (s *Server) handleWebhook(w http.ResponseWriter, r *http.Request) {
+	platformType := chi.URLParam(r, "platform_type")
+	integrationID := chi.URLParam(r, "integration_id")
+
+	if platformType == "" || integrationID == "" {
+		s.writeError(w, http.StatusBadRequest, "missing platform_type or integration_id")
+		return
+	}
+
+	s.messagingManager.HandleWebhook(platformType, integrationID, w, r)
+}
+
+// SetMessagingManager sets the messaging manager on the API server.
+// This is called during startup after the manager is constructed.
+func (s *Server) SetMessagingManager(mgr *messaging.Manager) {
+	s.messagingManager = mgr
+}

--- a/internal/messaging/dispatcher.go
+++ b/internal/messaging/dispatcher.go
@@ -1,0 +1,313 @@
+package messaging
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"unicode/utf8"
+
+	claude "github.com/shaharia-lab/claude-agent-sdk-go/claude"
+
+	"github.com/shaharia-lab/agento/internal/agent"
+	"github.com/shaharia-lab/agento/internal/service"
+	"github.com/shaharia-lab/agento/internal/storage"
+)
+
+// Dispatcher receives inbound messages from any Platform, maps them to
+// internal chat sessions, runs the agent, and sends the response back.
+type Dispatcher struct {
+	chatSvc      service.ChatService
+	mappingStore storage.ConversationMappingStore
+	platforms    *platformRegistry
+	logger       *slog.Logger
+}
+
+// NewDispatcher creates a Dispatcher wired to the given services.
+func NewDispatcher(
+	chatSvc service.ChatService,
+	mappingStore storage.ConversationMappingStore,
+	logger *slog.Logger,
+) *Dispatcher {
+	return &Dispatcher{
+		chatSvc:      chatSvc,
+		mappingStore: mappingStore,
+		platforms:    newPlatformRegistry(),
+		logger:       logger,
+	}
+}
+
+// RegisterPlatform makes a platform available for outbound messages.
+func (d *Dispatcher) RegisterPlatform(p Platform) {
+	d.platforms.put(p.ID(), p)
+}
+
+// UnregisterPlatform removes a platform from the registry.
+func (d *Dispatcher) UnregisterPlatform(id string) {
+	d.platforms.delete(id)
+}
+
+// HandleMessage implements MessageHandler. It is called by platform adapters
+// when an inbound message arrives.
+func (d *Dispatcher) HandleMessage(ctx context.Context, msg InboundMessage) error {
+	d.logger.Info("inbound message received",
+		"platform_type", msg.PlatformType,
+		"platform_id", msg.PlatformID,
+		"channel_id", msg.ChannelID,
+		"user", msg.UserDisplayName,
+	)
+
+	if msg.Content == "" {
+		d.logger.Debug("ignoring empty message", "channel_id", msg.ChannelID)
+		return nil
+	}
+
+	// Look up or create the internal chat session for this conversation.
+	mapping, err := d.getOrCreateMapping(ctx, msg)
+	if err != nil {
+		return fmt.Errorf("resolving conversation mapping: %w", err)
+	}
+
+	// Send typing indicator while we process.
+	if platform, ok := d.platforms.get(msg.PlatformID); ok {
+		if typErr := platform.SendTypingIndicator(ctx, msg.ChannelID); typErr != nil {
+			d.logger.Debug("typing indicator failed", "error", typErr)
+		}
+	}
+
+	// Run the agent and collect the response.
+	response, err := d.runAgent(ctx, mapping.SessionID, msg.Content)
+	if err != nil {
+		d.logger.Error("agent run failed",
+			"session_id", mapping.SessionID,
+			"error", err,
+		)
+		response = "Sorry, I encountered an error processing your message."
+	}
+
+	// Send the response back to the platform.
+	platform, ok := d.platforms.get(msg.PlatformID)
+	if !ok {
+		return fmt.Errorf("platform %q not registered", msg.PlatformID)
+	}
+	return platform.SendMessage(ctx, OutboundMessage{
+		ChannelID:        msg.ChannelID,
+		Content:          response,
+		ReplyToMessageID: msg.MessageID,
+	})
+}
+
+// getOrCreateMapping finds the existing mapping or creates a new chat session
+// and mapping for the given inbound message.
+func (d *Dispatcher) getOrCreateMapping(
+	ctx context.Context, msg InboundMessage,
+) (*storage.ConversationMapping, error) {
+	existing, err := d.mappingStore.GetByPlatformChannel(
+		msg.PlatformType, msg.PlatformID, msg.ChannelID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if existing != nil {
+		return existing, nil
+	}
+
+	// Determine agent slug from metadata if provided.
+	agentSlug := ""
+	if msg.Metadata != nil {
+		agentSlug = msg.Metadata["agent_slug"]
+	}
+
+	// Create a new chat session for this conversation.
+	title := fmt.Sprintf("%s — %s", msg.PlatformType, msg.UserDisplayName)
+	if utf8.RuneCountInString(title) > 60 {
+		title = string([]rune(title)[:57]) + "..."
+	}
+
+	session, err := d.chatSvc.CreateSession(ctx, agentSlug, "", "", "")
+	if err != nil {
+		return nil, fmt.Errorf("creating chat session: %w", err)
+	}
+
+	// Set a meaningful title.
+	session.Title = title
+	if updateErr := d.chatSvc.UpdateSession(ctx, session); updateErr != nil {
+		d.logger.Warn("failed to set session title", "error", updateErr)
+	}
+
+	mapping := &storage.ConversationMapping{
+		SessionID:    session.ID,
+		PlatformType: msg.PlatformType,
+		PlatformID:   msg.PlatformID,
+		ChannelID:    msg.ChannelID,
+		AgentSlug:    agentSlug,
+	}
+	if createErr := d.mappingStore.Create(mapping); createErr != nil {
+		return nil, fmt.Errorf("creating conversation mapping: %w", createErr)
+	}
+
+	d.logger.Info("new conversation mapping created",
+		"mapping_id", mapping.ID,
+		"session_id", session.ID,
+		"channel_id", msg.ChannelID,
+	)
+
+	return mapping, nil
+}
+
+// runAgent executes the agent for a given session and returns the text response.
+// It uses bypass permissions since messaging platforms have no interactive approval UI.
+func (d *Dispatcher) runAgent(ctx context.Context, sessionID, content string) (string, error) {
+	opts := agent.RunOptions{
+		// No PermissionHandler → bypass permissions (auto-approve all tools).
+	}
+
+	agentSession, _, err := d.chatSvc.BeginMessage(ctx, sessionID, content, opts)
+	if err != nil {
+		return "", fmt.Errorf("begin message: %w", err)
+	}
+	defer func() {
+		if cerr := agentSession.Close(); cerr != nil {
+			d.logger.Error("close agent session", "error", cerr)
+		}
+	}()
+
+	state := d.consumeEvents(ctx, agentSession)
+
+	// Commit the assistant response.
+	session, err := d.chatSvc.GetSession(ctx, sessionID)
+	if err != nil {
+		return state.text, fmt.Errorf("loading session for commit: %w", err)
+	}
+	if session == nil {
+		return state.text, fmt.Errorf("session %q not found for commit", sessionID)
+	}
+
+	isFirstMessage := session.Title == "New Chat"
+	if commitErr := d.chatSvc.CommitMessage(
+		ctx, session,
+		state.text, state.sdkSessionID, isFirstMessage,
+		state.blocks, state.usage,
+	); commitErr != nil {
+		d.logger.Error("commit message failed", "session_id", sessionID, "error", commitErr)
+	}
+
+	return state.text, nil
+}
+
+// agentState accumulates agent output during event consumption.
+type agentState struct {
+	text         string
+	sdkSessionID string
+	blocks       []storage.MessageBlock
+	usage        agent.UsageStats
+}
+
+// consumeEvents drains the agent session event channel and collects the response.
+func (d *Dispatcher) consumeEvents(ctx context.Context, session *claude.Session) agentState {
+	var state agentState
+
+	for {
+		select {
+		case event, ok := <-session.Events():
+			if !ok {
+				return state
+			}
+			if d.processEvent(event, &state) {
+				return state
+			}
+		case <-ctx.Done():
+			return state
+		}
+	}
+}
+
+// processEvent handles a single agent event. Returns true when done.
+func (d *Dispatcher) processEvent(event claude.Event, state *agentState) bool {
+	switch event.Type {
+	case claude.TypeAssistant:
+		state.blocks = appendBlocks(state.blocks, event.Raw)
+
+	case claude.TypeResult:
+		if event.Result == nil {
+			return false
+		}
+		addUsage(&state.usage, event.Result)
+
+		if event.Result.IsError {
+			state.sdkSessionID = ""
+			d.logger.Warn("agent returned error result",
+				"error", event.Result.Result,
+				"errors", event.Result.Errors,
+			)
+			return true
+		}
+
+		state.sdkSessionID = event.Result.SessionID
+		state.text = event.Result.Result
+		return true
+	}
+	return false
+}
+
+// appendBlocks extracts content blocks from a raw assistant event.
+func appendBlocks(blocks []storage.MessageBlock, raw json.RawMessage) []storage.MessageBlock {
+	var ae struct {
+		Message struct {
+			Content []struct {
+				Type     string          `json:"type"`
+				Text     string          `json:"text,omitempty"`
+				Thinking string          `json:"thinking,omitempty"`
+				ID       string          `json:"id,omitempty"`
+				Name     string          `json:"name,omitempty"`
+				Input    json.RawMessage `json:"input,omitempty"`
+			} `json:"content"`
+		} `json:"message"`
+	}
+	if json.Unmarshal(raw, &ae) != nil {
+		return blocks
+	}
+	for _, blk := range ae.Message.Content {
+		switch blk.Type {
+		case "thinking":
+			if blk.Thinking != "" {
+				blocks = append(blocks, storage.MessageBlock{Type: "thinking", Text: blk.Thinking})
+			}
+		case "text":
+			if blk.Text != "" {
+				blocks = append(blocks, storage.MessageBlock{Type: "text", Text: blk.Text})
+			}
+		case "tool_use":
+			blocks = append(blocks, storage.MessageBlock{
+				Type: "tool_use", ID: blk.ID, Name: blk.Name, Input: blk.Input,
+			})
+		}
+	}
+	return blocks
+}
+
+// addUsage accumulates token counts from a result event.
+func addUsage(usage *agent.UsageStats, r *claude.Result) {
+	if r == nil {
+		return
+	}
+	usage.InputTokens += r.Usage.InputTokens
+	usage.OutputTokens += r.Usage.OutputTokens
+	usage.CacheCreationInputTokens += r.Usage.CacheCreationInputTokens
+	usage.CacheReadInputTokens += r.Usage.CacheReadInputTokens
+	usage.WebSearchRequests += r.Usage.WebSearchRequests
+}
+
+// ExtractTextFromBlocks returns only the text content from message blocks,
+// stripping thinking and tool_use blocks. Useful for messaging platforms
+// that only need the final text response.
+func ExtractTextFromBlocks(blocks []storage.MessageBlock) string {
+	var parts []string
+	for _, b := range blocks {
+		if b.Type == "text" && b.Text != "" {
+			parts = append(parts, b.Text)
+		}
+	}
+	return strings.Join(parts, "\n\n")
+}

--- a/internal/messaging/dispatcher_test.go
+++ b/internal/messaging/dispatcher_test.go
@@ -1,0 +1,94 @@
+package messaging
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestPlatformRegistry(t *testing.T) {
+	reg := newPlatformRegistry()
+
+	// Test empty get.
+	_, ok := reg.get("nonexistent")
+	if ok {
+		t.Error("expected get to return false for nonexistent key")
+	}
+
+	// Test put and get.
+	mock := &mockPlatform{id: "test-1", typeName: "telegram"}
+	reg.put("test-1", mock)
+
+	p, ok := reg.get("test-1")
+	if !ok {
+		t.Error("expected get to return true after put")
+	}
+	if p.ID() != "test-1" {
+		t.Errorf("got ID %q, want %q", p.ID(), "test-1")
+	}
+	if p.Type() != "telegram" {
+		t.Errorf("got Type %q, want %q", p.Type(), "telegram")
+	}
+
+	// Test all.
+	mock2 := &mockPlatform{id: "test-2", typeName: "slack"}
+	reg.put("test-2", mock2)
+
+	all := reg.all()
+	if len(all) != 2 {
+		t.Errorf("got %d platforms, want 2", len(all))
+	}
+
+	// Test delete.
+	reg.delete("test-1")
+	_, ok = reg.get("test-1")
+	if ok {
+		t.Error("expected get to return false after delete")
+	}
+
+	all = reg.all()
+	if len(all) != 1 {
+		t.Errorf("got %d platforms after delete, want 1", len(all))
+	}
+}
+
+func TestMessageHandlerFunc(t *testing.T) {
+	called := false
+	handler := MessageHandlerFunc(func(_ context.Context, msg InboundMessage) error {
+		called = true
+		if msg.Content != "hello" {
+			t.Errorf("got content %q, want %q", msg.Content, "hello")
+		}
+		return nil
+	})
+
+	err := handler.HandleMessage(context.Background(), InboundMessage{Content: "hello"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("handler was not called")
+	}
+}
+
+// mockPlatform is a minimal Platform implementation for testing.
+type mockPlatform struct {
+	id            string
+	typeName      string
+	lastMessage   OutboundMessage
+	sendCallCount int
+}
+
+func (m *mockPlatform) ID() string                                     { return m.id }
+func (m *mockPlatform) Type() string                                   { return m.typeName }
+func (m *mockPlatform) Start(_ context.Context) error                  { return nil }
+func (m *mockPlatform) Stop() error                                    { return nil }
+func (m *mockPlatform) HandleWebhook(_ http.ResponseWriter, _ *http.Request) {}
+func (m *mockPlatform) SendTypingIndicator(_ context.Context, _ string) error {
+	return nil
+}
+func (m *mockPlatform) SendMessage(_ context.Context, msg OutboundMessage) error {
+	m.lastMessage = msg
+	m.sendCallCount++
+	return nil
+}

--- a/internal/messaging/manager.go
+++ b/internal/messaging/manager.go
@@ -1,0 +1,170 @@
+package messaging
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync"
+)
+
+// Manager manages the lifecycle of Platform adapters. It starts and stops
+// platforms, registers them with the Dispatcher, and routes inbound webhooks
+// to the correct adapter.
+type Manager struct {
+	dispatcher *Dispatcher
+	factories  map[string]PlatformFactory // platformType → factory
+	platforms  map[string]Platform        // integrationID → running platform
+	cancels   map[string]context.CancelFunc
+	mu        sync.RWMutex
+	logger    *slog.Logger
+}
+
+// NewManager creates a Manager backed by the given Dispatcher.
+func NewManager(dispatcher *Dispatcher, logger *slog.Logger) *Manager {
+	return &Manager{
+		dispatcher: dispatcher,
+		factories:  make(map[string]PlatformFactory),
+		platforms:  make(map[string]Platform),
+		cancels:    make(map[string]context.CancelFunc),
+		logger:     logger,
+	}
+}
+
+// RegisterFactory registers a PlatformFactory for a given platform type.
+// This is called once at startup for each supported platform type.
+func (m *Manager) RegisterFactory(platformType string, factory PlatformFactory) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.factories[platformType] = factory
+}
+
+// StartPlatform creates and starts a platform adapter for the given integration.
+// credentials is the parsed credential map (e.g. {"bot_token": "123:ABC"}).
+func (m *Manager) StartPlatform(
+	parentCtx context.Context,
+	platformType, integrationID string,
+	credentials map[string]string,
+) error {
+	m.mu.Lock()
+	factory, ok := m.factories[platformType]
+	m.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("no factory registered for platform type %q", platformType)
+	}
+
+	// Create the adapter with the dispatcher as its message handler.
+	platform, err := factory(integrationID, credentials, m.dispatcher)
+	if err != nil {
+		return fmt.Errorf("creating %s platform: %w", platformType, err)
+	}
+
+	ctx, cancel := context.WithCancel(parentCtx)
+	if startErr := platform.Start(ctx); startErr != nil {
+		cancel()
+		return fmt.Errorf("starting %s platform: %w", platformType, startErr)
+	}
+
+	m.mu.Lock()
+	// Stop any existing platform for this integration.
+	if existingCancel, exists := m.cancels[integrationID]; exists {
+		existingCancel()
+		delete(m.platforms, integrationID)
+	}
+	m.platforms[integrationID] = platform
+	m.cancels[integrationID] = cancel
+	m.mu.Unlock()
+
+	m.dispatcher.RegisterPlatform(platform)
+
+	m.logger.Info("messaging platform started",
+		"type", platformType,
+		"integration_id", integrationID,
+	)
+	return nil
+}
+
+// StopPlatform stops and removes the platform adapter for the given integration.
+func (m *Manager) StopPlatform(integrationID string) {
+	m.mu.Lock()
+	platform, ok := m.platforms[integrationID]
+	cancel, hasCancel := m.cancels[integrationID]
+	if ok {
+		delete(m.platforms, integrationID)
+	}
+	if hasCancel {
+		delete(m.cancels, integrationID)
+	}
+	m.mu.Unlock()
+
+	if hasCancel {
+		cancel()
+	}
+	if ok {
+		if err := platform.Stop(); err != nil {
+			m.logger.Warn("error stopping platform", "id", integrationID, "error", err)
+		}
+		m.dispatcher.UnregisterPlatform(integrationID)
+		m.logger.Info("messaging platform stopped", "integration_id", integrationID)
+	}
+}
+
+// StopAll stops all running platform adapters.
+func (m *Manager) StopAll() {
+	m.mu.RLock()
+	ids := make([]string, 0, len(m.platforms))
+	for id := range m.platforms {
+		ids = append(ids, id)
+	}
+	m.mu.RUnlock()
+
+	for _, id := range ids {
+		m.StopPlatform(id)
+	}
+}
+
+// HandleWebhook routes an inbound webhook to the correct platform adapter.
+// platformType and integrationID are extracted from the URL path by the
+// API router.
+func (m *Manager) HandleWebhook(platformType, integrationID string, w http.ResponseWriter, r *http.Request) {
+	m.mu.RLock()
+	platform, ok := m.platforms[integrationID]
+	m.mu.RUnlock()
+
+	if !ok {
+		m.logger.Warn("webhook for unknown platform",
+			"type", platformType,
+			"integration_id", integrationID,
+		)
+		http.Error(w, "platform not found", http.StatusNotFound)
+		return
+	}
+
+	if platform.Type() != platformType {
+		http.Error(w, "platform type mismatch", http.StatusBadRequest)
+		return
+	}
+
+	platform.HandleWebhook(w, r)
+}
+
+// GetPlatform returns a running platform by integration ID, or nil if not found.
+func (m *Manager) GetPlatform(integrationID string) (Platform, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	p, ok := m.platforms[integrationID]
+	return p, ok
+}
+
+// IsRunning checks if a platform adapter is running for the given integration.
+func (m *Manager) IsRunning(integrationID string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	_, ok := m.platforms[integrationID]
+	return ok
+}
+
+// Dispatcher returns the underlying Dispatcher.
+func (m *Manager) Dispatcher() *Dispatcher {
+	return m.dispatcher
+}

--- a/internal/messaging/platform.go
+++ b/internal/messaging/platform.go
@@ -1,0 +1,113 @@
+// Package messaging provides a generic abstraction for bidirectional messaging
+// integrations (Telegram, Slack, etc.). It decouples the messaging platform
+// specifics from the agent conversation lifecycle so new platforms can be added
+// by implementing the Platform interface.
+package messaging
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// Platform represents a bidirectional messaging integration that can receive
+// inbound messages from users and send outbound responses. Each concrete
+// adapter (Telegram, Slack, …) implements this interface.
+type Platform interface {
+	// ID returns the unique identifier of this platform instance (typically
+	// the integration ID from the database).
+	ID() string
+
+	// Type returns the platform type (e.g. "telegram", "slack").
+	Type() string
+
+	// Start initialises the platform adapter (e.g. sets up webhook or
+	// long-polling). The provided context controls the adapter's lifetime.
+	Start(ctx context.Context) error
+
+	// Stop gracefully shuts down the adapter.
+	Stop() error
+
+	// SendMessage sends a text response to the specified channel on the platform.
+	SendMessage(ctx context.Context, msg OutboundMessage) error
+
+	// SendTypingIndicator shows a "typing…" status in the given channel.
+	// Implementations may no-op if the platform does not support this.
+	SendTypingIndicator(ctx context.Context, channelID string) error
+
+	// HandleWebhook processes an inbound HTTP webhook from the platform.
+	// The adapter is responsible for parsing the request, extracting the
+	// message, and forwarding it via the MessageHandler.
+	HandleWebhook(w http.ResponseWriter, r *http.Request)
+}
+
+// MessageHandler is the callback that Platform adapters invoke when an inbound
+// message arrives. Typically implemented by the Dispatcher.
+type MessageHandler interface {
+	HandleMessage(ctx context.Context, msg InboundMessage) error
+}
+
+// MessageHandlerFunc is a convenience adapter that turns a plain function into
+// a MessageHandler.
+type MessageHandlerFunc func(ctx context.Context, msg InboundMessage) error
+
+// HandleMessage implements MessageHandler.
+func (f MessageHandlerFunc) HandleMessage(ctx context.Context, msg InboundMessage) error {
+	return f(ctx, msg)
+}
+
+// InboundMessage is a platform-agnostic representation of a message received
+// from an external messaging service.
+type InboundMessage struct {
+	// PlatformType identifies the source platform ("telegram", "slack", …).
+	PlatformType string
+
+	// PlatformID is the integration instance ID that received the message.
+	PlatformID string
+
+	// ChannelID is the platform-specific conversation identifier
+	// (e.g. Telegram chat_id, Slack channel ID).
+	ChannelID string
+
+	// MessageID is the platform-specific unique message identifier.
+	MessageID string
+
+	// UserID is the platform-specific sender identifier.
+	UserID string
+
+	// UserDisplayName is the human-readable name of the sender.
+	UserDisplayName string
+
+	// Content is the text body of the message.
+	Content string
+
+	// Timestamp is when the message was sent on the platform.
+	Timestamp time.Time
+
+	// Metadata carries platform-specific extra data that does not fit in
+	// the standard fields (e.g. Telegram update_id, Slack thread_ts).
+	Metadata map[string]string
+}
+
+// OutboundMessage is a platform-agnostic representation of a message to be
+// sent to an external messaging service.
+type OutboundMessage struct {
+	// ChannelID is the platform-specific conversation identifier.
+	ChannelID string
+
+	// Content is the text body to send. Platforms may apply their own
+	// formatting rules (e.g. Markdown for Telegram, mrkdwn for Slack).
+	Content string
+
+	// ReplyToMessageID optionally references the platform-specific message
+	// ID that this message is a reply to.
+	ReplyToMessageID string
+
+	// Metadata carries platform-specific options (e.g. parse_mode for Telegram).
+	Metadata map[string]string
+}
+
+// PlatformFactory creates a Platform adapter from an integration config.
+// The messageHandler is wired by the Manager so the adapter can forward
+// inbound messages to the Dispatcher.
+type PlatformFactory func(integrationID string, credentials map[string]string, handler MessageHandler) (Platform, error)

--- a/internal/messaging/registry.go
+++ b/internal/messaging/registry.go
@@ -1,0 +1,44 @@
+package messaging
+
+import "sync"
+
+// platformRegistry is a thread-safe map of Platform instances keyed by their ID.
+type platformRegistry struct {
+	mu        sync.RWMutex
+	platforms map[string]Platform
+}
+
+func newPlatformRegistry() *platformRegistry {
+	return &platformRegistry{
+		platforms: make(map[string]Platform),
+	}
+}
+
+func (r *platformRegistry) put(id string, p Platform) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.platforms[id] = p
+}
+
+func (r *platformRegistry) get(id string) (Platform, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	p, ok := r.platforms[id]
+	return p, ok
+}
+
+func (r *platformRegistry) delete(id string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.platforms, id)
+}
+
+func (r *platformRegistry) all() map[string]Platform {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make(map[string]Platform, len(r.platforms))
+	for id, p := range r.platforms {
+		out[id] = p
+	}
+	return out
+}

--- a/internal/messaging/telegram/adapter.go
+++ b/internal/messaging/telegram/adapter.go
@@ -1,0 +1,288 @@
+// Package telegram provides a Telegram bot adapter that implements the
+// messaging.Platform interface for bidirectional chat.
+package telegram
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/shaharia-lab/agento/internal/messaging"
+)
+
+// apiBaseURL is the Telegram Bot API base. Variable so tests can override.
+var apiBaseURL = "https://api.telegram.org"
+
+// httpClient used for outbound Telegram API calls.
+var httpClient = &http.Client{Timeout: 60 * time.Second}
+
+// Adapter implements messaging.Platform for Telegram.
+type Adapter struct {
+	integrationID string
+	botToken      string
+	handler       messaging.MessageHandler
+	logger        *slog.Logger
+	cancel        context.CancelFunc
+}
+
+// NewAdapter creates a Telegram messaging adapter.
+func NewAdapter(integrationID, botToken string, handler messaging.MessageHandler, logger *slog.Logger) *Adapter {
+	return &Adapter{
+		integrationID: integrationID,
+		botToken:      botToken,
+		handler:       handler,
+		logger:        logger,
+	}
+}
+
+// NewFactory returns a messaging.PlatformFactory for Telegram.
+func NewFactory(logger *slog.Logger) messaging.PlatformFactory {
+	return func(integrationID string, credentials map[string]string, handler messaging.MessageHandler) (messaging.Platform, error) {
+		botToken := credentials["bot_token"]
+		if botToken == "" {
+			return nil, fmt.Errorf("missing bot_token in credentials")
+		}
+		return NewAdapter(integrationID, botToken, handler, logger), nil
+	}
+}
+
+// ID returns the integration ID.
+func (a *Adapter) ID() string { return a.integrationID }
+
+// Type returns "telegram".
+func (a *Adapter) Type() string { return "telegram" }
+
+// Start initialises the adapter. Currently a no-op since we use webhooks.
+func (a *Adapter) Start(ctx context.Context) error {
+	_, cancel := context.WithCancel(ctx)
+	a.cancel = cancel
+	a.logger.Info("telegram messaging adapter started", "integration_id", a.integrationID)
+	return nil
+}
+
+// Stop gracefully shuts down the adapter.
+func (a *Adapter) Stop() error {
+	if a.cancel != nil {
+		a.cancel()
+	}
+	a.logger.Info("telegram messaging adapter stopped", "integration_id", a.integrationID)
+	return nil
+}
+
+// telegramUpdate represents the Telegram Update object received via webhook.
+type telegramUpdate struct {
+	UpdateID int64           `json:"update_id"`
+	Message  *telegramMsg    `json:"message,omitempty"`
+}
+
+type telegramMsg struct {
+	MessageID int64        `json:"message_id"`
+	From      *telegramUser `json:"from,omitempty"`
+	Chat      telegramChat `json:"chat"`
+	Date      int64        `json:"date"`
+	Text      string       `json:"text"`
+}
+
+type telegramUser struct {
+	ID        int64  `json:"id"`
+	IsBot     bool   `json:"is_bot"`
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name,omitempty"`
+	Username  string `json:"username,omitempty"`
+}
+
+type telegramChat struct {
+	ID   int64  `json:"id"`
+	Type string `json:"type"`
+}
+
+// HandleWebhook processes an inbound Telegram webhook request.
+func (a *Adapter) HandleWebhook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, 10*1024*1024))
+	if err != nil {
+		a.logger.Error("failed to read webhook body", "error", err)
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+
+	var update telegramUpdate
+	if err := json.Unmarshal(body, &update); err != nil {
+		a.logger.Error("failed to parse webhook update", "error", err)
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+
+	// Acknowledge the webhook immediately — process the message asynchronously.
+	w.WriteHeader(http.StatusOK)
+
+	if update.Message == nil || update.Message.Text == "" {
+		return
+	}
+
+	msg := a.toInboundMessage(update)
+	go func() {
+		ctx := context.Background()
+		if handleErr := a.handler.HandleMessage(ctx, msg); handleErr != nil {
+			a.logger.Error("failed to handle inbound message",
+				"chat_id", update.Message.Chat.ID,
+				"error", handleErr,
+			)
+		}
+	}()
+}
+
+// toInboundMessage converts a Telegram update to a generic InboundMessage.
+func (a *Adapter) toInboundMessage(update telegramUpdate) messaging.InboundMessage {
+	tgMsg := update.Message
+	channelID := strconv.FormatInt(tgMsg.Chat.ID, 10)
+	messageID := strconv.FormatInt(tgMsg.MessageID, 10)
+
+	displayName := ""
+	userID := ""
+	if tgMsg.From != nil {
+		userID = strconv.FormatInt(tgMsg.From.ID, 10)
+		displayName = tgMsg.From.FirstName
+		if tgMsg.From.LastName != "" {
+			displayName += " " + tgMsg.From.LastName
+		}
+		if displayName == "" {
+			displayName = tgMsg.From.Username
+		}
+	}
+
+	return messaging.InboundMessage{
+		PlatformType:    "telegram",
+		PlatformID:      a.integrationID,
+		ChannelID:       channelID,
+		MessageID:       messageID,
+		UserID:          userID,
+		UserDisplayName: displayName,
+		Content:         tgMsg.Text,
+		Timestamp:       time.Unix(tgMsg.Date, 0),
+		Metadata: map[string]string{
+			"update_id": strconv.FormatInt(update.UpdateID, 10),
+			"chat_type": tgMsg.Chat.Type,
+		},
+	}
+}
+
+// SendMessage sends a text message to a Telegram chat.
+func (a *Adapter) SendMessage(ctx context.Context, msg messaging.OutboundMessage) error {
+	chatID, err := strconv.ParseInt(msg.ChannelID, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid chat_id %q: %w", msg.ChannelID, err)
+	}
+
+	// Telegram has a 4096 character limit per message. Split if needed.
+	chunks := splitMessage(msg.Content, 4096)
+	for _, chunk := range chunks {
+		payload := map[string]any{
+			"chat_id":    chatID,
+			"text":       chunk,
+			"parse_mode": "Markdown",
+		}
+
+		if msg.ReplyToMessageID != "" {
+			if replyID, parseErr := strconv.ParseInt(msg.ReplyToMessageID, 10, 64); parseErr == nil {
+				payload["reply_to_message_id"] = replyID
+			}
+		}
+
+		if sendErr := a.callAPI(ctx, "sendMessage", payload); sendErr != nil {
+			return sendErr
+		}
+	}
+	return nil
+}
+
+// SendTypingIndicator sends a "typing" chat action.
+func (a *Adapter) SendTypingIndicator(ctx context.Context, channelID string) error {
+	chatID, err := strconv.ParseInt(channelID, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid chat_id %q: %w", channelID, err)
+	}
+	return a.callAPI(ctx, "sendChatAction", map[string]any{
+		"chat_id": chatID,
+		"action":  "typing",
+	})
+}
+
+// callAPI makes a POST request to the Telegram Bot API.
+func (a *Adapter) callAPI(ctx context.Context, method string, payload any) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshaling request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/bot%s/%s", apiBaseURL, a.botToken, method)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("calling Telegram %s: request failed", method)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
+	if err != nil {
+		return fmt.Errorf("reading response: %w", err)
+	}
+
+	var tgResp struct {
+		OK          bool   `json:"ok"`
+		Description string `json:"description,omitempty"`
+	}
+	if json.Unmarshal(respBody, &tgResp) == nil && !tgResp.OK {
+		return fmt.Errorf("telegram API error: %s", tgResp.Description)
+	}
+
+	return nil
+}
+
+// splitMessage splits a long message into chunks that fit within maxLen.
+func splitMessage(text string, maxLen int) []string {
+	if len(text) <= maxLen {
+		return []string{text}
+	}
+
+	var chunks []string
+	for len(text) > 0 {
+		if len(text) <= maxLen {
+			chunks = append(chunks, text)
+			break
+		}
+		// Try to split at a newline boundary.
+		cutAt := maxLen
+		if idx := lastIndexByte(text[:maxLen], '\n'); idx > 0 {
+			cutAt = idx + 1
+		}
+		chunks = append(chunks, text[:cutAt])
+		text = text[cutAt:]
+	}
+	return chunks
+}
+
+// lastIndexByte returns the last index of byte c in s, or -1.
+func lastIndexByte(s string, c byte) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/messaging/telegram/adapter_test.go
+++ b/internal/messaging/telegram/adapter_test.go
@@ -1,0 +1,258 @@
+package telegram
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/shaharia-lab/agento/internal/messaging"
+)
+
+func TestSplitMessage(t *testing.T) {
+	tests := []struct {
+		name   string
+		text   string
+		maxLen int
+		want   int // expected number of chunks
+	}{
+		{"short message", "hello", 4096, 1},
+		{"exactly at limit", strings.Repeat("a", 4096), 4096, 1},
+		{"over limit", strings.Repeat("a", 5000), 4096, 2},
+		{"with newline boundary", "line1\nline2\n" + strings.Repeat("a", 4090), 4096, 2},
+		{"empty message", "", 4096, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chunks := splitMessage(tt.text, tt.maxLen)
+			if len(chunks) != tt.want {
+				t.Errorf("got %d chunks, want %d", len(chunks), tt.want)
+			}
+			// Verify reassembled content matches original.
+			reassembled := strings.Join(chunks, "")
+			if reassembled != tt.text {
+				t.Error("reassembled text does not match original")
+			}
+			// Verify no chunk exceeds maxLen.
+			for i, chunk := range chunks {
+				if len(chunk) > tt.maxLen {
+					t.Errorf("chunk %d exceeds max length: %d > %d", i, len(chunk), tt.maxLen)
+				}
+			}
+		})
+	}
+}
+
+func TestAdapterHandleWebhook(t *testing.T) {
+	var mu sync.Mutex
+	var received []messaging.InboundMessage
+
+	handler := messaging.MessageHandlerFunc(func(_ context.Context, msg messaging.InboundMessage) error {
+		mu.Lock()
+		defer mu.Unlock()
+		received = append(received, msg)
+		return nil
+	})
+
+	adapter := NewAdapter("integration-1", "test-token", handler, nil)
+	// Use a no-op logger to avoid nil pointer.
+	adapter.logger = newTestLogger()
+
+	update := telegramUpdate{
+		UpdateID: 12345,
+		Message: &telegramMsg{
+			MessageID: 42,
+			From: &telegramUser{
+				ID:        100,
+				FirstName: "John",
+				LastName:  "Doe",
+				Username:  "johndoe",
+			},
+			Chat: telegramChat{
+				ID:   9876,
+				Type: "private",
+			},
+			Date: time.Now().Unix(),
+			Text: "Hello bot!",
+		},
+	}
+
+	body, _ := json.Marshal(update)
+	req := httptest.NewRequest(http.MethodPost, "/webhook", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	adapter.HandleWebhook(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("got status %d, want %d", w.Code, http.StatusOK)
+	}
+
+	// Wait a bit for the async handler goroutine.
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received) != 1 {
+		t.Fatalf("got %d messages, want 1", len(received))
+	}
+
+	msg := received[0]
+	if msg.PlatformType != "telegram" {
+		t.Errorf("got platform type %q, want %q", msg.PlatformType, "telegram")
+	}
+	if msg.PlatformID != "integration-1" {
+		t.Errorf("got platform ID %q, want %q", msg.PlatformID, "integration-1")
+	}
+	if msg.ChannelID != "9876" {
+		t.Errorf("got channel ID %q, want %q", msg.ChannelID, "9876")
+	}
+	if msg.UserID != "100" {
+		t.Errorf("got user ID %q, want %q", msg.UserID, "100")
+	}
+	if msg.UserDisplayName != "John Doe" {
+		t.Errorf("got display name %q, want %q", msg.UserDisplayName, "John Doe")
+	}
+	if msg.Content != "Hello bot!" {
+		t.Errorf("got content %q, want %q", msg.Content, "Hello bot!")
+	}
+}
+
+func TestAdapterHandleWebhookMethodNotAllowed(t *testing.T) {
+	adapter := NewAdapter("test", "token", nil, newTestLogger())
+
+	req := httptest.NewRequest(http.MethodGet, "/webhook", nil)
+	w := httptest.NewRecorder()
+
+	adapter.HandleWebhook(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("got status %d, want %d", w.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+func TestAdapterHandleWebhookEmptyMessage(t *testing.T) {
+	called := false
+	handler := messaging.MessageHandlerFunc(func(_ context.Context, _ messaging.InboundMessage) error {
+		called = true
+		return nil
+	})
+
+	adapter := NewAdapter("test", "token", handler, newTestLogger())
+
+	// Update with no message.
+	update := telegramUpdate{UpdateID: 1}
+	body, _ := json.Marshal(update)
+	req := httptest.NewRequest(http.MethodPost, "/webhook", strings.NewReader(string(body)))
+	w := httptest.NewRecorder()
+
+	adapter.HandleWebhook(w, req)
+
+	time.Sleep(50 * time.Millisecond)
+	if called {
+		t.Error("handler should not be called for empty message")
+	}
+}
+
+func TestAdapterSendMessage(t *testing.T) {
+	var receivedBody map[string]any
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &receivedBody) //nolint:errcheck
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]any{"ok": true}) //nolint:errcheck
+	}))
+	defer ts.Close()
+
+	// Override the API base URL.
+	origURL := apiBaseURL
+	apiBaseURL = ts.URL
+	defer func() { apiBaseURL = origURL }()
+
+	adapter := NewAdapter("test", "fake-token", nil, newTestLogger())
+
+	err := adapter.SendMessage(context.Background(), messaging.OutboundMessage{
+		ChannelID:        "12345",
+		Content:          "Hello!",
+		ReplyToMessageID: "42",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if receivedBody == nil {
+		t.Fatal("no request body received")
+	}
+	if receivedBody["text"] != "Hello!" {
+		t.Errorf("got text %v, want %q", receivedBody["text"], "Hello!")
+	}
+	if receivedBody["parse_mode"] != "Markdown" {
+		t.Errorf("got parse_mode %v, want %q", receivedBody["parse_mode"], "Markdown")
+	}
+}
+
+func TestAdapterSendTypingIndicator(t *testing.T) {
+	var receivedBody map[string]any
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &receivedBody) //nolint:errcheck
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]any{"ok": true}) //nolint:errcheck
+	}))
+	defer ts.Close()
+
+	origURL := apiBaseURL
+	apiBaseURL = ts.URL
+	defer func() { apiBaseURL = origURL }()
+
+	adapter := NewAdapter("test", "fake-token", nil, newTestLogger())
+
+	err := adapter.SendTypingIndicator(context.Background(), "12345")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if receivedBody["action"] != "typing" {
+		t.Errorf("got action %v, want %q", receivedBody["action"], "typing")
+	}
+}
+
+func TestNewFactory(t *testing.T) {
+	factory := NewFactory(newTestLogger())
+
+	handler := messaging.MessageHandlerFunc(func(_ context.Context, _ messaging.InboundMessage) error {
+		return nil
+	})
+
+	// Missing bot_token should error.
+	_, err := factory("id", map[string]string{}, handler)
+	if err == nil {
+		t.Error("expected error for missing bot_token")
+	}
+
+	// Valid credentials should work.
+	p, err := factory("id", map[string]string{"bot_token": "123:ABC"}, handler)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.ID() != "id" {
+		t.Errorf("got ID %q, want %q", p.ID(), "id")
+	}
+	if p.Type() != "telegram" {
+		t.Errorf("got Type %q, want %q", p.Type(), "telegram")
+	}
+}
+
+// newTestLogger returns a slog.Logger suitable for tests.
+func newTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}

--- a/internal/storage/conversation_mapping_store.go
+++ b/internal/storage/conversation_mapping_store.go
@@ -1,0 +1,41 @@
+package storage
+
+import "time"
+
+// ConversationMapping links a platform channel to an internal chat session.
+type ConversationMapping struct {
+	ID           string    `json:"id"`
+	SessionID    string    `json:"session_id"`
+	PlatformType string    `json:"platform_type"`
+	PlatformID   string    `json:"platform_id"`
+	ChannelID    string    `json:"channel_id"`
+	AgentSlug    string    `json:"agent_slug"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}
+
+// ConversationMappingStore persists the link between external platform
+// conversations and internal chat sessions.
+type ConversationMappingStore interface {
+	// GetByPlatformChannel returns the mapping for a given platform + channel
+	// combination, or nil if no mapping exists.
+	GetByPlatformChannel(platformType, platformID, channelID string) (*ConversationMapping, error)
+
+	// GetBySessionID returns the mapping for a given internal chat session, or nil.
+	GetBySessionID(sessionID string) (*ConversationMapping, error)
+
+	// Create inserts a new conversation mapping.
+	Create(mapping *ConversationMapping) error
+
+	// UpdateAgentSlug changes the agent associated with a mapping.
+	UpdateAgentSlug(id, agentSlug string) error
+
+	// Delete removes a mapping by its ID.
+	Delete(id string) error
+
+	// DeleteBySessionID removes the mapping for a given session.
+	DeleteBySessionID(sessionID string) error
+
+	// ListByPlatform returns all mappings for a given platform instance.
+	ListByPlatform(platformType, platformID string) ([]*ConversationMapping, error)
+}

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -192,6 +192,24 @@ CREATE INDEX idx_notification_log_created ON notification_log(created_at DESC);
 		version: 6,
 		sql:     `ALTER TABLE scheduled_tasks ADD COLUMN save_output INTEGER NOT NULL DEFAULT 0;`,
 	},
+	{
+		version: 7,
+		sql: `
+CREATE TABLE conversation_mappings (
+    id            TEXT PRIMARY KEY,
+    session_id    TEXT NOT NULL REFERENCES chat_sessions(id) ON DELETE CASCADE,
+    platform_type TEXT NOT NULL,
+    platform_id   TEXT NOT NULL,
+    channel_id    TEXT NOT NULL,
+    agent_slug    TEXT NOT NULL DEFAULT '',
+    created_at    DATETIME NOT NULL,
+    updated_at    DATETIME NOT NULL,
+    UNIQUE(platform_type, platform_id, channel_id)
+);
+CREATE INDEX idx_conversation_mappings_session ON conversation_mappings(session_id);
+CREATE INDEX idx_conversation_mappings_platform ON conversation_mappings(platform_type, platform_id);
+`,
+	},
 }
 
 // NewSQLiteDB opens (or creates) a SQLite database at dbPath, configures

--- a/internal/storage/sqlite_conversation_mapping_store.go
+++ b/internal/storage/sqlite_conversation_mapping_store.go
@@ -1,0 +1,161 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// SQLiteConversationMappingStore implements ConversationMappingStore backed by SQLite.
+type SQLiteConversationMappingStore struct {
+	db *sql.DB
+}
+
+// NewSQLiteConversationMappingStore returns a new store instance.
+func NewSQLiteConversationMappingStore(db *sql.DB) *SQLiteConversationMappingStore {
+	return &SQLiteConversationMappingStore{db: db}
+}
+
+// GetByPlatformChannel returns the mapping for a given platform + channel, or nil.
+func (s *SQLiteConversationMappingStore) GetByPlatformChannel(
+	platformType, platformID, channelID string,
+) (*ConversationMapping, error) {
+	ctx := context.Background()
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, session_id, platform_type, platform_id, channel_id, agent_slug, created_at, updated_at
+		FROM conversation_mappings
+		WHERE platform_type = ? AND platform_id = ? AND channel_id = ?`,
+		platformType, platformID, channelID,
+	)
+
+	m := &ConversationMapping{}
+	err := row.Scan(
+		&m.ID, &m.SessionID, &m.PlatformType, &m.PlatformID,
+		&m.ChannelID, &m.AgentSlug, &m.CreatedAt, &m.UpdatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("getting conversation mapping: %w", err)
+	}
+	return m, nil
+}
+
+// GetBySessionID returns the mapping for a given session, or nil.
+func (s *SQLiteConversationMappingStore) GetBySessionID(sessionID string) (*ConversationMapping, error) {
+	ctx := context.Background()
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, session_id, platform_type, platform_id, channel_id, agent_slug, created_at, updated_at
+		FROM conversation_mappings
+		WHERE session_id = ?`, sessionID,
+	)
+
+	m := &ConversationMapping{}
+	err := row.Scan(
+		&m.ID, &m.SessionID, &m.PlatformType, &m.PlatformID,
+		&m.ChannelID, &m.AgentSlug, &m.CreatedAt, &m.UpdatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("getting conversation mapping by session: %w", err)
+	}
+	return m, nil
+}
+
+// Create inserts a new conversation mapping.
+func (s *SQLiteConversationMappingStore) Create(mapping *ConversationMapping) error {
+	if mapping.ID == "" {
+		mapping.ID = uuid.New().String()
+	}
+	now := time.Now().UTC()
+	if mapping.CreatedAt.IsZero() {
+		mapping.CreatedAt = now
+	}
+	mapping.UpdatedAt = now
+
+	ctx := context.Background()
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO conversation_mappings
+			(id, session_id, platform_type, platform_id, channel_id, agent_slug, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		mapping.ID, mapping.SessionID, mapping.PlatformType, mapping.PlatformID,
+		mapping.ChannelID, mapping.AgentSlug, mapping.CreatedAt, mapping.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("creating conversation mapping: %w", err)
+	}
+	return nil
+}
+
+// UpdateAgentSlug changes the agent associated with a mapping.
+func (s *SQLiteConversationMappingStore) UpdateAgentSlug(id, agentSlug string) error {
+	ctx := context.Background()
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE conversation_mappings SET agent_slug = ?, updated_at = ? WHERE id = ?`,
+		agentSlug, time.Now().UTC(), id,
+	)
+	if err != nil {
+		return fmt.Errorf("updating agent slug for mapping %q: %w", id, err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("conversation mapping %q not found", id)
+	}
+	return nil
+}
+
+// Delete removes a mapping by its ID.
+func (s *SQLiteConversationMappingStore) Delete(id string) error {
+	ctx := context.Background()
+	_, err := s.db.ExecContext(ctx, "DELETE FROM conversation_mappings WHERE id = ?", id)
+	if err != nil {
+		return fmt.Errorf("deleting conversation mapping %q: %w", id, err)
+	}
+	return nil
+}
+
+// DeleteBySessionID removes the mapping for a given session.
+func (s *SQLiteConversationMappingStore) DeleteBySessionID(sessionID string) error {
+	ctx := context.Background()
+	_, err := s.db.ExecContext(ctx, "DELETE FROM conversation_mappings WHERE session_id = ?", sessionID)
+	if err != nil {
+		return fmt.Errorf("deleting conversation mapping for session %q: %w", sessionID, err)
+	}
+	return nil
+}
+
+// ListByPlatform returns all mappings for a given platform instance.
+func (s *SQLiteConversationMappingStore) ListByPlatform(
+	platformType, platformID string,
+) ([]*ConversationMapping, error) {
+	ctx := context.Background()
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, session_id, platform_type, platform_id, channel_id, agent_slug, created_at, updated_at
+		FROM conversation_mappings
+		WHERE platform_type = ? AND platform_id = ?
+		ORDER BY updated_at DESC`, platformType, platformID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listing conversation mappings: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	var result []*ConversationMapping
+	for rows.Next() {
+		m := &ConversationMapping{}
+		if scanErr := rows.Scan(
+			&m.ID, &m.SessionID, &m.PlatformType, &m.PlatformID,
+			&m.ChannelID, &m.AgentSlug, &m.CreatedAt, &m.UpdatedAt,
+		); scanErr != nil {
+			return nil, fmt.Errorf("scanning conversation mapping: %w", scanErr)
+		}
+		result = append(result, m)
+	}
+	return result, rows.Err()
+}

--- a/internal/storage/sqlite_conversation_mapping_store_test.go
+++ b/internal/storage/sqlite_conversation_mapping_store_test.go
@@ -1,0 +1,285 @@
+package storage
+
+import (
+	"testing"
+)
+
+// createTestSession is a helper that creates a chat session and returns its ID.
+func createTestSession(t *testing.T, store *SQLiteChatStore) string {
+	t.Helper()
+	session, err := store.CreateSession("", "", "", "")
+	if err != nil {
+		t.Fatalf("creating test session: %v", err)
+	}
+	return session.ID
+}
+
+func TestSQLiteConversationMappingStore_CreateAndGet(t *testing.T) {
+	db := newTestDB(t)
+	chatStore := NewSQLiteChatStore(db)
+	store := NewSQLiteConversationMappingStore(db)
+
+	sessionID := createTestSession(t, chatStore)
+
+	mapping := &ConversationMapping{
+		SessionID:    sessionID,
+		PlatformType: "telegram",
+		PlatformID:   "integration-1",
+		ChannelID:    "12345",
+		AgentSlug:    "test-agent",
+	}
+
+	if err := store.Create(mapping); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if mapping.ID == "" {
+		t.Error("expected ID to be set after Create")
+	}
+	if mapping.CreatedAt.IsZero() {
+		t.Error("expected CreatedAt to be set")
+	}
+
+	// Get by platform channel.
+	got, err := store.GetByPlatformChannel("telegram", "integration-1", "12345")
+	if err != nil {
+		t.Fatalf("GetByPlatformChannel failed: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected mapping, got nil")
+	}
+	if got.SessionID != sessionID {
+		t.Errorf("got session ID %q, want %q", got.SessionID, sessionID)
+	}
+	if got.AgentSlug != "test-agent" {
+		t.Errorf("got agent slug %q, want %q", got.AgentSlug, "test-agent")
+	}
+
+	// Get by session ID.
+	got2, err := store.GetBySessionID(sessionID)
+	if err != nil {
+		t.Fatalf("GetBySessionID failed: %v", err)
+	}
+	if got2 == nil {
+		t.Fatal("expected mapping, got nil")
+	}
+	if got2.ChannelID != "12345" {
+		t.Errorf("got channel ID %q, want %q", got2.ChannelID, "12345")
+	}
+}
+
+func TestSQLiteConversationMappingStore_NotFound(t *testing.T) {
+	db := newTestDB(t)
+	store := NewSQLiteConversationMappingStore(db)
+
+	got, err := store.GetByPlatformChannel("telegram", "nonexistent", "999")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Error("expected nil for nonexistent mapping")
+	}
+
+	got2, err := store.GetBySessionID("nonexistent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got2 != nil {
+		t.Error("expected nil for nonexistent session")
+	}
+}
+
+func TestSQLiteConversationMappingStore_UpdateAgentSlug(t *testing.T) {
+	db := newTestDB(t)
+	chatStore := NewSQLiteChatStore(db)
+	store := NewSQLiteConversationMappingStore(db)
+
+	sessionID := createTestSession(t, chatStore)
+
+	mapping := &ConversationMapping{
+		SessionID:    sessionID,
+		PlatformType: "telegram",
+		PlatformID:   "integration-1",
+		ChannelID:    "12345",
+		AgentSlug:    "old-agent",
+	}
+
+	if err := store.Create(mapping); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if err := store.UpdateAgentSlug(mapping.ID, "new-agent"); err != nil {
+		t.Fatalf("UpdateAgentSlug failed: %v", err)
+	}
+
+	got, _ := store.GetByPlatformChannel("telegram", "integration-1", "12345")
+	if got.AgentSlug != "new-agent" {
+		t.Errorf("got agent slug %q, want %q", got.AgentSlug, "new-agent")
+	}
+}
+
+func TestSQLiteConversationMappingStore_Delete(t *testing.T) {
+	db := newTestDB(t)
+	chatStore := NewSQLiteChatStore(db)
+	store := NewSQLiteConversationMappingStore(db)
+
+	sessionID := createTestSession(t, chatStore)
+
+	mapping := &ConversationMapping{
+		SessionID:    sessionID,
+		PlatformType: "telegram",
+		PlatformID:   "integration-1",
+		ChannelID:    "12345",
+	}
+
+	if err := store.Create(mapping); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if err := store.Delete(mapping.ID); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	got, _ := store.GetByPlatformChannel("telegram", "integration-1", "12345")
+	if got != nil {
+		t.Error("expected nil after delete")
+	}
+}
+
+func TestSQLiteConversationMappingStore_DeleteBySessionID(t *testing.T) {
+	db := newTestDB(t)
+	chatStore := NewSQLiteChatStore(db)
+	store := NewSQLiteConversationMappingStore(db)
+
+	sessionID := createTestSession(t, chatStore)
+
+	mapping := &ConversationMapping{
+		SessionID:    sessionID,
+		PlatformType: "telegram",
+		PlatformID:   "integration-1",
+		ChannelID:    "12345",
+	}
+
+	if err := store.Create(mapping); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if err := store.DeleteBySessionID(sessionID); err != nil {
+		t.Fatalf("DeleteBySessionID failed: %v", err)
+	}
+
+	got, _ := store.GetBySessionID(sessionID)
+	if got != nil {
+		t.Error("expected nil after delete by session ID")
+	}
+}
+
+func TestSQLiteConversationMappingStore_ListByPlatform(t *testing.T) {
+	db := newTestDB(t)
+	chatStore := NewSQLiteChatStore(db)
+	store := NewSQLiteConversationMappingStore(db)
+
+	// Create two mappings for the same platform.
+	for _, ch := range []string{"111", "222"} {
+		sid := createTestSession(t, chatStore)
+		m := &ConversationMapping{
+			SessionID:    sid,
+			PlatformType: "telegram",
+			PlatformID:   "integration-1",
+			ChannelID:    ch,
+		}
+		if err := store.Create(m); err != nil {
+			t.Fatalf("Create failed: %v", err)
+		}
+	}
+
+	// Create one for a different platform.
+	sid := createTestSession(t, chatStore)
+	m := &ConversationMapping{
+		SessionID:    sid,
+		PlatformType: "slack",
+		PlatformID:   "integration-2",
+		ChannelID:    "C123",
+	}
+	if err := store.Create(m); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	list, err := store.ListByPlatform("telegram", "integration-1")
+	if err != nil {
+		t.Fatalf("ListByPlatform failed: %v", err)
+	}
+	if len(list) != 2 {
+		t.Errorf("got %d mappings, want 2", len(list))
+	}
+
+	// Slack platform should only return 1.
+	list2, err := store.ListByPlatform("slack", "integration-2")
+	if err != nil {
+		t.Fatalf("ListByPlatform failed: %v", err)
+	}
+	if len(list2) != 1 {
+		t.Errorf("got %d mappings, want 1", len(list2))
+	}
+}
+
+func TestSQLiteConversationMappingStore_UniqueConstraint(t *testing.T) {
+	db := newTestDB(t)
+	chatStore := NewSQLiteChatStore(db)
+	store := NewSQLiteConversationMappingStore(db)
+
+	sid1 := createTestSession(t, chatStore)
+	sid2 := createTestSession(t, chatStore)
+
+	mapping := &ConversationMapping{
+		SessionID:    sid1,
+		PlatformType: "telegram",
+		PlatformID:   "integration-1",
+		ChannelID:    "12345",
+	}
+	if err := store.Create(mapping); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// Creating another mapping with same platform+channel should fail.
+	dup := &ConversationMapping{
+		SessionID:    sid2,
+		PlatformType: "telegram",
+		PlatformID:   "integration-1",
+		ChannelID:    "12345",
+	}
+	if err := store.Create(dup); err == nil {
+		t.Error("expected unique constraint violation")
+	}
+}
+
+func TestSQLiteConversationMappingStore_CascadeDelete(t *testing.T) {
+	db := newTestDB(t)
+	chatStore := NewSQLiteChatStore(db)
+	store := NewSQLiteConversationMappingStore(db)
+
+	sessionID := createTestSession(t, chatStore)
+
+	mapping := &ConversationMapping{
+		SessionID:    sessionID,
+		PlatformType: "telegram",
+		PlatformID:   "integration-1",
+		ChannelID:    "12345",
+	}
+	if err := store.Create(mapping); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// Deleting the chat session should cascade-delete the mapping.
+	if err := chatStore.DeleteSession(sessionID); err != nil {
+		t.Fatalf("DeleteSession failed: %v", err)
+	}
+
+	got, err := store.GetByPlatformChannel("telegram", "integration-1", "12345")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Error("expected mapping to be cascade-deleted with session")
+	}
+}

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -26,7 +26,7 @@ func newTestDB(t *testing.T) *sql.DB {
 func TestNewSQLiteDB_CreatesTables(t *testing.T) {
 	db := newTestDB(t)
 
-	tables := []string{"agents", "chat_sessions", "chat_messages", "integrations", "user_settings", "schema_migrations", "claude_session_cache", "claude_cache_metadata", "notification_log", "scheduled_tasks", "job_history"}
+	tables := []string{"agents", "chat_sessions", "chat_messages", "integrations", "user_settings", "schema_migrations", "claude_session_cache", "claude_cache_metadata", "notification_log", "scheduled_tasks", "job_history", "conversation_mappings"}
 	for _, table := range tables {
 		var name string
 		err := db.QueryRowContext(context.Background(), "SELECT name FROM sqlite_master WHERE type='table' AND name=?", table).Scan(&name)
@@ -44,8 +44,8 @@ func TestNewSQLiteDB_MigrationVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("querying version: %v", err)
 	}
-	if version != 6 {
-		t.Errorf("expected version 6, got %d", version)
+	if version != 7 {
+		t.Errorf("expected version 7, got %d", version)
 	}
 }
 


### PR DESCRIPTION
## Summary
This PR introduces a generic bidirectional messaging system that enables the agent to receive messages from external platforms (Telegram, Slack, etc.) and send responses back. It decouples platform-specific logic from the core agent conversation lifecycle through a clean abstraction layer.

## Key Changes

### Core Messaging Infrastructure
- **`internal/messaging/platform.go`**: Defines the `Platform` interface that all messaging adapters must implement, along with `InboundMessage` and `OutboundMessage` types for platform-agnostic message representation
- **`internal/messaging/dispatcher.go`**: Central message router that:
  - Receives inbound messages from platform adapters
  - Maps external conversations to internal chat sessions via `ConversationMapping`
  - Runs the agent with auto-approved permissions (no interactive UI available)
  - Sends responses back to the originating platform
  - Handles event consumption from the Claude SDK and formats responses
- **`internal/messaging/manager.go`**: Lifecycle manager for platform adapters that:
  - Registers platform factories at startup
  - Starts/stops platform adapters on demand
  - Routes webhooks to the correct adapter
- **`internal/messaging/registry.go`**: Thread-safe registry for managing active platform instances

### Telegram Adapter
- **`internal/messaging/telegram/adapter.go`**: Full Telegram Bot API integration that:
  - Implements the `Platform` interface
  - Handles webhook-based message reception
  - Converts Telegram updates to generic `InboundMessage` format
  - Sends responses via Telegram API with message splitting (4096 char limit)
  - Supports typing indicators
  - Includes factory function for dynamic adapter creation
- **`internal/messaging/telegram/adapter_test.go`**: Comprehensive test coverage for webhook handling, message sending, and edge cases

### Storage Layer
- **`internal/storage/conversation_mapping_store.go`**: Interface defining persistence operations for platform-to-session mappings
- **`internal/storage/sqlite_conversation_mapping_store.go`**: SQLite implementation with:
  - Lookup by platform+channel or session ID
  - CRUD operations with timestamps
  - Cascade delete when sessions are removed
  - Unique constraint on platform+channel combinations
- **`internal/storage/sqlite_conversation_mapping_store_test.go`**: Full test suite covering all store operations
- **`internal/storage/sqlite.go`**: Database migration (v7) creating the `conversation_mappings` table

### API Integration
- **`internal/api/webhooks.go`**: Generic webhook endpoint (`POST /webhooks/{platform_type}/{integration_id}`) that routes to the appropriate adapter
- **`internal/api/server.go`**: Added `messagingManager` field to wire up the messaging system
- **`cmd/web.go`**: Initialization code that:
  - Creates the dispatcher, manager, and mapping store
  - Registers the Telegram factory
  - Auto-starts messaging adapters for enabled integrations

## Notable Implementation Details

- **Permission Bypass**: The dispatcher runs agents with no `PermissionHandler`, automatically approving all tool calls since messaging platforms lack interactive approval UIs
- **Async Webhook Processing**: Telegram webhooks are acknowledged immediately (HTTP 200) with message processing happening asynchronously to avoid timeouts
- **Message Splitting**: Telegram responses are automatically split at 4096 characters with newline-aware boundaries
- **Session Mapping**: Each platform conversation is mapped to exactly one internal chat session, created on first message with a descriptive title
- **Event Consumption**: The dispatcher consumes Claude SDK events, extracting thinking blocks, tool calls, and final results for storage
- **Thread Safety**: Platform registry and manager use RWMutex for safe concurrent access