### PR TITLE
feat(desktop): port the Claude Agent SDK to Rust

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -110,6 +110,15 @@ src-tauri/src/
   sidecar.rs     spawn + health-wait + shutdown of the Go server
   proxy.rs       axum reverse proxy; route_is_native() is the porting switch
   menu.rs        native menu → menu://action events
+  claude/        the Claude Agent SDK, ported from Go (phase 5's foundation)
+    process.rs   spawn, the control protocol, and the initialize handshake
+    client.rs    Stream (events) + StreamControl (interrupt, set_model, …)
+    session.rs   persistent multi-turn conversations on one subprocess
+    options.rs   every option, and which of the two channels it travels on
+    messages.rs  the wire types and parse_line
+    permissions.rs / hooks.rs   the two callback round trips
+    mcp.rs       loopback HTTP host for in-process MCP servers
+    lenient.rs   Go's partial-decode semantics, which serde does not have
   native/        ported endpoints (phase 2+)
     mod.rs       endpoint registry, mode switch, response shaping
     gojson.rs    Go-compatible JSON encoder — read this before porting anything
@@ -315,7 +324,66 @@ rather than expecting the encoder to notice.
 | 2 ← | Pricing + analytics | `internal/pricing`, `internal/claudesessions` | Pure computation over JSONL + SQLite. No external deps. **In progress**: `/api/pricing/catalog`, `/api/claude-sessions`, `/api/claude-sessions/facets`, `/api/claude-analytics`, `/api/claude-sessions/insights/summary` and the agent reads are native and diff clean. |
 | 3 | Storage + tasks | `internal/storage`, `internal/scheduler` | 27 SQLite migrations; reuse the same DB file and schema. Scheduler is cron/interval. |
 | 4 | Integrations | `internal/integrations`, `internal/trigger` | OAuth2 + MCP servers. WhatsApp (`whatsmeow`) is the blocker — port it last or keep it in Go. |
-| 5 | Agent execution | `internal/agent`, `internal/service` | Spawns the `claude` CLI over stream-json stdin/stdout. Hardest, highest risk. |
+| 5 | Agent execution | `internal/agent`, `internal/service` | Spawns the `claude` CLI over stream-json stdin/stdout. **The SDK underneath it is ported** (`src/claude/`, below); what remains is the runner, the chat service and the SSE handler on top of it. |
+
+### The Claude Agent SDK (`src-tauri/src/claude/`)
+
+`github.com/shaharia-lab/claude-agent-sdk-go` reimplemented in Rust — the
+library every agent run goes through, and the thing phases 4 and 5 both sit on
+(every Agento integration is an in-process MCP server, which is this SDK's
+`StartInProcessMCPServer`). Read `~/Projects/claude-agent-sdk-go` as the spec;
+it is our own OSS project and carries the protocol decisions in its comments.
+
+It is **not an API client**: it spawns the `claude` CLI and speaks stream-json
+over stdio plus a control protocol, so there is no inference to reimplement and
+no API key — the CLI's own sign-in is the credential. Nothing calls it yet.
+
+**The parity bar is different here.** There is no JSON response to diff, so
+`parity-instance.sh` has nothing to say about it. What must hold is the **SSE
+stream**: raw CLI JSON lines passed through verbatim plus Agento's two synthetic
+events (`user_input_required`, `permission_request`). `Event::raw` is what makes
+that possible and is why every message keeps its bytes.
+
+The tests are a **scripted fake CLI** (`tests/claude_sdk.rs`) — a Python program
+that logs every stdin line and replies to order. That is the only way to test
+the things that are properties of a *sequence* rather than of a function, and
+all four failure modes below are silent without it.
+
+Four protocol facts that cost real time, all of them re-discoverable only the
+hard way:
+
+- **The handshake order is load-bearing.** Reader task live → register the
+  request id → write `initialize` → *block* on the acknowledgement → only then
+  the first user message. A `control_response` cannot be routed before something
+  reads stdout, and MCP servers, agents and hooks are configured during the
+  acknowledgement. Getting it wrong races rather than fails.
+- **`sdkMcpServers` is never sent.** The CLI accepts only an array of strings
+  there, and a rejection fails the *entire* initialize — silently taking hooks,
+  agents, the system prompt and the output format with it. Naming a server there
+  also marks it SDK-hosted, so the CLI drops its transport and routes tool calls
+  back over `mcp_message`, which this SDK does not implement. Every MCP server
+  travels as `--mcp-config` instead.
+- **`control_response` routes on the *nested* `response.request_id`**, and the
+  caller gets the *innermost* payload. There is no top-level fallback; inventing
+  one is what broke this before. An absent inner payload is a success with no
+  data, not an error.
+- **Every inbound `control_request` must be answered.** A missing reply hangs
+  the CLI with no error on either side — including for the requests we only
+  acknowledge. `can_use_tool` with no handler is answered with an *error*, never
+  an allow: fail closed.
+
+Four places where a mechanical port would have been wrong, each documented at
+its site: Go's partial-decode semantics (`lenient.rs`), the `Stream` /
+`StreamControl` split (reading a channel needs `&mut self`), async callbacks
+(Go blocks a goroutine inline; blocking a runtime worker is a bug), and handle
+lifetimes standing in for `context.Context`.
+
+One deliberate scope call: `start_in_process_mcp_server` takes an `McpService`
+trait rather than an `rmcp` server. Go hands its MCP SDK's `*mcp.Server` to its
+own streamable-HTTP handler; the equivalent here would pin `rmcp`'s API to
+satisfy no caller, since nothing has an MCP server to host until phase 4. The
+seam sits exactly where Go's does — the SDK owns the listener, the caller owns
+the tools — and an `rmcp` adapter is one impl away.
 
 ### Things that will bite
 
@@ -582,8 +650,18 @@ than about insights: the scanner port (issue #270) needs the same decoder and
 the same `isUserTurnContent` predicate, and two readers of one format is exactly
 how `message_count` and `turn_count` would drift apart.
 
-Nothing else is ported. Every write path, the per-session reads and every other
-read still forward to Go.
+**The Claude Agent SDK is ported** (`src/claude/`, see above) — the whole of
+`claude-agent-sdk-go`'s surface Agento uses: the session lifecycle, all the
+options, the control protocol including permission and hook round trips and
+interrupt, and in-process MCP servers. It is a library with no caller yet: the
+agent runner, the chat service and the SSE handler that would sit on it are
+still Go, and nothing in `native/` routes to it. It is here first because phases
+4 and 5 both need it — every integration is one of its MCP servers — and because
+its correctness is testable in isolation, against a scripted CLI, in a way it
+would not be once a route depends on it.
+
+Nothing else is ported. Every endpoint not listed above — every write path, the
+per-session reads and every other read — still forwards to Go.
 
 **Reading is what keeps the corpus fresh.** `Cache.ensureFresh` runs on every Go
 read path and starts a background rescan when the TTL expires, the pricing

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -16,6 +16,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "form_urlencoded",
+ "libc",
  "log",
  "mime_guess",
  "reqwest 0.12.28",
@@ -32,6 +33,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tempfile",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -4572,6 +4574,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -30,8 +30,27 @@ log = "0.4"
 # Local reverse proxy in front of the Go sidecar. No TLS backend: every hop is
 # loopback, and pulling in rustls here would cost build time for nothing.
 axum = "0.8"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "time"] }
-reqwest = { version = "0.12", default-features = false, features = ["stream"] }
+# `process` and `io-util` are for the Claude Agent SDK port (`src/claude/`),
+# which spawns the `claude` CLI and reads its stdout line by line. The sidecar
+# goes through tauri-plugin-shell instead, but that only launches binaries
+# declared as Tauri sidecars — the agent CLI is an arbitrary executable resolved
+# on PATH, so it needs a real process API.
+tokio = { version = "1", features = [
+    "rt-multi-thread",
+    "macros",
+    "net",
+    "time",
+    "process",
+    "io-util",
+    "io-std",
+    "sync",
+] }
+reqwest = { version = "0.12", default-features = false, features = ["stream", "json"] }
+
+# Control requests are correlated by a v4 UUID, and hook callbacks are
+# registered under one. Go generates them from crypto/rand by hand; the format
+# on the wire is the standard lowercase hyphenated one either way.
+uuid = { version = "1", features = ["v4"] }
 
 # Release builds serve the frontend from the proxy so the page is same-origin
 # with the API.
