### PR TITLE
feat(cli): restart a managed service after agento update (#177)

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,8 +431,15 @@ Usage:
   agento update [flags]
 
 Flags:
-  -y, --yes    Skip confirmation prompt
+  -y, --yes          Skip confirmation prompt
+      --no-restart   Do not restart a managed agento service after updating
 ```
+
+If Agento is installed as a background service (`agento service install`) and
+running, `agento update` restarts it automatically after a successful update so
+the new version takes effect — no manual `agento service restart` needed. Pass
+`--no-restart` to leave the running service on the old version until you restart
+it yourself.
 
 </details>
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/shaharia-lab/agento/internal/build"
 	"github.com/shaharia-lab/agento/internal/config"
+	"github.com/shaharia-lab/agento/internal/daemon"
 	"github.com/shaharia-lab/agento/internal/updater"
 )
 
@@ -21,21 +22,27 @@ import (
 // cache so the next auto-check can rely on it.
 func NewUpdateCmd(cfg *config.AppConfig) *cobra.Command {
 	var yes bool
+	var noRestart bool
 
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update agento to the latest release",
 		Long:  "Check GitHub releases for a newer version of agento and update the binary in place.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runUpdate(cmd.Context(), cfg, yes)
+			return runUpdate(cmd.Context(), cfg, yes, noRestart)
 		},
 	}
 
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompt")
+	cmd.Flags().BoolVar(&noRestart, "no-restart", false, "Do not restart a managed agento service after updating")
 	return cmd
 }
 
-func runUpdate(ctx context.Context, cfg *config.AppConfig, skipConfirm bool) error {
+// newServiceManager is a seam over daemon.New so tests can substitute a stub
+// Manager without touching a real init system.
+var newServiceManager = daemon.New
+
+func runUpdate(ctx context.Context, cfg *config.AppConfig, skipConfirm, noRestart bool) error {
 	current := strings.TrimPrefix(build.Version, "v")
 	if current == "dev" || current == "unknown" {
 		return fmt.Errorf("cannot update a dev build; install a tagged release first")
@@ -90,10 +97,58 @@ func runUpdate(ctx context.Context, cfg *config.AppConfig, skipConfirm bool) err
 		return fmt.Errorf("updating: %w", err)
 	}
 
-	fmt.Printf("Updated to %s. Restart agento to use the new version.\n", result.LatestVersion)
+	fmt.Printf("Updated to %s.\n", result.LatestVersion)
+	maybeRestartService(ctx, cfg, noRestart)
 
 	// Belt-and-suspenders: ensure stdout is flushed before the process exits in
 	// any embedded environment that may not auto-flush.
 	_ = os.Stdout.Sync() //nolint:errcheck
 	return nil
+}
+
+// maybeRestartService restarts a managed agento service after a successful
+// update so the new binary takes effect without manual intervention. It never
+// influences the command's exit code — the update itself already succeeded, so
+// every outcome here is informational: restarted, installed-but-stopped, no
+// managed service (manual hint), or a non-fatal warning.
+func maybeRestartService(ctx context.Context, cfg *config.AppConfig, noRestart bool) {
+	if noRestart {
+		fmt.Println("Restart agento to use the new version.")
+		return
+	}
+	mgr, err := newServiceManager(cfg)
+	if err != nil {
+		// Unsupported OS (e.g. Windows) or any daemon-layer error: there is no
+		// managed service we can restart — fall back to the manual hint.
+		fmt.Println("Restart agento to use the new version.")
+		return
+	}
+	restarted, status, err := restartManagedService(ctx, mgr)
+	switch {
+	case err != nil:
+		fmt.Printf("warning: restarting the agento service failed (%v) — run 'agento service restart' manually\n", err)
+	case restarted:
+		fmt.Println("Restarted the agento service — the new version is live.")
+	case status.Installed:
+		fmt.Println("The agento service is installed but not running; start it with 'agento service start'.")
+	default:
+		fmt.Println("Restart agento to use the new version.")
+	}
+}
+
+// restartManagedService restarts the managed service when it is both installed
+// and running. It reports the observed Status so the caller can word the
+// outcome; a Status error is returned as-is (treated as non-fatal upstream).
+func restartManagedService(ctx context.Context, mgr daemon.Manager) (restarted bool, status daemon.Status, err error) {
+	status, err = mgr.Status(ctx)
+	if err != nil {
+		return false, status, err
+	}
+	if !status.Installed || !status.Running {
+		return false, status, nil
+	}
+	if err := mgr.Restart(ctx); err != nil {
+		return false, status, err
+	}
+	return true, status, nil
 }

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -1,0 +1,213 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/shaharia-lab/agento/internal/config"
+	"github.com/shaharia-lab/agento/internal/daemon"
+)
+
+// stubManager implements daemon.Manager for update-restart tests, recording
+// whether Restart was invoked and returning canned Status/Restart results.
+type stubManager struct {
+	status      daemon.Status
+	statusErr   error
+	restartErr  error
+	restartHits int
+}
+
+func (m *stubManager) Install(context.Context, daemon.Options) error { return nil }
+func (m *stubManager) Uninstall(context.Context) error               { return nil }
+func (m *stubManager) Start(context.Context) error                   { return nil }
+func (m *stubManager) Stop(context.Context) error                    { return nil }
+
+func (m *stubManager) Restart(context.Context) error {
+	m.restartHits++
+	return m.restartErr
+}
+
+func (m *stubManager) Status(context.Context) (daemon.Status, error) {
+	return m.status, m.statusErr
+}
+
+// TestRestartManagedServiceMatrix drives restartManagedService across the
+// status matrix: only an installed AND running service is restarted, and a
+// Restart error propagates (so the caller can warn) while a Status error is
+// returned for the caller to treat as non-fatal.
+func TestRestartManagedServiceMatrix(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name         string
+		status       daemon.Status
+		statusErr    error
+		restartErr   error
+		wantRestart  bool
+		wantRestarts int
+		wantErr      bool
+	}{
+		{
+			name:         "installed and running restarts",
+			status:       daemon.Status{Installed: true, Running: true, PID: 1234},
+			wantRestart:  true,
+			wantRestarts: 1,
+		},
+		{
+			name:         "installed but stopped is left alone",
+			status:       daemon.Status{Installed: true, Running: false},
+			wantRestart:  false,
+			wantRestarts: 0,
+		},
+		{
+			name:         "not installed is left alone",
+			status:       daemon.Status{Installed: false, Running: false},
+			wantRestart:  false,
+			wantRestarts: 0,
+		},
+		{
+			name:         "restart error propagates",
+			status:       daemon.Status{Installed: true, Running: true, PID: 1234},
+			restartErr:   errors.New("systemctl failed"),
+			wantRestart:  false,
+			wantRestarts: 1,
+			wantErr:      true,
+		},
+		{
+			name:         "status error propagates without restart",
+			status:       daemon.Status{},
+			statusErr:    errors.New("status unavailable"),
+			wantRestart:  false,
+			wantRestarts: 0,
+			wantErr:      true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mgr := &stubManager{status: tc.status, statusErr: tc.statusErr, restartErr: tc.restartErr}
+			restarted, _, err := restartManagedService(context.Background(), mgr)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tc.wantErr)
+			}
+			if restarted != tc.wantRestart {
+				t.Errorf("restarted = %v, want %v", restarted, tc.wantRestart)
+			}
+			if mgr.restartHits != tc.wantRestarts {
+				t.Errorf("Restart called %d times, want %d", mgr.restartHits, tc.wantRestarts)
+			}
+		})
+	}
+}
+
+// TestMaybeRestartServiceUnsupportedOSFallsBackToHint asserts the
+// ErrUnsupportedOS path (e.g. Windows) prints the manual-restart hint and
+// never fails or attempts a restart.
+func TestMaybeRestartServiceUnsupportedOSFallsBackToHint(t *testing.T) {
+	prev := newServiceManager
+	newServiceManager = func(*config.AppConfig) (daemon.Manager, error) {
+		return nil, fmt.Errorf("wrap: %w", daemon.ErrUnsupportedOS)
+	}
+	t.Cleanup(func() { newServiceManager = prev })
+
+	out := captureStdout(t, func() {
+		maybeRestartService(context.Background(), &config.AppConfig{}, false)
+	})
+	if got := out; got != "Restart agento to use the new version.\n" {
+		t.Errorf("got %q, want the manual-restart hint", got)
+	}
+}
+
+// TestMaybeRestartServiceManagerErrorFallsBackToHint covers any non-OS daemon
+// construction failure — same manual hint, no panic, exit code untouched.
+func TestMaybeRestartServiceManagerErrorFallsBackToHint(t *testing.T) {
+	prev := newServiceManager
+	newServiceManager = func(*config.AppConfig) (daemon.Manager, error) {
+		return nil, errors.New("boom")
+	}
+	t.Cleanup(func() { newServiceManager = prev })
+
+	out := captureStdout(t, func() {
+		maybeRestartService(context.Background(), &config.AppConfig{}, false)
+	})
+	if got := out; got != "Restart agento to use the new version.\n" {
+		t.Errorf("got %q, want the manual-restart hint", got)
+	}
+}
+
+// TestMaybeRestartServiceNoRestartSkipsManager asserts --no-restart short-circuits
+// before any manager is even built (no systemctl/launchctl is possible) and
+// prints the manual hint.
+func TestMaybeRestartServiceNoRestartSkipsManager(t *testing.T) {
+	prev := newServiceManager
+	built := false
+	newServiceManager = func(*config.AppConfig) (daemon.Manager, error) {
+		built = true
+		return &stubManager{}, nil
+	}
+	t.Cleanup(func() { newServiceManager = prev })
+
+	out := captureStdout(t, func() {
+		maybeRestartService(context.Background(), &config.AppConfig{}, true)
+	})
+	if built {
+		t.Error("manager must not be built when --no-restart is set")
+	}
+	if got := out; got != "Restart agento to use the new version.\n" {
+		t.Errorf("got %q, want the manual-restart hint", got)
+	}
+}
+
+// TestMaybeRestartServiceMessages checks the user-facing wording for each
+// outcome via a stubbed manager.
+func TestMaybeRestartServiceMessages(t *testing.T) {
+	cases := []struct {
+		name       string
+		mgr        *stubManager
+		wantSubstr string
+	}{
+		{
+			name:       "restarted",
+			mgr:        &stubManager{status: daemon.Status{Installed: true, Running: true, PID: 42}},
+			wantSubstr: "Restarted the agento service — the new version is live.",
+		},
+		{
+			name:       "installed but stopped",
+			mgr:        &stubManager{status: daemon.Status{Installed: true, Running: false}},
+			wantSubstr: "installed but not running",
+		},
+		{
+			name:       "no managed service",
+			mgr:        &stubManager{status: daemon.Status{Installed: false, Running: false}},
+			wantSubstr: "Restart agento to use the new version.",
+		},
+		{
+			name: "restart failure warns",
+			mgr: &stubManager{
+				status:     daemon.Status{Installed: true, Running: true, PID: 42},
+				restartErr: errors.New("kickstart failed"),
+			},
+			wantSubstr: "warning: restarting the agento service failed",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prev := newServiceManager
+			newServiceManager = func(*config.AppConfig) (daemon.Manager, error) { return tc.mgr, nil }
+			t.Cleanup(func() { newServiceManager = prev })
+
+			out := captureStdout(t, func() {
+				maybeRestartService(context.Background(), &config.AppConfig{}, false)
+			})
+			if !strings.Contains(out, tc.wantSubstr) {
+				t.Errorf("output %q missing %q", out, tc.wantSubstr)
+			}
+			// The restart-failure warning must name the actionable command.
+			if tc.mgr.restartErr != nil && !strings.Contains(out, "agento service restart") {
+				t.Errorf("warning %q must point at 'agento service restart'", out)
+			}
+		})
+	}
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -109,6 +109,8 @@ agento update
 
 This checks GitHub for a newer release and replaces the binary in place. Add `--yes` to skip the confirmation prompt.
 
+When Agento runs as a background service (see above), a successful `agento update` also restarts the service so the new version goes live immediately. Use `--no-restart` to skip that and restart it later with `agento service restart`.
+
 ---
 
 ## Version


### PR DESCRIPTION
Closes #177

## What
After a successful `agento update`, detect an installed-and-running managed service and restart it automatically so the new binary takes effect — with `--no-restart` to opt out.

Previously `runUpdate` ended with a flat `Updated to %s. Restart agento to use the new version.`: the on-disk binary was new but the running service kept the old process, so the UI kept reporting the old version — the update looked applied but wasn't.

## How
- `cmd/update.go`: after `updater.Install` succeeds (and past the Homebrew guard), call `maybeRestartService`. It builds the platform `daemon.Manager` (new `newServiceManager` seam over `daemon.New`), swallows `daemon.ErrUnsupportedOS` / any construction error as "no service", and prints one of three outcomes:
  - **restarted** → `Restarted the agento service — the new version is live.`
  - **installed but stopped** → points at `agento service start`
  - **no managed service** → the original `Restart agento to use the new version.`
- `restartManagedService(ctx, mgr daemon.Manager)` restarts only when `Status.Installed && Status.Running`; taking the interface lets tests stub it directly.
- Restart failure prints `warning: … 'agento service restart' manually` and never fails the command — the update already succeeded.
- New `--no-restart` flag short-circuits before any manager is built.
- Auto-update path (`cmd/root.go`) is out of scope per the issue (the service unit sets `AGENTO_SKIP_UPDATE_CHECK=1` anyway).

## Tests
New `cmd/update_test.go`: table-driven matrix over `restartManagedService` (running / stopped / not-installed / restart-error / status-error) plus `maybeRestartService` message and fall-back coverage (`--no-restart`, `ErrUnsupportedOS`, manager-construction error). `go test ./...` green.

## Docs
`README.md` (agento update block) and `docs/getting-started.md` (Update section) now document the auto-restart and `--no-restart`.

## Note
If the running service points at a *different* binary than the one `agento update` replaced (`Options.BinaryPath` is symlink-resolved at install time), the restart is still correct-or-harmless; a mismatch warning is a possible follow-up, not part of this change (per the issue's Risks).