### PR TITLE
fix: do not cancel OAuth callback context when StartOAuth returns (#87)

### DIFF
--- a/internal/service/integration_service.go
+++ b/internal/service/integration_service.go
@@ -331,9 +331,14 @@ func (s *integrationService) StartOAuth(ctx context.Context, id string) (string,
 
 	// Detach from the request context so the callback server outlives the HTTP request,
 	// then apply a 10-minute deadline for the OAuth flow.
+	//
+	// IMPORTANT: Do NOT defer cancelCallback() here. The HTTP handler that calls
+	// StartOAuth returns immediately after receiving the auth URL, which would trigger
+	// the defer and cancel callbackCtx — killing the callback server before the user
+	// has a chance to complete the OAuth redirect. Instead, cancelCallback is called
+	// by onToken (guaranteed to be invoked by the callback server on success, error,
+	// or timeout) and also on the early-error paths below.
 	callbackCtx, cancelCallback := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Minute)
-	// cancelCallback is idempotent — safe to call multiple times (e.g. also called by onToken).
-	defer cancelCallback()
 
 	onToken := func(tok *oauth2.Token, tokErr error) {
 		defer cancelCallback()
@@ -344,17 +349,21 @@ func (s *integrationService) StartOAuth(ctx context.Context, id string) (string,
 	case "google":
 		authURL, buildErr = google.BuildAuthURL(cfg, port)
 		if buildErr != nil {
+			cancelCallback()
 			return "", fmt.Errorf("building auth URL: %w", buildErr)
 		}
 		if err := google.StartCallbackServer(callbackCtx, port, cfg, onToken, s.logger); err != nil {
+			cancelCallback()
 			return "", fmt.Errorf("starting callback server: %w", err)
 		}
 	case "slack":
 		authURL, buildErr = slackintegration.BuildAuthURL(cfg, port)
 		if buildErr != nil {
+			cancelCallback()
 			return "", fmt.Errorf("building auth URL: %w", buildErr)
 		}
 		if err := slackintegration.StartCallbackServer(callbackCtx, port, cfg, onToken, s.logger); err != nil {
+			cancelCallback()
 			return "", fmt.Errorf("starting callback server: %w", err)
 		}
 	}

--- a/internal/service/integration_service_test.go
+++ b/internal/service/integration_service_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/shaharia-lab/agento/internal/config"
 	"github.com/shaharia-lab/agento/internal/integrations"
@@ -822,6 +823,106 @@ func TestIntegrationService_AvailableTools(t *testing.T) {
 
 // ---------------------------------------------------------------------------
 // ValidateTokenAuth
+// ---------------------------------------------------------------------------
+// StartOAuth
+// ---------------------------------------------------------------------------
+
+func TestIntegrationService_StartOAuth_NotFound(t *testing.T) {
+	store := new(mocks.MockIntegrationStore)
+	store.On("Get", "no-exist").Return(nil, nil)
+	svc := NewIntegrationService(store, nil, testLogger())
+
+	_, err := svc.StartOAuth(context.Background(), "no-exist")
+	assert.Error(t, err)
+	assert.IsType(t, &NotFoundError{}, err)
+	store.AssertExpectations(t)
+}
+
+func TestIntegrationService_StartOAuth_StoreError(t *testing.T) {
+	store := new(mocks.MockIntegrationStore)
+	store.On("Get", "int-1").Return(nil, errors.New("db error"))
+	svc := NewIntegrationService(store, nil, testLogger())
+
+	_, err := svc.StartOAuth(context.Background(), "int-1")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "db error")
+	store.AssertExpectations(t)
+}
+
+func TestIntegrationService_StartOAuth_UnsupportedType(t *testing.T) {
+	store := new(mocks.MockIntegrationStore)
+	store.On("Get", "int-1").Return(&config.IntegrationConfig{
+		ID:   "int-1",
+		Type: "telegram",
+	}, nil)
+	svc := NewIntegrationService(store, nil, testLogger())
+
+	_, err := svc.StartOAuth(context.Background(), "int-1")
+	assert.Error(t, err)
+	var ve *ValidationError
+	assert.ErrorAs(t, err, &ve)
+	assert.Equal(t, "type", ve.Field)
+	store.AssertExpectations(t)
+}
+
+func TestIntegrationService_StartOAuth_GoogleReturnsAuthURL(t *testing.T) {
+	store := new(mocks.MockIntegrationStore)
+	cfg := &config.IntegrationConfig{
+		ID:   "int-google",
+		Type: "google",
+		Services: map[string]config.ServiceConfig{
+			"calendar": {Enabled: true},
+		},
+	}
+	_ = cfg.SetCredentials(config.GoogleCredentials{ClientID: "cid", ClientSecret: "csecret"})
+	store.On("Get", "int-google").Return(cfg, nil)
+
+	registry := integrations.NewRegistry(store, testLogger())
+	svc := NewIntegrationService(store, registry, testLogger())
+
+	authURL, err := svc.StartOAuth(context.Background(), "int-google")
+	assert.NoError(t, err)
+	assert.Contains(t, authURL, "accounts.google.com")
+	assert.Contains(t, authURL, "client_id=cid")
+	store.AssertExpectations(t)
+}
+
+// TestIntegrationService_StartOAuth_CallbackContextNotCanceledImmediately is a
+// regression test for the bug where defer cancelCallback() in StartOAuth was
+// canceling callbackCtx as soon as the function returned with the auth URL —
+// before the user had a chance to complete the OAuth redirect. This caused the
+// callback server to shut down immediately and all subsequent GetAuthStatus calls
+// to return "context canceled".
+func TestIntegrationService_StartOAuth_CallbackContextNotCanceledImmediately(t *testing.T) {
+	store := new(mocks.MockIntegrationStore)
+	cfg := &config.IntegrationConfig{
+		ID:   "int-google",
+		Type: "google",
+		Services: map[string]config.ServiceConfig{
+			"calendar": {Enabled: true},
+		},
+	}
+	_ = cfg.SetCredentials(config.GoogleCredentials{ClientID: "cid", ClientSecret: "csecret"})
+	store.On("Get", "int-google").Return(cfg, nil)
+
+	registry := integrations.NewRegistry(store, testLogger())
+	svc := NewIntegrationService(store, registry, testLogger())
+
+	_, err := svc.StartOAuth(context.Background(), "int-google")
+	require.NoError(t, err)
+
+	// Wait long enough for any background goroutine to fire if the context was
+	// incorrectly canceled inside StartOAuth (the broken defer scenario).
+	time.Sleep(100 * time.Millisecond)
+
+	// GetAuthStatus must NOT return an error: if the context was canceled before
+	// the user completed the OAuth flow, state.err would be set to context.Canceled
+	// and this call would return (false, context.Canceled).
+	auth, statusErr := svc.GetAuthStatus(context.Background(), "int-google")
+	assert.NoError(t, statusErr, "callback context must not be canceled immediately after StartOAuth returns")
+	assert.False(t, auth, "should not be authenticated yet — no callback received")
+}
+
 // ---------------------------------------------------------------------------
 
 func TestIntegrationService_ValidateTokenAuth(t *testing.T) {


### PR DESCRIPTION
## Problem

Fixes #87 — Google OAuth flow failing with `context canceled`.

The root cause was a **premature context cancellation** in `StartOAuth`. The function created a `callbackCtx` with a 10-minute timeout (detached from the HTTP request context) and then immediately deferred `cancelCallback()`. Because Go's defer runs when the enclosing function returns, `callbackCtx` was canceled the moment `StartOAuth` returned the auth URL to the caller — before the user had a chance to open it and complete the redirect.

This triggered the goroutine inside `StartCallbackServer`:
```go
select {
case result := <-resultCh:
    onToken(result.Token, result.Err)
case <-ctx.Done():              // ← fired immediately due to the bug
    onToken(nil, ctx.Err())     // ctx.Err() == context.Canceled
}
```
…which called `srv.Close()` and set `state.err = context.Canceled`. Every subsequent `GET /api/integrations/{id}/auth-status` call then returned `500 Internal Server Error`.

## Fix

- **Remove `defer cancelCallback()`** from `StartOAuth`.  
- Call `cancelCallback()` explicitly on the early-error return paths (invalid auth URL, failed callback server startup) so the context is still properly cleaned up in those cases.  
- `cancelCallback` continues to be called by `onToken` (via its own defer) on both success and error, and the 10-minute timeout provides the final safety net.

## Tests

Five new unit tests added to `integration_service_test.go`:

| Test | What it covers |
|------|---------------|
| `StartOAuth_NotFound` | Returns `NotFoundError` for unknown integration ID |
| `StartOAuth_StoreError` | Propagates store errors |
| `StartOAuth_UnsupportedType` | Returns `ValidationError` for non-OAuth integration types |
| `StartOAuth_GoogleReturnsAuthURL` | Returns a valid Google auth URL |
| `StartOAuth_CallbackContextNotCanceledImmediately` | **Regression test**: verifies that `GetAuthStatus` does not return `context.Canceled` immediately after `StartOAuth` returns — the exact failure mode of the bug |

## Note on desktop app OAuth clients

The user was using a Google OAuth2 **Desktop app** client. The existing implementation uses `http://localhost:PORT/callback` as the redirect URI, which is compatible with desktop app credentials. The fix above resolves the flow for all client types.