@@ -54,6 +73,12 @@ chrono = { version = "0.4.45", default-features = false, features = ["std", "clo
 # its own embedded tzdata through `time.LoadLocation`; this is the equivalent.
 chrono-tz = "0.10"
 form_urlencoded = "1.2.2"
+
+# Graceful shutdown of the `claude` subprocess is close stdin → SIGTERM →
+# SIGKILL after 5s, mirroring the TypeScript SDK's close(). Tokio's own
+# `Child::kill` is SIGKILL only, so the SIGTERM step needs raw kill(2).
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 
 [profile.release]
 codegen-units = 1

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -45,7 +45,7 @@ tokio = { version = "1", features = [
     "io-std",
     "sync",
 ] }
-reqwest = { version = "0.12", default-features = false, features = ["stream", "json"] }
+reqwest = { version = "0.12", default-features = false, features = ["stream"] }
 
 # Control requests are correlated by a v4 UUID, and hook callbacks are
 # registered under one. Go generates them from crypto/rand by hand; the format

--- a/desktop/src-tauri/src/claude/client.rs
+++ b/desktop/src-tauri/src/claude/client.rs
@@ -1,0 +1,587 @@
+//! The public entry points and the `Stream` type, ported from
+//! `claude/client.go`.
+//!
+//! Go hands the caller a `*Stream` carrying both an events channel and the
+//! control methods, and documents that the control methods are safe to call
+//! from any goroutine while another ranges the channel. Rust cannot express
+//! that on one type — reading the channel needs `&mut self` — so the two halves
+//! are split: [`Stream`] owns the receiver, and [`StreamControl`] is a cheap
+//! clonable handle carrying every control method. `Stream` delegates all of
+//! them, so single-task code never notices the split, and
+//! [`Stream::control`] is how a second task gets the ability to interrupt.
+//!
+//! Dropping a [`Stream`] shuts the subprocess down. That is the Rust stand-in
+//! for Go's context cancellation, and it is what stops a cancelled chat from
+//! leaving an orphaned `claude` process holding a session open.
+
+use std::sync::Arc;
+
+use serde_json::value::RawValue;
+use tokio::sync::{mpsc, oneshot};
+
+use super::errors::{Error, Result};
+use super::init_types::{AccountInfo, AgentInfo, InitializeResponse, ModelInfo, SlashCommand};
+use super::messages::{message_type, system_subtype, Event, Result as RunResult};
+use super::options::Options;
+use super::process::{self, ControlResponse, Shared};
+
+/// The result of an interrupt.
+///
+/// The CLI advertises this through the `interrupt_receipt_v1` capability on
+/// `system`/`init`; CLIs without it reply to an interrupt with an empty success
+/// and no receipt at all, which is reported as `None` rather than an error.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct InterruptReceipt {
+    /// The uuids of async user messages that survived the interrupt and remain
+    /// queued for a subsequent turn. Empty when nothing survived.
+    pub still_queued: Vec<String>,
+}
+
+/// Extracts the receipt from an interrupt control_response body.
+///
+/// Decoding is deliberately lenient: an interrupt the CLI acknowledged has
+/// succeeded regardless of what the payload looks like, so anything absent,
+/// null, unparseable, or of an unexpected type yields no receipt instead of an
+/// error. Only a well-formed `still_queued` array produces one, and only its
+/// string elements are kept — matching the reference implementation's
+/// `typeof r === "string"` filter, which exists because a JSON null would
+/// otherwise smuggle in an empty id.
+fn decode_interrupt_receipt(body: Option<&RawValue>) -> Option<InterruptReceipt> {
+    let body = body?;
+
+    #[derive(serde::Deserialize)]
+    struct Payload {
+        still_queued: Option<Vec<serde_json::Value>>,
+    }
+
+    let payload: Payload = serde_json::from_str(body.get()).ok()?;
+    let queued = payload.still_queued?;
+
+    Some(InterruptReceipt {
+        still_queued: queued
+            .into_iter()
+            .filter_map(|v| match v {
+                serde_json::Value::String(s) => Some(s),
+                _ => None,
+            })
+            .collect(),
+    })
+}
+
+/// The control half of a stream: every method that talks to the CLI rather than
+/// reading from it.
+///
+/// Cheap to clone and safe to use from any task while another reads events.
+#[derive(Clone)]
+pub struct StreamControl {
+    shared: Arc<Shared>,
+    /// The cached initialize response. Written once before the stream is handed
+    /// to the caller, so reads need no synchronisation.
+    init: Arc<InitializeResponse>,
+}
+
+impl StreamControl {
+    pub(crate) fn new(shared: Arc<Shared>, init: Arc<InitializeResponse>) -> Self {
+        StreamControl { shared, init }
+    }
+
+    /// Writes a `control_request` and blocks until its matching
+    /// `control_response` arrives, returning the raw body on success.
+    async fn send_control_request(
+        &self,
+        subtype: &str,
+        extras: serde_json::Value,
+    ) -> Result<Option<Box<RawValue>>> {
+        let request_id = process::new_uuid();
+        let (tx, rx) = oneshot::channel::<ControlResponse>();
+
+        if let Ok(mut pending) = self.shared.pending.lock() {
+            pending.insert(request_id.clone(), tx);
+        }
+
+        let mut request = serde_json::json!({ "subtype": subtype });
+        if let serde_json::Value::Object(extras) = extras {
+            for (key, value) in extras {
+                request[key] = value;
+            }
+        }
+
+        let envelope = serde_json::json!({
+            "type": "control_request",
+            "request_id": request_id,
+            "request": request,
+        });
+
+        if let Err(e) = self.shared.write(&envelope).await {
+            if let Ok(mut pending) = self.shared.pending.lock() {
+                pending.remove(&request_id);
+            }
+            return Err(Error::wrap(subtype, e));
+        }
+
+        match rx.await {
+            Ok(response) => {
+                if !response.success {
+                    return Err(Error::Other(format!(
+                        "claude: {subtype}: {}",
+                        response.error
+                    )));
+                }
+                Ok(response.body)
+            }
+            // The reader task ended without replying: the subprocess is gone.
+            Err(_) => {
+                if let Ok(mut pending) = self.shared.pending.lock() {
+                    pending.remove(&request_id);
+                }
+                Err(Error::Cancelled)
+            }
+        }
+    }
+
+    /// Asks the CLI to switch to a different model mid-session. Blocks until
+    /// the CLI acknowledges the change.
+    pub async fn set_model(&self, model: &str) -> Result<()> {
+        self.send_control_request("set_model", serde_json::json!({ "model": model }))
+            .await
+            .map(|_| ())
+    }
+
+    /// Asks the CLI to change the permission mode mid-session.
+    ///
+    /// Note the field is `mode`, not `permission_mode` — the outbound request
+    /// and the inbound notification do not share a spelling.
+    pub async fn set_permission_mode(&self, mode: &str) -> Result<()> {
+        self.send_control_request("set_permission_mode", serde_json::json!({ "mode": mode }))
+            .await
+            .map(|_| ())
+    }
+
+    /// Asks the CLI to update the max thinking token budget.
+    pub async fn set_max_thinking_tokens(&self, n: i64) -> Result<()> {
+        self.send_control_request(
+            "set_max_thinking_tokens",
+            serde_json::json!({ "max_thinking_tokens": n }),
+        )
+        .await
+        .map(|_| ())
+    }
+
+    /// Aborts the turn currently in progress and leaves the session alive.
+    ///
+    /// The subprocess keeps running, the event stream stays open, and the next
+    /// user message starts a new turn on the same conversation. To terminate
+    /// the session instead, call [`Stream::close`].
+    ///
+    /// The returned receipt lists async user messages that survived and are
+    /// still queued. It is `None` when the CLI sends no receipt — older CLIs
+    /// reply with an empty success, and only those advertising
+    /// `interrupt_receipt_v1` populate it. A missing receipt is not an error.
+    pub async fn interrupt(&self) -> Result<Option<InterruptReceipt>> {
+        // The request object carries exactly one key; interrupt takes no extras.
+        let body = self
+            .send_control_request("interrupt", serde_json::json!({}))
+            .await?;
+        Ok(decode_interrupt_receipt(body.as_deref()))
+    }
+
+    /// Injects an additional user message into the running subprocess.
+    ///
+    /// In single-turn usage this can be called mid-stream, before the result
+    /// arrives, to inject extra context. For persistent multi-turn usage prefer
+    /// [`super::Session::send`], which wraps this.
+    pub async fn send_user_message(&self, message: &str) -> Result<()> {
+        self.shared.write(&process::user_msg(message)).await
+    }
+
+    /// Asks the CLI to rewind files to the state at the given user message id.
+    pub async fn rewind_files(&self, user_message_id: &str) -> Result<()> {
+        self.send_control_request(
+            "rewind_files",
+            serde_json::json!({ "user_message_id": user_message_id }),
+        )
+        .await
+        .map(|_| ())
+    }
+
+    /// Asks the CLI to reconnect a named MCP server.
+    pub async fn reconnect_mcp_server(&self, server_name: &str) -> Result<()> {
+        self.send_control_request(
+            "reconnect_mcp_server",
+            serde_json::json!({ "server_name": server_name }),
+        )
+        .await
+        .map(|_| ())
+    }
+
+    /// Asks the CLI to enable or disable a named MCP server.
+    pub async fn toggle_mcp_server(&self, server_name: &str, enabled: bool) -> Result<()> {
+        self.send_control_request(
+            "toggle_mcp_server",
+            serde_json::json!({ "server_name": server_name, "enabled": enabled }),
+        )
+        .await
+        .map(|_| ())
+    }
+
+    /// Asks the CLI to replace the current MCP server configuration.
+    pub async fn set_mcp_servers(&self, servers: serde_json::Value) -> Result<()> {
+        self.send_control_request(
+            "set_mcp_servers",
+            serde_json::json!({ "mcp_servers": servers }),
+        )
+        .await
+        .map(|_| ())
+    }
+
+    /// Asks the CLI to stop a running background task.
+    pub async fn stop_task(&self, task_id: &str) -> Result<()> {
+        self.send_control_request("stop_task", serde_json::json!({ "task_id": task_id }))
+            .await
+            .map(|_| ())
+    }
+
+    /// The models the connected CLI offers.
+    ///
+    /// Read from the initialize handshake completed when the session started:
+    /// this performs no I/O and never blocks.
+    pub fn supported_models(&self) -> &[ModelInfo] {
+        &self.init.models
+    }
+
+    /// The slash commands available in this session, from the handshake.
+    pub fn supported_commands(&self) -> &[SlashCommand] {
+        &self.init.commands
+    }
+
+    /// The subagent types this session can dispatch to, from the handshake.
+    pub fn supported_agents(&self) -> &[AgentInfo] {
+        &self.init.agents
+    }
+
+    /// The account the CLI is authenticated as, from the handshake.
+    pub fn account_info(&self) -> &AccountInfo {
+        &self.init.account
+    }
+
+    /// The session's output style, and the styles available.
+    pub fn output_style(&self) -> (&str, &[String]) {
+        (&self.init.output_style, &self.init.available_output_styles)
+    }
+
+    /// The protocol capabilities the connected CLI advertises, for feature
+    /// detection.
+    ///
+    /// Unlike the other accessors this is **not** part of the initialize
+    /// response — the CLI advertises it on the `system`/`init` event instead,
+    /// which arrives with the first turn. It therefore returns `None` until a
+    /// turn has started. Treat that as "not yet known", never as "the CLI
+    /// supports nothing".
+    pub fn capabilities(&self) -> Option<Vec<String>> {
+        self.shared.capabilities.read().ok()?.clone()
+    }
+
+    /// Terminates the session: stdin is closed and the subprocess is signalled.
+    /// Idempotent.
+    pub fn close(&self) {
+        self.shared.shutdown();
+    }
+}
+
+/// An active `claude` subprocess streaming session.
+///
+/// Call [`Stream::next_event`] until it returns `None`; the stream ends when the
+/// agent finishes, the subprocess exits, or the stream is closed.
+pub struct Stream {
+    events: mpsc::Receiver<Event>,
+    control: StreamControl,
+}
+
+impl Stream {
+    pub(crate) fn new(events: mpsc::Receiver<Event>, control: StreamControl) -> Self {
+        Stream { events, control }
+    }
+
+    /// The next event, or `None` once the session has ended.
+    pub async fn next_event(&mut self) -> Option<Event> {
+        self.events.recv().await
+    }
+
+    /// A clonable handle carrying the control methods, for use from another
+    /// task while this one reads events. This is how a caller interrupts a turn
+    /// it is in the middle of streaming.
+    pub fn control(&self) -> StreamControl {
+        self.control.clone()
+    }
+
+    /// Terminates the session. Idempotent.
+    ///
+    /// To abort the current turn while keeping the session usable, call
+    /// [`StreamControl::interrupt`].
+    pub fn close(&self) {
+        self.control.close();
+    }
+}
+
+// Hand-written rather than derived: the interesting state is the handshake the
+// session negotiated, not the channel or the pipe handles behind it.
+impl std::fmt::Debug for StreamControl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StreamControl")
+            .field("models", &self.init.models.len())
+            .field("commands", &self.init.commands.len())
+            .field("agents", &self.init.agents.len())
+            .field("account", &self.init.account.api_provider)
+            .field("capabilities", &self.capabilities())
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for Stream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Stream")
+            .field("control", &self.control)
+            .finish()
+    }
+}
+
+impl Drop for Stream {
+    fn drop(&mut self) {
+        // Go ties the subprocess lifetime to a context; Rust ties it to the
+        // handle. Without this a dropped stream leaves `claude` running.
+        self.control.close();
+    }
+}
+
+/// Delegations so single-task callers never have to reach for
+/// [`Stream::control`].
+impl Stream {
+    pub async fn set_model(&self, model: &str) -> Result<()> {
+        self.control.set_model(model).await
+    }
+    pub async fn set_permission_mode(&self, mode: &str) -> Result<()> {
+        self.control.set_permission_mode(mode).await
+    }
+    pub async fn set_max_thinking_tokens(&self, n: i64) -> Result<()> {
+        self.control.set_max_thinking_tokens(n).await
+    }
+    pub async fn interrupt(&self) -> Result<Option<InterruptReceipt>> {
+        self.control.interrupt().await
+    }
+    pub async fn send_user_message(&self, message: &str) -> Result<()> {
+        self.control.send_user_message(message).await
+    }
+    pub async fn rewind_files(&self, user_message_id: &str) -> Result<()> {
+        self.control.rewind_files(user_message_id).await
+    }
+    pub async fn reconnect_mcp_server(&self, server_name: &str) -> Result<()> {
+        self.control.reconnect_mcp_server(server_name).await
+    }
+    pub async fn toggle_mcp_server(&self, server_name: &str, enabled: bool) -> Result<()> {
+        self.control.toggle_mcp_server(server_name, enabled).await
+    }
+    pub async fn set_mcp_servers(&self, servers: serde_json::Value) -> Result<()> {
+        self.control.set_mcp_servers(servers).await
+    }
+    pub async fn stop_task(&self, task_id: &str) -> Result<()> {
+        self.control.stop_task(task_id).await
+    }
+    pub fn supported_models(&self) -> &[ModelInfo] {
+        self.control.supported_models()
+    }
+    pub fn supported_commands(&self) -> &[SlashCommand] {
+        self.control.supported_commands()
+    }
+    pub fn supported_agents(&self) -> &[AgentInfo] {
+        self.control.supported_agents()
+    }
+    pub fn account_info(&self) -> &AccountInfo {
+        self.control.account_info()
+    }
+    pub fn output_style(&self) -> (&str, &[String]) {
+        self.control.output_style()
+    }
+    pub fn capabilities(&self) -> Option<Vec<String>> {
+        self.control.capabilities()
+    }
+}
+
+// ─── Entry points ────────────────────────────────────────────────────────────
+
+/// Runs the agent with the given prompt and returns a [`Stream`] for real-time
+/// event processing.
+///
+/// The stream ends when the agent emits a result, the subprocess exits, or the
+/// stream is dropped. Control methods may be called at any time while it is
+/// active.
+pub async fn query(prompt: &str, opts: Options) -> Result<Stream> {
+    process::spawn_and_stream(opts, prompt).await
+}
+
+/// Blocks until the agent finishes and returns only the final result.
+///
+/// Intermediate events (streaming deltas, system messages, rate-limit events)
+/// are discarded; use [`query`] directly to process them. Errors from the
+/// subprocess itself — bad flags, auth failures, crashes — are surfaced as
+/// errors so callers always get a meaningful message.
+pub async fn run(prompt: &str, opts: Options) -> Result<RunResult> {
+    let stream = query(prompt, opts).await?;
+    result_from_stream(stream).await
+}
+
+/// Renders a failed result as an error, surfacing the fields a caller would
+/// otherwise have to use [`query`] to see: why the loop ended, and the HTTP
+/// status when an upstream call was what failed.
+fn result_error(r: &RunResult) -> Error {
+    let mut detail = r.subtype.clone();
+    if !r.terminal_reason.is_empty() {
+        detail.push_str(&format!(", {}", r.terminal_reason.as_str()));
+    }
+    if let Some(status) = r.api_error_status {
+        detail.push_str(&format!(", HTTP {status}"));
+    }
+
+    // The CLI does not always send an errors list; repeating the subtype as the
+    // message when it doesn't adds nothing the detail above hasn't said.
+    if r.errors.is_empty() {
+        Error::Other(format!("claude: agent error ({detail})"))
+    } else {
+        Error::Other(format!(
+            "claude: agent error ({detail}): {}",
+            r.errors.join("; ")
+        ))
+    }
+}
+
+/// Drains a stream and returns its final result, converting error results and
+/// process-level failures into errors.
+async fn result_from_stream(mut stream: Stream) -> Result<RunResult> {
+    while let Some(event) = stream.next_event().await {
+        match event.event_type.as_str() {
+            message_type::RESULT => {
+                // parse_line leaves the result absent when the payload does not
+                // decode at all. Report that rather than inventing a value — a
+                // library must not claim success because the CLI sent a shape we
+                // do not model yet.
+                let Some(result) = event.result else {
+                    let raw = event
+                        .raw
+                        .as_ref()
+                        .map(|r| truncate(r.get(), 512))
+                        .unwrap_or_default();
+                    return Err(Error::Other(format!(
+                        "claude: could not decode the result message: {raw}"
+                    )));
+                };
+                if result.is_error {
+                    return Err(result_error(&result));
+                }
+                return Ok(result);
+            }
+            message_type::SYSTEM => {
+                // Surface process-level errors (bad flag, auth failure, crash)
+                // synthesised because no result message arrived.
+                if let Some(system) = &event.system {
+                    if system.subtype == system_subtype::ERROR {
+                        return Err(Error::Other(format!("claude: {}", system.error)));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Err(Error::Other(
+        "claude: agent finished without a result message".to_string(),
+    ))
+}
+
+/// Shortens a payload for inclusion in an error message. A result runs to
+/// several kilobytes; the head is enough to identify the offending shape.
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    // Slicing must land on a character boundary; the payload is arbitrary UTF-8.
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}… (truncated)", &s[..end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn raw(s: &str) -> Box<RawValue> {
+        RawValue::from_string(s.to_owned()).unwrap()
+    }
+
+    #[test]
+    fn an_absent_receipt_is_not_an_error() {
+        // Older CLIs reply to an interrupt with an empty success.
+        assert_eq!(decode_interrupt_receipt(None), None);
+    }
+
+    #[test]
+    fn an_unparseable_or_wrongly_typed_receipt_yields_none() {
+        assert_eq!(decode_interrupt_receipt(Some(&raw("null"))), None);
+        assert_eq!(
+            decode_interrupt_receipt(Some(&raw(r#"{"still_queued":7}"#))),
+            None
+        );
+        assert_eq!(decode_interrupt_receipt(Some(&raw(r#"{"other":1}"#))), None);
+    }
+
+    #[test]
+    fn a_receipt_keeps_only_its_string_elements() {
+        // A JSON null would otherwise smuggle in an empty id.
+        let receipt =
+            decode_interrupt_receipt(Some(&raw(r#"{"still_queued":["a",null,3,"b"]}"#))).unwrap();
+        assert_eq!(receipt.still_queued, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn an_empty_queue_is_still_a_receipt() {
+        let receipt = decode_interrupt_receipt(Some(&raw(r#"{"still_queued":[]}"#))).unwrap();
+        assert!(receipt.still_queued.is_empty());
+    }
+
+    #[test]
+    fn a_failed_result_names_the_reason_and_the_status() {
+        let r = RunResult {
+            subtype: "error_during_execution".into(),
+            terminal_reason: crate::claude::TerminalReason("aborted_streaming".into()),
+            api_error_status: Some(529),
+            ..Default::default()
+        };
+        assert_eq!(
+            result_error(&r).to_string(),
+            "claude: agent error (error_during_execution, aborted_streaming, HTTP 529)"
+        );
+    }
+
+    #[test]
+    fn an_errors_list_is_appended_when_the_cli_sends_one() {
+        let r = RunResult {
+            subtype: "error_max_turns".into(),
+            terminal_reason: crate::claude::TerminalReason("max_turns".into()),
+            errors: vec!["first".into(), "second".into()],
+            ..Default::default()
+        };
+        assert_eq!(
+            result_error(&r).to_string(),
+            "claude: agent error (error_max_turns, max_turns): first; second"
+        );
+    }
+
+    #[test]
+    fn truncate_respects_character_boundaries() {
+        let s = "é".repeat(400); // 800 bytes
+        let out = truncate(&s, 511);
+        assert!(out.ends_with("… (truncated)"));
+        // The point: slicing mid-character would panic rather than truncate.
+        assert!(out.len() <= 511 + "… (truncated)".len());
+    }
+}

--- a/desktop/src-tauri/src/claude/errors.rs
+++ b/desktop/src-tauri/src/claude/errors.rs
@@ -1,0 +1,86 @@
+//! Error types, ported from `claude/errors.go`.
+//!
+//! The Go SDK exposes four distinct error types rather than one enum, because a
+//! caller branches on them (`CLINotFoundError` means "install the CLI",
+//! `InitializeError{Timeout}` means "the CLI was still starting"). Rust models
+//! the same distinctions as variants of one enum so `?` composes, and keeps the
+//! `Display` text byte-for-byte identical to Go's — the strings surface in the
+//! chat UI and in logs, and a port that reworded them would look like a
+//! behaviour change to anyone reading a bug report.
+
+use std::fmt;
+
+/// Everything that can go wrong talking to the `claude` CLI.
+#[derive(Debug)]
+pub enum Error {
+    /// The `claude` binary could not be found or executed.
+    CliNotFound { executable: String },
+
+    /// The subprocess exited non-zero.
+    Process {
+        exit_code: i32,
+        stderr: String,
+        message: String,
+    },
+
+    /// A JSON line from stdout could not be decoded.
+    CliJsonDecode { line: String, source: String },
+
+    /// The initialize handshake was rejected, or never acknowledged.
+    ///
+    /// The session never started and the subprocess has been shut down. A
+    /// rejection usually points at something in the options the CLI could not
+    /// accept (an invalid agent definition, an unusable MCP server config);
+    /// `timeout` means the CLI was still starting up, which MCP servers can
+    /// make slow.
+    Initialize { message: String, timeout: bool },
+
+    /// The stream ended, or the caller's context was cancelled, before the
+    /// operation completed.
+    Cancelled,
+
+    /// Anything else, carrying the message Go would have formatted.
+    Other(String),
+}
+
+impl Error {
+    /// Builds the `claude: <context>: <source>` wrapping Go produces with `%w`.
+    pub(crate) fn wrap(context: &str, source: impl fmt::Display) -> Self {
+        Error::Other(format!("claude: {context}: {source}"))
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::CliNotFound { executable } => {
+                write!(f, "claude: binary not found: {executable:?}")
+            }
+            Error::Process {
+                exit_code,
+                stderr,
+                message,
+            } => {
+                let detail = if stderr.is_empty() { message } else { stderr };
+                write!(f, "claude: process error (exit {exit_code}): {detail}")
+            }
+            Error::CliJsonDecode { line, source } => {
+                write!(f, "claude: JSON decode error: {source} (line: {line})")
+            }
+            Error::Initialize { message, timeout } => {
+                if *timeout {
+                    write!(f, "claude: initialize timed out: {message}")
+                } else {
+                    write!(f, "claude: initialize rejected by the CLI: {message}")
+                }
+            }
+            Error::Cancelled => write!(f, "claude: cancelled"),
+            Error::Other(msg) => write!(f, "{msg}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// The crate-wide result type.
+pub type Result<T> = std::result::Result<T, Error>;

--- a/desktop/src-tauri/src/claude/hooks.rs
+++ b/desktop/src-tauri/src/claude/hooks.rs
@@ -1,0 +1,269 @@
+//! Lifecycle hooks, ported from `claude/hooks.go`.
+//!
+//! Hooks are declared in the initialize message as generated callback ids, and
+//! the CLI calls back with `hook_callback` control_requests carrying the id.
+//! Two details are easy to get wrong and were both shipped broken once:
+//!
+//! * the CLI expects **one entry per matcher**, carrying *all* of that
+//!   matcher's callback ids under `hookCallbackIds` — not one entry per hook;
+//! * `matcher` is **always present**, `null` when unset, mirroring the official
+//!   Python SDK.
+//!
+//! The event name travels inside the hook input payload as `hook_event_name`,
+//! not on the control_request envelope. See [`super::process`].
+
+use std::collections::BTreeMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use serde::Serialize;
+use serde_json::value::RawValue;
+
+use super::process::new_uuid;
+
+/// The lifecycle event that triggered a hook callback.
+pub mod hook_event {
+    pub const PRE_TOOL_USE: &str = "PreToolUse";
+    pub const POST_TOOL_USE: &str = "PostToolUse";
+    /// Fires after a tool call fails.
+    pub const POST_TOOL_USE_FAILURE: &str = "PostToolUseFailure";
+    pub const NOTIFICATION: &str = "Notification";
+    pub const STOP: &str = "Stop";
+    pub const SUBAGENT_STOP: &str = "SubagentStop";
+    /// Fires when a sub-agent is started.
+    pub const SUBAGENT_START: &str = "SubagentStart";
+    pub const PRE_COMPACT: &str = "PreCompact";
+    pub const USER_PROMPT_SUBMIT: &str = "UserPromptSubmit";
+    /// Fires when a session starts.
+    pub const SESSION_START: &str = "SessionStart";
+    pub const SETUP: &str = "Setup";
+    /// Fires when Claude requests permission to use a tool.
+    pub const PERMISSION_REQUEST: &str = "PermissionRequest";
+    /// Fires when a session ends.
+    pub const SESSION_END: &str = "SessionEnd";
+    /// Fires when a teammate agent becomes idle.
+    pub const TEAMMATE_IDLE: &str = "TeammateIdle";
+    /// Fires when a task completes.
+    pub const TASK_COMPLETED: &str = "TaskCompleted";
+    /// Fires when the CLI requests user elicitation.
+    pub const ELICITATION: &str = "Elicitation";
+    /// Fires after an elicitation is resolved.
+    pub const ELICITATION_RESULT: &str = "ElicitationResult";
+    /// Fires when configuration changes mid-session.
+    pub const CONFIG_CHANGE: &str = "ConfigChange";
+    /// Fires when a git worktree is created.
+    pub const WORKTREE_CREATE: &str = "WorktreeCreate";
+    /// Fires when a git worktree is removed.
+    pub const WORKTREE_REMOVE: &str = "WorktreeRemove";
+}
+
+/// The return value of a [`HookFunc`]. All fields are optional.
+#[derive(Debug, Clone, Default, Serialize, PartialEq)]
+pub struct HookOutput {
+    /// Controls whether the operation continues.
+    #[serde(rename = "continue", skip_serializing_if = "Option::is_none")]
+    pub continue_: Option<bool>,
+    /// Prevents the hook output from being shown to the user.
+    #[serde(rename = "suppressOutput", skip_serializing_if = "is_false")]
+    pub suppress_output: bool,
+    /// The reason provided when the hook stops execution.
+    #[serde(rename = "stopReason", skip_serializing_if = "String::is_empty")]
+    pub stop_reason: String,
+    /// An approval/rejection decision (`approve`, `reject`, `ask`).
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub decision: String,
+    /// An additional message injected into the context.
+    #[serde(rename = "systemMessage", skip_serializing_if = "String::is_empty")]
+    pub system_message: String,
+    /// The reason for the decision.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub reason: String,
+    /// Hook-type-specific structured output.
+    #[serde(rename = "hookSpecificOutput", skip_serializing_if = "Option::is_none")]
+    pub hook_specific_output: Option<serde_json::Value>,
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+/// The future a [`HookFunc`] returns. `Err` is answered with an error
+/// control_response carrying the message.
+pub type HookFuture = Pin<Box<dyn Future<Output = Result<Option<HookOutput>, String>> + Send>>;
+
+/// A hook callback.
+///
+/// Receives the lifecycle event, the raw JSON payload from the CLI, and the
+/// tool use id (non-empty for tool-related events). Like the permission
+/// handler, it is awaited inline on the reader task.
+pub type HookFunc = Arc<dyn Fn(String, Option<Box<RawValue>>, String) -> HookFuture + Send + Sync>;
+
+/// One or more hook functions for a specific tool matcher pattern.
+#[derive(Clone)]
+pub struct HookMatcher {
+    /// A glob-style pattern matching the tool name; empty matches all.
+    pub matcher: String,
+    /// The callbacks to invoke when the matcher fires.
+    pub hooks: Vec<HookFunc>,
+    /// Timeout in seconds for all hooks in this matcher (0 = the CLI default,
+    /// which is 60s).
+    pub timeout: i64,
+}
+
+impl std::fmt::Debug for HookMatcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HookMatcher")
+            .field("matcher", &self.matcher)
+            .field("hooks", &self.hooks.len())
+            .field("timeout", &self.timeout)
+            .finish()
+    }
+}
+
+/// Maps callback ids (assigned at init time) to their functions. Used by the
+/// reader task to dispatch `hook_callback` control_requests.
+pub(crate) type HookRegistry = BTreeMap<String, HookFunc>;
+
+/// Converts the caller's hook map into the shape the initialize message wants,
+/// and returns a registry mapping each generated callback id to its function.
+///
+/// An empty configuration yields an empty object rather than being omitted:
+/// `hooks` is always present in the initialize request.
+pub(crate) fn build_hooks_for_initialize(
+    hooks: &BTreeMap<String, Vec<HookMatcher>>,
+) -> (serde_json::Map<String, serde_json::Value>, HookRegistry) {
+    let mut registry = HookRegistry::new();
+    let mut config = serde_json::Map::new();
+
+    if hooks.is_empty() {
+        return (config, registry);
+    }
+
+    for (event, matchers) in hooks {
+        let mut matcher_configs = Vec::new();
+        for matcher in matchers {
+            if matcher.hooks.is_empty() {
+                continue;
+            }
+            let mut callback_ids = Vec::with_capacity(matcher.hooks.len());
+            for hook in &matcher.hooks {
+                let id = new_uuid();
+                registry.insert(id.clone(), hook.clone());
+                callback_ids.push(serde_json::Value::String(id));
+            }
+
+            // One entry per matcher, carrying all of that matcher's callback
+            // ids. "matcher" is always present, null when unset.
+            let mut cfg = serde_json::Map::new();
+            cfg.insert(
+                "matcher".into(),
+                if matcher.matcher.is_empty() {
+                    serde_json::Value::Null
+                } else {
+                    serde_json::Value::String(matcher.matcher.clone())
+                },
+            );
+            cfg.insert(
+                "hookCallbackIds".into(),
+                serde_json::Value::Array(callback_ids),
+            );
+            if matcher.timeout > 0 {
+                cfg.insert("timeout".into(), matcher.timeout.into());
+            }
+            matcher_configs.push(serde_json::Value::Object(cfg));
+        }
+        if !matcher_configs.is_empty() {
+            config.insert(event.clone(), serde_json::Value::Array(matcher_configs));
+        }
+    }
+
+    (config, registry)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn noop_hook() -> HookFunc {
+        Arc::new(|_, _, _| Box::pin(async { Ok(None) }))
+    }
+
+    #[test]
+    fn an_empty_configuration_is_an_empty_object() {
+        let (cfg, reg) = build_hooks_for_initialize(&BTreeMap::new());
+        assert!(cfg.is_empty());
+        assert!(reg.is_empty());
+        assert_eq!(serde_json::to_string(&cfg).unwrap(), "{}");
+    }
+
+    #[test]
+    fn one_matcher_carries_all_its_callback_ids_in_one_entry() {
+        // The shape that shipped broken: two hooks under one matcher must be
+        // one entry with two ids, not two entries.
+        let mut hooks = BTreeMap::new();
+        hooks.insert(
+            hook_event::PRE_TOOL_USE.to_string(),
+            vec![HookMatcher {
+                matcher: "Bash".into(),
+                hooks: vec![noop_hook(), noop_hook()],
+                timeout: 30,
+            }],
+        );
+
+        let (cfg, reg) = build_hooks_for_initialize(&hooks);
+        let entries = cfg["PreToolUse"].as_array().unwrap();
+        assert_eq!(entries.len(), 1, "one entry per matcher, not per hook");
+        assert_eq!(entries[0]["matcher"], "Bash");
+        assert_eq!(entries[0]["hookCallbackIds"].as_array().unwrap().len(), 2);
+        assert_eq!(entries[0]["timeout"], 30);
+        assert_eq!(reg.len(), 2, "both callbacks are dispatchable");
+    }
+
+    #[test]
+    fn an_unset_matcher_is_null_rather_than_absent() {
+        let mut hooks = BTreeMap::new();
+        hooks.insert(
+            hook_event::STOP.to_string(),
+            vec![HookMatcher {
+                matcher: String::new(),
+                hooks: vec![noop_hook()],
+                timeout: 0,
+            }],
+        );
+
+        let (cfg, _) = build_hooks_for_initialize(&hooks);
+        let entry = &cfg["Stop"].as_array().unwrap()[0];
+        assert!(entry.get("matcher").is_some(), "the key is always present");
+        assert!(entry["matcher"].is_null());
+        assert!(entry.get("timeout").is_none(), "zero means the CLI default");
+    }
+
+    #[test]
+    fn a_matcher_with_no_hooks_contributes_nothing() {
+        let mut hooks = BTreeMap::new();
+        hooks.insert(
+            hook_event::STOP.to_string(),
+            vec![HookMatcher {
+                matcher: "x".into(),
+                hooks: vec![],
+                timeout: 0,
+            }],
+        );
+        let (cfg, reg) = build_hooks_for_initialize(&hooks);
+        assert!(cfg.is_empty());
+        assert!(reg.is_empty());
+    }
+
+    #[test]
+    fn hook_output_omits_its_zero_values() {
+        let out = HookOutput {
+            decision: "approve".into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            serde_json::to_string(&out).unwrap(),
+            r#"{"decision":"approve"}"#
+        );
+    }
+}

--- a/desktop/src-tauri/src/claude/init_types.rs
+++ b/desktop/src-tauri/src/claude/init_types.rs
@@ -1,0 +1,186 @@
+//! The payload of the initialize control response — the CLI's own account of
+//! what the connected binary can do. Ported from `claude/init_types.go`.
+//!
+//! Field names come from a response captured from a real CLI, not from any SDK
+//! type definition. Note the mixed casing: the envelope is snake_case while the
+//! entries inside `models` and `commands` are camelCase, because the CLI passes
+//! those through verbatim from its TypeScript shape.
+//!
+//! Decoding is deliberately lenient throughout: an unknown or missing field must
+//! never fail a session, because the SDK is expected to run against CLI versions
+//! both older and newer than itself.
+
+use serde::Deserialize;
+use serde_json::value::RawValue;
+
+use super::lenient::lenient;
+
+/// One model the connected CLI offers.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct ModelInfo {
+    /// The identifier to pass to `with_model` or `set_model` (e.g. `default`,
+    /// `sonnet`). Not necessarily a concrete model id — see `resolved_model`.
+    #[serde(deserialize_with = "lenient")]
+    pub value: String,
+    /// The concrete model `value` resolves to, e.g. `claude-opus-5[1m]`.
+    #[serde(rename = "resolvedModel", deserialize_with = "lenient")]
+    pub resolved_model: String,
+    /// Human-readable name, e.g. `Default (recommended)`.
+    #[serde(rename = "displayName", deserialize_with = "lenient")]
+    pub display_name: String,
+    /// One-line summary of what the model is good for.
+    #[serde(deserialize_with = "lenient")]
+    pub description: String,
+
+    #[serde(rename = "supportsEffort", deserialize_with = "lenient")]
+    pub supports_effort: bool,
+    #[serde(rename = "supportedEffortLevels", deserialize_with = "lenient")]
+    pub supported_effort_levels: Vec<String>,
+    #[serde(rename = "supportsAdaptiveThinking", deserialize_with = "lenient")]
+    pub supports_adaptive_thinking: bool,
+    #[serde(rename = "supportsFastMode", deserialize_with = "lenient")]
+    pub supports_fast_mode: bool,
+    #[serde(rename = "supportsAutoMode", deserialize_with = "lenient")]
+    pub supports_auto_mode: bool,
+}
+
+/// One slash command available in the session.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct SlashCommand {
+    #[serde(deserialize_with = "lenient")]
+    pub name: String,
+    #[serde(deserialize_with = "lenient")]
+    pub description: String,
+    #[serde(deserialize_with = "lenient")]
+    pub aliases: Vec<String>,
+    /// Describes the command's expected arguments, when it takes any.
+    #[serde(rename = "argumentHint", deserialize_with = "lenient")]
+    pub argument_hint: String,
+}
+
+/// One subagent type the session can dispatch to.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct AgentInfo {
+    #[serde(deserialize_with = "lenient")]
+    pub name: String,
+    #[serde(deserialize_with = "lenient")]
+    pub description: String,
+    /// The agent's model override; empty when it inherits the session's.
+    #[serde(deserialize_with = "lenient")]
+    pub model: String,
+}
+
+/// The account the CLI is authenticated as.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct AccountInfo {
+    #[serde(deserialize_with = "lenient")]
+    pub email: String,
+    #[serde(deserialize_with = "lenient")]
+    pub organization: String,
+    /// e.g. `Claude Max`; empty on API-key auth.
+    #[serde(rename = "subscriptionType", deserialize_with = "lenient")]
+    pub subscription_type: String,
+    /// e.g. `firstParty`, `bedrock`, `vertex`.
+    #[serde(rename = "apiProvider", deserialize_with = "lenient")]
+    pub api_provider: String,
+}
+
+/// The decoded body of the initialize control response.
+///
+/// `raw` holds the undecoded body so that fields this SDK does not model yet
+/// remain reachable, and so a future CLI adding fields costs nothing here.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub(crate) struct InitializeResponse {
+    #[serde(deserialize_with = "lenient")]
+    pub commands: Vec<SlashCommand>,
+    #[serde(deserialize_with = "lenient")]
+    pub agents: Vec<AgentInfo>,
+    #[serde(deserialize_with = "lenient")]
+    pub models: Vec<ModelInfo>,
+    #[serde(deserialize_with = "lenient")]
+    pub account: AccountInfo,
+
+    #[serde(deserialize_with = "lenient")]
+    pub output_style: String,
+    #[serde(deserialize_with = "lenient")]
+    pub available_output_styles: Vec<String>,
+
+    /// `off`, `on`, …; `fast_mode_disabled_reason` explains why fast mode is
+    /// unavailable (e.g. `sdk_opt_in_required`).
+    #[serde(deserialize_with = "lenient")]
+    pub fast_mode_state: String,
+    #[serde(deserialize_with = "lenient")]
+    pub fast_mode_disabled_reason: String,
+
+    /// The CLI process id as the CLI reports it.
+    #[serde(deserialize_with = "lenient")]
+    pub pid: i64,
+
+    #[serde(skip)]
+    pub raw: Option<Box<RawValue>>,
+}
+
+/// Parses an initialize control response body.
+///
+/// This never fails: the handshake succeeded if the CLI acknowledged it, so a
+/// body that does not parse yields a response carrying only `raw` rather than
+/// failing the session. Callers get empty lists instead of data in that case.
+pub(crate) fn decode_initialize_response(body: Option<&RawValue>) -> InitializeResponse {
+    let Some(body) = body else {
+        return InitializeResponse::default();
+    };
+
+    let (mut resp, _) = super::lenient::decode::<InitializeResponse>(body.get().as_bytes());
+    resp.raw = RawValue::from_string(body.get().to_owned()).ok();
+    resp
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn raw(s: &str) -> Box<RawValue> {
+        RawValue::from_string(s.to_owned()).unwrap()
+    }
+
+    #[test]
+    fn an_absent_body_is_a_successful_handshake_with_no_data() {
+        let resp = decode_initialize_response(None);
+        assert!(resp.models.is_empty());
+        assert!(resp.raw.is_none());
+    }
+
+    #[test]
+    fn an_unparseable_body_still_yields_a_response() {
+        // The handshake succeeded; only the payload is unfamiliar.
+        let body = raw(r#"["not","an","object"]"#);
+        let resp = decode_initialize_response(Some(&body));
+        assert!(resp.models.is_empty());
+        assert_eq!(
+            resp.raw.as_ref().map(|r| r.get()),
+            Some(r#"["not","an","object"]"#)
+        );
+    }
+
+    #[test]
+    fn the_captured_shape_decodes_with_its_mixed_casing() {
+        let body = raw(
+            r#"{"models":[{"value":"default","resolvedModel":"claude-opus-5","displayName":"Default","supportsEffort":true}],
+                "commands":[{"name":"init","argumentHint":"[path]"}],
+                "account":{"email":"a@b.c","apiProvider":"firstParty"},
+                "output_style":"default","pid":4242}"#,
+        );
+        let resp = decode_initialize_response(Some(&body));
+        assert_eq!(resp.models[0].resolved_model, "claude-opus-5");
+        assert!(resp.models[0].supports_effort);
+        assert_eq!(resp.commands[0].argument_hint, "[path]");
+        assert_eq!(resp.account.api_provider, "firstParty");
+        assert_eq!(resp.output_style, "default");
+        assert_eq!(resp.pid, 4242);
+    }
+}

--- a/desktop/src-tauri/src/claude/lenient.rs
+++ b/desktop/src-tauri/src/claude/lenient.rs
@@ -1,0 +1,151 @@
+//! Decode tolerance — the one place Go's `encoding/json` and `serde_json`
+//! genuinely disagree, and the disagreement is load-bearing.
+//!
+//! `encoding/json` populates every field it processed successfully *before*
+//! returning an error, so one unexpected field degrades that field and leaves
+//! the rest of the message intact. `serde_json` aborts the whole struct on the
+//! first mismatch. The Go SDK depends on the former: `parseLine` records the
+//! failure in `Event.DecodeErr` and keeps whatever decoded, because a CLI that
+//! adds or reshapes a field must not blank an entire message (see #23, and
+//! `decode_tolerance_test.go`, which mutates `num_turns` into an array and
+//! asserts the rest of the result survives).
+//!
+//! [`lenient`] is a `deserialize_with` that routes one field through
+//! [`serde_json::Value`] and falls back to `Default` when it does not fit —
+//! per-field degradation, exactly Go's. Because it never fails, the surrounding
+//! `from_slice` never fails either, so the *reason* would be lost; [`lenient`]
+//! therefore records the first mismatch it sees in a thread-local slot that
+//! [`decode`] reads back. Decoding is synchronous, so no other decode can
+//! interleave on the same thread between clearing and reading that slot.
+//!
+//! Two deliberate exemptions:
+//!
+//! * **`RawValue` fields skip [`lenient`].** They accept any JSON so they
+//!   cannot mismatch, and routing them through `Value` would re-serialize them,
+//!   losing the verbatim bytes that are the only reason to keep a raw copy.
+//! * **JSON `null` is not a mismatch.** Go unmarshals `null` into a non-pointer
+//!   as a no-op and returns no error, so a null field degrades silently here
+//!   too; recording it would report drift on every message that omits an
+//!   optional field by sending `null`.
+
+use serde::{Deserialize, Deserializer};
+use std::cell::RefCell;
+
+thread_local! {
+    /// First field-level mismatch seen during the current [`decode`] call.
+    static FIRST_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
+}
+
+/// Deserializes a field, falling back to `Default` when the JSON does not fit
+/// the target type. Never fails, which is what makes the surrounding struct
+/// tolerant field by field.
+pub(crate) fn lenient<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: serde::de::DeserializeOwned + Default,
+{
+    // Deserializing into Value cannot fail for well-formed JSON, so a type
+    // mismatch surfaces at from_value and degrades to Default there.
+    let value = serde_json::Value::deserialize(deserializer)?;
+
+    // Go treats null as absent, without error. Match that, and do not report it.
+    if value.is_null() {
+        return Ok(T::default());
+    }
+
+    match serde_json::from_value(value) {
+        Ok(decoded) => Ok(decoded),
+        Err(err) => {
+            record_error(err.to_string());
+            Ok(T::default())
+        }
+    }
+}
+
+/// Records a field mismatch, keeping the first — Go's `DecodeErr` is whichever
+/// error `json.Unmarshal` returned, and it stops at the first.
+fn record_error(message: String) {
+    FIRST_ERROR.with(|slot| {
+        let mut slot = slot.borrow_mut();
+        if slot.is_none() {
+            *slot = Some(message);
+        }
+    });
+}
+
+/// Decodes `bytes` into `T`, mirroring Go's partial-population semantics.
+///
+/// Returns the decoded value plus the first field-level mismatch, if any. The
+/// caller stores that message the way Go stores `Event.DecodeErr`: as a record
+/// that the typed view is incomplete, alongside a raw copy that always is.
+///
+/// A payload that is not JSON at all — or whose shape does not fit `T` at the
+/// top level, which no `deserialize_with` can rescue — yields `T::default()`
+/// and the parse error, the same place Go lands.
+pub(crate) fn decode<T>(bytes: &[u8]) -> (T, Option<String>)
+where
+    T: serde::de::DeserializeOwned + Default,
+{
+    FIRST_ERROR.with(|slot| *slot.borrow_mut() = None);
+
+    let (value, top_level_error) = match serde_json::from_slice::<T>(bytes) {
+        Ok(value) => (value, None),
+        Err(err) => (T::default(), Some(err.to_string())),
+    };
+
+    let field_error = FIRST_ERROR.with(|slot| slot.borrow_mut().take());
+    (value, top_level_error.or(field_error))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Debug, Default, Deserialize, PartialEq)]
+    #[serde(default)]
+    struct Sample {
+        #[serde(deserialize_with = "lenient")]
+        num_turns: i64,
+        #[serde(deserialize_with = "lenient")]
+        result: String,
+    }
+
+    #[test]
+    fn a_bad_field_degrades_only_that_field() {
+        // The shape decode_tolerance_test.go mutates: num_turns as an array.
+        let (value, err) = decode::<Sample>(br#"{"num_turns":[1,2],"result":"kept"}"#);
+        assert_eq!(value.num_turns, 0, "the bad field falls back to its zero");
+        assert_eq!(value.result, "kept", "the good field survives alongside it");
+        assert!(err.is_some(), "the mismatch is reported, not swallowed");
+    }
+
+    #[test]
+    fn a_clean_payload_reports_nothing() {
+        let (value, err) = decode::<Sample>(br#"{"num_turns":3,"result":"ok"}"#);
+        assert_eq!(
+            value,
+            Sample {
+                num_turns: 3,
+                result: "ok".into()
+            }
+        );
+        assert!(err.is_none());
+    }
+
+    #[test]
+    fn null_is_absent_rather_than_a_mismatch() {
+        // Go unmarshals null into a string as a no-op and returns no error.
+        let (value, err) = decode::<Sample>(br#"{"num_turns":null,"result":null}"#);
+        assert_eq!(value, Sample::default());
+        assert!(err.is_none(), "null must not be reported as drift");
+    }
+
+    #[test]
+    fn the_error_slot_does_not_leak_between_decodes() {
+        let (_, err) = decode::<Sample>(br#"{"num_turns":[1]}"#);
+        assert!(err.is_some());
+        let (_, err) = decode::<Sample>(br#"{"num_turns":1}"#);
+        assert!(err.is_none(), "a later clean decode must not inherit it");
+    }
+}

--- a/desktop/src-tauri/src/claude/mcp.rs
+++ b/desktop/src-tauri/src/claude/mcp.rs
@@ -1,0 +1,320 @@
+//! In-process MCP servers, ported from `claude/mcp.go`.
+//!
+//! "In-process" is a description of where the *tools* live, not of the
+//! transport. The CLI has no way to call into this process directly, so the
+//! bridge is a loopback HTTP listener: bind `127.0.0.1:0`, serve MCP over it,
+//! and hand the CLI the URL as an ordinary `http` server config. That is the
+//! whole of what the Go SDK does here, and it is why in-process servers reach
+//! the CLI through `--mcp-config` rather than through the initialize message's
+//! `sdkMcpServers` — see [`super::process::initialize_msg`] for why naming one
+//! there would silently break it.
+//!
+//! ## One deliberate divergence from the Go SDK
+//!
+//! Go's `StartInProcessMCPServer` takes an `*mcp.Server` from the official
+//! `modelcontextprotocol/go-sdk` and hosts it with that SDK's
+//! `NewStreamableHTTPHandler`. This port takes an [`McpService`] — a trait for
+//! "handle one JSON-RPC message" — and owns only the transport.
+//!
+//! The reason is scope, and it is worth stating plainly rather than
+//! discovering later: the MCP *protocol* implementation (initialize,
+//! `tools/list`, `tools/call`, schema generation) is what the Go MCP SDK
+//! supplies, and on the Rust side that is `rmcp`. Nothing in this application
+//! has an MCP server to host yet — Agento's seven integrations are phase 4 of
+//! the port — so binding this module to `rmcp`'s type surface now would add a
+//! large dependency to satisfy no caller, and would pin an API that phase 4
+//! should be free to choose. The trait keeps the seam exactly where Go's is
+//! (the SDK owns the listener, the caller owns the tools), and an `rmcp`
+//! service is one adapter away.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use serde_json::value::RawValue;
+
+use super::errors::{Error, Result};
+use super::options::{McpHttpServer, McpStdioServer};
+
+/// The future an [`McpService`] returns: the JSON-RPC response, or `None` for a
+/// notification, which by definition has no reply.
+pub type McpResponseFuture = Pin<Box<dyn Future<Output = Option<serde_json::Value>> + Send>>;
+
+/// Something that can answer MCP JSON-RPC messages.
+///
+/// Implementors own the MCP protocol itself; this module owns getting messages
+/// to and from them.
+pub trait McpService: Send + Sync + 'static {
+    /// Handles one JSON-RPC message. Returning `None` means "no reply", which
+    /// is the correct answer for a notification and the only case where the
+    /// HTTP transport answers `202 Accepted`.
+    fn handle(&self, message: Box<RawValue>) -> McpResponseFuture;
+}
+
+impl<F> McpService for F
+where
+    F: Fn(Box<RawValue>) -> McpResponseFuture + Send + Sync + 'static,
+{
+    fn handle(&self, message: Box<RawValue>) -> McpResponseFuture {
+        self(message)
+    }
+}
+
+/// A running in-process MCP server.
+///
+/// Dropping this stops the listener. Go ties the server's lifetime to a
+/// context; here it is tied to the handle, so a caller that forgets it does not
+/// leak a bound port for the life of the process.
+pub struct InProcessMcpServer {
+    config: McpHttpServer,
+    shutdown: Option<tokio::sync::oneshot::Sender<()>>,
+}
+
+impl InProcessMcpServer {
+    /// The config to hand to [`super::Options::with_mcp_server`].
+    pub fn config(&self) -> &McpHttpServer {
+        &self.config
+    }
+
+    /// The URL the CLI will dial.
+    pub fn url(&self) -> &str {
+        &self.config.url
+    }
+}
+
+impl Drop for InProcessMcpServer {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+/// Starts an HTTP MCP server for `service` and returns a handle carrying the
+/// config to pass to [`super::Options::with_mcp_server`].
+///
+/// The listener is bound to a random port on `127.0.0.1` and stops when the
+/// returned handle is dropped.
+pub async fn start_in_process_mcp_server(
+    name: &str,
+    service: impl McpService,
+) -> Result<InProcessMcpServer> {
+    let service = Arc::new(service);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .map_err(|e| Error::Other(format!("claude: mcp {name:?}: listen: {e}")))?;
+    let addr = listener
+        .local_addr()
+        .map_err(|e| Error::Other(format!("claude: mcp {name:?}: local address: {e}")))?;
+
+    let app = axum::Router::new().route(
+        "/",
+        axum::routing::post({
+            let service = service.clone();
+            move |body: String| {
+                let service = service.clone();
+                async move {
+                    let Ok(message) = RawValue::from_string(body) else {
+                        // A malformed body is a parse error in JSON-RPC terms,
+                        // but the transport's job is only to say it could not
+                        // be read.
+                        return axum::http::Response::builder()
+                            .status(axum::http::StatusCode::BAD_REQUEST)
+                            .body(axum::body::Body::empty())
+                            .expect("a static response always builds");
+                    };
+
+                    match service.handle(message).await {
+                        Some(response) => {
+                            let body = serde_json::to_vec(&response).unwrap_or_default();
+                            axum::http::Response::builder()
+                                .status(axum::http::StatusCode::OK)
+                                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                                .body(axum::body::Body::from(body))
+                                .expect("a static response always builds")
+                        }
+                        // A notification has no reply; 202 is what the
+                        // streamable-HTTP transport says to answer.
+                        None => axum::http::Response::builder()
+                            .status(axum::http::StatusCode::ACCEPTED)
+                            .body(axum::body::Body::empty())
+                            .expect("a static response always builds"),
+                    }
+                }
+            }
+        }),
+    );
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_name = name.to_string();
+    tokio::spawn(async move {
+        let served = axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                let _ = shutdown_rx.await;
+            })
+            .await;
+        if let Err(e) = served {
+            log::warn!("claude: mcp {server_name:?}: server stopped: {e}");
+        }
+    });
+
+    Ok(InProcessMcpServer {
+        config: McpHttpServer {
+            server_type: "http".to_string(),
+            url: format!("http://{addr}"),
+            headers: Default::default(),
+        },
+        shutdown: Some(shutdown_tx),
+    })
+}
+
+/// Runs `service` as an MCP stdio server, reading from stdin and writing to
+/// stdout. Intended for a standalone binary registered via [`McpStdioServer`].
+///
+/// Blocks until stdin closes.
+pub async fn serve_stdio_mcp(service: impl McpService) -> Result<()> {
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    let mut lines = BufReader::new(tokio::io::stdin()).lines();
+    let mut stdout = tokio::io::stdout();
+
+    while let Some(line) = lines
+        .next_line()
+        .await
+        .map_err(|e| Error::wrap("reading stdin", e))?
+    {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let Ok(message) = RawValue::from_string(line) else {
+            continue;
+        };
+        if let Some(response) = service.handle(message).await {
+            let mut encoded = serde_json::to_vec(&response)
+                .map_err(|e| Error::wrap("encoding an MCP response", e))?;
+            encoded.push(b'\n');
+            stdout
+                .write_all(&encoded)
+                .await
+                .map_err(|e| Error::wrap("writing stdout", e))?;
+            stdout
+                .flush()
+                .await
+                .map_err(|e| Error::wrap("flushing stdout", e))?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Returns an [`McpStdioServer`] that runs the current binary with the given
+/// extra arguments — the self-invoking MCP stdio pattern, where one executable
+/// is both the client and, under a flag, the server.
+pub fn self_as_stdio_mcp_server<I, S>(extra_args: I) -> Result<McpStdioServer>
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    let exe = std::env::current_exe()
+        .map_err(|e| Error::wrap("resolve executable", e))?
+        .to_string_lossy()
+        .into_owned();
+
+    Ok(McpStdioServer {
+        server_type: "stdio".to_string(),
+        command: exe,
+        args: extra_args.into_iter().map(Into::into).collect(),
+        env: Default::default(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn echo_service() -> impl McpService {
+        |message: Box<RawValue>| -> McpResponseFuture {
+            Box::pin(async move {
+                let parsed: serde_json::Value =
+                    serde_json::from_str(message.get()).unwrap_or_default();
+                // A notification has no id, and therefore no reply.
+                let id = parsed.get("id")?.clone();
+                Some(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": { "echo": parsed.get("method").cloned() },
+                }))
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn the_server_binds_loopback_and_reports_an_http_config() {
+        let server = start_in_process_mcp_server("probe", echo_service())
+            .await
+            .unwrap();
+
+        assert_eq!(server.config().server_type, "http");
+        assert!(
+            server.url().starts_with("http://127.0.0.1:"),
+            "must not be reachable off-host: {}",
+            server.url()
+        );
+    }
+
+    #[tokio::test]
+    async fn a_request_is_answered_and_a_notification_is_only_accepted() {
+        let server = start_in_process_mcp_server("probe", echo_service())
+            .await
+            .unwrap();
+        let client = reqwest::Client::new();
+
+        let response = client
+            .post(server.url())
+            .body(r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+        let body: serde_json::Value = response.json().await.unwrap();
+        assert_eq!(body["id"], 1);
+        assert_eq!(body["result"]["echo"], "tools/list");
+
+        let response = client
+            .post(server.url())
+            .body(r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 202, "a notification has no reply");
+    }
+
+    #[tokio::test]
+    async fn dropping_the_handle_stops_the_listener() {
+        let server = start_in_process_mcp_server("probe", echo_service())
+            .await
+            .unwrap();
+        let url = server.url().to_string();
+        drop(server);
+
+        // Graceful shutdown is not instantaneous; poll briefly rather than
+        // racing it.
+        let client = reqwest::Client::new();
+        for _ in 0..50 {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            if client.post(&url).body("{}").send().await.is_err() {
+                return;
+            }
+        }
+        panic!("the listener outlived its handle");
+    }
+
+    #[test]
+    fn the_self_stdio_config_points_at_this_binary() {
+        let cfg = self_as_stdio_mcp_server(["--mcp-server"]).unwrap();
+        assert_eq!(cfg.server_type, "stdio");
+        assert!(!cfg.command.is_empty());
+        assert_eq!(cfg.args, vec!["--mcp-server"]);
+    }
+}

--- a/desktop/src-tauri/src/claude/mcp.rs
+++ b/desktop/src-tauri/src/claude/mcp.rs
@@ -277,7 +277,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), 200);
-        let body: serde_json::Value = response.json().await.unwrap();
+        // Parsed by hand rather than via reqwest's `json` feature: this is
+        // the only caller, and the feature would ship in the release binary.
+        let body: serde_json::Value =
+            serde_json::from_str(&response.text().await.unwrap()).unwrap();
         assert_eq!(body["id"], 1);
         assert_eq!(body["result"]["echo"], "tools/list");
 

--- a/desktop/src-tauri/src/claude/messages.rs
+++ b/desktop/src-tauri/src/claude/messages.rs
@@ -1,0 +1,1909 @@
+//! Event and message types, ported from `claude/messages.go`.
+//!
+//! Every type here mirrors a shape captured from a real `claude` CLI rather
+//! than any published schema, so the field names and the casing are the
+//! contract. Two casing quirks are real and deliberate: `modelUsage` and
+//! `rate_limit_info`'s contents are camelCase *inside* an otherwise snake_case
+//! message, because the CLI passes those values through verbatim from its
+//! TypeScript shape.
+//!
+//! Three rules run through the whole file:
+//!
+//! * **`raw` is always authoritative.** Every message keeps the bytes it was
+//!   built from, because this SDK is expected to run against CLI versions both
+//!   older and newer than itself and a field we do not model must still reach
+//!   the caller. Agento's chat SSE relies on exactly this: it forwards the raw
+//!   line rather than re-encoding a typed view.
+//! * **Decoding is best-effort.** A field the CLI reshapes degrades that field
+//!   and sets `decode_err`; it never blanks the message. See `lenient`.
+//! * **Open string types, not closed enums.** `terminal_reason`, task statuses
+//!   and rate-limit statuses are named strings so an unrecognised value decodes
+//!   through unchanged instead of being dropped.
+
+use serde::Deserialize;
+use serde_json::value::RawValue;
+
+use super::lenient::{decode, lenient};
+
+/// The `type` discriminant present on every message.
+///
+/// Kept as an open string rather than an enum, matching Go's
+/// `type MessageType string`: an unknown type must still reach the caller with
+/// its `raw` intact.
+pub mod message_type {
+    /// A complete assistant turn (`SDKAssistantMessage`).
+    pub const ASSISTANT: &str = "assistant";
+    /// A turn on the user side (`SDKUserMessage`) — most often the CLI
+    /// delivering a tool's result, not something a human typed.
+    pub const USER: &str = "user";
+    /// Incremental streaming deltas (`SDKPartialAssistantMessage`).
+    pub const STREAM_EVENT: &str = "stream_event";
+    /// The final message emitted when the agent finishes (`SDKResultMessage`).
+    pub const RESULT: &str = "result";
+    /// Status/info messages from the CLI (`SDKStatusMessage`).
+    pub const SYSTEM: &str = "system";
+    /// Emitted when rate-limit information is available.
+    pub const RATE_LIMIT_EVENT: &str = "rate_limit_event";
+    /// Incremental tool execution progress updates.
+    pub const TOOL_PROGRESS: &str = "tool_progress";
+    /// A summary of a tool use after completion.
+    pub const TOOL_USE_SUMMARY: &str = "tool_use_summary";
+    /// Authentication status updates.
+    pub const AUTH_STATUS: &str = "auth_status";
+    /// Prompt suggestions from the agent.
+    pub const PROMPT_SUGGESTION: &str = "prompt_suggestion";
+}
+
+/// Subtypes of a `system` message.
+///
+/// These are **not** top-level message types: nothing on the wire ever carries
+/// `type:"task_started"`. Treating them as top-level is what made eight parse
+/// branches permanently dead in the Go SDK before #23.
+pub mod system_subtype {
+    pub const INIT: &str = "init";
+    pub const STATUS: &str = "status";
+
+    // Task lifecycle.
+    pub const TASK_STARTED: &str = "task_started";
+    pub const TASK_PROGRESS: &str = "task_progress";
+    pub const TASK_NOTIFICATION: &str = "task_notification";
+    pub const TASK_UPDATED: &str = "task_updated";
+
+    // Hook lifecycle.
+    pub const HOOK_STARTED: &str = "hook_started";
+    pub const HOOK_PROGRESS: &str = "hook_progress";
+    pub const HOOK_RESPONSE: &str = "hook_response";
+
+    // Session lifecycle.
+    pub const COMPACT_BOUNDARY: &str = "compact_boundary";
+    pub const FILES_PERSISTED: &str = "files_persisted";
+
+    /// Observed on the wire but not typed — read `Event::raw`.
+    pub const THINKING_TOKENS: &str = "thinking_tokens";
+    /// Observed on the wire but not typed — read `Event::raw`.
+    pub const BACKGROUND_TASKS_CHANGED: &str = "background_tasks_changed";
+
+    /// Synthesised by this SDK for a process-level failure. The CLI never
+    /// sends `system`/`error`.
+    pub const ERROR: &str = "error";
+}
+
+/// Values of [`ContentBlock::block_type`].
+pub mod block {
+    pub const TEXT: &str = "text";
+    pub const THINKING: &str = "thinking";
+    pub const TOOL_USE: &str = "tool_use";
+    pub const TOOL_RESULT: &str = "tool_result";
+    pub const SERVER_TOOL_USE: &str = "server_tool_use";
+    pub const ADVISOR_TOOL_RESULT: &str = "advisor_tool_result";
+
+    // Server-side tool results are per-tool block types rather than one
+    // generic shape. All carry tool_use_id + content, so ContentBlock decodes
+    // them uniformly.
+    pub const WEB_SEARCH_TOOL_RESULT: &str = "web_search_tool_result";
+    pub const CODE_EXECUTION_TOOL_RESULT: &str = "code_execution_tool_result";
+}
+
+// ─── Content blocks ──────────────────────────────────────────────────────────
+
+/// The decodable half of [`ContentBlock`], kept separate so the block's custom
+/// `Deserialize` can capture the verbatim bytes before decoding fields.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+struct ContentBlockFields {
+    #[serde(rename = "type", deserialize_with = "lenient")]
+    block_type: String,
+
+    #[serde(deserialize_with = "lenient")]
+    text: String,
+
+    #[serde(deserialize_with = "lenient")]
+    thinking: String,
+    #[serde(deserialize_with = "lenient")]
+    signature: String,
+
+    #[serde(deserialize_with = "lenient")]
+    id: String,
+    #[serde(deserialize_with = "lenient")]
+    name: String,
+    input: Option<Box<RawValue>>,
+
+    caller: Option<Box<RawValue>>,
+
+    #[serde(rename = "tool_use_id", deserialize_with = "lenient")]
+    tool_use_id: String,
+    content: Option<Box<RawValue>>,
+    #[serde(deserialize_with = "lenient")]
+    is_error: Option<bool>,
+}
+
+/// One element of a message's content array.
+///
+/// The wire carries a discriminated union: `text`, `thinking`, `tool_use`,
+/// `tool_result`, the server-side tool blocks, and whatever the API adds next.
+/// This is one struct with a discriminator and the superset of fields rather
+/// than an enum, so a content array decodes in a single pass and an unknown
+/// block degrades to its type plus `raw` instead of being dropped.
+///
+/// Read only the fields that belong to `block_type`. `raw` is always the
+/// authoritative payload.
+#[derive(Debug, Clone, Default)]
+pub struct ContentBlock {
+    pub block_type: String,
+
+    /// Set when `block_type` is [`block::TEXT`].
+    pub text: String,
+
+    /// Set when `block_type` is [`block::THINKING`]. `signature` arrives whole
+    /// here, and incrementally as a `signature_delta` while streaming.
+    pub thinking: String,
+    pub signature: String,
+
+    /// Set when `block_type` is [`block::TOOL_USE`] or
+    /// [`block::SERVER_TOOL_USE`]. `input` is the tool's arguments object, kept
+    /// raw because its schema is the tool's own.
+    pub id: String,
+    pub name: String,
+    pub input: Option<Box<RawValue>>,
+
+    /// How the tool was invoked, e.g. `{"type":"direct"}`. Sent alongside every
+    /// `tool_use` block by CLI 2.1.224 — and described by no type definition,
+    /// which is why it is kept raw.
+    pub caller: Option<Box<RawValue>>,
+
+    /// Set on the result blocks. `tool_use_id` pairs the result back to the
+    /// `id` of the `tool_use` block that requested it.
+    ///
+    /// `content` is raw because the CLI sends either a plain string or an array
+    /// of blocks depending on the tool — both shapes were observed in one
+    /// session.
+    pub tool_use_id: String,
+    pub content: Option<Box<RawValue>>,
+    /// A pointer in Go, an `Option` here, for the same reason: absent and
+    /// `false` are different answers.
+    pub is_error: Option<bool>,
+
+    /// The complete block as received, including fields this struct does not
+    /// model. Always populated when the block came off the wire.
+    pub raw: Option<Box<RawValue>>,
+}
+
+impl<'de> Deserialize<'de> for ContentBlock {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        deserializer: D,
+    ) -> std::result::Result<Self, D::Error> {
+        // Capture the verbatim block first, exactly as Go's UnmarshalJSON does,
+        // so an unknown or partially-decodable block still carries its payload.
+        let raw = Box::<RawValue>::deserialize(deserializer)?;
+        let fields: ContentBlockFields = serde_json::from_str(raw.get()).unwrap_or_default();
+
+        Ok(ContentBlock {
+            block_type: fields.block_type,
+            text: fields.text,
+            thinking: fields.thinking,
+            signature: fields.signature,
+            id: fields.id,
+            name: fields.name,
+            input: fields.input,
+            caller: fields.caller,
+            tool_use_id: fields.tool_use_id,
+            content: fields.content,
+            is_error: fields.is_error,
+            raw: Some(raw),
+        })
+    }
+}
+
+impl ContentBlock {
+    /// The block's `content` as a plain string, when the CLI sent one.
+    ///
+    /// Result blocks carry either a string or an array of blocks; this returns
+    /// `None` for the array form, which the caller should decode itself.
+    pub fn content_text(&self) -> Option<String> {
+        let raw = self.content.as_ref()?;
+        serde_json::from_str::<String>(raw.get()).ok()
+    }
+
+    /// Whether this is a result block the tool reported as an error.
+    pub fn failed(&self) -> bool {
+        self.is_error == Some(true)
+    }
+}
+
+/// A message's content array.
+///
+/// The CLI sends content either as an array of blocks (every message it
+/// originates) or as a bare string (the shape this SDK itself sends for a user
+/// turn, and what stored transcripts replay). A string decodes to a single text
+/// block so callers have one shape to handle.
+#[derive(Debug, Clone, Default)]
+pub struct ContentBlocks(pub Vec<ContentBlock>);
+
+impl std::ops::Deref for ContentBlocks {
+    type Target = [ContentBlock];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for ContentBlocks {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        deserializer: D,
+    ) -> std::result::Result<Self, D::Error> {
+        let raw = Box::<RawValue>::deserialize(deserializer)?;
+        let text = raw.get();
+
+        // Check null first. Go unmarshals JSON null into a string as a no-op,
+        // so the string branch below would otherwise turn absent content into
+        // one empty text block rather than no content at all.
+        if text.trim() == "null" {
+            return Ok(ContentBlocks(Vec::new()));
+        }
+
+        if let Ok(s) = serde_json::from_str::<String>(text) {
+            return Ok(ContentBlocks(vec![ContentBlock {
+                block_type: block::TEXT.to_string(),
+                text: s,
+                raw: RawValue::from_string(text.to_owned()).ok(),
+                ..Default::default()
+            }]));
+        }
+
+        Ok(ContentBlocks(
+            serde_json::from_str::<Vec<ContentBlock>>(text).unwrap_or_default(),
+        ))
+    }
+}
+
+// ─── Assistant and user messages ─────────────────────────────────────────────
+
+/// The inner `message` object of an assistant or user message.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct MessagePayload {
+    #[serde(deserialize_with = "lenient")]
+    pub role: String,
+    pub content: ContentBlocks,
+
+    /// The API message id, e.g. `msg_011Cdz…`. Assistant messages only.
+    #[serde(deserialize_with = "lenient")]
+    pub id: String,
+    /// The API object type; the CLI sends `message`.
+    #[serde(rename = "type", deserialize_with = "lenient")]
+    pub payload_type: String,
+    /// The model that produced this turn, e.g. `claude-opus-5`.
+    #[serde(deserialize_with = "lenient")]
+    pub model: String,
+
+    /// `None` until the turn ends; `tool_use` and `end_turn` are the common
+    /// terminal values. `stop_sequence` is set only when a stop sequence
+    /// triggered the stop.
+    #[serde(deserialize_with = "lenient")]
+    pub stop_reason: Option<String>,
+    #[serde(deserialize_with = "lenient")]
+    pub stop_sequence: Option<String>,
+    pub stop_details: Option<Box<RawValue>>,
+
+    /// Classifies a failed turn; empty on success. One of
+    /// `authentication_failed`, `billing_error`, `rate_limit`,
+    /// `invalid_request`, `server_error`, `unknown`.
+    #[serde(deserialize_with = "lenient")]
+    pub error: String,
+
+    /// This turn's token counts, kept raw because the CLI nests
+    /// provider-specific detail under it (`cache_creation`, `inference_geo`, …)
+    /// that changes independently of this SDK.
+    ///
+    /// This is **not** the cost-accounting field: it reports a single turn of
+    /// the main loop only. Cumulative per-model usage and cost live in
+    /// [`Result::model_usages`].
+    pub usage: Option<Box<RawValue>>,
+}
+
+/// Emitted when Claude produces a complete response turn.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct AssistantMessage {
+    #[serde(rename = "type", deserialize_with = "lenient")]
+    pub message_type: String,
+    pub message: MessagePayload,
+    #[serde(deserialize_with = "lenient")]
+    pub parent_tool_use_id: Option<String>,
+    #[serde(deserialize_with = "lenient")]
+    pub session_id: String,
+    #[serde(deserialize_with = "lenient")]
+    pub uuid: String,
+
+    /// The CLI's send time, RFC 3339 with milliseconds.
+    #[serde(deserialize_with = "lenient")]
+    pub timestamp: String,
+    /// The upstream API request id, e.g. `req_011Cdz…`.
+    #[serde(deserialize_with = "lenient")]
+    pub request_id: String,
+}
+
+impl AssistantMessage {
+    /// The concatenated text from all text content blocks.
+    pub fn text(&self) -> String {
+        self.message
+            .content
+            .iter()
+            .filter(|b| b.block_type == block::TEXT)
+            .map(|b| b.text.as_str())
+            .collect()
+    }
+
+    /// The concatenated thinking text from all thinking content blocks.
+    pub fn thinking(&self) -> String {
+        self.message
+            .content
+            .iter()
+            .filter(|b| b.block_type == block::THINKING)
+            .map(|b| b.thinking.as_str())
+            .collect()
+    }
+
+    /// The `tool_use` blocks of this turn — the tools the agent is asking to
+    /// run. Each pairs by `id` to a `tool_result` block on the following
+    /// [`UserMessage`].
+    pub fn tool_uses(&self) -> Vec<&ContentBlock> {
+        self.message
+            .content
+            .iter()
+            .filter(|b| b.block_type == block::TOOL_USE || b.block_type == block::SERVER_TOOL_USE)
+            .collect()
+    }
+}
+
+/// A turn on the user side of the conversation.
+///
+/// Most of these are not typed by a human: the CLI emits one after every tool
+/// call, carrying the tool's output as `tool_result` blocks. They also carry
+/// every user turn of a stored transcript.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct UserMessage {
+    #[serde(rename = "type", deserialize_with = "lenient")]
+    pub message_type: String,
+    pub message: MessagePayload,
+    #[serde(deserialize_with = "lenient")]
+    pub parent_tool_use_id: Option<String>,
+    #[serde(deserialize_with = "lenient")]
+    pub session_id: String,
+    #[serde(deserialize_with = "lenient")]
+    pub uuid: String,
+
+    /// The CLI's send time, RFC 3339 with milliseconds.
+    #[serde(deserialize_with = "lenient")]
+    pub timestamp: String,
+
+    /// The tool's structured result, alongside the rendered form in the
+    /// `tool_result` block. Raw because its shape is the tool's own: a Read
+    /// sends an object with file metadata, a failure sends a plain string —
+    /// both observed in one session.
+    pub tool_use_result: Option<Box<RawValue>>,
+
+    /// Marks a message the CLI generated rather than one the user or a tool
+    /// produced.
+    #[serde(rename = "isSynthetic", deserialize_with = "lenient")]
+    pub is_synthetic: bool,
+}
+
+impl UserMessage {
+    /// The concatenated text from all text content blocks. For a user turn sent
+    /// as a bare string, that is the whole message.
+    pub fn text(&self) -> String {
+        self.message
+            .content
+            .iter()
+            .filter(|b| b.block_type == block::TEXT)
+            .map(|b| b.text.as_str())
+            .collect()
+    }
+
+    /// The `tool_result` blocks of this turn, including the server-side result
+    /// variants. Pair them to the preceding assistant turn's `tool_use` blocks
+    /// by `tool_use_id`.
+    pub fn tool_results(&self) -> Vec<&ContentBlock> {
+        self.message
+            .content
+            .iter()
+            .filter(|b| {
+                matches!(
+                    b.block_type.as_str(),
+                    block::TOOL_RESULT
+                        | block::ADVISOR_TOOL_RESULT
+                        | block::WEB_SEARCH_TOOL_RESULT
+                        | block::CODE_EXECUTION_TOOL_RESULT
+                )
+            })
+            .collect()
+    }
+}
+
+// ─── Stream events ───────────────────────────────────────────────────────────
+
+/// Values of [`StreamEvent::event_type`].
+pub mod stream {
+    pub const MESSAGE_START: &str = "message_start";
+    pub const MESSAGE_DELTA: &str = "message_delta";
+    pub const MESSAGE_STOP: &str = "message_stop";
+    pub const CONTENT_BLOCK_START: &str = "content_block_start";
+    pub const CONTENT_BLOCK_DELTA: &str = "content_block_delta";
+    pub const CONTENT_BLOCK_STOP: &str = "content_block_stop";
+}
+
+/// Values of [`StreamEventDelta::delta_type`].
+pub mod delta {
+    pub const TEXT: &str = "text_delta";
+    pub const THINKING: &str = "thinking_delta";
+    pub const INPUT_JSON: &str = "input_json_delta";
+    pub const SIGNATURE: &str = "signature_delta";
+}
+
+/// The incremental content of a `stream_event` delta. Which field carries the
+/// increment depends on `delta_type`.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct StreamEventDelta {
+    #[serde(rename = "type", deserialize_with = "lenient")]
+    pub delta_type: String,
+    #[serde(deserialize_with = "lenient")]
+    pub text: String,
+    #[serde(deserialize_with = "lenient")]
+    pub thinking: String,
+
+    /// A fragment of a tool's input, sent when `delta_type` is
+    /// [`delta::INPUT_JSON`]. Fragments split at arbitrary points — including
+    /// mid-token and mid-string — so they are only valid JSON once concatenated
+    /// across the whole block.
+    #[serde(deserialize_with = "lenient")]
+    pub partial_json: String,
+
+    /// A fragment of a thinking block's signature ([`delta::SIGNATURE`]).
+    #[serde(deserialize_with = "lenient")]
+    pub signature: String,
+
+    /// `stop_reason` and `stop_sequence` ride the `message_delta` at the end of
+    /// a turn, where this struct is the event's `delta` rather than a block's.
+    #[serde(deserialize_with = "lenient")]
+    pub stop_reason: Option<String>,
+    #[serde(deserialize_with = "lenient")]
+    pub stop_sequence: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+struct StreamEventFields {
+    #[serde(rename = "type", deserialize_with = "lenient")]
+    event_type: String,
+    #[serde(deserialize_with = "lenient")]
+    delta: Option<StreamEventDelta>,
+    #[serde(deserialize_with = "lenient")]
+    index: i64,
+    message: Option<Box<RawValue>>,
+    content_block: Option<Box<RawValue>>,
+    usage: Option<Box<RawValue>>,
+    context_management: Option<Box<RawValue>>,
+}
+
+/// The inner `event` object of a [`StreamEventMessage`].
+///
+/// Its shape varies by `event_type`, so the fields specific to each are kept
+/// raw and reached through the accessors below.
+#[derive(Debug, Clone, Default)]
+pub struct StreamEvent {
+    pub event_type: String,
+    pub delta: Option<StreamEventDelta>,
+    pub index: i64,
+
+    /// The opening message envelope on [`stream::MESSAGE_START`].
+    pub message: Option<Box<RawValue>>,
+
+    /// The block being opened on [`stream::CONTENT_BLOCK_START`]. For a
+    /// `tool_use` block it already carries `id` and `name`, with `input`
+    /// arriving as `input_json_delta` fragments.
+    pub content_block: Option<Box<RawValue>>,
+
+    /// Rides [`stream::MESSAGE_DELTA`] as a **sibling** of `delta`, not inside
+    /// it.
+    pub usage: Option<Box<RawValue>>,
+
+    /// Edits the CLI applied to the context window.
+    pub context_management: Option<Box<RawValue>>,
+
+    /// The complete event as received. Always populated off the wire.
+    pub raw: Option<Box<RawValue>>,
+}
+
+impl<'de> Deserialize<'de> for StreamEvent {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        deserializer: D,
+    ) -> std::result::Result<Self, D::Error> {
+        let raw = Box::<RawValue>::deserialize(deserializer)?;
+        let fields: StreamEventFields = serde_json::from_str(raw.get()).unwrap_or_default();
+        Ok(StreamEvent {
+            event_type: fields.event_type,
+            delta: fields.delta,
+            index: fields.index,
+            message: fields.message,
+            content_block: fields.content_block,
+            usage: fields.usage,
+            context_management: fields.context_management,
+            raw: Some(raw),
+        })
+    }
+}
+
+impl StreamEvent {
+    /// The tool-input fragment carried by this event, if it is an
+    /// `input_json_delta`. Concatenate the fragments of one block `index` in
+    /// arrival order to rebuild the tool's input.
+    pub fn partial_json(&self) -> Option<&str> {
+        let d = self.delta.as_ref()?;
+        (d.delta_type == delta::INPUT_JSON).then_some(d.partial_json.as_str())
+    }
+
+    /// The text increment carried by this event, if any.
+    pub fn text_delta(&self) -> Option<&str> {
+        let d = self.delta.as_ref()?;
+        (d.delta_type == delta::TEXT).then_some(d.text.as_str())
+    }
+
+    /// The thinking increment carried by this event, if any.
+    pub fn thinking_delta(&self) -> Option<&str> {
+        let d = self.delta.as_ref()?;
+        (d.delta_type == delta::THINKING).then_some(d.thinking.as_str())
+    }
+
+    /// The thinking-signature fragment carried by this event, if any.
+    pub fn signature_delta(&self) -> Option<&str> {
+        let d = self.delta.as_ref()?;
+        (d.delta_type == delta::SIGNATURE).then_some(d.signature.as_str())
+    }
+
+    /// The block being opened, when this event is a `content_block_start`.
+    /// This is where a streamed tool call announces its id and name, before any
+    /// of its input has arrived.
+    pub fn content_block_start(&self) -> Option<ContentBlock> {
+        if self.event_type != stream::CONTENT_BLOCK_START {
+            return None;
+        }
+        let raw = self.content_block.as_ref()?;
+        serde_json::from_str(raw.get()).ok()
+    }
+
+    /// The tail of a turn: why it stopped and its final usage. The stop reason
+    /// is empty if the CLI sent none.
+    pub fn message_delta(&self) -> Option<(String, Option<&RawValue>)> {
+        if self.event_type != stream::MESSAGE_DELTA {
+            return None;
+        }
+        let stop_reason = self
+            .delta
+            .as_ref()
+            .and_then(|d| d.stop_reason.clone())
+            .unwrap_or_default();
+        Some((stop_reason, self.usage.as_deref()))
+    }
+}
+
+/// Carries incremental deltas during a streaming response.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct StreamEventMessage {
+    #[serde(rename = "type", deserialize_with = "lenient")]
+    pub message_type: String,
+    pub event: StreamEvent,
+    #[serde(deserialize_with = "lenient")]
+    pub parent_tool_use_id: Option<String>,
+    #[serde(deserialize_with = "lenient")]
+    pub session_id: String,
+    #[serde(deserialize_with = "lenient")]
+    pub uuid: String,
+
+    /// Time to first token in milliseconds, sent on `message_start`.
+    #[serde(rename = "ttft_ms", deserialize_with = "lenient")]
+    pub ttft_ms: i64,
+}
+
+// ─── Usage ───────────────────────────────────────────────────────────────────
+
+/// Token and cache usage from a completed agent run.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct Usage {
+    #[serde(deserialize_with = "lenient")]
+    pub input_tokens: i64,
+    #[serde(deserialize_with = "lenient")]
+    pub output_tokens: i64,
+    #[serde(deserialize_with = "lenient")]
+    pub cache_read_input_tokens: i64,
+    #[serde(deserialize_with = "lenient")]
+    pub cache_creation_input_tokens: i64,
+
+    /// Server-side tool invocations. On the wire these are nested under
+    /// `usage.server_tool_use`, not top-level.
+    #[serde(deserialize_with = "lenient")]
+    pub server_tool_use: ServerToolUse,
+
+    /// e.g. `standard`.
+    #[serde(deserialize_with = "lenient")]
+    pub service_tier: String,
+}
+
+/// Tool invocations the server performed on the model's behalf.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct ServerToolUse {
+    #[serde(deserialize_with = "lenient")]
+    pub web_search_requests: i64,
+    #[serde(deserialize_with = "lenient")]
+    pub web_fetch_requests: i64,
+}
+
+/// Per-model token and cost breakdown, carried by a result's `modelUsage` map.
+///
+/// Its fields are **camelCase** on the wire — the CLI passes the value through
+/// verbatim from its TypeScript shape — unlike the snake_case used everywhere
+/// else in the protocol.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct ModelUsage {
+    #[serde(rename = "inputTokens", deserialize_with = "lenient")]
+    pub input_tokens: i64,
+    #[serde(rename = "outputTokens", deserialize_with = "lenient")]
+    pub output_tokens: i64,
+    #[serde(rename = "cacheReadInputTokens", deserialize_with = "lenient")]
+    pub cache_read_input_tokens: i64,
+    #[serde(rename = "cacheCreationInputTokens", deserialize_with = "lenient")]
+    pub cache_creation_input_tokens: i64,
+    #[serde(rename = "webSearchRequests", deserialize_with = "lenient")]
+    pub web_search_requests: i64,
+    #[serde(rename = "costUSD", deserialize_with = "lenient")]
+    pub cost_usd: f64,
+    #[serde(rename = "contextWindow", deserialize_with = "lenient")]
+    pub context_window: i64,
+    #[serde(rename = "maxOutputTokens", deserialize_with = "lenient")]
+    pub max_output_tokens: i64,
+    /// The model id without any suffix, e.g. `claude-haiku-4-5`.
+    #[serde(rename = "canonicalModel", deserialize_with = "lenient")]
+    pub canonical_model: String,
+    /// e.g. `firstParty`, `bedrock`, `vertex`.
+    #[serde(deserialize_with = "lenient")]
+    pub provider: String,
+}
+
+/// Values of [`ModelUsage::provider`].
+pub mod provider {
+    pub const FIRST_PARTY: &str = "firstParty";
+    pub const BEDROCK: &str = "bedrock";
+    pub const VERTEX: &str = "vertex";
+    pub const FOUNDRY: &str = "foundry";
+    pub const ANTHROPIC_AWS: &str = "anthropicAws";
+    pub const ANTHROPIC_GOOGLE_CLOUD: &str = "anthropicGoogleCloud";
+    pub const MANTLE: &str = "mantle";
+    pub const GATEWAY: &str = "gateway";
+}
+
+// ─── Result ──────────────────────────────────────────────────────────────────
+
+/// Values of [`Result::subtype`]. These are **not** system message subtypes —
+/// they classify how a run finished, and each pairs with a [`TerminalReason`].
+pub mod result_subtype {
+    pub const SUCCESS: &str = "success";
+    pub const ERROR_DURING_EXECUTION: &str = "error_during_execution";
+    pub const ERROR_MAX_TURNS: &str = "error_max_turns";
+    pub const ERROR_MAX_BUDGET_USD: &str = "error_max_budget_usd";
+    pub const ERROR_MAX_STRUCTURED_OUTPUT_RETRIES: &str = "error_max_structured_output_retries";
+}
+
+/// Why the agent's loop ended.
+///
+/// A named string, not a closed enum: the CLI may add reasons at any time and
+/// an unrecognised one must decode through unchanged rather than being dropped.
+///
+/// This is the field that distinguishes a cancelled turn from a failed one —
+/// `subtype` cannot, because interrupting a streaming turn produces
+/// `error_during_execution`, the same subtype as any execution failure.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+#[serde(transparent)]
+pub struct TerminalReason(pub String);
+
+impl TerminalReason {
+    /// A run that finished on its own.
+    pub const COMPLETED: &'static str = "completed";
+    /// The turn limit from `with_max_turns` being reached.
+    pub const MAX_TURNS: &'static str = "max_turns";
+    /// The turn was cancelled while streaming a response.
+    pub const ABORTED_STREAMING: &'static str = "aborted_streaming";
+    /// The turn was cancelled while running tools.
+    pub const ABORTED_TOOLS: &'static str = "aborted_tools";
+    /// An upstream API failure; see [`Result::api_error_status`].
+    pub const API_ERROR: &'static str = "api_error";
+    /// The cost limit was hit.
+    pub const BUDGET_EXHAUSTED: &'static str = "budget_exhausted";
+    /// Structured output failed schema validation too many times.
+    pub const STRUCTURED_OUTPUT_RETRY_EXHAUSTED: &'static str = "structured_output_retry_exhausted";
+    /// A deferred tool could not be run.
+    pub const TOOL_DEFERRED_UNAVAILABLE: &'static str = "tool_deferred_unavailable";
+    /// The turn failed before it began.
+    pub const TURN_SETUP_FAILED: &'static str = "turn_setup_failed";
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Whether the run was cancelled rather than finishing or failing on its
+    /// own. This is how a caller tells "the user stopped it" from "the model
+    /// finished".
+    pub fn aborted(&self) -> bool {
+        self.0 == Self::ABORTED_STREAMING || self.0 == Self::ABORTED_TOOLS
+    }
+}
+
+/// A tool call parked by a `PreToolUse` hook that returned permission decision
+/// `defer`. The run stops and reports the call here so the caller can inspect
+/// it and decide whether to resume.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct DeferredToolUse {
+    #[serde(deserialize_with = "lenient")]
+    pub id: String,
+    #[serde(deserialize_with = "lenient")]
+    pub name: String,
+    pub input: Option<Box<RawValue>>,
+}
+
+/// One tool call that was refused during a run, as reported in the final
+/// result message.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct PermissionDenial {
+    /// The tool that was denied (e.g. `Write`).
+    #[serde(deserialize_with = "lenient")]
+    pub tool_name: String,
+    /// Identifies the specific denied call.
+    #[serde(deserialize_with = "lenient")]
+    pub tool_use_id: String,
+    /// The raw input the tool would have been invoked with.
+    pub tool_input: Option<Box<RawValue>>,
+}
+
+/// The final message emitted by the agent.
+///
+/// Covers both the success and error cases; check `is_error` (or `subtype`) to
+/// determine which one you have.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct Result {
+    #[serde(rename = "type", deserialize_with = "lenient")]
+    pub message_type: String,
+    #[serde(deserialize_with = "lenient")]
+    pub subtype: String,
+    #[serde(deserialize_with = "lenient")]
+    pub duration_ms: i64,
+    #[serde(deserialize_with = "lenient")]
+    pub duration_api_ms: i64,
+    #[serde(deserialize_with = "lenient")]
+    pub is_error: bool,
+    #[serde(deserialize_with = "lenient")]
+    pub num_turns: i64,
+    #[serde(deserialize_with = "lenient")]
+    pub result: String,
+    #[serde(deserialize_with = "lenient")]
+    pub stop_reason: Option<String>,
+    #[serde(deserialize_with = "lenient")]
+    pub total_cost_usd: f64,
+    #[serde(deserialize_with = "lenient")]
+    pub usage: Usage,
+    #[serde(deserialize_with = "lenient")]
+    pub session_id: String,
+    #[serde(deserialize_with = "lenient")]
+    pub uuid: String,
+
+    /// Why the loop ended. Unlike `subtype`, this distinguishes a cancelled
+    /// turn from a completed one — see [`TerminalReason::aborted`].
+    #[serde(deserialize_with = "lenient")]
+    pub terminal_reason: TerminalReason,
+
+    /// The HTTP status of the failing upstream call (429, 500, 529, …) —
+    /// `None` when the CLI sent none, which is why it is an `Option` rather
+    /// than a zero-means-absent integer.
+    ///
+    /// It can be set on a `success` subtype whose `is_error` is true, so branch
+    /// on this field rather than on `subtype` when classifying a failure for
+    /// retry.
+    #[serde(deserialize_with = "lenient")]
+    pub api_error_status: Option<i64>,
+
+    /// The tool call a `PreToolUse` hook deferred, if any.
+    #[serde(deserialize_with = "lenient")]
+    pub deferred_tool_use: Option<DeferredToolUse>,
+
+    /// Per-model token and cost breakdowns keyed by model id.
+    #[serde(rename = "modelUsage", deserialize_with = "lenient")]
+    pub model_usages: std::collections::BTreeMap<String, ModelUsage>,
+
+    /// Populated when `is_error` is true.
+    #[serde(deserialize_with = "lenient")]
+    pub errors: Vec<String>,
+
+    /// Parsed structured output, when an output format of type `json` or
+    /// `json_schema` was requested.
+    pub structured_output: Option<Box<RawValue>>,
+
+    /// Tool calls that were denied during the run.
+    #[serde(deserialize_with = "lenient")]
+    pub permission_denials: Vec<PermissionDenial>,
+}
+
+// ─── System message ──────────────────────────────────────────────────────────
+
+/// One plugin loaded into the session, as reported on `system`/`init`.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct PluginInfo {
+    #[serde(deserialize_with = "lenient")]
+    pub name: String,
+    #[serde(deserialize_with = "lenient")]
+    pub path: String,
+    /// The marketplace reference, e.g. `lab-workflow@shaharia-lab`.
+    #[serde(deserialize_with = "lenient")]
+    pub source: String,
+    #[serde(deserialize_with = "lenient")]
+    pub version: String,
+}
+
+/// One MCP server as reported on `system`/`init`.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct McpServerInit {
+    #[serde(deserialize_with = "lenient")]
+    pub name: String,
+    /// `connected`, `pending`, `failed`, …
+    #[serde(deserialize_with = "lenient")]
+    pub status: String,
+}
+
+/// All `system` typed messages from the CLI.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct SystemMessage {
+    #[serde(rename = "type", deserialize_with = "lenient")]
+    pub message_type: String,
+    #[serde(deserialize_with = "lenient")]
+    pub subtype: String,
+
+    /// Populated when `subtype` is [`system_subtype::STATUS`].
+    #[serde(deserialize_with = "lenient")]
+    pub status: String,
+
+    /// The reason for a synthetic `system`/`error` event — one this SDK
+    /// generates when the subprocess fails without sending a result.
+    ///
+    /// It is **not** a wire field (hence `skip`): the CLI never sends
+    /// `system`/`error`. Carrying it as a general `message` field invited
+    /// callers to read it on real system messages, which is why it is named
+    /// `error` and skipped rather than decoded.
+    #[serde(skip)]
+    pub error: String,
+
+    // Init subtype fields.
+    #[serde(deserialize_with = "lenient")]
+    pub session_id: String,
+    #[serde(deserialize_with = "lenient")]
+    pub uuid: String,
+    #[serde(deserialize_with = "lenient")]
+    pub cwd: String,
+    #[serde(deserialize_with = "lenient")]
+    pub model: String,
+    #[serde(deserialize_with = "lenient")]
+    pub tools: Vec<String>,
+    #[serde(rename = "permissionMode", deserialize_with = "lenient")]
+    pub permission_mode: String,
+    #[serde(deserialize_with = "lenient")]
+    pub claude_code_version: String,
+    #[serde(rename = "apiKeySource", deserialize_with = "lenient")]
+    pub api_key_source: String,
+
+    #[serde(deserialize_with = "lenient")]
+    pub agents: Vec<String>,
+    #[serde(deserialize_with = "lenient")]
+    pub betas: Vec<String>,
+    #[serde(deserialize_with = "lenient")]
+    pub skills: Vec<String>,
+    #[serde(deserialize_with = "lenient")]
+    pub plugins: Vec<PluginInfo>,
+    #[serde(deserialize_with = "lenient")]
+    pub slash_commands: Vec<String>,
+
+    /// The CLI's feature list, e.g. `interrupt_receipt_v1`.
+    ///
+    /// This arrives **here** rather than in the initialize control response, so
+    /// it is unknown until the first turn starts.
+    #[serde(deserialize_with = "lenient")]
+    pub capabilities: Vec<String>,
+
+    /// Each configured MCP server and whether it connected.
+    #[serde(deserialize_with = "lenient")]
+    pub mcp_servers: Vec<McpServerInit>,
+
+    /// The active output style, e.g. `default`.
+    #[serde(deserialize_with = "lenient")]
+    pub output_style: String,
+
+    /// `on` or `off`; `fast_mode_disabled_reason` says why when the CLI turned
+    /// it off.
+    #[serde(deserialize_with = "lenient")]
+    pub fast_mode_state: String,
+    #[serde(deserialize_with = "lenient")]
+    pub fast_mode_disabled_reason: String,
+}
+
+// ─── Tool progress ───────────────────────────────────────────────────────────
+
+/// Reports that a tool is still running.
+///
+/// The field set is taken from the CLI's own emit code rather than from a
+/// specification: it has three shapes (a Bash/PowerShell progress tick, a REPL
+/// call, and a bare heartbeat), which share everything below. The `progress`
+/// and `message` fields older type definitions declared exist nowhere on the
+/// wire.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct ToolProgressMessage {
+    #[serde(rename = "type", deserialize_with = "lenient")]
+    pub message_type: String,
+    #[serde(deserialize_with = "lenient")]
+    pub tool_use_id: String,
+
+    /// The tool still running, e.g. `Bash` or `REPL`.
+    #[serde(deserialize_with = "lenient")]
+    pub tool_name: String,
+
+    /// How long it has been running.
+    #[serde(deserialize_with = "lenient")]
+    pub elapsed_time_seconds: f64,
+
+    /// Marks a keep-alive tick that reports no new progress.
+    #[serde(deserialize_with = "lenient")]
+    pub heartbeat: bool,
+
+    /// Set when the tool runs as a background task.
+    #[serde(deserialize_with = "lenient")]
+    pub task_id: String,
+
+    #[serde(deserialize_with = "lenient")]
+    pub parent_tool_use_id: Option<String>,
+    #[serde(deserialize_with = "lenient")]
+    pub session_id: String,
+    #[serde(deserialize_with = "lenient")]
+    pub uuid: String,
+
+    /// The complete message; REPL ticks carry a `repl_call` object this struct
+    /// does not model.
+    #[serde(skip)]
+    pub raw: Option<Box<RawValue>>,
+}
+
+// ─── Task lifecycle ──────────────────────────────────────────────────────────
+
+/// The state of a background task.
+///
+/// Two vocabularies overlap here: `task_updated` reports the raw lifecycle
+/// state (including `killed`), while `task_notification` reports the
+/// user-facing outcome (where a killed task becomes `stopped`). Use
+/// [`TaskStatus::is_terminal`] rather than comparing against one vocabulary.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+#[serde(transparent)]
+pub struct TaskStatus(pub String);
+
+impl TaskStatus {
+    pub const PENDING: &'static str = "pending";
+    pub const RUNNING: &'static str = "running";
+    pub const PAUSED: &'static str = "paused";
+    pub const COMPLETED: &'static str = "completed";
+    pub const FAILED: &'static str = "failed";
+    /// The notification vocabulary's name for a task the caller stopped;
+    /// `task_updated` calls the same event `killed`.
+    pub const STOPPED: &'static str = "stopped";
+    pub const KILLED: &'static str = "killed";
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Whether the task has finished for good.
+    ///
+    /// A consumer tracking active tasks must clear its entry on a terminal
+    /// status from *either* a `task_updated` or a `task_notification`. A
+    /// stopped task reports `killed` via `task_updated`, and the matching
+    /// notification is not guaranteed — so waiting only for the notification
+    /// can leak the task forever.
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self.0.as_str(),
+            Self::COMPLETED | Self::FAILED | Self::STOPPED | Self::KILLED
+        )
+    }
+}
+
+/// What a task has consumed so far.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct TaskUsage {
+    #[serde(deserialize_with = "lenient")]
+    pub total_tokens: i64,
+    #[serde(deserialize_with = "lenient")]
+    pub tool_uses: i64,
+    #[serde(deserialize_with = "lenient")]
+    pub duration_ms: i64,
+}
+
+/// Announces a background task, as `system`/`task_started`.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct TaskStartedMessage {
+    #[serde(deserialize_with = "lenient")]
+    pub subtype: String,
+    #[serde(deserialize_with = "lenient")]
+    pub task_id: String,
+    #[serde(deserialize_with = "lenient")]
+    pub tool_use_id: String,
+    /// The human-readable label, e.g. `Sleep 20 seconds then echo`.
+    #[serde(deserialize_with = "lenient")]
+    pub description: String,
+    /// The kind of task, e.g. `local_bash`.
+    #[serde(deserialize_with = "lenient")]
+    pub task_type: String,
+    #[serde(deserialize_with = "lenient")]
+    pub subagent_type: String,
+    #[serde(deserialize_with = "lenient")]
+    pub workflow_name: String,
+
+    #[serde(deserialize_with = "lenient")]
+    pub session_id: String,
+    #[serde(deserialize_with = "lenient")]
+    pub uuid: String,
+    #[serde(skip)]
+    pub raw: Option<Box<RawValue>>,
+}
+
+/// Reports a running task's progress, as `system`/`task_progress`.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct TaskProgressMessage {
+    #[serde(deserialize_with = "lenient")]
+    pub subtype: String,
+    #[serde(deserialize_with = "lenient")]
+    pub task_id: String,
+    #[serde(deserialize_with = "lenient")]
+    pub tool_use_id: String,
+    #[serde(deserialize_with = "lenient")]
+    pub description: String,
+    #[serde(deserialize_with = "lenient")]
+    pub subagent_type: String,
+
+    #[serde(deserialize_with = "lenient")]
+    pub usage: TaskUsage,
+    /// The most recent tool the task ran.
+    #[serde(deserialize_with = "lenient")]
+    pub last_tool_name: String,
+    #[serde(deserialize_with = "lenient")]
+    pub summary: String,
+
+    #[serde(deserialize_with = "lenient")]
+    pub session_id: String,
+    #[serde(deserialize_with = "lenient")]
+    pub uuid: String,
+    #[serde(skip)]
+    pub raw: Option<Box<RawValue>>,
+}
+
+/// Reports a task's outcome, as `system`/`task_notification`.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct TaskNotificationMessage {
+    #[serde(deserialize_with = "lenient")]
+    pub subtype: String,
+    #[serde(deserialize_with = "lenient")]
+    pub task_id: String,
+    #[serde(deserialize_with = "lenient")]
+    pub tool_use_id: String,
+    #[serde(deserialize_with = "lenient")]
+    pub status: TaskStatus,
+
+    /// Where the task's full output was written.
+    #[serde(deserialize_with = "lenient")]
+    pub output_file: String,
+    #[serde(deserialize_with = "lenient")]
+    pub summary: String,
+    #[serde(deserialize_with = "lenient")]
+    pub usage: TaskUsage,
+
+    #[serde(deserialize_with = "lenient")]
+    pub session_id: String,
+    #[serde(deserialize_with = "lenient")]
+    pub uuid: String,
+    #[serde(skip)]
+    pub raw: Option<Box<RawValue>>,
+}
+
+/// Carries a change to a task's state, as `system`/`task_updated`.
+///
+/// This is the message a consumer cannot skip: a task stopped via `stop_task`
+/// reports `killed` here, and the corresponding notification is not guaranteed
+/// to follow.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct TaskUpdatedMessage {
+    #[serde(deserialize_with = "lenient")]
+    pub subtype: String,
+    #[serde(deserialize_with = "lenient")]
+    pub task_id: String,
+
+    /// The raw change, e.g. `{"status":"completed","end_time":…}`. Kept whole
+    /// because the CLI puts arbitrary task fields in it.
+    pub patch: Option<Box<RawValue>>,
+
+    /// The task's new state.
+    ///
+    /// CLI 2.1.224 sends it inside `patch` rather than at the top level, so
+    /// [`parse_line`] lifts it out; the field stays so that a top-level status,
+    /// which the official SDKs' types declare, still decodes and wins over the
+    /// patch.
+    #[serde(deserialize_with = "lenient")]
+    pub status: TaskStatus,
+
+    #[serde(deserialize_with = "lenient")]
+    pub session_id: String,
+    #[serde(deserialize_with = "lenient")]
+    pub uuid: String,
+    #[serde(skip)]
+    pub raw: Option<Box<RawValue>>,
+}
+
+/// Reports a hook starting, progressing, or responding.
+///
+/// The CLI only emits these when hook events are enabled, so a session that
+/// configures hooks does not necessarily observe them.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct HookLifecycleMessage {
+    #[serde(deserialize_with = "lenient")]
+    pub subtype: String,
+    /// The hook that fired, e.g. `PreToolUse`.
+    #[serde(deserialize_with = "lenient")]
+    pub hook_event: String,
+
+    #[serde(deserialize_with = "lenient")]
+    pub session_id: String,
+    #[serde(deserialize_with = "lenient")]
+    pub uuid: String,
+    #[serde(skip)]
+    pub raw: Option<Box<RawValue>>,
+}
+
+// ─── Rate limit ──────────────────────────────────────────────────────────────
+
+/// Values of [`RateLimitInfo::status`].
+pub mod rate_limit_status {
+    pub const ALLOWED: &str = "allowed";
+    pub const ALLOWED_WARNING: &str = "allowed_warning";
+    pub const REJECTED: &str = "rejected";
+}
+
+/// Values of [`RateLimitInfo::rate_limit_type`].
+pub mod rate_limit_type {
+    pub const FIVE_HOUR: &str = "five_hour";
+    pub const SEVEN_DAY: &str = "seven_day";
+    pub const SEVEN_DAY_OPUS: &str = "seven_day_opus";
+    pub const SEVEN_DAY_SONNET: &str = "seven_day_sonnet";
+    pub const OVERAGE: &str = "overage";
+}
+
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+#[serde(default)]
+struct RateLimitInfoFields {
+    #[serde(deserialize_with = "lenient")]
+    status: String,
+    #[serde(rename = "resetsAt", deserialize_with = "lenient")]
+    resets_at: i64,
+    #[serde(rename = "rateLimitType", deserialize_with = "lenient")]
+    rate_limit_type: String,
+    #[serde(deserialize_with = "lenient")]
+    utilization: f64,
+    #[serde(rename = "overageStatus", deserialize_with = "lenient")]
+    overage_status: String,
+    #[serde(rename = "overageResetsAt", deserialize_with = "lenient")]
+    overage_resets_at: i64,
+    #[serde(rename = "overageDisabledReason", deserialize_with = "lenient")]
+    overage_disabled_reason: String,
+    #[serde(rename = "isUsingOverage", deserialize_with = "lenient")]
+    is_using_overage: bool,
+    #[serde(rename = "errorCode", deserialize_with = "lenient")]
+    error_code: String,
+}
+
+/// The rate-limit state carried by a `rate_limit_event`.
+///
+/// Its field names are camelCase on the wire — like `modelUsage`, and unlike
+/// the snake_case used by the surrounding message.
+#[derive(Debug, Clone, Default)]
+pub struct RateLimitInfo {
+    pub status: String,
+    /// A Unix timestamp in seconds.
+    pub resets_at: i64,
+    pub rate_limit_type: String,
+    /// The fraction of the window consumed, when sent.
+    pub utilization: f64,
+
+    /// Billing beyond the included allowance.
+    pub overage_status: String,
+    pub overage_resets_at: i64,
+    pub overage_disabled_reason: String,
+    pub is_using_overage: bool,
+
+    pub error_code: String,
+
+    /// The whole info object, including fields not modelled here.
+    pub raw: Option<Box<RawValue>>,
+}
+
+impl<'de> Deserialize<'de> for RateLimitInfo {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        deserializer: D,
+    ) -> std::result::Result<Self, D::Error> {
+        let raw = Box::<RawValue>::deserialize(deserializer)?;
+        let f: RateLimitInfoFields = serde_json::from_str(raw.get()).unwrap_or_default();
+        Ok(RateLimitInfo {
+            status: f.status,
+            resets_at: f.resets_at,
+            rate_limit_type: f.rate_limit_type,
+            utilization: f.utilization,
+            overage_status: f.overage_status,
+            overage_resets_at: f.overage_resets_at,
+            overage_disabled_reason: f.overage_disabled_reason,
+            is_using_overage: f.is_using_overage,
+            error_code: f.error_code,
+            raw: Some(raw),
+        })
+    }
+}
+
+impl RateLimitInfo {
+    /// Whether requests are currently being refused.
+    pub fn limited(&self) -> bool {
+        self.status == rate_limit_status::REJECTED
+    }
+}
+
+/// Reports a change in rate-limit state. The CLI sends one at the start of a
+/// turn and whenever the state changes.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct RateLimitEvent {
+    #[serde(rename = "type", deserialize_with = "lenient")]
+    pub message_type: String,
+    pub rate_limit_info: RateLimitInfo,
+    #[serde(deserialize_with = "lenient")]
+    pub session_id: String,
+    #[serde(deserialize_with = "lenient")]
+    pub uuid: String,
+}
+
+// ─── Top-level event ─────────────────────────────────────────────────────────
+
+/// The top-level value yielded from a stream.
+///
+/// `event_type` is always set. The corresponding typed field is populated for
+/// known types. System messages additionally populate one of the lifecycle
+/// fields according to their subtype, with `system` always set alongside them.
+///
+/// For unknown types only `raw` is set, so callers can handle
+/// forward-compatibility themselves.
+#[derive(Debug, Clone, Default)]
+pub struct Event {
+    pub event_type: String,
+    pub assistant: Option<AssistantMessage>,
+    pub user: Option<UserMessage>,
+    pub stream_event: Option<StreamEventMessage>,
+    pub result: Option<Result>,
+    pub system: Option<SystemMessage>,
+    pub tool_progress: Option<ToolProgressMessage>,
+    pub rate_limit: Option<RateLimitEvent>,
+
+    /// Task lifecycle, populated from the matching system subtype.
+    pub task_started: Option<TaskStartedMessage>,
+    pub task_progress: Option<TaskProgressMessage>,
+    pub task_notification: Option<TaskNotificationMessage>,
+    pub task_updated: Option<TaskUpdatedMessage>,
+
+    /// Populated from the `hook_started` / `hook_progress` / `hook_response`
+    /// subtypes.
+    pub hook_lifecycle: Option<HookLifecycleMessage>,
+
+    /// The verbatim line. Always populated off the wire, and always
+    /// authoritative — Agento's chat SSE forwards exactly these bytes.
+    pub raw: Option<Box<RawValue>>,
+
+    /// Why a typed field decoded only partially, if it did.
+    ///
+    /// Typed fields are best-effort: on a mismatch the fields that did decode
+    /// are kept and this is set, rather than the whole message being discarded.
+    pub decode_err: Option<String>,
+}
+
+/// Decodes one JSON line from stdout into an [`Event`].
+///
+/// Unknown types are returned with only `event_type` and `raw` set. Returns
+/// `None` when the line is not JSON at all, which the reader skips.
+pub(crate) fn parse_line(line: &[u8]) -> Option<Event> {
+    #[derive(Deserialize)]
+    struct Envelope {
+        #[serde(default, rename = "type")]
+        event_type: String,
+    }
+
+    let envelope: Envelope = serde_json::from_slice(line).ok()?;
+    let raw = std::str::from_utf8(line)
+        .ok()
+        .and_then(|s| RawValue::from_string(s.to_owned()).ok());
+
+    let mut event = Event {
+        event_type: envelope.event_type,
+        raw,
+        ..Default::default()
+    };
+
+    // Decoding is best-effort by design: a single unexpected field degrades
+    // that field rather than nulling the whole message. `decode_err` records
+    // what went wrong so drift stays observable instead of silent; `raw` is
+    // always authoritative.
+    match event.event_type.as_str() {
+        message_type::ASSISTANT => {
+            let (m, err) = decode::<AssistantMessage>(line);
+            event.decode_err = err;
+            event.assistant = Some(m);
+        }
+        message_type::USER => {
+            // The user side is half of every conversation: the CLI reports each
+            // tool's output as a user turn of tool_result blocks.
+            let (m, err) = decode::<UserMessage>(line);
+            event.decode_err = err;
+            event.user = Some(m);
+        }
+        message_type::STREAM_EVENT => {
+            let (m, err) = decode::<StreamEventMessage>(line);
+            event.decode_err = err;
+            event.stream_event = Some(m);
+        }
+        message_type::RESULT => {
+            let (m, err) = decode::<Result>(line);
+            event.decode_err = err;
+            event.result = Some(m);
+        }
+        message_type::TOOL_PROGRESS => {
+            let (mut m, err) = decode::<ToolProgressMessage>(line);
+            m.raw = event.raw.as_deref().and_then(clone_raw);
+            event.decode_err = err;
+            event.tool_progress = Some(m);
+        }
+        message_type::RATE_LIMIT_EVENT => {
+            let (m, err) = decode::<RateLimitEvent>(line);
+            event.decode_err = err;
+            event.rate_limit = Some(m);
+        }
+        message_type::SYSTEM => {
+            let (m, err) = decode::<SystemMessage>(line);
+            event.decode_err = err;
+            let subtype = m.subtype.clone();
+            event.system = Some(m);
+
+            // Task and hook lifecycle messages arrive as system subtypes, never
+            // as top-level types — dispatch on the subtype so they can be
+            // populated, each into its own payload type.
+            match subtype.as_str() {
+                system_subtype::TASK_STARTED => {
+                    let (mut t, err) = decode::<TaskStartedMessage>(line);
+                    t.raw = event.raw.as_deref().and_then(clone_raw);
+                    event.decode_err = event.decode_err.take().or(err);
+                    event.task_started = Some(t);
+                }
+                system_subtype::TASK_PROGRESS => {
+                    let (mut t, err) = decode::<TaskProgressMessage>(line);
+                    t.raw = event.raw.as_deref().and_then(clone_raw);
+                    event.decode_err = event.decode_err.take().or(err);
+                    event.task_progress = Some(t);
+                }
+                system_subtype::TASK_NOTIFICATION => {
+                    let (mut t, err) = decode::<TaskNotificationMessage>(line);
+                    t.raw = event.raw.as_deref().and_then(clone_raw);
+                    event.decode_err = event.decode_err.take().or(err);
+                    event.task_notification = Some(t);
+                }
+                system_subtype::TASK_UPDATED => {
+                    let (mut t, err) = decode::<TaskUpdatedMessage>(line);
+                    t.raw = event.raw.as_deref().and_then(clone_raw);
+                    event.decode_err = event.decode_err.take().or(err);
+
+                    // The new status lives inside the patch, not at the top
+                    // level. Lifting it out here is what lets a caller treat
+                    // task_updated and task_notification the same way — which
+                    // matters because a stopped task may report its terminal
+                    // state only here. A top-level status, if a future CLI
+                    // sends one, is authoritative and kept.
+                    if t.status.is_empty() {
+                        if let Some(patch) = t.patch.as_ref() {
+                            #[derive(Deserialize)]
+                            struct Patch {
+                                #[serde(default)]
+                                status: TaskStatus,
+                            }
+                            match serde_json::from_str::<Patch>(patch.get()) {
+                                Ok(p) => t.status = p.status,
+                                Err(e) => {
+                                    if event.decode_err.is_none() {
+                                        event.decode_err = Some(e.to_string());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    event.task_updated = Some(t);
+                }
+                system_subtype::HOOK_STARTED
+                | system_subtype::HOOK_PROGRESS
+                | system_subtype::HOOK_RESPONSE => {
+                    let (mut h, err) = decode::<HookLifecycleMessage>(line);
+                    h.raw = event.raw.as_deref().and_then(clone_raw);
+                    event.decode_err = event.decode_err.take().or(err);
+                    event.hook_lifecycle = Some(h);
+                }
+                _ => {}
+            }
+        }
+        _ => {}
+    }
+
+    Some(event)
+}
+
+/// `RawValue` is not `Clone`; re-parsing its text is the cheapest faithful copy.
+fn clone_raw(raw: &RawValue) -> Option<Box<RawValue>> {
+    RawValue::from_string(raw.get().to_owned()).ok()
+}
+
+/// Builds the synthetic `system`/`error` event used for process-level failures.
+///
+/// The reason goes in `error`, not in a `message` field: the CLI has no system
+/// `message` field, and carrying one invited callers to read it on real system
+/// messages.
+pub(crate) fn error_event(msg: impl Into<String>) -> Event {
+    Event {
+        event_type: message_type::SYSTEM.to_string(),
+        system: Some(SystemMessage {
+            message_type: message_type::SYSTEM.to_string(),
+            subtype: system_subtype::ERROR.to_string(),
+            error: msg.into(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(line: &str) -> Event {
+        parse_line(line.as_bytes()).expect("a JSON line always parses into an event")
+    }
+
+    #[test]
+    fn a_line_that_is_not_json_is_skipped_entirely() {
+        assert!(parse_line(b"not json").is_none());
+    }
+
+    #[test]
+    fn an_unknown_type_still_reaches_the_caller_with_its_raw() {
+        // Forward-compatibility: a type this SDK has never heard of must not be
+        // dropped, because the caller may know what to do with it.
+        let event = parse(r#"{"type":"tool_use_summary","summary":"did a thing"}"#);
+        assert_eq!(event.event_type, "tool_use_summary");
+        assert!(event.assistant.is_none() && event.result.is_none());
+        assert_eq!(
+            event.raw.as_ref().unwrap().get(),
+            r#"{"type":"tool_use_summary","summary":"did a thing"}"#
+        );
+    }
+
+    #[test]
+    fn the_raw_line_is_kept_byte_for_byte() {
+        // Agento's chat SSE forwards these bytes rather than re-encoding, so
+        // key order and spacing must survive the round trip untouched.
+        let line = r#"{"type":"result","z":1,"a":2,"cost":0.30000000000000004}"#;
+        assert_eq!(parse(line).raw.as_ref().unwrap().get(), line);
+    }
+
+    // ─── Content blocks ──────────────────────────────────────────────────────
+
+    #[test]
+    fn content_decodes_from_both_the_array_and_the_bare_string_form() {
+        let blocks = parse(
+            r#"{"type":"assistant","message":{"role":"assistant","content":[
+                {"type":"text","text":"hi"},{"type":"thinking","thinking":"hmm"}]}}"#,
+        );
+        let assistant = blocks.assistant.unwrap();
+        assert_eq!(assistant.text(), "hi");
+        assert_eq!(assistant.thinking(), "hmm");
+
+        // The shape this SDK itself sends for a user turn, and what stored
+        // transcripts replay.
+        let bare = parse(r#"{"type":"user","message":{"role":"user","content":"just text"}}"#);
+        let user = bare.user.unwrap();
+        assert_eq!(user.message.content.len(), 1);
+        assert_eq!(user.message.content[0].block_type, block::TEXT);
+        assert_eq!(user.text(), "just text");
+    }
+
+    #[test]
+    fn null_content_is_no_content_rather_than_one_empty_block() {
+        // Go unmarshals null into a string as a no-op, so the string branch
+        // would otherwise manufacture a block that was never sent.
+        let event = parse(r#"{"type":"user","message":{"role":"user","content":null}}"#);
+        assert!(event.user.unwrap().message.content.is_empty());
+    }
+
+    #[test]
+    fn an_unknown_block_degrades_to_its_type_and_raw() {
+        let event = parse(
+            r#"{"type":"assistant","message":{"role":"assistant","content":[
+                {"type":"some_future_block","payload":{"deep":[1,2]}}]}}"#,
+        );
+        let blocks = event.assistant.unwrap().message.content;
+        assert_eq!(blocks[0].block_type, "some_future_block");
+        assert_eq!(
+            blocks[0].raw.as_ref().unwrap().get(),
+            r#"{"type":"some_future_block","payload":{"deep":[1,2]}}"#
+        );
+    }
+
+    #[test]
+    fn tool_uses_and_tool_results_pair_across_the_two_turns() {
+        let assistant = parse(
+            r#"{"type":"assistant","message":{"role":"assistant","content":[
+                {"type":"tool_use","id":"tu_1","name":"Bash","input":{"command":"ls"},
+                 "caller":{"type":"direct"}}]}}"#,
+        )
+        .assistant
+        .unwrap();
+        let uses = assistant.tool_uses();
+        assert_eq!(uses.len(), 1);
+        assert_eq!(uses[0].id, "tu_1");
+        assert_eq!(uses[0].name, "Bash");
+        // input and caller are kept raw: their schemas are the tool's own.
+        assert_eq!(uses[0].input.as_ref().unwrap().get(), r#"{"command":"ls"}"#);
+        assert_eq!(
+            uses[0].caller.as_ref().unwrap().get(),
+            r#"{"type":"direct"}"#
+        );
+
+        let user = parse(
+            r#"{"type":"user","message":{"role":"user","content":[
+                {"type":"tool_result","tool_use_id":"tu_1","content":"a b c","is_error":false},
+                {"type":"web_search_tool_result","tool_use_id":"tu_2","content":[]}]}}"#,
+        )
+        .user
+        .unwrap();
+        let results = user.tool_results();
+        assert_eq!(results.len(), 2, "server-side results count too");
+        assert_eq!(results[0].tool_use_id, "tu_1");
+        // A result's content is a string for some tools and an array for
+        // others — both shapes were observed in one session.
+        assert_eq!(results[0].content_text().as_deref(), Some("a b c"));
+        assert!(!results[0].failed());
+        assert_eq!(results[1].content_text(), None);
+    }
+
+    #[test]
+    fn an_absent_is_error_is_not_the_same_as_false() {
+        let blocks = parse(
+            r#"{"type":"user","message":{"role":"user","content":[
+                {"type":"tool_result","tool_use_id":"a"},
+                {"type":"tool_result","tool_use_id":"b","is_error":true}]}}"#,
+        )
+        .user
+        .unwrap()
+        .message
+        .content;
+        assert_eq!(blocks[0].is_error, None, "absent, not false");
+        assert!(!blocks[0].failed());
+        assert!(blocks[1].failed());
+    }
+
+    // ─── Result ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn a_result_decodes_its_mixed_case_usage_and_open_terminal_reason() {
+        let result = parse(
+            r#"{"type":"result","subtype":"success","is_error":false,"num_turns":3,
+                "result":"done","total_cost_usd":1.5,"terminal_reason":"completed",
+                "usage":{"input_tokens":7,"output_tokens":2,
+                         "server_tool_use":{"web_search_requests":1}},
+                "modelUsage":{"claude-opus-5":{"inputTokens":7,"outputTokens":2,
+                              "costUSD":1.5,"canonicalModel":"claude-opus-5"}}}"#,
+        )
+        .result
+        .unwrap();
+
+        assert_eq!(result.num_turns, 3);
+        assert_eq!(result.usage.input_tokens, 7);
+        // server_tool_use is nested under usage, not top-level.
+        assert_eq!(result.usage.server_tool_use.web_search_requests, 1);
+        // modelUsage's contents are camelCase inside a snake_case message.
+        assert_eq!(result.model_usages["claude-opus-5"].cost_usd, 1.5);
+        assert_eq!(
+            result.model_usages["claude-opus-5"].canonical_model,
+            "claude-opus-5"
+        );
+        assert_eq!(result.terminal_reason.as_str(), TerminalReason::COMPLETED);
+    }
+
+    #[test]
+    fn an_unrecognised_terminal_reason_decodes_through_unchanged() {
+        // A closed enum would drop a reason the CLI adds tomorrow, which is
+        // exactly the field a caller needs to classify a failure.
+        let result = parse(r#"{"type":"result","terminal_reason":"abducted_by_aliens"}"#)
+            .result
+            .unwrap();
+        assert_eq!(result.terminal_reason.as_str(), "abducted_by_aliens");
+        assert!(!result.terminal_reason.aborted());
+    }
+
+    #[test]
+    fn aborted_distinguishes_a_cancelled_turn_from_a_failed_one() {
+        // subtype cannot: interrupting a streaming turn produces
+        // error_during_execution, the same subtype as any execution failure.
+        for reason in [
+            TerminalReason::ABORTED_STREAMING,
+            TerminalReason::ABORTED_TOOLS,
+        ] {
+            assert!(TerminalReason(reason.into()).aborted(), "{reason}");
+        }
+        for reason in [TerminalReason::COMPLETED, TerminalReason::MAX_TURNS] {
+            assert!(!TerminalReason(reason.into()).aborted(), "{reason}");
+        }
+    }
+
+    #[test]
+    fn an_api_error_status_is_absent_rather_than_zero_when_unsent() {
+        let with = parse(r#"{"type":"result","api_error_status":429}"#)
+            .result
+            .unwrap();
+        assert_eq!(with.api_error_status, Some(429));
+        let without = parse(r#"{"type":"result","subtype":"success"}"#)
+            .result
+            .unwrap();
+        assert_eq!(without.api_error_status, None);
+    }
+
+    #[test]
+    fn one_bad_field_degrades_only_itself_and_is_reported() {
+        // decode_tolerance_test.go's shape: num_turns mutated into an array.
+        let event = parse(
+            r#"{"type":"result","subtype":"success","num_turns":[1,2],"result":"survived",
+                "total_cost_usd":0.5}"#,
+        );
+        let result = event.result.as_ref().unwrap();
+        assert_eq!(result.num_turns, 0, "the bad field falls back");
+        assert_eq!(result.result, "survived", "the rest of the message is kept");
+        assert_eq!(result.total_cost_usd, 0.5);
+        assert!(
+            event.decode_err.is_some(),
+            "drift must stay observable, not silent"
+        );
+        assert!(event.raw.is_some(), "raw is always authoritative");
+    }
+
+    // ─── System subtypes ─────────────────────────────────────────────────────
+
+    #[test]
+    fn init_carries_the_capabilities_the_handshake_does_not() {
+        let event = parse(
+            r#"{"type":"system","subtype":"init","session_id":"s1","model":"claude-opus-5",
+                "tools":["Bash"],"capabilities":["interrupt_receipt_v1"],
+                "mcp_servers":[{"name":"local-tools","status":"connected"}],
+                "plugins":[{"name":"p","path":"/p","source":"m@o"}]}"#,
+        );
+        let system = event.system.unwrap();
+        assert_eq!(system.subtype, system_subtype::INIT);
+        assert_eq!(system.capabilities, vec!["interrupt_receipt_v1"]);
+        assert_eq!(system.mcp_servers[0].status, "connected");
+        assert_eq!(system.plugins[0].source, "m@o");
+    }
+
+    #[test]
+    fn task_lifecycle_arrives_as_system_subtypes_not_top_level_types() {
+        let event = parse(
+            r#"{"type":"system","subtype":"task_started","task_id":"t1",
+                "description":"Sleep then echo","task_type":"local_bash"}"#,
+        );
+        assert!(event.system.is_some(), "system is always set alongside");
+        let started = event.task_started.unwrap();
+        assert_eq!(started.task_id, "t1");
+        assert_eq!(started.task_type, "local_bash");
+        assert!(started.raw.is_some());
+    }
+
+    #[test]
+    fn a_task_status_is_lifted_out_of_the_patch() {
+        // CLI 2.1.224 sends it inside patch. A consumer that waited for the
+        // matching notification would leak a stopped task forever, because that
+        // notification is not guaranteed to follow.
+        let event = parse(
+            r#"{"type":"system","subtype":"task_updated","task_id":"t1",
+                "patch":{"status":"killed","end_time":"now"}}"#,
+        );
+        let updated = event.task_updated.unwrap();
+        assert_eq!(updated.status.as_str(), TaskStatus::KILLED);
+        assert!(updated.status.is_terminal());
+        assert_eq!(
+            updated.patch.as_ref().unwrap().get(),
+            r#"{"status":"killed","end_time":"now"}"#
+        );
+    }
+
+    #[test]
+    fn a_top_level_task_status_wins_over_the_patch() {
+        // The official SDKs' types declare one; if a future CLI sends it, it is
+        // authoritative.
+        let event = parse(
+            r#"{"type":"system","subtype":"task_updated","task_id":"t1","status":"completed",
+                "patch":{"status":"killed"}}"#,
+        );
+        assert_eq!(
+            event.task_updated.unwrap().status.as_str(),
+            TaskStatus::COMPLETED
+        );
+    }
+
+    #[test]
+    fn both_task_vocabularies_agree_on_what_is_terminal() {
+        // task_updated says "killed"; task_notification calls the same event
+        // "stopped".
+        for terminal in [
+            TaskStatus::COMPLETED,
+            TaskStatus::FAILED,
+            TaskStatus::STOPPED,
+            TaskStatus::KILLED,
+        ] {
+            assert!(TaskStatus(terminal.into()).is_terminal(), "{terminal}");
+        }
+        for live in [TaskStatus::PENDING, TaskStatus::RUNNING, TaskStatus::PAUSED] {
+            assert!(!TaskStatus(live.into()).is_terminal(), "{live}");
+        }
+    }
+
+    #[test]
+    fn hook_lifecycle_subtypes_all_populate_one_payload() {
+        for subtype in ["hook_started", "hook_progress", "hook_response"] {
+            let event = parse(&format!(
+                r#"{{"type":"system","subtype":"{subtype}","hook_event":"PreToolUse"}}"#
+            ));
+            let hook = event.hook_lifecycle.expect(subtype);
+            assert_eq!(hook.hook_event, "PreToolUse");
+        }
+    }
+
+    // ─── Streaming ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn stream_deltas_are_read_through_their_own_accessors() {
+        let text = parse(
+            r#"{"type":"stream_event","event":{"type":"content_block_delta","index":0,
+                "delta":{"type":"text_delta","text":"he"}}}"#,
+        )
+        .stream_event
+        .unwrap();
+        assert_eq!(text.event.text_delta(), Some("he"));
+        assert_eq!(text.event.thinking_delta(), None);
+        assert_eq!(text.event.partial_json(), None);
+
+        let json = parse(
+            r#"{"type":"stream_event","event":{"type":"content_block_delta","index":1,
+                "delta":{"type":"input_json_delta","partial_json":"{\"a\":"}}}"#,
+        )
+        .stream_event
+        .unwrap();
+        // Fragments split at arbitrary points and are only valid JSON once
+        // concatenated across the whole block.
+        assert_eq!(json.event.partial_json(), Some(r#"{"a":"#));
+    }
+
+    #[test]
+    fn a_content_block_start_announces_a_tool_call_before_its_input() {
+        let event = parse(
+            r#"{"type":"stream_event","event":{"type":"content_block_start","index":0,
+                "content_block":{"type":"tool_use","id":"tu_1","name":"Bash"}}}"#,
+        )
+        .stream_event
+        .unwrap();
+        let block = event.event.content_block_start().unwrap();
+        assert_eq!(block.id, "tu_1");
+        assert_eq!(block.name, "Bash");
+    }
+
+    #[test]
+    fn usage_rides_the_message_delta_as_a_sibling_of_delta() {
+        let event = parse(
+            r#"{"type":"stream_event","event":{"type":"message_delta",
+                "delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":12}}}"#,
+        )
+        .stream_event
+        .unwrap();
+        let (stop_reason, usage) = event.event.message_delta().unwrap();
+        assert_eq!(stop_reason, "end_turn");
+        assert_eq!(usage.unwrap().get(), r#"{"output_tokens":12}"#);
+    }
+
+    // ─── Rate limits ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn rate_limit_info_is_camel_case_inside_a_snake_case_message() {
+        let event = parse(
+            r#"{"type":"rate_limit_event","rate_limit_info":{"status":"rejected",
+                "resetsAt":1750000000,"rateLimitType":"five_hour","utilization":0.97}}"#,
+        )
+        .rate_limit
+        .unwrap();
+        let info = &event.rate_limit_info;
+        assert!(info.limited());
+        assert_eq!(info.resets_at, 1_750_000_000);
+        assert_eq!(info.rate_limit_type, rate_limit_type::FIVE_HOUR);
+        assert!(info.raw.is_some());
+    }
+
+    // ─── Synthetic errors ────────────────────────────────────────────────────
+
+    #[test]
+    fn the_synthetic_error_event_is_not_something_the_cli_can_send() {
+        let event = error_event("bad flag");
+        let system = event.system.unwrap();
+        assert_eq!(system.subtype, system_subtype::ERROR);
+        assert_eq!(system.error, "bad flag");
+        // `error` is skipped on the wire, so a real system message can never
+        // arrive carrying one and be mistaken for a process failure.
+        let real = parse(r#"{"type":"system","subtype":"status","error":"not a field"}"#);
+        assert_eq!(real.system.unwrap().error, "");
+    }
+}

