### PR TITLE
feat: show full session ID and copy it to clipboard on click (#155)

### DIFF
--- a/frontend/src/components/CopyableId.tsx
+++ b/frontend/src/components/CopyableId.tsx
@@ -1,0 +1,63 @@
+import { type MouseEvent, useCallback, useEffect, useRef, useState } from 'react'
+import { Copy, Check } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+/**
+ * Renders an identifier (e.g. a session UUID) in full and copies it to the
+ * clipboard when clicked, without triggering any surrounding navigation.
+ *
+ * Reuses the clipboard + transient-feedback pattern from JsonPreview in
+ * ClaudeSettingsTab.tsx. Safe to nest inside a clickable row: the click handler
+ * calls stopPropagation and no-ops when navigator.clipboard is unavailable
+ * (e.g. a non-secure context) rather than throwing.
+ */
+export function CopyableId({
+  value,
+  label = 'Copy ID',
+  className,
+}: Readonly<{ value: string; label?: string; className?: string }>) {
+  const [copied, setCopied] = useState(false)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    }
+  }, [])
+
+  const handleCopy = useCallback(
+    async (e: MouseEvent<HTMLButtonElement>) => {
+      e.stopPropagation()
+      if (!navigator.clipboard) return
+      try {
+        await navigator.clipboard.writeText(value)
+      } catch {
+        return
+      }
+      setCopied(true)
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+      timeoutRef.current = setTimeout(() => setCopied(false), 2000)
+    },
+    [value],
+  )
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      title={copied ? 'Copied!' : label}
+      aria-label={copied ? 'Copied!' : label}
+      className={cn(
+        'inline-flex items-start gap-1 text-left font-mono text-xs break-all text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors',
+        className,
+      )}
+    >
+      <span className="break-all">{value}</span>
+      {copied ? (
+        <Check className="h-3 w-3 shrink-0 mt-0.5 text-emerald-500" />
+      ) : (
+        <Copy className="h-3 w-3 shrink-0 mt-0.5 opacity-0 group-hover:opacity-100 transition-opacity" />
+      )}
+    </button>
+  )
+}

--- a/frontend/src/pages/ClaudeSessionsPage.tsx
+++ b/frontend/src/pages/ClaudeSessionsPage.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/ui/select'
 import { History, Search, RefreshCw, ExternalLink, Zap, Star, Activity } from 'lucide-react'
 import { Tooltip } from '@/components/ui/tooltip'
