### PR TITLE
chore: pin dependabot away from typescript 7 / react-hooks 7.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,13 @@ updates:
       time: "06:00"
       timezone: Europe/Berlin
     open-pull-requests-limit: 1
+    # typescript-eslint does not support TS 7 yet; eslint-plugin-react-hooks 7.1
+    # introduces stricter rules that need a dedicated cleanup pass
+    ignore:
+      - dependency-name: typescript
+        versions: [">=7.0.0"]
+      - dependency-name: eslint-plugin-react-hooks
+        versions: [">=7.1.0"]
     groups:
       frontend:
         patterns:


### PR DESCRIPTION
Ignore rules so the weekly grouped frontend PR stops proposing bumps that break CI:

- `typescript >= 7` — typescript-eslint does not support TS 7 (lint fails outright)
- `eslint-plugin-react-hooks >= 7.1` — new strict rules flag 23 errors across existing pages; needs a dedicated cleanup

Both can be revisited intentionally later.