--- a/desktop/src-tauri/src/claude/mod.rs
+++ b/desktop/src-tauri/src/claude/mod.rs
@@ -1,0 +1,92 @@
+//! A Rust port of `github.com/shaharia-lab/claude-agent-sdk-go` — the SDK
+//! Agento runs every agent through.
+//!
+//! This is **not an API client**. It spawns the `claude` CLI as a subprocess
+//! and speaks the same stream-json protocol the official TypeScript and Python
+//! SDKs use, so there is no model inference to reimplement and no API key to
+//! hold: the CLI's own sign-in is the credential.
+//!
+//! ```text
+//!   Options ──build_args──> claude --output-format stream-json …
+//!                              │  stdin: initialize, user messages,
+//!                              │         control_requests + responses
+//!                              │  stdout: assistant/user/result/system events
+//!                              │          interleaved with control traffic
+//!   Stream <──events(32)────── reader task
+//!   StreamControl ──control_request/response by request_id──> the same pipes
+//! ```
+//!
+//! ## Where to start
+//!
+//! * [`query`] for one prompt with a live event stream; [`run`] when only the
+//!   final [`Result`] matters.
+//! * [`Session`] for a persistent multi-turn conversation on one subprocess.
+//! * [`Options`] for configuration — note it splits across two channels, CLI
+//!   flags and the initialize message, and [`options`] documents which is
+//!   which.
+//! * [`start_in_process_mcp_server`] to expose local tools to the CLI.
+//!
+//! ## Ported deliberately, not mechanically
+//!
+//! Four places where Rust and Go genuinely differ, each documented at its site:
+//!
+//! * **Decode tolerance** ([`lenient`]) — Go keeps the fields that decoded and
+//!   reports the error; `serde_json` aborts. The port reproduces Go's
+//!   behaviour, because a CLI that reshapes one field must not blank a message.
+//! * **Stream vs control** ([`client`]) — Go's single `*Stream` is split into
+//!   [`Stream`] (owns the events) and [`StreamControl`] (clonable, carries the
+//!   control methods), because reading a channel needs `&mut self`.
+//! * **Callbacks are async** ([`permissions`]) — Go blocks a goroutine inline
+//!   on the reader; blocking a runtime worker instead would be a bug, so the
+//!   handlers return futures and are awaited in the same position.
+//! * **Lifetimes replace contexts** — Go cancels via `context.Context`;
+//!   dropping a [`Stream`] or an [`InProcessMcpServer`] is what stops the
+//!   subprocess or the listener here.
+//!
+//! ## Scope
+//!
+//! This module is the SDK only. Nothing in the desktop app calls it yet:
+//! wiring agent execution and the chat SSE onto it is the next step of the
+//! port, and Agento's integrations — every one of which is an in-process MCP
+//! server — come with it.
+
+pub mod client;
+pub mod errors;
+pub mod hooks;
+pub mod init_types;
+mod lenient;
+pub mod mcp;
+pub mod messages;
+pub mod options;
+pub mod permissions;
+pub mod process;
+pub mod session;
+pub mod sessions;
+
+/// The version reported to the CLI via `CLAUDE_AGENT_SDK_VERSION`, tracking the
+/// Go SDK release this was ported from.
+pub const SDK_VERSION: &str = "0.3.0";
+
+pub use client::{query, run, InterruptReceipt, Stream, StreamControl};
+pub use errors::{Error, Result};
+pub use hooks::{hook_event, HookFunc, HookMatcher, HookOutput};
+pub use init_types::{AccountInfo, AgentInfo, ModelInfo, SlashCommand};
+pub use mcp::{
+    self_as_stdio_mcp_server, serve_stdio_mcp, start_in_process_mcp_server, InProcessMcpServer,
+    McpService,
+};
+pub use messages::{
+    block, message_type, result_subtype, system_subtype, AssistantMessage, ContentBlock,
+    ContentBlocks, Event, ModelUsage, Result as RunResult, SystemMessage, TaskStatus,
+    TerminalReason, ToolProgressMessage, Usage, UserMessage,
+};
+pub use options::{
+    effort, permission_mode, setting_source, thinking, AgentDefinition, McpHttpServer,
+    McpSseServer, McpStdioServer, Options, OutputFormat, SandboxSettings, SdkPluginConfig,
+    SystemPromptPreset, ToolsPreset,
+};
+pub use permissions::{
+    ElicitationHandler, PermissionContext, PermissionHandler, PermissionResult, PermissionUpdate,
+};
+pub use session::Session;
+pub use sessions::{get_session_messages, list_sessions, SessionSummary, SessionTranscript};

