### PR TITLE
ci: pin SonarCloud action to SonarSource/sonarqube-scan-action@v7.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
           name: coverage
 
       - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v7.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary
- Replaces deprecated `sonarsource/sonarcloud-github-action@master` with pinned `SonarSource/sonarqube-scan-action@v7.0.0`
- Avoids using a floating `master` ref for better reproducibility and security

## Test plan
- [x] Verify CI passes with the updated SonarCloud action

🤖 Generated with [Claude Code](https://claude.com/claude-code)