### PR TITLE
feat(claude-sessions): add a Refresh button to the session detail page

### DIFF
--- a/frontend/src/pages/ClaudeSessionDetailPage.test.tsx
+++ b/frontend/src/pages/ClaudeSessionDetailPage.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import ClaudeSessionDetailPage from './ClaudeSessionDetailPage'
+import { claudeSessionsApi, insightsApi } from '@/lib/api'
+import type { ClaudeSessionDetail } from '@/types'
+
+vi.mock('@/lib/api', () => ({
+  claudeSessionsApi: {
+    get: vi.fn(),
+    refresh: vi.fn(),
+    toggleFavorite: vi.fn(),
+    updateTitle: vi.fn(),
+    continue: vi.fn(),
+  },
+  insightsApi: {
+    getSession: vi.fn(),
+  },
+}))
+
+const SESSION_ID = 'sess-1'
+
+const zeroUsage = {
+  input_tokens: 0,
+  output_tokens: 0,
+  cache_read_tokens: 0,
+  cache_creation_tokens: 0,
+  cache_creation_5m_tokens: 0,
+  cache_creation_1h_tokens: 0,
+}
+const zeroCost = {
+  input_usd: 0,
+  output_usd: 0,
+  cache_read_usd: 0,
+  cache_write_usd: 0,
+  total_usd: 0,
+}
+
+const detailFixture = (over: Partial<ClaudeSessionDetail> = {}): ClaudeSessionDetail =>
+  ({
+    session_id: SESSION_ID,
+    project_path: '/home/me/proj',
+    preview: 'A session',
+    start_time: '2026-08-13T08:00:00Z',
+    last_activity: '2026-08-13T08:15:00Z',
+    message_count: 3,
+    event_count: 5,
+    usage: { ...zeroUsage },
+    subagent_count: 0,
+    subagent_usage: { ...zeroUsage },
+    compaction_count: 0,
+    dropped_tokens: 0,
+    cost: { ...zeroCost },
+    subagent_cost: { ...zeroCost },
+    messages: [],
+    todos: [],
+    subagents: [],
+    ...over,
+  }) as ClaudeSessionDetail
+
+const renderPage = () =>
+  render(
+    <MemoryRouter initialEntries={[`/claude-sessions/${SESSION_ID}`]}>
+      <Routes>
+        <Route path="/claude-sessions/:id" element={<ClaudeSessionDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.setPointerCapture = vi.fn()
+  Element.prototype.releasePointerCapture = vi.fn()
+
+  class Observer {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() {
+      return []
+    }
+  }
+  vi.stubGlobal('IntersectionObserver', Observer)
+  vi.stubGlobal('ResizeObserver', Observer)
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  )
+})
+
+describe('ClaudeSessionDetailPage refresh', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(claudeSessionsApi.get).mockResolvedValue(detailFixture())
+    vi.mocked(claudeSessionsApi.refresh).mockResolvedValue(undefined as never)
+    vi.mocked(insightsApi.getSession).mockRejectedValue(new Error('no insights'))
+  })
+
+  // The detail page had no way to pull fresh data from Claude — you had to go
+  // back to the list, refresh there, and come back. This adds a Refresh button
+  // that mirrors the list: trigger the server rescan, then reload the detail.
+  it('rescans and reloads the session when Refresh is clicked', async () => {
+    const user = userEvent.setup()
+    renderPage()
+
+    // Initial load.
+    await waitFor(() => expect(claudeSessionsApi.get).toHaveBeenCalledTimes(1))
+
+    await user.click(await screen.findByRole('button', { name: /refresh/i }))
+
+    // Same behaviour as the list's refresh: kick off the background rescan that
+    // re-reads Claude's JSONL, then re-fetch this session's detail.
+    await waitFor(() => expect(claudeSessionsApi.refresh).toHaveBeenCalledTimes(1))
+    await waitFor(
+      () => expect(vi.mocked(claudeSessionsApi.get).mock.calls.length).toBeGreaterThanOrEqual(2),
+      { timeout: 2000 },
+    )
+  })
+})