+import { CopyableId } from '@/components/CopyableId'
 import { formatTokens, shortPath } from '@/lib/format'
 
 export default function ClaudeSessionsPage() {
@@ -230,110 +231,112 @@ function SessionRow({
   const hasTokens = totalTokens > 0
 
   return (
-    <div className="flex items-start gap-3 px-4 sm:px-6 py-3.5 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 cursor-pointer group transition-colors relative">
-      <button
-        type="button"
-        className="flex items-start gap-3 flex-1 min-w-0 text-left appearance-none bg-transparent border-0 p-0"
-        onClick={onClick}
-      >
-        <div className="flex h-8 w-8 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400 shrink-0 mt-0.5">
-          <History className="h-3.5 w-3.5" />
-        </div>
-        <div className="flex-1 min-w-0">
-          {/* Custom title or preview / first message */}
-          <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100 truncate leading-snug">
-            {session.custom_title || session.preview || (
-              <span className="italic text-zinc-400">No message content</span>
-            )}
-          </p>
-          {/* Meta row */}
-          <div className="flex items-center gap-2 mt-1 flex-wrap">
-            <Badge
-              variant="secondary"
-              className="text-xs py-0 h-4 bg-zinc-100 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-700 border-0 font-mono font-normal"
-            >
-              {shortPath(session.project_path)}
-            </Badge>
-            {session.git_branch && (
-              <span className="text-xs text-zinc-400 dark:text-zinc-500 font-mono">
-                {session.git_branch}
-              </span>
-            )}
-            <span className="text-xs text-zinc-400 dark:text-zinc-500">
-              {formatRelativeTime(session.last_activity)}
-            </span>
-            <span className="text-xs text-zinc-400 dark:text-zinc-500">
-              {session.message_count} msg{session.message_count === 1 ? '' : 's'}
-            </span>
-            {hasTokens && (
-              <Tooltip
-                side="top"
-                content={
-                  <div className="space-y-1">
-                    <div className="flex justify-between gap-4">
-                      <span className="text-zinc-400">Input tokens</span>
-                      <span>{session.usage.input_tokens.toLocaleString()}</span>
-                    </div>
-                    <div className="flex justify-between gap-4">
-                      <span className="text-zinc-400">Output tokens</span>
-                      <span>{session.usage.output_tokens.toLocaleString()}</span>
-                    </div>
-                    {session.usage.cache_read_tokens > 0 && (
-                      <div className="flex justify-between gap-4">
-                        <span className="text-zinc-400">Cache read</span>
-                        <span>{session.usage.cache_read_tokens.toLocaleString()}</span>
-                      </div>
-                    )}
-                    {session.usage.cache_creation_tokens > 0 && (
-                      <div className="flex justify-between gap-4">
-                        <span className="text-zinc-400">Cache write</span>
-                        <span>{session.usage.cache_creation_tokens.toLocaleString()}</span>
-                      </div>
-                    )}
-                  </div>
-                }
-              >
-                <span className="flex items-center gap-0.5 text-xs text-zinc-400 dark:text-zinc-500 cursor-default">
-                  <Zap className="h-2.5 w-2.5" />
-                  {formatTokens(session.usage.input_tokens)}↑&nbsp;
-                  {formatTokens(session.usage.output_tokens)}↓
-                </span>
-              </Tooltip>
-            )}
+    <div className="px-4 sm:px-6 py-3.5 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 cursor-pointer group transition-colors relative">
+      <div className="flex items-start gap-3">
+        <button
+          type="button"
+          className="flex items-start gap-3 flex-1 min-w-0 text-left appearance-none bg-transparent border-0 p-0"
+          onClick={onClick}
+        >
+          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400 shrink-0 mt-0.5">
+            <History className="h-3.5 w-3.5" />
           </div>
-          {/* Session ID */}
-          <p className="text-xs text-zinc-300 dark:text-zinc-600 font-mono mt-0.5 truncate">
-            {session.session_id}
-          </p>
-        </div>
-      </button>
-      <button
-        type="button"
-        className={`h-7 w-7 flex items-center justify-center rounded-md transition-all shrink-0 mt-0.5 ${
-          session.is_favorite
-            ? 'text-amber-400'
-            : 'opacity-0 group-hover:opacity-100 text-zinc-300 dark:text-zinc-600 hover:text-amber-400'
-        }`}
-        onClick={e => {
-          e.stopPropagation()
-          onToggleFavorite()
-        }}
-        title={session.is_favorite ? 'Remove from favorites' : 'Add to favorites'}
-      >
-        <Star className={`h-3.5 w-3.5 ${session.is_favorite ? 'fill-amber-400' : ''}`} />
-      </button>
-      <button
-        type="button"
-        className="h-7 w-7 flex items-center justify-center rounded-md opacity-0 group-hover:opacity-100 text-zinc-300 dark:text-zinc-600 hover:text-zinc-500 dark:hover:text-zinc-400 transition-all shrink-0 mt-0.5 cursor-pointer"
-        onClick={e => {
-          e.stopPropagation()
-          onJourney()
-        }}
-        title="View session journey"
-      >
-        <Activity className="h-3.5 w-3.5" />
-      </button>
-      <ExternalLink className="h-3.5 w-3.5 text-zinc-300 dark:text-zinc-600 group-hover:text-zinc-400 dark:group-hover:text-zinc-400 shrink-0 mt-1.5 transition-colors" />
+          <div className="flex-1 min-w-0">
+            {/* Custom title or preview / first message */}
+            <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100 truncate leading-snug">
+              {session.custom_title || session.preview || (
+                <span className="italic text-zinc-400">No message content</span>
+              )}
+            </p>
+            {/* Meta row */}
+            <div className="flex items-center gap-2 mt-1 flex-wrap">
+              <Badge
+                variant="secondary"
+                className="text-xs py-0 h-4 bg-zinc-100 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-700 border-0 font-mono font-normal"
+              >
+                {shortPath(session.project_path)}
+              </Badge>
+              {session.git_branch && (
+                <span className="text-xs text-zinc-400 dark:text-zinc-500 font-mono">
+                  {session.git_branch}
+                </span>
+              )}
+              <span className="text-xs text-zinc-400 dark:text-zinc-500">
+                {formatRelativeTime(session.last_activity)}
+              </span>
+              <span className="text-xs text-zinc-400 dark:text-zinc-500">
+                {session.message_count} msg{session.message_count === 1 ? '' : 's'}
+              </span>
+              {hasTokens && (
+                <Tooltip
+                  side="top"
+                  content={
+                    <div className="space-y-1">
+                      <div className="flex justify-between gap-4">
+                        <span className="text-zinc-400">Input tokens</span>
+                        <span>{session.usage.input_tokens.toLocaleString()}</span>
+                      </div>
+                      <div className="flex justify-between gap-4">
+                        <span className="text-zinc-400">Output tokens</span>
+                        <span>{session.usage.output_tokens.toLocaleString()}</span>
+                      </div>
+                      {session.usage.cache_read_tokens > 0 && (
+                        <div className="flex justify-between gap-4">
+                          <span className="text-zinc-400">Cache read</span>
+                          <span>{session.usage.cache_read_tokens.toLocaleString()}</span>
+                        </div>
+                      )}
+                      {session.usage.cache_creation_tokens > 0 && (
+                        <div className="flex justify-between gap-4">
+                          <span className="text-zinc-400">Cache write</span>
+                          <span>{session.usage.cache_creation_tokens.toLocaleString()}</span>
+                        </div>
+                      )}
+                    </div>
+                  }
+                >
+                  <span className="flex items-center gap-0.5 text-xs text-zinc-400 dark:text-zinc-500 cursor-default">
+                    <Zap className="h-2.5 w-2.5" />
+                    {formatTokens(session.usage.input_tokens)}↑&nbsp;
+                    {formatTokens(session.usage.output_tokens)}↓
+                  </span>
+                </Tooltip>
+              )}
+            </div>
+          </div>
+        </button>
+        <button
+          type="button"
+          className={`h-7 w-7 flex items-center justify-center rounded-md transition-all shrink-0 mt-0.5 ${
+            session.is_favorite
+              ? 'text-amber-400'
+              : 'opacity-0 group-hover:opacity-100 text-zinc-300 dark:text-zinc-600 hover:text-amber-400'
+          }`}
+          onClick={e => {
+            e.stopPropagation()
+            onToggleFavorite()
+          }}
+          title={session.is_favorite ? 'Remove from favorites' : 'Add to favorites'}
+        >
+          <Star className={`h-3.5 w-3.5 ${session.is_favorite ? 'fill-amber-400' : ''}`} />
+        </button>
+        <button
+          type="button"
+          className="h-7 w-7 flex items-center justify-center rounded-md opacity-0 group-hover:opacity-100 text-zinc-300 dark:text-zinc-600 hover:text-zinc-500 dark:hover:text-zinc-400 transition-all shrink-0 mt-0.5 cursor-pointer"
+          onClick={e => {
+            e.stopPropagation()
+            onJourney()
+          }}
+          title="View session journey"
+        >
+          <Activity className="h-3.5 w-3.5" />
+        </button>
+        <ExternalLink className="h-3.5 w-3.5 text-zinc-300 dark:text-zinc-600 group-hover:text-zinc-400 dark:group-hover:text-zinc-400 shrink-0 mt-1.5 transition-colors" />
+      </div>
+      {/* Session ID — copies to clipboard on click, does not navigate */}
+      <div className="pl-11 mt-0.5">
+        <CopyableId value={session.session_id} label="Copy session ID" />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Closes #155

## What
On the Claude Sessions list, the session ID row now renders the **full** UUID (no truncation) and copies it to the clipboard when clicked, without navigating to the session detail page.

## How
- New `frontend/src/components/CopyableId.tsx` — reusable copy control reusing the clipboard + transient-feedback pattern from `JsonPreview` (`ClaudeSettingsTab.tsx`). Guards non-secure contexts (no-ops if `navigator.clipboard` is absent), `stopPropagation` so it never triggers row navigation, cleans up its reset timer on unmount, `Copy` → `Check` icon swap (~2s).
- `SessionRow` in `ClaudeSessionsPage.tsx`: lifted the session-ID line **out** of the row-wide navigation `<button>` into a sibling `<div>` (removes the invalid nested-`<button>` that adding a copy control in place would have created), dropped `truncate`, and rendered `<CopyableId>` aligned under the meta row (`pl-11`). The full UUID now wraps via `break-all` instead of ellipsing.

## Acceptance criteria
- [x] Full session UUID visible at all breakpoints (no `truncate`; `break-all` wrap).
- [x] Clicking the ID copies the exact `session_id` and does not navigate.
- [x] Clicking elsewhere on the row still navigates; the favourite star still toggles.
- [x] Copy → check indicator reverts within ~2s.
- [x] No `<button>` nested inside another `<button>`.
- [x] `npm run lint`, `npm run typecheck`, `npm run build` (and `format:check`) pass in `frontend/`.

## Out of scope (per refined issue)
Search by session ID (already works), backend changes, applying `CopyableId` to detail/journey pages, and frontend DOM/e2e test infrastructure (no jsdom/testing-library in repo; e2e needs session JSONL fixtures) — verify manually at 375/768/1440px.