### PR TITLE
test(storage): build the migration-20 fixture forwards, not by rollback (#229)

### DIFF
--- a/internal/storage/export_test.go
+++ b/internal/storage/export_test.go
@@ -1,0 +1,39 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+)
+
+// ApplyMigrationsUpTo opens dbPath and applies every migration with
+// version <= v, recording them in schema_migrations exactly as the runner
+// does. It exists so upgrade-path tests can build a genuine old database
+// instead of mutilating a current one back into shape: undoing migrations by
+// hand needs an inverse statement for every migration above the target, and a
+// forgotten one leaves MAX(version) high, which makes the runner skip the
+// migration under test and the test pass while asserting nothing.
+//
+// It shares openSQLiteDB and applyMigrations with NewSQLiteDB rather than
+// re-implementing them, so the database it builds is the one the real open
+// path would have built at that version. Callers own the returned handle and
+// must close it before re-opening the file through NewSQLiteDB.
+func ApplyMigrationsUpTo(dbPath string, v int) (*sql.DB, error) {
+	ctx := context.Background()
+	logger := slog.Default()
+
+	db, err := openSQLiteDB(ctx, dbPath, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := applyMigrations(ctx, db, logger, v); err != nil {
+		if cerr := db.Close(); cerr != nil {
+			logger.Warn("failed to close database after migration error", "error", cerr)
+		}
+		return nil, fmt.Errorf("applying migrations up to %d: %w", v, err)
+	}
+
+	return db, nil
+}

--- a/internal/storage/export_test.go
+++ b/internal/storage/export_test.go
@@ -19,9 +19,21 @@ import (
 // re-implementing them, so the database it builds is the one the real open
 // path would have built at that version. Callers own the returned handle and
 // must close it before re-opening the file through NewSQLiteDB.
+//
+// A v at or above the newest declared migration is rejected rather than
+// silently returning a head database. That is the same failure the inverse-SQL
+// approach had — the fixture is not actually old, the migration under test has
+// already run, and the test passes while asserting nothing — and moving the
+// bound into one place is what stops it coming back through a stale literal in
+// a caller. Head is derived here rather than in production code; this file is
+// compiled only into the test binary.
 func ApplyMigrationsUpTo(dbPath string, v int) (*sql.DB, error) {
 	ctx := context.Background()
 	logger := slog.Default()
+
+	if head := latestMigrationVersion(); v >= head {
+		return nil, fmt.Errorf("ApplyMigrationsUpTo(%d): newest migration is %d, so this builds a head database, not an old one", v, head)
+	}
 
 	db, err := openSQLiteDB(ctx, dbPath, logger)
 	if err != nil {
@@ -36,4 +48,17 @@ func ApplyMigrationsUpTo(dbPath string, v int) (*sql.DB, error) {
 	}
 
 	return db, nil
+}
+
+// latestMigrationVersion is the highest version in the migrations slice. It
+// takes the maximum rather than the last element so it does not depend on the
+// slice being sorted, matching the bound check in applyMigrations.
+func latestMigrationVersion() int {
+	head := 0
+	for _, m := range migrations {
+		if m.version > head {
+			head = m.version
+		}
+	}
+	return head
 }

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"math"
 	"os"
 	"path/filepath"
 	"time"
@@ -539,37 +540,11 @@ ALTER TABLE claude_session_cache ADD COLUMN cost_by_model TEXT NOT NULL DEFAULT 
 // migrations. Returns true as the second value if the database was newly
 // created (i.e. no tables existed before this call).
 func NewSQLiteDB(dbPath string, logger *slog.Logger) (*sql.DB, bool, error) {
-	if err := os.MkdirAll(filepath.Dir(dbPath), 0750); err != nil {
-		return nil, false, fmt.Errorf("creating database directory: %w", err)
-	}
-
-	db, err := sql.Open("sqlite", dbPath)
-	if err != nil {
-		return nil, false, fmt.Errorf("opening database: %w", err)
-	}
-
-	// SQLite is single-writer; serialize all access through one connection
-	// to avoid SQLITE_BUSY errors from concurrent goroutines.
-	db.SetMaxOpenConns(1)
-	db.SetMaxIdleConns(1)
-	db.SetConnMaxLifetime(0)
-
 	ctx := context.Background()
 
-	// Configure SQLite pragmas.
-	pragmas := []string{
-		"PRAGMA journal_mode=WAL",
-		"PRAGMA busy_timeout=5000",
-		"PRAGMA foreign_keys=ON",
-		"PRAGMA synchronous=NORMAL",
-	}
-	for _, p := range pragmas {
-		if _, pragmaErr := db.ExecContext(ctx, p); pragmaErr != nil {
-			if cerr := db.Close(); cerr != nil {
-				logger.Warn("failed to close database after pragma error", "error", cerr)
-			}
-			return nil, false, fmt.Errorf("setting pragma %q: %w", p, pragmaErr)
-		}
+	db, err := openSQLiteDB(ctx, dbPath, logger)
+	if err != nil {
+		return nil, false, err
 	}
 
 	freshDB, err := runMigrations(ctx, db, logger)
@@ -583,10 +558,60 @@ func NewSQLiteDB(dbPath string, logger *slog.Logger) (*sql.DB, bool, error) {
 	return db, freshDB, nil
 }
 
+// openSQLiteDB creates the parent directory, opens the database and configures
+// its connection pool and pragmas. It does not migrate: callers decide which
+// schema version to bring the file to.
+func openSQLiteDB(ctx context.Context, dbPath string, logger *slog.Logger) (*sql.DB, error) {
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0750); err != nil {
+		return nil, fmt.Errorf("creating database directory: %w", err)
+	}
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("opening database: %w", err)
+	}
+
+	// SQLite is single-writer; serialize all access through one connection
+	// to avoid SQLITE_BUSY errors from concurrent goroutines.
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxLifetime(0)
+
+	// Configure SQLite pragmas.
+	pragmas := []string{
+		"PRAGMA journal_mode=WAL",
+		"PRAGMA busy_timeout=5000",
+		"PRAGMA foreign_keys=ON",
+		"PRAGMA synchronous=NORMAL",
+	}
+	for _, p := range pragmas {
+		if _, pragmaErr := db.ExecContext(ctx, p); pragmaErr != nil {
+			if cerr := db.Close(); cerr != nil {
+				logger.Warn("failed to close database after pragma error", "error", cerr)
+			}
+			return nil, fmt.Errorf("setting pragma %q: %w", p, pragmaErr)
+		}
+	}
+
+	return db, nil
+}
+
+// allMigrations is the upTo bound that applies every migration in the list —
+// what a normal database open does. Bounding below it is only for tests that
+// need to build a genuine older database (see ApplyMigrationsUpTo).
+const allMigrations = math.MaxInt
+
 // runMigrations ensures the schema_migrations table exists and applies any
 // pending migrations. Returns true if migration version 1 was applied during
 // this call (indicating a fresh database).
 func runMigrations(ctx context.Context, db *sql.DB, logger *slog.Logger) (bool, error) {
+	return applyMigrations(ctx, db, logger, allMigrations)
+}
+
+// applyMigrations ensures the schema_migrations table exists and applies every
+// pending migration whose version is <= upTo, recording each one. Returns true
+// if migration version 1 was applied during this call.
+func applyMigrations(ctx context.Context, db *sql.DB, logger *slog.Logger, upTo int) (bool, error) {
 	// Ensure the migrations tracking table exists.
 	_, err := db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS schema_migrations (
 		version    INTEGER PRIMARY KEY,
@@ -603,7 +628,7 @@ func runMigrations(ctx context.Context, db *sql.DB, logger *slog.Logger) (bool, 
 
 	freshDB := false
 	for _, m := range migrations {
-		if m.version <= current {
+		if m.version <= current || m.version > upTo {
 			continue
 		}
 		if m.version == 1 {

--- a/internal/storage/sqlite_session_insights_store_test.go
+++ b/internal/storage/sqlite_session_insights_store_test.go
@@ -641,35 +641,35 @@ func TestNeedsProcessing_ReturnsRowsBelowCurrentVersion(t *testing.T) {
 // database with insight rows must gain the column with its '{}' default, so a
 // pre-v6 row reads as "nothing attributed" until the processor-version bump
 // reprocesses it. A nullable column here would fail Scan on real data only.
+//
+// The version-19 fixture is built forwards, by replaying the migration list up
+// to 19, rather than by undoing everything above 19 on a current database. The
+// backwards version needed an inverse statement per later migration and had to
+// be hand-extended by every new one; worse, a forgotten inverse failed silently
+// — MAX(version) stayed high, migration 20 was skipped, and the test passed
+// asserting nothing. storage.ApplyMigrationsUpTo makes upgrade-path tests for
+// any other migration cheap to add the same way.
 func TestMigration20_AppliesToExistingDatabaseWithRows(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "test.db")
-	db, _, err := storage.NewSQLiteDB(dbPath, slog.Default())
+	db, err := storage.ApplyMigrationsUpTo(dbPath, 19)
 	if err != nil {
 		t.Fatal(err)
 	}
 	ctx := context.Background()
 
-	store := storage.NewSQLiteSessionInsightsStore(db)
-	r := sampleRecord("pre-migration")
-	r.AgentBreakdown = map[string]int{"Explore": 4}
-	if err := store.Upsert(ctx, r); err != nil {
-		t.Fatal(err)
-	}
-
-	// Roll the schema back to 19, with the row still in place. Everything
-	// above 19 has to go, not just 20: the runner replays by MAX(version), so
-	// leaving a later migration recorded would make it skip 20 entirely and
-	// this test would assert nothing.
-	for _, stmt := range []string{
-		"ALTER TABLE session_insights DROP COLUMN agent_breakdown",
-		"DROP TABLE IF EXISTS model_pricing_tier",
-		"ALTER TABLE claude_subagent_cache DROP COLUMN event_count",
-		"ALTER TABLE claude_session_cache DROP COLUMN cost_by_model",
-		"DELETE FROM schema_migrations WHERE version >= 20",
-	} {
-		if _, err := db.ExecContext(ctx, stmt); err != nil {
-			t.Fatalf("rolling back (%s): %v", stmt, err)
-		}
+	// Written as raw SQL against the version-19 column list, not through
+	// NewSQLiteSessionInsightsStore.Upsert: the store writes agent_breakdown,
+	// which does not exist yet. Knowing the old schema here is inherent to
+	// testing an upgrade — a row has to predate the column to prove it is
+	// backfilled. Only the NOT NULL columns without a default are required;
+	// the rest are left to their defaults exactly as a real old row would be.
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO session_insights
+			(session_id, processor_version, scanned_at, turn_count, tool_calls_total, tool_breakdown, session_type)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"pre-migration", 1, time.Now().UTC().Format(time.RFC3339), 3, 4, `{"Read":4}`, "coding",
+	); err != nil {
+		t.Fatalf("inserting a row through the version-19 schema: %v", err)
 	}
 	if err := db.Close(); err != nil {
 		t.Fatal(err)
@@ -686,7 +686,7 @@ func TestMigration20_AppliesToExistingDatabaseWithRows(t *testing.T) {
 	}
 
 	// Compared against a freshly created database rather than a literal: what
-	// this asserts is that the rollback replayed all the way back to head, not
+	// this asserts is that the upgrade replayed all the way up to head, not
 	// that head is any particular number. Pinning the number here made every
 	// new migration fail this test for a reason unrelated to what it covers.
 	var version, head int

--- a/internal/storage/sqlite_session_insights_store_test.go
+++ b/internal/storage/sqlite_session_insights_store_test.go
@@ -657,6 +657,21 @@ func TestMigration20_AppliesToExistingDatabaseWithRows(t *testing.T) {
 	}
 	ctx := context.Background()
 
+	// Assert the fixture really is at 19. Without this the test's whole premise
+	// rests on the literal above being right: a bound that overshoots leaves
+	// migration 20 already applied, and every assertion below still passes —
+	// the raw INSERT succeeds because agent_breakdown is NOT NULL DEFAULT '{}',
+	// the version check compares after the upgrade, and an empty breakdown is
+	// what a never-written column holds anyway. Exactly the silent pass this
+	// test was rewritten to eliminate, just relocated to a different literal.
+	var fixtureVersion int
+	if err := db.QueryRowContext(ctx, `SELECT MAX(version) FROM schema_migrations`).Scan(&fixtureVersion); err != nil {
+		t.Fatalf("reading the fixture's schema version: %v", err)
+	}
+	if fixtureVersion != 19 {
+		t.Fatalf("fixture is at schema version %d, want 19; migration 20 is not being exercised", fixtureVersion)
+	}
+
 	// Written as raw SQL against the version-19 column list, not through
 	// NewSQLiteSessionInsightsStore.Upsert: the store writes agent_breakdown,
 	// which does not exist yet. Knowing the old schema here is inherent to


### PR DESCRIPTION
Closes #229

## What

`TestMigration20_AppliesToExistingDatabaseWithRows` built its "database at version 19" fixture by opening at head and then *undoing* migration 20 with hand-written inverse SQL plus a `DELETE FROM schema_migrations WHERE version >= 20`. That made the test carry a second, manual definition of what each migration does — one that has to be re-derived by hand every time a migration is added, and that is only ever exercised in reverse, so a wrong inverse surfaces as a confusing symptom rather than as itself.

- `internal/storage/sqlite.go`: extract `openSQLiteDB` and `applyMigrations(ctx, db, logger, upTo)` out of `NewSQLiteDB`/`runMigrations`
- `internal/storage/export_test.go` (new): test-only seam `ApplyMigrationsUpTo(dbPath string, v int) (*sql.DB, error)`
- `internal/storage/sqlite_session_insights_store_test.go`: fixture built forwards, stopping at 19; inverse SQL and the `schema_migrations` DELETE are gone

## Notes

The extraction is a **pure move** — `NewSQLiteDB` keeps identical behaviour and error wrapping. The only semantic addition inside the loop is `|| m.version > upTo`, and `runMigrations` passes `math.MaxInt`, so the production path can never be bounded below head.

Two deliberate choices in that loop: `continue` rather than `break`, so the bound does not depend on the `migrations` slice being sorted; and `math.MaxInt` rather than a computed head, so there is no new "what is head" derivation in production code to drift out of sync.

`openSQLiteDB` is extracted as well, beyond the apply loop the issue mandated, so the seam opens the file through exactly the same pragmas and single-connection pool as production instead of a hand-rolled second open.

`export_test.go` is in `package storage` and compiles only into the test binary, so `ApplyMigrationsUpTo` is reachable from the external `storage_test` package without widening the shipped API surface.

The pre-migration row is a raw `INSERT` listing only v19 columns — going through `Upsert` would write `agent_breakdown` and fail against the v19 schema. All existing assertions are kept verbatim, and `sqlite_test.go`'s hardcoded `23` is untouched. The only version number left in the test file is the `19` target.

## Verification

- `go test ./internal/storage/...`: PASS, also under `-race`
- **Break-migration-20**: removing migration 20's `ALTER TABLE ... ADD COLUMN agent_breakdown` turns the test RED with a direct message (`no such column: agent_breakdown`). Reverted.
- **Throwaway-migration-24**: appending a no-op migration 24 leaves the test GREEN with zero edits to the test file — the property the issue asked for. Reverted.
- `make test`: PASS
- `go vet ./internal/storage/...`, `gofmt -l internal/storage/`: clean

`make lint` could not complete locally: the CI-pinned `golangci-lint v2.5.0` panics with `file requires newer Go version go1.26 (application built with go1.25)` before linting any code, and does so identically on a clean `main`. As a substitute, `golangci-lint 2.12.2` over `./...` reported 12 findings, all in pre-existing untouched files and **none** in `internal/storage`.