### PR TITLE
docs: update project context for OTel instrumentation and v0.5.1 features

### DIFF
--- a/.claude/skills/engineering/SKILL.md
+++ b/.claude/skills/engineering/SKILL.md
@@ -31,6 +31,7 @@ Read these as needed based on your task:
 | Development Guide | `docs/development.md` | Dev workflow, project structure, testing |
 | Agent Config | `docs/agents.md` | Agent YAML format, capabilities, template vars |
 | Integrations | `docs/integrations.md` | MCP, Google integrations, OAuth flow |
+| Monitoring | `docs/monitoring.md` | OpenTelemetry setup, exporters, Grafana LGTM local testing |
 
 ### Codebase Index
 
@@ -50,6 +51,7 @@ Read these as needed based on your task:
 | Scheduler | `internal/scheduler/` | Task scheduler and background job executor |
 | Event Bus | `internal/eventbus/` | In-process event bus for decoupled communication |
 | Notifications | `internal/notification/` | Notification system with SMTP email support |
+| Telemetry | `internal/telemetry/` | OpenTelemetry config, providers, instruments, hot-reload manager |
 | Frontend App | `frontend/src/App.tsx` | React Router, page routes |
 | Frontend API | `frontend/src/lib/api.ts` | Typed API client |
 | Frontend Types | `frontend/src/types.ts` | TypeScript types mirroring Go structs |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,14 @@ Two terminals are needed in dev mode:
 ANTHROPIC_API_KEY=...        # Optional (uses Claude Code CLI auth if unset)
 AGENTO_DATA_DIR=~/.agento   # Optional, default: ~/.agento (supports ~ expansion, e.g. ~/.agento-dev for local dev)
 PORT=8990                    # Optional, default: 8990
