### PR TITLE
fix: redirect all logs to file only, remove stderr output

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -9,7 +9,6 @@ package logger
 
 import (
 	"fmt"
-	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -18,8 +17,7 @@ import (
 )
 
 // NewSystemLogger creates a JSON slog.Logger that writes to <logDir>/system.log
-// with automatic log rotation. Logs are also written to stderr for developer
-// visibility. The directory is created if it does not exist.
+// with automatic log rotation. The directory is created if it does not exist.
 // The returned cleanup function closes the underlying log file and should be
 // called on shutdown (e.g. via defer).
 func NewSystemLogger(logDir string, level slog.Level) (*slog.Logger, func(), error) {
@@ -35,8 +33,7 @@ func NewSystemLogger(logDir string, level slog.Level) (*slog.Logger, func(), err
 		Compress:   true,
 	}
 
-	w := io.MultiWriter(rotatingFile, os.Stderr)
-	handler := slog.NewJSONHandler(w, &slog.HandlerOptions{Level: level})
+	handler := slog.NewJSONHandler(rotatingFile, &slog.HandlerOptions{Level: level})
 	cleanup := func() {
 		if err := rotatingFile.Close(); err != nil {
 			fmt.Fprintf(os.Stderr, "closing log file: %v\n", err)


### PR DESCRIPTION
## Summary

Commit 204c12a introduced `io.MultiWriter` to write system logs to **both** the rotating log file and `os.Stderr`. This caused all info-level log lines to be printed to the terminal every time the app starts.

All logs should go exclusively to `<AGENTO_DATA_DIR>/logs/system.log` as intended by the logging architecture.

## Change

- Remove `os.Stderr` from the `MultiWriter` in `NewSystemLogger`
- Log handler now writes only to the rotating file (`lumberjack`)
- Remove the now-unused `"io"` import

## Test plan

- [x] Start `make dev-backend` — no log output in the terminal
- [x] Verify `~/.agento/logs/system.log` (or `$AGENTO_DATA_DIR/logs/system.log`) receives all log entries
- [x] Confirm log rotation still works (lumberjack config unchanged)