### PR TITLE
feat(desktop): port the insights summary and the nine processors to Rust

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -124,6 +124,10 @@ src-tauri/src/
       params.rs  from/to/project/tz, and the granularity the window picks
       report.rs  every aggregate in the payload
       cards.rs   the Insights cards
+    insights/    GET /api/claude-sessions/insights/summary
+      transcript.rs the session JSONL, decoded — the scanner port builds on this
+      processors.rs the nine passes that produce a session_insights row
+      summary.rs    the aggregate the endpoint answers with
     diff.rs      byte comparison + reporting for shadow mode
 
 scripts/
@@ -308,7 +312,7 @@ rather than expecting the encoder to notice.
 | Phase | Subsystem | Go source | Notes |
 |---|---|---|---|
 | 1 ✅ | Sidecar + proxy | — | done |
-| 2 ← | Pricing + analytics | `internal/pricing`, `internal/claudesessions` | Pure computation over JSONL + SQLite. No external deps. **In progress**: `/api/pricing/catalog`, `/api/claude-sessions`, `/api/claude-sessions/facets`, `/api/claude-analytics` and the agent reads are native and diff clean. Next: `/api/claude-sessions/insights/summary`. |
+| 2 ← | Pricing + analytics | `internal/pricing`, `internal/claudesessions` | Pure computation over JSONL + SQLite. No external deps. **In progress**: `/api/pricing/catalog`, `/api/claude-sessions`, `/api/claude-sessions/facets`, `/api/claude-analytics`, `/api/claude-sessions/insights/summary` and the agent reads are native and diff clean. |
 | 3 | Storage + tasks | `internal/storage`, `internal/scheduler` | 27 SQLite migrations; reuse the same DB file and schema. Scheduler is cron/interval. |
 | 4 | Integrations | `internal/integrations`, `internal/trigger` | OAuth2 + MCP servers. WhatsApp (`whatsmeow`) is the blocker — port it last or keep it in Go. |
 | 5 | Agent execution | `internal/agent`, `internal/service` | Spawns the `claude` CLI over stream-json stdin/stdout. Hardest, highest risk. |
@@ -366,8 +370,14 @@ rather than expecting the encoder to notice.
 - **Go `omitempty` drops zero values** the JSON otherwise implies are always
   present (`InsightCard.percent/count/model`, `ProjectBreakdown.folded_projects`,
   `SessionFacets.config_dirs`). Default with `?? 0`; do not trust the type.
-- **Empty arrays are inconsistent**: `/claude-analytics` sends `[]`, but
-  `/claude-sessions/insights/summary` sends `null` for every `top_*` list.
+- **`null` vs `[]` is a real distinction, but not the one this file used to
+  claim.** The insights summary sends `[]` for every empty `top_*` list, on both
+  paths that reach the zero case — `sortedToolCounts` builds with
+  `make([]toolCount, 0, len)` and the zero branch returns explicit empty slices,
+  so no code path yields a nil one. What *does* send `null` is the **analytics**
+  report's zero-valued summary, whose `unknown_pricing_models` is a genuine nil
+  slice. Verified against a Go server built from the checkout; a port written to
+  the old claim would have been wrong.
 - **`summary.total_tokens` is conversation-only** (input + output). Cache read
   is a separate, much larger number — do not add them for a "total".
 - Every ranked insights entry keys its label **`tool`**, whatever the list is of.
@@ -543,8 +553,37 @@ three times per dashboard open; measured, that rebuild is ~50 ms, and this port
 does the same work. A cache is a second thing to invalidate correctly and
 nothing about the response depends on one.
 
-Nothing else is ported. Every write path, the insights summary, the per-session
-reads and every other read still forward to Go.
+`GET /api/claude-sessions/insights/summary` followed, together with the nine
+insight processors behind the rows it reads (`native/insights/`). Two things
+about that port are worth knowing:
+
+**The processors write nothing, deliberately.** On the Go side
+`insight_worker.go` is a background writer, and porting the *upsert* now would
+put two processes on one SQLite file — the sidecar's worker and ours — racing
+over the same rows. So they are ported as what they are: a function from a
+transcript to a `SessionInsight`. That is the whole of the logic, and it is
+verifiable without writing anything. The worker is a loop around it when the
+storage layer moves.
+
+**Their parity bar is the stored rows, not a response.** Every
+`session_insights` row at the current processor version is recomputed from its
+own transcript and compared field by field — ~900 sessions and ~1 GB of real
+JSONL on the reference corpus, which is a far stronger check than any fixture.
+It found nothing wrong with the port and two things about the *method*: a
+transcript that has grown since its row was written makes every figure read
+"computed is larger" (exactly what an over-counting bug looks like), so rows are
+anchored on `session_insights.scanned_at`; and `claude_working_time_ms` is not
+reproducible at all where two events share a timestamp and differ on whether
+they are assistant events, because the gap leading into the tied pair is
+credited by an unstable sort's order. Three sessions are in that state.
+
+`native/insights/transcript.rs` is deliberately about the *file format* rather
+than about insights: the scanner port (issue #270) needs the same decoder and
+the same `isUserTurnContent` predicate, and two readers of one format is exactly
+how `message_count` and `turn_count` would drift apart.
+
+Nothing else is ported. Every write path, the per-session reads and every other
+read still forward to Go.
 
 **Reading is what keeps the corpus fresh.** `Cache.ensureFresh` runs on every Go
 read path and starts a background rescan when the TTL expires, the pricing

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -48,7 +48,7 @@ tauri-plugin-process = "2.0.0-rc.1"
 rusqlite = { version = "0.40.2", features = ["bundled"] }
 # Effective-dated rates are timestamps, and their wire format has to match Go's
 # byte for byte. `clock` is only for "which rate is in force now".
-chrono = { version = "0.4.45", default-features = false, features = ["std", "clock"] }
+chrono = { version = "0.4.45", default-features = false, features = ["std", "clock", "serde"] }
 # Analytics buckets days, hours and weekdays in the *request's* timezone, so an
 # IANA name has to resolve to real offsets and real DST transitions. Go reaches
 # its own embedded tzdata through `time.LoadLocation`; this is the equivalent.

--- a/desktop/src-tauri/src/native/analytics/params.rs
+++ b/desktop/src-tauri/src/native/analytics/params.rs
@@ -98,6 +98,14 @@ impl AnalyticsParams {
     }
 }
 
+/// One query parameter, with `url.Values.Get` semantics.
+///
+/// Shared with the insights summary, which reads `ids` alongside the window
+/// this module parses.
+pub fn query_value(query: &str, key: &str) -> String {
+    first_values(query).remove(key).unwrap_or_default()
+}
+
 /// `url.Values.Get` semantics: the first occurrence of each key wins.
 fn first_values(query: &str) -> HashMap<String, String> {
     let mut out = HashMap::new();

--- a/desktop/src-tauri/src/native/analytics/report.rs
+++ b/desktop/src-tauri/src/native/analytics/report.rs
@@ -367,7 +367,7 @@ fn empty_report(projects: Vec<String>, loc: Tz, granularity: Granularity) -> Ana
 /// has to agree on this, and the insights summary answering it with its own SQL
 /// predicate over `start_time` is what made two dashboards report different
 /// totals for one window.
-fn filter_sessions<'a>(
+pub fn filter_sessions<'a>(
     sessions: &'a [SessionSummary],
     p: &AnalyticsParams,
 ) -> Vec<&'a SessionSummary> {

--- a/desktop/src-tauri/src/native/insights/mod.rs
+++ b/desktop/src-tauri/src/native/insights/mod.rs
@@ -1,0 +1,61 @@
+//! The Claude session insights pipeline and the summary it feeds.
+//!
+//! Two halves, deliberately split by what they can safely do today:
+//!
+//! - [`summary`] answers `GET /api/claude-sessions/insights/summary` by reading
+//!   the `session_insights` rows. It is live behind the seam.
+//! - [`processors`] recomputes those rows from a transcript. It is **pure
+//!   computation and writes nothing** — see below.
+//!
+//! ## Why the pipeline does not write
+//!
+//! On the Go side `insight_worker.go` is a background writer: it subscribes to
+//! session events, reprocesses on a version bump, and upserts `session_insights`.
+//! Porting that *writer* now would put two processes on one SQLite file — the
+//! Go sidecar's worker and this one — racing each other over the same rows.
+//! Storage and the write endpoints move together later.
+//!
+//! So the processors are ported as what they actually are: a function from a
+//! transcript to a `SessionInsight`. That is enough to verify them against real
+//! data — run them over the same transcripts the Go worker already processed and
+//! compare against the rows it stored — and it is the whole of the logic. When
+//! the storage layer moves, the worker is a loop around this.
+//!
+//! ## What decides the numbers
+//!
+//! `isUserTurnContent` is the single predicate behind three turn-segmentation
+//! sites (the scanner's `message_count`, this pipeline's `turn_count`, and the
+//! journey timeline), so a change to it moves all three plus everything derived
+//! from `turn_count`. Both `CurrentScannerVersion` and `CurrentProcessorVersion`
+//! must be bumped together when it changes — bumping one recreates exactly the
+//! drift the shared predicate exists to prevent.
+
+pub mod processors;
+pub mod summary;
+pub mod transcript;
+
+use axum::http::Method;
+
+use crate::native::{db, gojson, sessions, settings, Answer, Ctx, Endpoint, Request};
+
+/// This module's entry in `native::ENDPOINTS`.
+pub const ENDPOINT: Endpoint = Endpoint {
+    name: "claude session insights",
+    claims,
+    serve,
+};
+
+fn claims(method: &Method, path: &str) -> bool {
+    method == Method::GET && path == "/api/claude-sessions/insights/summary"
+}
+
+fn serve(ctx: &Ctx, req: &Request) -> Result<Answer, String> {
+    let conn = db::open_read_only(&ctx.db_path)?;
+    let data_settings = settings::load(&conn);
+    let summary = summary::summary(&conn, &data_settings, req.query)?;
+    Ok(Answer {
+        body: gojson::to_vec(&summary).map_err(|e| format!("encoding insights summary: {e}"))?,
+        // It reads the corpus through Cache.List, which runs ensureFresh.
+        probe: Some(sessions::PROBE_PATH),
+    })
+}

