### PR TITLE
docs: catch the docs up with the analytics, pricing and security work

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,44 @@
-# Required: Anthropic API key
-ANTHROPIC_API_KEY=your-api-key-here
+# Everything here is optional. Agento runs with no configuration at all, using
+# the authentication the Claude Code CLI already has.
+# See docs/getting-started.md for the full table.
 
-# Optional: Directory containing agent YAML files (default: ./agents)
-# AGENTS_DIR=./agents
+# HTTP server port (default: 8990)
+# PORT=8990
 
-# Optional: Path to the MCP registry YAML file (default: ./mcps.yaml)
-# MCPS_FILE=./mcps.yaml
+# Interface to listen on (default: 127.0.0.1 — loopback only).
+# 0.0.0.0 exposes an API that can run commands on this machine to your whole
+# network. Read docs/security.md first.
+# AGENTO_BIND=127.0.0.1
 
-# Optional: HTTP server port (default: 3000)
-# PORT=3000
+# Externally reachable URL, when Agento sits behind a reverse proxy or a tunnel,
+# or serves Telegram webhooks. Without it, requests under that hostname are
+# refused.
+# AGENTO_PUBLIC_URL=https://agento.example.com
 
-# Optional: MCP server API keys (referenced as ${ENV:VAR_NAME} in mcps.yaml)
-# STATSIG_MCP_API_KEY=your-statsig-key
+# Root data directory: database, logs, mcps.yaml (default: ~/.agento)
+# AGENTO_DATA_DIR=~/.agento
+
+# Which Claude Code account agent runs authenticate as. Claude Code's own
+# variable (default: ~/.claude)
+# CLAUDE_CONFIG_DIR=~/.claude
+
+# Model used for direct (no-agent) chat sessions (default: sonnet)
+# AGENTO_DEFAULT_MODEL=sonnet
+
+# Default working directory for agent sessions (default: <tmp>/agento/work)
+# AGENTO_WORKING_DIR=/tmp/agento/work
+
+# Log verbosity: debug, info, warn, error (default: info)
+# LOG_LEVEL=info
+
+# Optional: use the Anthropic API directly instead of Claude Code CLI auth
+# ANTHROPIC_API_KEY=your-api-key-here
+
+# OpenTelemetry — see docs/monitoring.md
+# OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317
+# OTEL_EXPORTER_OTLP_INSECURE=true
+# OTEL_METRICS_EXPORTER=otlp
+# OTEL_LOGS_EXPORTER=otlp
+
+# MCP server credentials, referenced as ${ENV:VAR_NAME} in ~/.agento/mcps.yaml
+# MY_SERVER_API_KEY=your-key

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,9 +27,11 @@ Opening an issue first gives the community the opportunity to discuss the proble
 Before making code changes, read the developer documentation in the [`docs/`](docs/) directory:
 
 - [Getting Started](docs/getting-started.md)
-- [Development](docs/development.md)
+- [Development](docs/development.md) — layout, tests, and the conventions that bite (migrations, cache version constants, metrics defined in two languages)
 - [Agents](docs/agents.md)
+- [Claude Sessions](docs/claude-sessions.md)
 - [Integrations](docs/integrations.md)
+- [Security](docs/security.md)
 
 ### Prerequisites
 
@@ -70,9 +72,13 @@ make dev-frontend
 ```bash
 make test          # Run all Go tests
 make lint          # Run Go linters
+cd frontend && npm run test       # Vitest
 cd frontend && npm run lint       # Frontend linting
 cd frontend && npm run typecheck  # TypeScript checks
 ```
