### PR TITLE
fix: move implement-issue skill to top-level for CLI discovery

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -24,8 +24,8 @@ Extract the issue number from `$ARGUMENTS`. Strip leading `#` if present. If no 
 
 ```
 Error: No issue number provided.
-Usage: /workflows:implement-issue <issue-number>
-Example: /workflows:implement-issue 123
+Usage: /implement-issue <issue-number>
+Example: /implement-issue 123
 ```
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,17 +123,9 @@ Custom Claude Code skills in `.claude/skills/`. Invoke with `/skill-name <args>`
 | `/pr-reviewer` | PR review — correctness, quality, security, UI/UX, cross-platform, docs | `/pr-reviewer 42` or `/pr-reviewer feature/my-branch` |
 | `/context-updater` | Documentation & context maintenance — keeps CLAUDE.md, README, docs/ current | `/context-updater since last 7 days` |
 | `/engineering` | Development agent — features, bugs, refactoring with full project context | `/engineering add pagination to list endpoints` |
-| `/workflows:implement-issue` | End-to-end autonomous workflow: GitHub issue → worktree → implementation → CI → PR review → ready PR | `/workflows:implement-issue 123` |
+| `/implement-issue` | End-to-end autonomous workflow: GitHub issue → worktree → implementation → CI → PR review → ready PR | `/implement-issue 123` |
 
 All review skills use Opus model, run in forked context, and include cross-platform checks (Linux, macOS, Windows).
-
-### Workflow Skills
-
-Workflow skills live in `.claude/skills/workflows/` and are invoked with `/workflows:<name> <args>`.
-
-| Workflow | Purpose | Usage |
-|----------|---------|-------|
-| `/workflows:implement-issue` | Full dev cycle: claim issue, create worktree, implement, commit, push, monitor CI, PR review, promote | `/workflows:implement-issue 123` |
 
 ## Linting
 


### PR DESCRIPTION
## Summary

- The `implement-issue` skill was nested at `.claude/skills/workflows/implement-issue/SKILL.md`, which Claude Code CLI cannot discover — it only looks at direct subdirectories of `.claude/skills/`
- Moved skill to `.claude/skills/implement-issue/SKILL.md` so it appears in auto-suggestions as `/implement-issue`
- Updated all references from `/workflows:implement-issue` → `/implement-issue` in `CLAUDE.md` and within `SKILL.md` itself
- Removed the now-redundant "Workflow Skills" subsection from `CLAUDE.md`

## Root Cause

Claude Code discovers custom skills by scanning **direct subdirectories** of `.claude/skills/`. Nested paths like `.claude/skills/workflows/implement-issue/` are not traversed. The `/workflows:implement-issue` colon-prefix syntax is reserved for plugin-provided skills, not project skills.

## Test plan

- [ ] Verify `/implement-issue` appears in CLI auto-suggestions after this change
- [ ] Verify `/implement-issue 123` triggers the skill correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)