--- a/desktop/src-tauri/src/claude/options.rs
+++ b/desktop/src-tauri/src/claude/options.rs
@@ -1,0 +1,1120 @@
+//! Configuration, ported from `claude/options.go`.
+//!
+//! Options split across **two channels**, and picking the wrong one is silent:
+//!
+//! * most become CLI flags, built by [`Options::build_args`];
+//! * the system prompt, agents, hooks, output format and sandbox settings are
+//!   sent in the `initialize` control message over stdin, because that is the
+//!   only channel that works in bidirectional mode.
+//!
+//! MCP servers are the subtle case. They travel as `--mcp-config`, an ordinary
+//! transport config the CLI dials directly, and are deliberately **never**
+//! named in the initialize message's `sdkMcpServers` — see
+//! [`super::process::initialize_msg`].
+//!
+//! Go's functional options become builder methods here. The names are kept
+//! (`WithModel` → [`Options::with_model`]) so the two files read against each
+//! other, and every default in [`Options::default`] matches Go's
+//! `defaultOptions()` exactly — including the two that matter most,
+//! `bypassPermissions` and `allow_dangerously_skip_permissions`.
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use serde::Serialize;
+
+use super::errors::{Error, Result};
+use super::hooks::HookMatcher;
+use super::permissions::{ElicitationHandler, PermissionHandler};
+
+/// Controls Claude's extended thinking behaviour.
+pub mod thinking {
+    /// Lets Claude decide when to think (the default).
+    pub const ADAPTIVE: &str = "adaptive";
+    /// Turns off extended thinking. Also sets `MAX_THINKING_TOKENS=0` in the
+    /// subprocess environment.
+    pub const DISABLED: &str = "disabled";
+    /// Always enables extended thinking.
+    pub const ENABLED: &str = "enabled";
+}
+
+/// Reasoning effort, via `--effort`.
+pub mod effort {
+    pub const LOW: &str = "low";
+    pub const MEDIUM: &str = "medium";
+    pub const HIGH: &str = "high";
+    /// The highest possible reasoning effort.
+    pub const MAX: &str = "max";
+}
+
+/// How Claude handles tool permission requests.
+pub mod permission_mode {
+    pub const DEFAULT: &str = "default";
+    pub const ACCEPT_EDITS: &str = "acceptEdits";
+    pub const BYPASS_PERMISSIONS: &str = "bypassPermissions";
+    /// Planning mode: the agent plans actions but does not execute tools that
+    /// modify state.
+    pub const PLAN: &str = "plan";
+    /// Silently denies any tool call that is not already pre-approved, without
+    /// prompting the user.
+    pub const DONT_ASK: &str = "dontAsk";
+}
+
+/// Which settings file(s) the subprocess should load.
+///
+/// By default the SDK loads **no** settings files (SDK isolation mode).
+/// Explicitly listing sources opts in to loading those files.
+pub mod setting_source {
+    /// `~/.claude/settings.json` (global user settings).
+    pub const USER: &str = "user";
+    /// `.claude/settings.json` (shared, version-controlled).
+    pub const PROJECT: &str = "project";
+    /// `.claude/settings.local.json` (gitignored local overrides).
+    pub const LOCAL: &str = "local";
+}
+
+// ─── MCP server configs ──────────────────────────────────────────────────────
+
+/// An external MCP server launched as a subprocess; the CLI spawns the binary
+/// and talks over its stdin/stdout.
+#[derive(Debug, Clone, Default, Serialize, PartialEq)]
+pub struct McpStdioServer {
+    #[serde(rename = "type")]
+    pub server_type: String,
+    pub command: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub env: BTreeMap<String, String>,
+}
+
+/// An MCP server reachable over HTTP (streamable transport).
+///
+/// This is how an in-process server is exposed to the CLI: bind an HTTP
+/// listener in this process and pass its URL here. See
+/// [`super::mcp::start_in_process_mcp_server`].
+#[derive(Debug, Clone, Default, Serialize, PartialEq)]
+pub struct McpHttpServer {
+    #[serde(rename = "type")]
+    pub server_type: String,
+    pub url: String,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub headers: BTreeMap<String, String>,
+}
+
+/// An MCP server reachable over SSE.
+#[derive(Debug, Clone, Default, Serialize, PartialEq)]
+pub struct McpSseServer {
+    #[serde(rename = "type")]
+    pub server_type: String,
+    pub url: String,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub headers: BTreeMap<String, String>,
+}
+
+/// A Claude Code plugin loaded for a session. Only local plugins (`type:
+/// "local"`) are supported; each directory must contain a
+/// `.claude-plugin/plugin.json` manifest.
+#[derive(Debug, Clone, Default, Serialize, PartialEq)]
+pub struct SdkPluginConfig {
+    #[serde(rename = "type")]
+    pub plugin_type: String,
+    pub path: String,
+}
+
+/// A preset system prompt instead of a plain string.
+///
+/// Takes precedence over a plain system prompt when both are set.
+#[derive(Debug, Clone, Default, Serialize, PartialEq)]
+pub struct SystemPromptPreset {
+    /// Must be `preset`.
+    #[serde(rename = "type")]
+    pub preset_type: String,
+    /// Names the preset, e.g. `claude_code`.
+    pub preset: String,
+    /// Optional extra text appended after the preset system prompt.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub append: String,
+}
+
+/// The base tool set via a named preset instead of an explicit list. Passed to
+/// the subprocess as `--tools`.
+#[derive(Debug, Clone, Default, Serialize, PartialEq)]
+pub struct ToolsPreset {
+    /// Must be `preset`.
+    #[serde(rename = "type")]
+    pub preset_type: String,
+    /// Names the preset, e.g. `claude_code`.
+    pub preset: String,
+}
+
+/// A named sub-agent the CLI can spawn.
+#[derive(Debug, Clone, Default, Serialize, PartialEq)]
+pub struct AgentDefinition {
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub description: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub prompt: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<String>,
+    #[serde(rename = "disallowedTools", skip_serializing_if = "Vec::is_empty")]
+    pub disallowed_tools: Vec<String>,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub model: String,
+    #[serde(rename = "maxTurns", skip_serializing_if = "is_zero_i64")]
+    pub max_turns: i64,
+    #[serde(rename = "mcpServers", skip_serializing_if = "Vec::is_empty")]
+    pub mcp_servers: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub skills: Vec<String>,
+}
+
+/// Structured output configuration.
+#[derive(Debug, Clone, Default, Serialize, PartialEq)]
+pub struct OutputFormat {
+    /// One of `text`, `json`, or `json_schema`.
+    #[serde(rename = "type")]
+    pub format_type: String,
+    /// The JSON schema used when the type is `json_schema`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema: Option<serde_json::Value>,
+}
+
+/// Network access for sandboxed command execution.
+#[derive(Debug, Clone, Default, Serialize, PartialEq)]
+pub struct NetworkSandboxSettings {
+    #[serde(rename = "allowLocalBinding", skip_serializing_if = "is_false")]
+    pub allow_local_binding: bool,
+    #[serde(rename = "allowUnixSockets", skip_serializing_if = "Vec::is_empty")]
+    pub allow_unix_sockets: Vec<String>,
+    #[serde(rename = "allowAllUnixSockets", skip_serializing_if = "is_false")]
+    pub allow_all_unix_sockets: bool,
+    #[serde(rename = "httpProxyPort", skip_serializing_if = "is_zero_i64")]
+    pub http_proxy_port: i64,
+    #[serde(rename = "socksProxyPort", skip_serializing_if = "is_zero_i64")]
+    pub socks_proxy_port: i64,
+}
+
+/// Patterns for which sandbox violations are silently ignored.
+#[derive(Debug, Clone, Default, Serialize, PartialEq)]
+pub struct SandboxIgnoreViolations {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub file: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub network: Vec<String>,
+}
+
+/// Command execution sandboxing.
+///
+/// These control whether shell commands run inside a sandbox; they do not
+/// configure filesystem or network permissions, which are the permission
+/// handler's and permission rules' job.
+#[derive(Debug, Clone, Default, Serialize, PartialEq)]
+pub struct SandboxSettings {
+    #[serde(skip_serializing_if = "is_false")]
+    pub enabled: bool,
+    #[serde(rename = "autoAllowBashIfSandboxed", skip_serializing_if = "is_false")]
+    pub auto_allow_bash_if_sandboxed: bool,
+    #[serde(rename = "excludedCommands", skip_serializing_if = "Vec::is_empty")]
+    pub excluded_commands: Vec<String>,
+    #[serde(rename = "allowUnsandboxedCommands", skip_serializing_if = "is_false")]
+    pub allow_unsandboxed_commands: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub network: Option<NetworkSandboxSettings>,
+    #[serde(rename = "ignoreViolations", skip_serializing_if = "Option::is_none")]
+    pub ignore_violations: Option<SandboxIgnoreViolations>,
+    #[serde(rename = "enableWeakerNestedSandbox", skip_serializing_if = "is_false")]
+    pub enable_weaker_nested_sandbox: bool,
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+fn is_zero_i64(n: &i64) -> bool {
+    *n == 0
+}
+
+// ─── Options ─────────────────────────────────────────────────────────────────
+
+/// The default the CLI is asked for when the caller names no model.
+pub const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
+
+/// The floor the official SDKs use for the initialize handshake.
+const DEFAULT_INIT_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Receives each line the `claude` subprocess writes to stderr.
+///
+/// Shared rather than owned because the reader task and the options outlive
+/// each other in either order, and a shadowed-permission-handler warning is
+/// written from the caller's task before the subprocess exists at all.
+pub type StderrSink = std::sync::Arc<dyn Fn(&str) + Send + Sync>;
+
+/// All configuration for a run. Build with [`Options::default`] plus the
+/// `with_*` methods.
+#[derive(Clone, Default)]
+pub struct Options {
+    /// Selects the Claude model. Defaults to [`DEFAULT_MODEL`].
+    pub model: String,
+
+    /// Overrides the default system prompt. Sent via the initialize message.
+    pub system_prompt: String,
+    /// Appended to the existing system prompt. Sent via the initialize message.
+    pub append_system_prompt: String,
+
+    /// Resumes an existing session by id (`--resume`).
+    pub resume_session_id: String,
+    /// Sets a custom UUID for a brand-new session (`--session-id`).
+    pub custom_session_id: String,
+    /// Resumes the most recent session (`--continue`).
+    pub continue_session: bool,
+    /// Forks the resumed session into a new id (`--fork-session`).
+    pub fork_session: bool,
+
+    /// Restricts which built-in tools may be used.
+    pub allowed_tools: Vec<String>,
+    /// Explicitly blocks specific tools.
+    pub disallowed_tools: Vec<String>,
+
+    /// Extended thinking mode. Defaults to [`thinking::ADAPTIVE`].
+    pub thinking: String,
+    /// Caps the thinking token budget via the `MAX_THINKING_TOKENS` env var.
+    pub max_thinking_tokens: i64,
+    /// Limits agentic turns via `--max-turns`.
+    pub max_turns: i64,
+    /// Reasoning effort via `--effort`.
+    pub effort: String,
+    /// Beta feature flags via `--betas`.
+    pub betas: Vec<String>,
+    /// The model to use when the primary model is unavailable.
+    pub fallback_model: String,
+    /// Maximum cost budget in USD via `--max-budget-usd`.
+    pub max_budget_usd: f64,
+
+    /// Structured output. Sent via the initialize message.
+    pub output_format: Option<OutputFormat>,
+    /// Enables file checkpointing.
+    pub enable_file_checkpointing: bool,
+    /// Enables strict MCP config validation.
+    pub strict_mcp_config: bool,
+
+    /// The working directory for the subprocess.
+    pub cwd: String,
+
+    /// Tool permission handling. Defaults to
+    /// [`permission_mode::BYPASS_PERMISSIONS`].
+    pub permission_mode: String,
+    /// Must be true when using bypass permissions.
+    pub allow_dangerously_skip_permissions: bool,
+    /// The MCP tool name used for permission prompts.
+    pub permission_prompt_tool_name: String,
+    /// Called for each `can_use_tool` control_request.
+    pub permission_handler: Option<PermissionHandler>,
+    /// Called for each `elicitation` control_request.
+    pub elicitation_handler: Option<ElicitationHandler>,
+
+    /// Streams partial assistant messages.
+    pub include_partial_messages: bool,
+
+    /// External MCP servers, keyed by server name. Values are the serialized
+    /// [`McpStdioServer`] / [`McpHttpServer`] / [`McpSseServer`] shapes.
+    ///
+    /// A `BTreeMap` rather than a `HashMap` because Go's `encoding/json` sorts
+    /// map keys when marshalling, and `--mcp-config` carries this map — an
+    /// unordered map would make the argument differ run to run.
+    pub mcp_servers: BTreeMap<String, serde_json::Value>,
+
+    /// Bounds the wait for the CLI to acknowledge the initialize handshake.
+    /// `None` means the default (60s, or `CLAUDE_CODE_STREAM_CLOSE_TIMEOUT`).
+    pub init_timeout: Option<Duration>,
+
+    /// Named sub-agents. Sent via the initialize message.
+    pub agents: BTreeMap<String, AgentDefinition>,
+    /// Lifecycle hooks, keyed by event name. Sent via the initialize message.
+    pub hooks: BTreeMap<String, Vec<HookMatcher>>,
+    /// Local plugins loaded for this session.
+    pub plugins: Vec<SdkPluginConfig>,
+
+    /// A settings file path or an inline JSON string passed via `--settings`.
+    /// Mutually exclusive with `setting_sources`: when both are set this wins
+    /// and `setting_sources` is ignored.
+    pub settings: String,
+    /// Which settings files the subprocess loads. Empty means SDK isolation
+    /// mode — no filesystem settings at all.
+    pub setting_sources: Vec<String>,
+    /// Extra directories added to the allowed set via `--add-dir`.
+    pub additional_directories: Vec<String>,
+
+    /// Arbitrary extra CLI flags passed verbatim, for forward-compatibility.
+    /// Keys are flag names (e.g. `--some-flag`); an empty value means a boolean
+    /// flag with no argument.
+    pub extra_args: BTreeMap<String, String>,
+
+    /// A named preset system prompt; takes precedence over `system_prompt`.
+    pub system_prompt_preset: Option<SystemPromptPreset>,
+    /// The base tool set via a preset; when set, `allowed_tools` is ignored by
+    /// the CLI.
+    pub tools_preset: Option<ToolsPreset>,
+
+    /// Called with each line the subprocess writes to stderr. When absent,
+    /// stderr is captured silently and included in errors on failure.
+    pub stderr: Option<StderrSink>,
+
+    /// Additional environment variables merged into the subprocess env, applied
+    /// last so they win.
+    pub env: BTreeMap<String, String>,
+
+    /// A message id to resume the session from. Retained for
+    /// forward-compatibility; **not wired to any flag**, because `--resume-at`
+    /// does not exist in the current CLI.
+    pub resume_session_at: String,
+
+    /// Whether the CLI returns prompt suggestions. Sent via the initialize
+    /// message.
+    pub prompt_suggestions: bool,
+
+    /// Command execution sandboxing. Sent via the initialize message.
+    pub sandbox: Option<SandboxSettings>,
+
+    /// Path to the `claude` binary. Defaults to the bare name, resolved on
+    /// `PATH`.
+    pub claude_executable: String,
+
+    /// Set internally when the caller opened a persistent session: the
+    /// subprocess stays alive across turns (stdin is not closed after a result)
+    /// and the caller drives the conversation.
+    pub(crate) session_mode: bool,
+}
+
+impl std::fmt::Debug for Options {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The handler fields are closures with no useful Debug; naming their
+        // presence is what a reader actually wants when a session misbehaves.
+        f.debug_struct("Options")
+            .field("model", &self.model)
+            .field("thinking", &self.thinking)
+            .field("permission_mode", &self.permission_mode)
+            .field("allowed_tools", &self.allowed_tools)
+            .field("mcp_servers", &self.mcp_servers.keys().collect::<Vec<_>>())
+            .field("cwd", &self.cwd)
+            .field("claude_executable", &self.claude_executable)
+            .field("session_mode", &self.session_mode)
+            .field("has_permission_handler", &self.permission_handler.is_some())
+            .field(
+                "has_elicitation_handler",
+                &self.elicitation_handler.is_some(),
+            )
+            .field("hook_events", &self.hooks.keys().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+/// Mirrors Go's `defaultOptions()`. The permission defaults are deliberate:
+/// the SDK bypasses prompts unless the caller opts back in.
+pub fn default_options() -> Options {
+    Options {
+        model: DEFAULT_MODEL.to_string(),
+        thinking: thinking::ADAPTIVE.to_string(),
+        permission_mode: permission_mode::BYPASS_PERMISSIONS.to_string(),
+        allow_dangerously_skip_permissions: true,
+        claude_executable: "claude".to_string(),
+        ..Default::default()
+    }
+}
+
+impl Options {
+    /// A fresh set of options carrying the SDK defaults.
+    pub fn new() -> Self {
+        default_options()
+    }
+
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.model = model.into();
+        self
+    }
+
+    pub fn with_system_prompt(mut self, prompt: impl Into<String>) -> Self {
+        self.system_prompt = prompt.into();
+        self
+    }
+
+    pub fn with_append_system_prompt(mut self, prompt: impl Into<String>) -> Self {
+        self.append_system_prompt = prompt.into();
+        self
+    }
+
+    /// Resumes an existing session by its id (`--resume`).
+    pub fn with_session_id_to_resume(mut self, id: impl Into<String>) -> Self {
+        self.resume_session_id = id.into();
+        self
+    }
+
+    /// Sets a custom UUID for a brand-new session (`--session-id`).
+    pub fn with_session_id(mut self, id: impl Into<String>) -> Self {
+        self.custom_session_id = id.into();
+        self
+    }
+
+    pub fn with_continue(mut self) -> Self {
+        self.continue_session = true;
+        self
+    }
+
+    pub fn with_fork_session(mut self) -> Self {
+        self.fork_session = true;
+        self
+    }
+
+    pub fn with_allowed_tools<I, S>(mut self, tools: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.allowed_tools = tools.into_iter().map(Into::into).collect();
+        self
+    }
+
+    pub fn with_disallowed_tools<I, S>(mut self, tools: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.disallowed_tools = tools.into_iter().map(Into::into).collect();
+        self
+    }
+
+    pub fn with_thinking(mut self, mode: impl Into<String>) -> Self {
+        self.thinking = mode.into();
+        self
+    }
+
+    pub fn with_max_thinking_tokens(mut self, n: i64) -> Self {
+        self.max_thinking_tokens = n;
+        self
+    }
+
+    pub fn with_max_turns(mut self, n: i64) -> Self {
+        self.max_turns = n;
+        self
+    }
+
+    pub fn with_effort(mut self, level: impl Into<String>) -> Self {
+        self.effort = level.into();
+        self
+    }
+
+    /// Appends, matching Go's `WithBetas`.
+    pub fn with_betas<I, S>(mut self, betas: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.betas.extend(betas.into_iter().map(Into::into));
+        self
+    }
+
+    pub fn with_fallback_model(mut self, model: impl Into<String>) -> Self {
+        self.fallback_model = model.into();
+        self
+    }
+
+    pub fn with_max_budget_usd(mut self, usd: f64) -> Self {
+        self.max_budget_usd = usd;
+        self
+    }
+
+    pub fn with_output_format(mut self, format: OutputFormat) -> Self {
+        self.output_format = Some(format);
+        self
+    }
+
+    pub fn with_enable_file_checkpointing(mut self) -> Self {
+        self.enable_file_checkpointing = true;
+        self
+    }
+
+    pub fn with_strict_mcp_config(mut self) -> Self {
+        self.strict_mcp_config = true;
+        self
+    }
+
+    pub fn with_cwd(mut self, dir: impl Into<String>) -> Self {
+        self.cwd = dir.into();
+        self
+    }
+
+    pub fn with_permission_mode(mut self, mode: impl Into<String>) -> Self {
+        self.permission_mode = mode.into();
+        self
+    }
+
+    /// Enables bypass permissions (the SDK default).
+    pub fn with_bypass_permissions(mut self) -> Self {
+        self.permission_mode = permission_mode::BYPASS_PERMISSIONS.to_string();
+        self.allow_dangerously_skip_permissions = true;
+        self
+    }
+
+    /// Restores normal (non-bypass) permission mode, overriding the SDK
+    /// defaults. Use together with [`Options::with_permission_handler`] so the
+    /// subprocess sends `can_use_tool` requests the handler can intercept.
+    pub fn with_default_permissions(mut self) -> Self {
+        self.permission_mode = permission_mode::DEFAULT.to_string();
+        self.allow_dangerously_skip_permissions = false;
+        self
+    }
+
+    pub fn with_permission_prompt_tool_name(mut self, name: impl Into<String>) -> Self {
+        self.permission_prompt_tool_name = name.into();
+        self
+    }
+
+    pub fn with_permission_handler(mut self, handler: PermissionHandler) -> Self {
+        self.permission_handler = Some(handler);
+        self
+    }
+
+    pub fn with_elicitation_handler(mut self, handler: ElicitationHandler) -> Self {
+        self.elicitation_handler = Some(handler);
+        self
+    }
+
+    pub fn with_include_partial_messages(mut self) -> Self {
+        self.include_partial_messages = true;
+        self
+    }
+
+    /// Sets how long to wait for the CLI to acknowledge the initialize
+    /// handshake. Zero or negative restores the default.
+    ///
+    /// MCP servers declared in the options are started during the handshake, so
+    /// a session with slow servers legitimately needs longer than a bare one.
+    pub fn with_init_timeout(mut self, d: Duration) -> Self {
+        self.init_timeout = if d.is_zero() { None } else { Some(d) };
+        self
+    }
+
+    /// Replaces the MCP server map. Values are the serialized server configs.
+    pub fn with_mcp_servers(mut self, servers: BTreeMap<String, serde_json::Value>) -> Self {
+        self.mcp_servers = servers;
+        self
+    }
+
+    /// Adds one MCP server under `name`.
+    pub fn with_mcp_server(
+        mut self,
+        name: impl Into<String>,
+        config: impl Serialize,
+    ) -> Result<Self> {
+        let value = serde_json::to_value(config)
+            .map_err(|e| Error::wrap("encoding the MCP server config", e))?;
+        self.mcp_servers.insert(name.into(), value);
+        Ok(self)
+    }
+
+    pub fn with_agents(mut self, agents: BTreeMap<String, AgentDefinition>) -> Self {
+        self.agents = agents;
+        self
+    }
+
+    pub fn with_hooks(mut self, hooks: BTreeMap<String, Vec<HookMatcher>>) -> Self {
+        self.hooks = hooks;
+        self
+    }
+
+    /// Appends, matching Go's `WithPlugins`.
+    pub fn with_plugins<I>(mut self, plugins: I) -> Self
+    where
+        I: IntoIterator<Item = SdkPluginConfig>,
+    {
+        self.plugins.extend(plugins);
+        self
+    }
+
+    /// Passes a settings file path or an inline JSON string via `--settings`.
+    /// When set, `setting_sources` is ignored.
+    pub fn with_settings(mut self, s: impl Into<String>) -> Self {
+        self.settings = s.into();
+        self
+    }
+
+    /// Appends, matching Go's `WithSettingSources`.
+    pub fn with_setting_sources<I, S>(mut self, sources: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.setting_sources
+            .extend(sources.into_iter().map(Into::into));
+        self
+    }
+
+    /// Appends, matching Go's `WithAdditionalDirectories`.
+    pub fn with_additional_directories<I, S>(mut self, dirs: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.additional_directories
+            .extend(dirs.into_iter().map(Into::into));
+        self
+    }
+
+    /// Merges, matching Go's `WithExtraArgs`; later keys overwrite.
+    pub fn with_extra_args<I, K, V>(mut self, args: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        for (k, v) in args {
+            self.extra_args.insert(k.into(), v.into());
+        }
+        self
+    }
+
+    pub fn with_system_prompt_preset(mut self, preset: SystemPromptPreset) -> Self {
+        self.system_prompt_preset = Some(preset);
+        self
+    }
+
+    pub fn with_tools_preset(mut self, preset: ToolsPreset) -> Self {
+        self.tools_preset = Some(preset);
+        self
+    }
+
+    pub fn with_stderr(mut self, f: impl Fn(&str) + Send + Sync + 'static) -> Self {
+        self.stderr = Some(std::sync::Arc::new(f));
+        self
+    }
+
+    /// Merges, matching Go's `WithEnv`.
+    pub fn with_env<I, K, V>(mut self, env: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        for (k, v) in env {
+            self.env.insert(k.into(), v.into());
+        }
+        self
+    }
+
+    pub fn with_sandbox(mut self, sandbox: SandboxSettings) -> Self {
+        self.sandbox = Some(sandbox);
+        self
+    }
+
+    pub fn with_claude_executable(mut self, path: impl Into<String>) -> Self {
+        self.claude_executable = path.into();
+        self
+    }
+
+    pub fn with_resume_session_at(mut self, message_id: impl Into<String>) -> Self {
+        self.resume_session_at = message_id.into();
+        self
+    }
+
+    pub fn with_prompt_suggestions(mut self, enabled: bool) -> Self {
+        self.prompt_suggestions = enabled;
+        self
+    }
+
+    /// Builds the argument list for the `claude` binary.
+    ///
+    /// Bidirectional mode: `--input-format stream-json` +
+    /// `--output-format stream-json` + `--verbose`, and **no `--print`** —
+    /// exactly what the official SDKs use. The prompt and system prompt are not
+    /// passed as arguments; they go over stdin.
+    pub fn build_args(&self) -> Vec<String> {
+        let mut args: Vec<String> = vec![
+            "--output-format".into(),
+            "stream-json".into(),
+            "--input-format".into(),
+            "stream-json".into(),
+            "--verbose".into(),
+        ];
+
+        // A macro rather than a closure: a closure capturing `args` mutably
+        // would conflict with the bare `args.push` calls for valueless flags.
+        macro_rules! push {
+            ($flag:expr, $value:expr) => {{
+                args.push($flag.to_string());
+                args.push($value);
+            }};
+        }
+
+        if !self.model.is_empty() {
+            push!("--model", self.model.clone());
+        }
+
+        // Every known mode is forwarded; an unrecognised one is dropped rather
+        // than passed through, matching Go's switch over the three constants.
+        match self.thinking.as_str() {
+            thinking::ADAPTIVE | thinking::DISABLED | thinking::ENABLED => {
+                push!("--thinking", self.thinking.clone());
+            }
+            _ => {}
+        }
+
+        if self.max_turns > 0 {
+            push!("--max-turns", self.max_turns.to_string());
+        }
+        if !self.effort.is_empty() {
+            push!("--effort", self.effort.clone());
+        }
+        if !self.resume_session_id.is_empty() {
+            push!("--resume", self.resume_session_id.clone());
+        }
+        if !self.custom_session_id.is_empty() {
+            push!("--session-id", self.custom_session_id.clone());
+        }
+        if self.continue_session {
+            args.push("--continue".into());
+        }
+        if self.fork_session {
+            // The CLI flag is --fork-session, not --fork.
+            args.push("--fork-session".into());
+        }
+        if !self.allowed_tools.is_empty() {
+            push!("--allowedTools", self.allowed_tools.join(","));
+        }
+        if !self.disallowed_tools.is_empty() {
+            push!("--disallowedTools", self.disallowed_tools.join(","));
+        }
+        if !self.permission_mode.is_empty() {
+            push!("--permission-mode", self.permission_mode.clone());
+        }
+        if self.allow_dangerously_skip_permissions {
+            args.push("--allow-dangerously-skip-permissions".into());
+        }
+        if self.include_partial_messages {
+            args.push("--include-partial-messages".into());
+        }
+        if !self.betas.is_empty() {
+            push!("--betas", self.betas.join(","));
+        }
+        if !self.fallback_model.is_empty() {
+            push!("--fallback-model", self.fallback_model.clone());
+        }
+        if self.max_budget_usd > 0.0 {
+            push!("--max-budget-usd", format!("{:.6}", self.max_budget_usd));
+        }
+        if self.enable_file_checkpointing {
+            args.push("--enable-file-checkpointing".into());
+        }
+        if self.strict_mcp_config {
+            args.push("--strict-mcp-config".into());
+        }
+
+        // A registered handler is routed over stdio; an explicit tool name
+        // selects an MCP tool instead. validate() guarantees the two are never
+        // both set.
+        if !self.permission_prompt_tool_name.is_empty() {
+            push!(
+                "--permission-prompt-tool",
+                self.permission_prompt_tool_name.clone()
+            );
+        } else if self.permission_handler.is_some() {
+            push!("--permission-prompt-tool", "stdio".into());
+        }
+
+        for plugin in &self.plugins {
+            if !plugin.path.is_empty() {
+                push!("--plugin-dir", plugin.path.clone());
+            }
+        }
+        for dir in &self.additional_directories {
+            if !dir.is_empty() {
+                push!("--add-dir", dir.clone());
+            }
+        }
+
+        if let Some(preset) = &self.tools_preset {
+            if let Ok(encoded) = serde_json::to_string(preset) {
+                push!("--tools", encoded);
+            }
+        }
+
+        // Settings takes precedence; when it is set --setting-sources is
+        // skipped entirely.
+        if !self.settings.is_empty() {
+            push!("--settings", self.settings.clone());
+        } else if !self.setting_sources.is_empty() {
+            push!("--setting-sources", self.setting_sources.join(","));
+        }
+
+        // MCP servers travel here and only here. They are deliberately not
+        // named in the initialize message's sdkMcpServers, which is reserved
+        // for servers the CLI expects to reach back over `mcp_message`.
+        if !self.mcp_servers.is_empty() {
+            let cfg = serde_json::json!({ "mcpServers": self.mcp_servers });
+            if let Ok(encoded) = serde_json::to_string(&cfg) {
+                push!("--mcp-config", encoded);
+            }
+        }
+
+        // Boolean flags (empty value) are one element; flags with a value are
+        // two.
+        for (flag, value) in &self.extra_args {
+            if flag.is_empty() {
+                continue;
+            }
+            if value.is_empty() {
+                args.push(flag.clone());
+            } else {
+                push!(flag, value.clone());
+            }
+        }
+
+        // Note: sandbox settings go via the initialize message, not a flag, and
+        // resume_session_at is omitted because --resume-at does not exist.
+
+        args
+    }
+
+    /// Reports usage errors that would otherwise surface as confusing CLI
+    /// failures or, worse, as silently missing enforcement.
+    ///
+    /// Runs before the process is spawned, so a misconfigured run fails without
+    /// starting one.
+    pub fn validate(&self) -> Result<()> {
+        if self.permission_handler.is_some() && !self.permission_prompt_tool_name.is_empty() {
+            return Err(Error::Other(
+                "claude: with_permission_handler cannot be used with \
+                 with_permission_prompt_tool_name: a handler is served over \
+                 --permission-prompt-tool stdio, which would override the named tool"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Resolves the initialize handshake timeout: the explicit option first,
+    /// then `CLAUDE_CODE_STREAM_CLOSE_TIMEOUT` (milliseconds, as the official
+    /// SDKs read it), then the 60s default.
+    ///
+    /// Values at or below zero fall through to the default rather than
+    /// disabling the timeout, which would let a wedged CLI hang startup forever.
+    /// The environment variable only ever *raises* the floor.
+    pub(crate) fn init_timeout(&self) -> Duration {
+        if let Some(d) = self.init_timeout {
+            if !d.is_zero() {
+                return d;
+            }
+        }
+        if let Ok(raw) = std::env::var("CLAUDE_CODE_STREAM_CLOSE_TIMEOUT") {
+            if let Ok(ms) = raw.parse::<u64>() {
+                if ms > 0 {
+                    let d = Duration::from_millis(ms);
+                    if d > DEFAULT_INIT_TIMEOUT {
+                        return d;
+                    }
+                }
+            }
+        }
+        DEFAULT_INIT_TIMEOUT
+    }
+
+    /// Warns when a permission handler is registered but cannot be reached,
+    /// because the configuration grants the tools up front.
+    ///
+    /// Without this the handler simply never fires and the caller believes
+    /// their policy is being enforced. The warning goes to the stderr callback
+    /// when one is set, so it lands wherever the caller already routes CLI
+    /// output.
+    pub(crate) fn warn_permission_handler_shadowed(&self) {
+        if self.permission_handler.is_none() {
+            return;
+        }
+
+        let reason = if self.permission_mode == permission_mode::BYPASS_PERMISSIONS {
+            format!("PermissionMode is {}", permission_mode::BYPASS_PERMISSIONS)
+        } else if self.allow_dangerously_skip_permissions {
+            "AllowDangerouslySkipPermissions is set".to_string()
+        } else if !self.allowed_tools.is_empty() {
+            format!(
+                "AllowedTools pre-approves {}",
+                self.allowed_tools.join(", ")
+            )
+        } else {
+            return;
+        };
+
+        let msg = format!(
+            "claude: warning: a PermissionHandler is registered but will not be consulted \
+             for every tool call because {reason}; use with_default_permissions() to have \
+             tool calls routed to the handler"
+        );
+
+        match &self.stderr {
+            Some(f) => f(&msg),
+            None => log::warn!("{msg}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_defaults_match_the_go_sdk() {
+        let o = Options::new();
+        assert_eq!(o.model, "claude-sonnet-4-6");
+        assert_eq!(o.thinking, thinking::ADAPTIVE);
+        assert_eq!(o.permission_mode, permission_mode::BYPASS_PERMISSIONS);
+        assert!(o.allow_dangerously_skip_permissions);
+        assert_eq!(o.claude_executable, "claude");
+    }
+
+    #[test]
+    fn bidirectional_mode_leads_and_carries_no_print_flag() {
+        let args = Options::new().build_args();
+        assert_eq!(
+            &args[..5],
+            &[
+                "--output-format",
+                "stream-json",
+                "--input-format",
+                "stream-json",
+                "--verbose"
+            ]
+        );
+        assert!(!args.iter().any(|a| a == "--print"));
+    }
+
+    #[test]
+    fn a_handler_routes_permissions_over_stdio() {
+        let handler: PermissionHandler = std::sync::Arc::new(|_, _, _| {
+            Box::pin(async { crate::claude::PermissionResult::allow() })
+        });
+        let args = Options::new()
+            .with_default_permissions()
+            .with_permission_handler(handler)
+            .build_args();
+        let i = args
+            .iter()
+            .position(|a| a == "--permission-prompt-tool")
+            .unwrap();
+        assert_eq!(args[i + 1], "stdio");
+    }
+
+    #[test]
+    fn a_named_prompt_tool_wins_over_the_stdio_route() {
+        let args = Options::new()
+            .with_permission_prompt_tool_name("mcp__x__ask")
+            .build_args();
+        let i = args
+            .iter()
+            .position(|a| a == "--permission-prompt-tool")
+            .unwrap();
+        assert_eq!(args[i + 1], "mcp__x__ask");
+    }
+
+    #[test]
+    fn a_handler_and_a_named_prompt_tool_together_are_a_usage_error() {
+        let handler: PermissionHandler = std::sync::Arc::new(|_, _, _| {
+            Box::pin(async { crate::claude::PermissionResult::allow() })
+        });
+        let o = Options::new()
+            .with_permission_handler(handler)
+            .with_permission_prompt_tool_name("mcp__x__ask");
+        assert!(o.validate().is_err());
+    }
+
+    #[test]
+    fn settings_suppresses_setting_sources() {
+        let args = Options::new()
+            .with_settings("/tmp/settings.json")
+            .with_setting_sources([setting_source::PROJECT])
+            .build_args();
+        assert!(args.iter().any(|a| a == "--settings"));
+        assert!(
+            !args.iter().any(|a| a == "--setting-sources"),
+            "settings takes precedence, and the two must not both be sent"
+        );
+    }
+
+    #[test]
+    fn setting_sources_are_comma_joined_when_settings_is_absent() {
+        let args = Options::new()
+            .with_setting_sources([setting_source::USER, setting_source::PROJECT])
+            .build_args();
+        let i = args.iter().position(|a| a == "--setting-sources").unwrap();
+        assert_eq!(args[i + 1], "user,project");
+    }
+
+    #[test]
+    fn mcp_servers_travel_as_one_mcp_config_argument() {
+        let o = Options::new()
+            .with_mcp_server(
+                "local-tools",
+                McpHttpServer {
+                    server_type: "http".into(),
+                    url: "http://127.0.0.1:5050".into(),
+                    headers: BTreeMap::new(),
+                },
+            )
+            .unwrap();
+        let args = o.build_args();
+        let i = args.iter().position(|a| a == "--mcp-config").unwrap();
+        assert_eq!(
+            args[i + 1],
+            r#"{"mcpServers":{"local-tools":{"type":"http","url":"http://127.0.0.1:5050"}}}"#
+        );
+    }
+
+    #[test]
+    fn plugins_and_directories_each_get_their_own_flag() {
+        let args = Options::new()
+            .with_plugins([
+                SdkPluginConfig {
+                    plugin_type: "local".into(),
+                    path: "/a".into(),
+                },
+                SdkPluginConfig {
+                    plugin_type: "local".into(),
+                    path: "/b".into(),
+                },
+            ])
+            .with_additional_directories(["/x", "/y"])
+            .build_args();
+        assert_eq!(args.iter().filter(|a| *a == "--plugin-dir").count(), 2);
+        assert_eq!(args.iter().filter(|a| *a == "--add-dir").count(), 2);
+    }
+
+    #[test]
+    fn a_boolean_extra_arg_is_one_element_and_a_valued_one_is_two() {
+        let args = Options::new()
+            .with_extra_args([("--flagged", ""), ("--valued", "7")])
+            .build_args();
+        let flagged = args.iter().position(|a| a == "--flagged").unwrap();
+        assert_ne!(args.get(flagged + 1).map(String::as_str), Some(""));
+        let valued = args.iter().position(|a| a == "--valued").unwrap();
+        assert_eq!(args[valued + 1], "7");
+    }
+
+    #[test]
+    fn budget_is_formatted_to_six_decimal_places() {
+        let args = Options::new().with_max_budget_usd(1.5).build_args();
+        let i = args.iter().position(|a| a == "--max-budget-usd").unwrap();
+        assert_eq!(args[i + 1], "1.500000");
+    }
+
+    #[test]
+    fn fork_uses_the_flag_the_cli_actually_has() {
+        let args = Options::new().with_fork_session().build_args();
+        assert!(args.iter().any(|a| a == "--fork-session"));
+        assert!(!args.iter().any(|a| a == "--fork"));
+    }
+
+    #[test]
+    fn resume_session_at_is_retained_but_never_sent() {
+        // --resume-at does not exist in the current CLI; sending it would fail
+        // the spawn outright.
+        let args = Options::new().with_resume_session_at("msg_1").build_args();
+        assert!(!args.iter().any(|a| a.contains("resume-at")));
+    }
+}

--- a/desktop/src-tauri/src/claude/permissions.rs
+++ b/desktop/src-tauri/src/claude/permissions.rs
@@ -1,0 +1,224 @@
+//! Permission types and the `can_use_tool` round trip, ported from the
+//! permission half of `claude/options.go`.
+//!
+//! The load-bearing rule here is **fail closed**. An absent handler is answered
+//! with an error control_response, never an allow, and a result whose behaviour
+//! is neither `allow` nor `deny` — including the default — is a usage error
+//! rather than an implicit allow. Answering a permission question nobody was
+//! asked would grant the tool call, which is the exact bug the explicit
+//! [`PermissionBehavior`] enum exists to make unrepresentable.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use serde_json::value::RawValue;
+
+use super::lenient::lenient;
+
+/// The allow/deny/ask outcome for a permission rule.
+pub mod permission_behavior {
+    pub const ALLOW: &str = "allow";
+    pub const DENY: &str = "deny";
+    pub const ASK: &str = "ask";
+}
+
+/// Where a permission update is persisted.
+pub mod permission_destination {
+    /// The global user settings file.
+    pub const USER_SETTINGS: &str = "userSettings";
+    /// The shared project settings file.
+    pub const PROJECT_SETTINGS: &str = "projectSettings";
+    /// The gitignored local settings file.
+    pub const LOCAL_SETTINGS: &str = "localSettings";
+    /// Applies only for the current session.
+    pub const SESSION: &str = "session";
+}
+
+/// A single permission rule identifying a tool and an optional content pattern
+/// (e.g. a glob for the Bash tool's command argument).
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
+#[serde(default)]
+pub struct PermissionRuleValue {
+    /// The tool the rule applies to (e.g. `Bash`, `Read`).
+    #[serde(rename = "toolName")]
+    pub tool_name: String,
+    /// An optional content pattern (e.g. `git commit:*`, `/src/**`). `None`
+    /// matches all invocations of the tool.
+    #[serde(rename = "ruleContent", skip_serializing_if = "Option::is_none")]
+    pub rule_content: Option<String>,
+}
+
+/// A single permission mutation. `update_type` is the discriminant; fill only
+/// the corresponding fields.
+///
+/// * `addRules` / `replaceRules` / `removeRules` → `rules`, `behavior`, `destination`
+/// * `setMode` → `mode`, `destination`
+/// * `addDirectories` / `removeDirectories` → `directories`, `destination`
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
+#[serde(default)]
+pub struct PermissionUpdate {
+    #[serde(rename = "type")]
+    pub update_type: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub rules: Vec<PermissionRuleValue>,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub behavior: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub destination: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub mode: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub directories: Vec<String>,
+}
+
+/// Full context about a tool call the CLI is asking permission for.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct PermissionContext {
+    /// Permission updates suggested by the CLI.
+    #[serde(rename = "permission_suggestions", deserialize_with = "lenient")]
+    pub suggestions: Vec<PermissionUpdate>,
+    /// Populated when a path restriction triggered the request.
+    #[serde(deserialize_with = "lenient")]
+    pub blocked_path: String,
+    /// The CLI's internal reason for asking.
+    #[serde(deserialize_with = "lenient")]
+    pub decision_reason: String,
+    /// The tool use identifier for this specific call.
+    #[serde(deserialize_with = "lenient")]
+    pub tool_use_id: String,
+    /// Set when the request originates from a sub-agent.
+    #[serde(deserialize_with = "lenient")]
+    pub agent_id: String,
+    /// A short heading for the permission prompt, when the CLI supplies one.
+    #[serde(deserialize_with = "lenient")]
+    pub title: String,
+    /// The human-friendly name of the tool being requested.
+    #[serde(deserialize_with = "lenient")]
+    pub display_name: String,
+    /// What the tool call will do.
+    #[serde(deserialize_with = "lenient")]
+    pub description: String,
+}
+
+/// What a [`PermissionHandler`] decided.
+///
+/// Go models the behaviour as a string whose zero value is a usage error; Rust
+/// makes the same distinction by making the enum have no default, so a handler
+/// cannot accidentally return "unset" and have it read as an allow.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PermissionResult {
+    Allow {
+        /// Replaces the tool input before execution. `None` echoes the CLI's
+        /// original input back verbatim — the CLI expects the input it should
+        /// actually run, so this field is always sent.
+        updated_input: Option<serde_json::Value>,
+        /// Persistent permission mutations to apply.
+        updated_permissions: Vec<PermissionUpdate>,
+    },
+    Deny {
+        /// Shown to the user, explaining the denial.
+        message: String,
+        /// Stops the agent entirely after this tool call.
+        interrupt: bool,
+    },
+}
+
+impl PermissionResult {
+    /// The common allow: run the tool exactly as the model asked.
+    pub fn allow() -> Self {
+        PermissionResult::Allow {
+            updated_input: None,
+            updated_permissions: Vec::new(),
+        }
+    }
+
+    /// The common deny, with a reason shown to the user.
+    pub fn deny(message: impl Into<String>) -> Self {
+        PermissionResult::Deny {
+            message: message.into(),
+            interrupt: false,
+        }
+    }
+}
+
+/// The future a [`PermissionHandler`] returns.
+pub type PermissionFuture = Pin<Box<dyn Future<Output = PermissionResult> + Send>>;
+
+/// Called when the CLI sends a `can_use_tool` control_request.
+///
+/// Registering a handler makes the SDK pass `--permission-prompt-tool stdio`,
+/// which is what causes the CLI to route tool calls here; it cannot be combined
+/// with a permission prompt tool name.
+///
+/// When no handler is registered, an incoming `can_use_tool` is answered with an
+/// error rather than being allowed — the SDK never grants a permission no one
+/// approved.
+///
+/// The handler is **async and awaited inline on the reader task**, mirroring Go,
+/// where it runs on the goroutine that owns stdout. A slow handler therefore
+/// stalls the message stream, which is the intended semantics: Agento's chat
+/// blocks the turn while a human answers the prompt. Making it a future rather
+/// than a blocking closure is the only departure, and it exists so a waiting
+/// handler parks the task instead of pinning a runtime worker thread.
+pub type PermissionHandler =
+    Arc<dyn Fn(String, Option<Box<RawValue>>, PermissionContext) -> PermissionFuture + Send + Sync>;
+
+/// The future an [`ElicitationHandler`] returns.
+pub type ElicitationFuture = Pin<Box<dyn Future<Output = Option<serde_json::Value>> + Send>>;
+
+/// Called when the CLI sends an `elicitation` control_request asking the SDK
+/// host for user input. The handler receives the raw JSON payload and returns a
+/// response object (e.g. `{"response": "user input"}`).
+///
+/// When absent — or when the handler returns `None` — elicitations are
+/// auto-cancelled with `{"cancel": true}`.
+pub type ElicitationHandler = Arc<dyn Fn(Option<Box<RawValue>>) -> ElicitationFuture + Send + Sync>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_rule_without_content_omits_it_rather_than_sending_null() {
+        let rule = PermissionRuleValue {
+            tool_name: "Bash".into(),
+            rule_content: None,
+        };
+        assert_eq!(
+            serde_json::to_string(&rule).unwrap(),
+            r#"{"toolName":"Bash"}"#
+        );
+    }
+
+    #[test]
+    fn an_update_omits_its_empty_halves() {
+        // addRules fills rules/behavior/destination; setMode fills mode. The
+        // unused half must not appear, matching Go's omitempty.
+        let update = PermissionUpdate {
+            update_type: "setMode".into(),
+            mode: "plan".into(),
+            destination: "session".into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            serde_json::to_string(&update).unwrap(),
+            r#"{"type":"setMode","destination":"session","mode":"plan"}"#
+        );
+    }
+
+    #[test]
+    fn the_context_decodes_from_the_control_request_field_names() {
+        let ctx: PermissionContext = serde_json::from_str(
+            r#"{"blocked_path":"/etc","decision_reason":"outside cwd","tool_use_id":"tu_1",
+                "permission_suggestions":[{"type":"addDirectories","directories":["/etc"]}]}"#,
+        )
+        .unwrap();
+        assert_eq!(ctx.blocked_path, "/etc");
+        assert_eq!(ctx.tool_use_id, "tu_1");
+        assert_eq!(ctx.suggestions[0].update_type, "addDirectories");
+        assert_eq!(ctx.suggestions[0].directories, vec!["/etc"]);
+    }
+}

--- a/desktop/src-tauri/src/claude/process.rs
+++ b/desktop/src-tauri/src/claude/process.rs
@@ -1,0 +1,1157 @@
+//! Subprocess lifecycle and the control protocol, ported from
+//! `claude/process.go`.
+//!
+//! The SDK does not call the Claude API. It spawns the `claude` CLI in
+//! bidirectional JSON-lines mode (`--input-format stream-json
+//! --output-format stream-json --verbose`, **no `--print`**) and speaks two
+//! interleaved protocols down one pair of pipes:
+//!
+//! * the **message stream** — assistant turns, tool results, deltas, the final
+//!   result — which flows to the caller;
+//! * the **control protocol** — `control_request` / `control_response` pairs
+//!   correlated by `request_id` — which never reaches the caller.
+//!
+//! ## The handshake order is the whole file's reason for existing
+//!
+//! `initialize` must be written *after* the reader task is live, because the
+//! acknowledgement is a `control_response` and nothing can route one until
+//! something is reading stdout and `pending` holds the id. The first user
+//! message must be written *after* the acknowledgement, because MCP servers,
+//! agents and hooks are configured during it. Getting this wrong does not fail
+//! loudly — it races, and the turn starts against a half-configured CLI.
+//!
+//! ## Two failure modes that are silent by construction
+//!
+//! * **Every inbound `control_request` must be answered.** A missing reply
+//!   hangs the CLI with no error on either side, so every branch of
+//!   [`handle_control_request`] writes exactly one response, including the
+//!   default branch for requests we only acknowledge.
+//! * **`sdkMcpServers` is never sent.** The CLI accepts only an array of
+//!   strings there, and rejecting it fails the *entire* initialize — silently
+//!   taking hooks, agents, the system prompt and the output format down with
+//!   it. Naming a server there would also mark it SDK-hosted, so the CLI would
+//!   drop its transport and route tool calls back over `mcp_message`, which
+//!   this SDK does not implement. See [`initialize_msg`].
+
+use std::collections::HashMap;
+use std::process::Stdio;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex as StdMutex, RwLock};
+
+use serde_json::value::RawValue;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::sync::{mpsc, oneshot, Mutex};
+
+use super::client::{Stream, StreamControl};
+use super::errors::{Error, Result};
+use super::hooks::{build_hooks_for_initialize, HookRegistry};
+use super::init_types::decode_initialize_response;
+use super::messages::{error_event, message_type, parse_line, system_subtype, Event};
+use super::options::{thinking, Options};
+use super::permissions::{PermissionContext, PermissionResult};
+use super::SDK_VERSION;
+
+/// Capacity of the event channel, matching Go's `make(chan Event, 32)`.
+const EVENT_CHANNEL_CAPACITY: usize = 32;
+
+/// Ceiling on one stdout line. Go sets the same figure on its `bufio.Scanner`
+/// because assistant messages with long content are large; Rust's reader has no
+/// default limit at all, so the cap is imposed deliberately rather than
+/// inherited. A line beyond it is reported as a read error, exactly as Go's
+/// scanner does.
+const MAX_LINE_BYTES: usize = 4 * 1024 * 1024;
+
+/// How long a terminating process is given before it is killed outright.
+const SIGKILL_GRACE: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// A reply to one of our outbound control requests, once correlated.
+#[derive(Debug, Default)]
+pub(crate) struct ControlResponse {
+    pub success: bool,
+    pub error: String,
+    /// The **innermost** response payload. `None` on replies that carry no
+    /// data, which is still a success.
+    pub body: Option<Box<RawValue>>,
+}
+
+/// Everything the reader task and the control methods share.
+pub(crate) struct Shared {
+    /// Serialises writes to the subprocess stdin. Safe to use from any task.
+    pub stdin: Mutex<Option<tokio::process::ChildStdin>>,
+    /// Maps `request_id` → the caller waiting for its reply.
+    pub pending: StdMutex<HashMap<String, oneshot::Sender<ControlResponse>>>,
+    /// Captured from the `system`/`init` event rather than from the initialize
+    /// response, which does not carry it — so it is unknown until a turn
+    /// starts.
+    pub capabilities: RwLock<Option<Vec<String>>>,
+    /// Triggers graceful shutdown, once.
+    shutdown_tx: StdMutex<Option<oneshot::Sender<()>>>,
+    shutdown_fired: AtomicBool,
+}
+
+impl Shared {
+    /// Serialises `value` as a JSON line and sends it to stdin.
+    pub(crate) async fn write(&self, value: &serde_json::Value) -> Result<()> {
+        let mut line = serde_json::to_vec(value)
+            .map_err(|e| Error::wrap("encoding a message for stdin", e))?;
+        line.push(b'\n');
+
+        let mut guard = self.stdin.lock().await;
+        let Some(stdin) = guard.as_mut() else {
+            return Err(Error::Other("claude: stdin is closed".into()));
+        };
+        stdin
+            .write_all(&line)
+            .await
+            .map_err(|e| Error::wrap("writing to stdin", e))?;
+        stdin
+            .flush()
+            .await
+            .map_err(|e| Error::wrap("flushing stdin", e))
+    }
+
+    /// Closes the subprocess stdin. Used on graceful shutdown, and after the
+    /// result in single-turn mode.
+    pub(crate) async fn close_stdin(&self) {
+        let mut guard = self.stdin.lock().await;
+        // Dropping the handle closes the pipe, which is what tells the CLI no
+        // more input is coming.
+        guard.take();
+    }
+
+    /// Triggers graceful shutdown. Idempotent.
+    ///
+    /// Deliberately **not** reachable from `interrupt`, which aborts the turn
+    /// via a control request and leaves the subprocess running.
+    pub(crate) fn shutdown(&self) {
+        if self.shutdown_fired.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        if let Ok(mut slot) = self.shutdown_tx.lock() {
+            if let Some(tx) = slot.take() {
+                let _ = tx.send(());
+            }
+        }
+    }
+
+    /// Records the capability list seen on a `system`/`init` event.
+    fn set_capabilities(&self, caps: Vec<String>) {
+        if let Ok(mut slot) = self.capabilities.write() {
+            *slot = Some(caps);
+        }
+    }
+}
+
+/// Generates a random UUID v4, lowercase and hyphenated — the format the CLI
+/// sees from every SDK. Used for both request ids and hook callback ids.
+pub(crate) fn new_uuid() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
+// ─── Spawn ───────────────────────────────────────────────────────────────────
+
+/// Starts the `claude` subprocess and completes the initialize handshake.
+///
+/// Returns once the CLI has acknowledged `initialize` — so by the time the
+/// caller holds a [`Stream`], MCP servers, agents and hooks are configured. In
+/// single-turn mode the first user message has also been written.
+pub(crate) async fn spawn_and_stream(opts: Options, prompt: &str) -> Result<Stream> {
+    opts.validate()?;
+    opts.warn_permission_handler_shadowed();
+
+    let args = opts.build_args();
+
+    let mut command = tokio::process::Command::new(&opts.claude_executable);
+    command
+        .args(&args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        // Killing the child when the handle drops is a backstop only; the
+        // shutdown path below is the one that runs in practice, and it is the
+        // one that gives the CLI a chance to exit cleanly.
+        .kill_on_drop(true);
+
+    if !opts.cwd.is_empty() {
+        command.current_dir(&opts.cwd);
+    }
+
+    command.env_clear();
+    command.envs(build_env(&opts));
+
+    let mut child = command.spawn().map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            Error::CliNotFound {
+                executable: opts.claude_executable.clone(),
+            }
+        } else {
+            Error::Other(format!("claude: start {:?}: {e}", opts.claude_executable))
+        }
+    })?;
+
+    let stdin = child.stdin.take().ok_or_else(|| {
+        Error::Other("claude: stdin pipe: the child exposed no stdin".to_string())
+    })?;
+    let stdout = child.stdout.take().ok_or_else(|| {
+        Error::Other("claude: stdout pipe: the child exposed no stdout".to_string())
+    })?;
+    let stderr = child.stderr.take();
+    let pid = child.id();
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let shared = Arc::new(Shared {
+        stdin: Mutex::new(Some(stdin)),
+        pending: StdMutex::new(HashMap::new()),
+        capabilities: RwLock::new(None),
+        shutdown_tx: StdMutex::new(Some(shutdown_tx)),
+        shutdown_fired: AtomicBool::new(false),
+    });
+
+    // Hook config for the initialize message, plus the registry the reader
+    // dispatches `hook_callback` requests through.
+    let (hooks_config, hook_registry) = build_hooks_for_initialize(&opts.hooks);
+
+    // Capture stderr. Each line goes to the callback when one is set, and every
+    // line is buffered for error reporting on an unexpected exit.
+    let stderr_buf = Arc::new(StdMutex::new(String::new()));
+    if let Some(stderr) = stderr {
+        let buf = stderr_buf.clone();
+        let sink = opts.stderr.clone();
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                if let Some(sink) = &sink {
+                    sink(&line);
+                }
+                if let Ok(mut buf) = buf.lock() {
+                    buf.push_str(&line);
+                    buf.push('\n');
+                }
+            }
+        });
+    }
+
+    let (event_tx, event_rx) = mpsc::channel::<Event>(EVENT_CHANNEL_CAPACITY);
+    let (proc_done_tx, proc_done_rx) = oneshot::channel::<()>();
+
+    // Graceful shutdown task, mirroring the TypeScript SDK's close():
+    //   stdin.end() → SIGTERM → SIGKILL after 5s.
+    {
+        let shared = shared.clone();
+        tokio::spawn(async move {
+            tokio::select! {
+                _ = shutdown_rx => {}
+                _ = proc_done_rx => return,
+            }
+            shared.close_stdin().await;
+            terminate(pid);
+            tokio::time::sleep(SIGKILL_GRACE).await;
+            // The process reaper races this; killing a pid that has already
+            // been reaped is a no-op error we deliberately ignore, exactly as
+            // Go ignores the error from cmd.Process.Kill().
+            kill(pid);
+        });
+    }
+
+    // Reader task: owns stdout, handles control messages, forwards everything
+    // else to the caller.
+    {
+        let shared = shared.clone();
+        let opts_for_reader = opts.clone();
+        let stderr_buf = stderr_buf.clone();
+        tokio::spawn(async move {
+            let session_mode = opts_for_reader.session_mode;
+            let mut reader = BufReader::new(stdout);
+            let mut got_result = false;
+            let mut read_error: Option<String> = None;
+
+            loop {
+                let line = match read_line(&mut reader).await {
+                    Ok(Some(line)) => line,
+                    Ok(None) => break,
+                    Err(e) => {
+                        read_error = Some(e);
+                        break;
+                    }
+                };
+                if line.is_empty() {
+                    continue;
+                }
+
+                // Peek at the message type for fast routing.
+                #[derive(serde::Deserialize)]
+                struct TypeCheck {
+                    #[serde(default, rename = "type")]
+                    message_type: String,
+                }
+                let Ok(peek) = serde_json::from_slice::<TypeCheck>(&line) else {
+                    continue; // skip non-JSON lines
+                };
+
+                match peek.message_type.as_str() {
+                    // These require a response on stdin and must not be
+                    // forwarded to the caller.
+                    "control_request" => {
+                        handle_control_request(&line, &shared, &opts_for_reader, &hook_registry)
+                            .await;
+                        continue;
+                    }
+                    // Replies to our own requests. Route to the pending map.
+                    "control_response" => {
+                        route_control_response(&line, &shared);
+                        continue;
+                    }
+                    _ => {}
+                }
+
+                let Some(event) = parse_line(&line) else {
+                    continue; // skip malformed lines
+                };
+
+                // The CLI advertises its protocol capabilities on system/init,
+                // not in the initialize control response, so they are captured
+                // here as the event flows past.
+                if let Some(system) = &event.system {
+                    if system.subtype == system_subtype::INIT {
+                        shared.set_capabilities(system.capabilities.clone());
+                    }
+                }
+
+                let is_result = event.event_type == message_type::RESULT;
+                if event_tx.send(event).await.is_err() {
+                    // The caller dropped the stream; stop reading.
+                    break;
+                }
+
+                if is_result {
+                    if session_mode {
+                        // Emit the result to signal "turn done" but keep stdin
+                        // open and the reader running, so the subprocess
+                        // survives for the next send.
+                    } else {
+                        got_result = true;
+                        shared.close_stdin().await;
+                        break;
+                    }
+                }
+            }
+
+            if let Some(err) = read_error {
+                let _ = event_tx
+                    .send(error_event(format!("stdout read error: {err}")))
+                    .await;
+            }
+
+            // Surface stderr on an unexpected exit (bad flag, auth error,
+            // crash). Suppressed when the caller asked us to stop.
+            let exit = child.wait().await;
+            let shutting_down = shared.shutdown_fired.load(Ordering::SeqCst);
+            if !got_result && !shutting_down {
+                let failed = match &exit {
+                    Ok(status) => !status.success(),
+                    Err(_) => true,
+                };
+                if failed {
+                    let captured = stderr_buf
+                        .lock()
+                        .map(|b| b.trim().to_string())
+                        .unwrap_or_default();
+                    let msg = if !captured.is_empty() {
+                        captured
+                    } else {
+                        match &exit {
+                            Ok(status) => format!("claude exited with {status}"),
+                            Err(e) => e.to_string(),
+                        }
+                    };
+                    let _ = event_tx.send(error_event(msg)).await;
+                }
+            }
+
+            let _ = proc_done_tx.send(());
+        });
+    }
+
+    // ── initialize handshake ────────────────────────────────────────────────
+    // The reader task is now live, so a control_response can be routed.
+    // Register the request id BEFORE writing, await the acknowledgement, and
+    // cache the payload — it is the SDK's only source of truth for the CLI's
+    // models, commands, agents and account.
+    let init_request_id = new_uuid();
+    let (init_tx, init_rx) = oneshot::channel::<ControlResponse>();
+    if let Ok(mut pending) = shared.pending.lock() {
+        pending.insert(init_request_id.clone(), init_tx);
+    }
+
+    if let Err(e) = shared
+        .write(&initialize_msg(&init_request_id, &opts, hooks_config))
+        .await
+    {
+        shared.shutdown();
+        return Err(Error::wrap("initialize", e));
+    }
+
+    let init_response = match tokio::time::timeout(opts.init_timeout(), init_rx).await {
+        Ok(Ok(response)) => {
+            if !response.success {
+                shared.shutdown();
+                return Err(Error::Initialize {
+                    message: response.error,
+                    timeout: false,
+                });
+            }
+            decode_initialize_response(response.body.as_deref())
+        }
+        // The sender was dropped: the reader task ended before acknowledging,
+        // which means the process died during startup.
+        Ok(Err(_)) => {
+            shared.shutdown();
+            return Err(Error::Initialize {
+                message: "the CLI exited before acknowledging initialize".to_string(),
+                timeout: false,
+            });
+        }
+        Err(_) => {
+            shared.shutdown();
+            return Err(Error::Initialize {
+                message: format!(
+                    "the CLI did not acknowledge initialize within {:?}",
+                    opts.init_timeout()
+                ),
+                timeout: true,
+            });
+        }
+    };
+
+    // Only now is it safe to start a turn: MCP servers, agents and hooks
+    // declared in the initialize message are configured. Session mode sends its
+    // first message through `send` instead.
+    if !opts.session_mode && !prompt.is_empty() {
+        if let Err(e) = shared.write(&user_msg(prompt)).await {
+            shared.shutdown();
+            return Err(Error::wrap("user message", e));
+        }
+    }
+
+    Ok(Stream::new(
+        event_rx,
+        StreamControl::new(shared, Arc::new(init_response)),
+    ))
+}
+
+/// Starts a persistent subprocess for multi-turn conversations.
+///
+/// Unlike [`spawn_and_stream`] it sends no initial user message — the caller
+/// sends each turn. The subprocess survives multiple results and exits only
+/// when the session is closed.
+pub(crate) async fn spawn_session(mut opts: Options) -> Result<Stream> {
+    opts.session_mode = true;
+    spawn_and_stream(opts, "").await
+}
+
+/// Reads one newline-terminated line, enforcing [`MAX_LINE_BYTES`].
+///
+/// Returns `Ok(None)` at end of stream.
+async fn read_line<R>(reader: &mut BufReader<R>) -> std::result::Result<Option<Vec<u8>>, String>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let mut buf = Vec::new();
+    match reader.read_until(b'\n', &mut buf).await {
+        Ok(0) => Ok(None),
+        Ok(_) => {
+            if buf.len() > MAX_LINE_BYTES {
+                return Err(format!(
+                    "a stdout line exceeded the {MAX_LINE_BYTES}-byte limit"
+                ));
+            }
+            while matches!(buf.last(), Some(b'\n') | Some(b'\r')) {
+                buf.pop();
+            }
+            Ok(Some(buf))
+        }
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+// ─── Inbound control requests ────────────────────────────────────────────────
+
+/// The envelope of an inbound `control_request`.
+#[derive(serde::Deserialize, Default)]
+struct InboundControl {
+    #[serde(default)]
+    request_id: String,
+    #[serde(default)]
+    request: InboundControlRequest,
+}
+
+#[derive(serde::Deserialize, Default)]
+struct InboundControlRequest {
+    #[serde(default)]
+    subtype: String,
+
+    // can_use_tool
+    #[serde(default)]
+    tool_name: String,
+    #[serde(default)]
+    input: Option<Box<RawValue>>,
+
+    // hook_callback
+    #[serde(default)]
+    callback_id: String,
+    #[serde(default)]
+    tool_use_id: String,
+}
+
+/// Answers a `control_request` with an error `control_response`.
+///
+/// Every inbound request must be answered — a missing reply hangs the CLI.
+async fn write_control_error(shared: &Shared, request_id: &str, message: &str) {
+    let _ = shared
+        .write(&serde_json::json!({
+            "type": "control_response",
+            "response": {
+                "subtype": "error",
+                "request_id": request_id,
+                "error": message,
+            }
+        }))
+        .await;
+}
+
+/// Answers a `control_request` with a success `control_response`, optionally
+/// carrying a payload.
+async fn write_control_success(
+    shared: &Shared,
+    request_id: &str,
+    payload: Option<serde_json::Value>,
+) {
+    let mut response = serde_json::json!({
+        "subtype": "success",
+        "request_id": request_id,
+    });
+    if let Some(payload) = payload {
+        response["response"] = payload;
+    }
+    let _ = shared
+        .write(&serde_json::json!({
+            "type": "control_response",
+            "response": response,
+        }))
+        .await;
+}
+
+/// Handles one inbound `control_request` and writes exactly one response.
+///
+/// Callbacks are awaited **inline**, mirroring Go, where they run on the
+/// goroutine that owns stdout: a slow handler stalls the message stream, which
+/// is what makes "block the turn until a human answers" work.
+pub(crate) async fn handle_control_request(
+    line: &[u8],
+    shared: &Shared,
+    opts: &Options,
+    hook_registry: &HookRegistry,
+) {
+    let Ok(envelope) = serde_json::from_slice::<InboundControl>(line) else {
+        return;
+    };
+    let request_id = envelope.request_id.as_str();
+
+    match envelope.request.subtype.as_str() {
+        "can_use_tool" => {
+            // Fail closed. Answering a permission question nobody was asked
+            // would grant the tool call, so an absent handler is an error,
+            // never an allow.
+            let Some(handler) = opts.permission_handler.clone() else {
+                write_control_error(shared, request_id, "canUseTool callback is not provided")
+                    .await;
+                return;
+            };
+
+            let context: PermissionContext = serde_json::from_slice::<serde_json::Value>(line)
+                .ok()
+                .and_then(|v| v.get("request").cloned())
+                .and_then(|r| serde_json::from_value(r).ok())
+                .unwrap_or_default();
+
+            let original_input = envelope
+                .request
+                .input
+                .as_ref()
+                .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw.get()).ok());
+
+            let input_for_handler = envelope
+                .request
+                .input
+                .as_ref()
+                .and_then(|raw| RawValue::from_string(raw.get().to_owned()).ok());
+
+            let result = handler(
+                envelope.request.tool_name.clone(),
+                input_for_handler,
+                context,
+            )
+            .await;
+
+            let payload = match result {
+                PermissionResult::Allow {
+                    updated_input,
+                    updated_permissions,
+                } => {
+                    let mut response = serde_json::json!({ "behavior": "allow" });
+                    // The CLI expects the input it should actually run; when
+                    // the handler does not rewrite it, echo the original back
+                    // verbatim.
+                    response["updatedInput"] = updated_input
+                        .or(original_input)
+                        .unwrap_or(serde_json::Value::Null);
+                    if !updated_permissions.is_empty() {
+                        response["updatedPermissions"] =
+                            serde_json::to_value(&updated_permissions).unwrap_or_default();
+                    }
+                    response
+                }
+                PermissionResult::Deny { message, interrupt } => {
+                    let mut response = serde_json::json!({
+                        "behavior": "deny",
+                        "message": message,
+                    });
+                    if interrupt {
+                        response["interrupt"] = serde_json::Value::Bool(true);
+                    }
+                    response
+                }
+            };
+
+            write_control_success(shared, request_id, Some(payload)).await;
+        }
+
+        "hook_callback" => {
+            let Some(hook) = hook_registry.get(&envelope.request.callback_id) else {
+                write_control_error(
+                    shared,
+                    request_id,
+                    &format!(
+                        "no hook callback found for ID: {}",
+                        envelope.request.callback_id
+                    ),
+                )
+                .await;
+                return;
+            };
+
+            // The event name travels inside the hook input payload, not on the
+            // control_request envelope. An absent or unparseable name yields
+            // "" rather than dropping the callback — a missing reply hangs the
+            // CLI.
+            #[derive(serde::Deserialize, Default)]
+            struct HookInput {
+                #[serde(default)]
+                hook_event_name: String,
+            }
+            let event_name = envelope
+                .request
+                .input
+                .as_ref()
+                .and_then(|raw| serde_json::from_str::<HookInput>(raw.get()).ok())
+                .unwrap_or_default()
+                .hook_event_name;
+
+            let input = envelope
+                .request
+                .input
+                .as_ref()
+                .and_then(|raw| RawValue::from_string(raw.get().to_owned()).ok());
+
+            match hook(event_name, input, envelope.request.tool_use_id.clone()).await {
+                Ok(output) => {
+                    let payload = output.and_then(|o| serde_json::to_value(o).ok());
+                    write_control_success(shared, request_id, payload).await;
+                }
+                Err(message) => write_control_error(shared, request_id, &message).await,
+            }
+        }
+
+        "elicitation" => {
+            let cancelled = serde_json::json!({ "cancel": true });
+            let payload = match opts.elicitation_handler.clone() {
+                Some(handler) => {
+                    let input = envelope
+                        .request
+                        .input
+                        .as_ref()
+                        .and_then(|raw| RawValue::from_string(raw.get().to_owned()).ok());
+                    handler(input).await.unwrap_or(cancelled)
+                }
+                None => cancelled,
+            };
+            write_control_success(shared, request_id, Some(payload)).await;
+        }
+
+        // set_model, set_permission_mode, set_max_thinking_tokens,
+        // mcp_message: read-only notifications from the CLI. Acknowledge
+        // silently — but do acknowledge.
+        _ => write_control_success(shared, request_id, None).await,
+    }
+}
+
+// ─── Outbound control responses ──────────────────────────────────────────────
+
+/// Routes a `control_response` to the caller waiting on its `request_id`.
+///
+/// The wire shape is three levels deep — the correlation id lives **inside** the
+/// response object, not at the top level of the envelope:
+///
+/// ```text
+/// {"type":"control_response","response":{"subtype":…,"request_id":…,"error":…,"response":{…}}}
+/// ```
+///
+/// Routing is strictly nested-only, matching the reference SDKs: a line whose
+/// response is not an object, or which carries no `request_id`, cannot be
+/// correlated to any caller and is dropped. There is no top-level fallback —
+/// the CLI has never emitted one, and inventing a shape here is what broke this
+/// in the first place.
+///
+/// The value handed to the caller is the **innermost** response payload, not
+/// the wrapper carrying subtype and request_id. The CLI omits that payload
+/// entirely on replies that carry no data (a real `set_model` success), in
+/// which case the body is `None` and the request still succeeded.
+pub(crate) fn route_control_response(line: &[u8], shared: &Shared) {
+    #[derive(serde::Deserialize, Default)]
+    struct Envelope {
+        #[serde(default)]
+        response: Inner,
+    }
+    #[derive(serde::Deserialize, Default)]
+    struct Inner {
+        #[serde(default)]
+        subtype: String,
+        #[serde(default)]
+        request_id: String,
+        #[serde(default)]
+        error: String,
+        #[serde(default)]
+        response: Option<Box<RawValue>>,
+    }
+
+    let Ok(envelope) = serde_json::from_slice::<Envelope>(line) else {
+        return;
+    };
+    if envelope.response.request_id.is_empty() {
+        return;
+    }
+
+    let waiting = shared
+        .pending
+        .lock()
+        .ok()
+        .and_then(|mut pending| pending.remove(&envelope.response.request_id));
+
+    if let Some(tx) = waiting {
+        // Send cannot block; a caller that has gone away simply drops the
+        // reply, matching Go's non-blocking select.
+        let _ = tx.send(ControlResponse {
+            success: envelope.response.subtype != "error",
+            error: envelope.response.error,
+            body: envelope.response.response,
+        });
+    }
+}
+
+// ─── Stdin message builders ──────────────────────────────────────────────────
+
+/// Builds the `initialize` control_request sent at session start.
+///
+/// This is how the system prompt, agents, hooks and output format are passed in
+/// bidirectional mode.
+///
+/// `sdkMcpServers` is **deliberately never sent**. That key declares
+/// SDK-*hosted* servers: the CLI keeps no transport for them and instead routes
+/// their JSON-RPC traffic back as `mcp_message` control_requests, which this
+/// SDK does not implement — the calls would be acknowledged and dropped.
+/// `start_in_process_mcp_server` binds a real loopback HTTP listener instead,
+/// so every server reaches the CLI as an ordinary transport through
+/// `--mcp-config` and is dialled directly.
+///
+/// The CLI also accepts only an array of strings there (verified against
+/// 2.1.224: omitted, `[]` and `["name"]` succeed; any object or array-of-objects
+/// is rejected with "sdkMcpServers and webSearchIsolationExemptMcpServers must
+/// be arrays of strings", which fails the *entire* initialize and silently takes
+/// hooks, agents, the system prompt and the output format down with it).
+pub(crate) fn initialize_msg(
+    request_id: &str,
+    opts: &Options,
+    hooks_config: serde_json::Map<String, serde_json::Value>,
+) -> serde_json::Value {
+    // A preset takes precedence over a plain string when both are set.
+    let system_prompt = match &opts.system_prompt_preset {
+        Some(preset) => serde_json::to_value(preset).unwrap_or(serde_json::Value::Null),
+        None => serde_json::Value::String(opts.system_prompt.clone()),
+    };
+
+    let mut request = serde_json::json!({
+        "subtype": "initialize",
+        "systemPrompt": system_prompt,
+        "appendSystemPrompt": opts.append_system_prompt,
+        "hooks": hooks_config,
+        "agents": opts.agents,
+        "promptSuggestions": opts.prompt_suggestions,
+    });
+
+    if let Some(format) = &opts.output_format {
+        request["outputFormat"] = serde_json::Value::String(format.format_type.clone());
+        if let Some(schema) = &format.schema {
+            request["jsonSchema"] = schema.clone();
+        }
+    }
+
+    if let Some(sandbox) = &opts.sandbox {
+        request["sandbox"] = serde_json::to_value(sandbox).unwrap_or(serde_json::Value::Null);
+    }
+
+    serde_json::json!({
+        "type": "control_request",
+        "request_id": request_id,
+        "request": request,
+    })
+}
+
+/// Builds the user message sent to stdin.
+pub(crate) fn user_msg(prompt: &str) -> serde_json::Value {
+    serde_json::json!({
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": prompt,
+        },
+        "parent_tool_use_id": serde_json::Value::Null,
+        "session_id": "",
+    })
+}
+
+// ─── Environment ─────────────────────────────────────────────────────────────
+
+/// The environment for the `claude` subprocess.
+///
+/// * Inherits the parent environment, so the Claude Code OAuth session passes
+///   through.
+/// * Strips `CLAUDECODE` so the subprocess can launch even inside an existing
+///   session (mirroring `delete process.env.CLAUDECODE` in the TS SDK).
+/// * Strips `CLAUDE_CODE_ENTRYPOINT` and `CLAUDE_AGENT_SDK_VERSION` so we can
+///   set our own.
+/// * Sets `MAX_THINKING_TOKENS=0` when thinking is disabled — the documented
+///   way to turn it off — or the caller's budget when they set one.
+/// * Merges the caller's extra variables **last**, so they win.
+pub(crate) fn build_env(opts: &Options) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String)> = Vec::new();
+
+    for (key, value) in std::env::vars() {
+        let stripped = matches!(
+            key.as_str(),
+            "CLAUDECODE"
+                | "CLAUDE_CODE_ENTRYPOINT"
+                | "CLAUDE_AGENT_SDK_VERSION"
+                | "MAX_THINKING_TOKENS"
+        ) || (!opts.cwd.is_empty() && key == "PWD")
+            // Also strip any caller-supplied key so theirs can override.
+            || opts.env.contains_key(&key);
+        if !stripped {
+            out.push((key, value));
+        }
+    }
+
+    // The entrypoint identifies which SDK is driving the CLI, for Anthropic's
+    // telemetry. The Go SDK reports `sdk-go`; this one is a different SDK and
+    // says so, following the same `sdk-<language>` convention. It is a
+    // reporting label only — nothing in the protocol or the SSE stream depends
+    // on its value.
+    out.push(("CLAUDE_CODE_ENTRYPOINT".into(), "sdk-rust".into()));
+    out.push(("CLAUDE_AGENT_SDK_VERSION".into(), SDK_VERSION.into()));
+
+    if opts.thinking == thinking::DISABLED {
+        out.push(("MAX_THINKING_TOKENS".into(), "0".into()));
+    } else if opts.max_thinking_tokens > 0 {
+        out.push((
+            "MAX_THINKING_TOKENS".into(),
+            opts.max_thinking_tokens.to_string(),
+        ));
+    }
+
+    // Set PWD when a working directory is configured, matching the Python SDK.
+    if !opts.cwd.is_empty() {
+        out.push(("PWD".into(), opts.cwd.clone()));
+    }
+
+    for (key, value) in &opts.env {
+        out.push((key.clone(), value.clone()));
+    }
+
+    out
+}
+
+// ─── Signals ─────────────────────────────────────────────────────────────────
+
+/// Sends SIGTERM, giving the CLI a chance to exit cleanly.
+#[cfg(unix)]
+fn terminate(pid: Option<u32>) {
+    if let Some(pid) = pid {
+        // SAFETY: kill(2) with a pid we spawned. A reaped pid yields ESRCH,
+        // which is the outcome we already ignore.
+        unsafe {
+            libc::kill(pid as libc::pid_t, libc::SIGTERM);
+        }
+    }
+}
+
+/// Windows has no SIGTERM; the kill below is the only available step.
+#[cfg(not(unix))]
+fn terminate(_pid: Option<u32>) {}
+
+#[cfg(unix)]
+fn kill(pid: Option<u32>) {
+    if let Some(pid) = pid {
+        // SAFETY: as above.
+        unsafe {
+            libc::kill(pid as libc::pid_t, libc::SIGKILL);
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn kill(_pid: Option<u32>) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::claude::options::{permission_mode, SystemPromptPreset};
+
+    /// A `Shared` with no subprocess behind it, for exercising response routing
+    /// on its own. Mirrors Go's `pendingStream` helper.
+    fn pending_shared(request_id: &str) -> (Arc<Shared>, oneshot::Receiver<ControlResponse>) {
+        let (tx, rx) = oneshot::channel();
+        let (shutdown_tx, _shutdown_rx) = oneshot::channel();
+        let shared = Arc::new(Shared {
+            stdin: Mutex::new(None),
+            pending: StdMutex::new(HashMap::from([(request_id.to_string(), tx)])),
+            capabilities: RwLock::new(None),
+            shutdown_tx: StdMutex::new(Some(shutdown_tx)),
+            shutdown_fired: AtomicBool::new(false),
+        });
+        (shared, rx)
+    }
+
+    #[test]
+    fn a_response_routes_on_the_nested_request_id() {
+        let (shared, rx) = pending_shared("req-1");
+        route_control_response(
+            br#"{"type":"control_response","response":{"subtype":"success","request_id":"req-1","response":{"ok":true}}}"#,
+            &shared,
+        );
+        let got = rx.blocking_recv().expect("the caller must be woken");
+        assert!(got.success);
+        // The caller gets the innermost payload, not the wrapper carrying
+        // subtype and request_id.
+        assert_eq!(got.body.as_ref().unwrap().get(), r#"{"ok":true}"#);
+    }
+
+    #[test]
+    fn a_top_level_request_id_resolves_nothing() {
+        // Routing is strictly nested-only. Inventing a top-level fallback is
+        // what broke this in the first place.
+        let (shared, rx) = pending_shared("req-1");
+        route_control_response(
+            br#"{"type":"control_response","request_id":"req-1","response":{"subtype":"success"}}"#,
+            &shared,
+        );
+        drop(shared);
+        assert!(rx.blocking_recv().is_err(), "nothing should have been sent");
+    }
+
+    #[test]
+    fn a_reply_with_no_payload_is_still_a_success() {
+        // A real set_model success carries no inner response at all.
+        let (shared, rx) = pending_shared("req-2");
+        route_control_response(
+            br#"{"type":"control_response","response":{"subtype":"success","request_id":"req-2"}}"#,
+            &shared,
+        );
+        let got = rx.blocking_recv().unwrap();
+        assert!(got.success);
+        assert!(got.body.is_none());
+    }
+
+    #[test]
+    fn an_error_subtype_carries_its_message() {
+        let (shared, rx) = pending_shared("req-3");
+        route_control_response(
+            br#"{"type":"control_response","response":{"subtype":"error","request_id":"req-3","error":"nope"}}"#,
+            &shared,
+        );
+        let got = rx.blocking_recv().unwrap();
+        assert!(!got.success);
+        assert_eq!(got.error, "nope");
+    }
+
+    #[test]
+    fn unroutable_lines_are_dropped_without_disturbing_the_pending_map() {
+        let (shared, rx) = pending_shared("req-4");
+        for line in [
+            &br#"{"type":"control_response","response":"not-an-object"}"#[..],
+            &br#"{"type":"control_response","response":{"subtype":"success"}}"#[..],
+            &br#"{"type":"control_response","response":{"request_id":"someone-else"}}"#[..],
+            &br#"not json at all"#[..],
+        ] {
+            route_control_response(line, &shared);
+        }
+        assert_eq!(
+            shared.pending.lock().unwrap().len(),
+            1,
+            "the waiting caller is still registered"
+        );
+        drop(shared);
+        assert!(rx.blocking_recv().is_err());
+    }
+
+    fn init_request(opts: &Options) -> serde_json::Value {
+        let (hooks, _) = build_hooks_for_initialize(&opts.hooks);
+        initialize_msg("req-1", opts, hooks)
+    }
+
+    #[test]
+    fn initialize_never_sends_sdk_mcp_servers() {
+        // The CLI rejects any object form, and a rejection fails the whole
+        // initialize — silently taking hooks, agents and the system prompt with
+        // it. The key must simply not be there.
+        let opts = Options::new()
+            .with_mcp_server(
+                "local-tools",
+                crate::claude::McpHttpServer {
+                    server_type: "http".into(),
+                    url: "http://127.0.0.1:1".into(),
+                    headers: Default::default(),
+                },
+            )
+            .unwrap();
+        let msg = init_request(&opts);
+        assert!(msg["request"].get("sdkMcpServers").is_none());
+    }
+
+    #[test]
+    fn initialize_always_carries_its_five_baseline_keys() {
+        let msg = init_request(&Options::new());
+        let request = &msg["request"];
+        assert_eq!(request["subtype"], "initialize");
+        for key in [
+            "systemPrompt",
+            "appendSystemPrompt",
+            "hooks",
+            "agents",
+            "promptSuggestions",
+        ] {
+            assert!(request.get(key).is_some(), "{key} must always be present");
+        }
+        // Empty rather than absent — the CLI expects objects here.
+        assert_eq!(request["hooks"], serde_json::json!({}));
+        assert_eq!(request["agents"], serde_json::json!({}));
+    }
+
+    #[test]
+    fn a_preset_replaces_the_plain_system_prompt() {
+        let opts = Options::new()
+            .with_system_prompt("ignored")
+            .with_system_prompt_preset(SystemPromptPreset {
+                preset_type: "preset".into(),
+                preset: "claude_code".into(),
+                append: "extra".into(),
+            });
+        let msg = init_request(&opts);
+        assert_eq!(msg["request"]["systemPrompt"]["preset"], "claude_code");
+        assert_eq!(msg["request"]["systemPrompt"]["append"], "extra");
+    }
+
+    #[test]
+    fn the_envelope_carries_the_request_id_at_the_top_level() {
+        let msg = init_request(&Options::new());
+        assert_eq!(msg["type"], "control_request");
+        assert_eq!(msg["request_id"], "req-1");
+    }
+
+    #[test]
+    fn a_user_message_carries_the_nulls_the_cli_expects() {
+        let msg = user_msg("hello");
+        assert_eq!(
+            serde_json::to_string(&msg).unwrap(),
+            r#"{"message":{"content":"hello","role":"user"},"parent_tool_use_id":null,"session_id":"","type":"user"}"#
+        );
+    }
+
+    #[test]
+    fn the_environment_strips_the_four_variables_it_owns() {
+        std::env::set_var("CLAUDECODE", "1");
+        std::env::set_var("CLAUDE_CODE_ENTRYPOINT", "cli");
+
+        let env = build_env(&Options::new());
+        let keys: Vec<&str> = env.iter().map(|(k, _)| k.as_str()).collect();
+
+        assert!(
+            !keys.contains(&"CLAUDECODE"),
+            "an existing session must not block the spawn"
+        );
+        assert_eq!(
+            env.iter()
+                .filter(|(k, _)| k == "CLAUDE_CODE_ENTRYPOINT")
+                .count(),
+            1,
+            "the inherited entrypoint is replaced, not duplicated"
+        );
+
+        std::env::remove_var("CLAUDECODE");
+        std::env::remove_var("CLAUDE_CODE_ENTRYPOINT");
+    }
+
+    #[test]
+    fn disabled_thinking_sets_the_token_budget_to_zero() {
+        let env = build_env(&Options::new().with_thinking(thinking::DISABLED));
+        assert_eq!(
+            env.iter()
+                .rev()
+                .find(|(k, _)| k == "MAX_THINKING_TOKENS")
+                .map(|(_, v)| v.as_str()),
+            Some("0")
+        );
+    }
+
+    #[test]
+    fn caller_supplied_variables_win_over_the_inherited_ones() {
+        std::env::set_var("AGENTO_SDK_ENV_PROBE", "inherited");
+        let env = build_env(&Options::new().with_env([("AGENTO_SDK_ENV_PROBE", "override")]));
+        let values: Vec<&str> = env
+            .iter()
+            .filter(|(k, _)| k == "AGENTO_SDK_ENV_PROBE")
+            .map(|(_, v)| v.as_str())
+            .collect();
+        assert_eq!(values, vec!["override"], "the inherited value is stripped");
+        std::env::remove_var("AGENTO_SDK_ENV_PROBE");
+    }
+
+    #[test]
+    fn a_working_directory_replaces_pwd() {
+        std::env::set_var("PWD", "/somewhere/else");
+        let env = build_env(&Options::new().with_cwd("/project"));
+        let pwd: Vec<&str> = env
+            .iter()
+            .filter(|(k, _)| k == "PWD")
+            .map(|(_, v)| v.as_str())
+            .collect();
+        assert_eq!(pwd, vec!["/project"]);
+        std::env::remove_var("PWD");
+    }
+
+    #[test]
+    fn bypass_is_the_default_permission_posture() {
+        assert_eq!(
+            Options::new().permission_mode,
+            permission_mode::BYPASS_PERMISSIONS
+        );
+    }
+}

--- a/desktop/src-tauri/src/claude/process.rs
+++ b/desktop/src-tauri/src/claude/process.rs
@@ -67,6 +67,10 @@ const EVENT_CHANNEL_CAPACITY: usize = 32;
 /// CLI, spawned by us.
 const MAX_LINE_BYTES: usize = 4 * 1024 * 1024;
 
+/// How long to wait for stderr to reach end of stream once the process has
+/// exited, before reporting whatever was captured.
+const STDERR_DRAIN_GRACE: std::time::Duration = std::time::Duration::from_secs(2);
+
 /// How long a terminating process is given before it is killed outright.
 const SIGKILL_GRACE: std::time::Duration = std::time::Duration::from_secs(5);
 
@@ -219,8 +223,14 @@ pub(crate) async fn spawn_and_stream(opts: Options, prompt: &str) -> Result<Stre
 
     // Capture stderr. Each line goes to the callback when one is set, and every
     // line is buffered for error reporting on an unexpected exit.
+    //
+    // The join handle is kept, not detached: `Child::wait` reaps the process but
+    // does **not** wait for this task, so reading the buffer straight after it
+    // races the last lines out of the pipe — and those lines are the entire
+    // content of the error the user sees. (Go does not have the race: its
+    // `cmd.Wait` waits for the goroutine copying into the buffer.)
     let stderr_buf = Arc::new(StdMutex::new(String::new()));
-    if let Some(stderr) = stderr {
+    let stderr_task = stderr.map(|stderr| {
         let buf = stderr_buf.clone();
         let sink = opts.stderr.clone();
         tokio::spawn(async move {
@@ -234,8 +244,8 @@ pub(crate) async fn spawn_and_stream(opts: Options, prompt: &str) -> Result<Stre
                     buf.push('\n');
                 }
             }
-        });
-    }
+        })
+    });
 
     let (event_tx, event_rx) = mpsc::channel::<Event>(EVENT_CHANNEL_CAPACITY);
     // A watch rather than a oneshot: the shutdown task waits on it twice —
