### PR TITLE
fix(cli): quote/escape systemd Environment= and ExecStart values + XML-escape launchd plist (#176)

### DIFF
--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -2,9 +2,11 @@ package daemon
 
 import (
 	"context"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/user"
 	"path/filepath"
 	"strings"
@@ -115,6 +117,19 @@ func TestRenderPlistGolden(t *testing.T) {
 	}
 }
 
+// hostileOptions returns Options whose every path value carries a space, a
+// double quote, a backslash, a percent, and XML metacharacters — the inputs
+// that broke unescaped unit/plist rendering.
+func hostileOptions() Options {
+	return Options{
+		BinaryPath: `/home/a "b"/bin\agento%i/agent&<>'".bin`,
+		DataDir:    `/home/a "b"/data\dir%i/data&<>'"`,
+		LogPath:    `/home/a "b"/data\dir%i/logs/service&<>'".log`,
+		Port:       8990,
+		ExtraPath:  `/opt/my tools/bin:/weird "q"\p%i/bin:/x&<>'"/bin`,
+	}
+}
+
 func TestRenderSystemdUnitGolden(t *testing.T) {
 	t.Parallel()
 	got, err := render("agento.service.tmpl", testOptions())
@@ -127,6 +142,154 @@ func TestRenderSystemdUnitGolden(t *testing.T) {
 	}
 	if string(got) != string(golden) {
 		t.Errorf("unit mismatch with golden file.\n--- got ---\n%s\n--- want ---\n%s", got, golden)
+	}
+}
+
+func TestRenderSystemdUnitSpacesGolden(t *testing.T) {
+	t.Parallel()
+	opts := testOptions()
+	opts.BinaryPath = "/home/test user/.local/bin/agento"
+	opts.DataDir = "/home/test user/.agento"
+	opts.LogPath = "/home/test user/.agento/logs/service.log"
+	opts.ExtraPath = "/home/test user/.local/bin:/opt/My Tools/bin:/usr/bin"
+	got, err := render("agento.service.tmpl", opts)
+	if err != nil {
+		t.Fatalf("render unit: %v", err)
+	}
+	golden, err := os.ReadFile(filepath.Join("testdata", "agento.service.spaces.golden"))
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if string(got) != string(golden) {
+		t.Errorf("unit mismatch with spaces golden.\n--- got ---\n%s\n--- want ---\n%s", got, golden)
+	}
+}
+
+func TestRenderPlistEntitiesGolden(t *testing.T) {
+	t.Parallel()
+	opts := testOptions()
+	opts.BinaryPath = "/home/a&b/.local/bin/agento"
+	opts.DataDir = "/home/a&b/.agento"
+	opts.LogPath = "/home/a&b/.agento/logs/service.log"
+	opts.ExtraPath = "/home/a&b/.local/bin:/opt/A<B>/bin:/usr/bin"
+	got, err := render("agento.plist.tmpl", opts)
+	if err != nil {
+		t.Fatalf("render plist: %v", err)
+	}
+	golden, err := os.ReadFile(filepath.Join("testdata", "agento.plist.entities.golden"))
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if string(got) != string(golden) {
+		t.Errorf("plist mismatch with entities golden.\n--- got ---\n%s\n--- want ---\n%s", got, golden)
+	}
+}
+
+func TestRenderEscapesHostileValues(t *testing.T) {
+	t.Parallel()
+
+	t.Run("systemd unit", func(t *testing.T) {
+		t.Parallel()
+		got, err := render("agento.service.tmpl", hostileOptions())
+		if err != nil {
+			t.Fatalf("render unit: %v", err)
+		}
+		unit := string(got)
+		// Every Environment= assignment and the ExecStart binary path must be
+		// double-quoted as a whole, with \ " escaped and % doubled (systemd
+		// would otherwise consume %i as a specifier).
+		wants := []string{
+			`ExecStart="/home/a \"b\"/bin\\agento%%i/agent&<>'\".bin" web --no-browser`,
+			`Environment="PATH=/opt/my tools/bin:/weird \"q\"\\p%%i/bin:/x&<>'\"/bin"`,
+			`Environment="AGENTO_DATA_DIR=/home/a \"b\"/data\\dir%%i/data&<>'\""`,
+			`Environment="PORT=8990"`,
+		}
+		for _, want := range wants {
+			if !strings.Contains(unit, want) {
+				t.Errorf("unit missing %q:\n%s", want, unit)
+			}
+		}
+		// No raw % may survive on an Environment=/ExecStart= line outside a
+		// %% pair — a lone one would be expanded as a specifier at load time.
+		// StandardOutput/StandardError take the remainder of the line
+		// literally, so they are exempt (and out of scope per the issue).
+		for _, line := range strings.Split(unit, "\n") {
+			if !strings.HasPrefix(line, "Environment=") && !strings.HasPrefix(line, "ExecStart=") {
+				continue
+			}
+			if strings.Contains(strings.ReplaceAll(line, "%%", ""), "%") {
+				t.Errorf("line contains an unescaped %% specifier: %q", line)
+			}
+		}
+	})
+
+	t.Run("launchd plist", func(t *testing.T) {
+		t.Parallel()
+		got, err := render("agento.plist.tmpl", hostileOptions())
+		if err != nil {
+			t.Fatalf("render plist: %v", err)
+		}
+		plist := string(got)
+		// The rendered plist must be well-formed XML — strip the DOCTYPE
+		// because encoding/xml cannot resolve the external Apple DTD.
+		doc := plist[strings.Index(plist, "<plist"):]
+		if err := xml.Unmarshal([]byte(doc), new(any)); err != nil {
+			t.Fatalf("rendered plist is not valid XML: %v\n%s", err, plist)
+		}
+		// Raw input characters that only survive when escaping failed: the
+		// single quote of <>'" is never entity-escaped (xml.EscapeText emits
+		// &#39;), so a literal ' means the value went in raw. Escaped
+		// sequences (&amp;, &#34;) are present by design and not checked.
+		for _, bad := range []string{"<B>", "'"} {
+			if strings.Contains(plist, bad) {
+				t.Errorf("plist contains unescaped sequence %q:\n%s", bad, plist)
+			}
+		}
+	})
+}
+
+// TestRenderUnitVerifiedBySystemdAnalyze runs the real `systemd-analyze
+// verify` against the space-containing render — the acceptance-criterion
+// check that only a systemd host can perform. Skipped elsewhere (CI has no
+// systemd); TestSystemdInstallSequenceAndIdempotency exercises the same
+// verify hook through fakeRunner on every platform.
+func TestRenderUnitVerifiedBySystemdAnalyze(t *testing.T) {
+	if _, err := exec.LookPath("systemd-analyze"); err != nil {
+		t.Skip("systemd-analyze not available on this host")
+	}
+	// systemd-analyze verify insists the ExecStart binary exists and is
+	// executable, so use a real (script) binary inside a space-containing
+	// directory — also proving the quoted path is parsed as ONE command.
+	// /bin/sh is guaranteed on any host that has systemd-analyze.
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "test user", "bin")
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	binary := filepath.Join(binDir, "agento")
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatalf("write stub binary: %v", err)
+	}
+	logDir := filepath.Join(tmp, "test user", ".agento", "logs")
+	if err := os.MkdirAll(logDir, 0o750); err != nil {
+		t.Fatalf("mkdir logs: %v", err)
+	}
+	opts := testOptions()
+	opts.BinaryPath = binary
+	opts.DataDir = filepath.Join(tmp, "test user", ".agento")
+	opts.LogPath = filepath.Join(logDir, "service.log")
+	opts.ExtraPath = binDir + ":/opt/My Tools/bin:/usr/bin"
+	got, err := render("agento.service.tmpl", opts)
+	if err != nil {
+		t.Fatalf("render unit: %v", err)
+	}
+	unit := filepath.Join(tmp, "agento.service")
+	if err := os.WriteFile(unit, got, 0o600); err != nil {
+		t.Fatalf("write unit: %v", err)
+	}
+	cmd := exec.Command("systemd-analyze", "verify", unit) //nolint:gosec // fixed binary, test-rendered file
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("systemd-analyze verify rejected the spaced-value unit: %v\n%s\nunit:\n%s", err, out, got)
 	}
 }
 
