### PR TITLE
docs: update documentation and context for changes since v0.4.1

### DIFF
--- a/.claude/skills/engineering/SKILL.md
+++ b/.claude/skills/engineering/SKILL.md
@@ -42,6 +42,8 @@ Read these as needed based on your task:
 | Business Logic | `internal/service/` | ChatService, AgentService, IntegrationService, NotificationService, TaskService, ClaudeSettingsProfileService |
 | Storage | `internal/storage/` | SQLite stores (Agent, Chat, Integration, Settings, Notification, Task) |
 | Agent Runner | `internal/agent/runner.go` | SDK integration, RunOptions, session execution |
+| Logging | `internal/logger/` | Structured slog loggers (system + per-session), log rotation |
+| Build Info | `internal/build/` | Build-time version variables (Version, CommitSHA, BuildDate) |
 | Configuration | `internal/config/` | AppConfig, profiles, integration config |
 | Built-in Tools | `internal/tools/` | Local MCP server, tool registry |
 | Integrations | `internal/integrations/` | Integration registry, MCP backends (Google, GitHub, Slack, Jira, Confluence, Telegram) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,10 @@ Browser → Vite (dev) / embedded FS (prod) → React SPA
 
 **`internal/notification/`** — Notification system with SMTP email support. `handler.go` processes events, `smtp.go` sends emails, `template.go` renders notification content.
 
+**`internal/logger/`** — Structured `slog` loggers for system-wide and per-session logging. `NewSystemLogger` writes JSON to a rotating log file via `lumberjack` (50MB, 3 backups, 30 days, compressed). `NewSessionLogger` writes per-session logs to `<logDir>/sessions/<id>.log`.
+
+**`internal/build/`** — Build-time version variables injected via `-ldflags` (Version, CommitSHA, BuildDate).
+
 ### Frontend
 
 **`frontend/src/lib/api.ts`** — Typed API client for all backend endpoints.
@@ -93,7 +97,7 @@ Browser → Vite (dev) / embedded FS (prod) → React SPA
 **`frontend/src/contexts/`** — Theme and appearance state shared across components.
 
 ### Agent Configuration
-Agents are stored in the SQLite database (legacy YAML files in `~/.agento/agents/` are auto-migrated on first startup). Create and edit agents via the UI or API. Fields: `name`, `slug`, `model`, `system_prompt`, `thinking`, `permission_mode`, `capabilities` (built_in/local/mcp/integration tools). Template variables: `{{current_date}}`, `{{current_time}}`.
+Agents are stored in the SQLite database (legacy YAML files in `~/.agento/agents/` are auto-migrated on first startup). Create and edit agents via the UI or API. Fields: `name`, `slug`, `model`, `system_prompt`, `thinking`, `permission_mode`, `capabilities` (built_in/local/mcp/integration tools). Permission modes: `bypass` (default), `default`, `plan`, `dontAsk`. Template variables: `{{current_date}}`, `{{current_time}}`.
 
 ### MCP Integration
 External MCP servers defined in `mcps.yaml` (or `MCPS_FILE`). Local in-process tools registered via `internal/tools/registry.go`. Claude settings profiles stored as `~/.claude/settings_<slug>.json` with metadata at `~/.claude/settings_profiles.json`.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ You can define agents with custom system prompts and tools, start multi-turn con
 - **Integrations** — Connect Google (Calendar, Gmail, Drive), GitHub, Slack, Jira, Confluence, and Telegram as agent tools
 - **Task scheduler** — Schedule recurring agent tasks with cron expressions and track job history
 - **Notifications** — Event-driven notification system with SMTP email support
+- **Auto-update check** — Banner notification when a newer release is available, with one-command update
 
 ---
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -38,6 +38,7 @@ After saving the file, restart Agento or use the UI to reload agents.
 | `description` | No | Short description shown in the UI |
 | `model` | No | Claude model ID. Defaults to `claude-sonnet-4-6` |
 | `thinking` | No | `adaptive` (default), `enabled`, or `disabled` |
+| `permission_mode` | No | `bypass` (default), `default`, `plan`, or `dontAsk` |
 | `system_prompt` | No | Instructions sent to the model before every conversation |
 | `capabilities` | No | Tools the agent can use (see below) |
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -85,9 +85,11 @@ agento/
 ├── cmd/              # Cobra commands (web, ask, update)
 ├── frontend/         # React + TypeScript UI
 ├── internal/
+│   ├── agent/        # SDK integration, RunOptions, session execution
 │   ├── api/          # HTTP handlers
 │   ├── build/        # Build-time version variables
 │   ├── config/       # AppConfig, AgentConfig, MCP config
+│   ├── logger/       # Structured slog loggers (system + per-session), log rotation
 │   ├── server/       # HTTP server wiring
 │   ├── claudesessions/ # Claude session scanner and analytics
 │   ├── eventbus/       # In-process event bus

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -54,6 +54,7 @@ Visit [http://localhost:8990](http://localhost:8990) in your browser.
 | — | `AGENTO_DATA_DIR` | `~/.agento` | Directory where agents, chats, and logs are stored |
 | — | `AGENTO_DEFAULT_MODEL` | Claude Sonnet | Claude model used for direct (no-agent) chat |
 | — | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warn`, `error` |
+| — | `AGENTO_WORKING_DIR` | `/tmp/agento/work` | Default working directory for agent sessions |
 | — | `ANTHROPIC_API_KEY` | — | Anthropic API key (optional if already stored by the Claude CLI) |
 
 **Example: run on a different port**


### PR DESCRIPTION
## Summary

- Adds `internal/logger/` and `internal/build/` to CLAUDE.md Backend Layers section
- Documents permission modes (`bypass`, `default`, `plan`, `dontAsk`) in CLAUDE.md and `docs/agents.md`
- Adds auto-update check feature to README.md features list
- Adds `AGENTO_WORKING_DIR` environment variable to `docs/getting-started.md`
- Adds `internal/agent/` and `internal/logger/` entries to project layout in `docs/development.md`
- Adds Logging and Build Info rows to engineering skill codebase index

## Test plan

- [x] Review each changed file for accuracy against the corresponding PRs (#57, #60, #61, #81)
- [x] Verify no broken links or formatting issues