+
+End-to-end tests (`make e2e-setup` once, then `make e2e`) and the scale harness
+(`make bench-scale`) are local-only — see [Development](docs/development.md#run-tests).
 
 ## Pull Request Guidelines
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Nothing needs configuring. Everything below is optional, and environment variabl
 |----------|---------|-------------|
 | `PORT` | `8990` | HTTP server port |
 | `AGENTO_BIND` | `127.0.0.1` | Interface to listen on (both loopback families). Set `0.0.0.0` to reach Agento from another device — see below |
+| `AGENTO_PUBLIC_URL` | none | Externally reachable URL, for a reverse proxy, a tunnel, or Telegram webhooks |
 | `CLAUDE_CONFIG_DIR` | `~/.claude` | Which Claude Code account agents run as. Claude Code's own variable |
 | `AGENTO_DATA_DIR` | `~/.agento` | Root directory for agents, chats, and logs. Supports `~` expansion |
 | `LOG_LEVEL` | `info` | Log verbosity: `debug`, `info`, `warn`, `error` |
@@ -287,9 +288,12 @@ Only do that on a network you trust, or put a proxy that authenticates in front 
 ## Documentation
 
 - [Getting started](docs/getting-started.md): setup and a first-run walkthrough
+- [Claude sessions](docs/claude-sessions.md): what is scanned, how cost and duration are measured, and the analytics built on top
 - [Agents](docs/agents.md): system prompts, models, tools and template variables
-- [Integrations](docs/integrations.md): connecting Google, GitHub, Slack, Jira, Confluence and Telegram
+- [Tasks](docs/tasks.md): running agents on a schedule, and job history
+- [Integrations](docs/integrations.md): connecting Google, GitHub, Slack, Jira, Confluence, Telegram and WhatsApp
 - [Pricing](docs/pricing.md): how cost is calculated and how to maintain the catalog
+- [Security](docs/security.md): network exposure, the API guards, and where your data lives
 - [Monitoring](docs/monitoring.md): OpenTelemetry traces, metrics and logs
 - [Development](docs/development.md): architecture and contribution guidelines
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,14 +1,39 @@
 # Agents
 
-An agent defines the model, system prompt, and tools it can use. Agents are stored in the SQLite database at `~/.agento/agento.db`. You can create and manage agents from the UI, or define them as YAML files in `~/.agento/agents/` (auto-migrated to SQLite on first startup).
+An agent is a saved configuration: a name, a system prompt, a model, a thinking
+mode, a permission mode, and an explicit list of the tools it may use. Save it
+once and run it from a chat, a [scheduled task](tasks.md), a
+[Telegram trigger](integrations.md#triggers-run-an-agent-from-an-incoming-message)
+or the CLI.
+
+Agents live in the SQLite database at `~/.agento/agento.db`. YAML files in
+`~/.agento/agents/` are imported into it on startup — that path is a legacy
+import, not the source of truth.
+
+- [Create an agent](#create-an-agent)
+- [Fields](#fields)
+- [Thinking and permission modes](#thinking-and-permission-modes)
+- [Tools](#tools)
+- [System prompt templates](#system-prompt-templates)
+- [Running as a different Claude account](#running-as-a-different-claude-account)
+- [Claude settings profiles](#claude-settings-profiles)
+- [Running an agent](#running-an-agent)
 
 ---
 
 ## Create an agent
 
-The recommended way is through the UI (see "Manage agents from the UI" below). You can also create a YAML file in `~/.agento/agents/` — it will be imported into the database on next startup.
+Go to **Agents → New Agent**. The form has two areas:
 
-**Example: `~/.agento/agents/support.yaml`**
+- **System Prompt** — a full-height editor for the agent's instructions.
+- **Configuration** — Basic Info (name, slug, description), Model & Behavior
+  (model, thinking mode, permission mode), Built-in Tools, and Integration
+  Tools for any [integration](integrations.md) you have connected.
+
+Changes take effect immediately.
+
+Agents can also be defined as YAML and dropped into `~/.agento/agents/`, which
+is useful for seeding a fresh install from version control:
 
 ```yaml
 name: Support Bot
@@ -16,16 +41,21 @@ slug: support-bot
 description: Answers customer support questions.
 model: claude-sonnet-4-6
 thinking: adaptive
+permission_mode: plan
 system_prompt: |
   You are a helpful support agent for Acme Inc.
   Answer questions clearly and concisely.
   Today is {{current_date}}.
 capabilities:
   built_in:
+    - Read
+    - Grep
+  local:
     - current_time
 ```
 
-After saving the file, restart Agento or use the UI to reload agents.
+The file is imported on the next startup. After that, edit the agent in the UI —
+the database is what runs.
 
 ---
 
@@ -40,55 +70,105 @@ After saving the file, restart Agento or use the UI to reload agents.
 | `thinking` | No | `adaptive` (default), `enabled`, or `disabled` |
 | `permission_mode` | No | `bypass` (default), `default`, `plan`, or `dontAsk` |
 | `system_prompt` | No | Instructions sent to the model before every conversation |
-| `capabilities` | No | Tools the agent can use (see below) |
+| `capabilities` | No | Which tools the agent may use (see below) |
+| `claude_config_dir` | No | Run as a different Claude Code account (see below) |
 
 ---
 
-## System prompt templates
+## Thinking and permission modes
 
-The system prompt supports these placeholders:
+**Thinking** — `adaptive` lets Claude decide, `enabled` forces extended
+thinking, `disabled` turns it off. `agento ask --no-thinking` overrides it for a
+single CLI run.
 
-| Placeholder | Replaced with |
-|-------------|--------------|
-| `{{current_date}}` | Today's date |
-| `{{current_time}}` | Current time |
+**Permission mode** decides what happens when the agent wants to use a tool:
+
+| Mode | Behaviour |
+|------|-----------|
+| `bypass` (default) | Tools run without asking |
+| `default` | Claude Code's normal prompting; the UI asks you in-chat |
+| `plan` | Plans first, acts only after you approve |
+| `dontAsk` | Runs permitted tools without prompting |
+
+`bypass` is the default because most agents are run unattended. It also means an
+agent holding `Bash` can do anything you can — so give an agent only the tools it
+needs, and prefer `plan` for anything that writes files or runs commands. See
+[Security](security.md#agent-permission-modes).
 
 ---
 
-## Capabilities
+## Tools
 
-### Built-in tools
+### Built-in Claude Code tools
+
+`Read`, `Write`, `Edit`, `Bash`, `Glob`, `Grep`, `WebFetch`, `WebSearch`,
+`Task`, `TaskOutput`, `TaskStop`, `NotebookEdit`. The agent form offers the
+commonly used ones as checkboxes; YAML accepts any name from that list.
 
 ```yaml
 capabilities:
   built_in:
-    - current_time
-    - current_date
+    - Read
+    - Grep
+    - Bash
 ```
+
+**Selecting none allows all of them.** An explicit list is an allowlist —
+anything not on it is unavailable to the agent.
 
 ### Local tools
 
-Local tools run as a local MCP server inside Agento.
+Local tools run inside Agento as an in-process MCP server. Currently:
+
+| Tool | Description |
+|------|-------------|
+| `current_time` | The current date and time for an IANA timezone (defaults to UTC) |
 
 ```yaml
 capabilities:
   local:
-    - bash
-    - read_file
+    - current_time
 ```
 
-### MCP servers
+### Integration tools
 
-First register the MCP server in `~/.agento/mcps.yaml`:
+Every [integration](integrations.md) you connect — Google, GitHub, Slack, Jira,
+Confluence, Telegram, WhatsApp — exposes its tools in the agent form under
+**Integration Tools**. Select the individual tools this agent should have; it
+cannot see the ones you leave unselected.
+
+### External MCP servers
+
+Register the server in `~/.agento/mcps.yaml`. The file is a map of server name
+to configuration, and `transport` is required:
 
 ```yaml
-servers:
-  my-server:
-    command: /path/to/mcp-server
-    args: ["--flag"]
+# stdio — a local process
+my-server:
+  transport: stdio
+  command: /path/to/mcp-server
+  args: ["--flag"]
+  env:
+    API_KEY: ${ENV:MY_SERVER_API_KEY}
+
+# streamable HTTP
+remote-server:
+  transport: streamable_http
+  url: https://mcp.example.com/mcp
+  headers:
+    Authorization: Bearer ${ENV:REMOTE_TOKEN}
+
+# server-sent events
+legacy-server:
+  transport: sse
+  url: https://mcp.example.com/sse
 ```
 
-Then reference it in the agent:
+`${ENV:VAR_NAME}` reads from Agento's own environment, so tokens stay out of the
+file. A referenced variable that is not set is an error at load time rather than
+a confusing failure later.
+
+Then reference the server from the agent:
 
 ```yaml
 capabilities:
@@ -99,33 +179,87 @@ capabilities:
         - tool_name_two
 ```
 
-Leave `tools` empty to allow all tools from that server.
+Leave `tools` empty to allow every tool that server exposes.
 
 ---
 
-## Chat with an agent
+## System prompt templates
 
-1. Open the Agento UI at [http://localhost:8990](http://localhost:8990).
-2. Select the agent from the sidebar.
-3. Type your message and press Enter.
+| Placeholder | Replaced with |
+|-------------|--------------|
+| `{{current_date}}` | Today's date |
+| `{{current_time}}` | The current time |
 
-Tool calls made by the agent are shown inline in the conversation. If the agent needs input from you during a run, a prompt appears automatically.
+Substitution happens at run time, so a scheduled task always sees the date it
+actually ran on.
 
 ---
 
-## Manage agents from the UI
+## Running as a different Claude account
 
-You can create, edit, and delete agents from the **Agents** section in the UI without editing YAML files by hand. Changes take effect immediately.
+Claude Code keeps its credentials, projects and settings in a config directory —
+`~/.claude` unless `CLAUDE_CONFIG_DIR` says otherwise. Setting
+`claude_config_dir` on an agent points *that agent's runs* at a different
+directory, which is how a work agent and a personal agent stay live in one
+Agento instance.
 
-### Creating or editing an agent in the UI
+The directory a run targets is resolved in this order:
 
-Go to **Agents → New Agent** (or click **Edit** on an existing agent). The form has two areas:
+1. the agent's own `claude_config_dir`
+2. the `CLAUDE_CONFIG_DIR` environment variable
+3. the global default (**Settings → General → Claude config directory**)
+4. `~/.claude`
 
-- **System Prompt** (left side on desktop, first tab on mobile) — A full-height editor where you write the agent's instructions. Line numbers are shown for reference. Use `{{current_date}}` and `{{current_time}}` as placeholders.
-- **Configuration** (right side on desktop, second tab on mobile) — Collapsible sections for all other settings:
-  - **Basic Info** — Name, slug, and description.
-  - **Model & Behavior** — Model selection, thinking mode, and permission mode.
-  - **Built-in Tools** — Select which built-in tools the agent can use. Leave all unchecked to allow all.
-  - **Integration Tools** — If you have connected integrations (e.g. Google), their tools appear here for selection.
+The environment variable comes before the stored setting because it is what the
+surrounding environment has already chosen for every subprocess — and Agento
+refuses to store a setting that conflicts with it.
 
-Click **Create Agent** or **Update Agent** to save.
+This applies to every entry point: chats, scheduled tasks, Telegram triggers and
+`agento ask`. Claude's `settings.json` is resolved **inside the directory the run
+targets**, and omitted when it does not exist there.
+
+Analytics works differently: it indexes *every* configured directory into one
+corpus, because reporting is retrospective. See
+[Claude Sessions](claude-sessions.md#multiple-claude-accounts).
+
+---
+
+## Claude settings profiles
+
+A settings profile is a named Claude Code `settings.json` you can switch between
+per agent, per chat or per [task](tasks.md). Profiles are stored as
+`settings_<slug>.json` in the run's config directory, with their metadata in
+`settings_profiles.json`; a default profile is created from your existing
+`settings.json` on first launch.
+
+Manage them under **Settings → Claude Settings**. Because profiles are a global
+CRUD surface, they live in the default run directory rather than inside any
+per-agent override — a named profile keeps its recorded absolute path.
+
+---
+
+## Running an agent
+
+**Chat** — pick the agent in the sidebar and type. Tool calls appear inline as
+they happen, responses stream live, and if the agent needs your input a prompt
+appears in the conversation. Drag and drop files or paste images straight into
+the input. The multi-chat workspace runs several conversations in parallel, each
+tab with its own agent and session.
+
+**Scheduled** — see [Tasks](tasks.md).
+
+**From an incoming message** — see
+[Triggers](integrations.md#triggers-run-an-agent-from-an-incoming-message).
+
+**CLI**
+
+```bash
+agento ask "What changed in the repo today?"
+agento ask --agent code-reviewer "Review the staged diff"
+agento ask --agent code-reviewer "Follow up on that" <session-id>
+agento ask --no-thinking --agent code-reviewer "Quick check"
+```
+
+Passing a session ID continues that conversation. `agento ask` honours the
+stored Claude config directory, so it authenticates as the same account the web
+UI does.

--- a/docs/claude-sessions.md
+++ b/docs/claude-sessions.md
@@ -1,0 +1,364 @@
+# Claude Sessions, Analytics and Insights
+
+Claude Code writes a JSONL transcript for every session it runs. Agento reads
+those files, caches what it finds in its own SQLite database, and builds the
+sessions browser, the cost analytics and the productivity insights on top of
+them.
+
+Nothing is uploaded and nothing is sent anywhere: the transcripts stay where
+Claude Code wrote them, and Agento only ever reads them.
+
+- [What Agento reads](#what-agento-reads)
+- [Multiple Claude accounts](#multiple-claude-accounts)
+- [How scanning works](#how-scanning-works)
+- [Sessions list](#sessions-list)
+- [Session detail and journey](#session-detail-and-journey)
+- [Duration means active duration](#duration-means-active-duration)
+- [Turns, not events](#turns-not-events)
+- [Sub-agents](#sub-agents)
+- [Cost](#cost)
+- [Analytics dashboard](#analytics-dashboard)
+- [Insights](#insights)
+- [Hiding projects](#hiding-projects)
+- [API reference](#api-reference)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## What Agento reads
+
+Inside a Claude Code config directory (`~/.claude` by default):
+
+| Path | What Agento takes from it |
+|------|---------------------------|
+| `projects/<encoded-path>/<session-id>.jsonl` | The session transcript: prompts, replies, tool calls, token usage, model, git branch, permission mode |
+| `projects/<encoded-path>/<session-id>/subagents/agent-*.jsonl` | Delegated sub-agent transcripts, plus their `.meta.json` sidecars |
+| `todos/` | The session's todo list |
+| `settings.json`, `settings_<slug>.json` | Claude settings and Agento's named settings profiles |
+
+Beyond the conversation itself the scanner reads the events Claude Code writes
+alongside it: `pr-link` (linked pull requests), `compact_boundary` (context
+compactions and the tokens dropped by each), the `custom-title` / `ai-title`
+naming events, and the `agent-name` / `permission-mode` / `mode` / `relocated` /
+`worktree-state` metadata events.
+
+Agento never writes to a transcript. Things you set in Agento — a renamed
+session, a favourite — live in Agento's own database and always win over the
+title Claude Code recorded.
+
+---
+
+## Multiple Claude accounts
+
+If you run Claude Code under more than one account — work and personal, or two
+organisations — each has its own config directory.
+
+**Reading is a set; running is a choice.**
+
+- **Every configured directory is indexed into one corpus.** Analytics is
+  retrospective: a machine running two accounts wants both in every total.
+  Manage the set in **Settings → Data & Analytics → Claude config directories**,
+  which also offers any config directory it finds sitting beside the default one
+  so you do not have to type a path. `~/.claude` and the directory agent runs
+  target are always indexed and do not need listing.
+- **A run authenticates as exactly one account.** Which one is resolved in this
+  order: the agent's own `claude_config_dir` → the `CLAUDE_CONFIG_DIR`
+  environment variable → the global setting (**Settings → General**) → `~/.claude`.
+  See [Agents](agents.md#running-as-a-different-claude-account).
+
+Two consequences worth knowing:
+
+- **A session that exists in two directories is counted once.** Setting up a
+  second account by copying the first duplicates every session ID; the first
+  directory in the indexing order claims it, so tokens and cost are not
+  doubled. The order is `~/.claude` first, then the directory agent runs target,
+  then the extras as listed.
+- **Removing a directory hides its sessions, it does not delete them.** The
+  cached rows stay, so re-adding it costs no re-read. Likewise, a directory
+  Agento cannot list right now — an unmounted drive, a permissions error — has
+  its rows left alone rather than treated as deleted.
+
+Filter the sessions list to one account with the config-directory filter.
+
+---
+
+## How scanning works
+
+A scan compares each transcript's modification time against what is cached and
+reads only what changed. Transcripts are decoded in parallel and written in
+batches, so a full re-read of a large corpus is bounded by disk and CPU rather
+than by one commit per file.
+
+Scans run on startup, when a page that needs fresh data is opened, and on
+demand from the sessions list. They run **in the background**: a request is
+served from the cache immediately rather than waiting.
+
+**A full re-read of every transcript is triggered by** — an Agento upgrade that
+changes how transcripts are parsed, any edit to the [pricing catalog](pricing.md),
+and any change to the [idle threshold](#duration-means-active-duration). All
+three change figures that are *stored* per session, so they cannot be applied
+without reading the transcripts again. This is normal and safe; on a large
+corpus it takes a few minutes.
+
+While a scan is running the sessions list shows its progress
+(`Scanning ~/.claude… 412 / 1,373 transcripts`) instead of pretending there is
+nothing there. `GET /api/claude-sessions/status` exposes the same information.
+
+---
+
+## Sessions list
+
+The list is filtered, sorted and paged **in SQL**, so it behaves the same with
+50 sessions or 5,000. Scrolling loads the next page by cursor rather than by
+offset, which means a scan finishing mid-scroll cannot shuffle the pages you
+have not reached yet.
+
+Available filters:
+
+| Filter | Notes |
+|--------|-------|
+| Search | Case-insensitive substring match across session ID, all three title fields, the preview and the project path. `%` and `_` are matched literally |
+| Project | Hidden projects are never offered |
+| Config directory | Which Claude account the session belongs to |
+| Model, permission mode | Values come from the sessions actually present |
+| Date range | Local-day boundaries, not UTC |
+| Messages, duration, tokens in/out, cost | Inclusive min/max ranges |
+| Links | Sessions with or without a linked pull request |
+| Favourites | Sessions you starred in Agento |
+
+Totals across the whole filtered set — not just the loaded page — come from a
+separate facets request, which is also where the dropdown options and the token
+bar scale come from. Day headers group the rows already loaded, so a day's
+roll-up always equals the rows shown beneath it.
+
+Every row carries the session's title, project, model, turn count, duration,
+tokens, cost, git branch, permission mode and any linked PRs.
+
+---
+
+## Session detail and journey
+
+The detail page shows the session's own metrics — turns, steps per turn,
+longest autonomous chain, active duration, time Claude spent working, your
+average reply time, tool error rate — plus its token and cost breakdown, its
+compactions, and its linked pull requests.
+
+**Journey** reconstructs the run step by step: every prompt, response, tool call
+and tool result in order, with each sub-agent's steps nested underneath the
+`Task` call that spawned it. A sub-agent whose spawning call cannot be matched
+is appended to its turn rather than dropped. The journey is built on read, so it
+always reflects the current transcript.
+
+**Continue** resumes the session in a new Agento chat.
+
+---
+
+## Duration means active duration
+
+Claude Code sessions are resumable. A session started on Monday and picked up
+the following Monday spans a week — which is not a week of work. Everywhere
+Agento shows a duration it means **active** duration: the sum of the gaps
+between consecutive events, with any gap longer than the idle threshold
+excluded.
+
+The raw first-seen → last-touched span is still shown as secondary context,
+because it answers a different question.
+
+**The threshold is yours to set** — **Settings → Data & Analytics → Idle
+Threshold**, default 10 minutes, allowed range 1–240 minutes. Below a minute,
+reading one long reply ends the sitting; past four hours, active duration stops
+differing from the wall-clock span it exists to be different from.
+
+Changing it re-reads every transcript, because the durations are stored rather
+than recomputed on read. The same threshold decides:
+
+- the Avg Duration figure and the duration column and filter in the list,
+- **Claude working time** — the subset of active gaps that end at a reply from
+  Claude,
+- the response-time averages, which *exclude* an over-threshold gap rather than
+  capping it: a resume is a new sitting, not a 226-hour reply.
+
+---
+
+## Turns, not events
+
+A transcript's raw event count is not a conversation length. Claude Code injects
+events that look like user messages but are not: `<system-reminder>` blocks,
+slash-command expansions, task notifications, skill-invocation preambles,
+`[Request interrupted by user]` markers, and every tool result.
+
+Agento counts a **turn** only when a user event carries genuine human input,
+and it applies that same rule in three places — the session's message count, the
+insight pipeline's turn segmentation, and the journey's turn boundaries — so
+they cannot disagree. The raw event total is kept separately.
+
+Everything derived from turns follows: steps per turn, autonomy score, tokens
+per turn, longest autonomous chain, and the response-time averages.
+
+One deliberate exception: a session that contains *no* genuine turn — a slash
+command and its expansion, and nothing else — still takes its **preview text**
+from the injected wrapper, rendered as `/my-command` or `skill: my-skill`
+rather than raw tag soup. An unidentifiable blank row is worse than an
+imperfect label.
+
+---
+
+## Sub-agents
+
+Delegated work is scanned from `<session-id>/subagents/agent-*.jsonl` and rolled
+up **additively**:
+
+| Figure | Covers |
+|--------|--------|
+| Usage / Cost | The main thread only |
+| Sub-agent usage / cost | Delegated work only |
+| Total | Both, and what every aggregate report uses |
+
+**Model attribution is the one deliberate exception.** A sub-agent routinely
+runs a different model from its parent, so tokens and cost are credited to the
+model that actually spent them — otherwise the one chart that should answer *is
+delegation routing work to a cheaper model?* would be incapable of answering it.
+Session *counts* per model still follow the parent, because a session belongs to
+whoever ran it.
+
+---
+
+## Cost
+
+Cost is computed **per assistant message**, at that message's own model and
+timestamp, against the effective-dated [pricing catalog](pricing.md). It is then
+stored on the session, because a stored total carries neither the model nor the
+timing of the messages behind it and no later pass could reconstruct it.
+
+- **Token types are priced separately.** Input, output, cache reads and cache
+  writes bill at very different rates, and cache writes are split by TTL
+  (5-minute vs 1-hour) because those tiers bill differently.
+- **Cost is also stored keyed by the model that spent it**, which is what makes
+  "where is my money going" answerable. Those per-model figures always sum to
+  the session total; they re-key money, they never change it.
+- **A model with no published rate contributes no cost.** Its tokens are counted
+  and reported separately as unknown, so a partly-priced total is disclosed as a
+  floor rather than presented as complete. This is different from a model that
+  is genuinely free, which resolves and contributes a confident $0.00.
+
+Editing a rate re-prices history on the next scan — see
+[Pricing](pricing.md#maintaining-rates-from-the-ui).
+
+---
+
+## Analytics dashboard
+
+**Granularity follows the window** — hourly up to 7 days, daily to 120, weekly
+to 3 years, monthly to 12 years, yearly beyond. The series is never truncated,
+because a truncated series would be a lie about the window you asked for.
+
+**Everything is bucketed in your browser's timezone.** Storage and transport are
+UTC end to end; the frontend sends its IANA zone name and the backend applies it
+before deriving any day, hour or weekday. A bare `YYYY-MM-DD` date bound is a
+local day boundary. See [Development → Timezones](development.md#timezones).
+
+**Activity by hour counts a session in every hour it was running**, sharing its
+tokens out by overlap, rather than only in the hour it ended. Bucketing at the
+end time made the chart answer *when do my sessions finish?*. As a result the
+per-hour session counts add up to more than the session total — by design, and
+stated in the UI. Clicking an hour or a heatmap cell drills into the sessions
+that were running then.
+
+**Project breakdown** folds everything past the top 20 into a single `Other
+projects` row that carries the count it stands for, so the table stays readable
+and its total stays the window's total.
+
+Reports are memoised per window, and the key includes everything that can change
+the answer — the last scan, the pricing revision, the idle threshold and the
+hidden-project set — so there is no window in which a stale report is served.
+
+---
+
+## Insights
+
+The insight pipeline runs nine processors over each session's transcript and its
+sub-agent transcripts, and stores the results. A background worker reprocesses
+sessions as they change, sweeping every five minutes.
+
+**Attribution** breaks tool calls down by six dimensions: the skill, the plugin,
+the MCP server, the MCP tool, the sub-agent responsible, and the reasoning-effort
+tier. The MCP-tool panel sits directly under the MCP-server one because it is
+that chart's drill-down. `agent_breakdown` is empty for main-thread-only work,
+since Claude Code only stamps it on sub-agent transcripts.
+
+**Cache hit rate has exactly one definition**: cache reads as a share of *every*
+input-side token — fresh input plus cache writes plus cache reads. Under that
+denominator a model with no prompt caching scores 0 rather than being excused,
+which is the whole point of the metric.
+
+The Insights page also derives actionable cards from the stored data. The
+cache-savings card is the one figure anywhere that prices a counterfactual, and
+it is labelled `Estimated` for exactly that reason.
+
+---
+
+## Hiding projects
+
+Some projects do not belong in your numbers — a scratch directory, a client's
+repository, an experiment that skews every average.
+
+**Settings → Data & Analytics → Excluded projects** removes a project from every
+figure Agento reports: the sessions list, the analytics dashboard and the insight
+cards alike. No project picker will offer it either.
+
+Hidden is not deleted. The transcripts are still scanned and the cached rows stay
+correct, so unhiding is immediate and costs no re-read.
+
+---
+
+## API reference
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /api/claude-sessions` | Paged, filtered session list — returns `{items, next_cursor, has_more}` |
+| `GET /api/claude-sessions/facets` | Totals, dropdown options and scales across the filtered set |
+| `GET /api/claude-sessions/projects` | Projects for the picker (`?include_hidden=true` to include excluded ones) |
+| `GET /api/claude-sessions/status` | `files_done` / `files_total` / `scan_in_progress` / `costs_stale` |
+| `POST /api/claude-sessions/refresh` | Request a scan |
+| `GET /api/claude-sessions/{id}` | One session with its full detail |
+| `GET /api/claude-sessions/{id}/insights` | Stored insights for one session |
+| `GET /api/claude-sessions/{id}/journey` | Step-by-step timeline, sub-agents nested |
+| `POST /api/claude-sessions/{id}/continue` | Resume the session in a new Agento chat |
+| `GET /api/claude-sessions/insights/summary` | Aggregate insights for a window |
+| `GET /api/claude-analytics` | The analytics report for a window |
+
+List query parameters: `project`, `config_dir`, `q`, `favorites`, `links`
+(`any` / `with` / `without`), `permission_mode`, `model`, `from`, `to`,
+`sort`, `limit`, `cursor`, and inclusive `_min` / `_max` pairs for `messages`,
+`duration`, `tokens_in`, `tokens_out` and `cost`. Analytics and insights
+endpoints additionally take `tz` (an IANA zone name).
+
+A malformed numeric bound is ignored rather than rejected — those arrive from a
+number input a user is halfway through typing, and blanking the list between
+keystrokes would be worse.
+
+---
+
+## Troubleshooting
+
+**"No Claude sessions found" on a machine that has plenty.**
+Check that the config directory is indexed (**Settings → Data & Analytics**).
+If a scan is running, the list says so and how far along it is.
+
+**Everything is re-reading after an upgrade or a settings change.**
+Expected. An upgrade that changes parsing, a pricing edit or an idle-threshold
+change all invalidate stored per-session figures. Let it finish once.
+
+**Tokens show up but cost is missing.**
+The model has no rate in the catalog. Unpriced models are listed at the top of
+**Settings → Model Pricing** — see [Pricing](pricing.md).
+
+**A session appears under the wrong account.**
+When the same session ID exists in two config directories, the first one in the
+indexing order claims it — `~/.claude`, then the directory agent runs target,
+then the extras. Changing which directory runs target (**Settings → General**,
+or `CLAUDE_CONFIG_DIR`) changes which of the two wins.
+
+**Durations look far too long.**
+Check the idle threshold. A very high value makes active duration converge on
+the wall-clock span.

--- a/docs/development.md
+++ b/docs/development.md
@@ -63,7 +63,38 @@ The binary includes version info from the current git state:
 ## Run tests
 
 ```bash
-make test
+make test                                        # all Go tests
+go test ./internal/service/... -run TestChatService   # a single Go test
+
+cd frontend && npm run test                      # Vitest, run once
+cd frontend && npm run test:watch                # the watcher
+
+make e2e-setup                                   # first time: Playwright + Chromium
+make e2e                                         # Playwright against the built binary
+```
+
+Two suites need a word of explanation:
+
+- **`make bench-scale`** runs the scale harness against a generated `~/.claude`
+  corpus and asserts the scan, sessions-list and analytics budgets against it.
+  `SCALE=medium` (default) is ~800 sessions; `SCALE=large` is 5,000 sessions
+  across 500 projects and writes about a gigabyte. It sits behind the `scale`
+  build tag, so `make test` never runs it.
+- **The Claude Sessions e2e specs read the machine's real `~/.claude`** and skip
+  when it is too small to exercise what they check. They exist because two
+  behaviours cannot be verified through a CDP-driven Chrome tab, which reports
+  `visibilityState: "hidden"`: the list's infinite-scroll sentinel
+  (IntersectionObserver stops delivering) and the transcript's timeline jump
+  (smooth scrolling does not animate).
+
+Frontend tests run under jsdom with `src/test/setup.ts` loaded for every suite,
+which registers jest-dom's matchers and an `afterEach(cleanup)` — a break there
+breaks every file at once, not just the one you edited.
+
+Regenerate mocks after changing an interface:
+
+```bash
+make generate    # mockery, reads .mockery.yaml
 ```
 
 ---
@@ -71,10 +102,17 @@ make test
 ## Lint
 
 ```bash
-make lint
+make lint                          # golangci-lint over ./...
+cd frontend && npm run lint        # ESLint
+cd frontend && npm run typecheck   # tsc -b
+cd frontend && npm run format      # Prettier
 ```
 
-Runs `go vet`, `golangci-lint` (Go), and ESLint + Prettier (TypeScript).
+`npm run typecheck` uses `tsc -b` deliberately: the root `tsconfig.json` is a
+solution file with `"files": []`, so a plain `tsc --noEmit` checks nothing and
+exits 0.
+
+Pre-commit hooks enforce all of the above on every commit.
 
 ---
 
@@ -82,28 +120,66 @@ Runs `go vet`, `golangci-lint` (Go), and ESLint + Prettier (TypeScript).
 
 ```
 agento/
-├── cmd/              # Cobra commands (web, ask, update)
+├── cmd/              # Cobra commands (web, ask, update, service)
 ├── frontend/         # React + TypeScript UI
 ├── internal/
-│   ├── agent/        # SDK integration, RunOptions, session execution
-│   ├── api/          # HTTP handlers
-│   ├── build/        # Build-time version variables
-│   ├── config/       # AppConfig, AgentConfig, MCP config
-│   ├── logger/       # Structured slog loggers (system + per-session), log rotation
-│   ├── server/       # HTTP server wiring
+│   ├── agent/          # SDK integration, RunOptions, session execution
+│   ├── api/            # HTTP handlers
+│   ├── build/          # Build-time version variables
 │   ├── claudesessions/ # Claude session scanner, analytics, processor pipeline, journey
+│   ├── config/         # AppConfig, AgentConfig, MCP config, Claude config dirs, settings
+│   ├── daemon/         # `agento service` — launchd / systemd user units
 │   ├── eventbus/       # In-process event bus
-│   ├── integrations/   # Integration registry + MCP servers (Google, GitHub, Slack, Jira, Confluence, Telegram)
+│   ├── integrations/   # Integration registry + in-process MCP servers
+│   │                   #   (Google, GitHub, Slack, Jira, Confluence, Telegram, WhatsApp)
+│   ├── logger/         # Structured slog loggers (system + per-session), log rotation
 │   ├── notification/   # Notification system (SMTP email)
+│   ├── pricing/        # Effective-dated model pricing catalog and resolver
 │   ├── scheduler/      # Task scheduler and job executor
-│   ├── service/        # Business logic (AgentService, ChatService, TaskService, NotificationService, etc.)
-│   ├── storage/        # SQLite persistence (~/.agento/agento.db)
-│   ├── telemetry/      # OpenTelemetry traces, metrics, logs (config, providers, hot-reload manager)
-│   └── tools/          # Local MCP tool server
+│   ├── server/         # HTTP server wiring, router, API guards
+│   ├── service/        # Business logic (AgentService, ChatService, TaskService, …)
+│   ├── storage/        # SQLite persistence (~/.agento/agento.db) and migrations
+│   ├── telemetry/      # OpenTelemetry traces, metrics, logs (config, providers, hot-reload)
+│   ├── tools/          # Local MCP tool server
+│   ├── trigger/        # Inbound-message dispatcher (Telegram triggers)
+│   └── updater/        # Release check and in-place self-update
+├── e2e/              # Playwright end-to-end tests
 ├── docs/             # Documentation
 ├── .goreleaser.yaml  # Release configuration
 └── Makefile
 ```
+
+**Import rule:** `config` ← `service` ← `api`, never the reverse.
+
+---
+
+## Conventions worth knowing before you change things
+
+**Database migrations** are appended to the migrations slice in
+`internal/storage/`; each one must also bump the hardcoded expected version in
+`sqlite_test.go`. Migrations are forward-only.
+
+**Cached-figure version constants.** Anything the scanner or the insight
+pipeline *stores* per session is only recomputed when the data looks stale.
+Changing how a stored figure is derived therefore means bumping the matching
+constant — `CurrentScannerVersion` for scanner output, `CurrentProcessorVersion`
+for insight output — to force a re-read. Some predicates are shared by both
+sides (turn segmentation is the notable one), and a change there needs **both**
+bumped, or the two halves drift apart.
+
+User-caused staleness works the same way but cannot be a constant: the pricing
+catalog revision and the idle threshold are recorded alongside the cache, and a
+drift in either invalidates it.
+
+**Per-session metrics are defined twice, deliberately** — in SQL
+(`internal/claudesessions/session_query.go`, which the list filters and sorts on)
+and in TypeScript (`frontend/src/lib/sessionMetrics.ts`, which renders the row).
+They must agree, or a row showing $36.30 gets hidden by "cost at most $40".
+`internal/claudesessions/testdata/session_metric_vectors.json` is read by both
+languages' tests so a change to one definition fails the other's.
+
+**API types are mirrored** in `frontend/src/types.ts`; keep them in step when
+changing a response shape.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,5 +1,9 @@
 # Getting Started
 
+**Requirements:** the [Claude Code CLI](https://claude.ai/code), installed and
+authenticated. If `claude` runs in your terminal, Agento works — it uses the
+authentication Claude Code already has, so no Anthropic API key is needed.
+
 ## Install
 
 **Homebrew (macOS and Linux)**
@@ -43,6 +47,29 @@ This starts Agento on port **8990** and opens your browser automatically.
 
 Visit [http://localhost:8990](http://localhost:8990) in your browser.
 
+Agento binds to **loopback only** and ships **without authentication** — it is
+meant to run on the machine you are working at. To reach it from a phone or
+another computer, see [Security](security.md#reaching-agento-from-another-device).
+
+---
+
+## What happens on first run
+
+Agento finds the Claude Code history already on your disk and starts indexing
+it. On a large corpus the first scan takes a few minutes; the sessions list shows
+its progress while it runs, and everything else is usable in the meantime.
+
+When it finishes you have a searchable history of every Claude Code session,
+cost analytics and productivity insights — see
+[Claude Sessions](claude-sessions.md). Nothing is uploaded; the transcripts are
+read where they already are and cached locally.
+
+From there:
+
+- Build an [agent](agents.md) and chat with it
+- Put it on a [schedule](tasks.md)
+- Connect [integrations](integrations.md) so agents can use your tools
+
 ---
 
 ## Options
@@ -51,13 +78,20 @@ Visit [http://localhost:8990](http://localhost:8990) in your browser.
 |------|---------------------|---------|-------------|
 | `--port` | `PORT` | `8990` | HTTP server port |
 | `--no-browser` | — | false | Do not open the browser on startup |
-| — | `AGENTO_DATA_DIR` | `~/.agento` | Directory where agents, chats, and logs are stored |
-| — | `AGENTO_DEFAULT_MODEL` | Claude Sonnet | Claude model used for direct (no-agent) chat |
+| — | `AGENTO_BIND` | `127.0.0.1` | Interface to listen on. `0.0.0.0` exposes an unauthenticated API to your whole network — read [Security](security.md) first |
+| — | `AGENTO_PUBLIC_URL` | — | The externally reachable URL, when Agento is behind a reverse proxy, a tunnel, or serving Telegram webhooks |
+| — | `AGENTO_DATA_DIR` | `~/.agento` | Directory where agents, chats, and logs are stored. `~` is expanded |
+| — | `CLAUDE_CONFIG_DIR` | `~/.claude` | Claude Code's own variable — which account agent runs authenticate as |
+| — | `AGENTO_DEFAULT_MODEL` | `sonnet` | Claude model used for direct (no-agent) chat |
+| — | `ANTHROPIC_DEFAULT_SONNET_MODEL` | — | Anthropic's standard variable, used as a soft default when the above is unset |
 | — | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warn`, `error` |
 | — | `AGENTO_WORKING_DIR` | `/tmp/agento/work` | Default working directory for agent sessions |
 | — | `ANTHROPIC_API_KEY` | — | Anthropic API key (optional if already stored by the Claude CLI) |
 | — | `OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP gRPC endpoint for traces/metrics/logs (see [Monitoring](monitoring.md)) |
 | — | `OTEL_METRICS_EXPORTER` | — | `otlp` or `prometheus` (see [Monitoring](monitoring.md)) |
+
+Most of these also have a field in **Settings**. An environment variable always
+wins, and the UI shows the field as locked when one is set.
 
 **Example: run on a different port**
 
@@ -118,3 +152,32 @@ When Agento runs as a background service (see above), a successful `agento updat
 ```bash
 agento --version
 ```
+
+---
+
+## Command reference
+
+```
+agento web [--port int] [--no-browser]              Start the web UI
+agento ask [--agent slug] [--no-thinking]           Ask an agent a one-off question
+           [--agents-dir path] [--mcps-file path]
+           <question> [session-id]
+agento update [-y] [--no-restart]                   Update to the latest release
+agento service <install|uninstall|start|stop|restart|status|logs>
+agento service logs [-f] [-n lines]                 Read the service log
+```
+
+Passing a session ID to `agento ask` continues that conversation.
+
+---
+
+## Where to go next
+
+- [Claude Sessions](claude-sessions.md) — the analytics built from your Claude Code history
+- [Agents](agents.md) — system prompts, models, tools, template variables
+- [Tasks](tasks.md) — running agents on a schedule
+- [Integrations](integrations.md) — Google, GitHub, Slack, Jira, Confluence, Telegram, WhatsApp
+- [Pricing](pricing.md) — how cost is calculated and how to maintain the catalog
+- [Security](security.md) — network exposure, guards, and where your data lives
+- [Monitoring](monitoring.md) — OpenTelemetry traces, metrics and logs
+- [Development](development.md) — architecture and contribution workflow

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -6,11 +6,15 @@ Currently supported:
 - **Google** — Calendar, Gmail, Drive (OAuth 2.0)
 - **GitHub** — Repos, issues, pull requests, actions, releases (Personal Access Token)
 - **Slack** — Channels, messages, users (Bot Token / OAuth)
-- **Jira** — Issues, projects, boards (API Token)
+- **Jira** — Issues, projects, transitions, comments (API Token)
 - **Confluence** — Pages, spaces, search (API Token)
-- **Telegram** — Messages, chats, media (Bot Token)
+- **Telegram** — Messages, chats, media (Bot Token) — and inbound [triggers](#triggers-run-an-agent-from-an-incoming-message)
+- **WhatsApp** — Messages, media, contacts (paired device, QR code)
 
 All integrations are managed from the **Integrations** page in the UI. Each has its own setup flow — click the service card to configure credentials, enable tools, and connect.
+
+> **Credentials are stored unencrypted** in `~/.agento/agento.db`, which is only
+> as protected as your home directory. See [Security](security.md#where-your-data-lives).
 
 ---
 
@@ -171,6 +175,10 @@ A Jira API Token and your Atlassian site URL (e.g., `https://yoursite.atlassian.
 | `search_issues` | Search issues with JQL |
 | `get_issue` | Get issue details by key (e.g., PROJ-123) |
 | `create_issue` | Create a new issue |
+| `update_issue` | Update an existing issue |
+| `add_comment` | Add a comment to an issue |
+| `list_transitions` | List the workflow transitions available on an issue |
+| `transition_issue` | Move an issue through a workflow transition |
 
 ---
 
@@ -196,6 +204,7 @@ A Confluence API Token and your Atlassian site URL.
 | `search_content` | Search content with CQL |
 | `get_page` | Get page content and metadata by ID |
 | `create_page` | Create a new page in a space |
+| `update_page` | Update an existing page |
 
 ---
 
@@ -221,3 +230,76 @@ A Telegram Bot Token from [@BotFather](https://t.me/botfather).
 | `send_location` | Send a geographic location |
 | `create_poll` | Create a poll in a chat |
 | `read_messages` | Read recent messages (bot updates) |
+| `get_chat_info` | Get details of a chat |
+| `get_chat_members` | List administrators/members of a chat |
+| `forward_message` | Forward a message to another chat |
+| `edit_message` | Edit a message the bot sent |
+| `delete_message` | Delete a message |
+| `pin_message` | Pin a message in a chat |
+
+---
+
+## WhatsApp Integration
+
+WhatsApp connects by **pairing a device**, the same way WhatsApp Web does —
+there is no token to create.
+
+### Setup
+
+1. Go to **Integrations** and click the **WhatsApp** card
+2. Enter a name and save
+3. Start pairing — a QR code appears
+4. Scan it from **WhatsApp → Linked devices** on your phone
+5. The card shows **Connected** once the device is linked
+
+If the session drops, reconnect from the integration page; if the link was
+removed on the phone, pair again to get a fresh QR code.
+
+### Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `send_message` | Send a text message to a phone number or group JID |
+| `send_media` | Send an image or document by URL |
+| `get_contacts` | List contacts from the linked device |
+
+---
+
+## Triggers: run an agent from an incoming message
+
+A trigger runs one of your [agents](agents.md) when a message arrives on
+Telegram, and replies in the same chat. Trigger rules are configured on the
+Telegram integration's page.
+
+### Rule fields
+
+| Field | Purpose |
+|-------|---------|
+| Name | Label for the rule |
+| Agent | Which agent handles a matching message |
+| Enabled | Turn the rule off without deleting it |
+| Prefix filter | Only messages starting with this text match (case-insensitive) |
+| Keyword filter | Only messages containing one of these keywords match |
+| Chat ID filter | Only messages from these chats match |
+
+Empty filters match everything. All configured filters must pass for a rule to
+fire, and runs are dispatched with bounded concurrency so a burst of messages
+cannot spawn unlimited agent runs.
+
+### Webhook setup
+
+Telegram delivers messages over a webhook, so Agento must be reachable from the
+internet:
+
+1. Set **Public URL** in **Settings → General** (or `AGENTO_PUBLIC_URL`) to the
+   address Telegram should call.
+2. Register the webhook from the Telegram integration page and check its status
+   there.
+
+Registration generates a secret token that Telegram returns on every delivery;
+Agento verifies it and rejects anything else. Regenerate it from the same page
+if it may have leaked. See [Security](security.md#inbound-webhooks).
+
+A trigger runs unattended, so mind the agent's
+[permission mode](security.md#agent-permission-modes) — anyone who can message
+the bot and pass the filters can start a run.

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -19,7 +19,9 @@ Go to **Settings → Monitoring**, toggle **Enable monitoring**, fill in your ex
 | Insecure | Enable when the collector does not use TLS (typical for local setups) |
 | Metric export interval | How often to push metrics, in milliseconds (default: 60 000) |
 
-> **Note:** If any `OTEL_*` environment variable is set, the UI shows an amber lock banner and the fields become read-only. Unset the env vars to use the UI instead.
+> **Note:** If any `OTEL_*` environment variable is set, the UI shows an amber lock banner and the fields become read-only (a write is rejected with `409 Conflict`). Unset the env vars to use the UI instead.
+
+Telemetry is **off unless you configure it**. Nothing is exported anywhere by default.
 
 ### Option 2 — Environment variables
 
@@ -48,6 +50,11 @@ export OTEL_METRICS_EXPORTER=prometheus
 agento web
 # Metrics available at http://localhost:8990/metrics
 ```
+
+`/metrics` and `/health` sit outside the API and its
+[guards](security.md#browser-based-protections), so a scraper does not need to
+send JSON or a matching `Host`. They are still only reachable wherever Agento is
+bound — loopback by default.
 
 ---
 

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -4,6 +4,10 @@ Agento estimates Claude Code session cost from the pricing catalog in
 `internal/pricing/`: a SQLite table (`model_pricing`) of effective-dated rates,
 seeded from the embedded `catalog.json` on startup.
 
+Cost is computed per assistant message, at that message's own model and
+timestamp, and stored on the session — see
+[Claude Sessions → Cost](claude-sessions.md#cost) for what is done with it.
+
 ## Why effective dating
 
 A rate row carries an `effective_from` timestamp, and cost lookups take
@@ -36,12 +40,18 @@ instead), and correcting refuses to create one. Reaching for "correct" when the
 price merely changed is how a user silently rewrites their own history, and the
 API is shaped to make that hard.
 
+A rate can also be **deleted** — for a row that should never have existed. That
+leaves the usage it covered priced by whatever earlier rate now wins, or unpriced
+if there is none.
+
 Models seen in your sessions with no rate at all appear at the top of the tab —
 their tokens are excluded from every cost total until priced, so that list is
 the tab's most useful starting point.
 
 Saving any change bumps the catalog revision, which invalidates the cached
-session costs; they recompute on the next scan. Rows you edit are marked
+session costs; they recompute on the next scan — a **full re-read of every
+transcript**, because re-pricing needs each message's own model and timestamp.
+On a large corpus that takes a few minutes. Rows you edit are marked
 user-modified and survive upgrades untouched.
 
 ## Maintaining rates
@@ -90,19 +100,57 @@ Two flags qualify a match:
   concrete model, so they are priced at that tier's current flagship and say
   so. The resolver also sets this when usage predates every row for a pattern.
 
+## Context-length rate tiers
+
+Some providers charge more for a long request. A rate can therefore carry
+**bands**, each keyed by an inclusive upper bound on the request's input tokens:
+
+```json
+"tiers": [
+  { "max_input_tokens": 256000,  "input": 0.40, "output": 1.60, "cache_read": 0.04 },
+  { "max_input_tokens": 1000000, "input": 1.20, "output": 4.80, "cache_read": 0.12 }
+]
+```
+
+Four things about how bands behave:
+
+- **A band is selected, not accumulated.** Alibaba bills every token of a request
+  at the chosen band's rate, so there is no progressive-bracket arithmetic. A
+  request larger than every declared bound uses the highest band.
+- **The boundary counts all input-side tokens** — fresh input plus cache reads
+  plus cache writes. The providers state how cached tokens are billed but not
+  whether they count toward the bound; this reading is documented in the code and
+  changed only there.
+- **A rate with no bands is unaffected.** The flat arithmetic did not move; an
+  empty band list simply skips band selection.
+- **The UI shows bands read-only.** Editing them is deliberately not offered —
+  and because a band is picked *before* any price is applied, correcting a tiered
+  rate by hand would otherwise save and then change nothing at any request size.
+  Correcting a rate therefore **clears its bands** and makes it flat: your value
+  wins, which is the same rule `user_modified` encodes elsewhere.
+
+Bands live in their own table, so the `UNIQUE(model_pattern, effective_from)`
+identity — and with it the add-vs-correct semantics above — is untouched. The
+catalog revision hashes them, so a band correction re-prices stored costs like
+any other change.
+
 ## Non-Anthropic providers
 
 Claude Code is routinely pointed at Anthropic-API-compatible backends, so the
-catalog is not Anthropic-only. Seeded as of 2026-08-09, International endpoints:
+catalog is not Anthropic-only. Seeded as of 2026-08-09, International endpoints,
+USD per million tokens:
 
-| Provider | Pattern | Input | Output | Cache read |
-|---|---|---|---|---|
-| Moonshot | `k3` (exact), `kimi-k3` | 3.00 | 15.00 | 0.30 |
-| Z.ai / Zhipu | `glm-5.2` | 1.40 | 4.40 | 0.26 |
-| Alibaba | `qwen3.5-397b-a17b` | 0.60 | 3.60 | 0.06 |
-| Alibaba | `qwen3.5-plus` | 0.40 | 2.40 | 0.04 |
-| Alibaba | `qwen3.5-flash` | 0.10 | 0.40 | 0.01 |
-| Alibaba | `qwen3-max` | 1.20 | 6.00 | 0.12 |
+| Provider | Pattern | Input | Output | Cache read | Context bands |
+|---|---|---|---|---|---|
+| Moonshot | `k3` (exact), `kimi-k3` | 3.00 | 15.00 | 0.30 | — |
+| Z.ai / Zhipu | `glm-5.2` | 1.40 | 4.40 | 0.26 | — |
+| Alibaba | `qwen3.7-max` | 2.50 | 7.50 | 0.25 | — |
+| Alibaba | `qwen3.7-plus` | 0.40 | 1.60 | 0.04 | ≤256K, then 1.20 / 4.80 |
+| Alibaba | `qwen3.6-flash` | 0.25 | 1.50 | 0.025 | ≤256K, then 1.00 / 4.00 |
+| Alibaba | `qwen3.5-397b-a17b` | 0.60 | 3.60 | 0.06 | — |
+| Alibaba | `qwen3.5-plus` | 0.40 | 2.40 | 0.04 | ≤256K, then 0.50 / 3.00 |
+| Alibaba | `qwen3.5-flash` | 0.10 | 0.40 | 0.01 | — |
+| Alibaba | `qwen3-max` | 1.20 | 6.00 | 0.12 | ≤32K, ≤128K 2.40 / 12.00, ≤256K 3.00 / 15.00 |
 
 Notes for the next refresh:
 
@@ -112,12 +160,13 @@ Notes for the next refresh:
 - **Alibaba prices caching as a percentage rule**, not per model: explicit-cache
   creation is 125% of input and hits are 10%. Their rows encode that, which is
   also why their 1-hour column is 1.25× rather than the Anthropic 2×.
-- **Alibaba tiers by context length** and the catalog has no context dimension.
-  The base tier is seeded; `qwen3.5-plus` costs $0.50/$3.00 above 256K and
-  `qwen3-max` $2.40/$12.00 above 32K, so long-context usage under-reports.
+- **Band bounds use the provider's own K/M labels read as decimal** (256K =
+  256,000). The pricing pages do not say whether K means 1000 or 1024, and
+  inventing the binary reading would be precision they never published.
 - Several Alibaba models carry a "Limited-time X% off" against a separate list
-  price. Capture those with an `effective_from` so the expiry does not silently
-  misprice history.
+  price. Where an expiry is published, capture it with an `effective_from` so
+  the reversion does not silently misprice history; where none is published, no
+  boundary row is seeded rather than guessing one.
 - **Qwen3.8-Max is deliberately absent.** It appears on Alibaba's marketplace
   but on no pricing page, with two competing IDs in circulation and no
   published rate — seeding it would be a guess. A missing row costs nothing and

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,181 @@
+# Security and network exposure
+
+Agento is a single-user desktop application. It ships **without
+authentication**, on purpose — there are no accounts to manage on a tool that
+runs on the machine you are already logged into.
+
+That choice is only safe while nothing else can reach the API. This page
+describes what protects it, what does not, and what you have to do yourself if
+you expose it.
+
+- [What the API can do](#what-the-api-can-do)
+- [The default: loopback only](#the-default-loopback-only)
+- [Browser-based protections](#browser-based-protections)
+- [Reaching Agento from another device](#reaching-agento-from-another-device)
+- [Behind a reverse proxy or tunnel](#behind-a-reverse-proxy-or-tunnel)
+- [Inbound webhooks](#inbound-webhooks)
+- [Where your data lives](#where-your-data-lives)
+- [Agent permission modes](#agent-permission-modes)
+- [Reporting a vulnerability](#reporting-a-vulnerability)
+
+---
+
+## What the API can do
+
+Treat access to the Agento API as **shell access to the machine**. Two requests
+are enough:
+
+```
+POST /api/agents            → create an agent with the Bash tool and bypass permissions
+POST /api/chats/{id}/messages → run it
+```
+
+There is no configuration that makes this untrue. Every protection below exists
+to control *who can send those requests*.
+
+---
+
+## The default: loopback only
+
+`AGENTO_BIND` defaults to `127.0.0.1`, so out of the box only processes on your
+own machine can connect. The startup log names the interface it bound to.
+
+> **Upgrading from an older version?** Agento used to listen on every interface.
+> If you reached it from another device and that stopped working, see
+> [below](#reaching-agento-from-another-device).
+
+---
+
+## Browser-based protections
+
+A loopback bind does not help against a web page you visit, because the browser
+is already inside the loopback boundary. Two middlewares, scoped to `/api`,
+close that route.
+
+**1. State-changing requests must declare JSON** — otherwise `415 Unsupported
+Media Type`.
+
+A cross-origin `POST` carrying `Content-Type: text/plain` is a CORS *simple
+request*: the browser sends it with **no preflight**. The attacker cannot read
+the response, but the side effect has already happened — and handlers decode
+JSON regardless of the declared type. Requiring `application/json` removes the
+simple-request status, which forces a preflight that same-origin CORS then
+refuses.
+
+`GET`, `HEAD` and `OPTIONS` are untouched. A body-less `POST` is deliberately
+*not* exempt, because a body-less cross-origin `POST` is itself a simple
+request. `multipart/form-data` is admitted for the one endpoint that uploads
+files.
+
+**2. The `Host` header must name a host Agento is served under** — otherwise
+`403 Forbidden`.
+
+DNS rebinding defeats CORS completely: an attacker's domain that resolves to
+`127.0.0.1` is *same-origin* as far as the browser is concerned, so no
+cross-origin rule applies at all. Validating `Host` is what stops it.
+
+Accepted: `localhost`, any loopback IP, the host of your configured
+[public URL](#behind-a-reverse-proxy-or-tunnel), and the bind address — where a
+bind of `0.0.0.0` or `::` admits any bare **IP literal**, since clients dial the
+machine's LAN address rather than the wildcard. That keeps the rebinding
+property intact, because rebinding needs a *name* whose DNS the attacker
+controls, and a name is never an IP literal. Reaching Agento over the LAN under
+a hostname needs the public URL set.
+
+**Both guards apply to `/api` only.** `/health`, `/metrics` and
+`POST /webhooks/telegram/{id}` are outside them — the webhook arrives from
+Telegram's servers with a foreign `Host` and is authenticated by
+[its own secret](#inbound-webhooks) instead.
+
+---
+
+## Reaching Agento from another device
+
+```bash
+AGENTO_BIND=0.0.0.0 agento web
+```
+
+This exposes an unauthenticated API that can run commands on your machine to
+**everyone on that network**. Only do it on a network you trust, or put a proxy
+that authenticates in front of it.
+
+---
+
+## Behind a reverse proxy or tunnel
+
+If you reach Agento under a hostname rather than an IP, tell it that hostname or
+every API request will be refused with `403`:
+
+- **Settings → General → Public URL**, or
+- the `AGENTO_PUBLIC_URL` environment variable, which locks the field in the UI.
+
+```bash
+AGENTO_PUBLIC_URL=https://agento.example.com AGENTO_BIND=0.0.0.0 agento web
+```
+
+The stored value is re-read per request, so setting it in the UI takes effect
+immediately — no restart. A value without a scheme (`agento.example.com`) is
+accepted.
+
+Agento does not terminate TLS. If it is reachable beyond your machine, put HTTPS
+and authentication on the proxy.
+
+---
+
+## Inbound webhooks
+
+Telegram triggers require a publicly reachable URL, which is what the public URL
+setting is for. Registering the webhook generates a secret token that Telegram
+sends back in the `X-Telegram-Bot-Api-Secret-Token` header; Agento verifies it on
+every delivery and rejects anything else. Rotate it from the integration page if
+it may have leaked.
+
+---
+
+## Where your data lives
+
+Everything is local, in `~/.agento` (or `AGENTO_DATA_DIR`):
+
+| Path | Contents |
+|------|----------|
+| `agento.db` | Agents, chats, tasks, integrations, settings, cached Claude session analytics |
+| `logs/system.log` | Rotating application log |
+| `logs/sessions/<id>.log` | Per-session logs |
+| `mcps.yaml` | External MCP server registry |
+
+**Integration credentials — bot tokens, API tokens, OAuth refresh tokens — are
+stored in that database as-is.** There is no encryption at rest, and the
+database is only as protected as the file permissions on your home directory.
+Treat `~/.agento/agento.db` as a secret, and do not sync it to a shared
+location.
+
+Claude Code's own transcripts are read from `~/.claude` (and any other
+[indexed config directory](claude-sessions.md#multiple-claude-accounts)) and
+never modified. Nothing is uploaded anywhere: there is no account, no telemetry
+and no server component. OpenTelemetry export is off unless you configure it
+yourself — see [Monitoring](monitoring.md).
+
+---
+
+## Agent permission modes
+
+An agent's permission mode decides what happens when it wants to use a tool:
+
+| Mode | Behaviour |
+|------|-----------|
+| `bypass` (default) | Tools run without asking |
+| `default` | Claude Code's normal prompting |
+| `plan` | Plans first, acts only after you approve |
+| `dontAsk` | Runs without prompting for permitted tools |
+
+`bypass` is the default because agents are usually run unattended, but it means
+an agent holding `Bash` can do anything you can. Give an agent only the tools it
+needs, and prefer `plan` for anything that writes files or runs commands —
+especially for scheduled tasks and Telegram triggers, where nobody is watching
+the run.
+
+---
+
+## Reporting a vulnerability
+
+See [SECURITY.md](../SECURITY.md).

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,0 +1,103 @@
+# Scheduled tasks
+
+A task runs an agent on a schedule and records every execution. Create and
+manage them under **Tasks** in the UI.
+
+- [Creating a task](#creating-a-task)
+- [Schedule types](#schedule-types)
+- [Stop conditions](#stop-conditions)
+- [Job history](#job-history)
+- [Notifications](#notifications)
+- [API](#api)
+
+---
+
+## Creating a task
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| Name | Yes | Shown in the task list and in notifications |
+| Description | No | Free text |
+| Prompt | Yes | What the agent is asked to do on every run |
+| Agent | No | Which saved [agent](agents.md) runs it. Without one, the default model and no system prompt are used |
+| Working directory | No | Where the run executes. Defaults to `AGENTO_WORKING_DIR` |
+| Model | No | Overrides the agent's model for this task |
+| Settings profile | No | Which [Claude settings profile](agents.md#claude-settings-profiles) the run uses |
+| Timeout | No | Minutes before the run is abandoned |
+| Save output | No | Keep the full response text in job history |
+
+The prompt supports the same `{{current_date}}` and `{{current_time}}`
+placeholders as an agent's system prompt.
+
+A task runs unattended, so the agent's [permission mode](security.md#agent-permission-modes)
+matters more than usual — nobody is there to answer a prompt.
+
+---
+
+## Schedule types
+
+| Type | Configuration | Behaviour |
+|------|---------------|-----------|
+| `run_immediately` | — | Runs once, as soon as it is saved. The default when no schedule is chosen |
+| `one_off` | A date and time | Runs once, then goes idle |
+| `interval` | Every N minutes / hours / days, optionally at a fixed `HH:MM` for daily intervals | Repeats |
+| `cron` | A cron expression | Repeats |
+
+The task list shows each task's last run, its outcome, and when it is next due.
+A task can be **paused** and **resumed** without losing its history; resuming
+recalculates the next run.
+
+---
+
+## Stop conditions
+
+A repeating task can be told to stop by itself:
+
+- **after N runs** — `stop_after_count`
+- **after a date** — `stop_after_time`
+
+Both are optional; without them the task repeats indefinitely until paused or
+deleted.
+
+---
+
+## Job history
+
+Every execution is recorded, whether it succeeded or not:
+
+- status (`running`, `success`, `failed`), start time and duration
+- the model used and the chat session the run created
+- input, output, cache-read and cache-write token counts
+- the error message on failure, and the full response text when **Save output**
+  is on
+
+Browse it per task from the task's page, or across all tasks under **Job
+History**, where old records can be deleted in bulk.
+
+---
+
+## Notifications
+
+With SMTP configured under **Settings → Notifications**, Agento can email you
+when a task finishes and when one fails — each toggled separately, both on by
+default. Send a test message from the same tab to verify the configuration, and
+check the notification log to see what was delivered.
+
+---
+
+## API
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET/POST /api/tasks` | List and create |
+| `GET/PUT/DELETE /api/tasks/{id}` | Read, update, delete |
+| `POST /api/tasks/{id}/pause` · `/resume` | Pause and resume |
+| `GET /api/tasks/{id}/job-history` | One task's runs |
+| `GET/DELETE /api/job-history` | All runs; bulk delete |
+| `GET/DELETE /api/job-history/{id}` | One run |
+| `GET/PUT /api/notifications/settings` | Notification configuration |
+| `POST /api/notifications/test` | Send a test email |
+| `GET /api/notifications/log` | Delivery log |
+
+State-changing requests must send `Content-Type: application/json` — see
+[Security](security.md#browser-based-protections).


### PR DESCRIPTION
Closes #250

Documentation-only. No code, no behaviour change.

The last few weeks moved a lot of behaviour and touched no documentation. The gap was not evenly spread: the Claude Sessions surface — the thing most of that work was about — had no page at all, while the pages that did exist had drifted into stating things that are no longer true.

## Outdated claims fixed

| File | Was |
|---|---|
| `docs/pricing.md` | "the catalog has no context dimension", long-context usage "under-reports" — context tiers landed in #218. Rate table two generations behind the seeds, no bands |
| `docs/agents.md` | `built_in` = `current_time`/`current_date`, `local` = `bash`/`read_file`; `mcps.yaml` example with a `servers:` root key the parser does not read, and no `transport` |
| `docs/development.md` | Layout predating `internal/{pricing,trigger,updater,daemon}` and the `service` command |
| `.env.example` | `AGENTS_DIR` / `MCPS_FILE` (no longer env vars), `ANTHROPIC_API_KEY` marked required, port 3000 |
| env tables | No `AGENTO_BIND`, `AGENTO_PUBLIC_URL` or `CLAUDE_CONFIG_DIR` anywhere in `docs/` |

## New pages

- **`docs/claude-sessions.md`** — what is scanned, indexing several Claude accounts (reading is a set, running is a choice), what triggers a full re-read, the paged sessions list and its filters, active duration and the idle threshold, why turns are not events, sub-agent roll-up and the model-attribution exception, stored cost and `cost_by_model`, analytics granularity and span-based hour bucketing, insights, hidden projects, the API surface, troubleshooting.
- **`docs/security.md`** — API access is shell access, the loopback default, both #246 guards and the attacks they close (CORS simple requests, DNS rebinding), reaching Agento from another device, the public URL, webhook secrets, permission modes, and that integration credentials sit unencrypted in `agento.db`.
- **`docs/tasks.md`** — the scheduler's four schedule types, stop conditions, job history and notifications.

## Also

- Integrations: the missing WhatsApp section, the Telegram trigger + webhook flow, and the Jira / Confluence / Telegram tools added since that page was written.
- Getting started: a first-run section (the initial scan), the full env table, and a command reference.
- Development: the real test commands (Vitest, Playwright, `bench-scale`, mockery) and the conventions that bite — migrations, the scanner/processor version constants, and per-session metrics defined in both SQL and TypeScript.

## Verification

Every claim was checked against the code rather than carried over from `CLAUDE.md`. Corrections found that way include: `MCPS_FILE`/`AGENTS_DIR` are CLI flags now, not env vars; the sessions search covers session ID + three title columns + preview + project path; `Host` validation admits bare IP literals under a wildcard bind. A script checked that every relative link and anchor across all doc files resolves.

Pre-commit passed on everything applicable — the four frontend hooks were skipped, as this branch changes no file under `frontend/src`, and their node environment does not install on this machine.