@@ -288,6 +298,7 @@ pub(crate) async fn spawn_and_stream(opts: Options, prompt: &str) -> Result<Stre
         let shared = shared.clone();
         let opts_for_reader = opts.clone();
         let stderr_buf = stderr_buf.clone();
+        let stderr_task = stderr_task;
         tokio::spawn(async move {
             let session_mode = opts_for_reader.session_mode;
             let mut reader = BufReader::new(stdout);
@@ -374,6 +385,17 @@ pub(crate) async fn spawn_and_stream(opts: Options, prompt: &str) -> Result<Stre
             // Surface stderr on an unexpected exit (bad flag, auth error,
             // crash). Suppressed when the caller asked us to stop.
             let exit = child.wait().await;
+
+            // Drain stderr before reading the buffer, so the message is the
+            // whole of what the CLI said rather than whatever had arrived by
+            // now. Bounded, because the pipe stays open as long as any process
+            // holds it — `claude` spawning a longer-lived grandchild would
+            // otherwise wedge this task, and with it the caller's stream. Go
+            // waits unbounded here and can hang for the same reason.
+            if let Some(task) = stderr_task {
+                let _ = tokio::time::timeout(STDERR_DRAIN_GRACE, task).await;
+            }
+
             let shutting_down = shared.shutdown_fired.load(Ordering::SeqCst);
             if !got_result && !shutting_down {
                 let failed = match &exit {

--- a/desktop/src-tauri/src/claude/process.rs
+++ b/desktop/src-tauri/src/claude/process.rs
@@ -57,8 +57,14 @@ const EVENT_CHANNEL_CAPACITY: usize = 32;
 /// Ceiling on one stdout line. Go sets the same figure on its `bufio.Scanner`
 /// because assistant messages with long content are large; Rust's reader has no
 /// default limit at all, so the cap is imposed deliberately rather than
-/// inherited. A line beyond it is reported as a read error, exactly as Go's
-/// scanner does.
+/// inherited, and an over-long line ends the stream with a read error the way
+/// Go's scanner does.
+///
+/// It bounds what is *accepted*, not what is *allocated*: `read_until` has
+/// already grown its buffer to the newline by the time the length is checked,
+/// where Go's scanner refuses past its fixed buffer. That is a real difference
+/// and would matter against a hostile writer; the writer here is the `claude`
+/// CLI, spawned by us.
 const MAX_LINE_BYTES: usize = 4 * 1024 * 1024;
 
 /// How long a terminating process is given before it is killed outright.
@@ -232,24 +238,47 @@ pub(crate) async fn spawn_and_stream(opts: Options, prompt: &str) -> Result<Stre
     }
 
     let (event_tx, event_rx) = mpsc::channel::<Event>(EVENT_CHANNEL_CAPACITY);
-    let (proc_done_tx, proc_done_rx) = oneshot::channel::<()>();
+    // A watch rather than a oneshot: the shutdown task waits on it twice —
+    // once for the shutdown-vs-exit race, once for the SIGTERM grace period —
+    // and a oneshot receiver is consumed by its first await.
+    let (proc_done_tx, proc_done_rx) = tokio::sync::watch::channel(false);
+    // A second view for the handshake wait below, so a process that dies during
+    // startup is reported at once instead of at the timeout.
+    let proc_done_watch = proc_done_rx.clone();
 
     // Graceful shutdown task, mirroring the TypeScript SDK's close():
     //   stdin.end() → SIGTERM → SIGKILL after 5s.
+    //
+    // Both waits are raced against the process actually exiting, and both are
+    // `biased` toward that branch. **Never signal a pid that has already been
+    // reaped**: the reader task calls `wait()`, after which the kernel is free
+    // to hand that pid to an unrelated process, and a stray SIGTERM/SIGKILL
+    // would land on it. Go guards the same two points with `select` on
+    // `procDone` for exactly this reason. `biased` matters because on the
+    // ordinary path — result received, child reaped, stream dropped — both
+    // branches are ready at once and an unbiased select would sometimes pick
+    // the signalling one.
     {
         let shared = shared.clone();
+        let mut proc_done = proc_done_rx;
         tokio::spawn(async move {
             tokio::select! {
+                biased;
+                _ = proc_done.changed() => return,
                 _ = shutdown_rx => {}
-                _ = proc_done_rx => return,
             }
             shared.close_stdin().await;
+
+            if *proc_done.borrow() {
+                return;
+            }
             terminate(pid);
-            tokio::time::sleep(SIGKILL_GRACE).await;
-            // The process reaper races this; killing a pid that has already
-            // been reaped is a no-op error we deliberately ignore, exactly as
-            // Go ignores the error from cmd.Process.Kill().
-            kill(pid);
+
+            tokio::select! {
+                biased;
+                _ = proc_done.changed() => {}
+                _ = tokio::time::sleep(SIGKILL_GRACE) => kill(pid),
+            }
         });
     }
 
@@ -368,7 +397,7 @@ pub(crate) async fn spawn_and_stream(opts: Options, prompt: &str) -> Result<Stre
                 }
             }
 
-            let _ = proc_done_tx.send(());
+            let _ = proc_done_tx.send(true);
         });
     }
 
