### PR TITLE
feat(updater): auto-check on every command with Homebrew awareness

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,22 +1,51 @@
 package cmd
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
+	"strings"
 
+	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 
 	"github.com/shaharia-lab/agento/internal/build"
 	"github.com/shaharia-lab/agento/internal/config"
+	"github.com/shaharia-lab/agento/internal/updater"
 )
 
+// skipUpdateCheckEnv is the environment variable users can set to disable the
+// pre-run update check entirely (useful in CI, scripts, or any environment
+// where prompting or network calls are unwanted).
+const skipUpdateCheckEnv = "AGENTO_SKIP_UPDATE_CHECK"
+
+// updateCheckSkipCommands lists subcommand names that must never trigger the
+// auto-update check. The "update" command runs its own (uncached) check, and
+// help/version are non-interactive metadata commands.
+var updateCheckSkipCommands = map[string]struct{}{ //nolint:gochecknoglobals
+	"update":     {},
+	"help":       {},
+	"completion": {},
+	"__complete": {}, // cobra's hidden shell-completion command
+}
+
 // NewRootCmd returns the root cobra command wired with the provided AppConfig.
+//
+// The root command attaches a PersistentPreRunE hook that performs an opportunistic
+// update check before any subcommand runs. The hook is intentionally best-effort:
+// it never returns an error to the caller, so a failed network call or a missing
+// cache directory cannot prevent the user's command from running.
 func NewRootCmd(cfg *config.AppConfig) *cobra.Command {
 	root := &cobra.Command{
 		Use:     "agento",
 		Short:   "Agento — AI Agents Platform",
 		Long:    "A platform for running Claude agents defined in YAML configuration files.",
 		Version: build.String(),
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			runAutoUpdateCheck(cmd, cfg)
+			return nil
+		},
 	}
 	root.SetVersionTemplate("{{.Version}}\n")
 	return root
@@ -34,10 +63,109 @@ func Execute() {
 	root := NewRootCmd(cfg)
 	root.AddCommand(NewWebCmd(cfg))
 	root.AddCommand(NewAskCmd(cfg))
-	root.AddCommand(NewUpdateCmd())
+	root.AddCommand(NewUpdateCmd(cfg))
 
 	if err := root.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+}