+# OpenTelemetry (all optional — can also be configured via Settings UI)
+OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317  # OTLP collector gRPC endpoint
+OTEL_EXPORTER_OTLP_INSECURE=true           # Skip TLS for local collectors
+OTEL_METRICS_EXPORTER=otlp                 # "otlp" or "prometheus"
+OTEL_LOGS_EXPORTER=otlp                    # "otlp"
+OTEL_EXPORTER_OTLP_HEADERS=key=value       # Auth headers for the collector
+OTEL_METRIC_EXPORT_INTERVAL=60000          # Push interval in ms (default: 60000)
+OTEL_SDK_DISABLED=true                     # Disable telemetry entirely
 ```
 
 ## Architecture
@@ -61,15 +69,15 @@ Browser → Vite (dev) / embedded FS (prod) → React SPA
 
 **`cmd/`** — Cobra CLI commands: `web` (HTTP server), `ask` (CLI), `update` (self-update). `cmd/assets.go` embeds the frontend build; `cmd/assets_dev.go` proxies to Vite.
 
-**`internal/server/`** — Chi router setup with middleware (Recoverer, RequestID, request logger). Mounts `/api` routes and serves SPA. Graceful shutdown with 5s timeout.
+**`internal/server/`** — Chi router setup with middleware (Recoverer, RequestID, request logger), wrapped in `otelhttp.NewHandler` for automatic HTTP trace/span generation. Mounts `/api` routes, serves SPA, and exposes a dynamic `/metrics` handler (Prometheus pull endpoint, active only when configured). Graceful shutdown with 5s timeout.
 
-**`internal/api/`** — HTTP handlers. `Server` struct holds all service dependencies. `Mount()` registers all routes. SSE streaming for live sessions via `livesessions.go`. `types.go` defines request/response types shared across handlers.
+**`internal/api/`** — HTTP handlers. `Server` struct holds all service dependencies (including `MonitoringManager`). `Mount()` registers all routes. SSE streaming for live sessions via `livesessions.go` (includes per-session mutex for concurrent send serialization). `monitoring.go` exposes `GET/PUT /api/monitoring` and `POST /api/monitoring/test` for OTel configuration. `PATCH /api/chats/{id}` and `PATCH /api/claude-sessions/{id}` support title editing and favorites. `types.go` defines request/response types shared across handlers.
 
 **`internal/service/`** — Business logic. `ChatService`, `AgentService`, `IntegrationService`, `NotificationService`, `TaskService`, and `ClaudeSettingsProfileService` interfaces decouple handlers from storage. `errors.go` defines typed errors for HTTP mapping.
 
-**`internal/agent/runner.go`** — Integration with `github.com/shaharia-lab/claude-agent-sdk-go`. Converts agent config to SDK `RunOptions`, executes sessions, streams results.
+**`internal/agent/`** — Integration with `github.com/shaharia-lab/claude-agent-sdk-go`. `runner.go` converts agent config to SDK `RunOptions`, executes sessions, streams results. `tracing.go` provides OTel span helpers for per-tool-call and per-run tracing in both chat and scheduler paths.
 
-**`internal/storage/`** — SQLite persistence (`~/.agento/agento.db`). `SQLiteAgentStore`, `SQLiteChatStore`, `SQLiteIntegrationStore`, `SQLiteSettingsStore`, `SQLiteNotificationStore`, `SQLiteTaskStore` implement store interfaces. `migrate_fs_to_sqlite.go` handles one-time migration from the legacy filesystem format. Uses `modernc.org/sqlite` (pure Go, no CGo).
+**`internal/storage/`** — SQLite persistence (`~/.agento/agento.db`). `SQLiteAgentStore`, `SQLiteChatStore`, `SQLiteIntegrationStore`, `SQLiteSettingsStore`, `SQLiteNotificationStore`, `SQLiteTaskStore` implement store interfaces. `migrate_fs_to_sqlite.go` handles one-time migration from the legacy filesystem format. `telemetry.go` provides `withStorageSpan` helper for OTel span/metric instrumentation on storage operations. Uses `modernc.org/sqlite` (pure Go, no CGo).
 
 **`internal/config/`** — Shared configuration layer. `AppConfig` loads from env. `profiles.go` has shared profile types to prevent import cycles. **Import rule**: `config` ← `service` ← `api` (never reverse).
 
@@ -85,7 +93,9 @@ Browser → Vite (dev) / embedded FS (prod) → React SPA
 
 **`internal/notification/`** — Notification system with SMTP email support. `handler.go` processes events, `smtp.go` sends emails, `template.go` renders notification content.
 
-**`internal/logger/`** — Structured `slog` loggers for system-wide and per-session logging. `NewSystemLogger` writes JSON to a rotating log file via `lumberjack` (50MB, 3 backups, 30 days, compressed). `NewSessionLogger` writes per-session logs to `<logDir>/sessions/<id>.log`.
+**`internal/logger/`** — Structured `slog` loggers for system-wide and per-session logging. `NewSystemLogger` writes JSON to a rotating log file via `lumberjack` (50MB, 3 backups, 30 days, compressed). `NewSessionLogger` writes per-session logs to `<logDir>/sessions/<id>.log`. Includes an `otelslog` bridge that forwards structured logs to the OTel LoggerProvider when telemetry is enabled.
+
+**`internal/telemetry/`** — OpenTelemetry integration. `config.go` reads `OTEL_*` env vars into `MonitoringConfig`. `provider.go` initializes TracerProvider/MeterProvider/LoggerProvider with OTLP gRPC or Prometheus exporters. `manager.go` persists config to `<data_dir>/monitoring.json` and hot-reloads providers via `Update()`. `instruments.go` holds pre-built metric instruments (`agento.http.*`, `agento.agent.*`, `agento.chat.*`, `agento.storage.*`). Returns `EnvLockedError` (HTTP 409) when env vars override UI config.
 
 **`internal/build/`** — Build-time version variables injected via `-ldflags` (Version, CommitSHA, BuildDate).
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ You can define agents with custom system prompts and tools, start multi-turn con
 - **Integrations** — Connect Google (Calendar, Gmail, Drive), GitHub, Slack, Jira, Confluence, and Telegram as agent tools
 - **Task scheduler** — Schedule recurring agent tasks with cron expressions and track job history
 - **Notifications** — Event-driven notification system with SMTP email support
+- **Observability** — OpenTelemetry traces, metrics, and logs with OTLP and Prometheus exporters, configurable via UI or environment variables
 - **Auto-update check** — Banner notification when a newer release is available, with one-command update
 
 ---
@@ -129,6 +130,9 @@ All settings are optional and can be overridden with environment variables:
 | `ANTHROPIC_API_KEY` | — | Use the Anthropic API directly instead of Claude Code CLI authentication |
 | `AGENTO_DEFAULT_MODEL` | *(Claude default)* | Lock the Claude model used for direct chat sessions |
 | `AGENTO_WORKING_DIR` | `/tmp/agento/work` | Default working directory for agent sessions |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP gRPC collector endpoint (e.g. `localhost:4317`). Can also be configured via Settings UI |
+| `OTEL_METRICS_EXPORTER` | — | `otlp` (push) or `prometheus` (pull via `/metrics`) |
+| `OTEL_LOGS_EXPORTER` | — | `otlp` |
 
 ### Local Development Isolation
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -98,6 +98,7 @@ agento/
 │   ├── scheduler/      # Task scheduler and job executor
 │   ├── service/        # Business logic (AgentService, ChatService, TaskService, NotificationService, etc.)
 │   ├── storage/        # SQLite persistence (~/.agento/agento.db)
+│   ├── telemetry/      # OpenTelemetry traces, metrics, logs (config, providers, hot-reload manager)
 │   └── tools/          # Local MCP tool server
 ├── docs/             # Documentation
 ├── .goreleaser.yaml  # Release configuration

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -56,6 +56,8 @@ Visit [http://localhost:8990](http://localhost:8990) in your browser.
 | — | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warn`, `error` |
 | — | `AGENTO_WORKING_DIR` | `/tmp/agento/work` | Default working directory for agent sessions |
 | — | `ANTHROPIC_API_KEY` | — | Anthropic API key (optional if already stored by the Claude CLI) |
