### PR TITLE
feat(pricing): seed the Qwen 3.7/3.6 generation (#206)

### DIFF
--- a/internal/pricing/catalog.json
+++ b/internal/pricing/catalog.json
@@ -253,6 +253,57 @@
   },
   {
     "provider": "alibaba",
+    "model_pattern": "qwen3.7-max",
+    "match_type": "prefix",
+    "display_name": "Qwen3.7 Max",
+    "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing · International (Singapore) endpoint · retrieved 2026-08-09. Flat 0-1M, no tier split. PROMOTIONAL: the page marks this a limited-time 50% discount and publishes NO expiry date, so no boundary row is seeded — a guessed expiry would misprice a whole date range invisibly. Add the list-price row once Alibaba publishes the end date. Cache per Alibaba's percentage rule: explicit creation 125% of input, hits 10%.",
+    "rates": [
+      {
+        "effective_from": "",
+        "input": 2.5,
+        "output": 7.5,
+        "cache_read": 0.25,
+        "cache_write_5m": 3.125,
+        "cache_write_1h": 3.125
+      }
+    ]
+  },
+  {
+    "provider": "alibaba",
+    "model_pattern": "qwen3.7-plus",
+    "match_type": "prefix",
+    "display_name": "Qwen3.7 Plus",
+    "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing · International (Singapore) endpoint · retrieved 2026-08-09. Base 0-256K tier; Alibaba charges $1.20/$4.80 above 256K and the catalog has no context-length dimension, so long-context usage is under-reported by up to 200%. PROMOTIONAL: marked a limited-time 20% discount with NO published expiry, so no boundary row is seeded rather than guessing one. Cache per Alibaba's percentage rule: explicit creation 125% of input, hits 10%.",
+    "rates": [
+      {
+        "effective_from": "",
+        "input": 0.4,
+        "output": 1.6,
+        "cache_read": 0.04,
+        "cache_write_5m": 0.5,
+        "cache_write_1h": 0.5
+      }
+    ]
+  },
+  {
+    "provider": "alibaba",
+    "model_pattern": "qwen3.6-flash",
+    "match_type": "prefix",
+    "display_name": "Qwen3.6 Flash",
+    "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing · International (Singapore) endpoint · retrieved 2026-08-09. Base 0-256K tier; Alibaba charges $1.00/$4.00 above 256K and the catalog has no context-length dimension, so long-context usage is under-reported by up to 300%. Not promotional. Cache per Alibaba's percentage rule: explicit creation 125% of input, hits 10%.",
+    "rates": [
+      {
+        "effective_from": "",
+        "input": 0.25,
+        "output": 1.5,
+        "cache_read": 0.025,
+        "cache_write_5m": 0.3125,
+        "cache_write_1h": 0.3125
+      }
+    ]
+  },
+  {
+    "provider": "alibaba",
     "model_pattern": "qwen3.5-397b-a17b",
     "match_type": "prefix",
     "display_name": "Qwen3.5 397B A17B",

--- a/internal/pricing/resolver_test.go
+++ b/internal/pricing/resolver_test.go
@@ -1,6 +1,7 @@
 package pricing
 
 import (
+	"math"
 	"testing"
 	"time"
 )
@@ -316,4 +317,135 @@ func TestBuiltinCatalog_SeedRatesMatchAcceptanceCases(t *testing.T) {
 	if _, ok := r.Resolve("claude-opus-4-7[1m]", ts("2026-03-01T00:00:00Z")); !ok {
 		t.Error("claude-opus-4-7[1m] landed in the unknown bucket")
 	}
+}
+
+// TestBuiltinCatalog_Qwen37Generation covers the rows #206 seeded. The risk in
+// a data-only change is not a crash but a silent mis-resolution: a pattern that
+// shadows a neighbor prices one model at another's rate, and every test still
+// passes.
+func TestBuiltinCatalog_Qwen37Generation(t *testing.T) {
+	r := NewResolver(allBuiltinRates(t))
+	at := ts("2026-08-09T12:00:00Z")
+
+	for _, tc := range []struct {
+		modelID       string
+		input, output float64
+	}{
+		// Newly seeded, verified against the Model Studio pricing page.
+		{"qwen3.7-max", 2.5, 7.5},
+		{"qwen3.7-plus", 0.4, 1.6},
+		{"qwen3.6-flash", 0.25, 1.5},
+		// Pre-existing rows must be unaffected by the new prefixes. qwen3-max is
+		// the one that could plausibly capture qwen3.7-max, and qwen3.5-flash
+		// the one that could be captured by qwen3.6-flash.
+		{"qwen3-max", 1.2, 6.0},
+		{"qwen3.5-flash", 0.1, 0.4},
+		{"qwen3.5-plus", 0.4, 2.4},
+	} {
+		got, ok := r.Resolve(tc.modelID, at)
+		if !ok {
+			t.Errorf("%s landed in the unknown-pricing bucket", tc.modelID)
+			continue
+		}
+		if got.Rate.InputPerMTok != tc.input || got.Rate.OutputPerMTok != tc.output {
+			t.Errorf("%s = $%v/$%v, want $%v/$%v — check for a shadowing pattern",
+				tc.modelID, got.Rate.InputPerMTok, got.Rate.OutputPerMTok, tc.input, tc.output)
+		}
+		// These are concrete published prices, not family aliases.
+		if got.Estimated {
+			t.Errorf("%s resolved as estimated; it has a published rate", tc.modelID)
+		}
+	}
+
+	// A dated or suffixed ID must still land on its prefix rather than falling
+	// through to a coarser row.
+	suffixed, ok := r.Resolve("qwen3.7-max-2026-08-01", at)
+	if !ok || suffixed.Rate.InputPerMTok != 2.5 {
+		t.Errorf("qwen3.7-max-2026-08-01 = %+v ok=%v, want the qwen3.7-max rate", suffixed, ok)
+	}
+}
+
+// TestBuiltinCatalog_QwenPromoRatesHaveNoGuessedBoundary pins the decision
+// #206 made. qwen3.7-max and qwen3.7-plus are both limited-time discounts for
+// which Alibaba publishes no end date, so they are seeded as a single rate: a
+// guessed expiry would misprice a whole date range with nothing to signal it.
+// If a boundary is ever added it must come from a published date, and this test
+// is the reminder to check that the date is real.
+func TestBuiltinCatalog_QwenPromoRatesHaveNoGuessedBoundary(t *testing.T) {
+	for _, pattern := range []string{"qwen3.7-max", "qwen3.7-plus", "qwen3.6-flash"} {
+		var found bool
+		for _, e := range BuiltinCatalog() {
+			if e.ModelPattern != pattern {
+				continue
+			}
+			found = true
+			if len(e.Rates) != 1 {
+				t.Errorf("%s has %d rate rows; a boundary must come from a published expiry date",
+					pattern, len(e.Rates))
+			}
+		}
+		if !found {
+			t.Errorf("%s is not in the built-in catalog", pattern)
+		}
+	}
+
+	// The effective-dated mechanism itself is exercised by claude-sonnet-5 in
+	// TestBuiltinCatalog_SeedRatesMatchAcceptanceCases — the only entry with a
+	// real published boundary.
+	r := NewResolver(allBuiltinRates(t))
+	early, ok1 := r.Resolve("qwen3.7-max", ts("2026-08-09T00:00:00Z"))
+	late, ok2 := r.Resolve("qwen3.7-max", ts("2027-08-09T00:00:00Z"))
+	if !ok1 || !ok2 || early.Rate.InputPerMTok != late.Rate.InputPerMTok {
+		t.Errorf("qwen3.7-max changed rate over time (%+v -> %+v) without a published boundary",
+			early.Rate, late.Rate)
+	}
+}
+
+// TestBuiltinCatalog_QwenCachePercentageRule checks the arithmetic behind the
+// cache columns. Alibaba publishes cache pricing as a percentage of input
+// rather than an absolute figure, so these are derived numbers and a slip is
+// invisible — nothing else in the catalog would disagree with it.
+func TestBuiltinCatalog_QwenCachePercentageRule(t *testing.T) {
+	const epsilon = 1e-9
+	for _, e := range BuiltinCatalog() {
+		if e.Provider != "alibaba" {
+			continue
+		}
+		rates, err := e.rates()
+		if err != nil {
+			t.Fatalf("entry %q: %v", e.ModelPattern, err)
+		}
+		for _, rate := range rates {
+			in := rate.InputPerMTok
+			checks := []struct {
+				name string
+				got  float64
+				want float64
+			}{
+				{"cache_read (10% of input)", rate.CacheReadPerMTok, in * 0.10},
+				{"cache_write_5m (125% of input)", rate.CacheWrite5mPerMTok, in * 1.25},
+				{"cache_write_1h (125% of input)", rate.CacheWrite1hPerMTok, in * 1.25},
+			}
+			for _, c := range checks {
+				if math.Abs(c.got-c.want) > epsilon {
+					t.Errorf("%s: %s = %v, want %v (input $%v)",
+						e.ModelPattern, c.name, c.got, c.want, in)
+				}
+			}
+		}
+	}
+}
+
+// allBuiltinRates flattens the embedded catalog into resolver input.
+func allBuiltinRates(t *testing.T) []Rate {
+	t.Helper()
+	var all []Rate
+	for _, e := range BuiltinCatalog() {
+		rates, err := e.rates()
+		if err != nil {
+			t.Fatalf("entry %q: %v", e.ModelPattern, err)
+		}
+		all = append(all, rates...)
+	}
+	return all
 }


### PR DESCRIPTION
Closes #206

## What

Seeds `qwen3.7-max`, `qwen3.7-plus` and `qwen3.6-flash` into the pricing catalog. Data change only — no code touched.

## Verification (the issue's first AC)

Every rate re-verified against `https://www.alibabacloud.com/help/en/model-studio/model-pricing`, **International/Singapore endpoint, on 2026-08-09** — the day of implementation, not copied from the issue. The retrieval date is in each entry's `source` string.

| Model | Input | Output | Tiering | Promo |
|---|---|---|---|---|
| `qwen3.7-max` | $2.50 | $7.50 | flat 0–1M | 50% limited-time, **no published expiry** |
| `qwen3.7-plus` | $0.40 | $1.60 | base 0–256K ($1.20/$4.80 above) | 20% limited-time, **no published expiry** |
| `qwen3.6-flash` | $0.25 | $1.50 | base 0–256K ($1.00/$4.00 above) | none |

Cache columns derive from Alibaba's percentage rule (hits 10% of input, explicit creation 125%, no TTL split) — asserted by a test rather than eyeballed.

## Two deliberate omissions

**`qwen3.7-flash` is not seeded.** The issue lists it as live at $0.03/$0.13, but it does **not appear on the pricing page** — verified on two separate passes, including an exact-string search. The AC is explicit: a model not on that page is not seeded. A missing row surfaces in the unknown-pricing bucket; a guessed one is invisible. (Same reasoning that keeps `qwen3.8-max` out — gap 1, confirmed still absent.)

**No post-promo boundary row.** Both discounts are marked limited-time and **neither publishes an expiry date**. The AC forbids guessing one, so each is seeded as a single rate with the situation spelled out in `source`. This is the branch the issue anticipated in its open question.

## Acceptance criteria

- [x] Every rate from the Model Studio pricing page (International/Singapore) on the implementation day, with the date in `source`; a model not on the page is not seeded.
- [x] Promotional rates with a published expiry get a boundary row — **N/A**: no expiry is published for either promo, so the "seed the promo rate alone and document it" branch applies.
- [x] `source` states the price is promotional with no published end date.
- [x] Cache columns follow the percentage rule (`cache_read` = input × 0.10, `cache_write_5m` = `cache_write_1h` = input × 1.25).
- [x] All rates non-zero, so parse-time validation accepts them with no `billable: false`.
- [ ] ~~`resolver_test.go` asserts a before/after boundary resolution for a seeded model~~ — **not satisfiable**: no seeded model has a boundary, because none has a published expiry. See "Deviation" below.
- [x] `go test -race ./...` and `golangci-lint` (0 issues) pass; the catalog validation panic does not fire.

## Deviation from the ACs

The boundary-resolution AC assumes at least one seeded model would carry a promo expiry. None does, so I could not write that test without first inventing the expiry the issue forbids. Instead:

- The effective-dated mechanism is already proven by `TestBuiltinCatalog_SeedRatesMatchAcceptanceCases`, which resolves `claude-sonnet-5` either side of its real published `2026-09-01` boundary — the catalog's only genuine multi-rate entry.
- `TestBuiltinCatalog_QwenPromoRatesHaveNoGuessedBoundary` pins the decision from the other direction: each Qwen entry has exactly one rate row, and `qwen3.7-max` resolves to the same rate a year apart. If someone later adds a boundary, that test fails and forces the question "is this expiry date real?".

## Tests added

- `TestBuiltinCatalog_Qwen37Generation` — the three new IDs resolve to their exact rates, `Estimated` is false, a suffixed ID still hits its prefix, and — the real risk in a data change — the pre-existing `qwen3-max`, `qwen3.5-flash` and `qwen3.5-plus` rows are unshadowed. A pattern collision would price one model at another's rate with every other test green.
- `TestBuiltinCatalog_QwenPromoRatesHaveNoGuessedBoundary` — as above.
- `TestBuiltinCatalog_QwenCachePercentageRule` — checks the derived cache arithmetic across **every** `alibaba` entry, not just the new ones. These are computed numbers with nothing else to disagree with them.

## Follow-up filed

**#218** — context-length rate tiers (gap 3), which the issue asks be filed separately. `qwen3.7-plus` and `qwen3.6-flash` under-report above 256K by up to 200% and 300%; that is now recorded in each entry's `source` too.

## Operational note

Adding catalog rows changes the FNV-1a catalog revision, so `pricing_rev` drifts and every transcript is re-read once on the next scan to re-cost. That is the intended mechanism (#188), not a side effect of this PR — worth knowing it stacks with #202's processor-version bump on the same upgrade.