--- a/desktop/src-tauri/src/native/insights/processors.rs
+++ b/desktop/src-tauri/src/native/insights/processors.rs
@@ -1,0 +1,1012 @@
+//! The nine static-analysis passes over a session transcript.
+//!
+//! Mirrors `internal/claudesessions/`: `processor.go` (the record),
+//! `processor_registry.go` (the pass), and one section below per
+//! `*_processor.go`. Read them side by side — the Go comments carry the *why*
+//! for each metric and are not repeated except where the port needs a decision.
+//!
+//! **This writes nothing.** See the module docs in `insights/mod.rs`: porting
+//! the Go worker's *upsert* now would put two processes on one SQLite file. The
+//! processors are ported as what they are — a function from a transcript to a
+//! [`SessionInsight`] — which is the whole of the logic and is verifiable
+//! against the rows the Go worker already stored.
+//!
+//! ## Order is a dependency, not a style
+//!
+//! Processors run in registration order and some read what earlier ones wrote:
+//! `AutonomyScore` is derived entirely from `TurnCount`'s two outputs, and
+//! `TokenProfile` divides by `TurnCount`. Reordering [`PIPELINE`] changes the
+//! numbers.
+//!
+//! ## Divide by one, never by zero
+//!
+//! Several metrics are per-turn averages, and a session can legitimately have
+//! **zero** genuine turns: since #226 a skill-driven session's only user event
+//! is the injected preamble, with the user's argument inside it. Those are
+//! often long, highly autonomous runs. Reporting 0 steps-per-turn for them
+//! would say the work did not happen, and `AutonomyScore` reads that value —
+//! it would score the most autonomous sessions in the corpus at the wrong
+//! extreme.
+
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Utc};
+
+use super::transcript::{self, is_turn_start, parse_content_blocks, Event};
+use crate::native::pricing::{Cost, PricedUsage, Resolver};
+
+/// Bumped whenever any processor's logic changes; rows below it are reprocessed.
+///
+/// Kept in step with Go's `CurrentProcessorVersion` because the parity check
+/// only compares rows written at this version — an older row holds figures a
+/// *correct* port must disagree with.
+pub const CURRENT_PROCESSOR_VERSION: i64 = 10;
+
+/// Every computed metric for one session. Mirrors `claudesessions.SessionInsight`
+/// minus the two fields that are not computed from the transcript
+/// (`processor_version`, `scanned_at`) and the reserved `session_type`.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SessionInsight {
+    pub session_id: String,
+
+    // TurnCountProcessor
+    pub turn_count: i64,
+    pub steps_per_turn_avg: f64,
+
+    // AutonomyScoreProcessor
+    pub autonomy_score: f64,
+
+    // ToolUsageProcessor
+    pub tool_calls_total: i64,
+    pub tool_breakdown: BTreeMap<String, i64>,
+
+    // AttributionProcessor. Every breakdown counts tool_use blocks, so they
+    // share tool_calls_total as their denominator:
+    // sum(skill_breakdown) + unattributed_calls == tool_calls_total.
+    pub skill_breakdown: BTreeMap<String, i64>,
+    pub plugin_breakdown: BTreeMap<String, i64>,
+    pub mcp_server_breakdown: BTreeMap<String, i64>,
+    pub mcp_tool_breakdown: BTreeMap<String, i64>,
+    pub effort_breakdown: BTreeMap<String, i64>,
+    pub agent_breakdown: BTreeMap<String, i64>,
+    pub unattributed_calls: i64,
+
+    // TimeProfileProcessor
+    pub total_duration_ms: i64,
+    pub active_duration_ms: i64,
+    pub claude_working_time_ms: i64,
+
+    // TokenProfileProcessor
+    pub cache_hit_rate: f64,
+    pub tokens_per_turn_avg: f64,
+    pub cost_estimate_usd: f64,
+
+    // ErrorRateProcessor
+    pub tool_error_rate: f64,
+    pub tool_error_count: i64,
+    pub has_errors: bool,
+
+    // ConversationDepthProcessor
+    pub max_consecutive_tool_calls: i64,
+    pub longest_autonomous_chain: i64,
+
+    // SessionRhythmProcessor
+    pub avg_user_response_time_ms: f64,
+    pub avg_claude_response_time_ms: f64,
+}
+
+/// One pass over a session's events.
+trait Processor {
+    fn process(&mut self, ev: &Event);
+    /// Written after every event, so a processor may read what an earlier one
+    /// wrote.
+    fn finalize(&self, insight: &mut SessionInsight);
+}
+
+/// The processors, in dependency order. **Reordering changes the numbers.**
+fn pipeline<'a>(ctx: &Ctx<'a>) -> Vec<Box<dyn Processor + 'a>> {
+    vec![
+        Box::new(TurnCount::default()),
+        Box::new(AutonomyScore),
+        Box::new(ToolUsage::default()),
+        Box::new(Attribution::default()),
+        Box::new(TimeProfile::new(ctx.idle_gap_ms)),
+        Box::new(TokenProfile::new(ctx)),
+        Box::new(ErrorRate::default()),
+        Box::new(ConversationDepth::default()),
+        Box::new(SessionRhythm::new(ctx.idle_gap_ms)),
+    ]
+}
+
+/// What a run needs from outside the transcript.
+pub struct Ctx<'a> {
+    /// The user-configurable "still working" threshold, in milliseconds. Read
+    /// once per run: a settings save landing mid-pass must not judge two gaps
+    /// of the same conversation by different rules.
+    pub idle_gap_ms: i64,
+    /// `None` prices nothing, matching Go's inert accumulator when no resolver
+    /// is wired.
+    pub resolver: Option<&'a Resolver>,
+}
+
+/// Run the pipeline over one session's transcripts.
+///
+/// **The parent must come first.** Turn-scoped processors derive their
+/// structure from it, and every sub-agent event is flagged `isSidechain`, which
+/// those processors deliberately do not treat as a new turn. Feeding one set of
+/// processors means the insight covers delegated work additively — tool calls,
+/// cost and error counts include what sub-agents did.
+///
+/// A sub-agent transcript that cannot be read is skipped; only a failure on the
+/// parent is fatal.
+pub fn run(
+    session_id: &str,
+    files: &[std::path::PathBuf],
+    ctx: &Ctx,
+) -> Result<SessionInsight, String> {
+    let Some((parent, subagents)) = files.split_first() else {
+        return Err(format!("no session files given for {session_id:?}"));
+    };
+
+    let mut processors = pipeline(ctx);
+    feed(parent, &mut processors)?;
+    for file in subagents {
+        if let Err(e) = feed(file, &mut processors) {
+            log::warn!("skipping unreadable sub-agent transcript: {e}");
+        }
+    }
+
+    let mut insight = SessionInsight {
+        session_id: session_id.to_string(),
+        ..Default::default()
+    };
+    for p in &processors {
+        p.finalize(&mut insight);
+    }
+    Ok(insight)
+}
+
+fn feed(path: &std::path::Path, processors: &mut [Box<dyn Processor + '_>]) -> Result<(), String> {
+    for ev in transcript::read(path)? {
+        // Not a conversation event; Go skips it before any processor sees it.
+        if ev.event_type == "file-history-snapshot" {
+            continue;
+        }
+        for p in processors.iter_mut() {
+            p.process(&ev);
+        }
+    }
+    Ok(())
+}
+
+// ─── turn_processor.go ────────────────────────────────────────────────────────
+
+/// Genuine user turns, and the average number of events between them.
+#[derive(Default)]
+struct TurnCount {
+    turns: i64,
+    events: i64,
+}
+
+impl Processor for TurnCount {
+    fn process(&mut self, ev: &Event) {
+        self.events += 1;
+        if is_turn_start(ev) {
+            self.turns += 1;
+        }
+    }
+
+    fn finalize(&self, insight: &mut SessionInsight) {
+        insight.turn_count = self.turns;
+        // One unattended run of n steps is n steps per turn, which is what
+        // turn_count == 1 already means to every consumer.
+        insight.steps_per_turn_avg = self.events as f64 / self.turns.max(1) as f64;
+    }
+}
+
+// ─── autonomy_processor.go ────────────────────────────────────────────────────
+
+/// How much the user let Claude run between interventions, 0–100.
+///
+/// Derives everything from `TurnCount`'s output, so it must run after it.
+struct AutonomyScore;
+
+impl Processor for AutonomyScore {
+    fn process(&mut self, _ev: &Event) {}
+
+    fn finalize(&self, insight: &mut SessionInsight) {
+        let log_factor = (insight.steps_per_turn_avg + 1.0).ln() / 10f64.ln();
+        let log_factor = log_factor.min(1.0);
+
+        // Zero turns takes the same branch as one, deliberately: since #226 a
+        // skill-driven session has no genuine user turn at all, and zero
+        // interventions is more autonomous than one, not less.
+        let score = if insight.turn_count <= 1 {
+            100.0 * log_factor
+        } else {
+            100.0 * (1.0 / insight.turn_count as f64) * log_factor
+        };
+        insight.autonomy_score = score.clamp(0.0, 100.0);
+    }
+}
+
+// ─── tool_processor.go ────────────────────────────────────────────────────────
+
+/// How many tool calls were made, and which tools.
+///
+/// Error tracking is deliberately left to [`ErrorRate`], so there is one source
+/// of truth for error metrics.
+#[derive(Default)]
+struct ToolUsage {
+    breakdown: BTreeMap<String, i64>,
+}
+
+impl Processor for ToolUsage {
+    fn process(&mut self, ev: &Event) {
+        let Some(msg) = &ev.message else { return };
+        if msg.role != "assistant" {
+            return;
+        }
+        for b in parse_content_blocks(&msg.content) {
+            if b.block_type == "tool_use" && !b.name.is_empty() {
+                *self.breakdown.entry(b.name).or_default() += 1;
+            }
+        }
+    }
+
+    fn finalize(&self, insight: &mut SessionInsight) {
+        insight.tool_calls_total = self.breakdown.values().sum();
+        insight.tool_breakdown = self.breakdown.clone();
+    }
+}
+
+// ─── attribution_processor.go ─────────────────────────────────────────────────
+
+/// How Claude Code names a tool exposed by an MCP server.
+const MCP_TOOL_PREFIX: &str = "mcp__";
+
+/// Tool usage broken down by the skill, plugin, MCP server and sub-agent
+/// responsible, plus the reasoning-effort tier.
+///
+/// **Counted per `tool_use` block, not per event.** Claude Code splits one
+/// assistant message into several JSONL events — thinking, text, each tool call
+/// — which all share a message id and therefore carry identical attribution
+/// fields. Counting per event would inflate every number by a variable factor.
+///
+/// **MCP attribution comes from the block name**, not from
+/// `attributionMcpServer`/`attributionMcpTool`. Those hold the last MCP tool
+/// touched and persist onto later, unrelated turns: across the reference corpus
+/// only ~63 of ~730 tool-bearing events had them agree with the block actually
+/// being called.
+#[derive(Default)]
+struct Attribution {
+    skills: BTreeMap<String, i64>,
+    plugins: BTreeMap<String, i64>,
+    mcp_servers: BTreeMap<String, i64>,
+    mcp_tools: BTreeMap<String, i64>,
+    efforts: BTreeMap<String, i64>,
+    agents: BTreeMap<String, i64>,
+    unattributed: i64,
+}
+
+impl Processor for Attribution {
+    fn process(&mut self, ev: &Event) {
+        let Some(msg) = &ev.message else { return };
+        if msg.role != "assistant" {
+            return;
+        }
+        for b in parse_content_blocks(&msg.content) {
+            if b.block_type != "tool_use" || b.name.is_empty() {
+                continue;
+            }
+            self.attribute(ev, &b.name);
+        }
+    }
+
+    fn finalize(&self, insight: &mut SessionInsight) {
+        insight.skill_breakdown = self.skills.clone();
+        insight.plugin_breakdown = self.plugins.clone();
+        insight.mcp_server_breakdown = self.mcp_servers.clone();
+        insight.mcp_tool_breakdown = self.mcp_tools.clone();
+        insight.effort_breakdown = self.efforts.clone();
+        insight.agent_breakdown = self.agents.clone();
+        insight.unattributed_calls = self.unattributed;
+    }
+}
+
+impl Attribution {
+    /// Credit one block to every dimension the event names. An empty field
+    /// contributes nothing rather than creating a `""` bucket — except the
+    /// skill, whose absence is itself the signal that this was built-in tool
+    /// use, counted as unattributed so the totals reconcile.
+    fn attribute(&mut self, ev: &Event, block_name: &str) {
+        if ev.attribution_skill.is_empty() {
+            self.unattributed += 1;
+        } else {
+            *self.skills.entry(ev.attribution_skill.clone()).or_default() += 1;
+        }
+        // A skill can be user-level rather than shipped by a plugin, so the
+        // plugin is counted independently instead of nested under the skill.
+        if !ev.attribution_plugin.is_empty() {
+            *self
+                .plugins
+                .entry(ev.attribution_plugin.clone())
+                .or_default() += 1;
+        }
+        if !ev.effort.is_empty() {
+            *self.efforts.entry(ev.effort.clone()).or_default() += 1;
+        }
+        // Sub-agent transcripts carry the agent type that owns the turn; a
+        // parent transcript leaves it empty, so main-thread work contributes
+        // nothing here rather than landing in a catch-all bucket.
+        if !ev.attribution_agent.is_empty() {
+            *self.agents.entry(ev.attribution_agent.clone()).or_default() += 1;
+        }
+        if let Some((server, tool)) = split_mcp_tool_name(block_name) {
+            *self.mcp_servers.entry(server.to_string()).or_default() += 1;
+            *self.mcp_tools.entry(tool.to_string()).or_default() += 1;
+        }
+    }
+}
+
+/// Split `mcp__<server>__<tool>`.
+///
+/// Server names may themselves contain underscores (`vibexp_io_vibexp_team`),
+/// so the split is on the **first** `__` after the prefix rather than on every
+/// underscore.
+fn split_mcp_tool_name(name: &str) -> Option<(&str, &str)> {
+    let rest = name.strip_prefix(MCP_TOOL_PREFIX)?;
+    let (server, tool) = rest.split_once("__")?;
+    if server.is_empty() || tool.is_empty() {
+        return None;
+    }
+    Some((server, tool))
+}
+
+// ─── time_processor.go + active_duration.go ───────────────────────────────────
+
+/// The session's three time figures.
+///
+/// `total_duration_ms` is the raw first-to-last span — honest as "first seen →
+/// last touched" and nothing else, since a resumed session's span contains
+/// every idle day in between. `active_duration_ms` caps each inter-event gap at
+/// the idle threshold and is the figure dashboards average.
+/// `claude_working_time_ms` is the subset of that ending at an assistant event.
+struct TimeProfile {
+    idle_gap_ms: i64,
+    first: Option<DateTime<Utc>>,
+    last: Option<DateTime<Utc>>,
+    stamps: Vec<(DateTime<Utc>, bool)>,
+}
+
+impl TimeProfile {
+    fn new(idle_gap_ms: i64) -> Self {
+        TimeProfile {
+            idle_gap_ms,
+            first: None,
+            last: None,
+            stamps: Vec::new(),
+        }
+    }
+}
+
+impl Processor for TimeProfile {
+    fn process(&mut self, ev: &Event) {
+        let Some(ts) = ev.timestamp else { return };
+        if self.first.is_none_or_earlier(ts) {
+            self.first = Some(ts);
+        }
+        if self.last.is_none_or_later(ts) {
+            self.last = Some(ts);
+        }
+        self.stamps.push((ts, ev.event_type == "assistant"));
+    }
+
+    fn finalize(&self, insight: &mut SessionInsight) {
+        if let (Some(first), Some(last)) = (self.first, self.last) {
+            insight.total_duration_ms = (last - first).num_milliseconds();
+        }
+        let (active, assistant) = self.durations();
+        insight.active_duration_ms = active;
+        insight.claude_working_time_ms = assistant;
+    }
+}
+
+impl TimeProfile {
+    /// Sum the capped inter-event gaps.
+    ///
+    /// Sorted first because the pipeline feeds parent-then-sub-agent
+    /// transcripts whose timestamps interleave — which is also what credits a
+    /// 40-minute delegated run instead of collapsing the parent's `Task` wait
+    /// to one capped gap.
+    ///
+    /// A **stable** sort where Go uses `sort.Slice`: with two events sharing a
+    /// timestamp but differing in whether they are assistant events, the gap
+    /// *into* the pair is attributed to whichever sorts first, so Go's result
+    /// is order-dependent there. Stable keeps file order, which is the order
+    /// the events were written in.
+    fn durations(&self) -> (i64, i64) {
+        if self.stamps.len() < 2 {
+            return (0, 0);
+        }
+        let mut sorted = self.stamps.clone();
+        sorted.sort_by_key(|(ts, _)| *ts);
+
+        let (mut active, mut assistant) = (0i64, 0i64);
+        for pair in sorted.windows(2) {
+            let gap = (pair[1].0 - pair[0].0)
+                .num_milliseconds()
+                .min(self.idle_gap_ms);
+            active += gap;
+            if pair[1].1 {
+                assistant += gap;
+            }
+        }
+        (active, assistant)
+    }
+}
+
+/// `Option<DateTime>` comparisons spelled out, so the min/max reads the way
+/// Go's zero-time checks do.
+trait BoundExt {
+    fn is_none_or_earlier(&self, ts: DateTime<Utc>) -> bool;
+    fn is_none_or_later(&self, ts: DateTime<Utc>) -> bool;
+}
+
+impl BoundExt for Option<DateTime<Utc>> {
+    fn is_none_or_earlier(&self, ts: DateTime<Utc>) -> bool {
+        self.is_none() || self.is_some_and(|cur| ts < cur)
+    }
+    fn is_none_or_later(&self, ts: DateTime<Utc>) -> bool {
+        // Go compares against the zero time, which every real timestamp is
+        // after, so an unset bound always loses.
+        self.is_none() || self.is_some_and(|cur| ts > cur)
+    }
+}
+
+// ─── token_processor.go ───────────────────────────────────────────────────────
+
+/// Token usage across assistant messages, and the cost and cache figures.
+///
+/// Cost is accumulated **per assistant message** at that message's own model
+/// and timestamp — the same resolver the scanner uses, so a session's insight
+/// cost and its analytics cost cannot diverge over a first-seen-model or a
+/// price-boundary difference.
+struct TokenProfile<'a> {
+    resolver: Option<&'a Resolver>,
+    input: i64,
+    output: i64,
+    cache_creation: i64,
+    cache_read: i64,
+    cost: Cost,
+    priced_messages: i64,
+}
+
+impl<'a> TokenProfile<'a> {
+    fn new(ctx: &Ctx<'a>) -> Self {
+        TokenProfile {
+            resolver: ctx.resolver,
+            input: 0,
+            output: 0,
+            cache_creation: 0,
+            cache_read: 0,
+            cost: Cost::default(),
+            priced_messages: 0,
+        }
+    }
+}
+
+impl Processor for TokenProfile<'_> {
+    fn process(&mut self, ev: &Event) {
+        let Some(msg) = &ev.message else { return };
+        if msg.role != "assistant" {
+            return;
+        }
+        let Some(u) = &msg.usage else { return };
+        let (five_min, one_hour) = u.split_cache_tiers();
+        self.input += u.input_tokens;
+        self.output += u.output_tokens;
+        self.cache_creation += u.cache_creation_input_tokens;
+        self.cache_read += u.cache_read_input_tokens;
+
+        let Some(resolver) = self.resolver else {
+            return;
+        };
+        if u.input_tokens
+            + u.output_tokens
+            + u.cache_creation_input_tokens
+            + u.cache_read_input_tokens
+            == 0
+        {
+            return;
+        }
+        // An event with no timestamp is priced at Go's zero time, which
+        // resolves to the earliest rate marked estimated rather than to
+        // nothing.
+        let at = ev.timestamp.unwrap_or(DateTime::<Utc>::MIN_UTC);
+        self.price_at(resolver, &msg.model, five_min, one_hour, u, at);
+    }
+
+    fn finalize(&self, insight: &mut SessionInsight) {
+        // Via the shared definition, so this and the analytics dashboard cannot
+        // report two different numbers under the same name again.
+        insight.cache_hit_rate = crate::native::analytics::report::cache_hit_rate(
+            self.input,
+            self.cache_read,
+            self.cache_creation,
+        );
+
+        // Divide by one when there are no turns, for the reason in the module
+        // docs: reporting 0 tokens per turn for a session that spent millions
+        // says the opposite of what happened.
+        insight.tokens_per_turn_avg =
+            (self.input + self.output) as f64 / insight.turn_count.max(1) as f64;
+
+        // A session with no usage-bearing messages — or run without a resolver
+        // — leaves the estimate at zero, matching the semantics where an
+        // unpriced model contributes no cost.
+        if self.priced_messages > 0 {
+            insight.cost_estimate_usd = self.cost.total_cost_usd;
+        }
+    }
+}
+
+impl TokenProfile<'_> {
+    fn price_at(
+        &mut self,
+        resolver: &Resolver,
+        model: &str,
+        five_min: i64,
+        one_hour: i64,
+        u: &transcript::Usage,
+        at: DateTime<Utc>,
+    ) {
+        // The synthetic placeholder and embedding models resolve to
+        // non-billable catalog rows, so they price at $0.00 without being
+        // mistaken for a gap in the catalog.
+        let Some(resolved) = resolver.resolve(model, at) else {
+            return;
+        };
+        let priced = resolved.rate.price(PricedUsage {
+            input_tokens: u.input_tokens,
+            output_tokens: u.output_tokens,
+            cache_creation_5m_tokens: five_min,
+            cache_creation_1h_tokens: one_hour,
+            cache_read_tokens: u.cache_read_input_tokens,
+        });
+        self.cost.add(&priced);
+        self.priced_messages += 1;
+    }
+}
+
+// ─── error_processor.go ───────────────────────────────────────────────────────
+
+/// Tool errors and the rate they occurred at.
+#[derive(Default)]
+struct ErrorRate {
+    errors: i64,
+    results: i64,
+}
+
+impl Processor for ErrorRate {
+    fn process(&mut self, ev: &Event) {
+        let Some(msg) = &ev.message else { return };
+        if msg.role != "user" {
+            return;
+        }
+        for b in parse_content_blocks(&msg.content) {
+            if b.block_type == "tool_result" {
+                self.results += 1;
+                if b.is_error {
+                    self.errors += 1;
+                }
+            }
+        }
+    }
+
+    fn finalize(&self, insight: &mut SessionInsight) {
+        insight.tool_error_count = self.errors;
+        insight.has_errors = self.errors > 0;
+        if self.results > 0 {
+            insight.tool_error_rate = self.errors as f64 / self.results as f64;
+        }
+    }
+}
+
+// ─── depth_processor.go ───────────────────────────────────────────────────────
+
+/// How deeply Claude goes without user intervention.
+///
+/// One known imprecision, measured and accepted: since #226 an interrupt notice
+/// is injected content rather than a genuine turn, so it no longer breaks the
+/// chain — even though it is literally the user intervening. On the reference
+/// corpus 115 of 120 interrupts are not followed by a genuine turn, so the
+/// break is lost rather than moved, and only 2 sessions change at all.
+#[derive(Default)]
+struct ConversationDepth {
+    max_consecutive: i64,
+    longest_chain: i64,
+    current_chain: i64,
+}
+
+impl Processor for ConversationDepth {
+    fn process(&mut self, ev: &Event) {
+        match ev.event_type.as_str() {
+            "assistant" => {
+                if let Some(msg) = &ev.message {
+                    self.process_assistant(&parse_content_blocks(&msg.content));
+                }
+            }
+            // Genuine user input breaks the autonomous chain.
+            "user" if is_turn_start(ev) => self.current_chain = 0,
+            _ => {}
+        }
+    }
+
+    fn finalize(&self, insight: &mut SessionInsight) {
+        insight.max_consecutive_tool_calls = self.max_consecutive;
+        insight.longest_autonomous_chain = self.longest_chain;
+    }
+}
+
+impl ConversationDepth {
+    /// A non-`tool_use` block (e.g. text) resets the per-message consecutive
+    /// counter but not the session-wide chain.
+    fn process_assistant(&mut self, blocks: &[transcript::ContentBlock]) {
+        let mut consecutive = 0i64;
+        for b in blocks {
+            if b.block_type == "tool_use" {
+                consecutive += 1;
+                self.current_chain += 1;
+            } else {
+                self.max_consecutive = self.max_consecutive.max(consecutive);
+                consecutive = 0;
+            }
+        }
+        self.max_consecutive = self.max_consecutive.max(consecutive);
+        self.longest_chain = self.longest_chain.max(self.current_chain);
+    }
+}
+
+// ─── rhythm_processor.go ──────────────────────────────────────────────────────
+
+/// How long the user and Claude each take to respond.
+///
+/// Gaps above the idle threshold are **excluded rather than capped**. A message
+/// sent after lunch or on resuming days later is a new sitting, not a reply —
+/// the corpus contained a 226-hour "user response time" from exactly that — and
+/// capping would only make every resumed session's average converge on the cap.
+/// On the Claude side a gap that large is a queued-message artifact: the event
+/// carries the typed-at timestamp and delivery came after the running turn.
+struct SessionRhythm {
+    max_gap_ms: i64,
+    last_assistant: Option<DateTime<Utc>>,
+    last_genuine_user: Option<DateTime<Utc>>,
+    user_gaps: Vec<i64>,
+    claude_gaps: Vec<i64>,
+}
+
+impl SessionRhythm {
+    fn new(idle_gap_ms: i64) -> Self {
+        SessionRhythm {
+            max_gap_ms: idle_gap_ms,
+            last_assistant: None,
+            last_genuine_user: None,
+            user_gaps: Vec::new(),
+            claude_gaps: Vec::new(),
+        }
+    }
+}
+
+impl Processor for SessionRhythm {
+    fn process(&mut self, ev: &Event) {
+        let Some(ts) = ev.timestamp else { return };
+        match ev.event_type.as_str() {
+            "user" => {
+                if !is_turn_start(ev) {
+                    return;
+                }
+                if let Some(last) = self.last_assistant {
+                    let gap = (ts - last).num_milliseconds();
+                    if (0..=self.max_gap_ms).contains(&gap) {
+                        self.user_gaps.push(gap);
+                    }
+                }
+                self.last_genuine_user = Some(ts);
+            }
+            "assistant" => {
+                if let Some(last) = self.last_genuine_user {
+                    let gap = (ts - last).num_milliseconds();
+                    if gap >= 0 {
+                        if gap <= self.max_gap_ms {
+                            self.claude_gaps.push(gap);
+                        }
+                        // Consume the pair even when the gap was an artifact,
+                        // so a later assistant event is not measured against it
+                        // too.
+                        self.last_genuine_user = None;
+                    }
+                }
+                self.last_assistant = Some(ts);
+            }
+            _ => {}
+        }
+    }
+
+    fn finalize(&self, insight: &mut SessionInsight) {
+        insight.avg_user_response_time_ms = mean(&self.user_gaps);
+        insight.avg_claude_response_time_ms = mean(&self.claude_gaps);
+    }
+}
+
+/// The mean of a slice, or 0 when empty.
+fn mean(values: &[i64]) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    values.iter().sum::<i64>() as f64 / values.len() as f64
+}
+
+// ─── Locating a session's transcripts ─────────────────────────────────────────
+
+/// The sub-agent transcript paths belonging to the session whose own transcript
+/// is at `session_file`, sorted — `SubagentFiles` in `scanner.go`.
+///
+/// They live at `<dir of parent>/<session-id>/subagents/*.jsonl`. A missing
+/// directory means the session delegated nothing, which is not an error.
+pub fn subagent_files(session_id: &str, session_file: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let dir = match session_file.parent() {
+        Some(parent) => parent.join(session_id).join("subagents"),
+        None => return Vec::new(),
+    };
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+
+    let mut paths: Vec<std::path::PathBuf> = entries
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "jsonl"))
+        .filter(|e| e.file_type().is_ok_and(|t| !t.is_dir()))
+        .map(|e| e.path())
+        .collect();
+    // Go sorts the joined paths as strings; within one directory that is the
+    // same order as sorting the file names.
+    paths.sort();
+    paths
+}
+
+/// Every transcript one session's insight is computed from: the parent first,
+/// then each sub-agent's.
+pub fn session_files(session_id: &str, session_file: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut files = vec![session_file.to_path_buf()];
+    files.extend(subagent_files(session_id, session_file));
+    files
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::io::Write;
+
+    /// Build a transcript from JSON lines and run the pipeline over it.
+    fn insight_of(lines: &[serde_json::Value]) -> SessionInsight {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("session.jsonl");
+        let mut file = std::fs::File::create(&path).expect("create");
+        for line in lines {
+            writeln!(file, "{line}").expect("write");
+        }
+        drop(file);
+
+        run(
+            "s1",
+            &[path],
+            &Ctx {
+                idle_gap_ms: 600_000,
+                resolver: None,
+            },
+        )
+        .expect("run")
+    }
+
+    fn user(content: serde_json::Value) -> serde_json::Value {
+        json!({"type": "user", "message": {"role": "user", "content": content}})
+    }
+
+    fn assistant(content: serde_json::Value) -> serde_json::Value {
+        json!({"type": "assistant", "message": {"role": "assistant", "content": content}})
+    }
+
+    fn tool_use(name: &str) -> serde_json::Value {
+        json!({"type": "tool_use", "id": "t", "name": name, "input": {}})
+    }
+
+    #[test]
+    fn a_skill_driven_session_has_no_turns_and_still_reports_its_work() {
+        // The case #226 created: the only user event is the injected preamble,
+        // so turn_count is legitimately 0 for a real, long, autonomous run.
+        let insight = insight_of(&[
+            user(json!([{
+                "type": "text",
+                "text": "Base directory for this skill: /home/u/.claude/skills/foo"
+            }])),
+            assistant(json!([tool_use("Bash")])),
+            assistant(json!([tool_use("Read")])),
+        ]);
+
+        assert_eq!(insight.turn_count, 0);
+        // Divided by one, not by zero: three events, one notional turn.
+        assert_eq!(insight.steps_per_turn_avg, 3.0);
+        // …and it scores as maximally autonomous rather than as zero.
+        assert!(insight.autonomy_score > 0.0, "{}", insight.autonomy_score);
+        assert_eq!(insight.tool_calls_total, 2);
+    }
+
+    #[test]
+    fn tool_calls_are_counted_per_block_and_split_by_mcp_server() {
+        let insight = insight_of(&[json!({
+            "type": "assistant",
+            "attributionSkill": "vibexp:prime",
+            "effort": "high",
+            "message": {"role": "assistant", "content": [
+                tool_use("Bash"),
+                tool_use("mcp__vibexp_io_vibexp_team__vibexp_io_search"),
+            ]},
+        })]);
+
+        assert_eq!(insight.tool_calls_total, 2);
+        assert_eq!(insight.tool_breakdown["Bash"], 1);
+        // Both blocks are credited to the skill that was in context.
+        assert_eq!(insight.skill_breakdown["vibexp:prime"], 2);
+        assert_eq!(insight.effort_breakdown["high"], 2);
+        // The server name contains underscores; the split is on the first `__`
+        // after the prefix.
+        assert_eq!(insight.mcp_server_breakdown["vibexp_io_vibexp_team"], 1);
+        assert_eq!(insight.mcp_tool_breakdown["vibexp_io_search"], 1);
+        assert_eq!(insight.unattributed_calls, 0);
+    }
+
+    #[test]
+    fn built_in_tool_use_is_unattributed_so_the_totals_reconcile() {
+        let insight = insight_of(&[
+            assistant(json!([tool_use("Bash")])),
+            json!({
+                "type": "assistant",
+                "attributionSkill": "update-docs",
+                "message": {"role": "assistant", "content": [tool_use("Edit")]},
+            }),
+        ]);
+
+        let attributed: i64 = insight.skill_breakdown.values().sum();
+        assert_eq!(
+            attributed + insight.unattributed_calls,
+            insight.tool_calls_total
+        );
+        assert_eq!(insight.unattributed_calls, 1);
+    }
+
+    #[test]
+    fn errors_come_from_tool_results_not_from_tool_calls() {
+        let insight = insight_of(&[
+            assistant(json!([tool_use("Bash")])),
+            user(json!([{"type": "tool_result", "tool_use_id": "t", "is_error": true}])),
+            user(json!([{"type": "tool_result", "tool_use_id": "t"}])),
+        ]);
+
+        assert_eq!(insight.tool_error_count, 1);
+        assert!(insight.has_errors);
+        assert_eq!(insight.tool_error_rate, 0.5);
+        // A tool_result carrier is not a turn.
+        assert_eq!(insight.turn_count, 0);
+    }
+
+    #[test]
+    fn a_genuine_turn_breaks_the_autonomous_chain_and_an_injection_does_not() {
+        let insight = insight_of(&[
+            assistant(json!([tool_use("Bash"), tool_use("Read")])),
+            // Injected, so the chain continues across it.
+            user(json!("<system-reminder>keep going</system-reminder>")),
+            assistant(json!([tool_use("Edit")])),
+            // Genuine: breaks the chain.
+            user(json!("now do something else")),
+            assistant(json!([tool_use("Write")])),
+        ]);
+
+        assert_eq!(insight.turn_count, 1);
+        assert_eq!(insight.longest_autonomous_chain, 3);
+        // Within one message: two consecutive tool_use blocks.
+        assert_eq!(insight.max_consecutive_tool_calls, 2);
+    }
+
+    #[test]
+    fn a_text_block_resets_the_consecutive_run_but_not_the_chain() {
+        let insight = insight_of(&[assistant(json!([
+            tool_use("Bash"),
+            {"type": "text", "text": "let me check"},
+            tool_use("Read"),
+            tool_use("Edit"),
+        ]))]);
+
+        assert_eq!(insight.max_consecutive_tool_calls, 2);
+        assert_eq!(insight.longest_autonomous_chain, 3);
+    }
+
+    #[test]
+    fn idle_gaps_are_capped_for_active_time_and_excluded_from_the_averages() {
+        let at = |s: &str| json!(s);
+        let insight = insight_of(&[
+            json!({"type": "user", "timestamp": at("2026-08-01T10:00:00Z"),
+                   "message": {"role": "user", "content": "start"}}),
+            // 1 minute later: a real reply, counted in both.
+            json!({"type": "assistant", "timestamp": at("2026-08-01T10:01:00Z"),
+                   "message": {"role": "assistant", "content": [{"type": "text", "text": "ok"}]}}),
+            // 3 hours later: a new sitting, not a reply.
+            json!({"type": "user", "timestamp": at("2026-08-01T13:01:00Z"),
+                   "message": {"role": "user", "content": "back"}}),
+            json!({"type": "assistant", "timestamp": at("2026-08-01T13:02:00Z"),
+                   "message": {"role": "assistant", "content": [{"type": "text", "text": "ok"}]}}),
+        ]);
+
+        // The raw span is the whole 3h02m…
+        assert_eq!(insight.total_duration_ms, 3 * 3_600_000 + 120_000);
+        // …while active time caps the idle gap at the 10-minute threshold:
+        // 60s + 600s (capped) + 60s.
+        assert_eq!(insight.active_duration_ms, 60_000 + 600_000 + 60_000);
+        // Claude's working time is the subset ending at an assistant event.
+        assert_eq!(insight.claude_working_time_ms, 120_000);
+        // The 3-hour gap is excluded from the user average, not capped into it.
+        assert_eq!(insight.avg_user_response_time_ms, 0.0);
+        assert_eq!(insight.avg_claude_response_time_ms, 60_000.0);
+    }
+
+    #[test]
+    fn a_file_history_snapshot_is_not_a_step() {
+        let insight = insight_of(&[
+            user(json!("hello")),
+            json!({"type": "file-history-snapshot", "snapshot": {"a": 1}}),
+            assistant(json!([{"type": "text", "text": "hi"}])),
+        ]);
+        // Two events, one turn — the snapshot is skipped before any processor.
+        assert_eq!(insight.turn_count, 1);
+        assert_eq!(insight.steps_per_turn_avg, 2.0);
+    }
+
+    #[test]
+    fn cache_hit_rate_uses_the_shared_definition() {
+        let insight = insight_of(&[json!({
+            "type": "assistant",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": "x"}],
+                        "usage": {"input_tokens": 100, "output_tokens": 20,
+                                  "cache_read_input_tokens": 300,
+                                  "cache_creation_input_tokens": 0}},
+        })]);
+        assert_eq!(insight.cache_hit_rate, 0.75);
+        // No resolver wired, so nothing is priced.
+        assert_eq!(insight.cost_estimate_usd, 0.0);
+        assert_eq!(insight.tokens_per_turn_avg, 120.0);
+    }
+
+    #[test]
+    fn sub_agent_transcripts_are_found_beside_the_parent_and_sorted() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let parent = dir.path().join("abc.jsonl");
+        std::fs::write(&parent, "").expect("write parent");
+        let subs = dir.path().join("abc").join("subagents");
+        std::fs::create_dir_all(&subs).expect("mkdir");
+        for name in ["agent-2.jsonl", "agent-1.jsonl", "agent-1.meta.json"] {
+            std::fs::write(subs.join(name), "").expect("write");
+        }
+
+        let files = session_files("abc", &parent);
+        assert_eq!(files.len(), 3, "{files:?}");
+        assert_eq!(files[0], parent);
+        assert!(files[1].ends_with("agent-1.jsonl"), "{files:?}");
+        assert!(files[2].ends_with("agent-2.jsonl"), "{files:?}");
+
+        // A session that delegated nothing yields the parent alone.
+        let lone = dir.path().join("none.jsonl");
+        std::fs::write(&lone, "").expect("write");
+        assert_eq!(session_files("none", &lone), vec![lone]);
+    }
+}

