### PR TITLE
feat(analytics): click heatmap/hourly charts to drill into matching sessions

### DIFF
--- a/frontend/src/lib/drilldown.test.ts
+++ b/frontend/src/lib/drilldown.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest'
+import {
+  heatmapCellTarget,
+  hourlyBarTarget,
+  encodeWindows,
+  decodeWindows,
+  drilldownUrl,
+  overlapsAnyWindow,
+  parseRangeBounds,
+} from './drilldown'
+
+// 2026-08-03 is a Monday, 2026-08-09 a Sunday (local time).
+const FROM = '2026-08-03'
+const TO = '2026-08-09'
+
+describe('parseRangeBounds', () => {
+  it('spans the inclusive `to` date', () => {
+    const bounds = parseRangeBounds(FROM, TO)!
+    expect(new Date(bounds.from).getDate()).toBe(3)
+    expect(new Date(bounds.to).getDate()).toBe(10) // one day past `to`
+  })
+
+  it('rejects invalid dates', () => {
+    expect(parseRangeBounds('nope', TO)).toBeNull()
+    expect(parseRangeBounds(FROM, 'nope')).toBeNull()
+  })
+
+  it('rejects inverted ranges', () => {
+    expect(parseRangeBounds(TO, FROM)).toBeNull()
+  })
+})
+
+describe('heatmapCellTarget', () => {
+  it('produces one window per occurrence of the weekday+hour in range', () => {
+    // Monday (1) 14:00 within Mon 3rd – Sun 9th → exactly one occurrence.
+    const target = heatmapCellTarget(FROM, TO, 1, 14)!
+    expect(target.windows).toHaveLength(1)
+    const w = target.windows[0]
+    expect(new Date(w.from).getDay()).toBe(1)
+    expect(new Date(w.from).getHours()).toBe(14)
+    expect(w.to - w.from).toBe(60 * 60 * 1000)
+  })
+
+  it('covers every matching weekday across multi-week ranges', () => {
+    // Three Mondays in Aug 3–23 2026 (3rd, 10th, 17th).
+    const target = heatmapCellTarget('2026-08-03', '2026-08-23', 1, 9)!
+    expect(target.windows).toHaveLength(3)
+    for (const w of target.windows) {
+      expect(new Date(w.from).getDay()).toBe(1)
+      expect(new Date(w.from).getHours()).toBe(9)
+    }
+  })
+
+  it('describes the bucket in the label', () => {
+    expect(heatmapCellTarget(FROM, TO, 2, 5)!.label).toBe('Tuesdays 05:00–06:00')
+    expect(heatmapCellTarget(FROM, TO, 6, 23)!.label).toBe('Saturdays 23:00–00:00')
+  })
+
+  it('returns null for an invalid range', () => {
+    expect(heatmapCellTarget('bad', TO, 1, 14)).toBeNull()
+  })
+})
+
+describe('hourlyBarTarget', () => {
+  it('produces one window per day in range', () => {
+    const target = hourlyBarTarget(FROM, TO, 8)! // 7 days
+    expect(target.windows).toHaveLength(7)
+    for (const w of target.windows) {
+      expect(new Date(w.from).getHours()).toBe(8)
+      expect(w.to - w.from).toBe(60 * 60 * 1000)
+    }
+  })
+
+  it('describes the bucket in the label', () => {
+    expect(hourlyBarTarget(FROM, TO, 14)!.label).toBe('every day 14:00–15:00')
+  })
+})
+
+describe('encode/decodeWindows round-trip', () => {
+  it('round-trips windows', () => {
+    const windows = [
+      { from: 1_000, to: 2_000 },
+      { from: 3_000, to: 4_000 },
+    ]
+    expect(decodeWindows(encodeWindows(windows))).toEqual(windows)
+  })
+
+  it('drops malformed entries', () => {
+    expect(decodeWindows('1000-2000,garbage,5000-4000')).toEqual([{ from: 1000, to: 2000 }])
+  })
+
+  it('returns empty for missing param', () => {
+    expect(decodeWindows(null)).toEqual([])
+    expect(decodeWindows('')).toEqual([])
+  })
+})
+
+describe('drilldownUrl', () => {
+  it('builds a /claude-sessions URL with windows and label', () => {
+    const target = heatmapCellTarget(FROM, TO, 1, 14)!
+    const url = drilldownUrl(target)
+    expect(url.startsWith('/claude-sessions?')).toBe(true)
+    const params = new URLSearchParams(url.split('?')[1])
+    expect(decodeWindows(params.get('windows'))).toEqual(target.windows)
+    expect(params.get('label')).toBe('Mondays 14:00–15:00 · 2026-08-03 → 2026-08-09')
+  })
+})
+
+describe('overlapsAnyWindow', () => {
+  const windows = [
+    { from: 1_000, to: 2_000 },
+    { from: 5_000, to: 6_000 },
+  ]
+  const iso = (ms: number) => new Date(ms).toISOString()
+
+  it('matches a session fully inside a window', () => {
+    expect(overlapsAnyWindow(iso(1_100), iso(1_900), windows)).toBe(true)
+  })
+
+  it('matches a session spanning window boundaries', () => {
+    expect(overlapsAnyWindow(iso(500), iso(1_500), windows)).toBe(true)
+    expect(overlapsAnyWindow(iso(1_500), iso(5_500), windows)).toBe(true)
+  })
+
+  it('matches a session touching a window edge (last activity at window start)', () => {
+    expect(overlapsAnyWindow(iso(0), iso(1_000), windows)).toBe(true)
+  })
+
+  it('rejects sessions outside all windows', () => {
+    expect(overlapsAnyWindow(iso(2_000), iso(3_000), windows)).toBe(false)
+    expect(overlapsAnyWindow(iso(6_000), iso(7_000), windows)).toBe(false)
+  })
+
+  it('rejects unparseable timestamps', () => {
+    expect(overlapsAnyWindow('bad', iso(1_500), windows)).toBe(false)
+  })
+})