+| — | `OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP gRPC endpoint for traces/metrics/logs (see [Monitoring](monitoring.md)) |
+| — | `OTEL_METRICS_EXPORTER` | — | `otlp` or `prometheus` (see [Monitoring](monitoring.md)) |
 
 **Example: run on a different port**
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -55,9 +55,9 @@ agento web
 
 | Signal | What is captured |
 |--------|-----------------|
-| **Traces** | Every HTTP request (method, path, status, duration) |
-| **Metrics** | HTTP requests & duration · Agent runs, duration, input/output tokens · Chat sessions created/deleted · Storage operation counts & duration |
-| **Logs** | All structured application logs (startup, requests, errors, agent events) |
+| **Traces** | Every HTTP request (method, path, status, duration) · `chat.agent_execution` span covering the full streaming window + commit · `tool_use.<ToolName>` child spans per tool call with input/result attributes · `agent.session_init` and `agent.model_usage` span events · Scheduler `task.execution` root span with `agent.run` child span and the same granular tool/event tracing · Storage `db.operation` / `db.entity` spans via `withStorageSpan` |
+| **Metrics** | HTTP requests & duration · Agent runs, duration, input/output tokens (with `model` + `status` attributes) · Chat sessions created/deleted · Storage operation counts & duration |
+| **Logs** | All structured application logs forwarded to OTel via `otelslog` bridge (startup, requests, errors, agent events) |
 
 ---
 


### PR DESCRIPTION
## Summary

- Documents the new `internal/telemetry/` package (TracerProvider, MeterProvider, LoggerProvider, `MonitoringConfig`, hot-reload via `Update()`, `instruments.go`, `EnvLockedError`)
- Updates `internal/server/`, `internal/api/`, `internal/agent/`, `internal/storage/`, and `internal/logger/` descriptions to reflect OTel wrappers, monitoring endpoints, PATCH endpoints, per-session mutex, tracing helpers, storage span helpers, and otelslog bridge
- Adds all `OTEL_*` environment variables to `CLAUDE.md` Required Environment and `docs/getting-started.md`
- Expands `docs/monitoring.md` instrumentation table with granular chat/tool tracing spans, scheduler task tracing, and storage spans
- Adds `internal/telemetry/` to the `docs/development.md` project layout tree
- Updates `.claude/skills/engineering/SKILL.md` codebase/docs index tables with Telemetry and Monitoring rows
- Surfaces in `README.md`: Observability added to features list, three OTEL env vars added to configuration table

## Test plan

- [x] Review each changed file for accuracy against the implemented code
- [x] Confirm `CLAUDE.md` Required Environment section lists all active `OTEL_*` vars
- [x] Confirm `docs/monitoring.md` instrumentation table matches spans emitted in `internal/agent/tracing.go` and `internal/storage/telemetry.go`
- [x] Confirm no broken links or cross-references in the docs