+
+// runAutoUpdateCheck is the PersistentPreRunE body. It performs a cached
+// update check and, on a fresh hit, prompts the user to update.
+//
+// The function is split out so it can be unit-tested without spinning up cobra.
+// All paths return without raising errors — auto-check must never fail the user's command.
+func runAutoUpdateCheck(cmd *cobra.Command, cfg *config.AppConfig) {
+	if !shouldRunAutoCheck(cmd) {
+		return
+	}
+
+	checker := &updater.Checker{CacheDir: cfg.DataDir}
+	result, err := checker.Check(cmd.Context(), build.Version, false)
+	if err != nil {
+		// Includes ErrNotReleaseBuild, network errors, and timeouts. All are
+		// non-fatal — the user did not ask for an update check.
+		return
+	}
+	if !result.UpdateAvailable {
+		return
+	}
+
+	promptAndMaybeUpdate(cmd.Context(), result)
+}
+
+// shouldRunAutoCheck applies all skip rules and returns true only when the
+// auto-check should proceed.
+func shouldRunAutoCheck(cmd *cobra.Command) bool {
+	// Skip dev/unknown builds — they cannot meaningfully update.
+	current := strings.TrimPrefix(build.Version, "v")
+	if current == "dev" || current == "unknown" || current == "" {
+		return false
+	}
+
+	// User opt-out via env var.
+	if v := os.Getenv(skipUpdateCheckEnv); v == "1" || strings.EqualFold(v, "true") {
+		return false
+	}
+
+	// Non-interactive (CI, pipes, redirected stdin/stdout) — no point prompting.
+	if !isInteractive() {
+		return false
+	}
+
+	// Skip subcommands where the check is irrelevant or duplicative.
+	if cmd != nil {
+		if _, skip := updateCheckSkipCommands[cmd.Name()]; skip {
+			return false
+		}
+	}
+	return true
+}
+
+// isInteractive reports whether both stdin and stdout are connected to a TTY.
+// We require both because a yes/no prompt is meaningless if either side is piped.
+func isInteractive() bool {
+	return isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stdout.Fd())
+}
+
+// promptAndMaybeUpdate handles the interactive flow when an update is available.
+// It writes prompts to stderr so it doesn't pollute the stdout of subcommands
+// that emit machine-readable output.
+//
+// On confirmed update, it installs the new binary and exits the process — the
+// user will rerun their command against the new binary. On decline or error,
+// it returns and the original command proceeds.
+func promptAndMaybeUpdate(ctx context.Context, result *updater.CheckResult) {
+	// Homebrew install: print instructions and continue with the user's command.
+	if updater.DetectInstallMethod() == updater.InstallMethodHomebrew {
+		fmt.Fprintf(os.Stderr, "\nA new version (v%s) is available.\n", result.LatestVersion)
+		fmt.Fprintln(os.Stderr, updater.HomebrewUpgradeMessage)
+		fmt.Fprintln(os.Stderr)
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, "\nA new version (v%s) is available. Update now? [y/N] ", result.LatestVersion)
+	var input string
+	if _, err := fmt.Scanln(&input); err != nil {
+		// Empty input or read error → treat as decline. Continue with the user's command.
+		return
+	}
+	if input != "y" && input != "Y" {
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, "Updating to %s...\n", result.LatestVersion)
+	if err := updater.Install(ctx, result.LatestVersion); err != nil {
+		if errors.Is(err, updater.ErrHomebrewManaged) {
+			fmt.Fprintln(os.Stderr, updater.HomebrewUpgradeMessage)
+			return
+		}
+		fmt.Fprintf(os.Stderr, "Update failed: %v\n", err)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "Updated to %s. Re-run your command to use the new version.\n", result.LatestVersion)
+	// Exit cleanly so the user re-runs against the new binary. We use 0 because
+	// the update succeeded — the original subcommand simply hasn't been invoked.
+	os.Exit(0)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -114,11 +115,23 @@ func shouldRunAutoCheck(cmd *cobra.Command) bool {
 		return false
 	}
 
+	if cmd == nil {
+		return false
+	}
+	// Skip when no subcommand is being run (bare `agento` prints help) or when
+	// help was requested via --help/-h on any subcommand.
+	if !cmd.Runnable() {
+		return false
+	}
+	// GetBool returns an error only when the flag is undefined; cobra adds
+	// --help to every command at execute time, but skip-on-error is the safe
+	// default if it ever isn't there.
+	if helpFlag, err := cmd.Flags().GetBool("help"); err == nil && helpFlag {
+		return false
+	}
 	// Skip subcommands where the check is irrelevant or duplicative.
-	if cmd != nil {
-		if _, skip := updateCheckSkipCommands[cmd.Name()]; skip {
-			return false
-		}
+	if _, skip := updateCheckSkipCommands[cmd.Name()]; skip {
+		return false
 	}
 	return true
 }
@@ -146,12 +159,17 @@ func promptAndMaybeUpdate(ctx context.Context, result *updater.CheckResult) {
 	}
 
 	fmt.Fprintf(os.Stderr, "\nA new version (v%s) is available. Update now? [y/N] ", result.LatestVersion)
-	var input string
-	if _, err := fmt.Scanln(&input); err != nil {
-		// Empty input or read error → treat as decline. Continue with the user's command.
+	// bufio.Reader is used (rather than fmt.Scanln) so the whole line — including
+	// the trailing newline — is consumed. Otherwise leftover bytes leak into the
+	// stdin of the user's subcommand (e.g. `agento ask` reading from a pipe).
+	reader := bufio.NewReader(os.Stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		// EOF or read error → treat as decline. Continue with the user's command.
 		return
 	}
-	if input != "y" && input != "Y" {
+	answer := strings.TrimSpace(strings.ToLower(line))
+	if answer != "y" && answer != "yes" {
 		return
 	}
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -14,15 +14,26 @@ func TestShouldRunAutoCheck_SkipDevBuild(t *testing.T) {
 	original := build.Version
 	defer func() { build.Version = original }()
 
-	for _, v := range []string{"dev", "unknown", "", "vdev"} {
-		// "vdev" trims to "dev" → skip
+	for _, v := range []string{"dev", "unknown", ""} {
 		build.Version = v
 		// Cobra command is present but should not influence the result.
-		cmd := &cobra.Command{Use: "web"}
+		cmd := newTestCmd("web")
 		if shouldRunAutoCheck(cmd) {
 			t.Errorf("shouldRunAutoCheck() with version=%q should be false", v)
 		}
 	}
+}
+
+// newTestCmd builds a runnable cobra subcommand attached to a root, mirroring
+// the real wiring so cmd.Runnable()/cmd.Flags() behave as they would at runtime.
+func newTestCmd(name string) *cobra.Command {
+	root := &cobra.Command{Use: "agento"}
+	sub := &cobra.Command{
+		Use: name,
+		Run: func(_ *cobra.Command, _ []string) {},
+	}
+	root.AddCommand(sub)
+	return sub
 }
 
 func TestShouldRunAutoCheck_SkipEnvVar(t *testing.T) {
@@ -32,7 +43,7 @@ func TestShouldRunAutoCheck_SkipEnvVar(t *testing.T) {
 
 	for _, v := range []string{"1", "true", "TRUE", "True"} {
 		t.Setenv(skipUpdateCheckEnv, v)
-		cmd := &cobra.Command{Use: "web"}
+		cmd := newTestCmd("web")
 		if shouldRunAutoCheck(cmd) {
 			t.Errorf("shouldRunAutoCheck() with %s=%q should be false", skipUpdateCheckEnv, v)
 		}
@@ -47,10 +58,49 @@ func TestShouldRunAutoCheck_SkipCommands(t *testing.T) {
 
 	// Skipped commands are skipped regardless of TTY.
 	for _, name := range []string{"update", "help", "completion", "__complete"} {
-		cmd := &cobra.Command{Use: name}
+		cmd := newTestCmd(name)
 		if shouldRunAutoCheck(cmd) {
 			t.Errorf("shouldRunAutoCheck() for %q should be false", name)
 		}
+	}
+}
+
+// TestShouldRunAutoCheck_SkipNonRunnable ensures bare `agento` (no subcommand)
+// and `--help` invocations don't trigger an interactive prompt.
+func TestShouldRunAutoCheck_SkipNonRunnable(t *testing.T) {
+	original := build.Version
+	defer func() { build.Version = original }()
+	build.Version = "v1.0.0"
+	t.Setenv(skipUpdateCheckEnv, "")
+
+	// Nil command (defensive).
+	if shouldRunAutoCheck(nil) {
+		t.Error("shouldRunAutoCheck(nil) should be false")
+	}
+
+	// Non-runnable command (e.g. bare `agento` printing its own help).
+	bare := &cobra.Command{Use: "agento"}
+	if shouldRunAutoCheck(bare) {
+		t.Error("shouldRunAutoCheck() for non-runnable command should be false")
+	}
+}
+
+// TestShouldRunAutoCheck_SkipHelpFlag verifies that `agento web --help` does
+// not trigger an interactive prompt during help rendering.
+func TestShouldRunAutoCheck_SkipHelpFlag(t *testing.T) {
+	original := build.Version
+	defer func() { build.Version = original }()
+	build.Version = "v1.0.0"
+	t.Setenv(skipUpdateCheckEnv, "")
+
+	cmd := newTestCmd("web")
+	// Cobra adds the --help flag during execution; simulate that here.
+	cmd.Flags().BoolP("help", "h", false, "help for web")
+	if err := cmd.Flags().Set("help", "true"); err != nil {
+		t.Fatalf("setting --help flag: %v", err)
+	}
+	if shouldRunAutoCheck(cmd) {
+		t.Error("shouldRunAutoCheck() with --help flag set should be false")
 	}
 }
 
@@ -64,7 +114,7 @@ func TestShouldRunAutoCheck_NonInteractive(t *testing.T) {
 	build.Version = "v1.0.0"
 	t.Setenv(skipUpdateCheckEnv, "")
 
-	cmd := &cobra.Command{Use: "web"}
+	cmd := newTestCmd("web")
 	if shouldRunAutoCheck(cmd) {
 		t.Errorf("shouldRunAutoCheck() in non-interactive test runner should be false")
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/shaharia-lab/agento/internal/build"
+)
+
+// TestShouldRunAutoCheck_SkipDevBuild verifies that dev/unknown builds are
+// skipped regardless of any other condition.
+func TestShouldRunAutoCheck_SkipDevBuild(t *testing.T) {
+	original := build.Version
+	defer func() { build.Version = original }()
+
+	for _, v := range []string{"dev", "unknown", "", "vdev"} {
+		// "vdev" trims to "dev" → skip
+		build.Version = v
+		// Cobra command is present but should not influence the result.
+		cmd := &cobra.Command{Use: "web"}
+		if shouldRunAutoCheck(cmd) {
+			t.Errorf("shouldRunAutoCheck() with version=%q should be false", v)
+		}
+	}
+}
+
+func TestShouldRunAutoCheck_SkipEnvVar(t *testing.T) {
+	original := build.Version
+	defer func() { build.Version = original }()
+	build.Version = "v1.0.0"
+
+	for _, v := range []string{"1", "true", "TRUE", "True"} {
+		t.Setenv(skipUpdateCheckEnv, v)
+		cmd := &cobra.Command{Use: "web"}
+		if shouldRunAutoCheck(cmd) {
+			t.Errorf("shouldRunAutoCheck() with %s=%q should be false", skipUpdateCheckEnv, v)
+		}
+	}
+}
+
+func TestShouldRunAutoCheck_SkipCommands(t *testing.T) {
+	original := build.Version
+	defer func() { build.Version = original }()
+	build.Version = "v1.0.0"
+	t.Setenv(skipUpdateCheckEnv, "")
+
+	// Skipped commands are skipped regardless of TTY.
+	for _, name := range []string{"update", "help", "completion", "__complete"} {
+		cmd := &cobra.Command{Use: name}
+		if shouldRunAutoCheck(cmd) {
+			t.Errorf("shouldRunAutoCheck() for %q should be false", name)
+		}
+	}
+}
+
+// TestShouldRunAutoCheck_NonInteractive ensures the check is skipped when
+// stdin/stdout aren't TTYs. In the `go test` runner stdin is generally not a
+// TTY, so this also serves as a sanity check that we never auto-prompt during
+// tests.
+func TestShouldRunAutoCheck_NonInteractive(t *testing.T) {
+	original := build.Version
+	defer func() { build.Version = original }()
+	build.Version = "v1.0.0"
+	t.Setenv(skipUpdateCheckEnv, "")
+
+	cmd := &cobra.Command{Use: "web"}
+	if shouldRunAutoCheck(cmd) {
+		t.Errorf("shouldRunAutoCheck() in non-interactive test runner should be false")
+	}
+}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -2,18 +2,24 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 
-	"github.com/creativeprojects/go-selfupdate"
 	"github.com/spf13/cobra"
 
 	"github.com/shaharia-lab/agento/internal/build"
+	"github.com/shaharia-lab/agento/internal/config"
+	"github.com/shaharia-lab/agento/internal/updater"
 )
 
 // NewUpdateCmd returns the "update" subcommand that self-updates the binary.
-func NewUpdateCmd() *cobra.Command {
+//
+// Unlike the auto-check hook, this command always performs a live network
+// check (no 24-hour cache) and writes the freshly observed result back to the
+// cache so the next auto-check can rely on it.
+func NewUpdateCmd(cfg *config.AppConfig) *cobra.Command {
 	var yes bool
 
 	cmd := &cobra.Command{
@@ -21,7 +27,7 @@ func NewUpdateCmd() *cobra.Command {
 		Short: "Update agento to the latest release",
 		Long:  "Check GitHub releases for a newer version of agento and update the binary in place.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runUpdate(yes)
+			return runUpdate(cmd.Context(), cfg, yes)
 		},
 	}
 
@@ -29,7 +35,7 @@ func NewUpdateCmd() *cobra.Command {
 	return cmd
 }
 
-func runUpdate(skipConfirm bool) error {
+func runUpdate(ctx context.Context, cfg *config.AppConfig, skipConfirm bool) error {
 	current := strings.TrimPrefix(build.Version, "v")
 	if current == "dev" || current == "unknown" {
 		return fmt.Errorf("cannot update a dev build; install a tagged release first")
@@ -38,25 +44,32 @@ func runUpdate(skipConfirm bool) error {
 	fmt.Printf("Current version: %s\n", build.Version)
 	fmt.Print("Checking for updates... ")
 
-	updater, err := selfupdate.NewUpdater(selfupdate.Config{})
+	checker := &updater.Checker{CacheDir: cfg.DataDir}
+	result, err := checker.Check(ctx, build.Version, true) // forceFresh: explicit command bypasses cache
 	if err != nil {
-		return fmt.Errorf("creating updater: %w", err)
-	}
-
-	release, found, err := updater.DetectLatest(context.Background(), selfupdate.ParseSlug("shaharia-lab/agento"))
-	if err != nil {
+		if errors.Is(err, updater.ErrNotReleaseBuild) {
+			fmt.Println()
+			return fmt.Errorf("cannot update a non-release build (%s)", build.Version)
+		}
 		return fmt.Errorf("checking for updates: %w", err)
 	}
 
-	if !found || !release.GreaterThan(current) {
+	if !result.UpdateAvailable {
 		fmt.Println("already up to date.")
 		return nil
 	}
 
-	fmt.Printf("found %s\n", release.Version())
+	fmt.Printf("found %s\n", result.LatestVersion)
+
+	// Homebrew installs cannot be self-updated; print instructions and return.
+	if updater.DetectInstallMethod() == updater.InstallMethodHomebrew {
+		fmt.Printf("\nA new version (v%s) is available.\n", result.LatestVersion)
+		fmt.Println(updater.HomebrewUpgradeMessage)
+		return nil
+	}
 
 	if !skipConfirm {
-		fmt.Printf("Update to %s? [y/N] ", release.Version())
+		fmt.Printf("Update to %s? [y/N] ", result.LatestVersion)
 		var input string
 		fmt.Scanln(&input) //nolint:errcheck,gosec
 		if input != "y" && input != "Y" {
@@ -65,16 +78,22 @@ func runUpdate(skipConfirm bool) error {
 		}
 	}
 
-	exe, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("finding current executable: %w", err)
-	}
-
-	fmt.Printf("Updating to %s...\n", release.Version())
-	if err := updater.UpdateTo(context.Background(), release, exe); err != nil {
+	fmt.Printf("Updating to %s...\n", result.LatestVersion)
+	if err := updater.Install(ctx, result.LatestVersion); err != nil {
+		if errors.Is(err, updater.ErrHomebrewManaged) {
+			// Defensive: the earlier branch already handled this, but keep the
+			// guard so a future refactor cannot accidentally call Install on a
+			// Homebrew binary.
+			fmt.Println(updater.HomebrewUpgradeMessage)
+			return nil
+		}
 		return fmt.Errorf("updating: %w", err)
 	}
 
-	fmt.Printf("Updated to %s. Restart agento to use the new version.\n", release.Version())
+	fmt.Printf("Updated to %s. Restart agento to use the new version.\n", result.LatestVersion)
+
+	// Belt-and-suspenders: ensure stdout is flushed before the process exits in
+	// any embedded environment that may not auto-flush.
+	_ = os.Stdout.Sync() //nolint:errcheck
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/go-co-op/gocron/v2 v2.19.1
 	github.com/google/uuid v1.6.0
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/mattn/go-isatty v0.0.20
 	github.com/modelcontextprotocol/go-sdk v1.4.1
 	github.com/muesli/termenv v0.16.0
 	github.com/prometheus/client_golang v1.23.2
@@ -80,7 +81,6 @@ require (
 	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect

--- a/internal/updater/checker.go
+++ b/internal/updater/checker.go
@@ -1,0 +1,243 @@
+// Package updater provides shared update-check and self-update logic used by
+// both the explicit `agento update` command and the implicit pre-run hook that
+// fires before every other command.
+//
+// The package is intentionally narrow: it caches release-detection results to
+// avoid hammering GitHub on every CLI invocation, and it dispatches between
+// in-place self-update and Homebrew-managed installs.
+package updater
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/creativeprojects/go-selfupdate"
+)
+
+// DefaultCacheTTL is the time the cached release-check result is considered fresh.
+// While the cache is fresh the checker will not contact GitHub.
+const DefaultCacheTTL = 24 * time.Hour
+
+// DefaultCheckTimeout is the hard upper bound for a single network call to GitHub.
+// On timeout the checker returns an error so callers can fail silently in the
+// auto-check path without blocking the user's command.
+const DefaultCheckTimeout = 5 * time.Second
+
+// repoSlug is the GitHub repository the checker queries for releases.
+const repoSlug = "shaharia-lab/agento"
+
+// CacheFileName is the name of the cache file written under AGENTO_DATA_DIR.
+const CacheFileName = "update-check.json"
+
+// CheckResult describes what was found during a release check.
+// A CheckResult with UpdateAvailable=false is still valid and should be cached
+// to avoid re-querying GitHub on every command.
+type CheckResult struct {
+	UpdateAvailable bool      `json:"update_available"`
+	LatestVersion   string    `json:"latest_version"`
+	ReleaseURL      string    `json:"release_url"`
+	CurrentVersion  string    `json:"current_version"`
+	CheckedAt       time.Time `json:"checked_at"`
+}
+
+// Checker performs cached release detection against GitHub.
+//
+// A zero Checker is valid but will use the current working directory for the
+// cache file. Callers should set CacheDir explicitly (typically AGENTO_DATA_DIR).
+type Checker struct {
+	// CacheDir is the directory where the cache file is written.
+	// If empty, caching is effectively disabled (a fresh check runs every time).
+	CacheDir string
+
+	// CacheTTL is the duration a cached result is considered fresh.
+	// If zero, DefaultCacheTTL is used.
+	CacheTTL time.Duration
+
+	// Timeout is the hard upper bound for a single network call.
+	// If zero, DefaultCheckTimeout is used.
+	Timeout time.Duration
+
+	// now is overridable for tests. If nil, time.Now is used.
+	now func() time.Time
+
+	// detectLatest is overridable for tests. If nil, the real go-selfupdate path is used.
+	// Returns (latestVersion, releaseURL, found, error).
+	detectLatest func(ctx context.Context) (latestVersion, releaseURL string, found bool, err error)
+}
+
+// nowFunc returns the time provider to use, defaulting to time.Now.
+func (c *Checker) nowFunc() func() time.Time {
+	if c.now != nil {
+		return c.now
+	}
+	return time.Now
+}
+
+func (c *Checker) cacheTTL() time.Duration {
+	if c.CacheTTL > 0 {
+		return c.CacheTTL
+	}
+	return DefaultCacheTTL
+}
+
+func (c *Checker) timeout() time.Duration {
+	if c.Timeout > 0 {
+		return c.Timeout
+	}
+	return DefaultCheckTimeout
+}
+
+// Check returns the freshest available CheckResult for currentVersion.
+//
+// If forceFresh is false and the on-disk cache is still within TTL, the cached
+// result is returned without contacting the network. If forceFresh is true (used
+// by the explicit `agento update` command) the cache is bypassed and a live
+// check is always performed; the cache is then updated with the new result.
+//
+// currentVersion may include a leading "v"; it is trimmed before comparison.
+// Non-semver versions (e.g. "dev", "unknown", a bare git SHA) cause Check to
+// return ErrNotReleaseBuild so callers can skip silently.
+func (c *Checker) Check(ctx context.Context, currentVersion string, forceFresh bool) (*CheckResult, error) {
+	currentTrimmed := strings.TrimPrefix(currentVersion, "v")
+	if _, err := semver.NewVersion(currentTrimmed); err != nil {
+		return nil, ErrNotReleaseBuild
+	}
+
+	if !forceFresh {
+		if cached, ok := c.readCache(currentVersion); ok {
+			return cached, nil
+		}
+	}
+
+	result, err := c.fetch(ctx, currentTrimmed)
+	if err != nil {
+		return nil, err
+	}
+	result.CurrentVersion = currentVersion
+	result.CheckedAt = c.nowFunc()()
+
+	// Best-effort cache write. Failures here are logged-via-return only and
+	// must not break the caller — auto-check should never block a user.
+	_ = c.writeCache(result) //nolint:errcheck
+
+	return result, nil
+}
+
+// ErrNotReleaseBuild is returned by Check when the running binary's version
+// is not a parseable semver release (e.g. "dev", "unknown", a commit SHA).
+// Callers in the auto-check path should treat this as "skip silently".
+var ErrNotReleaseBuild = errors.New("not a release build")
+
+// fetch performs a live release-detection call against GitHub with a hard timeout.
+func (c *Checker) fetch(ctx context.Context, currentTrimmed string) (*CheckResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, c.timeout())
+	defer cancel()
+
+	detect := c.detectLatest
+	if detect == nil {
+		detect = defaultDetectLatest
+	}
+
+	latestVersion, releaseURL, found, err := detect(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("detecting latest release: %w", err)
+	}
+
+	result := &CheckResult{}
+	if !found {
+		return result, nil
+	}
+
+	// Compare semver-trimmed strings. We trust go-selfupdate to return a parseable version.
+	latestSemver, err := semver.NewVersion(strings.TrimPrefix(latestVersion, "v"))
+	if err != nil {
+		// Not a semver release — treat as no update.
+		return result, nil
+	}
+	currentSemver, err := semver.NewVersion(currentTrimmed)
+	if err != nil {
+		return result, nil
+	}
+	if latestSemver.GreaterThan(currentSemver) {
+		result.UpdateAvailable = true
+		result.LatestVersion = latestVersion
+		result.ReleaseURL = releaseURL
+	}
+	return result, nil
+}
+
+// defaultDetectLatest is the production path: call go-selfupdate against the GitHub repo.
+func defaultDetectLatest(ctx context.Context) (string, string, bool, error) {
+	upd, err := selfupdate.NewUpdater(selfupdate.Config{})
+	if err != nil {
+		return "", "", false, fmt.Errorf("creating updater: %w", err)
+	}
+	release, found, err := upd.DetectLatest(ctx, selfupdate.ParseSlug(repoSlug))
+	if err != nil {
+		return "", "", false, err
+	}
+	if !found {
+		return "", "", false, nil
+	}
+	url := fmt.Sprintf("https://github.com/%s/releases/tag/v%s", repoSlug, release.Version())
+	return release.Version(), url, true, nil
+}
+
+// cachePath returns the absolute path to the cache file, or "" if caching is disabled.
+func (c *Checker) cachePath() string {
+	if c.CacheDir == "" {
+		return ""
+	}
+	return filepath.Join(c.CacheDir, CacheFileName)
+}
+
+// readCache returns the cached CheckResult if it is present, fresh, and was
+// written for the same currentVersion. A cache entry from a different version
+// is treated as stale (otherwise an upgrade-and-revert cycle could mask updates).
+func (c *Checker) readCache(currentVersion string) (*CheckResult, bool) {
+	path := c.cachePath()
+	if path == "" {
+		return nil, false
+	}
+	data, err := os.ReadFile(path) //nolint:gosec // path is under our own data dir
+	if err != nil {
+		return nil, false
+	}
+	var cached CheckResult
+	if err := json.Unmarshal(data, &cached); err != nil {
+		return nil, false
+	}
+	if cached.CurrentVersion != currentVersion {
+		return nil, false
+	}
+	if c.nowFunc()().Sub(cached.CheckedAt) >= c.cacheTTL() {
+		return nil, false
+	}
+	return &cached, true
+}
+
+// writeCache persists result to disk. The cache directory is created if needed.
+func (c *Checker) writeCache(result *CheckResult) error {
+	path := c.cachePath()
+	if path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(c.CacheDir, 0o750); err != nil {
+		return fmt.Errorf("creating cache dir: %w", err)
+	}
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling cache: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("writing cache: %w", err)
+	}
+	return nil
+}

--- a/internal/updater/checker.go
+++ b/internal/updater/checker.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -40,11 +41,20 @@ const CacheFileName = "update-check.json"
 // A CheckResult with UpdateAvailable=false is still valid and should be cached
 // to avoid re-querying GitHub on every command.
 type CheckResult struct {
-	UpdateAvailable bool      `json:"update_available"`
-	LatestVersion   string    `json:"latest_version"`
-	ReleaseURL      string    `json:"release_url"`
-	CurrentVersion  string    `json:"current_version"`
-	CheckedAt       time.Time `json:"checked_at"`
+	UpdateAvailable bool   `json:"update_available"`
+	LatestVersion   string `json:"latest_version"`
+	ReleaseURL      string `json:"release_url"`
+	CurrentVersion  string `json:"current_version"`
+	// Platform is the GOOS/GOARCH the result was computed for. A cache entry
+	// from a different platform (e.g. shared ~/.agento across machines) must
+	// be invalidated because the install step would fail on missing assets.
+	Platform  string    `json:"platform"`
+	CheckedAt time.Time `json:"checked_at"`
+}
+
+// currentPlatform returns the runtime platform string used for cache validation.
+func currentPlatform() string {
+	return runtime.GOOS + "/" + runtime.GOARCH
 }
 
 // Checker performs cached release detection against GitHub.
@@ -121,6 +131,7 @@ func (c *Checker) Check(ctx context.Context, currentVersion string, forceFresh b
 		return nil, err
 	}
 	result.CurrentVersion = currentVersion
+	result.Platform = currentPlatform()
 	result.CheckedAt = c.nowFunc()()
 
 	// Best-effort cache write. Failures here are logged-via-return only and
@@ -217,6 +228,12 @@ func (c *Checker) readCache(currentVersion string) (*CheckResult, bool) {
 	if cached.CurrentVersion != currentVersion {
 		return nil, false
 	}
+	// Invalidate cache entries that were written for a different GOOS/GOARCH
+	// (e.g. when ~/.agento is shared across machines via dotfiles or syncthing).
+	// Empty Platform on legacy cache files is also treated as a miss.
+	if cached.Platform != currentPlatform() {
+		return nil, false
+	}
 	if c.nowFunc()().Sub(cached.CheckedAt) >= c.cacheTTL() {
 		return nil, false
 	}
@@ -229,7 +246,7 @@ func (c *Checker) writeCache(result *CheckResult) error {
 	if path == "" {
 		return nil
 	}
-	if err := os.MkdirAll(c.CacheDir, 0o750); err != nil {
+	if err := os.MkdirAll(c.CacheDir, 0o700); err != nil {
 		return fmt.Errorf("creating cache dir: %w", err)
 	}
 	data, err := json.MarshalIndent(result, "", "  ")

--- a/internal/updater/checker_test.go
+++ b/internal/updater/checker_test.go
@@ -126,6 +126,7 @@ func TestChecker_Check_UsesCacheWhenFresh(t *testing.T) {
 		LatestVersion:   "9.9.9",
 		ReleaseURL:      "https://example.com",
 		CurrentVersion:  "v1.0.0",
+		Platform:        currentPlatform(),
 		CheckedAt:       fixedNow.Add(-1 * time.Hour),
 	}
 	data, _ := json.Marshal(cached)
@@ -163,6 +164,7 @@ func TestChecker_Check_BypassesCacheWhenStale(t *testing.T) {
 		UpdateAvailable: true,
 		LatestVersion:   "9.9.9",
 		CurrentVersion:  "v1.0.0",
+		Platform:        currentPlatform(),
 		CheckedAt:       fixedNow.Add(-25 * time.Hour), // older than DefaultCacheTTL
 	}
 	data, _ := json.Marshal(cached)
@@ -196,6 +198,7 @@ func TestChecker_Check_BypassesCacheWhenVersionDiffers(t *testing.T) {
 		UpdateAvailable: true,
 		LatestVersion:   "0.6.0",
 		CurrentVersion:  "v0.5.0",
+		Platform:        currentPlatform(),
 		CheckedAt:       fixedNow.Add(-1 * time.Hour),
 	}
 	data, _ := json.Marshal(cached)
@@ -224,6 +227,91 @@ func TestChecker_Check_BypassesCacheWhenVersionDiffers(t *testing.T) {
 	}
 }
 
+// TestChecker_Check_BypassesCacheWhenPlatformDiffers covers the case where
+// ~/.agento is shared across machines (e.g. via dotfiles) and the cached
+// release was written for a different GOOS/GOARCH.
+func TestChecker_Check_BypassesCacheWhenPlatformDiffers(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	fixedNow := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	cached := CheckResult{
+		UpdateAvailable: true,
+		LatestVersion:   "9.9.9",
+		CurrentVersion:  "v1.0.0",
+		Platform:        "some-other-os/some-other-arch",
+		CheckedAt:       fixedNow.Add(-1 * time.Hour),
+	}
+	data, _ := json.Marshal(cached)
+	if err := os.WriteFile(filepath.Join(tmp, CacheFileName), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	called := false
+	c := &Checker{
+		CacheDir: tmp,
+		now:      func() time.Time { return fixedNow },
+		detectLatest: func(_ context.Context) (string, string, bool, error) {
+			called = true
+			return "1.2.3", "", true, nil
+		},
+	}
+	got, err := c.Check(context.Background(), "v1.0.0", false)
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if !called {
+		t.Fatalf("detectLatest must be called when cached Platform mismatches")
+	}
+	if got.LatestVersion != "1.2.3" {
+		t.Errorf("LatestVersion = %q, want %q", got.LatestVersion, "1.2.3")
+	}
+	if got.Platform != currentPlatform() {
+		t.Errorf("Platform = %q, want %q", got.Platform, currentPlatform())
+	}
+}
+
+// TestChecker_Check_LegacyCacheMissingPlatformIsInvalidated handles cache
+// files written by an earlier version of agento that did not record Platform.
+func TestChecker_Check_LegacyCacheMissingPlatformIsInvalidated(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	fixedNow := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	// Marshal a struct that omits the platform field entirely.
+	legacy := struct {
+		UpdateAvailable bool      `json:"update_available"`
+		LatestVersion   string    `json:"latest_version"`
+		CurrentVersion  string    `json:"current_version"`
+		CheckedAt       time.Time `json:"checked_at"`
+	}{
+		UpdateAvailable: true,
+		LatestVersion:   "9.9.9",
+		CurrentVersion:  "v1.0.0",
+		CheckedAt:       fixedNow.Add(-1 * time.Hour),
+	}
+	data, _ := json.Marshal(legacy)
+	if err := os.WriteFile(filepath.Join(tmp, CacheFileName), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	called := false
+	c := &Checker{
+		CacheDir: tmp,
+		now:      func() time.Time { return fixedNow },
+		detectLatest: func(_ context.Context) (string, string, bool, error) {
+			called = true
+			return "1.2.3", "", true, nil
+		},
+	}
+	if _, err := c.Check(context.Background(), "v1.0.0", false); err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if !called {
+		t.Fatalf("detectLatest must be called when cached Platform is empty (legacy cache)")
+	}
+}
+
 func TestChecker_Check_ForceFreshBypassesCache(t *testing.T) {
 	t.Parallel()
 	tmp := t.TempDir()
@@ -233,6 +321,7 @@ func TestChecker_Check_ForceFreshBypassesCache(t *testing.T) {
 		UpdateAvailable: true,
 		LatestVersion:   "9.9.9",
 		CurrentVersion:  "v1.0.0",
+		Platform:        currentPlatform(),
 		CheckedAt:       fixedNow.Add(-1 * time.Hour),
 	}
 	data, _ := json.Marshal(cached)

--- a/internal/updater/checker_test.go
+++ b/internal/updater/checker_test.go
@@ -1,0 +1,324 @@
+package updater
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestChecker_Check_NotReleaseBuild(t *testing.T) {
+	t.Parallel()
+	c := &Checker{CacheDir: t.TempDir()}
+	for _, v := range []string{"dev", "unknown", "00f2331", ""} {
+		v := v
+		t.Run(v, func(t *testing.T) {
+			t.Parallel()
+			_, err := c.Check(context.Background(), v, false)
+			if !errors.Is(err, ErrNotReleaseBuild) {
+				t.Fatalf("expected ErrNotReleaseBuild for %q, got %v", v, err)
+			}
+		})
+	}
+}
+
+func TestChecker_Check_FetchSuccess_UpdateAvailable(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	fixedNow := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	c := &Checker{
+		CacheDir: tmp,
+		now:      func() time.Time { return fixedNow },
+		detectLatest: func(_ context.Context) (string, string, bool, error) {
+			return "1.2.3", "https://example.com/release", true, nil
+		},
+	}
+	got, err := c.Check(context.Background(), "v1.0.0", false)
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if !got.UpdateAvailable {
+		t.Fatalf("expected UpdateAvailable=true, got %+v", got)
+	}
+	if got.LatestVersion != "1.2.3" {
+		t.Errorf("LatestVersion = %q, want %q", got.LatestVersion, "1.2.3")
+	}
+	if got.CurrentVersion != "v1.0.0" {
+		t.Errorf("CurrentVersion = %q, want %q", got.CurrentVersion, "v1.0.0")
+	}
+	if !got.CheckedAt.Equal(fixedNow) {
+		t.Errorf("CheckedAt = %v, want %v", got.CheckedAt, fixedNow)
+	}
+
+	// Cache file should exist on disk.
+	data, err := os.ReadFile(filepath.Join(tmp, CacheFileName)) //nolint:gosec // test-controlled path under t.TempDir()
+	if err != nil {
+		t.Fatalf("expected cache file written, got: %v", err)
+	}
+	var cached CheckResult
+	if err := json.Unmarshal(data, &cached); err != nil {
+		t.Fatalf("cache file is not valid JSON: %v", err)
+	}
+	if cached.LatestVersion != "1.2.3" {
+		t.Errorf("cached LatestVersion = %q, want %q", cached.LatestVersion, "1.2.3")
+	}
+}
+
+func TestChecker_Check_FetchSuccess_NoUpdate(t *testing.T) {
+	t.Parallel()
+	c := &Checker{
+		CacheDir: t.TempDir(),
+		detectLatest: func(_ context.Context) (string, string, bool, error) {
+			return "1.0.0", "", true, nil
+		},
+	}
+	got, err := c.Check(context.Background(), "v1.0.0", false)
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if got.UpdateAvailable {
+		t.Errorf("expected UpdateAvailable=false, got %+v", got)
+	}
+}
+
+func TestChecker_Check_LowerVersion(t *testing.T) {
+	t.Parallel()
+	c := &Checker{
+		CacheDir: t.TempDir(),
+		detectLatest: func(_ context.Context) (string, string, bool, error) {
+			return "0.9.0", "", true, nil
+		},
+	}
+	got, err := c.Check(context.Background(), "v1.0.0", false)
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if got.UpdateAvailable {
+		t.Errorf("a lower version should not be reported as an update")
+	}
+}
+
+func TestChecker_Check_FetchError(t *testing.T) {
+	t.Parallel()
+	c := &Checker{
+		CacheDir: t.TempDir(),
+		detectLatest: func(_ context.Context) (string, string, bool, error) {
+			return "", "", false, errors.New("network down")
+		},
+	}
+	_, err := c.Check(context.Background(), "v1.0.0", false)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}
+
+func TestChecker_Check_UsesCacheWhenFresh(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	fixedNow := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	// Pre-populate the cache with a fresh entry.
+	cached := CheckResult{
+		UpdateAvailable: true,
+		LatestVersion:   "9.9.9",
+		ReleaseURL:      "https://example.com",
+		CurrentVersion:  "v1.0.0",
+		CheckedAt:       fixedNow.Add(-1 * time.Hour),
+	}
+	data, _ := json.Marshal(cached)
+	if err := os.WriteFile(filepath.Join(tmp, CacheFileName), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	called := false
+	c := &Checker{
+		CacheDir: tmp,
+		now:      func() time.Time { return fixedNow },
+		detectLatest: func(_ context.Context) (string, string, bool, error) {
+			called = true
+			return "1.2.3", "", true, nil
+		},
+	}
+	got, err := c.Check(context.Background(), "v1.0.0", false)
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if called {
+		t.Fatalf("detectLatest must not be called when cache is fresh")
+	}
+	if got.LatestVersion != "9.9.9" {
+		t.Errorf("LatestVersion = %q, want cached %q", got.LatestVersion, "9.9.9")
+	}
+}
+
+func TestChecker_Check_BypassesCacheWhenStale(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	fixedNow := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	cached := CheckResult{
+		UpdateAvailable: true,
+		LatestVersion:   "9.9.9",
+		CurrentVersion:  "v1.0.0",
+		CheckedAt:       fixedNow.Add(-25 * time.Hour), // older than DefaultCacheTTL
+	}
+	data, _ := json.Marshal(cached)
+	if err := os.WriteFile(filepath.Join(tmp, CacheFileName), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &Checker{
+		CacheDir: tmp,
+		now:      func() time.Time { return fixedNow },
+		detectLatest: func(_ context.Context) (string, string, bool, error) {
+			return "1.2.3", "", true, nil
+		},
+	}
+	got, err := c.Check(context.Background(), "v1.0.0", false)
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if got.LatestVersion != "1.2.3" {
+		t.Errorf("LatestVersion = %q, want fresh %q", got.LatestVersion, "1.2.3")
+	}
+}
+
+func TestChecker_Check_BypassesCacheWhenVersionDiffers(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	fixedNow := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	// Cache was written for v0.5.0 — we are now running v1.0.0.
+	cached := CheckResult{
+		UpdateAvailable: true,
+		LatestVersion:   "0.6.0",
+		CurrentVersion:  "v0.5.0",
+		CheckedAt:       fixedNow.Add(-1 * time.Hour),
+	}
+	data, _ := json.Marshal(cached)
+	if err := os.WriteFile(filepath.Join(tmp, CacheFileName), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	called := false
+	c := &Checker{
+		CacheDir: tmp,
+		now:      func() time.Time { return fixedNow },
+		detectLatest: func(_ context.Context) (string, string, bool, error) {
+			called = true
+			return "1.2.3", "", true, nil
+		},
+	}
+	got, err := c.Check(context.Background(), "v1.0.0", false)
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if !called {
+		t.Fatalf("detectLatest must be called when cached CurrentVersion mismatches")
+	}
+	if got.LatestVersion != "1.2.3" {
+		t.Errorf("LatestVersion = %q, want %q", got.LatestVersion, "1.2.3")
+	}
+}
+
+func TestChecker_Check_ForceFreshBypassesCache(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	fixedNow := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	cached := CheckResult{
+		UpdateAvailable: true,
+		LatestVersion:   "9.9.9",
+		CurrentVersion:  "v1.0.0",
+		CheckedAt:       fixedNow.Add(-1 * time.Hour),
+	}
+	data, _ := json.Marshal(cached)
+	if err := os.WriteFile(filepath.Join(tmp, CacheFileName), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	called := false
+	c := &Checker{
+		CacheDir: tmp,
+		now:      func() time.Time { return fixedNow },
+		detectLatest: func(_ context.Context) (string, string, bool, error) {
+			called = true
+			return "1.2.3", "", true, nil
+		},
+	}
+	got, err := c.Check(context.Background(), "v1.0.0", true)
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if !called {
+		t.Fatalf("detectLatest must be called when forceFresh=true")
+	}
+	if got.LatestVersion != "1.2.3" {
+		t.Errorf("LatestVersion = %q, want %q", got.LatestVersion, "1.2.3")
+	}
+}
+
+func TestChecker_Check_NoCacheDirSkipsPersistence(t *testing.T) {
+	t.Parallel()
+	c := &Checker{
+		CacheDir: "", // disabled
+		detectLatest: func(_ context.Context) (string, string, bool, error) {
+			return "1.2.3", "", true, nil
+		},
+	}
+	_, err := c.Check(context.Background(), "v1.0.0", false)
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	// Nothing to assert — the test simply ensures no panic and no error when
+	// CacheDir is empty.
+}
+
+func TestChecker_Check_CorruptedCacheFallsThroughToFetch(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, CacheFileName), []byte("not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	called := false
+	c := &Checker{
+		CacheDir: tmp,
+		detectLatest: func(_ context.Context) (string, string, bool, error) {
+			called = true
+			return "1.2.3", "", true, nil
+		},
+	}
+	got, err := c.Check(context.Background(), "v1.0.0", false)
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if !called {
+		t.Fatalf("expected fetch to be called when cache is corrupted")
+	}
+	if got.LatestVersion != "1.2.3" {
+		t.Errorf("LatestVersion = %q, want %q", got.LatestVersion, "1.2.3")
+	}
+}
+
+func TestChecker_Check_TimeoutPropagated(t *testing.T) {
+	t.Parallel()
+	c := &Checker{
+		CacheDir: t.TempDir(),
+		Timeout:  10 * time.Millisecond,
+		detectLatest: func(ctx context.Context) (string, string, bool, error) {
+			select {
+			case <-time.After(200 * time.Millisecond):
+				return "1.2.3", "", true, nil
+			case <-ctx.Done():
+				return "", "", false, ctx.Err()
+			}
+		},
+	}
+	_, err := c.Check(context.Background(), "v1.0.0", false)
+	if err == nil {
+		t.Fatalf("expected timeout error, got nil")
+	}
+}

--- a/internal/updater/installer.go
+++ b/internal/updater/installer.go
@@ -128,6 +128,18 @@ func Install(ctx context.Context, latestVersion string) error {
 		return fmt.Errorf("release %s not found on GitHub", latestVersion)
 	}
 
+	// Guard against the cache-vs-live race: between Check (cache hit) and Install,
+	// a newer release may have landed on GitHub. Refuse to install a different
+	// version than the user agreed to — they should re-run and confirm.
+	if want := strings.TrimPrefix(latestVersion, "v"); want != "" {
+		if got := strings.TrimPrefix(release.Version(), "v"); got != want {
+			return fmt.Errorf(
+				"release on GitHub (%s) no longer matches the version you confirmed (%s); please re-run",
+				got, want,
+			)
+		}
+	}
+
 	// go-selfupdate handles the Windows rename trick internally, so the same
 	// call path works on Linux, macOS, and Windows.
 	if err := upd.UpdateTo(ctx, release, exe); err != nil {

--- a/internal/updater/installer.go
+++ b/internal/updater/installer.go
@@ -1,0 +1,137 @@
+package updater
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/creativeprojects/go-selfupdate"
+)
+
+// InstallMethod describes how the running binary was installed, which determines
+// the correct upgrade path.
+type InstallMethod int
+
+const (
+	// InstallMethodSelfUpdate means the binary can be replaced in place using
+	// go-selfupdate (works on Linux, macOS, and Windows for direct downloads).
+	InstallMethodSelfUpdate InstallMethod = iota
+
+	// InstallMethodHomebrew means the binary lives under a Homebrew prefix and
+	// must be upgraded via `brew upgrade agento` to keep Homebrew's metadata in sync.
+	InstallMethodHomebrew
+)
+
+// homebrewPathPrefixes lists path prefixes that uniquely identify a
+// Homebrew-managed binary across the three supported install layouts.
+//
+// We deliberately match by prefix on the resolved executable path:
+//   - macOS Intel:    /usr/local/Cellar/...   or  /usr/local/opt/...
+//   - macOS Silicon:  /opt/homebrew/Cellar/...   or  /opt/homebrew/opt/...
+//   - Linuxbrew:      /home/linuxbrew/.linuxbrew/...
+//
+// Note: prefixes use forward slashes intentionally — Homebrew does not exist on
+// Windows, so checks against these prefixes are no-ops on a Windows binary path
+// (which would be drive-letter rooted with backslashes).
+var homebrewPathPrefixes = []string{ //nolint:gochecknoglobals
+	"/usr/local/Cellar/",
+	"/usr/local/opt/",
+	"/opt/homebrew/Cellar/",
+	"/opt/homebrew/opt/",
+	"/home/linuxbrew/.linuxbrew/",
+}
+
+// DetectInstallMethod inspects the path of the running executable and returns
+// the install method to use. It evaluates symlinks so a Homebrew binary linked
+// into /usr/local/bin still resolves to its Cellar prefix.
+//
+// On any error resolving the executable, DetectInstallMethod falls back to
+// InstallMethodSelfUpdate — this matches user expectation that an unknown layout
+// should still be upgradable in place.
+func DetectInstallMethod() InstallMethod {
+	// Homebrew is not available on Windows; skip the path inspection entirely.
+	if runtime.GOOS == "windows" {
+		return InstallMethodSelfUpdate
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		return InstallMethodSelfUpdate
+	}
+	resolved, err := filepath.EvalSymlinks(exe)
+	if err != nil {
+		// EvalSymlinks may fail on permissions or a missing target. Fall back
+		// to the un-resolved path so we still attempt prefix matching.
+		resolved = exe
+	}
+	if isHomebrewPath(resolved) {
+		return InstallMethodHomebrew
+	}
+	return InstallMethodSelfUpdate
+}
+
+// isHomebrewPath reports whether path is rooted under a known Homebrew prefix.
+// The check uses forward-slash prefixes so Windows paths (which use backslashes
+// and drive letters) cannot accidentally match.
+func isHomebrewPath(path string) bool {
+	// Normalize to forward slashes for prefix matching. On Unix this is a no-op.
+	normalized := filepath.ToSlash(path)
+	for _, prefix := range homebrewPathPrefixes {
+		if strings.HasPrefix(normalized, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// HomebrewUpgradeMessage is the user-facing instruction printed when an update
+// is available for a Homebrew-managed install. It is exported so callers can
+// log or format it however they need.
+const HomebrewUpgradeMessage = "You installed agento via Homebrew. Run: brew upgrade agento"
+
+// ErrHomebrewManaged is returned by Install when the binary is Homebrew-managed
+// and self-update was attempted. Callers should print HomebrewUpgradeMessage instead.
+var ErrHomebrewManaged = errors.New("binary is managed by Homebrew; use 'brew upgrade agento'")
+
+// Install replaces the running binary with the release matching latestVersion.
+//
+// Returns ErrHomebrewManaged when DetectInstallMethod reports a Homebrew install;
+// in that case the caller is responsible for printing user instructions and
+// must not treat the error as fatal.
+//
+// On success the caller should print a "restart agento" message — the new
+// binary is in place but the running process is still the old one.
+func Install(ctx context.Context, latestVersion string) error {
+	if DetectInstallMethod() == InstallMethodHomebrew {
+		return ErrHomebrewManaged
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("finding current executable: %w", err)
+	}
+
+	upd, err := selfupdate.NewUpdater(selfupdate.Config{})
+	if err != nil {
+		return fmt.Errorf("creating updater: %w", err)
+	}
+
+	release, found, err := upd.DetectLatest(ctx, selfupdate.ParseSlug(repoSlug))
+	if err != nil {
+		return fmt.Errorf("detecting release: %w", err)
+	}
+	if !found {
+		return fmt.Errorf("release %s not found on GitHub", latestVersion)
+	}
+
+	// go-selfupdate handles the Windows rename trick internally, so the same
+	// call path works on Linux, macOS, and Windows.
+	if err := upd.UpdateTo(ctx, release, exe); err != nil {
+		return fmt.Errorf("updating: %w", err)
+	}
+	return nil
+}

--- a/internal/updater/installer_test.go
+++ b/internal/updater/installer_test.go
@@ -1,0 +1,67 @@
+package updater
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestIsHomebrewPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		// Positive cases — paths that must be detected as Homebrew.
+		{"macos-intel-cellar", "/usr/local/Cellar/agento/1.2.3/bin/agento", true},
+		{"macos-intel-opt", "/usr/local/opt/agento/bin/agento", true},
+		{"macos-silicon-cellar", "/opt/homebrew/Cellar/agento/1.2.3/bin/agento", true},
+		{"macos-silicon-opt", "/opt/homebrew/opt/agento/bin/agento", true},
+		{"linuxbrew", "/home/linuxbrew/.linuxbrew/Cellar/agento/1.2.3/bin/agento", true},
+		{"linuxbrew-bin-symlink", "/home/linuxbrew/.linuxbrew/bin/agento", true},
+
+		// Negative cases — paths that must NOT be detected as Homebrew.
+		{"linux-system", "/usr/local/bin/agento", false},
+		{"linux-user-bin", "/home/user/bin/agento", false},
+		{"linux-go-install", "/home/user/go/bin/agento", false},
+		{"macos-non-brew", "/Applications/agento", false},
+		{"empty", "", false},
+		// Windows-style paths must never match.
+		{"windows-program-files", `C:\Program Files\agento\agento.exe`, false},
+		{"windows-user-bin", `C:\Users\alice\bin\agento.exe`, false},
+		// Tricky: substring in the middle of a path must not match.
+		{"substring-not-prefix", "/var/lib/usr/local/Cellar/foo", false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isHomebrewPath(tt.path); got != tt.want {
+				t.Errorf("isHomebrewPath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectInstallMethod_WindowsAlwaysSelfUpdate(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("only runs on windows")
+	}
+	if got := DetectInstallMethod(); got != InstallMethodSelfUpdate {
+		t.Errorf("DetectInstallMethod() on windows = %v, want InstallMethodSelfUpdate", got)
+	}
+}
+
+func TestDetectInstallMethod_NonHomebrewPath(t *testing.T) {
+	// On the typical test environment, the test binary lives under a temp
+	// directory chosen by `go test`, which is never a Homebrew prefix.
+	// The check should report InstallMethodSelfUpdate.
+	if runtime.GOOS == "windows" {
+		t.Skip("covered by TestDetectInstallMethod_WindowsAlwaysSelfUpdate")
+	}
+	if got := DetectInstallMethod(); got != InstallMethodSelfUpdate {
+		t.Errorf("DetectInstallMethod() in test env = %v, want InstallMethodSelfUpdate", got)
+	}
+}


### PR DESCRIPTION
## Summary

Implements #128. Adds an opt-out, cache-backed update check that runs before every `agento` subcommand, with first-class awareness of Homebrew-managed installs.

- New `internal/updater` package wraps release detection (24h on-disk cache, 5s timeout, semver comparison) and install dispatch (native self-update via `go-selfupdate`, or Homebrew-managed short-circuit).
- New `PersistentPreRunE` in `cmd/root.go` runs the check before each subcommand. Skipped for: dev/unknown builds, `update`/`help`/`completion`/`__complete` subcommands, non-TTY environments (stdin AND stdout), and `AGENTO_SKIP_UPDATE_CHECK=1|true`.
- When an update is available and the install is Homebrew-managed, prints `brew upgrade agento` and continues without modifying the binary. Otherwise prompts on stderr; on confirmation, self-updates and exits 0.
- `agento update` refactored onto the same package and passes `forceFresh=true` so the explicit command always bypasses the 24h cache.

## Acceptance criteria (from #128)

- [x] Auto-check on `agento web`/`ask`/etc., at most once per 24h via on-disk cache
- [x] Yes/no prompt when an update is available
- [x] Homebrew installs print `brew upgrade agento` instead of self-updating
- [x] Non-TTY / CI silently skipped (both stdin and stdout)
- [x] `AGENTO_SKIP_UPDATE_CHECK=1` disables entirely
- [x] `agento update` bypasses the 24h cache
- [x] Cross-platform: Homebrew detection short-circuits on Windows; cache uses `filepath.Join`
- [x] No regression to web UI `GET /api/version/update-check`
- [x] Dev/unknown builds skipped via `ErrNotReleaseBuild` and explicit guard

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (15 new unit tests covering cache hit/miss/stale, dev-build skip, version mismatch, force-fresh, no-cache mode, corrupted cache fallthrough, timeout propagation, and all Homebrew path layouts incl. negative cases)
- [x] `make lint` (0 issues)
- [ ] Manual smoke on a release build: `AGENTO_SKIP_UPDATE_CHECK=1 agento web` skips; non-TTY (`agento ask < /dev/null`) skips; Homebrew layout prints upgrade hint without modifying binary

Closes #128

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbSNk8rhf2DAxGHgUxZjJ6)_