### PR TITLE
feat(desktop): port the Claude session scanner to Rust

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -120,6 +120,15 @@ src-tauri/src/
     mcp.rs       loopback HTTP host for in-process MCP servers
     lenient.rs   Go's partial-decode semantics, which serde does not have
   native/        ported endpoints (phase 2+)
+    active_time.rs the capped-gap rule, shared by the scanner and the pipeline
+    scanner/     the Claude session scanner (issue #270) — computes, never writes
+      summary_file.rs one transcript → one cache row
+      walk.rs      config dirs, project dirs, claim_session, walked vs protected
+      diff.rs      insert/update/delete, and why a moved path is not a discovery
+      staleness.rs the three markers that force a full re-read
+      store.rs     the cache tables' reads and writes
+      apply.rs     parallel read, batched write
+      cost.rs      per-message pricing
     mod.rs       endpoint registry, mode switch, response shaping
     gojson.rs    Go-compatible JSON encoder — read this before porting anything
     gotime.rs    Go's time.Time on the wire
@@ -325,6 +334,54 @@ rather than expecting the encoder to notice.
 | 3 | Storage + tasks | `internal/storage`, `internal/scheduler` | 27 SQLite migrations; reuse the same DB file and schema. Scheduler is cron/interval. |
 | 4 | Integrations | `internal/integrations`, `internal/trigger` | OAuth2 + MCP servers. WhatsApp (`whatsmeow`) is the blocker — port it last or keep it in Go. |
 | 5 | Agent execution | `internal/agent`, `internal/service` | Spawns the `claude` CLI over stream-json stdin/stdout. **The SDK underneath it is ported** (`src/claude/`, below); what remains is the runner, the chat service and the SSE handler on top of it. |
+
+### The session scanner (`src-tauri/src/native/scanner/`)
+
+`scanner.go` + `scan_apply.go` in Rust: the walk, the diff, the staleness
+rules, the transcript→row reader and the parallel-read/batched-write apply.
+
+**It computes; it does not write.** `native/db.rs` opens the database
+read-only on purpose, and the Go sidecar runs its own scanner on every read
+path — two processes writing one SQLite file is what that read-only flag
+exists to prevent. So this follows the precedent #263 set for the insight
+processors: port the logic, verify it against the rows Go already wrote.
+Wiring it in, and with it retiring `freshness_probe`, belongs to phase 3.
+
+**Parity is the stored rows, not a response.** Every
+`claude_session_cache` and `claude_subagent_cache` row is recomputed from
+its own transcript and compared field by field — 926 and 920 rows on the
+reference corpus (`tests/parity_scanner.rs`). The row records the mtime it
+was read at, so "has this file grown since" is exact; rows that moved on
+are skipped, because every figure would read as "computed is larger",
+which is also what an over-counting bug looks like.
+
+Four rules that are silent when wrong:
+
+- **"No file on disk" and "we could not look" are different answers.** A
+  config dir that failed to list is left out of `walked` and its rows are
+  excluded from the delete pass; an unmounted drive would otherwise wipe an
+  account's corpus, `custom_title` and `is_favorite` included. A dir that
+  exists but has no `projects/` is the case that looks like a failure and
+  is not. Protection is per project, not per config dir.
+- **A moved path is an update, not a discovery** (#245). Rows key on
+  `(session_id, project_path)` while `file_path` is a non-unique index, so
+  a claim shift legitimately brings the same row under a new path. The diff
+  indexes the cache twice — by path and by row key — to tell them apart.
+- **`custom_title` and `is_favorite` are in neither write list.** They are
+  the only columns here the user typed.
+- **Three markers force a full re-read with nothing changed on disk**:
+  scanner version, pricing revision, idle threshold. The last cannot be a
+  version constant but makes the same rows stale. Invalidation zeroes
+  mtimes rather than dropping rows, so a re-read is an update.
+
+Two encodings to get wrong: `cost_by_model` is JSON but empty stores as
+`""`, and `unpriced_models` is newline-joined rather than JSON, because a
+model id may contain a slash but never a newline.
+
+`transcript.rs` and `native/active_time.rs` are shared with the insight
+pipeline deliberately — `is_user_turn_content` decides `message_count`,
+`turn_count` and the journey's turns at once, and the same session's active
+duration is stored in two tables under a user-configurable threshold.
 
 ### The Claude Agent SDK (`src-tauri/src/claude/`)
 

--- a/desktop/src-tauri/src/native/active_time.rs
+++ b/desktop/src-tauri/src/native/active_time.rs
@@ -1,0 +1,129 @@
+//! Active duration, ported from `internal/claudesessions/active_duration.go`.
+//!
+//! **Duration means active duration everywhere a user reads one.** Sessions are
+//! resumable, so the raw start→last span counts every idle day between
+//! sittings — one resumed-after-28-days session carried 82% of the dashboard's
+//! "Avg Duration" (476 min shown against a 17 min median). The fix is to cap
+//! each inter-event gap at the idle threshold and sum those.
+//!
+//! This lives outside both callers because **the scanner and the insight
+//! pipeline must agree**. The scanner stores `active_duration_ms` on the cache
+//! row; the pipeline stores its own on `session_insights`; the journey computes
+//! one on read. Three implementations of one rule is how they would drift, and
+//! the threshold is user-configurable, so the drift would be invisible until
+//! someone changed it.
+
+use chrono::{DateTime, Utc};
+
+/// Accumulates the timestamps of one session's events and reports the capped
+/// active spans over them.
+#[derive(Debug, Clone, Default)]
+pub struct ActiveTimeTracker {
+    idle_gap_ms: i64,
+    stamps: Vec<(DateTime<Utc>, bool)>,
+}
+
+impl ActiveTimeTracker {
+    pub fn new(idle_gap_ms: i64) -> Self {
+        ActiveTimeTracker {
+            idle_gap_ms,
+            stamps: Vec::new(),
+        }
+    }
+
+    /// Records one event. `assistant` marks an assistant event, which is what
+    /// separates Claude's working time from the session's active time.
+    pub fn observe(&mut self, ts: DateTime<Utc>, assistant: bool) {
+        self.stamps.push((ts, assistant));
+    }
+
+    /// The session's active time, in milliseconds.
+    pub fn active_ms(&self) -> i64 {
+        self.durations().0
+    }
+
+    /// `(active, claude_working)` — the capped inter-event gaps, and the subset
+    /// of them that end at an assistant event.
+    ///
+    /// Sorted first because callers feed parent-then-sub-agent transcripts
+    /// whose timestamps interleave — which is also what credits a 40-minute
+    /// delegated run instead of collapsing the parent's `Task` wait to one
+    /// capped gap.
+    ///
+    /// A **stable** sort where Go uses `sort.Slice`: with two events sharing a
+    /// timestamp but differing in whether they are assistant events, the gap
+    /// *into* the pair is attributed to whichever sorts first, so Go's result
+    /// is order-dependent there. Stable keeps file order, which is the order
+    /// the events were written in.
+    ///
+    /// The threshold is read once per call, so a settings save landing mid-walk
+    /// cannot cap two gaps of the same session differently.
+    pub fn durations(&self) -> (i64, i64) {
+        if self.stamps.len() < 2 {
+            return (0, 0);
+        }
+        let mut sorted = self.stamps.clone();
+        sorted.sort_by_key(|(ts, _)| *ts);
+
+        let cap = self.idle_gap_ms;
+        let (mut active, mut assistant) = (0i64, 0i64);
+        for pair in sorted.windows(2) {
+            let gap = (pair[1].0 - pair[0].0).num_milliseconds().min(cap);
+            active += gap;
+            if pair[1].1 {
+                assistant += gap;
+            }
+        }
+        (active, assistant)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t(minutes: i64) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-03-15T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc)
+            + chrono::Duration::minutes(minutes)
+    }
+
+    #[test]
+    fn fewer_than_two_events_have_no_duration() {
+        let mut tracker = ActiveTimeTracker::new(600_000);
+        assert_eq!(tracker.durations(), (0, 0));
+        tracker.observe(t(0), false);
+        assert_eq!(tracker.durations(), (0, 0));
+    }
+
+    #[test]
+    fn a_long_gap_is_capped_at_the_threshold() {
+        // The resumed-after-days case: without the cap this reads as hours.
+        let mut tracker = ActiveTimeTracker::new(600_000); // 10 minutes
+        tracker.observe(t(0), false);
+        tracker.observe(t(60 * 24), false);
+        assert_eq!(tracker.active_ms(), 600_000);
+    }
+
+    #[test]
+    fn assistant_time_is_the_subset_of_gaps_ending_at_an_assistant() {
+        let mut tracker = ActiveTimeTracker::new(600_000);
+        tracker.observe(t(0), false);
+        tracker.observe(t(1), true); // 1 min, credited to both
+        tracker.observe(t(3), false); // 2 min, active only
+        let (active, assistant) = tracker.durations();
+        assert_eq!(active, 3 * 60_000);
+        assert_eq!(assistant, 60_000);
+    }
+
+    #[test]
+    fn out_of_order_stamps_are_sorted_before_the_walk() {
+        // Parent-then-sub-agent feeding is not chronological.
+        let mut tracker = ActiveTimeTracker::new(600_000);
+        tracker.observe(t(4), false);
+        tracker.observe(t(0), false);
+        tracker.observe(t(2), false);
+        assert_eq!(tracker.active_ms(), 4 * 60_000);
+    }
+}

--- a/desktop/src-tauri/src/native/insights/processors.rs
+++ b/desktop/src-tauri/src/native/insights/processors.rs
@@ -33,6 +33,7 @@ use std::collections::BTreeMap;
 use chrono::{DateTime, Utc};
 
 use super::transcript::{self, is_turn_start, parse_content_blocks, Event};
+use crate::native::active_time::ActiveTimeTracker;
 use crate::native::pricing::{Cost, PricedUsage, Resolver};
 
 /// Bumped whenever any processor's logic changes; rows below it are reprocessed.
@@ -373,19 +374,22 @@ fn split_mcp_tool_name(name: &str) -> Option<(&str, &str)> {
 /// the idle threshold and is the figure dashboards average.
 /// `claude_working_time_ms` is the subset of that ending at an assistant event.
 struct TimeProfile {
-    idle_gap_ms: i64,
     first: Option<DateTime<Utc>>,
     last: Option<DateTime<Utc>>,
-    stamps: Vec<(DateTime<Utc>, bool)>,
+    /// The capped-gap walk itself lives in `native::active_time`, shared with
+    /// the scanner: the same session's active duration is stored on both
+    /// `session_insights` and `claude_session_cache`, and two implementations
+    /// of one rule is how they would drift — invisibly, since the threshold is
+    /// user-configurable.
+    active: ActiveTimeTracker,
 }
 
 impl TimeProfile {
     fn new(idle_gap_ms: i64) -> Self {
         TimeProfile {
-            idle_gap_ms,
             first: None,
             last: None,
-            stamps: Vec::new(),
+            active: ActiveTimeTracker::new(idle_gap_ms),
         }
     }
 }
@@ -399,50 +403,16 @@ impl Processor for TimeProfile {
         if self.last.is_none_or_later(ts) {
             self.last = Some(ts);
         }
-        self.stamps.push((ts, ev.event_type == "assistant"));
+        self.active.observe(ts, ev.event_type == "assistant");
     }
 
     fn finalize(&self, insight: &mut SessionInsight) {
         if let (Some(first), Some(last)) = (self.first, self.last) {
             insight.total_duration_ms = (last - first).num_milliseconds();
         }
-        let (active, assistant) = self.durations();
+        let (active, assistant) = self.active.durations();
         insight.active_duration_ms = active;
         insight.claude_working_time_ms = assistant;
-    }
-}
-
-impl TimeProfile {
-    /// Sum the capped inter-event gaps.
-    ///
-    /// Sorted first because the pipeline feeds parent-then-sub-agent
-    /// transcripts whose timestamps interleave — which is also what credits a
-    /// 40-minute delegated run instead of collapsing the parent's `Task` wait
-    /// to one capped gap.
-    ///
-    /// A **stable** sort where Go uses `sort.Slice`: with two events sharing a
-    /// timestamp but differing in whether they are assistant events, the gap
-    /// *into* the pair is attributed to whichever sorts first, so Go's result
-    /// is order-dependent there. Stable keeps file order, which is the order
-    /// the events were written in.
-    fn durations(&self) -> (i64, i64) {
-        if self.stamps.len() < 2 {
-            return (0, 0);
-        }
-        let mut sorted = self.stamps.clone();
-        sorted.sort_by_key(|(ts, _)| *ts);
-
-        let (mut active, mut assistant) = (0i64, 0i64);
-        for pair in sorted.windows(2) {
-            let gap = (pair[1].0 - pair[0].0)
-                .num_milliseconds()
-                .min(self.idle_gap_ms);
-            active += gap;
-            if pair[1].1 {
-                assistant += gap;
-            }
-        }
-        (active, assistant)
     }
 }
 

--- a/desktop/src-tauri/src/native/insights/transcript.rs
+++ b/desktop/src-tauri/src/native/insights/transcript.rs
@@ -73,6 +73,90 @@ pub struct Event {
     /// The reasoning-effort tier the turn ran at.
     #[serde(default)]
     pub effort: String,
+
+    // ── Fields the scanner reads (issue #270) ───────────────────────────────
+    //
+    // The insight pipeline ignores all of these; they are here because this is
+    // the one decoder for this file format, and a second struct over the same
+    // lines is how two readers of one format drift apart.
+    /// First non-empty value wins — the session's working directory.
+    #[serde(default)]
+    pub cwd: String,
+    #[serde(default, rename = "gitBranch")]
+    pub git_branch: String,
+
+    /// Title events carry no timestamp and no message — only these fields.
+    /// Claude Code re-appends them on every resume, so last-in-file wins.
+    #[serde(default, rename = "customTitle")]
+    pub custom_title: String,
+    /// Claude Code's own auto-title, distinct from a user rename.
+    #[serde(default, rename = "aiTitle")]
+    pub ai_title: String,
+
+    /// `pr-link`: the pull request a session produced. Unlike the other
+    /// metadata events this one carries a **real** timestamp, which is why
+    /// `bounds_session_time_range` has to exclude it explicitly.
+    #[serde(default, rename = "prNumber")]
+    pub pr_number: i64,
+    #[serde(default, rename = "prUrl")]
+    pub pr_url: String,
+    #[serde(default, rename = "prRepository")]
+    pub pr_repository: String,
+
+    /// Session metadata events. Like the title events these carry no timestamp
+    /// and are re-appended on every resume, so the last one in the file wins.
+    #[serde(default, rename = "agentName")]
+    pub agent_name: String,
+    #[serde(default, rename = "permissionMode")]
+    pub permission_mode: String,
+    #[serde(default)]
+    pub mode: String,
+    #[serde(default, rename = "relocatedCwd")]
+    pub relocated_cwd: String,
+    #[serde(default, rename = "worktreeSession")]
+    pub worktree_session: Option<WorktreeSession>,
+
+    /// `system` events: the subtype selects the payload, and only
+    /// `compact_boundary` carries compaction metadata.
+    #[serde(default)]
+    pub subtype: String,
+    #[serde(default, rename = "compactMetadata")]
+    pub compact_metadata: Option<CompactMetadata>,
+}
+
+/// The payload of a `worktree-state` event: the throwaway worktree a session
+/// ran in, plus where it came from.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct WorktreeSession {
+    #[serde(default, rename = "worktreeName")]
+    pub worktree_name: String,
+    #[serde(default, rename = "worktreeBranch")]
+    pub worktree_branch: String,
+    #[serde(default, rename = "originalBranch")]
+    pub original_branch: String,
+    #[serde(default, rename = "originalCwd")]
+    pub original_cwd: String,
+    #[serde(default, rename = "originalHeadCommit")]
+    pub original_head_commit: String,
+}
+
+/// The payload of a `system`/`compact_boundary` event.
+///
+/// `cumulative_dropped_tokens` is a **running total** across the session, not a
+/// delta — the largest value seen is the session's figure, and summing would
+/// multiply-count it.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct CompactMetadata {
+    #[serde(default)]
+    pub trigger: String,
+    #[serde(default, rename = "preTokens")]
+    pub pre_tokens: i64,
+    #[serde(default, rename = "postTokens")]
+    pub post_tokens: i64,
+    #[serde(default, rename = "cumulativeDroppedTokens")]
+    pub cumulative_dropped_tokens: i64,
+    #[serde(default, rename = "durationMs")]
+    pub duration_ms: i64,
 }
 
 /// The message payload of a user or assistant event.
