### PR TITLE
test(claude-sessions): cover the sessions-list filter predicates (#199)

### DIFF
--- a/frontend/src/lib/sessionFilters.test.ts
+++ b/frontend/src/lib/sessionFilters.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect } from 'vitest'
+import {
+  matchesFilters,
+  permissionModesOf,
+  hasPRs,
+  hasFavorites,
+  type SessionFilters,
+} from './sessionFilters'
+import type {
+  ClaudeSessionSummary,
+  ClaudeSessionCost,
+  ClaudeSessionPR,
+  ClaudeTokenUsage,
+} from '../types'
+
+const emptyUsage: ClaudeTokenUsage = {
+  input_tokens: 0,
+  output_tokens: 0,
+  cache_creation_tokens: 0,
+  cache_creation_5m_tokens: 0,
+  cache_creation_1h_tokens: 0,
+  cache_read_tokens: 0,
+}
+
+const zeroCost: ClaudeSessionCost = {
+  input_usd: 0,
+  output_usd: 0,
+  cache_read_usd: 0,
+  cache_write_usd: 0,
+  total_usd: 0,
+}
+
+const samplePR: ClaudeSessionPR = {
+  pr_number: 1,
+  pr_url: 'https://github.com/shaharia-lab/agento/pull/1',
+  pr_repository: 'shaharia-lab/agento',
+  first_seen_at: '2026-08-07T10:30:00.000Z',
+}
+
+function makeSession(overrides: Partial<ClaudeSessionSummary> = {}): ClaudeSessionSummary {
+  return {
+    session_id: 'sess-1',
+    project_path: '/home/dev/alpha',
+    preview: 'add a login form',
+    display_title: 'Login form',
+    is_favorite: true,
+    start_time: '2026-08-07T10:00:00.000Z',
+    last_activity: '2026-08-07T11:00:00.000Z',
+    message_count: 4,
+    event_count: 9,
+    usage: { ...emptyUsage },
+    subagent_count: 0,
+    subagent_usage: { ...emptyUsage },
+    permission_mode: 'bypassPermissions',
+    compaction_count: 0,
+    dropped_tokens: 0,
+    cost: { ...zeroCost },
+    subagent_cost: { ...zeroCost },
+    prs: [samplePR],
+    ...overrides,
+  }
+}
+
+/** Every filter set to its match-everything value. */
+function noFilters(overrides: Partial<SessionFilters> = {}): SessionFilters {
+  return {
+    project: 'all',
+    search: '',
+    favorites: false,
+    hasPR: false,
+    permissionMode: 'all',
+    from: null,
+    to: null,
+    drilldownActive: false,
+    drilldownWindows: [],
+    ...overrides,
+  }
+}
+
+describe('matchesFilters — each predicate in isolation', () => {
+  it('project matches "all" and the exact path only', () => {
+    const s = makeSession({ project_path: '/home/dev/alpha' })
+    expect(matchesFilters(s, noFilters())).toBe(true)
+    expect(matchesFilters(s, noFilters({ project: '/home/dev/alpha' }))).toBe(true)
+    expect(matchesFilters(s, noFilters({ project: '/home/dev/beta' }))).toBe(false)
+    // Not a prefix or substring match.
+    expect(matchesFilters(s, noFilters({ project: '/home/dev' }))).toBe(false)
+  })
+
+  it('search is match-all when empty', () => {
+    expect(matchesFilters(makeSession(), noFilters({ search: '' }))).toBe(true)
+  })
+
+  it('search matches each of the four searched fields, case-insensitively', () => {
+    const s = makeSession({
+      session_id: 'ABC-123',
+      display_title: 'Refactor Pricing',
+      preview: 'Rename the CATALOG',
+      project_path: '/home/dev/Gamma',
+    })
+    for (const q of ['abc-123', 'refactor pricing', 'catalog', 'gamma']) {
+      expect(matchesFilters(s, noFilters({ search: q })), `query ${q}`).toBe(true)
+    }
+    // And uppercase queries against lowercase content.
+    expect(matchesFilters(s, noFilters({ search: 'RENAME' }))).toBe(true)
+    expect(matchesFilters(s, noFilters({ search: 'nothing here' }))).toBe(false)
+  })
+
+  it('search tolerates a missing display_title rather than matching on "undefined"', () => {
+    const s = makeSession({ display_title: undefined })
+    expect(matchesFilters(s, noFilters({ search: 'undefined' }))).toBe(false)
+    expect(matchesFilters(s, noFilters({ search: 'login' }))).toBe(true)
+  })
+
+  it('favorites only excludes when enabled', () => {
+    const fav = makeSession({ is_favorite: true })
+    const notFav = makeSession({ is_favorite: false })
+    const absent = makeSession({ is_favorite: undefined })
+    expect(matchesFilters(notFav, noFilters({ favorites: false }))).toBe(true)
+    expect(matchesFilters(fav, noFilters({ favorites: true }))).toBe(true)
+    expect(matchesFilters(notFav, noFilters({ favorites: true }))).toBe(false)
+    expect(matchesFilters(absent, noFilters({ favorites: true }))).toBe(false)
+  })
+
+  it('has-PR treats a missing and an empty prs array alike', () => {
+    const withPR = makeSession()
+    const emptyPRs = makeSession({ prs: [] })
+    const noPRs = makeSession({ prs: undefined })
+    expect(matchesFilters(emptyPRs, noFilters({ hasPR: false }))).toBe(true)
+    expect(matchesFilters(withPR, noFilters({ hasPR: true }))).toBe(true)
+    expect(matchesFilters(emptyPRs, noFilters({ hasPR: true }))).toBe(false)
+    expect(matchesFilters(noPRs, noFilters({ hasPR: true }))).toBe(false)
+  })
+
+  it('permission mode matches "all" and the exact mode only', () => {
+    const s = makeSession({ permission_mode: 'plan' })
+    expect(matchesFilters(s, noFilters({ permissionMode: 'all' }))).toBe(true)
+    expect(matchesFilters(s, noFilters({ permissionMode: 'plan' }))).toBe(true)
+    expect(matchesFilters(s, noFilters({ permissionMode: 'default' }))).toBe(false)
+    // A session with no recorded mode is excluded by any specific mode.
+    const unset = makeSession({ permission_mode: undefined })
+    expect(matchesFilters(unset, noFilters({ permissionMode: 'plan' }))).toBe(false)
+    expect(matchesFilters(unset, noFilters({ permissionMode: 'all' }))).toBe(true)
+  })
+
+  it('time range keeps sessions overlapping [from, to] and drops the rest', () => {
+    const s = makeSession({
+      start_time: '2026-08-07T10:00:00.000Z',
+      last_activity: '2026-08-07T11:00:00.000Z',
+    })
+    // Fully inside.
+    expect(
+      matchesFilters(
+        s,
+        noFilters({ from: new Date('2026-08-07T09:00:00Z'), to: new Date('2026-08-07T12:00:00Z') }),
+      ),
+    ).toBe(true)
+    // Overlapping the tail only — still a match.
+    expect(matchesFilters(s, noFilters({ from: new Date('2026-08-07T10:30:00Z') }))).toBe(true)
+    // Entirely before the window.
+    expect(matchesFilters(s, noFilters({ from: new Date('2026-08-08T00:00:00Z') }))).toBe(false)
+    // Entirely after it.
+    expect(matchesFilters(s, noFilters({ to: new Date('2026-08-07T09:00:00Z') }))).toBe(false)
+  })
+})
+
+describe('matchesFilters — the && chain', () => {
+  /**
+   * One case per filter: the session fails that filter and passes the other
+   * five. A dropped clause makes exactly one of these return true, which no
+   * single-filter test can catch.
+   */
+  const allSix = noFilters({
+    project: '/home/dev/alpha',
+    search: 'login',
+    favorites: true,
+    hasPR: true,
+    permissionMode: 'bypassPermissions',
+    from: new Date('2026-08-07T09:00:00Z'),
+    to: new Date('2026-08-07T12:00:00Z'),
+  })
+
+  it('passes a session satisfying every filter', () => {
+    expect(matchesFilters(makeSession(), allSix)).toBe(true)
+  })
+
+  it.each([
+    ['project', { project_path: '/home/dev/beta' }],
+    ['search', { preview: 'unrelated', display_title: 'unrelated', session_id: 'zzz' }],
+    ['favorites', { is_favorite: false }],
+    ['has-PR', { prs: [] }],
+    ['permission mode', { permission_mode: 'plan' }],
+    [
+      'time range',
+      { start_time: '2026-08-01T00:00:00.000Z', last_activity: '2026-08-01T01:00:00.000Z' },
+    ],
+  ] as [string, Partial<ClaudeSessionSummary>][])(
+    'rejects a session failing only the %s filter',
+    (_name, overrides) => {
+      expect(matchesFilters(makeSession(overrides), allSix)).toBe(false)
+    },
+  )
+})
+
+describe('matchesFilters — drill-down branch', () => {
+  const s = makeSession({
+    start_time: '2026-08-07T10:00:00.000Z',
+    last_activity: '2026-08-07T11:00:00.000Z',
+  })
+
+  it('uses the windows and ignores from/to when a drill-down is active', () => {
+    const overlapping = {
+      from: Date.parse('2026-08-07T10:30:00Z'),
+      to: Date.parse('2026-08-07T12:00:00Z'),
+    }
+    // from/to here would exclude the session outright; the drill-down wins.
+    expect(
+      matchesFilters(
+        s,
+        noFilters({
+          drilldownActive: true,
+          drilldownWindows: [overlapping],
+          from: new Date('2020-01-01T00:00:00Z'),
+          to: new Date('2020-01-02T00:00:00Z'),
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('rejects a session outside every window', () => {
+    const elsewhere = {
+      from: Date.parse('2026-08-09T00:00:00Z'),
+      to: Date.parse('2026-08-10T00:00:00Z'),
+    }
+    expect(
+      matchesFilters(s, noFilters({ drilldownActive: true, drilldownWindows: [elsewhere] })),
+    ).toBe(false)
+  })
+
+  it('matches when any one of several windows overlaps', () => {
+    const miss = {
+      from: Date.parse('2026-08-01T00:00:00Z'),
+      to: Date.parse('2026-08-02T00:00:00Z'),
+    }
+    const hit = {
+      from: Date.parse('2026-08-07T09:00:00Z'),
+      to: Date.parse('2026-08-07T10:30:00Z'),
+    }
+    expect(
+      matchesFilters(s, noFilters({ drilldownActive: true, drilldownWindows: [miss, hit] })),
+    ).toBe(true)
+  })
+
+  it('matches nothing when active with no windows', () => {
+    expect(matchesFilters(s, noFilters({ drilldownActive: true, drilldownWindows: [] }))).toBe(
+      false,
+    )
+  })
+
+  it('ignores the windows entirely when not active', () => {
+    const elsewhere = {
+      from: Date.parse('2026-08-09T00:00:00Z'),
+      to: Date.parse('2026-08-10T00:00:00Z'),
+    }
+    expect(
+      matchesFilters(s, noFilters({ drilldownActive: false, drilldownWindows: [elsewhere] })),
+    ).toBe(true)
+  })
+})
+
+describe('control-visibility gates', () => {
+  it('permissionModesOf de-duplicates, drops empty and missing, and sorts', () => {
+    const sessions = [
+      makeSession({ permission_mode: 'plan' }),
+      makeSession({ permission_mode: 'bypassPermissions' }),
+      makeSession({ permission_mode: 'plan' }),
+      makeSession({ permission_mode: '' }),
+      makeSession({ permission_mode: undefined }),
+    ]
+    expect(permissionModesOf(sessions)).toEqual(['bypassPermissions', 'plan'])
+  })
+
+  it('permissionModesOf returns empty for no sessions, so the control stays hidden', () => {
+    expect(permissionModesOf([])).toEqual([])
+    expect(permissionModesOf([makeSession({ permission_mode: undefined })])).toEqual([])
+  })
+
+  it('hasPRs is false for both a missing and an empty prs array', () => {
+    expect(hasPRs([])).toBe(false)
+    expect(hasPRs([makeSession({ prs: undefined })])).toBe(false)
+    expect(hasPRs([makeSession({ prs: [] })])).toBe(false)
+    expect(hasPRs([makeSession({ prs: [] }), makeSession()])).toBe(true)
+  })
+
+  it('hasFavorites distinguishes absent, false and true', () => {
+    expect(hasFavorites([])).toBe(false)
+    expect(hasFavorites([makeSession({ is_favorite: undefined })])).toBe(false)
+    expect(hasFavorites([makeSession({ is_favorite: false })])).toBe(false)
+    expect(hasFavorites([makeSession({ is_favorite: false }), makeSession()])).toBe(true)
+  })
+})

--- a/frontend/src/lib/sessionFilters.ts
+++ b/frontend/src/lib/sessionFilters.ts
@@ -1,0 +1,74 @@
+import type { ClaudeSessionSummary } from '../types'
+import type { DrilldownWindow } from './drilldown'
+import { overlapsAnyWindow } from './drilldown'
+import { overlapsRange } from './timefilter'
+
+/**
+ * The six sessions-list predicates, resolved to plain values. The time range is
+ * already resolved (`resolvePresetRange` runs once per render, not per session),
+ * so this stays a pure function of its arguments.
+ */
+export interface SessionFilters {
+  /** `'all'` matches every project. */
+  project: string
+  /** Empty matches everything; matched case-insensitively. */
+  search: string
+  favorites: boolean
+  hasPR: boolean
+  /** `'all'` matches every mode. */
+  permissionMode: string
+  from: Date | null
+  to: Date | null
+  /** When true the drill-down windows replace the preset range entirely. */
+  drilldownActive: boolean
+  drilldownWindows: DrilldownWindow[]
+}
+
+/**
+ * Returns true when a session passes every filter. Extracted from the sessions
+ * page so the `&&` chain can be tested directly: a dropped clause returns a
+ * plausible-looking subset rather than throwing, which is invisible in the UI.
+ */
+export function matchesFilters(s: ClaudeSessionSummary, f: SessionFilters): boolean {
+  const matchesProject = f.project === 'all' || s.project_path === f.project
+  const q = f.search.toLowerCase()
+  const matchesSearch =
+    !q ||
+    s.session_id.toLowerCase().includes(q) ||
+    (s.display_title ?? '').toLowerCase().includes(q) ||
+    s.preview.toLowerCase().includes(q) ||
+    s.project_path.toLowerCase().includes(q)
+  const matchesFavorites = !f.favorites || !!s.is_favorite
+  const matchesHasPR = !f.hasPR || (s.prs?.length ?? 0) > 0
+  const matchesPermissionMode = f.permissionMode === 'all' || s.permission_mode === f.permissionMode
+  const matchesTime = f.drilldownActive
+    ? overlapsAnyWindow(s.start_time, s.last_activity, f.drilldownWindows)
+    : overlapsRange(s.start_time, s.last_activity, f.from, f.to)
+  return (
+    matchesProject &&
+    matchesSearch &&
+    matchesFavorites &&
+    matchesHasPR &&
+    matchesPermissionMode &&
+    matchesTime
+  )
+}
+
+/**
+ * The distinct permission modes present, sorted. The page only offers the
+ * filter once this has more than one entry — a single-value dropdown filters
+ * nothing — so dropping a mode here makes the control vanish.
+ */
+export function permissionModesOf(sessions: ClaudeSessionSummary[]): string[] {
+  return [...new Set(sessions.map(s => s.permission_mode).filter((m): m is string => !!m))].sort()
+}
+
+/** Whether any session is linked to a PR, gating the has-PR toggle. */
+export function hasPRs(sessions: ClaudeSessionSummary[]): boolean {
+  return sessions.some(s => (s.prs?.length ?? 0) > 0)
+}
+
+/** Whether any session is favorited, gating the favorites toggle. */
+export function hasFavorites(sessions: ClaudeSessionSummary[]): boolean {
+  return sessions.some(s => s.is_favorite)
+}

--- a/frontend/src/pages/ClaudeSessionsPage.tsx
+++ b/frontend/src/pages/ClaudeSessionsPage.tsx
@@ -136,19 +136,19 @@ export default function ClaudeSessionsPage() {
 
   const filtered = useMemo(() => {
     const { from, to } = resolvePresetRange(timePreset, customFrom, customTo)
-    return sessions.filter(s =>
-      matchesFilters(s, {
-        project: filterProject,
-        search,
-        favorites: filterFavorites,
-        hasPR: filterHasPR,
-        permissionMode: filterPermissionMode,
-        from,
-        to,
-        drilldownActive,
-        drilldownWindows,
-      }),
-    )
+    // Built once, not per session — the predicate is the same for every row.
+    const filters = {
+      project: filterProject,
+      search,
+      favorites: filterFavorites,
+      hasPR: filterHasPR,
+      permissionMode: filterPermissionMode,
+      from,
+      to,
+      drilldownActive,
+      drilldownWindows,
+    }
+    return sessions.filter(s => matchesFilters(s, filters))
   }, [
     sessions,
     search,

--- a/frontend/src/pages/ClaudeSessionsPage.tsx
+++ b/frontend/src/pages/ClaudeSessionsPage.tsx
@@ -29,8 +29,14 @@ import {
 import { Tooltip } from '@/components/ui/tooltip'
 import { CopyableId } from '@/components/CopyableId'
 import { formatCost, formatTokens, shortPath } from '@/lib/format'
-import { overlapsRange, resolvePresetRange, type TimePreset } from '@/lib/timefilter'
-import { decodeWindows, overlapsAnyWindow } from '@/lib/drilldown'
+import { resolvePresetRange, type TimePreset } from '@/lib/timefilter'
+import { decodeWindows } from '@/lib/drilldown'
+import {
+  matchesFilters,
+  permissionModesOf,
+  hasPRs as sessionsHavePRs,
+  hasFavorites as hasFavoriteSessions,
+} from '@/lib/sessionFilters'
 
 const TIME_PRESET_LABELS: Record<TimePreset, string> = {
   all: 'All time',
@@ -111,14 +117,11 @@ export default function ClaudeSessionsPage() {
       .catch(() => setSessions(applyFavorite(sessionId, !next)))
   }
 
-  const hasFavorites = sessions.some(s => s.is_favorite)
-  const hasPRs = sessions.some(s => (s.prs?.length ?? 0) > 0)
+  const hasFavorites = hasFavoriteSessions(sessions)
+  const hasPRs = sessionsHavePRs(sessions)
   // Only offer the permission-mode filter once more than one mode is present —
   // a single-value dropdown filters nothing.
-  const permissionModes = useMemo(
-    () => [...new Set(sessions.map(s => s.permission_mode).filter((m): m is string => !!m))].sort(),
-    [sessions],
-  )
+  const permissionModes = useMemo(() => permissionModesOf(sessions), [sessions])
 
   const timeFilterActive = drilldownActive || timePreset !== 'all'
 
@@ -133,32 +136,19 @@ export default function ClaudeSessionsPage() {
 
   const filtered = useMemo(() => {
     const { from, to } = resolvePresetRange(timePreset, customFrom, customTo)
-    const result = sessions.filter(s => {
-      const matchesProject = filterProject === 'all' || s.project_path === filterProject
-      const q = search.toLowerCase()
-      const matchesSearch =
-        !q ||
-        s.session_id.toLowerCase().includes(q) ||
-        (s.display_title ?? '').toLowerCase().includes(q) ||
-        s.preview.toLowerCase().includes(q) ||
-        s.project_path.toLowerCase().includes(q)
-      const matchesFavorites = !filterFavorites || !!s.is_favorite
-      const matchesHasPR = !filterHasPR || (s.prs?.length ?? 0) > 0
-      const matchesPermissionMode =
-        filterPermissionMode === 'all' || s.permission_mode === filterPermissionMode
-      const matchesTime = drilldownActive
-        ? overlapsAnyWindow(s.start_time, s.last_activity, drilldownWindows)
-        : overlapsRange(s.start_time, s.last_activity, from, to)
-      return (
-        matchesProject &&
-        matchesSearch &&
-        matchesFavorites &&
-        matchesHasPR &&
-        matchesPermissionMode &&
-        matchesTime
-      )
-    })
-    return result
+    return sessions.filter(s =>
+      matchesFilters(s, {
+        project: filterProject,
+        search,
+        favorites: filterFavorites,
+        hasPR: filterHasPR,
+        permissionMode: filterPermissionMode,
+        from,
+        to,
+        drilldownActive,
+        drilldownWindows,
+      }),
+    )
   }, [
     sessions,
     search,


### PR DESCRIPTION
Closes #199

## What

Extracts the sessions-list filter predicate into a pure `matchesFilters(session, filters)` in `frontend/src/lib/sessionFilters.ts`, plus the three control-visibility derivations, and covers all of it with 24 vitest cases. **Behavior is unchanged** — this is a test-coverage issue.

## Why

Six predicates composed in one `useMemo` and none had a test. The failure mode is silent: a wrong `&&`, an inverted `!` or a dropped clause returns a plausible-looking subset rather than throwing, so the user concludes the session is gone. The gate derivations are worse — a regression there makes a filter *vanish from the UI* rather than misbehave visibly.

## How

- **`lib/sessionFilters.ts`** *(new)* — `matchesFilters` with the six clauses lifted **verbatim**, still delegating to `overlapsRange` / `overlapsAnyWindow`; `permissionModesOf`, `hasPRs`, `hasFavorites`.
- **`lib/sessionFilters.test.ts`** *(new)* — the coverage.
- **`ClaudeSessionsPage.tsx`** — `useMemo` delegates; dependency array untouched. `resolvePresetRange` still runs once per render, not per session. The two gate helpers are imported under aliases (`sessionsHavePRs` / `hasFavoriteSessions`) so the local `hasPRs` / `hasFavorites` consts keep their names and no JSX changed.

## Acceptance criteria

- [x] `matchesFilters` is pure and exported, no React or router imports.
- [x] Each of the six predicates covered in isolation.
- [x] Combined-filter cases prove the `&&` chain — one session passing all six, plus a **"fails exactly one of six"** matrix, one case per filter.
- [x] Search covers all four fields (`session_id`, `display_title`, `preview`, `project_path`), is case-insensitive, and empty is match-all.
- [x] Gate derivations covered: `permissionModesOf` de-duplicates, drops null/empty and sorts; `hasPRs` false for both missing and empty `prs`; `hasFavorites` for absent vs `false` vs `true`.
- [x] Drill-down branch covered — when active, `overlapsAnyWindow` is used and the preset range is ignored (asserted with a from/to that would otherwise exclude the session).
- [x] `npm run lint` (0 errors), `npm run typecheck`, `npm run format:check`, `npm run build` pass; the 24 new tests pass.

## The tests were verified to actually catch the bug they exist for

Removing `matchesFavorites &&` from the chain fails exactly one case — `rejects a session failing only the favorites filter` — and nothing else. Restored afterwards. That mutation is the whole point of the matrix: no single-filter test catches a dropped clause.

The fixture is fully typed with no `as` cast, so `tsc` validates it against `ClaudeSessionSummary` rather than rubber-stamping a wrong shape.

## ⚠️ Pre-existing failure found — filed as #215

`npm run test` does **not** currently pass on `main`, for reasons unrelated to this PR: **CI never runs the vitest suite** (the `Frontend` job runs typecheck/lint/format/build only), and 7 tests in `streamingBlocks.test.ts` have been failing on `main` unnoticed — `streamingBlocks.ts` gained a `_key` field and the assertions were never updated.

That is out of scope here (#199 is about the sessions-list filters) and is tracked in **#215**, which also proposes adding `npm run test` to CI. Worth flagging on this PR specifically: tests CI never runs buy less than they appear to, and this repo just demonstrated that on itself.