@@ -391,35 +420,61 @@ pub(crate) async fn spawn_and_stream(opts: Options, prompt: &str) -> Result<Stre
         return Err(Error::wrap("initialize", e));
     }
 
-    let init_response = match tokio::time::timeout(opts.init_timeout(), init_rx).await {
-        Ok(Ok(response)) => {
-            if !response.success {
+    // The wait races three outcomes rather than Go's two. Go waits only for the
+    // acknowledgement or the timeout, so a CLI that dies during startup — an
+    // unusable `--settings` path, a bad flag, a failed auth — costs the caller
+    // the full 60s before it hears anything, even though the answer was known
+    // in milliseconds. The pending sender lives in `shared`, not in the reader
+    // task, so nothing else would report it either. `biased` puts the
+    // acknowledgement first: a reply already in flight when the process exits
+    // is still a successful handshake.
+    let mut init_proc_done = proc_done_watch;
+    let init_response = {
+        let outcome = tokio::select! {
+            biased;
+            reply = init_rx => Some(reply),
+            _ = init_proc_done.changed() => None,
+            _ = tokio::time::sleep(opts.init_timeout()) => {
                 shared.shutdown();
                 return Err(Error::Initialize {
-                    message: response.error,
+                    message: format!(
+                        "the CLI did not acknowledge initialize within {:?}",
+                        opts.init_timeout()
+                    ),
+                    timeout: true,
+                });
+            }
+        };
+
+        match outcome {
+            Some(Ok(response)) => {
+                if !response.success {
+                    shared.shutdown();
+                    return Err(Error::Initialize {
+                        message: response.error,
+                        timeout: false,
+                    });
+                }
+                decode_initialize_response(response.body.as_deref())
+            }
+            // The process exited, or its sender was dropped, before
+            // acknowledging. Either way the session never started.
+            _ => {
+                shared.shutdown();
+                let stderr = stderr_buf
+                    .lock()
+                    .map(|b| b.trim().to_string())
+                    .unwrap_or_default();
+                let message = if stderr.is_empty() {
+                    "the CLI exited before acknowledging initialize".to_string()
+                } else {
+                    format!("the CLI exited before acknowledging initialize: {stderr}")
+                };
+                return Err(Error::Initialize {
+                    message,
                     timeout: false,
                 });
             }
-            decode_initialize_response(response.body.as_deref())
-        }
-        // The sender was dropped: the reader task ended before acknowledging,
-        // which means the process died during startup.
-        Ok(Err(_)) => {
-            shared.shutdown();
-            return Err(Error::Initialize {
-                message: "the CLI exited before acknowledging initialize".to_string(),
-                timeout: false,
-            });
-        }
-        Err(_) => {
-            shared.shutdown();
-            return Err(Error::Initialize {
-                message: format!(
-                    "the CLI did not acknowledge initialize within {:?}",
-                    opts.init_timeout()
-                ),
-                timeout: true,
-            });
         }
     };
 

--- a/desktop/src-tauri/src/claude/session.rs
+++ b/desktop/src-tauri/src/claude/session.rs
@@ -1,0 +1,132 @@
+//! Persistent multi-turn sessions, ported from `claude/session.go`.
+//!
+//! A [`Session`] keeps the `claude` subprocess alive between turns, where
+//! [`super::query`] spawns one per call. The difference is entirely in what
+//! happens when a result arrives: single-turn mode closes stdin and lets the
+//! process exit, session mode leaves both open so the next
+//! [`Session::send`] starts a new turn on the same conversation.
+//!
+//! Consume one turn by reading events until a `result`, then send again.
+
+use super::client::{InterruptReceipt, Stream, StreamControl};
+use super::errors::Result;
+use super::init_types::{AccountInfo, AgentInfo, ModelInfo, SlashCommand};
+use super::messages::Event;
+use super::options::Options;
+use super::process;
+
+/// A persistent Claude session.
+///
+/// The subprocess starts immediately; the first turn begins when
+/// [`Session::send`] is called.
+pub struct Session {
+    stream: Stream,
+}
+
+impl Session {
+    /// Creates a new persistent session.
+    pub async fn new(opts: Options) -> Result<Self> {
+        let stream = process::spawn_session(opts).await?;
+        Ok(Session { stream })
+    }
+
+    /// Sends a user message and starts a new turn. Call this before reading
+    /// events for each turn.
+    pub async fn send(&self, message: &str) -> Result<()> {
+        self.stream.send_user_message(message).await
+    }
+
+    /// The next event. Read until a `result` to consume one turn, then
+    /// [`Session::send`] again. Returns `None` when the session has ended.
+    pub async fn next_event(&mut self) -> Option<Event> {
+        self.stream.next_event().await
+    }
+
+    /// A clonable handle carrying the control methods, for use from another
+    /// task — notably to interrupt a turn this one is streaming.
+    pub fn control(&self) -> StreamControl {
+        self.stream.control()
+    }
+
+    /// Terminates the session and its subprocess. Idempotent.
+    ///
+    /// To abort the current turn while keeping the session usable, call
+    /// [`Session::interrupt`].
+    pub fn close(&self) {
+        self.stream.close();
+    }
+
+    /// Aborts the turn currently in progress; the session stays open, so call
+    /// [`Session::send`] to start the next turn.
+    ///
+    /// The returned receipt lists async user messages that survived the
+    /// interrupt, and is `None` when the CLI sends none.
+    pub async fn interrupt(&self) -> Result<Option<InterruptReceipt>> {
+        self.stream.interrupt().await
+    }
+
+    pub async fn set_model(&self, model: &str) -> Result<()> {
+        self.stream.set_model(model).await
+    }
+
+    pub async fn set_permission_mode(&self, mode: &str) -> Result<()> {
+        self.stream.set_permission_mode(mode).await
+    }
+
+    pub async fn set_max_thinking_tokens(&self, n: i64) -> Result<()> {
+        self.stream.set_max_thinking_tokens(n).await
+    }
+
+    pub async fn rewind_files(&self, user_message_id: &str) -> Result<()> {
+        self.stream.rewind_files(user_message_id).await
+    }
+
+    pub async fn stop_task(&self, task_id: &str) -> Result<()> {
+        self.stream.stop_task(task_id).await
+    }
+
+    pub async fn reconnect_mcp_server(&self, server_name: &str) -> Result<()> {
+        self.stream.reconnect_mcp_server(server_name).await
+    }
+
+    pub async fn toggle_mcp_server(&self, server_name: &str, enabled: bool) -> Result<()> {
+        self.stream.toggle_mcp_server(server_name, enabled).await
+    }
+
+    pub async fn set_mcp_servers(&self, servers: serde_json::Value) -> Result<()> {
+        self.stream.set_mcp_servers(servers).await
+    }
+
+    /// The models the connected CLI offers, from the initialize handshake. No
+    /// I/O; never blocks.
+    pub fn supported_models(&self) -> &[ModelInfo] {
+        self.stream.supported_models()
+    }
+
+    /// The slash commands available in this session, from the handshake.
+    pub fn supported_commands(&self) -> &[SlashCommand] {
+        self.stream.supported_commands()
+    }
+
+    /// The subagent types this session can dispatch to, from the handshake.
+    pub fn supported_agents(&self) -> &[AgentInfo] {
+        self.stream.supported_agents()
+    }
+
+    /// The account the CLI is authenticated as, from the handshake.
+    pub fn account_info(&self) -> &AccountInfo {
+        self.stream.account_info()
+    }
+
+    /// The session's output style and the styles available.
+    pub fn output_style(&self) -> (&str, &[String]) {
+        self.stream.output_style()
+    }
+
+    /// The protocol capabilities the CLI advertises. These come from the
+    /// `system`/`init` event rather than the handshake, so the list is `None`
+    /// until the first turn has started.
+    pub fn capabilities(&self) -> Option<Vec<String>> {
+        self.stream.capabilities()
+    }
+}

--- a/desktop/src-tauri/src/claude/sessions.rs
+++ b/desktop/src-tauri/src/claude/sessions.rs
@@ -1,0 +1,126 @@
+//! Out-of-band session introspection, ported from `claude/sessions.go`.
+//!
+//! These do not use the streaming protocol at all — they shell out to
+//! `claude sessions …` and parse its JSON. They are here rather than in
+//! [`super::process`] because they share nothing with it but the executable
+//! path and the environment.
+
+use serde::Deserialize;
+use serde_json::value::RawValue;
+
+use super::errors::{Error, Result};
+use super::options::Options;
+use super::process::build_env;
+
+/// Metadata about a stored session, as returned by
+/// `claude sessions list --output-format json`.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct SessionSummary {
+    pub id: String,
+    pub project: String,
+    pub created_at: String,
+    pub updated_at: String,
+    pub summary: String,
+}
+
+/// The messages of a stored session, as returned by
+/// `claude sessions get <id> --output-format json`.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct SessionTranscript {
+    pub id: String,
+    /// Kept raw: the transcript's message shapes are the CLI's, and a stored
+    /// transcript can carry forms this SDK does not model.
+    pub messages: Vec<Box<RawValue>>,
+}
+
+/// Runs the CLI with `args` and returns its stdout, honouring the executable
+/// path, environment and working directory from `opts`.
+async fn run_cli(opts: &Options, args: &[&str], context: &str) -> Result<Vec<u8>> {
+    let mut command = tokio::process::Command::new(&opts.claude_executable);
+    command.args(args);
+    command.env_clear();
+    command.envs(build_env(opts));
+    if !opts.cwd.is_empty() {
+        command.current_dir(&opts.cwd);
+    }
+
+    let output = command
+        .output()
+        .await
+        .map_err(|e| Error::wrap(context, e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(Error::Process {
+            exit_code: output.status.code().unwrap_or(-1),
+            stderr,
+            message: context.to_string(),
+        });
+    }
+
+    Ok(output.stdout)
+}
+
+/// Runs `claude sessions list --output-format json` and returns the parsed
+/// list.
+pub async fn list_sessions(opts: &Options) -> Result<Vec<SessionSummary>> {
+    let out = run_cli(
+        opts,
+        &["sessions", "list", "--output-format", "json"],
+        "sessions list",
+    )
+    .await?;
+
+    serde_json::from_slice(&out).map_err(|e| Error::wrap("sessions list: unmarshal", e))
+}
+
+/// Runs `claude sessions get <id> --output-format json` and returns the raw
+/// transcript.
+pub async fn get_session_messages(opts: &Options, session_id: &str) -> Result<SessionTranscript> {
+    if session_id.is_empty() {
+        return Err(Error::Other(
+            "claude: sessions get: session_id must not be empty".to_string(),
+        ));
+    }
+
+    let context = format!("sessions get {session_id}");
+    let out = run_cli(
+        opts,
+        &["sessions", "get", session_id, "--output-format", "json"],
+        &context,
+    )
+    .await?;
+
+    serde_json::from_slice(&out).map_err(|e| Error::wrap(&format!("{context}: unmarshal"), e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn an_empty_session_id_is_rejected_without_spawning() {
+        let opts = Options::new().with_claude_executable("/nonexistent/claude");
+        let err = get_session_messages(&opts, "").await.unwrap_err();
+        assert!(err.to_string().contains("must not be empty"));
+    }
+
+    #[test]
+    fn a_summary_decodes_with_every_field_optional() {
+        let list: Vec<SessionSummary> =
+            serde_json::from_str(r#"[{"id":"abc"},{"id":"def","project":"/p"}]"#).unwrap();
+        assert_eq!(list[0].id, "abc");
+        assert!(list[0].project.is_empty());
+        assert_eq!(list[1].project, "/p");
+    }
+
+    #[test]
+    fn a_transcript_keeps_its_messages_verbatim() {
+        let t: SessionTranscript =
+            serde_json::from_str(r#"{"id":"s1","messages":[{"unknown_shape":[1,2]}]}"#).unwrap();
+        assert_eq!(t.id, "s1");
+        assert_eq!(t.messages[0].get(), r#"{"unknown_shape":[1,2]}"#);
+    }
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1,3 +1,8 @@
+// The Claude Agent SDK, ported from Go. Public because it is a library in its
+// own right — the agent runtime, the integrations' MCP servers and the chat SSE
+// all build on it — and because its tests drive it against a scripted CLI from
+// outside the crate.
+pub mod claude;
 mod menu;
 // `native` and `paths` are public so `tests/live_parity.rs` can diff a ported
 // endpoint against the running Go server without going through a window.

--- a/desktop/src-tauri/tests/claude_sdk.rs
+++ b/desktop/src-tauri/tests/claude_sdk.rs
@@ -339,6 +339,52 @@ async fn a_rejected_initialize_is_reported_as_a_rejection() {
     }
 }
 
+#[tokio::test]
+async fn a_cli_that_dies_during_startup_is_reported_at_once() {
+    if python3().is_none() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("stdin.jsonl");
+    // Exits before acknowledging — an unusable --settings path, a bad flag, a
+    // failed auth all look like this.
+    let exe = fake_cli(
+        dir.path(),
+        &log,
+        r#"    sys.stderr.write("invalid settings file\n")
+    sys.stderr.flush()
+    sys.exit(2)"#,
+    );
+
+    // A generous handshake timeout, so the assertion below is about the process
+    // dying and not about the clock.
+    let opts = Options::new()
+        .with_claude_executable(exe.to_string_lossy().into_owned())
+        .with_init_timeout(Duration::from_secs(60));
+
+    let started = std::time::Instant::now();
+    let err = query_err("hello", opts).await;
+    let elapsed = started.elapsed();
+
+    match err {
+        claude::Error::Initialize { timeout, message } => {
+            assert!(!timeout, "the CLI answered by exiting, it did not go quiet");
+            assert!(
+                message.contains("invalid settings file"),
+                "stderr is the only clue the user gets: {message}"
+            );
+        }
+        other => panic!("expected an initialize failure, got {other}"),
+    }
+    // The pending sender lives in the shared state, not in the reader task, so
+    // nothing else would ever report this — without the race against process
+    // exit the caller waits out the whole timeout for an answer already known.
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "a dead CLI must not cost the full handshake timeout, took {elapsed:?}"
+    );
+}
+
 // ─── A turn end to end ───────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/desktop/src-tauri/tests/claude_sdk.rs
+++ b/desktop/src-tauri/tests/claude_sdk.rs
@@ -1,0 +1,779 @@
+//! The Claude Agent SDK port, driven against a **scripted fake CLI**.
+//!
+//! This is the technique the Go SDK proved, and it is here for the same reason:
+//! the guarantees that matter are properties of a *sequence* the spawn path
+//! performs, not of any single function. Only a real subprocess on the other end
+//! of real pipes can show that `initialize` is written before the user message,
+//! that the wait for the acknowledgement is a wait, or that an unanswered
+//! `control_request` is what hangs a session.
+//!
+//! The fake is a small Python program that logs every stdin line it receives to
+//! a JSONL file and replies according to a per-test script. No `claude` binary
+//! and no API key are involved, so these run in CI like any other test.
+//!
+//! The one imported subtlety from the Go tests: the acknowledgement is sent from
+//! a **separate thread after a deliberate sleep**, and the `__ack_sent__` marker
+//! is written *before* the reply is flushed. The sleep is what makes "waited for
+//! the acknowledgement" distinguishable from "wrote the user message
+//! immediately" — in a racing implementation the user message lands inside that
+//! window. Marking before flushing removes the test's own race, since once the
+//! reply is on the wire the SDK may write the next message instantly.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use agento_lib::claude::{self, Options, PermissionResult};
+
+/// Skips a test when the machine has no `python3`, the way the Go suite skips
+/// on Windows: the fake CLI is a script, not a compiled fixture.
+fn python3() -> Option<String> {
+    for candidate in ["python3", "python"] {
+        if std::process::Command::new(candidate)
+            .arg("--version")
+            .output()
+            .is_ok()
+        {
+            return Some(candidate.to_string());
+        }
+    }
+    None
+}
+
+/// Writes an executable fake `claude` into `dir` and returns its path.
+///
+/// `emit` is Python appended to the request loop; it receives `msg` (the
+/// decoded stdin line), and may call `ack(request_id)` or `say(obj)`.
+fn fake_cli(dir: &Path, log_path: &Path, emit: &str) -> PathBuf {
+    let script = format!(
+        r#"#!/usr/bin/env {python}
+import json, sys, threading, time
+
+LOG = {log}
+
+log = open(LOG, "a")
+lock = threading.Lock()
+
+def record(entry):
+    with lock:
+        log.write(json.dumps(entry) + "\n")
+        log.flush()
+
+def say(obj):
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+
+def ack(request_id, body=None):
+    # Deliberately slow, and on its own thread so stdin keeps being read and
+    # logged meanwhile. That is what lets a test tell "waited for the
+    # acknowledgement" from "wrote the user message immediately".
+    time.sleep(0.5)
+    if body is None:
+        body = {{"models": [{{"value": "fake", "displayName": "Fake"}}],
+                 "account": {{"apiProvider": "fake"}},
+                 "output_style": "default"}}
+    # Mark BEFORE flushing: once the response is on the wire the SDK may write
+    # the next message immediately, and the reader thread would log it ahead of
+    # a marker recorded afterwards.
+    record({{"type": "__ack_sent__"}})
+    say({{"type": "control_response",
+         "response": {{"subtype": "success", "request_id": request_id, "response": body}}}})
+
+def ack_now(request_id):
+    say({{"type": "control_response",
+         "response": {{"subtype": "success", "request_id": request_id,
+                      "response": {{"account": {{"apiProvider": "fake"}}}}}}}})
+
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        msg = json.loads(line)
+    except Exception:
+        continue
+    record(msg)
+    req = msg.get("request") or {{}}
+{emit}
+"#,
+        python = python3().unwrap_or_else(|| "python3".into()),
+        log = serde_json::to_string(&log_path.to_string_lossy()).unwrap(),
+        emit = emit,
+    );
+
+    let path = dir.join("fake-claude");
+    std::fs::write(&path, script).expect("write fake CLI");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod fake CLI");
+    }
+    path
+}
+
+/// The message types the fake CLI received, in order — `control_request`s
+/// labelled with their subtype, so ordering assertions read as a sequence.
+fn logged(log_path: &Path) -> Vec<String> {
+    let Ok(raw) = std::fs::read_to_string(log_path) else {
+        return Vec::new();
+    };
+    raw.lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|line| {
+            let v: serde_json::Value = serde_json::from_str(line).ok()?;
+            let kind = v.get("type")?.as_str()?;
+            if kind == "control_request" {
+                let subtype = v
+                    .get("request")
+                    .and_then(|r| r.get("subtype"))
+                    .and_then(|s| s.as_str())
+                    .unwrap_or("");
+                Some(format!("control_request:{subtype}"))
+            } else {
+                Some(kind.to_string())
+            }
+        })
+        .collect()
+}
+
+/// Polls the log until it holds at least `n` entries, so assertions do not race
+/// the fake CLI's own writes.
+async fn wait_for_logged(log_path: &Path, n: usize) -> Vec<String> {
+    for _ in 0..500 {
+        let entries = logged(log_path);
+        if entries.len() >= n {
+            return entries;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    logged(log_path)
+}
+
+/// The full stdin line for the first message of the given type.
+fn logged_message(log_path: &Path, kind: &str) -> Option<serde_json::Value> {
+    let raw = std::fs::read_to_string(log_path).ok()?;
+    raw.lines()
+        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+        .find(|v| v.get("type").and_then(|t| t.as_str()) == Some(kind))
+}
+
+fn options_for(exe: &Path) -> Options {
+    Options::new()
+        .with_claude_executable(exe.to_string_lossy().into_owned())
+        .with_init_timeout(Duration::from_secs(10))
+}
+
+/// Whether a spawn failure is the `ETXTBSY` race rather than a real one.
+///
+/// These tests write an executable and then exec it, from several threads at
+/// once. On Linux `execve` refuses a file any process has open for writing, and
+/// a `fork` in one thread duplicates another thread's still-open write fd into
+/// the child until that child's own `exec` closes it. So thread A can be
+/// refused its own freshly written script because thread B forked mid-write.
+/// It is a property of the harness — one process writing and executing many
+/// files concurrently — not of the SDK, which never writes what it spawns.
+fn is_text_file_busy(err: &claude::Error) -> bool {
+    err.to_string().contains("Text file busy")
+}
+
+/// Starts a query, retrying past the `ETXTBSY` race described above.
+async fn query(prompt: &str, opts: Options) -> claude::Stream {
+    for _ in 0..50 {
+        match claude::query(prompt, opts.clone()).await {
+            Err(e) if is_text_file_busy(&e) => {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+            other => return other.expect("query"),
+        }
+    }
+    panic!("the fake CLI stayed busy for a second");
+}
+
+/// Starts a query that is expected to fail, retrying past the `ETXTBSY` race so
+/// the harness's own flake cannot be mistaken for the failure under test.
+async fn query_err(prompt: &str, opts: Options) -> claude::Error {
+    for _ in 0..50 {
+        match claude::query(prompt, opts.clone()).await {
+            Err(e) if is_text_file_busy(&e) => {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+            Err(e) => return e,
+            Ok(_) => panic!("expected the query to fail"),
+        }
+    }
+    panic!("the fake CLI stayed busy for a second");
+}
+
+/// Opens a session, retrying past the `ETXTBSY` race described above.
+async fn session(opts: Options) -> claude::Session {
+    for _ in 0..50 {
+        match claude::Session::new(opts.clone()).await {
+            Err(e) if is_text_file_busy(&e) => {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+            other => return other.expect("session"),
+        }
+    }
+    panic!("the fake CLI stayed busy for a second");
+}
+
+// ─── The handshake ordering ──────────────────────────────────────────────────
+
+#[tokio::test]
+async fn the_user_message_waits_for_the_initialize_acknowledgement() {
+    if python3().is_none() {
+        eprintln!("skipping: no python3 for the fake CLI");
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("stdin.jsonl");
+    let exe = fake_cli(
+        dir.path(),
+        &log,
+        r#"    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        threading.Thread(target=ack, args=(msg.get("request_id"),), daemon=True).start()"#,
+    );
+
+    let stream = query("hello", options_for(&exe)).await;
+
+    let entries = wait_for_logged(&log, 3).await;
+    assert_eq!(
+        entries,
+        vec!["control_request:initialize", "__ack_sent__", "user"],
+        "the turn must not start before the CLI has configured MCP servers, agents and hooks"
+    );
+
+    // The handshake payload is the SDK's only source of truth for what the CLI
+    // offers, so it has to survive into the stream.
+    assert_eq!(stream.supported_models().len(), 1);
+    assert_eq!(stream.supported_models()[0].value, "fake");
+    assert_eq!(stream.account_info().api_provider, "fake");
+    assert_eq!(stream.output_style().0, "default");
+}
+
+#[tokio::test]
+async fn a_session_writes_the_handshake_and_nothing_else() {
+    if python3().is_none() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("stdin.jsonl");
+    let exe = fake_cli(
+        dir.path(),
+        &log,
+        r#"    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        threading.Thread(target=ack, args=(msg.get("request_id"),), daemon=True).start()"#,
+    );
+
+    let session = session(options_for(&exe)).await;
+
+    let entries = wait_for_logged(&log, 2).await;
+    assert_eq!(entries, vec!["control_request:initialize", "__ack_sent__"]);
+
+    // The first turn only begins when the caller sends one.
+    session.send("now we begin").await.unwrap();
+    let entries = wait_for_logged(&log, 3).await;
+    assert_eq!(entries.last().unwrap(), "user");
+}
+
+#[tokio::test]
+async fn a_cli_that_never_acknowledges_fails_as_a_timeout() {
+    if python3().is_none() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("stdin.jsonl");
+    // Logs everything, answers nothing.
+    let exe = fake_cli(dir.path(), &log, "    pass");
+
+    let opts = Options::new()
+        .with_claude_executable(exe.to_string_lossy().into_owned())
+        .with_init_timeout(Duration::from_millis(750));
+
+    let started = std::time::Instant::now();
+    let err = query_err("hello", opts).await;
+    let elapsed = started.elapsed();
+
+    match err {
+        claude::Error::Initialize { timeout, .. } => {
+            assert!(timeout, "a silent CLI is a timeout, not a rejection")
+        }
+        other => panic!("expected an initialize timeout, got {other}"),
+    }
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "the timeout must bound startup, took {elapsed:?}"
+    );
+    assert!(
+        !logged(&log).contains(&"user".to_string()),
+        "a failed handshake must not have started a turn"
+    );
+}
+
+#[tokio::test]
+async fn a_rejected_initialize_is_reported_as_a_rejection() {
+    if python3().is_none() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("stdin.jsonl");
+    let exe = fake_cli(
+        dir.path(),
+        &log,
+        r#"    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        say({"type": "control_response",
+             "response": {"subtype": "error", "request_id": msg.get("request_id"),
+                          "error": "sdkMcpServers and webSearchIsolationExemptMcpServers must be arrays of strings"}})"#,
+    );
+
+    let err = query_err("hello", options_for(&exe)).await;
+    match err {
+        claude::Error::Initialize { timeout, message } => {
+            assert!(!timeout);
+            assert!(
+                message.contains("arrays of strings"),
+                "the CLI's own reason must survive: {message}"
+            );
+        }
+        other => panic!("expected an initialize rejection, got {other}"),
+    }
+}
+
+// ─── A turn end to end ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn a_turn_streams_its_events_and_ends_on_the_result() {
+    if python3().is_none() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("stdin.jsonl");
+    let exe = fake_cli(
+        dir.path(),
+        &log,
+        r#"    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack_now(msg.get("request_id"))
+    elif msg.get("type") == "user":
+        say({"type": "system", "subtype": "init", "session_id": "s-1",
+             "capabilities": ["interrupt_receipt_v1"]})
+        say({"type": "assistant", "session_id": "s-1",
+             "message": {"role": "assistant", "model": "fake",
+                         "content": [{"type": "text", "text": "four"}]}})
+        say({"type": "result", "subtype": "success", "session_id": "s-1",
+             "is_error": False, "num_turns": 1, "result": "four",
+             "total_cost_usd": 0.25, "terminal_reason": "completed",
+             "usage": {"input_tokens": 10, "output_tokens": 2},
+             "modelUsage": {"fake": {"inputTokens": 10, "outputTokens": 2, "costUSD": 0.25}}})"#,
+    );
+
+    let mut stream = query("2+2?", options_for(&exe)).await;
+
+    let mut kinds = Vec::new();
+    let mut text = String::new();
+    let mut result = None;
+    while let Some(event) = stream.next_event().await {
+        kinds.push(event.event_type.clone());
+        if let Some(assistant) = &event.assistant {
+            text.push_str(&assistant.text());
+        }
+        if let Some(r) = event.result {
+            result = Some(r);
+        }
+    }
+
+    assert_eq!(kinds, vec!["system", "assistant", "result"]);
+    assert_eq!(text, "four");
+
+    let result = result.expect("the run must produce a result");
+    assert!(!result.is_error);
+    assert_eq!(result.result, "four");
+    assert_eq!(result.total_cost_usd, 0.25);
+    assert_eq!(result.terminal_reason.as_str(), "completed");
+    assert!(!result.terminal_reason.aborted());
+    assert_eq!(result.usage.input_tokens, 10);
+    // modelUsage is camelCase inside an otherwise snake_case message.
+    assert_eq!(result.model_usages["fake"].cost_usd, 0.25);
+
+    // capabilities come from system/init, not from the handshake.
+    assert_eq!(
+        stream.capabilities(),
+        Some(vec!["interrupt_receipt_v1".to_string()])
+    );
+}
+
+#[tokio::test]
+async fn run_returns_the_final_result_and_surfaces_an_error_one() {
+    if python3().is_none() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("stdin.jsonl");
+    let exe = fake_cli(
+        dir.path(),
+        &log,
+        r#"    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack_now(msg.get("request_id"))
+    elif msg.get("type") == "user":
+        say({"type": "result", "subtype": "error_during_execution", "is_error": True,
+             "terminal_reason": "aborted_streaming", "api_error_status": 529,
+             "errors": ["upstream said no"]})"#,
+    );
+
+    let err = claude::run("go", options_for(&exe)).await.unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "claude: agent error (error_during_execution, aborted_streaming, HTTP 529): upstream said no"
+    );
+}
+
+// ─── The permission round trip ───────────────────────────────────────────────
+
+#[tokio::test]
+async fn an_allow_echoes_the_original_input_back_verbatim() {
+    if python3().is_none() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("stdin.jsonl");
+    let exe = fake_cli(
+        dir.path(),
+        &log,
+        r#"    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack_now(msg.get("request_id"))
+    elif msg.get("type") == "user":
+        say({"type": "control_request", "request_id": "perm-1",
+             "request": {"subtype": "can_use_tool", "tool_name": "Bash",
+                         "tool_use_id": "tu_9", "blocked_path": "/etc",
+                         "input": {"command": "ls -la"}}})"#,
+    );
+
+    let handler: claude::PermissionHandler = std::sync::Arc::new(|tool, _input, ctx| {
+        Box::pin(async move {
+            assert_eq!(tool, "Bash");
+            assert_eq!(ctx.tool_use_id, "tu_9");
+            assert_eq!(ctx.blocked_path, "/etc");
+            PermissionResult::allow()
+        })
+    });
+
+    let opts = options_for(&exe)
+        .with_default_permissions()
+        .with_permission_handler(handler);
+    let _stream = query("run it", opts).await;
+
+    // The reply is a control_response written back on stdin, so it shows up in
+    // the fake CLI's own log.
+    for _ in 0..250 {
+        if let Some(reply) = logged_message(&log, "control_response") {
+            let response = &reply["response"];
+            assert_eq!(response["subtype"], "success");
+            assert_eq!(response["request_id"], "perm-1");
+            assert_eq!(response["response"]["behavior"], "allow");
+            // The CLI expects the input it should actually run; an allow that
+            // omitted it would leave the call with nothing to execute.
+            assert_eq!(response["response"]["updatedInput"]["command"], "ls -la");
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("the SDK never answered the permission request; a missing reply hangs the CLI");
+}
+
+#[tokio::test]
+async fn a_deny_carries_its_message_and_optional_interrupt() {
+    if python3().is_none() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("stdin.jsonl");
+    let exe = fake_cli(
+        dir.path(),
+        &log,
+        r#"    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack_now(msg.get("request_id"))
+    elif msg.get("type") == "user":
+        say({"type": "control_request", "request_id": "perm-2",
+             "request": {"subtype": "can_use_tool", "tool_name": "Write",
+                         "input": {"path": "/etc/passwd"}}})"#,
+    );
+
+    let handler: claude::PermissionHandler = std::sync::Arc::new(|_, _, _| {
+        Box::pin(async {
+            PermissionResult::Deny {
+                message: "not that file".into(),
+                interrupt: true,
+            }
+        })
+    });
+
+    let opts = options_for(&exe)
+        .with_default_permissions()
+        .with_permission_handler(handler);
+    let _stream = query("write it", opts).await;
+
+    for _ in 0..250 {
+        if let Some(reply) = logged_message(&log, "control_response") {
+            let response = &reply["response"]["response"];
+            assert_eq!(response["behavior"], "deny");
+            assert_eq!(response["message"], "not that file");
+            assert_eq!(response["interrupt"], true);
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("the SDK never answered the permission request");
+}
+
+#[tokio::test]
+async fn no_handler_fails_closed_rather_than_allowing() {
+    if python3().is_none() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("stdin.jsonl");
+    let exe = fake_cli(
+        dir.path(),
+        &log,
+        r#"    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack_now(msg.get("request_id"))
+    elif msg.get("type") == "user":
+        say({"type": "control_request", "request_id": "perm-3",
+             "request": {"subtype": "can_use_tool", "tool_name": "Bash",
+                         "input": {"command": "rm -rf /"}}})"#,
+    );
+
+    // No handler registered: answering would grant a permission nobody approved.
+    let _stream = query("go", options_for(&exe)).await;
+
+    for _ in 0..250 {
+        if let Some(reply) = logged_message(&log, "control_response") {
+            let response = &reply["response"];
+            assert_eq!(response["subtype"], "error");
+            assert_eq!(response["request_id"], "perm-3");
+            assert_eq!(response["error"], "canUseTool callback is not provided");
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("an unanswered can_use_tool hangs the CLI");
+}
+
+#[tokio::test]
+async fn an_unknown_control_request_is_still_acknowledged() {
+    if python3().is_none() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("stdin.jsonl");
+    let exe = fake_cli(
+        dir.path(),
+        &log,
+        r#"    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack_now(msg.get("request_id"))
+    elif msg.get("type") == "user":
+        say({"type": "control_request", "request_id": "note-1",
+             "request": {"subtype": "some_future_notification"}})"#,
+    );
+
+    let _stream = query("go", options_for(&exe)).await;
+
+    for _ in 0..250 {
+        if let Some(reply) = logged_message(&log, "control_response") {
+            assert_eq!(reply["response"]["subtype"], "success");
+            assert_eq!(reply["response"]["request_id"], "note-1");
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("every inbound control_request must be answered, including ones we only acknowledge");
+}
+
+// ─── Outbound control requests ───────────────────────────────────────────────
+
+#[tokio::test]
+async fn interrupt_leaves_the_session_alive_and_decodes_its_receipt() {
+    if python3().is_none() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("stdin.jsonl");
+    let exe = fake_cli(
+        dir.path(),
+        &log,
+        r#"    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack_now(msg.get("request_id"))
+    elif msg.get("type") == "control_request" and req.get("subtype") == "interrupt":
+        say({"type": "control_response",
+             "response": {"subtype": "success", "request_id": msg.get("request_id"),
+                          "response": {"still_queued": ["u-1", None, "u-2"]}}})"#,
+    );
+
+    let session = session(options_for(&exe)).await;
+    let receipt = session.interrupt().await.unwrap().expect("a receipt");
+    // Non-string elements are filtered; a JSON null would otherwise smuggle in
+    // an empty id.
+    assert_eq!(receipt.still_queued, vec!["u-1", "u-2"]);
+
+    // The session is still usable: interrupt aborts the turn, not the process.
+    session.send("next turn").await.unwrap();
+    let entries = wait_for_logged(&log, 4).await;
+    assert!(entries.contains(&"control_request:interrupt".to_string()));
+    assert_eq!(entries.last().unwrap(), "user");
+}
+
+#[tokio::test]
+async fn set_permission_mode_sends_mode_not_permission_mode() {
+    if python3().is_none() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("stdin.jsonl");
+    let exe = fake_cli(
+        dir.path(),
+        &log,
+        r#"    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack_now(msg.get("request_id"))
+    elif msg.get("type") == "control_request":
+        say({"type": "control_response",
+             "response": {"subtype": "success", "request_id": msg.get("request_id")}})"#,
+    );
+
+    let session = session(options_for(&exe)).await;
+    session
+        .set_permission_mode(claude::permission_mode::PLAN)
+        .await
+        .unwrap();
+
+    let raw = std::fs::read_to_string(&log).unwrap();
+    let sent = raw
+        .lines()
+        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+        .find(|v| v["request"]["subtype"] == "set_permission_mode")
+        .expect("the request must have been written");
+
+    assert_eq!(sent["request"]["mode"], "plan");
+    assert!(
+        sent["request"].get("permission_mode").is_none(),
+        "the outbound request and the inbound notification do not share a spelling"
+    );
+}
+
+#[tokio::test]
+async fn a_control_request_reports_the_clis_error_text() {
+    if python3().is_none() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("stdin.jsonl");
+    let exe = fake_cli(
+        dir.path(),
+        &log,
+        r#"    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack_now(msg.get("request_id"))
+    elif msg.get("type") == "control_request":
+        say({"type": "control_response",
+             "response": {"subtype": "error", "request_id": msg.get("request_id"),
+                          "error": "unsupported subtype"}})"#,
+    );
+
+    let session = session(options_for(&exe)).await;
+    let err = session.set_model("nope").await.unwrap_err();
+    assert_eq!(err.to_string(), "claude: set_model: unsupported subtype");
+}
+
+// ─── Process-level failures ──────────────────────────────────────────────────
+
+#[tokio::test]
+async fn a_missing_binary_is_reported_as_such() {
+    let opts = Options::new().with_claude_executable("/nonexistent/definitely/not/claude");
+    let err = claude::query("hi", opts).await.unwrap_err();
+    match err {
+        claude::Error::CliNotFound { executable } => {
+            assert!(executable.contains("not/claude"))
+        }
+        other => panic!("expected CliNotFound, got {other}"),
+    }
+}
+
+#[tokio::test]
+async fn a_crash_after_the_handshake_surfaces_stderr_as_a_system_error() {
+    if python3().is_none() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("stdin.jsonl");
+    let exe = fake_cli(
+        dir.path(),
+        &log,
+        r#"    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack_now(msg.get("request_id"))
+    elif msg.get("type") == "user":
+        sys.stderr.write("something went badly wrong\n")
+        sys.stderr.flush()
+        sys.exit(3)"#,
+    );
+
+    let mut stream = query("go", options_for(&exe)).await;
+
+    let mut saw = None;
+    while let Some(event) = stream.next_event().await {
+        if let Some(system) = &event.system {
+            if system.subtype == "error" {
+                saw = Some(system.error.clone());
+            }
+        }
+    }
+
+    // A process that dies without a result would otherwise end the stream
+    // silently, and the caller would have nothing to report.
+    assert_eq!(saw.as_deref(), Some("something went badly wrong"));
+}
+
+#[tokio::test]
+async fn dropping_a_stream_does_not_leave_the_subprocess_running() {
+    // The liveness check reads /proc, so the assertion is only meaningful on
+    // Linux; elsewhere it would be a guess rather than a check.
+    if python3().is_none() || !cfg!(target_os = "linux") {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("stdin.jsonl");
+    // Acknowledges, then blocks forever on stdin — the shape of a live session.
+    let exe = fake_cli(
+        dir.path(),
+        &log,
+        r#"    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack_now(msg.get("request_id"))"#,
+    );
+
+    let marker = exe.to_string_lossy().into_owned();
+    {
+        let _session = session(options_for(&exe)).await;
+        assert!(process_alive(&marker), "the fake CLI should be running");
+    }
+
+    for _ in 0..300 {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        if !process_alive(&marker) {
+            return;
+        }
+    }
+    panic!("the subprocess outlived its stream; a cancelled chat would leak one per turn");
+}
+
+/// Whether any process was launched with `marker` in its command line. Linux
+/// only; elsewhere the assertion is skipped rather than guessed at.
+fn process_alive(marker: &str) -> bool {
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let cmdline = entry.path().join("cmdline");
+        if let Ok(raw) = std::fs::read(&cmdline) {
+            if String::from_utf8_lossy(&raw).contains(marker) {
+                return true;
+            }
+        }
+    }
+    false
+}


### PR DESCRIPTION
Closes #269.

Targets `desktop`; `main` untouched.

## What

`github.com/shaharia-lab/claude-agent-sdk-go` reimplemented in Rust as `desktop/src-tauri/src/claude/`. It is **not an API client** but a subprocess protocol client: it spawns the `claude` CLI, speaks stream-json over stdio, and multiplexes a control protocol down the same pipes. There is no model inference to reimplement and no API key — the CLI's own sign-in is the credential.

Ported surface, all of what Agento uses across its 21 call sites:

- session lifecycle — `query`, `run`, `Session`, `Stream`
- every option, across both channels it splits over (CLI flags, and the initialize message)
- the control protocol — handshake, permission and hook round trips, interrupt, and the `set_*`/mcp requests
- the wire types and the line parser
- `start_in_process_mcp_server` — what all seven integrations are built on

## Why now, ahead of anything that calls it

Nothing routes to it yet: the runner, chat service and SSE handler are still Go. It lands first because **phases 4 and 5 both need it** — every integration is one of its MCP servers, so phase 4 cannot move before it does — and because its correctness is testable in isolation, against a scripted CLI, in a way it stops being once a live route depends on it.

## How it was verified

There is no JSON response to diff, so `parity-instance.sh` has nothing to say here. The bar is the **SSE stream**: raw CLI lines passed through verbatim plus Agento's two synthetic events, which is why `Event::raw` keeps every message's bytes.

The tests are the technique the Go SDK proved — a **scripted fake CLI** (`tests/claude_sdk.rs`), a Python program that logs every stdin line and replies to order. That is the only way to check things that are properties of a *sequence* rather than of a function. **106 tests: 90 unit, 16 driving the real spawn path.**

Local gates, all green: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo build --release`.

## Four protocol facts carried over rather than re-discovered

Each is silent when wrong, which is why they are in the code as comments and in `desktop/CLAUDE.md`:

- **The handshake order.** Reader task live → register the request id → write `initialize` → *block* on the acknowledgement → only then the first user message. A `control_response` cannot be routed before something reads stdout, and MCP servers, agents and hooks are configured during the ack. Wrong ordering races; it does not fail.
- **`sdkMcpServers` is never sent.** The CLI accepts only an array of strings there, and a rejection fails the *entire* initialize — silently taking hooks, agents, the system prompt and the output format with it.
- **`control_response` routes on the nested `response.request_id`** and hands back the *innermost* payload. No top-level fallback; an absent inner payload is a success with no data.
- **Every inbound `control_request` must be answered** or the CLI hangs, including ones we only acknowledge. `can_use_tool` with no handler is answered with an **error, never an allow** — fail closed.

## Four places a mechanical port would have been wrong

Documented at each site:

| | |
|---|---|
| `lenient.rs` | Go keeps the fields that decoded and reports the error; serde aborts the struct. Reproduced, because a CLI that reshapes one field must not blank a message. |
| `Stream` / `StreamControl` | Go's single `*Stream` is safe from any goroutine; reading a channel in Rust needs `&mut self`, so the control half is a separate clonable handle. |
| async callbacks | Go blocks a goroutine inline on the reader. Blocking a runtime worker would be a bug, so handlers return futures awaited in the same position — same semantics, no pinned thread. |
| handle lifetimes | Go cancels via `context.Context`. Dropping a `Stream` shuts the subprocess down, so a cancelled chat cannot orphan one. |

## One scope call worth reviewing

`start_in_process_mcp_server` takes an `McpService` trait rather than an `rmcp` server. Go hands its MCP SDK's `*mcp.Server` to that SDK's streamable-HTTP handler; the equivalent here would pin `rmcp`'s API to satisfy **no caller**, since nothing has an MCP server to host until phase 4. The seam sits exactly where Go's does — the SDK owns the listener, the caller owns the tools — and an `rmcp` adapter is one impl away. Say so if you would rather take the dependency now.

## Dependencies added

`tokio` gains `process`/`io-util`/`io-std`/`sync` (the sidecar goes through tauri-plugin-shell, which only launches declared sidecars; the agent CLI is an arbitrary executable on `PATH`), plus `uuid` for request ids and `libc` on unix for the SIGTERM step of shutdown.