### PR TITLE
feat: Playwright e2e test suite for chat user journey

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-frontend build-go dev-frontend dev-backend run-serve run-ask tidy lint test generate clean
+.PHONY: build build-frontend build-go dev-frontend dev-backend run-serve run-ask tidy lint test generate clean e2e e2e-setup
 
 BINARY := agento
 
@@ -46,6 +46,16 @@ lint:
 
 test:
 	go test ./...
+
+# ── E2E tests (local only — requires built binary) ────────────────────────────
+# First-time setup: installs Playwright + downloads Chromium
+e2e-setup:
+	cd e2e && npm ci && npx playwright install chromium
+
+# Run e2e tests against the locally-built binary.
+# The binary must be built first: make build
+e2e: build
+	cd e2e && npm test
 
 # ── Clean ─────────────────────────────────────────────────────────────────────
 clean:

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+playwright-report/
+test-results/

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,34 @@
+import fs from 'fs'
+import path from 'path'
+
+const DATA_DIR = '/tmp/agento-e2e-test'
+
+/**
+ * Runs once before any test worker starts.
+ * Wipes the e2e data directory so every test run begins with a fresh
+ * SQLite database (no stale chats, settings, or sessions from prior runs).
+ */
+export default async function globalSetup() {
+  if (fs.existsSync(DATA_DIR)) {
+    fs.rmSync(DATA_DIR, { recursive: true, force: true })
+    console.log(`[global-setup] Cleaned data dir: ${DATA_DIR}`)
+  }
+  fs.mkdirSync(DATA_DIR, { recursive: true })
+  console.log(`[global-setup] Created fresh data dir: ${DATA_DIR}`)
+
+  // Also clean any files Claude may have left behind from previous runs
+  const tmpArtifacts = [
+    '/tmp/hello-world.txt',
+    '/tmp/agento-test-output.txt',
+  ]
+  for (const f of tmpArtifacts) {
+    try {
+      if (fs.existsSync(f)) {
+        fs.rmSync(f)
+        console.log(`[global-setup] Removed leftover artifact: ${path.basename(f)}`)
+      }
+    } catch {
+      // best-effort
+    }
+  }
+}

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,111 @@
+{
+  "name": "agento-e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agento-e2e",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.49.0",
+        "@types/node": "^20.0.0",
+        "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "agento-e2e",
+  "version": "1.0.0",
+  "description": "End-to-end tests for Agento using Playwright",
+  "scripts": {
+    "test": "playwright test",
+    "test:ui": "playwright test --ui",
+    "test:headed": "playwright test --headed",
+    "test:debug": "playwright test --debug"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -21,6 +21,7 @@ const PORT = 8990;
 const BASE_URL = `http://localhost:${PORT}`;
 
 export default defineConfig({
+  globalSetup: './global-setup',
   testDir: './tests',
   timeout: 120_000,       // 2 min per test (Claude may take time to respond)
   expect: { timeout: 30_000 },

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,60 @@
+import { defineConfig, devices } from '@playwright/test';
+import path from 'path';
+
+/**
+ * E2E tests for Agento.
+ *
+ * Prerequisites:
+ *   1. Build the binary first: `make build` (from repo root)
+ *   2. Install Playwright browsers: `cd e2e && npm ci && npx playwright install chromium`
+ *
+ * Run tests:
+ *   cd e2e && npm test
+ *
+ * The test runner starts the Agento server automatically using a clean data
+ * directory at /tmp/agento-e2e-test and tears it down after the suite.
+ */
+
+const AGENTO_BINARY = path.resolve(__dirname, '../agento');
+const DATA_DIR = '/tmp/agento-e2e-test';
+const PORT = 8990;
+const BASE_URL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 120_000,       // 2 min per test (Claude may take time to respond)
+  expect: { timeout: 30_000 },
+  fullyParallel: false,   // run sequentially — each test starts/stops the server
+  retries: 0,
+  workers: 1,
+  reporter: [
+    ['list'],
+    ['html', { open: 'never', outputFolder: 'playwright-report' }],
+  ],
+
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'on-first-retry',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: {
+    command: `AGENTO_DATA_DIR=${DATA_DIR} ${AGENTO_BINARY} web --no-browser`,
+    url: BASE_URL,
+    reuseExistingServer: false,
+    timeout: 30_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: {
+      AGENTO_DATA_DIR: DATA_DIR,
+    },
+  },
+});

--- a/e2e/tests/agents.spec.ts
+++ b/e2e/tests/agents.spec.ts
@@ -1,0 +1,220 @@
+import { test, expect, type Page, request as playwrightRequest } from '@playwright/test'
+
+/**
+ * E2E tests for the Agent feature.
+ *
+ * Covers:
+ *   - Create an agent via the UI form
+ *   - Agent appears in the agents list with correct name/slug
+ *   - Start a chat with the agent via the New Chat dialog
+ *   - Chat header shows the agent label
+ *   - Streaming response renders
+ *   - Model field locks when an agent with a model is selected
+ *   - Delete an agent via the UI
+ */
+
+const BASE_URL = 'http://localhost:8990'
+
+// Agent used for chat tests — created via API in beforeAll so chat tests
+// do not depend on the UI creation test succeeding first.
+const CHAT_AGENT = {
+  name: 'E2E Chat Agent',
+  slug: 'e2e-chat-agent',
+  systemPrompt: 'You are a simple test agent. Always respond concisely in one or two sentences.',
+}
+
+// Agent used only for the UI-creation test — different slug to avoid conflicts.
+const UI_AGENT = {
+  name: 'E2E UI Agent',
+  slug: 'e2e-ui-agent',
+  description: 'Created by the UI creation test',
+  systemPrompt: 'You are a UI-created test agent.',
+}
+
+// Agent used for the model-lock test — pre-created via API in beforeAll.
+const LOCKED_AGENT = {
+  name: 'E2E Locked Model Agent',
+  slug: 'e2e-locked-model-agent',
+  model: 'sonnet',
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function completeOnboardingViaApi() {
+  const ctx = await playwrightRequest.newContext({ baseURL: BASE_URL })
+  await ctx.put('/api/settings', {
+    data: { default_working_dir: '/tmp', default_model: 'sonnet', onboarding_complete: true },
+  })
+  await ctx.dispose()
+}
+
+async function createAgentViaApi(slug: string, name: string, systemPrompt: string, model = '') {
+  const ctx = await playwrightRequest.newContext({ baseURL: BASE_URL })
+  const res = await ctx.post('/api/agents', {
+    data: { name, slug, model, system_prompt: systemPrompt, capabilities: { built_in: [] } },
+  })
+  await ctx.dispose()
+  return res
+}
+
+async function deleteAgentViaApi(slug: string) {
+  const ctx = await playwrightRequest.newContext({ baseURL: BASE_URL })
+  await ctx.delete(`/api/agents/${slug}`).catch(() => {})
+  await ctx.dispose()
+}
+
+async function loadApp(page: Page) {
+  await page.goto('/')
+  await expect(page.getByRole('button', { name: 'New Chat' }).first()).toBeVisible({
+    timeout: 10_000,
+  })
+}
+
+async function waitForStreamingToComplete(page: Page, timeoutMs = 90_000) {
+  const stopBtn = page.locator('button[title="Stop generation"]')
+  await stopBtn.waitFor({ state: 'visible', timeout: 30_000 })
+  await stopBtn.waitFor({ state: 'hidden', timeout: timeoutMs })
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+test.describe('Agents', () => {
+  test.beforeAll(async () => {
+    await completeOnboardingViaApi()
+    // Ensure no stale agents from previous runs
+    await deleteAgentViaApi(CHAT_AGENT.slug)
+    await deleteAgentViaApi(UI_AGENT.slug)
+    await deleteAgentViaApi(LOCKED_AGENT.slug)
+    // Pre-create agents used for tests that should be independent of UI creation
+    await createAgentViaApi(CHAT_AGENT.slug, CHAT_AGENT.name, CHAT_AGENT.systemPrompt)
+    await createAgentViaApi(LOCKED_AGENT.slug, LOCKED_AGENT.name, 'Test.', LOCKED_AGENT.model)
+  })
+
+  test.afterAll(async () => {
+    await deleteAgentViaApi(CHAT_AGENT.slug)
+    await deleteAgentViaApi(UI_AGENT.slug)
+    await deleteAgentViaApi(LOCKED_AGENT.slug)
+  })
+
+  test.beforeEach(async ({ page }) => {
+    await loadApp(page)
+  })
+
+  // ── 1. Create agent via UI form ───────────────────────────────────────────
+
+  test('creates an agent via the form and shows it in the agents list', async ({ page }) => {
+    await page.getByRole('link', { name: 'Agents' }).click()
+    await expect(page).toHaveURL(/\/agents$/)
+    // Use exact:true — "No agents yet" also contains the word "agents"
+    await expect(page.getByRole('heading', { name: 'Agents', exact: true })).toBeVisible()
+
+    await page.getByRole('button', { name: 'New Agent' }).click()
+    await expect(page).toHaveURL(/\/agents\/new$/)
+
+    // Fill Basic Info (section is expanded by default)
+    await page.getByLabel('Name *').fill(UI_AGENT.name)
+    // Slug auto-derives from name
+    await expect(page.getByLabel('Slug *')).toHaveValue(UI_AGENT.slug, { timeout: 3_000 })
+    await page.getByLabel('Description').fill(UI_AGENT.description)
+
+    // System Prompt (left column on desktop) — form renders dual layout (desktop + mobile),
+    // both share the same id; use .first() to target the visible desktop one
+    await page.locator('textarea#system_prompt').first().fill(UI_AGENT.systemPrompt)
+
+    await page.getByRole('button', { name: 'Create Agent' }).click()
+    await page.waitForURL(/\/agents$/, { timeout: 10_000 })
+
+    // Agent card visible with correct name and slug
+    await expect(page.getByRole('heading', { name: UI_AGENT.name })).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByText(UI_AGENT.slug)).toBeVisible()
+  })
+
+  // ── 2. Chat with an agent ─────────────────────────────────────────────────
+
+  test('starts a chat with an agent and receives a streaming response', async ({ page }) => {
+    // Open New Chat dialog
+    await page.getByRole('button', { name: 'New Chat' }).first().click()
+    await expect(page.getByRole('heading', { name: 'New Chat' })).toBeVisible({ timeout: 5_000 })
+
+    // The agent selector defaults to "No agent (direct chat)".
+    // Click it and pick our pre-created chat agent.
+    // Scope to the dialog to avoid matching background page comboboxes (e.g. Directories filter).
+    const dialog = page.getByRole('dialog')
+    const agentCombobox = dialog.locator('[role="combobox"]').first()
+    await agentCombobox.click()
+    // Options render in a Radix portal — search the whole page
+    await page.locator('[role="option"]').filter({ hasText: CHAT_AGENT.name }).click()
+
+    // Trigger now shows the selected agent name
+    await expect(agentCombobox).toContainText(CHAT_AGENT.name)
+
+    // Type and submit the first message
+    const firstMsg = 'Say hello.'
+    await page.getByPlaceholder('Type your first message… (Enter to send)').fill(firstMsg)
+    await page.getByRole('button', { name: 'Start Chat' }).click()
+
+    await page.waitForURL(/\/chats\/[^/]+$/, { timeout: 15_000 })
+
+    // ── Chat session ────────────────────────────────────────────────────────
+    // Header shows the agent slug (replaces "Direct chat" label)
+    await expect(page.getByText(CHAT_AGENT.slug).first()).toBeVisible({ timeout: 5_000 })
+
+    // User message visible
+    await expect(page.getByText(firstMsg).first()).toBeVisible({ timeout: 10_000 })
+
+    // Streaming completes successfully
+    await waitForStreamingToComplete(page)
+
+    // Input re-enabled for follow-up
+    await expect(
+      page.getByPlaceholder('Message… (Enter to send, Shift+Enter for new line, drop/paste files)'),
+    ).toBeEnabled()
+  })
+
+  // ── 3. Model locks when agent has a model ─────────────────────────────────
+
+  test('model field is locked in New Chat dialog when agent has a fixed model', async ({ page }) => {
+    // LOCKED_AGENT is pre-created in beforeAll — no API call or reload needed here
+    await page.getByRole('button', { name: 'New Chat' }).first().click()
+    await expect(page.getByRole('heading', { name: 'New Chat' })).toBeVisible({ timeout: 5_000 })
+
+    // Scope to the dialog to avoid matching background page comboboxes (e.g. Directories filter).
+    const dialog = page.getByRole('dialog')
+    const agentTrigger = dialog.locator('[role="combobox"]').first()
+    await agentTrigger.click()
+    await page.locator('[role="option"]').filter({ hasText: LOCKED_AGENT.name }).waitFor({ state: 'visible', timeout: 5_000 })
+    await page.locator('[role="option"]').filter({ hasText: LOCKED_AGENT.name }).click()
+
+    // Model input becomes a disabled text field, not a select
+    await expect(page.locator('input[disabled]')).toBeVisible({ timeout: 3_000 })
+    await expect(page.getByText('Model set by agent configuration')).toBeVisible()
+  })
+
+  // ── 4. Delete agent via the UI ────────────────────────────────────────────
+
+  test('deletes an agent via the agents list', async ({ page }) => {
+    // Create a throwaway agent to delete
+    const slug = 'e2e-delete-me'
+    await createAgentViaApi(slug, 'E2E Delete Me', 'Temporary.')
+
+    await page.goto('/agents')
+    await expect(page.getByRole('heading', { name: 'E2E Delete Me' })).toBeVisible({ timeout: 5_000 })
+
+    // Click Delete on that card — scope to the card element to avoid matching nested divs
+    const card = page.locator('div.rounded-lg').filter({ hasText: 'E2E Delete Me' }).last()
+    await card.getByRole('button', { name: 'Delete' }).first().click()
+
+    // Confirm in the alert dialog
+    await expect(page.getByRole('alertdialog')).toBeVisible()
+    await page.getByRole('alertdialog').getByRole('button', { name: 'Delete' }).click()
+
+    // Card disappears
+    await expect(page.getByRole('heading', { name: 'E2E Delete Me' })).not.toBeVisible({
+      timeout: 5_000,
+    })
+  })
+})

--- a/e2e/tests/chat.spec.ts
+++ b/e2e/tests/chat.spec.ts
@@ -187,8 +187,9 @@ test.describe('Chat', () => {
     await expect(inputTextarea).toBeEnabled()
 
     // Both user messages visible in the conversation
-    await expect(page.getByText('Say "hello" and nothing else.')).toBeVisible()
-    await expect(page.getByText('Now say "goodbye" and nothing else.')).toBeVisible()
+    // .first() because the text also appears in the auto-generated chat title
+    await expect(page.getByText('Say "hello" and nothing else.').first()).toBeVisible()
+    await expect(page.getByText('Now say "goodbye" and nothing else.').first()).toBeVisible()
   })
 
   // ── 3. Stop generation ────────────────────────────────────────────────────

--- a/e2e/tests/chat.spec.ts
+++ b/e2e/tests/chat.spec.ts
@@ -3,11 +3,9 @@ import { test, expect, type Page, request as playwrightRequest } from '@playwrig
 /**
  * E2E tests for the Chat feature.
  *
- * These tests exercise the full user journey:
- *   1. Open the app
- *   2. Click "New Chat" from the sidebar
- *   3. Fill in the first message and submit
- *   4. Verify that the conversation view opens and streaming responses are rendered
+ * These tests exercise the full user journey including:
+ *   - New Chat dialog open / cancel / disabled-state
+ *   - Streaming rendering: thinking blocks, tool call cards, completion dots
  */
 
 const BASE_URL = 'http://localhost:8990'
@@ -18,8 +16,7 @@ const BASE_URL = 'http://localhost:8990'
 
 /**
  * Mark onboarding as complete via the settings API so the wizard never
- * blocks the UI during tests. Also ensures a default working dir and model
- * are set.
+ * blocks the UI during tests. Sets working dir to /tmp and model to sonnet.
  */
 async function completeOnboardingViaApi() {
   const ctx = await playwrightRequest.newContext({ baseURL: BASE_URL })
@@ -33,48 +30,37 @@ async function completeOnboardingViaApi() {
   await ctx.dispose()
 }
 
-/**
- * Wait for the New Chat dialog to appear and be visible.
- * The sidebar "New Chat" button navigates to /chats?new=1 which auto-opens it.
- */
+/** Click the sidebar "New Chat" button and wait for the dialog to open. */
 async function openNewChatDialog(page: Page) {
   const newChatBtn = page.getByRole('button', { name: 'New Chat' }).first()
   await newChatBtn.waitFor({ state: 'visible', timeout: 10_000 })
   await newChatBtn.click()
-
-  // Wait for the dialog title to appear
   await expect(page.getByRole('heading', { name: 'New Chat' })).toBeVisible({ timeout: 5_000 })
 }
 
 /**
  * Fill the first-message textarea in the New Chat dialog and submit.
- * Waits for navigation to the new chat session URL.
+ * Waits until the URL changes to /chats/:id.
  */
 async function startChat(page: Page, message: string) {
   const textarea = page.getByPlaceholder('Type your first message… (Enter to send)')
   await textarea.waitFor({ state: 'visible', timeout: 5_000 })
   await textarea.fill(message)
 
-  // Click the "Start Chat" footer button
   const startBtn = page.getByRole('button', { name: 'Start Chat' })
   await expect(startBtn).toBeEnabled()
   await startBtn.click()
 
-  // Navigation to /chats/:id should happen immediately after chat creation
   await page.waitForURL(/\/chats\/[^/]+$/, { timeout: 15_000 })
 }
 
 /**
  * Wait for streaming to begin (Stop button appears) then wait for it to
- * complete (Stop button disappears and the send button returns).
+ * complete (Stop button disappears).
  */
 async function waitForStreamingToComplete(page: Page, timeoutMs = 90_000) {
   const stopBtn = page.locator('button[title="Stop generation"]')
-
-  // Wait for streaming to START — Stop button must appear
   await stopBtn.waitFor({ state: 'visible', timeout: 30_000 })
-
-  // Wait for streaming to FINISH — Stop button disappears
   await stopBtn.waitFor({ state: 'hidden', timeout: timeoutMs })
 }
 
@@ -85,54 +71,75 @@ async function waitForStreamingToComplete(page: Page, timeoutMs = 90_000) {
 test.describe('Chat', () => {
   test.beforeAll(async () => {
     // Mark onboarding complete so the wizard never blocks the UI.
-    // This API call runs once before all tests in this suite.
     await completeOnboardingViaApi()
   })
 
   test.beforeEach(async ({ page }) => {
-    // Navigate to root — React Router redirects to /chats
     await page.goto('/')
-    // Wait for the sidebar to be interactive
     await expect(page.getByRole('button', { name: 'New Chat' }).first()).toBeVisible({
       timeout: 10_000,
     })
   })
 
-  test('creates a new chat and renders streaming response', async ({ page }) => {
+  // ── Main journey ──────────────────────────────────────────────────────────
+
+  test('creates a new chat and renders streaming response with thinking and tool call blocks', async ({ page }) => {
     const prompt =
       'Create file hello-world.txt somewhere and do the read/write/edit operations.'
 
-    // ── Step 1: open the New Chat dialog ────────────────────────────────────
+    // ── 1. Open dialog and start chat ────────────────────────────────────────
     await openNewChatDialog(page)
-
-    // Verify dialog description is shown
-    await expect(
-      page.getByText('Type your first message. Optionally choose an agent'),
-    ).toBeVisible()
-
-    // Default settings are used (no agent, /tmp working dir, sonnet model)
-
-    // ── Step 2: type the prompt and submit ───────────────────────────────────
+    await expect(page.getByText('Type your first message. Optionally choose an agent')).toBeVisible()
     await startChat(page, prompt)
 
-    // ── Step 3: chat session page opens ─────────────────────────────────────
     await expect(page).toHaveURL(/\/chats\/[^/]+$/)
 
-    // The user's own message should appear on screen
+    // User message must appear in the conversation
     await expect(page.getByText(prompt)).toBeVisible({ timeout: 15_000 })
 
-    // ── Step 4: streaming response is rendered ───────────────────────────────
-    await waitForStreamingToComplete(page)
+    // ── 2. During streaming: thinking block and first tool call appear ────────
+    // The Stop button marks that streaming has started
+    const stopBtn = page.locator('button[title="Stop generation"]')
+    await stopBtn.waitFor({ state: 'visible', timeout: 30_000 })
 
-    // After streaming, an assistant response must be visible somewhere on
-    // the page. We look for the "C" avatar circle that marks Claude's turns,
-    // or any tool-use block, which confirms content was rendered.
-    const assistantContent = page
-      .locator('p, div')
-      .filter({ hasText: /hello-world\.txt|All operations|created|Success/i })
-    await expect(assistantContent.first()).toBeVisible({ timeout: 5_000 })
+    // At least one tool call card is rendered while streaming
+    // (e.g. "Write hello-world.txt" collapses into span.font-mono.font-semibold)
+    const firstToolName = page.locator('span.font-mono.font-semibold').first()
+    await firstToolName.waitFor({ state: 'visible', timeout: 30_000 })
 
-    // Input textarea should be re-enabled and ready for follow-up
+    // ── 3. Wait for streaming to finish ──────────────────────────────────────
+    await stopBtn.waitFor({ state: 'hidden', timeout: 90_000 })
+
+    // ── 4. After streaming: thinking blocks (if any) ─────────────────────────
+    // Claude uses ThinkingAdaptive by default — thinking may or may not appear.
+    // If it does appear, verify the toggle can be expanded to reveal content.
+    const thinkingToggles = page.getByRole('button', { name: 'Thinking' })
+    const thinkingCount = await thinkingToggles.count()
+    if (thinkingCount > 0) {
+      await thinkingToggles.first().click()
+      const thinkingContent = page.locator('div.font-mono.whitespace-pre-wrap').first()
+      await expect(thinkingContent).toBeVisible({ timeout: 3_000 })
+      const thinkingText = await thinkingContent.textContent()
+      expect(thinkingText?.length ?? 0).toBeGreaterThan(0)
+    }
+
+    // ── 5. After streaming: at least one tool call was rendered ──────────────
+    // Claude is non-deterministic — it may use any combination of tools
+    // (Write, Read, Edit, Bash, …). We only assert that at least one tool call
+    // card rendered; we do not enforce specific names or ordering.
+    const toolNameSpans = page.locator('span.font-mono.font-semibold')
+    const toolNameCount = await toolNameSpans.count()
+    expect(toolNameCount).toBeGreaterThan(0)
+
+    // ── 6. After streaming: completed tool calls have green dots ─────────────
+    // Every ToolCallCard that received a result renders a span.bg-emerald-400.
+    // There must be at least one, and no more than the total number of tool calls.
+    const completionDots = page.locator('span.bg-emerald-400')
+    const dotCount = await completionDots.count()
+    expect(dotCount).toBeGreaterThan(0)
+    expect(dotCount).toBeLessThanOrEqual(toolNameCount)
+
+    // ── 7. Input textarea re-enabled for follow-up ────────────────────────────
     const inputTextarea = page.getByPlaceholder(
       'Message… (Enter to send, Shift+Enter for new line, drop/paste files)',
     )
@@ -140,10 +147,10 @@ test.describe('Chat', () => {
     await expect(inputTextarea).toBeEnabled()
   })
 
+  // ── Dialog UX ─────────────────────────────────────────────────────────────
+
   test('new chat dialog can be cancelled', async ({ page }) => {
     await openNewChatDialog(page)
-
-    // Click Cancel — dialog should close, URL stays at /chats
     await page.getByRole('button', { name: 'Cancel' }).click()
     await expect(page.getByRole('heading', { name: 'New Chat' })).not.toBeVisible()
     await expect(page).toHaveURL(/\/chats/)
@@ -153,10 +160,8 @@ test.describe('Chat', () => {
     await openNewChatDialog(page)
 
     const startBtn = page.getByRole('button', { name: 'Start Chat' })
-    // With empty textarea the button must be disabled
     await expect(startBtn).toBeDisabled()
 
-    // Typing something enables it
     await page.getByPlaceholder('Type your first message… (Enter to send)').fill('hello')
     await expect(startBtn).toBeEnabled()
   })

--- a/e2e/tests/chat.spec.ts
+++ b/e2e/tests/chat.spec.ts
@@ -1,0 +1,163 @@
+import { test, expect, type Page, request as playwrightRequest } from '@playwright/test'
+
+/**
+ * E2E tests for the Chat feature.
+ *
+ * These tests exercise the full user journey:
+ *   1. Open the app
+ *   2. Click "New Chat" from the sidebar
+ *   3. Fill in the first message and submit
+ *   4. Verify that the conversation view opens and streaming responses are rendered
+ */
+
+const BASE_URL = 'http://localhost:8990'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Mark onboarding as complete via the settings API so the wizard never
+ * blocks the UI during tests. Also ensures a default working dir and model
+ * are set.
+ */
+async function completeOnboardingViaApi() {
+  const ctx = await playwrightRequest.newContext({ baseURL: BASE_URL })
+  await ctx.put('/api/settings', {
+    data: {
+      default_working_dir: '/tmp',
+      default_model: 'sonnet',
+      onboarding_complete: true,
+    },
+  })
+  await ctx.dispose()
+}
+
+/**
+ * Wait for the New Chat dialog to appear and be visible.
+ * The sidebar "New Chat" button navigates to /chats?new=1 which auto-opens it.
+ */
+async function openNewChatDialog(page: Page) {
+  const newChatBtn = page.getByRole('button', { name: 'New Chat' }).first()
+  await newChatBtn.waitFor({ state: 'visible', timeout: 10_000 })
+  await newChatBtn.click()
+
+  // Wait for the dialog title to appear
+  await expect(page.getByRole('heading', { name: 'New Chat' })).toBeVisible({ timeout: 5_000 })
+}
+
+/**
+ * Fill the first-message textarea in the New Chat dialog and submit.
+ * Waits for navigation to the new chat session URL.
+ */
+async function startChat(page: Page, message: string) {
+  const textarea = page.getByPlaceholder('Type your first message… (Enter to send)')
+  await textarea.waitFor({ state: 'visible', timeout: 5_000 })
+  await textarea.fill(message)
+
+  // Click the "Start Chat" footer button
+  const startBtn = page.getByRole('button', { name: 'Start Chat' })
+  await expect(startBtn).toBeEnabled()
+  await startBtn.click()
+
+  // Navigation to /chats/:id should happen immediately after chat creation
+  await page.waitForURL(/\/chats\/[^/]+$/, { timeout: 15_000 })
+}
+
+/**
+ * Wait for streaming to begin (Stop button appears) then wait for it to
+ * complete (Stop button disappears and the send button returns).
+ */
+async function waitForStreamingToComplete(page: Page, timeoutMs = 90_000) {
+  const stopBtn = page.locator('button[title="Stop generation"]')
+
+  // Wait for streaming to START — Stop button must appear
+  await stopBtn.waitFor({ state: 'visible', timeout: 30_000 })
+
+  // Wait for streaming to FINISH — Stop button disappears
+  await stopBtn.waitFor({ state: 'hidden', timeout: timeoutMs })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe('Chat', () => {
+  test.beforeAll(async () => {
+    // Mark onboarding complete so the wizard never blocks the UI.
+    // This API call runs once before all tests in this suite.
+    await completeOnboardingViaApi()
+  })
+
+  test.beforeEach(async ({ page }) => {
+    // Navigate to root — React Router redirects to /chats
+    await page.goto('/')
+    // Wait for the sidebar to be interactive
+    await expect(page.getByRole('button', { name: 'New Chat' }).first()).toBeVisible({
+      timeout: 10_000,
+    })
+  })
+
+  test('creates a new chat and renders streaming response', async ({ page }) => {
+    const prompt =
+      'Create file hello-world.txt somewhere and do the read/write/edit operations.'
+
+    // ── Step 1: open the New Chat dialog ────────────────────────────────────
+    await openNewChatDialog(page)
+
+    // Verify dialog description is shown
+    await expect(
+      page.getByText('Type your first message. Optionally choose an agent'),
+    ).toBeVisible()
+
+    // Default settings are used (no agent, /tmp working dir, sonnet model)
+
+    // ── Step 2: type the prompt and submit ───────────────────────────────────
+    await startChat(page, prompt)
+
+    // ── Step 3: chat session page opens ─────────────────────────────────────
+    await expect(page).toHaveURL(/\/chats\/[^/]+$/)
+
+    // The user's own message should appear on screen
+    await expect(page.getByText(prompt)).toBeVisible({ timeout: 15_000 })
+
+    // ── Step 4: streaming response is rendered ───────────────────────────────
+    await waitForStreamingToComplete(page)
+
+    // After streaming, an assistant response must be visible somewhere on
+    // the page. We look for the "C" avatar circle that marks Claude's turns,
+    // or any tool-use block, which confirms content was rendered.
+    const assistantContent = page
+      .locator('p, div')
+      .filter({ hasText: /hello-world\.txt|All operations|created|Success/i })
+    await expect(assistantContent.first()).toBeVisible({ timeout: 5_000 })
+
+    // Input textarea should be re-enabled and ready for follow-up
+    const inputTextarea = page.getByPlaceholder(
+      'Message… (Enter to send, Shift+Enter for new line, drop/paste files)',
+    )
+    await expect(inputTextarea).toBeVisible()
+    await expect(inputTextarea).toBeEnabled()
+  })
+
+  test('new chat dialog can be cancelled', async ({ page }) => {
+    await openNewChatDialog(page)
+
+    // Click Cancel — dialog should close, URL stays at /chats
+    await page.getByRole('button', { name: 'Cancel' }).click()
+    await expect(page.getByRole('heading', { name: 'New Chat' })).not.toBeVisible()
+    await expect(page).toHaveURL(/\/chats/)
+  })
+
+  test('start chat button is disabled when message is empty', async ({ page }) => {
+    await openNewChatDialog(page)
+
+    const startBtn = page.getByRole('button', { name: 'Start Chat' })
+    // With empty textarea the button must be disabled
+    await expect(startBtn).toBeDisabled()
+
+    // Typing something enables it
+    await page.getByPlaceholder('Type your first message… (Enter to send)').fill('hello')
+    await expect(startBtn).toBeEnabled()
+  })
+})

--- a/e2e/tests/chat.spec.ts
+++ b/e2e/tests/chat.spec.ts
@@ -1,23 +1,32 @@
+import fs from 'fs'
 import { test, expect, type Page, request as playwrightRequest } from '@playwright/test'
 
 /**
  * E2E tests for the Chat feature.
  *
- * These tests exercise the full user journey including:
- *   - New Chat dialog open / cancel / disabled-state
- *   - Streaming rendering: thinking blocks, tool call cards, completion dots
+ * Covers:
+ *   - New Chat dialog (open, cancel, disabled state)
+ *   - Full streaming journey: thinking blocks, tool call cards, completion dots
+ *   - Follow-up message in an existing session
+ *   - Stop generation mid-stream
+ *   - Completed chat appears in the chat list
  */
 
 const BASE_URL = 'http://localhost:8990'
+
+/**
+ * Files Claude may create when running the hello-world file-operations prompt.
+ * Cleaned up after tests that use that prompt.
+ */
+const CLAUDE_ARTIFACTS = [
+  '/tmp/hello-world.txt',
+  '/tmp/hello_world.txt',
+]
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Mark onboarding as complete via the settings API so the wizard never
- * blocks the UI during tests. Sets working dir to /tmp and model to sonnet.
- */
 async function completeOnboardingViaApi() {
   const ctx = await playwrightRequest.newContext({ baseURL: BASE_URL })
   await ctx.put('/api/settings', {
@@ -30,34 +39,41 @@ async function completeOnboardingViaApi() {
   await ctx.dispose()
 }
 
-/** Click the sidebar "New Chat" button and wait for the dialog to open. */
+function cleanupArtifacts() {
+  for (const f of CLAUDE_ARTIFACTS) {
+    try {
+      if (fs.existsSync(f)) fs.rmSync(f)
+    } catch {
+      // best-effort — file may not exist or may have a different path
+    }
+  }
+}
+
+/** Navigate to root and wait for the sidebar "New Chat" button to be ready. */
+async function loadApp(page: Page) {
+  await page.goto('/')
+  await expect(page.getByRole('button', { name: 'New Chat' }).first()).toBeVisible({
+    timeout: 10_000,
+  })
+}
+
+/** Click the sidebar "New Chat" button and wait for the dialog. */
 async function openNewChatDialog(page: Page) {
-  const newChatBtn = page.getByRole('button', { name: 'New Chat' }).first()
-  await newChatBtn.waitFor({ state: 'visible', timeout: 10_000 })
-  await newChatBtn.click()
+  await page.getByRole('button', { name: 'New Chat' }).first().click()
   await expect(page.getByRole('heading', { name: 'New Chat' })).toBeVisible({ timeout: 5_000 })
 }
 
 /**
- * Fill the first-message textarea in the New Chat dialog and submit.
- * Waits until the URL changes to /chats/:id.
+ * Fill the first-message textarea and click Start Chat.
+ * Returns after the URL changes to /chats/:id.
  */
 async function startChat(page: Page, message: string) {
-  const textarea = page.getByPlaceholder('Type your first message… (Enter to send)')
-  await textarea.waitFor({ state: 'visible', timeout: 5_000 })
-  await textarea.fill(message)
-
-  const startBtn = page.getByRole('button', { name: 'Start Chat' })
-  await expect(startBtn).toBeEnabled()
-  await startBtn.click()
-
+  await page.getByPlaceholder('Type your first message… (Enter to send)').fill(message)
+  await page.getByRole('button', { name: 'Start Chat' }).click()
   await page.waitForURL(/\/chats\/[^/]+$/, { timeout: 15_000 })
 }
 
-/**
- * Wait for streaming to begin (Stop button appears) then wait for it to
- * complete (Stop button disappears).
- */
+/** Wait for streaming to start (Stop button appears) then finish (Stop disappears). */
 async function waitForStreamingToComplete(page: Page, timeoutMs = 90_000) {
   const stopBtn = page.locator('button[title="Stop generation"]')
   await stopBtn.waitFor({ state: 'visible', timeout: 30_000 })
@@ -65,81 +81,74 @@ async function waitForStreamingToComplete(page: Page, timeoutMs = 90_000) {
 }
 
 // ---------------------------------------------------------------------------
-// Tests
+// Suite
 // ---------------------------------------------------------------------------
 
 test.describe('Chat', () => {
   test.beforeAll(async () => {
-    // Mark onboarding complete so the wizard never blocks the UI.
     await completeOnboardingViaApi()
   })
 
   test.beforeEach(async ({ page }) => {
-    await page.goto('/')
-    await expect(page.getByRole('button', { name: 'New Chat' }).first()).toBeVisible({
-      timeout: 10_000,
-    })
+    await loadApp(page)
   })
 
-  // ── Main journey ──────────────────────────────────────────────────────────
+  // ── 1. Full streaming journey ──────────────────────────────────────────────
 
   test('creates a new chat and renders streaming response with thinking and tool call blocks', async ({ page }) => {
-    const prompt =
-      'Create file hello-world.txt somewhere and do the read/write/edit operations.'
+    const prompt = 'Create file hello-world.txt somewhere and do the read/write/edit operations.'
 
-    // ── 1. Open dialog and start chat ────────────────────────────────────────
     await openNewChatDialog(page)
     await expect(page.getByText('Type your first message. Optionally choose an agent')).toBeVisible()
     await startChat(page, prompt)
 
+    // ── Chat session page opened ─────────────────────────────────────────────
     await expect(page).toHaveURL(/\/chats\/[^/]+$/)
-
-    // User message must appear in the conversation
     await expect(page.getByText(prompt)).toBeVisible({ timeout: 15_000 })
 
-    // ── 2. During streaming: thinking block and first tool call appear ────────
-    // The Stop button marks that streaming has started
+    // ── Stop button marks streaming started ──────────────────────────────────
     const stopBtn = page.locator('button[title="Stop generation"]')
     await stopBtn.waitFor({ state: 'visible', timeout: 30_000 })
 
-    // At least one tool call card is rendered while streaming
-    // (e.g. "Write hello-world.txt" collapses into span.font-mono.font-semibold)
-    const firstToolName = page.locator('span.font-mono.font-semibold').first()
-    await firstToolName.waitFor({ state: 'visible', timeout: 30_000 })
+    // ── At least one tool call card renders while streaming ──────────────────
+    await page.locator('span.font-mono.font-semibold').first().waitFor({ state: 'visible', timeout: 30_000 })
 
-    // ── 3. Wait for streaming to finish ──────────────────────────────────────
+    // ── Wait for streaming to finish ─────────────────────────────────────────
     await stopBtn.waitFor({ state: 'hidden', timeout: 90_000 })
 
-    // ── 4. After streaming: thinking blocks (if any) ─────────────────────────
-    // Claude uses ThinkingAdaptive by default — thinking may or may not appear.
-    // If it does appear, verify the toggle can be expanded to reveal content.
+    // ── Thinking blocks (if Claude emitted any) ──────────────────────────────
+    // ThinkingAdaptive is the default — Claude decides whether to think.
+    // If thinking blocks are present: verify each has a toggle and can be expanded.
     const thinkingToggles = page.getByRole('button', { name: 'Thinking' })
     const thinkingCount = await thinkingToggles.count()
     if (thinkingCount > 0) {
+      // The toggle should be visible (collapsed by default)
+      await expect(thinkingToggles.first()).toBeVisible()
+      // Clicking it should expand the block and reveal thinking text
       await thinkingToggles.first().click()
       const thinkingContent = page.locator('div.font-mono.whitespace-pre-wrap').first()
       await expect(thinkingContent).toBeVisible({ timeout: 3_000 })
-      const thinkingText = await thinkingContent.textContent()
-      expect(thinkingText?.length ?? 0).toBeGreaterThan(0)
+      expect((await thinkingContent.textContent())?.length ?? 0).toBeGreaterThan(0)
     }
 
-    // ── 5. After streaming: at least one tool call was rendered ──────────────
-    // Claude is non-deterministic — it may use any combination of tools
-    // (Write, Read, Edit, Bash, …). We only assert that at least one tool call
-    // card rendered; we do not enforce specific names or ordering.
+    // ── At least one tool call card rendered ─────────────────────────────────
+    // Claude is non-deterministic — tool names and order vary per run.
     const toolNameSpans = page.locator('span.font-mono.font-semibold')
-    const toolNameCount = await toolNameSpans.count()
-    expect(toolNameCount).toBeGreaterThan(0)
+    const toolCount = await toolNameSpans.count()
+    expect(toolCount).toBeGreaterThan(0)
 
-    // ── 6. After streaming: completed tool calls have green dots ─────────────
-    // Every ToolCallCard that received a result renders a span.bg-emerald-400.
-    // There must be at least one, and no more than the total number of tool calls.
-    const completionDots = page.locator('span.bg-emerald-400')
-    const dotCount = await completionDots.count()
+    // ── All completed tool calls have a green dot ─────────────────────────────
+    // span.bg-emerald-400 appears on each ToolCallCard that received a result.
+    const greenDots = page.locator('span.bg-emerald-400')
+    const dotCount = await greenDots.count()
     expect(dotCount).toBeGreaterThan(0)
-    expect(dotCount).toBeLessThanOrEqual(toolNameCount)
+    expect(dotCount).toBeLessThanOrEqual(toolCount)
 
-    // ── 7. Input textarea re-enabled for follow-up ────────────────────────────
+    // ── Final assistant response text is visible ──────────────────────────────
+    const assistantContent = page.locator('p, div').filter({ hasText: /hello-world\.txt|operations|success/i })
+    await expect(assistantContent.first()).toBeVisible({ timeout: 5_000 })
+
+    // ── Input textarea re-enabled for follow-up ───────────────────────────────
     const inputTextarea = page.getByPlaceholder(
       'Message… (Enter to send, Shift+Enter for new line, drop/paste files)',
     )
@@ -147,7 +156,86 @@ test.describe('Chat', () => {
     await expect(inputTextarea).toBeEnabled()
   })
 
-  // ── Dialog UX ─────────────────────────────────────────────────────────────
+  test.afterEach(async () => {
+    cleanupArtifacts()
+  })
+
+  // ── 2. Follow-up message ───────────────────────────────────────────────────
+
+  test('sends a follow-up message in an existing session', async ({ page }) => {
+    // Start a short initial chat to open a session
+    await openNewChatDialog(page)
+    await startChat(page, 'Say "hello" and nothing else.')
+    await waitForStreamingToComplete(page)
+
+    // Verify first response arrived
+    const inputTextarea = page.getByPlaceholder(
+      'Message… (Enter to send, Shift+Enter for new line, drop/paste files)',
+    )
+    await expect(inputTextarea).toBeEnabled()
+
+    // Send a follow-up
+    await inputTextarea.fill('Now say "goodbye" and nothing else.')
+    await inputTextarea.press('Enter')
+
+    // Streaming must start and finish for the follow-up
+    const stopBtn = page.locator('button[title="Stop generation"]')
+    await stopBtn.waitFor({ state: 'visible', timeout: 30_000 })
+    await stopBtn.waitFor({ state: 'hidden', timeout: 90_000 })
+
+    // Input re-enabled after follow-up
+    await expect(inputTextarea).toBeEnabled()
+
+    // Both user messages visible in the conversation
+    await expect(page.getByText('Say "hello" and nothing else.')).toBeVisible()
+    await expect(page.getByText('Now say "goodbye" and nothing else.')).toBeVisible()
+  })
+
+  // ── 3. Stop generation ────────────────────────────────────────────────────
+
+  test('stops generation mid-stream when Stop button is clicked', async ({ page }) => {
+    await openNewChatDialog(page)
+    // Use a prompt likely to produce a long response so we can stop it in time
+    await startChat(page, 'Write a very long detailed essay about software engineering best practices. Include at least 10 sections.')
+
+    // Wait for streaming to start
+    const stopBtn = page.locator('button[title="Stop generation"]')
+    await stopBtn.waitFor({ state: 'visible', timeout: 30_000 })
+
+    // Click Stop
+    await stopBtn.click()
+
+    // Streaming must end: Stop button disappears and input becomes available
+    await stopBtn.waitFor({ state: 'hidden', timeout: 15_000 })
+
+    const inputTextarea = page.getByPlaceholder(
+      'Message… (Enter to send, Shift+Enter for new line, drop/paste files)',
+    )
+    await expect(inputTextarea).toBeEnabled({ timeout: 10_000 })
+
+    // No error banner visible after stopping
+    await expect(page.locator('.text-red-600, .text-red-700').first()).not.toBeVisible()
+  })
+
+  // ── 4. Completed chat appears in the chat list ────────────────────────────
+
+  test('completed chat appears in the chats list with a title', async ({ page }) => {
+    // Create and complete a short chat
+    await openNewChatDialog(page)
+    await startChat(page, 'Say only the word "pineapple".')
+    await waitForStreamingToComplete(page)
+
+    // Navigate back to the chats list
+    await page.getByRole('link', { name: 'Chats' }).first().click()
+    await expect(page).toHaveURL(/\/chats$/)
+
+    // The new chat should appear in the list (it may show "New Chat" as title
+    // until Claude sets it — just assert at least one item exists)
+    const chatList = page.locator('[class*="cursor-pointer"]').filter({ hasText: /pineapple|New Chat/i })
+    await expect(chatList.first()).toBeVisible({ timeout: 10_000 })
+  })
+
+  // ── 5. Dialog UX ──────────────────────────────────────────────────────────
 
   test('new chat dialog can be cancelled', async ({ page }) => {
     await openNewChatDialog(page)

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "types": ["node", "@playwright/test"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist", "playwright-report", "test-results"]
+}


### PR DESCRIPTION
## Summary

- Sets up a local-only Playwright (Chromium) e2e test framework under `e2e/`
- Tests start the compiled `agento` binary automatically via `webServer` config with a clean data directory at `/tmp/agento-e2e-test`
- Adds `make e2e-setup` (first-time install) and `make e2e` (build + run) Makefile targets

## Chat tests (`e2e/tests/chat.spec.ts`)

- Full user journey: New Chat dialog → prompt → streaming renders thinking blocks, tool call cards (Write/Read/Edit/Bash), and green completion dots
- All assertions are non-deterministic-safe (no hardcoded tool names/counts/ordering)
- Dialog cancel behaviour
- Start Chat button disabled state when message is empty

## Test plan

- [ ] Run `make e2e-setup` (first time only)
- [ ] Run `make e2e` — should show `3 passed`
- [ ] Confirm streaming screenshot shows thinking toggle + tool call cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)