### PR TITLE
feat: add date-time range filter to claude sessions page (#157)

### DIFF
--- a/frontend/src/lib/timefilter.test.ts
+++ b/frontend/src/lib/timefilter.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest'
+import { resolvePresetRange, overlapsRange } from './timefilter'
+
+describe('resolvePresetRange', () => {
+  const now = new Date('2026-08-07T12:00:00')
+
+  it('returns open range for "all"', () => {
+    expect(resolvePresetRange('all', undefined, undefined, now)).toEqual({ from: null, to: null })
+  })
+
+  it('computes preset ranges relative to now with open end', () => {
+    expect(resolvePresetRange('1h', undefined, undefined, now)).toEqual({
+      from: new Date('2026-08-07T11:00:00'),
+      to: null,
+    })
+    expect(resolvePresetRange('24h', undefined, undefined, now).from).toEqual(
+      new Date('2026-08-06T12:00:00'),
+    )
+    expect(resolvePresetRange('7d', undefined, undefined, now).from).toEqual(
+      new Date('2026-07-31T12:00:00'),
+    )
+    expect(resolvePresetRange('30d', undefined, undefined, now).from).toEqual(
+      new Date('2026-07-08T12:00:00'),
+    )
+  })
+
+  it('parses custom bounds and supports open-ended ranges', () => {
+    expect(resolvePresetRange('custom', '2026-08-01T09:00', '2026-08-02T17:30', now)).toEqual({
+      from: new Date('2026-08-01T09:00'),
+      to: new Date('2026-08-02T17:30'),
+    })
+    expect(resolvePresetRange('custom', '2026-08-01T09:00', undefined, now)).toEqual({
+      from: new Date('2026-08-01T09:00'),
+      to: null,
+    })
+    expect(resolvePresetRange('custom', undefined, '2026-08-02T17:30', now)).toEqual({
+      from: null,
+      to: new Date('2026-08-02T17:30'),
+    })
+    expect(resolvePresetRange('custom', undefined, undefined, now)).toEqual({
+      from: null,
+      to: null,
+    })
+  })
+})
+
+describe('overlapsRange', () => {
+  const from = new Date('2026-08-05T10:00:00')
+  const to = new Date('2026-08-05T14:00:00')
+
+  it('matches a session fully inside the window', () => {
+    expect(overlapsRange('2026-08-05T10:30:00', '2026-08-05T11:00:00', from, to)).toBe(true)
+  })
+
+  it('matches a session started before but active inside the window', () => {
+    expect(overlapsRange('2026-08-03T09:00:00', '2026-08-05T11:00:00', from, to)).toBe(true)
+  })
+
+  it('matches a session spanning the entire window', () => {
+    expect(overlapsRange('2026-08-01T00:00:00', '2026-08-10T00:00:00', from, to)).toBe(true)
+  })
+
+  it('matches sessions touching the window boundaries', () => {
+    expect(overlapsRange('2026-08-05T14:00:00', '2026-08-05T15:00:00', from, to)).toBe(true)
+    expect(overlapsRange('2026-08-05T08:00:00', '2026-08-05T10:00:00', from, to)).toBe(true)
+  })
+
+  it('rejects sessions entirely before or after the window', () => {
+    expect(overlapsRange('2026-08-01T00:00:00', '2026-08-05T09:59:59', from, to)).toBe(false)
+    expect(overlapsRange('2026-08-05T14:00:01', '2026-08-06T00:00:00', from, to)).toBe(false)
+  })
+
+  it('supports open-ended ranges', () => {
+    // only from: any activity after from
+    expect(overlapsRange('2026-08-01T00:00:00', '2026-08-05T12:00:00', from, null)).toBe(true)
+    expect(overlapsRange('2026-08-01T00:00:00', '2026-08-04T12:00:00', from, null)).toBe(false)
+    // only to: any activity before to
+    expect(overlapsRange('2026-08-01T00:00:00', '2026-08-05T12:00:00', null, to)).toBe(true)
+    expect(overlapsRange('2026-08-05T15:00:00', '2026-08-06T00:00:00', null, to)).toBe(false)
+    // fully open: everything matches
+    expect(overlapsRange('2020-01-01T00:00:00', '2020-01-02T00:00:00', null, null)).toBe(true)
+  })
+
+  it('rejects invalid timestamps', () => {
+    expect(overlapsRange('not-a-date', '2026-08-05T11:00:00', from, to)).toBe(false)
+    expect(overlapsRange('2026-08-05T10:30:00', '', from, to)).toBe(false)
+  })
+})

--- a/frontend/src/lib/timefilter.ts
+++ b/frontend/src/lib/timefilter.ts
@@ -1,0 +1,51 @@
+export type TimePreset = 'all' | '1h' | '24h' | '7d' | '30d' | 'custom'
+
+export interface TimeRange {
+  from: Date | null
+  to: Date | null
+}
+
+const PRESET_DURATIONS_MS: Partial<Record<TimePreset, number>> = {
+  '1h': 60 * 60 * 1000,
+  '24h': 24 * 60 * 60 * 1000,
+  '7d': 7 * 24 * 60 * 60 * 1000,
+  '30d': 30 * 24 * 60 * 60 * 1000,
+}
+
+/**
+ * Resolves a preset (plus optional custom bounds) into an absolute range.
+ * Presets are relative to `now`; a null bound means open-ended.
+ */
+export function resolvePresetRange(
+  preset: TimePreset,
+  customFrom?: string,
+  customTo?: string,
+  now: Date = new Date(),
+): TimeRange {
+  if (preset === 'all') return { from: null, to: null }
+  if (preset === 'custom') {
+    return {
+      from: customFrom ? new Date(customFrom) : null,
+      to: customTo ? new Date(customTo) : null,
+    }
+  }
+  return { from: new Date(now.getTime() - PRESET_DURATIONS_MS[preset]!), to: null }
+}
+
+/**
+ * Returns true when the session activity window [startISO, lastActivityISO]
+ * overlaps the range [from, to]. Null bounds are open-ended.
+ */
+export function overlapsRange(
+  startISO: string,
+  lastActivityISO: string,
+  from: Date | null,
+  to: Date | null,
+): boolean {
+  const start = new Date(startISO).getTime()
+  const lastActivity = new Date(lastActivityISO).getTime()
+  if (Number.isNaN(start) || Number.isNaN(lastActivity)) return false
+  if (to !== null && start > to.getTime()) return false
+  if (from !== null && lastActivity < from.getTime()) return false
+  return true
+}

--- a/frontend/src/pages/ClaudeSessionsPage.tsx
+++ b/frontend/src/pages/ClaudeSessionsPage.tsx
@@ -11,9 +11,19 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { History, Search, RefreshCw, ExternalLink, Zap, Star, Activity } from 'lucide-react'
+import { History, Search, RefreshCw, ExternalLink, Zap, Star, Activity, Clock } from 'lucide-react'
 import { Tooltip } from '@/components/ui/tooltip'
 import { formatTokens, shortPath } from '@/lib/format'
+import { overlapsRange, resolvePresetRange, type TimePreset } from '@/lib/timefilter'
+
+const TIME_PRESET_LABELS: Record<TimePreset, string> = {
+  all: 'All time',
+  '1h': 'Last hour',
+  '24h': 'Last 24 hours',
+  '7d': 'Last 7 days',
+  '30d': 'Last 30 days',
+  custom: 'Custom range…',
+}
 
 export default function ClaudeSessionsPage() {
   const navigate = useNavigate()
@@ -25,6 +35,9 @@ export default function ClaudeSessionsPage() {
   const [search, setSearch] = useState('')
   const [filterProject, setFilterProject] = useState('all')
   const [filterFavorites, setFilterFavorites] = useState(false)
+  const [timePreset, setTimePreset] = useState<TimePreset>('all')
+  const [customFrom, setCustomFrom] = useState('')
+  const [customTo, setCustomTo] = useState('')
 
   const load = useCallback(async () => {
     try {
@@ -70,7 +83,10 @@ export default function ClaudeSessionsPage() {
 
   const hasFavorites = sessions.some(s => s.is_favorite)
 
+  const timeFilterActive = timePreset !== 'all'
+
   const filtered = useMemo(() => {
+    const { from, to } = resolvePresetRange(timePreset, customFrom, customTo)
     const result = sessions.filter(s => {
       const matchesProject = filterProject === 'all' || s.project_path === filterProject
       const q = search.toLowerCase()
@@ -80,10 +96,11 @@ export default function ClaudeSessionsPage() {
         s.preview.toLowerCase().includes(q) ||
         s.project_path.toLowerCase().includes(q)
       const matchesFavorites = !filterFavorites || !!s.is_favorite
-      return matchesProject && matchesSearch && matchesFavorites
+      const matchesTime = overlapsRange(s.start_time, s.last_activity, from, to)
+      return matchesProject && matchesSearch && matchesFavorites && matchesTime
     })
     return result
-  }, [sessions, search, filterProject, filterFavorites])
+  }, [sessions, search, filterProject, filterFavorites, timePreset, customFrom, customTo])
 
   if (loading) {
     return (
@@ -111,13 +128,17 @@ export default function ClaudeSessionsPage() {
   } else if (filtered.length === 0) {
     sessionListContent = (
       <div className="flex flex-col items-center justify-center py-16 text-center">
-        <p className="text-sm text-zinc-400">No sessions match your filters.</p>
+        <p className="text-sm text-zinc-400">
+          {timeFilterActive
+            ? 'No sessions active in the selected time range.'
+            : 'No sessions match your filters.'}
+        </p>
       </div>
     )
   } else {
     sessionListContent = (
       <div
-        key={`${filterFavorites}-${filterProject}-${search}`}
+        key={`${filterFavorites}-${filterProject}-${search}-${timePreset}-${customFrom}-${customTo}`}
         className="divide-y divide-zinc-100 dark:divide-zinc-700/50"
       >
         {filtered.map(session => (
@@ -183,6 +204,38 @@ export default function ClaudeSessionsPage() {
                 ))}
               </SelectContent>
             </Select>
+          )}
+          <Select value={timePreset} onValueChange={v => setTimePreset(v as TimePreset)}>
+            <SelectTrigger className="w-full sm:w-44 h-8 text-xs">
+              <Clock className="h-3.5 w-3.5 text-zinc-400 dark:text-zinc-500 mr-1.5 shrink-0" />
+              <SelectValue placeholder="All time" />
+            </SelectTrigger>
+            <SelectContent>
+              {(Object.keys(TIME_PRESET_LABELS) as TimePreset[]).map(p => (
+                <SelectItem key={p} value={p} className="text-xs">
+                  {TIME_PRESET_LABELS[p]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {timePreset === 'custom' && (
+            <div className="flex items-center gap-1.5 shrink-0">
+              <input
+                type="datetime-local"
+                value={customFrom}
+                onChange={e => setCustomFrom(e.target.value)}
+                aria-label="Active from"
+                className="rounded-md border border-zinc-200 dark:border-zinc-600 bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 px-2 py-1 h-8 text-xs focus:outline-none focus:ring-1 focus:ring-zinc-900 dark:focus:ring-zinc-400"
+              />
+              <span className="text-xs text-zinc-400 dark:text-zinc-500">–</span>
+              <input
+                type="datetime-local"
+                value={customTo}
+                onChange={e => setCustomTo(e.target.value)}
+                aria-label="Active to"
+                className="rounded-md border border-zinc-200 dark:border-zinc-600 bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 px-2 py-1 h-8 text-xs focus:outline-none focus:ring-1 focus:ring-zinc-900 dark:focus:ring-zinc-400"
+              />
+            </div>
           )}
           {hasFavorites && (
             <button


### PR DESCRIPTION
## Summary
Adds a date-time range filter to the `/claude-sessions` page so users can find sessions that had **any activity** during a selected window — not just sessions created then.

## What
- Preset selector: All time (default), Last hour, Last 24 hours, Last 7 days, Last 30 days
- Custom range: from/to `datetime-local` pickers, either bound optional (open-ended)
- Overlap semantics: a session matches when `start_time <= to AND last_activity >= from` (covers sessions started before the window but active inside it, and long-running sessions spanning it)
- AND-combined with existing search / project / favorites filters
- Time-aware empty state ("No sessions active in the selected time range")

## How
Client-side filtering, matching the page's existing pattern: `GET /api/claude-sessions` returns the full unpaginated list, so the overlap predicate runs in the `filtered` memo over the already-loaded `start_time`/`last_activity` fields. Range math lives in a new pure, unit-tested helper module `frontend/src/lib/timefilter.ts` (`resolvePresetRange`, `overlapsRange`). No backend or API changes (server-side params deferred until the list gains pagination, per issue scope).

## Testing
- 10 new Vitest cases for `timefilter.ts`: presets, inside/spanning/boundary-touching/before/after overlap, open-ended ranges, invalid timestamps
- Typecheck, ESLint, Prettier, production build all pass; full Vitest suite passes except 7 pre-existing `streamingBlocks.test.ts` failures that also fail on main (unrelated file)

Closes #157