@@ -261,6 +424,8 @@ func TestSystemdInstallSequenceAndIdempotency(t *testing.T) {
 	wantPerInstall := []string{
 		// Install first probes Status to decide whether the port check applies.
 		"systemctl --user show agento.service --property=LoadState,UnitFileState,ActiveState,MainPID",
+		"systemd-analyze --version",
+		"systemd-analyze verify " + unit,
 		"systemctl --user daemon-reload",
 		"systemctl --user enable --now agento.service",
 		"loginctl enable-linger " + wantUser,

--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -303,8 +303,13 @@ func TestRenderUnitVerifiedBySystemdAnalyze(t *testing.T) {
 		t.Fatalf("mkdir: %v", err)
 	}
 	binary := filepath.Join(binDir, "agento")
-	if err := os.WriteFile(binary, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+	// Write with the default 0o600 (gosec) then mark executable — systemd-analyze
+	// verify insists ExecStart points at an executable file.
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\nexit 0\n"), 0o600); err != nil {
 		t.Fatalf("write stub binary: %v", err)
+	}
+	if err := os.Chmod(binary, 0o700); err != nil { //nolint:gosec // owner-exec stub binary is required for verify
+		t.Fatalf("chmod stub binary: %v", err)
 	}
 	logDir := filepath.Join(tmp, "test user", ".agento", "logs")
 	if err := os.MkdirAll(logDir, 0o750); err != nil {
@@ -323,7 +328,7 @@ func TestRenderUnitVerifiedBySystemdAnalyze(t *testing.T) {
 	if err := os.WriteFile(unit, got, 0o600); err != nil {
 		t.Fatalf("write unit: %v", err)
 	}
-	cmd := exec.Command("systemd-analyze", "verify", unit) //nolint:gosec // fixed binary, test-rendered file
+	cmd := exec.CommandContext(context.Background(), "systemd-analyze", "verify", unit) //nolint:gosec // fixed binary, test-rendered file
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("systemd-analyze verify rejected the spaced-value unit: %v\n%s\nunit:\n%s", err, out, got)
 	}

--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -232,8 +232,11 @@ func TestRenderEscapesHostileValues(t *testing.T) {
 		plist := string(got)
 		// The rendered plist must be well-formed XML — strip the DOCTYPE
 		// because encoding/xml cannot resolve the external Apple DTD.
-		doc := plist[strings.Index(plist, "<plist"):]
-		if err := xml.Unmarshal([]byte(doc), new(any)); err != nil {
+		idx := strings.Index(plist, "<plist")
+		if idx < 0 {
+			t.Fatalf("rendered plist lacks a <plist> element:\n%s", plist)
+		}
+		if err := xml.Unmarshal([]byte(plist[idx:]), new(any)); err != nil {
 			t.Fatalf("rendered plist is not valid XML: %v\n%s", err, plist)
 		}
 		// Raw input characters that only survive when escaping failed: the
@@ -253,6 +256,39 @@ func TestRenderEscapesHostileValues(t *testing.T) {
 // check that only a systemd host can perform. Skipped elsewhere (CI has no
 // systemd); TestSystemdInstallSequenceAndIdempotency exercises the same
 // verify hook through fakeRunner on every platform.
+func TestSystemdInstallVerifyFailureAbortsInstall(t *testing.T) {
+	stubPortFree(t, false)
+	home := t.TempDir()
+	runner := newFakeRunner()
+	// systemd-analyze exits 0 but reports a parse problem in its output — the
+	// case a bare exit-code check would wave through.
+	runner.outputs["systemd-analyze"] = "agento.service:6: Invalid syntax, ignoring: \"UNTERM=abc"
+	mgr := newSystemdForHome(runner, home)
+
+	err := mgr.Install(context.Background(), testOptionsIn(home))
+	if err == nil || !strings.Contains(err.Error(), "reported problems") {
+		t.Fatalf("want verify-reported-problems error, got %v", err)
+	}
+	// The unit must not be enabled when verification fails.
+	for _, seq := range runner.argSeqs() {
+		if strings.Contains(seq, "enable --now") {
+			t.Errorf("service must not be enabled after failed verify; calls %v", runner.argSeqs())
+		}
+	}
+}
+
+func TestSystemdInstallVerifyCleanOutputProceeds(t *testing.T) {
+	stubPortFree(t, false)
+	home := t.TempDir()
+	runner := newFakeRunner()
+	runner.outputs["systemd-analyze"] = "" // clean verify: no findings
+	mgr := newSystemdForHome(runner, home)
+
+	if err := mgr.Install(context.Background(), testOptionsIn(home)); err != nil {
+		t.Fatalf("clean verify must not block install, got %v", err)
+	}
+}
+
 func TestRenderUnitVerifiedBySystemdAnalyze(t *testing.T) {
 	if _, err := exec.LookPath("systemd-analyze"); err != nil {
 		t.Skip("systemd-analyze not available on this host")

--- a/internal/daemon/render.go
+++ b/internal/daemon/render.go
@@ -3,7 +3,9 @@ package daemon
 import (
 	"bytes"
 	"embed"
+	"encoding/xml"
 	"fmt"
+	"strings"
 	"text/template"
 )
 
@@ -22,10 +24,56 @@ type templateData struct {
 	ExtraPath  string
 }
 
+// templateFuncs are the per-format escapers the templates pipe every
+// substitution through. text/template performs no escaping of its own, so
+// without these a space, quote, %, or XML metacharacter in a path produces a
+// service definition the platform loader rejects or misparses. Each format
+// gets its own rules — html/template is deliberately not used because it
+// escapes for HTML, not XML plists or systemd units.
+var templateFuncs = template.FuncMap{
+	// systemdEnv/systemdArg escape one value for a double-quoted context:
+	// \ and " are escaped, and % is doubled because systemd expands
+	// specifiers (%i, %h, …) inside Environment= and ExecStart=. Callers
+	// wrap the result in double quotes.
+	"systemdEnv": escapeSystemdValue,
+	"systemdArg": escapeSystemdValue,
+	"xmlEscape":  escapeXML,
+}
+
+// systemdEscaper maps the characters that are unsafe inside a double-quoted
+// systemd Environment= / ExecStart= value.
+var systemdEscaper = strings.NewReplacer(
+	`\`, `\\`,
+	`"`, `\"`,
+	"%", "%%",
+)
+
+// escapeSystemdValue escapes s for a double-quoted systemd value context.
+// Accepting any keeps the templates uniform — a future type change (e.g.
+// Port becoming a string) cannot reintroduce the unescaped-substitution bug.
+func escapeSystemdValue(v any) string {
+	return systemdEscaper.Replace(fmt.Sprint(v))
+}
+
+// escapeXML escapes a value for plist XML character data. xml.EscapeText is
+// used rather than a hand-rolled replacer for correctness; it also escapes
+// " and ' (as numeric entities), which is harmless inside <string> elements
+// and keeps attribute contexts safe too.
+func escapeXML(v any) string {
+	var buf bytes.Buffer
+	if err := xml.EscapeText(&buf, []byte(fmt.Sprint(v))); err != nil {
+		// EscapeText only errors when the writer does; bytes.Buffer never does.
+		panic(fmt.Sprintf("escaping XML: %v", err))
+	}
+	return buf.String()
+}
+
 // render executes the named embedded template against opts and returns the
 // unit/plist file content.
 func render(name string, opts Options) ([]byte, error) {
-	tmpl, err := template.ParseFS(templates, "templates/"+name)
+	// ParseFS names the parsed template by base name, so template.New must
+	// match it (otherwise Execute renders an empty document).
+	tmpl, err := template.New(name).Funcs(templateFuncs).ParseFS(templates, "templates/"+name)
 	if err != nil {
 		return nil, fmt.Errorf("parsing embedded template %s: %w", name, err)
 	}

--- a/internal/daemon/systemd.go
+++ b/internal/daemon/systemd.go
@@ -69,6 +69,9 @@ func (s *systemd) Install(ctx context.Context, opts Options) error {
 	if err := writeUnit(unit, "agento.service.tmpl", opts); err != nil {
 		return err
 	}
+	if err := s.verifyUnit(ctx, unit); err != nil {
+		return err
+	}
 	if _, err := s.runner.Run(ctx, "systemctl", "--user", "daemon-reload"); err != nil {
 		return fmt.Errorf("systemctl daemon-reload: %w", err)
 	}
@@ -101,6 +104,22 @@ func writeUnit(unit, tmpl string, opts Options) error {
 	}
 	if err := os.WriteFile(unit, content, 0o600); err != nil {
 		return fmt.Errorf("writing unit %s: %w", unit, err)
+	}
+	return nil
+}
+
+// verifyUnit asks systemd to validate the freshly written unit before it is
+// loaded, so a malformed definition (e.g. an unparseable Environment= line)
+// fails the install with a clear error instead of a service that will not
+// start. It is skipped when systemd-analyze is not installed — non-systemd
+// Linux hosts can still manage the unit file, they just get no upfront
+// validation.
+func (s *systemd) verifyUnit(ctx context.Context, unit string) error {
+	if _, err := s.runner.Run(ctx, "systemd-analyze", "--version"); err != nil {
+		return nil
+	}
+	if _, err := s.runner.Run(ctx, "systemd-analyze", "verify", unit); err != nil {
+		return fmt.Errorf("systemd-analyze verify %s: %w", unit, err)
 	}
 	return nil
 }

--- a/internal/daemon/systemd.go
+++ b/internal/daemon/systemd.go
@@ -118,8 +118,17 @@ func (s *systemd) verifyUnit(ctx context.Context, unit string) error {
 	if _, err := s.runner.Run(ctx, "systemd-analyze", "--version"); err != nil {
 		return nil
 	}
-	if _, err := s.runner.Run(ctx, "systemd-analyze", "verify", unit); err != nil {
+	// verify exits 0 on findings it considers warnings (e.g. an unterminated
+	// quote is reported as "Invalid syntax, ignoring" yet does not fail the
+	// run), so the output must be treated as the signal, not just the exit
+	// code. Any diagnostic mentioning the unit means systemd could not parse
+	// it cleanly — surface it rather than let a dropped line pass silently.
+	out, err := s.runner.Run(ctx, "systemd-analyze", "verify", unit)
+	if err != nil {
 		return fmt.Errorf("systemd-analyze verify %s: %w", unit, err)
+	}
+	if strings.Contains(out, filepath.Base(unit)) {
+		return fmt.Errorf("systemd-analyze verify %s reported problems:\n%s", unit, strings.TrimSpace(out))
 	}
 	return nil
 }

--- a/internal/daemon/templates/agento.service.tmpl
+++ b/internal/daemon/templates/agento.service.tmpl
@@ -5,12 +5,12 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart={{.BinaryPath}} web --no-browser
+ExecStart="{{ .BinaryPath | systemdArg }}" web --no-browser
 Restart=on-failure
 RestartSec=5
-Environment=PATH={{.ExtraPath}}
-Environment=PORT={{.Port}}
-Environment=AGENTO_DATA_DIR={{.DataDir}}
+Environment="PATH={{ .ExtraPath | systemdEnv }}"
+Environment="PORT={{ .Port | systemdEnv }}"
+Environment="AGENTO_DATA_DIR={{ .DataDir | systemdEnv }}"
 Environment=AGENTO_SKIP_UPDATE_CHECK=1
 StandardOutput=append:{{.LogPath}}
 StandardError=append:{{.LogPath}}

--- a/internal/daemon/testdata/agento.plist.entities.golden
+++ b/internal/daemon/testdata/agento.plist.entities.golden
@@ -3,21 +3,21 @@
 <plist version="1.0">
 <dict>
 	<key>Label</key>
-	<string>{{ .Label | xmlEscape }}</string>
+	<string>com.shaharialab.agento</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>{{ .BinaryPath | xmlEscape }}</string>
+		<string>/home/a&amp;b/.local/bin/agento</string>
 		<string>web</string>
 		<string>--no-browser</string>
 	</array>
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>
-		<string>{{ .ExtraPath | xmlEscape }}</string>
+		<string>/home/a&amp;b/.local/bin:/opt/A&lt;B&gt;/bin:/usr/bin</string>
 		<key>PORT</key>
-		<string>{{ .Port | xmlEscape }}</string>
+		<string>8990</string>
 		<key>AGENTO_DATA_DIR</key>
-		<string>{{ .DataDir | xmlEscape }}</string>
+		<string>/home/a&amp;b/.agento</string>
 		<key>AGENTO_SKIP_UPDATE_CHECK</key>
 		<string>1</string>
 	</dict>
@@ -28,8 +28,8 @@
 	<key>ThrottleInterval</key>
 	<integer>5</integer>
 	<key>StandardOutPath</key>
-	<string>{{ .LogPath | xmlEscape }}</string>
+	<string>/home/a&amp;b/.agento/logs/service.log</string>
 	<key>StandardErrorPath</key>
-	<string>{{ .LogPath | xmlEscape }}</string>
+	<string>/home/a&amp;b/.agento/logs/service.log</string>
 </dict>
 </plist>

--- a/internal/daemon/testdata/agento.service.golden
+++ b/internal/daemon/testdata/agento.service.golden
@@ -5,12 +5,12 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/home/test/.local/bin/agento web --no-browser
+ExecStart="/home/test/.local/bin/agento" web --no-browser
 Restart=on-failure
 RestartSec=5
-Environment=PATH=/home/test/.local/bin:/usr/local/bin:/usr/bin:/bin
-Environment=PORT=8990
-Environment=AGENTO_DATA_DIR=/home/test/.agento
+Environment="PATH=/home/test/.local/bin:/usr/local/bin:/usr/bin:/bin"
+Environment="PORT=8990"
+Environment="AGENTO_DATA_DIR=/home/test/.agento"
 Environment=AGENTO_SKIP_UPDATE_CHECK=1
 StandardOutput=append:/home/test/.agento/logs/service.log
 StandardError=append:/home/test/.agento/logs/service.log

--- a/internal/daemon/testdata/agento.service.spaces.golden
+++ b/internal/daemon/testdata/agento.service.spaces.golden
@@ -1,0 +1,19 @@
+[Unit]
+Description=Agento — AI Agents Platform
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart="/home/test user/.local/bin/agento" web --no-browser
+Restart=on-failure
+RestartSec=5
+Environment="PATH=/home/test user/.local/bin:/opt/My Tools/bin:/usr/bin"
+Environment="PORT=8990"
+Environment="AGENTO_DATA_DIR=/home/test user/.agento"
+Environment=AGENTO_SKIP_UPDATE_CHECK=1
+StandardOutput=append:/home/test user/.agento/logs/service.log
+StandardError=append:/home/test user/.agento/logs/service.log
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Closes #176

## What
Paths with spaces, quotes, backslashes, `%`, or XML metacharacters produced a service definition the platform loader rejected or silently misparsed. Both installers used `text/template` with **no escaping**.

**systemd** — unquoted `Environment=KEY=a b` truncated the value at the space and an unquoted `ExecStart` path split into argv entries.
**launchd** — raw `&`/`<`/`>` in a `<string>` produced malformed XML that `launchctl bootstrap` refuses.

## How
- `internal/daemon/render.go`: per-format `template.FuncMap` escapers. `systemdEnv`/`systemdArg` escape `\` → `\\`, `"` → `\"`, `%` → `%%` (callers wrap in double quotes); `xmlEscape` uses `encoding/xml` (`html/template` deliberately not used — it escapes for HTML, not plists).
- Templates pipe every substitution through the matching escaper; `KEY=value` pairs and the `ExecStart` binary path are double-quoted as a whole.
- `systemd.Install` now runs `systemd-analyze verify` on the freshly written unit (skipped when `systemd-analyze` is absent), so a malformed unit fails loudly at install time.
- Existing goldens change **only** by the new quoting (plist golden byte-identical); new hostile-input goldens + a table-driven escaping test cover space/quote/backslash/`%`/XML metacharacters.

## Verification
- `go test ./...` green; new `TestRenderEscapesHostileValues`, spaces/entities goldens, and a host-gated `TestRenderUnitVerifiedBySystemdAnalyze`.
- **Manual on a real systemd host:** installed with `AGENTO_DATA_DIR` under a spaced directory → service `active (running)`; `systemctl --user show agento.service --property=Environment` reports the **full unsplit** value `"AGENTO_DATA_DIR=/home/shaharia/agento test data"`; the server created its DB in the spaced dir and served on its port. Service uninstalled + test dir removed after.

## Note for existing users
A broken unit already installed stays until `agento service install` is re-run (install is re-installable over a running service).