### PR TITLE
test(claude-sessions): stop the real scan racing the faked one

### DIFF
--- a/internal/claudesessions/cache_test.go
+++ b/internal/claudesessions/cache_test.go
@@ -373,6 +373,12 @@ func setupPopulatedCache(t *testing.T) *Cache {
 	if got := len(cache.List()); got != 1 {
 		t.Fatalf("cold List returned %d sessions, want 1", got)
 	}
+	// The cold List returns as soon as there are rows to serve, which can be
+	// before the scan goroutine has run its cleanup — leaving a real scan in
+	// flight. A test that then fakes one with markScanning gets its flag
+	// cleared out from under it when the real one finishes. Wait the scan out
+	// so every caller starts from a quiescent cache.
+	<-cache.EnsureScan()
 	return cache
 }
 


### PR DESCRIPTION
## What

`TestCache_ListDoesNotBlockOnAnInFlightScan` fails intermittently on CI with `ScanInProgress() = false during an in-flight scan` — it blocked an unrelated PR (#234, which touches only `internal/storage`). Pre-existing, not introduced by any open PR.

## Root cause

The scan the test asks about is *faked* by `markScanning`, and nothing in the test body can clear that flag. A **real** scan can, because `setupPopulatedCache` leaves one running.

`Cache.List` returns as soon as `loadOrEmpty` finds rows:

```go
sessions := c.loadOrEmpty()
if len(sessions) > 0 || done == nil {
    return sessions            // <- scan goroutine may still be finishing
}
```

On the one-file corpus the helper writes, the scan can persist its row before the goroutine reaches its deferred cleanup. The *cold* path is safe — it waits on `scanDone`, which is closed only after `scanning` is set false — but this early return is not. The helper's caller then sets `scanning = true` and installs a fresh `scanDone`, and the lagging goroutine clears the flag and closes the now-orphaned channel. `ScanInProgress()` reads false.

## Fix

`setupPopulatedCache` waits the scan out via `EnsureScan`, which returns the in-flight channel when there is one and otherwise runs a scan of the same one-file corpus to completion. Either way the cache is quiescent when the helper returns, so every test that fakes a scan starts from a known state.

## Verification

- `go test ./internal/claudesessions/ -run TestCache_ -count=10`: PASS
- `golangci-lint` at the CI-pinned v2.5.0: 0 issues

Honest caveat: the window is scheduling-dependent and I could **not** reproduce it locally — 200 iterations of the helper on a many-core machine showed the leak 0 times, and 90 runs of the cache suite were green. The diagnosis is from reading the lifecycle, and it is the only path that can clear `scanning` while the test believes it owns the flag. CI's contended two-core runners are where it surfaces.