--- a/frontend/src/pages/ClaudeSessionDetailPage.tsx
+++ b/frontend/src/pages/ClaudeSessionDetailPage.tsx
@@ -17,6 +17,7 @@ import {
   Clock,
   Play,
   Loader2,
+  RefreshCw,
   Star,
   Activity,
   Search,
@@ -675,6 +676,7 @@ export default function ClaudeSessionDetailPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [continuing, setContinuing] = useState(false)
+  const [refreshing, setRefreshing] = useState(false)
   const [editingTitle, setEditingTitle] = useState(false)
   const [titleDraft, setTitleDraft] = useState('')
   const titleInputRef = useRef<HTMLInputElement>(null)
@@ -694,6 +696,23 @@ export default function ClaudeSessionDetailPage() {
   useEffect(() => {
     load()
   }, [load])
+
+  // Mirrors the sessions list's Refresh: this is not a page reload — it asks the
+  // server to rescan Claude's transcripts (POST /claude-sessions/refresh), then
+  // re-fetches the detail so the freshly-scanned figures (cost, sub-agents) show
+  // alongside the live token counts. The brief pause lets the rescan start.
+  const handleRefresh = async () => {
+    setRefreshing(true)
+    try {
+      await claudeSessionsApi.refresh()
+      await new Promise(r => setTimeout(r, 800))
+      await load()
+    } catch {
+      // Ignore refresh errors — load() surfaces them if the reload itself fails.
+    } finally {
+      setRefreshing(false)
+    }
+  }
 
   const startEditingTitle = () => {
     if (!detail) return
@@ -876,6 +895,15 @@ export default function ClaudeSessionDetailPage() {
               }`}
             >
               <Star className={`h-4 w-4 ${detail.is_favorite ? 'fill-amber-400' : ''}`} />
+            </button>
+            <button
+              onClick={() => handleRefresh()}
+              disabled={refreshing}
+              title="Rescan this session from Claude and reload"
+              className="flex items-center gap-1.5 h-[34px] px-3 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-[13px] text-zinc-700 dark:text-zinc-200 hover:bg-zinc-50 dark:hover:bg-zinc-800 disabled:opacity-50 transition-colors"
+            >
+              <RefreshCw className={`h-3.5 w-3.5 ${refreshing ? 'animate-spin' : ''}`} />
+              Refresh
             </button>
             <button
               onClick={() => navigate(`/claude-sessions/${id ?? ''}/journey`)}


### PR DESCRIPTION
## Summary

Adds a **Refresh** button to the Claude session detail page, so you can pull fresh data from Claude without leaving for the sessions list and coming back. It mirrors the list's Refresh exactly — it is not a page reload. Implements #254.

## Why not just reload the page

`GET /claude-sessions/{id}` re-reads the transcript **live**, so input/output/cache tokens, duration and messages refresh on any reload. But **Cost** and the **delegated sub-agent** tokens/cost come from the **cached scan** (`GetSummary(id)` / `ListSubagents(id)`), so for an active session those stay stale until a scan runs. The list's Refresh handles this by triggering the server rescan; the detail page now does the same.

## Behaviour

`RefreshCw` icon + label in the header action row (⭐ · **Refresh** · Journey · Resume), styled like the Journey button:

1. `POST /claude-sessions/refresh` → invalidate the cache + `EnsureScan` (re-reads Claude's JSONL).
2. Brief pause, then re-fetch the detail (`GET /claude-sessions/{id}`).

Icon spins while in flight; button disabled during the request. This is a deliberate 1:1 match of the list page's `handleRefresh`.

## Scope

Frontend-only — both endpoints already exist. No API, type, or docs changes.

## Testing

- Added `ClaudeSessionDetailPage.test.tsx` (TDD, red first): renders the page, clicks Refresh, asserts `refresh()` fires and the detail re-fetches.
- `npm run test` — 16 files, **199 tests pass**.
- `npm run typecheck` / `npm run lint` (0 errors) / `prettier --check` — clean.
- Verified live in a local build on the real corpus: clicking Refresh returned `202` from the rescan endpoint and the header's Cost + Insights updated to fresh values (not just the live token counts).

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011DEe9NxrnSq48rC9PYYSXd
