### PR TITLE
feat(ui): show full timestamps on session detail page

### DIFF
--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -21,6 +21,21 @@ export function formatRelativeTime(dateStr: string): string {
   return date.toLocaleDateString()
 }
 
+export function formatDateTime(dateStr: string, withSeconds = false): string {
+  const date = new Date(dateStr)
+  const datePart = date.toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  })
+  const timePart = date.toLocaleTimeString('en-GB', {
+    hour: '2-digit',
+    minute: '2-digit',
+    ...(withSeconds ? { second: '2-digit' as const } : {}),
+  })
+  return `${datePart} ${timePart}`
+}
+
 export function truncate(str: string, max: number): string {
   if (str.length <= max) return str
   return str.slice(0, max) + '…'

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -23,6 +23,7 @@ export function formatRelativeTime(dateStr: string): string {
 
 export function formatDateTime(dateStr: string, withSeconds = false): string {
   const date = new Date(dateStr)
+  if (isNaN(date.getTime())) return ''
   const datePart = date.toLocaleDateString('en-GB', {
     day: 'numeric',
     month: 'short',

--- a/frontend/src/pages/ClaudeSessionDetailPage.tsx
+++ b/frontend/src/pages/ClaudeSessionDetailPage.tsx
@@ -181,10 +181,7 @@ function UserMessage({ msg }: Readonly<{ msg: ClaudeMessage }>) {
         <p className="text-sm text-zinc-800 dark:text-zinc-200 whitespace-pre-wrap leading-relaxed">
           {msg.content}
         </p>
-        <span
-          className="text-xs text-zinc-400 dark:text-zinc-500 mt-0.5 block"
-          title={formatDateTime(msg.timestamp, true)}
-        >
+        <span className="text-xs text-zinc-400 dark:text-zinc-500 mt-0.5 block">
           {formatDateTime(msg.timestamp, true)}
         </span>
       </div>
@@ -209,10 +206,7 @@ function AssistantMessage({ msg }: Readonly<{ msg: ClaudeMessage }>) {
         )}
         {hasChildren && <ProgressChildren messages={msg.children!} />}
         <div className="flex items-center gap-3 mt-1">
-          <span
-            className="text-xs text-zinc-400 dark:text-zinc-500"
-            title={formatDateTime(msg.timestamp, true)}
-          >
+          <span className="text-xs text-zinc-400 dark:text-zinc-500">
             {formatDateTime(msg.timestamp, true)}
           </span>
           {msg.usage && (

--- a/frontend/src/pages/ClaudeSessionDetailPage.tsx
+++ b/frontend/src/pages/ClaudeSessionDetailPage.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { claudeSessionsApi } from '@/lib/api'
 import type { ClaudeSessionDetail, ClaudeMessage, ClaudeNormalizedBlock, ClaudeTodo } from '@/types'
-import { formatRelativeTime } from '@/lib/utils'
+import { formatRelativeTime, formatDateTime } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { CopyableId } from '@/components/CopyableId'
@@ -181,8 +181,11 @@ function UserMessage({ msg }: Readonly<{ msg: ClaudeMessage }>) {
         <p className="text-sm text-zinc-800 dark:text-zinc-200 whitespace-pre-wrap leading-relaxed">
           {msg.content}
         </p>
-        <span className="text-xs text-zinc-400 dark:text-zinc-500 mt-0.5 block">
-          {formatRelativeTime(msg.timestamp)}
+        <span
+          className="text-xs text-zinc-400 dark:text-zinc-500 mt-0.5 block"
+          title={formatDateTime(msg.timestamp, true)}
+        >
+          {formatDateTime(msg.timestamp, true)}
         </span>
       </div>
     </div>
@@ -206,8 +209,11 @@ function AssistantMessage({ msg }: Readonly<{ msg: ClaudeMessage }>) {
         )}
         {hasChildren && <ProgressChildren messages={msg.children!} />}
         <div className="flex items-center gap-3 mt-1">
-          <span className="text-xs text-zinc-400 dark:text-zinc-500">
-            {formatRelativeTime(msg.timestamp)}
+          <span
+            className="text-xs text-zinc-400 dark:text-zinc-500"
+            title={formatDateTime(msg.timestamp, true)}
+          >
+            {formatDateTime(msg.timestamp, true)}
           </span>
           {msg.usage && (
             <span className="flex items-center gap-0.5 text-xs text-zinc-400 dark:text-zinc-500">
@@ -423,6 +429,24 @@ export default function ClaudeSessionDetailPage() {
                 </Badge>
               )}
               {id && <CopyableId value={id} label="Copy session ID" />}
+              {detail.start_time && (
+                <span
+                  className="flex items-center gap-1 text-xs text-zinc-500 dark:text-zinc-400"
+                  title={formatDateTime(detail.start_time, true)}
+                >
+                  <Play className="h-3 w-3" />
+                  Started {formatRelativeTime(detail.start_time)}
+                </span>
+              )}
+              {detail.last_activity && (
+                <span
+                  className="flex items-center gap-1 text-xs text-zinc-500 dark:text-zinc-400"
+                  title={formatDateTime(detail.last_activity, true)}
+                >
+                  <Clock className="h-3 w-3" />
+                  Active {formatRelativeTime(detail.last_activity)}
+                </span>
+              )}
             </div>
           </div>
           <button


### PR DESCRIPTION
## Changes
- Each message timestamp now shows full date and time down to seconds (e.g. `29 Sept 2026 14:30:45`) instead of relative-only
- Header meta row (next to session ID, cwd, model) now shows:
  - **Started** — relative time (`2 days ago`), hover reveals full date-time
  - **Active** — last activity relative time, hover reveals full date-time
- Added reusable `formatDateTime()` helper in `lib/utils.ts` producing the readable `D Mon YYYY HH:mm` format