### PR TITLE
fix(security): upgrade postcss to 8.5.13 to remediate CVE-2026-41305 XSS

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6141,9 +6141,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,7 +39,8 @@
   "overrides": {
     "minimatch": ">=10.2.3",
     "picomatch": ">=4.0.4",
-    "flatted": ">=3.4.2"
+    "flatted": ">=3.4.2",
+    "postcss": ">=8.5.10"
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",


### PR DESCRIPTION
## Summary

Fixes Dependabot security alert [#18](https://github.com/shaharia-lab/agento/security/dependabot/18).

- Added `"postcss": ">=8.5.10"` to the `overrides` section in `frontend/package.json`
- Regenerated `frontend/package-lock.json` — postcss upgraded from `8.5.6` → `8.5.13`

## Vulnerability Details

| Field | Value |
|-------|-------|
| Advisory | [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) |
| CVE | CVE-2026-41305 |
| Severity | Medium (CVSS 6.1) |
| CWE | CWE-79 (XSS) |
| Affected range | postcss < 8.5.10 |
| Patched version | 8.5.10+ |

**Root cause:** PostCSS did not escape `</style>` sequences in its CSS stringify output. When user-submitted CSS was parsed and re-embedded in HTML `<style>` tags, the unescaped sequence could close the style context and execute arbitrary scripts.

**Impact:** Development dependency only (used by Vite/Tailwind build pipeline). Not a runtime dependency in production bundles. Low exploitability in this context, but the fix is trivial and eliminates the alert.

## Changes

- `frontend/package.json` — added `"postcss": ">=8.5.10"` override
- `frontend/package-lock.json` — postcss updated from `8.5.6` to `8.5.13`

## Test Plan

- [ ] CI passes (build, lint, typecheck, tests)
- [ ] `npm audit` in `frontend/` shows no more postcss vulnerability

https://claude.ai/code/session_0128TJt1VjY5mpJ5eQ4UnxPu

---
_Generated by [Claude Code](https://claude.ai/code/session_0128TJt1VjY5mpJ5eQ4UnxPu)_