### PR TITLE
fix(analytics): time buckets and date ranges are UTC — show everything in the browser timezone (#190)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,8 @@ One line per package — list files in a directory to see current contents.
 - **`internal/daemon/`** — `agento service` backend: installs and manages Agento as a user-level background service (launchd on macOS, systemd user units on Linux), with embedded unit/plist templates and a `commandRunner` seam for tests.
 - **`internal/build/`** — Version variables injected via `-ldflags`.
 
+**Timezones**: UTC end to end in storage and transport; **aggregation and display follow the browser** (#190). The analytics and insights endpoints take a `tz` IANA name (the frontend sends `Intl.DateTimeFormat().resolvedOptions().timeZone`), and `AnalyticsParams.Loc` is applied via `.In(loc)` before any bucket key is derived — a day, hour or weekday is meaningless until you say whose it is. A bare `YYYY-MM-DD` `from`/`to` is a **local** day boundary (`time.ParseInLocation`), not a UTC one. Missing or unrecognized `tz` falls back to UTC rather than erroring, so pre-`tz` callers are unchanged. `main.go` imports `_ "time/tzdata"` because a distroless container has no `/usr/share/zoneinfo` and every `LoadLocation` would silently degrade the dashboard to UTC. Daily bucket walks (`walkBuckets`) step the **calendar day**, not 24 hours — a local day is 23 or 25 hours across a DST transition, and a fixed step duplicates one key while skipping another. One deliberate UTC exception on the frontend: `formatRateDate` (`lib/pricing.ts`), because a pricing rate is keyed to a day rather than an instant.
+
 **Import rule**: `config` ← `service` ← `api` (never reverse).
 
 ### Frontend

--- a/docs/development.md
+++ b/docs/development.md
@@ -123,3 +123,41 @@ To verify the release config locally (no publish):
 ```bash
 goreleaser release --snapshot --clean
 ```
+
+---
+
+## Timezones
+
+**Storage and transport are UTC, end to end.** Session timestamps are parsed
+from the JSONL `Z` values, cached as UTC, and serialized as UTC on every API
+response. Nothing below the presentation layer knows about the user's zone.
+
+**Aggregation and display follow the browser.** A day, an hour and a weekday
+only mean something once you say whose they are — so the analytics and insights
+endpoints take a `tz` query parameter (an IANA name such as `Europe/Berlin`),
+which the frontend fills in from
+`Intl.DateTimeFormat().resolvedOptions().timeZone`. The backend resolves it and
+applies `.In(loc)` before deriving any bucket key, and interprets a bare
+`YYYY-MM-DD` `from`/`to` as a local day boundary rather than a UTC one.
+
+A missing or unrecognized `tz` falls back to UTC rather than erroring: analytics
+is a read-only dashboard, and refusing to render it over a bad zone string is
+worse than rendering what every caller got before the parameter existed.
+
+Two consequences worth knowing:
+
+- **The zone database is embedded** (`_ "time/tzdata"` in `main.go`). Without
+  it `time.LoadLocation` depends on the host's `/usr/share/zoneinfo`, which a
+  distroless or scratch container does not have — every lookup would fail and
+  silently fall the whole dashboard back to UTC. Costs about 450KB.
+- **Daily bucket walks step the calendar day, not 24 hours.** A local day is 23
+  or 25 hours long across a DST transition, so a fixed step drifts off the wall
+  clock and duplicates one day key while skipping another. The heatmap grid
+  stays a fixed 24 columns: a spring-forward day has one empty cell and a
+  fall-back day has one doubled, which is the honest answer for a "when do I
+  work?" chart.
+
+Non-analytics timestamps already render locally through `toLocale*` helpers and
+need nothing special. One deliberate exception: `formatRateDate`
+(`frontend/src/lib/pricing.ts`) pins UTC, because a pricing rate is keyed to a
+day rather than an instant — see `docs/pricing.md`.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -710,12 +710,22 @@ export const monitoringApi = {
 
 // ── Analytics ─────────────────────────────────────────────────────────────────
 
+/**
+ * The browser's IANA timezone, sent so the backend buckets days, hours and
+ * weekdays the way the user experiences them. Timestamps stay UTC on the wire;
+ * only aggregation moves. An unset or unrecognised value means UTC server-side.
+ */
+export function browserTimezone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone
+}
+
 export const analyticsApi = {
   get: (params?: { from?: string; to?: string; project?: string }): Promise<AnalyticsReport> => {
     const qs = new URLSearchParams()
     if (params?.from) qs.set('from', params.from)
     if (params?.to) qs.set('to', params.to)
     if (params?.project) qs.set('project', params.project)
+    qs.set('tz', browserTimezone())
     const query = qs.toString()
     const suffix = query ? `?${query}` : ''
     return request<AnalyticsReport>(`/claude-analytics${suffix}`)
@@ -735,6 +745,7 @@ export const insightsApi = {
     if (params?.ids && params.ids.length > 0) qs.set('ids', params.ids.join(','))
     if (params?.from) qs.set('from', params.from)
     if (params?.to) qs.set('to', params.to)
+    qs.set('tz', browserTimezone())
     const suffix = qs.toString() ? `?${qs.toString()}` : ''
     return request<InsightSummary>(`/claude-sessions/insights/summary${suffix}`)
   },

--- a/frontend/src/lib/dateRange.test.ts
+++ b/frontend/src/lib/dateRange.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { fmt, subDays, presetToRange } from '@/pages/analyticsShared'
+
+// These helpers had no coverage at all, which is how `fmt` came to serialise a
+// locally-built Date through a UTC formatter. Every assertion here is in local
+// time; run the suite under a few TZ values to confirm it holds either side of
+// the meridian.
+describe('fmt', () => {
+  it('formats a local date, not its UTC equivalent', () => {
+    // Local midnight on the 1st. toISOString would render this as the previous
+    // month's last day for anyone east of UTC.
+    expect(fmt(new Date(2026, 7, 1))).toBe('2026-08-01')
+  })
+
+  it('formats late-evening local times as the same local day', () => {
+    // 23:30 local on the 8th is the 9th in UTC east of the meridian; the range
+    // the user picked is the local one.
+    expect(fmt(new Date(2026, 7, 8, 23, 30))).toBe('2026-08-08')
+  })
+
+  it('formats early-morning local times as the same local day', () => {
+    // 00:30 local is the previous day in UTC west of the meridian.
+    expect(fmt(new Date(2026, 7, 8, 0, 30))).toBe('2026-08-08')
+  })
+
+  it('zero-pads month and day', () => {
+    expect(fmt(new Date(2026, 0, 5))).toBe('2026-01-05')
+  })
+})
+
+describe('subDays', () => {
+  it('steps back across a month boundary', () => {
+    expect(fmt(subDays(new Date(2026, 7, 3), 7))).toBe('2026-07-27')
+  })
+
+  it('does not mutate its argument', () => {
+    const d = new Date(2026, 7, 3)
+    subDays(d, 7)
+    expect(fmt(d)).toBe('2026-08-03')
+  })
+})
+
+describe('presetToRange', () => {
+  // The bug: presetToRange builds its dates with local calendar arithmetic
+  // (new Date(y, m, 1)) and then serialised them through a UTC formatter, so
+  // the two halves disagreed at every boundary.
+  it('starts "this month" on the local 1st', () => {
+    const { from } = presetToRange('this-month')
+    expect(from.endsWith('-01')).toBe(true)
+    const now = new Date()
+    expect(from).toBe(fmt(new Date(now.getFullYear(), now.getMonth(), 1)))
+  })
+
+  it('ends "last month" on the local last day of that month', () => {
+    const { from, to } = presetToRange('last-month')
+    const now = new Date()
+    expect(from).toBe(fmt(new Date(now.getFullYear(), now.getMonth() - 1, 1)))
+    expect(to).toBe(fmt(new Date(now.getFullYear(), now.getMonth(), 0)))
+  })
+
+  it('ends the rolling presets on the local today', () => {
+    const today = fmt(new Date())
+    for (const preset of ['7d', '30d', '90d', 'all-time'] as const) {
+      expect(presetToRange(preset).to).toBe(today)
+    }
+  })
+
+  it('spans the requested number of days', () => {
+    const { from, to } = presetToRange('7d')
+    expect(from).toBe(fmt(subDays(new Date(to + 'T00:00:00'), 7)))
+  })
+})

--- a/frontend/src/lib/drilldown.test.ts
+++ b/frontend/src/lib/drilldown.test.ts
@@ -9,15 +9,29 @@ import {
   parseRangeBounds,
 } from './drilldown'
 
-// 2026-08-03 is a Monday, 2026-08-09 a Sunday (local time).
+// 2026-08-03 is a Monday, 2026-08-09 a Sunday.
+//
+// Every expectation below is expressed in LOCAL time, matching what the backend
+// now buckets in. Anchoring these with an explicit `Z` is what made the old
+// suite pass while the feature was wrong for everyone outside UTC, so the
+// assertions deliberately parse without one and read local Date fields.
 const FROM = '2026-08-03'
 const TO = '2026-08-09'
 
 describe('parseRangeBounds', () => {
-  it('spans the inclusive `to` date, anchored to UTC', () => {
+  it('spans the inclusive `to` date, anchored to local midnight', () => {
     const bounds = parseRangeBounds(FROM, TO)!
-    expect(bounds.from).toBe(Date.parse('2026-08-03T00:00:00Z'))
-    expect(bounds.to).toBe(Date.parse('2026-08-10T00:00:00Z')) // one day past `to`
+    expect(bounds.from).toBe(Date.parse('2026-08-03T00:00:00'))
+    expect(bounds.to).toBe(Date.parse('2026-08-10T00:00:00')) // one day past `to`
+  })
+
+  it('starts at local midnight, not UTC midnight', () => {
+    // The bug this fixes: a range edge landing on the wrong local day for
+    // anyone whose offset is not zero.
+    const bounds = parseRangeBounds(FROM, TO)!
+    const start = new Date(bounds.from)
+    expect(start.getHours()).toBe(0)
+    expect(start.getDate()).toBe(3)
   })
 
   it('rejects invalid dates', () => {
@@ -38,14 +52,14 @@ describe('parseRangeBounds', () => {
 })
 
 describe('heatmapCellTarget', () => {
-  it('produces one window per occurrence of the weekday+hour in range (UTC)', () => {
-    // Monday (1) 14:00 UTC within Mon 3rd – Sun 9th → exactly one occurrence.
+  it('produces one window per occurrence of the local weekday+hour in range', () => {
+    // Monday (1) 14:00 local within Mon 3rd – Sun 9th → exactly one occurrence.
     const target = heatmapCellTarget(FROM, TO, 1, 14)!
     expect(target.windows).toHaveLength(1)
     const w = target.windows[0]
-    expect(w.from).toBe(Date.parse('2026-08-03T14:00:00Z'))
-    expect(new Date(w.from).getUTCDay()).toBe(1)
-    expect(new Date(w.from).getUTCHours()).toBe(14)
+    expect(w.from).toBe(Date.parse('2026-08-03T14:00:00'))
+    expect(new Date(w.from).getDay()).toBe(1)
+    expect(new Date(w.from).getHours()).toBe(14)
     expect(w.to - w.from).toBe(60 * 60 * 1000)
   })
 
@@ -54,14 +68,14 @@ describe('heatmapCellTarget', () => {
     const target = heatmapCellTarget('2026-08-03', '2026-08-23', 1, 9)!
     expect(target.windows).toHaveLength(3)
     for (const w of target.windows) {
-      expect(new Date(w.from).getUTCDay()).toBe(1)
-      expect(new Date(w.from).getUTCHours()).toBe(9)
+      expect(new Date(w.from).getDay()).toBe(1)
+      expect(new Date(w.from).getHours()).toBe(9)
     }
   })
 
   it('describes the bucket in the label', () => {
-    expect(heatmapCellTarget(FROM, TO, 2, 5)!.label).toBe('Tuesdays 05:00–06:00 UTC')
-    expect(heatmapCellTarget(FROM, TO, 6, 23)!.label).toBe('Saturdays 23:00–00:00 UTC')
+    expect(heatmapCellTarget(FROM, TO, 2, 5)!.label).toBe('Tuesdays 05:00–06:00')
+    expect(heatmapCellTarget(FROM, TO, 6, 23)!.label).toBe('Saturdays 23:00–00:00')
   })
 
   it('returns null for an invalid range', () => {
@@ -70,18 +84,18 @@ describe('heatmapCellTarget', () => {
 })
 
 describe('hourlyBarTarget', () => {
-  it('produces one window per day in range (UTC)', () => {
+  it('produces one window per day in range, at the local hour', () => {
     const target = hourlyBarTarget(FROM, TO, 8)! // 7 days
     expect(target.windows).toHaveLength(7)
-    expect(target.windows[0].from).toBe(Date.parse('2026-08-03T08:00:00Z'))
+    expect(target.windows[0].from).toBe(Date.parse('2026-08-03T08:00:00'))
     for (const w of target.windows) {
-      expect(new Date(w.from).getUTCHours()).toBe(8)
+      expect(new Date(w.from).getHours()).toBe(8)
       expect(w.to - w.from).toBe(60 * 60 * 1000)
     }
   })
 
   it('describes the bucket in the label', () => {
-    expect(hourlyBarTarget(FROM, TO, 14)!.label).toBe('every day 14:00–15:00 UTC')
+    expect(hourlyBarTarget(FROM, TO, 14)!.label).toBe('every day 14:00–15:00')
   })
 })
 
@@ -111,7 +125,7 @@ describe('drilldownUrl', () => {
     expect(url.startsWith('/claude-sessions?')).toBe(true)
     const params = new URLSearchParams(url.split('?')[1])
     expect(decodeWindows(params.get('windows'))).toEqual(target.windows)
-    expect(params.get('label')).toBe('Mondays 14:00–15:00 UTC · 2026-08-03 → 2026-08-09')
+    expect(params.get('label')).toBe('Mondays 14:00–15:00 · 2026-08-03 → 2026-08-09')
     expect(params.get('project')).toBeNull()
   })
 

--- a/frontend/src/lib/drilldown.test.ts
+++ b/frontend/src/lib/drilldown.test.ts
@@ -44,6 +44,14 @@ describe('parseRangeBounds', () => {
     expect(parseRangeBounds(TO, FROM)).toBeNull()
   })
 
+  it('measures the length guard in calendar days, not elapsed hours', () => {
+    // A local day is 23 or 25 hours across a DST transition, so an
+    // exactly-at-the-limit range that crosses a fall-back measures an hour over.
+    // Counting days keeps both directions symmetric.
+    expect(parseRangeBounds('2026-06-01', '2026-11-27')).not.toBeNull() // 180 days, fall-back
+    expect(parseRangeBounds('2026-02-09', '2026-08-07')).not.toBeNull() // 180 days, spring-forward
+  })
+
   it('rejects ranges beyond MAX_DRILLDOWN_DAYS (URL length guard)', () => {
     expect(parseRangeBounds('2020-01-01', '2026-08-07')).toBeNull() // all-time preset
     expect(parseRangeBounds('2026-02-08', '2026-08-07')).toBeNull() // 181 days

--- a/frontend/src/lib/drilldown.ts
+++ b/frontend/src/lib/drilldown.ts
@@ -13,10 +13,10 @@ const DAY_NAMES_PLURAL = [
 /**
  * Drill-down helpers for the analytics → Claude Sessions navigation.
  *
- * The backend buckets sessions by the UTC weekday/hour of their last activity
- * (session timestamps are parsed from JSONL `Z` timestamps and never converted,
- * and the analytics `from`/`to` params are UTC midnights). So a click must
- * expand back into every matching concrete UTC hour window inside the range.
+ * The backend buckets sessions by the weekday/hour of their last activity in
+ * the browser's timezone (it is sent as `tz` and applied before bucketing; the
+ * `from`/`to` params are local day boundaries). So a click must expand back
+ * into every matching concrete local hour window inside the range.
  * The sessions page then keeps the sessions whose activity window overlaps any
  * of those windows.
  */
@@ -38,9 +38,9 @@ export interface DrilldownTarget {
 }
 
 /**
- * Parses the analytics date range ("YYYY-MM-DD" strings, inclusive) into UTC
- * millisecond bounds, matching how the backend parses the same params
- * (`time.Parse("2006-01-02", …)` → UTC midnight). Returns null when either
+ * Parses the analytics date range ("YYYY-MM-DD" strings, inclusive) into
+ * millisecond bounds at local midnight, matching how the backend now parses the
+ * same params (`time.ParseInLocation("2006-01-02", …, tz)`). Returns null when either
  * bound is invalid, or when the range exceeds MAX_DRILLDOWN_DAYS — the
  * serialized window list would otherwise exceed URL length limits.
  */
@@ -50,8 +50,10 @@ export function parseRangeBounds(
 ): { from: number; to: number } | null {
   const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
   if (!DATE_RE.test(fromDate) || !DATE_RE.test(toDate)) return null
-  const from = Date.parse(`${fromDate}T00:00:00Z`)
-  const to = Date.parse(`${toDate}T00:00:00Z`) + 24 * 60 * 60 * 1000 // `to` date is inclusive
+  // No `Z`: a bare date-time string is parsed in the browser's zone, which is
+  // the zone the backend was asked to bucket in.
+  const from = Date.parse(`${fromDate}T00:00:00`)
+  const to = Date.parse(`${toDate}T00:00:00`) + 24 * 60 * 60 * 1000 // `to` date is inclusive
   if (Number.isNaN(from) || Number.isNaN(to) || from >= to) return null
   if (to - from > MAX_DRILLDOWN_DAYS * 24 * 60 * 60 * 1000) return null
   return { from, to }
@@ -68,16 +70,23 @@ function collectWindows(
   bounds: { from: number; to: number },
   matches: (start: Date) => boolean,
 ): DrilldownWindow[] {
+  const HOUR_MS = 60 * 60 * 1000
   const windows: DrilldownWindow[] = []
   // Walk hour-by-hour from the range start; ranges are capped at
   // MAX_DRILLDOWN_DAYS so this stays cheap (≤ ~4400 iterations) and avoids
   // day/hour juggling edge cases.
-  const cursor = new Date(bounds.from)
-  while (cursor.getTime() < bounds.to) {
-    if (matches(cursor)) {
-      windows.push({ from: cursor.getTime(), to: cursor.getTime() + 60 * 60 * 1000 })
+  //
+  // Stepping by a real hour rather than setHours(getHours() + 1) keeps this
+  // correct across DST: the wall clock skips an hour in spring and repeats one
+  // in autumn, so incrementing the local hour field can jump two hours or stall.
+  // Walking absolute time visits every hour that actually elapsed exactly once,
+  // and `matches` reads the local fields off each one — a repeated 02:00 legitimately
+  // yields two windows, and a skipped one yields none.
+  for (let ms = bounds.from; ms < bounds.to; ms += HOUR_MS) {
+    const start = new Date(ms)
+    if (matches(start)) {
+      windows.push({ from: ms, to: ms + HOUR_MS })
     }
-    cursor.setUTCHours(cursor.getUTCHours() + 1)
   }
   return windows
 }
@@ -92,13 +101,13 @@ export function heatmapCellTarget(
   const bounds = parseRangeBounds(fromDate, toDate)
   if (!bounds) return null
   return {
-    windows: collectWindows(bounds, d => d.getUTCDay() === dayOfWeek && d.getUTCHours() === hour),
-    label: `${DAY_NAMES_PLURAL[dayOfWeek] ?? DAY_NAMES[dayOfWeek]} ${padHour(hour)}:00–${padHour((hour + 1) % 24)}:00 UTC`,
+    windows: collectWindows(bounds, d => d.getDay() === dayOfWeek && d.getHours() === hour),
+    label: `${DAY_NAMES_PLURAL[dayOfWeek] ?? DAY_NAMES[dayOfWeek]} ${padHour(hour)}:00–${padHour((hour + 1) % 24)}:00`,
     rangeLabel: `${fromDate} → ${toDate}`,
   }
 }
 
-/** Windows for an hourly bar: the given UTC hour of every day in the range. */
+/** Windows for an hourly bar: the given local hour of every day in the range. */
 export function hourlyBarTarget(
   fromDate: string,
   toDate: string,
@@ -107,8 +116,8 @@ export function hourlyBarTarget(
   const bounds = parseRangeBounds(fromDate, toDate)
   if (!bounds) return null
   return {
-    windows: collectWindows(bounds, d => d.getUTCHours() === hour),
-    label: `every day ${padHour(hour)}:00–${padHour((hour + 1) % 24)}:00 UTC`,
+    windows: collectWindows(bounds, d => d.getHours() === hour),
+    label: `every day ${padHour(hour)}:00–${padHour((hour + 1) % 24)}:00`,
     rangeLabel: `${fromDate} → ${toDate}`,
   }
 }

--- a/frontend/src/lib/drilldown.ts
+++ b/frontend/src/lib/drilldown.ts
@@ -55,7 +55,10 @@ export function parseRangeBounds(
   const from = Date.parse(`${fromDate}T00:00:00`)
   const to = Date.parse(`${toDate}T00:00:00`) + 24 * 60 * 60 * 1000 // `to` date is inclusive
   if (Number.isNaN(from) || Number.isNaN(to) || from >= to) return null
-  if (to - from > MAX_DRILLDOWN_DAYS * 24 * 60 * 60 * 1000) return null
+  // Count calendar days rather than elapsed milliseconds. Local days are 23 or
+  // 25 hours long across a DST transition, so an exactly-at-the-limit range
+  // that crosses a fall-back measures an hour over and would be rejected.
+  if (Math.round((to - from) / (24 * 60 * 60 * 1000)) > MAX_DRILLDOWN_DAYS) return null
   return { from, to }
 }
 

--- a/frontend/src/pages/GeneralUsagePage.tsx
+++ b/frontend/src/pages/GeneralUsagePage.tsx
@@ -323,8 +323,8 @@ function ActivityHeatmap({
           </div>
           {onCellClick && (
             <p className="text-[11px] text-zinc-400 dark:text-zinc-500 mt-1.5 ml-8">
-              Click a cell to view the sessions from that day and hour (UTC). Keyboard: tab to the
-              grid, arrow keys to move, Enter to open.
+              Click a cell to view the sessions from that day and hour. Keyboard: tab to the grid,
+              arrow keys to move, Enter to open.
             </p>
           )}
         </div>
@@ -389,7 +389,7 @@ function HourlyActivityChart({
       </ResponsiveContainer>
       {onBarClick && (
         <p className="text-[11px] text-zinc-400 dark:text-zinc-500 mt-1.5">
-          Click a bar to view the sessions from that hour (UTC).
+          Click a bar to view the sessions from that hour.
         </p>
       )}
     </ChartCard>

--- a/frontend/src/pages/analyticsShared.tsx
+++ b/frontend/src/pages/analyticsShared.tsx
@@ -37,8 +37,18 @@ export const PRESETS: { label: string; value: DatePreset }[] = [
 
 // ─── Utilities ────────────────────────────────────────────────────────────────
 
+/**
+ * Formats a Date as the YYYY-MM-DD the analytics API expects, using its **local**
+ * calendar fields.
+ *
+ * toISOString would render the UTC day, and every caller here builds its Date
+ * from local arithmetic (`new Date(y, m, 1)`, `setDate(...)`). Mixing the two
+ * shifted every range edge by a day for anyone whose offset crosses midnight —
+ * "this month" starting on the last day of the previous one.
+ */
 export function fmt(d: Date) {
-  return d.toISOString().slice(0, 10)
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
 }
 
 export function subDays(d: Date, n: number): Date {
@@ -90,6 +100,14 @@ export function formatModelName(model: string): string {
   return model
 }
 
+/**
+ * Renders a backend bucket key ("2026-08-08" or "2026-08-08T14") for display.
+ *
+ * The key is already in the browser's timezone — it is bucketed there — so the
+ * date part is parsed without a `Z` (local) and the hour is printed verbatim.
+ * Both halves therefore describe the same wall clock; before the backend took a
+ * `tz`, the hour was UTC while the date was parsed locally.
+ */
 export function formatDateLabel(date: string): string {
   if (date.includes('T')) {
     const [d, h] = date.split('T')

--- a/internal/api/claude_analytics.go
+++ b/internal/api/claude_analytics.go
@@ -15,22 +15,27 @@ import (
 //	from    YYYY-MM-DD or RFC3339 start (default: 30 days ago)
 //	to      YYYY-MM-DD or RFC3339 end   (default: now)
 //	project decoded project path to filter by (optional, empty = all projects)
+//	tz      IANA timezone the buckets and day boundaries are derived in
+//	        (default: UTC). Timestamps stay UTC on the wire either way.
 func (s *Server) handleGetClaudeAnalytics(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
+	loc := parseTimezone(q.Get("tz"))
 
-	now := time.Now()
+	// A "day" is only meaningful in a timezone, so the default window is
+	// anchored in the requested one rather than the server's.
+	now := time.Now().In(loc)
 	from := now.AddDate(0, 0, -30)
 	to := now
 
 	if raw := q.Get("from"); raw != "" {
-		if t, err := parseAnalyticsDate(raw); err == nil {
+		if t, err := parseAnalyticsDate(raw, loc); err == nil {
 			from = t
 		}
 	}
 	if raw := q.Get("to"); raw != "" {
-		if t, err := parseAnalyticsDate(raw); err == nil {
-			// Make the end date inclusive by advancing to end of day.
-			to = time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 0, t.Location())
+		if t, err := parseAnalyticsDate(raw, loc); err == nil {
+			// Make the end date inclusive by advancing to end of local day.
+			to = time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 0, loc)
 		}
 	}
 
@@ -38,6 +43,7 @@ func (s *Server) handleGetClaudeAnalytics(w http.ResponseWriter, r *http.Request
 		From:    from,
 		To:      to,
 		Project: q.Get("project"),
+		Loc:     loc,
 	}
 
 	sessions := s.claudeSessionCache.List()
@@ -45,10 +51,31 @@ func (s *Server) handleGetClaudeAnalytics(w http.ResponseWriter, r *http.Request
 	s.writeJSON(w, http.StatusOK, report)
 }
 
-// parseAnalyticsDate tries RFC3339 first, then YYYY-MM-DD.
-func parseAnalyticsDate(s string) (time.Time, error) {
+// parseAnalyticsDate tries RFC3339 first, then YYYY-MM-DD in loc.
+//
+// A bare date carries no offset, so it has to be interpreted in the requesting
+// timezone — parsing it as UTC is what shifted every range edge by the user's
+// offset. An RFC3339 value states its own offset and is taken at its word.
+func parseAnalyticsDate(s string, loc *time.Location) (time.Time, error) {
 	if t, err := time.Parse(time.RFC3339, s); err == nil {
 		return t, nil
 	}
-	return time.Parse("2006-01-02", s)
+	return time.ParseInLocation("2006-01-02", s, loc)
+}
+
+// parseTimezone resolves an IANA timezone name, falling back to UTC.
+//
+// A bad or missing zone is never an error: analytics is a read-only dashboard,
+// and refusing to render it over an unrecognized timezone string would be a
+// worse outcome than rendering it in UTC, which is what every caller got
+// before this parameter existed.
+func parseTimezone(name string) *time.Location {
+	if name == "" {
+		return time.UTC
+	}
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		return time.UTC
+	}
+	return loc
 }

--- a/internal/api/claude_session_insights.go
+++ b/internal/api/claude_session_insights.go
@@ -56,9 +56,14 @@ func (s *Server) handleGetClaudeSessionInsightsSummary(w http.ResponseWriter, r 
 		}
 	}
 
+	// A bare YYYY-MM-DD names a day, not an instant, so it is resolved in the
+	// requesting timezone. The store turns `to` into an exclusive next-midnight,
+	// which then covers the whole local day rather than the whole UTC one.
+	loc := parseTimezone(r.URL.Query().Get("tz"))
+
 	var from, to *time.Time
 	if raw := r.URL.Query().Get("from"); raw != "" {
-		t, err := time.Parse("2006-01-02", raw)
+		t, err := time.ParseInLocation("2006-01-02", raw, loc)
 		if err != nil {
 			s.writeError(w, http.StatusBadRequest, "invalid 'from' date: expected YYYY-MM-DD")
 			return
@@ -66,7 +71,7 @@ func (s *Server) handleGetClaudeSessionInsightsSummary(w http.ResponseWriter, r 
 		from = &t
 	}
 	if raw := r.URL.Query().Get("to"); raw != "" {
-		t, err := time.Parse("2006-01-02", raw)
+		t, err := time.ParseInLocation("2006-01-02", raw, loc)
 		if err != nil {
 			s.writeError(w, http.StatusBadRequest, "invalid 'to' date: expected YYYY-MM-DD")
 			return

--- a/internal/api/timezone_test.go
+++ b/internal/api/timezone_test.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"testing"
+	"time"
+)
+
+// TestParseTimezone covers the fallback contract: analytics is a read-only
+// dashboard, so an unrecognized or absent zone renders in UTC rather than
+// failing the request — which is exactly what every caller got before the
+// parameter existed.
+func TestParseTimezone(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty falls back to UTC", "", "UTC"},
+		{"garbage falls back to UTC", "Not/AZone", "UTC"},
+		{"nonsense falls back to UTC", "🙂", "UTC"},
+		{"a real zone resolves", "Europe/Berlin", "Europe/Berlin"},
+		{"UTC resolves to itself", "UTC", "UTC"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseTimezone(tt.in).String(); got != tt.want {
+				t.Errorf("parseTimezone(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseTimezone_EmbeddedTzdata is the acceptance criterion for shipping the
+// zone database in the binary: these must resolve with no system zoneinfo, as
+// in a distroless or scratch container.
+func TestParseTimezone_EmbeddedTzdata(t *testing.T) {
+	for _, name := range []string{
+		"Europe/Berlin", "America/Los_Angeles", "Asia/Tokyo", "Australia/Sydney",
+	} {
+		if got := parseTimezone(name).String(); got != name {
+			t.Errorf("parseTimezone(%q) = %q — the tzdata import is missing", name, got)
+		}
+	}
+}
+
+// TestParseAnalyticsDate covers the two shapes the endpoint accepts. A bare
+// date names a day and must be read in the requesting zone; an RFC3339 value
+// states its own offset and is taken at its word.
+func TestParseAnalyticsDate(t *testing.T) {
+	berlin, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Fatalf("LoadLocation: %v", err)
+	}
+
+	got, err := parseAnalyticsDate("2026-08-08", berlin)
+	if err != nil {
+		t.Fatalf("parse bare date: %v", err)
+	}
+	want := time.Date(2026, 8, 8, 0, 0, 0, 0, berlin)
+	if !got.Equal(want) {
+		t.Errorf("bare date = %s, want local midnight %s", got, want)
+	}
+	// Berlin is UTC+2 in August, so local midnight is 22:00Z the day before.
+	if got.UTC().Day() != 7 {
+		t.Errorf("bare date in UTC = %s, want the 7th — local midnight precedes UTC midnight", got.UTC())
+	}
+
+	got, err = parseAnalyticsDate("2026-08-08T12:00:00Z", berlin)
+	if err != nil {
+		t.Fatalf("parse RFC3339: %v", err)
+	}
+	if !got.Equal(time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)) {
+		t.Errorf("RFC3339 = %s, want its own stated offset honored", got)
+	}
+
+	if _, err := parseAnalyticsDate("the eighth", berlin); err == nil {
+		t.Error("an unparseable date must return an error so the caller keeps its default")
+	}
+}

--- a/internal/claudesessions/analytics.go
+++ b/internal/claudesessions/analytics.go
@@ -205,6 +205,19 @@ type AnalyticsParams struct {
 	From    time.Time
 	To      time.Time
 	Project string // empty = all projects
+	// Loc is the timezone the day, hour and weekday buckets are derived in.
+	// Storage and transport stay UTC; only aggregation and labeling move, so
+	// "when do I work?" is answered in the hours the user actually worked.
+	// Nil means UTC, which keeps callers that predate this working unchanged.
+	Loc *time.Location
+}
+
+// location returns the bucketing timezone, defaulting to UTC.
+func (p AnalyticsParams) location() *time.Location {
+	if p.Loc == nil {
+		return time.UTC
+	}
+	return p.Loc
 }
 
 // Granularity returns "hourly" when the range is ≤7 days, "daily" otherwise.
@@ -231,6 +244,7 @@ func AggregateAnalytics(sessions []ClaudeSessionSummary, p AnalyticsParams) Anal
 	}
 	sort.Strings(projects)
 
+	loc := p.location()
 	filtered := filterSessions(sessions, p)
 
 	if len(filtered) == 0 {
@@ -241,7 +255,7 @@ func AggregateAnalytics(sessions []ClaudeSessionSummary, p AnalyticsParams) Anal
 			SessionsPerModel: []ModelSessionStat{},
 			MostActiveDays:   []DayActivity{},
 			Heatmap:          []HeatmapCell{},
-			HourlyActivity:   buildHourlyActivity(nil),
+			HourlyActivity:   buildHourlyActivity(nil, loc),
 			CostOverTime:     []CostPoint{},
 			Projects:         projects,
 		}
@@ -249,7 +263,7 @@ func AggregateAnalytics(sessions []ClaudeSessionSummary, p AnalyticsParams) Anal
 
 	granularity := p.Granularity()
 	summary, costSummary := buildSummary(filtered)
-	timeSeries := buildTimeSeries(filtered, p.From, p.To, granularity)
+	timeSeries := buildTimeSeries(filtered, p.From, p.To, granularity, loc)
 
 	return AnalyticsReport{
 		Summary:          summary,
@@ -257,10 +271,10 @@ func AggregateAnalytics(sessions []ClaudeSessionSummary, p AnalyticsParams) Anal
 		CacheEfficiency:  buildCacheEfficiency(timeSeries),
 		ModelBreakdown:   buildModelBreakdown(filtered),
 		SessionsPerModel: buildSessionsPerModel(filtered),
-		MostActiveDays:   buildMostActiveDays(filtered),
-		Heatmap:          buildHeatmap(filtered),
-		HourlyActivity:   buildHourlyActivity(filtered),
-		CostOverTime:     buildCostOverTime(filtered, p.From, p.To, granularity),
+		MostActiveDays:   buildMostActiveDays(filtered, loc),
+		Heatmap:          buildHeatmap(filtered, loc),
+		HourlyActivity:   buildHourlyActivity(filtered, loc),
+		CostOverTime:     buildCostOverTime(filtered, p.From, p.To, granularity, loc),
 		CostSummary:      costSummary,
 		Projects:         projects,
 	}
@@ -329,13 +343,15 @@ func buildSummary(sessions []ClaudeSessionSummary) (AnalyticsSummary, CostSummar
 	}, cost
 }
 
-func buildTimeSeries(sessions []ClaudeSessionSummary, from, to time.Time, granularity string) []TimeSeriesPoint {
+func buildTimeSeries(
+	sessions []ClaudeSessionSummary, from, to time.Time, granularity string, loc *time.Location,
+) []TimeSeriesPoint {
 	buckets := make(map[string]*TimeSeriesPoint)
 
 	for _, s := range sessions {
-		key := bucketKey(s.LastActivity, granularity)
+		key := bucketKey(s.LastActivity, granularity, loc)
 		if buckets[key] == nil {
-			buckets[key] = &TimeSeriesPoint{Date: bucketLabel(s.LastActivity, granularity)}
+			buckets[key] = &TimeSeriesPoint{Date: bucketLabel(s.LastActivity, granularity, loc)}
 		}
 		b := buckets[key]
 		u := s.TotalUsage()
@@ -347,7 +363,7 @@ func buildTimeSeries(sessions []ClaudeSessionSummary, from, to time.Time, granul
 		b.Sessions++
 	}
 
-	return fillTimeSeries(buckets, from, to, granularity)
+	return fillTimeSeries(buckets, from, to, granularity, loc)
 }
 
 func buildCacheEfficiency(ts []TimeSeriesPoint) []CacheEfficiencyPoint {
@@ -416,10 +432,11 @@ func buildSessionsPerModel(sessions []ClaudeSessionSummary) []ModelSessionStat {
 	return out
 }
 
-func buildMostActiveDays(sessions []ClaudeSessionSummary) []DayActivity {
+func buildMostActiveDays(sessions []ClaudeSessionSummary, loc *time.Location) []DayActivity {
 	byDay := make(map[string]*DayActivity)
 	for _, s := range sessions {
-		key := s.LastActivity.Format("2006-01-02")
+		// Via bucketKey so there is exactly one place that formats a day.
+		key := bucketKey(s.LastActivity, "daily", loc)
 		if byDay[key] == nil {
 			byDay[key] = &DayActivity{Date: key}
 		}
@@ -438,11 +455,12 @@ func buildMostActiveDays(sessions []ClaudeSessionSummary) []DayActivity {
 	return out
 }
 
-func buildHeatmap(sessions []ClaudeSessionSummary) []HeatmapCell {
+func buildHeatmap(sessions []ClaudeSessionSummary, loc *time.Location) []HeatmapCell {
 	type cellKey struct{ dow, hour int }
 	cells := make(map[cellKey]*HeatmapCell)
 	for _, s := range sessions {
-		k := cellKey{int(s.LastActivity.Weekday()), s.LastActivity.Hour()}
+		at := s.LastActivity.In(loc)
+		k := cellKey{int(at.Weekday()), at.Hour()}
 		if cells[k] == nil {
 			cells[k] = &HeatmapCell{DayOfWeek: k.dow, Hour: k.hour}
 		}
@@ -463,13 +481,13 @@ func buildHeatmap(sessions []ClaudeSessionSummary) []HeatmapCell {
 	return out
 }
 
-func buildHourlyActivity(sessions []ClaudeSessionSummary) []HourlyActivity {
+func buildHourlyActivity(sessions []ClaudeSessionSummary, loc *time.Location) []HourlyActivity {
 	var hours [24]HourlyActivity
 	for i := range hours {
 		hours[i] = HourlyActivity{Hour: i}
 	}
 	for _, s := range sessions {
-		h := s.LastActivity.Hour()
+		h := s.LastActivity.In(loc).Hour()
 		u := s.TotalUsage()
 		hours[h].Sessions++
 		hours[h].Tokens += u.InputTokens + u.OutputTokens
@@ -479,60 +497,77 @@ func buildHourlyActivity(sessions []ClaudeSessionSummary) []HourlyActivity {
 	return out
 }
 
-func buildCostOverTime(sessions []ClaudeSessionSummary, from, to time.Time, granularity string) []CostPoint {
+func buildCostOverTime(
+	sessions []ClaudeSessionSummary, from, to time.Time, granularity string, loc *time.Location,
+) []CostPoint {
 	buckets := make(map[string]*CostPoint)
 	for _, s := range sessions {
-		key := bucketKey(s.LastActivity, granularity)
+		key := bucketKey(s.LastActivity, granularity, loc)
 		if buckets[key] == nil {
-			buckets[key] = &CostPoint{Date: bucketLabel(s.LastActivity, granularity)}
+			buckets[key] = &CostPoint{Date: bucketLabel(s.LastActivity, granularity, loc)}
 		}
 		// Stored cost, for the same reason buildSummary reads it — the two must
 		// add up to the same money.
 		buckets[key].EstimatedCostUSD += s.TotalCost().TotalUSD
 	}
 
-	step := 24 * time.Hour
-	if granularity == "hourly" {
-		step = time.Hour
-	}
 	var result []CostPoint
-	for cur := from; !cur.After(to); cur = cur.Add(step) {
-		key := bucketKey(cur, granularity)
+	walkBuckets(from, to, granularity, loc, func(key string, cur time.Time) {
 		if b, ok := buckets[key]; ok {
 			result = append(result, *b)
-		} else {
-			result = append(result, CostPoint{Date: bucketLabel(cur, granularity)})
+			return
 		}
-	}
+		result = append(result, CostPoint{Date: bucketLabel(cur, granularity, loc)})
+	})
 	return result
 }
 
 // ─── Time bucket helpers ──────────────────────────────────────────────────────
 
-func bucketKey(t time.Time, granularity string) string {
+// bucketKey derives a session's bucket in loc. Format renders in the time's own
+// location, so the conversion has to happen here rather than at the edges — an
+// instant is only a day or an hour once you say whose day you mean.
+func bucketKey(t time.Time, granularity string, loc *time.Location) string {
+	t = t.In(loc)
 	if granularity == "hourly" {
 		return t.Format("2006-01-02T15")
 	}
 	return t.Format("2006-01-02")
 }
 
-func bucketLabel(t time.Time, granularity string) string {
-	return bucketKey(t, granularity)
+func bucketLabel(t time.Time, granularity string, loc *time.Location) string {
+	return bucketKey(t, granularity, loc)
 }
 
-func fillTimeSeries(buckets map[string]*TimeSeriesPoint, from, to time.Time, granularity string) []TimeSeriesPoint {
-	step := 24 * time.Hour
-	if granularity == "hourly" {
-		step = time.Hour
+// walkBuckets calls fn once per bucket from `from` to `to` inclusive, stepping
+// in loc.
+//
+// Daily steps advance the calendar day rather than adding 24 hours: across a
+// DST transition a local day is 23 or 25 hours long, and a fixed 24h step drifts
+// off the wall clock, duplicating one day key and skipping another.
+func walkBuckets(from, to time.Time, granularity string, loc *time.Location, fn func(string, time.Time)) {
+	cur := from.In(loc)
+	end := to.In(loc)
+	for !cur.After(end) {
+		fn(bucketKey(cur, granularity, loc), cur)
+		if granularity == "hourly" {
+			cur = cur.Add(time.Hour)
+			continue
+		}
+		cur = cur.AddDate(0, 0, 1)
 	}
+}
+
+func fillTimeSeries(
+	buckets map[string]*TimeSeriesPoint, from, to time.Time, granularity string, loc *time.Location,
+) []TimeSeriesPoint {
 	var result []TimeSeriesPoint
-	for cur := from; !cur.After(to); cur = cur.Add(step) {
-		key := bucketKey(cur, granularity)
+	walkBuckets(from, to, granularity, loc, func(key string, cur time.Time) {
 		if b, ok := buckets[key]; ok {
 			result = append(result, *b)
-		} else {
-			result = append(result, TimeSeriesPoint{Date: bucketLabel(cur, granularity)})
+			return
 		}
-	}
+		result = append(result, TimeSeriesPoint{Date: bucketLabel(cur, granularity, loc)})
+	})
 	return result
 }

--- a/internal/claudesessions/analytics_timezone_test.go
+++ b/internal/claudesessions/analytics_timezone_test.go
@@ -1,0 +1,221 @@
+package claudesessions
+
+import (
+	"testing"
+	"time"
+)
+
+func mustLoad(t *testing.T, name string) *time.Location {
+	t.Helper()
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		t.Fatalf("LoadLocation(%q): %v — is time/tzdata embedded?", name, err)
+	}
+	return loc
+}
+
+// lateNightSession is 2026-08-08T00:30 in Berlin, i.e. 2026-08-07T22:30 UTC.
+// Bucketed in UTC it lands on the 7th at hour 22; bucketed in Berlin it lands
+// on the 8th at hour 0. That one session is the whole issue.
+func lateNightSession() ClaudeSessionSummary {
+	at := time.Date(2026, 8, 7, 22, 30, 0, 0, time.UTC)
+	return ClaudeSessionSummary{
+		SessionID: "late-night", Model: "claude-sonnet-4-6",
+		StartTime: at, LastActivity: at,
+		Usage: TokenUsage{InputTokens: 100, OutputTokens: 50},
+	}
+}
+
+// TestBucketing_FollowsRequestedTimezone pins both behaviors at once: the
+// acceptance criterion in the requested zone, and the unchanged UTC result for
+// callers that send no timezone.
+func TestBucketing_FollowsRequestedTimezone(t *testing.T) {
+	berlin := mustLoad(t, "Europe/Berlin")
+	sessions := []ClaudeSessionSummary{lateNightSession()}
+
+	tests := []struct {
+		name     string
+		loc      *time.Location
+		wantDay  string
+		wantHour int
+		// 2026-08-07 is a Friday, 2026-08-08 a Saturday.
+		wantWeekday time.Weekday
+	}{
+		{"berlin puts late-night work on the local day", berlin, "2026-08-08", 0, time.Saturday},
+		{"utc keeps the previous behavior", time.UTC, "2026-08-07", 22, time.Friday},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			days := buildMostActiveDays(sessions, tt.loc)
+			if len(days) != 1 || days[0].Date != tt.wantDay {
+				t.Errorf("most active day = %+v, want %s", days, tt.wantDay)
+			}
+
+			cells := buildHeatmap(sessions, tt.loc)
+			if len(cells) != 1 {
+				t.Fatalf("heatmap cells = %d, want 1", len(cells))
+			}
+			if cells[0].Hour != tt.wantHour {
+				t.Errorf("heatmap hour = %d, want %d", cells[0].Hour, tt.wantHour)
+			}
+			if time.Weekday(cells[0].DayOfWeek) != tt.wantWeekday {
+				t.Errorf("heatmap weekday = %v, want %v",
+					time.Weekday(cells[0].DayOfWeek), tt.wantWeekday)
+			}
+
+			hourly := buildHourlyActivity(sessions, tt.loc)
+			if hourly[tt.wantHour].Sessions != 1 {
+				t.Errorf("hour %d has %d sessions, want 1", tt.wantHour, hourly[tt.wantHour].Sessions)
+			}
+		})
+	}
+}
+
+// TestAnalyticsParams_NilLocationIsUTC keeps every caller that predates the
+// timezone parameter working exactly as before.
+func TestAnalyticsParams_NilLocationIsUTC(t *testing.T) {
+	if got := (AnalyticsParams{}).location(); got != time.UTC {
+		t.Errorf("location() = %v, want UTC", got)
+	}
+	berlin := mustLoad(t, "Europe/Berlin")
+	if got := (AnalyticsParams{Loc: berlin}).location(); got != berlin {
+		t.Errorf("location() = %v, want Europe/Berlin", got)
+	}
+}
+
+// TestBucketKey_RendersInLocation covers the helper both other builders route
+// through, at both granularities.
+func TestBucketKey_RendersInLocation(t *testing.T) {
+	tokyo := mustLoad(t, "Asia/Tokyo") // UTC+9, no DST
+	at := time.Date(2026, 8, 7, 22, 30, 0, 0, time.UTC)
+
+	if got := bucketKey(at, "daily", tokyo); got != "2026-08-08" {
+		t.Errorf("daily key = %q, want 2026-08-08", got)
+	}
+	if got := bucketKey(at, "hourly", tokyo); got != "2026-08-08T07" {
+		t.Errorf("hourly key = %q, want 2026-08-08T07", got)
+	}
+	if got := bucketKey(at, "daily", time.UTC); got != "2026-08-07" {
+		t.Errorf("daily key in UTC = %q, want 2026-08-07", got)
+	}
+}
+
+// TestWalkBuckets_DailyStepsCalendarDaysAcrossDST is why the stepping loops
+// stopped adding 24 hours. Berlin's spring-forward day (2026-03-29) is 23 hours
+// long, so a fixed 24h step drifts off the wall clock and emits one day twice
+// while skipping another.
+func TestWalkBuckets_DailyStepsCalendarDaysAcrossDST(t *testing.T) {
+	berlin := mustLoad(t, "Europe/Berlin")
+	from := time.Date(2026, 3, 27, 0, 0, 0, 0, berlin)
+	to := time.Date(2026, 3, 31, 23, 59, 59, 0, berlin)
+
+	var keys []string
+	walkBuckets(from, to, "daily", berlin, func(key string, _ time.Time) {
+		keys = append(keys, key)
+	})
+
+	want := []string{"2026-03-27", "2026-03-28", "2026-03-29", "2026-03-30", "2026-03-31"}
+	if len(keys) != len(want) {
+		t.Fatalf("keys = %v, want %v — a DST day must not be duplicated or skipped", keys, want)
+	}
+	for i := range want {
+		if keys[i] != want[i] {
+			t.Errorf("keys = %v, want %v", keys, want)
+			break
+		}
+	}
+}
+
+// TestWalkBuckets_HourlyCoversFallBackDay checks the other DST direction. Berlin
+// gains an hour on 2026-10-25, so that local day really does have 25 hours and
+// the walk must emit them all rather than stopping an hour early.
+func TestWalkBuckets_HourlyCoversFallBackDay(t *testing.T) {
+	berlin := mustLoad(t, "Europe/Berlin")
+	from := time.Date(2026, 10, 25, 0, 0, 0, 0, berlin)
+	to := from.AddDate(0, 0, 1)
+
+	count := 0
+	walkBuckets(from, to, "hourly", berlin, func(string, time.Time) { count++ })
+
+	// 25 wall-clock hours in the day, plus the inclusive endpoint at next midnight.
+	if count != 26 {
+		t.Errorf("hourly buckets across the fall-back day = %d, want 26", count)
+	}
+}
+
+// TestAggregateAnalytics_ThreadsLocationToEveryBuilder guards against a builder
+// being missed: half-converted analytics, where the heatmap is local but the
+// day list is not, is worse than either being uniformly wrong.
+func TestAggregateAnalytics_ThreadsLocationToEveryBuilder(t *testing.T) {
+	berlin := mustLoad(t, "Europe/Berlin")
+	sessions := []ClaudeSessionSummary{lateNightSession()}
+
+	report := AggregateAnalytics(sessions, AnalyticsParams{
+		From: time.Date(2026, 8, 1, 0, 0, 0, 0, berlin),
+		To:   time.Date(2026, 8, 31, 23, 59, 59, 0, berlin),
+		Loc:  berlin,
+	})
+
+	if len(report.MostActiveDays) != 1 || report.MostActiveDays[0].Date != "2026-08-08" {
+		t.Errorf("most active days = %+v, want the 8th", report.MostActiveDays)
+	}
+	if len(report.Heatmap) != 1 || report.Heatmap[0].Hour != 0 {
+		t.Errorf("heatmap = %+v, want hour 0", report.Heatmap)
+	}
+	if report.HourlyActivity[0].Sessions != 1 {
+		t.Errorf("hourly activity hour 0 = %d sessions, want 1", report.HourlyActivity[0].Sessions)
+	}
+
+	// The daily series must carry the same local day key, or the chart and the
+	// day list disagree about which day the work happened on.
+	found := false
+	for _, p := range report.TimeSeries {
+		if p.Date == "2026-08-08" && p.Sessions == 1 {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("time series has no 2026-08-08 bucket with the session in it")
+	}
+}
+
+// TestAggregateAnalytics_EmptyResultStillHonoursLocation covers the early-return
+// branch, which builds hourly activity from a nil slice.
+func TestAggregateAnalytics_EmptyResultStillHonoursLocation(t *testing.T) {
+	berlin := mustLoad(t, "Europe/Berlin")
+	report := AggregateAnalytics(nil, AnalyticsParams{
+		From: time.Date(2026, 8, 1, 0, 0, 0, 0, berlin),
+		To:   time.Date(2026, 8, 2, 0, 0, 0, 0, berlin),
+		Loc:  berlin,
+	})
+	if len(report.HourlyActivity) != 24 {
+		t.Errorf("hourly activity = %d buckets, want 24", len(report.HourlyActivity))
+	}
+}
+
+// TestFilterSessions_UsesLocalDayBoundaries checks the range edges. A session at
+// 00:30 Berlin on the 8th must fall inside a "8 Aug to 8 Aug" local range, even
+// though its UTC instant is on the 7th.
+func TestFilterSessions_UsesLocalDayBoundaries(t *testing.T) {
+	berlin := mustLoad(t, "Europe/Berlin")
+	sessions := []ClaudeSessionSummary{lateNightSession()}
+
+	inLocalDay := filterSessions(sessions, AnalyticsParams{
+		From: time.Date(2026, 8, 8, 0, 0, 0, 0, berlin),
+		To:   time.Date(2026, 8, 8, 23, 59, 59, 0, berlin),
+		Loc:  berlin,
+	})
+	if len(inLocalDay) != 1 {
+		t.Error("a session at 00:30 local on the 8th must be inside the local 8th")
+	}
+
+	// The same range expressed as UTC days excludes it, which is the old bug.
+	inUTCDay := filterSessions(sessions, AnalyticsParams{
+		From: time.Date(2026, 8, 8, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 8, 8, 23, 59, 59, 0, time.UTC),
+	})
+	if len(inUTCDay) != 0 {
+		t.Error("UTC day boundaries should not contain the 22:30Z session")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,13 @@ package main
 
 import (
 	"log"
+	// Embeds the IANA timezone database so time.LoadLocation works in a
+	// distroless or scratch container, which has no /usr/share/zoneinfo.
+	// Analytics buckets in the browser's timezone, so a lookup failure would
+	// silently fall the whole dashboard back to UTC — the bug being fixed.
+	// Costs roughly 450KB, which is the right trade for a single self-contained
+	// binary.
+	_ "time/tzdata"
 
 	"github.com/shaharia-lab/agento/cmd"
 )


### PR DESCRIPTION
Closes #190

## What

The heatmap, hourly chart and "most active days" exist to answer one question — *when do I work?* — and they answered it in a timezone the user does not live in. Every bucketing helper derived its calendar fields from a UTC instant, so for anyone off UTC±0 the charts were wrong by their offset. At `Europe/Berlin` a 9-to-5 day rendered as 7am-to-3pm, and work at 00:30 was filed under the previous day. The UI accommodated this by printing "(UTC)" rather than fixing it.

**Storage and transport stay UTC end to end.** Only aggregation and display move: the frontend sends its IANA zone as `tz`, and the backend applies `.In(loc)` before deriving any bucket key. A bare `YYYY-MM-DD` `from`/`to` becomes a local day boundary via `ParseInLocation`, which is what makes "this month" cover the user's month.

A missing or unrecognized `tz` falls back to UTC rather than erroring — analytics is a read-only dashboard, and refusing to render it over a bad zone string is worse than rendering what every caller got before the parameter existed.

## Three things beyond a literal `.In(loc)` sweep

1. **The two byte-identical stepping loops became one `walkBuckets`, and daily steps advance the calendar day instead of adding 24 hours.** A local day is 23 or 25 hours across a DST transition, so a fixed step drifts off the wall clock, emitting one day key twice and skipping another.
2. **`collectWindows` steps by a real hour** rather than `setHours(getHours() + 1)`, which can jump two hours in spring or stall in autumn. Walking absolute time visits each elapsed hour exactly once and reads the local fields off it — a repeated 02:00 correctly yields two windows, a skipped one yields none.
3. **tzdata is embedded** (`_ "time/tzdata"`). Without it `LoadLocation` depends on the host's `/usr/share/zoneinfo`, absent in a distroless image — every lookup would fail and silently degrade the whole dashboard back to UTC, which is the bug being fixed. ~450KB, the right trade for a self-contained binary. It also fixes the `current_time` MCP tool, which has the same dependency.

## A second, independent defect

`fmt()` serialised a locally-built `Date` through `toISOString`, so it disagreed with `presetToRange`'s local calendar arithmetic (`new Date(y, m, 1)`) and shifted every range edge by a day. Making it local **incidentally fixes** `InsightsPage.previousPeriod` too, which parsed `from + 'T00:00:00'` locally and then formatted through the UTC `fmt` — those halves now agree.

## Acceptance criteria

- [x] At Berlin (UTC+2), a session at 2026-08-08T00:30 local is attributed to **8 Aug**, not 7 Aug
- [x] The heatmap and hourly chart place it in **00:00–01:00**, not 22:00–23:00
- [x] `from`/`to` are inclusive of full local days
- [x] `fmt()` and `presetToRange` agree at both edges west of UTC
- [x] Heatmap-cell drill-down selects the local weekday+hour window; labels carry no "UTC"
- [x] No `tz`, or an unparseable one, returns UTC-bucketed data without erroring
- [x] `LoadLocation("Europe/Berlin")` resolves with no system zoneinfo
- [x] All stored and transported timestamps remain UTC — no storage or API-shape change

## Review round

One finding, applied in `9d82b66`: parsing bounds at local midnight made the `MAX_DRILLDOWN_DAYS` span DST-sensitive, so a range crossing a fall-back measured 180 days **+ 1 hour** and was rejected. Verified in Berlin — `2026-06-01 → 2026-11-27` was refused while the spring-forward equivalent measured 179.96 days and passed, which is why the existing test stayed green. The guard now counts calendar days, and the new case pins both directions.

Deferred to #213: the sessions-list custom range still parses bare dates as UTC midnight while the presets beside it are local. Different page, untouched here, and its drill-down path is timezone-neutral epoch milliseconds.

## Testing

`analytics.go` had **no tests at all**. It has 8 now, covering both bucketing zones, both DST directions, and that every builder actually receives the location — half-converted analytics, heatmap local but day list UTC, would be worse than uniformly wrong.

`drilldown.test.ts` asserted UTC as correct and is rewritten rather than patched. It and the new `dateRange.test.ts` pass under **UTC, Europe/Berlin, America/Los_Angeles, Pacific/Kiritimati (UTC+14), Pacific/Midway (UTC−11) and Australia/Sydney** — so CI needs no pinned `TZ`, which is more robust than the issue's suggestion.

`go build`, `go vet`, `golangci-lint` (v2.5.0, 0 issues), `go test -race ./...` — 18/18 green. Frontend: typecheck, ESLint (0 errors), Prettier, build clean.

## Deliberately untouched

`formatRateDate` (`lib/pricing.ts`) pins UTC, because a pricing rate is keyed to a **day** rather than an instant — it has a test asserting exactly that, and harmonising it would reintroduce the bug #189 fixed.

> **Unrelated pre-existing issue:** `src/lib/streamingBlocks.test.ts` has 7 failing tests on `main`. CI's frontend job runs typecheck/lint/format/build but not `npm test`.
