### PR TITLE
fix: resolve 7 SonarQube frontend issues

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -11,7 +11,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Roboto:wght@400;500&family=Open+Sans:wght@400;600&family=Lato:wght@400;700&family=Merriweather:wght@400;700&family=JetBrains+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
-    <script type="module" crossorigin src="/assets/index-t92GWZSX.js"></script>
+    <script type="module" crossorigin src="/assets/index-DE249QV8.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-Dr9nBNcJ.css">
   </head>
   <body>

--- a/frontend/src/components/UpdateBanner.tsx
+++ b/frontend/src/components/UpdateBanner.tsx
@@ -6,9 +6,9 @@ import type { UpdateCheckResponse } from '@/types'
 const DISMISS_STORAGE_KEY = 'agento-update-dismissed-version'
 
 interface HowToUpdateModalProps {
-  latestVersion: string
-  releaseUrl: string
-  onClose: () => void
+  readonly latestVersion: string
+  readonly releaseUrl: string
+  readonly onClose: () => void
 }
 
 function HowToUpdateModal({ latestVersion, releaseUrl, onClose }: HowToUpdateModalProps) {
@@ -16,22 +16,22 @@ function HowToUpdateModal({ latestVersion, releaseUrl, onClose }: HowToUpdateMod
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose()
     }
-    window.addEventListener('keydown', handler)
-    return () => window.removeEventListener('keydown', handler)
+    globalThis.addEventListener('keydown', handler)
+    return () => globalThis.removeEventListener('keydown', handler)
   }, [onClose])
 
   return (
     <div
+      role="none"
       className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm"
       onClick={e => {
         if (e.target === e.currentTarget) onClose()
       }}
     >
-      <div
-        role="dialog"
-        aria-modal="true"
+      <dialog
+        open
         aria-labelledby="update-modal-title"
-        className="relative w-full max-w-lg rounded-xl bg-white dark:bg-zinc-900 shadow-2xl border border-zinc-200 dark:border-zinc-700 overflow-hidden"
+        className="relative m-0 p-0 w-full max-w-lg rounded-xl bg-white dark:bg-zinc-900 shadow-2xl border border-zinc-200 dark:border-zinc-700 overflow-hidden"
       >
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-zinc-200 dark:border-zinc-700">
@@ -133,7 +133,7 @@ function HowToUpdateModal({ latestVersion, releaseUrl, onClose }: HowToUpdateMod
             Got it
           </button>
         </div>
-      </div>
+      </dialog>
     </div>
   )
 }

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -19,7 +19,6 @@ export function Tooltip({ content, children, side = 'right' }: TooltipProps) {
 
   return (
     <div
-      role="group"
       className="relative inline-flex"
       onMouseEnter={() => setVisible(true)}
       onMouseLeave={() => setVisible(false)}


### PR DESCRIPTION
## Summary

- Mark `HowToUpdateModalProps` interface properties as `readonly`
- Replace `window` with `globalThis` for keydown event listeners in `UpdateBanner`
- Add `role="none"` to backdrop overlay div (non-interactive element with click handler)
- Replace `<div role="dialog">` with native `<dialog open>` element in the update modal
- Remove incorrect `role="group"` from `Tooltip` wrapper div

## Issues fixed

All 7 open SonarQube issues cleared:

| Severity | Rule | File |
|----------|------|------|
| MINOR | Props should be read-only | `UpdateBanner.tsx` |
| MINOR ×2 | Prefer `globalThis` over `window` | `UpdateBanner.tsx` |
| MAJOR | Non-native interactive element requires role | `UpdateBanner.tsx` |
| BUG | Click handler without keyboard listener | `UpdateBanner.tsx` |
| MAJOR | Use `<dialog>` instead of `role="dialog"` | `UpdateBanner.tsx` |
| MAJOR | Use semantic HTML instead of `role="group"` | `tooltip.tsx` |

## Test plan

- [ ] Update banner still renders and shows when a new version is available
- [ ] "How to update" modal opens and closes correctly (button click, Escape key, backdrop click)
- [ ] Tooltip still shows/hides on hover and focus
- [ ] TypeScript, ESLint, and build checks pass