### PR TITLE
feat(desktop): port the agent reads to Rust

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -117,6 +117,7 @@ src-tauri/src/
     db.rs        read-only SQLite handle on the file the Go server owns
     settings.rs  user preferences + Claude config dirs a read is scoped to
     pricing.rs   GET /api/pricing/catalog
+    agents.rs    GET /api/agents and /api/agents/{slug}
     sessions/    GET /api/claude-sessions and /facets
     diff.rs      byte comparison + reporting for shadow mode
 
@@ -204,7 +205,11 @@ only a byte comparison catches all four.
 2. Implement it, mirroring the Go source's ordering and grouping exactly —
    including anything hashed, since a fingerprint over rows in a different
    order is a different fingerprint for identical data.
-3. Prove it three ways:
+3. Seed the scratch instance if the endpoint has no data on this machine. It is
+   a *copy*, so writing to it is safe and it is the only way to diff a shape the
+   developer's own install does not contain — the agents list was empty here, so
+   the first "identical" meant nothing until two agents were created through it.
+4. Prove it three ways:
    - a fixture both languages build, compared against a golden file Go wrote
      (`desktop/parity/`, `go test ./desktop/parity/ -update-golden`);
    - the live diff, against real data **and a Go server built from this
@@ -216,7 +221,7 @@ only a byte comparison catches all four.
      ```
    - optionally `AGENTO_DESKTOP_NATIVE=diff npm run app`, which compares every
      real request the UI makes.
-4. Only then leave it claimed.
+5. Only then leave it claimed.
 
 ### Never diff against the installed server
 
@@ -248,7 +253,7 @@ rather than expecting the encoder to notice.
 | Phase | Subsystem | Go source | Notes |
 |---|---|---|---|
 | 1 ✅ | Sidecar + proxy | — | done |
-| 2 ← | Pricing + analytics | `internal/pricing`, `internal/claudesessions` | Pure computation over JSONL + SQLite. No external deps. **In progress**: `/api/pricing/catalog`, `/api/claude-sessions` and `/api/claude-sessions/facets` are native and diff clean. Next: `/api/claude-analytics`, then the per-session reads. |
+| 2 ← | Pricing + analytics | `internal/pricing`, `internal/claudesessions` | Pure computation over JSONL + SQLite. No external deps. **In progress**: `/api/pricing/catalog`, `/api/claude-sessions`, `/api/claude-sessions/facets` and the agent reads are native and diff clean. Next: `/api/claude-analytics`. |
 | 3 | Storage + tasks | `internal/storage`, `internal/scheduler` | 27 SQLite migrations; reuse the same DB file and schema. Scheduler is cron/interval. |
 | 4 | Integrations | `internal/integrations`, `internal/trigger` | OAuth2 + MCP servers. WhatsApp (`whatsmeow`) is the blocker — port it last or keep it in Go. |
 | 5 | Agent execution | `internal/agent`, `internal/service` | Spawns the `claude` CLI over stream-json stdin/stdout. Hardest, highest risk. |
@@ -448,6 +453,12 @@ The sessions list and its facets followed (`native/sessions/`), diffed across 21
 filter and sort combinations plus four pages of cursor interoperability per
 sort — each page continuing from the cursor **Go** minted, so the two have to
 agree on the cursor's bytes as well as the page's.
+
+The agent reads followed (`native/agents.rs`), which is where the **nil-versus-
+empty** rule bites: Go marshals a nil slice as `null` and an empty one as `[]`,
+and `capabilities.built_in` is stored as whichever the writer produced. Every
+list field there is an `Option` for that reason — a `Vec` defaulting to empty
+would change the wire for every agent.
 
 Nothing else is ported. Every write path, all of analytics and every other read
 still forwards to Go.

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-shell",
  "tauri-plugin-updater",
+ "tempfile",
  "tokio",
 ]
 

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -57,3 +57,6 @@ lto = true
 opt-level = "s"
 panic = "abort"
 strip = true
+
+[dev-dependencies]
+tempfile = "3.27.0"

--- a/desktop/src-tauri/src/native/agents.rs
+++ b/desktop/src-tauri/src/native/agents.rs
@@ -1,0 +1,231 @@
+//! `GET /api/agents` and `GET /api/agents/{slug}`.
+//!
+//! Mirrors `SQLiteAgentStore.List`/`Get` (`internal/storage/sqlite_agent_store.go`),
+//! `agentService.List`/`Get` and the two handlers in `internal/api/agents.go`.
+//! The service layer only wraps the store in a span, so the shape the handler
+//! writes is the store's row.
+//!
+//! Reads only. Create, update and delete stay with Go until the storage layer
+//! moves, which is the right split for now: this is the same database file, and
+//! a second writer would race the migrations and seeding the Go server performs
+//! on every startup.
+//!
+//! Two Go-isms decide the bytes here and neither is visible in the struct:
+//! **field order is declaration order**, and **a nil slice marshals as `null`**,
+//! not `[]`. `capabilities.built_in` is exactly that case — an agent with no
+//! built-in tools sends `null`, and a `Vec` defaulting to empty would send `[]`.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use rusqlite::OptionalExtension;
+use serde::{Deserialize, Serialize};
+
+use super::db;
+
+/// One agent. Mirrors `config.AgentConfig`.
+#[derive(Debug, Clone, Serialize)]
+pub struct Agent {
+    pub name: String,
+    pub slug: String,
+    pub description: String,
+    pub model: String,
+    /// "adaptive", "disabled" or "enabled".
+    pub thinking: String,
+    /// "bypass" (default), "default", "plan" or "dontAsk".
+    pub permission_mode: String,
+    pub system_prompt: String,
+    pub capabilities: Capabilities,
+    /// Overrides which Claude config dir this agent's runs target — how a work
+    /// agent and a personal agent stay live in one instance. Empty means the
+    /// global default.
+    pub claude_config_dir: String,
+}
+
+/// What tools an agent may use. Mirrors `config.AgentCapabilities`.
+///
+/// Every field is `Option`, because Go distinguishes a nil slice (`null`) from
+/// an empty one (`[]`) on the wire and the stored JSON carries whichever the
+/// writer produced. Round-tripping the distinction is the only way the bytes
+/// match.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Capabilities {
+    pub built_in: Option<Vec<String>>,
+    pub local: Option<Vec<String>>,
+    pub mcp: Option<BTreeMap<String, McpCapability>>,
+}
+
+/// Which tools from one MCP server an agent may use.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct McpCapability {
+    pub tools: Option<Vec<String>>,
+}
+
+const COLUMNS: &str = "SELECT slug, name, description, model, thinking, permission_mode,
+       system_prompt, capabilities, claude_config_dir
+FROM agents";
+
+/// Every agent, ordered by name as the store orders them.
+pub fn list(db_path: &Path) -> Result<Vec<Agent>, String> {
+    let conn = db::open_read_only(db_path)?;
+    let sql = format!("{COLUMNS}\nORDER BY name ASC");
+    let mut stmt = conn
+        .prepare(&sql)
+        .map_err(|e| format!("listing agents: {e}"))?;
+    let rows = stmt
+        .query_map([], scan)
+        .map_err(|e| format!("listing agents: {e}"))?;
+
+    let mut agents = Vec::new();
+    for row in rows {
+        agents.push(row.map_err(|e| format!("listing agents: {e}"))?);
+    }
+    Ok(agents)
+}
+
+/// One agent by slug, or `None` when there is no such row — which the caller
+/// turns into the 404 Go returns.
+pub fn get(db_path: &Path, slug: &str) -> Result<Option<Agent>, String> {
+    let conn = db::open_read_only(db_path)?;
+    let sql = format!("{COLUMNS} WHERE slug = ?");
+    conn.query_row(&sql, [slug], scan)
+        .optional()
+        .map_err(|e| format!("getting agent {slug:?}: {e}"))
+}
+
+fn scan(row: &rusqlite::Row<'_>) -> rusqlite::Result<Agent> {
+    let capabilities: String = row.get(7)?;
+    Ok(Agent {
+        name: row.get(1)?,
+        slug: row.get(0)?,
+        description: row.get(2)?,
+        model: row.get(3)?,
+        thinking: row.get(4)?,
+        permission_mode: row.get(5)?,
+        system_prompt: row.get(6)?,
+        // Go fails the whole request on unparsable capabilities rather than
+        // serving an agent whose tool allowlist is unknown. So does this: the
+        // error reaches the proxy, which falls back to Go.
+        capabilities: serde_json::from_str(&capabilities).map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(
+                7,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::other(format!("parsing capabilities: {e}"))),
+            )
+        })?,
+        claude_config_dir: row.get(8)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::native::gojson;
+
+    const SCHEMA: &str = "
+        CREATE TABLE agents (
+            slug            TEXT PRIMARY KEY,
+            name            TEXT NOT NULL,
+            description     TEXT NOT NULL DEFAULT '',
+            model           TEXT NOT NULL DEFAULT 'claude-sonnet-4-6',
+            thinking        TEXT NOT NULL DEFAULT 'adaptive',
+            permission_mode TEXT NOT NULL DEFAULT 'bypass',
+            system_prompt   TEXT NOT NULL DEFAULT '',
+            capabilities    TEXT NOT NULL DEFAULT '{}',
+            claude_config_dir TEXT NOT NULL DEFAULT '',
+            created_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );";
+
+    fn fixture() -> tempfile::NamedTempFile {
+        let file = tempfile::NamedTempFile::new().expect("temp file");
+        let conn = rusqlite::Connection::open(file.path()).expect("open");
+        conn.execute_batch(SCHEMA).expect("schema");
+        conn.execute(
+            "INSERT INTO agents (slug, name, description, capabilities, claude_config_dir)
+             VALUES ('zeta', 'Zeta', 'last by name', '{\"built_in\":[\"Read\"],\"local\":null,\"mcp\":{\"github\":{\"tools\":[\"list_prs\"]}}}', '/home/u/.claude-work')",
+            [],
+        )
+        .expect("insert");
+        conn.execute(
+            "INSERT INTO agents (slug, name, capabilities) VALUES ('alpha', 'Alpha', '{}')",
+            [],
+        )
+        .expect("insert");
+        file
+    }
+
+    #[test]
+    fn agents_are_ordered_by_name() {
+        let file = fixture();
+        let agents = list(file.path()).expect("list");
+        assert_eq!(
+            agents.iter().map(|a| a.slug.as_str()).collect::<Vec<_>>(),
+            vec!["alpha", "zeta"]
+        );
+    }
+
+    #[test]
+    fn a_missing_agent_is_none_not_an_error() {
+        let file = fixture();
+        assert!(get(file.path(), "nope").expect("get").is_none());
+        assert!(get(file.path(), "zeta").expect("get").is_some());
+    }
+
+    /// The nil-versus-empty distinction Go puts on the wire. An agent whose
+    /// capabilities were never filled in sends `null` for each list, and one
+    /// with a built-in tool sends an array — mixing the two up would be a
+    /// silent wire change for every agent in the list.
+    #[test]
+    fn nil_and_empty_capability_lists_stay_distinct() {
+        let file = fixture();
+        let agents = list(file.path()).expect("list");
+
+        let alpha = gojson::to_vec(&agents[0]).expect("encode");
+        let alpha = String::from_utf8(alpha).expect("utf-8");
+        assert!(
+            alpha.contains(r#""capabilities":{"built_in":null,"local":null,"mcp":null}"#),
+            "{alpha}"
+        );
+
+        let zeta = gojson::to_vec(&agents[1]).expect("encode");
+        let zeta = String::from_utf8(zeta).expect("utf-8");
+        assert!(
+            zeta.contains(r#""built_in":["Read"],"local":null"#),
+            "{zeta}"
+        );
+        assert!(
+            zeta.contains(r#""mcp":{"github":{"tools":["list_prs"]}}"#),
+            "{zeta}"
+        );
+    }
+
+    #[test]
+    fn the_field_order_is_gos_declaration_order() {
+        let file = fixture();
+        let agents = list(file.path()).expect("list");
+        let json = String::from_utf8(gojson::to_vec(&agents[0]).expect("encode")).expect("utf-8");
+        assert!(
+            json.starts_with(r#"{"name":"Alpha","slug":"alpha","description":""#),
+            "{json}"
+        );
+        assert!(
+            json.trim_end().ends_with(r#""claude_config_dir":""}"#),
+            "{json}"
+        );
+    }
+
+    #[test]
+    fn unparsable_capabilities_fail_the_read_rather_than_guessing_an_allowlist() {
+        let file = tempfile::NamedTempFile::new().expect("temp file");
+        let conn = rusqlite::Connection::open(file.path()).expect("open");
+        conn.execute_batch(SCHEMA).expect("schema");
+        conn.execute(
+            "INSERT INTO agents (slug, name, capabilities) VALUES ('broken', 'Broken', 'not json')",
+            [],
+        )
+        .expect("insert");
+
+        assert!(list(file.path()).is_err());
+    }
+}

--- a/desktop/src-tauri/src/native/mod.rs
+++ b/desktop/src-tauri/src/native/mod.rs
@@ -11,6 +11,7 @@
 //! unported one, and a schema change that outruns the Rust reader degrades to
 //! the behaviour the app had before the port instead of a 500.
 
+pub mod agents;
 pub mod db;
 pub mod diff;
 pub mod gojson;
@@ -63,13 +64,29 @@ pub fn mode() -> Mode {
 /// which chi treats as a different route — falls through to Go and keeps
 /// whatever answer Go gives it.
 pub fn claims(method: &Method, path: &str) -> bool {
+    if method != Method::GET {
+        return false;
+    }
     matches!(
-        (method.as_str(), path),
-        (
-            "GET",
-            "/api/pricing/catalog" | "/api/claude-sessions" | "/api/claude-sessions/facets"
-        )
-    )
+        path,
+        "/api/pricing/catalog"
+            | "/api/claude-sessions"
+            | "/api/claude-sessions/facets"
+            | "/api/agents"
+    ) || agent_slug(path).is_some()
+}
+
+/// The slug in `/api/agents/{slug}`, or `None` for anything else.
+///
+/// One segment only: `/api/agents/{slug}/duplicate` is a different route with a
+/// different method, and a prefix match would swallow it. An empty slug is not
+/// a match either — chi routes `/api/agents/` to nothing, and so does this.
+fn agent_slug(path: &str) -> Option<&str> {
+    let rest = path.strip_prefix("/api/agents/")?;
+    if rest.is_empty() || rest.contains('/') {
+        return None;
+    }
+    Some(rest)
 }
 
 /// A claimed request: the parts a native handler needs.
@@ -100,6 +117,11 @@ pub fn serve(req: &Request) -> Result<Answer, String> {
                 probe: None,
             })
         }
+        ("GET", "/api/agents") => Ok(Answer {
+            body: gojson::to_vec(&agents::list(&db_path)?)
+                .map_err(|e| format!("encoding agents: {e}"))?,
+            probe: None,
+        }),
         ("GET", path @ ("/api/claude-sessions" | "/api/claude-sessions/facets")) => {
             let q = sessions::query::SessionQuery::parse(req.query)?;
             let conn = db::open_read_only(&db_path)?;
@@ -116,6 +138,18 @@ pub fn serve(req: &Request) -> Result<Answer, String> {
                 body,
                 probe: sessions::freshness_probe(path, &q),
             })
+        }
+        ("GET", path) if agent_slug(path).is_some() => {
+            let slug = agent_slug(path).unwrap_or_default();
+            match agents::get(&db_path, slug)? {
+                Some(agent) => Ok(Answer {
+                    body: gojson::to_vec(&agent).map_err(|e| format!("encoding agent: {e}"))?,
+                    probe: None,
+                }),
+                // Falling back lets Go answer the 404, rather than this having
+                // to reproduce its body and status.
+                None => Err(format!("agent {slug:?} not found")),
+            }
         }
         _ => Err(format!(
             "{} {} is claimed but has no handler",
@@ -156,6 +190,15 @@ mod tests {
         assert!(!claims(&Method::GET, "/api/claude-sessions/abc-123"));
         assert!(!claims(&Method::GET, "/api/claude-sessions/"));
         assert!(!claims(&Method::GET, "/api/claude-analytics"));
+
+        // Agents: the two reads, and nothing that writes or nests.
+        assert!(claims(&Method::GET, "/api/agents"));
+        assert!(claims(&Method::GET, "/api/agents/my-agent"));
+        assert!(!claims(&Method::POST, "/api/agents"));
+        assert!(!claims(&Method::PUT, "/api/agents/my-agent"));
+        assert!(!claims(&Method::DELETE, "/api/agents/my-agent"));
+        assert!(!claims(&Method::GET, "/api/agents/my-agent/duplicate"));
+        assert!(!claims(&Method::GET, "/api/agents/"));
     }
 
     #[test]

--- a/desktop/src-tauri/tests/live_parity.rs
+++ b/desktop/src-tauri/tests/live_parity.rs
@@ -25,7 +25,7 @@ use std::path::PathBuf;
 
 use agento_lib::native::sessions::page;
 use agento_lib::native::sessions::query::SessionQuery;
-use agento_lib::native::{db, diff, gojson, pricing, settings};
+use agento_lib::native::{agents, db, diff, gojson, pricing, settings};
 
 fn live_url() -> String {
     std::env::var("AGENTO_LIVE_URL").unwrap_or_else(|_| "http://127.0.0.1:8990".to_string())
@@ -207,4 +207,43 @@ async fn a_cursor_from_another_sort_is_refused() {
     let q = SessionQuery::parse(&format!("limit=2&sort=recent&cursor={cursor}")).expect("parse");
     let err = page::list_page(&conn, &data_settings, &q).expect_err("mismatch");
     assert!(err.contains("does not match the requested sort"), "{err}");
+}
+
+/// The agents list and every agent it names, against real stored rows.
+///
+/// The per-agent read is driven from the list rather than from a hardcoded
+/// slug, so the case only tests what the instance actually has — and covers
+/// every capability shape stored there rather than the one a fixture imagines.
+#[tokio::test]
+#[ignore = "needs a running Agento instance and its database"]
+async fn agents_match_the_live_go_responses() {
+    let db_path = live_db();
+
+    let go = fetch("/api/agents").await;
+    let native = gojson::to_vec(&agents::list(&db_path).expect("native list")).expect("encode");
+    assert_identical("agents", &go, &native);
+
+    let listed: serde_json::Value = serde_json::from_slice(&go).expect("json");
+    let slugs: Vec<String> = listed
+        .as_array()
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|a| a["slug"].as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+    if slugs.is_empty() {
+        println!("no agents configured; per-agent read not exercised");
+        return;
+    }
+
+    for slug in slugs {
+        let go = fetch(&format!("/api/agents/{slug}")).await;
+        let agent = agents::get(&db_path, &slug)
+            .expect("native get")
+            .expect("agent");
+        let native = gojson::to_vec(&agent).expect("encode");
+        assert_identical(&format!("agent {slug}"), &go, &native);
+    }
 }


### PR DESCRIPTION
`GET /api/agents` and `GET /api/agents/{slug}` are answered natively. Small and
self-contained — the service layer only wraps the store in a span — but it is the
first port where **Go's nil-versus-empty rule decides the bytes**.

Go marshals a nil slice as `null` and an empty one as `[]`, and
`capabilities.built_in` is stored as whichever the writer produced. Every list
field in `Capabilities` is therefore an `Option`; a `Vec` defaulting to empty
would silently change the wire for every agent in the list.

A missing agent falls back to Go rather than reproducing its 404 body, so that
response has one definition rather than two.

## Verifying this needed a seeded instance

The developer's own install has **no agents configured**, so the first live diff
compared `[]` against `[]` and proved nothing. The parity instance is a scratch
copy of the database, so two agents were created *through* it:

- one with built-in tools, an MCP server, and a system prompt full of characters
  Go HTML-escapes (`You are <helpful> & precise`)
- one with nothing set, exercising the `null` capability shape

Both round trips are byte-identical (550, 229 and 319 bytes). That step is now in
the porting checklist in `desktop/CLAUDE.md`, because **an endpoint with no data
on this machine will always diff clean and always be untested** — the same class
of false-green as diffing against a stale server, which the last PR fixed.

## Scope

Reads only. Create, update and delete stay with Go: this is the same database
file, and a second writer would race the migrations and seeding the Go server
runs on every startup.

## Verified

`cargo fmt --check`, `clippy -D warnings`, `cargo test` (61), `cargo build
--release`, `go test ./desktop/...`, pinned golangci-lint — all clean. Live diff:
5/5 parity tests identical against a Go server built from this checkout.
