### PR TITLE
feat: granular OTel tracing for chat SSE events, tool calls, and scheduler tasks

### DIFF
--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -467,7 +467,7 @@ func RunAgent(
 		return nil, fmt.Errorf("starting agent: %w", err)
 	}
 
-	result, err := collectRunResult(stream, span)
+	result, err := collectRunResult(ctx, stream, span)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -534,14 +534,14 @@ func resolveSystemPrompt(agentCfg *config.AgentConfig, opts RunOptions) (string,
 	return Interpolate(agentCfg.SystemPrompt, opts.Variables)
 }
 
-func collectRunResult(stream *claude.Stream, runSpan trace.Span) (*AgentResult, error) {
+func collectRunResult(ctx context.Context, stream *claude.Stream, runSpan trace.Span) (*AgentResult, error) {
 	var finalThinking string
 	var result *AgentResult
 	var resultErr error
 	toolSpans := make(map[string]ToolSpanEntry)
 
 	for event := range stream.Events() {
-		processRunEvent(event, &finalThinking, &result, &resultErr, runSpan, toolSpans)
+		processRunEvent(ctx, event, &finalThinking, &result, &resultErr, runSpan, toolSpans)
 	}
 	FlushToolSpans(toolSpans)
 
@@ -560,7 +560,7 @@ func collectRunResult(stream *claude.Stream, runSpan trace.Span) (*AgentResult, 
 // We do NOT return early on TypeResult — the remaining events must be drained
 // so the subprocess has time to finish writing the session to disk.
 func processRunEvent(
-	event claude.Event,
+	ctx context.Context, event claude.Event,
 	thinking *string, result **AgentResult, resultErr *error,
 	runSpan trace.Span, toolSpans map[string]ToolSpanEntry,
 ) {
@@ -571,7 +571,7 @@ func processRunEvent(
 				*thinking = t
 			}
 		}
-		OpenToolSpans(runSpan, event.Raw, toolSpans)
+		OpenToolSpans(ctx, runSpan, event.Raw, toolSpans)
 	case claude.TypeSystem:
 		AddSystemInitEvent(runSpan, event.System)
 	case claude.TypeToolProgress:

--- a/internal/agent/tracing.go
+++ b/internal/agent/tracing.go
@@ -17,12 +17,14 @@ const MessageTypeUser claude.MessageType = "user"
 
 // ToolSpanEntry tracks an in-flight tool_use span keyed by tool_use_id.
 type ToolSpanEntry struct {
-	span trace.Span
+	Span trace.Span
 }
 
 // OpenToolSpans starts a child span for every tool_use block found in an
 // assistant event. Existing entries are skipped (idempotent).
-func OpenToolSpans(runSpan trace.Span, raw json.RawMessage, toolSpans map[string]ToolSpanEntry) {
+// ctx is used as the parent context so W3C baggage and sampling decisions
+// are preserved; runSpan is injected as the parent span.
+func OpenToolSpans(ctx context.Context, runSpan trace.Span, raw json.RawMessage, toolSpans map[string]ToolSpanEntry) {
 	var msg struct {
 		Message struct {
 			Content []struct {
@@ -43,14 +45,14 @@ func OpenToolSpans(runSpan trace.Span, raw json.RawMessage, toolSpans map[string
 		if _, exists := toolSpans[blk.ID]; exists {
 			continue
 		}
-		parentCtx := trace.ContextWithSpan(context.Background(), runSpan)
+		parentCtx := trace.ContextWithSpan(ctx, runSpan)
 		_, span := otel.Tracer("agento").Start(parentCtx, "tool_use."+blk.Name)
 		span.SetAttributes(
 			attribute.String("tool.id", blk.ID),
 			attribute.String("tool.name", blk.Name),
 			attribute.String("tool.input", TruncateAttr(string(blk.Input), 512)),
 		)
-		toolSpans[blk.ID] = ToolSpanEntry{span: span}
+		toolSpans[blk.ID] = ToolSpanEntry{Span: span}
 	}
 }
 
@@ -77,10 +79,10 @@ func CloseToolSpans(raw json.RawMessage, toolSpans map[string]ToolSpanEntry) {
 		if !ok {
 			continue
 		}
-		entry.span.SetAttributes(
+		entry.Span.SetAttributes(
 			attribute.String("tool.result", TruncateAttr(string(c.Content), 512)),
 		)
-		entry.span.End()
+		entry.Span.End()
 		delete(toolSpans, c.ToolUseID)
 	}
 }
@@ -89,7 +91,7 @@ func CloseToolSpans(raw json.RawMessage, toolSpans map[string]ToolSpanEntry) {
 // exits to prevent spans from being left open on cancellation or error.
 func FlushToolSpans(toolSpans map[string]ToolSpanEntry) {
 	for id, entry := range toolSpans {
-		entry.span.End()
+		entry.Span.End()
 		delete(toolSpans, id)
 	}
 }
@@ -103,7 +105,7 @@ func RecordToolProgress(tp *claude.ToolProgressMessage, toolSpans map[string]Too
 	if !ok {
 		return
 	}
-	entry.span.AddEvent("tool.progress",
+	entry.Span.AddEvent("tool.progress",
 		trace.WithAttributes(
 			attribute.String("tool.message", tp.Message),
 			attribute.Float64("tool.progress_pct", tp.Progress),

--- a/internal/api/chats.go
+++ b/internal/api/chats.go
@@ -453,7 +453,7 @@ func (ep *eventProcessor) processAgentEvent(event claude.Event, state *streamSta
 	switch event.Type {
 	case claude.TypeAssistant:
 		state.blocks = appendAssistantBlocks(state.blocks, event.Raw)
-		agent.OpenToolSpans(ep.execSpan, event.Raw, state.toolSpans)
+		agent.OpenToolSpans(ep.r.Context(), ep.execSpan, event.Raw, state.toolSpans)
 		if input := extractAskUserQuestionInput(event.Raw); input != nil {
 			state.pendingInput = input
 			ep.server.logger.Info("AskUserQuestion detected in stream", "session_id", ep.id)


### PR DESCRIPTION
## Summary

Extends the existing OTel instrumentation (from #93) with granular span coverage across the chat SSE pipeline and the task scheduler agent runner.

### Chat handler (`internal/api/`)
- **`chat.agent_execution` span** wraps the full streaming window + commit so the real agent duration (seconds) is visible instead of the sub-ms `chat.begin_message` span
- **`tool_use.<ToolName>` child spans** created for every tool call in `assistant` events; closed with result when the matching `tool_result` arrives in `user` events; flushed on cancellation/error
- **`agent.session_init` span event** — model, session_id, claude_version, tool_count, permission_mode from the `system` init event
- **`tool.progress` span events** on in-flight tool spans from `TypeToolProgress` events
- **Result metadata attributes** on `chat.agent_execution`: `agent.num_turns`, `agent.duration_ms`, `agent.duration_api_ms`, `agent.cost_usd`, all token counts, `agent.web_searches`, `agent.permission_denials`, `agent.is_error`
- **`agent.model_usage` span events** with per-model token and cost breakdown
- **Fix: `modelUsage` / `web_search_requests` JSON key mismatch** — the Claude CLI emits these fields in camelCase / nested under `server_tool_use`, which the SDK's snake_case struct tags cannot parse; fixed by parsing directly from `event.Raw` via `rawResultExtras`

### Scheduler agent runner (`internal/agent/`)
- Same granular tracing applied to `agent.run` span used by the task scheduler via `collectRunResult` / `processRunEvent`
- New `internal/agent/tracing.go` with all helpers (mirrors `chat_tracing.go` pattern in the `agent` package)

### Other (from initial instrumentation commit)
- Storage span helpers (`internal/storage/telemetry.go`)
- `chat_service.go` and `executor.go` span coverage
- SQLite store spans

## Test plan

- [x] `go build ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] Chat with tool calls: verified `tool_use.Write`, `tool_use.Read` etc. appear as child spans of `chat.agent_execution` in Grafana/Tempo with `tool.input` and `tool.result` attributes
- [x] `agent.model_usage` span event visible with per-model cost/token breakdown
- [x] `agent.session_init` span event visible with model, session_id, tool_count
- [x] Scheduler task: `agent.run` span attributes (`agent.num_turns`, `agent.cost_usd`, `agent.duration_ms`, etc.) and events (`agent.session_init`, `agent.model_usage`) visible in Grafana/Tempo
- [x] No span leaks — `flushToolSpans` called after event loop exits in both chat and scheduler paths