### PR TITLE
fix(ui): make session ID copyable and full-length on session detail page

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -11,8 +11,8 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Roboto:wght@400;500&family=Open+Sans:wght@400;600&family=Lato:wght@400;700&family=Merriweather:wght@400;700&family=JetBrains+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
-    <script type="module" crossorigin src="/assets/index-C08aF0fo.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-Rsjf44gI.css">
+    <script type="module" crossorigin src="/assets/index-Du_BRkUh.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-CkyI0lUR.css">
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/CopyableId.tsx
+++ b/frontend/src/components/CopyableId.tsx
@@ -10,6 +10,10 @@ import { cn } from '@/lib/utils'
  * ClaudeSettingsTab.tsx. Safe to nest inside a clickable row: the click handler
  * calls stopPropagation and no-ops when navigator.clipboard is unavailable
  * (e.g. a non-secure context) rather than throwing.
+ *
+ * The copy icon reveals on hover of either the component itself (group/copyable)
+ * or a surrounding `group` container, so it works standalone in a page header as
+ * well as inside a hoverable list row.
  */
 export function CopyableId({
   value,
@@ -48,7 +52,7 @@ export function CopyableId({
       title={copied ? 'Copied!' : label}
       aria-label={copied ? 'Copied!' : label}
       className={cn(
-        'inline-flex items-start gap-1 text-left font-mono text-xs break-all text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors',
+        'group/copyable inline-flex items-start gap-1 text-left font-mono text-xs break-all text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors',
         className,
       )}
     >
@@ -56,7 +60,7 @@ export function CopyableId({
       {copied ? (
         <Check className="h-3 w-3 shrink-0 mt-0.5 text-emerald-500" />
       ) : (
-        <Copy className="h-3 w-3 shrink-0 mt-0.5 opacity-0 group-hover:opacity-100 transition-opacity" />
+        <Copy className="h-3 w-3 shrink-0 mt-0.5 opacity-0 group-hover:opacity-100 group-hover/copyable:opacity-100 transition-opacity" />
       )}
     </button>
   )

--- a/frontend/src/pages/ClaudeSessionDetailPage.tsx
+++ b/frontend/src/pages/ClaudeSessionDetailPage.tsx
@@ -5,6 +5,7 @@ import type { ClaudeSessionDetail, ClaudeMessage, ClaudeNormalizedBlock, ClaudeT
 import { formatRelativeTime } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { CopyableId } from '@/components/CopyableId'
 import {
   ArrowLeft,
   ChevronDown,
@@ -421,9 +422,7 @@ export default function ClaudeSessionDetailPage() {
                   {detail.model}
                 </Badge>
               )}
-              <span className="text-xs text-zinc-400 dark:text-zinc-500 font-mono">
-                {(id ?? '').slice(0, 8)}…
-              </span>
+              {id && <CopyableId value={id} label="Copy session ID" />}
             </div>
           </div>
           <button


### PR DESCRIPTION
## What

The Claude session detail page showed the session ID as a hard-trimmed `{id.slice(0, 8)}…` span (`ClaudeSessionDetailPage.tsx:424-426`) that could not be selected or copied. It now renders the existing `CopyableId` component: the full UUID is visible and one click copies it to the clipboard.

## Why

Follow-up to #155, which made the ID copyable on the sessions *list* page only. Users landing on a session detail page still had no way to grab the ID (needed for `claude --resume <id>`, per-session logs, and the list page's own search box).

## Changes

- `frontend/src/pages/ClaudeSessionDetailPage.tsx` — replace the truncated ID span in the meta row with `<CopyableId value={id} label="Copy session ID" />`.
- `frontend/src/components/CopyableId.tsx` — the copy icon used `opacity-0 group-hover:opacity-100`, which depends on an ancestor `.group` (present on the list row, absent in the detail header), so it would have been permanently invisible here. Added a named `group/copyable` on the component itself and reveal on either group — list-page hover behaviour is unchanged.

## Verification

`npm run typecheck`, `npm run lint` (0 errors), `npx prettier --check` and `npm run build` all pass in `frontend/`.