### PR TITLE
perf(insights): fetch all four breakdown columns in one scan (#201)

### DIFF
--- a/internal/storage/sqlite_session_insights_store.go
+++ b/internal/storage/sqlite_session_insights_store.go
@@ -290,21 +290,8 @@ func (s *SQLiteSessionInsightsStore) GetAggregateSummary(
 		return summary, err
 	}
 
-	for _, col := range []struct {
-		name string
-		into *[]string
-	}{
-		{"tool_breakdown", &summary.ToolBreakdowns},
-		{"skill_breakdown", &summary.SkillBreakdowns},
-		{"plugin_breakdown", &summary.PluginBreakdowns},
-		{"mcp_server_breakdown", &summary.McpServerBreakdowns},
-	} {
-		values, qErr := s.queryBreakdowns(ctx, col.name, where, args)
-		if qErr != nil {
-			err = qErr
-			return summary, err
-		}
-		*col.into = values
+	if err = s.queryAllBreakdowns(ctx, where, args, summary); err != nil {
+		return summary, err
 	}
 	return summary, nil
 }
@@ -399,34 +386,53 @@ func (s *SQLiteSessionInsightsStore) queryAggregateScalars(
 	return summary, err
 }
 
-// queryBreakdowns fetches one breakdown JSON column per matching session, for
-// the caller to merge. column is chosen from a fixed set by GetAggregateSummary
-// and is never user input.
-func (s *SQLiteSessionInsightsStore) queryBreakdowns(
-	ctx context.Context, column, where string, args []any,
-) ([]string, error) {
-	//nolint:gosec // column comes from a fixed literal set; where uses placeholders only
-	rows, err := s.db.QueryContext(ctx, "SELECT "+column+" FROM session_insights"+where, args...)
+const insightBreakdownSQL = `SELECT tool_breakdown, skill_breakdown, plugin_breakdown, mcp_server_breakdown
+FROM session_insights`
+
+// queryAllBreakdowns fetches every breakdown JSON column in a single scan and
+// fills the summary's four slices, for the caller to merge. One query rather
+// than one per column: the row-scan cost then grows with the corpus only, not
+// with how many breakdown dimensions the feature has accumulated.
+//
+// Each column is filtered independently — a row with tools but no skills
+// contributes to ToolBreakdowns alone. Skipping the whole row when any column
+// is empty would silently drop real data from the merged totals.
+func (s *SQLiteSessionInsightsStore) queryAllBreakdowns(
+	ctx context.Context, where string, args []any, summary *InsightAggregateSummary,
+) (err error) {
+	//nolint:gosec // where clause uses parameterized placeholders only
+	rows, err := s.db.QueryContext(ctx, insightBreakdownSQL+where, args...)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer func() {
-		if cerr := rows.Close(); cerr != nil {
+		// Named return, so this actually reaches the caller — but never at the
+		// cost of a scan/iteration error, which is the more informative one.
+		if cerr := rows.Close(); cerr != nil && err == nil {
 			err = cerr
 		}
 	}()
 
-	var breakdowns []string
 	for rows.Next() {
-		var tb string
-		if scanErr := rows.Scan(&tb); scanErr != nil {
-			return nil, scanErr
+		var tool, skill, plugin, mcpServer string
+		if scanErr := rows.Scan(&tool, &skill, &plugin, &mcpServer); scanErr != nil {
+			return scanErr
 		}
-		if tb != "" && tb != "{}" {
-			breakdowns = append(breakdowns, tb)
-		}
+		summary.ToolBreakdowns = appendIfPresent(summary.ToolBreakdowns, tool)
+		summary.SkillBreakdowns = appendIfPresent(summary.SkillBreakdowns, skill)
+		summary.PluginBreakdowns = appendIfPresent(summary.PluginBreakdowns, plugin)
+		summary.McpServerBreakdowns = appendIfPresent(summary.McpServerBreakdowns, mcpServer)
 	}
-	return breakdowns, rows.Err()
+	return rows.Err()
+}
+
+// appendIfPresent appends v unless it carries no breakdown data. An empty
+// string and "{}" are both "nothing attributed" — the columns default to '{}'.
+func appendIfPresent(dst []string, v string) []string {
+	if v == "" || v == "{}" {
+		return dst
+	}
+	return append(dst, v)
 }
 
 // SessionToProcess pairs a session ID with its JSONL file path for processing.

--- a/internal/storage/sqlite_session_insights_store_test.go
+++ b/internal/storage/sqlite_session_insights_store_test.go
@@ -435,6 +435,107 @@ func TestGetAggregateSummary_BreakdownColumnsNotCrossWired(t *testing.T) {
 	}
 }
 
+// TestGetAggregateSummary_BreakdownsFilteredPerColumn pins the one behavior a
+// single-scan rewrite can silently break: the four columns are filtered
+// independently, so a row with tools but no skills must contribute to
+// ToolBreakdowns alone. Discarding such a row wholesale would drop real data
+// from the merged totals with every other test still green.
+func TestGetAggregateSummary_BreakdownsFilteredPerColumn(t *testing.T) {
+	store := setupInsightsTestDB(t)
+	ctx := context.Background()
+
+	// Three rows, each empty in a different place; "empty" reaches SQLite as the
+	// column's '{}' default because an empty map marshals to "{}".
+	toolsOnly := sampleRecord("tools-only")
+	toolsOnly.ToolBreakdown = map[string]int{"TOOL_KEY": 1}
+	toolsOnly.SkillBreakdown = nil
+	toolsOnly.PluginBreakdown = nil
+	toolsOnly.McpServerBreakdown = nil
+
+	skillsAndServers := sampleRecord("skills-and-servers")
+	skillsAndServers.ToolBreakdown = nil
+	skillsAndServers.SkillBreakdown = map[string]int{"SKILL_KEY": 2}
+	skillsAndServers.PluginBreakdown = map[string]int{}
+	skillsAndServers.McpServerBreakdown = map[string]int{"SERVER_KEY": 4}
+
+	allEmpty := sampleRecord("all-empty")
+	allEmpty.ToolBreakdown = nil
+	allEmpty.SkillBreakdown = nil
+	allEmpty.PluginBreakdown = nil
+	allEmpty.McpServerBreakdown = nil
+
+	for _, r := range []storage.InsightRecord{toolsOnly, skillsAndServers, allEmpty} {
+		if err := store.Upsert(ctx, r); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	summary, err := store.GetAggregateSummary(ctx, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.TotalSessions != 3 {
+		t.Fatalf("TotalSessions = %d, want 3", summary.TotalSessions)
+	}
+
+	for _, tc := range []struct {
+		field string
+		blobs []string
+		want  []string
+	}{
+		{"ToolBreakdowns", summary.ToolBreakdowns, []string{"TOOL_KEY"}},
+		{"SkillBreakdowns", summary.SkillBreakdowns, []string{"SKILL_KEY"}},
+		{"PluginBreakdowns", summary.PluginBreakdowns, nil},
+		{"McpServerBreakdowns", summary.McpServerBreakdowns, []string{"SERVER_KEY"}},
+	} {
+		if len(tc.blobs) != len(tc.want) {
+			t.Errorf("%s: got %d blobs %v, want %d — empty columns must be skipped per column, not per row",
+				tc.field, len(tc.blobs), tc.blobs, len(tc.want))
+			continue
+		}
+		for i, want := range tc.want {
+			if !strings.Contains(tc.blobs[i], want) {
+				t.Errorf("%s[%d] = %s, want it to contain %q", tc.field, i, tc.blobs[i], want)
+			}
+		}
+	}
+}
+
+// TestGetAggregateSummary_BreakdownColumnsScanAsPlainString pins the schema
+// guarantee the single-scan query relies on: the breakdown columns are
+// NOT NULL DEFAULT '{}', so a row written without them still scans into a
+// plain string. Were any of them nullable, Scan would fail at runtime and only
+// on real, pre-migration data.
+func TestGetAggregateSummary_BreakdownColumnsScanAsPlainString(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db, _, err := storage.NewSQLiteDB(dbPath, slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store := storage.NewSQLiteSessionInsightsStore(db)
+	ctx := context.Background()
+
+	// Insert bypassing Upsert so the breakdown columns fall to their defaults.
+	if _, err := db.ExecContext(ctx, `
+INSERT INTO session_insights (session_id, processor_version, scanned_at)
+VALUES ('defaults-only', 1, '2026-01-01T00:00:00Z')`); err != nil {
+		t.Fatal(err)
+	}
+
+	summary, err := store.GetAggregateSummary(ctx, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("GetAggregateSummary: %v — breakdown columns must scan into string", err)
+	}
+	if summary.TotalSessions != 1 {
+		t.Fatalf("TotalSessions = %d, want 1", summary.TotalSessions)
+	}
+	if len(summary.ToolBreakdowns)+len(summary.SkillBreakdowns)+
+		len(summary.PluginBreakdowns)+len(summary.McpServerBreakdowns) != 0 {
+		t.Errorf("default '{}' columns must contribute nothing, got %+v", summary)
+	}
+}
+
 // TestGetAggregateSummary_ToolCallTotals covers the denominator the skills
 // panel needs: a breakdown without the unattributed share overstates how much
 // of the work skills account for.


### PR DESCRIPTION
Closes #201

## What

`GetAggregateSummary` fetched the four breakdown JSON columns with one `SELECT <column> FROM session_insights` each. This replaces that loop with a single multi-column query scanned into the four slices in one pass.

## Why

Four full scans per call where one would do — and the insights page also fetches a comparison period, so one page load was **8 scans**, each materializing a TEXT column for every matching row. Queries per call drop 5 → 2; row-scan work becomes O(rows) rather than O(rows × dimensions), so adding a fifth dimension (#202) costs one more `Scan` target instead of two more full scans.

It was also the only reason the file interpolated a column name into SQL — `queryBreakdowns`' `//nolint:gosec` goes away with it.

## How

- `queryAllBreakdowns` — one `QueryContext` over a literal column list, `rows.Scan(&tool, &skill, &plugin, &mcpServer)` per row, filling the summary's four slices.
- `appendIfPresent` — the `"" | "{}"` skip rule expressed once instead of replicated four times.
- `queryBreakdowns` and its `//nolint:gosec` deleted.

## Acceptance criteria

- [x] `GetAggregateSummary` issues exactly 2 queries (`queryAggregateScalars` + one breakdown query), down from 5.
- [x] `queryBreakdowns` and `//nolint:gosec // column comes from a fixed literal set` are gone; no interpolated column name remains in the file.
- [x] The four slices stay **independently** filtered — covered by `TestGetAggregateSummary_BreakdownsFilteredPerColumn`, which fails if a row is skipped wholesale.
- [x] Merged totals unchanged for the same fixtures — existing `GetAggregateSummary` tests and `..._BreakdownColumnsNotCrossWired` still pass untouched.
- [x] `go test -race ./...` and `golangci-lint run` pass.

## Tests added

- `TestGetAggregateSummary_BreakdownsFilteredPerColumn` — three rows empty in different places; asserts each slice independently. This is the test a per-row skip fails.
- `TestGetAggregateSummary_BreakdownColumnsScanAsPlainString` — a row inserted bypassing `Upsert` so the columns fall to their `NOT NULL DEFAULT '{}'`, pinning that they scan into `string` without `sql.NullString`.

## Deviations from the HOW

- The HOW sketched `queryAllBreakdowns(...) (tools, skills, plugins, mcpServers []string, err error)`. Implemented as `queryAllBreakdowns(ctx, where, args, summary *InsightAggregateSummary) error` instead — a five-value return is awkward in Go and the caller only ever assigns straight into the summary. Behavior is identical.
- `err` is a **named** return in the new function so the deferred `rows.Close()` error actually reaches the caller (in the old `queryBreakdowns` that assignment was dead), guarded so it never masks a scan or iteration error.