@@ -203,7 +287,11 @@ const INJECTED_ARRAY_TURN_MARKERS: [&str; 2] = [
 
 /// Whether content is one of Claude Code's own injections rather than something
 /// a person typed. Handles both shapes the harness writes.
-fn is_injected_user_content(content: &serde_json::Value) -> bool {
+///
+/// Public because the scanner's *preview* rule is deliberately weaker than
+/// its turn rule: an injected wrapper is not a turn, but it is still a
+/// preview candidate when nothing better ever arrives.
+pub fn is_injected_user_content(content: &serde_json::Value) -> bool {
     if let Some(s) = content.as_str() {
         return has_injected_prefix(s.trim(), &INJECTED_TURN_MARKERS);
     }
@@ -227,15 +315,24 @@ fn is_injected_user_content(content: &serde_json::Value) -> bool {
 /// person could type. Hand-written rather than pulling in a regex crate for one
 /// anchored pattern.
 fn is_skill_preamble(text: &str) -> bool {
+    skill_preamble_path(text).is_some()
+}
+
+/// The `(\S+)` capture of `skillPreamblePattern` — the skill's directory.
+///
+/// The scanner turns it into a readable preview label; the turn predicate
+/// only cares whether it matched at all. One implementation so the two
+/// cannot disagree about what counts as a preamble.
+pub fn skill_preamble_path(text: &str) -> Option<String> {
     const PREFIX: &str = "Base directory for this skill:";
-    let Some(rest) = text.strip_prefix(PREFIX) else {
-        return false;
-    };
+    let rest = text.strip_prefix(PREFIX)?;
     // `\s*` then `\S+`: at least one non-space character must follow.
-    rest.trim_start()
+    let token: String = rest
+        .trim_start()
         .chars()
-        .next()
-        .is_some_and(|c| !c.is_whitespace())
+        .take_while(|c| !c.is_whitespace())
+        .collect();
+    (!token.is_empty()).then_some(token)
 }
 
 fn has_injected_prefix(s: &str, markers: &[&str]) -> bool {
@@ -415,5 +512,57 @@ mod tests {
         assert!(parse_content_blocks(&bad).is_empty());
         // …so it is not seen as a carrier, exactly as on the Go side.
         assert!(is_user_turn_content(&bad));
+    }
+}
+
+/// Plain text from a message's content field, which is either a JSON string or
+/// an array of content blocks. Ported from `extractTextContent` in
+/// `scanner.go`; text blocks are joined with newlines and everything else is
+/// dropped.
+pub fn extract_text_content(content: &serde_json::Value) -> String {
+    if let Some(s) = content.as_str() {
+        return s.to_string();
+    }
+    if !content.is_array() {
+        return String::new();
+    }
+    parse_content_blocks(content)
+        .iter()
+        .filter(|b| b.block_type == "text" && !b.text.is_empty())
+        .map(|b| b.text.as_str())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+mod scanner_shared_tests {
+    use super::*;
+
+    #[test]
+    fn a_skill_preamble_yields_its_path_and_a_bare_colon_does_not() {
+        assert_eq!(
+            skill_preamble_path("Base directory for this skill: /a/b/skills/x"),
+            Some("/a/b/skills/x".to_string())
+        );
+        // Ordinary prose a person could type must not match.
+        assert_eq!(skill_preamble_path("Base directory for this skill:"), None);
+        assert_eq!(
+            skill_preamble_path("Base directory for this skill:   "),
+            None
+        );
+    }
+
+    #[test]
+    fn text_is_extracted_from_both_content_shapes() {
+        assert_eq!(extract_text_content(&serde_json::json!("plain")), "plain");
+        assert_eq!(
+            extract_text_content(&serde_json::json!([
+                {"type": "text", "text": "one"},
+                {"type": "tool_use", "name": "Bash"},
+                {"type": "text", "text": "two"}
+            ])),
+            "one\ntwo"
+        );
+        assert_eq!(extract_text_content(&serde_json::json!({"a": 1})), "");
     }
 }

--- a/desktop/src-tauri/src/native/mod.rs
+++ b/desktop/src-tauri/src/native/mod.rs
@@ -11,6 +11,7 @@
 //! unported one, and a schema change that outruns the Rust reader degrades to
 //! the behaviour the app had before the port instead of a 500.
 
+pub mod active_time;
 pub mod agents;
 pub mod analytics;
 pub mod db;
@@ -19,6 +20,7 @@ pub mod gojson;
 pub mod gotime;
 pub mod insights;
 pub mod pricing;
+pub mod scanner;
 pub mod sessions;
 pub mod settings;
 

--- a/desktop/src-tauri/src/native/scanner/apply.rs
+++ b/desktop/src-tauri/src/native/scanner/apply.rs
@@ -133,8 +133,11 @@ pub fn apply_changes(
             let work_rx = &work_rx;
             scope.spawn(move || {
                 loop {
-                    // The lock is held only to take the next unit, never across
-                    // the read itself.
+                    // The lock spans the wait for the next unit, so only one
+                    // reader queues for work at a time — but it is released
+                    // before the read, which is where all the time goes.
+                    // Handing out a unit is nanoseconds against decoding a
+                    // transcript, so the readers still overlap fully.
                     let unit = {
                         let rx = work_rx.lock().expect("work queue");
                         rx.recv()

--- a/desktop/src-tauri/src/native/scanner/apply.rs
+++ b/desktop/src-tauri/src/native/scanner/apply.rs
@@ -1,0 +1,410 @@
+//! Applying a scan's changes: read in parallel, write in batches. Ported from
+//! `internal/claudesessions/scan_apply.go`.
+//!
+//! The two halves have opposite shapes. **Reading** is I/O plus JSON decoding —
+//! 17.2 seconds for 1,671 transcripts single-threaded on the reference machine
+//! — and parallelizes well. **Writing** does not parallelize at all, because
+//! SQLite serializes writers; but a transaction per file does not help either,
+//! since a full re-read of 5,000 sessions would be 5,000 commits, each with its
+//! own fsync.
+//!
+//! So: a bounded pool of readers, and one writer draining them in batches. The
+//! triggers for a full re-read are routine rather than exotic — any pricing
+//! rate edit, any idle-threshold change — so this is the difference between a
+//! settings save costing seconds and costing minutes.
+//!
+//! Three failure rules, each chosen so one bad file cannot cost the rest:
+//!
+//! * **An unreadable transcript is not fatal.** A file being appended to right
+//!   now, or one the user cannot read, is logged and skipped; the scan
+//!   continues for every other session.
+//! * **A batch that fails to commit is dropped, not retried.** The rows carry
+//!   each file's mtime, so an uncommitted file still looks changed to the next
+//!   diff and is re-read then. Retrying here risks looping on a persistent
+//!   error while the user waits.
+//! * **Notifications follow the writes.** A dropped batch emits none, and one
+//!   session with N changed sub-agents produces one notification rather than
+//!   N+1 — on a first scan that fan-out overflows the worker queue.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::mpsc;
+
+use rusqlite::Connection;
+
+use crate::native::pricing::Resolver;
+use crate::native::sessions::summary::SessionSummary;
+
+use super::diff::CachedEntry;
+use super::store::{self, SubagentMeta};
+use super::summary_file::{read_session_summary, read_subagent_summary};
+use super::walk::DiskFile;
+
+/// How many files one write transaction covers.
+///
+/// Large enough that the per-commit cost is amortized to nothing, small enough
+/// that a failure loses a bounded amount of work and that a reader is never
+/// blocked long behind the writer.
+pub const SCAN_BATCH_SIZE: usize = 100;
+
+/// Bounds the reader pool.
+///
+/// One less than the available parallelism, floored at 2 and capped at 8: this
+/// runs on the user's own laptop while they are working, and a pool wide enough
+/// to saturate every core reading a multi-gigabyte corpus is felt as the
+/// machine getting slower. The cap is where the returns flatten anyway — past
+/// it the work is bound by the single writer and by the page cache, not by
+/// decode throughput.
+pub fn scan_readers() -> usize {
+    let cores = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(2);
+    cores.saturating_sub(1).clamp(2, 8)
+}
+
+/// One file to re-read, with what the diff already knows about it.
+#[derive(Debug, Clone)]
+pub struct ScanUnit {
+    pub file: DiskFile,
+    pub is_new: bool,
+}
+
+/// A decoded transcript on its way to the writer.
+struct ScanResult {
+    unit: ScanUnit,
+    /// `None` when the file could not be read, or yielded no row. Counted as
+    /// done, written as nothing.
+    summary: Option<SessionSummary>,
+    meta: SubagentMeta,
+}
+
+/// What one session's change should be announced as.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Notification {
+    pub session_id: String,
+    pub file_path: PathBuf,
+    /// True only for a genuinely new row. A claim shift is an update, and a
+    /// sub-agent is never a discovery in its own right.
+    pub is_new: bool,
+}
+
+/// The outcome of applying one scan.
+#[derive(Debug, Default, PartialEq)]
+pub struct ApplyOutcome {
+    pub rows_written: usize,
+    pub rows_deleted: usize,
+    /// Files that could not be read, or produced no row.
+    pub skipped: usize,
+    /// One per session, however many of its files changed.
+    pub notifications: Vec<Notification>,
+}
+
+/// Reads every unit in parallel and writes the results in batches.
+///
+/// Deletes run **after** every write, which is what makes a claim shift safe:
+/// the row is upserted under its new path first, and only then is the stale
+/// path reconciled away.
+pub fn apply_changes(
+    conn: &mut Connection,
+    units: Vec<ScanUnit>,
+    to_delete: &[CachedEntry],
+    resolver: Option<&Resolver>,
+    idle_gap_ms: i64,
+    mut progress: impl FnMut(usize, usize),
+) -> ApplyOutcome {
+    let total = units.len();
+    progress(0, total);
+
+    let mut outcome = ApplyOutcome::default();
+    // Keyed by session id so a session with several changed files is announced
+    // once. Ordered so the announcement order is deterministic.
+    let mut pending: BTreeMap<String, Notification> = BTreeMap::new();
+
+    let (result_tx, result_rx) = mpsc::sync_channel::<ScanResult>(SCAN_BATCH_SIZE);
+    // A rendezvous channel: a reader takes the next unit only when it is free,
+    // so the queue cannot run ahead of the pool. Both ends are created outside
+    // the scope so the borrow the readers share outlives them.
+    let (work_tx, work_rx) = mpsc::sync_channel::<ScanUnit>(0);
+    let work_rx = std::sync::Mutex::new(work_rx);
+
+    std::thread::scope(|scope| {
+        for _ in 0..scan_readers().min(total.max(1)) {
+            let result_tx = result_tx.clone();
+            let work_rx = &work_rx;
+            scope.spawn(move || {
+                loop {
+                    // The lock is held only to take the next unit, never across
+                    // the read itself.
+                    let unit = {
+                        let rx = work_rx.lock().expect("work queue");
+                        rx.recv()
+                    };
+                    let Ok(unit) = unit else { return };
+                    if result_tx
+                        .send(read_unit(unit, resolver, idle_gap_ms))
+                        .is_err()
+                    {
+                        return;
+                    }
+                }
+            });
+        }
+        drop(result_tx);
+
+        scope.spawn(move || {
+            for unit in units {
+                if work_tx.send(unit).is_err() {
+                    return;
+                }
+            }
+        });
+
+        // The writer runs on this thread: SQLite serializes writers anyway, and
+        // keeping it here means the scan is finished when this function returns.
+        let mut batch: Vec<ScanResult> = Vec::with_capacity(SCAN_BATCH_SIZE);
+        let mut done = 0usize;
+
+        for result in result_rx {
+            if result.summary.is_none() {
+                outcome.skipped += 1;
+                done += 1;
+                progress(done, total);
+                continue;
+            }
+            batch.push(result);
+            if batch.len() >= SCAN_BATCH_SIZE {
+                done += flush(conn, &mut batch, &mut outcome, &mut pending);
+                progress(done, total);
+            }
+        }
+        if !batch.is_empty() {
+            done += flush(conn, &mut batch, &mut outcome, &mut pending);
+            progress(done, total);
+        }
+    });
+
+    // The delete pass is a single transaction that aborts wholesale on the
+    // first error, unlike the batched writes: a partial reconciliation is worse
+    // than none, since the rows it would leave behind look deleted to nothing.
+    if !to_delete.is_empty() {
+        match run_deletes(conn, to_delete) {
+            Ok(n) => outcome.rows_deleted = n,
+            Err(e) => log::warn!("claude sessions: delete pass failed, leaving rows: {e}"),
+        }
+    }
+
+    outcome.notifications = pending.into_values().collect();
+    outcome
+}
+
+/// Reads one unit. Touches no database, which is what makes it parallel-safe.
+fn read_unit(unit: ScanUnit, resolver: Option<&Resolver>, idle_gap_ms: i64) -> ScanResult {
+    let file = &unit.file;
+    let (summary, meta) = if file.is_subagent {
+        match read_subagent_summary(
+            &file.session_id,
+            &file.project_path,
+            &file.file_path,
+            resolver,
+            idle_gap_ms,
+        ) {
+            Ok(Some(s)) => {
+                // The sidecar is read only once the transcript itself was
+                // readable; it is a label for data that has to exist.
+                let meta = store::read_subagent_meta(&file.file_path);
+                (Some(s), meta)
+            }
+            Ok(None) => (None, SubagentMeta::default()),
+            Err(e) => {
+                log::warn!(
+                    "claude sessions: skipping unreadable sub-agent {}: {e}",
+                    file.file_path.display()
+                );
+                (None, SubagentMeta::default())
+            }
+        }
+    } else {
+        match read_session_summary(
+            &file.session_id,
+            &file.project_path,
+            &file.file_path,
+            resolver,
+            idle_gap_ms,
+        ) {
+            Ok(s) => (s, SubagentMeta::default()),
+            Err(e) => {
+                log::warn!(
+                    "claude sessions: skipping unreadable transcript {}: {e}",
+                    file.file_path.display()
+                );
+                (None, SubagentMeta::default())
+            }
+        }
+    };
+
+    ScanResult {
+        unit,
+        summary,
+        meta,
+    }
+}
+
+/// Commits one batch, returning how many files it accounted for.
+///
+/// A batch that fails is logged and dropped; its files still carry their old
+/// mtimes, so the next diff re-reads them.
+fn flush(
+    conn: &mut Connection,
+    batch: &mut Vec<ScanResult>,
+    outcome: &mut ApplyOutcome,
+    pending: &mut BTreeMap<String, Notification>,
+) -> usize {
+    let count = batch.len();
+    let items = std::mem::take(batch);
+
+    match write_batch(conn, &items) {
+        Ok(()) => {
+            outcome.rows_written += count;
+            for item in &items {
+                record_pending(pending, item);
+            }
+        }
+        Err(e) => {
+            // Not retried, and deliberately not notified either: nothing
+            // changed, so announcing a change would be a lie.
+            log::warn!("claude sessions: dropping a batch of {count} rows: {e}");
+            outcome.skipped += count;
+        }
+    }
+    count
+}
+
+fn write_batch(conn: &mut Connection, items: &[ScanResult]) -> Result<(), String> {
+    let tx = conn.transaction().map_err(|e| e.to_string())?;
+    for item in items {
+        let Some(summary) = &item.summary else {
+            continue;
+        };
+        let file = &item.unit.file;
+        if file.is_subagent {
+            store::upsert_subagent_row(&tx, file, summary, &item.meta)?;
+        } else {
+            store::insert_cache_row(&tx, file, summary)?;
+            // The session row and its pull requests go together: the row
+            // carries the file's mtime, so a PR write failing after the row
+            // committed would leave the file looking unchanged to the next diff
+            // and the PR rows would never be rebuilt.
+            store::replace_pr_rows(&tx, summary)?;
+        }
+    }
+    tx.commit().map_err(|e| e.to_string())
+}
+
+/// Records one session's notification.
+///
+/// A sub-agent is recorded against its **parent's** id and path, always as an
+/// update, and never overwrites an entry already present — so the parent's own
+/// record, which may be a discovery, wins regardless of write order.
+fn record_pending(pending: &mut BTreeMap<String, Notification>, item: &ScanResult) {
+    let file = &item.unit.file;
+    let (path, is_new) = if file.is_subagent {
+        (file.parent_file_path.clone(), false)
+    } else {
+        (file.file_path.clone(), item.unit.is_new)
+    };
+
+    pending
+        .entry(file.session_id.clone())
+        .or_insert(Notification {
+            session_id: file.session_id.clone(),
+            file_path: path,
+            is_new,
+        });
+}
+
+fn run_deletes(conn: &mut Connection, to_delete: &[CachedEntry]) -> Result<usize, String> {
+    let tx = conn.transaction().map_err(|e| e.to_string())?;
+    for entry in to_delete {
+        store::delete_cached_file(&tx, entry)?;
+    }
+    tx.commit().map_err(|e| e.to_string())?;
+    Ok(to_delete.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_reader_pool_stays_within_its_bounds() {
+        let n = scan_readers();
+        assert!((2..=8).contains(&n), "got {n}");
+    }
+
+    #[test]
+    fn a_sub_agent_never_overwrites_its_parents_discovery() {
+        // Whichever order the batch happens to write them in, the session is
+        // announced once, as what the parent made it.
+        let mut pending = BTreeMap::new();
+        let parent = result("s1", "/d/s1.jsonl", false, true);
+        let sub = result("s1", "/d/s1/subagents/a.jsonl", true, false);
+
+        record_pending(&mut pending, &sub);
+        record_pending(&mut pending, &parent);
+        assert_eq!(pending.len(), 1);
+        let n = &pending["s1"];
+        assert_eq!(
+            n.file_path,
+            PathBuf::from("/d/s1.jsonl"),
+            "a sub-agent is announced against its parent"
+        );
+        assert!(
+            !n.is_new,
+            "the sub-agent got there first and it is an update"
+        );
+
+        // The other order: the parent's discovery is what sticks.
+        let mut pending = BTreeMap::new();
+        record_pending(&mut pending, &parent);
+        record_pending(&mut pending, &sub);
+        assert!(pending["s1"].is_new);
+    }
+
+    #[test]
+    fn several_sub_agents_collapse_to_one_notification() {
+        // A first scan of a session with N sub-agents would otherwise enqueue
+        // N+1 items that each re-read all N+1 files.
+        let mut pending = BTreeMap::new();
+        for i in 0..5 {
+            record_pending(
+                &mut pending,
+                &result("s1", &format!("/d/s1/subagents/a{i}.jsonl"), true, false),
+            );
+        }
+        assert_eq!(pending.len(), 1);
+    }
+
+    fn result(session: &str, path: &str, is_subagent: bool, is_new: bool) -> ScanResult {
+        ScanResult {
+            unit: ScanUnit {
+                file: DiskFile {
+                    session_id: session.into(),
+                    project_path: "/p".into(),
+                    file_path: PathBuf::from(path),
+                    mtime: chrono::DateTime::UNIX_EPOCH,
+                    is_subagent,
+                    agent_id: if is_subagent {
+                        "a".into()
+                    } else {
+                        String::new()
+                    },
+                    parent_file_path: PathBuf::from("/d/s1.jsonl"),
+                    config_dir: "/d".into(),
+                },
+                is_new,
+            },
+            summary: Some(SessionSummary::default()),
+            meta: SubagentMeta::default(),
+        }
+    }
+}

--- a/desktop/src-tauri/src/native/scanner/cost.rs
+++ b/desktop/src-tauri/src/native/scanner/cost.rs
@@ -1,0 +1,170 @@
+//! Per-message pricing, ported from the `costAccumulator` half of
+//! `internal/claudesessions/types.go`.
+//!
+//! A session is priced **message by message**, each assistant message resolved
+//! against the catalog at its own timestamp with its own model. That is what
+//! makes a session which spans a price change — or mixes models — cost
+//! correctly, and it is why the scanner is the only place that can compute
+//! `cost_by_model`: the stored row carries neither the timing nor the model of
+//! the messages behind its total, so no later pass could reconstruct it without
+//! re-reading the transcript.
+//!
+//! A model with no known rate contributes **no cost and no silence**: its
+//! tokens accumulate into the unpriced counters so an aggregate can disclose
+//! what its total left out. Pricing an unknown model at another model's rate,
+//! or at zero, are both worse than saying so.
+
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Utc};
+
+use crate::native::pricing::{PricedUsage, Resolver};
+use crate::native::sessions::summary::{display_model, SessionCost, TokenUsage};
+
+/// Prices a transcript as it is read.
+///
+/// With no resolver the accumulator is inert, so a fixture needs no pricing
+/// setup to exercise everything else the reader does.
+#[derive(Default)]
+pub struct CostAccumulator<'a> {
+    resolver: Option<&'a Resolver>,
+    cost: SessionCost,
+    priced_messages: i64,
+    /// Input+output tokens seen per model with no known rate.
+    unknown_models: BTreeMap<String, i64>,
+    /// The same money, keyed by the model that spent it. Filled at the one
+    /// point that knows both the model and the amount.
+    by_model: BTreeMap<String, SessionCost>,
+}
+
+impl<'a> CostAccumulator<'a> {
+    pub fn new(resolver: Option<&'a Resolver>) -> Self {
+        CostAccumulator {
+            resolver,
+            ..Default::default()
+        }
+    }
+
+    /// Prices one assistant message.
+    ///
+    /// A message with no tokens at all is skipped: it is not a pricing gap, and
+    /// counting it would inflate `priced_messages` with nothing.
+    pub fn add_assistant_message(&mut self, model: &str, usage: &TokenUsage, at: DateTime<Utc>) {
+        let Some(resolver) = self.resolver else {
+            return;
+        };
+        if usage.input_tokens
+            + usage.output_tokens
+            + usage.cache_creation_tokens
+            + usage.cache_read_tokens
+            == 0
+        {
+            return;
+        }
+
+        // The synthetic placeholder and the embedding models resolve to
+        // non-billable catalog rows, so they price at $0.00 without being
+        // mistaken for a gap in the catalog — no special case is needed here.
+        let Some(resolved) = resolver.resolve(model, at) else {
+            if !model.is_empty() {
+                *self.unknown_models.entry(model.to_string()).or_insert(0) +=
+                    usage.input_tokens + usage.output_tokens;
+            }
+            return;
+        };
+
+        let priced = resolved.rate.price(PricedUsage {
+            input_tokens: usage.input_tokens,
+            output_tokens: usage.output_tokens,
+            cache_creation_5m_tokens: usage.cache_creation_5m_tokens,
+            cache_creation_1h_tokens: usage.cache_creation_1h_tokens,
+            cache_read_tokens: usage.cache_read_tokens,
+        });
+
+        let one = SessionCost {
+            input_usd: priced.input_cost_usd,
+            output_usd: priced.output_cost_usd,
+            cache_read_usd: priced.cache_read_cost_usd,
+            cache_write_usd: priced.cache_write_cost_usd,
+            total_usd: priced.total_cost_usd,
+        };
+        add_cost(&mut self.cost, &one);
+        self.priced_messages += 1;
+
+        let entry = self.by_model.entry(display_model(model)).or_default();
+        add_cost(entry, &one);
+    }
+
+    /// The session's running total.
+    pub fn total(&self) -> SessionCost {
+        self.cost.clone()
+    }
+
+    /// The session's cost keyed by the model that spent it.
+    ///
+    /// The values sum to [`CostAccumulator::total`] exactly — this re-keys
+    /// money, it never changes an amount. Empty when nothing was priced.
+    pub fn cost_by_model(&self) -> BTreeMap<String, SessionCost> {
+        self.by_model.clone()
+    }
+
+    /// Input+output tokens seen on models with no known rate, so an aggregate
+    /// can state what its cost total left out.
+    pub fn unknown_pricing_tokens(&self) -> i64 {
+        self.unknown_models.values().sum()
+    }
+
+    /// The distinct models this session used that carry no known rate.
+    ///
+    /// Sorted, so the persisted list is deterministic and a rescan that changes
+    /// nothing does not rewrite the row. (A `BTreeMap` gives that for free
+    /// where Go has to `sort.Strings`.)
+    pub fn unpriced_models(&self) -> Vec<String> {
+        self.unknown_models.keys().cloned().collect()
+    }
+}
+
+/// Go's `SessionCost.Add`. Kept here rather than on the type because the type
+/// is the sessions list's wire shape and gains nothing from a mutator.
+fn add_cost(into: &mut SessionCost, other: &SessionCost) {
+    into.input_usd += other.input_usd;
+    into.output_usd += other.output_usd;
+    into.cache_read_usd += other.cache_read_usd;
+    into.cache_write_usd += other.cache_write_usd;
+    into.total_usd += other.total_usd;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn usage(input: i64, output: i64) -> TokenUsage {
+        TokenUsage {
+            input_tokens: input,
+            output_tokens: output,
+            ..Default::default()
+        }
+    }
+
+    fn at() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-03-15T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    #[test]
+    fn without_a_resolver_it_is_inert() {
+        let mut acc = CostAccumulator::new(None);
+        acc.add_assistant_message("claude-opus-5", &usage(100, 50), at());
+        assert_eq!(acc.total().total_usd, 0.0);
+        assert!(acc.unpriced_models().is_empty(), "not a pricing gap either");
+    }
+
+    #[test]
+    fn a_message_with_no_tokens_is_not_a_pricing_gap() {
+        let mut acc = CostAccumulator::new(None);
+        acc.add_assistant_message("who-knows", &usage(0, 0), at());
+        assert_eq!(acc.unknown_pricing_tokens(), 0);
+        assert!(acc.unpriced_models().is_empty());
+    }
+}

--- a/desktop/src-tauri/src/native/scanner/diff.rs
+++ b/desktop/src-tauri/src/native/scanner/diff.rs
@@ -1,0 +1,375 @@
+//! What changed since the last scan, ported from `diffDiskAndCache` in
+//! `internal/claudesessions/scanner.go`.
+//!
+//! The diff turns "what is on disk" plus "what is cached" into three lists:
+//! files to insert, files to re-read, and rows to delete. Two of its rules
+//! exist because of failures that were shipped once.
+//!
+//! ## A path that moved is an update, not a discovery (#245)
+//!
+//! Rows are keyed on `(session_id, project_path)` — or, for a sub-agent, on
+//! `(parent_session_id, agent_id)` — while `file_path` is only a non-unique
+//! index. So the *same row* can legitimately arrive under a new path: an
+//! unmounted drive hands a duplicated session to the surviving copy, and the
+//! claim shifts. Classifying that as an insert re-fires a discovery event for
+//! a session that has been cached for months, and makes the scan log call it
+//! new.
+//!
+//! So the cache is indexed **twice**: by path, and by row key. A file whose
+//! path is unknown but whose key exists is an update. The row exists; only its
+//! path moved. The upsert conflicts on the primary key and the old path is
+//! reconciled away by the delete pass, which runs after the writes.
+//!
+//! This is a correctness fix for what `is_new` *means*, not a performance one:
+//! the insight worker subscribes to discovered and updated alike, and the
+//! scanner re-reads an updated transcript exactly as it re-reads a new one, so
+//! the work done is the same either way.
+//!
+//! ## A row is only deleted if we actually looked
+//!
+//! [`row_reconcilable`] is the guard. "No file on disk" and "we could not look"
+//! are indistinguishable here, and only one of them means the session is gone.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+
+use super::walk::{DiskFile, DiskWalk};
+
+/// One cached row, in the columns the diff needs.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CachedEntry {
+    pub file_path: PathBuf,
+    pub mtime: DateTime<Utc>,
+    pub is_subagent: bool,
+    pub config_dir: String,
+    /// The parent's id for a sub-agent row, matching the stored column.
+    pub session_id: String,
+    pub project_path: String,
+    pub agent_id: String,
+}
+
+/// The identity of a row, which is **not** its path.
+///
+/// The two tables key differently, so the `is_subagent` prefix keeps the
+/// populations disjoint: a sub-agent row carries the *parent's* session id and
+/// would otherwise alias the parent's own key.
+pub fn row_key(is_subagent: bool, session_id: &str, project_path: &str, agent_id: &str) -> String {
+    if is_subagent {
+        format!("s\u{0}{session_id}\u{0}{agent_id}")
+    } else {
+        format!("p\u{0}{session_id}\u{0}{project_path}")
+    }
+}
+
+impl CachedEntry {
+    pub fn key(&self) -> String {
+        row_key(
+            self.is_subagent,
+            &self.session_id,
+            &self.project_path,
+            &self.agent_id,
+        )
+    }
+}
+
+impl DiskFile {
+    pub fn key(&self) -> String {
+        row_key(
+            self.is_subagent,
+            &self.session_id,
+            &self.project_path,
+            &self.agent_id,
+        )
+    }
+}
+
+/// What one scan has to do.
+#[derive(Debug, Default, PartialEq)]
+pub struct DiskDiff {
+    /// Paths never seen before, whose row does not exist either.
+    pub to_insert: Vec<PathBuf>,
+    /// Paths whose file changed, or whose row exists under a different path.
+    pub to_update: Vec<PathBuf>,
+    /// Cached rows with no file behind them, in directories we could list.
+    pub to_delete: Vec<CachedEntry>,
+}
+
+/// Classifies every on-disk file and every cached row.
+///
+/// `default_config_dir` is what a blank `config_dir` means: the column was
+/// added by a migration that could not backfill it, because the home directory
+/// is not a SQL constant.
+pub fn diff_disk_and_cache(
+    on_disk: &HashMap<PathBuf, DiskFile>,
+    cached: &HashMap<PathBuf, CachedEntry>,
+    walk: &DiskWalk,
+    default_config_dir: &str,
+) -> DiskDiff {
+    let mut diff = DiskDiff::default();
+
+    // The second view: the cache by row identity rather than by path.
+    let by_key: HashSet<String> = cached.values().map(CachedEntry::key).collect();
+
+    for (path, file) in on_disk {
+        match cached.get(path) {
+            None => {
+                if by_key.contains(&file.key()) {
+                    // The row exists; only its path moved.
+                    diff.to_update.push(path.clone());
+                } else {
+                    diff.to_insert.push(path.clone());
+                }
+            }
+            Some(entry) => {
+                if entry.mtime != file.mtime {
+                    diff.to_update.push(path.clone());
+                }
+            }
+        }
+    }
+
+    for (path, entry) in cached {
+        if on_disk.contains_key(path) {
+            continue;
+        }
+        if row_reconcilable(entry, walk, default_config_dir) {
+            diff.to_delete.push(entry.clone());
+        }
+    }
+
+    // The maps are unordered; sorting makes a scan's work deterministic, which
+    // matters for the batching writer's progress reporting and for tests.
+    diff.to_insert.sort();
+    diff.to_update.sort();
+    diff.to_delete.sort_by(|a, b| a.file_path.cmp(&b.file_path));
+    diff
+}
+
+/// Whether a row with no file behind it may be deleted.
+///
+/// Two ways to fail: the row's config dir was never listed, or its file sits
+/// under a project directory that could not be read. Either way the absence is
+/// not evidence.
+pub fn row_reconcilable(entry: &CachedEntry, walk: &DiskWalk, default_config_dir: &str) -> bool {
+    let dir = if entry.config_dir.is_empty() {
+        default_config_dir
+    } else {
+        &entry.config_dir
+    };
+
+    if !walk.walked.contains(dir) {
+        return false;
+    }
+    !walk
+        .protected
+        .iter()
+        .any(|protected| is_under(&entry.file_path, protected))
+}
+
+/// Path-prefix containment, on directory boundaries — `/a/bc` is not under
+/// `/a/b`.
+fn is_under(path: &Path, dir: &Path) -> bool {
+    path.starts_with(dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn utc(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    fn disk(path: &str, session: &str, project: &str, mtime: &str, dir: &str) -> DiskFile {
+        DiskFile {
+            session_id: session.into(),
+            project_path: project.into(),
+            file_path: PathBuf::from(path),
+            mtime: utc(mtime),
+            is_subagent: false,
+            agent_id: String::new(),
+            parent_file_path: PathBuf::new(),
+            config_dir: dir.into(),
+        }
+    }
+
+    fn cached(path: &str, session: &str, project: &str, mtime: &str, dir: &str) -> CachedEntry {
+        CachedEntry {
+            file_path: PathBuf::from(path),
+            mtime: utc(mtime),
+            is_subagent: false,
+            config_dir: dir.into(),
+            session_id: session.into(),
+            project_path: project.into(),
+            agent_id: String::new(),
+        }
+    }
+
+    fn walked(dirs: &[&str]) -> DiskWalk {
+        DiskWalk {
+            files: HashMap::new(),
+            walked: dirs.iter().map(|d| d.to_string()).collect(),
+            protected: Vec::new(),
+        }
+    }
+
+    fn maps(
+        disk_files: Vec<DiskFile>,
+        cached_rows: Vec<CachedEntry>,
+    ) -> (HashMap<PathBuf, DiskFile>, HashMap<PathBuf, CachedEntry>) {
+        (
+            disk_files
+                .into_iter()
+                .map(|f| (f.file_path.clone(), f))
+                .collect(),
+            cached_rows
+                .into_iter()
+                .map(|c| (c.file_path.clone(), c))
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn the_four_base_cases() {
+        let (on_disk, cache) = maps(
+            vec![
+                disk("/d/new.jsonl", "new", "/p", "2026-03-01T00:00:00Z", "/d"),
+                disk("/d/mod.jsonl", "mod", "/p", "2026-03-02T00:00:00Z", "/d"),
+                disk("/d/same.jsonl", "same", "/p", "2026-03-01T00:00:00Z", "/d"),
+            ],
+            vec![
+                cached("/d/mod.jsonl", "mod", "/p", "2026-03-01T00:00:00Z", "/d"),
+                cached("/d/same.jsonl", "same", "/p", "2026-03-01T00:00:00Z", "/d"),
+                cached("/d/gone.jsonl", "gone", "/p", "2026-03-01T00:00:00Z", "/d"),
+            ],
+        );
+
+        let diff = diff_disk_and_cache(&on_disk, &cache, &walked(&["/d"]), "/default");
+        assert_eq!(diff.to_insert, vec![PathBuf::from("/d/new.jsonl")]);
+        assert_eq!(diff.to_update, vec![PathBuf::from("/d/mod.jsonl")]);
+        assert_eq!(diff.to_delete.len(), 1);
+        assert_eq!(diff.to_delete[0].session_id, "gone");
+    }
+
+    #[test]
+    fn a_claim_shift_is_an_update_rather_than_a_discovery() {
+        // #245: the same session, now owned by a different config dir. Its row
+        // has been cached for months; calling it new re-fires a discovery.
+        let (on_disk, cache) = maps(
+            vec![disk(
+                "/second/s1.jsonl",
+                "s1",
+                "/p",
+                "2026-03-01T00:00:00Z",
+                "/second",
+            )],
+            vec![cached(
+                "/default/s1.jsonl",
+                "s1",
+                "/p",
+                "2026-03-01T00:00:00Z",
+                "/default",
+            )],
+        );
+
+        let diff = diff_disk_and_cache(&on_disk, &cache, &walked(&["/default", "/second"]), "/x");
+        assert!(diff.to_insert.is_empty(), "the row already existed");
+        assert_eq!(diff.to_update, vec![PathBuf::from("/second/s1.jsonl")]);
+        // The old path is reconciled away by the delete pass, which runs after
+        // the writes.
+        assert_eq!(diff.to_delete.len(), 1);
+        assert_eq!(
+            diff.to_delete[0].file_path,
+            PathBuf::from("/default/s1.jsonl")
+        );
+    }
+
+    #[test]
+    fn a_row_from_a_dir_that_was_not_walked_is_never_deleted() {
+        // The unplugged-drive case: absence is not evidence.
+        let (on_disk, cache) = maps(
+            vec![],
+            vec![cached(
+                "/unplugged/s1.jsonl",
+                "s1",
+                "/p",
+                "2026-03-01T00:00:00Z",
+                "/unplugged",
+            )],
+        );
+        let diff = diff_disk_and_cache(&on_disk, &cache, &walked(&["/default"]), "/default");
+        assert!(diff.to_delete.is_empty());
+    }
+
+    #[test]
+    fn a_blank_config_dir_means_the_default_one() {
+        // Migration 27 could not backfill it: the home directory is not a SQL
+        // constant.
+        let (on_disk, cache) = maps(
+            vec![],
+            vec![cached(
+                "/default/projects/p/s1.jsonl",
+                "s1",
+                "/p",
+                "2026-03-01T00:00:00Z",
+                "",
+            )],
+        );
+        let diff = diff_disk_and_cache(&on_disk, &cache, &walked(&["/default"]), "/default");
+        assert_eq!(
+            diff.to_delete.len(),
+            1,
+            "reconcilable against the default dir"
+        );
+
+        let diff = diff_disk_and_cache(&on_disk, &cache, &walked(&["/other"]), "/default");
+        assert!(diff.to_delete.is_empty(), "the default dir was not walked");
+    }
+
+    #[test]
+    fn a_protected_project_shields_only_its_own_rows() {
+        // One root-owned directory must not stop every other project's deleted
+        // transcripts from ever being reconciled.
+        let mut walk = walked(&["/d"]);
+        walk.protected.push(PathBuf::from("/d/projects/locked"));
+
+        let (on_disk, cache) = maps(
+            vec![],
+            vec![
+                cached(
+                    "/d/projects/locked/a.jsonl",
+                    "a",
+                    "/p",
+                    "2026-03-01T00:00:00Z",
+                    "/d",
+                ),
+                cached(
+                    "/d/projects/open/b.jsonl",
+                    "b",
+                    "/q",
+                    "2026-03-01T00:00:00Z",
+                    "/d",
+                ),
+            ],
+        );
+        let diff = diff_disk_and_cache(&on_disk, &cache, &walk, "/default");
+        assert_eq!(diff.to_delete.len(), 1);
+        assert_eq!(diff.to_delete[0].session_id, "b");
+    }
+
+    #[test]
+    fn a_sub_agent_key_cannot_alias_its_parent() {
+        // Both carry the parent's session id; only the prefix keeps them apart.
+        assert_ne!(
+            row_key(false, "s1", "/p", ""),
+            row_key(true, "s1", "/p", "agent-1")
+        );
+        // And two sub-agents of one parent are distinct rows.
+        assert_ne!(
+            row_key(true, "s1", "/p", "agent-1"),
+            row_key(true, "s1", "/p", "agent-2")
+        );
+    }
+}

--- a/desktop/src-tauri/src/native/scanner/mod.rs
+++ b/desktop/src-tauri/src/native/scanner/mod.rs
@@ -1,0 +1,35 @@
+//! The Claude session scanner, ported from `internal/claudesessions/scanner.go`
+//! and `scan_apply.go` (issue #270).
+//!
+//! The scanner is what keeps `claude_session_cache` in step with the JSONL
+//! transcripts on disk. It walks every configured Claude config dir, diffs what
+//! it finds against what is cached, and re-reads the transcripts that changed.
+//!
+//! ## This port computes; it does not write
+//!
+//! The Go scanner is a *writer*, and the sidecar runs its own copy of it on
+//! every read path. Two processes writing one SQLite file is precisely what
+//! `native::db` refuses to allow — it opens read-only so that a second writer
+//! is impossible by accident, because the Go server also holds the file open,
+//! runs migrations against it and re-seeds the pricing catalog on startup.
+//!
+//! So this follows the precedent the insight processors set (#263): the logic
+//! is ported as what it actually is — a function from a transcript to a row —
+//! and verified against the rows Go already wrote, field by field, over the
+//! real corpus. That is a stronger check than any fixture, and it needs no
+//! writes at all. Wiring it to the live database, and with it retiring the
+//! freshness probe, belongs to phase 3, when storage moves and the sidecar
+//! stops being a writer.
+
+pub mod cost;
+pub mod summary_file;
+
+/// Bumped whenever the scanner extracts something new from a transcript that
+/// already-cached rows would be missing.
+///
+/// Cached rows carry the version that produced them; when this constant is
+/// ahead of the stored one, the next incremental scan re-reads **every** file
+/// even though no mtime changed, then records the new version. It must track
+/// Go's `CurrentScannerVersion` exactly — a port that disagreed would either
+/// force a re-read Go does not want or skip one it does.
+pub const CURRENT_SCANNER_VERSION: i64 = 13;

--- a/desktop/src-tauri/src/native/scanner/mod.rs
+++ b/desktop/src-tauri/src/native/scanner/mod.rs
@@ -21,9 +21,11 @@
 //! freshness probe, belongs to phase 3, when storage moves and the sidecar
 //! stops being a writer.
 
+pub mod apply;
 pub mod cost;
 pub mod diff;
 pub mod staleness;
+pub mod store;
 pub mod summary_file;
 pub mod walk;
 

--- a/desktop/src-tauri/src/native/scanner/mod.rs
+++ b/desktop/src-tauri/src/native/scanner/mod.rs
@@ -22,7 +22,10 @@
 //! stops being a writer.
 
 pub mod cost;
+pub mod diff;
+pub mod staleness;
 pub mod summary_file;
+pub mod walk;
 
 /// Bumped whenever the scanner extracts something new from a transcript that
 /// already-cached rows would be missing.

--- a/desktop/src-tauri/src/native/scanner/staleness.rs
+++ b/desktop/src-tauri/src/native/scanner/staleness.rs
@@ -1,0 +1,204 @@
+//! When a scan must re-read everything, ported from the staleness half of
+//! `internal/claudesessions/scanner.go`.
+//!
+//! An incremental scan normally re-reads only what changed on disk. Three
+//! things make that wrong, and each forces a **full** re-read of every
+//! transcript even though no file moved:
+//!
+//! | marker | drifts when | why a re-read is the only fix |
+//! |---|---|---|
+//! | `scanner_version` | the scanner learns to extract something new | cached rows are simply missing the field |
+//! | `pricing_rev` | any rate is added or corrected | cost is *stored*, and re-pricing needs each message's own model and timestamp — neither of which the row keeps |
+//! | `idle_threshold_ms` | the user changes the idle gap | active durations are stored, computed under the old threshold |
+//!
+//! The last one is why this exists at all: a user-caused drift cannot be
+//! expressed as a version constant, but it makes exactly the same rows stale.
+//!
+//! **The markers are recorded only after the re-read succeeds.** A scan that
+//! fails leaves the drift recorded and retryable, rather than claiming freshness
+//! it did not achieve.
+//!
+//! Invalidation zeroes each cached row's mtime rather than dropping the row.
+//! That is deliberate: a zeroed row still exists, so the diff classifies it as
+//! an **update** rather than a discovery — no spurious "new session" events for
+//! a corpus that has been cached for months — and deletions are still detected.
+
+use rusqlite::Connection;
+
+use super::diff::CachedEntry;
+use super::CURRENT_SCANNER_VERSION;
+
+/// The revision a process with no pricing catalog reports.
+///
+/// It must never be treated as a drift: a process that cannot price anything
+/// would otherwise re-read the whole corpus on every scan, forever.
+pub const PRICING_REV_UNKNOWN: i64 = -1;
+
+/// What the next scan has to invalidate.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct CacheStaleness {
+    /// The scanner extracts something the cached rows do not carry.
+    pub reader: bool,
+    /// The pricing catalog moved.
+    pub pricing: bool,
+    pub pricing_rev: i64,
+    /// The idle-gap threshold moved.
+    pub idle: bool,
+    pub idle_ms: i64,
+}
+
+impl CacheStaleness {
+    /// Whether anything at all forces a full re-read.
+    pub fn any(&self) -> bool {
+        self.reader || self.pricing || self.idle
+    }
+}
+
+/// Compares the recorded markers against the live ones.
+///
+/// `live_pricing_rev` is the catalog's current fingerprint, or
+/// [`PRICING_REV_UNKNOWN`]; `live_idle_ms` is the configured threshold.
+pub fn detect_staleness(
+    conn: &Connection,
+    live_pricing_rev: i64,
+    live_idle_ms: i64,
+) -> CacheStaleness {
+    let stored_version = stored_i64(conn, "scanner_version");
+    let stored_pricing = stored_i64(conn, "pricing_rev");
+    let stored_idle = stored_i64(conn, "idle_threshold_ms");
+
+    CacheStaleness {
+        reader: stored_version < CURRENT_SCANNER_VERSION,
+        // An unpriced process must not loop.
+        pricing: live_pricing_rev != PRICING_REV_UNKNOWN && stored_pricing != live_pricing_rev,
+        pricing_rev: live_pricing_rev,
+        // Zero — unreadable, or a row predating the column — differs from every
+        // valid threshold, which is what produces exactly one forced re-read.
+        idle: stored_idle != live_idle_ms,
+        idle_ms: live_idle_ms,
+    }
+}
+
+/// One marker column from the single metadata row. Unreadable means zero, which
+/// is a value no live marker takes.
+fn stored_i64(conn: &Connection, column: &str) -> i64 {
+    let sql = format!("SELECT COALESCE({column}, 0) FROM claude_cache_metadata WHERE id = 1");
+    conn.query_row(&sql, [], |r| r.get(0)).unwrap_or(0)
+}
+
+/// Zeroes every cached row's mtime so the next diff sees each file as modified.
+///
+/// The rows are **kept**, not dropped: a dropped row would come back as an
+/// insert and re-fire a discovery event for a session that has been cached for
+/// months, and the delete pass would lose the ability to detect a genuine
+/// removal in the same scan.
+pub fn invalidate_cached_mtimes(cached: &mut [CachedEntry]) {
+    let zero = chrono::DateTime::UNIX_EPOCH;
+    for entry in cached.iter_mut() {
+        entry.mtime = zero;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A metadata table with the three markers set.
+    fn conn_with(version: i64, pricing: i64, idle: i64) -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE claude_cache_metadata (
+                 id INTEGER PRIMARY KEY CHECK (id = 1),
+                 last_scanned_at DATETIME NOT NULL,
+                 scanner_version INTEGER NOT NULL DEFAULT 0,
+                 pricing_rev INTEGER NOT NULL DEFAULT 0,
+                 idle_threshold_ms INTEGER NOT NULL DEFAULT 600000
+             );",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO claude_cache_metadata
+                 (id, last_scanned_at, scanner_version, pricing_rev, idle_threshold_ms)
+             VALUES (1, '2026-03-01', ?, ?, ?)",
+            [version, pricing, idle],
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn a_corpus_at_the_current_markers_is_fresh() {
+        let conn = conn_with(CURRENT_SCANNER_VERSION, 42, 600_000);
+        let stale = detect_staleness(&conn, 42, 600_000);
+        assert!(!stale.any());
+    }
+
+    #[test]
+    fn an_older_scanner_version_forces_a_re_read() {
+        let conn = conn_with(CURRENT_SCANNER_VERSION - 1, 42, 600_000);
+        assert!(detect_staleness(&conn, 42, 600_000).reader);
+    }
+
+    #[test]
+    fn a_newer_stored_version_does_not() {
+        // A downgrade should not thrash the corpus back and forth.
+        let conn = conn_with(CURRENT_SCANNER_VERSION + 1, 42, 600_000);
+        assert!(!detect_staleness(&conn, 42, 600_000).reader);
+    }
+
+    #[test]
+    fn a_rate_edit_forces_a_re_read_because_cost_is_stored() {
+        let conn = conn_with(CURRENT_SCANNER_VERSION, 42, 600_000);
+        assert!(detect_staleness(&conn, 43, 600_000).pricing);
+    }
+
+    #[test]
+    fn an_unpriced_process_never_reports_pricing_drift() {
+        // Otherwise it would re-read the whole corpus on every single scan.
+        let conn = conn_with(CURRENT_SCANNER_VERSION, 42, 600_000);
+        let stale = detect_staleness(&conn, PRICING_REV_UNKNOWN, 600_000);
+        assert!(!stale.pricing);
+        assert!(!stale.any());
+    }
+
+    #[test]
+    fn an_idle_threshold_change_forces_a_re_read() {
+        let conn = conn_with(CURRENT_SCANNER_VERSION, 42, 600_000);
+        assert!(detect_staleness(&conn, 42, 900_000).idle);
+    }
+
+    #[test]
+    fn a_missing_metadata_row_reads_as_stale_exactly_once() {
+        // Zero is a value no live marker takes, so the first scan re-reads and
+        // records; the second is fresh.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE claude_cache_metadata (
+                 id INTEGER PRIMARY KEY CHECK (id = 1),
+                 last_scanned_at DATETIME NOT NULL,
+                 scanner_version INTEGER NOT NULL DEFAULT 0,
+                 pricing_rev INTEGER NOT NULL DEFAULT 0,
+                 idle_threshold_ms INTEGER NOT NULL DEFAULT 600000
+             );",
+        )
+        .unwrap();
+        let stale = detect_staleness(&conn, 42, 600_000);
+        assert!(stale.reader && stale.pricing && stale.idle);
+    }
+
+    #[test]
+    fn invalidation_keeps_the_rows_and_only_zeroes_their_mtimes() {
+        let mut rows = vec![CachedEntry {
+            file_path: "/d/s1.jsonl".into(),
+            mtime: chrono::Utc::now(),
+            is_subagent: false,
+            config_dir: "/d".into(),
+            session_id: "s1".into(),
+            project_path: "/p".into(),
+            agent_id: String::new(),
+        }];
+        invalidate_cached_mtimes(&mut rows);
+        assert_eq!(rows.len(), 1, "dropping the row would re-fire a discovery");
+        assert_eq!(rows[0].mtime, chrono::DateTime::UNIX_EPOCH);
+    }
+}

--- a/desktop/src-tauri/src/native/scanner/store.rs
+++ b/desktop/src-tauri/src/native/scanner/store.rs
@@ -250,16 +250,14 @@ pub struct SubagentMeta {
 /// A missing or malformed sidecar yields the zero value rather than an error:
 /// the transcript is the data, and the sidecar is a label for it.
 pub fn read_subagent_meta(transcript: &std::path::Path) -> SubagentMeta {
-    let path = transcript.with_extension("").with_extension("meta.json");
-    // `.jsonl` → `.meta.json`, matching Go's TrimSuffix + append.
-    let path = if path.exists() {
-        path
-    } else {
-        PathBuf::from(format!(
-            "{}.meta.json",
-            transcript.to_string_lossy().trim_end_matches(".jsonl")
-        ))
-    };
+    // Trim the suffix and append, rather than swapping extensions: an agent id
+    // containing a dot — `agent-1.2.jsonl` — would lose its last component to
+    // `with_extension`, and the sidecar would be looked for under a name that
+    // does not exist.
+    let path = PathBuf::from(format!(
+        "{}.meta.json",
+        transcript.to_string_lossy().trim_end_matches(".jsonl")
+    ));
 
     std::fs::read_to_string(&path)
         .ok()
@@ -440,6 +438,22 @@ mod tests {
         assert_eq!(meta.agent_type, "Explore");
         assert_eq!(meta.description, "map it");
         assert_eq!(meta.tool_use_id, "tu_1");
+    }
+
+    #[test]
+    fn an_agent_id_containing_a_dot_still_finds_its_sidecar() {
+        // `with_extension` would turn `agent-1.2.jsonl` into `agent-1.meta.json`
+        // and quietly find nothing.
+        let dir = tempfile::tempdir().unwrap();
+        let transcript = dir.path().join("agent-1.2.jsonl");
+        std::fs::write(&transcript, "{}\n").unwrap();
+        std::fs::write(
+            dir.path().join("agent-1.2.meta.json"),
+            r#"{"agentType":"Explore"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(read_subagent_meta(&transcript).agent_type, "Explore");
     }
 
     #[test]

--- a/desktop/src-tauri/src/native/scanner/store.rs
+++ b/desktop/src-tauri/src/native/scanner/store.rs
@@ -1,0 +1,455 @@
+//! Reading and writing the cache tables, ported from the persistence half of
+//! `internal/claudesessions/scanner.go`.
+//!
+//! ## Two columns are never written
+//!
+//! `custom_title` and `is_favorite` appear in neither the insert list nor the
+//! `DO UPDATE SET` list, deliberately: they are the user's, and a rescan must
+//! preserve them. `native_title` and `ai_title` *are* refreshed, because they
+//! mirror Claude Code's own title events — including a rename that clears one —
+//! and `custom_title` wins over both when the display title is resolved.
+//!
+//! ## Two encodings that are not what they look like
+//!
+//! `cost_by_model` is JSON, but an empty map stores as `""` rather than `"{}"`.
+//! `unpriced_models` is **not** JSON at all: it is newline-joined, because a
+//! model id may contain a slash but never a newline.
+//!
+//! ## Nothing here touches the application's own database
+//!
+//! Every function takes a connection the caller opened. The app's own handle is
+//! read-only ([`crate::native::db`]), so the only connections these can be
+//! handed are the scratch databases the tests build. See the module docs on
+//! [`super`] for why the port stops short of writing for real.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use rusqlite::{params, Connection, Transaction};
+
+use crate::native::gotime::{to_go_string_utc, GoTime};
+use crate::native::sessions::summary::SessionSummary;
+
+use super::diff::CachedEntry;
+use super::walk::DiskFile;
+
+/// Loads every cached row from both tables, keyed by file path.
+///
+/// The union is what the diff needs: one path either has a row or it does not,
+/// whichever table it lives in.
+pub fn load_cached_entries(conn: &Connection) -> Result<HashMap<PathBuf, CachedEntry>, String> {
+    let mut cached = HashMap::new();
+    load_from(conn, &mut cached, false)?;
+    load_from(conn, &mut cached, true)?;
+    Ok(cached)
+}
+
+fn load_from(
+    conn: &Connection,
+    cached: &mut HashMap<PathBuf, CachedEntry>,
+    is_subagent: bool,
+) -> Result<(), String> {
+    let sql = if is_subagent {
+        "SELECT file_path, file_mtime, COALESCE(config_dir, ''), parent_session_id, agent_id
+         FROM claude_subagent_cache"
+    } else {
+        "SELECT file_path, file_mtime, COALESCE(config_dir, ''), session_id, project_path
+         FROM claude_session_cache"
+    };
+
+    let mut stmt = conn.prepare(sql).map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map([], |r| {
+            let file_path: String = r.get(0)?;
+            let mtime: String = r.get(1)?;
+            let config_dir: String = r.get(2)?;
+            let key_a: String = r.get(3)?;
+            let key_b: String = r.get(4)?;
+            Ok(CachedEntry {
+                file_path: PathBuf::from(file_path),
+                mtime: GoTime::parse_any(&mtime)
+                    .map(|t| t.instant())
+                    .unwrap_or(chrono::DateTime::UNIX_EPOCH),
+                is_subagent,
+                config_dir,
+                session_id: key_a,
+                project_path: if is_subagent {
+                    String::new()
+                } else {
+                    key_b.clone()
+                },
+                agent_id: if is_subagent { key_b } else { String::new() },
+            })
+        })
+        .map_err(|e| e.to_string())?;
+
+    for row in rows.flatten() {
+        cached.insert(row.file_path.clone(), row);
+    }
+    Ok(())
+}
+
+/// Writes one session row.
+///
+/// The conflict target is the table's primary key, so a claim shift — the same
+/// row arriving under a new path — updates in place and the stale path is
+/// reconciled away by the delete pass afterwards.
+pub fn insert_cache_row(
+    tx: &Transaction,
+    file: &DiskFile,
+    s: &SessionSummary,
+) -> Result<(), String> {
+    tx.execute(
+        "INSERT INTO claude_session_cache (
+             session_id, project_path, file_path, file_mtime,
+             preview, start_time, last_activity, message_count, event_count,
+             input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+             cache_creation_5m_tokens, cache_creation_1h_tokens,
+             git_branch, model, cwd, native_title, ai_title,
+             agent_name, permission_mode, mode, relocated_cwd,
+             worktree_name, worktree_branch, original_branch,
+             compaction_count, dropped_tokens,
+             input_cost_usd, output_cost_usd, cache_read_cost_usd,
+             cache_write_cost_usd, total_cost_usd, unpriced_models, unpriced_tokens,
+             cost_by_model, active_duration_ms, config_dir
+         ) VALUES (
+             ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10,
+             ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20,
+             ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30,
+             ?31, ?32, ?33, ?34, ?35, ?36, ?37, ?38, ?39
+         )
+         ON CONFLICT(session_id, project_path) DO UPDATE SET
+             file_path = excluded.file_path,
+             file_mtime = excluded.file_mtime,
+             preview = excluded.preview,
+             start_time = excluded.start_time,
+             last_activity = excluded.last_activity,
+             message_count = excluded.message_count,
+             event_count = excluded.event_count,
+             input_tokens = excluded.input_tokens,
+             output_tokens = excluded.output_tokens,
+             cache_creation_tokens = excluded.cache_creation_tokens,
+             cache_read_tokens = excluded.cache_read_tokens,
+             cache_creation_5m_tokens = excluded.cache_creation_5m_tokens,
+             cache_creation_1h_tokens = excluded.cache_creation_1h_tokens,
+             git_branch = excluded.git_branch,
+             model = excluded.model,
+             cwd = excluded.cwd,
+             native_title = excluded.native_title,
+             ai_title = excluded.ai_title,
+             agent_name = excluded.agent_name,
+             permission_mode = excluded.permission_mode,
+             mode = excluded.mode,
+             relocated_cwd = excluded.relocated_cwd,
+             worktree_name = excluded.worktree_name,
+             worktree_branch = excluded.worktree_branch,
+             original_branch = excluded.original_branch,
+             compaction_count = excluded.compaction_count,
+             dropped_tokens = excluded.dropped_tokens,
+             input_cost_usd = excluded.input_cost_usd,
+             output_cost_usd = excluded.output_cost_usd,
+             cache_read_cost_usd = excluded.cache_read_cost_usd,
+             cache_write_cost_usd = excluded.cache_write_cost_usd,
+             total_cost_usd = excluded.total_cost_usd,
+             unpriced_models = excluded.unpriced_models,
+             unpriced_tokens = excluded.unpriced_tokens,
+             cost_by_model = excluded.cost_by_model,
+             active_duration_ms = excluded.active_duration_ms,
+             config_dir = excluded.config_dir",
+        params![
+            s.session_id,
+            s.project_path,
+            file.file_path.to_string_lossy(),
+            to_go_string_utc(GoTime(file.mtime.fixed_offset())),
+            s.preview,
+            to_go_string_utc(s.start_time),
+            to_go_string_utc(s.last_activity),
+            s.message_count,
+            s.event_count,
+            s.usage.input_tokens,
+            s.usage.output_tokens,
+            s.usage.cache_creation_tokens,
+            s.usage.cache_read_tokens,
+            s.usage.cache_creation_5m_tokens,
+            s.usage.cache_creation_1h_tokens,
+            s.git_branch,
+            s.model,
+            s.cwd,
+            s.native_title,
+            s.ai_title,
+            s.agent_name,
+            s.permission_mode,
+            s.mode,
+            s.relocated_cwd,
+            s.worktree_name,
+            s.worktree_branch,
+            s.original_branch,
+            s.compaction_count,
+            s.dropped_tokens,
+            s.cost.input_usd,
+            s.cost.output_usd,
+            s.cost.cache_read_usd,
+            s.cost.cache_write_usd,
+            s.cost.total_usd,
+            encode_unpriced_models(&s.unpriced_models),
+            s.unpriced_tokens,
+            encode_cost_by_model(s),
+            s.active_duration_ms,
+            file.config_dir,
+        ],
+    )
+    .map(|_| ())
+    .map_err(|e| format!("writing session row {}: {e}", s.session_id))
+}
+
+/// Replaces a session's linked pull requests.
+///
+/// A full replace rather than a merge, so a PR link removed upstream disappears
+/// here too. It runs in the same transaction as the session row: the row
+/// carries the file's mtime, so a PR write failing after the row committed
+/// would leave the file looking unchanged to the next diff and the PR rows
+/// would never be rebuilt.
+pub fn replace_pr_rows(tx: &Transaction, s: &SessionSummary) -> Result<(), String> {
+    tx.execute(
+        "DELETE FROM claude_session_pr WHERE session_id = ?1",
+        params![s.session_id],
+    )
+    .map_err(|e| format!("clearing PR rows for {}: {e}", s.session_id))?;
+
+    for pr in &s.prs {
+        tx.execute(
+            "INSERT INTO claude_session_pr
+                 (session_id, pr_url, pr_number, pr_repository, first_seen_at)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                s.session_id,
+                pr.pr_url,
+                pr.pr_number,
+                pr.pr_repository,
+                to_go_string_utc(pr.first_seen_at),
+            ],
+        )
+        .map_err(|e| format!("writing PR row for {}: {e}", s.session_id))?;
+    }
+    Ok(())
+}
+
+/// Metadata from a sub-agent transcript's `.meta.json` sidecar.
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+pub struct SubagentMeta {
+    #[serde(default, rename = "agentType")]
+    pub agent_type: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default, rename = "toolUseId")]
+    pub tool_use_id: String,
+}
+
+/// Reads the sidecar beside a sub-agent transcript.
+///
+/// A missing or malformed sidecar yields the zero value rather than an error:
+/// the transcript is the data, and the sidecar is a label for it.
+pub fn read_subagent_meta(transcript: &std::path::Path) -> SubagentMeta {
+    let path = transcript.with_extension("").with_extension("meta.json");
+    // `.jsonl` → `.meta.json`, matching Go's TrimSuffix + append.
+    let path = if path.exists() {
+        path
+    } else {
+        PathBuf::from(format!(
+            "{}.meta.json",
+            transcript.to_string_lossy().trim_end_matches(".jsonl")
+        ))
+    };
+
+    std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .unwrap_or_default()
+}
+
+/// Writes one sub-agent row.
+///
+/// This table stores a subset of the session columns — no preview, no titles,
+/// no `cost_by_model`, no `project_path`.
+pub fn upsert_subagent_row(
+    tx: &Transaction,
+    file: &DiskFile,
+    s: &SessionSummary,
+    meta: &SubagentMeta,
+) -> Result<(), String> {
+    tx.execute(
+        "INSERT INTO claude_subagent_cache (
+             parent_session_id, agent_id, file_path, file_mtime,
+             agent_type, description, tool_use_id,
+             start_time, last_activity, message_count, event_count,
+             input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+             cache_creation_5m_tokens, cache_creation_1h_tokens,
+             model,
+             input_cost_usd, output_cost_usd, cache_read_cost_usd,
+             cache_write_cost_usd, total_cost_usd, unpriced_models, unpriced_tokens,
+             active_duration_ms, config_dir
+         ) VALUES (
+             ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10,
+             ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20,
+             ?21, ?22, ?23, ?24, ?25, ?26, ?27
+         )
+         ON CONFLICT(parent_session_id, agent_id) DO UPDATE SET
+             file_path = excluded.file_path,
+             file_mtime = excluded.file_mtime,
+             agent_type = excluded.agent_type,
+             description = excluded.description,
+             tool_use_id = excluded.tool_use_id,
+             start_time = excluded.start_time,
+             last_activity = excluded.last_activity,
+             message_count = excluded.message_count,
+             event_count = excluded.event_count,
+             input_tokens = excluded.input_tokens,
+             output_tokens = excluded.output_tokens,
+             cache_creation_tokens = excluded.cache_creation_tokens,
+             cache_read_tokens = excluded.cache_read_tokens,
+             cache_creation_5m_tokens = excluded.cache_creation_5m_tokens,
+             cache_creation_1h_tokens = excluded.cache_creation_1h_tokens,
+             model = excluded.model,
+             input_cost_usd = excluded.input_cost_usd,
+             output_cost_usd = excluded.output_cost_usd,
+             cache_read_cost_usd = excluded.cache_read_cost_usd,
+             cache_write_cost_usd = excluded.cache_write_cost_usd,
+             total_cost_usd = excluded.total_cost_usd,
+             unpriced_models = excluded.unpriced_models,
+             unpriced_tokens = excluded.unpriced_tokens,
+             active_duration_ms = excluded.active_duration_ms,
+             config_dir = excluded.config_dir",
+        params![
+            file.session_id,
+            file.agent_id,
+            file.file_path.to_string_lossy(),
+            to_go_string_utc(GoTime(file.mtime.fixed_offset())),
+            meta.agent_type,
+            meta.description,
+            meta.tool_use_id,
+            to_go_string_utc(s.start_time),
+            to_go_string_utc(s.last_activity),
+            s.message_count,
+            s.event_count,
+            s.usage.input_tokens,
+            s.usage.output_tokens,
+            s.usage.cache_creation_tokens,
+            s.usage.cache_read_tokens,
+            s.usage.cache_creation_5m_tokens,
+            s.usage.cache_creation_1h_tokens,
+            s.model,
+            s.cost.input_usd,
+            s.cost.output_usd,
+            s.cost.cache_read_usd,
+            s.cost.cache_write_usd,
+            s.cost.total_usd,
+            encode_unpriced_models(&s.unpriced_models),
+            s.unpriced_tokens,
+            s.active_duration_ms,
+            file.config_dir,
+        ],
+    )
+    .map(|_| ())
+    .map_err(|e| format!("writing sub-agent row {}: {e}", file.agent_id))
+}
+
+/// Removes one cached row and, for a session, its pull requests.
+///
+/// The PR delete resolves the session id *through* the session row, so it must
+/// run before that row is removed.
+pub fn delete_cached_file(tx: &Transaction, entry: &CachedEntry) -> Result<(), String> {
+    let path = entry.file_path.to_string_lossy().into_owned();
+
+    if !entry.is_subagent {
+        tx.execute(
+            "DELETE FROM claude_session_pr WHERE session_id IN
+                 (SELECT session_id FROM claude_session_cache WHERE file_path = ?1)",
+            params![path],
+        )
+        .map_err(|e| format!("clearing PR rows for {path}: {e}"))?;
+    }
+
+    let table = if entry.is_subagent {
+        "claude_subagent_cache"
+    } else {
+        "claude_session_cache"
+    };
+    tx.execute(
+        &format!("DELETE FROM {table} WHERE file_path = ?1"),
+        params![path],
+    )
+    .map(|_| ())
+    .map_err(|e| format!("deleting {path}: {e}"))
+}
+
+/// Newline-joined, not JSON: a model id may contain a slash but never a
+/// newline.
+fn encode_unpriced_models(models: &[String]) -> String {
+    models.join("\n")
+}
+
+/// JSON, but an empty map stores as `""` rather than `"{}"` — the sessions list
+/// reads both as "nothing".
+fn encode_cost_by_model(s: &SessionSummary) -> String {
+    if s.cost_by_model.is_empty() {
+        return String::new();
+    }
+    serde_json::to_string(&s.cost_by_model).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_empty_cost_map_stores_as_empty_rather_than_an_empty_object() {
+        let s = SessionSummary::default();
+        assert_eq!(encode_cost_by_model(&s), "");
+    }
+
+    #[test]
+    fn unpriced_models_are_newline_joined_not_json() {
+        // A model id may contain a slash — `moonshot/kimi-k2` — but never a
+        // newline, which is why this is not JSON.
+        assert_eq!(
+            encode_unpriced_models(&["a/b".to_string(), "c".to_string()]),
+            "a/b\nc"
+        );
+        assert_eq!(encode_unpriced_models(&[]), "");
+    }
+
+    #[test]
+    fn a_missing_sidecar_yields_the_zero_value() {
+        let meta = read_subagent_meta(std::path::Path::new("/nonexistent/agent-1.jsonl"));
+        assert_eq!(meta.agent_type, "");
+        assert_eq!(meta.description, "");
+    }
+
+    #[test]
+    fn a_sidecar_is_read_from_beside_its_transcript() {
+        let dir = tempfile::tempdir().unwrap();
+        let transcript = dir.path().join("agent-1.jsonl");
+        std::fs::write(&transcript, "{}\n").unwrap();
+        std::fs::write(
+            dir.path().join("agent-1.meta.json"),
+            r#"{"agentType":"Explore","description":"map it","toolUseId":"tu_1"}"#,
+        )
+        .unwrap();
+
+        let meta = read_subagent_meta(&transcript);
+        assert_eq!(meta.agent_type, "Explore");
+        assert_eq!(meta.description, "map it");
+        assert_eq!(meta.tool_use_id, "tu_1");
+    }
+
+    #[test]
+    fn a_malformed_sidecar_degrades_rather_than_failing() {
+        let dir = tempfile::tempdir().unwrap();
+        let transcript = dir.path().join("agent-1.jsonl");
+        std::fs::write(&transcript, "{}\n").unwrap();
+        std::fs::write(dir.path().join("agent-1.meta.json"), "not json").unwrap();
+
+        // The transcript is the data; the sidecar is only a label for it.
+        assert_eq!(read_subagent_meta(&transcript).agent_type, "");
+    }
+}

--- a/desktop/src-tauri/src/native/scanner/summary_file.rs
+++ b/desktop/src-tauri/src/native/scanner/summary_file.rs
@@ -1,0 +1,571 @@
+//! One transcript → one cache row, ported from the `readSummaryFile` half of
+//! `internal/claudesessions/scanner.go`.
+//!
+//! This is the function the whole scanner exists to call. Everything else —
+//! the walk, the diff, the batching — decides *which* files reach it; this
+//! decides what a row says.
+//!
+//! Five rules here are load-bearing, and each is a number a user reads:
+//!
+//! * **`message_count` counts turns, `event_count` counts events.** The turn
+//!   test is [`transcript::is_user_turn_content`], shared with the insight
+//!   pipeline and the journey — changing it moves all three, which is why Go
+//!   requires both version constants to move together.
+//! * **The time range is bounded by a denylist, not an allowlist**
+//!   ([`bounds_session_time_range`]). `pr-link` is the one that matters today:
+//!   it carries a real timestamp that can post-date the conversation, and
+//!   letting it extend `last_activity` would reorder the sessions list by
+//!   something that is not conversation.
+//! * **Timestamps are normalized to UTC**, because SQLite stores the driver's
+//!   rendering and both the list's `ORDER BY` and its keyset pagination compare
+//!   that as *text*. Lexical order matches chronological order only while every
+//!   value carries the same zone suffix.
+//! * **Compaction's dropped-token figure is a maximum, not a sum** — the CLI
+//!   reports a running total, so adding them up multiply-counts.
+//! * **A transcript with no timestamped event produces no row at all.**
+//!
+//! The preview deliberately uses a *weaker* rule than the counter: a genuine
+//! turn always wins, but a transcript that never contains one — a slash command
+//! and its expansion — still takes its preview from the wrapper, because the
+//! preview is the last fallback for a session's display title and an empty one
+//! renders as a blank, unidentifiable row.
+
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+
+use crate::native::gotime::GoTime;
+use crate::native::insights::transcript::{self, Event};
+use crate::native::pricing::Resolver;
+use crate::native::sessions::summary::{SessionPR, SessionSummary, TokenUsage};
+
+use super::cost::CostAccumulator;
+use crate::native::active_time::ActiveTimeTracker;
+
+/// Preview truncation, in runes rather than bytes.
+const PREVIEW_MAX_CHARS: usize = 120;
+
+/// Reads a parent session transcript.
+pub fn read_session_summary(
+    session_id: &str,
+    project_path: &str,
+    file_path: &Path,
+    resolver: Option<&Resolver>,
+    idle_gap_ms: i64,
+) -> Result<Option<SessionSummary>, String> {
+    read_summary_file(
+        session_id,
+        project_path,
+        file_path,
+        false,
+        resolver,
+        idle_gap_ms,
+    )
+}
+
+/// Reads a sub-agent transcript.
+///
+/// Sub-agent files use the same event schema as a parent session, but **every**
+/// event in them is flagged `isSidechain` — the marker a parent transcript uses
+/// for delegated turns it should not count twice. Inside a sub-agent file that
+/// marker is universal and carries no such meaning, so sidechain user turns are
+/// counted here; otherwise `message_count` would silently degrade to
+/// assistant-only.
+pub fn read_subagent_summary(
+    session_id: &str,
+    project_path: &str,
+    file_path: &Path,
+    resolver: Option<&Resolver>,
+    idle_gap_ms: i64,
+) -> Result<Option<SessionSummary>, String> {
+    read_summary_file(
+        session_id,
+        project_path,
+        file_path,
+        true,
+        resolver,
+        idle_gap_ms,
+    )
+}
+
+/// Reads one transcript into a summary.
+///
+/// Returns `Ok(None)` when the file yielded no timestamped event — Go's
+/// `StartTime.IsZero()` check. The caller treats that exactly as it treats a
+/// read failure: the file is counted as done, and no row is written.
+fn read_summary_file(
+    session_id: &str,
+    project_path: &str,
+    file_path: &Path,
+    count_sidechain_users: bool,
+    resolver: Option<&Resolver>,
+    idle_gap_ms: i64,
+) -> Result<Option<SessionSummary>, String> {
+    let events = transcript::read(file_path)?;
+
+    let mut summary = SessionSummary {
+        session_id: session_id.to_string(),
+        project_path: project_path.to_string(),
+        ..Default::default()
+    };
+    // True while the preview came from an injected wrapper rather than a
+    // genuine turn, so a real prompt arriving later can replace it.
+    let mut preview_is_fallback = false;
+
+    let mut range = TimeRange::default();
+    let mut active = ActiveTimeTracker::new(idle_gap_ms);
+    let mut costs = CostAccumulator::new(resolver);
+
+    for ev in &events {
+        // A file-history snapshot is neither conversation nor metadata; it is
+        // skipped before anything observes it, including the time range.
+        if ev.event_type == "file-history-snapshot" {
+            continue;
+        }
+
+        if bounds_session_time_range(&ev.event_type) {
+            if let Some(ts) = ev.timestamp {
+                range.update(ts);
+                // The same event set that bounds the time range feeds active
+                // duration, so active time is contained in [start, last] by
+                // construction — a pr-link posted days after the conversation
+                // can extend neither.
+                active.observe(ts, ev.event_type == "assistant");
+            }
+        }
+
+        update_metadata_from_event(&mut summary, ev);
+        process_summary_event(
+            &mut summary,
+            &mut preview_is_fallback,
+            ev,
+            count_sidechain_users,
+        );
+
+        if ev.event_type == "assistant" {
+            if let Some(message) = &ev.message {
+                if message.usage.is_some() {
+                    let mut u = TokenUsage::default();
+                    add_assistant_usage(&mut u, message);
+                    if let Some(ts) = ev.timestamp {
+                        costs.add_assistant_message(&message.model, &u, ts);
+                    }
+                }
+            }
+        }
+    }
+
+    // A transcript with only denylisted or timestampless events yields no row.
+    let Some(start) = range.start else {
+        return Ok(None);
+    };
+
+    summary.start_time = GoTime(start.fixed_offset());
+    summary.last_activity = GoTime(range.last.unwrap_or(start).fixed_offset());
+    summary.active_duration_ms = active.active_ms();
+    summary.cost = costs.total();
+    summary.cost_by_model = costs.cost_by_model();
+    summary.unpriced_models = costs.unpriced_models();
+    summary.unpriced_tokens = costs.unknown_pricing_tokens();
+
+    Ok(Some(summary))
+}
+
+/// Whether an event type may extend the session's start/last-activity range.
+///
+/// A **denylist on purpose**. Many event types carry timestamps and
+/// legitimately bound the range — `queue-operation` and `file-history-delta`
+/// among them — so enumerating the ones that count would silently shrink the
+/// range for existing sessions as Claude Code adds types.
+///
+/// Excluded are the events that *describe* the session rather than occur within
+/// it. The title and metadata events carry no timestamp today, so excluding
+/// them is a no-op the zero check already handles — but a future release adding
+/// one must not drag `start_time` backwards. `pr-link` is the exception that
+/// matters today.
+pub fn bounds_session_time_range(event_type: &str) -> bool {
+    !matches!(
+        event_type,
+        "custom-title"
+            | "ai-title"
+            | "pr-link"
+            | "agent-name"
+            | "permission-mode"
+            | "mode"
+            | "relocated"
+            | "worktree-state"
+    )
+}
+
+/// The session's `[start, last]` bounds.
+#[derive(Default)]
+struct TimeRange {
+    start: Option<DateTime<Utc>>,
+    last: Option<DateTime<Utc>>,
+}
+
+impl TimeRange {
+    /// Widens the range to include `ts`, normalized to UTC.
+    ///
+    /// The normalization is what makes the stored bounds orderable: SQLite
+    /// holds them as text, and lexical order matches chronological order only
+    /// while every value carries the same zone suffix. Claude Code writes
+    /// Z-suffixed timestamps, so in practice this changes no stored value —
+    /// which is why Go needed no scanner-version bump for it.
+    fn update(&mut self, ts: DateTime<Utc>) {
+        match self.start {
+            Some(start) if ts >= start => {}
+            _ => self.start = Some(ts),
+        }
+        match self.last {
+            Some(last) if ts <= last => {}
+            _ => self.last = Some(ts),
+        }
+    }
+}
+
+/// Sets cwd and git branch from the first event that has them.
+fn update_metadata_from_event(summary: &mut SessionSummary, ev: &Event) {
+    if summary.cwd.is_empty() && !ev.cwd.is_empty() {
+        summary.cwd = ev.cwd.clone();
+    }
+    if summary.git_branch.is_empty() && !ev.git_branch.is_empty() {
+        summary.git_branch = ev.git_branch.clone();
+    }
+}
+
+/// Accumulates one assistant message's usage.
+fn add_assistant_usage(usage: &mut TokenUsage, message: &transcript::Message) {
+    let Some(u) = &message.usage else {
+        return;
+    };
+    let (five_min, one_hour) = u.split_cache_tiers();
+    usage.input_tokens += u.input_tokens;
+    usage.output_tokens += u.output_tokens;
+    usage.cache_creation_tokens += u.cache_creation_input_tokens;
+    usage.cache_creation_5m_tokens += five_min;
+    usage.cache_creation_1h_tokens += one_hour;
+    usage.cache_read_tokens += u.cache_read_input_tokens;
+}
+
+fn process_summary_event(
+    summary: &mut SessionSummary,
+    preview_is_fallback: &mut bool,
+    ev: &Event,
+    count_sidechain_users: bool,
+) {
+    match ev.event_type.as_str() {
+        "user" => {
+            if ev.is_sidechain && !count_sidechain_users {
+                return;
+            }
+            add_summary_user_event(summary, preview_is_fallback, ev);
+        }
+        "assistant" => add_summary_assistant_event(summary, ev),
+        "pr-link" => add_summary_pr_link(summary, ev),
+        "system" => add_summary_compaction(summary, ev),
+        _ => apply_session_metadata(summary, ev),
+    }
+}
+
+/// Records the events that describe the session rather than occurring within
+/// it.
+///
+/// Claude Code re-appends every one of them on each resume, so unconditional
+/// assignment during a sequential read gives last-wins for free — which is the
+/// correct rule, since the final value is the current one.
+fn apply_session_metadata(summary: &mut SessionSummary, ev: &Event) {
+    match ev.event_type.as_str() {
+        "custom-title" => summary.native_title = ev.custom_title.clone(),
+        "ai-title" => summary.ai_title = ev.ai_title.clone(),
+        "agent-name" => summary.agent_name = ev.agent_name.clone(),
+        "permission-mode" => summary.permission_mode = ev.permission_mode.clone(),
+        "mode" => summary.mode = ev.mode.clone(),
+        "relocated" => summary.relocated_cwd = ev.relocated_cwd.clone(),
+        "worktree-state" => {
+            if let Some(w) = &ev.worktree_session {
+                summary.worktree_name = w.worktree_name.clone();
+                summary.worktree_branch = w.worktree_branch.clone();
+                summary.original_branch = w.original_branch.clone();
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Records a linked pull request, deduplicated by URL.
+///
+/// Claude Code re-emits the event on every resume, so the same PR appears many
+/// times in one file; the earliest sighting keeps its timestamp.
+fn add_summary_pr_link(summary: &mut SessionSummary, ev: &Event) {
+    if ev.pr_url.is_empty() {
+        return;
+    }
+    if summary.prs.iter().any(|pr| pr.pr_url == ev.pr_url) {
+        return;
+    }
+    summary.prs.push(SessionPR {
+        pr_number: ev.pr_number,
+        pr_url: ev.pr_url.clone(),
+        pr_repository: ev.pr_repository.clone(),
+        first_seen_at: ev
+            .timestamp
+            .map(|t| GoTime(t.fixed_offset()))
+            .unwrap_or_default(),
+    });
+}
+
+/// Records a conversation compaction.
+///
+/// Only the `compact_boundary` subtype carries compaction metadata; every other
+/// system subtype is ignored here.
+fn add_summary_compaction(summary: &mut SessionSummary, ev: &Event) {
+    if ev.subtype != "compact_boundary" {
+        return;
+    }
+    let Some(meta) = &ev.compact_metadata else {
+        return;
+    };
+    summary.compaction_count += 1;
+
+    // A running total across the session, so the largest value seen is the
+    // session's figure — summing would multiply-count.
+    if meta.cumulative_dropped_tokens > 0 {
+        if meta.cumulative_dropped_tokens > summary.dropped_tokens {
+            summary.dropped_tokens = meta.cumulative_dropped_tokens;
+        }
+        return;
+    }
+    // Older Claude Code releases omit cumulativeDroppedTokens while still
+    // reporting preTokens/postTokens. Reporting zero there would be a visibly
+    // wrong headline number — one real transcript compacts 1,000,563 tokens
+    // down to 26,087 — so this boundary's own drop is accumulated instead.
+    let dropped = meta.pre_tokens - meta.post_tokens;
+    if dropped > 0 {
+        summary.dropped_tokens += dropped;
+    }
+}
+
+/// Records one user event.
+///
+/// Every event bumps `event_count`, but only genuine human input counts as a
+/// message — the bulk of user events merely carry `tool_result` blocks back to
+/// the model.
+fn add_summary_user_event(
+    summary: &mut SessionSummary,
+    preview_is_fallback: &mut bool,
+    ev: &Event,
+) {
+    summary.event_count += 1;
+    let Some(message) = &ev.message else {
+        return;
+    };
+
+    if !transcript::is_user_turn_content(&message.content) {
+        // Still a preview candidate if nothing better ever arrives — but never
+        // a tool_result carrier, which is unreadable machine payload.
+        if summary.preview.is_empty() && !transcript::is_injected_user_content(&message.content) {
+            return;
+        }
+        if summary.preview.is_empty() {
+            let raw = transcript::extract_text_content(&message.content);
+            summary.preview = truncate_chars(&fallback_preview_label(&raw), PREVIEW_MAX_CHARS);
+            *preview_is_fallback = true;
+        }
+        return;
+    }
+
+    summary.message_count += 1;
+    // A genuine turn replaces a wrapper-sourced preview, so the label prefers
+    // what the person actually typed even when a wrapper came first.
+    //
+    // Every known injected form is classified above and takes the fallback
+    // branch, so this call is normally a no-op on real prose. It stays because
+    // the marker tables are empirical: a wrapper shape a future Claude Code
+    // release invents reaches this branch until the tables catch up, and
+    // labeling it beats rendering raw tag soup.
+    if summary.preview.is_empty() || *preview_is_fallback {
+        let raw = transcript::extract_text_content(&message.content);
+        summary.preview = truncate_chars(&fallback_preview_label(&raw), PREVIEW_MAX_CHARS);
+        *preview_is_fallback = false;
+    }
+}
+
+/// Records one assistant event: always an event, but a message only when it
+/// contains text the user actually saw.
+fn add_summary_assistant_event(summary: &mut SessionSummary, ev: &Event) {
+    summary.event_count += 1;
+    let Some(message) = &ev.message else {
+        return;
+    };
+    if transcript::is_assistant_reply(&message.content) {
+        summary.message_count += 1;
+    }
+    if summary.model.is_empty() && !message.model.is_empty() {
+        summary.model = message.model.clone();
+    }
+    add_assistant_usage(&mut summary.usage, message);
+}
+
+/// Turns an injected wrapper into something a person can recognize in a list.
+///
+/// These previews are the last resort for a session's display title, and for a
+/// session that is only a slash command they are all there is. Unprocessed they
+/// render as rows reading `<command-message>lab-workflow:…</command-message>…`
+/// or `Base directory for this skill: /home/…` — three of nine rows on the
+/// reference corpus. The command or skill name was in there the whole time.
+///
+/// Anything matching neither shape is returned **unchanged and untrimmed**, so
+/// a wrapper form this does not know about is still shown rather than blanked.
+pub fn fallback_preview_label(raw: &str) -> String {
+    let trimmed = raw.trim();
+
+    if let Some(name) = command_name(trimmed) {
+        return format!("/{}", name.trim());
+    }
+    if let Some(path) = transcript::skill_preamble_path(trimmed) {
+        let name = skill_name_from_path(&path);
+        if !name.is_empty() {
+            return format!("skill: {name}");
+        }
+    }
+    raw.to_string()
+}
+
+/// Extracts the slash command Claude Code records when a session was started by
+/// one — Go's `<command-name>([^<]+)</command-name>` regexp, hand-rolled to
+/// keep the crate free of a regex dependency it otherwise does not need.
+fn command_name(s: &str) -> Option<&str> {
+    const OPEN: &str = "<command-name>";
+    const CLOSE: &str = "</command-name>";
+    let start = s.find(OPEN)? + OPEN.len();
+    let rest = &s[start..];
+    // `[^<]+` — the capture stops at the first `<`, which must be the closing
+    // tag for the match to be the one Go's regexp finds.
+    let end = rest.find('<')?;
+    if end == 0 || !rest[end..].starts_with(CLOSE) {
+        return None;
+    }
+    Some(&rest[..end])
+}
+
+/// Reads the skill's name out of its directory path.
+///
+/// Claude Code lays these out as `…/skills/<name>`, so the segment after
+/// `skills` is the name; a path that does not contain one falls back to its
+/// last segment, which is the same thing for a bare skill directory.
+fn skill_name_from_path(path: &str) -> String {
+    let segments: Vec<&str> = path.trim_matches('/').split('/').collect();
+    for (i, seg) in segments.iter().enumerate() {
+        if *seg == "skills" && i + 1 < segments.len() {
+            return segments[i + 1].to_string();
+        }
+    }
+    segments.last().map(|s| s.to_string()).unwrap_or_default()
+}
+
+/// Truncates to `max` characters, appending an ellipsis — Go's
+/// `truncateRunes`, which counts runes rather than bytes.
+fn truncate_chars(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let kept: String = s.chars().take(max).collect();
+    format!("{kept}…")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_denylist_is_exactly_the_eight_describing_events() {
+        for denied in [
+            "custom-title",
+            "ai-title",
+            "pr-link",
+            "agent-name",
+            "permission-mode",
+            "mode",
+            "relocated",
+            "worktree-state",
+        ] {
+            assert!(!bounds_session_time_range(denied), "{denied}");
+        }
+        // Everything else bounds the range, including types this build has
+        // never heard of — that is the point of a denylist.
+        for allowed in [
+            "user",
+            "assistant",
+            "system",
+            "queue-operation",
+            "file-history-delta",
+            "some-future-event",
+        ] {
+            assert!(bounds_session_time_range(allowed), "{allowed}");
+        }
+    }
+
+    #[test]
+    fn a_command_wrapper_becomes_its_command_name() {
+        assert_eq!(
+            fallback_preview_label(
+                "<command-message>lab-workflow:github-issue-to-pr</command-message>\
+                 <command-name>lab-workflow:github-issue-to-pr</command-name>"
+            ),
+            "/lab-workflow:github-issue-to-pr"
+        );
+    }
+
+    #[test]
+    fn a_skill_preamble_becomes_its_skill_name() {
+        assert_eq!(
+            fallback_preview_label(
+                "Base directory for this skill: /home/u/.claude/plugins/cache/x/skills/deploy-thing"
+            ),
+            "skill: deploy-thing"
+        );
+    }
+
+    #[test]
+    fn anything_else_is_returned_untouched_including_its_whitespace() {
+        // Go returns the *untrimmed* raw on no match, though it matches against
+        // the trimmed string — reproduce both halves.
+        assert_eq!(fallback_preview_label("  hello  "), "  hello  ");
+        assert_eq!(
+            fallback_preview_label("<unknown-wrapper>x"),
+            "<unknown-wrapper>x"
+        );
+    }
+
+    #[test]
+    fn a_skill_path_without_a_skills_segment_falls_back_to_its_last() {
+        assert_eq!(skill_name_from_path("/a/b/deploy"), "deploy");
+        assert_eq!(skill_name_from_path("/a/skills/deploy/sub"), "deploy");
+        assert_eq!(skill_name_from_path("deploy/"), "deploy");
+    }
+
+    #[test]
+    fn truncation_counts_characters_not_bytes() {
+        let s = "é".repeat(130);
+        let out = truncate_chars(&s, PREVIEW_MAX_CHARS);
+        assert_eq!(
+            out.chars().count(),
+            PREVIEW_MAX_CHARS + 1,
+            "120 plus the ellipsis"
+        );
+        assert!(out.ends_with('…'));
+        assert_eq!(truncate_chars("short", PREVIEW_MAX_CHARS), "short");
+    }
+
+    #[test]
+    fn the_time_range_widens_in_both_directions() {
+        let t = |s: &str| DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc);
+        let mut r = TimeRange::default();
+        r.update(t("2026-03-15T12:00:00Z"));
+        r.update(t("2026-03-15T10:00:00Z"));
+        r.update(t("2026-03-15T14:00:00Z"));
+        assert_eq!(r.start, Some(t("2026-03-15T10:00:00Z")));
+        assert_eq!(r.last, Some(t("2026-03-15T14:00:00Z")));
+    }
+}

--- a/desktop/src-tauri/src/native/scanner/walk.rs
+++ b/desktop/src-tauri/src/native/scanner/walk.rs
@@ -305,54 +305,77 @@ fn mtime_utc(meta: &std::fs::Metadata) -> DateTime<Utc> {
 
 /// Turns Claude Code's dash-encoded project directory name back into a path.
 ///
-/// The encoding is lossy — every `/` and every `.` became a `-` — so this
-/// resolves greedily against the filesystem, preferring a segment that exists.
-/// A name that resolves to nothing is returned unchanged, which is what the
-/// sessions list stores for such projects.
+/// The encoding is lossy: `/` and `.` both became `-`, so the only way back is
+/// to walk the filesystem and prefer whichever split actually exists. Segments
+/// accumulate until one resolves, then the walk advances.
+///
+/// This mirrors `DecodeProjectPath` exactly, because `project_path` is half of
+/// `claude_session_cache`'s primary key — a different answer here writes rows
+/// under a different key than Go does. Four details are load-bearing and each
+/// was got wrong once in this port:
+///
+/// * **Only one leading `-` is stripped.** `--claude` is a hidden directory,
+///   and the second dash is what `find_existing_dir`'s dot-prefixed variant
+///   recovers.
+/// * **Empty tokens are skipped**, not folded into the segment: consecutive
+///   hyphens come from an encoded `.` or `/` and the next token continues the
+///   segment as if they were not there.
+/// * **Only directories match.** A file of the right name is not a path
+///   component.
+/// * **The fallback tests the final result**, not whether anything resolved
+///   along the way; a partial resolution that lands nowhere returns the raw
+///   encoded name, which is what the sessions list then stores.
 pub fn decode_project_path(encoded: &str) -> String {
-    if !encoded.starts_with('-') {
-        return encoded.to_string();
-    }
+    // TrimPrefix, not trim_start_matches: exactly one dash.
+    let trimmed = encoded.strip_prefix('-').unwrap_or(encoded);
 
-    let mut current = String::from("/");
-    let mut segment = String::new();
-    let mut resolved_any = false;
+    let mut current_path = String::new();
+    let mut current_segment = String::new();
 
-    for part in encoded.trim_start_matches('-').split('-') {
-        let candidate = if segment.is_empty() {
-            part.to_string()
+    for token in trimmed.split('-') {
+        // Empty tokens come from consecutive hyphens. Skipping them lets the
+        // next token continue the segment, and the dot-prefixed variant below
+        // covers the hidden directories that produced them.
+        if token.is_empty() {
+            continue;
+        }
+
+        if current_segment.is_empty() {
+            current_segment = token.to_string();
         } else {
-            format!("{segment}-{part}")
-        };
+            current_segment.push('-');
+            current_segment.push_str(token);
+        }
 
-        if let Some(found) = find_existing_dir(&current, &candidate) {
-            current = join_path(&current, &found);
-            segment.clear();
-            resolved_any = true;
-        } else {
-            segment = candidate;
+        // Greedily advance when the accumulated segment names a real directory.
+        if let Some(next) = find_existing_dir(&current_path, &current_segment) {
+            current_path = next;
+            current_segment.clear();
         }
     }
 
-    if !segment.is_empty() {
-        current = join_path(&current, &segment);
-    }
-    if resolved_any || Path::new(&current).exists() {
-        current
+    let result = if current_segment.is_empty() {
+        current_path
+    } else {
+        format!("{current_path}/{current_segment}")
+    };
+
+    if Path::new(&result).exists() {
+        result
     } else {
         encoded.to_string()
     }
 }
 
-/// Tries `segment` and `.segment`, since a leading dot also encodes as a dash.
+/// Whether `parent/segment` or `parent/.segment` is an existing **directory**.
+///
+/// The dot-prefixed variant recovers hidden directories such as `.claude`,
+/// which Claude Code encodes with the same `-` it uses for a path separator.
 fn find_existing_dir(parent: &str, segment: &str) -> Option<String> {
     [segment.to_string(), format!(".{segment}")]
         .into_iter()
-        .find(|candidate| Path::new(parent).join(candidate).exists())
-}
-
-fn join_path(parent: &str, child: &str) -> String {
-    Path::new(parent).join(child).to_string_lossy().into_owned()
+        .map(|name| format!("{parent}/{name}"))
+        .find(|candidate| Path::new(candidate).is_dir())
 }
 
 #[cfg(test)]
@@ -489,6 +512,48 @@ mod tests {
         );
         // A name that was never encoded passes through untouched.
         assert_eq!(decode_project_path("plain"), "plain");
+    }
+
+    #[test]
+    fn only_one_leading_dash_is_stripped_so_hidden_dirs_survive() {
+        // `--claude` is `/.claude`: the first dash is the root, the second is
+        // the dot. Stripping both loses the hidden directory.
+        let tmp = tempfile::tempdir().unwrap();
+        let hidden = tmp.path().join(".claude");
+        std::fs::create_dir_all(&hidden).unwrap();
+
+        let root = tmp.path().to_string_lossy().replace('/', "-");
+        assert_eq!(
+            decode_project_path(&format!("{root}--claude")),
+            hidden.to_string_lossy().into_owned()
+        );
+    }
+
+    #[test]
+    fn a_file_of_the_right_name_is_not_a_path_component() {
+        // Only directories may resolve a segment.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("notadir"), "x").unwrap();
+
+        let root = tmp.path().to_string_lossy().replace('/', "-");
+        let encoded = format!("{root}-notadir-deeper");
+        assert_eq!(
+            decode_project_path(&encoded),
+            encoded,
+            "nothing resolved, so the raw name is kept"
+        );
+    }
+
+    #[test]
+    fn a_partial_resolution_that_lands_nowhere_keeps_the_raw_name() {
+        // The fallback tests the *final* result, not whether anything resolved
+        // along the way.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("real")).unwrap();
+
+        let root = tmp.path().to_string_lossy().replace('/', "-");
+        let encoded = format!("{root}-real-missing-deeper");
+        assert_eq!(decode_project_path(&encoded), encoded);
     }
 
     #[test]

--- a/desktop/src-tauri/src/native/scanner/walk.rs
+++ b/desktop/src-tauri/src/native/scanner/walk.rs
@@ -1,0 +1,514 @@
+//! Enumerating what is on disk, ported from the walk half of
+//! `internal/claudesessions/scanner.go`.
+//!
+//! The walk produces two things, and the second is the one that matters:
+//! the set of transcripts found, and **which directories were actually listed
+//! end to end**. Everything about deletion safety hangs on the latter.
+//!
+//! ## "No file on disk" and "we could not look" are different answers
+//!
+//! The diff can only tell that a cached row has no matching file. If the
+//! directory that row came from could not be listed — an unplugged drive, a
+//! permission change — that is not evidence the session is gone, and deleting
+//! on it would wipe an account's whole corpus, taking `custom_title` and
+//! `is_favorite` (the two user-owned columns a rescan deliberately preserves)
+//! with it. So a dir that failed to list is left out of [`DiskWalk::walked`],
+//! and the delete pass skips every row belonging to it.
+//!
+//! Three outcomes, and the middle one is easy to miss:
+//!
+//! | what happened | walked? | protected? |
+//! |---|---|---|
+//! | listed end to end | yes | — |
+//! | config dir itself unreadable | **no** | the whole dir |
+//! | listed, but some project dirs failed | yes | those projects only |
+//!
+//! A config dir that exists but has no `projects/` is the case that looks like
+//! a failure and is not: it has genuinely never run a session, so it walked
+//! fine and contributed nothing, and its (nonexistent) rows are safe to
+//! reconcile. Protection is per **project** rather than per config dir so one
+//! root-owned directory does not stop every *other* project's genuinely
+//! deleted transcripts from ever being reconciled away.
+//!
+//! ## One session, however many dirs hold a copy
+//!
+//! The ordinary way to set up a second Claude account is to copy the first
+//! config dir, which duplicates every session id under the same project paths.
+//! Indexing both would double that corpus's tokens and cost in every total,
+//! and — because `claude_session_cache` is keyed on `(session_id,
+//! project_path)` while `file_path` is only a non-unique index — would leave
+//! the losing path permanently classified as an insert, re-firing a discovery
+//! event on every scan. [`claim_session`] gives each session to the first dir
+//! that has it, which is why the caller must pass dirs **default-first**.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use chrono::{DateTime, Utc};
+
+const JSONL_EXT: &str = ".jsonl";
+
+/// One transcript found on disk.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DiskFile {
+    /// For a sub-agent file this is the **parent's** id, matching the column
+    /// `claude_subagent_cache` keys on.
+    pub session_id: String,
+    pub project_path: String,
+    pub file_path: PathBuf,
+    pub mtime: DateTime<Utc>,
+    pub is_subagent: bool,
+    pub agent_id: String,
+    pub parent_file_path: PathBuf,
+    pub config_dir: String,
+}
+
+/// The result of walking every configured config dir.
+#[derive(Debug, Default)]
+pub struct DiskWalk {
+    /// Every transcript found, keyed by its path.
+    pub files: HashMap<PathBuf, DiskFile>,
+    /// The config dirs that produced a complete listing.
+    ///
+    /// Not bookkeeping: a cached row whose config dir is absent from this set
+    /// must be excluded from the delete pass.
+    pub walked: HashSet<String>,
+    /// Directory paths whose contents could not be fully listed. Rows beneath
+    /// them are excluded from the delete pass.
+    pub protected: Vec<PathBuf>,
+}
+
+/// Walks every configured config dir into one set.
+///
+/// Failure is isolated per dir on purpose: a dir that cannot be listed is
+/// skipped and left out of `walked`, so the rest of the scan proceeds and that
+/// dir's rows are protected rather than deleted.
+///
+/// `dirs` must be **default-first** — that is what makes [`claim_session`]
+/// deterministic about which copy of a duplicated session wins.
+pub fn walk_all_disk_files(dirs: &[String]) -> DiskWalk {
+    let mut walk = DiskWalk::default();
+    // Tracks which (session, project) pair a config dir already claimed, so a
+    // corpus copied between dirs is indexed once.
+    let mut claimed: HashMap<String, String> = HashMap::new();
+
+    for dir in dirs {
+        match walk_one_dir(dir, &mut walk.files, &mut claimed) {
+            DirOutcome::Complete => {
+                walk.walked.insert(dir.clone());
+            }
+            DirOutcome::Unreadable => {
+                // The config dir itself could not be listed; protect all of it.
+                walk.protected.push(PathBuf::from(dir));
+            }
+            DirOutcome::Partial(failed) => {
+                walk.walked.insert(dir.clone());
+                walk.protected.extend(failed);
+            }
+        }
+    }
+    walk
+}
+
+/// What listing one config dir produced.
+enum DirOutcome {
+    /// Listed end to end. Its rows may be reconciled.
+    Complete,
+    /// The config dir itself could not be listed. Every row under it is
+    /// protected.
+    Unreadable,
+    /// Listed, but these project directories failed. Only they are protected.
+    Partial(Vec<PathBuf>),
+}
+
+fn walk_one_dir(
+    dir: &str,
+    on_disk: &mut HashMap<PathBuf, DiskFile>,
+    claimed: &mut HashMap<String, String>,
+) -> DirOutcome {
+    let projects_dir = Path::new(dir).join("projects");
+    let entries = match std::fs::read_dir(&projects_dir) {
+        Ok(entries) => entries,
+        Err(e) => {
+            // A config dir that exists but has no projects/ has genuinely never
+            // run a session: it walked fine and contributed nothing, and its
+            // (nonexistent) rows are safe to reconcile. A config dir that is
+            // itself missing or unreadable is a different thing entirely — the
+            // user may have unplugged a drive — and must protect its rows.
+            if e.kind() == std::io::ErrorKind::NotFound && Path::new(dir).is_dir() {
+                return DirOutcome::Complete;
+            }
+            log::warn!("claude sessions: skipping unreadable config dir {dir}: {e}");
+            return DirOutcome::Unreadable;
+        }
+    };
+
+    let mut failed = Vec::new();
+    for entry in entries.flatten() {
+        if !entry.path().is_dir() {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if !collect_project_disk_files(dir, &projects_dir, &name, on_disk, claimed) {
+            failed.push(projects_dir.join(&name));
+        }
+    }
+
+    if failed.is_empty() {
+        DirOutcome::Complete
+    } else {
+        DirOutcome::Partial(failed)
+    }
+}
+
+/// Decides whether a config dir may index a `(session, project)` pair,
+/// recording the winner so later dirs lose.
+///
+/// Returns true for the owner — the first dir to ask, or the same dir asking
+/// again.
+pub fn claim_session(claimed: &mut HashMap<String, String>, key: String, dir: &str) -> bool {
+    match claimed.get(&key) {
+        None => {
+            claimed.insert(key, dir.to_string());
+            true
+        }
+        Some(owner) => owner == dir,
+    }
+}
+
+/// Collects one project directory. Returns false when it could not be listed,
+/// which the caller turns into protection for that project.
+fn collect_project_disk_files(
+    config_dir: &str,
+    projects_dir: &Path,
+    dir_name: &str,
+    on_disk: &mut HashMap<PathBuf, DiskFile>,
+    claimed: &mut HashMap<String, String>,
+) -> bool {
+    let project_path = decode_project_path(dir_name);
+    let project_dir = projects_dir.join(dir_name);
+
+    let entries = match std::fs::read_dir(&project_dir) {
+        Ok(entries) => entries.flatten().collect::<Vec<_>>(),
+        Err(e) => {
+            // A project dir that cannot be listed drops every file under it
+            // from the walk, which the diff reads as "deleted" — so it is
+            // reported as an incomplete listing and its rows are protected.
+            log::warn!(
+                "claude sessions: skipping unreadable project dir {}: {e}",
+                project_dir.display()
+            );
+            return false;
+        }
+    };
+
+    // Session ids are needed before their sibling directories can be matched,
+    // and directory listings give no ordering guarantee, so the flat files are
+    // collected first.
+    let mut session_ids: HashSet<String> = HashSet::new();
+    for entry in &entries {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if entry.path().is_dir() || !name.ends_with(JSONL_EXT) {
+            continue;
+        }
+        let Ok(meta) = entry.metadata() else { continue };
+        let session_id = name.trim_end_matches(JSONL_EXT).to_string();
+
+        if !claim_session(
+            claimed,
+            format!("{session_id}\u{0}{project_path}"),
+            config_dir,
+        ) {
+            // Another config dir already indexed this exact session. Skipping
+            // it here also keeps its sub-agent directory out, since the second
+            // pass only descends into ids collected in the first.
+            continue;
+        }
+
+        session_ids.insert(session_id.clone());
+        let file_path = project_dir.join(&name);
+        on_disk.insert(
+            file_path.clone(),
+            DiskFile {
+                session_id,
+                project_path: project_path.clone(),
+                file_path,
+                mtime: mtime_utc(&meta),
+                is_subagent: false,
+                agent_id: String::new(),
+                parent_file_path: PathBuf::new(),
+                config_dir: config_dir.to_string(),
+            },
+        );
+    }
+
+    for entry in &entries {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if !entry.path().is_dir() || !session_ids.contains(&name) {
+            continue;
+        }
+        collect_subagent_disk_files(config_dir, &project_dir, &name, &project_path, on_disk);
+    }
+    true
+}
+
+/// Emits one entry per sub-agent transcript under
+/// `<project_dir>/<session_id>/subagents/`.
+///
+/// Claude Code moved delegated work out of the parent JSONL into this
+/// directory; a session with no such directory simply contributes nothing.
+fn collect_subagent_disk_files(
+    config_dir: &str,
+    project_dir: &Path,
+    session_id: &str,
+    project_path: &str,
+    on_disk: &mut HashMap<PathBuf, DiskFile>,
+) {
+    let subagents_dir = project_dir.join(session_id).join("subagents");
+    let Ok(entries) = std::fs::read_dir(&subagents_dir) else {
+        return;
+    };
+    let parent_file_path = project_dir.join(format!("{session_id}{JSONL_EXT}"));
+
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if entry.path().is_dir() || !name.ends_with(JSONL_EXT) {
+            continue;
+        }
+        let Ok(meta) = entry.metadata() else { continue };
+        let file_path = subagents_dir.join(&name);
+        on_disk.insert(
+            file_path.clone(),
+            DiskFile {
+                // The parent's id: `claude_subagent_cache` keys on
+                // `(parent_session_id, agent_id)`.
+                session_id: session_id.to_string(),
+                project_path: project_path.to_string(),
+                file_path,
+                mtime: mtime_utc(&meta),
+                is_subagent: true,
+                agent_id: name.trim_end_matches(JSONL_EXT).to_string(),
+                parent_file_path: parent_file_path.clone(),
+                config_dir: config_dir.to_string(),
+            },
+        );
+    }
+}
+
+/// Normalized to UTC, because the stored bounds are compared as text and
+/// lexical order matches chronological order only while every value carries the
+/// same zone suffix.
+fn mtime_utc(meta: &std::fs::Metadata) -> DateTime<Utc> {
+    meta.modified().unwrap_or(SystemTime::UNIX_EPOCH).into()
+}
+
+/// Turns Claude Code's dash-encoded project directory name back into a path.
+///
+/// The encoding is lossy — every `/` and every `.` became a `-` — so this
+/// resolves greedily against the filesystem, preferring a segment that exists.
+/// A name that resolves to nothing is returned unchanged, which is what the
+/// sessions list stores for such projects.
+pub fn decode_project_path(encoded: &str) -> String {
+    if !encoded.starts_with('-') {
+        return encoded.to_string();
+    }
+
+    let mut current = String::from("/");
+    let mut segment = String::new();
+    let mut resolved_any = false;
+
+    for part in encoded.trim_start_matches('-').split('-') {
+        let candidate = if segment.is_empty() {
+            part.to_string()
+        } else {
+            format!("{segment}-{part}")
+        };
+
+        if let Some(found) = find_existing_dir(&current, &candidate) {
+            current = join_path(&current, &found);
+            segment.clear();
+            resolved_any = true;
+        } else {
+            segment = candidate;
+        }
+    }
+
+    if !segment.is_empty() {
+        current = join_path(&current, &segment);
+    }
+    if resolved_any || Path::new(&current).exists() {
+        current
+    } else {
+        encoded.to_string()
+    }
+}
+
+/// Tries `segment` and `.segment`, since a leading dot also encodes as a dash.
+fn find_existing_dir(parent: &str, segment: &str) -> Option<String> {
+    [segment.to_string(), format!(".{segment}")]
+        .into_iter()
+        .find(|candidate| Path::new(parent).join(candidate).exists())
+}
+
+fn join_path(parent: &str, child: &str) -> String {
+    Path::new(parent).join(child).to_string_lossy().into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    /// Builds `<root>/<dir>/projects/<project>/<session>.jsonl` and returns the
+    /// config dir.
+    fn config_dir_with(root: &Path, name: &str, project: &str, sessions: &[&str]) -> String {
+        let dir = root.join(name);
+        let project_dir = dir.join("projects").join(project);
+        fs::create_dir_all(&project_dir).unwrap();
+        for s in sessions {
+            fs::write(project_dir.join(format!("{s}.jsonl")), "{}\n").unwrap();
+        }
+        dir.to_string_lossy().into_owned()
+    }
+
+    #[test]
+    fn every_configured_dir_contributes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let a = config_dir_with(tmp.path(), "a", "-home-x", &["s1"]);
+        let b = config_dir_with(tmp.path(), "b", "-home-y", &["s2"]);
+
+        let walk = walk_all_disk_files(&[a.clone(), b.clone()]);
+        assert_eq!(walk.files.len(), 2);
+        assert!(walk.walked.contains(&a) && walk.walked.contains(&b));
+        assert!(walk.protected.is_empty());
+    }
+
+    #[test]
+    fn a_session_copied_between_dirs_is_indexed_once_by_the_first() {
+        // Copying the config dir is the ordinary way to set up a second
+        // account; both copies carry the same ids under the same project.
+        let tmp = tempfile::tempdir().unwrap();
+        let default = config_dir_with(tmp.path(), "default", "-home-x", &["s1"]);
+        let second = config_dir_with(tmp.path(), "second", "-home-x", &["s1"]);
+
+        let walk = walk_all_disk_files(&[default.clone(), second.clone()]);
+        assert_eq!(walk.files.len(), 1, "one session, not two");
+        let owner = &walk.files.values().next().unwrap().config_dir;
+        assert_eq!(owner, &default, "dirs are walked default-first");
+    }
+
+    #[test]
+    fn a_missing_config_dir_is_protected_rather_than_walked() {
+        let tmp = tempfile::tempdir().unwrap();
+        let present = config_dir_with(tmp.path(), "present", "-home-x", &["s1"]);
+        let absent = tmp.path().join("unplugged").to_string_lossy().into_owned();
+
+        let walk = walk_all_disk_files(&[present.clone(), absent.clone()]);
+        assert!(walk.walked.contains(&present));
+        assert!(
+            !walk.walked.contains(&absent),
+            "an unplugged drive must not be reconciled"
+        );
+        assert!(walk.protected.contains(&PathBuf::from(&absent)));
+    }
+
+    #[test]
+    fn a_present_dir_without_projects_walked_fine_and_is_reconcilable() {
+        // The case that looks like a failure and is not: it has genuinely never
+        // run a session.
+        let tmp = tempfile::tempdir().unwrap();
+        let empty = tmp.path().join("empty");
+        fs::create_dir_all(&empty).unwrap();
+        let empty = empty.to_string_lossy().into_owned();
+
+        let walk = walk_all_disk_files(std::slice::from_ref(&empty));
+        assert!(walk.walked.contains(&empty));
+        assert!(walk.protected.is_empty());
+        assert!(walk.files.is_empty());
+    }
+
+    #[test]
+    fn sub_agent_transcripts_are_collected_under_their_parent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = config_dir_with(tmp.path(), "a", "-home-x", &["s1"]);
+        let subagents = Path::new(&dir)
+            .join("projects")
+            .join("-home-x")
+            .join("s1")
+            .join("subagents");
+        fs::create_dir_all(&subagents).unwrap();
+        fs::write(subagents.join("agent-1.jsonl"), "{}\n").unwrap();
+
+        let walk = walk_all_disk_files(&[dir]);
+        assert_eq!(walk.files.len(), 2);
+        let sub = walk.files.values().find(|f| f.is_subagent).unwrap();
+        assert_eq!(sub.agent_id, "agent-1");
+        assert_eq!(sub.session_id, "s1", "the parent's id, not the agent's");
+        assert!(sub.parent_file_path.ends_with("s1.jsonl"));
+    }
+
+    #[test]
+    fn a_sub_agent_dir_without_a_claimed_parent_is_not_descended_into() {
+        // The second dir loses the session, so its sub-agents must not sneak in
+        // through the second pass.
+        let tmp = tempfile::tempdir().unwrap();
+        let default = config_dir_with(tmp.path(), "default", "-home-x", &["s1"]);
+        let second = config_dir_with(tmp.path(), "second", "-home-x", &["s1"]);
+        let subagents = Path::new(&second)
+            .join("projects")
+            .join("-home-x")
+            .join("s1")
+            .join("subagents");
+        fs::create_dir_all(&subagents).unwrap();
+        fs::write(subagents.join("agent-9.jsonl"), "{}\n").unwrap();
+
+        let walk = walk_all_disk_files(&[default, second]);
+        assert!(
+            !walk.files.values().any(|f| f.is_subagent),
+            "the losing dir's sub-agents come with the session it lost"
+        );
+    }
+
+    #[test]
+    fn claiming_is_first_dir_wins_and_is_idempotent_for_the_owner() {
+        let mut claimed = HashMap::new();
+        assert!(claim_session(&mut claimed, "k".into(), "a"));
+        assert!(
+            claim_session(&mut claimed, "k".into(), "a"),
+            "same dir again"
+        );
+        assert!(!claim_session(&mut claimed, "k".into(), "b"));
+    }
+
+    #[test]
+    fn an_unresolvable_project_name_is_kept_as_written() {
+        assert_eq!(
+            decode_project_path("-nowhere-at-all-really"),
+            "-nowhere-at-all-really"
+        );
+        // A name that was never encoded passes through untouched.
+        assert_eq!(decode_project_path("plain"), "plain");
+    }
+
+    #[test]
+    fn a_project_name_resolves_against_directories_that_exist() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nested = tmp.path().join("my-project").join("sub");
+        fs::create_dir_all(&nested).unwrap();
+
+        // The dashes in "my-project" are ambiguous; resolution prefers the
+        // segment that exists on disk.
+        let encoded = format!(
+            "-{}",
+            nested
+                .to_string_lossy()
+                .trim_start_matches('/')
+                .replace('/', "-")
+        );
+        assert_eq!(
+            decode_project_path(&encoded),
+            nested.to_string_lossy().into_owned()
+        );
+    }
+}

--- a/desktop/src-tauri/src/native/sessions/summary.rs
+++ b/desktop/src-tauri/src/native/sessions/summary.rs
@@ -56,7 +56,10 @@ pub struct SessionPR {
 }
 
 /// One session as the list renders it.
-#[derive(Debug, Clone, Serialize)]
+///
+/// `Default` exists for the scanner, which builds a row field by field from a
+/// transcript rather than from a query.
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct SessionSummary {
     pub session_id: String,
     pub project_path: String,

--- a/desktop/src-tauri/tests/parity_scanner.rs
+++ b/desktop/src-tauri/tests/parity_scanner.rs
@@ -1,0 +1,410 @@
+//! Scanner parity: **every stored cache row, recomputed from its own
+//! transcript**.
+//!
+//! There is no HTTP response to diff here — the scanner's output is a table —
+//! so the parity bar is the rows Go already wrote. Each one is rebuilt from the
+//! JSONL it was built from and compared field by field, across the whole local
+//! corpus. On the reference machine that is ~900 sessions and about a gigabyte
+//! of real transcripts, which is a far stronger check than any fixture: it
+//! exercises every event shape the corpus happens to contain, including the
+//! ones nobody thought to write a fixture for.
+//!
+//! Two anchors keep it honest, both learned from the insight parity suite:
+//!
+//! * **The row records the mtime it was read at.** A transcript that has grown
+//!   since — the session running this very test is one — is not a divergence;
+//!   the stored row describes a shorter file. Every figure would read as
+//!   "computed is larger", which is exactly what an over-counting bug also
+//!   looks like, so those rows are skipped rather than tolerated.
+//! * **The scanner version and idle threshold must match.** A row written under
+//!   a different version or threshold is a different computation. Comparing
+//!   across one would fail as a thousand mismatches instead of one clear
+//!   message.
+
+mod parity_common;
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use agento_lib::native::gotime::GoTime;
+use agento_lib::native::pricing;
+use agento_lib::native::scanner::summary_file::read_session_summary;
+use agento_lib::native::scanner::CURRENT_SCANNER_VERSION;
+use agento_lib::native::sessions::summary::{SessionCost, SessionSummary};
+use agento_lib::native::{db, settings};
+
+use parity_common::live_db;
+
+/// The stored row, in the columns `insertCacheRow` writes.
+struct StoredRow {
+    session_id: String,
+    project_path: String,
+    file_path: String,
+    file_mtime: String,
+    summary: SessionSummary,
+}
+
+#[test]
+#[ignore = "needs a running Agento instance and its database"]
+fn every_stored_session_row_recomputes_to_the_same_values() {
+    let db_path = live_db();
+    let conn = db::open_read_only(&db_path).expect("open database");
+
+    let (stored_version, stored_threshold): (i64, i64) = conn
+        .query_row(
+            "SELECT COALESCE(scanner_version, 0), COALESCE(idle_threshold_ms, 0)
+             FROM claude_cache_metadata WHERE id = 1",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .expect("cache metadata");
+
+    assert_eq!(
+        stored_version, CURRENT_SCANNER_VERSION,
+        "the corpus was scanned by a different scanner version; rescan before comparing"
+    );
+    let configured = settings::load(&conn).idle_gap_ms;
+    assert_eq!(
+        stored_threshold, configured,
+        "the idle threshold moved since the last scan; rescan before comparing"
+    );
+
+    let resolver = pricing::Resolver::load(&conn).expect("pricing catalog");
+    let rows = load_stored_rows(&conn);
+    assert!(
+        !rows.is_empty(),
+        "no session rows to compare; let the Go scanner walk the corpus first"
+    );
+    println!("comparing {} stored session rows", rows.len());
+
+    let mut mismatches: Vec<String> = Vec::new();
+    let mut missing_files = 0usize;
+    let mut moved_on = 0usize;
+    let mut no_row = 0usize;
+    let mut compared = 0usize;
+
+    for row in &rows {
+        let path = Path::new(&row.file_path);
+        let Ok(meta) = std::fs::metadata(path) else {
+            // Deleted since the row was written. Nothing to recompute from, and
+            // not a divergence.
+            missing_files += 1;
+            continue;
+        };
+
+        // The row carries the mtime it was read at, so "has this file moved on"
+        // is answerable exactly rather than by a timestamp comparison.
+        if !mtime_matches(&meta, &row.file_mtime) {
+            moved_on += 1;
+            continue;
+        }
+
+        let got = match read_session_summary(
+            &row.session_id,
+            &row.project_path,
+            path,
+            Some(&resolver),
+            stored_threshold,
+        ) {
+            Ok(Some(summary)) => summary,
+            Ok(None) => {
+                // The scanner writes no row for a transcript with no
+                // timestamped event, so a stored row means one existed.
+                no_row += 1;
+                mismatches.push(format!(
+                    "{}: recomputed to no row at all, but a row is stored",
+                    row.session_id
+                ));
+                continue;
+            }
+            Err(e) => {
+                mismatches.push(format!("{}: {e}", row.session_id));
+                continue;
+            }
+        };
+
+        compared += 1;
+        if let Some(detail) = describe_mismatch(&row.summary, &got) {
+            mismatches.push(format!("{} ({}):\n{detail}", row.session_id, row.file_path));
+        }
+    }
+
+    println!(
+        "compared {compared}, skipped {missing_files} deleted and {moved_on} grown since the scan"
+    );
+    assert_eq!(no_row, 0, "rows exist that recompute to nothing");
+    assert!(
+        compared > 0,
+        "every row was skipped; nothing was actually compared"
+    );
+
+    if !mismatches.is_empty() {
+        let shown: Vec<&String> = mismatches.iter().take(10).collect();
+        panic!(
+            "{} of {compared} rows diverged:\n\n{}\n\n(showing up to 10)",
+            mismatches.len(),
+            shown
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<_>>()
+                .join("\n\n")
+        );
+    }
+}
+
+/// Whether the file's current mtime is the one the row was built from.
+///
+/// The stored value is Go's `time.Time` rendering; comparing at second
+/// granularity avoids a false mismatch from the two sides' sub-second
+/// formatting while still catching any real append.
+fn mtime_matches(meta: &std::fs::Metadata, stored: &str) -> bool {
+    let Ok(modified) = meta.modified() else {
+        return false;
+    };
+    let Ok(stored) = GoTime::parse_any(stored) else {
+        return false;
+    };
+    let current: chrono::DateTime<chrono::Utc> = modified.into();
+    current.timestamp() == stored.instant().timestamp()
+}
+
+fn load_stored_rows(conn: &rusqlite::Connection) -> Vec<StoredRow> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT session_id, project_path, file_path, file_mtime,
+                    preview, start_time, last_activity, message_count, event_count,
+                    input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+                    cache_creation_5m_tokens, cache_creation_1h_tokens,
+                    git_branch, model, cwd, native_title, ai_title,
+                    agent_name, permission_mode, mode, relocated_cwd,
+                    worktree_name, worktree_branch, original_branch,
+                    compaction_count, dropped_tokens,
+                    input_cost_usd, output_cost_usd, cache_read_cost_usd,
+                    cache_write_cost_usd, total_cost_usd, unpriced_models, unpriced_tokens,
+                    cost_by_model, active_duration_ms
+             FROM claude_session_cache",
+        )
+        .expect("prepare");
+
+    let rows = stmt
+        .query_map([], |r| {
+            let mut summary = SessionSummary {
+                session_id: r.get(0)?,
+                project_path: r.get(1)?,
+                preview: r.get(4)?,
+                start_time: parse(r.get::<_, String>(5)?),
+                last_activity: parse(r.get::<_, String>(6)?),
+                message_count: r.get(7)?,
+                event_count: r.get(8)?,
+                git_branch: r.get(15)?,
+                model: r.get(16)?,
+                cwd: r.get(17)?,
+                native_title: r.get(18)?,
+                ai_title: r.get(19)?,
+                agent_name: r.get(20)?,
+                permission_mode: r.get(21)?,
+                mode: r.get(22)?,
+                relocated_cwd: r.get(23)?,
+                worktree_name: r.get(24)?,
+                worktree_branch: r.get(25)?,
+                original_branch: r.get(26)?,
+                compaction_count: r.get(27)?,
+                dropped_tokens: r.get(28)?,
+                unpriced_tokens: r.get(35)?,
+                active_duration_ms: r.get(37)?,
+                ..Default::default()
+            };
+            summary.usage.input_tokens = r.get(9)?;
+            summary.usage.output_tokens = r.get(10)?;
+            summary.usage.cache_creation_tokens = r.get(11)?;
+            summary.usage.cache_read_tokens = r.get(12)?;
+            summary.usage.cache_creation_5m_tokens = r.get(13)?;
+            summary.usage.cache_creation_1h_tokens = r.get(14)?;
+            summary.cost = SessionCost {
+                input_usd: r.get(29)?,
+                output_usd: r.get(30)?,
+                cache_read_usd: r.get(31)?,
+                cache_write_usd: r.get(32)?,
+                total_usd: r.get(33)?,
+            };
+            // Newline-joined, not JSON: a model id may contain a slash but
+            // never a newline.
+            let unpriced: String = r.get(34)?;
+            summary.unpriced_models = unpriced
+                .lines()
+                .filter(|l| !l.is_empty())
+                .map(str::to_string)
+                .collect();
+            let by_model: String = r.get(36)?;
+            summary.cost_by_model = decode_cost_by_model(&by_model);
+
+            Ok(StoredRow {
+                session_id: r.get(0)?,
+                project_path: r.get(1)?,
+                file_path: r.get(2)?,
+                file_mtime: r.get(3)?,
+                summary,
+            })
+        })
+        .expect("query")
+        .filter_map(Result::ok)
+        .collect();
+    rows
+}
+
+fn parse(text: String) -> GoTime {
+    GoTime::parse_any(&text).unwrap_or_default()
+}
+
+/// The stored `cost_by_model` column: JSON, and `""` rather than `"{}"` when
+/// empty.
+fn decode_cost_by_model(raw: &str) -> BTreeMap<String, SessionCost> {
+    if raw.is_empty() || raw == "{}" {
+        return BTreeMap::new();
+    }
+    serde_json::from_str(raw).unwrap_or_default()
+}
+
+/// A field-by-field report, so a divergence names the field rather than dumping
+/// two structs.
+fn describe_mismatch(want: &SessionSummary, got: &SessionSummary) -> Option<String> {
+    let mut out = Vec::new();
+
+    macro_rules! cmp {
+        ($field:ident) => {
+            if want.$field != got.$field {
+                out.push(format!(
+                    "  {}: stored {:?} vs computed {:?}",
+                    stringify!($field),
+                    want.$field,
+                    got.$field
+                ));
+            }
+        };
+    }
+
+    cmp!(preview);
+    cmp!(message_count);
+    cmp!(event_count);
+    cmp!(git_branch);
+    cmp!(model);
+    cmp!(cwd);
+    cmp!(native_title);
+    cmp!(ai_title);
+    cmp!(agent_name);
+    cmp!(permission_mode);
+    cmp!(mode);
+    cmp!(relocated_cwd);
+    cmp!(worktree_name);
+    cmp!(worktree_branch);
+    cmp!(original_branch);
+    cmp!(compaction_count);
+    cmp!(dropped_tokens);
+    cmp!(active_duration_ms);
+    cmp!(unpriced_tokens);
+    cmp!(unpriced_models);
+
+    if want.start_time.instant() != got.start_time.instant() {
+        out.push(format!(
+            "  start_time: stored {} vs computed {}",
+            want.start_time.rfc3339_nano_utc(),
+            got.start_time.rfc3339_nano_utc()
+        ));
+    }
+    if want.last_activity.instant() != got.last_activity.instant() {
+        out.push(format!(
+            "  last_activity: stored {} vs computed {}",
+            want.last_activity.rfc3339_nano_utc(),
+            got.last_activity.rfc3339_nano_utc()
+        ));
+    }
+
+    for (label, a, b) in [
+        (
+            "usage.input_tokens",
+            want.usage.input_tokens,
+            got.usage.input_tokens,
+        ),
+        (
+            "usage.output_tokens",
+            want.usage.output_tokens,
+            got.usage.output_tokens,
+        ),
+        (
+            "usage.cache_creation_tokens",
+            want.usage.cache_creation_tokens,
+            got.usage.cache_creation_tokens,
+        ),
+        (
+            "usage.cache_read_tokens",
+            want.usage.cache_read_tokens,
+            got.usage.cache_read_tokens,
+        ),
+        (
+            "usage.cache_creation_5m_tokens",
+            want.usage.cache_creation_5m_tokens,
+            got.usage.cache_creation_5m_tokens,
+        ),
+        (
+            "usage.cache_creation_1h_tokens",
+            want.usage.cache_creation_1h_tokens,
+            got.usage.cache_creation_1h_tokens,
+        ),
+    ] {
+        if a != b {
+            out.push(format!("  {label}: stored {a} vs computed {b}"));
+        }
+    }
+
+    // Money is compared with a tolerance: both sides sum the same per-message
+    // amounts, but float addition is not associative and the two languages'
+    // accumulation order need not match to the last bit.
+    for (label, a, b) in [
+        ("cost.input_usd", want.cost.input_usd, got.cost.input_usd),
+        ("cost.output_usd", want.cost.output_usd, got.cost.output_usd),
+        (
+            "cost.cache_read_usd",
+            want.cost.cache_read_usd,
+            got.cost.cache_read_usd,
+        ),
+        (
+            "cost.cache_write_usd",
+            want.cost.cache_write_usd,
+            got.cost.cache_write_usd,
+        ),
+        ("cost.total_usd", want.cost.total_usd, got.cost.total_usd),
+    ] {
+        if !close_enough(a, b) {
+            out.push(format!("  {label}: stored {a} vs computed {b}"));
+        }
+    }
+
+    let want_models: Vec<&String> = want.cost_by_model.keys().collect();
+    let got_models: Vec<&String> = got.cost_by_model.keys().collect();
+    if want_models != got_models {
+        out.push(format!(
+            "  cost_by_model keys: stored {want_models:?} vs computed {got_models:?}"
+        ));
+    } else {
+        for (model, want_cost) in &want.cost_by_model {
+            let got_cost = &got.cost_by_model[model];
+            if !close_enough(want_cost.total_usd, got_cost.total_usd) {
+                out.push(format!(
+                    "  cost_by_model[{model}].total_usd: stored {} vs computed {}",
+                    want_cost.total_usd, got_cost.total_usd
+                ));
+            }
+        }
+    }
+
+    (!out.is_empty()).then(|| out.join("\n"))
+}
+
+/// Relative tolerance for a summed money figure.
+fn close_enough(a: f64, b: f64) -> bool {
+    if a == b {
+        return true;
+    }
+    let scale = a.abs().max(b.abs()).max(1e-9);
+    (a - b).abs() / scale < 1e-9
+}

--- a/desktop/src-tauri/tests/parity_scanner.rs
+++ b/desktop/src-tauri/tests/parity_scanner.rs
@@ -28,7 +28,7 @@ use std::path::Path;
 
 use agento_lib::native::gotime::GoTime;
 use agento_lib::native::pricing;
-use agento_lib::native::scanner::summary_file::read_session_summary;
+use agento_lib::native::scanner::summary_file::{read_session_summary, read_subagent_summary};
 use agento_lib::native::scanner::CURRENT_SCANNER_VERSION;
 use agento_lib::native::sessions::summary::{SessionCost, SessionSummary};
 use agento_lib::native::{db, settings};
@@ -407,4 +407,231 @@ fn close_enough(a: f64, b: f64) -> bool {
     }
     let scale = a.abs().max(b.abs()).max(1e-9);
     (a - b).abs() / scale < 1e-9
+}
+
+/// One stored sub-agent row, in the columns `upsertSubagentRow` writes.
+struct StoredSubagent {
+    parent_session_id: String,
+    agent_id: String,
+    file_path: String,
+    file_mtime: String,
+    summary: SessionSummary,
+}
+
+#[test]
+#[ignore = "needs a running Agento instance and its database"]
+fn every_stored_subagent_row_recomputes_to_the_same_values() {
+    let db_path = live_db();
+    let conn = db::open_read_only(&db_path).expect("open database");
+
+    let (stored_version, stored_threshold): (i64, i64) = conn
+        .query_row(
+            "SELECT COALESCE(scanner_version, 0), COALESCE(idle_threshold_ms, 0)
+             FROM claude_cache_metadata WHERE id = 1",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .expect("cache metadata");
+    assert_eq!(
+        stored_version, CURRENT_SCANNER_VERSION,
+        "the corpus was scanned by a different scanner version; rescan before comparing"
+    );
+
+    let resolver = pricing::Resolver::load(&conn).expect("pricing catalog");
+    let rows = load_stored_subagents(&conn);
+    if rows.is_empty() {
+        println!("no sub-agent rows on this corpus; nothing to compare");
+        return;
+    }
+    println!("comparing {} stored sub-agent rows", rows.len());
+
+    let mut mismatches: Vec<String> = Vec::new();
+    let (mut compared, mut skipped) = (0usize, 0usize);
+
+    for row in &rows {
+        let path = Path::new(&row.file_path);
+        let Ok(meta) = std::fs::metadata(path) else {
+            skipped += 1;
+            continue;
+        };
+        if !mtime_matches(&meta, &row.file_mtime) {
+            skipped += 1;
+            continue;
+        }
+
+        // Every event in a sub-agent transcript carries `isSidechain`. Reading
+        // one with the parent's rule would count no user turns at all, so
+        // `message_count` would silently degrade to assistant-only — which is
+        // exactly what this comparison would catch.
+        let got = match read_subagent_summary(
+            &row.parent_session_id,
+            "",
+            path,
+            Some(&resolver),
+            stored_threshold,
+        ) {
+            Ok(Some(summary)) => summary,
+            Ok(None) => {
+                mismatches.push(format!(
+                    "{}/{}: recomputed to no row, but a row is stored",
+                    row.parent_session_id, row.agent_id
+                ));
+                continue;
+            }
+            Err(e) => {
+                mismatches.push(format!("{}/{}: {e}", row.parent_session_id, row.agent_id));
+                continue;
+            }
+        };
+
+        compared += 1;
+        if let Some(detail) = describe_subagent_mismatch(&row.summary, &got) {
+            mismatches.push(format!(
+                "{}/{} ({}):\n{detail}",
+                row.parent_session_id, row.agent_id, row.file_path
+            ));
+        }
+    }
+
+    println!("compared {compared}, skipped {skipped}");
+    assert!(compared > 0, "every sub-agent row was skipped");
+    if !mismatches.is_empty() {
+        let shown: Vec<&str> = mismatches.iter().take(10).map(String::as_str).collect();
+        panic!(
+            "{} of {compared} sub-agent rows diverged:\n\n{}\n\n(showing up to 10)",
+            mismatches.len(),
+            shown.join("\n\n")
+        );
+    }
+}
+
+fn load_stored_subagents(conn: &rusqlite::Connection) -> Vec<StoredSubagent> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT parent_session_id, agent_id, file_path, file_mtime,
+                    start_time, last_activity, message_count, event_count,
+                    input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+                    cache_creation_5m_tokens, cache_creation_1h_tokens, model,
+                    input_cost_usd, output_cost_usd, cache_read_cost_usd,
+                    cache_write_cost_usd, total_cost_usd, unpriced_tokens,
+                    active_duration_ms
+             FROM claude_subagent_cache",
+        )
+        .expect("prepare");
+
+    stmt.query_map([], |r| {
+        let mut summary = SessionSummary {
+            message_count: r.get(6)?,
+            event_count: r.get(7)?,
+            model: r.get(14)?,
+            unpriced_tokens: r.get(20)?,
+            active_duration_ms: r.get(21)?,
+            start_time: parse(r.get::<_, String>(4)?),
+            last_activity: parse(r.get::<_, String>(5)?),
+            ..Default::default()
+        };
+        summary.usage.input_tokens = r.get(8)?;
+        summary.usage.output_tokens = r.get(9)?;
+        summary.usage.cache_creation_tokens = r.get(10)?;
+        summary.usage.cache_read_tokens = r.get(11)?;
+        summary.usage.cache_creation_5m_tokens = r.get(12)?;
+        summary.usage.cache_creation_1h_tokens = r.get(13)?;
+        summary.cost = SessionCost {
+            input_usd: r.get(15)?,
+            output_usd: r.get(16)?,
+            cache_read_usd: r.get(17)?,
+            cache_write_usd: r.get(18)?,
+            total_usd: r.get(19)?,
+        };
+        Ok(StoredSubagent {
+            parent_session_id: r.get(0)?,
+            agent_id: r.get(1)?,
+            file_path: r.get(2)?,
+            file_mtime: r.get(3)?,
+            summary,
+        })
+    })
+    .expect("query")
+    .filter_map(Result::ok)
+    .collect()
+}
+
+/// The sub-agent table stores a subset of the session columns — no preview, no
+/// titles, no cwd, no `cost_by_model` — so only what it holds is compared.
+fn describe_subagent_mismatch(want: &SessionSummary, got: &SessionSummary) -> Option<String> {
+    let mut out = Vec::new();
+
+    for (label, a, b) in [
+        ("message_count", want.message_count, got.message_count),
+        ("event_count", want.event_count, got.event_count),
+        (
+            "active_duration_ms",
+            want.active_duration_ms,
+            got.active_duration_ms,
+        ),
+        ("unpriced_tokens", want.unpriced_tokens, got.unpriced_tokens),
+        (
+            "usage.input_tokens",
+            want.usage.input_tokens,
+            got.usage.input_tokens,
+        ),
+        (
+            "usage.output_tokens",
+            want.usage.output_tokens,
+            got.usage.output_tokens,
+        ),
+        (
+            "usage.cache_creation_tokens",
+            want.usage.cache_creation_tokens,
+            got.usage.cache_creation_tokens,
+        ),
+        (
+            "usage.cache_read_tokens",
+            want.usage.cache_read_tokens,
+            got.usage.cache_read_tokens,
+        ),
+        (
+            "usage.cache_creation_5m_tokens",
+            want.usage.cache_creation_5m_tokens,
+            got.usage.cache_creation_5m_tokens,
+        ),
+        (
+            "usage.cache_creation_1h_tokens",
+            want.usage.cache_creation_1h_tokens,
+            got.usage.cache_creation_1h_tokens,
+        ),
+    ] {
+        if a != b {
+            out.push(format!("  {label}: stored {a} vs computed {b}"));
+        }
+    }
+
+    if want.model != got.model {
+        out.push(format!(
+            "  model: stored {:?} vs computed {:?}",
+            want.model, got.model
+        ));
+    }
+    if want.start_time.instant() != got.start_time.instant() {
+        out.push(format!(
+            "  start_time: stored {} vs computed {}",
+            want.start_time.rfc3339_nano_utc(),
+            got.start_time.rfc3339_nano_utc()
+        ));
+    }
+    if want.last_activity.instant() != got.last_activity.instant() {
+        out.push(format!(
+            "  last_activity: stored {} vs computed {}",
+            want.last_activity.rfc3339_nano_utc(),
+            got.last_activity.rfc3339_nano_utc()
+        ));
+    }
+    if !close_enough(want.cost.total_usd, got.cost.total_usd) {
+        out.push(format!(
+            "  cost.total_usd: stored {} vs computed {}",
+            want.cost.total_usd, got.cost.total_usd
+        ));
+    }
+
+    (!out.is_empty()).then(|| out.join("\n"))
 }

--- a/desktop/src-tauri/tests/scanner_roundtrip.rs
+++ b/desktop/src-tauri/tests/scanner_roundtrip.rs
@@ -1,0 +1,342 @@
+//! The scanner end to end, against a scratch database.
+//!
+//! Walk → diff → apply, over a corpus built in a temp directory. This is where
+//! the pieces are checked as a *sequence*: that a first scan inserts and
+//! announces discoveries, that a second scan does nothing, that a touched file
+//! is re-read as an update, that a removed transcript is reconciled away, and
+//! that the two user-owned columns survive all of it.
+//!
+//! The database here is created by the test. The application's own handle is
+//! read-only, and nothing in the app calls these writers — see the module docs
+//! on `native::scanner` for why the port stops short of writing for real.
+
+use std::path::{Path, PathBuf};
+
+use agento_lib::native::scanner::apply::{apply_changes, ScanUnit};
+use agento_lib::native::scanner::diff::diff_disk_and_cache;
+use agento_lib::native::scanner::store::load_cached_entries;
+use agento_lib::native::scanner::walk::walk_all_disk_files;
+use rusqlite::Connection;
+
+/// The columns the scanner writes, as the migrations define them.
+const SCHEMA: &str = "
+CREATE TABLE claude_session_cache (
+    session_id TEXT NOT NULL, project_path TEXT NOT NULL,
+    file_path TEXT NOT NULL, file_mtime DATETIME NOT NULL,
+    preview TEXT NOT NULL DEFAULT '',
+    start_time DATETIME NOT NULL, last_activity DATETIME NOT NULL,
+    message_count INTEGER NOT NULL DEFAULT 0, event_count INTEGER NOT NULL DEFAULT 0,
+    input_tokens INTEGER NOT NULL DEFAULT 0, output_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_creation_5m_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_creation_1h_tokens INTEGER NOT NULL DEFAULT 0,
+    git_branch TEXT NOT NULL DEFAULT '', model TEXT NOT NULL DEFAULT '',
+    cwd TEXT NOT NULL DEFAULT '',
+    custom_title TEXT NOT NULL DEFAULT '', is_favorite INTEGER NOT NULL DEFAULT 0,
+    native_title TEXT NOT NULL DEFAULT '', ai_title TEXT NOT NULL DEFAULT '',
+    agent_name TEXT NOT NULL DEFAULT '', permission_mode TEXT NOT NULL DEFAULT '',
+    mode TEXT NOT NULL DEFAULT '', relocated_cwd TEXT NOT NULL DEFAULT '',
+    worktree_name TEXT NOT NULL DEFAULT '', worktree_branch TEXT NOT NULL DEFAULT '',
+    original_branch TEXT NOT NULL DEFAULT '',
+    compaction_count INTEGER NOT NULL DEFAULT 0, dropped_tokens INTEGER NOT NULL DEFAULT 0,
+    input_cost_usd REAL NOT NULL DEFAULT 0, output_cost_usd REAL NOT NULL DEFAULT 0,
+    cache_read_cost_usd REAL NOT NULL DEFAULT 0, cache_write_cost_usd REAL NOT NULL DEFAULT 0,
+    total_cost_usd REAL NOT NULL DEFAULT 0,
+    unpriced_models TEXT NOT NULL DEFAULT '', unpriced_tokens INTEGER NOT NULL DEFAULT 0,
+    cost_by_model TEXT NOT NULL DEFAULT '', active_duration_ms INTEGER NOT NULL DEFAULT 0,
+    config_dir TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (session_id, project_path)
+);
+CREATE TABLE claude_subagent_cache (
+    parent_session_id TEXT NOT NULL, agent_id TEXT NOT NULL,
+    file_path TEXT NOT NULL, file_mtime DATETIME NOT NULL,
+    agent_type TEXT NOT NULL DEFAULT '', description TEXT NOT NULL DEFAULT '',
+    tool_use_id TEXT NOT NULL DEFAULT '',
+    start_time DATETIME, last_activity DATETIME,
+    message_count INTEGER NOT NULL DEFAULT 0, event_count INTEGER NOT NULL DEFAULT 0,
+    input_tokens INTEGER NOT NULL DEFAULT 0, output_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_creation_5m_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_creation_1h_tokens INTEGER NOT NULL DEFAULT 0,
+    model TEXT NOT NULL DEFAULT '',
+    input_cost_usd REAL NOT NULL DEFAULT 0, output_cost_usd REAL NOT NULL DEFAULT 0,
+    cache_read_cost_usd REAL NOT NULL DEFAULT 0, cache_write_cost_usd REAL NOT NULL DEFAULT 0,
+    total_cost_usd REAL NOT NULL DEFAULT 0,
+    unpriced_models TEXT NOT NULL DEFAULT '', unpriced_tokens INTEGER NOT NULL DEFAULT 0,
+    active_duration_ms INTEGER NOT NULL DEFAULT 0, config_dir TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (parent_session_id, agent_id)
+);
+CREATE TABLE claude_session_pr (
+    session_id TEXT NOT NULL, pr_url TEXT NOT NULL,
+    pr_number INTEGER NOT NULL DEFAULT 0, pr_repository TEXT NOT NULL DEFAULT '',
+    first_seen_at DATETIME,
+    PRIMARY KEY (session_id, pr_url)
+);
+";
+
+const IDLE_GAP_MS: i64 = 600_000;
+
+/// A minimal but realistic transcript: a user turn, an assistant reply with
+/// usage, and a linked PR.
+fn transcript(base_minute: u32) -> String {
+    format!(
+        r#"{{"type":"user","timestamp":"2026-03-15T12:{base_minute:02}:00Z","cwd":"/w","gitBranch":"main","message":{{"role":"user","content":"do the thing"}}}}
+{{"type":"assistant","timestamp":"2026-03-15T12:{:02}:30Z","message":{{"role":"assistant","model":"claude-opus-5","content":[{{"type":"text","text":"done"}}],"usage":{{"input_tokens":10,"output_tokens":4,"cache_read_input_tokens":2}}}}}}
+{{"type":"pr-link","timestamp":"2026-03-15T13:00:00Z","prUrl":"https://github.com/o/r/pull/7","prNumber":7,"prRepository":"o/r"}}
+"#,
+        base_minute + 1
+    )
+}
+
+/// Builds `<root>/cfg/projects/-w/<session>.jsonl` for each session.
+fn build_corpus(root: &Path, sessions: &[&str]) -> String {
+    let cfg = root.join("cfg");
+    let project = cfg.join("projects").join("-w");
+    std::fs::create_dir_all(&project).unwrap();
+    for (i, s) in sessions.iter().enumerate() {
+        std::fs::write(project.join(format!("{s}.jsonl")), transcript(i as u32)).unwrap();
+    }
+    cfg.to_string_lossy().into_owned()
+}
+
+fn scratch_db() -> Connection {
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(SCHEMA).unwrap();
+    conn
+}
+
+/// One scan: walk, diff, apply. Returns what the apply reported.
+fn scan(
+    conn: &mut Connection,
+    dirs: &[String],
+) -> agento_lib::native::scanner::apply::ApplyOutcome {
+    let walk = walk_all_disk_files(dirs);
+    let cached = load_cached_entries(conn).unwrap();
+    let diff = diff_disk_and_cache(&walk.files, &cached, &walk, "/nonexistent-default");
+
+    let mut units: Vec<ScanUnit> = Vec::new();
+    for path in &diff.to_insert {
+        units.push(ScanUnit {
+            file: walk.files[path].clone(),
+            is_new: true,
+        });
+    }
+    for path in &diff.to_update {
+        units.push(ScanUnit {
+            file: walk.files[path].clone(),
+            is_new: false,
+        });
+    }
+
+    apply_changes(
+        conn,
+        units,
+        &diff.to_delete,
+        None,
+        IDLE_GAP_MS,
+        |_done, _total| {},
+    )
+}
+
+fn row_count(conn: &Connection, table: &str) -> i64 {
+    conn.query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |r| r.get(0))
+        .unwrap()
+}
+
+#[test]
+fn a_first_scan_inserts_every_session_and_announces_each_once() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = build_corpus(tmp.path(), &["s1", "s2"]);
+    let mut conn = scratch_db();
+
+    let outcome = scan(&mut conn, std::slice::from_ref(&cfg));
+
+    assert_eq!(outcome.rows_written, 2);
+    assert_eq!(outcome.skipped, 0);
+    assert_eq!(row_count(&conn, "claude_session_cache"), 2);
+    assert_eq!(outcome.notifications.len(), 2);
+    assert!(
+        outcome.notifications.iter().all(|n| n.is_new),
+        "a first scan is all discoveries"
+    );
+
+    // The PR rows are written in the same transaction as their session.
+    assert_eq!(row_count(&conn, "claude_session_pr"), 2);
+
+    let (preview, model, messages): (String, String, i64) = conn
+        .query_row(
+            "SELECT preview, model, message_count FROM claude_session_cache WHERE session_id = 's1'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(preview, "do the thing");
+    assert_eq!(model, "claude-opus-5");
+    assert_eq!(messages, 2, "one user turn and one assistant reply");
+}
+
+#[test]
+fn a_second_scan_with_nothing_changed_does_no_work() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = build_corpus(tmp.path(), &["s1"]);
+    let mut conn = scratch_db();
+
+    scan(&mut conn, std::slice::from_ref(&cfg));
+    let second = scan(&mut conn, std::slice::from_ref(&cfg));
+
+    assert_eq!(second.rows_written, 0, "nothing changed on disk");
+    assert!(second.notifications.is_empty(), "and nothing to announce");
+    assert_eq!(row_count(&conn, "claude_session_cache"), 1);
+}
+
+#[test]
+fn a_rescan_preserves_the_two_user_owned_columns() {
+    // custom_title and is_favorite appear in neither the insert list nor the
+    // DO UPDATE SET list. A rescan that clobbered them would silently discard
+    // the only data in these tables the user typed.
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = build_corpus(tmp.path(), &["s1"]);
+    let mut conn = scratch_db();
+    scan(&mut conn, std::slice::from_ref(&cfg));
+
+    conn.execute(
+        "UPDATE claude_session_cache SET custom_title = 'my name for it', is_favorite = 1",
+        [],
+    )
+    .unwrap();
+
+    // Touch the transcript so the file is genuinely re-read.
+    let path = Path::new(&cfg).join("projects").join("-w").join("s1.jsonl");
+    let mut text = std::fs::read_to_string(&path).unwrap();
+    text.push_str(
+        r#"{"type":"assistant","timestamp":"2026-03-15T12:05:00Z","message":{"role":"assistant","model":"claude-opus-5","content":[{"type":"text","text":"more"}]}}
+"#,
+    );
+    std::fs::write(&path, text).unwrap();
+    filetime_bump(&path);
+
+    let outcome = scan(&mut conn, std::slice::from_ref(&cfg));
+    assert_eq!(outcome.rows_written, 1, "the touched file was re-read");
+    assert!(
+        !outcome.notifications[0].is_new,
+        "a re-read is an update, not a discovery"
+    );
+
+    let (title, favorite, messages): (String, i64, i64) = conn
+        .query_row(
+            "SELECT custom_title, is_favorite, message_count FROM claude_session_cache",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(title, "my name for it");
+    assert_eq!(favorite, 1);
+    assert_eq!(messages, 3, "and the row did pick up the new turn");
+}
+
+#[test]
+fn a_removed_transcript_is_reconciled_away_with_its_pull_requests() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = build_corpus(tmp.path(), &["s1", "s2"]);
+    let mut conn = scratch_db();
+    scan(&mut conn, std::slice::from_ref(&cfg));
+    assert_eq!(row_count(&conn, "claude_session_pr"), 2);
+
+    std::fs::remove_file(Path::new(&cfg).join("projects").join("-w").join("s2.jsonl")).unwrap();
+
+    let outcome = scan(&mut conn, std::slice::from_ref(&cfg));
+    assert_eq!(outcome.rows_deleted, 1);
+    assert_eq!(row_count(&conn, "claude_session_cache"), 1);
+    // No foreign key does this for us; the delete pass resolves the session id
+    // through the row before removing it.
+    assert_eq!(row_count(&conn, "claude_session_pr"), 1);
+}
+
+#[test]
+fn an_unreadable_config_dir_protects_its_rows_from_the_delete_pass() {
+    // The unplugged-drive case, end to end: the rows must survive a scan that
+    // could not see their files.
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = build_corpus(tmp.path(), &["s1"]);
+    let mut conn = scratch_db();
+    scan(&mut conn, std::slice::from_ref(&cfg));
+    assert_eq!(row_count(&conn, "claude_session_cache"), 1);
+
+    // The dir vanishes, as an unmounted volume does.
+    std::fs::remove_dir_all(&cfg).unwrap();
+
+    let outcome = scan(&mut conn, std::slice::from_ref(&cfg));
+    assert_eq!(outcome.rows_deleted, 0, "absence is not evidence");
+    assert_eq!(row_count(&conn, "claude_session_cache"), 1);
+}
+
+#[test]
+fn a_sub_agent_is_written_to_its_own_table_and_announced_via_its_parent() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = build_corpus(tmp.path(), &["s1"]);
+    let subagents = Path::new(&cfg)
+        .join("projects")
+        .join("-w")
+        .join("s1")
+        .join("subagents");
+    std::fs::create_dir_all(&subagents).unwrap();
+    std::fs::write(subagents.join("agent-1.jsonl"), transcript(20)).unwrap();
+    std::fs::write(
+        subagents.join("agent-1.meta.json"),
+        r#"{"agentType":"Explore","description":"map it","toolUseId":"tu_1"}"#,
+    )
+    .unwrap();
+
+    let mut conn = scratch_db();
+    let outcome = scan(&mut conn, std::slice::from_ref(&cfg));
+
+    assert_eq!(row_count(&conn, "claude_subagent_cache"), 1);
+    assert_eq!(
+        outcome.notifications.len(),
+        1,
+        "the parent and its sub-agent are one session"
+    );
+
+    let (agent_type, description, messages): (String, String, i64) = conn
+        .query_row(
+            "SELECT agent_type, description, message_count FROM claude_subagent_cache",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(agent_type, "Explore", "from the sidecar");
+    assert_eq!(description, "map it");
+    assert_eq!(messages, 2);
+}
+
+#[test]
+fn an_unreadable_transcript_does_not_abort_the_scan() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = build_corpus(tmp.path(), &["s1", "s2"]);
+    // A file with no timestamped event produces no row — the same path a read
+    // failure takes.
+    std::fs::write(
+        Path::new(&cfg).join("projects").join("-w").join("s2.jsonl"),
+        "not json at all\n",
+    )
+    .unwrap();
+
+    let mut conn = scratch_db();
+    let outcome = scan(&mut conn, std::slice::from_ref(&cfg));
+
+    assert_eq!(outcome.rows_written, 1, "the good session still landed");
+    assert_eq!(outcome.skipped, 1);
+    assert_eq!(row_count(&conn, "claude_session_cache"), 1);
+}
+
+/// Pushes a file's mtime forward, so a same-second rewrite still reads as
+/// changed.
+fn filetime_bump(path: &PathBuf) {
+    // Rewriting through a fresh handle after a moment is enough on every
+    // filesystem this runs on; the diff compares the stored mtime exactly.
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+    let text = std::fs::read_to_string(path).unwrap();
+    std::fs::write(path, text).unwrap();
+}


### PR DESCRIPTION
Closes #270.

Targets `desktop`; `main` untouched.

## What

`internal/claudesessions/scanner.go` and `scan_apply.go` in Rust, as `desktop/src-tauri/src/native/scanner/`:

| module | what it owns |
|---|---|
| `summary_file.rs` | one transcript → one cache row |
| `walk.rs` | config dirs, project dirs, `claim_session`, walked vs protected |
| `diff.rs` | insert / update / delete, and why a moved path is not a discovery |
| `staleness.rs` | the three markers that force a full re-read |
| `store.rs` | the cache tables' reads and writes |
| `apply.rs` | parallel read, batched write |
| `cost.rs` | per-message pricing |

## The one decision the issue leaves open

**This computes; it does not write.** The scanner is a writer, but `native/db.rs` opens the database read-only *on purpose* — "the Go server holds the file open, runs migrations against it and seeds the pricing catalog on every startup; a second writer would race those" — and the sidecar runs its own scanner on every read path.

So this follows the precedent #263 set for the insight processors: port the logic as what it actually is, and verify it against the rows Go already wrote. The writers exist and are exercised, but only against scratch databases the tests build. Nothing claims a route, and `freshness_probe` stays — retiring it needs Go to stop scanning, which is phase 3.

The issue lists "unlocks four endpoints and retires the freshness probe" as what this makes possible; I read that as the value, not as this PR's scope. Say so if you meant otherwise.

## How it was verified

**Parity is the stored rows.** Every `claude_session_cache` and `claude_subagent_cache` row recomputed from its own transcript and compared field by field:

```
comparing 926 stored session rows      → compared 925, 1 grown since the scan
comparing 920 stored sub-agent rows    → compared 919, 1 skipped
```

Zero divergences across ~1GB of real JSONL. That is a stronger check than any fixture — it exercises every event shape the corpus happens to contain. The row records the mtime it was read at, so "has this file grown since" is exact rather than a timestamp guess; those rows are skipped because every figure would read as "computed is larger", which is also what an over-counting bug looks like.

Plus **236 unit tests** and **7 round-trip tests** driving walk → diff → apply against a scratch DB: first scan inserts and announces, second does nothing, a touched file is re-read as an update with the user columns intact, a removed transcript is reconciled away with its PRs, an unreadable config dir protects its rows, a sub-agent lands in its own table and is announced through its parent, and an undecodable transcript does not abort the scan.

Local gates: `fmt`, `clippy --all-targets -D warnings`, `cargo test`, `cargo build --release`.

## Rules carried over rather than re-discovered

- **"No file on disk" and "we could not look" are different answers.** A config dir that failed to list is left out of `walked` and its rows are excluded from the delete pass — an unmounted drive would otherwise wipe an account's corpus, `custom_title` and `is_favorite` included. A dir that exists but has no `projects/` is the case that *looks* like a failure and is not. Protection is per project, not per config dir.
- **A moved path is an update, not a discovery** (#245). Rows key on `(session_id, project_path)` while `file_path` is a non-unique index, so a claim shift legitimately brings the same row under a new path. The cache is indexed twice — by path and by row key — to tell them apart.
- **`custom_title` and `is_favorite` are in neither write list.** They are the only columns in these tables the user typed.
- **Three markers force a full re-read with nothing changed on disk.** The idle threshold is the one that cannot be a version constant but makes the same rows stale. Invalidation zeroes mtimes rather than dropping rows, so a re-read is an update and deletions are still detected.
- **Two encodings that are not what they look like**: `cost_by_model` is JSON but empty stores as `""`; `unpriced_models` is newline-joined, because a model id may contain a slash but never a newline.

## Shared code, extracted rather than copied

- `transcript.rs` gains the scanner's event fields, `extract_text_content` and `skill_preamble_path`. Its own module doc says the scanner port should extend it rather than start a second decoder — `is_user_turn_content` decides `message_count`, `turn_count` and the journey's turns at once.
- The capped-gap walk moves to `native/active_time.rs`, shared with `TimeProfile`. The same session's active duration is stored in two tables under a user-configurable threshold, so a drift would be invisible until someone changed it. Behaviour-preserving — all 24 insight tests still pass.