### PR TITLE
feat(claude-sessions): redesign the sessions list and detail pages, add advanced filters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -88,6 +88,12 @@ linters:
       excludes: []
 
   exclusions:
+    # Third-party Go files vendored inside npm packages. `frontend/node_modules`
+    # is gitignored, so CI never sees it — but any developer who has run
+    # `npm ci` has it on disk, where it fails the pre-commit hook with issues in
+    # code we neither wrote nor can fix.
+    paths:
+      - frontend/node_modules
     rules:
       - path: _test\.go
         linters:

--- a/frontend/src/lib/sessionFilters.test.ts
+++ b/frontend/src/lib/sessionFilters.test.ts
@@ -2,8 +2,12 @@ import { describe, it, expect } from 'vitest'
 import {
   matchesFilters,
   permissionModesOf,
+  modelsOf,
   hasPRs,
   hasFavorites,
+  inRange,
+  isBounded,
+  UNBOUNDED,
   type SessionFilters,
 } from './sessionFilters'
 import type {
@@ -67,14 +71,33 @@ function noFilters(overrides: Partial<SessionFilters> = {}): SessionFilters {
     project: 'all',
     search: '',
     favorites: false,
-    hasPR: false,
+    links: 'all',
     permissionMode: 'all',
+    model: 'all',
+    messages: UNBOUNDED,
+    durationMinutes: UNBOUNDED,
+    tokensIn: UNBOUNDED,
+    tokensOut: UNBOUNDED,
+    cost: UNBOUNDED,
     from: null,
     to: null,
     drilldownActive: false,
     drilldownWindows: [],
     ...overrides,
   }
+}
+
+/** A session whose in/out tokens and cost span the main thread and a sub-agent. */
+function withMetrics(
+  main: { in: number; out: number; usd: number },
+  sub: { in: number; out: number; usd: number } = { in: 0, out: 0, usd: 0 },
+): ClaudeSessionSummary {
+  return makeSession({
+    usage: { ...emptyUsage, input_tokens: main.in, output_tokens: main.out },
+    subagent_usage: { ...emptyUsage, input_tokens: sub.in, output_tokens: sub.out },
+    cost: { ...zeroCost, total_usd: main.usd },
+    subagent_cost: { ...zeroCost, total_usd: sub.usd },
+  })
 }
 
 describe('matchesFilters — each predicate in isolation', () => {
@@ -122,14 +145,99 @@ describe('matchesFilters — each predicate in isolation', () => {
     expect(matchesFilters(absent, noFilters({ favorites: true }))).toBe(false)
   })
 
-  it('has-PR treats a missing and an empty prs array alike', () => {
+  it('links treats a missing and an empty prs array alike', () => {
     const withPR = makeSession()
     const emptyPRs = makeSession({ prs: [] })
     const noPRs = makeSession({ prs: undefined })
-    expect(matchesFilters(emptyPRs, noFilters({ hasPR: false }))).toBe(true)
-    expect(matchesFilters(withPR, noFilters({ hasPR: true }))).toBe(true)
-    expect(matchesFilters(emptyPRs, noFilters({ hasPR: true }))).toBe(false)
-    expect(matchesFilters(noPRs, noFilters({ hasPR: true }))).toBe(false)
+
+    // 'all' is the match-everything value.
+    for (const s of [withPR, emptyPRs, noPRs]) {
+      expect(matchesFilters(s, noFilters({ links: 'all' }))).toBe(true)
+    }
+    expect(matchesFilters(withPR, noFilters({ links: 'with' }))).toBe(true)
+    expect(matchesFilters(emptyPRs, noFilters({ links: 'with' }))).toBe(false)
+    expect(matchesFilters(noPRs, noFilters({ links: 'with' }))).toBe(false)
+    // 'without' is the exact complement of 'with', not merely "not with".
+    expect(matchesFilters(withPR, noFilters({ links: 'without' }))).toBe(false)
+    expect(matchesFilters(emptyPRs, noFilters({ links: 'without' }))).toBe(true)
+    expect(matchesFilters(noPRs, noFilters({ links: 'without' }))).toBe(true)
+  })
+
+  it('message count honours a min, a max and both together', () => {
+    const s = makeSession({ message_count: 10 })
+    expect(matchesFilters(s, noFilters({ messages: { min: 10, max: null } }))).toBe(true)
+    expect(matchesFilters(s, noFilters({ messages: { min: 11, max: null } }))).toBe(false)
+    expect(matchesFilters(s, noFilters({ messages: { min: null, max: 10 } }))).toBe(true)
+    expect(matchesFilters(s, noFilters({ messages: { min: null, max: 9 } }))).toBe(false)
+    expect(matchesFilters(s, noFilters({ messages: { min: 5, max: 15 } }))).toBe(true)
+    expect(matchesFilters(s, noFilters({ messages: { min: 11, max: 15 } }))).toBe(false)
+  })
+
+  it('model matches "all" and the exact id only', () => {
+    const s = makeSession({ model: 'claude-opus-5' })
+    expect(matchesFilters(s, noFilters({ model: 'all' }))).toBe(true)
+    expect(matchesFilters(s, noFilters({ model: 'claude-opus-5' }))).toBe(true)
+    expect(matchesFilters(s, noFilters({ model: 'claude-sonnet-5' }))).toBe(false)
+    // Not a prefix match — "claude-opus-5" must not be matched by "claude-opus".
+    expect(matchesFilters(s, noFilters({ model: 'claude-opus' }))).toBe(false)
+    // A session with no recorded model is excluded by any specific model.
+    const unset = makeSession({ model: undefined })
+    expect(matchesFilters(unset, noFilters({ model: 'claude-opus-5' }))).toBe(false)
+    expect(matchesFilters(unset, noFilters({ model: 'all' }))).toBe(true)
+  })
+
+  it('duration is measured in minutes from start to last activity', () => {
+    // 10:00 → 11:00 is 60 minutes.
+    const s = makeSession()
+    expect(matchesFilters(s, noFilters({ durationMinutes: { min: 60, max: 60 } }))).toBe(true)
+    expect(matchesFilters(s, noFilters({ durationMinutes: { min: 61, max: null } }))).toBe(false)
+    expect(matchesFilters(s, noFilters({ durationMinutes: { min: null, max: 59 } }))).toBe(false)
+    expect(matchesFilters(s, noFilters({ durationMinutes: { min: 30, max: 90 } }))).toBe(true)
+  })
+
+  it('a reversed timestamp pair reads as zero duration, not a negative', () => {
+    // A negative would pass every "at most" bound, so a corrupt row would show
+    // up in exactly the searches meant to find the short sessions.
+    const reversed = makeSession({
+      start_time: '2026-08-07T11:00:00.000Z',
+      last_activity: '2026-08-07T10:00:00.000Z',
+    })
+    expect(matchesFilters(reversed, noFilters({ durationMinutes: { min: null, max: 5 } }))).toBe(
+      true,
+    )
+    expect(matchesFilters(reversed, noFilters({ durationMinutes: { min: 1, max: null } }))).toBe(
+      false,
+    )
+  })
+
+  it('an unparseable timestamp is dropped by the time predicate, before duration', () => {
+    // Documented rather than asserted on duration alone: overlapsRange already
+    // rejects NaN timestamps outright, so such a row never reaches the list at
+    // all — no duration bound can bring it back.
+    const broken = makeSession({ start_time: 'nonsense', last_activity: 'nonsense' })
+    expect(matchesFilters(broken, noFilters())).toBe(false)
+  })
+
+  it('token and cost ranges include sub-agent work, matching the columns shown', () => {
+    // Main thread alone would fail every one of these; the displayed figure is
+    // the total, so the filter must use the total too.
+    const s = withMetrics({ in: 100, out: 20, usd: 1 }, { in: 400, out: 80, usd: 4 })
+    expect(matchesFilters(s, noFilters({ tokensIn: { min: 500, max: null } }))).toBe(true)
+    expect(matchesFilters(s, noFilters({ tokensIn: { min: 501, max: null } }))).toBe(false)
+    expect(matchesFilters(s, noFilters({ tokensOut: { min: 100, max: null } }))).toBe(true)
+    expect(matchesFilters(s, noFilters({ tokensOut: { min: null, max: 99 } }))).toBe(false)
+    expect(matchesFilters(s, noFilters({ cost: { min: 5, max: 5 } }))).toBe(true)
+    expect(matchesFilters(s, noFilters({ cost: { min: null, max: 4.99 } }))).toBe(false)
+  })
+
+  it('a zero bound filters, where an absent bound does not', () => {
+    const zero = withMetrics({ in: 0, out: 0, usd: 0 })
+    // max: 0 is a real constraint that this session satisfies...
+    expect(matchesFilters(zero, noFilters({ cost: { min: null, max: 0 } }))).toBe(true)
+    // ...and one that a paid session fails, rather than 0 reading as "unset".
+    const paid = withMetrics({ in: 0, out: 0, usd: 2 })
+    expect(matchesFilters(paid, noFilters({ cost: { min: null, max: 0 } }))).toBe(false)
+    expect(matchesFilters(paid, noFilters({ cost: { min: 0, max: null } }))).toBe(true)
   })
 
   it('permission mode matches "all" and the exact mode only', () => {
@@ -170,26 +278,46 @@ describe('matchesFilters — the && chain', () => {
    * five. A dropped clause makes exactly one of these return true, which no
    * single-filter test can catch.
    */
-  const allSix = noFilters({
+  const allFilters = noFilters({
     project: '/home/dev/alpha',
     search: 'login',
     favorites: true,
-    hasPR: true,
+    links: 'with',
     permissionMode: 'bypassPermissions',
+    model: 'claude-opus-5',
+    messages: { min: 2, max: 8 },
+    durationMinutes: { min: 30, max: 90 },
+    tokensIn: { min: 10, max: 1000 },
+    tokensOut: { min: 5, max: 500 },
+    cost: { min: 0.5, max: 50 },
     from: new Date('2026-08-07T09:00:00Z'),
     to: new Date('2026-08-07T12:00:00Z'),
   })
 
+  /** Satisfies every clause of `allFilters`. */
+  const passing = (): ClaudeSessionSummary =>
+    makeSession({
+      model: 'claude-opus-5',
+      usage: { ...emptyUsage, input_tokens: 100, output_tokens: 50 },
+      cost: { ...zeroCost, total_usd: 5 },
+    })
+
   it('passes a session satisfying every filter', () => {
-    expect(matchesFilters(makeSession(), allSix)).toBe(true)
+    expect(matchesFilters(passing(), allFilters)).toBe(true)
   })
 
   it.each([
     ['project', { project_path: '/home/dev/beta' }],
     ['search', { preview: 'unrelated', display_title: 'unrelated', session_id: 'zzz' }],
     ['favorites', { is_favorite: false }],
-    ['has-PR', { prs: [] }],
+    ['links', { prs: [] }],
     ['permission mode', { permission_mode: 'plan' }],
+    ['messages', { message_count: 99 }],
+    ['model', { model: 'claude-sonnet-5' }],
+    ['duration', { last_activity: '2026-08-07T10:05:00.000Z' }],
+    ['tokens in', { usage: { ...emptyUsage, input_tokens: 5, output_tokens: 50 } }],
+    ['tokens out', { usage: { ...emptyUsage, input_tokens: 100, output_tokens: 1 } }],
+    ['cost', { cost: { ...zeroCost, total_usd: 0.1 } }],
     [
       'time range',
       { start_time: '2026-08-01T00:00:00.000Z', last_activity: '2026-08-01T01:00:00.000Z' },
@@ -197,7 +325,7 @@ describe('matchesFilters — the && chain', () => {
   ] as [string, Partial<ClaudeSessionSummary>][])(
     'rejects a session failing only the %s filter',
     (_name, overrides) => {
-      expect(matchesFilters(makeSession(overrides), allSix)).toBe(false)
+      expect(matchesFilters({ ...passing(), ...overrides }, allFilters)).toBe(false)
     },
   )
 })
@@ -268,6 +396,31 @@ describe('matchesFilters — drill-down branch', () => {
   })
 })
 
+describe('numeric range helpers', () => {
+  it('inRange is inclusive on both ends', () => {
+    expect(inRange(5, { min: 5, max: 5 })).toBe(true)
+    expect(inRange(4, { min: 5, max: 10 })).toBe(false)
+    expect(inRange(11, { min: 5, max: 10 })).toBe(false)
+  })
+
+  it('a null side is unbounded, not zero', () => {
+    expect(inRange(-100, UNBOUNDED)).toBe(true)
+    expect(inRange(1e9, UNBOUNDED)).toBe(true)
+    expect(inRange(1e9, { min: 5, max: null })).toBe(true)
+    expect(inRange(-100, { min: null, max: 5 })).toBe(true)
+  })
+
+  it('an inverted range matches nothing rather than silently swapping', () => {
+    expect(inRange(7, { min: 10, max: 5 })).toBe(false)
+  })
+
+  it('isBounded drives the active-filter count', () => {
+    expect(isBounded(UNBOUNDED)).toBe(false)
+    expect(isBounded({ min: 0, max: null })).toBe(true)
+    expect(isBounded({ min: null, max: 0 })).toBe(true)
+  })
+})
+
 describe('control-visibility gates', () => {
   it('permissionModesOf de-duplicates, drops empty and missing, and sorts', () => {
     const sessions = [
@@ -278,6 +431,18 @@ describe('control-visibility gates', () => {
       makeSession({ permission_mode: undefined }),
     ]
     expect(permissionModesOf(sessions)).toEqual(['bypassPermissions', 'plan'])
+  })
+
+  it('modelsOf de-duplicates, drops empty and missing, and sorts', () => {
+    const sessions = [
+      makeSession({ model: 'claude-sonnet-5' }),
+      makeSession({ model: 'claude-opus-5' }),
+      makeSession({ model: 'claude-sonnet-5' }),
+      makeSession({ model: '' }),
+      makeSession({ model: undefined }),
+    ]
+    expect(modelsOf(sessions)).toEqual(['claude-opus-5', 'claude-sonnet-5'])
+    expect(modelsOf([])).toEqual([])
   })
 
   it('permissionModesOf returns empty for no sessions, so the control stays hidden', () => {

--- a/frontend/src/lib/sessionFilters.ts
+++ b/frontend/src/lib/sessionFilters.ts
@@ -2,11 +2,51 @@ import type { ClaudeSessionSummary } from '../types'
 import type { DrilldownWindow } from './drilldown'
 import { overlapsAnyWindow } from './drilldown'
 import { overlapsRange } from './timefilter'
+import {
+  sessionCost,
+  sessionDurationMinutes,
+  sessionInputTokens,
+  sessionOutputTokens,
+} from './sessionMetrics'
 
 /**
- * The six sessions-list predicates, resolved to plain values. The time range is
+ * An inclusive numeric bound where `null` means unbounded on that side.
+ *
+ * One min/max pair expresses all three comparisons the UI needs — min alone is
+ * "at least", max alone is "at most", both is "between" — so no operator
+ * selector is needed beside each field.
+ */
+export interface NumericRange {
+  min: number | null
+  max: number | null
+}
+
+/** A range that matches every value. */
+export const UNBOUNDED: NumericRange = { min: null, max: null }
+
+/** Whether a range constrains anything, i.e. counts as an active filter. */
+export function isBounded(r: NumericRange): boolean {
+  return r.min !== null || r.max !== null
+}
+
+/** Inclusive on both ends: `min: 5` keeps a session with exactly 5. */
+export function inRange(value: number, r: NumericRange): boolean {
+  if (r.min !== null && value < r.min) return false
+  if (r.max !== null && value > r.max) return false
+  return true
+}
+
+/** Whether a session must have linked PRs, must have none, or either. */
+export type LinkFilter = 'all' | 'with' | 'without'
+
+/**
+ * The sessions-list predicates, resolved to plain values. The time range is
  * already resolved (`resolvePresetRange` runs once per render, not per session),
  * so this stays a pure function of its arguments.
+ *
+ * The numeric ranges compare against the same main-thread-plus-sub-agent totals
+ * the list's columns render (see `sessionMetrics`), so a visible figure and the
+ * filter that hides its row can never disagree.
  */
 export interface SessionFilters {
   /** `'all'` matches every project. */
@@ -14,9 +54,18 @@ export interface SessionFilters {
   /** Empty matches everything; matched case-insensitively. */
   search: string
   favorites: boolean
-  hasPR: boolean
+  links: LinkFilter
   /** `'all'` matches every mode. */
   permissionMode: string
+  /** `'all'` matches every model. */
+  model: string
+  messages: NumericRange
+  /** Wall-clock span in minutes. */
+  durationMinutes: NumericRange
+  tokensIn: NumericRange
+  tokensOut: NumericRange
+  /** USD. */
+  cost: NumericRange
   from: Date | null
   to: Date | null
   /** When true the drill-down windows replace the preset range entirely. */
@@ -39,7 +88,6 @@ export function matchesFilters(s: ClaudeSessionSummary, f: SessionFilters): bool
     s.preview.toLowerCase().includes(q) ||
     s.project_path.toLowerCase().includes(q)
   const matchesFavorites = !f.favorites || !!s.is_favorite
-  const matchesHasPR = !f.hasPR || (s.prs?.length ?? 0) > 0
   const matchesPermissionMode = f.permissionMode === 'all' || s.permission_mode === f.permissionMode
   const matchesTime = f.drilldownActive
     ? overlapsAnyWindow(s.start_time, s.last_activity, f.drilldownWindows)
@@ -48,10 +96,23 @@ export function matchesFilters(s: ClaudeSessionSummary, f: SessionFilters): bool
     matchesProject &&
     matchesSearch &&
     matchesFavorites &&
-    matchesHasPR &&
+    matchesLinks(s, f.links) &&
     matchesPermissionMode &&
+    (f.model === 'all' || s.model === f.model) &&
+    inRange(s.message_count ?? 0, f.messages) &&
+    inRange(sessionDurationMinutes(s), f.durationMinutes) &&
+    inRange(sessionInputTokens(s), f.tokensIn) &&
+    inRange(sessionOutputTokens(s), f.tokensOut) &&
+    inRange(sessionCost(s), f.cost) &&
     matchesTime
   )
+}
+
+/** A missing `prs` array and an empty one both mean "no linked PRs". */
+function matchesLinks(s: ClaudeSessionSummary, filter: LinkFilter): boolean {
+  if (filter === 'all') return true
+  const linked = (s.prs?.length ?? 0) > 0
+  return filter === 'with' ? linked : !linked
 }
 
 /**
@@ -61,6 +122,17 @@ export function matchesFilters(s: ClaudeSessionSummary, f: SessionFilters): bool
  */
 export function permissionModesOf(sessions: ClaudeSessionSummary[]): string[] {
   return [...new Set(sessions.map(s => s.permission_mode).filter((m): m is string => !!m))].sort()
+}
+
+/**
+ * The distinct models present, sorted — the options for the model dropdown.
+ *
+ * Aggregated from the sessions on hand rather than the pricing catalog: the
+ * catalog lists models this machine may never have run, and a dropdown of
+ * options that match nothing is worse than a short one.
+ */
+export function modelsOf(sessions: ClaudeSessionSummary[]): string[] {
+  return [...new Set(sessions.map(s => s.model).filter((m): m is string => !!m))].sort()
 }
 
 /** Whether any session is linked to a PR, gating the has-PR toggle. */

--- a/frontend/src/lib/sessionGroups.test.ts
+++ b/frontend/src/lib/sessionGroups.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest'
+import type { ClaudeSessionSummary } from '../types'
+import { dayLabel, groupSessionsByDay, tokenBarReference } from './sessionGroups'
+
+const zeroUsage = {
+  input_tokens: 0,
+  output_tokens: 0,
+  cache_read_tokens: 0,
+  cache_creation_tokens: 0,
+  cache_creation_5m_tokens: 0,
+  cache_creation_1h_tokens: 0,
+}
+const zeroCost = {
+  input_usd: 0,
+  output_usd: 0,
+  cache_read_usd: 0,
+  cache_write_usd: 0,
+  total_usd: 0,
+}
+
+function session(over: Partial<ClaudeSessionSummary> = {}): ClaudeSessionSummary {
+  return {
+    session_id: 'id',
+    project_path: '/home/u/p',
+    preview: '',
+    start_time: '2026-08-09T10:00:00Z',
+    last_activity: '2026-08-09T11:00:00Z',
+    message_count: 0,
+    event_count: 0,
+    usage: { ...zeroUsage },
+    subagent_count: 0,
+    subagent_usage: { ...zeroUsage },
+    compaction_count: 0,
+    dropped_tokens: 0,
+    cost: { ...zeroCost },
+    subagent_cost: { ...zeroCost },
+    ...over,
+  } as ClaudeSessionSummary
+}
+
+/** Local noon, so the assertions never straddle a UTC day boundary. */
+const at = (y: number, m: number, d: number, h = 12) => new Date(y, m - 1, d, h).toISOString()
+
+describe('tokenBarReference', () => {
+  const withTokens = (n: number) =>
+    session({ usage: { ...zeroUsage, input_tokens: n, output_tokens: 0 } })
+
+  it('ignores a lone outlier so the rest stay visible', () => {
+    const rows = [
+      ...Array(9)
+        .fill(0)
+        .map(() => withTokens(100_000)),
+      withTokens(75_000_000),
+    ]
+    // p90 of the sorted list, not the 75M maximum.
+    expect(tokenBarReference(rows)).toBe(100_000)
+  })
+
+  it('is zero for an empty list, so callers draw no bar', () => {
+    expect(tokenBarReference([])).toBe(0)
+  })
+
+  it('handles a single session', () => {
+    expect(tokenBarReference([withTokens(5_000)])).toBe(5_000)
+  })
+})
+
+describe('dayLabel', () => {
+  const now = new Date(2026, 7, 9, 15) // Sun 9 Aug 2026, local
+
+  it('names today and yesterday relatively', () => {
+    expect(dayLabel(new Date(2026, 7, 9, 1), now)).toBe('Today')
+    expect(dayLabel(new Date(2026, 7, 8, 23), now)).toBe('Yesterday')
+  })
+
+  it('falls back to an absolute date beyond that', () => {
+    expect(dayLabel(new Date(2026, 7, 7, 9), now)).toMatch(/7 Aug$/)
+  })
+
+  it('appends the year only when it differs from now', () => {
+    expect(dayLabel(new Date(2025, 7, 7, 9), now)).toMatch(/2025$/)
+  })
+})
+
+describe('groupSessionsByDay', () => {
+  const now = new Date(2026, 7, 9, 15)
+
+  it('buckets by the local day of last_activity, newest first', () => {
+    const groups = groupSessionsByDay(
+      [
+        session({ session_id: 'older', last_activity: at(2026, 8, 7) }),
+        session({ session_id: 'newest', last_activity: at(2026, 8, 9, 14) }),
+        session({ session_id: 'mid', last_activity: at(2026, 8, 9, 9) }),
+      ],
+      now,
+    )
+    expect(groups.map(g => g.label)).toEqual(['Today', 'Fri 7 Aug'])
+    expect(groups[0].sessions.map(s => s.session_id)).toEqual(['newest', 'mid'])
+  })
+
+  it('rolls up messages, tokens and cost per day', () => {
+    const groups = groupSessionsByDay(
+      [
+        session({
+          last_activity: at(2026, 8, 9, 14),
+          message_count: 3,
+          usage: { ...zeroUsage, input_tokens: 10, output_tokens: 2 },
+          cost: { ...zeroCost, total_usd: 1 },
+        }),
+        session({
+          last_activity: at(2026, 8, 9, 9),
+          message_count: 4,
+          subagent_usage: { ...zeroUsage, input_tokens: 8, output_tokens: 0 },
+          subagent_cost: { ...zeroCost, total_usd: 0.5 },
+        }),
+      ],
+      now,
+    )
+    expect(groups).toHaveLength(1)
+    expect(groups[0].messageCount).toBe(7)
+    expect(groups[0].tokens).toBe(20)
+    expect(groups[0].cost).toBeCloseTo(1.5)
+  })
+
+  it('keeps a session with an unparseable timestamp visible', () => {
+    const groups = groupSessionsByDay([session({ last_activity: 'not-a-date' })], now)
+    expect(groups.map(g => g.label)).toEqual(['Unknown date'])
+  })
+
+  it('returns nothing for an empty list', () => {
+    expect(groupSessionsByDay([], now)).toEqual([])
+  })
+})

--- a/frontend/src/lib/sessionGroups.ts
+++ b/frontend/src/lib/sessionGroups.ts
@@ -1,0 +1,107 @@
+import type { ClaudeSessionSummary } from '../types'
+import { sessionCost, sessionTokens } from './sessionMetrics'
+
+/**
+ * One day's worth of sessions plus the roll-ups the day header shows.
+ *
+ * Days are keyed by the *local* calendar date of `last_activity`, matching the
+ * rest of the analytics surface (#190): a day is meaningless until you say
+ * whose it is, and the list is read by the person whose machine ran it.
+ */
+export interface SessionDayGroup {
+  /** Local `YYYY-MM-DD` of the day, stable across renders. */
+  key: string
+  /** "Today", "Yesterday", or e.g. "Fri 7 Aug" (year appended when not this one). */
+  label: string
+  sessions: ClaudeSessionSummary[]
+  messageCount: number
+  /** Input + output tokens, main thread plus delegated sub-agents. */
+  tokens: number
+  /** Main-thread plus sub-agent cost in USD. */
+  cost: number
+}
+
+/**
+ * Reference length for the token bars: the 90th percentile of what is on
+ * screen, not the maximum.
+ *
+ * A single 75M-token session against a corpus whose median is ~100K would push
+ * every other bar below one pixel, turning the column into a blank strip with
+ * one outlier. Sessions at or above the reference simply fill the bar; the
+ * figure beside it stays the authoritative number.
+ */
+export function tokenBarReference(sessions: readonly ClaudeSessionSummary[]): number {
+  if (sessions.length === 0) return 0
+  const sorted = sessions.map(sessionTokens).sort((a, b) => a - b)
+  return sorted[Math.floor(0.9 * (sorted.length - 1))]
+}
+
+function dayKey(d: Date): string {
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${d.getFullYear()}-${m}-${day}`
+}
+
+/**
+ * Human label for a day header. Relative for the two days people actually
+ * recognise, absolute after that — "3d ago" as a *heading* forces arithmetic
+ * the row-level relative times already cover.
+ */
+export function dayLabel(d: Date, now: Date): string {
+  const key = dayKey(d)
+  if (key === dayKey(now)) return 'Today'
+  const yesterday = new Date(now)
+  yesterday.setDate(yesterday.getDate() - 1)
+  if (key === dayKey(yesterday)) return 'Yesterday'
+
+  const weekday = d.toLocaleDateString(undefined, { weekday: 'short' })
+  const month = d.toLocaleDateString(undefined, { month: 'short' })
+  const base = `${weekday} ${d.getDate()} ${month}`
+  return d.getFullYear() === now.getFullYear() ? base : `${base} ${d.getFullYear()}`
+}
+
+/**
+ * Groups sessions into newest-first day buckets with per-day roll-ups.
+ *
+ * Sorting happens here rather than relying on the API order: the day headers
+ * carry totals, and a single out-of-order row would silently split one day into
+ * two buckets with half the roll-up each.
+ */
+export function groupSessionsByDay(
+  sessions: readonly ClaudeSessionSummary[],
+  now: Date = new Date(),
+): SessionDayGroup[] {
+  const ordered = [...sessions].sort(
+    (a, b) => new Date(b.last_activity).getTime() - new Date(a.last_activity).getTime(),
+  )
+
+  const groups: SessionDayGroup[] = []
+  const byKey = new Map<string, SessionDayGroup>()
+
+  for (const s of ordered) {
+    const d = new Date(s.last_activity)
+    // An unparseable timestamp still belongs somewhere visible; bucketing it
+    // under "Unknown" beats dropping the row out of the list entirely.
+    const valid = !Number.isNaN(d.getTime())
+    const key = valid ? dayKey(d) : 'unknown'
+    let group = byKey.get(key)
+    if (!group) {
+      group = {
+        key,
+        label: valid ? dayLabel(d, now) : 'Unknown date',
+        sessions: [],
+        messageCount: 0,
+        tokens: 0,
+        cost: 0,
+      }
+      byKey.set(key, group)
+      groups.push(group)
+    }
+    group.sessions.push(s)
+    group.messageCount += s.message_count ?? 0
+    group.tokens += sessionTokens(s)
+    group.cost += sessionCost(s)
+  }
+
+  return groups
+}

--- a/frontend/src/lib/sessionMetrics.test.ts
+++ b/frontend/src/lib/sessionMetrics.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import type { ClaudeSessionSummary } from '../types'
+import {
+  sessionCost,
+  sessionDurationMinutes,
+  sessionDurationMs,
+  sessionInputTokens,
+  sessionOutputTokens,
+  sessionTokens,
+} from './sessionMetrics'
+
+const zeroUsage = {
+  input_tokens: 0,
+  output_tokens: 0,
+  cache_read_tokens: 0,
+  cache_creation_tokens: 0,
+  cache_creation_5m_tokens: 0,
+  cache_creation_1h_tokens: 0,
+}
+const zeroCost = {
+  input_usd: 0,
+  output_usd: 0,
+  cache_read_usd: 0,
+  cache_write_usd: 0,
+  total_usd: 0,
+}
+
+function session(over: Partial<ClaudeSessionSummary> = {}): ClaudeSessionSummary {
+  return {
+    session_id: 'id',
+    project_path: '/home/u/p',
+    preview: '',
+    start_time: '2026-08-09T10:00:00Z',
+    last_activity: '2026-08-09T11:00:00Z',
+    message_count: 0,
+    event_count: 0,
+    usage: { ...zeroUsage },
+    subagent_count: 0,
+    subagent_usage: { ...zeroUsage },
+    compaction_count: 0,
+    dropped_tokens: 0,
+    cost: { ...zeroCost },
+    subagent_cost: { ...zeroCost },
+    ...over,
+  } as ClaudeSessionSummary
+}
+
+describe('session metrics', () => {
+  const busy = session({
+    usage: { ...zeroUsage, input_tokens: 100, output_tokens: 10 },
+    subagent_usage: { ...zeroUsage, input_tokens: 5, output_tokens: 1 },
+    cost: { ...zeroCost, total_usd: 1.5 },
+    subagent_cost: { ...zeroCost, total_usd: 0.25 },
+  })
+
+  it('adds delegated sub-agent work to the main thread', () => {
+    expect(sessionInputTokens(busy)).toBe(105)
+    expect(sessionOutputTokens(busy)).toBe(11)
+    expect(sessionTokens(busy)).toBe(116)
+    expect(sessionCost(busy)).toBeCloseTo(1.75)
+  })
+
+  it('ignores cache tokens, which are not input+output', () => {
+    const s = session({ usage: { ...zeroUsage, cache_read_tokens: 900_000 } })
+    expect(sessionTokens(s)).toBe(0)
+  })
+
+  it('measures duration from start to last activity', () => {
+    const s = session({
+      start_time: '2026-08-09T10:00:00Z',
+      last_activity: '2026-08-09T11:30:00Z',
+    })
+    expect(sessionDurationMs(s)).toBe(90 * 60_000)
+    expect(sessionDurationMinutes(s)).toBe(90)
+  })
+
+  it('clamps an unparseable or reversed pair to zero, never NaN or negative', () => {
+    // NaN fails every comparison and a negative passes every "at most" one —
+    // either way a corrupt row lands in the wrong filter results.
+    const broken = session({ start_time: 'nonsense', last_activity: 'nonsense' })
+    const reversed = session({
+      start_time: '2026-08-09T11:00:00Z',
+      last_activity: '2026-08-09T10:00:00Z',
+    })
+    for (const s of [broken, reversed]) {
+      expect(sessionDurationMs(s)).toBe(0)
+      expect(sessionDurationMinutes(s)).toBe(0)
+    }
+  })
+
+  it('treats a missing usage or cost object as zero rather than throwing', () => {
+    const bare = { session_id: 'x' } as ClaudeSessionSummary
+    expect(sessionInputTokens(bare)).toBe(0)
+    expect(sessionOutputTokens(bare)).toBe(0)
+    expect(sessionTokens(bare)).toBe(0)
+    expect(sessionCost(bare)).toBe(0)
+  })
+})

--- a/frontend/src/lib/sessionMetrics.ts
+++ b/frontend/src/lib/sessionMetrics.ts
@@ -1,0 +1,47 @@
+import type { ClaudeSessionSummary } from '../types'
+
+/**
+ * The per-session figures the sessions list displays and filters on.
+ *
+ * Every one of these sums the main thread and its delegated sub-agents, which
+ * is what the list's columns render. Filtering on a different basis than the
+ * column shows is the bug this module exists to prevent: a row displaying
+ * $36.30 must not be hidden by "cost at most $40".
+ */
+
+export function sessionInputTokens(s: ClaudeSessionSummary): number {
+  return (s.usage?.input_tokens ?? 0) + (s.subagent_usage?.input_tokens ?? 0)
+}
+
+export function sessionOutputTokens(s: ClaudeSessionSummary): number {
+  return (s.usage?.output_tokens ?? 0) + (s.subagent_usage?.output_tokens ?? 0)
+}
+
+/** Input + output tokens. Cache tokens are excluded, as in the list column. */
+export function sessionTokens(s: ClaudeSessionSummary): number {
+  return sessionInputTokens(s) + sessionOutputTokens(s)
+}
+
+/** Total cost in USD: main thread plus delegated sub-agents. */
+export function sessionCost(s: ClaudeSessionSummary): number {
+  return (s.cost?.total_usd ?? 0) + (s.subagent_cost?.total_usd ?? 0)
+}
+
+/**
+ * Wall-clock span from the first event to the last, in milliseconds.
+ *
+ * Zero for an unparseable or reversed pair rather than NaN or a negative: those
+ * would make every duration comparison false, silently hiding the row from a
+ * filter it should simply not have matched.
+ */
+export function sessionDurationMs(s: ClaudeSessionSummary): number {
+  const start = new Date(s.start_time).getTime()
+  const end = new Date(s.last_activity).getTime()
+  if (Number.isNaN(start) || Number.isNaN(end)) return 0
+  return Math.max(0, end - start)
+}
+
+/** The same span in minutes, the unit the duration filter is entered in. */
+export function sessionDurationMinutes(s: ClaudeSessionSummary): number {
+  return sessionDurationMs(s) / 60_000
+}

--- a/frontend/src/lib/transcript.test.ts
+++ b/frontend/src/lib/transcript.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest'
+import type { ClaudeMessage, ClaudeNormalizedBlock } from '../types'
+import {
+  filesTouched,
+  hasProse,
+  hasToolUse,
+  messageText,
+  outline,
+  tailPath,
+  toolSummary,
+  toolUsage,
+} from './transcript'
+
+const tool = (name: string, input: Record<string, unknown>): ClaudeNormalizedBlock => ({
+  type: 'tool_use',
+  name,
+  input,
+})
+
+const msg = (over: Partial<ClaudeMessage>): ClaudeMessage =>
+  ({
+    uuid: 'u1',
+    type: 'assistant',
+    role: 'assistant',
+    timestamp: '2026-08-09T10:00:00Z',
+    ...over,
+  }) as ClaudeMessage
+
+describe('toolSummary', () => {
+  it('names the file for file tools', () => {
+    expect(toolSummary(tool('Edit', { file_path: '/a/b.ts' }))).toBe('/a/b.ts')
+    expect(toolSummary(tool('NotebookEdit', { notebook_path: '/a/n.ipynb' }))).toBe('/a/n.ipynb')
+  })
+
+  it('uses the command, pattern, url or description per tool', () => {
+    expect(toolSummary(tool('Bash', { command: 'ls -la' }))).toBe('ls -la')
+    expect(toolSummary(tool('Grep', { pattern: 'foo' }))).toBe('foo')
+    expect(toolSummary(tool('WebFetch', { url: 'https://x' }))).toBe('https://x')
+    expect(toolSummary(tool('Task', { description: 'do it' }))).toBe('do it')
+  })
+
+  it('falls back to the first string argument for unknown tools', () => {
+    expect(toolSummary(tool('mcp__x__y', { count: 3, target: 'thing' }))).toBe('thing')
+  })
+
+  it('is empty when there is nothing worth showing', () => {
+    expect(toolSummary({ type: 'tool_use', name: 'Bash' })).toBe('')
+    expect(toolSummary(tool('TodoWrite', { todos: [] }))).toBe('')
+    expect(toolSummary(tool('Unknown', { n: 1 }))).toBe('')
+  })
+})
+
+describe('hasProse / hasToolUse', () => {
+  it('separates prose from tool-only turns', () => {
+    const proseOnly = msg({ blocks: [{ type: 'text', text: 'hi' }] })
+    const toolOnly = msg({ blocks: [tool('Bash', { command: 'ls' })] })
+    expect(hasProse(proseOnly)).toBe(true)
+    expect(hasToolUse(proseOnly)).toBe(false)
+    expect(hasProse(toolOnly)).toBe(false)
+    expect(hasToolUse(toolOnly)).toBe(true)
+  })
+
+  it('treats whitespace-only text as no prose', () => {
+    expect(hasProse(msg({ blocks: [{ type: 'text', text: '  \n ' }] }))).toBe(false)
+  })
+
+  it('counts a user message body as prose', () => {
+    expect(hasProse(msg({ role: 'user', content: 'do the thing' }))).toBe(true)
+  })
+})
+
+describe('messageText', () => {
+  it('searches content, block text and tool input alike, case-insensitively', () => {
+    const m = msg({
+      content: 'Outer',
+      blocks: [{ type: 'text', text: 'Inner' }, tool('Bash', { command: 'RUN-ME' })],
+    })
+    const text = messageText(m)
+    expect(text).toContain('outer')
+    expect(text).toContain('inner')
+    expect(text).toContain('run-me')
+    expect(text).toContain('bash')
+  })
+})
+
+describe('toolUsage', () => {
+  it('counts per tool_use block, not per message, busiest first', () => {
+    const messages = [
+      msg({ blocks: [tool('Bash', {}), tool('Bash', {}), tool('Read', {})] }),
+      msg({ blocks: [tool('Bash', {})] }),
+    ]
+    expect(toolUsage(messages)).toEqual([
+      { name: 'Bash', count: 3 },
+      { name: 'Read', count: 1 },
+    ])
+  })
+
+  it('is empty for a transcript with no tools', () => {
+    expect(toolUsage([msg({ blocks: [{ type: 'text', text: 'hi' }] })])).toEqual([])
+  })
+})
+
+describe('filesTouched', () => {
+  it('counts file-tool paths and ignores other tools', () => {
+    const messages = [
+      msg({
+        blocks: [
+          tool('Read', { file_path: '/a/x.ts' }),
+          tool('Edit', { file_path: '/a/x.ts' }),
+          tool('Bash', { command: 'rm /a/y.ts' }),
+        ],
+      }),
+    ]
+    expect(filesTouched(messages)).toEqual([{ path: '/a/x.ts', count: 2 }])
+  })
+
+  it('skips a file tool with no path rather than recording an empty one', () => {
+    expect(filesTouched([msg({ blocks: [tool('Read', { offset: 1 })] })])).toEqual([])
+  })
+})
+
+describe('outline', () => {
+  it('lists only genuine user turns, first line, in order', () => {
+    const messages = [
+      msg({ uuid: 'a', role: 'user', content: 'First ask\nmore detail' }),
+      msg({ uuid: 'b', role: 'assistant', blocks: [{ type: 'text', text: 'ok' }] }),
+      msg({ uuid: 'c', role: 'user', content: '<local-command-caveat>noise' }),
+      msg({ uuid: 'd', role: 'user', content: '   ' }),
+      msg({ uuid: 'e', role: 'user', content: 'Second ask' }),
+    ]
+    expect(outline(messages).map(o => [o.uuid, o.label])).toEqual([
+      ['a', 'First ask'],
+      ['e', 'Second ask'],
+    ])
+  })
+
+  it('truncates a long instruction', () => {
+    const long = 'x'.repeat(200)
+    expect(outline([msg({ role: 'user', content: long })])[0].label).toHaveLength(90)
+  })
+})
+
+describe('tailPath', () => {
+  it('keeps the last two segments', () => {
+    expect(tailPath('/home/u/proj/src/pages/Page.tsx')).toBe('pages/Page.tsx')
+  })
+
+  it('returns short paths unchanged', () => {
+    expect(tailPath('Page.tsx')).toBe('Page.tsx')
+    expect(tailPath('src/Page.tsx')).toBe('src/Page.tsx')
+  })
+
+  it('handles Windows separators', () => {
+    expect(tailPath('C:\\Users\\u\\src\\pages\\Page.tsx')).toBe('pages/Page.tsx')
+  })
+})

--- a/frontend/src/lib/transcript.ts
+++ b/frontend/src/lib/transcript.ts
@@ -1,0 +1,138 @@
+import type { ClaudeMessage, ClaudeNormalizedBlock } from '../types'
+
+/** Tools whose input names a file the session read or changed. */
+const FILE_TOOLS = new Set(['Read', 'Write', 'Edit', 'MultiEdit', 'NotebookEdit'])
+
+const str = (v: unknown): string => (typeof v === 'string' ? v : '')
+
+/**
+ * One-line summary of a tool call, shown beside the tool name on the collapsed
+ * header. Falls back to the first string argument so an unrecognised tool — an
+ * MCP tool, a new built-in — still says something rather than nothing.
+ */
+export function toolSummary(block: ClaudeNormalizedBlock): string {
+  const input = block.input
+  if (!input) return ''
+  const name = block.name ?? ''
+
+  if (FILE_TOOLS.has(name)) return str(input.file_path ?? input.filePath ?? input.notebook_path)
+  if (name === 'Bash') return str(input.command)
+  if (name === 'Glob' || name === 'Grep') return str(input.pattern ?? input.query)
+  if (name === 'WebFetch' || name === 'WebSearch') return str(input.url ?? input.query)
+  if (name === 'Task') return str(input.description)
+  if (name === 'TodoWrite') return ''
+
+  const firstString = Object.values(input).find(v => typeof v === 'string' && v.length > 0)
+  return str(firstString)
+}
+
+/** Everything in a message that a transcript search should look at. */
+export function messageText(msg: ClaudeMessage): string {
+  const blocks = msg.blocks ?? []
+  const fromBlocks = blocks
+    .map(b => `${b.name ?? ''} ${b.text ?? ''} ${b.input ? JSON.stringify(b.input) : ''}`)
+    .join(' ')
+  return `${msg.content ?? ''} ${fromBlocks}`.toLowerCase()
+}
+
+/** Whether a message carries any renderable prose (as opposed to only tool calls). */
+export function hasProse(msg: ClaudeMessage): boolean {
+  if ((msg.content ?? '').trim()) return true
+  return (msg.blocks ?? []).some(b => b.type === 'text' && (b.text ?? '').trim())
+}
+
+/** Whether a message issued at least one tool call. */
+export function hasToolUse(msg: ClaudeMessage): boolean {
+  return (msg.blocks ?? []).some(b => b.type === 'tool_use')
+}
+
+export interface ToolUsage {
+  name: string
+  count: number
+}
+
+/**
+ * Tool call counts across the transcript, busiest first. Counted per `tool_use`
+ * block rather than per message, because one assistant message can issue
+ * several calls.
+ */
+export function toolUsage(messages: readonly ClaudeMessage[]): ToolUsage[] {
+  const counts = new Map<string, number>()
+  for (const msg of messages) {
+    for (const b of msg.blocks ?? []) {
+      if (b.type !== 'tool_use') continue
+      const name = b.name ?? 'unknown'
+      counts.set(name, (counts.get(name) ?? 0) + 1)
+    }
+  }
+  return [...counts.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
+}
+
+export interface FileTouch {
+  path: string
+  count: number
+}
+
+/**
+ * Files the session read or wrote, most-touched first.
+ *
+ * The transcript records no diff stat, so this reports how many times each path
+ * was touched — a real figure — rather than an invented line count.
+ */
+export function filesTouched(messages: readonly ClaudeMessage[]): FileTouch[] {
+  const counts = new Map<string, number>()
+  for (const msg of messages) {
+    for (const b of msg.blocks ?? []) {
+      if (b.type !== 'tool_use' || !FILE_TOOLS.has(b.name ?? '')) continue
+      const path = str(b.input?.file_path ?? b.input?.filePath ?? b.input?.notebook_path)
+      if (!path) continue
+      counts.set(path, (counts.get(path) ?? 0) + 1)
+    }
+  }
+  return [...counts.entries()]
+    .map(([path, count]) => ({ path, count }))
+    .sort((a, b) => b.count - a.count || a.path.localeCompare(b.path))
+}
+
+/**
+ * The last `segments` path components — "pages/ClaudeSessionsPage.tsx".
+ *
+ * A sidebar 300px wide cannot show a full repo path, and plain truncation cuts
+ * off the filename, which is the only part that identifies the file.
+ */
+export function tailPath(path: string, segments = 2): string {
+  const parts = path.split(/[/\\]/).filter(Boolean)
+  if (parts.length <= segments) return path
+  return parts.slice(-segments).join('/')
+}
+
+export interface OutlineEntry {
+  uuid: string
+  timestamp: string
+  label: string
+}
+
+/**
+ * The session's turning points: what the user asked, in order.
+ *
+ * Claude Code injects synthetic user events (command caveats, hook output,
+ * tool results). Those are not things the user said, so listing them as
+ * milestones would bury the four or five real instructions among dozens.
+ */
+export function outline(messages: readonly ClaudeMessage[]): OutlineEntry[] {
+  const entries: OutlineEntry[] = []
+  for (const msg of messages) {
+    if ((msg.role ?? msg.type) !== 'user') continue
+    const text = (msg.content ?? '').trim()
+    if (!text || text.startsWith('<')) continue
+    const firstLine = text.split('\n').find(l => l.trim()) ?? text
+    entries.push({
+      uuid: msg.uuid,
+      timestamp: msg.timestamp,
+      label: firstLine.trim().slice(0, 90),
+    })
+  }
+  return entries
+}

--- a/frontend/src/pages/ClaudeSessionDetailPage.tsx
+++ b/frontend/src/pages/ClaudeSessionDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef, type ReactNode } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { claudeSessionsApi } from '@/lib/api'
 import type {
@@ -9,349 +9,610 @@ import type {
   ClaudeSubagent,
 } from '@/types'
 import { formatRelativeTime, formatDateTime } from '@/lib/utils'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import { CopyableId } from '@/components/CopyableId'
 import {
   ArrowLeft,
-  ChevronDown,
   ChevronRight,
-  GitBranch,
-  Folder,
-  Cpu,
-  Zap,
   CheckCircle2,
   Circle,
   Clock,
   Play,
   Loader2,
-  Pencil,
   Star,
   Activity,
-  Bot,
-  Shield,
-  Scissors,
+  Search,
+  Copy,
+  Check,
   GitPullRequest,
-  Trees,
-  DollarSign,
 } from 'lucide-react'
-import { formatCost, formatTokens, shortPath } from '@/lib/format'
+import { formatCost, formatTokens, formatDuration, shortPath } from '@/lib/format'
+import {
+  filesTouched,
+  hasProse,
+  hasToolUse,
+  messageText,
+  outline,
+  tailPath,
+  toolSummary,
+  toolUsage,
+  type OutlineEntry,
+  type ToolUsage,
+  type FileTouch,
+} from '@/lib/transcript'
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
+/**
+ * How recently the transcript must have been written to for the header to call
+ * the session active. Claude Code appends as it works, so a gap this long means
+ * nothing is running.
+ */
+const ACTIVE_WINDOW_MS = 10 * 60 * 1000
 
-function todoIcon(status: string) {
-  if (status === 'completed')
-    return <CheckCircle2 className="h-3.5 w-3.5 text-green-500 shrink-0" />
-  if (status === 'in_progress')
-    return <Clock className="h-3.5 w-3.5 text-yellow-500 shrink-0 animate-pulse" />
-  return <Circle className="h-3.5 w-3.5 text-zinc-400 shrink-0" />
+type TranscriptFilter = 'all' | 'messages' | 'tools'
+
+const FILTER_LABELS: Record<TranscriptFilter, string> = {
+  all: 'All',
+  messages: 'Messages',
+  tools: 'Tools',
 }
 
-// ── Block renderer ────────────────────────────────────────────────────────────
+// ── Small presentational pieces ───────────────────────────────────────────────
 
-function ThinkingBlock({ text }: Readonly<{ text: string }>) {
-  const [open, setOpen] = useState(false)
+/** A metadata chip in the header: filled for identity, outlined for attributes. */
+function MetaChip({
+  children,
+  variant = 'outline',
+  title,
+}: Readonly<{ children: ReactNode; variant?: 'filled' | 'outline'; title?: string }>) {
+  const base = 'font-mono text-[11.5px] rounded-md whitespace-nowrap'
   return (
-    <div className="rounded-md border border-purple-200 dark:border-purple-900/50 bg-purple-50 dark:bg-purple-950/20 text-xs overflow-hidden">
-      <button
-        className="flex w-full items-center gap-1.5 px-3 py-1.5 text-purple-700 dark:text-purple-400 hover:bg-purple-100 dark:hover:bg-purple-900/30 transition-colors text-left"
-        onClick={() => setOpen(o => !o)}
-      >
-        {open ? (
-          <ChevronDown className="h-3 w-3 shrink-0" />
-        ) : (
-          <ChevronRight className="h-3 w-3 shrink-0" />
-        )}
-        <Cpu className="h-3 w-3 shrink-0" />
-        <span>Thinking</span>
-      </button>
-      {open && (
-        <pre className="px-3 pb-2 text-purple-800 dark:text-purple-300 whitespace-pre-wrap break-words font-mono text-[12px] leading-relaxed border-t border-purple-200 dark:border-purple-900/50">
-          {text}
-        </pre>
-      )}
+    <span
+      title={title}
+      className={
+        variant === 'filled'
+          ? `${base} px-1.5 py-[3px] bg-zinc-100 dark:bg-zinc-800 text-zinc-800 dark:text-zinc-100`
+          : `${base} px-1.5 py-[2px] border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400`
+      }
+    >
+      {children}
+    </span>
+  )
+}
+
+function MetaDivider() {
+  return <span className="w-px h-3.5 bg-zinc-200 dark:bg-zinc-700 mx-1" />
+}
+
+/** One cell of the six-across summary strip under the header. */
+function StatCell({ label, value }: Readonly<{ label: string; value: string }>) {
+  return (
+    <div className="bg-white dark:bg-zinc-900 px-3 py-2 flex flex-col gap-0.5 min-w-0">
+      <span className="text-[10.5px] uppercase tracking-[0.06em] font-semibold text-zinc-500 dark:text-zinc-400">
+        {label}
+      </span>
+      <span className="text-[14.5px] font-semibold tabular-nums text-zinc-900 dark:text-zinc-100 truncate">
+        {value}
+      </span>
     </div>
   )
 }
 
-function ToolUseBlock({ block }: Readonly<{ block: ClaudeNormalizedBlock }>) {
-  const [open, setOpen] = useState(false)
-  const toolName = block.name ?? 'unknown'
-  const inputStr = block.input ? JSON.stringify(block.input, null, 2) : ''
+function SidebarCard({ title, children }: Readonly<{ title: string; children: ReactNode }>) {
+  return (
+    <div className="rounded-xl border border-zinc-200 dark:border-zinc-700/60 bg-white dark:bg-zinc-900 p-3.5">
+      <div className="text-[11px] uppercase tracking-[0.06em] font-semibold text-zinc-500 dark:text-zinc-400 mb-2.5">
+        {title}
+      </div>
+      {children}
+    </div>
+  )
+}
 
-  // Extract a short summary from the input for common tools.
-  let summary = ''
-  if (block.input) {
-    const inp = block.input
-    const str = (v: unknown) => (typeof v === 'string' ? v : '')
-    if (toolName === 'Read' || toolName === 'Write' || toolName === 'Edit') {
-      summary = str(inp.file_path ?? inp.filePath)
-    } else if (toolName === 'Bash') {
-      summary = str(inp.command).slice(0, 60)
-    } else if (toolName === 'Glob' || toolName === 'Grep') {
-      summary = str(inp.pattern ?? inp.query)
-    } else if (toolName === 'WebFetch' || toolName === 'WebSearch') {
-      summary = str(inp.url ?? inp.query)
-    } else if (toolName === 'Task') {
-      summary = str(inp.description).slice(0, 60)
+/** Copies the session ID, echoing the confirmation on the chip like the design. */
+function CopyIdChip({ value }: Readonly<{ value: string }>) {
+  const [copied, setCopied] = useState(false)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => () => clearTimeout(timeoutRef.current ?? undefined), [])
+
+  const handleCopy = async () => {
+    if (!navigator.clipboard) return
+    try {
+      await navigator.clipboard.writeText(value)
+    } catch {
+      return
     }
+    setCopied(true)
+    clearTimeout(timeoutRef.current ?? undefined)
+    timeoutRef.current = setTimeout(() => setCopied(false), 1400)
   }
 
   return (
-    <div className="rounded-md border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800/50 text-xs overflow-hidden">
-      <button
-        className="flex w-full items-center gap-1.5 px-3 py-1.5 text-zinc-600 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-700/50 transition-colors text-left"
-        onClick={() => setOpen(o => !o)}
-      >
-        {open ? (
-          <ChevronDown className="h-3 w-3 shrink-0" />
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="inline-flex items-center gap-1.5 font-mono text-[11.5px] text-zinc-500 dark:text-zinc-400 hover:text-zinc-800 dark:hover:text-zinc-100 transition-colors"
+    >
+      {value}
+      <span className="inline-flex items-center gap-1 border border-zinc-200 dark:border-zinc-700 rounded-[5px] px-1.5 py-px text-[10.5px]">
+        {copied ? (
+          <Check className="h-2.5 w-2.5 text-emerald-500" />
         ) : (
-          <ChevronRight className="h-3 w-3 shrink-0" />
+          <Copy className="h-2.5 w-2.5" />
         )}
-        <Badge
-          variant="secondary"
-          className="text-[12px] py-0 h-4 bg-zinc-200 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-300 border-0 font-mono px-1"
-        >
-          {toolName}
-        </Badge>
+        {copied ? 'Copied' : 'Copy'}
+      </span>
+    </button>
+  )
+}
+
+// ── Transcript blocks ─────────────────────────────────────────────────────────
+
+/**
+ * A collapsible tool call or thinking block.
+ *
+ * Openness is `explicit ?? defaultOpen` so the toolbar's expand/collapse-all
+ * moves every block that has not been touched individually, without the page
+ * having to hold one entry per block up front.
+ */
+function CollapsibleBlock({
+  label,
+  summary,
+  body,
+  open,
+  onToggle,
+}: Readonly<{
+  label: string
+  summary?: string
+  body: string
+  open: boolean
+  onToggle: () => void
+}>) {
+  return (
+    <div className="rounded-lg border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800/50 overflow-hidden">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-center gap-2 px-2.5 py-[7px] text-[12.5px] text-left hover:bg-zinc-100 dark:hover:bg-zinc-700/50 transition-colors"
+      >
+        <ChevronRight
+          className={`h-3 w-3 shrink-0 text-zinc-400 dark:text-zinc-500 transition-transform duration-150 ${
+            open ? 'rotate-90' : ''
+          }`}
+        />
+        <span className="font-mono font-semibold text-zinc-800 dark:text-zinc-100 shrink-0">
+          {label}
+        </span>
         {summary && (
-          <span className="text-zinc-500 dark:text-zinc-400 font-mono truncate">{summary}</span>
+          <span className="font-mono text-[11.5px] text-zinc-500 dark:text-zinc-400 truncate">
+            {summary}
+          </span>
         )}
       </button>
-      {open && inputStr && (
-        <pre className="px-3 pb-2 text-zinc-600 dark:text-zinc-400 whitespace-pre-wrap break-words font-mono text-[12px] leading-relaxed border-t border-zinc-200 dark:border-zinc-700">
-          {inputStr}
+      {open && body && (
+        <pre className="m-0 px-3 py-2.5 border-t border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 font-mono text-[11.5px] leading-[1.55] text-zinc-700 dark:text-zinc-300 overflow-x-auto whitespace-pre-wrap break-words">
+          {body}
         </pre>
       )}
     </div>
   )
 }
 
-function MessageBlocks({ blocks }: Readonly<{ blocks: ClaudeNormalizedBlock[] }>) {
-  return (
-    <div className="flex flex-col gap-2">
-      {blocks.map((b, i) => {
-        const blockKey = b.id ?? `${b.type}-${i}`
-        if (b.type === 'thinking') {
-          return <ThinkingBlock key={`thinking-${blockKey}`} text={b.text ?? ''} />
-        }
-        if (b.type === 'text') {
-          return (
-            <p
-              key={`text-${blockKey}`}
-              className="text-sm text-zinc-800 dark:text-zinc-200 whitespace-pre-wrap leading-relaxed"
-            >
-              {b.text}
-            </p>
-          )
-        }
-        if (b.type === 'tool_use') {
-          return <ToolUseBlock key={`tool-${blockKey}`} block={b} />
-        }
-        return null
-      })}
-    </div>
-  )
-}
+// ── Transcript row ────────────────────────────────────────────────────────────
 
-// ── Progress children ─────────────────────────────────────────────────────────
+function EventRow({
+  msg,
+  filter,
+  isBlockOpen,
+  onToggleBlock,
+}: Readonly<{
+  msg: ClaudeMessage
+  filter: TranscriptFilter
+  isBlockOpen: (key: string) => boolean
+  onToggleBlock: (key: string) => void
+}>) {
+  const isUser = (msg.role ?? msg.type) === 'user'
+  const blocks = msg.blocks ?? []
+  const showProse = filter !== 'tools'
+  const showTools = filter !== 'messages'
 
-function ProgressChildren({ messages }: Readonly<{ messages: ClaudeMessage[] }>) {
-  const [open, setOpen] = useState(false)
-  if (!messages || messages.length === 0) return null
+  const rendered: ReactNode[] = []
+  if (isUser && showProse && (msg.content ?? '').trim()) {
+    rendered.push(
+      <div key="content" className="text-[13.5px] leading-[1.6] whitespace-pre-wrap text-pretty">
+        {msg.content}
+      </div>,
+    )
+  }
+  blocks.forEach((b: ClaudeNormalizedBlock, i) => {
+    const key = `${msg.uuid}-${i}`
+    if (b.type === 'text' && showProse) {
+      rendered.push(
+        <div key={key} className="text-[13.5px] leading-[1.6] whitespace-pre-wrap text-pretty">
+          {b.text}
+        </div>,
+      )
+    } else if (b.type === 'thinking' && showProse) {
+      rendered.push(
+        <CollapsibleBlock
+          key={key}
+          label="Thinking"
+          body={b.text ?? ''}
+          open={isBlockOpen(key)}
+          onToggle={() => onToggleBlock(key)}
+        />,
+      )
+    } else if (b.type === 'tool_use' && showTools) {
+      rendered.push(
+        <CollapsibleBlock
+          key={key}
+          label={b.name ?? 'unknown'}
+          summary={toolSummary(b)}
+          body={b.input ? JSON.stringify(b.input, null, 2) : ''}
+          open={isBlockOpen(key)}
+          onToggle={() => onToggleBlock(key)}
+        />,
+      )
+    }
+  })
+
+  if (rendered.length === 0) return null
+
+  const inTokens = msg.usage?.input_tokens ?? 0
+  const outTokens = msg.usage?.output_tokens ?? 0
+
   return (
-    <div className="mt-2">
-      <button
-        className="flex items-center gap-1 text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-400 transition-colors"
-        onClick={() => setOpen(o => !o)}
+    <div
+      id={`event-${msg.uuid}`}
+      className={`grid gap-3 px-4 py-3.5 border-b border-zinc-100 dark:border-zinc-700/50 scroll-mt-4 ${
+        isUser ? 'bg-zinc-50 dark:bg-zinc-800/40' : ''
+      }`}
+      style={{ gridTemplateColumns: '26px minmax(0,1fr) 96px' }}
+    >
+      <div
+        className={`h-6 w-6 rounded-md flex items-center justify-center text-[10.5px] font-bold border border-zinc-200 dark:border-zinc-700 ${
+          isUser
+            ? 'bg-white dark:bg-zinc-900 text-zinc-500 dark:text-zinc-400'
+            : 'bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900'
+        }`}
       >
-        {open ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-        {messages.length} sub-agent event{messages.length === 1 ? '' : 's'}
-      </button>
-      {open && (
-        <div className="mt-1 pl-3 border-l border-zinc-200 dark:border-zinc-700 flex flex-col gap-0.5">
-          {messages.map(c => (
-            <div key={c.uuid} className="text-xs text-zinc-400 dark:text-zinc-500 font-mono">
-              {new Date(c.timestamp).toLocaleTimeString()}
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
-  )
-}
-
-// ── Message components ────────────────────────────────────────────────────────
-
-function UserMessage({ msg }: Readonly<{ msg: ClaudeMessage }>) {
-  return (
-    <div className="flex gap-3">
-      <div className="flex h-7 w-7 items-center justify-center rounded-full bg-zinc-200 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-300 shrink-0 text-xs font-semibold mt-0.5">
-        U
+        {isUser ? 'U' : 'A'}
       </div>
-      <div className="flex-1 min-w-0">
-        <p className="text-sm text-zinc-800 dark:text-zinc-200 whitespace-pre-wrap leading-relaxed">
-          {msg.content}
-        </p>
-        <span className="text-xs text-zinc-400 dark:text-zinc-500 mt-0.5 block">
-          {formatDateTime(msg.timestamp, true)}
+
+      <div className="min-w-0 flex flex-col gap-2">{rendered}</div>
+
+      <div className="flex flex-col gap-[3px] items-end text-right tabular-nums">
+        <span className="text-[11.5px] text-zinc-400 dark:text-zinc-500">
+          {new Date(msg.timestamp).toLocaleTimeString('en-GB')}
         </span>
+        {(inTokens > 0 || outTokens > 0) && (
+          <span className="text-[11px] font-mono text-zinc-400 dark:text-zinc-500">
+            {formatTokens(inTokens)}↑ {formatTokens(outTokens)}↓
+          </span>
+        )}
       </div>
     </div>
   )
 }
 
-function AssistantMessage({ msg }: Readonly<{ msg: ClaudeMessage }>) {
-  const hasBlocks = (msg.blocks ?? []).length > 0
-  const hasChildren = (msg.children ?? []).length > 0
+// ── Sidebar sections ──────────────────────────────────────────────────────────
 
+function todoIcon(status: string) {
+  if (status === 'completed')
+    return <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500 shrink-0 mt-px" />
+  if (status === 'in_progress')
+    return <Clock className="h-3.5 w-3.5 text-amber-500 shrink-0 mt-px animate-pulse" />
+  return <Circle className="h-3.5 w-3.5 text-zinc-400 shrink-0 mt-px" />
+}
+
+function TodosCard({ todos }: Readonly<{ todos: ClaudeTodo[] }>) {
+  if (!todos?.length) return null
+  const done = todos.filter(t => t.status === 'completed').length
   return (
-    <div className="flex gap-3">
-      <div className="flex h-7 w-7 items-center justify-center rounded-full bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 shrink-0 text-xs font-semibold mt-0.5">
-        A
-      </div>
-      <div className="flex-1 min-w-0">
-        {hasBlocks ? (
-          <MessageBlocks blocks={msg.blocks!} />
-        ) : (
-          <p className="text-sm text-zinc-400 dark:text-zinc-500 italic">No text content</p>
-        )}
-        {hasChildren && <ProgressChildren messages={msg.children!} />}
-        <div className="flex items-center gap-3 mt-1">
-          <span className="text-xs text-zinc-400 dark:text-zinc-500">
-            {formatDateTime(msg.timestamp, true)}
-          </span>
-          {msg.usage && (
-            <span className="flex items-center gap-0.5 text-xs text-zinc-400 dark:text-zinc-500">
-              <Zap className="h-2.5 w-2.5" />
-              {formatTokens(msg.usage.input_tokens)}↑&nbsp;{formatTokens(msg.usage.output_tokens)}↓
+    <SidebarCard title={`Todos · ${done}/${todos.length}`}>
+      <div className="flex flex-col gap-1.5">
+        {todos.map((t, i) => (
+          <div key={`${t.content.slice(0, 40)}-${i}`} className="flex items-start gap-2 text-xs">
+            {todoIcon(t.status)}
+            <span
+              className={
+                t.status === 'completed'
+                  ? 'text-zinc-400 dark:text-zinc-500 line-through'
+                  : 'text-zinc-700 dark:text-zinc-300'
+              }
+            >
+              {t.content}
             </span>
-          )}
-        </div>
+          </div>
+        ))}
       </div>
-    </div>
+    </SidebarCard>
   )
 }
 
-// ── Todos ─────────────────────────────────────────────────────────────────────
+function SubagentsCard({ subagents }: Readonly<{ subagents: ClaudeSubagent[] }>) {
+  if (!subagents?.length) return null
+  return (
+    <SidebarCard title={`Sub-agents · ${subagents.length}`}>
+      <div className="flex flex-col gap-2.5">
+        {subagents.map(sa => (
+          <div key={sa.agent_id} className="text-xs min-w-0">
+            <div className="font-mono text-[11.5px] text-zinc-800 dark:text-zinc-100 truncate">
+              {sa.agent_type || 'sub-agent'}
+            </div>
+            {sa.description && (
+              <div className="text-[11.5px] text-zinc-500 dark:text-zinc-400 line-clamp-2">
+                {sa.description}
+              </div>
+            )}
+            <div className="text-[11px] tabular-nums text-zinc-400 dark:text-zinc-500 mt-0.5">
+              {sa.message_count} msgs ·{' '}
+              {formatTokens(sa.usage.input_tokens + sa.usage.output_tokens)} tokens
+            </div>
+          </div>
+        ))}
+      </div>
+    </SidebarCard>
+  )
+}
 
-function TodosSection({ todos }: Readonly<{ todos: ClaudeTodo[] }>) {
-  const [open, setOpen] = useState(false)
-  if (!todos || todos.length === 0) return null
+/**
+ * The transcript itself: search, the All/Messages/Tools filter, expand-all, and
+ * the event rows. It owns that state because nothing outside it reads the
+ * filter — the sidebar reaches rows through their DOM ids, not through React.
+ */
+function TranscriptPanel({
+  messages,
+  isActive,
+}: Readonly<{ messages: ClaudeMessage[]; isActive: boolean }>) {
+  const [search, setSearch] = useState('')
+  const [filter, setFilter] = useState<TranscriptFilter>('all')
+  const [defaultOpen, setDefaultOpen] = useState(false)
+  const [overrides, setOverrides] = useState<ReadonlyMap<string, boolean>>(() => new Map())
 
-  const completed = todos.filter(t => t.status === 'completed').length
+  const visible = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    return messages.filter(m => {
+      if (filter === 'messages' && !hasProse(m)) return false
+      if (filter === 'tools' && !hasToolUse(m)) return false
+      return !q || messageText(m).includes(q)
+    })
+  }, [messages, filter, search])
+
+  const isBlockOpen = useCallback(
+    (key: string) => overrides.get(key) ?? defaultOpen,
+    [overrides, defaultOpen],
+  )
+  const toggleBlock = useCallback(
+    (key: string) =>
+      setOverrides(prev => {
+        const next = new Map(prev)
+        next.set(key, !(prev.get(key) ?? defaultOpen))
+        return next
+      }),
+    [defaultOpen],
+  )
+  const toggleAll = () => {
+    setDefaultOpen(v => !v)
+    setOverrides(new Map())
+  }
 
   return (
-    <div className="rounded-md border border-zinc-200 dark:border-zinc-700 overflow-hidden">
-      <button
-        className="flex w-full items-center gap-2 px-4 py-2.5 bg-zinc-50 dark:bg-zinc-800/50 hover:bg-zinc-100 dark:hover:bg-zinc-700/50 transition-colors text-left"
-        onClick={() => setOpen(o => !o)}
-      >
-        {open ? (
-          <ChevronDown className="h-3.5 w-3.5 text-zinc-400" />
-        ) : (
-          <ChevronRight className="h-3.5 w-3.5 text-zinc-400" />
-        )}
-        <span className="text-xs font-medium text-zinc-700 dark:text-zinc-300">Todos</span>
-        <span className="text-xs text-zinc-400 dark:text-zinc-500">
-          {completed}/{todos.length} completed
-        </span>
-      </button>
-      {open && (
-        <div className="divide-y divide-zinc-100 dark:divide-zinc-700/50">
-          {todos.map((todo, i) => (
-            <div
-              key={`todo-${todo.content.slice(0, 50)}-${i}`}
-              className="flex items-start gap-2 px-4 py-2"
+    <div className="flex flex-col gap-3 min-w-0">
+      <div className="flex items-center gap-2 flex-wrap">
+        <div className="relative w-full sm:w-[280px]">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-zinc-400 dark:text-zinc-500" />
+          <input
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder="Search this transcript…"
+            className="w-full h-8 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 pl-8 pr-3 text-[12.5px] placeholder:text-zinc-500 dark:placeholder:text-zinc-400 focus:outline-none focus:ring-1 focus:ring-zinc-900 dark:focus:ring-zinc-400"
+          />
+        </div>
+        <div className="flex rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden bg-white dark:bg-zinc-900">
+          {(Object.keys(FILTER_LABELS) as TranscriptFilter[]).map((f, i) => (
+            <button
+              key={f}
+              onClick={() => setFilter(f)}
+              className={`px-3 py-1.5 text-[12.5px] transition-colors ${
+                i > 0 ? 'border-l border-zinc-200 dark:border-zinc-700' : ''
+              } ${
+                filter === f
+                  ? 'bg-zinc-100 dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 font-semibold'
+                  : 'text-zinc-500 dark:text-zinc-400 hover:text-zinc-800 dark:hover:text-zinc-100'
+              }`}
             >
-              {todoIcon(todo.status)}
-              <span
-                className={`text-xs leading-relaxed ${
-                  todo.status === 'completed'
-                    ? 'text-zinc-400 dark:text-zinc-500 line-through'
-                    : 'text-zinc-700 dark:text-zinc-300'
-                }`}
-              >
-                {todo.content}
-              </span>
-            </div>
+              {FILTER_LABELS[f]}
+            </button>
           ))}
         </div>
-      )}
-    </div>
-  )
-}
+        <div className="flex-1" />
+        <button
+          onClick={toggleAll}
+          className="text-[12.5px] text-zinc-500 dark:text-zinc-400 hover:text-zinc-800 dark:hover:text-zinc-100 transition-colors"
+        >
+          {defaultOpen ? 'Collapse all tools' : 'Expand all tools'}
+        </button>
+      </div>
 
-// ── Sub-agents ────────────────────────────────────────────────────────────────
-
-function SubagentRow({ subagent }: Readonly<{ subagent: ClaudeSubagent }>) {
-  const total = subagent.usage.input_tokens + subagent.usage.output_tokens
-  return (
-    <div className="flex items-start gap-2 px-4 py-2">
-      <Bot className="h-3 w-3 mt-0.5 text-indigo-600 dark:text-indigo-400 shrink-0" />
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2 flex-wrap">
-          <span className="text-xs font-medium text-zinc-700 dark:text-zinc-300">
-            {subagent.agent_type || 'sub-agent'}
-          </span>
-          {subagent.model && (
-            <span className="text-xs text-zinc-400 dark:text-zinc-500">{subagent.model}</span>
-          )}
-        </div>
-        {subagent.description && (
-          <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5 break-words">
-            {subagent.description}
+      <div className="rounded-[14px] border border-zinc-200 dark:border-zinc-700/60 bg-white dark:bg-zinc-900 overflow-hidden">
+        {visible.length === 0 ? (
+          <p className="text-sm text-zinc-400 text-center py-12">
+            {messages.length === 0
+              ? 'No messages in this session.'
+              : 'No events match the current filter.'}
           </p>
+        ) : (
+          <>
+            {visible.map(msg => (
+              <EventRow
+                key={msg.uuid}
+                msg={msg}
+                filter={filter}
+                isBlockOpen={isBlockOpen}
+                onToggleBlock={toggleBlock}
+              />
+            ))}
+            <div className="flex items-center justify-center gap-2 py-3.5 text-[12.5px] text-zinc-400 dark:text-zinc-500">
+              <span
+                className={`w-1.5 h-1.5 rounded-full ${
+                  isActive ? 'bg-emerald-500' : 'bg-zinc-300 dark:bg-zinc-600'
+                }`}
+              />
+              {isActive
+                ? 'Session is live — reload to pick up new events'
+                : `End of transcript · ${visible.length} of ${messages.length} events`}
+            </div>
+          </>
         )}
-        <div className="flex items-center gap-3 mt-1 text-xs text-zinc-400 dark:text-zinc-500">
-          <span>{subagent.message_count} messages</span>
-          {total > 0 && (
-            <span className="flex items-center gap-0.5">
-              <Zap className="h-2.5 w-2.5" />
-              {formatTokens(subagent.usage.input_tokens)}↑&nbsp;
-              {formatTokens(subagent.usage.output_tokens)}↓
-            </span>
-          )}
-        </div>
       </div>
     </div>
   )
 }
 
-function SubagentsSection({ subagents }: Readonly<{ subagents: ClaudeSubagent[] }>) {
-  const [open, setOpen] = useState(false)
-  if (!subagents || subagents.length === 0) return null
-
-  const totalTokens = subagents.reduce(
-    (sum, sa) => sum + sa.usage.input_tokens + sa.usage.output_tokens,
-    0,
-  )
-
+/** Timeline outline, tool histogram, files touched, todos and sub-agents. */
+function SessionSidebar({
+  timeline,
+  tools,
+  files,
+  todos,
+  subagents,
+}: Readonly<{
+  timeline: OutlineEntry[]
+  tools: ToolUsage[]
+  files: FileTouch[]
+  todos: ClaudeTodo[]
+  subagents: ClaudeSubagent[]
+}>) {
+  const maxToolCount = tools[0]?.count ?? 0
   return (
-    <div className="rounded-md border border-zinc-200 dark:border-zinc-700 overflow-hidden">
-      <button
-        className="flex w-full items-center gap-2 px-4 py-2.5 bg-zinc-50 dark:bg-zinc-800/50 hover:bg-zinc-100 dark:hover:bg-zinc-700/50 transition-colors text-left"
-        onClick={() => setOpen(o => !o)}
-      >
-        {open ? (
-          <ChevronDown className="h-3.5 w-3.5 text-zinc-400" />
-        ) : (
-          <ChevronRight className="h-3.5 w-3.5 text-zinc-400" />
-        )}
-        <span className="text-xs font-medium text-zinc-700 dark:text-zinc-300">
-          Sub-agents ({subagents.length})
-        </span>
-        <span className="text-xs text-zinc-400 dark:text-zinc-500">
-          {formatTokens(totalTokens)} tokens
-        </span>
-      </button>
-      {open && (
-        <div className="divide-y divide-zinc-100 dark:divide-zinc-700/50">
-          {subagents.map(sa => (
-            <SubagentRow key={sa.agent_id} subagent={sa} />
-          ))}
-        </div>
+    <div className="flex flex-col gap-4">
+      {timeline.length > 0 && (
+        <SidebarCard title="Timeline">
+          <div className="flex flex-col">
+            {timeline.map(entry => (
+              <button
+                key={entry.uuid}
+                onClick={() =>
+                  document
+                    .getElementById(`event-${entry.uuid}`)
+                    ?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+                }
+                className="grid gap-2.5 items-baseline py-[5px] text-[12.5px] text-left text-zinc-700 dark:text-zinc-300 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
+                style={{ gridTemplateColumns: '52px 1fr' }}
+              >
+                <span className="tabular-nums text-[11.5px] text-zinc-400 dark:text-zinc-500">
+                  {new Date(entry.timestamp).toLocaleTimeString('en-GB', {
+                    hour: '2-digit',
+                    minute: '2-digit',
+                  })}
+                </span>
+                <span className="text-pretty line-clamp-2">{entry.label}</span>
+              </button>
+            ))}
+          </div>
+        </SidebarCard>
       )}
+
+      {tools.length > 0 && (
+        <SidebarCard title="Tool usage">
+          <div className="flex flex-col gap-2">
+            {tools.map(t => (
+              <div
+                key={t.name}
+                className="grid gap-2 items-center text-[12.5px]"
+                style={{ gridTemplateColumns: '1fr 34px' }}
+              >
+                <div className="flex flex-col gap-1 min-w-0">
+                  <span className="font-mono text-[11.5px] truncate text-zinc-700 dark:text-zinc-300">
+                    {t.name}
+                  </span>
+                  <span className="h-[5px] rounded-[3px] bg-zinc-100 dark:bg-zinc-700/70 overflow-hidden block">
+                    <span
+                      className="block h-full bg-zinc-900/80 dark:bg-zinc-100/80"
+                      style={{ width: `${maxToolCount ? (t.count / maxToolCount) * 100 : 0}%` }}
+                    />
+                  </span>
+                </div>
+                <span className="text-right tabular-nums text-[11.5px] text-zinc-400 dark:text-zinc-500">
+                  {t.count}
+                </span>
+              </div>
+            ))}
+          </div>
+        </SidebarCard>
+      )}
+
+      {files.length > 0 && (
+        <SidebarCard title="Files touched">
+          <div className="flex flex-col gap-1.5">
+            {files.map(f => (
+              <div key={f.path} className="flex items-center gap-2 text-xs">
+                <span
+                  title={shortPath(f.path)}
+                  className="font-mono text-[11.5px] truncate flex-1 text-zinc-700 dark:text-zinc-300"
+                >
+                  {tailPath(f.path)}
+                </span>
+                <span className="tabular-nums text-[11px] text-zinc-400 dark:text-zinc-500">
+                  ×{f.count}
+                </span>
+              </div>
+            ))}
+          </div>
+        </SidebarCard>
+      )}
+
+      <TodosCard todos={todos} />
+      <SubagentsCard subagents={subagents} />
+    </div>
+  )
+}
+
+/** Everything the transcript records about the run, as one wrapping chip row. */
+function SessionMetaRow({
+  detail,
+  sessionId,
+}: Readonly<{ detail: ClaudeSessionDetail; sessionId?: string }>) {
+  const worktreeLabel = detail.worktree_name || detail.worktree_branch
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 text-xs text-zinc-500 dark:text-zinc-400">
+      <MetaChip variant="filled">{shortPath(detail.cwd || detail.project_path)}</MetaChip>
+      {detail.git_branch && <MetaChip>⑂ {detail.git_branch}</MetaChip>}
+      {detail.worktree_branch && (
+        <MetaChip
+          title={
+            detail.original_branch
+              ? `Worktree ${worktreeLabel}, branched from ${detail.original_branch}`
+              : `Worktree ${worktreeLabel}`
+          }
+        >
+          🌳 {detail.worktree_branch}
+        </MetaChip>
+      )}
+      {detail.permission_mode && <MetaChip>{detail.permission_mode}</MetaChip>}
+      {detail.model && <MetaChip variant="filled">{detail.model}</MetaChip>}
+      {detail.compaction_count > 0 && (
+        <MetaChip title={`${detail.dropped_tokens.toLocaleString()} tokens dropped`}>
+          {detail.compaction_count} compaction{detail.compaction_count === 1 ? '' : 's'}
+        </MetaChip>
+      )}
+      {detail.prs?.map(pr => (
+        <a
+          key={pr.pr_url}
+          href={pr.pr_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          title={pr.pr_repository ? `${pr.pr_repository}#${pr.pr_number}` : pr.pr_url}
+          className="inline-flex items-center gap-1 font-mono text-[11.5px] rounded-md px-1.5 py-[2px] border border-zinc-200 dark:border-zinc-700 text-emerald-600 dark:text-emerald-400 hover:border-emerald-400"
+        >
+          <GitPullRequest className="h-3 w-3" />#{pr.pr_number}
+        </a>
+      ))}
+      <MetaDivider />
+      <span className="tabular-nums" title={formatDateTime(detail.start_time, true)}>
+        Started {formatDateTime(detail.start_time)} · {formatRelativeTime(detail.last_activity)}
+      </span>
+      <MetaDivider />
+      {sessionId && <CopyIdChip value={sessionId} />}
     </div>
   )
 }
@@ -380,6 +641,10 @@ export default function ClaudeSessionDetailPage() {
       setLoading(false)
     }
   }, [id])
+
+  useEffect(() => {
+    load()
+  }, [load])
 
   const startEditingTitle = () => {
     if (!detail) return
@@ -414,12 +679,6 @@ export default function ClaudeSessionDetailPage() {
     }
   }
 
-  const cancelEditingTitle = () => setEditingTitle(false)
-
-  useEffect(() => {
-    load()
-  }, [load])
-
   const handleContinue = async () => {
     if (!id || continuing) return
     setContinuing(true)
@@ -431,6 +690,12 @@ export default function ClaudeSessionDetailPage() {
       setContinuing(false)
     }
   }
+
+  const messages = useMemo(() => detail?.messages ?? [], [detail])
+
+  const tools = useMemo(() => toolUsage(messages), [messages])
+  const files = useMemo(() => filesTouched(messages), [messages])
+  const timeline = useMemo(() => outline(messages), [messages])
 
   if (loading) {
     return (
@@ -449,7 +714,7 @@ export default function ClaudeSessionDetailPage() {
             className="flex items-center gap-1.5 text-xs text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors"
           >
             <ArrowLeft className="h-3.5 w-3.5" />
-            Back to Sessions
+            Back to sessions
           </button>
         </div>
         <div className="flex flex-col items-center justify-center flex-1 text-center">
@@ -459,269 +724,156 @@ export default function ClaudeSessionDetailPage() {
     )
   }
 
-  const totalTokens = (detail.usage?.input_tokens ?? 0) + (detail.usage?.output_tokens ?? 0)
-  // Delegated work is reported additively — `usage` stays main-thread only.
-  const subagentTokens =
-    (detail.subagent_usage?.input_tokens ?? 0) + (detail.subagent_usage?.output_tokens ?? 0)
-  // Cost mirrors usage: main-thread plus delegated, as one figure.
+  // Totals mirror the sessions list: main thread plus delegated sub-agents.
+  const usage = detail.usage
+  const sub = detail.subagent_usage
+  const inTokens = (usage?.input_tokens ?? 0) + (sub?.input_tokens ?? 0)
+  const outTokens = (usage?.output_tokens ?? 0) + (sub?.output_tokens ?? 0)
+  const cacheWrite = (usage?.cache_creation_tokens ?? 0) + (sub?.cache_creation_tokens ?? 0)
+  const cacheRead = (usage?.cache_read_tokens ?? 0) + (sub?.cache_read_tokens ?? 0)
   const totalCost = (detail.cost?.total_usd ?? 0) + (detail.subagent_cost?.total_usd ?? 0)
   const unpricedModels = detail.unpriced_models ?? []
   const partiallyPriced = unpricedModels.length > 0
 
+  const durationMs =
+    new Date(detail.last_activity).getTime() - new Date(detail.start_time).getTime()
+  const isActive = Date.now() - new Date(detail.last_activity).getTime() < ACTIVE_WINDOW_MS
+  const title = detail.display_title || detail.preview || `Session ${(id ?? '').slice(0, 8)}`
+
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
-      <div className="border-b border-zinc-100 dark:border-zinc-700/50 px-4 sm:px-6 py-4 shrink-0">
+      <div className="shrink-0 border-b border-zinc-200 dark:border-zinc-700/60 px-4 sm:px-7 pt-3.5 pb-3 flex flex-col gap-2.5">
         <button
           onClick={() => navigate('/claude-sessions')}
-          className="flex items-center gap-1.5 text-xs text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors mb-3"
+          className="flex items-center gap-1.5 text-[12.5px] text-zinc-500 dark:text-zinc-400 hover:text-zinc-800 dark:hover:text-zinc-100 transition-colors w-fit"
         >
           <ArrowLeft className="h-3.5 w-3.5" />
-          Back to Sessions
+          Back to sessions
         </button>
-        <div className="flex items-start justify-between gap-3">
-          <div className="flex-1 min-w-0">
-            {editingTitle ? (
-              <input
-                ref={titleInputRef}
-                value={titleDraft}
-                onChange={e => setTitleDraft(e.target.value)}
-                onBlur={saveTitle}
-                onKeyDown={e => {
-                  if (e.key === 'Enter') e.currentTarget.blur()
-                  if (e.key === 'Escape') cancelEditingTitle()
-                }}
-                className="w-full text-base font-semibold text-zinc-900 dark:text-zinc-100 bg-transparent border-b border-zinc-400 dark:border-zinc-500 outline-none pb-0.5 truncate"
-                autoFocus
-              />
-            ) : (
-              <button
-                type="button"
-                onClick={startEditingTitle}
-                className="group flex items-center gap-1.5 text-left w-full min-w-0"
-              >
-                <p className="text-base font-semibold text-zinc-900 dark:text-zinc-100 truncate">
-                  {detail.display_title || detail.preview || 'Session ' + (id ?? '').slice(0, 8)}
-                </p>
-                <Pencil className="h-3 w-3 text-zinc-300 dark:text-zinc-600 group-hover:text-zinc-500 dark:group-hover:text-zinc-400 shrink-0 transition-colors" />
-              </button>
-            )}
-            {/* Session meta */}
-            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1.5">
-              {detail.cwd && (
-                <span className="flex items-center gap-1 text-xs text-zinc-500 dark:text-zinc-400">
-                  <Folder className="h-3 w-3" />
-                  <span className="font-mono">{shortPath(detail.cwd)}</span>
-                </span>
+
+        <div className="flex items-start gap-4">
+          <div className="flex flex-col gap-2 min-w-0 flex-1">
+            <div className="flex items-center gap-2.5 min-w-0">
+              {editingTitle ? (
+                <input
+                  ref={titleInputRef}
+                  value={titleDraft}
+                  onChange={e => setTitleDraft(e.target.value)}
+                  onBlur={saveTitle}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter') e.currentTarget.blur()
+                    if (e.key === 'Escape') setEditingTitle(false)
+                  }}
+                  className="flex-1 min-w-0 text-[21px] font-bold tracking-[-0.02em] text-zinc-900 dark:text-zinc-100 bg-transparent border-b border-zinc-400 dark:border-zinc-500 outline-none"
+                  autoFocus
+                />
+              ) : (
+                <>
+                  <h1 className="text-[21px] font-bold tracking-[-0.02em] text-zinc-900 dark:text-zinc-100 truncate">
+                    {title}
+                  </h1>
+                  <button
+                    type="button"
+                    onClick={startEditingTitle}
+                    className="text-xs text-zinc-500 dark:text-zinc-400 hover:text-zinc-800 dark:hover:text-zinc-100 shrink-0 transition-colors"
+                  >
+                    Rename
+                  </button>
+                </>
               )}
-              {detail.git_branch && (
-                <span className="flex items-center gap-1 text-xs text-zinc-500 dark:text-zinc-400">
-                  <GitBranch className="h-3 w-3" />
-                  <span className="font-mono">{detail.git_branch}</span>
-                </span>
-              )}
-              {detail.worktree_branch && (
+              {isActive && (
                 <span
-                  className="flex items-center gap-1 text-xs text-zinc-500 dark:text-zinc-400"
-                  title={
-                    detail.original_branch
-                      ? `Worktree ${detail.worktree_name || detail.worktree_branch}, branched from ${detail.original_branch}`
-                      : `Worktree ${detail.worktree_name || detail.worktree_branch}`
-                  }
+                  title="Transcript was written to in the last 10 minutes"
+                  className="inline-flex items-center h-5 rounded-full px-2.5 text-[11px] bg-blue-500/10 text-blue-600 dark:text-blue-400 shrink-0"
                 >
-                  <Trees className="h-3 w-3" />
-                  <span className="font-mono">{detail.worktree_branch}</span>
-                </span>
-              )}
-              {detail.permission_mode && (
-                <span className="flex items-center gap-1 text-xs text-zinc-500 dark:text-zinc-400">
-                  <Shield className="h-3 w-3" />
-                  <span className="font-mono">{detail.permission_mode}</span>
-                </span>
-              )}
-              {detail.compaction_count > 0 && (
-                <span
-                  className="flex items-center gap-1 text-xs text-amber-600 dark:text-amber-400"
-                  title={`${detail.dropped_tokens.toLocaleString()} tokens dropped by compaction`}
-                >
-                  <Scissors className="h-3 w-3" />
-                  {detail.compaction_count} compaction
-                  {detail.compaction_count === 1 ? '' : 's'}
-                </span>
-              )}
-              {detail.prs?.map(pr => (
-                <a
-                  key={pr.pr_url}
-                  href={pr.pr_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400 hover:underline"
-                  title={pr.pr_repository ? `${pr.pr_repository}#${pr.pr_number}` : pr.pr_url}
-                >
-                  <GitPullRequest className="h-3 w-3" />#{pr.pr_number}
-                </a>
-              ))}
-              {detail.model && (
-                <Badge
-                  variant="secondary"
-                  className="text-xs py-0 h-4 bg-zinc-100 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-300 border-0 font-mono font-normal"
-                >
-                  {detail.model}
-                </Badge>
-              )}
-              {id && <CopyableId value={id} label="Copy session ID" />}
-              {detail.start_time && (
-                <span
-                  className="flex items-center gap-1 text-xs text-zinc-500 dark:text-zinc-400"
-                  title={formatDateTime(detail.start_time, true)}
-                >
-                  <Play className="h-3 w-3" />
-                  Started {formatRelativeTime(detail.start_time)}
-                </span>
-              )}
-              {detail.last_activity && (
-                <span
-                  className="flex items-center gap-1 text-xs text-zinc-500 dark:text-zinc-400"
-                  title={formatDateTime(detail.last_activity, true)}
-                >
-                  <Clock className="h-3 w-3" />
-                  Active {formatRelativeTime(detail.last_activity)}
+                  Active
                 </span>
               )}
             </div>
+
+            <SessionMetaRow detail={detail} sessionId={id} />
           </div>
-          <button
-            className={`h-8 w-8 flex items-center justify-center rounded-md transition-colors shrink-0 ${
-              detail.is_favorite
-                ? 'text-amber-400'
-                : 'text-zinc-300 dark:text-zinc-600 hover:text-amber-400 hover:bg-zinc-100 dark:hover:bg-zinc-800'
-            }`}
-            onClick={() => {
-              if (!id) return
-              const next = !detail.is_favorite
-              setDetail(prev => (prev ? { ...prev, is_favorite: next } : prev))
-              claudeSessionsApi.toggleFavorite(id, next).catch(() => {
-                setDetail(prev => (prev ? { ...prev, is_favorite: !next } : prev))
-              })
-            }}
-            title={detail.is_favorite ? 'Remove from favorites' : 'Add to favorites'}
-          >
-            <Star className={`h-4 w-4 ${detail.is_favorite ? 'fill-amber-400' : ''}`} />
-          </button>
-          <button
-            className="h-8 w-8 flex items-center justify-center rounded-md text-zinc-300 dark:text-zinc-600 hover:text-zinc-500 dark:hover:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors shrink-0"
-            onClick={() => navigate(`/claude-sessions/${id ?? ''}/journey`)}
-            title="View session journey"
-          >
-            <Activity className="h-4 w-4" />
-          </button>
-          <Button
-            size="sm"
-            className="gap-1.5 bg-zinc-900 hover:bg-zinc-800 text-white text-xs h-8 shrink-0"
-            onClick={() => handleContinue()}
-            disabled={continuing}
-          >
-            {continuing ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <Play className="h-3.5 w-3.5" />
-            )}
-            {continuing ? 'Opening…' : 'Continue'}
-          </Button>
+
+          <div className="flex gap-2 shrink-0 pt-0.5">
+            <button
+              onClick={() => {
+                if (!id) return
+                const next = !detail.is_favorite
+                setDetail(prev => (prev ? { ...prev, is_favorite: next } : prev))
+                claudeSessionsApi.toggleFavorite(id, next).catch(() => {
+                  setDetail(prev => (prev ? { ...prev, is_favorite: !next } : prev))
+                })
+              }}
+              title={detail.is_favorite ? 'Remove from favorites' : 'Add to favorites'}
+              className={`h-[34px] w-[34px] flex items-center justify-center rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 transition-colors ${
+                detail.is_favorite
+                  ? 'text-amber-400'
+                  : 'text-zinc-400 dark:text-zinc-500 hover:text-amber-400'
+              }`}
+            >
+              <Star className={`h-4 w-4 ${detail.is_favorite ? 'fill-amber-400' : ''}`} />
+            </button>
+            <button
+              onClick={() => navigate(`/claude-sessions/${id ?? ''}/journey`)}
+              className="flex items-center gap-1.5 h-[34px] px-3 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-[13px] text-zinc-700 dark:text-zinc-200 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors"
+            >
+              <Activity className="h-3.5 w-3.5" />
+              Journey
+            </button>
+            <button
+              onClick={() => handleContinue()}
+              disabled={continuing}
+              className="flex items-center gap-1.5 h-[34px] px-4 rounded-lg bg-zinc-900 dark:bg-zinc-100 text-[13px] font-medium text-white dark:text-zinc-900 hover:bg-zinc-800 dark:hover:bg-zinc-200 disabled:opacity-50 transition-colors"
+            >
+              {continuing ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Play className="h-3.5 w-3.5" />
+              )}
+              {continuing ? 'Opening…' : 'Resume'}
+            </button>
+          </div>
         </div>
+
+        {/* Summary strip. The 1px grid gap is the divider — the background shows
+            through between the cells. */}
+        <div className="grid grid-cols-3 sm:grid-cols-6 gap-px bg-zinc-200 dark:bg-zinc-700/60 border border-zinc-200 dark:border-zinc-700/60 rounded-[10px] overflow-hidden mt-0.5">
+          <StatCell label="Input" value={formatTokens(inTokens)} />
+          <StatCell label="Output" value={formatTokens(outTokens)} />
+          <StatCell label="Cache write" value={formatTokens(cacheWrite)} />
+          <StatCell label="Cache read" value={formatTokens(cacheRead)} />
+          <StatCell label="Duration" value={durationMs > 0 ? formatDuration(durationMs) : '—'} />
+          <StatCell label="Cost" value={`${partiallyPriced ? '~' : ''}${formatCost(totalCost)}`} />
+        </div>
+        {partiallyPriced && (
+          // The total is a floor, so say which models it left out rather than
+          // letting an understated figure read as complete.
+          <p className="text-[11.5px] text-amber-600 dark:text-amber-400">
+            Cost excludes {unpricedModels.join(', ')} — no published rate.
+          </p>
+        )}
       </div>
 
-      {/* Token usage banner */}
-      {totalTokens > 0 && (
-        <div className="flex items-center gap-4 px-4 sm:px-6 py-2 border-b border-zinc-100 dark:border-zinc-700/50 bg-zinc-50 dark:bg-zinc-900/50 shrink-0">
-          <Zap className="h-3.5 w-3.5 text-zinc-400 shrink-0" />
-          <div className="flex items-center gap-4 text-xs text-zinc-500 dark:text-zinc-400">
-            <span>
-              <span className="font-medium text-zinc-700 dark:text-zinc-300">
-                {formatTokens(detail.usage.input_tokens)}
-              </span>{' '}
-              input
-            </span>
-            <span>
-              <span className="font-medium text-zinc-700 dark:text-zinc-300">
-                {formatTokens(detail.usage.output_tokens)}
-              </span>{' '}
-              output
-            </span>
-            {detail.usage.cache_creation_tokens > 0 && (
-              <span>
-                <span className="font-medium text-zinc-700 dark:text-zinc-300">
-                  {formatTokens(detail.usage.cache_creation_tokens)}
-                </span>{' '}
-                cache write
-              </span>
-            )}
-            {detail.usage.cache_read_tokens > 0 && (
-              <span>
-                <span className="font-medium text-zinc-700 dark:text-zinc-300">
-                  {formatTokens(detail.usage.cache_read_tokens)}
-                </span>{' '}
-                cache read
-              </span>
-            )}
-            {subagentTokens > 0 && (
-              <span className="flex items-center gap-1">
-                <Bot className="h-3 w-3 text-indigo-600 dark:text-indigo-400 shrink-0" />
-                <span className="font-medium text-zinc-700 dark:text-zinc-300">
-                  {formatTokens(subagentTokens)}
-                </span>{' '}
-                sub-agents
-              </span>
-            )}
-            <span className="flex items-center gap-1">
-              <DollarSign
-                className={`h-3 w-3 shrink-0 ${
-                  partiallyPriced
-                    ? 'text-amber-600 dark:text-amber-400'
-                    : 'text-emerald-600 dark:text-emerald-400'
-                }`}
-              />
-              <span className="font-medium text-zinc-700 dark:text-zinc-300">
-                {partiallyPriced && '~'}
-                {formatCost(totalCost)}
-              </span>{' '}
-              cost
-            </span>
-            {partiallyPriced && (
-              // The total is a floor, so say which models it left out rather
-              // than letting an understated figure read as complete.
-              <span className="text-amber-600 dark:text-amber-400">
-                excludes {unpricedModels.join(', ')} — no published rate
-              </span>
-            )}
-          </div>
+      {/* Body. Side by side the two columns are independent scroll panes rather
+          than one page scroll with a sticky sidebar: a sidebar taller than the
+          viewport pins at the top and its lower cards become unreachable, which
+          a long tool list or file list reaches easily. Stacked (below xl) the
+          whole body scrolls as one, so nothing is trapped there either. */}
+      <div className="flex-1 min-h-0 overflow-y-auto xl:overflow-hidden xl:flex xl:gap-7 px-4 sm:px-7 pt-5 pb-14 xl:pb-5 max-w-[1600px]">
+        <div className="min-w-0 xl:flex-1 xl:h-full xl:overflow-y-auto">
+          <TranscriptPanel messages={messages} isActive={isActive} />
         </div>
-      )}
 
-      {/* Body */}
-      <div className="flex-1 overflow-y-auto px-4 sm:px-6 py-4 flex flex-col gap-4">
-        {/* Todos */}
-        {detail.todos && detail.todos.length > 0 && <TodosSection todos={detail.todos} />}
-
-        {/* Sub-agents */}
-        <SubagentsSection subagents={detail.subagents} />
-
-        {/* Conversation */}
-        {detail.messages.length === 0 ? (
-          <p className="text-sm text-zinc-400 text-center py-8">No messages in this session.</p>
-        ) : (
-          <div className="flex flex-col gap-5">
-            {detail.messages.map(msg => {
-              if (msg.role === 'user') {
-                return <UserMessage key={msg.uuid} msg={msg} />
-              }
-              if (msg.role === 'assistant') {
-                return <AssistantMessage key={msg.uuid} msg={msg} />
-              }
-              return null
-            })}
-          </div>
-        )}
+        <div className="mt-6 xl:mt-0 xl:w-[300px] xl:shrink-0 xl:h-full xl:overflow-y-auto">
+          <SessionSidebar
+            timeline={timeline}
+            tools={tools}
+            files={files}
+            todos={detail.todos}
+            subagents={detail.subagents}
+          />
+        </div>
       </div>
     </div>
   )

--- a/frontend/src/pages/ClaudeSessionsPage.tsx
+++ b/frontend/src/pages/ClaudeSessionsPage.tsx
@@ -1,4 +1,12 @@
-import { useState, useEffect, useCallback, useMemo, useRef, type ReactNode } from 'react'
+import {
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+  useRef,
+  type KeyboardEvent,
+  type ReactNode,
+} from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { claudeSessionsApi } from '@/lib/api'
 import type {
@@ -7,8 +15,7 @@ import type {
   ClaudeProject,
   ClaudeSessionStatus,
 } from '@/types'
-import { formatRelativeTime } from '@/lib/utils'
-import { Badge } from '@/components/ui/badge'
+import { formatDateTime, formatRelativeTime } from '@/lib/utils'
 import {
   Select,
   SelectContent,
@@ -20,28 +27,34 @@ import {
   History,
   Search,
   RefreshCw,
-  ExternalLink,
-  Zap,
   Star,
-  Activity,
   Clock,
   X,
   Shield,
-  GitPullRequest,
-  Scissors,
-  DollarSign,
+  ChevronRight,
+  ChevronDown,
+  SlidersHorizontal,
+  Cpu,
+  Copy,
+  Check,
 } from 'lucide-react'
 import { Tooltip } from '@/components/ui/tooltip'
-import { CopyableId } from '@/components/CopyableId'
-import { formatCost, formatTokens, shortPath } from '@/lib/format'
+import { formatCost, formatTokens, formatDuration, shortPath } from '@/lib/format'
 import { resolvePresetRange, type TimePreset } from '@/lib/timefilter'
 import { decodeWindows } from '@/lib/drilldown'
 import {
   matchesFilters,
   permissionModesOf,
+  modelsOf,
   hasPRs as sessionsHavePRs,
   hasFavorites as hasFavoriteSessions,
+  isBounded,
+  UNBOUNDED,
+  type LinkFilter,
+  type NumericRange,
 } from '@/lib/sessionFilters'
+import { groupSessionsByDay, tokenBarReference } from '@/lib/sessionGroups'
+import { sessionCost, sessionDurationMs } from '@/lib/sessionMetrics'
 
 // How often to re-check whether the background re-cost finished. Slow enough
 // to be free, fast enough that a ~18s corpus rescan is noticed promptly.
@@ -55,6 +68,92 @@ const TIME_PRESET_LABELS: Record<TimePreset, string> = {
   '30d': 'Last 30 days',
   custom: 'Custom range…',
 }
+
+/**
+ * The row grid. Every cell in the header, the rows and the day headers shares
+ * this template — a column that drifts here misaligns the whole table, so it is
+ * declared exactly once.
+ */
+const ROW_GRID = '28px minmax(200px,2fr) minmax(170px,1fr) 92px 108px 56px 146px 82px 66px'
+/**
+ * Width at which the two flexible columns hit their minimum. Below it the table
+ * scrolls sideways rather than squashing titles and branches into nothing.
+ */
+const ROW_MIN_WIDTH = 1076
+
+/**
+ * Presentation for the permission mode a session ran under. This is the one
+ * genuine per-session state Claude Code records — there is no "succeeded /
+ * failed" in a transcript — so it fills the design's status column rather than
+ * a derived label that would be guesswork.
+ */
+const MODE_PRESENTATION: Record<string, { label: string; tone: string }> = {
+  bypassPermissions: {
+    label: 'Bypass',
+    tone: 'bg-amber-500/15 text-amber-600 dark:text-amber-400',
+  },
+  acceptEdits: {
+    label: 'Accept',
+    tone: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+  },
+  plan: { label: 'Plan', tone: 'bg-blue-500/10 text-blue-600 dark:text-blue-400' },
+  dontAsk: { label: "Don't ask", tone: 'bg-amber-500/15 text-amber-600 dark:text-amber-400' },
+  default: { label: 'Default', tone: 'bg-zinc-500/10 text-zinc-500 dark:text-zinc-400' },
+}
+
+const NEUTRAL_TONE = 'bg-zinc-500/10 text-zinc-500 dark:text-zinc-400'
+
+/**
+ * The filters behind the "Advanced" disclosure: everything that is either
+ * rarely needed or too wide for the toolbar. They live in one object so the
+ * active-count badge and "Clear" can treat them as a unit — a filter left set
+ * behind a collapsed panel is otherwise invisible.
+ */
+interface AdvancedFilters {
+  permissionMode: string
+  model: string
+  links: LinkFilter
+  messages: NumericRange
+  durationMinutes: NumericRange
+  tokensIn: NumericRange
+  tokensOut: NumericRange
+  cost: NumericRange
+}
+
+const NO_ADVANCED: AdvancedFilters = {
+  permissionMode: 'all',
+  model: 'all',
+  links: 'all',
+  messages: UNBOUNDED,
+  durationMinutes: UNBOUNDED,
+  tokensIn: UNBOUNDED,
+  tokensOut: UNBOUNDED,
+  cost: UNBOUNDED,
+}
+
+const ADVANCED_RANGES = [
+  'messages',
+  'durationMinutes',
+  'tokensIn',
+  'tokensOut',
+  'cost',
+] as const satisfies readonly (keyof AdvancedFilters)[]
+
+/** How many advanced filters are narrowing the list, for the button's badge. */
+function countActive(a: AdvancedFilters): number {
+  return (
+    (a.permissionMode === 'all' ? 0 : 1) +
+    (a.model === 'all' ? 0 : 1) +
+    (a.links === 'all' ? 0 : 1) +
+    ADVANCED_RANGES.filter(k => isBounded(a[k])).length
+  )
+}
+
+const LINK_OPTIONS: { value: LinkFilter; label: string }[] = [
+  { value: 'all', label: 'Any' },
+  { value: 'with', label: 'With PR' },
+  { value: 'without', label: 'No PR' },
+]
 
 export default function ClaudeSessionsPage() {
   const navigate = useNavigate()
@@ -70,6 +169,7 @@ export default function ClaudeSessionsPage() {
   const [error, setError] = useState<string | null>(null)
   const [search, setSearch] = useState('')
   const [filterProject, setFilterProject] = useState(searchParams.get('project') ?? 'all')
+  const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set())
 
   // Keep the project filter in sync when arriving via a new drill-down URL
   // while the page is already mounted.
@@ -78,8 +178,21 @@ export default function ClaudeSessionsPage() {
     if (projectParam) setFilterProject(projectParam)
   }, [projectParam])
   const [filterFavorites, setFilterFavorites] = useState(false)
-  const [filterHasPR, setFilterHasPR] = useState(false)
-  const [filterPermissionMode, setFilterPermissionMode] = useState('all')
+  const [advancedOpen, setAdvancedOpen] = useState(false)
+  // `advanced` is what the list is filtered by; `advancedDraft` is what the
+  // panel is showing. They diverge only while the user is mid-edit.
+  const [advanced, setAdvanced] = useState<AdvancedFilters>(NO_ADVANCED)
+  const [advancedDraft, setAdvancedDraft] = useState<AdvancedFilters>(NO_ADVANCED)
+  const toggleAdvanced = () => {
+    // Re-seed on every open so a draft abandoned last time cannot reappear as
+    // if it were applied.
+    setAdvancedDraft(advanced)
+    setAdvancedOpen(o => !o)
+  }
+  const resetAdvanced = () => {
+    setAdvancedDraft(NO_ADVANCED)
+    setAdvanced(NO_ADVANCED)
+  }
   const [timePreset, setTimePreset] = useState<TimePreset>('all')
   const [customFrom, setCustomFrom] = useState('')
   const [customTo, setCustomTo] = useState('')
@@ -163,11 +276,21 @@ export default function ClaudeSessionsPage() {
       .catch(() => setSessions(applyFavorite(sessionId, !next)))
   }
 
+  const handleToggleExpanded = useCallback((sessionId: string) => {
+    setExpanded(prev => {
+      const next = new Set(prev)
+      if (!next.delete(sessionId)) next.add(sessionId)
+      return next
+    })
+  }, [])
+
   const hasFavorites = hasFavoriteSessions(sessions)
   const hasPRs = sessionsHavePRs(sessions)
   // Only offer the permission-mode filter once more than one mode is present —
   // a single-value dropdown filters nothing.
   const permissionModes = useMemo(() => permissionModesOf(sessions), [sessions])
+  const models = useMemo(() => modelsOf(sessions), [sessions])
+  const activeAdvanced = countActive(advanced)
 
   const timeFilterActive = drilldownActive || timePreset !== 'all'
 
@@ -180,34 +303,55 @@ export default function ClaudeSessionsPage() {
     setSearchParams(next, { replace: true })
   }
 
-  const filtered = useMemo(() => {
+  // The filters outside the advanced panel, built once rather than per session.
+  const baseFilters = useMemo(() => {
     const { from, to } = resolvePresetRange(timePreset, customFrom, customTo)
-    // Built once, not per session — the predicate is the same for every row.
-    const filters = {
+    return {
       project: filterProject,
       search,
       favorites: filterFavorites,
-      hasPR: filterHasPR,
-      permissionMode: filterPermissionMode,
       from,
       to,
       drilldownActive,
       drilldownWindows,
     }
-    return sessions.filter(s => matchesFilters(s, filters))
   }, [
-    sessions,
     search,
     filterProject,
     filterFavorites,
-    filterHasPR,
-    filterPermissionMode,
     timePreset,
     customFrom,
     customTo,
     drilldownActive,
     drilldownWindows,
   ])
+
+  const filtered = useMemo(
+    () => sessions.filter(s => matchesFilters(s, { ...baseFilters, ...advanced })),
+    [sessions, baseFilters, advanced],
+  )
+
+  // What the panel's unapplied draft would leave, so "Apply" is never a leap in
+  // the dark. Only counted while the panel is open.
+  const draftMatchCount = useMemo(() => {
+    if (!advancedOpen) return 0
+    return sessions.filter(s => matchesFilters(s, { ...baseFilters, ...advancedDraft })).length
+  }, [advancedOpen, sessions, baseFilters, advancedDraft])
+
+  const groups = useMemo(() => groupSessionsByDay(filtered), [filtered])
+
+  const totals = useMemo(
+    () =>
+      groups.reduce((acc, g) => ({ tokens: acc.tokens + g.tokens, cost: acc.cost + g.cost }), {
+        tokens: 0,
+        cost: 0,
+      }),
+    [groups],
+  )
+
+  // The token bar is a comparison within what is on screen, scaled so a single
+  // outlier session cannot flatten every other bar to nothing.
+  const tokenRef = useMemo(() => tokenBarReference(filtered), [filtered])
 
   if (loading) {
     return (
@@ -217,9 +361,9 @@ export default function ClaudeSessionsPage() {
     )
   }
 
-  let sessionListContent: ReactNode
+  let listContent: ReactNode
   if (sessions.length === 0) {
-    sessionListContent = (
+    listContent = (
       <div className="flex flex-col items-center justify-center py-20 text-center">
         <div className="flex h-12 w-12 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800 mb-4">
           <History className="h-5 w-5 text-zinc-400" />
@@ -233,7 +377,7 @@ export default function ClaudeSessionsPage() {
       </div>
     )
   } else if (filtered.length === 0) {
-    sessionListContent = (
+    listContent = (
       <div className="flex flex-col items-center justify-center py-16 text-center">
         <p className="text-sm text-zinc-400">
           {timeFilterActive
@@ -251,22 +395,35 @@ export default function ClaudeSessionsPage() {
       </div>
     )
   } else {
-    sessionListContent = (
-      <div
-        key={`${filterFavorites}-${filterHasPR}-${filterPermissionMode}-${filterProject}-${search}-${timePreset}-${customFrom}-${customTo}`}
-        className="divide-y divide-zinc-100 dark:divide-zinc-700/50"
-      >
-        {filtered.map(session => (
+    listContent = groups.map(group => (
+      <div key={group.key}>
+        <div className="flex items-center gap-3 px-4 py-[7px] bg-zinc-50 dark:bg-zinc-800/60 border-b border-zinc-200 dark:border-zinc-700/60">
+          <span className="text-xs font-bold uppercase tracking-[0.04em] text-zinc-900 dark:text-zinc-100">
+            {group.label}
+          </span>
+          <span className="text-xs text-zinc-500 dark:text-zinc-400 tabular-nums">
+            {group.sessions.length} session{group.sessions.length === 1 ? '' : 's'} ·{' '}
+            {group.messageCount} msgs · {formatTokens(group.tokens)} tokens
+          </span>
+          <div className="flex-1" />
+          <span className="text-xs font-bold tabular-nums text-zinc-900 dark:text-zinc-100">
+            {formatCost(group.cost)}
+          </span>
+        </div>
+        {group.sessions.map(session => (
           <SessionRow
             key={session.session_id}
             session={session}
-            onClick={() => navigate(`/claude-sessions/${session.session_id}`)}
+            tokenRef={tokenRef}
+            open={expanded.has(session.session_id)}
+            onToggle={() => handleToggleExpanded(session.session_id)}
+            onOpen={() => navigate(`/claude-sessions/${session.session_id}`)}
             onJourney={() => navigate(`/claude-sessions/${session.session_id}/journey`)}
             onToggleFavorite={() => handleToggleFavorite(session.session_id, !!session.is_favorite)}
           />
         ))}
       </div>
-    )
+    ))
   }
 
   return (
@@ -324,78 +481,321 @@ export default function ClaudeSessionsPage() {
         </div>
       )}
 
-      {/* Filters */}
-      {sessions.length > 0 && (
-        <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2 sm:gap-3 px-4 sm:px-6 py-3 border-b border-zinc-100 dark:border-zinc-700/50 shrink-0">
-          <div className="relative flex-1 sm:max-w-xs">
-            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-zinc-400 dark:text-zinc-500" />
-            <input
-              value={search}
-              onChange={e => setSearch(e.target.value)}
-              placeholder="Search by ID or message…"
-              className="w-full rounded-md border border-zinc-200 dark:border-zinc-600 bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 pl-8 pr-3 py-1.5 text-sm placeholder:text-zinc-400 dark:placeholder:text-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-900 dark:focus:ring-zinc-400 focus:border-zinc-900 dark:focus:border-zinc-400"
-            />
-          </div>
-          {projects.length > 1 && (
-            <Select value={filterProject} onValueChange={setFilterProject}>
-              <SelectTrigger className="w-full sm:w-56 h-8 text-xs">
-                <SelectValue placeholder="All projects" />
+      {error && (
+        <div className="mx-4 sm:mx-6 mt-3 rounded-md border border-red-200 bg-red-50 px-4 py-2.5 text-sm text-red-700 shrink-0">
+          {error}
+        </div>
+      )}
+
+      {/* The table card */}
+      <div className="flex-1 min-h-0 flex flex-col px-4 sm:px-6 py-4">
+        {/* Capped and centred: the design is a bounded card, and past ~1800px the
+            two flexible columns turn into whitespace rather than useful room. */}
+        <div className="flex-1 min-h-0 w-full max-w-[1800px] mx-auto flex flex-col overflow-hidden rounded-[14px] border border-zinc-200 dark:border-zinc-700/60 bg-white dark:bg-zinc-900">
+          {/* Toolbar */}
+          <div className="flex flex-wrap items-center gap-2.5 px-4 py-3 border-b border-zinc-200 dark:border-zinc-700/60 shrink-0">
+            <div className="relative w-full sm:w-[300px]">
+              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-zinc-400 dark:text-zinc-500" />
+              <input
+                value={search}
+                onChange={e => setSearch(e.target.value)}
+                placeholder="Search by ID or message…"
+                className="w-full h-[34px] rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 pl-8 pr-3 text-[13px] placeholder:text-zinc-500 dark:placeholder:text-zinc-400 focus:outline-none focus:ring-1 focus:ring-zinc-900 dark:focus:ring-zinc-400 focus:border-zinc-900 dark:focus:border-zinc-400"
+              />
+            </div>
+            {projects.length > 1 && (
+              <Select value={filterProject} onValueChange={setFilterProject}>
+                <SelectTrigger className="w-full sm:w-52 h-[34px] text-xs">
+                  <SelectValue placeholder="All projects" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All projects</SelectItem>
+                  {projects.map(p => (
+                    <SelectItem key={p.encoded_name} value={p.decoded_path} className="text-xs">
+                      <span className="font-mono">{shortPath(p.decoded_path)}</span>
+                      <span className="ml-1.5 text-zinc-400">({p.session_count})</span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+            <Select
+              value={timePreset}
+              onValueChange={v => setTimePreset(v as TimePreset)}
+              disabled={drilldownActive}
+            >
+              <SelectTrigger className="w-full sm:w-40 h-[34px] text-xs">
+                <Clock className="h-3.5 w-3.5 text-zinc-400 dark:text-zinc-500 mr-1.5 shrink-0" />
+                <SelectValue placeholder="All time" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="all">All projects</SelectItem>
-                {projects.map(p => (
-                  <SelectItem key={p.encoded_name} value={p.decoded_path} className="text-xs">
-                    <span className="font-mono">{shortPath(p.decoded_path)}</span>
-                    <span className="ml-1.5 text-zinc-400">({p.session_count})</span>
+                {(Object.keys(TIME_PRESET_LABELS) as TimePreset[]).map(p => (
+                  <SelectItem key={p} value={p} className="text-xs">
+                    {TIME_PRESET_LABELS[p]}
                   </SelectItem>
                 ))}
               </SelectContent>
             </Select>
-          )}
-          <Select
-            value={timePreset}
-            onValueChange={v => setTimePreset(v as TimePreset)}
-            disabled={drilldownActive}
-          >
-            <SelectTrigger className="w-full sm:w-44 h-8 text-xs">
-              <Clock className="h-3.5 w-3.5 text-zinc-400 dark:text-zinc-500 mr-1.5 shrink-0" />
-              <SelectValue placeholder="All time" />
-            </SelectTrigger>
-            <SelectContent>
-              {(Object.keys(TIME_PRESET_LABELS) as TimePreset[]).map(p => (
-                <SelectItem key={p} value={p} className="text-xs">
-                  {TIME_PRESET_LABELS[p]}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          {timePreset === 'custom' && !drilldownActive && (
-            <div className="flex items-center gap-1.5 shrink-0">
-              <input
-                type="datetime-local"
-                value={customFrom}
-                onChange={e => setCustomFrom(e.target.value)}
-                aria-label="Active from"
-                className="rounded-md border border-zinc-200 dark:border-zinc-600 bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 px-2 py-1 h-8 text-xs focus:outline-none focus:ring-1 focus:ring-zinc-900 dark:focus:ring-zinc-400"
+            {timePreset === 'custom' && !drilldownActive && (
+              <div className="flex items-center gap-1.5 shrink-0">
+                <input
+                  type="datetime-local"
+                  value={customFrom}
+                  onChange={e => setCustomFrom(e.target.value)}
+                  aria-label="Active from"
+                  className="rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 px-2 h-[34px] text-xs focus:outline-none focus:ring-1 focus:ring-zinc-900 dark:focus:ring-zinc-400"
+                />
+                <span className="text-xs text-zinc-400 dark:text-zinc-500">–</span>
+                <input
+                  type="datetime-local"
+                  value={customTo}
+                  onChange={e => setCustomTo(e.target.value)}
+                  aria-label="Active to"
+                  className="rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 px-2 h-[34px] text-xs focus:outline-none focus:ring-1 focus:ring-zinc-900 dark:focus:ring-zinc-400"
+                />
+              </div>
+            )}
+            <ToolbarToggle
+              active={advancedOpen || activeAdvanced > 0}
+              onClick={toggleAdvanced}
+              title="Filter by mode, links, messages, tokens or cost"
+              activeClass="border-zinc-900 dark:border-zinc-300 bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900"
+            >
+              <SlidersHorizontal className="h-3.5 w-3.5" />
+              Advanced
+              {activeAdvanced > 0 && (
+                <span
+                  className={`ml-0.5 inline-flex items-center justify-center min-w-4 h-4 px-1 rounded-full text-[10px] font-semibold tabular-nums ${
+                    advancedOpen || activeAdvanced > 0
+                      ? 'bg-white/25 dark:bg-zinc-900/20'
+                      : 'bg-zinc-200 dark:bg-zinc-700'
+                  }`}
+                >
+                  {activeAdvanced}
+                </span>
+              )}
+              <ChevronDown
+                className={`h-3 w-3 transition-transform duration-150 ${advancedOpen ? 'rotate-180' : ''}`}
               />
-              <span className="text-xs text-zinc-400 dark:text-zinc-500">–</span>
-              <input
-                type="datetime-local"
-                value={customTo}
-                onChange={e => setCustomTo(e.target.value)}
-                aria-label="Active to"
-                className="rounded-md border border-zinc-200 dark:border-zinc-600 bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 px-2 py-1 h-8 text-xs focus:outline-none focus:ring-1 focus:ring-zinc-900 dark:focus:ring-zinc-400"
-              />
+            </ToolbarToggle>
+            {hasFavorites && (
+              <ToolbarToggle
+                active={filterFavorites}
+                onClick={() => setFilterFavorites(f => !f)}
+                title={filterFavorites ? 'Show all' : 'Show favorites only'}
+                activeClass="border-amber-400 bg-amber-50 dark:bg-amber-950/30 text-amber-600 dark:text-amber-400"
+              >
+                <Star
+                  className={`h-3.5 w-3.5 ${filterFavorites ? 'fill-amber-400 text-amber-400' : ''}`}
+                />
+                Favorites
+              </ToolbarToggle>
+            )}
+            <div className="flex-1" />
+            <div className="text-xs text-zinc-500 dark:text-zinc-400 tabular-nums shrink-0">
+              {filtered.length} session{filtered.length === 1 ? '' : 's'} ·{' '}
+              {formatTokens(totals.tokens)} tokens · {formatCost(totals.cost)}
             </div>
+          </div>
+
+          {advancedOpen && (
+            <AdvancedFilterPanel
+              draft={advancedDraft}
+              applied={advanced}
+              onChange={setAdvancedDraft}
+              onApply={() => setAdvanced(advancedDraft)}
+              onReset={resetAdvanced}
+              permissionModes={permissionModes}
+              models={models}
+              showLinks={hasPRs}
+              matchCount={draftMatchCount}
+            />
           )}
-          {permissionModes.length > 1 && (
-            <Select value={filterPermissionMode} onValueChange={setFilterPermissionMode}>
-              <SelectTrigger className="w-full sm:w-48 h-8 text-xs">
+
+          {/* Column headers and rows share one horizontal scroll box, sized by a
+              single min-width wrapper so every track lines up when it scrolls. */}
+          <div className="flex-1 min-h-0 overflow-auto">
+            {filtered.length > 0 ? (
+              <div style={{ minWidth: ROW_MIN_WIDTH }}>
+                <div
+                  className="sticky top-0 z-10 grid items-center gap-3 px-4 py-2 border-b border-zinc-200 dark:border-zinc-700/60 bg-zinc-50 dark:bg-zinc-800/80 text-[11px] font-semibold uppercase tracking-[0.06em] text-zinc-500 dark:text-zinc-400"
+                  style={{ gridTemplateColumns: ROW_GRID }}
+                >
+                  <div />
+                  <div>Session</div>
+                  <div>Project · branch</div>
+                  <div>Mode</div>
+                  <div>Links</div>
+                  <div className="text-right">Msgs</div>
+                  <div>Tokens in / out</div>
+                  <div className="text-right">Cost</div>
+                  <div className="text-right">Last</div>
+                </div>
+                {listContent}
+              </div>
+            ) : (
+              listContent
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** Empty means "no bound", not zero — and a half-typed "-" must not become NaN. */
+function parseBound(raw: string): number | null {
+  if (raw.trim() === '') return null
+  const n = Number(raw)
+  return Number.isFinite(n) ? n : null
+}
+
+const boundValue = (n: number | null) => (n === null ? '' : String(n))
+
+const sameRange = (a: NumericRange, b: NumericRange) => a.min === b.min && a.max === b.max
+
+/** Whether two advanced-filter sets are equivalent, gating the Apply button. */
+function sameAdvanced(a: AdvancedFilters, b: AdvancedFilters): boolean {
+  return (
+    a.permissionMode === b.permissionMode &&
+    a.model === b.model &&
+    a.links === b.links &&
+    ADVANCED_RANGES.every(k => sameRange(a[k], b[k]))
+  )
+}
+
+// A number input only ever holds 3-6 characters here, so it is sized to that
+// rather than stretched to the column. The spinner arrows are removed because
+// at this width they cover the value they are meant to help edit.
+const NUMBER_INPUT =
+  'w-[74px] h-8 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 ' +
+  'text-zinc-900 dark:text-zinc-100 px-2 text-xs tabular-nums placeholder:text-zinc-400 ' +
+  'dark:placeholder:text-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-900 ' +
+  'dark:focus:ring-zinc-400 [appearance:textfield] ' +
+  '[&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none'
+
+const FIELD_LABEL =
+  'text-[11px] uppercase tracking-[0.06em] font-semibold text-zinc-500 dark:text-zinc-400'
+
+/** Label above any advanced field, so every control lines up on one baseline. */
+function Field({
+  label,
+  hint,
+  children,
+}: Readonly<{ label: string; hint?: string; children: ReactNode }>) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className={FIELD_LABEL}>
+        {label}
+        {hint && <span className="ml-1 normal-case tracking-normal font-normal">{hint}</span>}
+      </span>
+      {children}
+    </div>
+  )
+}
+
+/**
+ * One min–max pair. Two bounds rather than an operator dropdown plus a value:
+ * min alone reads as "at least", max alone as "at most", both as "between" —
+ * every comparison asked for, with one fewer control per field.
+ */
+function RangeField({
+  label,
+  hint,
+  range,
+  onChange,
+  step,
+}: Readonly<{
+  label: string
+  hint?: string
+  range: NumericRange
+  onChange: (next: NumericRange) => void
+  step?: string
+}>) {
+  return (
+    <Field label={label} hint={hint}>
+      <div className="flex items-center gap-1.5">
+        <input
+          type="number"
+          min="0"
+          step={step}
+          value={boundValue(range.min)}
+          onChange={e => onChange({ ...range, min: parseBound(e.target.value) })}
+          placeholder="Min"
+          aria-label={`${label} minimum`}
+          className={NUMBER_INPUT}
+        />
+        <span className="text-xs text-zinc-400 dark:text-zinc-500">–</span>
+        <input
+          type="number"
+          min="0"
+          step={step}
+          value={boundValue(range.max)}
+          onChange={e => onChange({ ...range, max: parseBound(e.target.value) })}
+          placeholder="Max"
+          aria-label={`${label} maximum`}
+          className={NUMBER_INPUT}
+        />
+      </div>
+    </Field>
+  )
+}
+
+/**
+ * The advanced-filter area below the toolbar.
+ *
+ * Edits go to a draft and take effect on Apply rather than on every keystroke:
+ * typing "50" into a minimum would otherwise filter on "5" first, throwing the
+ * list away and back mid-keystroke. The draft is measured against the list
+ * before it is committed, so the match count answers "will this leave me
+ * anything?" before the user gives up their current view.
+ */
+function AdvancedFilterPanel({
+  draft,
+  applied,
+  onChange,
+  onApply,
+  onReset,
+  permissionModes,
+  models,
+  showLinks,
+  matchCount,
+}: Readonly<{
+  draft: AdvancedFilters
+  applied: AdvancedFilters
+  onChange: (next: AdvancedFilters) => void
+  onApply: () => void
+  onReset: () => void
+  permissionModes: string[]
+  models: string[]
+  showLinks: boolean
+  matchCount: number
+}>) {
+  const dirty = !sameAdvanced(draft, applied)
+  const anySet = countActive(draft) > 0 || countActive(applied) > 0
+  const patch = (p: Partial<AdvancedFilters>) => onChange({ ...draft, ...p })
+
+  return (
+    <form
+      onSubmit={e => {
+        e.preventDefault()
+        onApply()
+      }}
+      className="border-b border-zinc-200 dark:border-zinc-700/60 bg-zinc-50/60 dark:bg-zinc-800/30 px-4 py-3.5 shrink-0"
+    >
+      <div className="flex flex-wrap items-end gap-x-5 gap-y-3">
+        {/* One recorded mode is still worth filtering on here, unlike in the
+            toolbar: it separates those sessions from the ones Claude Code
+            recorded no mode for at all. */}
+        {permissionModes.length > 0 && (
+          <Field label="Mode">
+            <Select value={draft.permissionMode} onValueChange={v => patch({ permissionMode: v })}>
+              <SelectTrigger className="w-40 h-8 text-xs">
                 <Shield className="h-3.5 w-3.5 text-zinc-400 dark:text-zinc-500 mr-1.5 shrink-0" />
-                <SelectValue placeholder="All permissions" />
+                <SelectValue placeholder="All modes" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="all">All permissions</SelectItem>
+                <SelectItem value="all">All modes</SelectItem>
                 {permissionModes.map(m => (
                   <SelectItem key={m} value={m} className="text-xs">
                     <span className="font-mono">{m}</span>
@@ -403,49 +803,137 @@ export default function ClaudeSessionsPage() {
                 ))}
               </SelectContent>
             </Select>
-          )}
-          {hasPRs && (
-            <button
-              onClick={() => setFilterHasPR(f => !f)}
-              className={`flex items-center gap-1.5 rounded-md border h-8 px-3 text-xs transition-colors shrink-0 ${
-                filterHasPR
-                  ? 'border-emerald-400 bg-emerald-50 dark:bg-emerald-950/30 text-emerald-600 dark:text-emerald-400'
-                  : 'border-zinc-200 dark:border-zinc-600 bg-white dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400 hover:border-emerald-300 hover:text-emerald-500'
-              }`}
-              title={filterHasPR ? 'Show all' : 'Show sessions with a linked PR only'}
-            >
-              <GitPullRequest className="h-3.5 w-3.5" />
-              Has PR
-            </button>
-          )}
-          {hasFavorites && (
-            <button
-              onClick={() => setFilterFavorites(f => !f)}
-              className={`flex items-center gap-1.5 rounded-md border h-8 px-3 text-xs transition-colors shrink-0 ${
-                filterFavorites
-                  ? 'border-amber-400 bg-amber-50 dark:bg-amber-950/30 text-amber-600 dark:text-amber-400'
-                  : 'border-zinc-200 dark:border-zinc-600 bg-white dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400 hover:border-amber-300 hover:text-amber-500'
-              }`}
-              title={filterFavorites ? 'Show all' : 'Show favorites only'}
-            >
-              <Star
-                className={`h-3.5 w-3.5 ${filterFavorites ? 'fill-amber-400 text-amber-400' : ''}`}
-              />
-              Favorites
-            </button>
-          )}
-        </div>
-      )}
+          </Field>
+        )}
 
-      {error && (
-        <div className="mx-6 mt-3 rounded-md border border-red-200 bg-red-50 px-4 py-2.5 text-sm text-red-700">
-          {error}
-        </div>
-      )}
+        {models.length > 0 && (
+          <Field label="Model">
+            <Select value={draft.model} onValueChange={v => patch({ model: v })}>
+              <SelectTrigger className="w-44 h-8 text-xs">
+                <Cpu className="h-3.5 w-3.5 text-zinc-400 dark:text-zinc-500 mr-1.5 shrink-0" />
+                <SelectValue placeholder="All models" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All models</SelectItem>
+                {models.map(m => (
+                  <SelectItem key={m} value={m} className="text-xs">
+                    <span className="font-mono">{m}</span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </Field>
+        )}
 
-      {/* Session list */}
-      <div className="flex-1 overflow-y-auto">{sessionListContent}</div>
-    </div>
+        {showLinks && (
+          <Field label="Links">
+            <div className="flex h-8 rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden bg-white dark:bg-zinc-900">
+              {LINK_OPTIONS.map((opt, i) => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onClick={() => patch({ links: opt.value })}
+                  className={`px-3 text-xs whitespace-nowrap transition-colors ${
+                    i > 0 ? 'border-l border-zinc-200 dark:border-zinc-700' : ''
+                  } ${
+                    draft.links === opt.value
+                      ? 'bg-zinc-100 dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 font-semibold'
+                      : 'text-zinc-500 dark:text-zinc-400 hover:text-zinc-800 dark:hover:text-zinc-100'
+                  }`}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </Field>
+        )}
+
+        <RangeField
+          label="Messages"
+          range={draft.messages}
+          onChange={r => patch({ messages: r })}
+        />
+        <RangeField
+          label="Duration"
+          hint="(min)"
+          range={draft.durationMinutes}
+          onChange={r => patch({ durationMinutes: r })}
+        />
+        <RangeField
+          label="Tokens in"
+          range={draft.tokensIn}
+          onChange={r => patch({ tokensIn: r })}
+        />
+        <RangeField
+          label="Tokens out"
+          range={draft.tokensOut}
+          onChange={r => patch({ tokensOut: r })}
+        />
+        <RangeField
+          label="Cost"
+          hint="(USD)"
+          step="0.01"
+          range={draft.cost}
+          onChange={r => patch({ cost: r })}
+        />
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3 mt-3.5 pt-3 border-t border-zinc-200 dark:border-zinc-700/60">
+        <p className="text-[11px] text-zinc-400 dark:text-zinc-500">
+          Leave a side empty for an open bound — min only is “at least”, max only “at most”.
+        </p>
+        <div className="flex-1" />
+        {dirty && (
+          <span className="text-xs text-zinc-500 dark:text-zinc-400 tabular-nums">
+            {matchCount} session{matchCount === 1 ? '' : 's'} match
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={onReset}
+          disabled={!anySet}
+          className="h-8 px-3 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-xs text-zinc-700 dark:text-zinc-200 hover:bg-zinc-50 dark:hover:bg-zinc-800 disabled:opacity-40 disabled:pointer-events-none transition-colors"
+        >
+          Reset
+        </button>
+        <button
+          type="submit"
+          disabled={!dirty}
+          className="h-8 px-4 rounded-lg bg-zinc-900 dark:bg-zinc-100 text-xs font-medium text-white dark:text-zinc-900 hover:bg-zinc-800 dark:hover:bg-zinc-200 disabled:opacity-40 disabled:pointer-events-none transition-colors"
+        >
+          Apply filters
+        </button>
+      </div>
+    </form>
+  )
+}
+
+/** Filter pill in the toolbar — same shape as the outline buttons in the design. */
+function ToolbarToggle({
+  active,
+  onClick,
+  title,
+  activeClass,
+  children,
+}: Readonly<{
+  active: boolean
+  onClick: () => void
+  title: string
+  activeClass: string
+  children: ReactNode
+}>) {
+  return (
+    <button
+      onClick={onClick}
+      title={title}
+      className={`flex items-center gap-1.5 rounded-lg border h-[34px] px-3 text-[13px] transition-colors shrink-0 ${
+        active
+          ? activeClass
+          : 'border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-600 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800'
+      }`}
+    >
+      {children}
+    </button>
   )
 }
 
@@ -461,16 +949,16 @@ function CostLine({ label, usd }: Readonly<{ label: string; usd: number }>) {
 }
 
 /**
- * Cost badge for a session row, a sibling of the token badge above it.
+ * Cost cell for a session row.
  *
  * A session that used a model with no published rate is marked with `~` and
  * names the offending models: its total is a floor, and presenting an
  * understated figure as complete is the failure this disclosure prevents.
  */
-function SessionCostBadge({ session }: Readonly<{ session: ClaudeSessionSummary }>) {
+function SessionCostCell({ session }: Readonly<{ session: ClaudeSessionSummary }>) {
   const main = session.cost
   const sub = session.subagent_cost
-  const total = (main?.total_usd ?? 0) + (sub?.total_usd ?? 0)
+  const total = sessionCost(session)
   const unpriced = session.unpriced_models ?? []
   const partial = unpriced.length > 0
 
@@ -496,11 +984,10 @@ function SessionCostBadge({ session }: Readonly<{ session: ClaudeSessionSummary 
       }
     >
       <span
-        className={`flex items-center gap-0.5 text-xs cursor-default ${
-          partial ? 'text-amber-600 dark:text-amber-400' : 'text-emerald-600 dark:text-emerald-400'
+        className={`block w-full text-right tabular-nums cursor-default ${
+          partial ? 'text-amber-600 dark:text-amber-400' : 'text-zinc-900 dark:text-zinc-100'
         }`}
       >
-        <DollarSign className="h-2.5 w-2.5" />
         {partial && '~'}
         {formatCost(total)}
       </span>
@@ -508,180 +995,293 @@ function SessionCostBadge({ session }: Readonly<{ session: ClaudeSessionSummary 
   )
 }
 
-function SessionRow({
-  session,
-  onClick,
-  onToggleFavorite,
-  onJourney,
-}: Readonly<{
-  session: ClaudeSessionSummary
-  onClick: () => void
-  onToggleFavorite: () => void
-  onJourney: () => void
-}>) {
-  const totalTokens = (session.usage?.input_tokens ?? 0) + (session.usage?.output_tokens ?? 0)
-  const hasTokens = totalTokens > 0
+/** Copies the session ID, echoing the confirmation on the label like the design. */
+function CopyIdButton({ value }: Readonly<{ value: string }>) {
+  const [copied, setCopied] = useState(false)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => () => clearTimeout(timeoutRef.current ?? undefined), [])
+
+  const handleCopy = async () => {
+    if (!navigator.clipboard) return
+    try {
+      await navigator.clipboard.writeText(value)
+    } catch {
+      return
+    }
+    setCopied(true)
+    clearTimeout(timeoutRef.current ?? undefined)
+    timeoutRef.current = setTimeout(() => setCopied(false), 1400)
+  }
 
   return (
-    <div className="px-4 sm:px-6 py-3.5 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 cursor-pointer group transition-colors relative">
-      <div className="flex items-start gap-3">
-        <button
-          type="button"
-          className="flex items-start gap-3 flex-1 min-w-0 text-left appearance-none bg-transparent border-0 p-0"
-          onClick={onClick}
-        >
-          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400 shrink-0 mt-0.5">
-            <History className="h-3.5 w-3.5" />
-          </div>
-          <div className="flex-1 min-w-0">
-            {/* Resolved title: Agento rename › native rename › AI title › preview */}
-            <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100 truncate leading-snug">
-              {session.display_title || session.preview || (
-                <span className="italic text-zinc-400">No message content</span>
-              )}
-            </p>
-            {/* Meta row */}
-            <div className="flex items-center gap-2 mt-1 flex-wrap">
-              <Badge
-                variant="secondary"
-                className="text-xs py-0 h-4 bg-zinc-100 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-700 border-0 font-mono font-normal"
-              >
-                {shortPath(session.project_path)}
-              </Badge>
-              {session.git_branch && (
-                <span className="text-xs text-zinc-400 dark:text-zinc-500 font-mono">
-                  {session.git_branch}
-                </span>
-              )}
-              {session.prs?.map(pr => (
-                <a
-                  key={pr.pr_url}
-                  href={pr.pr_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={e => e.stopPropagation()}
-                  className="flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400 hover:underline"
-                  title={pr.pr_repository ? `${pr.pr_repository}#${pr.pr_number}` : pr.pr_url}
-                >
-                  <GitPullRequest className="h-3 w-3" />#{pr.pr_number}
-                </a>
-              ))}
-              {session.compaction_count > 0 && (
-                <Tooltip
-                  side="top"
-                  content={
-                    <div className="space-y-1">
-                      <div className="flex justify-between gap-4">
-                        <span className="text-zinc-400">Compactions</span>
-                        <span>{session.compaction_count.toLocaleString()}</span>
-                      </div>
-                      <div className="flex justify-between gap-4">
-                        <span className="text-zinc-400">Dropped tokens</span>
-                        <span>{session.dropped_tokens.toLocaleString()}</span>
-                      </div>
-                    </div>
-                  }
-                >
-                  <span className="flex items-center gap-0.5 text-xs text-amber-600 dark:text-amber-400 cursor-default">
-                    <Scissors className="h-2.5 w-2.5" />
-                    {session.compaction_count}
-                  </span>
-                </Tooltip>
-              )}
-              <span className="text-xs text-zinc-400 dark:text-zinc-500">
-                {formatRelativeTime(session.last_activity)}
-              </span>
-              <Tooltip
-                side="top"
-                content={
-                  <div className="space-y-1">
-                    <div className="flex justify-between gap-4">
-                      <span className="text-zinc-400">Messages</span>
-                      <span>{session.message_count.toLocaleString()}</span>
-                    </div>
-                    <div className="flex justify-between gap-4">
-                      <span className="text-zinc-400">Raw events</span>
-                      <span>{session.event_count.toLocaleString()}</span>
-                    </div>
-                  </div>
-                }
-              >
-                <span className="text-xs text-zinc-400 dark:text-zinc-500 cursor-default">
-                  {session.message_count} msg{session.message_count === 1 ? '' : 's'}
-                </span>
-              </Tooltip>
-              {hasTokens && (
-                <Tooltip
-                  side="top"
-                  content={
-                    <div className="space-y-1">
-                      <div className="flex justify-between gap-4">
-                        <span className="text-zinc-400">Input tokens</span>
-                        <span>{session.usage.input_tokens.toLocaleString()}</span>
-                      </div>
-                      <div className="flex justify-between gap-4">
-                        <span className="text-zinc-400">Output tokens</span>
-                        <span>{session.usage.output_tokens.toLocaleString()}</span>
-                      </div>
-                      {session.usage.cache_read_tokens > 0 && (
-                        <div className="flex justify-between gap-4">
-                          <span className="text-zinc-400">Cache read</span>
-                          <span>{session.usage.cache_read_tokens.toLocaleString()}</span>
-                        </div>
-                      )}
-                      {session.usage.cache_creation_tokens > 0 && (
-                        <div className="flex justify-between gap-4">
-                          <span className="text-zinc-400">Cache write</span>
-                          <span>{session.usage.cache_creation_tokens.toLocaleString()}</span>
-                        </div>
-                      )}
-                    </div>
-                  }
-                >
-                  <span className="flex items-center gap-0.5 text-xs text-zinc-400 dark:text-zinc-500 cursor-default">
-                    <Zap className="h-2.5 w-2.5" />
-                    {formatTokens(session.usage.input_tokens)}↑&nbsp;
-                    {formatTokens(session.usage.output_tokens)}↓
-                  </span>
-                </Tooltip>
-              )}
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="flex items-center gap-1.5 h-8 px-3 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-[13px] text-zinc-700 dark:text-zinc-200 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors"
+    >
+      {copied ? (
+        <Check className="h-3.5 w-3.5 text-emerald-500" />
+      ) : (
+        <Copy className="h-3.5 w-3.5" />
+      )}
+      {copied ? 'Copied' : 'Copy ID'}
+    </button>
+  )
+}
 
-              {hasTokens && <SessionCostBadge session={session} />}
+/** One label/value pair in the expanded detail grid. */
+function DetailField({ label, value }: Readonly<{ label: string; value: string }>) {
+  return (
+    <>
+      <span className="text-zinc-500 dark:text-zinc-400">{label}</span>
+      <span className="tabular-nums text-zinc-900 dark:text-zinc-100 truncate">{value}</span>
+    </>
+  )
+}
+
+function SessionRow({
+  session,
+  tokenRef,
+  open,
+  onToggle,
+  onOpen,
+  onJourney,
+  onToggleFavorite,
+}: Readonly<{
+  session: ClaudeSessionSummary
+  tokenRef: number
+  open: boolean
+  onToggle: () => void
+  onOpen: () => void
+  onJourney: () => void
+  onToggleFavorite: () => void
+}>) {
+  const inTokens = (session.usage?.input_tokens ?? 0) + (session.subagent_usage?.input_tokens ?? 0)
+  const outTokens =
+    (session.usage?.output_tokens ?? 0) + (session.subagent_usage?.output_tokens ?? 0)
+  const total = inTokens + outTokens
+  // Bars are proportional to the largest session on screen, then split in/out.
+  const scale = tokenRef > 0 ? Math.min(1, total / tokenRef) : 0
+  const inPct = total > 0 ? (scale * 100 * inTokens) / total : 0
+  const outPct = total > 0 ? (scale * 100 * outTokens) / total : 0
+
+  const mode = session.permission_mode
+  const presentation = mode
+    ? (MODE_PRESENTATION[mode] ?? { label: mode, tone: NEUTRAL_TONE })
+    : null
+
+  const cacheRead =
+    (session.usage?.cache_read_tokens ?? 0) + (session.subagent_usage?.cache_read_tokens ?? 0)
+  // Shared with the duration filter so the figure shown and the bound that
+  // hides the row are computed the same way.
+  const durationMs = sessionDurationMs(session)
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      onToggle()
+    }
+  }
+
+  return (
+    <div className="border-b border-zinc-100 dark:border-zinc-700/50">
+      <div
+        role="button"
+        tabIndex={0}
+        aria-expanded={open}
+        onClick={onToggle}
+        onKeyDown={handleKeyDown}
+        className="group/row grid items-center gap-3 px-4 h-11 text-[13px] cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors"
+        style={{ gridTemplateColumns: ROW_GRID }}
+      >
+        <ChevronRight
+          className={`h-3.5 w-3.5 text-zinc-400 dark:text-zinc-500 transition-transform duration-150 ${
+            open ? 'rotate-90' : ''
+          }`}
+        />
+
+        {/* Session title, with the favourite toggle inline so every title still
+            starts at the same x-position whether or not it is starred. */}
+        <div className="flex items-center gap-1.5 min-w-0">
+          <button
+            type="button"
+            onClick={e => {
+              e.stopPropagation()
+              onToggleFavorite()
+            }}
+            title={session.is_favorite ? 'Remove from favorites' : 'Add to favorites'}
+            className={`shrink-0 transition-opacity ${
+              session.is_favorite
+                ? 'text-amber-400'
+                : 'opacity-0 group-hover/row:opacity-100 focus-visible:opacity-100 text-zinc-300 dark:text-zinc-600 hover:text-amber-400'
+            }`}
+          >
+            <Star className={`h-3.5 w-3.5 ${session.is_favorite ? 'fill-amber-400' : ''}`} />
+          </button>
+          <span className="truncate text-zinc-900 dark:text-zinc-100">
+            {session.display_title || session.preview || (
+              <span className="italic font-normal text-zinc-400">No message content</span>
+            )}
+          </span>
+        </div>
+
+        <div className="flex items-center gap-1.5 min-w-0">
+          <span className="font-mono text-[11.5px] bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-300 rounded-md px-1.5 py-0.5 truncate">
+            {shortPath(session.project_path)}
+          </span>
+          {session.git_branch && (
+            <span className="font-mono text-[11.5px] text-zinc-400 dark:text-zinc-500 truncate">
+              {session.git_branch}
+            </span>
+          )}
+        </div>
+
+        <div className="min-w-0">
+          {presentation && (
+            <span
+              className={`inline-flex items-center h-5 rounded-full px-2.5 text-[11px] whitespace-nowrap ${presentation.tone}`}
+            >
+              {presentation.label}
+            </span>
+          )}
+        </div>
+
+        <div className="flex items-center gap-1 min-w-0 overflow-hidden">
+          {session.prs?.map(pr => (
+            <a
+              key={pr.pr_url}
+              href={pr.pr_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={e => e.stopPropagation()}
+              title={pr.pr_repository ? `${pr.pr_repository}#${pr.pr_number}` : pr.pr_url}
+              className="font-mono text-[11.5px] text-zinc-500 dark:text-zinc-400 border border-zinc-200 dark:border-zinc-700 rounded-[5px] px-[5px] py-px hover:text-emerald-600 dark:hover:text-emerald-400 hover:border-emerald-400"
+            >
+              #{pr.pr_number}
+            </a>
+          ))}
+        </div>
+
+        <Tooltip
+          side="top"
+          content={
+            <div className="space-y-1">
+              <div className="flex justify-between gap-4">
+                <span className="text-zinc-400">Messages</span>
+                <span>{session.message_count.toLocaleString()}</span>
+              </div>
+              <div className="flex justify-between gap-4">
+                <span className="text-zinc-400">Raw events</span>
+                <span>{session.event_count.toLocaleString()}</span>
+              </div>
+            </div>
+          }
+        >
+          <span className="block w-full text-right tabular-nums text-zinc-500 dark:text-zinc-400 cursor-default">
+            {session.message_count}
+          </span>
+        </Tooltip>
+
+        <Tooltip
+          side="top"
+          content={
+            <div className="space-y-1">
+              <div className="flex justify-between gap-4">
+                <span className="text-zinc-400">Input tokens</span>
+                <span>{inTokens.toLocaleString()}</span>
+              </div>
+              <div className="flex justify-between gap-4">
+                <span className="text-zinc-400">Output tokens</span>
+                <span>{outTokens.toLocaleString()}</span>
+              </div>
+              {session.subagent_count > 0 && (
+                <div className="flex justify-between gap-4">
+                  <span className="text-zinc-400">Sub-agents</span>
+                  <span>{session.subagent_count.toLocaleString()}</span>
+                </div>
+              )}
+            </div>
+          }
+        >
+          <span className="flex w-full items-center gap-2 cursor-default">
+            <span className="flex-1 h-1.5 rounded-[3px] bg-zinc-100 dark:bg-zinc-700/70 overflow-hidden flex">
+              <span
+                className="h-full bg-zinc-900/85 dark:bg-zinc-100/85"
+                style={{ width: `${inPct}%` }}
+              />
+              <span
+                className="h-full bg-zinc-900/30 dark:bg-zinc-100/30"
+                style={{ width: `${outPct}%` }}
+              />
+            </span>
+            <span className="tabular-nums text-[11.5px] text-zinc-500 dark:text-zinc-400 whitespace-nowrap">
+              {formatTokens(inTokens)} / {formatTokens(outTokens)}
+            </span>
+          </span>
+        </Tooltip>
+
+        <SessionCostCell session={session} />
+
+        <span className="text-right tabular-nums text-xs text-zinc-400 dark:text-zinc-500 truncate">
+          {formatRelativeTime(session.last_activity)}
+        </span>
+      </div>
+
+      {open && (
+        <div
+          className="grid gap-7 pl-14 pr-4 pt-3.5 pb-4 bg-zinc-50 dark:bg-zinc-800/50 border-t border-zinc-200 dark:border-zinc-700/60"
+          style={{ gridTemplateColumns: '1fr 260px 200px' }}
+        >
+          <div className="flex flex-col gap-2.5 min-w-0">
+            <div className="text-[12.5px] leading-[1.55] text-zinc-500 dark:text-zinc-400 text-pretty line-clamp-3">
+              {session.preview || 'No message content.'}
+            </div>
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="font-mono text-[11.5px] bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded-md px-2 py-1 text-zinc-600 dark:text-zinc-300">
+                {session.session_id}
+              </span>
+              <CopyIdButton value={session.session_id} />
             </div>
           </div>
-        </button>
-        <button
-          type="button"
-          className={`h-7 w-7 flex items-center justify-center rounded-md transition-all shrink-0 mt-0.5 ${
-            session.is_favorite
-              ? 'text-amber-400'
-              : 'opacity-0 group-hover:opacity-100 text-zinc-300 dark:text-zinc-600 hover:text-amber-400'
-          }`}
-          onClick={e => {
-            e.stopPropagation()
-            onToggleFavorite()
-          }}
-          title={session.is_favorite ? 'Remove from favorites' : 'Add to favorites'}
-        >
-          <Star className={`h-3.5 w-3.5 ${session.is_favorite ? 'fill-amber-400' : ''}`} />
-        </button>
-        <button
-          type="button"
-          className="h-7 w-7 flex items-center justify-center rounded-md opacity-0 group-hover:opacity-100 text-zinc-300 dark:text-zinc-600 hover:text-zinc-500 dark:hover:text-zinc-400 transition-all shrink-0 mt-0.5 cursor-pointer"
-          onClick={e => {
-            e.stopPropagation()
-            onJourney()
-          }}
-          title="View session journey"
-        >
-          <Activity className="h-3.5 w-3.5" />
-        </button>
-        <ExternalLink className="h-3.5 w-3.5 text-zinc-300 dark:text-zinc-600 group-hover:text-zinc-400 dark:group-hover:text-zinc-400 shrink-0 mt-1.5 transition-colors" />
-      </div>
-      {/* Session ID — copies to clipboard on click, does not navigate */}
-      <div className="pl-11 mt-0.5">
-        <CopyableId value={session.session_id} label="Copy session ID" />
-      </div>
+
+          <div className="grid grid-cols-[auto_1fr] gap-y-1 gap-x-3.5 text-xs content-start min-w-0">
+            <DetailField label="Model" value={session.model || '—'} />
+            <DetailField label="Started" value={formatDateTime(session.start_time) || '—'} />
+            <DetailField
+              label="Duration"
+              value={durationMs > 0 ? formatDuration(durationMs) : '—'}
+            />
+            <DetailField label="Cache read" value={cacheRead > 0 ? formatTokens(cacheRead) : '—'} />
+            {session.compaction_count > 0 && (
+              <DetailField
+                label="Compactions"
+                value={`${session.compaction_count} · ${formatTokens(session.dropped_tokens)} dropped`}
+              />
+            )}
+            {session.subagent_count > 0 && (
+              <DetailField label="Sub-agents" value={String(session.subagent_count)} />
+            )}
+          </div>
+
+          <div className="flex gap-2 items-start justify-end">
+            <button
+              type="button"
+              onClick={onJourney}
+              className="h-8 px-3 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-[13px] text-zinc-700 dark:text-zinc-200 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors"
+            >
+              Journey
+            </button>
+            <button
+              type="button"
+              onClick={onOpen}
+              className="h-8 px-4 rounded-lg bg-zinc-900 dark:bg-zinc-100 text-[13px] font-medium text-white dark:text-zinc-900 hover:bg-zinc-800 dark:hover:bg-zinc-200 transition-colors"
+            >
+              Open
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/shaharia-lab/agento/internal/api"
+	"github.com/shaharia-lab/agento/internal/build"
 	"github.com/shaharia-lab/agento/internal/config"
 	cfgmocks "github.com/shaharia-lab/agento/internal/config/mocks"
 	"github.com/shaharia-lab/agento/internal/service"
@@ -1011,6 +1012,31 @@ func TestUpdateCheck_DevBuild(t *testing.T) {
 	assert.Equal(t, false, result["update_available"])
 	assert.Equal(t, "", result["latest_version"])
 	assert.Equal(t, "", result["release_url"])
+}
+
+// TestUpdateCheck_LocalGitDescribeBuild covers the version shape `make build`
+// stamps during development. It is valid semver, so the handler's parse accepts
+// it, and semver ranks a prerelease below its release — meaning the published
+// v0.8.0 looks newer than a tree 21 commits past that tag. Without the
+// dev-build gate this reaches GitHub and shows an update banner offering a
+// version the developer is already ahead of.
+func TestUpdateCheck_LocalGitDescribeBuild(t *testing.T) {
+	for _, v := range []string{"v0.8.0-21-gc325de6-dirty", "v0.8.0-21-gc325de6", "v0.8.0-dirty"} {
+		t.Run(v, func(t *testing.T) {
+			original := build.Version
+			build.Version = v
+			t.Cleanup(func() { build.Version = original })
+
+			h := newHarness(t)
+			w := h.do(httptest.NewRequest(http.MethodGet, "/version/update-check", nil))
+			assert.Equal(t, http.StatusOK, w.Code)
+
+			var result map[string]interface{}
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+			assert.Equal(t, false, result["update_available"])
+			assert.Equal(t, v, result["current_version"])
+		})
+	}
 }
 
 func TestUpdateCheck_ResponseShape(t *testing.T) {

--- a/internal/api/claude_sessions.go
+++ b/internal/api/claude_sessions.go
@@ -87,6 +87,17 @@ func (s *Server) handleGetClaudeSession(w http.ResponseWriter, r *http.Request) 
 		detail.NativeTitle, detail.AITitle = s.claudeSessionCache.GetTitles(id)
 	}
 	detail.DisplayTitle = detail.ResolveDisplayTitle()
+	// Cost is stored per session by the scanner, not derivable from a re-read of
+	// the transcript, so it comes from the cache along with the unpriced-model
+	// disclosure that qualifies it. A session the scanner has not reached yet
+	// keeps the zero value, which the UI shows as $0.00 rather than a wrong
+	// figure.
+	if cached := s.claudeSessionCache.GetSummary(id); cached != nil {
+		detail.Cost = cached.Cost
+		detail.SubagentCost = cached.SubagentCost
+		detail.UnpricedModels = cached.UnpricedModels
+		detail.UnpricedTokens = cached.UnpricedTokens
+	}
 	// Sub-agent transcripts live in sibling files, so they come from the cache
 	// too rather than from the session JSONL this detail was read from.
 	detail.Subagents = s.claudeSessionCache.ListSubagents(id)

--- a/internal/api/version.go
+++ b/internal/api/version.go
@@ -45,9 +45,12 @@ func (s *Server) handleUpdateCheck(w http.ResponseWriter, r *http.Request) {
 	current := build.Version
 	currentTrimmed := strings.TrimPrefix(current, "v")
 
-	// Skip the update check for any build that is not a proper semver release
-	// (e.g. "dev", "unknown", or a bare git commit SHA like "00f2331").
-	if _, err := semver.NewVersion(currentTrimmed); err != nil {
+	// Skip the update check for any build that names no published release:
+	// "dev", "unknown", a bare git commit SHA like "00f2331", or a local
+	// `git describe` build such as "v0.8.0-21-gc325de6-dirty". The last one
+	// parses as valid semver but ranks *below* the release it is ahead of, so
+	// it needs the shape check rather than the parse.
+	if _, err := semver.NewVersion(currentTrimmed); err != nil || build.IsDevBuild(current) {
 		s.writeJSON(w, http.StatusOK, map[string]interface{}{
 			"current_version":  current,
 			"update_available": false,

--- a/internal/build/devbuild.go
+++ b/internal/build/devbuild.go
@@ -1,0 +1,38 @@
+package build
+
+import (
+	"regexp"
+	"strings"
+)
+
+// gitDescribeSuffix matches the "-<commits>-g<sha>" tail `git describe` appends
+// when HEAD is ahead of the most recent tag.
+var gitDescribeSuffix = regexp.MustCompile(`-\d+-g[0-9a-f]{7,40}$`)
+
+// IsDevBuild reports whether version names a local working tree rather than a
+// published release.
+//
+// The Makefile stamps `git describe --tags --always --dirty`, so a developer
+// build reads as "v0.8.0-21-gc325de6-dirty". That is *valid* semver — the tail
+// parses as a prerelease identifier — and semver ranks a prerelease below the
+// release it precedes. So the published v0.8.0 compares as newer than a build
+// 21 commits ahead of it, and the update banner offers a "newer" version the
+// developer already has. A plain semver parse cannot catch this; only the shape
+// of the version string can.
+//
+// Both markers are checked because they appear independently: "-dirty" alone
+// disappears the moment the tree is clean, while a clean tree several commits
+// past the tag is still not a release.
+//
+// A genuine prerelease tag such as "v1.0.0-rc.1" is deliberately NOT a dev
+// build — those are published, and their users should be offered updates.
+func IsDevBuild(version string) bool {
+	v := strings.TrimPrefix(strings.TrimSpace(version), "v")
+	if v == "" || v == "dev" || v == "unknown" {
+		return true
+	}
+	if strings.HasSuffix(v, "-dirty") {
+		return true
+	}
+	return gitDescribeSuffix.MatchString(v)
+}

--- a/internal/build/devbuild_test.go
+++ b/internal/build/devbuild_test.go
@@ -1,0 +1,42 @@
+package build
+
+import "testing"
+
+func TestIsDevBuild(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		// The case this exists for: `git describe --tags --always --dirty` on a
+		// working tree. Valid semver, so a parse-only check lets it through.
+		{"dirty tree ahead of tag", "v0.8.0-21-gc325de6-dirty", true},
+		{"dirty tree on the tag", "v0.8.0-dirty", true},
+		{"clean tree ahead of tag", "v0.8.0-21-gc325de6", true},
+		{"clean tree ahead, long sha", "v1.2.3-4-g0123456789abcdef0123456789abcdef01234567", true},
+		{"no leading v", "0.8.0-21-gc325de6-dirty", true},
+
+		{"unstamped default", "dev", true},
+		{"unknown", "unknown", true},
+		{"empty", "", true},
+		{"whitespace only", "  ", true},
+
+		// Published releases must keep checking for updates.
+		{"release tag", "v0.8.0", false},
+		{"release tag without v", "0.8.0", false},
+		// A prerelease tag is published — its users should still be offered
+		// updates, so it must not be mistaken for a working-tree build.
+		{"release candidate", "v1.0.0-rc.1", false},
+		{"beta tag", "v1.0.0-beta.2", false},
+		// A bare SHA is rejected here too, though the semver parse also catches it.
+		{"bare sha", "c325de6", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsDevBuild(tt.version); got != tt.want {
+				t.Errorf("IsDevBuild(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/claudesessions/cache.go
+++ b/internal/claudesessions/cache.go
@@ -421,6 +421,26 @@ func (c *Cache) GetCustomTitle(sessionID string) string {
 	return title
 }
 
+// GetSummary returns the cached summary row for one session, or nil when the
+// scanner has not reached it yet.
+//
+// The detail endpoint reads the session's own JSONL, which carries token counts
+// but no cost: cost is accumulated per assistant message during a scan and
+// stored (#188), because a re-read has no per-message pricing context to work
+// from. Without this the detail page would report $0.00 for a session the list
+// prices correctly.
+func (c *Cache) GetSummary(sessionID string) *ClaudeSessionSummary {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	s, err := querySessionSummary(c.db, c.logger, sessionID)
+	if err != nil {
+		c.logger.Warn("claude sessions: failed to read cached summary",
+			"session_id", sessionID, "error", err)
+		return nil
+	}
+	return s
+}
+
 // GetTitles returns the cached native and AI titles for a session. Both are
 // empty when the session is not cached or Claude Code recorded no title.
 func (c *Cache) GetTitles(sessionID string) (nativeTitle, aiTitle string) {

--- a/internal/claudesessions/cache_test.go
+++ b/internal/claudesessions/cache_test.go
@@ -502,3 +502,48 @@ func TestCache_ScanGuardClearsAfterScan(t *testing.T) {
 		t.Error("a scan after the first never completed; admission is stuck")
 	}
 }
+
+// TestCacheGetSummary covers the read the detail endpoint depends on: cost is
+// stored by the scanner and cannot be recovered from a re-read of the
+// transcript, so a detail view that could not read this row would report $0.00
+// for a session the list prices correctly.
+func TestCacheGetSummary(t *testing.T) {
+	db := setupTestDB(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	projectDir := filepath.Join(home, ".claude", "projects", "test-project")
+	writeJSONL(t, projectDir, "session-abc", time.Date(2025, 6, 1, 10, 0, 0, 0, time.UTC))
+
+	listed, err := IncrementalScan(db, logger)
+	if err != nil {
+		t.Fatalf("IncrementalScan: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(listed))
+	}
+
+	cache := NewCache(db, logger)
+	got := cache.GetSummary("session-abc")
+	if got == nil {
+		t.Fatal("GetSummary returned nil for a scanned session")
+	}
+	if got.SessionID != listed[0].SessionID {
+		t.Errorf("session id: got %q, want %q", got.SessionID, listed[0].SessionID)
+	}
+	// The whole point of the row: the same figures the list serves.
+	if got.Cost != listed[0].Cost {
+		t.Errorf("cost: got %+v, want %+v", got.Cost, listed[0].Cost)
+	}
+	if got.SubagentCost != listed[0].SubagentCost {
+		t.Errorf("subagent cost: got %+v, want %+v", got.SubagentCost, listed[0].SubagentCost)
+	}
+	if got.Usage != listed[0].Usage {
+		t.Errorf("usage: got %+v, want %+v", got.Usage, listed[0].Usage)
+	}
+
+	if missing := cache.GetSummary("no-such-session"); missing != nil {
+		t.Errorf("GetSummary for an unknown session: got %+v, want nil", missing)
+	}
+}

--- a/internal/claudesessions/scanner.go
+++ b/internal/claudesessions/scanner.go
@@ -1125,7 +1125,7 @@ func updateLastScanned(db *sql.DB, logger *slog.Logger) {
 // folded in. The aggregate is a grouped sub-select rather than a join against
 // the raw rows so a session with several sub-agents is not multiplied out, and
 // COALESCE keeps the LEFT JOIN's NULLs from reaching the int scans.
-const sessionSummarySelect = `
+const sessionSummaryFrom = `
 	SELECT c.session_id, c.project_path, c.preview, c.custom_title, c.is_favorite,
 	       c.start_time, c.last_activity, c.message_count, c.event_count,
 	       c.input_tokens, c.output_tokens, c.cache_creation_tokens, c.cache_read_tokens,
@@ -1163,8 +1163,17 @@ const sessionSummarySelect = `
 		       GROUP_CONCAT(NULLIF(unpriced_models, ''), char(10)) AS um
 		FROM claude_subagent_cache
 		GROUP BY parent_session_id
-	) sa ON sa.parent_session_id = c.session_id
+	) sa ON sa.parent_session_id = c.session_id`
+
+const sessionSummarySelect = sessionSummaryFrom + `
 	ORDER BY c.last_activity DESC`
+
+// sessionSummaryByID is the same projection narrowed to one session, so the
+// detail endpoint reads back exactly the figures the list shows. It must stay
+// derived from sessionSummaryFrom: the costs are stored rather than recomputed
+// (#188), and a second hand-written projection would be free to drift.
+const sessionSummaryByID = sessionSummaryFrom + `
+	WHERE c.session_id = ?`
 
 // querySessionSummaries runs sessionSummarySelect and scans the result. Both
 // loadAllSessions and Cache.loadAll share it so the two paths cannot drift.
@@ -1181,37 +1190,10 @@ func querySessionSummaries(db *sql.DB, logger *slog.Logger) ([]ClaudeSessionSumm
 
 	sessions := []ClaudeSessionSummary{}
 	for rows.Next() {
-		var s ClaudeSessionSummary
-		var unpriced, subagentUnpricedModels string
-		var subagentUnpriced int
-		if err := rows.Scan(
-			&s.SessionID, &s.ProjectPath, &s.Preview, &s.CustomTitle, &s.IsFavorite,
-			&s.StartTime, &s.LastActivity, &s.MessageCount, &s.EventCount,
-			&s.Usage.InputTokens, &s.Usage.OutputTokens,
-			&s.Usage.CacheCreationTokens, &s.Usage.CacheReadTokens,
-			&s.Usage.CacheCreation5mTokens, &s.Usage.CacheCreation1hTokens,
-			&s.GitBranch, &s.Model, &s.CWD, &s.NativeTitle, &s.AITitle,
-			&s.AgentName, &s.PermissionMode, &s.Mode, &s.RelocatedCWD,
-			&s.WorktreeName, &s.WorktreeBranch, &s.OriginalBranch,
-			&s.CompactionCount, &s.DroppedTokens,
-			&s.Cost.InputUSD, &s.Cost.OutputUSD, &s.Cost.CacheReadUSD,
-			&s.Cost.CacheWriteUSD, &s.Cost.TotalUSD, &unpriced, &s.UnpricedTokens,
-			&s.SubagentCount, &s.SubagentUsage.InputTokens, &s.SubagentUsage.OutputTokens,
-			&s.SubagentUsage.CacheCreationTokens, &s.SubagentUsage.CacheReadTokens,
-			&s.SubagentUsage.CacheCreation5mTokens, &s.SubagentUsage.CacheCreation1hTokens,
-			&s.SubagentCost.InputUSD, &s.SubagentCost.OutputUSD, &s.SubagentCost.CacheReadUSD,
-			&s.SubagentCost.CacheWriteUSD, &s.SubagentCost.TotalUSD, &subagentUnpriced,
-			&subagentUnpricedModels,
-		); err != nil {
+		s, err := scanSessionSummary(rows)
+		if err != nil {
 			return nil, err
 		}
-		// Delegated work's unpriced models and tokens both count toward the
-		// session's disclosure. Reading one without the other would let a row
-		// report excluded tokens attributed to no model — or worse, show a
-		// confident total for a session that is only partly priced.
-		s.UnpricedModels = mergeUnpricedModels(unpriced, subagentUnpricedModels)
-		s.UnpricedTokens += subagentUnpriced
-		s.DisplayTitle = s.ResolveDisplayTitle()
 		sessions = append(sessions, s)
 	}
 	if err := rows.Err(); err != nil {
@@ -1277,6 +1259,70 @@ func attachSubagentUsageByModel(db *sql.DB, logger *slog.Logger, sessions []Clau
 			sessions[i].SubagentUsageByModel = m
 		}
 	}
+}
+
+// querySessionSummary returns the cached summary for one session, or nil when
+// the scanner has not reached it yet.
+//
+// Unlike querySessionSummaries this attaches neither the linked PRs nor the
+// per-model sub-agent breakdown: its caller (the detail endpoint) reads the
+// stored cost off this row and already has both from the transcript it parsed.
+// A future caller needing them must attach them explicitly.
+func querySessionSummary(db *sql.DB, logger *slog.Logger, sessionID string) (*ClaudeSessionSummary, error) {
+	rows, err := db.QueryContext(context.Background(), sessionSummaryByID, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if cerr := rows.Close(); cerr != nil {
+			logger.Warn("failed to close rows", "error", cerr)
+		}
+	}()
+
+	if !rows.Next() {
+		return nil, rows.Err()
+	}
+	s, err := scanSessionSummary(rows)
+	if err != nil {
+		return nil, err
+	}
+	return &s, rows.Err()
+}
+
+// scanSessionSummary reads one row of the sessionSummaryFrom projection.
+func scanSessionSummary(rows *sql.Rows) (ClaudeSessionSummary, error) {
+	var s ClaudeSessionSummary
+	var unpriced, subagentUnpricedModels string
+	var subagentUnpriced int
+	if err := rows.Scan(
+		&s.SessionID, &s.ProjectPath, &s.Preview, &s.CustomTitle, &s.IsFavorite,
+		&s.StartTime, &s.LastActivity, &s.MessageCount, &s.EventCount,
+		&s.Usage.InputTokens, &s.Usage.OutputTokens,
+		&s.Usage.CacheCreationTokens, &s.Usage.CacheReadTokens,
+		&s.Usage.CacheCreation5mTokens, &s.Usage.CacheCreation1hTokens,
+		&s.GitBranch, &s.Model, &s.CWD, &s.NativeTitle, &s.AITitle,
+		&s.AgentName, &s.PermissionMode, &s.Mode, &s.RelocatedCWD,
+		&s.WorktreeName, &s.WorktreeBranch, &s.OriginalBranch,
+		&s.CompactionCount, &s.DroppedTokens,
+		&s.Cost.InputUSD, &s.Cost.OutputUSD, &s.Cost.CacheReadUSD,
+		&s.Cost.CacheWriteUSD, &s.Cost.TotalUSD, &unpriced, &s.UnpricedTokens,
+		&s.SubagentCount, &s.SubagentUsage.InputTokens, &s.SubagentUsage.OutputTokens,
+		&s.SubagentUsage.CacheCreationTokens, &s.SubagentUsage.CacheReadTokens,
+		&s.SubagentUsage.CacheCreation5mTokens, &s.SubagentUsage.CacheCreation1hTokens,
+		&s.SubagentCost.InputUSD, &s.SubagentCost.OutputUSD, &s.SubagentCost.CacheReadUSD,
+		&s.SubagentCost.CacheWriteUSD, &s.SubagentCost.TotalUSD, &subagentUnpriced,
+		&subagentUnpricedModels,
+	); err != nil {
+		return s, err
+	}
+	// Delegated work's unpriced models and tokens both count toward the
+	// session's disclosure. Reading one without the other would let a row
+	// report excluded tokens attributed to no model — or worse, show a
+	// confident total for a session that is only partly priced.
+	s.UnpricedModels = mergeUnpricedModels(unpriced, subagentUnpricedModels)
+	s.UnpricedTokens += subagentUnpriced
+	s.DisplayTitle = s.ResolveDisplayTitle()
+	return s, nil
 }
 
 // attachPRs fills in each session's linked pull requests with a single query

--- a/internal/updater/checker.go
+++ b/internal/updater/checker.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/creativeprojects/go-selfupdate"
+
+	"github.com/shaharia-lab/agento/internal/build"
 )
 
 // DefaultCacheTTL is the time the cached release-check result is considered fresh.
@@ -116,6 +118,12 @@ func (c *Checker) timeout() time.Duration {
 // return ErrNotReleaseBuild so callers can skip silently.
 func (c *Checker) Check(ctx context.Context, currentVersion string, forceFresh bool) (*CheckResult, error) {
 	currentTrimmed := strings.TrimPrefix(currentVersion, "v")
+	// A local `git describe` build ("v0.8.0-21-gc325de6-dirty") parses as valid
+	// semver, so the parse below cannot reject it — and semver ranks it below
+	// the release it is ahead of, which would report a downgrade as an update.
+	if build.IsDevBuild(currentVersion) {
+		return nil, ErrNotReleaseBuild
+	}
 	if _, err := semver.NewVersion(currentTrimmed); err != nil {
 		return nil, ErrNotReleaseBuild
 	}

--- a/internal/updater/checker_test.go
+++ b/internal/updater/checker_test.go
@@ -13,7 +13,14 @@ import (
 func TestChecker_Check_NotReleaseBuild(t *testing.T) {
 	t.Parallel()
 	c := &Checker{CacheDir: t.TempDir()}
-	for _, v := range []string{"dev", "unknown", "00f2331", ""} {
+	// The `git describe` forms are the ones a plain semver parse accepts: they
+	// are valid prereleases, and semver ranks them below the tag they are ahead
+	// of, so without the dev-build gate a local build reports an update to the
+	// release it already contains.
+	for _, v := range []string{
+		"dev", "unknown", "00f2331", "",
+		"v0.8.0-21-gc325de6-dirty", "v0.8.0-dirty", "v0.8.0-21-gc325de6",
+	} {
 		v := v
 		t.Run(v, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
Implements the two Claude Design projects for the Claude Sessions list and detail pages, adds advanced filtering to the list, and fixes two bugs found while verifying the work in the running app.

## Sessions list

Day-grouped column table: day headers carry the session/message/token roll-up and that day's cost, rows align on one shared grid, and clicking a row expands its detail in place (preview, session id with copy, model, start, duration, cache read, plus compactions and sub-agents when present).

**Advanced filters** sit behind a disclosure so the toolbar keeps only what is reached often — mode, model, links, messages, duration, tokens in/out and cost.

Two design decisions worth a look:

- Each numeric filter is a **min/max pair** rather than an operator dropdown plus a value. Min alone reads as "at least", max alone as "at most", both as "between" — every comparison asked for, with one fewer control per field.
- Edits go to a **draft applied on a button**, not live. Typing `50` into a minimum would otherwise filter on `5` first, throwing the list away and back mid-keystroke. The draft is counted against the list before it is committed (`43 sessions match`), so Apply is never a leap in the dark.

The model dropdown is aggregated from the sessions on hand rather than the pricing catalog — the catalog lists models a given machine may never have run, and options that match nothing are worse than a short list.

## Session detail

Header with inline rename and the run's metadata as chips, a six-cell summary strip, and a transcript/sidebar split with search, an All/Messages/Tools filter, expand-all, and a sidebar of timeline, tool usage, files touched, todos and sub-agents.

Side by side the two columns are **independent scroll panes** rather than one page scroll with a sticky sidebar. A sticky element taller than the viewport pins at the top and its lower half becomes unreachable, which a long tool or file list reaches easily. Stacked below `xl` the whole body scrolls as one. Neither pane needs a magic pixel height.

## Where this departs from the mocks

Called out because they are judgement calls, not oversights:

- The design's **Status column** (Active/Done/Failed) has no backing data — a transcript records no outcome. The column shows the permission mode and is labelled **Mode**. The per-tool result badges are dropped for the same reason.
- **Export/Fork** are omitted: no endpoint behind them.
- **Token bars scale to the 90th percentile**, not the maximum. One 75.6M-token session in my corpus flattened every other bar to zero width.
- **Files touched** reports touch counts rather than a diff stat, because the transcript records no line counts.
- The **"Active" badge** means exactly one thing: the transcript was written to in the last ten minutes.

## Two bugs fixed along the way

**`GET /api/claude-sessions/{id}` reported $0.00 for every session** while the list showed the real figure. The detail is built by re-reading the transcript, but cost is accumulated per assistant message during a scan and stored (#188) — a re-read has no per-message pricing context to recompute from. It now reads the stored value back from the cache, like it already does for the title, favourite flag and sub-agents. The redesign made this loud by putting Cost in the summary strip.

**The update banner offered an "update" on every local build.** `make build` stamps `git describe --tags --always --dirty`, so a dev build reads as `v0.8.0-21-gc325de6-dirty`. That is *valid* semver — the tail parses as a prerelease — and semver ranks a prerelease below the release it precedes, so the published `v0.8.0` compared as newer than a tree 21 commits ahead of it. The existing `semver.NewVersion` guard cannot catch this; only the string's shape gives it away. Both check paths are now gated on `build.IsDevBuild`. A genuine prerelease tag like `v1.0.0-rc.1` is deliberately still offered updates.

## Consistency guarantee

Per-session figures moved to `lib/sessionMetrics` because two modules now need them, and every filter compares against the same main-thread-plus-sub-agent totals the columns render. Filtering on a different basis than the column displays is the bug that split prevents: a row reading `$36.30` must not be hidden by "cost at most $40". The expanded row's duration calls the same accessor the duration filter uses, for the same reason.

## Also included

`frontend/node_modules` is excluded from golangci-lint. It holds Go files vendored inside npm packages which fail the pre-commit hook for anyone who has run `npm ci`; CI never saw them because its Go job does not install frontend dependencies.

## Testing

- 40 new frontend tests across `sessionFilters`, `sessionGroups`, `sessionMetrics` and `transcript`; 183 passing overall
- New `TestCacheGetSummary` asserts the detail read returns the same cost the list serves
- New `build.IsDevBuild` table test; the API regression test was checked to fail without the fix (it returns `update_available: true`)
- Verified in the running app: filters applied and cross-checked against each row's own expanded detail, sidebar scrolling confirmed by measurement in both layouts, light and dark
