### PR TITLE
fix(build): use npm ci --legacy-peer-deps in build-frontend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ LDFLAGS := -s -w \
 build: build-frontend build-go
 
 build-frontend:
-	cd frontend && npm install && npm run build
+	cd frontend && npm ci --legacy-peer-deps && npm run build
 
 build-go:
 	go build -ldflags "$(LDFLAGS)" -o $(BINARY) .


### PR DESCRIPTION
## Problem
`make build` failed on a fresh install: the `build-frontend` target ran plain `npm install`, and npm's strict peer resolution rejects the pinned `eslint@10` + `eslint-plugin-react-hooks@7` combination (peer range caps at `eslint ^9`). The exact-version pinning from #169 made this failure deterministic.

## Fix
Change the target to `npm ci --legacy-peer-deps` — matching the install command already documented in CLAUDE.md. `npm ci` also installs exactly from the lockfile, which is more correct for reproducible builds.

## Verified
`rm -rf frontend/node_modules && make build-frontend` completes cleanly.