### PR TITLE
test(frontend): repair stale streamingBlocks assertions and run vitest in CI (#215)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,9 @@ jobs:
       - name: ESLint
         run: npm run lint
 
+      - name: Test
+        run: npm run test
+
       - name: Prettier check
         run: npm run format:check
 

--- a/frontend/src/lib/streamingBlocks.test.ts
+++ b/frontend/src/lib/streamingBlocks.test.ts
@@ -5,7 +5,7 @@ import type { MessageBlock, SDKContentBlock } from '@/types'
 describe('applyThinkingDelta', () => {
   it('creates a new thinking block when blocks are empty', () => {
     const result = applyThinkingDelta([], 'hello')
-    expect(result).toEqual([{ type: 'thinking', text: 'hello' }])
+    expect(result).toEqual([expect.objectContaining({ type: 'thinking', text: 'hello' })])
   })
 
   it('appends to the last thinking block', () => {
@@ -18,8 +18,8 @@ describe('applyThinkingDelta', () => {
     const blocks: MessageBlock[] = [{ type: 'text', text: 'some text' }]
     const result = applyThinkingDelta(blocks, 'thinking')
     expect(result).toEqual([
-      { type: 'text', text: 'some text' },
-      { type: 'thinking', text: 'thinking' },
+      expect.objectContaining({ type: 'text', text: 'some text' }),
+      expect.objectContaining({ type: 'thinking', text: 'thinking' }),
     ])
   })
 
@@ -34,7 +34,7 @@ describe('applyThinkingDelta', () => {
 describe('applyTextDelta', () => {
   it('creates a new text block when blocks are empty', () => {
     const result = applyTextDelta([], 'hello')
-    expect(result).toEqual([{ type: 'text', text: 'hello' }])
+    expect(result).toEqual([expect.objectContaining({ type: 'text', text: 'hello' })])
   })
 
   it('appends to the last text block', () => {
@@ -49,8 +49,13 @@ describe('applyTextDelta', () => {
     ]
     const result = applyTextDelta(blocks, 'output')
     expect(result).toEqual([
-      { type: 'tool_use', name: 'Bash', id: '1', input: { command: 'ls' } },
-      { type: 'text', text: 'output' },
+      expect.objectContaining({
+        type: 'tool_use',
+        name: 'Bash',
+        id: '1',
+        input: { command: 'ls' },
+      }),
+      expect.objectContaining({ type: 'text', text: 'output' }),
     ])
   })
 
@@ -132,9 +137,14 @@ describe('streaming block ordering (integration)', () => {
     blocks = applyTextDelta(blocks, 'Here is the content.')
 
     expect(blocks).toEqual([
-      { type: 'text', text: 'Let me read the file.' },
-      { type: 'tool_use', id: 'tool-1', name: 'Read', input: { file_path: '/tmp/a.txt' } },
-      { type: 'text', text: 'Here is the content.' },
+      expect.objectContaining({ type: 'text', text: 'Let me read the file.' }),
+      expect.objectContaining({
+        type: 'tool_use',
+        id: 'tool-1',
+        name: 'Read',
+        input: { file_path: '/tmp/a.txt' },
+      }),
+      expect.objectContaining({ type: 'text', text: 'Here is the content.' }),
     ])
 
     // Verify order: text, tool_use, text
@@ -199,7 +209,7 @@ describe('streaming block ordering (integration)', () => {
     blocks = applyTextDelta(blocks, ' ')
     blocks = applyTextDelta(blocks, 'world')
 
-    expect(blocks).toEqual([{ type: 'text', text: 'Hello world' }])
+    expect(blocks).toEqual([expect.objectContaining({ type: 'text', text: 'Hello world' })])
   })
 
   it('text deltas after a tool create a new separate text block', () => {
@@ -210,7 +220,7 @@ describe('streaming block ordering (integration)', () => {
 
     // Must be 3 separate blocks, not 2 (text must not merge across a tool_use)
     expect(blocks).toHaveLength(3)
-    expect(blocks[0]).toEqual({ type: 'text', text: 'before' })
-    expect(blocks[2]).toEqual({ type: 'text', text: 'after' })
+    expect(blocks[0]).toEqual(expect.objectContaining({ type: 'text', text: 'before' }))
+    expect(blocks[2]).toEqual(expect.objectContaining({ type: 'text', text: 'after' }))
   })
 })


### PR DESCRIPTION
Closes #215

## What

Repairs the 7 stale `streamingBlocks.test.ts` assertions, then wires `npm run test` into the `Frontend` CI job so the vitest suite can no longer rot unnoticed.

- `frontend/src/lib/streamingBlocks.test.ts` — 7 assertions across `applyThinkingDelta`, `applyTextDelta` and `streaming block ordering (integration)` now use `expect.objectContaining({ type, text })` instead of whole-object `toEqual`. The existing `toHaveLength` count assertions are kept untouched.
- `.github/workflows/ci.yml` — new `Test` step in the `frontend` job, positioned after `ESLint` and before `Build`.

## Why

`streamingBlocks.ts` gained a `_key` field on every newly-created block (commit `682f4fa`, Sonar rule S6479) and the assertions were never updated. Nothing caught it, because the `frontend` job ran `typecheck`, `lint`, `format:check` and `build` — never `npm run test`. Seven tests guarding the chat UI's most order-sensitive logic have been red on `main` with CI fully green.

Matching on the fields each test is actually about (rather than adding `_key: 'kN'` to the expectations) avoids hardcoding the module-global key counter, which is order-coupled across tests and would re-break on the next internal field.

## How

Fix first, wire second — landing the CI step before the assertions would have turned `main` red.

## Acceptance criteria

- [x] `cd frontend && npm run test` exits 0 — **8 test files, 123 tests passing** (was `7 failed | 116 passed`).
- [x] `ci.yml` `frontend` job runs `npm run test`, after `ESLint` and before `Build` — confirmed in CI as step 7, between ESLint (6) and Build (9).
- [x] The repaired assertions do not name `_key`; a further internal field cannot break them again.
- [x] The assertions still bite: temporarily disabling the text-merge branch in `streamingBlocks.ts` turned 2 tests red (including the repaired `consecutive text deltas merge into a single text block`), and the source was reverted.
- [x] CI on this PR shows the new `Test` step executing and passing.

## Out of scope / deferred

- No change to `streamingBlocks.ts` — the implementation is correct.
- Deferred to #223: the vitest `include` glob is `src/**/*.test.ts`, so `.tsx` is not matched and a future component test would silently never run. Needs a DOM environment (the repo has no jsdom/testing-library today), so it is tracked separately.

## Notes

`pre-commit run` could not be used as the local gate on this machine — its node hook environment fails to install (`npm error EUNKNOWNCONFIG: --ignore-prepublish`). The equivalent commands (`typecheck`, `lint`, `test`, `format:check`, `build`) were run directly, plus `actionlint` on the modified workflow.