### PR TITLE
feat(desktop): port the sessions list and facets to Rust

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -115,8 +115,13 @@ src-tauri/src/
     gojson.rs    Go-compatible JSON encoder — read this before porting anything
     gotime.rs    Go's time.Time on the wire
     db.rs        read-only SQLite handle on the file the Go server owns
+    settings.rs  user preferences + Claude config dirs a read is scoped to
     pricing.rs   GET /api/pricing/catalog
+    sessions/    GET /api/claude-sessions and /facets
     diff.rs      byte comparison + reporting for shadow mode
+
+scripts/
+  parity-instance.sh   Go server built from THIS checkout, on a copy of the DB
 
 parity/          cross-language fixtures, asserted by both Go and Rust tests
 ```
@@ -202,13 +207,35 @@ only a byte comparison catches all four.
 3. Prove it three ways:
    - a fixture both languages build, compared against a golden file Go wrote
      (`desktop/parity/`, `go test ./desktop/parity/ -update-golden`);
-   - the live diff, against the user's own data:
-     `cargo test --test live_parity -- --ignored --nocapture`;
+   - the live diff, against real data **and a Go server built from this
+     checkout**:
+     ```bash
+     eval "$(./scripts/parity-instance.sh start)"
+     (cd src-tauri && cargo test --test live_parity -- --ignored --nocapture)
+     ./scripts/parity-instance.sh stop
+     ```
    - optionally `AGENTO_DESKTOP_NATIVE=diff npm run app`, which compares every
      real request the UI makes.
 4. Only then leave it claimed.
 
+### Never diff against the installed server
+
+`parity-instance.sh` exists because the Agento on `:8990` is whatever binary the
+developer installed, which drifts behind the repo. The first sessions-list diff
+"failed" purely because that instance predated `config_dir` joining the summary
+— the port was right and the baseline was stale. The reverse is worse: an old
+server that happens to agree hides a real divergence. The script builds the
+server from the checkout and runs it against a **copy** of `~/.agento` (the
+current source may carry migrations the installed one has never applied, and
+applying them to the real file would upgrade it under a running instance).
+
 ### Known encoder divergence
+
+`serde_json`'s float **parser** is not bit-exact by default — `0.36238800000000004`
+in a stored JSON column decodes to a different double and re-encodes as
+`0.362388`. `Cargo.toml` enables its `float_roundtrip` feature to fix that; do
+not remove it. (Rust's own `str::parse` was always correct; only serde_json's
+fast path was not.)
 
 `serde_json` turns NaN and infinity into `null`; Go fails the encode outright
 (after `writeJSON` has already committed a 200, so the client gets a truncated
@@ -221,7 +248,7 @@ rather than expecting the encoder to notice.
 | Phase | Subsystem | Go source | Notes |
 |---|---|---|---|
 | 1 ✅ | Sidecar + proxy | — | done |
-| 2 ← | Pricing + analytics | `internal/pricing`, `internal/claudesessions` | Pure computation over JSONL + SQLite. No external deps. **In progress**: `GET /api/pricing/catalog` is native and diffs clean. Next: the rest of `/api/pricing/*` reads, then `/api/claude-analytics`. |
+| 2 ← | Pricing + analytics | `internal/pricing`, `internal/claudesessions` | Pure computation over JSONL + SQLite. No external deps. **In progress**: `/api/pricing/catalog`, `/api/claude-sessions` and `/api/claude-sessions/facets` are native and diff clean. Next: `/api/claude-analytics`, then the per-session reads. |
 | 3 | Storage + tasks | `internal/storage`, `internal/scheduler` | 27 SQLite migrations; reuse the same DB file and schema. Scheduler is cron/interval. |
 | 4 | Integrations | `internal/integrations`, `internal/trigger` | OAuth2 + MCP servers. WhatsApp (`whatsmeow`) is the blocker — port it last or keep it in Go. |
 | 5 | Agent execution | `internal/agent`, `internal/service` | Spawns the `claude` CLI over stream-json stdin/stdout. Hardest, highest risk. |
@@ -409,7 +436,7 @@ axum proxy streams `/api` through with the `Host` rewrite the Go guard needs.
 All nine views are wired to the real API, typecheck clean, and were verified
 against live data — including a real chat turn streamed end to end over SSE.
 
-**Phase 2 started.** `GET /api/pricing/catalog` is answered by Rust
+**Phase 2 in progress.** `GET /api/pricing/catalog` is answered by Rust
 (`native/pricing.rs`), reading the same SQLite file the sidecar writes. It is
 byte-identical to Go on the reference instance — 46,681 bytes both sides, 36
 models, matching FNV revision — and on the shared fixture in `parity/`. The
@@ -417,8 +444,21 @@ infrastructure it brought is what the rest of the phase rides on: `gojson.rs`
 (Go's encoder in Rust), `gotime.rs`, `paths.rs`, the read-only DB handle, the
 three-mode seam and the two parity harnesses.
 
+The sessions list and its facets followed (`native/sessions/`), diffed across 21
+filter and sort combinations plus four pages of cursor interoperability per
+sort — each page continuing from the cursor **Go** minted, so the two have to
+agree on the cursor's bytes as well as the page's.
+
 Nothing else is ported. Every write path, all of analytics and every other read
 still forwards to Go.
+
+**Reading is what keeps the corpus fresh.** `Cache.ensureFresh` runs on every Go
+read path and starts a background rescan when the TTL expires, the pricing
+catalog moves, or the idle threshold changes. A ported read removes that trigger
+and nothing would say so — transcripts would stop being re-read and a rate edit
+would never reach stored costs. `native/sessions/freshness_probe` puts it back by
+firing one cheap request at the sidecar, so the *rules* stay in the code that
+owns them rather than being reimplemented and left to drift.
 
 Verified but not exercised against real data: task/job writes, integration
 OAuth and WhatsApp pairing, and agent CRUD — the reference instance has none of

--- a/desktop/parity/gojson_parity_test.go
+++ b/desktop/parity/gojson_parity_test.go
@@ -19,8 +19,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 const vectorsFile = "gojson_vectors.json"
@@ -34,6 +36,14 @@ type gojsonVectors struct {
 		Value string `json:"value"`
 		Want  string `json:"want"`
 	} `json:"strings"`
+	CursorFloats []struct {
+		Value float64 `json:"value"`
+		Want  string  `json:"want"`
+	} `json:"cursor_floats"`
+	GoTimes []struct {
+		Value string `json:"value"`
+		Want  string `json:"want"`
+	} `json:"go_times"`
 }
 
 // encode is exactly what internal/api.Server.writeJSON does, minus the newline
@@ -57,8 +67,9 @@ func loadVectors(t *testing.T) gojsonVectors {
 	if err := json.Unmarshal(raw, &v); err != nil {
 		t.Fatalf("parsing %s: %v", vectorsFile, err)
 	}
-	if len(v.Floats) == 0 || len(v.Strings) == 0 {
-		t.Fatalf("%s has no vectors to check", vectorsFile)
+	if len(v.Floats) == 0 || len(v.Strings) == 0 ||
+		len(v.CursorFloats) == 0 || len(v.GoTimes) == 0 {
+		t.Fatalf("%s is missing a whole section of vectors", vectorsFile)
 	}
 	return v
 }
@@ -75,6 +86,36 @@ func TestGoJSONVectors_Strings(t *testing.T) {
 	for _, tc := range loadVectors(t).Strings {
 		if got := encode(t, tc.Value); got != tc.Want {
 			t.Errorf("encode(%q) = %s, want %s", tc.Value, got, tc.Want)
+		}
+	}
+}
+
+// TestGoJSONVectors_CursorFloats pins strconv.FormatFloat(_, 'g', -1, 64), the
+// spelling the sessions list's keyset cursor uses. It is deliberately not the
+// one encoding/json uses — 'g' switches to exponent form at 1e6 rather than
+// 1e21 and pads the exponent instead of trimming it — and a cursor minted by
+// one implementation is parsed by the other, so the bytes have to agree.
+func TestGoJSONVectors_CursorFloats(t *testing.T) {
+	for _, tc := range loadVectors(t).CursorFloats {
+		if got := strconv.FormatFloat(tc.Value, 'g', -1, 64); got != tc.Want {
+			t.Errorf("FormatFloat(%v, 'g') = %s, want %s", tc.Value, got, tc.Want)
+		}
+	}
+}
+
+// TestGoJSONVectors_GoTimes pins the DATETIME round trip. Every timestamp in
+// the database is stored as time.Time.String() by the driver, not as RFC 3339,
+// so a Rust reader has to parse that layout and render the wire form from it.
+func TestGoJSONVectors_GoTimes(t *testing.T) {
+	const layout = "2006-01-02 15:04:05.999999999 -0700 MST"
+	for _, tc := range loadVectors(t).GoTimes {
+		parsed, err := time.Parse(layout, tc.Value)
+		if err != nil {
+			t.Errorf("parsing %q: %v", tc.Value, err)
+			continue
+		}
+		if got := parsed.UTC().Format(time.RFC3339Nano); got != tc.Want {
+			t.Errorf("%q -> %s, want %s", tc.Value, got, tc.Want)
 		}
 	}
 }

--- a/desktop/parity/gojson_vectors.json
+++ b/desktop/parity/gojson_vectors.json
@@ -1,12 +1,75 @@
 {
   "_comment": [
-    "Cross-language encoder parity vectors for the Go-\u003eRust desktop port.",
-    "Generated from Go's encoding/json, then frozen. Read by",
-    "desktop/parity/gojson_parity_test.go (Go) and by",
-    "desktop/src-tauri/src/native/gojson.rs (Rust): 'want' is the exact",
-    "text Go's encoder produces for 'value', so a divergence fails one",
-    "language's tests against the other's real output rather than against",
-    "a belief about it. Add a vector here when a port turns up a new shape."
+    "Cross-language parity vectors for the Go-\u003eRust desktop port.",
+    "Generated from Go, then frozen. Read by",
+    "desktop/parity/gojson_parity_test.go (Go) and by the Rust tests in",
+    "desktop/src-tauri/src/native/. 'want' is exactly what Go produces for",
+    "'value', so a divergence fails one language's tests against the",
+    "other's real output rather than against a belief about it.",
+    "floats/strings: encoding/json. cursor_floats: strconv.FormatFloat(v,'g',-1,64).",
+    "go_times: time.Time.String() parsed back, re-rendered as RFC3339Nano."
+  ],
+  "cursor_floats": [
+    {
+      "value": 0,
+      "want": "0"
+    },
+    {
+      "value": 1,
+      "want": "1"
+    },
+    {
+      "value": 36.3,
+      "want": "36.3"
+    },
+    {
+      "value": 0.5,
+      "want": "0.5"
+    },
+    {
+      "value": 15.308084000000003,
+      "want": "15.308084000000003"
+    },
+    {
+      "value": 1234.5,
+      "want": "1234.5"
+    },
+    {
+      "value": 0.00001,
+      "want": "1e-05"
+    },
+    {
+      "value": 0.000001,
+      "want": "1e-06"
+    },
+    {
+      "value": 0.0001234,
+      "want": "0.0001234"
+    },
+    {
+      "value": 999999,
+      "want": "999999"
+    },
+    {
+      "value": 1000000,
+      "want": "1e+06"
+    },
+    {
+      "value": 1234567,
+      "want": "1.234567e+06"
+    },
+    {
+      "value": 1e+21,
+      "want": "1e+21"
+    },
+    {
+      "value": 22.349290000000025,
+      "want": "22.349290000000025"
+    },
+    {
+      "value": 0.000001234,
+      "want": "1.234e-06"
+    }
   ],
   "floats": [
     {
@@ -80,6 +143,28 @@
     {
       "value": 123456.789,
       "want": "123456.789"
+    }
+  ],
+  "go_times": [
+    {
+      "value": "2026-06-14 18:25:20.492 +0000 UTC",
+      "want": "2026-06-14T18:25:20.492Z"
+    },
+    {
+      "value": "2026-06-14 19:00:29.177 +0000 UTC",
+      "want": "2026-06-14T19:00:29.177Z"
+    },
+    {
+      "value": "2020-01-01 00:00:00 +0000 UTC",
+      "want": "2020-01-01T00:00:00Z"
+    },
+    {
+      "value": "2026-08-13 21:51:41.123456789 +0000 UTC",
+      "want": "2026-08-13T21:51:41.123456789Z"
+    },
+    {
+      "value": "0001-01-01 00:00:00 +0000 UTC",
+      "want": "0001-01-01T00:00:00Z"
     }
   ],
   "strings": [

--- a/desktop/scripts/parity-instance.sh
+++ b/desktop/scripts/parity-instance.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# Start a Go server built from the CURRENT source, on a scratch copy of the
+# user's database, for the Rust port to be diffed against.
+#
+# Why this exists: the "live instance" a developer happens to be running is
+# whatever binary they installed, which drifts behind the repo. Diffing a port
+# against it compares Rust to an old Go, and the failure mode is the worst kind
+# — the diff comes out clean while the port is wrong, or dirty while the port is
+# right. The bar is byte-identical to the Go source in *this* checkout, so that
+# is what the diff has to ask.
+#
+# The database is copied rather than shared. The current source may carry
+# migrations the installed server has never applied, and applying them to the
+# real file would upgrade it underneath a running older instance.
+#
+#   ./scripts/parity-instance.sh start   # prints AGENTO_LIVE_URL / AGENTO_LIVE_DB
+#   ./scripts/parity-instance.sh stop
+#
+# Typical use:
+#   eval "$(./scripts/parity-instance.sh start)"
+#   (cd src-tauri && cargo test --test live_parity -- --ignored --nocapture)
+#   ./scripts/parity-instance.sh stop
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK_DIR="${AGENTO_PARITY_DIR:-${TMPDIR:-/tmp}/agento-parity}"
+DATA_DIR="$WORK_DIR/data"
+BIN="$WORK_DIR/agento-parity"
+PID_FILE="$WORK_DIR/server.pid"
+PORT_FILE="$WORK_DIR/server.port"
+LOG_FILE="$WORK_DIR/server.log"
+SOURCE_DATA_DIR="${AGENTO_SOURCE_DATA_DIR:-$HOME/.agento}"
+
+free_port() {
+  python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()'
+}
+
+start() {
+  stop >/dev/null 2>&1 || true
+  mkdir -p "$DATA_DIR"
+
+  # Build from the checkout, not from PATH.
+  (cd "$REPO_ROOT" && go build -o "$BIN" .) >&2
+
+  # A copy, so the scratch instance's migrations and scans cannot touch the
+  # real database. The -wal and -shm carry writes the main file has not
+  # checkpointed yet, so all three travel together or the copy loses data.
+  for suffix in "" "-wal" "-shm"; do
+    if [ -f "$SOURCE_DATA_DIR/agento.db$suffix" ]; then
+      cp "$SOURCE_DATA_DIR/agento.db$suffix" "$DATA_DIR/agento.db$suffix"
+    fi
+  done
+
+  local port
+  port="$(free_port)"
+  echo "$port" >"$PORT_FILE"
+
+  AGENTO_DATA_DIR="$DATA_DIR" AGENTO_BIND=127.0.0.1 \
+    "$BIN" web --port "$port" --no-browser >"$LOG_FILE" 2>&1 &
+  echo $! >"$PID_FILE"
+
+  for _ in $(seq 1 150); do
+    if curl -fsS "http://127.0.0.1:$port/health" >/dev/null 2>&1; then
+      break
+    fi
+    sleep 0.2
+  done
+  if ! curl -fsS "http://127.0.0.1:$port/health" >/dev/null 2>&1; then
+    echo "parity server did not become healthy; see $LOG_FILE" >&2
+    exit 1
+  fi
+
+  # The first read starts a rescan, and rows changing underneath a diff would
+  # make it flap. Wait it out before handing the URL over.
+  curl -fsS -H 'Content-Type: application/json' \
+    "http://127.0.0.1:$port/api/claude-sessions?limit=1" >/dev/null 2>&1 || true
+  for _ in $(seq 1 600); do
+    if curl -fsS -H 'Content-Type: application/json' \
+      "http://127.0.0.1:$port/api/claude-sessions/status" 2>/dev/null |
+      grep -q '"scan_in_progress":false'; then
+      break
+    fi
+    sleep 1
+  done
+
+  echo "export AGENTO_LIVE_URL=http://127.0.0.1:$port"
+  echo "export AGENTO_LIVE_DB=$DATA_DIR/agento.db"
+}
+
+stop() {
+  if [ -f "$PID_FILE" ]; then
+    kill "$(cat "$PID_FILE")" 2>/dev/null || true
+    rm -f "$PID_FILE"
+  fi
+  rm -f "$PORT_FILE"
+}
+
+case "${1:-start}" in
+start) start ;;
+stop) stop ;;
+*)
+  echo "usage: $0 [start|stop]" >&2
+  exit 2
+  ;;
+esac

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -14,6 +14,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "chrono",
+ "form_urlencoded",
  "log",
  "mime_guess",
  "reqwest 0.12.28",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -18,7 +18,13 @@ tauri = { version = "2", features = [] }
 tauri-plugin-shell = "2"
 tauri-plugin-log = "2"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+# `float_roundtrip` is not optional here. Without it serde_json's float parser
+# is not bit-exact: `0.36238800000000004` in a stored JSON column decodes to a
+# *different* double, which re-encodes as `0.362388` and breaks byte parity
+# with Go on any endpoint that reads one (per-model costs today, analytics
+# next). Rust's own `str::parse` was always correct; only serde_json's fast
+# path was not.
+serde_json = { version = "1", features = ["float_roundtrip"] }
 log = "0.4"
 
 # Local reverse proxy in front of the Go sidecar. No TLS backend: every hop is
@@ -43,6 +49,7 @@ rusqlite = { version = "0.40.2", features = ["bundled"] }
 # Effective-dated rates are timestamps, and their wire format has to match Go's
 # byte for byte. `clock` is only for "which rate is in force now".
 chrono = { version = "0.4.45", default-features = false, features = ["std", "clock"] }
+form_urlencoded = "1.2.2"
 
 [profile.release]
 codegen-units = 1

--- a/desktop/src-tauri/src/native/gojson.rs
+++ b/desktop/src-tauri/src/native/gojson.rs
@@ -51,6 +51,49 @@ where
     Ok(buf)
 }
 
+/// Encode as Go's `json.Marshal` does: same escaping and float spelling, but
+/// no trailing newline.
+///
+/// `writeJSON` uses an Encoder and so terminates with one; values marshalled
+/// *into* something else — the sessions list's keyset cursor, a JSON column —
+/// use `Marshal` and must not.
+pub fn to_vec_marshal<T>(value: &T) -> Result<Vec<u8>, serde_json::Error>
+where
+    T: ?Sized + Serialize,
+{
+    let mut buf = Vec::with_capacity(256);
+    let mut ser = Serializer::with_formatter(&mut buf, GoFormatter);
+    value.serialize(&mut ser)?;
+    Ok(buf)
+}
+
+/// Render a float as `strconv.FormatFloat(f, 'g', -1, 64)`.
+///
+/// This is NOT the spelling `encoding/json` uses, and the difference is not
+/// cosmetic: `'g'` switches to exponent form at 1e6 rather than 1e21 and pads
+/// the exponent to two digits without trimming, so 1000000 is `1e+06` here and
+/// `1000000` in JSON. The sessions list's cursor is built with it, and a cursor
+/// is compared against the one the other implementation minted.
+pub fn format_g(value: f64) -> String {
+    if !value.is_finite() {
+        return format!("{value}");
+    }
+    let scientific = format!("{value:e}");
+    let (mantissa, exp) = match scientific.split_once('e') {
+        Some(parts) => parts,
+        None => return scientific,
+    };
+    let exp10: i32 = exp.parse().unwrap_or(0);
+
+    // Go's ftoa with the shortest representation fixes eprec at 6, so exponent
+    // form is used when the decimal exponent is below -4 or at least 6.
+    if !(-4..6).contains(&exp10) {
+        let sign = if exp10 < 0 { '-' } else { '+' };
+        return format!("{mantissa}e{sign}{:02}", exp10.abs());
+    }
+    format!("{value}")
+}
+
 /// The parts of Go's encoder that `serde_json` spells differently.
 struct GoFormatter;
 
@@ -140,6 +183,7 @@ mod tests {
     struct Vectors {
         floats: Vec<FloatVector>,
         strings: Vec<StringVector>,
+        cursor_floats: Vec<FloatVector>,
     }
 
     #[derive(serde::Deserialize)]
@@ -181,6 +225,24 @@ mod tests {
         for v in vectors().strings {
             assert_eq!(encoded(&v.value), v.want, "string {:?}", v.value);
         }
+    }
+
+    /// `strconv.FormatFloat(_, 'g', -1, 64)`, which the sessions list's cursor
+    /// uses and which is deliberately not the JSON spelling: exponent form
+    /// starts at 1e6 rather than 1e21, and the exponent is padded to two digits
+    /// rather than trimmed.
+    #[test]
+    fn cursor_floats_match_gos_g_format() {
+        for v in vectors().cursor_floats {
+            assert_eq!(format_g(v.value), v.want, "format_g({})", v.value);
+        }
+    }
+
+    #[test]
+    fn the_two_float_spellings_really_do_differ() {
+        // Guards the pair above from being "fixed" into one function.
+        assert_eq!(encoded(&1_000_000.0_f64), "1000000");
+        assert_eq!(format_g(1_000_000.0), "1e+06");
     }
 
     #[test]

--- a/desktop/src-tauri/src/native/gotime.rs
+++ b/desktop/src-tauri/src/native/gotime.rs
@@ -43,6 +43,86 @@ impl GoTime {
     }
 }
 
+/// Go's `time.Time.String()` layout, which is what every DATETIME column in
+/// the database actually holds.
+///
+/// The Go server writes timestamps through `database/sql`, and the driver
+/// stores a `time.Time` by its `String()` rendering —
+/// `2026-06-14 18:25:20.492 +0000 UTC` — not RFC 3339. Two consequences a
+/// reader must respect: the fraction is variable-length (trailing zeros are
+/// already trimmed), and the ordering the sessions list pages on is *lexical
+/// over this text*, which coincides with chronological order only because
+/// every value is UTC.
+const GO_STRING_LAYOUT: &str = "%Y-%m-%d %H:%M:%S%.f %z";
+
+impl GoTime {
+    /// Parse the `time.Time.String()` text a DATETIME column holds.
+    ///
+    /// The trailing zone abbreviation (`UTC`, `CEST`) is dropped rather than
+    /// interpreted: Go prints it for humans and it is redundant beside the
+    /// numeric offset, which is what actually fixes the instant.
+    pub fn parse_go_string(text: &str) -> Result<Self, String> {
+        let trimmed = text.trim();
+        // Split off the abbreviation: everything from the third space on.
+        let numeric = match trimmed.match_indices(' ').nth(2) {
+            Some((idx, _)) => &trimmed[..idx],
+            None => trimmed,
+        };
+        DateTime::parse_from_str(numeric, GO_STRING_LAYOUT)
+            .map(GoTime)
+            .map_err(|e| format!("unparsable Go timestamp {text:?}: {e}"))
+    }
+
+    /// Parse either form: the `time.Time.String()` text the DATETIME columns
+    /// hold, or RFC 3339 as the pricing catalog stores it.
+    pub fn parse_any(text: &str) -> Result<Self, String> {
+        Self::parse(text).or_else(|_| Self::parse_go_string(text))
+    }
+
+    /// The wire rendering, for a value that is not being serialized directly.
+    pub fn to_rfc3339_nano(self) -> String {
+        format_go_rfc3339(&self.0)
+    }
+}
+
+/// Render a timestamp as Go's `time.Time.String()` in UTC — the exact text the
+/// database driver writes into a DATETIME column, and therefore the only shape
+/// a bound parameter may take.
+///
+/// The columns are compared **as text**: both the sessions list's `ORDER BY`
+/// and every time predicate depend on lexical order matching chronological
+/// order, which holds only because every stored value is UTC with its trailing
+/// fractional zeros trimmed. A bound formatted any other way — RFC 3339, a
+/// fixed nine-digit fraction — sorts into a different place and silently
+/// mis-filters rather than failing.
+pub fn to_go_string_utc(t: GoTime) -> String {
+    format_go_string(&t.instant())
+}
+
+/// The same rendering for an epoch-milliseconds value, which is how the
+/// analytics drill-down encodes its windows.
+pub fn go_string_from_millis(ms: i64) -> String {
+    match DateTime::from_timestamp_millis(ms) {
+        Some(t) => format_go_string(&t),
+        // Out of range for a timestamp. An empty bound matches nothing, which
+        // is the safe direction: a filter that silently matched everything
+        // would present an unfiltered list as a filtered one.
+        None => String::new(),
+    }
+}
+
+fn format_go_string(t: &DateTime<Utc>) -> String {
+    let mut out = t.format("%Y-%m-%d %H:%M:%S").to_string();
+    let nanos = t.timestamp_subsec_nanos();
+    if nanos > 0 {
+        let fraction = format!("{nanos:09}");
+        out.push('.');
+        out.push_str(fraction.trim_end_matches('0'));
+    }
+    out.push_str(" +0000 UTC");
+    out
+}
+
 impl Serialize for GoTime {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_str(&format_go_rfc3339(&self.0))
@@ -83,6 +163,44 @@ mod tests {
             .expect("utf-8")
             .trim_end()
             .to_string()
+    }
+
+    /// The DATETIME columns hold `time.Time.String()`, and the vectors record
+    /// what Go gets when it parses that text back and renders it for the wire.
+    #[test]
+    fn stored_timestamps_parse_and_render_as_go_does() {
+        #[derive(serde::Deserialize)]
+        struct Vectors {
+            go_times: Vec<Vector>,
+        }
+        #[derive(serde::Deserialize)]
+        struct Vector {
+            value: String,
+            want: String,
+        }
+
+        let raw = include_str!("../../../parity/gojson_vectors.json");
+        let vectors: Vectors = serde_json::from_str(raw).expect("parity vectors parse");
+        assert!(!vectors.go_times.is_empty(), "no timestamp vectors");
+
+        for v in vectors.go_times {
+            let parsed = GoTime::parse_go_string(&v.value).expect(&v.value);
+            assert_eq!(parsed.to_rfc3339_nano(), v.want, "parsing {:?}", v.value);
+        }
+    }
+
+    /// Round trip: the text a bound parameter carries has to be the text the
+    /// column already holds, or a range filter compares two different shapes.
+    #[test]
+    fn rendering_a_stored_timestamp_reproduces_it_exactly() {
+        for text in [
+            "2026-06-14 18:25:20.492 +0000 UTC",
+            "2020-01-01 00:00:00 +0000 UTC",
+            "2026-08-13 21:51:41.123456789 +0000 UTC",
+        ] {
+            let parsed = GoTime::parse_go_string(text).expect(text);
+            assert_eq!(to_go_string_utc(parsed), text);
+        }
     }
 
     #[test]

--- a/desktop/src-tauri/src/native/mod.rs
+++ b/desktop/src-tauri/src/native/mod.rs
@@ -16,6 +16,8 @@ pub mod diff;
 pub mod gojson;
 pub mod gotime;
 pub mod pricing;
+pub mod sessions;
+pub mod settings;
 
 use axum::body::Body;
 use axum::http::{header, Method, Response, StatusCode};
@@ -61,19 +63,64 @@ pub fn mode() -> Mode {
 /// which chi treats as a different route — falls through to Go and keeps
 /// whatever answer Go gives it.
 pub fn claims(method: &Method, path: &str) -> bool {
-    matches!((method.as_str(), path), ("GET", "/api/pricing/catalog"))
+    matches!(
+        (method.as_str(), path),
+        (
+            "GET",
+            "/api/pricing/catalog" | "/api/claude-sessions" | "/api/claude-sessions/facets"
+        )
+    )
+}
+
+/// A claimed request: the parts a native handler needs.
+pub struct Request<'a> {
+    pub method: &'a Method,
+    pub path: &'a str,
+    /// The raw query string without its leading `?`.
+    pub query: &'a str,
+}
+
+/// What a native handler produced: the response body, plus any request the
+/// proxy should fire at the sidecar afterwards to keep the corpus fresh.
+pub struct Answer {
+    pub body: Vec<u8>,
+    pub probe: Option<&'static str>,
 }
 
 /// Answer a claimed request. `Err` means "fall back to the Go sidecar".
-pub fn serve(method: &Method, path: &str) -> Result<Vec<u8>, String> {
-    match (method.as_str(), path) {
+pub fn serve(req: &Request) -> Result<Answer, String> {
+    let db_path = paths::database_path().ok_or("no home directory to resolve the data dir")?;
+
+    match (req.method.as_str(), req.path) {
         ("GET", "/api/pricing/catalog") => {
-            let db_path =
-                paths::database_path().ok_or("no home directory to resolve the data dir")?;
             let catalog = pricing::catalog(&db_path)?;
-            gojson::to_vec(&catalog).map_err(|e| format!("encoding pricing catalog: {e}"))
+            Ok(Answer {
+                body: gojson::to_vec(&catalog)
+                    .map_err(|e| format!("encoding pricing catalog: {e}"))?,
+                probe: None,
+            })
         }
-        _ => Err(format!("{method} {path} is claimed but has no handler")),
+        ("GET", path @ ("/api/claude-sessions" | "/api/claude-sessions/facets")) => {
+            let q = sessions::query::SessionQuery::parse(req.query)?;
+            let conn = db::open_read_only(&db_path)?;
+            let data_settings = settings::load(&conn);
+
+            let body = if path == "/api/claude-sessions" {
+                let page = sessions::page::list_page(&conn, &data_settings, &q)?;
+                gojson::to_vec(&page).map_err(|e| format!("encoding session page: {e}"))?
+            } else {
+                let facets = sessions::page::facets(&conn, &data_settings, &q)?;
+                gojson::to_vec(&facets).map_err(|e| format!("encoding session facets: {e}"))?
+            };
+            Ok(Answer {
+                body,
+                probe: sessions::freshness_probe(path, &q),
+            })
+        }
+        _ => Err(format!(
+            "{} {} is claimed but has no handler",
+            req.method, req.path
+        )),
     }
 }
 
@@ -94,22 +141,30 @@ mod tests {
     use super::*;
 
     #[test]
-    fn the_pricing_catalog_is_claimed_and_its_siblings_are_not() {
+    fn the_ported_reads_are_claimed_and_their_siblings_are_not() {
         assert!(claims(&Method::GET, "/api/pricing/catalog"));
+        assert!(claims(&Method::GET, "/api/claude-sessions"));
+        assert!(claims(&Method::GET, "/api/claude-sessions/facets"));
 
         // Writes stay with Go until phase 3 moves the storage layer.
         assert!(!claims(&Method::POST, "/api/pricing/rates"));
-        assert!(!claims(&Method::PUT, "/api/pricing/rates"));
-        assert!(!claims(&Method::DELETE, "/api/pricing/rates"));
+        assert!(!claims(&Method::POST, "/api/claude-sessions/refresh"));
+        // Scan lifecycle stays with Go while the scanner does.
+        assert!(!claims(&Method::GET, "/api/claude-sessions/status"));
         // Not a prefix match: an unported endpoint under the same namespace
-        // must not be swallowed.
-        assert!(!claims(&Method::GET, "/api/pricing/catalog/extra"));
-        assert!(!claims(&Method::GET, "/api/pricing/catalog/"));
+        // must not be swallowed. A session ID is a path segment, not a suffix.
+        assert!(!claims(&Method::GET, "/api/claude-sessions/abc-123"));
+        assert!(!claims(&Method::GET, "/api/claude-sessions/"));
         assert!(!claims(&Method::GET, "/api/claude-analytics"));
     }
 
     #[test]
     fn an_unhandled_claim_is_an_error_so_the_proxy_falls_back() {
-        assert!(serve(&Method::GET, "/api/nothing-here").is_err());
+        assert!(serve(&Request {
+            method: &Method::GET,
+            path: "/api/nothing-here",
+            query: "",
+        })
+        .is_err());
     }
 }

--- a/desktop/src-tauri/src/native/sessions/mod.rs
+++ b/desktop/src-tauri/src/native/sessions/mod.rs
@@ -1,0 +1,86 @@
+//! The Claude sessions list, ported from `internal/claudesessions`.
+//!
+//! Two endpoints, deliberately separate on the Go side and kept separate here:
+//! the page changes as the user scrolls, the facets change when the filter
+//! changes, and folding them together would recompute a corpus-wide aggregate
+//! on every scroll tick.
+//!
+//! ## The scan trigger
+//!
+//! On the Go side, **reading is what keeps the corpus fresh**:
+//! `Cache.ensureFresh` runs on every read path — `ListPage` on a first page,
+//! `Facets` always — and starts a background rescan when the TTL has expired,
+//! the pricing catalog has moved, or the idle threshold has changed. Serving
+//! these routes from Rust therefore removes the trigger, and nothing would say
+//! so: transcripts would stop being re-read, a rate edit would never reach
+//! stored costs, and the list would serve indefinitely stale figures.
+//!
+//! Rather than reimplement that decision — four pieces of metadata, a TTL, a
+//! pricing fingerprint and a user-set threshold, each of which could drift out
+//! of step with the Go original — this delegates it. `freshness_probe` names a
+//! cheap request against the sidecar that goes through `ensureFresh` itself, so
+//! the *rules* stay in the code that owns them. It is fire-and-forget: the page
+//! never waits for it, exactly as `ListPage` never waits for the rescan it
+//! starts.
+
+pub mod page;
+pub mod query;
+pub mod summary;
+
+#[cfg(test)]
+mod tests_db;
+
+/// The request to fire at the Go sidecar to keep the corpus fresh, if this
+/// route is one that would have triggered a rescan.
+///
+/// A continuation — a request carrying a cursor — deliberately returns `None`,
+/// matching `ListPage`: freshness is a property of the scroll, decided when it
+/// starts, and re-deciding it per page would put four metadata queries behind
+/// every scroll tick to reach a conclusion the first page already reached.
+pub fn freshness_probe(path: &str, q: &query::SessionQuery) -> Option<&'static str> {
+    match path {
+        "/api/claude-sessions" if q.cursor.is_empty() => Some(PROBE_PATH),
+        "/api/claude-sessions/facets" => Some(PROBE_PATH),
+        _ => None,
+    }
+}
+
+/// The cheapest request that still runs `ensureFresh`: one page of one row,
+/// unfiltered. The filter is irrelevant — freshness is a property of the
+/// corpus, not of the query.
+const PROBE_PATH: &str = "/api/claude-sessions?limit=1";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_first_page_probes_and_a_continuation_does_not() {
+        let mut q = query::SessionQuery::default();
+        assert_eq!(
+            freshness_probe("/api/claude-sessions", &q),
+            Some(PROBE_PATH)
+        );
+
+        q.cursor = "abc".into();
+        assert_eq!(freshness_probe("/api/claude-sessions", &q), None);
+    }
+
+    #[test]
+    fn facets_always_probe_since_go_always_checks() {
+        let q = query::SessionQuery {
+            cursor: "abc".into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            freshness_probe("/api/claude-sessions/facets", &q),
+            Some(PROBE_PATH)
+        );
+    }
+
+    #[test]
+    fn an_unrelated_route_never_probes() {
+        let q = query::SessionQuery::default();
+        assert_eq!(freshness_probe("/api/pricing/catalog", &q), None);
+    }
+}

--- a/desktop/src-tauri/src/native/sessions/page.rs
+++ b/desktop/src-tauri/src/native/sessions/page.rs
@@ -1,0 +1,402 @@
+//! `GET /api/claude-sessions` and `GET /api/claude-sessions/facets`.
+//!
+//! Mirrors `listSessionPage` and `sessionFacets` in
+//! `internal/claudesessions/session_page.go`.
+//!
+//! The list used to ship every session to the browser and filter, sort, group
+//! and render all of them there. That worked at 800 sessions and stopped
+//! working well before 5,000. Everything here exists so the browser never holds
+//! more than one page — which means the filtering, sorting and paging must be
+//! SQL, and must produce exactly what the Go implementation produces.
+
+use std::collections::BTreeMap;
+
+use rusqlite::Connection;
+use serde::Serialize;
+
+use super::query::{
+    add_config_dir_scope, add_links, build_filter, cursor_value, Cursor, Filter, Links,
+    SessionQuery, Value, SQL_COST_USD, SQL_TOKENS,
+};
+use super::summary::{display_model, scan, SessionCost, SessionPR, SessionSummary, TokenUsage};
+use super::summary::{SUMMARY_COLUMNS, SUMMARY_SOURCE};
+use crate::native::gotime::GoTime;
+use crate::native::settings::DataSettings;
+
+/// One page of the sessions list.
+#[derive(Debug, Serialize)]
+pub struct SessionPage {
+    pub items: Vec<SessionSummary>,
+    /// Continues the list. Empty means this was the last page.
+    pub next_cursor: String,
+    /// `next_cursor != ""`, stated explicitly so a client need not know that.
+    pub has_more: bool,
+}
+
+/// What the toolbar needs and a single page cannot answer.
+#[derive(Debug, Default, Serialize)]
+pub struct SessionFacets {
+    pub total: i64,
+    pub total_tokens: i64,
+    pub total_cost_usd: f64,
+    /// The 90th percentile of input+output tokens across the filtered set — the
+    /// reference length for the list's token bars. The 90th rather than the
+    /// maximum, because one 75M-token session against a ~100K median would push
+    /// every other bar below a pixel.
+    pub token_p90: i64,
+    /// Dropdown options, derived from every visible session rather than from
+    /// the filtered set: a dropdown that removes the option you just picked
+    /// cannot be un-picked.
+    pub models: Vec<String>,
+    pub permission_modes: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub config_dirs: Vec<String>,
+    pub has_favorites: bool,
+    pub has_prs: bool,
+}
+
+/// Read one page of sessions matching `q`.
+pub fn list_page(
+    conn: &Connection,
+    settings: &DataSettings,
+    q: &SessionQuery,
+) -> Result<SessionPage, String> {
+    let (expr, is_time) = q.sort.expr();
+    let mut filter = build_filter(q, &settings.hidden_projects, &settings.indexed_config_dirs)?;
+
+    if let Some(cur) = Cursor::decode(&q.cursor, q.sort)? {
+        let bound = cur.bind(is_time)?;
+        // Strictly after the cursor in the same total order the ORDER BY
+        // imposes. The tiebreak on session_id is what makes that order total:
+        // without it two sessions sharing a cost or a timestamp would page
+        // against each other, one repeating and one disappearing.
+        filter.add(
+            format!("({expr} < ? OR ({expr} = ? AND c.session_id < ?))"),
+            vec![bound.clone(), bound, Value::Text(cur.id)],
+        );
+    }
+
+    let limit = q.page_size();
+    // One extra row, so "is there a next page" is answered without a second
+    // COUNT over the same predicate.
+    let sql = format!(
+        "{SUMMARY_COLUMNS}{SUMMARY_SOURCE}{}\nORDER BY {expr} DESC, c.session_id DESC\nLIMIT {}",
+        filter.where_clause(),
+        limit + 1
+    );
+
+    let mut stmt = conn
+        .prepare(&sql)
+        .map_err(|e| format!("claudesessions: preparing session page: {e}"))?;
+    let rows = stmt
+        .query_map(rusqlite::params_from_iter(filter.args.iter()), |row| {
+            scan(row)
+        })
+        .map_err(|e| format!("claudesessions: querying session page: {e}"))?;
+
+    let mut items = Vec::with_capacity(limit as usize);
+    for row in rows {
+        items.push(row.map_err(|e| format!("claudesessions: scanning session page: {e}"))?);
+    }
+
+    let mut page = SessionPage {
+        items: Vec::new(),
+        next_cursor: String::new(),
+        has_more: false,
+    };
+    if items.len() as i64 > limit {
+        items.truncate(limit as usize);
+        if let Some(last) = items.last() {
+            page.next_cursor = Cursor {
+                sort: q.sort.as_str().to_string(),
+                value: cursor_value(last, q.sort),
+                id: last.session_id.clone(),
+            }
+            .encode();
+            page.has_more = !page.next_cursor.is_empty();
+        }
+    }
+
+    attach_prs(conn, &mut items);
+    attach_subagent_usage_by_model(conn, &mut items);
+    page.items = items;
+    Ok(page)
+}
+
+/// The filtered totals and the filter options for `q`.
+pub fn facets(
+    conn: &Connection,
+    settings: &DataSettings,
+    q: &SessionQuery,
+) -> Result<SessionFacets, String> {
+    let filter = build_filter(q, &settings.hidden_projects, &settings.indexed_config_dirs)?;
+    let where_clause = filter.where_clause();
+
+    let totals_sql = format!(
+        "SELECT COUNT(*), COALESCE(SUM({SQL_TOKENS}), 0), COALESCE(SUM({SQL_COST_USD}), 0)\
+         {SUMMARY_SOURCE}{where_clause}"
+    );
+    let mut f: SessionFacets = conn
+        .query_row(
+            &totals_sql,
+            rusqlite::params_from_iter(filter.args.iter()),
+            |row| {
+                Ok(SessionFacets {
+                    total: row.get(0)?,
+                    total_tokens: row.get(1)?,
+                    total_cost_usd: row.get(2)?,
+                    ..SessionFacets::default()
+                })
+            },
+        )
+        .map_err(|e| format!("claudesessions: session totals: {e}"))?;
+
+    if f.total > 0 {
+        // The same index the TypeScript implementation takes: floor(0.9*(n-1))
+        // into the ascending series, so both languages pick the same row rather
+        // than two neighbouring ones.
+        let offset = (0.9 * (f.total - 1) as f64) as i64;
+        let p90_sql = format!(
+            "SELECT {SQL_TOKENS}{SUMMARY_SOURCE}{where_clause}\
+             \nORDER BY {SQL_TOKENS} ASC\nLIMIT 1 OFFSET {offset}"
+        );
+        match conn.query_row(
+            &p90_sql,
+            rusqlite::params_from_iter(filter.args.iter()),
+            |row| row.get::<_, i64>(0),
+        ) {
+            Ok(p90) => f.token_p90 = p90,
+            // Warned rather than fatal, as in Go: the bars degrade to a shared
+            // scale, the totals beside them stay correct.
+            Err(e) => log::warn!("claude sessions: failed to compute token p90: {e}"),
+        }
+    }
+
+    load_facet_options(conn, settings, &mut f)?;
+    Ok(f)
+}
+
+/// Fill the dropdown options and the toggle gates.
+///
+/// Scoped to visible projects but not to the rest of the filter: the options
+/// are what the corpus contains, so picking one never removes the others.
+fn load_facet_options(
+    conn: &Connection,
+    settings: &DataSettings,
+    f: &mut SessionFacets,
+) -> Result<(), String> {
+    let mut visible = Filter::default();
+    for p in &settings.hidden_projects {
+        visible.add("c.project_path != ?", vec![Value::Text(p.clone())]);
+    }
+    add_config_dir_scope(&mut visible, &settings.indexed_config_dirs);
+    let where_clause = visible.where_clause();
+
+    f.config_dirs = distinct_strings(
+        conn,
+        &format!(
+            "SELECT DISTINCT c.config_dir FROM claude_session_cache c{where_clause} ORDER BY c.config_dir"
+        ),
+        &visible.args,
+    )?;
+    f.models = distinct_strings(
+        conn,
+        &format!(
+            "SELECT DISTINCT c.model FROM claude_session_cache c{where_clause} ORDER BY c.model"
+        ),
+        &visible.args,
+    )?;
+    f.permission_modes = distinct_strings(
+        conn,
+        &format!(
+            "SELECT DISTINCT c.permission_mode FROM claude_session_cache c{where_clause} ORDER BY c.permission_mode"
+        ),
+        &visible.args,
+    )?;
+
+    let mut favorites = Filter::default();
+    favorites.add_all(&visible);
+    favorites.add("c.is_favorite = 1", vec![]);
+    f.has_favorites = exists_row(
+        conn,
+        &format!(
+            "SELECT 1 FROM claude_session_cache c{} LIMIT 1",
+            favorites.where_clause()
+        ),
+        &favorites.args,
+    )?;
+
+    let mut prs = Filter::default();
+    prs.add_all(&visible);
+    add_links(&mut prs, Links::With);
+    f.has_prs = exists_row(
+        conn,
+        &format!(
+            "SELECT 1 FROM claude_session_cache c{} LIMIT 1",
+            prs.where_clause()
+        ),
+        &prs.args,
+    )?;
+    Ok(())
+}
+
+/// Distinct non-empty values, in the column's own order. Blank values are
+/// dropped rather than offered as an unlabelled dropdown entry.
+fn distinct_strings(conn: &Connection, sql: &str, args: &[Value]) -> Result<Vec<String>, String> {
+    let mut stmt = conn
+        .prepare(sql)
+        .map_err(|e| format!("claudesessions: reading facet options: {e}"))?;
+    let rows = stmt
+        .query_map(rusqlite::params_from_iter(args.iter()), |row| {
+            row.get::<_, String>(0)
+        })
+        .map_err(|e| format!("claudesessions: reading facet options: {e}"))?;
+
+    let mut out = Vec::new();
+    for row in rows {
+        let v = row.map_err(|e| format!("claudesessions: scanning facet option: {e}"))?;
+        if !v.is_empty() {
+            out.push(v);
+        }
+    }
+    Ok(out)
+}
+
+fn exists_row(conn: &Connection, sql: &str, args: &[Value]) -> Result<bool, String> {
+    let mut stmt = conn
+        .prepare(sql)
+        .map_err(|e| format!("claudesessions: reading facet flag: {e}"))?;
+    let mut rows = stmt
+        .query(rusqlite::params_from_iter(args.iter()))
+        .map_err(|e| format!("claudesessions: reading facet flag: {e}"))?;
+    Ok(rows
+        .next()
+        .map_err(|e| format!("claudesessions: reading facet flag: {e}"))?
+        .is_some())
+}
+
+/// Attach each session's linked pull requests, one query for the whole page.
+///
+/// Best-effort, as in Go: a failure here logs and leaves the lists empty rather
+/// than failing a page that is otherwise complete.
+fn attach_prs(conn: &Connection, sessions: &mut [SessionSummary]) {
+    if sessions.is_empty() {
+        return;
+    }
+    let placeholders = vec!["?"; sessions.len()].join(", ");
+    let sql = format!(
+        "SELECT session_id, pr_number, pr_url, pr_repository, first_seen_at
+         FROM claude_session_pr WHERE session_id IN ({placeholders})
+         ORDER BY first_seen_at, pr_url"
+    );
+    let ids: Vec<&str> = sessions.iter().map(|s| s.session_id.as_str()).collect();
+
+    let mut by_session: BTreeMap<String, Vec<SessionPR>> = BTreeMap::new();
+    let read = (|| -> rusqlite::Result<()> {
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(rusqlite::params_from_iter(ids.iter()), |row| {
+            let session_id: String = row.get(0)?;
+            let first_seen: String = row.get(4)?;
+            Ok((
+                session_id,
+                SessionPR {
+                    pr_number: row.get(1)?,
+                    pr_url: row.get(2)?,
+                    pr_repository: row.get(3)?,
+                    first_seen_at: GoTime::parse_any(&first_seen).map_err(|e| {
+                        rusqlite::Error::FromSqlConversionFailure(
+                            4,
+                            rusqlite::types::Type::Text,
+                            Box::new(std::io::Error::other(e)),
+                        )
+                    })?,
+                },
+            ))
+        })?;
+        for row in rows {
+            let (session_id, pr) = row?;
+            by_session.entry(session_id).or_default().push(pr);
+        }
+        Ok(())
+    })();
+    if let Err(e) = read {
+        log::warn!("claude sessions: failed to load linked PRs for page: {e}");
+        return;
+    }
+
+    for s in sessions.iter_mut() {
+        if let Some(prs) = by_session.remove(&s.session_id) {
+            s.prs = prs;
+        }
+    }
+}
+
+/// Attach delegated usage and cost keyed by the sub-agent's own model.
+///
+/// The summary select's roll-up groups by parent session alone — deliberately,
+/// so a multi-sub-agent session is not multiplied out — which collapses the
+/// model dimension. This is the second grouped read that keeps it, and it is
+/// what lets model attribution credit delegated tokens to the model that spent
+/// them rather than to the delegating parent.
+fn attach_subagent_usage_by_model(conn: &Connection, sessions: &mut [SessionSummary]) {
+    if sessions.is_empty() {
+        return;
+    }
+    let placeholders = vec!["?"; sessions.len()].join(", ");
+    let sql = format!(
+        "SELECT parent_session_id, model,
+                SUM(input_tokens), SUM(output_tokens),
+                SUM(cache_creation_tokens), SUM(cache_read_tokens),
+                SUM(cache_creation_5m_tokens), SUM(cache_creation_1h_tokens),
+                SUM(input_cost_usd), SUM(output_cost_usd),
+                SUM(cache_read_cost_usd), SUM(cache_write_cost_usd), SUM(total_cost_usd)
+         FROM claude_subagent_cache WHERE parent_session_id IN ({placeholders})
+         GROUP BY parent_session_id, model"
+    );
+    let ids: Vec<&str> = sessions.iter().map(|s| s.session_id.as_str()).collect();
+
+    type ByModel = BTreeMap<String, (BTreeMap<String, TokenUsage>, BTreeMap<String, SessionCost>)>;
+    let mut by_session: ByModel = BTreeMap::new();
+    let read = (|| -> rusqlite::Result<()> {
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(rusqlite::params_from_iter(ids.iter()), |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                display_model(&row.get::<_, String>(1)?),
+                TokenUsage {
+                    input_tokens: row.get(2)?,
+                    output_tokens: row.get(3)?,
+                    cache_creation_tokens: row.get(4)?,
+                    cache_creation_5m_tokens: row.get(6)?,
+                    cache_creation_1h_tokens: row.get(7)?,
+                    cache_read_tokens: row.get(5)?,
+                },
+                SessionCost {
+                    input_usd: row.get(8)?,
+                    output_usd: row.get(9)?,
+                    cache_read_usd: row.get(10)?,
+                    cache_write_usd: row.get(11)?,
+                    total_usd: row.get(12)?,
+                },
+            ))
+        })?;
+        for row in rows {
+            let (session_id, model, usage, cost) = row?;
+            let entry = by_session.entry(session_id).or_default();
+            entry.0.insert(model.clone(), usage);
+            entry.1.insert(model, cost);
+        }
+        Ok(())
+    })();
+    if let Err(e) = read {
+        log::warn!("claude sessions: failed to load sub-agent usage by model for page: {e}");
+        return;
+    }
+
+    for s in sessions.iter_mut() {
+        if let Some((usage, cost)) = by_session.remove(&s.session_id) {
+            s.subagent_usage_by_model = usage;
+            s.subagent_cost_by_model = cost;
+        }
+    }
+}

--- a/desktop/src-tauri/src/native/sessions/query.rs
+++ b/desktop/src-tauri/src/native/sessions/query.rs
@@ -1,0 +1,719 @@
+//! The sessions list's filter, sort and page position.
+//!
+//! Mirrors `internal/claudesessions/session_query.go` and the cursor half of
+//! `session_page.go`, plus `sessionQueryFromRequest` in
+//! `internal/api/claude_sessions.go`.
+//!
+//! The metric expressions below are the load-bearing part. They must agree
+//! exactly with `frontend/src/lib/sessionMetrics.ts`, which renders the columns:
+//! a row showing $36.30 must not be hidden by "cost at most $40". Go and
+//! TypeScript already assert that agreement from
+//! `internal/claudesessions/testdata/session_metric_vectors.json`; this file's
+//! tests make Rust the third reader of the same fixture.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::native::gojson;
+use crate::native::gotime::GoTime;
+
+/// Per-session figures as SQL over the summary select's `c` (session) and `sa`
+/// (sub-agent roll-up) aliases. Every one but `messages` sums the main thread
+/// and its delegated sub-agents, because that is what the list's columns show.
+pub const SQL_INPUT_TOKENS: &str = "(c.input_tokens + COALESCE(sa.it, 0))";
+pub const SQL_OUTPUT_TOKENS: &str = "(c.output_tokens + COALESCE(sa.ot, 0))";
+pub const SQL_TOKENS: &str =
+    "(c.input_tokens + COALESCE(sa.it, 0) + c.output_tokens + COALESCE(sa.ot, 0))";
+pub const SQL_COST_USD: &str = "(c.total_cost_usd + COALESCE(sa.tc, 0))";
+/// Active duration, not the wall-clock span: a resumable session's span counts
+/// every idle day between sittings.
+pub const SQL_ACTIVE_DURATION_MS: &str = "(c.active_duration_ms + COALESCE(sa.adm, 0))";
+/// Message count stays main-thread, matching the column beside it.
+pub const SQL_MESSAGE_COUNT: &str = "c.message_count";
+
+/// The order a page is returned in. A closed set, because keyset pagination
+/// needs the sort column indexed and the tiebreak stable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum Sort {
+    #[default]
+    Recent,
+    Cost,
+    Tokens,
+    Duration,
+    Messages,
+}
+
+impl Sort {
+    /// Parse the `sort` parameter. An unknown value falls back to `Recent`
+    /// rather than erroring: the list is a read-only view, and a stale bookmark
+    /// is better rendered in the default order than refused.
+    pub fn parse(raw: &str) -> Self {
+        match raw {
+            "cost" => Sort::Cost,
+            "tokens" => Sort::Tokens,
+            "duration" => Sort::Duration,
+            "messages" => Sort::Messages,
+            _ => Sort::Recent,
+        }
+    }
+
+    /// The wire name, which the cursor carries.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Sort::Recent => "recent",
+            Sort::Cost => "cost",
+            Sort::Tokens => "tokens",
+            Sort::Duration => "duration",
+            Sort::Messages => "messages",
+        }
+    }
+
+    /// The SQL the sort orders and pages on, and whether its values are
+    /// timestamps (which page through a time cursor rather than a float).
+    pub fn expr(self) -> (&'static str, bool) {
+        match self {
+            Sort::Cost => (SQL_COST_USD, false),
+            Sort::Tokens => (SQL_TOKENS, false),
+            Sort::Duration => (SQL_ACTIVE_DURATION_MS, false),
+            Sort::Messages => (SQL_MESSAGE_COUNT, false),
+            Sort::Recent => ("c.last_activity", true),
+        }
+    }
+}
+
+/// Whether a session must have linked pull requests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Links {
+    #[default]
+    Any,
+    With,
+    Without,
+}
+
+/// An inclusive numeric filter. One min/max pair expresses all three
+/// comparisons the UI offers.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NumericRange {
+    pub min: Option<f64>,
+    pub max: Option<f64>,
+}
+
+impl NumericRange {
+    fn set(&self) -> bool {
+        self.min.is_some() || self.max.is_some()
+    }
+}
+
+/// A half-open interval a drill-down selected.
+#[derive(Debug, Clone, Copy)]
+pub struct TimeWindow {
+    pub from_ms: i64,
+    pub to_ms: i64,
+}
+
+/// Bounds the OR-group a drill-down expands into, so a hand-written query
+/// string cannot turn one request into a several-thousand-term predicate.
+const MAX_DRILLDOWN_WINDOWS: usize = 512;
+
+/// Page size bounds.
+pub const DEFAULT_PAGE_SIZE: i64 = 50;
+pub const MAX_PAGE_SIZE: i64 = 200;
+
+/// Everything the sessions list can narrow, sort and page by. The default
+/// selects every visible session, newest first.
+#[derive(Debug, Clone, Default)]
+pub struct SessionQuery {
+    pub project: String,
+    pub config_dir: String,
+    pub search: String,
+    pub favorites_only: bool,
+    pub links: Links,
+    pub permission_mode: String,
+    pub model: String,
+    pub messages: NumericRange,
+    pub duration_minutes: NumericRange,
+    pub tokens_in: NumericRange,
+    pub tokens_out: NumericRange,
+    pub cost: NumericRange,
+    pub from: Option<GoTime>,
+    pub to: Option<GoTime>,
+    pub windows: Vec<TimeWindow>,
+    pub sort: Sort,
+    pub limit: i64,
+    pub cursor: String,
+}
+
+impl SessionQuery {
+    /// The clamped page size.
+    pub fn page_size(&self) -> i64 {
+        match self.limit {
+            n if n <= 0 => DEFAULT_PAGE_SIZE,
+            n if n > MAX_PAGE_SIZE => MAX_PAGE_SIZE,
+            n => n,
+        }
+    }
+
+    /// Parse the list's parameters from a raw query string.
+    ///
+    /// A malformed numeric bound is ignored rather than rejected: these arrive
+    /// from number inputs a user is part-way through typing, and refusing the
+    /// request would blank the list between keystrokes. A malformed *window* is
+    /// an error, because the windows **are** the filter when a drill-down is
+    /// active and silently dropping half of them would show a plausible-looking
+    /// but wrong set of sessions.
+    pub fn parse(raw_query: &str) -> Result<Self, String> {
+        let params = parse_params(raw_query);
+        let get = |k: &str| params.get(k).cloned().unwrap_or_default();
+
+        let links = match get("links").as_str() {
+            "" => Links::Any,
+            "with" => Links::With,
+            "without" => Links::Without,
+            other => return Err(format!("invalid links filter {other:?}")),
+        };
+
+        let limit = match get("limit") {
+            raw if raw.is_empty() => 0,
+            raw => raw
+                .parse::<i64>()
+                .map_err(|_| format!("invalid limit {raw:?}"))?,
+        };
+
+        Ok(SessionQuery {
+            project: get("project"),
+            config_dir: get("config_dir"),
+            search: get("q"),
+            favorites_only: get("favorites") == "true",
+            links,
+            permission_mode: get("permission_mode"),
+            model: get("model"),
+            messages: numeric_range(&params, "messages"),
+            duration_minutes: numeric_range(&params, "duration"),
+            tokens_in: numeric_range(&params, "tokens_in"),
+            tokens_out: numeric_range(&params, "tokens_out"),
+            cost: numeric_range(&params, "cost"),
+            from: optional_time(&get("from")),
+            to: optional_time(&get("to")),
+            windows: parse_windows(&get("windows"))?,
+            sort: Sort::parse(&get("sort")),
+            limit,
+            cursor: get("cursor"),
+        })
+    }
+}
+
+/// Decode a query string into first-value-wins parameters, as Go's
+/// `url.Values.Get` reads them.
+fn parse_params(raw: &str) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    for (k, v) in form_urlencoded::parse(raw.as_bytes()) {
+        out.entry(k.into_owned()).or_insert_with(|| v.into_owned());
+    }
+    out
+}
+
+fn numeric_range(params: &HashMap<String, String>, name: &str) -> NumericRange {
+    NumericRange {
+        min: optional_float(params.get(&format!("{name}_min"))),
+        max: optional_float(params.get(&format!("{name}_max"))),
+    }
+}
+
+/// `None` for an absent or unparseable value, which the filter reads as
+/// "unbounded on that side" — distinct from zero, which is a real bound.
+fn optional_float(raw: Option<&String>) -> Option<f64> {
+    raw.filter(|s| !s.is_empty())?.parse::<f64>().ok()
+}
+
+fn optional_time(raw: &str) -> Option<GoTime> {
+    if raw.is_empty() {
+        return None;
+    }
+    GoTime::parse(raw).ok()
+}
+
+/// Decode the `fromMs-toMs,fromMs-toMs` form the analytics charts link with.
+fn parse_windows(raw: &str) -> Result<Vec<TimeWindow>, String> {
+    if raw.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut windows = Vec::new();
+    for part in raw.split(',') {
+        let (from, to) = part
+            .split_once('-')
+            .ok_or_else(|| format!("invalid drill-down window {part:?}"))?;
+        let from_ms = from
+            .parse::<i64>()
+            .map_err(|_| format!("invalid drill-down window start {from:?}"))?;
+        let to_ms = to
+            .parse::<i64>()
+            .map_err(|_| format!("invalid drill-down window end {to:?}"))?;
+        if to_ms <= from_ms {
+            return Err(format!("drill-down window {part:?} ends before it starts"));
+        }
+        windows.push(TimeWindow { from_ms, to_ms });
+    }
+    Ok(windows)
+}
+
+/// An accumulated WHERE fragment with its bound arguments.
+#[derive(Default)]
+pub struct Filter {
+    sql: Vec<String>,
+    pub args: Vec<Value>,
+}
+
+/// A bound parameter. Timestamps are bound as the text the column holds, so the
+/// comparison is against the same rendering the driver wrote.
+#[derive(Debug, Clone)]
+pub enum Value {
+    Text(String),
+    Real(f64),
+    Int(i64),
+}
+
+impl rusqlite::ToSql for Value {
+    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
+        match self {
+            Value::Text(s) => s.to_sql(),
+            Value::Real(f) => f.to_sql(),
+            Value::Int(i) => i.to_sql(),
+        }
+    }
+}
+
+impl Filter {
+    pub fn add(&mut self, sql: impl Into<String>, args: Vec<Value>) {
+        self.sql.push(sql.into());
+        self.args.extend(args);
+    }
+
+    /// Copy another filter's terms and arguments in, for the facet queries
+    /// that start from the visible-session scope and add one term.
+    pub fn add_all(&mut self, other: &Filter) {
+        self.sql.extend(other.sql.iter().cloned());
+        self.args.extend(other.args.iter().cloned());
+    }
+
+    /// The rendered predicate, or empty when nothing was added. Always AND:
+    /// every filter narrows.
+    pub fn where_clause(&self) -> String {
+        if self.sql.is_empty() {
+            return String::new();
+        }
+        format!("\nWHERE {}", self.sql.join("\n  AND "))
+    }
+}
+
+/// Turn a query into its WHERE clause, excluding pagination — the same
+/// predicate serves the page, the facet aggregate and the total count, so the
+/// counter in the toolbar and the rows below it cannot disagree.
+pub fn build_filter(
+    q: &SessionQuery,
+    hidden_projects: &[String],
+    indexed_dirs: &[String],
+) -> Result<Filter, String> {
+    let mut f = Filter::default();
+
+    for p in hidden_projects {
+        f.add("c.project_path != ?", vec![Value::Text(p.clone())]);
+    }
+    add_config_dir_scope(&mut f, indexed_dirs);
+
+    if !q.project.is_empty() {
+        f.add("c.project_path = ?", vec![Value::Text(q.project.clone())]);
+    }
+    if !q.config_dir.is_empty() {
+        f.add("c.config_dir = ?", vec![Value::Text(q.config_dir.clone())]);
+    }
+    if q.favorites_only {
+        f.add("c.is_favorite = 1", vec![]);
+    }
+    if !q.permission_mode.is_empty() {
+        f.add(
+            "c.permission_mode = ?",
+            vec![Value::Text(q.permission_mode.clone())],
+        );
+    }
+    if !q.model.is_empty() {
+        f.add("c.model = ?", vec![Value::Text(q.model.clone())]);
+    }
+    add_search(&mut f, &q.search);
+    add_links(&mut f, q.links);
+
+    add_range(&mut f, SQL_MESSAGE_COUNT, q.messages, 1.0);
+    // The duration filter is entered in minutes; the column stores milliseconds.
+    add_range(&mut f, SQL_ACTIVE_DURATION_MS, q.duration_minutes, 60_000.0);
+    add_range(&mut f, SQL_INPUT_TOKENS, q.tokens_in, 1.0);
+    add_range(&mut f, SQL_OUTPUT_TOKENS, q.tokens_out, 1.0);
+    add_range(&mut f, SQL_COST_USD, q.cost, 1.0);
+
+    add_time_filter(&mut f, q)?;
+    Ok(f)
+}
+
+/// Restrict results to the config dirs currently indexed.
+///
+/// Removing a dir hides its sessions rather than deleting them. The empty
+/// string is always admitted: rows written before the column existed carry it
+/// and belong to the default dir.
+pub fn add_config_dir_scope(f: &mut Filter, dirs: &[String]) {
+    if dirs.is_empty() {
+        return;
+    }
+    let placeholders = vec!["?"; dirs.len()].join(", ");
+    let args = dirs.iter().cloned().map(Value::Text).collect();
+    f.add(
+        format!("(c.config_dir = '' OR c.config_dir IN ({placeholders}))"),
+        args,
+    );
+}
+
+/// Match the same fields the client-side predicate did, case-insensitively.
+///
+/// `LOWER` on both sides rather than `COLLATE NOCASE`, because NOCASE is
+/// ASCII-only in SQLite and project paths and titles are not.
+fn add_search(f: &mut Filter, search: &str) {
+    let q = search.trim().to_lowercase();
+    if q.is_empty() {
+        return;
+    }
+    // Bound, not interpolated, so % and _ typed by the user match literally.
+    let pattern = format!("%{}%", escape_like(&q));
+    f.add(
+        r"(LOWER(c.session_id) LIKE ? ESCAPE '\'
+    OR LOWER(c.preview) LIKE ? ESCAPE '\'
+    OR LOWER(c.custom_title) LIKE ? ESCAPE '\'
+    OR LOWER(c.native_title) LIKE ? ESCAPE '\'
+    OR LOWER(c.ai_title) LIKE ? ESCAPE '\'
+    OR LOWER(c.project_path) LIKE ? ESCAPE '\')",
+        vec![Value::Text(pattern); 6],
+    );
+}
+
+/// Neutralize LIKE's wildcards so a search for "100%" does not match
+/// everything beginning with "100".
+fn escape_like(s: &str) -> String {
+    s.replace('\\', r"\\")
+        .replace('%', r"\%")
+        .replace('_', r"\_")
+}
+
+const PR_EXISTS: &str =
+    "EXISTS (SELECT 1 FROM claude_session_pr p WHERE p.session_id = c.session_id)";
+
+pub fn add_links(f: &mut Filter, links: Links) {
+    match links {
+        Links::With => f.add(PR_EXISTS, vec![]),
+        Links::Without => f.add(format!("NOT {PR_EXISTS}"), vec![]),
+        Links::Any => {}
+    }
+}
+
+/// An inclusive bound on `expr`. `scale` converts the filter's unit into the
+/// column's, so the bound moves rather than the column — keeping the expression
+/// indexable and the comparison exact.
+fn add_range(f: &mut Filter, expr: &str, r: NumericRange, scale: f64) {
+    if !r.set() {
+        return;
+    }
+    if let Some(min) = r.min {
+        f.add(format!("{expr} >= ?"), vec![Value::Real(min * scale)]);
+    }
+    if let Some(max) = r.max {
+        f.add(format!("{expr} <= ?"), vec![Value::Real(max * scale)]);
+    }
+}
+
+/// Apply either the drill-down windows or the from/to range — never both,
+/// matching the UI, where an active drill-down replaces the preset.
+fn add_time_filter(f: &mut Filter, q: &SessionQuery) -> Result<(), String> {
+    if !q.windows.is_empty() {
+        if q.windows.len() > MAX_DRILLDOWN_WINDOWS {
+            return Err(format!(
+                "claudesessions: {} drill-down windows exceeds the {} limit",
+                q.windows.len(),
+                MAX_DRILLDOWN_WINDOWS
+            ));
+        }
+        let mut terms = Vec::with_capacity(q.windows.len());
+        let mut args = Vec::with_capacity(q.windows.len() * 2);
+        for w in &q.windows {
+            // Half-open, matching the client's overlapsAnyWindow: a session
+            // starting exactly at a window's end is in the next window.
+            terms.push("(c.start_time < ? AND c.last_activity >= ?)");
+            args.push(Value::Text(sql_time_from_millis(w.to_ms)));
+            args.push(Value::Text(sql_time_from_millis(w.from_ms)));
+        }
+        f.add(format!("({})", terms.join("\n    OR ")), args);
+        return Ok(());
+    }
+    if let Some(to) = q.to {
+        f.add("c.start_time <= ?", vec![Value::Text(sql_time(to))]);
+    }
+    if let Some(from) = q.from {
+        f.add("c.last_activity >= ?", vec![Value::Text(sql_time(from))]);
+    }
+    Ok(())
+}
+
+/// Render a timestamp the way the driver rendered the stored one.
+///
+/// The DATETIME columns hold Go's `time.Time.String()` text, and both the
+/// `ORDER BY` and every time predicate compare it **as text** — an ordering
+/// that matches chronological order only because every value is UTC with its
+/// trailing zeros trimmed. A bound formatted any other way would compare
+/// against a different string shape and silently mis-filter.
+pub fn sql_time(t: GoTime) -> String {
+    crate::native::gotime::to_go_string_utc(t)
+}
+
+fn sql_time_from_millis(ms: i64) -> String {
+    crate::native::gotime::go_string_from_millis(ms)
+}
+
+/// A keyset position: the sort value of the last row returned, plus its session
+/// ID as the tiebreak.
+///
+/// Keyset rather than OFFSET, because OFFSET makes the database walk and
+/// discard every skipped row, and because a scan completing mid-scroll would
+/// shift every subsequent page.
+///
+/// Field order is the wire order Go marshals, and the short names are Go's.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Cursor {
+    #[serde(rename = "s")]
+    pub sort: String,
+    /// The sort column's value: RFC3339Nano for the time sort, a decimal
+    /// otherwise. A string either way, so one encoding covers both.
+    #[serde(rename = "v")]
+    pub value: String,
+    pub id: String,
+}
+
+/// Returned when a cursor was minted under a different sort than the request
+/// asks for. Continuing would page through one ordering using another's
+/// position, silently skipping and repeating rows.
+pub const ERR_CURSOR_MISMATCH: &str = "claudesessions: cursor does not match the requested sort";
+
+impl Cursor {
+    pub fn encode(&self) -> String {
+        match gojson::to_vec_marshal(self) {
+            Ok(bytes) => base64_url_nopad(&bytes),
+            Err(_) => String::new(),
+        }
+    }
+
+    pub fn decode(raw: &str, want: Sort) -> Result<Option<Cursor>, String> {
+        if raw.is_empty() {
+            return Ok(None);
+        }
+        let bytes = base64_url_nopad_decode(raw)
+            .ok_or_else(|| "claudesessions: malformed cursor".to_string())?;
+        let c: Cursor = serde_json::from_slice(&bytes)
+            .map_err(|e| format!("claudesessions: malformed cursor: {e}"))?;
+        if c.sort != want.as_str() {
+            return Err(ERR_CURSOR_MISMATCH.to_string());
+        }
+        Ok(Some(c))
+    }
+
+    /// The argument the keyset predicate compares against.
+    pub fn bind(&self, is_time: bool) -> Result<Value, String> {
+        if is_time {
+            let t = GoTime::parse(&self.value)
+                .map_err(|e| format!("claudesessions: malformed cursor timestamp: {e}"))?;
+            return Ok(Value::Text(sql_time(t)));
+        }
+        self.value
+            .parse::<f64>()
+            .map(Value::Real)
+            .map_err(|e| format!("claudesessions: malformed cursor value: {e}"))
+    }
+}
+
+/// Render a row's sort value for the next cursor, in the spelling Go uses:
+/// `strconv.FormatFloat(_, 'g', -1, 64)` for the cost, plain integers for the
+/// counts, and RFC3339Nano for the timestamp.
+pub fn cursor_value(s: &super::summary::SessionSummary, sort: Sort) -> String {
+    match sort {
+        Sort::Cost => gojson::format_g(s.total_cost_usd()),
+        Sort::Tokens => s.total_conversation_tokens().to_string(),
+        Sort::Duration => s.total_active_duration_ms().to_string(),
+        Sort::Messages => s.message_count.to_string(),
+        Sort::Recent => s.last_activity.to_rfc3339_nano(),
+    }
+}
+
+/// base64 RawURLEncoding: URL alphabet, no padding.
+fn base64_url_nopad(bytes: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
+    for chunk in bytes.chunks(3) {
+        let b = [
+            chunk[0],
+            *chunk.get(1).unwrap_or(&0),
+            *chunk.get(2).unwrap_or(&0),
+        ];
+        let n = (u32::from(b[0]) << 16) | (u32::from(b[1]) << 8) | u32::from(b[2]);
+        let indices = [n >> 18 & 63, n >> 12 & 63, n >> 6 & 63, n & 63];
+        for (i, idx) in indices.iter().enumerate() {
+            if i <= chunk.len() {
+                out.push(ALPHABET[*idx as usize] as char);
+            }
+        }
+    }
+    out
+}
+
+fn base64_url_nopad_decode(text: &str) -> Option<Vec<u8>> {
+    let value = |c: u8| -> Option<u32> {
+        Some(match c {
+            b'A'..=b'Z' => u32::from(c - b'A'),
+            b'a'..=b'z' => u32::from(c - b'a') + 26,
+            b'0'..=b'9' => u32::from(c - b'0') + 52,
+            b'-' => 62,
+            b'_' => 63,
+            _ => return None,
+        })
+    };
+    let mut out = Vec::with_capacity(text.len() / 4 * 3);
+    for chunk in text.as_bytes().chunks(4) {
+        if chunk.len() == 1 {
+            return None;
+        }
+        let mut n = 0u32;
+        for (i, c) in chunk.iter().enumerate() {
+            n |= value(*c)? << (18 - 6 * i);
+        }
+        for i in 0..chunk.len() - 1 {
+            out.push(((n >> (16 - 8 * i)) & 0xFF) as u8);
+        }
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base64_round_trips_in_gos_raw_url_alphabet() {
+        for payload in [
+            &b""[..],
+            b"a",
+            b"ab",
+            b"abc",
+            b"abcd",
+            br#"{"s":"cost","v":"36.3","id":"abc-123"}"#,
+            &[0xff, 0xfe, 0xfd][..],
+        ] {
+            let encoded = base64_url_nopad(payload);
+            assert!(!encoded.contains('='), "padding in {encoded}");
+            assert_eq!(
+                base64_url_nopad_decode(&encoded).as_deref(),
+                Some(payload),
+                "round trip of {payload:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_cursor_from_another_sort_is_rejected() {
+        let c = Cursor {
+            sort: "cost".into(),
+            value: "36.3".into(),
+            id: "s1".into(),
+        };
+        let encoded = c.encode();
+        assert!(Cursor::decode(&encoded, Sort::Cost)
+            .expect("decode")
+            .is_some());
+        let err = Cursor::decode(&encoded, Sort::Recent).expect_err("mismatch");
+        assert_eq!(err, ERR_CURSOR_MISMATCH);
+    }
+
+    #[test]
+    fn an_empty_cursor_is_the_first_page_not_an_error() {
+        assert!(Cursor::decode("", Sort::Recent).expect("decode").is_none());
+    }
+
+    #[test]
+    fn the_cursor_encodes_the_fields_go_encodes_in_gos_order() {
+        let c = Cursor {
+            sort: "recent".into(),
+            value: "2026-08-13T10:00:00Z".into(),
+            id: "s1".into(),
+        };
+        let decoded = base64_url_nopad_decode(&c.encode()).expect("decode");
+        assert_eq!(
+            String::from_utf8(decoded).expect("utf-8"),
+            r#"{"s":"recent","v":"2026-08-13T10:00:00Z","id":"s1"}"#
+        );
+    }
+
+    #[test]
+    fn an_unknown_sort_falls_back_to_recent_rather_than_erroring() {
+        assert_eq!(Sort::parse("nonsense"), Sort::Recent);
+        assert_eq!(Sort::parse(""), Sort::Recent);
+        assert_eq!(Sort::parse("cost"), Sort::Cost);
+    }
+
+    #[test]
+    fn query_parsing_matches_the_go_handler() {
+        let q = SessionQuery::parse(
+            "project=%2Fhome%2Fu%2Fp&q=hello+world&favorites=true&links=with\
+             &permission_mode=bypass&model=opus&cost_min=1.5&cost_max=40\
+             &duration_min=5&sort=cost&limit=25&cursor=abc",
+        )
+        .expect("parse");
+
+        assert_eq!(q.project, "/home/u/p");
+        assert_eq!(q.search, "hello world");
+        assert!(q.favorites_only);
+        assert_eq!(q.links, Links::With);
+        assert_eq!(q.permission_mode, "bypass");
+        assert_eq!(q.model, "opus");
+        assert_eq!(q.cost.min, Some(1.5));
+        assert_eq!(q.cost.max, Some(40.0));
+        assert_eq!(q.duration_minutes.min, Some(5.0));
+        assert_eq!(q.sort, Sort::Cost);
+        assert_eq!(q.limit, 25);
+        assert_eq!(q.cursor, "abc");
+    }
+
+    #[test]
+    fn a_half_typed_number_is_ignored_but_a_bad_window_is_an_error() {
+        let q = SessionQuery::parse("cost_min=&cost_max=notanumber").expect("parse");
+        assert_eq!(q.cost.min, None);
+        assert_eq!(q.cost.max, None);
+
+        assert!(SessionQuery::parse("windows=123-456").is_ok());
+        assert!(SessionQuery::parse("windows=nonsense").is_err());
+        assert!(SessionQuery::parse("windows=abc-456").is_err());
+    }
+
+    #[test]
+    fn an_invalid_links_filter_is_rejected() {
+        assert!(SessionQuery::parse("links=maybe").is_err());
+        assert!(SessionQuery::parse("links=").is_ok());
+    }
+
+    #[test]
+    fn page_size_is_clamped_not_refused() {
+        let mut q = SessionQuery::default();
+        assert_eq!(q.page_size(), DEFAULT_PAGE_SIZE);
+        q.limit = 1000;
+        assert_eq!(q.page_size(), MAX_PAGE_SIZE);
+        q.limit = 25;
+        assert_eq!(q.page_size(), 25);
+    }
+
+    #[test]
+    fn search_wildcards_are_escaped_so_they_match_literally() {
+        assert_eq!(escape_like("100%"), r"100\%");
+        assert_eq!(escape_like("a_b"), r"a\_b");
+        assert_eq!(escape_like(r"back\slash"), r"back\\slash");
+    }
+}

--- a/desktop/src-tauri/src/native/sessions/summary.rs
+++ b/desktop/src-tauri/src/native/sessions/summary.rs
@@ -1,0 +1,445 @@
+//! One row of the sessions list, and the projection every reader shares.
+//!
+//! Mirrors `claudesessions.ClaudeSessionSummary` and the
+//! `sessionSummaryColumns` / `sessionSummarySource` constants in
+//! `internal/claudesessions/scanner.go`. The SQL is reproduced verbatim rather
+//! than rewritten, because the sub-agent roll-up's column aliases (`it`, `ot`,
+//! `tc`, `adm`, …) are what the filter expressions in `query.rs` are written
+//! against, and because a grouped sub-select is what stops a session with
+//! several sub-agents from being multiplied out by the join.
+//!
+//! **Field order is wire order.** Every struct below declares its fields in the
+//! order the Go struct declares them; `serde` and `encoding/json` both emit
+//! declaration order, so re-sorting them for tidiness changes the bytes.
+//!
+//! **Maps are `BTreeMap`.** Go marshals a map with its keys sorted, so a
+//! `HashMap` here would emit the same data in an order that changes run to run.
+
+use std::collections::BTreeMap;
+
+use rusqlite::Row;
+use serde::Serialize;
+
+use crate::native::gotime::GoTime;
+
+/// Token consumption. Mirrors `claudesessions.TokenUsage`.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct TokenUsage {
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    /// The authoritative cache-write total; the 5m/1h fields split it by TTL
+    /// (they bill at 1.25× and 2× input) and always sum to this.
+    pub cache_creation_tokens: i64,
+    pub cache_creation_5m_tokens: i64,
+    pub cache_creation_1h_tokens: i64,
+    pub cache_read_tokens: i64,
+}
+
+/// USD cost, broken down by token category. Mirrors `claudesessions.SessionCost`.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct SessionCost {
+    pub input_usd: f64,
+    pub output_usd: f64,
+    pub cache_read_usd: f64,
+    pub cache_write_usd: f64,
+    pub total_usd: f64,
+}
+
+/// A pull request a session was linked to.
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionPR {
+    pub pr_number: i64,
+    pub pr_url: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub pr_repository: String,
+    pub first_seen_at: GoTime,
+}
+
+/// One session as the list renders it.
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionSummary {
+    pub session_id: String,
+    pub project_path: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub config_dir: String,
+    pub preview: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub custom_title: String,
+    #[serde(skip_serializing_if = "is_false")]
+    pub is_favorite: bool,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub native_title: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub ai_title: String,
+    pub display_title: String,
+    pub start_time: GoTime,
+    pub last_activity: GoTime,
+    pub active_duration_ms: i64,
+    pub subagent_active_duration_ms: i64,
+    pub message_count: i64,
+    pub event_count: i64,
+    /// Main thread only — `subagent_usage` holds delegated work.
+    pub usage: TokenUsage,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub git_branch: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub model: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub cwd: String,
+    pub subagent_count: i64,
+    pub subagent_usage: TokenUsage,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub subagent_usage_by_model: BTreeMap<String, TokenUsage>,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub agent_name: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub permission_mode: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub mode: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub relocated_cwd: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub worktree_name: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub worktree_branch: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub original_branch: String,
+    pub compaction_count: i64,
+    pub dropped_tokens: i64,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub prs: Vec<SessionPR>,
+    pub cost: SessionCost,
+    pub subagent_cost: SessionCost,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub cost_by_model: BTreeMap<String, SessionCost>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub subagent_cost_by_model: BTreeMap<String, SessionCost>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub unpriced_models: Vec<String>,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub unpriced_tokens: i64,
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+fn is_zero(n: &i64) -> bool {
+    *n == 0
+}
+
+impl SessionSummary {
+    /// Total input+output tokens, main thread plus delegated — what the cursor
+    /// renders for the token sort.
+    pub fn total_conversation_tokens(&self) -> i64 {
+        self.usage.input_tokens
+            + self.usage.output_tokens
+            + self.subagent_usage.input_tokens
+            + self.subagent_usage.output_tokens
+    }
+
+    /// Main-thread plus delegated cost, the figure the cost sort pages on.
+    pub fn total_cost_usd(&self) -> f64 {
+        self.cost.total_usd + self.subagent_cost.total_usd
+    }
+
+    /// Main-thread plus delegated active duration.
+    pub fn total_active_duration_ms(&self) -> i64 {
+        self.active_duration_ms + self.subagent_active_duration_ms
+    }
+}
+
+/// The projection every reader of a session summary shares, so the list, the
+/// detail page and the paged query cannot drift into reporting different
+/// figures for the same row.
+pub const SUMMARY_COLUMNS: &str = "
+	SELECT c.session_id, c.project_path, c.preview, c.custom_title, c.is_favorite,
+	       c.start_time, c.last_activity, c.message_count, c.event_count,
+	       c.input_tokens, c.output_tokens, c.cache_creation_tokens, c.cache_read_tokens,
+	       c.cache_creation_5m_tokens, c.cache_creation_1h_tokens,
+	       c.git_branch, c.model, c.cwd, c.native_title, c.ai_title,
+	       c.agent_name, c.permission_mode, c.mode, c.relocated_cwd,
+	       c.worktree_name, c.worktree_branch, c.original_branch,
+	       c.compaction_count, c.dropped_tokens,
+	       c.input_cost_usd, c.output_cost_usd, c.cache_read_cost_usd,
+	       c.cache_write_cost_usd, c.total_cost_usd, c.unpriced_models, c.unpriced_tokens,
+	       c.cost_by_model, c.active_duration_ms, c.config_dir,
+	       COALESCE(sa.n, 0), COALESCE(sa.it, 0), COALESCE(sa.ot, 0),
+	       COALESCE(sa.cct, 0), COALESCE(sa.crt, 0),
+	       COALESCE(sa.c5m, 0), COALESCE(sa.c1h, 0),
+	       COALESCE(sa.ic, 0), COALESCE(sa.oc, 0), COALESCE(sa.crc, 0),
+	       COALESCE(sa.cwc, 0), COALESCE(sa.tc, 0), COALESCE(sa.ut, 0),
+	       COALESCE(sa.um, ''), COALESCE(sa.adm, 0)";
+
+/// The FROM/JOIN half, split out so an aggregate can reuse it without the
+/// projection. Its aliases are what `query.rs`'s metric expressions name.
+pub const SUMMARY_SOURCE: &str = "
+	FROM claude_session_cache c
+	LEFT JOIN (
+		SELECT parent_session_id,
+		       COUNT(*) AS n,
+		       SUM(input_tokens) AS it,
+		       SUM(output_tokens) AS ot,
+		       SUM(cache_creation_tokens) AS cct,
+		       SUM(cache_read_tokens) AS crt,
+		       SUM(cache_creation_5m_tokens) AS c5m,
+		       SUM(cache_creation_1h_tokens) AS c1h,
+		       SUM(input_cost_usd) AS ic,
+		       SUM(output_cost_usd) AS oc,
+		       SUM(cache_read_cost_usd) AS crc,
+		       SUM(cache_write_cost_usd) AS cwc,
+		       SUM(total_cost_usd) AS tc,
+		       SUM(unpriced_tokens) AS ut,
+		       SUM(active_duration_ms) AS adm,
+		       GROUP_CONCAT(NULLIF(unpriced_models, ''), char(10)) AS um
+		FROM claude_subagent_cache
+		GROUP BY parent_session_id
+	) sa ON sa.parent_session_id = c.session_id";
+
+/// Scan one row of `SUMMARY_COLUMNS`, applying the same post-processing
+/// `scanSessionSummary` does.
+pub fn scan(row: &Row<'_>) -> rusqlite::Result<SessionSummary> {
+    let start_time: String = row.get(5)?;
+    let last_activity: String = row.get(6)?;
+    let unpriced: String = row.get(34)?;
+    let cost_by_model: String = row.get(36)?;
+    let subagent_unpriced_tokens: i64 = row.get(51)?;
+    let subagent_unpriced_models: String = row.get(52)?;
+
+    let mut s = SessionSummary {
+        session_id: row.get(0)?,
+        project_path: row.get(1)?,
+        config_dir: row.get(38)?,
+        preview: row.get(2)?,
+        custom_title: row.get(3)?,
+        is_favorite: row.get::<_, i64>(4)? == 1,
+        native_title: row.get(18)?,
+        ai_title: row.get(19)?,
+        display_title: String::new(),
+        start_time: parse_time(&start_time, 5)?,
+        last_activity: parse_time(&last_activity, 6)?,
+        active_duration_ms: row.get(37)?,
+        subagent_active_duration_ms: row.get(53)?,
+        message_count: row.get(7)?,
+        event_count: row.get(8)?,
+        usage: TokenUsage {
+            input_tokens: row.get(9)?,
+            output_tokens: row.get(10)?,
+            cache_creation_tokens: row.get(11)?,
+            cache_creation_5m_tokens: row.get(13)?,
+            cache_creation_1h_tokens: row.get(14)?,
+            cache_read_tokens: row.get(12)?,
+        },
+        git_branch: row.get(15)?,
+        model: row.get(16)?,
+        cwd: row.get(17)?,
+        subagent_count: row.get(39)?,
+        subagent_usage: TokenUsage {
+            input_tokens: row.get(40)?,
+            output_tokens: row.get(41)?,
+            cache_creation_tokens: row.get(42)?,
+            cache_creation_5m_tokens: row.get(44)?,
+            cache_creation_1h_tokens: row.get(45)?,
+            cache_read_tokens: row.get(43)?,
+        },
+        subagent_usage_by_model: BTreeMap::new(),
+        agent_name: row.get(20)?,
+        permission_mode: row.get(21)?,
+        mode: row.get(22)?,
+        relocated_cwd: row.get(23)?,
+        worktree_name: row.get(24)?,
+        worktree_branch: row.get(25)?,
+        original_branch: row.get(26)?,
+        compaction_count: row.get(27)?,
+        dropped_tokens: row.get(28)?,
+        prs: Vec::new(),
+        cost: SessionCost {
+            input_usd: row.get(29)?,
+            output_usd: row.get(30)?,
+            cache_read_usd: row.get(31)?,
+            cache_write_usd: row.get(32)?,
+            total_usd: row.get(33)?,
+        },
+        subagent_cost: SessionCost {
+            input_usd: row.get(46)?,
+            output_usd: row.get(47)?,
+            cache_read_usd: row.get(48)?,
+            cache_write_usd: row.get(49)?,
+            total_usd: row.get(50)?,
+        },
+        cost_by_model: decode_cost_by_model(&cost_by_model),
+        subagent_cost_by_model: BTreeMap::new(),
+        unpriced_models: merge_unpriced_models(&unpriced, &subagent_unpriced_models),
+        unpriced_tokens: row.get::<_, i64>(35)? + subagent_unpriced_tokens,
+    };
+    s.display_title = resolve_display_title(&s);
+    Ok(s)
+}
+
+fn parse_time(text: &str, column: usize) -> rusqlite::Result<GoTime> {
+    GoTime::parse_any(text).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            column,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::other(e)),
+        )
+    })
+}
+
+/// The label the UI renders. Agento's own rename wins, then Claude Code's
+/// native title, then its AI-generated one, then the first prompt.
+fn resolve_display_title(s: &SessionSummary) -> String {
+    for candidate in [&s.custom_title, &s.native_title, &s.ai_title, &s.preview] {
+        if !candidate.is_empty() {
+            return candidate.clone();
+        }
+    }
+    String::new()
+}
+
+/// Decode the `cost_by_model` JSON column. Anything unusable yields no map at
+/// all rather than a partial one, matching Go's `decodeCostByModel`.
+fn decode_cost_by_model(raw: &str) -> BTreeMap<String, SessionCost> {
+    if raw.is_empty() || raw == "{}" {
+        return BTreeMap::new();
+    }
+    serde_json::from_str(raw).unwrap_or_default()
+}
+
+/// Merge the session's own unpriced models with its sub-agents', deduplicated
+/// and sorted.
+///
+/// Both halves count toward the same disclosure: reading one without the other
+/// would let a row report excluded tokens attributed to no model, or show a
+/// confident total for a session that is only partly priced.
+fn merge_unpriced_models(own: &str, delegated: &str) -> Vec<String> {
+    let mut seen = std::collections::BTreeSet::new();
+    for group in [own, delegated] {
+        for model in group.split('\n') {
+            if !model.is_empty() {
+                seen.insert(model.to_string());
+            }
+        }
+    }
+    seen.into_iter().collect()
+}
+
+/// `displayModel`: an empty model ID reads as "unknown" rather than as a blank
+/// key.
+pub fn display_model(model: &str) -> String {
+    if model.is_empty() {
+        "unknown".to_string()
+    } else {
+        model.to_string()
+    }
+}
+
+/// Deserialization counterpart for the `cost_by_model` column, whose stored
+/// shape is this struct's own JSON.
+impl<'de> serde::Deserialize<'de> for SessionCost {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        #[derive(serde::Deserialize)]
+        struct Raw {
+            #[serde(default)]
+            input_usd: f64,
+            #[serde(default)]
+            output_usd: f64,
+            #[serde(default)]
+            cache_read_usd: f64,
+            #[serde(default)]
+            cache_write_usd: f64,
+            #[serde(default)]
+            total_usd: f64,
+        }
+        let r = Raw::deserialize(d)?;
+        Ok(SessionCost {
+            input_usd: r.input_usd,
+            output_usd: r.output_usd,
+            cache_read_usd: r.cache_read_usd,
+            cache_write_usd: r.cache_write_usd,
+            total_usd: r.total_usd,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_title_precedence_puts_the_users_rename_first() {
+        let mut s = blank();
+        s.preview = "first prompt".into();
+        assert_eq!(resolve_display_title(&s), "first prompt");
+        s.ai_title = "AI title".into();
+        assert_eq!(resolve_display_title(&s), "AI title");
+        s.native_title = "native".into();
+        assert_eq!(resolve_display_title(&s), "native");
+        s.custom_title = "mine".into();
+        assert_eq!(resolve_display_title(&s), "mine");
+    }
+
+    #[test]
+    fn unpriced_models_merge_dedupe_and_sort_across_both_halves() {
+        assert_eq!(
+            merge_unpriced_models("kimi-k2\nglm-4.6", "glm-4.6\nqwen-plus"),
+            vec!["glm-4.6", "kimi-k2", "qwen-plus"]
+        );
+        assert!(merge_unpriced_models("", "").is_empty());
+    }
+
+    #[test]
+    fn a_malformed_cost_column_yields_no_map_rather_than_half_a_map() {
+        assert!(decode_cost_by_model("").is_empty());
+        assert!(decode_cost_by_model("{}").is_empty());
+        assert!(decode_cost_by_model("not json").is_empty());
+
+        let decoded = decode_cost_by_model(r#"{"opus":{"input_usd":1.5,"total_usd":2}}"#);
+        assert_eq!(decoded["opus"].input_usd, 1.5);
+        assert_eq!(decoded["opus"].total_usd, 2.0);
+        assert_eq!(decoded["opus"].output_usd, 0.0);
+    }
+
+    fn blank() -> SessionSummary {
+        SessionSummary {
+            session_id: String::new(),
+            project_path: String::new(),
+            config_dir: String::new(),
+            preview: String::new(),
+            custom_title: String::new(),
+            is_favorite: false,
+            native_title: String::new(),
+            ai_title: String::new(),
+            display_title: String::new(),
+            start_time: GoTime::parse("2026-01-01T00:00:00Z").expect("parse"),
+            last_activity: GoTime::parse("2026-01-01T00:00:00Z").expect("parse"),
+            active_duration_ms: 0,
+            subagent_active_duration_ms: 0,
+            message_count: 0,
+            event_count: 0,
+            usage: TokenUsage::default(),
+            git_branch: String::new(),
+            model: String::new(),
+            cwd: String::new(),
+            subagent_count: 0,
+            subagent_usage: TokenUsage::default(),
+            subagent_usage_by_model: BTreeMap::new(),
+            agent_name: String::new(),
+            permission_mode: String::new(),
+            mode: String::new(),
+            relocated_cwd: String::new(),
+            worktree_name: String::new(),
+            worktree_branch: String::new(),
+            original_branch: String::new(),
+            compaction_count: 0,
+            dropped_tokens: 0,
+            prs: Vec::new(),
+            cost: SessionCost::default(),
+            subagent_cost: SessionCost::default(),
+            cost_by_model: BTreeMap::new(),
+            subagent_cost_by_model: BTreeMap::new(),
+            unpriced_models: Vec::new(),
+            unpriced_tokens: 0,
+        }
+    }
+}

--- a/desktop/src-tauri/src/native/sessions/tests_db.rs
+++ b/desktop/src-tauri/src/native/sessions/tests_db.rs
@@ -1,0 +1,465 @@
+//! Tests for the sessions list that need a database.
+//!
+//! The metric-vector test here is the third reader of
+//! `internal/claudesessions/testdata/session_metric_vectors.json`, after
+//! `session_page_test.go` and `frontend/src/lib/sessionMetrics.test.ts`. The
+//! fixture exists because a rendered column and the filter that hides its row
+//! must not disagree — a session showing $36.30 must not be hidden by "cost at
+//! most $40" — and that bug had already happened once before the filtering
+//! moved into SQL. Adding a third implementation of those figures without
+//! adding a third reader of the fixture would reopen it in a new language.
+
+use rusqlite::Connection;
+
+use super::page::{facets, list_page};
+use super::query::{
+    build_filter, SessionQuery, Sort, SQL_ACTIVE_DURATION_MS, SQL_COST_USD, SQL_INPUT_TOKENS,
+    SQL_MESSAGE_COUNT, SQL_OUTPUT_TOKENS, SQL_TOKENS,
+};
+use super::summary::SUMMARY_SOURCE;
+use crate::native::gojson;
+use crate::native::settings::DataSettings;
+
+/// The columns these tests write, which is the subset of the real schema the
+/// list reads. Kept in the shape `internal/storage/sqlite.go` produces.
+const SCHEMA: &str = "
+    CREATE TABLE claude_session_cache (
+        session_id TEXT PRIMARY KEY,
+        project_path TEXT NOT NULL DEFAULT '',
+        preview TEXT NOT NULL DEFAULT '',
+        custom_title TEXT NOT NULL DEFAULT '',
+        is_favorite INTEGER NOT NULL DEFAULT 0,
+        start_time DATETIME NOT NULL,
+        last_activity DATETIME NOT NULL,
+        message_count INTEGER NOT NULL DEFAULT 0,
+        event_count INTEGER NOT NULL DEFAULT 0,
+        input_tokens INTEGER NOT NULL DEFAULT 0,
+        output_tokens INTEGER NOT NULL DEFAULT 0,
+        cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+        cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+        cache_creation_5m_tokens INTEGER NOT NULL DEFAULT 0,
+        cache_creation_1h_tokens INTEGER NOT NULL DEFAULT 0,
+        git_branch TEXT NOT NULL DEFAULT '',
+        model TEXT NOT NULL DEFAULT '',
+        cwd TEXT NOT NULL DEFAULT '',
+        native_title TEXT NOT NULL DEFAULT '',
+        ai_title TEXT NOT NULL DEFAULT '',
+        agent_name TEXT NOT NULL DEFAULT '',
+        permission_mode TEXT NOT NULL DEFAULT '',
+        mode TEXT NOT NULL DEFAULT '',
+        relocated_cwd TEXT NOT NULL DEFAULT '',
+        worktree_name TEXT NOT NULL DEFAULT '',
+        worktree_branch TEXT NOT NULL DEFAULT '',
+        original_branch TEXT NOT NULL DEFAULT '',
+        compaction_count INTEGER NOT NULL DEFAULT 0,
+        dropped_tokens INTEGER NOT NULL DEFAULT 0,
+        input_cost_usd REAL NOT NULL DEFAULT 0,
+        output_cost_usd REAL NOT NULL DEFAULT 0,
+        cache_read_cost_usd REAL NOT NULL DEFAULT 0,
+        cache_write_cost_usd REAL NOT NULL DEFAULT 0,
+        total_cost_usd REAL NOT NULL DEFAULT 0,
+        unpriced_models TEXT NOT NULL DEFAULT '',
+        unpriced_tokens INTEGER NOT NULL DEFAULT 0,
+        cost_by_model TEXT NOT NULL DEFAULT '',
+        active_duration_ms INTEGER NOT NULL DEFAULT 0,
+        config_dir TEXT NOT NULL DEFAULT ''
+    );
+    CREATE TABLE claude_subagent_cache (
+        parent_session_id TEXT NOT NULL,
+        agent_id TEXT NOT NULL,
+        model TEXT NOT NULL DEFAULT '',
+        input_tokens INTEGER NOT NULL DEFAULT 0,
+        output_tokens INTEGER NOT NULL DEFAULT 0,
+        cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+        cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+        cache_creation_5m_tokens INTEGER NOT NULL DEFAULT 0,
+        cache_creation_1h_tokens INTEGER NOT NULL DEFAULT 0,
+        input_cost_usd REAL NOT NULL DEFAULT 0,
+        output_cost_usd REAL NOT NULL DEFAULT 0,
+        cache_read_cost_usd REAL NOT NULL DEFAULT 0,
+        cache_write_cost_usd REAL NOT NULL DEFAULT 0,
+        total_cost_usd REAL NOT NULL DEFAULT 0,
+        unpriced_models TEXT NOT NULL DEFAULT '',
+        unpriced_tokens INTEGER NOT NULL DEFAULT 0,
+        active_duration_ms INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (parent_session_id, agent_id)
+    );
+    CREATE TABLE claude_session_pr (
+        session_id TEXT NOT NULL,
+        pr_number INTEGER NOT NULL,
+        pr_url TEXT NOT NULL,
+        pr_repository TEXT NOT NULL DEFAULT '',
+        first_seen_at DATETIME NOT NULL,
+        PRIMARY KEY (session_id, pr_url)
+    );
+    CREATE TABLE user_settings (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        hidden_projects TEXT NOT NULL DEFAULT '',
+        claude_config_dir TEXT NOT NULL DEFAULT '',
+        claude_config_dirs TEXT NOT NULL DEFAULT ''
+    );
+";
+
+/// One session's stored figures, main thread and delegated.
+#[derive(Default, Clone)]
+struct TestSession {
+    id: &'static str,
+    project: &'static str,
+    last_activity: &'static str,
+    input_tokens: i64,
+    output_tokens: i64,
+    cost_usd: f64,
+    active_ms: i64,
+    messages: i64,
+    sub_input_tokens: i64,
+    sub_output_tokens: i64,
+    sub_cost_usd: f64,
+    sub_active_ms: i64,
+    favorite: bool,
+}
+
+fn fixture(sessions: &[TestSession]) -> Connection {
+    let conn = Connection::open_in_memory().expect("in-memory database");
+    conn.execute_batch(SCHEMA).expect("schema");
+    for s in sessions {
+        let last = if s.last_activity.is_empty() {
+            "2026-08-01 12:00:00 +0000 UTC"
+        } else {
+            s.last_activity
+        };
+        conn.execute(
+            "INSERT INTO claude_session_cache
+                (session_id, project_path, start_time, last_activity, message_count,
+                 input_tokens, output_tokens, total_cost_usd, active_duration_ms, is_favorite)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            rusqlite::params![
+                s.id,
+                s.project,
+                "2026-08-01 10:00:00 +0000 UTC",
+                last,
+                s.messages,
+                s.input_tokens,
+                s.output_tokens,
+                s.cost_usd,
+                s.active_ms,
+                i64::from(s.favorite),
+            ],
+        )
+        .expect("insert session");
+
+        if s.sub_input_tokens != 0
+            || s.sub_output_tokens != 0
+            || s.sub_cost_usd != 0.0
+            || s.sub_active_ms != 0
+        {
+            conn.execute(
+                "INSERT INTO claude_subagent_cache
+                    (parent_session_id, agent_id, input_tokens, output_tokens,
+                     total_cost_usd, active_duration_ms)
+                 VALUES (?, 'agent-1', ?, ?, ?, ?)",
+                rusqlite::params![
+                    s.id,
+                    s.sub_input_tokens,
+                    s.sub_output_tokens,
+                    s.sub_cost_usd,
+                    s.sub_active_ms
+                ],
+            )
+            .expect("insert sub-agent");
+        }
+    }
+    conn
+}
+
+fn no_settings() -> DataSettings {
+    DataSettings::default()
+}
+
+#[test]
+fn metric_sql_matches_the_shared_cross_language_vectors() {
+    #[derive(serde::Deserialize)]
+    struct Vectors {
+        cases: Vec<Case>,
+    }
+    #[derive(serde::Deserialize)]
+    struct Case {
+        name: String,
+        session: Stored,
+        expect: Expected,
+    }
+    #[derive(serde::Deserialize)]
+    struct Stored {
+        input_tokens: i64,
+        output_tokens: i64,
+        subagent_input_tokens: i64,
+        subagent_output_tokens: i64,
+        total_cost_usd: f64,
+        subagent_cost_usd: f64,
+        active_duration_ms: i64,
+        subagent_active_duration_ms: i64,
+        message_count: i64,
+    }
+    #[derive(serde::Deserialize)]
+    struct Expected {
+        input_tokens: i64,
+        output_tokens: i64,
+        tokens: i64,
+        cost_usd: f64,
+        duration_ms: i64,
+        duration_minutes: f64,
+        messages: i64,
+    }
+
+    let raw =
+        include_str!("../../../../../internal/claudesessions/testdata/session_metric_vectors.json");
+    let vectors: Vectors = serde_json::from_str(raw).expect("parsing the shared vectors");
+    assert!(
+        !vectors.cases.is_empty(),
+        "the shared vectors file declares no cases"
+    );
+
+    for (i, case) in vectors.cases.iter().enumerate() {
+        let id: &'static str = Box::leak(format!("vec-{i}").into_boxed_str());
+        let conn = fixture(&[TestSession {
+            id,
+            input_tokens: case.session.input_tokens,
+            output_tokens: case.session.output_tokens,
+            cost_usd: case.session.total_cost_usd,
+            active_ms: case.session.active_duration_ms,
+            messages: case.session.message_count,
+            sub_input_tokens: case.session.subagent_input_tokens,
+            sub_output_tokens: case.session.subagent_output_tokens,
+            sub_cost_usd: case.session.subagent_cost_usd,
+            sub_active_ms: case.session.subagent_active_duration_ms,
+            ..Default::default()
+        }]);
+
+        let sql = format!(
+            "SELECT {SQL_INPUT_TOKENS}, {SQL_OUTPUT_TOKENS}, {SQL_TOKENS}, {SQL_COST_USD}, \
+             {SQL_ACTIVE_DURATION_MS}, {SQL_MESSAGE_COUNT}{SUMMARY_SOURCE}\nWHERE c.session_id = ?"
+        );
+        let (input, output, tokens, cost, duration_ms, messages): (i64, i64, i64, f64, i64, i64) =
+            conn.query_row(&sql, [id], |r| {
+                Ok((
+                    r.get(0)?,
+                    r.get(1)?,
+                    r.get(2)?,
+                    r.get(3)?,
+                    r.get(4)?,
+                    r.get(5)?,
+                ))
+            })
+            .expect("querying metrics");
+
+        let name = &case.name;
+        assert_eq!(input, case.expect.input_tokens, "{name}: input tokens");
+        assert_eq!(output, case.expect.output_tokens, "{name}: output tokens");
+        assert_eq!(tokens, case.expect.tokens, "{name}: tokens");
+        assert_eq!(messages, case.expect.messages, "{name}: messages");
+        assert!(
+            (cost - case.expect.cost_usd).abs() < 1e-9,
+            "{name}: cost = {cost}, want {}",
+            case.expect.cost_usd
+        );
+        assert_eq!(duration_ms, case.expect.duration_ms, "{name}: duration");
+        let minutes = duration_ms as f64 / 60_000.0;
+        assert!(
+            (minutes - case.expect.duration_minutes).abs() < 1e-9,
+            "{name}: duration = {minutes} min, want {}",
+            case.expect.duration_minutes
+        );
+    }
+}
+
+#[test]
+fn keyset_pagination_visits_every_row_exactly_once() {
+    let sessions: Vec<TestSession> = (0..12)
+        .map(|i| TestSession {
+            id: Box::leak(format!("s{i:02}").into_boxed_str()),
+            // A deliberate tie in the sort column: without the session_id
+            // tiebreak these would page against each other, one repeating and
+            // one disappearing.
+            cost_usd: if i % 3 == 0 { 10.0 } else { i as f64 },
+            ..Default::default()
+        })
+        .collect();
+    let conn = fixture(&sessions);
+
+    let mut seen = Vec::new();
+    let mut cursor = String::new();
+    for _ in 0..10 {
+        let q = SessionQuery {
+            limit: 5,
+            sort: Sort::Cost,
+            cursor: cursor.clone(),
+            ..Default::default()
+        };
+        let page = list_page(&conn, &no_settings(), &q).expect("page");
+        seen.extend(page.items.iter().map(|s| s.session_id.clone()));
+        cursor = page.next_cursor.clone();
+        if cursor.is_empty() {
+            break;
+        }
+    }
+
+    seen.sort();
+    let mut want: Vec<String> = sessions.iter().map(|s| s.id.to_string()).collect();
+    want.sort();
+    assert_eq!(seen, want, "every row exactly once");
+}
+
+#[test]
+fn filters_read_delegated_totals_not_just_the_main_thread() {
+    let conn = fixture(&[
+        TestSession {
+            id: "main-only",
+            cost_usd: 10.0,
+            ..Default::default()
+        },
+        TestSession {
+            id: "delegated",
+            cost_usd: 10.0,
+            sub_cost_usd: 26.3,
+            ..Default::default()
+        },
+    ]);
+
+    let q = SessionQuery {
+        cost: super::query::NumericRange {
+            min: Some(30.0),
+            max: None,
+        },
+        ..Default::default()
+    };
+    let page = list_page(&conn, &no_settings(), &q).expect("page");
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.items[0].session_id, "delegated");
+    // The row's own total agrees with the filter that let it through.
+    assert!((page.items[0].total_cost_usd() - 36.3).abs() < 1e-9);
+}
+
+#[test]
+fn hidden_projects_are_excluded_from_both_the_page_and_the_totals() {
+    let conn = fixture(&[
+        TestSession {
+            id: "visible",
+            project: "/home/u/keep",
+            cost_usd: 5.0,
+            ..Default::default()
+        },
+        TestSession {
+            id: "hidden",
+            project: "/home/u/secret",
+            cost_usd: 50.0,
+            ..Default::default()
+        },
+    ]);
+    let settings = DataSettings {
+        hidden_projects: vec!["/home/u/secret".to_string()],
+        indexed_config_dirs: Vec::new(),
+    };
+
+    let q = SessionQuery::default();
+    let page = list_page(&conn, &settings, &q).expect("page");
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.items[0].session_id, "visible");
+
+    // The toolbar's counter must describe the same set as the rows below it.
+    let f = facets(&conn, &settings, &q).expect("facets");
+    assert_eq!(f.total, 1);
+    assert!((f.total_cost_usd - 5.0).abs() < 1e-9);
+}
+
+#[test]
+fn the_facet_total_and_the_page_describe_the_same_predicate() {
+    let conn = fixture(&[
+        TestSession {
+            id: "a",
+            cost_usd: 1.0,
+            favorite: true,
+            ..Default::default()
+        },
+        TestSession {
+            id: "b",
+            cost_usd: 2.0,
+            ..Default::default()
+        },
+        TestSession {
+            id: "c",
+            cost_usd: 3.0,
+            favorite: true,
+            ..Default::default()
+        },
+    ]);
+
+    let q = SessionQuery {
+        favorites_only: true,
+        ..Default::default()
+    };
+    let page = list_page(&conn, &no_settings(), &q).expect("page");
+    let f = facets(&conn, &no_settings(), &q).expect("facets");
+    assert_eq!(page.items.len() as i64, f.total);
+    assert!((f.total_cost_usd - 4.0).abs() < 1e-9);
+    // Options come from the whole corpus, so a toggle never removes itself.
+    assert!(f.has_favorites);
+}
+
+#[test]
+fn an_empty_page_serializes_as_an_empty_array_not_null() {
+    let conn = fixture(&[]);
+    let page = list_page(&conn, &no_settings(), &SessionQuery::default()).expect("page");
+    let json = String::from_utf8(gojson::to_vec(&page).expect("encode")).expect("utf-8");
+    assert_eq!(
+        json,
+        "{\"items\":[],\"next_cursor\":\"\",\"has_more\":false}\n"
+    );
+}
+
+#[test]
+fn the_config_dir_scope_admits_blank_rows() {
+    let conn = fixture(&[TestSession {
+        id: "legacy",
+        ..Default::default()
+    }]);
+    // Rows written before migration 27 carry a blank config dir and belong to
+    // the default dir, so a scope that excluded them would hide real history.
+    let settings = DataSettings {
+        hidden_projects: Vec::new(),
+        indexed_config_dirs: vec!["/home/u/.claude".to_string()],
+    };
+    let page = list_page(&conn, &settings, &SessionQuery::default()).expect("page");
+    assert_eq!(page.items.len(), 1);
+}
+
+#[test]
+fn a_drilldown_window_replaces_the_range_rather_than_narrowing_it() {
+    let conn = fixture(&[TestSession {
+        id: "inside",
+        last_activity: "2026-08-01 12:00:00 +0000 UTC",
+        ..Default::default()
+    }]);
+
+    let filter = build_filter(
+        &SessionQuery::parse("windows=1000-2000&from=2026-01-01T00:00:00Z").expect("parse"),
+        &[],
+        &[],
+    )
+    .expect("filter");
+    let rendered = filter.where_clause();
+    // One window term, bound to its two ends — and nothing from the range.
+    // The window's own predicate mentions last_activity, so the check is on
+    // the argument count and the *strict* comparison a window uses, not on a
+    // substring that both forms share.
+    assert!(rendered.contains("c.start_time < ?"), "{rendered}");
+    assert!(
+        !rendered.contains("c.start_time <= ?"),
+        "the from/to range must not survive a drill-down: {rendered}"
+    );
+    assert_eq!(
+        filter.args.len(),
+        2,
+        "one window binds exactly its two ends"
+    );
+
+    let _ = conn;
+}

--- a/desktop/src-tauri/src/native/settings.rs
+++ b/desktop/src-tauri/src/native/settings.rs
@@ -1,0 +1,233 @@
+//! The user preferences a read has to honour, and the Claude config dirs they
+//! scope it to.
+//!
+//! Go keeps both as process-wide snapshots (`claudesessions.dataSettings`,
+//! `config.claudeDirs`) installed during startup wiring, because the readers —
+//! the scanner, nine insight processors, the journey builder, the sessions list
+//! — have no settings dependency and must all agree. A ported endpoint has no
+//! startup wiring to hook into, so it reads the same row from SQLite on demand.
+//! That is not merely convenient: the settings row is the authority, and
+//! re-reading it means a preference saved through the Go server is honoured by
+//! the very next native request rather than at some later restart.
+//!
+//! Getting this wrong does not fail loudly. A hidden project that is not
+//! filtered out simply appears — in a list the user has told us to leave it out
+//! of, and in totals the Go server computes without it.
+
+use std::path::{Path, PathBuf};
+
+use rusqlite::{Connection, OptionalExtension};
+
+use crate::paths;
+
+/// The Data & Analytics preferences a session read depends on.
+#[derive(Debug, Clone, Default)]
+pub struct DataSettings {
+    /// Decoded project paths excluded from every figure Agento reports.
+    /// Matched against `claude_session_cache.project_path` exactly.
+    pub hidden_projects: Vec<String>,
+    /// Every Claude config dir Agento indexes, default first. Order is
+    /// load-bearing on the Go side (it decides which dir owns a session present
+    /// in two); here it only has to contain the same set.
+    pub indexed_config_dirs: Vec<String>,
+}
+
+/// Read the settings row. A missing row, a missing column, or malformed JSON
+/// all degrade to defaults rather than failing the request — exactly as Go's
+/// snapshot starts at its defaults before `ApplyDataSettings` runs.
+pub fn load(conn: &Connection) -> DataSettings {
+    let row: Option<(String, String, String)> = conn
+        .query_row(
+            "SELECT COALESCE(hidden_projects, ''),
+                    COALESCE(claude_config_dir, ''),
+                    COALESCE(claude_config_dirs, '')
+             FROM user_settings WHERE id = 1",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .optional()
+        .unwrap_or_else(|e| {
+            log::warn!("native settings: reading user_settings failed: {e}");
+            None
+        });
+
+    let (hidden_raw, run_override, extra_raw) = row.unwrap_or_default();
+    DataSettings {
+        hidden_projects: decode_string_array(&hidden_raw),
+        indexed_config_dirs: claude_config_dirs(&run_override, &decode_string_array(&extra_raw)),
+    }
+}
+
+/// Decode a JSON string array column, treating anything unusable as empty.
+fn decode_string_array(raw: &str) -> Vec<String> {
+    if raw.trim().is_empty() {
+        return Vec::new();
+    }
+    serde_json::from_str::<Vec<String>>(raw).unwrap_or_else(|e| {
+        log::warn!("native settings: malformed string array {raw:?}: {e}");
+        Vec::new()
+    })
+}
+
+/// Every config dir Agento indexes, mirroring `config.ClaudeConfigDirs`:
+/// the default dir, the dir a run targets, then the user's extras, deduped.
+///
+/// **Reading is a set, running is a choice.** This is the union the sessions
+/// list is scoped to — analytics is retrospective, and a machine with two
+/// accounts wants both corpora in every total.
+fn claude_config_dirs(run_override: &str, extra: &[String]) -> Vec<String> {
+    let mut dirs = Vec::with_capacity(extra.len() + 2);
+    dirs.push(default_claude_config_dir());
+    dirs.push(run_config_dir(run_override));
+    dirs.extend(extra.iter().cloned());
+
+    let mut out: Vec<String> = Vec::with_capacity(dirs.len());
+    for dir in dirs {
+        let normalized = match absolute_dir(&normalize(&dir)) {
+            Some(d) => d,
+            None => continue,
+        };
+        if !out.contains(&normalized) {
+            out.push(normalized);
+        }
+    }
+    out
+}
+
+/// `~/.claude`, or `/root/.claude` when there is no home — the fallback Go's
+/// `DefaultClaudeConfigDir` uses.
+fn default_claude_config_dir() -> String {
+    paths::home()
+        .unwrap_or_else(|| PathBuf::from("/root"))
+        .join(".claude")
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// The single dir a run targets: `CLAUDE_CONFIG_DIR` first, then the stored
+/// global setting, then the default. The environment comes first because it is
+/// what the surrounding environment has already chosen for every subprocess.
+fn run_config_dir(stored: &str) -> String {
+    if let Ok(env) = std::env::var("CLAUDE_CONFIG_DIR") {
+        if let Some(dir) = absolute_dir(&normalize(&env)) {
+            return dir;
+        }
+    }
+    if let Some(dir) = absolute_dir(&normalize(stored)) {
+        return dir;
+    }
+    default_claude_config_dir()
+}
+
+/// Expand a leading `~` and clean the path, as `NormalizeClaudeConfigDir` does.
+/// Blank stays blank so "not set" is distinguishable from a real value.
+///
+/// This is not tidiness: the dirs are deduplicated by string comparison and
+/// recorded on cached rows, so `~/.claude`, `$HOME/.claude` and `$HOME/.claude/`
+/// must collapse to one value or the same corpus is attributed to two dirs.
+fn normalize(p: &str) -> String {
+    let p = p.trim();
+    if p.is_empty() {
+        return String::new();
+    }
+    let expanded = if p == "~" {
+        paths::home().map(|h| h.to_string_lossy().into_owned())
+    } else if let Some(rest) = p.strip_prefix("~/") {
+        paths::home().map(|h| h.join(rest).to_string_lossy().into_owned())
+    } else {
+        None
+    };
+    clean(&expanded.unwrap_or_else(|| p.to_string()))
+}
+
+/// `filepath.Clean` for the subset of paths a config dir can be: collapse
+/// repeated separators, resolve `.` and `..`, and drop a trailing separator.
+fn clean(p: &str) -> String {
+    if p.is_empty() {
+        return String::new();
+    }
+    let rooted = p.starts_with('/');
+    let mut parts: Vec<&str> = Vec::new();
+    for part in p.split('/') {
+        match part {
+            "" | "." => continue,
+            ".." => {
+                if let Some(last) = parts.last() {
+                    if *last != ".." {
+                        parts.pop();
+                        continue;
+                    }
+                }
+                if !rooted {
+                    parts.push("..");
+                }
+            }
+            other => parts.push(other),
+        }
+    }
+    let joined = parts.join("/");
+    match (rooted, joined.is_empty()) {
+        (true, _) => format!("/{joined}"),
+        (false, true) => ".".to_string(),
+        (false, false) => joined,
+    }
+}
+
+/// Absolute paths only. A relative config dir means two different things at
+/// once — Agento resolves it against the server's working directory, Claude
+/// Code against the subprocess's — so Go drops it and so does this.
+fn absolute_dir(p: &str) -> Option<String> {
+    if p.is_empty() || !Path::new(p).is_absolute() {
+        return None;
+    }
+    Some(p.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clean_matches_filepath_clean() {
+        assert_eq!(clean("/home/u/.claude/"), "/home/u/.claude");
+        assert_eq!(clean("/home//u/./.claude"), "/home/u/.claude");
+        assert_eq!(clean("/home/u/x/../.claude"), "/home/u/.claude");
+        assert_eq!(clean("/"), "/");
+    }
+
+    #[test]
+    fn relative_dirs_are_dropped_not_resolved() {
+        assert_eq!(absolute_dir("relative/dir"), None);
+        assert_eq!(absolute_dir(""), None);
+        assert_eq!(
+            absolute_dir("/var/lib/claude"),
+            Some("/var/lib/claude".to_string())
+        );
+    }
+
+    #[test]
+    fn the_default_dir_leads_and_duplicates_collapse() {
+        let home = paths::home().expect("a home directory");
+        let default = home.join(".claude").to_string_lossy().into_owned();
+
+        // The same dir spelled three ways must appear once.
+        let dirs = claude_config_dirs("~/.claude", &[format!("{default}/"), default.clone()]);
+        assert_eq!(dirs, vec![default]);
+    }
+
+    #[test]
+    fn extra_dirs_follow_the_default() {
+        let home = paths::home().expect("a home directory");
+        let default = home.join(".claude").to_string_lossy().into_owned();
+
+        let dirs = claude_config_dirs("", &["/var/lib/claude-work".to_string()]);
+        assert_eq!(dirs, vec![default, "/var/lib/claude-work".to_string()]);
+    }
+
+    #[test]
+    fn a_malformed_settings_column_degrades_to_empty() {
+        assert!(decode_string_array("not json").is_empty());
+        assert!(decode_string_array("").is_empty());
+        assert_eq!(decode_string_array(r#"["/a","/b"]"#), vec!["/a", "/b"]);
+    }
+}

--- a/desktop/src-tauri/src/proxy.rs
+++ b/desktop/src-tauri/src/proxy.rs
@@ -102,12 +102,31 @@ async fn handle(State(state): State<ProxyState>, req: Request<Body>) -> Response
         // Reading SQLite is blocking work; keeping it off the axum worker means
         // one slow read cannot stall an SSE stream sharing the runtime.
         let method = req.method().clone();
-        let native_body = {
+        let query = req.uri().query().unwrap_or_default().to_string();
+        let native_answer = {
             let path = path.clone();
-            tokio::task::spawn_blocking(move || native::serve(&method, &path))
-                .await
-                .unwrap_or_else(|e| Err(format!("native handler panicked: {e}")))
+            tokio::task::spawn_blocking(move || {
+                native::serve(&native::Request {
+                    method: &method,
+                    path: &path,
+                    query: &query,
+                })
+            })
+            .await
+            .unwrap_or_else(|e| Err(format!("native handler panicked: {e}")))
         };
+
+        // Some ported reads are what kept the corpus fresh on the Go side, so
+        // answering them here removes the trigger. The probe puts it back by
+        // asking the sidecar a cheap question that runs its own freshness
+        // check — fire-and-forget, because the page never waited for the
+        // rescan it started either.
+        if let Ok(answer) = &native_answer {
+            if let Some(probe) = answer.probe {
+                spawn_freshness_probe(&state, probe);
+            }
+        }
+        let native_body = native_answer.map(|answer| answer.body);
 
         match (native::mode(), native_body) {
             // Go stays authoritative in shadow mode; Rust is only compared.
@@ -243,6 +262,29 @@ async fn forward_buffered(
         .map_err(|e| format!("buffering upstream body: {e}"))?;
     let replayed = Response::from_parts(parts, Body::from(bytes.clone()));
     Ok((replayed, bytes.to_vec()))
+}
+
+/// Ask the Go sidecar a question that runs its freshness check, and ignore the
+/// answer.
+///
+/// This goes straight to the sidecar rather than back through the proxy, so it
+/// cannot recurse into the native handler that scheduled it.
+fn spawn_freshness_probe(state: &ProxyState, path: &str) {
+    let url = format!("{}{path}", state.upstream);
+    let client = state.client.clone();
+    tauri::async_runtime::spawn(async move {
+        // A short deadline on purpose: the request only has to *start* the
+        // scan, and the scan itself runs in the background on the Go side.
+        match client
+            .get(&url)
+            .timeout(std::time::Duration::from_secs(10))
+            .send()
+            .await
+        {
+            Ok(resp) => log::debug!("freshness probe {url} -> {}", resp.status()),
+            Err(e) => log::warn!("freshness probe {url} failed: {e}"),
+        }
+    });
 }
 
 fn error_response(status: StatusCode, message: &str) -> Response<Body> {

--- a/desktop/src-tauri/tests/live_parity.rs
+++ b/desktop/src-tauri/tests/live_parity.rs
@@ -23,7 +23,9 @@
 
 use std::path::PathBuf;
 
-use agento_lib::native::{diff, gojson, pricing};
+use agento_lib::native::sessions::page;
+use agento_lib::native::sessions::query::SessionQuery;
+use agento_lib::native::{db, diff, gojson, pricing, settings};
 
 fn live_url() -> String {
     std::env::var("AGENTO_LIVE_URL").unwrap_or_else(|_| "http://127.0.0.1:8990".to_string())
@@ -79,4 +81,130 @@ async fn pricing_catalog_matches_the_live_go_response() {
         diff::Outcome::Identical => println!("identical"),
         diff::Outcome::Differs(detail) => panic!("{detail}"),
     }
+}
+
+/// Compare a native body against the live server's for the same request.
+fn assert_identical(label: &str, go: &[u8], native: &[u8]) {
+    println!(
+        "{label}: go {} bytes, native {} bytes",
+        go.len(),
+        native.len()
+    );
+    match diff::compare(go, native) {
+        diff::Outcome::Identical => println!("{label}: identical"),
+        diff::Outcome::Differs(detail) => panic!("{label}\n{detail}"),
+    }
+}
+
+/// Every filter, sort and page shape the list offers, against real data.
+///
+/// One test rather than one per case: each case is a live HTTP round trip plus
+/// a database read, and a single ignored test that covers the whole surface is
+/// what actually gets run before a flip.
+#[tokio::test]
+#[ignore = "needs a running Agento instance and its database"]
+async fn session_list_and_facets_match_the_live_go_responses() {
+    let db_path = live_db();
+    let conn = db::open_read_only(&db_path).expect("open database");
+    let data_settings = settings::load(&conn);
+
+    let cases = [
+        "",
+        "limit=5",
+        "limit=3&sort=cost",
+        "limit=3&sort=tokens",
+        "limit=3&sort=duration",
+        "limit=3&sort=messages",
+        "limit=3&sort=nonsense",
+        "limit=200",
+        "q=claude",
+        "q=100%25",
+        "favorites=true",
+        "links=with",
+        "links=without",
+        "cost_min=1&cost_max=40",
+        "tokens_in_min=1000",
+        "tokens_out_max=5000",
+        "duration_min=5&duration_max=120",
+        "messages_min=10",
+        "from=2026-01-01T00:00:00Z&to=2026-12-31T23:59:59Z",
+        "windows=1767225600000-1767229200000",
+        "sort=cost&cost_min=0.5&limit=7",
+    ];
+
+    for case in cases {
+        let label = if case.is_empty() { "(no filter)" } else { case };
+
+        let go = fetch(&format!("/api/claude-sessions?{case}")).await;
+        let q = SessionQuery::parse(case).expect("parse query");
+        let native_page = page::list_page(&conn, &data_settings, &q).expect("native page");
+        let native = gojson::to_vec(&native_page).expect("encode page");
+        assert_identical(&format!("list [{label}]"), &go, &native);
+
+        let go = fetch(&format!("/api/claude-sessions/facets?{case}")).await;
+        let native_facets = page::facets(&conn, &data_settings, &q).expect("native facets");
+        let native = gojson::to_vec(&native_facets).expect("encode facets");
+        assert_identical(&format!("facets [{label}]"), &go, &native);
+    }
+}
+
+/// Paging is where a keyset implementation goes wrong quietly: a cursor that
+/// disagrees by one formatting character repeats or skips rows rather than
+/// failing. This walks several pages through both implementations, each time
+/// feeding Rust the cursor **Go** minted, so the two have to agree on the
+/// cursor's bytes as well as the page's.
+#[tokio::test]
+#[ignore = "needs a running Agento instance and its database"]
+async fn cursors_interoperate_across_several_pages() {
+    let db_path = live_db();
+    let conn = db::open_read_only(&db_path).expect("open database");
+    let data_settings = settings::load(&conn);
+
+    for sort in ["recent", "cost", "tokens", "duration", "messages"] {
+        let mut cursor = String::new();
+        for page_number in 1..=4 {
+            let case = format!("limit=5&sort={sort}&cursor={cursor}");
+            let go = fetch(&format!("/api/claude-sessions?{case}")).await;
+
+            let q = SessionQuery::parse(&case).expect("parse query");
+            let native_page = page::list_page(&conn, &data_settings, &q).expect("native page");
+            let native = gojson::to_vec(&native_page).expect("encode page");
+            assert_identical(&format!("{sort} page {page_number}"), &go, &native);
+
+            // Continue from Go's cursor, so a divergence in how the two mint
+            // one shows up as a divergent page rather than staying hidden.
+            let parsed: serde_json::Value = serde_json::from_slice(&go).expect("json");
+            cursor = parsed["next_cursor"]
+                .as_str()
+                .unwrap_or_default()
+                .to_string();
+            if cursor.is_empty() {
+                break;
+            }
+        }
+    }
+}
+
+/// A cursor minted under one sort must be refused by another, not silently
+/// paged with. Go answers 400; the native handler's error means the proxy falls
+/// back to Go, which answers the same 400 — so the observable behaviour is
+/// identical either way.
+#[tokio::test]
+#[ignore = "needs a running Agento instance and its database"]
+async fn a_cursor_from_another_sort_is_refused() {
+    let db_path = live_db();
+    let conn = db::open_read_only(&db_path).expect("open database");
+    let data_settings = settings::load(&conn);
+
+    let first = fetch("/api/claude-sessions?limit=2&sort=cost").await;
+    let parsed: serde_json::Value = serde_json::from_slice(&first).expect("json");
+    let cursor = parsed["next_cursor"].as_str().unwrap_or_default();
+    if cursor.is_empty() {
+        println!("corpus too small to page; skipping");
+        return;
+    }
+
+    let q = SessionQuery::parse(&format!("limit=2&sort=recent&cursor={cursor}")).expect("parse");
+    let err = page::list_page(&conn, &data_settings, &q).expect_err("mismatch");
+    assert!(err.contains("does not match the requested sort"), "{err}");
 }


### PR DESCRIPTION
`GET /api/claude-sessions` and `/api/claude-sessions/facets` are answered
natively. They are the app's highest-traffic surface and the first port with
real machinery behind it: a filter builder, a keyset cursor, a 40-column
projection with a sub-agent roll-up, and settings-derived scopes.

**Diffed byte-for-byte across 21 filter and sort combinations for both
endpoints**, plus four pages per sort of cursor interoperability — each page
continuing from the cursor *Go* minted, so the two implementations have to agree
on the cursor's bytes as well as the page's.

## Three findings that would have shipped silently

**1. serde_json's float parser is not bit-exact.** A stored
`0.36238800000000004` decoded to a different double and re-encoded as
`0.362388`:

```
"0.36238800000000004".parse::<f64>()  →  0.36238800000000004   ✓
serde_json::from_str(same literal)    →  0.362388              ✗
```

Fixed by enabling serde_json's `float_roundtrip` feature. Every later port needs
it — any endpoint reading a JSON column of floats hits this, and analytics is
next.

**2. Never diff against the installed server.** The Agento running on `:8990` was
built from a commit predating `config_dir` joining the session summary, so the
first diff "failed" against a stale baseline while the port was correct. The
reverse is worse: an old server that happens to agree hides a real divergence.
`scripts/parity-instance.sh` now builds the server from the checkout and runs it
against a **copy** of `~/.agento` — the current source may carry migrations the
installed server has never applied, and applying them to the real file would
upgrade it underneath a running instance.

**3. Reading is what keeps the corpus fresh.** `Cache.ensureFresh` runs on every
Go read path and starts a background rescan when the TTL expires, the pricing
catalog moves, or the idle threshold changes. Serving these routes from Rust
removes that trigger and nothing would say so — transcripts stop being re-read, a
rate edit never reaches stored costs, and the UI serves indefinitely stale
figures. Rather than reimplement that decision (a TTL, a fingerprint, a
user-set threshold — three things to drift), `freshness_probe` fires one cheap
request at the sidecar so the rules stay in the code that owns them.

## New primitives the rest of phase 2 rides on

| module | why it exists |
|---|---|
| `gotime` | DATETIME columns hold Go's `time.Time.String()`, **not** RFC 3339 — and are compared *as text*, so a bound parameter in any other shape sorts into a different place and mis-filters rather than failing |
| `gojson::format_g` | `strconv.FormatFloat(_, 'g', -1, 64)`, which the cursor uses — exponent form at 1e6, padded not trimmed, deliberately not the JSON spelling |
| `settings` | hidden projects and indexed Claude config dirs, read from the settings row rather than the startup wiring Rust doesn't have |

## Parity coverage

- Shared vectors gain **cursor-float** and **Go-timestamp** sections, asserted by
  both languages.
- Rust becomes the **third reader** of `session_metric_vectors.json`, after Go
  and TypeScript — the fixture that keeps a rendered column and the filter that
  hides its row from disagreeing. A third implementation of those figures without
  a third reader of the fixture would reopen exactly the bug it was extracted to
  prevent.
- 56 Rust unit tests (up from 23), covering keyset paging over ties, delegated
  totals in filters, hidden projects in both the page and the totals, and the
  drill-down replacing rather than narrowing the range.

## Verified

`cargo fmt --check`, `clippy -D warnings`, `cargo test` (56), `cargo build
--release`, `go test ./desktop/...`, and the pinned golangci-lint v2.5.0 over
`./internal/... ./cmd/... ./desktop/... .` — all clean. Live diff: 4/4 parity
tests identical against a Go server built from this checkout.

## Not in scope

`/api/claude-analytics`, the per-session reads (`/{id}`, `/insights`,
`/journey`), the scan lifecycle (`/status`, `/refresh` — those stay with Go while
the scanner does), and every write path.