--- a/desktop/src-tauri/src/native/insights/summary.rs
+++ b/desktop/src-tauri/src/native/insights/summary.rs
@@ -1,0 +1,376 @@
+//! `GET /api/claude-sessions/insights/summary`, ported from Go.
+//!
+//! Go sources this mirrors:
+//!
+//! - `internal/api/claude_session_insights.go` — the handler, the response type
+//!   and `sortedToolCounts`
+//! - `internal/api/insight_store_adapter.go`   — `GetSummary`, `mergeBreakdowns`
+//! - `internal/storage/sqlite_session_insights_store.go` — `GetAggregateSummary`
+//!
+//! It resolves its window through `AnalyticsParams` and selects through
+//! [`crate::native::analytics::report::filter_sessions`] — the Go counterpart of
+//! which is exported precisely so more than one endpoint can share it. The
+//! summary used to answer "which sessions does this window contain" with its own
+//! SQL predicate over `start_time`, and the same range produced a different
+//! session count and a different total cost on two dashboards showing the same
+//! window.
+//!
+//! ## The ID set is the whole filter
+//!
+//! Windowing happens in Rust, over the corpus; the SQL sees only a set of
+//! session IDs and never a date. That is deliberate on the Go side too, and not
+//! merely for consistency: the DATETIME columns hold Go's `time.Time.String()`
+//! rendering (`2024-03-15 12:00:00 +0000 UTC`), so comparing one against an
+//! RFC 3339 bound compares `' '` with `'T'` at index 10 and misplaces every row
+//! whose date equals a boundary's.
+//!
+//! **An empty set means empty, not everything.** The set travels as a single
+//! JSON parameter expanded by `json_each` rather than one placeholder per ID,
+//! because a window can legitimately hold thousands of sessions and a
+//! placeholder each would hit SQLite's variable limit on exactly the corpora
+//! this exists for.
+//!
+//! ## Every list is `[]`, never `null`
+//!
+//! `desktop/CLAUDE.md` and the porting issue both said this endpoint sends
+//! `null` for its empty `top_*` lists. It does not, on either path that reaches
+//! the zero case: `sortedToolCounts` builds with `make([]toolCount, 0, len)`,
+//! which is non-nil when empty, and the zero branch returns each list as an
+//! explicit `[]toolCount{}`. There is no code path that yields a nil slice.
+//! (The *analytics* report does have one — its zero-valued summary sends
+//! `"unknown_pricing_models":null` — which is where the belief came from.)
+
+use std::collections::BTreeMap;
+
+use rusqlite::Connection;
+use serde::Serialize;
+
+use crate::native::analytics::params::{query_value, AnalyticsParams};
+use crate::native::analytics::report::filter_sessions;
+use crate::native::gojson;
+use crate::native::sessions::corpus;
+use crate::native::settings::DataSettings;
+
+/// How many entries each breakdown panel shows.
+const TOP_BREAKDOWN_ENTRIES: usize = 10;
+
+/// Aggregated statistics across the window's sessions. Mirrors
+/// `api.insightsSummary`; field order is that struct's declaration order.
+#[derive(Debug, Default, Serialize)]
+pub struct InsightsSummary {
+    pub total_sessions: i64,
+    pub avg_autonomy_score: f64,
+    pub avg_turn_count: f64,
+    pub avg_tool_calls_total: f64,
+    pub avg_cost_estimate_usd: f64,
+    pub total_cost_estimate_usd: f64,
+    pub avg_cache_hit_rate: f64,
+    pub sessions_with_errors: i64,
+    pub total_tool_errors: i64,
+    pub avg_total_duration_ms: f64,
+    /// The mean of per-session *active* durations — every inter-event gap
+    /// capped at the idle threshold — which is what the dashboard labels "Avg
+    /// Duration". `avg_total_duration_ms` is the raw span mean, kept because
+    /// "first seen → last touched" is an honest answer to a different question.
+    pub avg_active_duration_ms: f64,
+    pub top_tools: Vec<ToolCount>,
+    /// With `unattributed_calls`, gives the breakdowns a denominator: without
+    /// them a "top skills" panel silently omits every built-in call.
+    pub total_tool_calls: i64,
+    pub unattributed_calls: i64,
+    pub top_skills: Vec<ToolCount>,
+    pub top_plugins: Vec<ToolCount>,
+    pub top_mcp_servers: Vec<ToolCount>,
+    /// The drill-down under `top_mcp_servers`, not a peer dimension.
+    pub top_mcp_tools: Vec<ToolCount>,
+    pub top_efforts: Vec<ToolCount>,
+    pub top_agents: Vec<ToolCount>,
+}
+
+/// A name and its aggregate call count. Every ranked entry keys its label
+/// `tool`, whatever the list is of.
+#[derive(Debug, Serialize)]
+pub struct ToolCount {
+    pub tool: String,
+    pub count: i64,
+}
+
+/// Build the summary for one request's query string.
+pub fn summary(
+    conn: &Connection,
+    settings: &DataSettings,
+    query: &str,
+) -> Result<InsightsSummary, String> {
+    let p = AnalyticsParams::parse(query)?;
+    let sessions = corpus::load(conn, settings)?;
+
+    let mut ids: Vec<String> = filter_sessions(&sessions, &p)
+        .iter()
+        .map(|s| s.session_id.clone())
+        .collect();
+
+    // An explicit `ids` list narrows the window rather than replacing it, so a
+    // caller cannot accidentally widen the range by naming a session outside it.
+    let explicit = parse_session_ids(&query_value(query, "ids"));
+    if !explicit.is_empty() {
+        ids.retain(|id| explicit.iter().any(|wanted| wanted == id));
+    }
+
+    Ok(build(aggregate(conn, &ids)?))
+}
+
+/// Split the comma-separated `ids` parameter, dropping blanks.
+fn parse_session_ids(raw: &str) -> Vec<String> {
+    if raw.is_empty() {
+        return Vec::new();
+    }
+    raw.split(',')
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+/// The SQL-computed scalars plus the merged breakdowns.
+#[derive(Default)]
+struct Aggregate {
+    total_sessions: i64,
+    avg_autonomy_score: f64,
+    avg_turn_count: f64,
+    avg_tool_calls_total: f64,
+    total_cost_estimate_usd: f64,
+    avg_cache_hit_rate: f64,
+    avg_total_duration_ms: f64,
+    avg_active_duration_ms: f64,
+    sessions_with_errors: i64,
+    total_tool_calls: i64,
+    unattributed_calls: i64,
+    total_tool_errors: i64,
+    /// One merged map per dimension, in the order the columns are selected:
+    /// tool, skill, plugin, MCP server, MCP tool, effort, agent.
+    breakdowns: [BTreeMap<String, i64>; BREAKDOWN_COLUMNS],
+}
+
+const BREAKDOWN_COLUMNS: usize = 7;
+
+/// Scalars in SQL — the aggregation never loads a row into memory.
+const AGGREGATE_SQL: &str = "SELECT
+	COUNT(*),
+	COALESCE(AVG(autonomy_score), 0),
+	COALESCE(AVG(turn_count), 0),
+	COALESCE(AVG(tool_calls_total), 0),
+	COALESCE(SUM(cost_estimate_usd), 0),
+	COALESCE(AVG(cache_hit_rate), 0),
+	COALESCE(AVG(total_duration_ms), 0),
+	COALESCE(AVG(active_duration_ms), 0),
+	COALESCE(SUM(has_errors), 0),
+	COALESCE(SUM(tool_calls_total), 0),
+	COALESCE(SUM(unattributed_calls), 0),
+	COALESCE(SUM(tool_error_count), 0)
+FROM session_insights";
+
+/// One query for every breakdown column rather than one per column: the
+/// row-scan cost then grows with the corpus only, not with how many dimensions
+/// the feature has accumulated.
+const BREAKDOWN_SQL: &str = "SELECT tool_breakdown, skill_breakdown, plugin_breakdown,
+       mcp_server_breakdown, mcp_tool_breakdown, effort_breakdown, agent_breakdown
+FROM session_insights";
+
+/// Restricts a query to the given session IDs.
+const ID_FILTER: &str = " WHERE session_id IN (SELECT value FROM json_each(?))";
+
+fn aggregate(conn: &Connection, ids: &[String]) -> Result<Aggregate, String> {
+    if ids.is_empty() {
+        return Ok(Aggregate::default());
+    }
+
+    // Marshalled through the Go encoder so the bound parameter is the same text
+    // Go binds.
+    let bound = String::from_utf8(
+        gojson::to_vec_marshal(&ids).map_err(|e| format!("marshaling session id filter: {e}"))?,
+    )
+    .map_err(|e| format!("session id filter is not utf-8: {e}"))?;
+
+    let mut agg = conn
+        .query_row(&format!("{AGGREGATE_SQL}{ID_FILTER}"), [&bound], |row| {
+            Ok(Aggregate {
+                total_sessions: row.get(0)?,
+                avg_autonomy_score: row.get(1)?,
+                avg_turn_count: row.get(2)?,
+                avg_tool_calls_total: row.get(3)?,
+                total_cost_estimate_usd: row.get(4)?,
+                avg_cache_hit_rate: row.get(5)?,
+                avg_total_duration_ms: row.get(6)?,
+                avg_active_duration_ms: row.get(7)?,
+                sessions_with_errors: row.get(8)?,
+                total_tool_calls: row.get(9)?,
+                unattributed_calls: row.get(10)?,
+                total_tool_errors: row.get(11)?,
+                breakdowns: Default::default(),
+            })
+        })
+        .map_err(|e| format!("claudesessions: insight aggregate: {e}"))?;
+
+    // No matching insight rows: Go returns before touching the breakdowns.
+    if agg.total_sessions == 0 {
+        return Ok(agg);
+    }
+
+    let mut stmt = conn
+        .prepare(&format!("{BREAKDOWN_SQL}{ID_FILTER}"))
+        .map_err(|e| format!("claudesessions: preparing insight breakdowns: {e}"))?;
+    let rows = stmt
+        .query_map([&bound], |row| {
+            let mut blobs: [String; BREAKDOWN_COLUMNS] = Default::default();
+            for (i, blob) in blobs.iter_mut().enumerate() {
+                *blob = row.get(i)?;
+            }
+            Ok(blobs)
+        })
+        .map_err(|e| format!("claudesessions: querying insight breakdowns: {e}"))?;
+
+    for row in rows {
+        let blobs = row.map_err(|e| format!("claudesessions: reading insight breakdowns: {e}"))?;
+        // Each column is merged independently — a row with tools but no skills
+        // contributes to the tool totals alone. Skipping the whole row when any
+        // column is empty would silently drop real data.
+        for (dimension, blob) in agg.breakdowns.iter_mut().zip(blobs.iter()) {
+            merge_breakdown(dimension, blob);
+        }
+    }
+    Ok(agg)
+}
+
+/// Sum one session's breakdown blob into the running totals.
+///
+/// An empty string and `{}` are both "nothing attributed" — the columns default
+/// to `'{}'`. A blob that fails to parse is skipped rather than failing the
+/// summary: one bad row should not blank the whole insights page.
+fn merge_breakdown(totals: &mut BTreeMap<String, i64>, blob: &str) {
+    if blob.is_empty() || blob == "{}" {
+        return;
+    }
+    let Ok(parsed) = serde_json::from_str::<BTreeMap<String, i64>>(blob) else {
+        return;
+    };
+    for (key, count) in parsed {
+        *totals.entry(key).or_default() += count;
+    }
+}
+
+fn build(agg: Aggregate) -> InsightsSummary {
+    if agg.total_sessions == 0 {
+        // Go returns a zero-valued struct with every list explicitly empty, so
+        // the response carries `[]` rather than `null` throughout.
+        return InsightsSummary {
+            top_tools: Vec::new(),
+            top_skills: Vec::new(),
+            top_plugins: Vec::new(),
+            top_mcp_servers: Vec::new(),
+            top_mcp_tools: Vec::new(),
+            top_efforts: Vec::new(),
+            top_agents: Vec::new(),
+            ..Default::default()
+        };
+    }
+
+    let n = agg.total_sessions as f64;
+    let mut ranked = agg.breakdowns.into_iter().map(sorted_tool_counts);
+    let mut next = || ranked.next().unwrap_or_default();
+
+    InsightsSummary {
+        total_sessions: agg.total_sessions,
+        avg_autonomy_score: agg.avg_autonomy_score,
+        avg_turn_count: agg.avg_turn_count,
+        avg_tool_calls_total: agg.avg_tool_calls_total,
+        avg_cost_estimate_usd: agg.total_cost_estimate_usd / n,
+        total_cost_estimate_usd: agg.total_cost_estimate_usd,
+        avg_cache_hit_rate: agg.avg_cache_hit_rate,
+        sessions_with_errors: agg.sessions_with_errors,
+        total_tool_errors: agg.total_tool_errors,
+        avg_total_duration_ms: agg.avg_total_duration_ms,
+        avg_active_duration_ms: agg.avg_active_duration_ms,
+        top_tools: next(),
+        total_tool_calls: agg.total_tool_calls,
+        unattributed_calls: agg.unattributed_calls,
+        top_skills: next(),
+        top_plugins: next(),
+        top_mcp_servers: next(),
+        top_mcp_tools: next(),
+        top_efforts: next(),
+        top_agents: next(),
+    }
+}
+
+/// The top entries by count, descending.
+///
+/// Go collects into a map — random iteration order — and then insertion-sorts,
+/// so **two entries tying on count come out in either order**, and at the
+/// boundary a tie changes which entry is in the top ten at all rather than just
+/// where it sits. A `BTreeMap` plus a stable sort makes a tie break on the
+/// name; see "Go itself is not always byte-stable" in `desktop/CLAUDE.md`.
+fn sorted_tool_counts(totals: BTreeMap<String, i64>) -> Vec<ToolCount> {
+    let mut counts: Vec<ToolCount> = totals
+        .into_iter()
+        .map(|(tool, count)| ToolCount { tool, count })
+        .collect();
+    counts.sort_by_key(|c| std::cmp::Reverse(c.count));
+    counts.truncate(TOP_BREAKDOWN_ENTRIES);
+    counts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_ids_parameter_drops_blanks_and_trims() {
+        assert_eq!(parse_session_ids(""), Vec::<String>::new());
+        assert_eq!(parse_session_ids(" , ,"), Vec::<String>::new());
+        assert_eq!(parse_session_ids("a, b ,,c"), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn breakdown_blobs_merge_and_a_broken_one_is_skipped_not_fatal() {
+        let mut totals = BTreeMap::new();
+        merge_breakdown(&mut totals, r#"{"Bash":3,"Read":1}"#);
+        merge_breakdown(&mut totals, r#"{"Bash":4}"#);
+        // The two "nothing attributed" spellings, and blobs that are not a
+        // string→int map at all.
+        merge_breakdown(&mut totals, "{}");
+        merge_breakdown(&mut totals, "");
+        merge_breakdown(&mut totals, "not json");
+        merge_breakdown(&mut totals, r#"{"Bash":"lots"}"#);
+
+        assert_eq!(totals.get("Bash"), Some(&7));
+        assert_eq!(totals.get("Read"), Some(&1));
+        assert_eq!(totals.len(), 2);
+    }
+
+    #[test]
+    fn ranked_entries_are_capped_at_ten_and_ties_break_on_name() {
+        let totals: BTreeMap<String, i64> = (0..12)
+            .map(|i| (format!("tool-{i:02}"), 100 - i))
+            .chain([("zzz".to_string(), 100)])
+            .collect();
+
+        let ranked = sorted_tool_counts(totals);
+        assert_eq!(ranked.len(), TOP_BREAKDOWN_ENTRIES);
+        // tool-00 and zzz both score 100; the name decides, deterministically.
+        assert_eq!(ranked[0].tool, "tool-00");
+        assert_eq!(ranked[1].tool, "zzz");
+        assert_eq!(ranked[2].tool, "tool-01");
+    }
+
+    /// The trap the issue and `CLAUDE.md` both got backwards.
+    #[test]
+    fn an_empty_aggregate_serializes_every_list_as_an_array_not_null() {
+        let encoded =
+            String::from_utf8(gojson::to_vec(&build(Aggregate::default())).expect("encode"))
+                .expect("utf-8");
+        assert!(!encoded.contains("null"), "{encoded}");
+        assert!(encoded.contains(r#""top_tools":[]"#), "{encoded}");
+        assert!(encoded.contains(r#""top_agents":[]"#), "{encoded}");
+        assert!(encoded.contains(r#""total_sessions":0"#), "{encoded}");
+    }
+}

--- a/desktop/src-tauri/src/native/insights/transcript.rs
+++ b/desktop/src-tauri/src/native/insights/transcript.rs
@@ -1,0 +1,419 @@
+//! Claude Code's session JSONL, decoded.
+//!
+//! Mirrors the event model in `internal/claudesessions/processor.go` plus the
+//! two predicates it shares with the scanner. **Written to be the transcript
+//! reader the scanner port needs too** (issue #270): everything here is about
+//! the file format, not about insights, so that port should extend this module
+//! rather than start a second decoder. Two readers of one format is exactly how
+//! `message_count` and `turn_count` would drift apart.
+//!
+//! ## The predicate that decides three different numbers
+//!
+//! [`is_user_turn_content`] is the single rule behind the scanner's
+//! `message_count`, this pipeline's `turn_count`, and the journey timeline's
+//! turns. Changing it moves all three at once, plus everything derived from
+//! `turn_count` — steps-per-turn, autonomy, tokens-per-turn, the longest
+//! autonomous chain and the response-time averages. On the Go side that means
+//! **both** `CurrentScannerVersion` and `CurrentProcessorVersion` must be bumped
+//! together; bumping one recreates exactly the drift the shared predicate exists
+//! to prevent.
+//!
+//! It rejects two classes of user event: carriers for `tool_result` blocks, and
+//! content that *opens with* one of Claude Code's own injections. The match is
+//! prefix-anchored after a trim and never a substring, because a person can
+//! legitimately write *about* a marker — the reference corpus already contains a
+//! genuine prompt quoting "system-reminder" mid-sentence, and a substring test
+//! would silently stop counting it.
+//!
+//! Both marker tables are **empirical**: read off the local corpus, and a new
+//! Claude Code release can add a form neither lists. That failure mode is
+//! benign — a missed marker leaves the count where it already was — so
+//! re-sampling is maintenance, not a correctness dependency.
+
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+/// One decoded line of a session JSONL file.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct Event {
+    #[serde(default, rename = "type")]
+    pub event_type: String,
+    #[serde(default)]
+    pub timestamp: Option<DateTime<Utc>>,
+    /// Set on every event of a sub-agent transcript, and on delegated events
+    /// inside a parent transcript. **The check is deliberately left to each
+    /// caller**: the flag means "delegated work, skip" in a parent transcript
+    /// but carries no such meaning in a sub-agent's own.
+    #[serde(default, rename = "isSidechain")]
+    pub is_sidechain: bool,
+    #[serde(default)]
+    pub message: Option<Message>,
+
+    /// Stamped by Claude Code at the *top level* of assistant events — never
+    /// inside `message`, and never on user events. It names which skill's
+    /// instructions were in context when the turn ran, so on a `Skill` tool
+    /// call it names the **caller**, not the skill being invoked.
+    #[serde(default, rename = "attributionSkill")]
+    pub attribution_skill: String,
+    #[serde(default, rename = "attributionPlugin")]
+    pub attribution_plugin: String,
+    #[serde(default, rename = "attributionAgent")]
+    pub attribution_agent: String,
+    /// Decoded but deliberately **not counted**: these hold the last MCP tool
+    /// touched and persist onto later, unrelated turns. MCP attribution comes
+    /// from the `mcp__<server>__<tool>` block name instead, which is
+    /// authoritative.
+    #[serde(default, rename = "attributionMcpServer")]
+    pub attribution_mcp_server: String,
+    #[serde(default, rename = "attributionMcpTool")]
+    pub attribution_mcp_tool: String,
+    /// The reasoning-effort tier the turn ran at.
+    #[serde(default)]
+    pub effort: String,
+}
+
+/// The message payload of a user or assistant event.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct Message {
+    #[serde(default)]
+    pub role: String,
+    #[serde(default)]
+    pub model: String,
+    /// Left raw: it is a bare JSON string on some events and an array of
+    /// content blocks on others, and telling those apart is what the turn
+    /// predicates are about.
+    #[serde(default)]
+    pub content: serde_json::Value,
+    #[serde(default)]
+    pub usage: Option<Usage>,
+}
+
+/// Token counters attached to an assistant message.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct Usage {
+    #[serde(default)]
+    pub input_tokens: i64,
+    #[serde(default)]
+    pub output_tokens: i64,
+    #[serde(default)]
+    pub cache_creation_input_tokens: i64,
+    #[serde(default)]
+    pub cache_read_input_tokens: i64,
+    /// Absent on transcripts written before Claude Code emitted the split.
+    #[serde(default)]
+    pub cache_creation: Option<CacheCreation>,
+}
+
+/// The cache-TTL split of `cache_creation_input_tokens`. The tiers bill at
+/// different multiples of the input rate (1.25× for 5-minute, 2× for 1-hour),
+/// which is the only reason the split is carried at all.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct CacheCreation {
+    #[serde(default)]
+    pub ephemeral_5m_input_tokens: i64,
+    #[serde(default)]
+    pub ephemeral_1h_input_tokens: i64,
+}
+
+impl Usage {
+    /// Attribute the cache-creation total across the 5m and 1h buckets.
+    ///
+    /// The nested 1h figure is trusted but clamped: it is the *reported* split
+    /// of a total the same message also reports, and an inconsistent pair must
+    /// not produce a negative 5m bucket.
+    pub fn split_cache_tiers(&self) -> (i64, i64) {
+        let nested_1h = self
+            .cache_creation
+            .as_ref()
+            .map_or(0, |c| c.ephemeral_1h_input_tokens);
+        split_cache_tiers(self.cache_creation_input_tokens, nested_1h)
+    }
+}
+
+/// `splitCacheTiers` from `scanner.go`, shared so the two decoders cannot drift.
+pub fn split_cache_tiers(total: i64, nested_1h: i64) -> (i64, i64) {
+    let one_hour = nested_1h.clamp(0, total.max(0));
+    (total - one_hour, one_hour)
+}
+
+/// One block within a message's content array.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ContentBlock {
+    #[serde(default, rename = "type")]
+    pub block_type: String,
+    #[serde(default)]
+    pub text: String,
+    #[serde(default)]
+    pub thinking: String,
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub input: serde_json::Value,
+    #[serde(default)]
+    pub tool_use_id: String,
+    #[serde(default)]
+    pub is_error: bool,
+}
+
+/// Decode array content into blocks. String content and anything undecodable
+/// yield none, matching Go's `parseContentBlocks`.
+pub fn parse_content_blocks(content: &serde_json::Value) -> Vec<ContentBlock> {
+    let Some(items) = content.as_array() else {
+        return Vec::new();
+    };
+    // Go decodes the whole array or nothing: a single malformed block makes
+    // `json.Unmarshal` fail and the function return nil.
+    let mut blocks = Vec::with_capacity(items.len());
+    for item in items {
+        match serde_json::from_value::<ContentBlock>(item.clone()) {
+            Ok(block) => blocks.push(block),
+            Err(_) => return Vec::new(),
+        }
+    }
+    blocks
+}
+
+/// The wrappers Claude Code writes as user-role events that nobody typed:
+/// slash-command expansions, local command output, sub-agent completion
+/// notices, and injected reminders. These only ever appear as *string* content.
+const INJECTED_TURN_MARKERS: [&str; 6] = [
+    "<task-notification>",
+    "<command-message>",
+    "<command-name>",
+    "<local-command-caveat>",
+    "<local-command-stdout>",
+    "<system-reminder>",
+];
+
+/// The injected user events that arrive as *array* content — a single text
+/// block, no `tool_result`.
+///
+/// A separate table because the two populations do not overlap. Both entries
+/// are required: neither is a prefix of the other, since the shorter one closes
+/// its bracket where the longer one continues (`" for tool use]"`).
+const INJECTED_ARRAY_TURN_MARKERS: [&str; 2] = [
+    "[Request interrupted by user]",
+    "[Request interrupted by user for tool use]",
+];
+
+/// Whether content is one of Claude Code's own injections rather than something
+/// a person typed. Handles both shapes the harness writes.
+fn is_injected_user_content(content: &serde_json::Value) -> bool {
+    if let Some(s) = content.as_str() {
+        return has_injected_prefix(s.trim(), &INJECTED_TURN_MARKERS);
+    }
+    if content.is_array() {
+        let blocks = parse_content_blocks(content);
+        // Any other array shape — several blocks, or a block that is not text —
+        // is genuine, because the injected forms are always emitted alone.
+        if blocks.len() != 1 || blocks[0].block_type != "text" {
+            return false;
+        }
+        let text = blocks[0].text.trim();
+        return has_injected_prefix(text, &INJECTED_ARRAY_TURN_MARKERS) || is_skill_preamble(text);
+    }
+    false
+}
+
+/// `skillPreamblePattern`: `^Base directory for this skill:\s*(\S+)`.
+///
+/// Matched as a pattern rather than a bare prefix so the colon must be followed
+/// by a path token — `Base directory for this skill:` alone is ordinary prose a
+/// person could type. Hand-written rather than pulling in a regex crate for one
+/// anchored pattern.
+fn is_skill_preamble(text: &str) -> bool {
+    const PREFIX: &str = "Base directory for this skill:";
+    let Some(rest) = text.strip_prefix(PREFIX) else {
+        return false;
+    };
+    // `\s*` then `\S+`: at least one non-space character must follow.
+    rest.trim_start()
+        .chars()
+        .next()
+        .is_some_and(|c| !c.is_whitespace())
+}
+
+fn has_injected_prefix(s: &str, markers: &[&str]) -> bool {
+    markers.iter().any(|m| s.starts_with(m))
+}
+
+/// Whether a user message's content is genuine human input.
+///
+/// The sidechain check is deliberately **not** here — see the module docs.
+pub fn is_user_turn_content(content: &serde_json::Value) -> bool {
+    if parse_content_blocks(content)
+        .iter()
+        .any(|b| b.block_type == "tool_result")
+    {
+        return false;
+    }
+    !is_injected_user_content(content)
+}
+
+/// Whether an assistant message contains something the user actually saw — at
+/// least one text block. A turn that only issues tool calls is a round-trip,
+/// not a message.
+pub fn is_assistant_reply(content: &serde_json::Value) -> bool {
+    let blocks = parse_content_blocks(content);
+    if blocks.is_empty() {
+        // No decodable blocks: absent, null, or non-array content. Only a
+        // non-empty bare string carries text the user saw.
+        return content.as_str().is_some_and(|s| !s.is_empty());
+    }
+    blocks.iter().any(|b| b.block_type == "text")
+}
+
+/// Whether this event starts a turn: a non-sidechain user message carrying
+/// genuine input.
+pub fn is_turn_start(ev: &Event) -> bool {
+    if ev.event_type != "user" || ev.is_sidechain {
+        return false;
+    }
+    ev.message
+        .as_ref()
+        .is_some_and(|m| is_user_turn_content(&m.content))
+}
+
+/// Read a transcript, dropping lines that do not decode.
+///
+/// A malformed line is skipped rather than failing the file: transcripts are
+/// appended to live by a process that can be killed mid-write, so a truncated
+/// last line is normal rather than exceptional.
+pub fn read(path: &Path) -> Result<Vec<Event>, String> {
+    let file = std::fs::File::open(path)
+        .map_err(|e| format!("opening transcript {}: {e}", path.display()))?;
+    let mut events = Vec::new();
+    for line in BufReader::new(file).lines() {
+        let line = match line {
+            Ok(line) => line,
+            // An unreadable line mid-file means the rest is unreliable too.
+            Err(e) => return Err(format!("reading transcript {}: {e}", path.display())),
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        if let Ok(event) = serde_json::from_str::<Event>(&line) {
+            events.push(event);
+        }
+    }
+    Ok(events)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn a_tool_result_carrier_is_not_a_turn() {
+        let content = json!([{"type": "tool_result", "tool_use_id": "t1"}]);
+        assert!(!is_user_turn_content(&content));
+        // Position does not matter: a carrier is a carrier wherever the block
+        // sits.
+        let mixed = json!([{"type": "text", "text": "hi"}, {"type": "tool_result"}]);
+        assert!(!is_user_turn_content(&mixed));
+    }
+
+    #[test]
+    fn string_wrappers_are_rejected_only_at_the_start() {
+        assert!(!is_user_turn_content(&json!(
+            "<system-reminder>do the thing</system-reminder>"
+        )));
+        // Leading whitespace is trimmed first.
+        assert!(!is_user_turn_content(&json!("\n  <command-name>/foo")));
+        // …but a person writing *about* a marker is still a turn. The corpus
+        // contains exactly this.
+        assert!(is_user_turn_content(&json!(
+            "why does the <system-reminder> block keep appearing?"
+        )));
+    }
+
+    #[test]
+    fn the_array_shaped_injections_are_rejected_and_only_when_alone() {
+        let interrupted = json!([{"type": "text", "text": "[Request interrupted by user]"}]);
+        assert!(!is_user_turn_content(&interrupted));
+
+        let for_tool_use =
+            json!([{"type": "text", "text": "[Request interrupted by user for tool use]"}]);
+        assert!(!is_user_turn_content(&for_tool_use));
+
+        // Two blocks is a genuine turn — the injected forms are emitted alone.
+        let two = json!([
+            {"type": "text", "text": "[Request interrupted by user]"},
+            {"type": "text", "text": "actually, do this instead"}
+        ]);
+        assert!(is_user_turn_content(&two));
+    }
+
+    #[test]
+    fn the_skill_preamble_needs_a_path_after_the_colon() {
+        let preamble = json!([{
+            "type": "text",
+            "text": "Base directory for this skill: /home/u/.claude/skills/foo"
+        }]);
+        assert!(!is_user_turn_content(&preamble));
+
+        // Prose that merely opens with the same words stays a turn.
+        let prose = json!([{
+            "type": "text",
+            "text": "Base directory for this skill: what should it be?"
+        }]);
+        assert!(!is_user_turn_content(&prose), "a word still counts as \\S+");
+
+        let no_token = json!([{"type": "text", "text": "Base directory for this skill:"}]);
+        assert!(is_user_turn_content(&no_token));
+    }
+
+    #[test]
+    fn an_assistant_reply_needs_text_the_user_saw() {
+        assert!(is_assistant_reply(
+            &json!([{"type": "text", "text": "done"}])
+        ));
+        assert!(is_assistant_reply(&json!("plain string")));
+        assert!(!is_assistant_reply(&json!("")));
+        // Tool calls alone are a round-trip, not a message.
+        assert!(!is_assistant_reply(&json!([
+            {"type": "tool_use", "name": "Bash", "id": "t1"}
+        ])));
+        assert!(!is_assistant_reply(&json!(null)));
+    }
+
+    #[test]
+    fn a_sidechain_user_event_never_starts_a_turn_in_a_parent_transcript() {
+        let mut ev = Event {
+            event_type: "user".into(),
+            message: Some(Message {
+                content: json!("real input"),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(is_turn_start(&ev));
+        ev.is_sidechain = true;
+        assert!(!is_turn_start(&ev));
+    }
+
+    #[test]
+    fn cache_tiers_split_and_clamp_an_inconsistent_pair() {
+        assert_eq!(split_cache_tiers(100, 40), (60, 40));
+        assert_eq!(split_cache_tiers(100, 0), (100, 0));
+        // A reported 1h figure larger than the total must not make 5m negative.
+        assert_eq!(split_cache_tiers(100, 500), (0, 100));
+        assert_eq!(split_cache_tiers(100, -5), (100, 0));
+    }
+
+    #[test]
+    fn a_malformed_block_discards_the_whole_array_as_gos_decoder_does() {
+        // `is_error` is a bool in the schema; a string fails the decode, and Go
+        // returns nil for the array rather than the blocks it managed to read.
+        let bad = json!([{"type": "tool_result", "is_error": "yes"}]);
+        assert!(parse_content_blocks(&bad).is_empty());
+        // …so it is not seen as a carrier, exactly as on the Go side.
+        assert!(is_user_turn_content(&bad));
+    }
+}

--- a/desktop/src-tauri/src/native/mod.rs
+++ b/desktop/src-tauri/src/native/mod.rs
@@ -17,6 +17,7 @@ pub mod db;
 pub mod diff;
 pub mod gojson;
 pub mod gotime;
+pub mod insights;
 pub mod pricing;
 pub mod sessions;
 pub mod settings;
@@ -111,6 +112,7 @@ const ENDPOINTS: &[Endpoint] = &[
     agents::ENDPOINT,
     sessions::ENDPOINT,
     analytics::ENDPOINT,
+    insights::ENDPOINT,
 ];
 
 /// Whether this request is answered by ported Rust code.
@@ -170,12 +172,12 @@ mod tests {
         // must not be swallowed. A session ID is a path segment, not a suffix.
         assert!(!claims(&Method::GET, "/api/claude-sessions/abc-123"));
         assert!(!claims(&Method::GET, "/api/claude-sessions/"));
-        // The insights summary is a different endpoint with different empty-array
-        // conventions, and is not ported yet.
-        assert!(!claims(
+        assert!(claims(
             &Method::GET,
             "/api/claude-sessions/insights/summary"
         ));
+        // The per-session insight record is a different route and stays with Go.
+        assert!(!claims(&Method::GET, "/api/claude-sessions/abc/insights"));
 
         // Agents: the two reads, and nothing that writes or nests.
         assert!(claims(&Method::GET, "/api/agents"));
@@ -207,6 +209,7 @@ mod tests {
             "/api/claude-sessions",
             "/api/claude-sessions/facets",
             "/api/claude-analytics",
+            "/api/claude-sessions/insights/summary",
             "/api/agents",
             "/api/agents/my-agent",
         ];
@@ -229,6 +232,7 @@ mod tests {
             "/api/claude-sessions",
             "/api/claude-sessions/facets",
             "/api/claude-analytics",
+            "/api/claude-sessions/insights/summary",
             "/api/agents",
             "/api/agents/my-agent",
         ];

--- a/desktop/src-tauri/src/native/pricing.rs
+++ b/desktop/src-tauri/src/native/pricing.rs
@@ -367,6 +367,101 @@ fn read_unpriced(conn: &Connection) -> Result<Vec<String>, String> {
     Ok(seen.into_iter().collect())
 }
 
+// ─── Pricing arithmetic ───────────────────────────────────────────────────────
+
+/// Token counts as a rate prices them. Mirrors `pricing.Usage`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PricedUsage {
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_creation_5m_tokens: i64,
+    pub cache_creation_1h_tokens: i64,
+    pub cache_read_tokens: i64,
+}
+
+impl PricedUsage {
+    /// The count a tiered rate's band is chosen by: **all** input-side tokens,
+    /// fresh plus cache-read plus cache-write.
+    ///
+    /// Alibaba states how cached tokens are billed but not whether they count
+    /// toward the context-length bound. The reading that they do is encoded
+    /// here, in one place, and is the only place to change it.
+    fn tier_input_tokens(&self) -> i64 {
+        self.input_tokens
+            + self.cache_read_tokens
+            + self.cache_creation_5m_tokens
+            + self.cache_creation_1h_tokens
+    }
+}
+
+/// USD cost of one priced unit. Mirrors `pricing.Cost`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Cost {
+    pub input_cost_usd: f64,
+    pub output_cost_usd: f64,
+    pub cache_read_cost_usd: f64,
+    pub cache_write_cost_usd: f64,
+    pub total_cost_usd: f64,
+}
+
+impl Cost {
+    /// Accumulate another cost, component by component, in Go's order.
+    pub fn add(&mut self, o: &Cost) {
+        self.input_cost_usd += o.input_cost_usd;
+        self.output_cost_usd += o.output_cost_usd;
+        self.cache_read_cost_usd += o.cache_read_cost_usd;
+        self.cache_write_cost_usd += o.cache_write_cost_usd;
+        self.total_cost_usd += o.total_cost_usd;
+    }
+}
+
+impl Rate {
+    /// The cost of `u` under this rate.
+    ///
+    /// Bands are **selected, not accumulated** — a provider that tiers by
+    /// context length bills every token of a request at the chosen band's
+    /// rate, so there is no progressive-bracket arithmetic — and a request
+    /// above every declared bound uses the highest band rather than falling
+    /// back to flat or to zero.
+    pub fn price(&self, u: PricedUsage) -> Cost {
+        let band = self.tier_for(u.tier_input_tokens());
+        let mut c = Cost {
+            input_cost_usd: u.input_tokens as f64 / 1_000_000.0 * band.input_per_mtok,
+            output_cost_usd: u.output_tokens as f64 / 1_000_000.0 * band.output_per_mtok,
+            cache_read_cost_usd: u.cache_read_tokens as f64 / 1_000_000.0
+                * band.cache_read_per_mtok,
+            cache_write_cost_usd: u.cache_creation_5m_tokens as f64 / 1_000_000.0
+                * band.cache_write_5m_per_mtok
+                + u.cache_creation_1h_tokens as f64 / 1_000_000.0 * band.cache_write_1h_per_mtok,
+            total_cost_usd: 0.0,
+        };
+        c.total_cost_usd =
+            c.input_cost_usd + c.output_cost_usd + c.cache_read_cost_usd + c.cache_write_cost_usd;
+        c
+    }
+
+    /// The prices governing a request of the given input size. An untiered rate
+    /// is one empty-slice check and nothing else, so the flat path is unchanged.
+    fn tier_for(&self, input_tokens: i64) -> TierRate {
+        let flat = TierRate {
+            max_input_tokens: 0,
+            input_per_mtok: self.input_per_mtok,
+            output_per_mtok: self.output_per_mtok,
+            cache_write_5m_per_mtok: self.cache_write_5m_per_mtok,
+            cache_write_1h_per_mtok: self.cache_write_1h_per_mtok,
+            cache_read_per_mtok: self.cache_read_per_mtok,
+        };
+        let Some(highest) = self.tiers.last() else {
+            return flat;
+        };
+        self.tiers
+            .iter()
+            .find(|t| input_tokens <= t.max_input_tokens)
+            .unwrap_or(highest)
+            .clone()
+    }
+}
+
 // ─── The seam ─────────────────────────────────────────────────────────────────
 
 /// This module's entry in `native::ENDPOINTS`.

--- a/desktop/src-tauri/src/native/sessions/tests_db.rs
+++ b/desktop/src-tauri/src/native/sessions/tests_db.rs
@@ -356,7 +356,7 @@ fn hidden_projects_are_excluded_from_both_the_page_and_the_totals() {
     ]);
     let settings = DataSettings {
         hidden_projects: vec!["/home/u/secret".to_string()],
-        indexed_config_dirs: Vec::new(),
+        ..Default::default()
     };
 
     let q = SessionQuery::default();
@@ -424,8 +424,8 @@ fn the_config_dir_scope_admits_blank_rows() {
     // Rows written before migration 27 carry a blank config dir and belong to
     // the default dir, so a scope that excluded them would hide real history.
     let settings = DataSettings {
-        hidden_projects: Vec::new(),
         indexed_config_dirs: vec!["/home/u/.claude".to_string()],
+        ..Default::default()
     };
     let page = list_page(&conn, &settings, &SessionQuery::default()).expect("page");
     assert_eq!(page.items.len(), 1);

--- a/desktop/src-tauri/src/native/settings.rs
+++ b/desktop/src-tauri/src/native/settings.rs
@@ -30,7 +30,20 @@ pub struct DataSettings {
     /// load-bearing on the Go side (it decides which dir owns a session present
     /// in two); here it only has to contain the same set.
     pub indexed_config_dirs: Vec<String>,
+    /// The user's definition of "still working", in milliseconds — the largest
+    /// gap between two consecutive transcript events that still counts as
+    /// continuous work.
+    ///
+    /// Every consumer of "how long did this actually run" shares this one
+    /// value — the scanner, the insight processors and the journey builder — so
+    /// no two pages can disagree about what active time means.
+    pub idle_gap_ms: i64,
 }
+
+/// Ten minutes: long enough to keep reading a long reply or manually testing a
+/// change inside a sitting, short enough to exclude everything a person would
+/// not call working time. `config.DefaultIdleGapThresholdMinutes`.
+pub const DEFAULT_IDLE_GAP_MS: i64 = 10 * 60 * 1000;
 
 impl DataSettings {
     /// `config.IsIndexedClaudeDir`: whether a cached row's config dir is still
@@ -54,14 +67,15 @@ impl DataSettings {
 /// all degrade to defaults rather than failing the request — exactly as Go's
 /// snapshot starts at its defaults before `ApplyDataSettings` runs.
 pub fn load(conn: &Connection) -> DataSettings {
-    let row: Option<(String, String, String)> = conn
+    let row: Option<(String, String, String, i64)> = conn
         .query_row(
             "SELECT COALESCE(hidden_projects, ''),
                     COALESCE(claude_config_dir, ''),
-                    COALESCE(claude_config_dirs, '')
+                    COALESCE(claude_config_dirs, ''),
+                    COALESCE(idle_gap_threshold_minutes, 0)
              FROM user_settings WHERE id = 1",
             [],
-            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
         )
         .optional()
         .unwrap_or_else(|e| {
@@ -69,10 +83,17 @@ pub fn load(conn: &Connection) -> DataSettings {
             None
         });
 
-    let (hidden_raw, run_override, extra_raw) = row.unwrap_or_default();
+    let (hidden_raw, run_override, extra_raw, idle_minutes) = row.unwrap_or_default();
     DataSettings {
         hidden_projects: decode_string_array(&hidden_raw),
         indexed_config_dirs: claude_config_dirs(&run_override, &decode_string_array(&extra_raw)),
+        // Zero is "unset", not "no idle time at all": the column defaults to 0
+        // and the setting is bounded to 1–240 minutes when the user does set it.
+        idle_gap_ms: if idle_minutes > 0 {
+            idle_minutes * 60 * 1000
+        } else {
+            DEFAULT_IDLE_GAP_MS
+        },
     }
 }
 

--- a/desktop/src-tauri/tests/parity_insights.rs
+++ b/desktop/src-tauri/tests/parity_insights.rs
@@ -1,0 +1,510 @@
+//! Live parity for the Claude session insights: the summary endpoint, and the
+//! nine processors behind the rows it reads.
+//!
+//! Two different checks, because the two halves ship differently.
+//!
+//! **The summary** is a claimed route, so it is diffed byte for byte against a
+//! running Go server like every other ported endpoint.
+//!
+//! **The processors write nothing** (see `native/insights/mod.rs`), so there is
+//! no response to diff. Instead they are run over the same transcripts the Go
+//! worker already processed and compared against the rows it stored — which is
+//! a far stronger check than any fixture: ~900 real sessions, ~1 GB of JSONL,
+//! every shape the corpus contains.
+//!
+//! Only rows at the current processor version are compared. An older row holds
+//! figures a *correct* port must disagree with, since a version bump exists
+//! precisely because the logic changed.
+//!
+//! ```sh
+//! cd desktop && eval "$(./scripts/parity-instance.sh start)"
+//! (cd src-tauri && cargo test --test parity_insights -- --ignored --nocapture)
+//! ./scripts/parity-instance.sh stop
+//! ```
+//!
+//! **Read-only.** GETs and a read-only database handle, nothing else.
+
+mod parity_common;
+
+use parity_common::*;
+
+use agento_lib::native::insights::processors::{self, SessionInsight, CURRENT_PROCESSOR_VERSION};
+use agento_lib::native::{db, gojson, insights, pricing, settings};
+
+/// The summary endpoint, across the windows the dashboards request plus the
+/// `ids` narrowing the analytics endpoint has no equivalent of.
+///
+/// Same caveat as the analytics suite: `sortedToolCounts` on the Go side ranks
+/// a map's entries with an insertion sort, so entries tying on count come out
+/// in either order — and at the tenth place a tie changes *membership*, not
+/// just position. `fetch_until` re-asks rather than failing on the first
+/// disagreement. This endpoint is not memoized, so no eviction is needed.
+#[tokio::test]
+#[ignore = "needs a running Agento instance and its database"]
+async fn insights_summary_matches_the_live_go_responses() {
+    let db_path = live_db();
+    let conn = db::open_read_only(&db_path).expect("open database");
+    let data_settings = settings::load(&conn);
+
+    let mut cases = vec![
+        String::new(),
+        "from=2026-06-01&to=2026-08-14".to_string(),
+        "from=2026-06-01&to=2026-08-14&tz=Europe/Berlin".to_string(),
+        "from=2020-01-01&to=2026-12-31".to_string(),
+        // Empty window: the zero-valued summary, every list an empty array —
+        // the case `CLAUDE.md` and the issue both described as `null`.
+        "from=1990-01-01&to=1990-12-31".to_string(),
+        // Blanks and whitespace in `ids` are dropped, not matched.
+        "from=2020-01-01&to=2026-12-31&ids=%20,%20,".to_string(),
+        // An id outside the window must not widen it.
+        "from=1990-01-01&to=1990-12-31&ids=whatever".to_string(),
+    ];
+
+    // Real ids, taken from the corpus: the narrowing only means something
+    // against sessions the window already contains.
+    let listed = fetch("/api/claude-sessions?limit=3").await;
+    let parsed: serde_json::Value = serde_json::from_slice(&listed).expect("json");
+    let ids: Vec<String> = parsed["items"]
+        .as_array()
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|s| s["session_id"].as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+    if !ids.is_empty() {
+        cases.push(format!(
+            "from=2020-01-01&to=2026-12-31&ids={}",
+            ids.join(",")
+        ));
+        // One real id plus one that does not exist: the intersection keeps the
+        // first and silently drops the second.
+        cases.push(format!(
+            "from=2020-01-01&to=2026-12-31&ids={},not-a-session",
+            ids[0]
+        ));
+    }
+
+    for case in &cases {
+        let label = if case.is_empty() { "(defaults)" } else { case };
+        let native = gojson::to_vec(
+            &insights::summary::summary(&conn, &data_settings, case).expect("native summary"),
+        )
+        .expect("encode summary");
+
+        let go = fetch(&format!("/api/claude-sessions/insights/summary?{case}")).await;
+        assert_matches_modulo_ties(&format!("insights [{label}]"), &go, &native);
+    }
+}
+
+/// The seven ranked lists, every one of which can tie.
+const RANKED_LISTS: [&str; 7] = [
+    "top_tools",
+    "top_skills",
+    "top_plugins",
+    "top_mcp_servers",
+    "top_mcp_tools",
+    "top_efforts",
+    "top_agents",
+];
+
+/// Byte-identical, or different only where Go itself is not reproducible.
+///
+/// `sortedToolCounts` ranks a Go map's entries with an insertion sort, so
+/// entries **tying on count** come out in an order Go does not fix — and at the
+/// tenth place a tie decides *membership*, not just position. On this corpus
+/// `vibexp_io_update_artifact` and `vibexp_io_create_artifact` both score 217
+/// and swap between requests, across seven such lists at once, so re-asking Go
+/// until it agrees (what the analytics suite does for its single tie) would
+/// almost never converge.
+///
+/// The rule instead: everything must match byte for byte, **except** that a
+/// `tool` name may differ where its `count` is shared with another entry. Every
+/// scalar, every count, every list length and the order of distinct counts are
+/// still compared exactly, so a mis-keyed or miscounted breakdown still fails.
+fn assert_matches_modulo_ties(label: &str, go: &[u8], native: &[u8]) {
+    if go == native {
+        println!("{label}: identical ({} bytes)", go.len());
+        return;
+    }
+
+    let mut go_json: serde_json::Value = serde_json::from_slice(go).expect("go json");
+    let mut native_json: serde_json::Value = serde_json::from_slice(native).expect("native json");
+    let mut masked = 0;
+    for list in RANKED_LISTS {
+        masked += mask_tied_names(&mut go_json, &mut native_json, list);
+    }
+
+    assert_eq!(
+        go_json,
+        native_json,
+        "{label}: differs outside the tied entries\n go:     {}\n native: {}",
+        String::from_utf8_lossy(go),
+        String::from_utf8_lossy(native)
+    );
+    assert!(
+        masked > 0,
+        "{label}: bodies differ but no tie explains it\n go:     {}\n native: {}",
+        String::from_utf8_lossy(go),
+        String::from_utf8_lossy(native)
+    );
+    println!("{label}: identical apart from {masked} tied entries");
+}
+
+/// Blank the `tool` of every entry the tie makes ambiguous, returning how many
+/// were blanked. A count that is unique still has its name compared.
+///
+/// Two shapes are ambiguous, and the second is the one that bites: a count
+/// shared *within* a list, and the **last entry of a full list**, where an
+/// equal-scoring competitor was cut by the top-ten cap and so does not appear in
+/// the response at all. On this corpus `vibexp_io_update_artifact` and
+/// `vibexp_io_create_artifact` both score 217 and take turns being tenth, with
+/// nothing in the payload to show a tie happened.
+///
+/// The residual gap is deliberate and small: a wrong name at exactly position
+/// ten, with the right count, would pass. Every other position, every count and
+/// every scalar are still compared exactly.
+fn mask_tied_names(
+    go: &mut serde_json::Value,
+    native: &mut serde_json::Value,
+    list: &str,
+) -> usize {
+    let counts = |v: &serde_json::Value| -> Vec<i64> {
+        v[list]
+            .as_array()
+            .map(|a| a.iter().filter_map(|e| e["count"].as_i64()).collect())
+            .unwrap_or_default()
+    };
+    let mut seen: std::collections::HashMap<i64, usize> = std::collections::HashMap::new();
+    for c in counts(go).into_iter().chain(counts(native)) {
+        *seen.entry(c).or_default() += 1;
+    }
+    // A count seen twice across the two lists is one entry in each; three or
+    // more means it is shared within a list, which is the ambiguous case.
+    let tied: std::collections::HashSet<i64> = seen
+        .into_iter()
+        .filter(|(_, n)| *n > 2)
+        .map(|(c, _)| c)
+        .collect();
+
+    /// The cap `sortedToolCounts` truncates to.
+    const TOP_BREAKDOWN_ENTRIES: usize = 10;
+
+    let mut masked = 0;
+    for value in [go, native] {
+        let Some(entries) = value[list].as_array_mut() else {
+            continue;
+        };
+        let truncated = entries.len() == TOP_BREAKDOWN_ENTRIES;
+        let last = entries.len().saturating_sub(1);
+        for (i, entry) in entries.iter_mut().enumerate() {
+            let shared = entry["count"].as_i64().is_some_and(|c| tied.contains(&c));
+            if shared || (truncated && i == last) {
+                entry["tool"] = serde_json::Value::String("<tied>".into());
+                masked += 1;
+            }
+        }
+    }
+    masked
+}
+
+/// One session's stored row, as the Go worker wrote it.
+struct StoredRow {
+    session_id: String,
+    file_path: String,
+    /// When the worker computed this row. If a transcript on disk is newer,
+    /// the row describes a *shorter* file and cannot be compared.
+    ///
+    /// The insight's own timestamp, not the scanner's `file_mtime`: those are
+    /// written by different passes, and on a machine still using Claude Code
+    /// the scan routinely runs after the worker last processed a session.
+    scanned_at: std::time::SystemTime,
+    insight: SessionInsight,
+}
+
+/// Recompute every stored insight from its transcript and compare.
+///
+/// This is the processors' whole parity bar. It reads ~1 GB of JSONL on the
+/// reference corpus, so it is slow by design — and it is the only check that
+/// exercises the shapes real transcripts contain rather than the ones a fixture
+/// imagines.
+#[test]
+#[ignore = "needs a scanned Agento database and its transcripts"]
+fn every_stored_insight_recomputes_to_the_same_values() {
+    let db_path = live_db();
+    let conn = db::open_read_only(&db_path).expect("open database");
+
+    // The threshold the *stored* rows were computed under, not the one
+    // configured now. They agree at rest — a change re-reads and reprocesses —
+    // but reading the recorded value means a mid-flight change fails loudly
+    // rather than as a thousand duration mismatches.
+    let stored_threshold: i64 = conn
+        .query_row(
+            "SELECT COALESCE(idle_threshold_ms, 0) FROM claude_cache_metadata WHERE id = 1",
+            [],
+            |r| r.get(0),
+        )
+        .expect("cache metadata");
+    let configured = settings::load(&conn).idle_gap_ms;
+    assert_eq!(
+        stored_threshold, configured,
+        "the idle threshold moved since the last scan; rescan before comparing"
+    );
+
+    let resolver = pricing::Resolver::load(&conn).expect("pricing catalog");
+    let ctx = processors::Ctx {
+        idle_gap_ms: stored_threshold,
+        resolver: Some(&resolver),
+    };
+
+    let rows = load_stored_rows(&conn);
+    assert!(
+        !rows.is_empty(),
+        "no insight rows at version {CURRENT_PROCESSOR_VERSION}; \
+         let the Go worker process the corpus first"
+    );
+    println!("comparing {} stored insights", rows.len());
+
+    let mut mismatches = Vec::new();
+    let mut missing_files = 0;
+    let mut moved_on = 0;
+    let mut tie_ambiguous = 0;
+    for row in &rows {
+        let path = std::path::Path::new(&row.file_path);
+        if !path.exists() {
+            // The transcript was deleted after the row was written. Nothing to
+            // recompute from, and not a divergence.
+            missing_files += 1;
+            continue;
+        }
+        let files = processors::session_files(&row.session_id, path);
+        // A transcript that has grown since the scan is the common case on a
+        // machine that is still using Claude Code — the session running this
+        // very test is one — and it is not a divergence: the stored row
+        // describes a shorter file. Every figure would read as "computed is
+        // larger", which is exactly what an over-counting bug also looks like,
+        // so this has to be excluded rather than tolerated.
+        if written_since(&files, row.scanned_at) {
+            moved_on += 1;
+            continue;
+        }
+        let got = match processors::run(&row.session_id, &files, &ctx) {
+            Ok(insight) => insight,
+            Err(e) => {
+                mismatches.push(format!("{}: {e}", row.session_id));
+                continue;
+            }
+        };
+        if got == row.insight {
+            continue;
+        }
+        // The one divergence Go cannot be held to: a tied timestamp makes the
+        // stored working-time figure depend on an unstable sort's order. Only
+        // that field, and only for a session that actually contains such a tie.
+        let mut comparable = got.clone();
+        comparable.claude_working_time_ms = row.insight.claude_working_time_ms;
+        if comparable == row.insight && has_ambiguous_timestamp_tie(&files) {
+            tie_ambiguous += 1;
+            continue;
+        }
+        mismatches.push(describe_mismatch(&row.insight, &got));
+    }
+
+    if missing_files > 0 {
+        println!("{missing_files} transcripts no longer on disk; skipped");
+    }
+    if moved_on > 0 {
+        println!("{moved_on} transcripts grew since the row was written; skipped");
+    }
+    if tie_ambiguous > 0 {
+        println!(
+            "{tie_ambiguous} sessions differ only in claude_working_time_ms, \
+             on a tied timestamp Go's unstable sort does not order"
+        );
+    }
+    let compared = rows.len() - missing_files - moved_on;
+    assert!(
+        compared > 0,
+        "every stored row was skipped; nothing was actually compared"
+    );
+    assert!(
+        mismatches.is_empty(),
+        "{} of {} sessions diverged:\n{}",
+        mismatches.len(),
+        rows.len(),
+        mismatches
+            .iter()
+            .take(10)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+    println!("all {compared} comparable sessions recompute identically");
+}
+
+/// The `time.Time.String()` text a DATETIME column holds, as a `SystemTime`.
+fn parse_go_time(text: &str) -> std::time::SystemTime {
+    match agento_lib::native::gotime::GoTime::parse_any(text) {
+        Ok(t) => {
+            std::time::UNIX_EPOCH
+                + std::time::Duration::from_nanos(
+                    t.instant().timestamp_nanos_opt().unwrap_or(0).max(0) as u64,
+                )
+        }
+        // An unparsable mtime compares as "very old", so the row is skipped
+        // rather than silently compared against a file it may not describe.
+        Err(_) => std::time::UNIX_EPOCH,
+    }
+}
+
+/// Whether any of a session's transcripts has been written since the row was
+/// computed. A millisecond of slack absorbs the DATETIME column's text
+/// round trip.
+fn written_since(files: &[std::path::PathBuf], at: std::time::SystemTime) -> bool {
+    let slack = std::time::Duration::from_millis(1);
+    files.iter().any(|f| {
+        std::fs::metadata(f)
+            .and_then(|m| m.modified())
+            .is_ok_and(|m| m > at + slack)
+    })
+}
+
+/// Whether a session contains two events sharing a timestamp where one is an
+/// assistant event and the other is not.
+///
+/// That is the one shape where Go's stored figure is **not reproducible**:
+/// `activeTimeTracker.durations` sorts with `sort.Slice`, which is unstable, and
+/// the gap *leading into* a tied pair is credited to whichever member sorts
+/// first — so `claude_working_time_ms` depends on an order Go does not fix.
+/// This port sorts stably, which is deterministic but agrees with only one of
+/// the orders Go could have stored.
+fn has_ambiguous_timestamp_tie(files: &[std::path::PathBuf]) -> bool {
+    let mut stamps: Vec<(chrono::DateTime<chrono::Utc>, bool)> = Vec::new();
+    for file in files {
+        let Ok(events) = agento_lib::native::insights::transcript::read(file) else {
+            continue;
+        };
+        for ev in events {
+            if ev.event_type == "file-history-snapshot" {
+                continue;
+            }
+            if let Some(ts) = ev.timestamp {
+                stamps.push((ts, ev.event_type == "assistant"));
+            }
+        }
+    }
+    stamps.sort_by_key(|(ts, _)| *ts);
+    stamps
+        .windows(2)
+        .any(|w| w[0].0 == w[1].0 && w[0].1 != w[1].1)
+}
+
+fn load_stored_rows(conn: &rusqlite::Connection) -> Vec<StoredRow> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT i.session_id, c.file_path, i.scanned_at,
+                    i.turn_count, i.steps_per_turn_avg, i.autonomy_score,
+                    i.tool_calls_total, i.tool_breakdown,
+                    i.skill_breakdown, i.plugin_breakdown, i.mcp_server_breakdown,
+                    i.mcp_tool_breakdown, i.effort_breakdown, i.agent_breakdown,
+                    i.unattributed_calls,
+                    i.total_duration_ms, i.active_duration_ms, i.claude_working_time_ms,
+                    i.cache_hit_rate, i.tokens_per_turn_avg, i.cost_estimate_usd,
+                    i.tool_error_rate, i.tool_error_count, i.has_errors,
+                    i.max_consecutive_tool_calls, i.longest_autonomous_chain,
+                    i.avg_user_response_time_ms, i.avg_claude_response_time_ms
+             FROM session_insights i
+             JOIN claude_session_cache c ON c.session_id = i.session_id
+             WHERE i.processor_version = ?",
+        )
+        .expect("prepare stored insights");
+
+    let rows = stmt
+        .query_map([CURRENT_PROCESSOR_VERSION], |row| {
+            let decode = |raw: String| -> std::collections::BTreeMap<String, i64> {
+                serde_json::from_str(&raw).unwrap_or_default()
+            };
+            let scanned_at: String = row.get(2)?;
+            Ok(StoredRow {
+                session_id: row.get(0)?,
+                file_path: row.get(1)?,
+                scanned_at: parse_go_time(&scanned_at),
+                insight: SessionInsight {
+                    session_id: row.get(0)?,
+                    turn_count: row.get(3)?,
+                    steps_per_turn_avg: row.get(4)?,
+                    autonomy_score: row.get(5)?,
+                    tool_calls_total: row.get(6)?,
+                    tool_breakdown: decode(row.get(7)?),
+                    skill_breakdown: decode(row.get(8)?),
+                    plugin_breakdown: decode(row.get(9)?),
+                    mcp_server_breakdown: decode(row.get(10)?),
+                    mcp_tool_breakdown: decode(row.get(11)?),
+                    effort_breakdown: decode(row.get(12)?),
+                    agent_breakdown: decode(row.get(13)?),
+                    unattributed_calls: row.get(14)?,
+                    total_duration_ms: row.get(15)?,
+                    active_duration_ms: row.get(16)?,
+                    claude_working_time_ms: row.get(17)?,
+                    cache_hit_rate: row.get(18)?,
+                    tokens_per_turn_avg: row.get(19)?,
+                    cost_estimate_usd: row.get(20)?,
+                    tool_error_rate: row.get(21)?,
+                    tool_error_count: row.get(22)?,
+                    has_errors: row.get::<_, i64>(23)? == 1,
+                    max_consecutive_tool_calls: row.get(24)?,
+                    longest_autonomous_chain: row.get(25)?,
+                    avg_user_response_time_ms: row.get(26)?,
+                    avg_claude_response_time_ms: row.get(27)?,
+                },
+            })
+        })
+        .expect("query stored insights");
+
+    rows.map(|r| r.expect("scan stored insight")).collect()
+}
+
+/// Name the fields that differ, rather than dumping two whole structs: a
+/// hundred-session divergence should read as one repeated cause.
+fn describe_mismatch(want: &SessionInsight, got: &SessionInsight) -> String {
+    let mut fields = Vec::new();
+    macro_rules! check {
+        ($($field:ident),* $(,)?) => {$(
+            if want.$field != got.$field {
+                fields.push(format!(
+                    "{}: stored {:?} != computed {:?}",
+                    stringify!($field), want.$field, got.$field
+                ));
+            }
+        )*};
+    }
+    check!(
+        turn_count,
+        steps_per_turn_avg,
+        autonomy_score,
+        tool_calls_total,
+        tool_breakdown,
+        skill_breakdown,
+        plugin_breakdown,
+        mcp_server_breakdown,
+        mcp_tool_breakdown,
+        effort_breakdown,
+        agent_breakdown,
+        unattributed_calls,
+        total_duration_ms,
+        active_duration_ms,
+        claude_working_time_ms,
+        cache_hit_rate,
+        tokens_per_turn_avg,
+        cost_estimate_usd,
+        tool_error_rate,
+        tool_error_count,
+        has_errors,
+        max_consecutive_tool_calls,
+        longest_autonomous_chain,
+        avg_user_response_time_ms,
+        avg_claude_response_time_ms,
+    );
+    format!("{}\n    {}", want.session_id, fields.join("\n    "))
+}


### PR DESCRIPTION
Closes #263. Targets `desktop`; `main` untouched.

Two halves, split by what each can safely do today.

## The summary endpoint

`GET /api/claude-sessions/insights/summary` is claimed behind the seam and diffed against a Go server **built from this checkout** across nine cases: four windows, a timezone, the empty window, and three shapes of the `ids` narrowing.

## The nine processors write nothing, deliberately

On the Go side `insight_worker.go` is a background writer. Porting the upsert now would put two processes on one SQLite file — the sidecar's worker and ours — racing over the same rows. So they are ported as what they actually are: a function from a transcript to a `SessionInsight`. That is the whole of the logic; the worker is a loop around it when storage moves (#274).

**Their parity bar is the stored rows, not a response.** Every `session_insights` row at the current processor version is recomputed from its own transcript and compared field by field — 923 sessions and ~1 GB of real JSONL on the reference corpus.

> **all 921 comparable sessions recompute identically**

The other two are not port bugs, and working out why was most of the effort:

- **A transcript that grew since its row was written** makes every figure read "computed is larger" — indistinguishable from an over-counting bug, and it is how this first failed. Rows are anchored on `session_insights.scanned_at`, not the scanner's `file_mtime`: those are written by different passes, and on a machine still using Claude Code the scan routinely runs after the worker last processed a session.
- **`claude_working_time_ms` is not reproducible** where two events share a timestamp and differ on whether they are assistant events. `activeTimeTracker.durations` sorts with `sort.Slice`, and the gap leading into the tied pair is credited by an order Go does not fix. Three sessions are in that state; the test excludes that single field for exactly those, after verifying the tie is real.

## A documented trap that was wrong

The issue and `desktop/CLAUDE.md` both said this endpoint sends `null` for empty `top_*` lists. **It sends `[]`** — `sortedToolCounts` builds with `make([]toolCount, 0, len)` and the zero branch returns explicit empty slices, so no path yields a nil one. What *does* send `null` is the **analytics** report's zero-valued summary, whose `unknown_pricing_models` is a genuine nil slice. Both corrected; building to the old claim would have shipped a broken port.

## Comparing the ranked lists

Go ranks a map's entries with an insertion sort, so ties come out in an arbitrary order — and at the tenth place a tie decides *membership*: the loser is truncated away, leaving nothing in the payload to show a tie happened. On this corpus `vibexp_io_update_artifact` and `vibexp_io_create_artifact` both score 217 and take turns being tenth, across seven such lists at once, so the retry approach the analytics suite uses would almost never converge.

The test compares byte for byte and, only on a mismatch, permits a differing `tool` where its `count` is shared or the entry sits at the truncation boundary. Every scalar, every count, every list length and the order of distinct counts are still compared exactly. The residual gap — a wrong name at exactly position ten with the right count — is stated in the code.

## Groundwork for #270

`native/insights/transcript.rs` is deliberately about the **file format** rather than about insights: the scanner port needs the same decoder and the same `isUserTurnContent` predicate, and two readers of one format is how `message_count` and `turn_count` would drift apart. Also lands `Rate::price` in `native/pricing.rs` and `idle_gap_ms` in `native/settings.rs`, both of which that port needs.

## Verification

109 Rust unit tests (22 new), the recomputation above, the nine-case live diff, `cargo clippy --all-targets -D warnings` and `cargo fmt --check` clean, CI-pinned golangci-lint clean.