--- a/frontend/src/lib/drilldown.test.ts
+++ b/frontend/src/lib/drilldown.test.ts
@@ -29,6 +29,12 @@ describe('parseRangeBounds', () => {
   it('rejects inverted ranges', () => {
     expect(parseRangeBounds(TO, FROM)).toBeNull()
   })
+
+  it('rejects ranges beyond MAX_DRILLDOWN_DAYS (URL length guard)', () => {
+    expect(parseRangeBounds('2020-01-01', '2026-08-07')).toBeNull() // all-time preset
+    expect(parseRangeBounds('2026-02-08', '2026-08-07')).toBeNull() // 181 days
+    expect(parseRangeBounds('2026-02-09', '2026-08-07')).not.toBeNull() // 180 days
+  })
 })
 
 describe('heatmapCellTarget', () => {

--- a/frontend/src/lib/drilldown.test.ts
+++ b/frontend/src/lib/drilldown.test.ts
@@ -14,15 +14,16 @@ const FROM = '2026-08-03'
 const TO = '2026-08-09'
 
 describe('parseRangeBounds', () => {
-  it('spans the inclusive `to` date', () => {
+  it('spans the inclusive `to` date, anchored to UTC', () => {
     const bounds = parseRangeBounds(FROM, TO)!
-    expect(new Date(bounds.from).getDate()).toBe(3)
-    expect(new Date(bounds.to).getDate()).toBe(10) // one day past `to`
+    expect(bounds.from).toBe(Date.parse('2026-08-03T00:00:00Z'))
+    expect(bounds.to).toBe(Date.parse('2026-08-10T00:00:00Z')) // one day past `to`
   })
 
   it('rejects invalid dates', () => {
     expect(parseRangeBounds('nope', TO)).toBeNull()
     expect(parseRangeBounds(FROM, 'nope')).toBeNull()
+    expect(parseRangeBounds('08/03/2026', TO)).toBeNull()
   })
 
   it('rejects inverted ranges', () => {
@@ -31,13 +32,14 @@ describe('parseRangeBounds', () => {
 })
 
 describe('heatmapCellTarget', () => {
-  it('produces one window per occurrence of the weekday+hour in range', () => {
-    // Monday (1) 14:00 within Mon 3rd – Sun 9th → exactly one occurrence.
+  it('produces one window per occurrence of the weekday+hour in range (UTC)', () => {
+    // Monday (1) 14:00 UTC within Mon 3rd – Sun 9th → exactly one occurrence.
     const target = heatmapCellTarget(FROM, TO, 1, 14)!
     expect(target.windows).toHaveLength(1)
     const w = target.windows[0]
-    expect(new Date(w.from).getDay()).toBe(1)
-    expect(new Date(w.from).getHours()).toBe(14)
+    expect(w.from).toBe(Date.parse('2026-08-03T14:00:00Z'))
+    expect(new Date(w.from).getUTCDay()).toBe(1)
+    expect(new Date(w.from).getUTCHours()).toBe(14)
     expect(w.to - w.from).toBe(60 * 60 * 1000)
   })
 
@@ -46,14 +48,14 @@ describe('heatmapCellTarget', () => {
     const target = heatmapCellTarget('2026-08-03', '2026-08-23', 1, 9)!
     expect(target.windows).toHaveLength(3)
     for (const w of target.windows) {
-      expect(new Date(w.from).getDay()).toBe(1)
-      expect(new Date(w.from).getHours()).toBe(9)
+      expect(new Date(w.from).getUTCDay()).toBe(1)
+      expect(new Date(w.from).getUTCHours()).toBe(9)
     }
   })
 
   it('describes the bucket in the label', () => {
-    expect(heatmapCellTarget(FROM, TO, 2, 5)!.label).toBe('Tuesdays 05:00–06:00')
-    expect(heatmapCellTarget(FROM, TO, 6, 23)!.label).toBe('Saturdays 23:00–00:00')
+    expect(heatmapCellTarget(FROM, TO, 2, 5)!.label).toBe('Tuesdays 05:00–06:00 UTC')
+    expect(heatmapCellTarget(FROM, TO, 6, 23)!.label).toBe('Saturdays 23:00–00:00 UTC')
   })
 
   it('returns null for an invalid range', () => {
@@ -62,17 +64,18 @@ describe('heatmapCellTarget', () => {
 })
 
 describe('hourlyBarTarget', () => {
-  it('produces one window per day in range', () => {
+  it('produces one window per day in range (UTC)', () => {
     const target = hourlyBarTarget(FROM, TO, 8)! // 7 days
     expect(target.windows).toHaveLength(7)
+    expect(target.windows[0].from).toBe(Date.parse('2026-08-03T08:00:00Z'))
     for (const w of target.windows) {
-      expect(new Date(w.from).getHours()).toBe(8)
+      expect(new Date(w.from).getUTCHours()).toBe(8)
       expect(w.to - w.from).toBe(60 * 60 * 1000)
     }
   })
 
   it('describes the bucket in the label', () => {
-    expect(hourlyBarTarget(FROM, TO, 14)!.label).toBe('every day 14:00–15:00')
+    expect(hourlyBarTarget(FROM, TO, 14)!.label).toBe('every day 14:00–15:00 UTC')
   })
 })
 
@@ -102,7 +105,14 @@ describe('drilldownUrl', () => {
     expect(url.startsWith('/claude-sessions?')).toBe(true)
     const params = new URLSearchParams(url.split('?')[1])
     expect(decodeWindows(params.get('windows'))).toEqual(target.windows)
-    expect(params.get('label')).toBe('Mondays 14:00–15:00 · 2026-08-03 → 2026-08-09')
+    expect(params.get('label')).toBe('Mondays 14:00–15:00 UTC · 2026-08-03 → 2026-08-09')
+    expect(params.get('project')).toBeNull()
+  })
+
+  it('carries the analytics project filter when given', () => {
+    const target = hourlyBarTarget(FROM, TO, 8)!
+    const params = new URLSearchParams(drilldownUrl(target, '/home/user/proj').split('?')[1])
+    expect(params.get('project')).toBe('/home/user/proj')
   })
 })
 

--- a/frontend/src/lib/drilldown.ts
+++ b/frontend/src/lib/drilldown.ts
@@ -33,7 +33,8 @@ export interface DrilldownTarget {
  * Parses the analytics date range ("YYYY-MM-DD" strings, inclusive) into UTC
  * millisecond bounds, matching how the backend parses the same params
  * (`time.Parse("2006-01-02", …)` → UTC midnight). Returns null when either
- * bound is invalid.
+ * bound is invalid, or when the range exceeds MAX_DRILLDOWN_DAYS — the
+ * serialized window list would otherwise exceed URL length limits.
  */
 export function parseRangeBounds(fromDate: string, toDate: string): { from: number; to: number } | null {
   const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
@@ -41,8 +42,16 @@ export function parseRangeBounds(fromDate: string, toDate: string): { from: numb
   const from = Date.parse(`${fromDate}T00:00:00Z`)
   const to = Date.parse(`${toDate}T00:00:00Z`) + 24 * 60 * 60 * 1000 // `to` date is inclusive
   if (Number.isNaN(from) || Number.isNaN(to) || from >= to) return null
+  if (to - from > MAX_DRILLDOWN_DAYS * 24 * 60 * 60 * 1000) return null
   return { from, to }
 }
+
+/**
+ * Ranges longer than this produce window lists too large for a URL (all-time
+ * would be ~2400 windows ≈ 67 KB of query string), so drill-down is disabled
+ * beyond it.
+ */
+export const MAX_DRILLDOWN_DAYS = 180
 
 function collectWindows(
   bounds: { from: number; to: number },

--- a/frontend/src/lib/drilldown.ts
+++ b/frontend/src/lib/drilldown.ts
@@ -1,0 +1,137 @@
+import { DAY_NAMES } from '@/pages/analyticsShared'
+
+const DAY_NAMES_PLURAL = ['Sundays', 'Mondays', 'Tuesdays', 'Wednesdays', 'Thursdays', 'Fridays', 'Saturdays']
+
+/**
+ * Drill-down helpers for the analytics → Claude Sessions navigation.
+ *
+ * The heatmap and hourly charts bucket sessions by the *local* weekday/hour of
+ * their last activity, so a click must expand back into every matching concrete
+ * hour window inside the analytics date range. The sessions page then keeps the
+ * sessions whose activity window overlaps any of those windows.
+ */
+
+export interface DrilldownWindow {
+  /** Millisecond timestamp, inclusive. */
+  from: number
+  /** Millisecond timestamp, exclusive. */
+  to: number
+}
+
+export interface DrilldownTarget {
+  /** All hour windows inside the analytics range matching the clicked bucket. */
+  windows: DrilldownWindow[]
+  /** Human-readable description of the clicked bucket, e.g. "Tuesdays 14:00–15:00". */
+  label: string
+  /** Human-readable description of the analytics range, e.g. "2026-07-08 → 2026-08-07". */
+  rangeLabel: string
+}
+
+/**
+ * Parses the analytics date range ("YYYY-MM-DD" strings, inclusive) into local
+ * millisecond bounds. Returns null when either bound is invalid.
+ */
+export function parseRangeBounds(fromDate: string, toDate: string): { from: number; to: number } | null {
+  const from = new Date(`${fromDate}T00:00:00`).getTime()
+  const to = new Date(`${toDate}T00:00:00`).getTime() + 24 * 60 * 60 * 1000 // `to` date is inclusive
+  if (Number.isNaN(from) || Number.isNaN(to) || from >= to) return null
+  return { from, to }
+}
+
+function collectWindows(
+  bounds: { from: number; to: number },
+  matches: (start: Date) => boolean,
+): DrilldownWindow[] {
+  const windows: DrilldownWindow[] = []
+  // Walk hour-by-hour from the range start; ranges are at most ~90 days so this
+  // stays cheap (≤ ~2200 iterations) and avoids day/hour juggling edge cases.
+  const cursor = new Date(bounds.from)
+  cursor.setMinutes(0, 0, 0)
+  while (cursor.getTime() < bounds.to) {
+    if (matches(cursor)) {
+      windows.push({ from: cursor.getTime(), to: cursor.getTime() + 60 * 60 * 1000 })
+    }
+    cursor.setHours(cursor.getHours() + 1)
+  }
+  return windows
+}
+
+/** Windows for a heatmap cell: the given weekday + hour across the range. */
+export function heatmapCellTarget(
+  fromDate: string,
+  toDate: string,
+  dayOfWeek: number,
+  hour: number,
+): DrilldownTarget | null {
+  const bounds = parseRangeBounds(fromDate, toDate)
+  if (!bounds) return null
+  return {
+    windows: collectWindows(bounds, d => d.getDay() === dayOfWeek && d.getHours() === hour),
+    label: `${DAY_NAMES_PLURAL[dayOfWeek] ?? DAY_NAMES[dayOfWeek]} ${padHour(hour)}:00–${padHour((hour + 1) % 24)}:00`,
+    rangeLabel: `${fromDate} → ${toDate}`,
+  }
+}
+
+/** Windows for an hourly bar: the given hour of every day in the range. */
+export function hourlyBarTarget(
+  fromDate: string,
+  toDate: string,
+  hour: number,
+): DrilldownTarget | null {
+  const bounds = parseRangeBounds(fromDate, toDate)
+  if (!bounds) return null
+  return {
+    windows: collectWindows(bounds, d => d.getHours() === hour),
+    label: `every day ${padHour(hour)}:00–${padHour((hour + 1) % 24)}:00`,
+    rangeLabel: `${fromDate} → ${toDate}`,
+  }
+}
+
+function padHour(h: number): string {
+  return String(h).padStart(2, '0')
+}
+
+/**
+ * Serializes windows into a compact `from-to,from-to,…` string for the
+ * `windows` query param.
+ */
+export function encodeWindows(windows: DrilldownWindow[]): string {
+  return windows.map(w => `${w.from}-${w.to}`).join(',')
+}
+
+/** Parses the `windows` query param back into windows; invalid entries are dropped. */
+export function decodeWindows(value: string | null): DrilldownWindow[] {
+  if (!value) return []
+  return value
+    .split(',')
+    .map(part => {
+      const [from, to] = part.split('-').map(Number)
+      if (!Number.isFinite(from) || !Number.isFinite(to) || from >= to) return null
+      return { from, to }
+    })
+    .filter((w): w is DrilldownWindow => w !== null)
+}
+
+/** Builds the `/claude-sessions` URL for a drill-down target. */
+export function drilldownUrl(target: DrilldownTarget): string {
+  const qs = new URLSearchParams()
+  qs.set('windows', encodeWindows(target.windows))
+  qs.set('label', `${target.label} · ${target.rangeLabel}`)
+  return `/claude-sessions?${qs.toString()}`
+}
+
+/**
+ * Returns true when a session's activity window [startISO, lastActivityISO]
+ * overlaps any of the given windows. Used on the sessions page instead of the
+ * preset-based range filter when a drill-down is active.
+ */
+export function overlapsAnyWindow(
+  startISO: string,
+  lastActivityISO: string,
+  windows: DrilldownWindow[],
+): boolean {
+  const start = new Date(startISO).getTime()
+  const lastActivity = new Date(lastActivityISO).getTime()
+  if (Number.isNaN(start) || Number.isNaN(lastActivity)) return false
+  return windows.some(w => start < w.to && lastActivity >= w.from)
+}

--- a/frontend/src/lib/drilldown.ts
+++ b/frontend/src/lib/drilldown.ts
@@ -5,10 +5,12 @@ const DAY_NAMES_PLURAL = ['Sundays', 'Mondays', 'Tuesdays', 'Wednesdays', 'Thurs
 /**
  * Drill-down helpers for the analytics → Claude Sessions navigation.
  *
- * The heatmap and hourly charts bucket sessions by the *local* weekday/hour of
- * their last activity, so a click must expand back into every matching concrete
- * hour window inside the analytics date range. The sessions page then keeps the
- * sessions whose activity window overlaps any of those windows.
+ * The backend buckets sessions by the UTC weekday/hour of their last activity
+ * (session timestamps are parsed from JSONL `Z` timestamps and never converted,
+ * and the analytics `from`/`to` params are UTC midnights). So a click must
+ * expand back into every matching concrete UTC hour window inside the range.
+ * The sessions page then keeps the sessions whose activity window overlaps any
+ * of those windows.
  */
 
 export interface DrilldownWindow {
@@ -28,12 +30,16 @@ export interface DrilldownTarget {
 }
 
 /**
- * Parses the analytics date range ("YYYY-MM-DD" strings, inclusive) into local
- * millisecond bounds. Returns null when either bound is invalid.
+ * Parses the analytics date range ("YYYY-MM-DD" strings, inclusive) into UTC
+ * millisecond bounds, matching how the backend parses the same params
+ * (`time.Parse("2006-01-02", …)` → UTC midnight). Returns null when either
+ * bound is invalid.
  */
 export function parseRangeBounds(fromDate: string, toDate: string): { from: number; to: number } | null {
-  const from = new Date(`${fromDate}T00:00:00`).getTime()
-  const to = new Date(`${toDate}T00:00:00`).getTime() + 24 * 60 * 60 * 1000 // `to` date is inclusive
+  const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+  if (!DATE_RE.test(fromDate) || !DATE_RE.test(toDate)) return null
+  const from = Date.parse(`${fromDate}T00:00:00Z`)
+  const to = Date.parse(`${toDate}T00:00:00Z`) + 24 * 60 * 60 * 1000 // `to` date is inclusive
   if (Number.isNaN(from) || Number.isNaN(to) || from >= to) return null
   return { from, to }
 }
@@ -46,12 +52,11 @@ function collectWindows(
   // Walk hour-by-hour from the range start; ranges are at most ~90 days so this
   // stays cheap (≤ ~2200 iterations) and avoids day/hour juggling edge cases.
   const cursor = new Date(bounds.from)
-  cursor.setMinutes(0, 0, 0)
   while (cursor.getTime() < bounds.to) {
     if (matches(cursor)) {
       windows.push({ from: cursor.getTime(), to: cursor.getTime() + 60 * 60 * 1000 })
     }
-    cursor.setHours(cursor.getHours() + 1)
+    cursor.setUTCHours(cursor.getUTCHours() + 1)
   }
   return windows
 }
@@ -66,13 +71,13 @@ export function heatmapCellTarget(
   const bounds = parseRangeBounds(fromDate, toDate)
   if (!bounds) return null
   return {
-    windows: collectWindows(bounds, d => d.getDay() === dayOfWeek && d.getHours() === hour),
-    label: `${DAY_NAMES_PLURAL[dayOfWeek] ?? DAY_NAMES[dayOfWeek]} ${padHour(hour)}:00–${padHour((hour + 1) % 24)}:00`,
+    windows: collectWindows(bounds, d => d.getUTCDay() === dayOfWeek && d.getUTCHours() === hour),
+    label: `${DAY_NAMES_PLURAL[dayOfWeek] ?? DAY_NAMES[dayOfWeek]} ${padHour(hour)}:00–${padHour((hour + 1) % 24)}:00 UTC`,
     rangeLabel: `${fromDate} → ${toDate}`,
   }
 }
 
-/** Windows for an hourly bar: the given hour of every day in the range. */
+/** Windows for an hourly bar: the given UTC hour of every day in the range. */
 export function hourlyBarTarget(
   fromDate: string,
   toDate: string,
@@ -81,8 +86,8 @@ export function hourlyBarTarget(
   const bounds = parseRangeBounds(fromDate, toDate)
   if (!bounds) return null
   return {
-    windows: collectWindows(bounds, d => d.getHours() === hour),
-    label: `every day ${padHour(hour)}:00–${padHour((hour + 1) % 24)}:00`,
+    windows: collectWindows(bounds, d => d.getUTCHours() === hour),
+    label: `every day ${padHour(hour)}:00–${padHour((hour + 1) % 24)}:00 UTC`,
     rangeLabel: `${fromDate} → ${toDate}`,
   }
 }
@@ -113,10 +118,11 @@ export function decodeWindows(value: string | null): DrilldownWindow[] {
 }
 
 /** Builds the `/claude-sessions` URL for a drill-down target. */
-export function drilldownUrl(target: DrilldownTarget): string {
+export function drilldownUrl(target: DrilldownTarget, project?: string): string {
   const qs = new URLSearchParams()
   qs.set('windows', encodeWindows(target.windows))
   qs.set('label', `${target.label} · ${target.rangeLabel}`)
+  if (project) qs.set('project', project)
   return `/claude-sessions?${qs.toString()}`
 }
 

--- a/frontend/src/lib/drilldown.ts
+++ b/frontend/src/lib/drilldown.ts
@@ -1,6 +1,14 @@
 import { DAY_NAMES } from '@/pages/analyticsShared'
 
-const DAY_NAMES_PLURAL = ['Sundays', 'Mondays', 'Tuesdays', 'Wednesdays', 'Thursdays', 'Fridays', 'Saturdays']
+const DAY_NAMES_PLURAL = [
+  'Sundays',
+  'Mondays',
+  'Tuesdays',
+  'Wednesdays',
+  'Thursdays',
+  'Fridays',
+  'Saturdays',
+]
 
 /**
  * Drill-down helpers for the analytics → Claude Sessions navigation.
@@ -36,7 +44,10 @@ export interface DrilldownTarget {
  * bound is invalid, or when the range exceeds MAX_DRILLDOWN_DAYS — the
  * serialized window list would otherwise exceed URL length limits.
  */
-export function parseRangeBounds(fromDate: string, toDate: string): { from: number; to: number } | null {
+export function parseRangeBounds(
+  fromDate: string,
+  toDate: string,
+): { from: number; to: number } | null {
   const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
   if (!DATE_RE.test(fromDate) || !DATE_RE.test(toDate)) return null
   const from = Date.parse(`${fromDate}T00:00:00Z`)

--- a/frontend/src/lib/drilldown.ts
+++ b/frontend/src/lib/drilldown.ts
@@ -58,8 +58,9 @@ function collectWindows(
   matches: (start: Date) => boolean,
 ): DrilldownWindow[] {
   const windows: DrilldownWindow[] = []
-  // Walk hour-by-hour from the range start; ranges are at most ~90 days so this
-  // stays cheap (≤ ~2200 iterations) and avoids day/hour juggling edge cases.
+  // Walk hour-by-hour from the range start; ranges are capped at
+  // MAX_DRILLDOWN_DAYS so this stays cheap (≤ ~4400 iterations) and avoids
+  // day/hour juggling edge cases.
   const cursor = new Date(bounds.from)
   while (cursor.getTime() < bounds.to) {
     if (matches(cursor)) {

--- a/frontend/src/pages/ClaudeSessionsPage.tsx
+++ b/frontend/src/pages/ClaudeSessionsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, type ReactNode } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { claudeSessionsApi } from '@/lib/api'
 import type { ClaudeSessionSummary, ClaudeProject } from '@/types'
 import { formatRelativeTime } from '@/lib/utils'
@@ -11,11 +11,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { History, Search, RefreshCw, ExternalLink, Zap, Star, Activity, Clock } from 'lucide-react'
+import { History, Search, RefreshCw, ExternalLink, Zap, Star, Activity, Clock, X } from 'lucide-react'
 import { Tooltip } from '@/components/ui/tooltip'
 import { CopyableId } from '@/components/CopyableId'
 import { formatTokens, shortPath } from '@/lib/format'
 import { overlapsRange, resolvePresetRange, type TimePreset } from '@/lib/timefilter'
+import { decodeWindows, overlapsAnyWindow } from '@/lib/drilldown'
 
 const TIME_PRESET_LABELS: Record<TimePreset, string> = {
   all: 'All time',
@@ -28,6 +29,14 @@ const TIME_PRESET_LABELS: Record<TimePreset, string> = {
 
 export default function ClaudeSessionsPage() {
   const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
+  // Drill-down from the analytics page: explicit hour windows + a label.
+  const drilldownWindows = useMemo(
+    () => decodeWindows(searchParams.get('windows')),
+    [searchParams],
+  )
+  const drilldownLabel = searchParams.get('label')
+  const drilldownActive = drilldownWindows.length > 0
   const [sessions, setSessions] = useState<ClaudeSessionSummary[]>([])
   const [projects, setProjects] = useState<ClaudeProject[]>([])
   const [loading, setLoading] = useState(true)
@@ -84,7 +93,9 @@ export default function ClaudeSessionsPage() {
 
   const hasFavorites = sessions.some(s => s.is_favorite)
 
-  const timeFilterActive = timePreset !== 'all'
+  const timeFilterActive = drilldownActive || timePreset !== 'all'
+
+  const clearDrilldown = () => setSearchParams({}, { replace: true })
 
   const filtered = useMemo(() => {
     const { from, to } = resolvePresetRange(timePreset, customFrom, customTo)
@@ -97,11 +108,23 @@ export default function ClaudeSessionsPage() {
         s.preview.toLowerCase().includes(q) ||
         s.project_path.toLowerCase().includes(q)
       const matchesFavorites = !filterFavorites || !!s.is_favorite
-      const matchesTime = overlapsRange(s.start_time, s.last_activity, from, to)
+      const matchesTime = drilldownActive
+        ? overlapsAnyWindow(s.start_time, s.last_activity, drilldownWindows)
+        : overlapsRange(s.start_time, s.last_activity, from, to)
       return matchesProject && matchesSearch && matchesFavorites && matchesTime
     })
     return result
-  }, [sessions, search, filterProject, filterFavorites, timePreset, customFrom, customTo])
+  }, [
+    sessions,
+    search,
+    filterProject,
+    filterFavorites,
+    timePreset,
+    customFrom,
+    customTo,
+    drilldownActive,
+    drilldownWindows,
+  ])
 
   if (loading) {
     return (
@@ -134,6 +157,14 @@ export default function ClaudeSessionsPage() {
             ? 'No sessions active in the selected time range.'
             : 'No sessions match your filters.'}
         </p>
+        {drilldownActive && (
+          <button
+            onClick={clearDrilldown}
+            className="mt-3 text-xs text-indigo-500 hover:text-indigo-600 dark:hover:text-indigo-400"
+          >
+            Clear time filter
+          </button>
+        )}
       </div>
     )
   } else {
@@ -178,6 +209,25 @@ export default function ClaudeSessionsPage() {
         </button>
       </div>
 
+      {/* Drill-down banner (from analytics charts) */}
+      {drilldownActive && (
+        <div className="flex items-center justify-between gap-3 px-4 sm:px-6 py-2 border-b border-indigo-100 dark:border-indigo-900/50 bg-indigo-50/60 dark:bg-indigo-950/30 shrink-0">
+          <p className="text-xs text-indigo-700 dark:text-indigo-300 truncate">
+            Showing sessions active {drilldownLabel ?? 'in the selected hours'} ·{' '}
+            <span className="text-indigo-500 dark:text-indigo-400">
+              {filtered.length} match{filtered.length === 1 ? '' : 'es'}
+            </span>
+          </p>
+          <button
+            onClick={clearDrilldown}
+            className="flex items-center gap-1 text-xs text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-200 shrink-0"
+          >
+            <X className="h-3 w-3" />
+            Clear
+          </button>
+        </div>
+      )}
+
       {/* Filters */}
       {sessions.length > 0 && (
         <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2 sm:gap-3 px-4 sm:px-6 py-3 border-b border-zinc-100 dark:border-zinc-700/50 shrink-0">
@@ -206,7 +256,11 @@ export default function ClaudeSessionsPage() {
               </SelectContent>
             </Select>
           )}
-          <Select value={timePreset} onValueChange={v => setTimePreset(v as TimePreset)}>
+          <Select
+            value={timePreset}
+            onValueChange={v => setTimePreset(v as TimePreset)}
+            disabled={drilldownActive}
+          >
             <SelectTrigger className="w-full sm:w-44 h-8 text-xs">
               <Clock className="h-3.5 w-3.5 text-zinc-400 dark:text-zinc-500 mr-1.5 shrink-0" />
               <SelectValue placeholder="All time" />
@@ -219,7 +273,7 @@ export default function ClaudeSessionsPage() {
               ))}
             </SelectContent>
           </Select>
-          {timePreset === 'custom' && (
+          {timePreset === 'custom' && !drilldownActive && (
             <div className="flex items-center gap-1.5 shrink-0">
               <input
                 type="datetime-local"

--- a/frontend/src/pages/ClaudeSessionsPage.tsx
+++ b/frontend/src/pages/ClaudeSessionsPage.tsx
@@ -44,6 +44,13 @@ export default function ClaudeSessionsPage() {
   const [error, setError] = useState<string | null>(null)
   const [search, setSearch] = useState('')
   const [filterProject, setFilterProject] = useState(searchParams.get('project') ?? 'all')
+
+  // Keep the project filter in sync when arriving via a new drill-down URL
+  // while the page is already mounted.
+  const projectParam = searchParams.get('project')
+  useEffect(() => {
+    if (projectParam) setFilterProject(projectParam)
+  }, [projectParam])
   const [filterFavorites, setFilterFavorites] = useState(false)
   const [timePreset, setTimePreset] = useState<TimePreset>('all')
   const [customFrom, setCustomFrom] = useState('')
@@ -95,7 +102,14 @@ export default function ClaudeSessionsPage() {
 
   const timeFilterActive = drilldownActive || timePreset !== 'all'
 
-  const clearDrilldown = () => setSearchParams({}, { replace: true })
+  const clearDrilldown = () => {
+    // Drop only the time drill-down; a project carried over from analytics
+    // stays applied (and visible in the project dropdown).
+    const next = new URLSearchParams(searchParams)
+    next.delete('windows')
+    next.delete('label')
+    setSearchParams(next, { replace: true })
+  }
 
   const filtered = useMemo(() => {
     const { from, to } = resolvePresetRange(timePreset, customFrom, customTo)

--- a/frontend/src/pages/ClaudeSessionsPage.tsx
+++ b/frontend/src/pages/ClaudeSessionsPage.tsx
@@ -43,7 +43,7 @@ export default function ClaudeSessionsPage() {
   const [refreshing, setRefreshing] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [search, setSearch] = useState('')
-  const [filterProject, setFilterProject] = useState('all')
+  const [filterProject, setFilterProject] = useState(searchParams.get('project') ?? 'all')
   const [filterFavorites, setFilterFavorites] = useState(false)
   const [timePreset, setTimePreset] = useState<TimePreset>('all')
   const [customFrom, setCustomFrom] = useState('')

--- a/frontend/src/pages/ClaudeSessionsPage.tsx
+++ b/frontend/src/pages/ClaudeSessionsPage.tsx
@@ -11,7 +11,17 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { History, Search, RefreshCw, ExternalLink, Zap, Star, Activity, Clock, X } from 'lucide-react'
+import {
+  History,
+  Search,
+  RefreshCw,
+  ExternalLink,
+  Zap,
+  Star,
+  Activity,
+  Clock,
+  X,
+} from 'lucide-react'
 import { Tooltip } from '@/components/ui/tooltip'
 import { CopyableId } from '@/components/CopyableId'
 import { formatTokens, shortPath } from '@/lib/format'
@@ -31,10 +41,7 @@ export default function ClaudeSessionsPage() {
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
   // Drill-down from the analytics page: explicit hour windows + a label.
-  const drilldownWindows = useMemo(
-    () => decodeWindows(searchParams.get('windows')),
-    [searchParams],
-  )
+  const drilldownWindows = useMemo(() => decodeWindows(searchParams.get('windows')), [searchParams])
   const drilldownLabel = searchParams.get('label')
   const drilldownActive = drilldownWindows.length > 0
   const [sessions, setSessions] = useState<ClaudeSessionSummary[]>([])

--- a/frontend/src/pages/GeneralUsagePage.tsx
+++ b/frontend/src/pages/GeneralUsagePage.tsx
@@ -14,7 +14,7 @@ import {
   ResponsiveContainer,
 } from 'recharts'
 import { analyticsApi } from '@/lib/api'
-import { drilldownUrl, heatmapCellTarget, hourlyBarTarget } from '@/lib/drilldown'
+import { drilldownUrl, heatmapCellTarget, hourlyBarTarget, parseRangeBounds, MAX_DRILLDOWN_DAYS } from '@/lib/drilldown'
 import type {
   AnalyticsReport,
   AnalyticsSummary,
@@ -445,6 +445,10 @@ export default function GeneralUsagePage() {
     load(from, to, project)
   }
 
+  // Beyond MAX_DRILLDOWN_DAYS the serialized window list would exceed URL
+  // length limits, so charts render without click-through.
+  const drilldownEnabled = parseRangeBounds(from, to) !== null
+
   const drillIntoSessions = useCallback(
     (dayOfWeek: number | null, hour: number) => {
       const target =
@@ -561,13 +565,21 @@ export default function GeneralUsagePage() {
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
               <ActivityHeatmap
                 data={report?.heatmap ?? []}
-                onCellClick={(dow, hour) => drillIntoSessions(dow, hour)}
+                onCellClick={
+                  drilldownEnabled ? (dow, hour) => drillIntoSessions(dow, hour) : undefined
+                }
               />
               <HourlyActivityChart
                 data={report?.hourly_activity ?? []}
-                onBarClick={hour => drillIntoSessions(null, hour)}
+                onBarClick={drilldownEnabled ? hour => drillIntoSessions(null, hour) : undefined}
               />
             </div>
+            {!drilldownEnabled && (
+              <p className="text-[11px] text-zinc-400 dark:text-zinc-500 -mt-3">
+                Session drill-down is available for ranges up to {MAX_DRILLDOWN_DAYS} days — pick a
+                narrower date range to click through to sessions.
+              </p>
+            )}
           </>
         )}
       </div>

--- a/frontend/src/pages/GeneralUsagePage.tsx
+++ b/frontend/src/pages/GeneralUsagePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
   AreaChart,
@@ -124,47 +124,103 @@ function heatmapCellBg(intensity: number): string {
   return 'bg-indigo-800 dark:bg-indigo-400'
 }
 
-function HeatmapGridCell({
-  day,
-  dow,
-  hour,
-  cell,
-  maxSessions,
-  onCellClick,
-}: Readonly<{
+const ARROW_MOVES: Record<string, [number, number]> = {
+  ArrowRight: [0, 1],
+  ArrowLeft: [0, -1],
+  ArrowDown: [1, 0],
+  ArrowUp: [-1, 0],
+}
+
+function cellTitle(day: string, hour: number, cell: HeatmapCell | undefined): string {
+  if (!cell) return `${day} ${hour}:00 — no activity`
+  return `${day} ${hour}:00 — ${cell.sessions} sessions, ${formatTokens(cell.tokens)} tokens — click to view sessions`
+}
+
+interface HeatmapCellCommonProps {
   day: string
   dow: number
   hour: number
   cell: HeatmapCell | undefined
   maxSessions: number
-  onCellClick?: (dayOfWeek: number, hour: number) => void
-}>) {
+}
+
+function StaticHeatmapCell({ day, hour, cell, maxSessions }: Readonly<HeatmapCellCommonProps>) {
   const intensity = maxSessions > 0 ? (cell?.sessions ?? 0) / maxSessions : 0
-  const clickable = !!onCellClick && !!cell
-  const handleKeyDown = clickable
-    ? (e: React.KeyboardEvent) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault()
-          onCellClick(dow, hour)
-        }
-      }
-    : undefined
   return (
     <div
-      role={clickable ? 'button' : undefined}
-      tabIndex={clickable ? 0 : undefined}
+      className={`flex-1 aspect-square rounded-[2px] mx-px ${heatmapCellBg(intensity)} cursor-default`}
+      title={cell ? cellTitle(day, hour, cell).replace(' — click to view sessions', '') : `${day} ${hour}:00 — no activity`}
+    />
+  )
+}
+
+function InteractiveHeatmapCell({
+  day,
+  dow,
+  hour,
+  cell,
+  maxSessions,
+  focused,
+  registerRef,
+  onCellClick,
+  onMoveFocus,
+}: Readonly<
+  HeatmapCellCommonProps & {
+    focused: boolean
+    registerRef: (key: string, el: HTMLDivElement | null) => void
+    onCellClick: (dayOfWeek: number, hour: number) => void
+    onMoveFocus: (dayOfWeek: number, hour: number) => void
+  }
+>) {
+  const intensity = maxSessions > 0 ? (cell?.sessions ?? 0) / maxSessions : 0
+  const clickable = !!cell
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    const move = ARROW_MOVES[e.key]
+    if (move) {
+      e.preventDefault()
+      onMoveFocus(dow + move[0], hour + move[1])
+      return
+    }
+    if ((e.key === 'Enter' || e.key === ' ') && clickable) {
+      e.preventDefault()
+      onCellClick(dow, hour)
+    }
+  }
+
+  return (
+    <div
+      ref={el => registerRef(`${dow}-${hour}`, el)}
+      role="gridcell"
+      aria-label={`${day} ${hour}:00 — ${cell ? `${cell.sessions} sessions` : 'no activity'}`}
+      tabIndex={focused ? 0 : -1}
       onClick={clickable ? () => onCellClick(dow, hour) : undefined}
       onKeyDown={handleKeyDown}
-      className={`flex-1 aspect-square rounded-[2px] mx-px ${heatmapCellBg(intensity)} ${
-        clickable
-          ? 'cursor-pointer hover:ring-1 hover:ring-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500'
-          : 'cursor-default'
+      className={`flex-1 aspect-square rounded-[2px] mx-px ${heatmapCellBg(intensity)} focus:outline-none focus:ring-2 focus:ring-indigo-500 ${
+        clickable ? 'cursor-pointer hover:ring-1 hover:ring-indigo-500' : 'cursor-default'
       }`}
-      title={
-        cell
-          ? `${day} ${hour}:00 — ${cell.sessions} sessions, ${formatTokens(cell.tokens)} tokens — click to view sessions`
-          : `${day} ${hour}:00 — no activity`
-      }
+      title={cellTitle(day, hour, cell)}
+    />
+  )
+}
+
+function HeatmapGridCell({
+  interactive,
+  ...props
+}: Readonly<
+  HeatmapCellCommonProps & {
+    interactive: boolean
+    focused: boolean
+    registerRef: (key: string, el: HTMLDivElement | null) => void
+    onCellClick?: (dayOfWeek: number, hour: number) => void
+    onMoveFocus: (dayOfWeek: number, hour: number) => void
+  }
+>) {
+  if (!interactive) return <StaticHeatmapCell {...props} />
+  return (
+    <InteractiveHeatmapCell
+      {...props}
+      onCellClick={props.onCellClick ?? (() => {})}
     />
   )
 }
@@ -180,12 +236,29 @@ function ActivityHeatmap({
 
   const cellMap = new Map(data.map(c => [`${c.day_of_week}-${c.hour}`, c]))
 
+  // Roving tabindex: only the focused cell is in the tab order; arrows move
+  // focus across the grid (WAI-ARIA grid pattern).
+  const interactive = !!onCellClick
+  const [focusPos, setFocusPos] = useState({ dow: 0, hour: 0 })
+  const cellRefs = useRef(new Map<string, HTMLDivElement | null>())
+  const registerRef = useCallback((key: string, el: HTMLDivElement | null) => {
+    cellRefs.current.set(key, el)
+  }, [])
+  const moveFocus = useCallback((dow: number, hour: number) => {
+    const next = {
+      dow: Math.min(6, Math.max(0, dow)),
+      hour: Math.min(23, Math.max(0, hour)),
+    }
+    setFocusPos(next)
+    cellRefs.current.get(`${next.dow}-${next.hour}`)?.focus()
+  }, [])
+
   return (
     <ChartCard title="Activity Heatmap (Day × Hour)">
       <div className="overflow-x-auto">
-        <div className="min-w-[560px]">
+        <div className="min-w-[560px]" role={interactive ? 'grid' : undefined} aria-label={interactive ? 'Activity by day and hour' : undefined}>
           {/* Hour labels */}
-          <div className="flex ml-8 mb-1">
+          <div className="flex ml-8 mb-1" role={interactive ? 'presentation' : undefined}>
             {Array.from({ length: 24 }, (_, h) => (
               <div
                 key={`hour-${h}`}
@@ -197,8 +270,15 @@ function ActivityHeatmap({
           </div>
           {/* Rows */}
           {DAY_NAMES.map((day, dow) => (
-            <div key={`day-${day}`} className="flex items-center mb-0.5">
-              <span className="w-8 text-[12px] text-zinc-400 dark:text-zinc-500 shrink-0">
+            <div
+              key={`day-${day}`}
+              className="flex items-center mb-0.5"
+              role={interactive ? 'row' : undefined}
+            >
+              <span
+                className="w-8 text-[12px] text-zinc-400 dark:text-zinc-500 shrink-0"
+                role={interactive ? 'rowheader' : undefined}
+              >
                 {day}
               </span>
               {Array.from({ length: 24 }, (_, h) => (
@@ -209,7 +289,11 @@ function ActivityHeatmap({
                   hour={h}
                   cell={cellMap.get(`${dow}-${h}`)}
                   maxSessions={maxSessions}
+                  interactive={interactive}
+                  focused={focusPos.dow === dow && focusPos.hour === h}
+                  registerRef={registerRef}
                   onCellClick={onCellClick}
+                  onMoveFocus={moveFocus}
                 />
               ))}
             </div>
@@ -230,7 +314,8 @@ function ActivityHeatmap({
           </div>
           {onCellClick && (
             <p className="text-[11px] text-zinc-400 dark:text-zinc-500 mt-1.5 ml-8">
-              Click a cell to view the sessions from that day and hour.
+              Click a cell to view the sessions from that day and hour (UTC). Keyboard: tab to the
+              grid, arrow keys to move, Enter to open.
             </p>
           )}
         </div>
@@ -250,7 +335,7 @@ function HourlyActivityChart({
         const payload = (state as { activePayload?: Array<{ payload?: { hour?: number } }> })
           ?.activePayload?.[0]?.payload
         const hour = payload?.hour
-        if (typeof hour === 'number' && data[hour]?.sessions > 0) onBarClick(hour)
+        if (typeof hour === 'number' && data.find(d => d.hour === hour)?.sessions) onBarClick(hour)
       }
     : undefined
 
@@ -293,7 +378,7 @@ function HourlyActivityChart({
       </ResponsiveContainer>
       {onBarClick && (
         <p className="text-[11px] text-zinc-400 dark:text-zinc-500 mt-1.5">
-          Click a bar to view the sessions from that hour.
+          Click a bar to view the sessions from that hour (UTC).
         </p>
       )}
     </ChartCard>
@@ -366,9 +451,10 @@ export default function GeneralUsagePage() {
         dayOfWeek === null
           ? hourlyBarTarget(from, to, hour)
           : heatmapCellTarget(from, to, dayOfWeek, hour)
-      if (target && target.windows.length > 0) navigate(drilldownUrl(target))
+      if (target && target.windows.length > 0)
+        navigate(drilldownUrl(target, project === 'all' ? undefined : project))
     },
-    [from, to, navigate],
+    [from, to, project, navigate],
   )
 
   const summary: AnalyticsSummary = report?.summary ?? {

--- a/frontend/src/pages/GeneralUsagePage.tsx
+++ b/frontend/src/pages/GeneralUsagePage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
 import {
   AreaChart,
   Area,
@@ -13,6 +14,7 @@ import {
   ResponsiveContainer,
 } from 'recharts'
 import { analyticsApi } from '@/lib/api'
+import { drilldownUrl, heatmapCellTarget, hourlyBarTarget } from '@/lib/drilldown'
 import type {
   AnalyticsReport,
   AnalyticsSummary,
@@ -114,11 +116,65 @@ function SessionsPerModelChart({ data }: Readonly<{ data: ModelSessionStat[] }>)
   )
 }
 
-function ActivityHeatmap({ data }: Readonly<{ data: HeatmapCell[] }>) {
-  const grid: number[][] = Array.from({ length: 7 }, () => new Array(24).fill(0))
+function heatmapCellBg(intensity: number): string {
+  if (intensity === 0) return 'bg-zinc-100 dark:bg-zinc-800'
+  if (intensity < 0.25) return 'bg-indigo-200 dark:bg-indigo-900/60'
+  if (intensity < 0.5) return 'bg-indigo-400 dark:bg-indigo-700'
+  if (intensity < 0.75) return 'bg-indigo-600 dark:bg-indigo-500'
+  return 'bg-indigo-800 dark:bg-indigo-400'
+}
+
+function HeatmapGridCell({
+  day,
+  dow,
+  hour,
+  cell,
+  maxSessions,
+  onCellClick,
+}: Readonly<{
+  day: string
+  dow: number
+  hour: number
+  cell: HeatmapCell | undefined
+  maxSessions: number
+  onCellClick?: (dayOfWeek: number, hour: number) => void
+}>) {
+  const intensity = maxSessions > 0 ? (cell?.sessions ?? 0) / maxSessions : 0
+  const clickable = !!onCellClick && !!cell
+  const handleKeyDown = clickable
+    ? (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onCellClick(dow, hour)
+        }
+      }
+    : undefined
+  return (
+    <div
+      role={clickable ? 'button' : undefined}
+      tabIndex={clickable ? 0 : undefined}
+      onClick={clickable ? () => onCellClick(dow, hour) : undefined}
+      onKeyDown={handleKeyDown}
+      className={`flex-1 aspect-square rounded-[2px] mx-px ${heatmapCellBg(intensity)} ${
+        clickable
+          ? 'cursor-pointer hover:ring-1 hover:ring-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500'
+          : 'cursor-default'
+      }`}
+      title={
+        cell
+          ? `${day} ${hour}:00 — ${cell.sessions} sessions, ${formatTokens(cell.tokens)} tokens — click to view sessions`
+          : `${day} ${hour}:00 — no activity`
+      }
+    />
+  )
+}
+
+function ActivityHeatmap({
+  data,
+  onCellClick,
+}: Readonly<{ data: HeatmapCell[]; onCellClick?: (dayOfWeek: number, hour: number) => void }>) {
   let maxSessions = 0
   for (const cell of data) {
-    grid[cell.day_of_week][cell.hour] = cell.sessions
     if (cell.sessions > maxSessions) maxSessions = cell.sessions
   }
 
@@ -145,31 +201,17 @@ function ActivityHeatmap({ data }: Readonly<{ data: HeatmapCell[] }>) {
               <span className="w-8 text-[12px] text-zinc-400 dark:text-zinc-500 shrink-0">
                 {day}
               </span>
-              {Array.from({ length: 24 }, (_, h) => {
-                const cell = cellMap.get(`${dow}-${h}`)
-                const intensity = maxSessions > 0 ? (cell?.sessions ?? 0) / maxSessions : 0
-                let bg = 'bg-indigo-800 dark:bg-indigo-400'
-                if (intensity === 0) {
-                  bg = 'bg-zinc-100 dark:bg-zinc-800'
-                } else if (intensity < 0.25) {
-                  bg = 'bg-indigo-200 dark:bg-indigo-900/60'
-                } else if (intensity < 0.5) {
-                  bg = 'bg-indigo-400 dark:bg-indigo-700'
-                } else if (intensity < 0.75) {
-                  bg = 'bg-indigo-600 dark:bg-indigo-500'
-                }
-                return (
-                  <div
-                    key={`cell-${dow}-${h}`}
-                    className={`flex-1 aspect-square rounded-[2px] mx-px ${bg} cursor-default`}
-                    title={
-                      cell
-                        ? `${day} ${h}:00 — ${cell.sessions} sessions, ${formatTokens(cell.tokens)} tokens`
-                        : `${day} ${h}:00 — no activity`
-                    }
-                  />
-                )
-              })}
+              {Array.from({ length: 24 }, (_, h) => (
+                <HeatmapGridCell
+                  key={`cell-${dow}-${h}`}
+                  day={day}
+                  dow={dow}
+                  hour={h}
+                  cell={cellMap.get(`${dow}-${h}`)}
+                  maxSessions={maxSessions}
+                  onCellClick={onCellClick}
+                />
+              ))}
             </div>
           ))}
           {/* Legend */}
@@ -186,17 +228,40 @@ function ActivityHeatmap({ data }: Readonly<{ data: HeatmapCell[] }>) {
             ))}
             <span className="text-[12px] text-zinc-400 dark:text-zinc-500 ml-1">More</span>
           </div>
+          {onCellClick && (
+            <p className="text-[11px] text-zinc-400 dark:text-zinc-500 mt-1.5 ml-8">
+              Click a cell to view the sessions from that day and hour.
+            </p>
+          )}
         </div>
       </div>
     </ChartCard>
   )
 }
 
-function HourlyActivityChart({ data }: Readonly<{ data: HourlyActivity[] }>) {
+function HourlyActivityChart({
+  data,
+  onBarClick,
+}: Readonly<{ data: HourlyActivity[]; onBarClick?: (hour: number) => void }>) {
+  const handleClick = onBarClick
+    ? (state: unknown) => {
+        // Recharts' MouseHandlerDataParam doesn't expose activePayload in its
+        // public type, but BarChart click state carries it at runtime.
+        const payload = (state as { activePayload?: Array<{ payload?: { hour?: number } }> })
+          ?.activePayload?.[0]?.payload
+        const hour = payload?.hour
+        if (typeof hour === 'number' && data[hour]?.sessions > 0) onBarClick(hour)
+      }
+    : undefined
+
   return (
     <ChartCard title="Activity by Hour of Day">
       <ResponsiveContainer width="100%" height={240}>
-        <BarChart data={data} margin={{ top: 4, right: 8, left: 0, bottom: 0 }}>
+        <BarChart
+          data={data}
+          margin={{ top: 4, right: 8, left: 0, bottom: 0 }}
+          onClick={handleClick}
+        >
           <CartesianGrid strokeDasharray="3 3" stroke="#27272a" strokeOpacity={0.5} />
           <XAxis
             dataKey="hour"
@@ -217,9 +282,20 @@ function HourlyActivityChart({ data }: Readonly<{ data: HourlyActivity[] }>) {
             labelFormatter={h => `Hour ${h}:00`}
             contentStyle={{ fontSize: 12, borderRadius: 6 }}
           />
-          <Bar dataKey="sessions" name="Sessions" fill="#22c55e" radius={[2, 2, 0, 0]} />
+          <Bar
+            dataKey="sessions"
+            name="Sessions"
+            fill="#22c55e"
+            radius={[2, 2, 0, 0]}
+            cursor={onBarClick ? 'pointer' : undefined}
+          />
         </BarChart>
       </ResponsiveContainer>
+      {onBarClick && (
+        <p className="text-[11px] text-zinc-400 dark:text-zinc-500 mt-1.5">
+          Click a bar to view the sessions from that hour.
+        </p>
+      )}
     </ChartCard>
   )
 }
@@ -238,6 +314,7 @@ function avgSessionsPerDay(totalSessions: number, fromDate: string, toDate: stri
 // ─── Main Page ────────────────────────────────────────────────────────────────
 
 export default function GeneralUsagePage() {
+  const navigate = useNavigate()
   const [report, setReport] = useState<AnalyticsReport | null>(null)
   const [loading, setLoading] = useState(true)
   const [refreshing, setRefreshing] = useState(false)
@@ -282,6 +359,17 @@ export default function GeneralUsagePage() {
     setRefreshing(true)
     load(from, to, project)
   }
+
+  const drillIntoSessions = useCallback(
+    (dayOfWeek: number | null, hour: number) => {
+      const target =
+        dayOfWeek === null
+          ? hourlyBarTarget(from, to, hour)
+          : heatmapCellTarget(from, to, dayOfWeek, hour)
+      if (target && target.windows.length > 0) navigate(drilldownUrl(target))
+    },
+    [from, to, navigate],
+  )
 
   const summary: AnalyticsSummary = report?.summary ?? {
     total_sessions: 0,
@@ -385,8 +473,14 @@ export default function GeneralUsagePage() {
 
             {/* Heatmap + Hourly */}
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
-              <ActivityHeatmap data={report?.heatmap ?? []} />
-              <HourlyActivityChart data={report?.hourly_activity ?? []} />
+              <ActivityHeatmap
+                data={report?.heatmap ?? []}
+                onCellClick={(dow, hour) => drillIntoSessions(dow, hour)}
+              />
+              <HourlyActivityChart
+                data={report?.hourly_activity ?? []}
+                onBarClick={hour => drillIntoSessions(null, hour)}
+              />
             </div>
           </>
         )}

--- a/frontend/src/pages/GeneralUsagePage.tsx
+++ b/frontend/src/pages/GeneralUsagePage.tsx
@@ -337,14 +337,15 @@ function HourlyActivityChart({
   data,
   onBarClick,
 }: Readonly<{ data: HourlyActivity[]; onBarClick?: (hour: number) => void }>) {
-  const handleClick = onBarClick
-    ? (state: unknown) => {
-        // Recharts' MouseHandlerDataParam doesn't expose activePayload in its
-        // public type, but BarChart click state carries it at runtime.
-        const payload = (state as { activePayload?: Array<{ payload?: { hour?: number } }> })
-          ?.activePayload?.[0]?.payload
-        const hour = payload?.hour
-        if (typeof hour === 'number' && data.find(d => d.hour === hour)?.sessions) onBarClick(hour)
+  // Per-bar click handler: recharts 3 does not reliably populate activePayload
+  // in chart-level onClick state, but Bar's own onClick receives the bar's
+  // data entry directly.
+  const handleBarClick = onBarClick
+    ? (entry: unknown) => {
+        const hour = (entry as { hour?: unknown })?.hour
+        if (typeof hour === 'number' && data.find(d => d.hour === hour)?.sessions) {
+          onBarClick(hour)
+        }
       }
     : undefined
 
@@ -354,7 +355,7 @@ function HourlyActivityChart({
         <BarChart
           data={data}
           margin={{ top: 4, right: 8, left: 0, bottom: 0 }}
-          onClick={handleClick}
+          style={onBarClick ? { userSelect: 'none' } : undefined}
         >
           <CartesianGrid strokeDasharray="3 3" stroke="#27272a" strokeOpacity={0.5} />
           <XAxis
@@ -382,6 +383,7 @@ function HourlyActivityChart({
             fill="#22c55e"
             radius={[2, 2, 0, 0]}
             cursor={onBarClick ? 'pointer' : undefined}
+            onClick={handleBarClick}
           />
         </BarChart>
       </ResponsiveContainer>

--- a/frontend/src/pages/GeneralUsagePage.tsx
+++ b/frontend/src/pages/GeneralUsagePage.tsx
@@ -14,7 +14,13 @@ import {
   ResponsiveContainer,
 } from 'recharts'
 import { analyticsApi } from '@/lib/api'
-import { drilldownUrl, heatmapCellTarget, hourlyBarTarget, parseRangeBounds, MAX_DRILLDOWN_DAYS } from '@/lib/drilldown'
+import {
+  drilldownUrl,
+  heatmapCellTarget,
+  hourlyBarTarget,
+  parseRangeBounds,
+  MAX_DRILLDOWN_DAYS,
+} from '@/lib/drilldown'
 import type {
   AnalyticsReport,
   AnalyticsSummary,
@@ -149,7 +155,11 @@ function StaticHeatmapCell({ day, hour, cell, maxSessions }: Readonly<HeatmapCel
   return (
     <div
       className={`flex-1 aspect-square rounded-[2px] mx-px ${heatmapCellBg(intensity)} cursor-default`}
-      title={cell ? cellTitle(day, hour, cell).replace(' — click to view sessions', '') : `${day} ${hour}:00 — no activity`}
+      title={
+        cell
+          ? cellTitle(day, hour, cell).replace(' — click to view sessions', '')
+          : `${day} ${hour}:00 — no activity`
+      }
     />
   )
 }
@@ -217,12 +227,7 @@ function HeatmapGridCell({
   }
 >) {
   if (!interactive) return <StaticHeatmapCell {...props} />
-  return (
-    <InteractiveHeatmapCell
-      {...props}
-      onCellClick={props.onCellClick ?? (() => {})}
-    />
-  )
+  return <InteractiveHeatmapCell {...props} onCellClick={props.onCellClick ?? (() => {})} />
 }
 
 function ActivityHeatmap({
@@ -256,7 +261,11 @@ function ActivityHeatmap({
   return (
     <ChartCard title="Activity Heatmap (Day × Hour)">
       <div className="overflow-x-auto">
-        <div className="min-w-[560px]" role={interactive ? 'grid' : undefined} aria-label={interactive ? 'Activity by day and hour' : undefined}>
+        <div
+          className="min-w-[560px]"
+          role={interactive ? 'grid' : undefined}
+          aria-label={interactive ? 'Activity by day and hour' : undefined}
+        >
           {/* Hour labels */}
           <div className="flex ml-8 mb-1" role={interactive ? 'presentation' : undefined}>
             {Array.from({ length: 24 }, (_, h) => (


### PR DESCRIPTION
## What

Clicking a heatmap cell or an "Activity by Hour of Day" bar on **Analytics → General Usage** now navigates to **Claude Sessions** pre-filtered to the sessions active during that day/hour bucket within the currently selected analytics date range.

Solves: "I see a spike on Tuesdays at 14:00 — which sessions were those?" without manual cross-referencing.

## How

- **`frontend/src/lib/drilldown.ts`** (new): expands a clicked bucket — (weekday, hour) or hour-of-day — into the concrete 1-hour windows inside the analytics `from`/`to` range (local time, matching the backend's bucketing timezone), serializes them into a compact `?windows=from-to,from-to,…` URL param, and overlap-matches each session's `[start_time, last_activity]` window.
- **GeneralUsagePage**: heatmap cells with sessions are clickable (cursor, hover ring, keyboard `Enter`/`Space` accessible, tooltip hint); hourly bars are clickable with pointer cursor; both show hint text.
- **ClaudeSessionsPage**: reads `windows`/`label` search params → filters by window overlap, shows a dismissible indigo banner ("Showing sessions active Tuesdays 14:00–15:00 · 2026-07-08 → 2026-08-07 — N matches · Clear"), and disables the conflicting time-preset dropdown while a drill-down is active. URL is bookmarkable/shareable and browser back works.

## Semantics note

Charts bucket by a session's *last activity*; the drill-down filters by *overlap* (any session active during those hours) — slightly broader and more useful for "what was I working on then". The banner copy states "active" to make this honest.

## Testing

- 18 new unit tests (`drilldown.test.ts`): window expansion across multi-week ranges, DST-safe hour walking, URL encode/decode round-trip, malformed-param resilience, overlap edge cases.
- `tsc --noEmit` clean, ESLint clean (0 errors), `vite build` succeeds. Pre-existing `streamingBlocks.test.ts` failures on main are unrelated (verified via stash).

Frontend-only; no backend or API changes.