### PR TITLE
feat(desktop): port the settings, monitoring and version reads to Rust (#266)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -133,7 +133,9 @@ src-tauri/src/
     gojson.rs    Go-compatible JSON encoder — read this before porting anything
     gotime.rs    Go's time.Time on the wire
     db.rs        read-only SQLite handle on the file the Go server owns
-    settings.rs  user preferences + Claude config dirs a read is scoped to
+    settings.rs  GET /api/settings; also the preferences + config dirs a read is scoped to
+    monitoring.rs GET /api/monitoring — monitoring.json and the OTEL_* locks, no exporters
+    version.rs   GET /api/version and /version/update-check (dev builds only)
     pricing.rs   GET /api/pricing/catalog, plus the rate Resolver
     agents.rs    GET /api/agents and /api/agents/{slug}
     chats.rs     GET /api/chats and /api/chats/{id}; compact() is Go's, byte for byte
@@ -326,6 +328,27 @@ fast path was not.)
 body). Nothing read from SQLite can be either — SQLite stores NaN as NULL — but
 a *computed* average or ratio can be, so guard the division at the source
 rather than expecting the encoder to notice.
+
+### The build stamp, and the half of `/version` that is not ported
+
+`internal/build`'s three variables are set by `-ldflags`, and **only the
+Makefile does that**. `scripts/build-sidecar.sh` builds with `-ldflags "-s -w"`
+and `scripts/parity-instance.sh` with none at all, so the sidecar the app ships
+and the server every parity test diffs against both serve the package defaults —
+`dev` / `unknown` / `unknown`. `native/version.rs` declares the same defaults,
+behind `option_env!("AGENTO_BUILD_VERSION")` and friends, so stamping the desktop
+bundle later is a build-script change rather than a code change. Do not stamp
+Rust while the Go sidecar is still unstamped: that is a parity failure by
+construction.
+
+`/api/version/update-check` is deliberately **half** ported. Go's answer for a
+build that names no published release needs no network — it short-circuits to
+`update_available: false`, and that is every build the desktop app ships. Its
+other branch asks GitHub for the latest release and compares, which *is* the
+self-updater, the one subsystem the handover excludes because Tauri's updater
+replaces it. So the short-circuit is native and anything else returns `Err` and
+forwards. That is the seam working as designed, not an omission — but it is one
+of the `Err` arms the cut-over has to turn into a real response.
 
 ### Phase order (easiest → hardest)
 

--- a/desktop/src-tauri/src/native/mod.rs
+++ b/desktop/src-tauri/src/native/mod.rs
@@ -20,11 +20,13 @@ pub mod diff;
 pub mod gojson;
 pub mod gotime;
 pub mod insights;
+pub mod monitoring;
 pub mod pricing;
 pub mod scanner;
 pub mod sessions;
 pub mod settings;
 pub mod tasks;
+pub mod version;
 
 use axum::body::Body;
 use axum::http::{header, Method, Response, StatusCode};
@@ -119,6 +121,9 @@ const ENDPOINTS: &[Endpoint] = &[
     insights::ENDPOINT,
     chats::ENDPOINT,
     tasks::ENDPOINT,
+    settings::ENDPOINT,
+    monitoring::ENDPOINT,
+    version::ENDPOINT,
 ];
 
 /// Whether this request is answered by ported Rust code.
@@ -221,6 +226,28 @@ mod tests {
         assert!(!claims(&Method::DELETE, "/api/job-history"));
         assert!(!claims(&Method::GET, "/api/tasks/"));
         assert!(!claims(&Method::GET, "/api/job-history/"));
+
+        // Settings: the row read. The write re-applies the process-wide
+        // snapshots and triggers a rescan, neither of which Rust can do while
+        // Go owns the database — and the config-dir editor probes the
+        // filesystem rather than reading this row.
+        assert!(claims(&Method::GET, "/api/settings"));
+        assert!(!claims(&Method::PUT, "/api/settings"));
+        assert!(!claims(&Method::GET, "/api/settings/claude-config-dirs"));
+        // A different tree entirely: Claude Code's own settings.json.
+        assert!(!claims(&Method::GET, "/api/claude-settings"));
+
+        // Monitoring: the read. The write hot-reloads the OTel providers and
+        // the test dials the collector over gRPC.
+        assert!(claims(&Method::GET, "/api/monitoring"));
+        assert!(!claims(&Method::PUT, "/api/monitoring"));
+        assert!(!claims(&Method::POST, "/api/monitoring/test"));
+
+        // Version: both reads are claimed, but the update check falls back for
+        // a stamped release — that branch is the self-updater, not a read.
+        assert!(claims(&Method::GET, "/api/version"));
+        assert!(claims(&Method::GET, "/api/version/update-check"));
+        assert!(!claims(&Method::GET, "/api/version/"));
     }
 
     #[test]
@@ -253,6 +280,10 @@ mod tests {
             "/api/tasks/abc-123/job-history",
             "/api/job-history",
             "/api/job-history/abc-123",
+            "/api/settings",
+            "/api/monitoring",
+            "/api/version",
+            "/api/version/update-check",
         ];
         for path in paths {
             let owners: Vec<&str> = ENDPOINTS
@@ -283,6 +314,10 @@ mod tests {
             "/api/tasks/abc-123/job-history",
             "/api/job-history",
             "/api/job-history/abc-123",
+            "/api/settings",
+            "/api/monitoring",
+            "/api/version",
+            "/api/version/update-check",
         ];
         for endpoint in ENDPOINTS {
             assert!(

--- a/desktop/src-tauri/src/native/monitoring.rs
+++ b/desktop/src-tauri/src/native/monitoring.rs
@@ -1,0 +1,409 @@
+//! `GET /api/monitoring` — the OpenTelemetry configuration the settings page
+//! renders, and which of its fields the environment has pinned.
+//!
+//! Mirrors `getMonitoring` (`internal/api/monitoring.go`) over
+//! `telemetry.MonitoringManager` (`internal/telemetry/manager.go`).
+//!
+//! **This ports the read, not the telemetry.** The desktop app does not run OTel
+//! providers and is not going to — the handover records that OTel/Prometheus is
+//! replaced rather than reimplemented. What it does have is a settings page that
+//! shows the stored configuration, so the endpoint behind that page has to
+//! answer. Everything here is `monitoring.json` plus `OTEL_*`; nothing here
+//! exports anything.
+//!
+//! `PUT /api/monitoring` and `POST /api/monitoring/test` stay with Go: one
+//! writes the file *and* hot-reloads the providers, the other dials the OTLP
+//! endpoint over gRPC. Neither is a read.
+//!
+//! The two env-override mechanisms in Agento are not the same shape and this is
+//! the one that returns 409: monitoring answers a conflicting write with an
+//! `EnvLockedError`, while `UserSettings` carries a `locked` map and answers
+//! with a 400. Both surfaces expose a `locked` map, which is why they look
+//! alike from here — but only this one also carries `env_locked`.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use axum::http::Method;
+use serde::{Deserialize, Serialize};
+
+/// The config as it travels. Mirrors `api.MonitoringConfigDTO`, whose field
+/// order is the key order on the wire.
+///
+/// The interval is milliseconds rather than a `time.Duration` on purpose: Go's
+/// duration marshals as a nanosecond count, which is not a number any UI wants
+/// to render.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MonitoringConfigDto {
+    pub enabled: bool,
+    pub metrics_exporter: String,
+    pub logs_exporter: String,
+    pub otlp_endpoint: String,
+    /// `omitempty`, so an install with no headers omits the key entirely rather
+    /// than sending `{}`. A `BTreeMap` because Go marshals map keys sorted.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub otlp_headers: BTreeMap<String, String>,
+    pub otlp_insecure: bool,
+    pub metric_export_interval_ms: i64,
+}
+
+/// The envelope. Mirrors `api.MonitoringResponse`.
+#[derive(Debug, Clone, Serialize)]
+pub struct MonitoringResponse {
+    pub settings: MonitoringConfigDto,
+    /// Field name → the `OTEL_*` variable pinning it. Never nil on the Go side,
+    /// so an unpinned install ships `{}`.
+    pub locked: BTreeMap<String, String>,
+    pub env_locked: bool,
+}
+
+/// `telemetry.DefaultMonitoringConfig`: disabled, no exporters, one minute.
+fn default_config() -> MonitoringConfigDto {
+    MonitoringConfigDto {
+        enabled: false,
+        metrics_exporter: "none".to_string(),
+        logs_exporter: "none".to_string(),
+        otlp_endpoint: String::new(),
+        otlp_headers: BTreeMap::new(),
+        otlp_insecure: false,
+        metric_export_interval_ms: 60_000,
+    }
+}
+
+/// `telemetry.envVarChecks`, in the map's key order — which is also the order
+/// the `locked` map ships in, since Go sorts map keys on marshal.
+const ENV_VAR_CHECKS: &[(&str, &str)] = &[
+    ("enabled", "OTEL_SDK_DISABLED"),
+    ("logs_exporter", "OTEL_LOGS_EXPORTER"),
+    ("metric_export_interval", "OTEL_METRIC_EXPORT_INTERVAL"),
+    ("metrics_exporter", "OTEL_METRICS_EXPORTER"),
+    ("otlp_endpoint", "OTEL_EXPORTER_OTLP_ENDPOINT"),
+    ("otlp_headers", "OTEL_EXPORTER_OTLP_HEADERS"),
+    ("otlp_insecure", "OTEL_EXPORTER_OTLP_INSECURE"),
+];
+
+/// The persisted file. Mirrors `telemetry.monitoringConfigStore`.
+///
+/// Every field is an `Option` so a stored `null` decodes to the zero value
+/// instead of failing, which is what Go's decoder does. A *type* mismatch still
+/// fails the decode — also Go's behaviour, and the whole file then degrades to
+/// the default, because `MonitoringManager.Load` returns the error and
+/// `initMonitoringManager` logs it and leaves `current` at the env config.
+#[derive(Debug, Default, Deserialize)]
+struct StoredMonitoring {
+    #[serde(default)]
+    enabled: Option<bool>,
+    #[serde(default)]
+    metrics_exporter: Option<String>,
+    #[serde(default)]
+    logs_exporter: Option<String>,
+    #[serde(default)]
+    otlp_endpoint: Option<String>,
+    #[serde(default)]
+    otlp_headers: Option<BTreeMap<String, String>>,
+    #[serde(default)]
+    otlp_insecure: Option<bool>,
+    #[serde(default)]
+    metric_export_interval_ms: Option<i64>,
+}
+
+impl StoredMonitoring {
+    /// `telemetry.storeToConfig`.
+    ///
+    /// The two exporter names are passed through **unvalidated**: the file is
+    /// only validated on the way in (`validateMonitoringDTO` on `PUT`), so a
+    /// hand-edited `"metrics_exporter": "bogus"` is what `GET` returns. Parsing
+    /// it here would answer with something the Go server does not.
+    fn into_dto(self) -> MonitoringConfigDto {
+        let default = default_config();
+        MonitoringConfigDto {
+            enabled: self.enabled.unwrap_or(false),
+            metrics_exporter: self.metrics_exporter.unwrap_or_default(),
+            logs_exporter: self.logs_exporter.unwrap_or_default(),
+            otlp_endpoint: self.otlp_endpoint.unwrap_or_default(),
+            otlp_headers: self.otlp_headers.unwrap_or_default(),
+            otlp_insecure: self.otlp_insecure.unwrap_or(false),
+            // A non-positive interval is "unset", not "export continuously".
+            metric_export_interval_ms: match self.metric_export_interval_ms.unwrap_or(0) {
+                ms if ms > 0 => ms,
+                _ => default.metric_export_interval_ms,
+            },
+        }
+    }
+}
+
+/// `telemetry.ConfigFromEnv`.
+///
+/// Note what it does *not* do: an `OTEL_*` variable that is set but names
+/// nothing meaningful — `OTEL_SDK_DISABLED=false` alone, say — still locks every
+/// field, but leaves the config at its default. The lock and the value are two
+/// different questions.
+fn config_from_env() -> MonitoringConfigDto {
+    let cfg = default_config();
+
+    let sdk_disabled = env_raw("OTEL_SDK_DISABLED");
+    if sdk_disabled == "true" || sdk_disabled == "1" {
+        return cfg;
+    }
+
+    let metrics = env_raw("OTEL_METRICS_EXPORTER").trim().to_ascii_lowercase();
+    let logs = env_raw("OTEL_LOGS_EXPORTER").trim().to_ascii_lowercase();
+    let endpoint = env_raw("OTEL_EXPORTER_OTLP_ENDPOINT").trim().to_string();
+
+    if metrics.is_empty() && logs.is_empty() && endpoint.is_empty() {
+        return cfg;
+    }
+
+    let insecure = env_raw("OTEL_EXPORTER_OTLP_INSECURE");
+    MonitoringConfigDto {
+        enabled: true,
+        metrics_exporter: match metrics.as_str() {
+            "otlp" => "otlp",
+            "prometheus" => "prometheus",
+            _ => "none",
+        }
+        .to_string(),
+        logs_exporter: if logs == "otlp" { "otlp" } else { "none" }.to_string(),
+        otlp_endpoint: endpoint,
+        otlp_headers: parse_otlp_headers(&env_raw("OTEL_EXPORTER_OTLP_HEADERS")),
+        otlp_insecure: insecure == "true" || insecure == "1",
+        metric_export_interval_ms: match env_raw("OTEL_METRIC_EXPORT_INTERVAL").parse::<i64>() {
+            Ok(ms) if ms > 0 => ms,
+            _ => cfg.metric_export_interval_ms,
+        },
+    }
+}
+
+/// `telemetry.parseOTLPHeaders`: `key=value,key2=value2`. A pair with no `=`,
+/// or one whose `=` opens it, is dropped rather than stored under an empty key.
+fn parse_otlp_headers(raw: &str) -> BTreeMap<String, String> {
+    let mut headers = BTreeMap::new();
+    if raw.is_empty() {
+        return headers;
+    }
+    for pair in raw.split(',') {
+        let pair = pair.trim();
+        if pair.is_empty() {
+            continue;
+        }
+        match pair.find('=') {
+            Some(idx) if idx > 0 => {
+                headers.insert(
+                    pair[..idx].trim().to_string(),
+                    pair[idx + 1..].trim().to_string(),
+                );
+            }
+            _ => continue,
+        }
+    }
+    headers
+}
+
+fn env_raw(name: &str) -> String {
+    std::env::var(name).unwrap_or_default()
+}
+
+/// The answer `GET /api/monitoring` gives, resolved the way the manager does.
+///
+/// **The environment wins outright.** `MonitoringManager.Load` returns before
+/// touching the file when any `OTEL_*` variable is set, so a stored config is
+/// not merged with the environment — it is ignored. Reproducing that matters
+/// more than it looks: the two configurations routinely disagree, and merging
+/// would show the user a page that describes neither.
+pub fn response(data_dir: &Path) -> MonitoringResponse {
+    let locked: BTreeMap<String, String> = ENV_VAR_CHECKS
+        .iter()
+        .filter(|(_, var)| !env_raw(var).is_empty())
+        .map(|(field, var)| (field.to_string(), var.to_string()))
+        .collect();
+    let env_locked = !locked.is_empty();
+
+    let settings = if env_locked {
+        config_from_env()
+    } else {
+        load_file(&data_dir.join("monitoring.json"))
+    };
+
+    MonitoringResponse {
+        settings,
+        locked,
+        env_locked,
+    }
+}
+
+/// Read `monitoring.json`. A missing file, an unreadable one and a malformed
+/// one all resolve to the default, because that is where `current` is left in
+/// each case — the manager seeds it from the env config (which, with no
+/// variables set, *is* the default) and only replaces it on a clean load.
+fn load_file(path: &Path) -> MonitoringConfigDto {
+    let raw = match std::fs::read(path) {
+        Ok(raw) => raw,
+        Err(e) => {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                log::warn!("native monitoring: reading {}: {e}", path.display());
+            }
+            return default_config();
+        }
+    };
+    match serde_json::from_slice::<StoredMonitoring>(&raw) {
+        Ok(stored) => stored.into_dto(),
+        Err(e) => {
+            log::warn!("native monitoring: parsing {}: {e}", path.display());
+            default_config()
+        }
+    }
+}
+
+// ─── The seam ─────────────────────────────────────────────────────────────────
+
+/// This module's entry in `native::ENDPOINTS`.
+pub const ENDPOINT: super::Endpoint = super::Endpoint {
+    name: "monitoring",
+    claims,
+    serve,
+};
+
+fn claims(method: &Method, path: &str) -> bool {
+    method == Method::GET && path == "/api/monitoring"
+}
+
+fn serve(ctx: &super::Ctx, _req: &super::Request) -> Result<super::Answer, String> {
+    // The data dir is the database's parent by construction (`paths::data_dir`
+    // joins `agento.db` onto it), which is also what makes the parity instance
+    // work: it points both at its scratch copy.
+    let data_dir = ctx
+        .db_path
+        .parent()
+        .ok_or("no data directory beside the database")?;
+    let body = super::gojson::to_vec(&response(data_dir))
+        .map_err(|e| format!("encoding monitoring config: {e}"))?;
+    Ok(super::Answer { body, probe: None })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(dir: &Path, body: &str) {
+        std::fs::create_dir_all(dir).expect("temp dir");
+        std::fs::write(dir.join("monitoring.json"), body).expect("write");
+    }
+
+    fn scratch(name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("agento-monitoring-test-{name}"));
+        let _ = std::fs::remove_dir_all(&dir);
+        dir
+    }
+
+    #[test]
+    fn an_absent_file_is_the_default_config() {
+        let dto = load_file(&scratch("absent").join("monitoring.json"));
+        assert_eq!(dto, default_config());
+    }
+
+    /// The failure the manager swallows: it logs and leaves `current` where the
+    /// env config put it, so a corrupt file reads as "not configured" rather
+    /// than taking the endpoint down.
+    #[test]
+    fn a_malformed_file_degrades_to_the_default() {
+        let dir = scratch("malformed");
+        write(&dir, "{not json");
+        assert_eq!(load_file(&dir.join("monitoring.json")), default_config());
+    }
+
+    /// A stored `null` is not a malformed file — Go decodes it into the zero
+    /// value without complaint, and so must this.
+    #[test]
+    fn stored_nulls_decode_to_zero_values() {
+        let dir = scratch("nulls");
+        write(
+            &dir,
+            r#"{"enabled":null,"metrics_exporter":null,"metric_export_interval_ms":null}"#,
+        );
+        let dto = load_file(&dir.join("monitoring.json"));
+        assert!(!dto.enabled);
+        assert_eq!(dto.metrics_exporter, "");
+        assert_eq!(dto.metric_export_interval_ms, 60_000);
+    }
+
+    /// A non-positive interval means "unset". Zero is what a file written
+    /// before the field existed carries.
+    #[test]
+    fn a_non_positive_interval_falls_back_to_a_minute() {
+        let dir = scratch("interval");
+        write(&dir, r#"{"enabled":true,"metric_export_interval_ms":0}"#);
+        assert_eq!(
+            load_file(&dir.join("monitoring.json")).metric_export_interval_ms,
+            60_000
+        );
+        write(&dir, r#"{"enabled":true,"metric_export_interval_ms":-5}"#);
+        assert_eq!(
+            load_file(&dir.join("monitoring.json")).metric_export_interval_ms,
+            60_000
+        );
+    }
+
+    /// An exporter name the UI would never write is passed through, because
+    /// validation happens on `PUT` and `GET` reports what is stored.
+    #[test]
+    fn an_unknown_exporter_name_is_not_corrected() {
+        let dir = scratch("exporter");
+        write(
+            &dir,
+            r#"{"metrics_exporter":"bogus","logs_exporter":"otlp"}"#,
+        );
+        let dto = load_file(&dir.join("monitoring.json"));
+        assert_eq!(dto.metrics_exporter, "bogus");
+        assert_eq!(dto.logs_exporter, "otlp");
+    }
+
+    #[test]
+    fn headers_parse_the_way_the_env_var_is_written() {
+        assert!(parse_otlp_headers("").is_empty());
+        let headers = parse_otlp_headers("x-api-key=secret, x-tenant = acme ,,broken,=novalue");
+        assert_eq!(headers.get("x-api-key").map(String::as_str), Some("secret"));
+        assert_eq!(headers.get("x-tenant").map(String::as_str), Some("acme"));
+        assert_eq!(headers.len(), 2, "{headers:?}");
+    }
+
+    /// Empty headers are omitted, not sent as `{}` — the field carries
+    /// `omitempty` and that is one of the four ways a port drifts.
+    #[test]
+    fn the_response_shape_is_the_go_envelope() {
+        let body = super::super::gojson::to_vec(&MonitoringResponse {
+            settings: default_config(),
+            locked: BTreeMap::new(),
+            env_locked: false,
+        })
+        .expect("encode");
+
+        assert_eq!(
+            String::from_utf8(body).expect("utf8"),
+            concat!(
+                r#"{"settings":{"enabled":false,"metrics_exporter":"none","#,
+                r#""logs_exporter":"none","otlp_endpoint":"","otlp_insecure":false,"#,
+                r#""metric_export_interval_ms":60000},"locked":{},"env_locked":false}"#,
+                "\n"
+            )
+        );
+    }
+
+    #[test]
+    fn populated_headers_are_sent_with_sorted_keys() {
+        let mut settings = default_config();
+        settings.otlp_headers = parse_otlp_headers("z-last=2,a-first=1");
+        let body = super::super::gojson::to_vec(&settings).expect("encode");
+        assert!(String::from_utf8(body)
+            .expect("utf8")
+            .contains(r#""otlp_headers":{"a-first":"1","z-last":"2"}"#));
+    }
+
+    #[test]
+    fn only_the_monitoring_read_is_claimed() {
+        assert!(claims(&Method::GET, "/api/monitoring"));
+        assert!(!claims(&Method::PUT, "/api/monitoring"));
+        assert!(!claims(&Method::POST, "/api/monitoring/test"));
+        assert!(!claims(&Method::GET, "/api/monitoring/test"));
+        assert!(!claims(&Method::GET, "/api/monitoring/"));
+    }
+}

--- a/desktop/src-tauri/src/native/monitoring.rs
+++ b/desktop/src-tauri/src/native/monitoring.rs
@@ -268,9 +268,11 @@ fn claims(method: &Method, path: &str) -> bool {
 }
 
 fn serve(ctx: &super::Ctx, _req: &super::Request) -> Result<super::Answer, String> {
-    // The data dir is the database's parent by construction (`paths::data_dir`
-    // joins `agento.db` onto it), which is also what makes the parity instance
-    // work: it points both at its scratch copy.
+    // The data dir is the database's parent by construction — `paths::data_dir`
+    // joins `agento.db` onto it, and `paths::tests::database_sits_beside_the_data_dir`
+    // pins that. It is also what makes the parity instance work: the same
+    // derivation points both the database read and this file read at its
+    // scratch copy.
     let data_dir = ctx
         .db_path
         .parent()
@@ -284,21 +286,27 @@ fn serve(ctx: &super::Ctx, _req: &super::Request) -> Result<super::Answer, Strin
 mod tests {
     use super::*;
 
-    fn write(dir: &Path, body: &str) {
-        std::fs::create_dir_all(dir).expect("temp dir");
-        std::fs::write(dir.join("monitoring.json"), body).expect("write");
+    /// A private directory per test. Not a fixed path under the system temp
+    /// dir: two agents running `cargo test` in separate worktrees is a
+    /// supported arrangement here, and a shared path would have each run
+    /// deleting the other's fixture mid-test.
+    fn scratch() -> tempfile::TempDir {
+        tempfile::tempdir().expect("temp dir")
     }
 
-    fn scratch(name: &str) -> std::path::PathBuf {
-        let dir = std::env::temp_dir().join(format!("agento-monitoring-test-{name}"));
-        let _ = std::fs::remove_dir_all(&dir);
-        dir
+    fn write(dir: &tempfile::TempDir, body: &str) -> std::path::PathBuf {
+        let path = dir.path().join("monitoring.json");
+        std::fs::write(&path, body).expect("write");
+        path
     }
 
     #[test]
     fn an_absent_file_is_the_default_config() {
-        let dto = load_file(&scratch("absent").join("monitoring.json"));
-        assert_eq!(dto, default_config());
+        let dir = scratch();
+        assert_eq!(
+            load_file(&dir.path().join("monitoring.json")),
+            default_config()
+        );
     }
 
     /// The failure the manager swallows: it logs and leaves `current` where the
@@ -306,21 +314,20 @@ mod tests {
     /// than taking the endpoint down.
     #[test]
     fn a_malformed_file_degrades_to_the_default() {
-        let dir = scratch("malformed");
-        write(&dir, "{not json");
-        assert_eq!(load_file(&dir.join("monitoring.json")), default_config());
+        let dir = scratch();
+        assert_eq!(load_file(&write(&dir, "{not json")), default_config());
     }
 
     /// A stored `null` is not a malformed file — Go decodes it into the zero
     /// value without complaint, and so must this.
     #[test]
     fn stored_nulls_decode_to_zero_values() {
-        let dir = scratch("nulls");
-        write(
+        let dir = scratch();
+        let path = write(
             &dir,
             r#"{"enabled":null,"metrics_exporter":null,"metric_export_interval_ms":null}"#,
         );
-        let dto = load_file(&dir.join("monitoring.json"));
+        let dto = load_file(&path);
         assert!(!dto.enabled);
         assert_eq!(dto.metrics_exporter, "");
         assert_eq!(dto.metric_export_interval_ms, 60_000);
@@ -330,31 +337,85 @@ mod tests {
     /// before the field existed carries.
     #[test]
     fn a_non_positive_interval_falls_back_to_a_minute() {
-        let dir = scratch("interval");
-        write(&dir, r#"{"enabled":true,"metric_export_interval_ms":0}"#);
-        assert_eq!(
-            load_file(&dir.join("monitoring.json")).metric_export_interval_ms,
-            60_000
-        );
-        write(&dir, r#"{"enabled":true,"metric_export_interval_ms":-5}"#);
-        assert_eq!(
-            load_file(&dir.join("monitoring.json")).metric_export_interval_ms,
-            60_000
-        );
+        let dir = scratch();
+        let zero = write(&dir, r#"{"enabled":true,"metric_export_interval_ms":0}"#);
+        assert_eq!(load_file(&zero).metric_export_interval_ms, 60_000);
+        let negative = write(&dir, r#"{"enabled":true,"metric_export_interval_ms":-5}"#);
+        assert_eq!(load_file(&negative).metric_export_interval_ms, 60_000);
     }
 
     /// An exporter name the UI would never write is passed through, because
     /// validation happens on `PUT` and `GET` reports what is stored.
     #[test]
     fn an_unknown_exporter_name_is_not_corrected() {
-        let dir = scratch("exporter");
-        write(
+        let dir = scratch();
+        let path = write(
             &dir,
             r#"{"metrics_exporter":"bogus","logs_exporter":"otlp"}"#,
         );
-        let dto = load_file(&dir.join("monitoring.json"));
+        let dto = load_file(&path);
         assert_eq!(dto.metrics_exporter, "bogus");
         assert_eq!(dto.logs_exporter, "otlp");
+    }
+
+    /// The resolution rule, not just the file read: with nothing pinned, the
+    /// stored config *is* the answer, `locked` is empty and `env_locked` is
+    /// false. The precedence in the other direction — any `OTEL_*` set means the
+    /// file is ignored rather than merged — cannot be asserted here without
+    /// mutating process-global state that every other test shares, so it is
+    /// covered by `tests/parity_settings.rs`, which diffs an env-locked instance
+    /// against Go.
+    #[test]
+    fn an_unpinned_install_answers_with_the_stored_config() {
+        if ENV_VAR_CHECKS
+            .iter()
+            .any(|(_, var)| !env_raw(var).is_empty())
+        {
+            // This shell exports an OTEL_* variable, so the not-env-locked path
+            // is unreachable. Skipping beats asserting the wrong branch.
+            return;
+        }
+
+        let dir = scratch();
+        write(
+            &dir,
+            r#"{"enabled":true,"metrics_exporter":"prometheus","logs_exporter":"none",
+                "otlp_endpoint":"collector:4317","otlp_headers":{"x-key":"v"},
+                "otlp_insecure":true,"metric_export_interval_ms":15000}"#,
+        );
+
+        let answer = response(dir.path());
+        assert!(!answer.env_locked);
+        assert!(answer.locked.is_empty());
+        assert!(answer.settings.enabled);
+        assert_eq!(answer.settings.metrics_exporter, "prometheus");
+        assert_eq!(answer.settings.otlp_endpoint, "collector:4317");
+        assert_eq!(answer.settings.metric_export_interval_ms, 15_000);
+        assert_eq!(
+            answer
+                .settings
+                .otlp_headers
+                .get("x-key")
+                .map(String::as_str),
+            Some("v")
+        );
+    }
+
+    /// An install that has never opened the monitoring page has no file at all,
+    /// and that is the shape the endpoint answers with most often.
+    #[test]
+    fn an_install_with_no_file_answers_with_the_default() {
+        if ENV_VAR_CHECKS
+            .iter()
+            .any(|(_, var)| !env_raw(var).is_empty())
+        {
+            return;
+        }
+        let dir = scratch();
+        let answer = response(dir.path());
+        assert_eq!(answer.settings, default_config());
+        assert!(!answer.env_locked);
+        assert!(answer.locked.is_empty());
     }
 
     #[test]

--- a/desktop/src-tauri/src/native/settings.rs
+++ b/desktop/src-tauri/src/native/settings.rs
@@ -498,6 +498,109 @@ mod tests {
         assert_eq!(dirs, vec![default, "/var/lib/claude-work".to_string()]);
     }
 
+    /// `internal/storage/sqlite.go`'s `user_settings`, with the columns the
+    /// later migrations appended. Only the ones the read touches.
+    const SCHEMA: &str = "
+        CREATE TABLE user_settings (
+            id                         INTEGER PRIMARY KEY CHECK (id = 1),
+            default_working_dir        TEXT    NOT NULL DEFAULT '',
+            default_model              TEXT    NOT NULL DEFAULT '',
+            onboarding_complete        INTEGER NOT NULL DEFAULT 0,
+            appearance_dark_mode       INTEGER NOT NULL DEFAULT 0,
+            appearance_font_size       INTEGER NOT NULL DEFAULT 0,
+            appearance_font_family     TEXT    NOT NULL DEFAULT '',
+            notification_settings      TEXT    NOT NULL DEFAULT '{}',
+            event_bus_worker_pool_size INTEGER NOT NULL DEFAULT 3,
+            public_url                 TEXT    NOT NULL DEFAULT '',
+            hidden_projects            TEXT    NOT NULL DEFAULT '[]',
+            idle_gap_threshold_minutes INTEGER NOT NULL DEFAULT 0,
+            claude_config_dir          TEXT    NOT NULL DEFAULT '',
+            claude_config_dirs         TEXT    NOT NULL DEFAULT '[]'
+        );";
+
+    fn fixture(row: Option<&str>) -> Connection {
+        let conn = Connection::open_in_memory().expect("in-memory database");
+        conn.execute_batch(SCHEMA).expect("schema");
+        if let Some(insert) = row {
+            conn.execute_batch(insert).expect("row");
+        }
+        conn
+    }
+
+    /// The read is positional, and the struct is not filled in the `SELECT`'s
+    /// order — the two bools and the two JSON columns are pulled out first. So
+    /// every value gets a **distinct** marker here: two adjacent `TEXT` columns
+    /// swapped would compile, pass every other test in this file, and only
+    /// surface in the live parity run, which CI does not run.
+    #[test]
+    fn every_column_lands_on_its_own_field() {
+        let conn = fixture(Some(
+            r#"INSERT INTO user_settings
+                 (id, default_working_dir, default_model, onboarding_complete,
+                  appearance_dark_mode, appearance_font_size, appearance_font_family,
+                  notification_settings, event_bus_worker_pool_size, public_url,
+                  hidden_projects, idle_gap_threshold_minutes,
+                  claude_config_dir, claude_config_dirs)
+               VALUES (1, 'working-dir', 'the-model', 1,
+                       1, 13, 'the-font',
+                       'the-notifications', 7, 'the-url',
+                       '["/hidden/one"]', 25,
+                       '/run/dir', '["/extra/dir"]')"#,
+        ));
+
+        let stored = load_stored(&conn);
+        assert_eq!(stored.default_working_dir, "working-dir");
+        assert_eq!(stored.default_model, "the-model");
+        assert!(stored.onboarding_complete);
+        assert!(stored.appearance_dark_mode);
+        assert_eq!(stored.appearance_font_size, 13);
+        assert_eq!(stored.appearance_font_family, "the-font");
+        assert_eq!(stored.notification_settings, "the-notifications");
+        assert_eq!(stored.event_bus_worker_pool_size, 7);
+        assert_eq!(stored.public_url, "the-url");
+        assert_eq!(
+            stored.hidden_projects,
+            Some(vec!["/hidden/one".to_string()])
+        );
+        assert_eq!(stored.idle_gap_threshold_minutes, 25);
+        assert_eq!(stored.claude_config_dir, "/run/dir");
+        assert_eq!(
+            stored.claude_config_dirs,
+            Some(vec!["/extra/dir".to_string()])
+        );
+
+        // The narrowed view must agree with the row it was derived from — one
+        // reader is the point.
+        let data = from_stored(&stored);
+        assert_eq!(data.hidden_projects, vec!["/hidden/one".to_string()]);
+        assert_eq!(data.idle_gap_ms, 25 * 60 * 1000);
+        assert!(data.indexed_config_dirs.contains(&"/extra/dir".to_string()));
+    }
+
+    /// No row at all is Go's `sql.ErrNoRows`, which its store answers with
+    /// zero-value settings rather than an error — and the zero value is where
+    /// the two lists are nil, so they ship as `null`.
+    #[test]
+    fn an_install_with_no_row_reads_as_the_zero_value() {
+        let stored = load_stored(&fixture(None));
+        assert_eq!(stored.default_model, "");
+        assert_eq!(stored.hidden_projects, None);
+        assert_eq!(stored.claude_config_dirs, None);
+        // And the derived view still resolves the threshold to the default.
+        assert_eq!(from_stored(&stored).idle_gap_ms, DEFAULT_IDLE_GAP_MS);
+    }
+
+    /// A read failure is not a 500: the table can be missing entirely on a
+    /// database the Go server has not migrated yet, and the endpoint answers
+    /// with defaults exactly as the snapshot does before `ApplyDataSettings`.
+    #[test]
+    fn a_missing_table_degrades_rather_than_failing() {
+        let conn = Connection::open_in_memory().expect("in-memory database");
+        let stored = load_stored(&conn);
+        assert_eq!(stored.hidden_projects, None);
+        assert_eq!(from_stored(&stored).idle_gap_ms, DEFAULT_IDLE_GAP_MS);
+    }
+
     /// A nil list is `null` and an empty one is `[]`, and only the stored `[]`
     /// produces the second. Collapsing the two would change the wire for every
     /// install that has never hidden a project.

--- a/desktop/src-tauri/src/native/settings.rs
+++ b/desktop/src-tauri/src/native/settings.rs
@@ -13,10 +13,21 @@
 //! Getting this wrong does not fail loudly. A hidden project that is not
 //! filtered out simply appears — in a list the user has told us to leave it out
 //! of, and in totals the Go server computes without it.
+//!
+//! Since #266 this module also answers `GET /api/settings`, which is the whole
+//! row rather than the four columns a session read cares about. **One reader,
+//! not two**: [`load_stored`] is the single `SELECT`, [`load`] narrows it to
+//! [`DataSettings`] and [`resolve`] applies the defaults and env overrides the
+//! way `config.SettingsManager` does. A second reader would drift, and the drift
+//! would show as the settings page disagreeing with the sessions list about
+//! which projects are hidden.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+use axum::http::Method;
 use rusqlite::{Connection, OptionalExtension};
+use serde::Serialize;
 
 use crate::paths;
 
@@ -63,19 +74,76 @@ impl DataSettings {
     }
 }
 
-/// Read the settings row. A missing row, a missing column, or malformed JSON
-/// all degrade to defaults rather than failing the request — exactly as Go's
-/// snapshot starts at its defaults before `ApplyDataSettings` runs.
-pub fn load(conn: &Connection) -> DataSettings {
-    let row: Option<(String, String, String, i64)> = conn
+/// The persisted settings row, exactly as `storage.SQLiteSettingsStore.Load`
+/// returns it — before `SettingsManager` fills defaults or the environment
+/// overrides anything. Field order is `config.UserSettings`'s declaration
+/// order, which is what decides the key order on the wire.
+///
+/// The two string-list columns are `Option` rather than `Vec` because Go's
+/// `decodeStringList` returns a **nil** slice for a blank or unparseable column
+/// and a non-nil empty one for a stored `[]` — and a nil slice marshals as
+/// `null` while an empty one marshals as `[]`. The distinction is stored, so it
+/// travels.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct UserSettings {
+    pub default_working_dir: String,
+    pub default_model: String,
+    pub onboarding_complete: bool,
+    pub appearance_dark_mode: bool,
+    pub appearance_font_size: i64,
+    pub appearance_font_family: String,
+    pub notification_settings: String,
+    pub event_bus_worker_pool_size: i64,
+    pub public_url: String,
+    pub hidden_projects: Option<Vec<String>>,
+    pub idle_gap_threshold_minutes: i64,
+    pub claude_config_dir: String,
+    pub claude_config_dirs: Option<Vec<String>>,
+}
+
+/// Read the settings row as stored. A missing row, a read error, or malformed
+/// JSON all degrade to the zero value rather than failing — exactly as Go's
+/// store returns zero-value settings for `sql.ErrNoRows` and its snapshot
+/// starts at its defaults before `ApplyDataSettings` runs.
+pub fn load_stored(conn: &Connection) -> UserSettings {
+    let row: Option<UserSettings> = conn
         .query_row(
-            "SELECT COALESCE(hidden_projects, ''),
+            "SELECT COALESCE(default_working_dir, ''),
+                    COALESCE(default_model, ''),
+                    COALESCE(onboarding_complete, 0),
+                    COALESCE(appearance_dark_mode, 0),
+                    COALESCE(appearance_font_size, 0),
+                    COALESCE(appearance_font_family, ''),
+                    COALESCE(notification_settings, ''),
+                    COALESCE(event_bus_worker_pool_size, 0),
+                    COALESCE(public_url, ''),
+                    COALESCE(hidden_projects, ''),
+                    COALESCE(idle_gap_threshold_minutes, 0),
                     COALESCE(claude_config_dir, ''),
-                    COALESCE(claude_config_dirs, ''),
-                    COALESCE(idle_gap_threshold_minutes, 0)
+                    COALESCE(claude_config_dirs, '')
              FROM user_settings WHERE id = 1",
             [],
-            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+            |r| {
+                let onboarding: i64 = r.get(2)?;
+                let dark_mode: i64 = r.get(3)?;
+                let hidden_raw: String = r.get(9)?;
+                let extra_raw: String = r.get(12)?;
+                Ok(UserSettings {
+                    default_working_dir: r.get(0)?,
+                    default_model: r.get(1)?,
+                    onboarding_complete: onboarding != 0,
+                    appearance_dark_mode: dark_mode != 0,
+                    appearance_font_size: r.get(4)?,
+                    appearance_font_family: r.get(5)?,
+                    notification_settings: r.get(6)?,
+                    event_bus_worker_pool_size: r.get(7)?,
+                    public_url: r.get(8)?,
+                    hidden_projects: decode_string_list(&hidden_raw),
+                    idle_gap_threshold_minutes: r.get(10)?,
+                    claude_config_dir: r.get(11)?,
+                    claude_config_dirs: decode_string_list(&extra_raw),
+                })
+            },
         )
         .optional()
         .unwrap_or_else(|e| {
@@ -83,29 +151,46 @@ pub fn load(conn: &Connection) -> DataSettings {
             None
         });
 
-    let (hidden_raw, run_override, extra_raw, idle_minutes) = row.unwrap_or_default();
+    row.unwrap_or_default()
+}
+
+/// Narrow the stored row to the preferences a session read depends on.
+pub fn load(conn: &Connection) -> DataSettings {
+    from_stored(&load_stored(conn))
+}
+
+/// The [`DataSettings`] view of a stored row.
+fn from_stored(stored: &UserSettings) -> DataSettings {
     DataSettings {
-        hidden_projects: decode_string_array(&hidden_raw),
-        indexed_config_dirs: claude_config_dirs(&run_override, &decode_string_array(&extra_raw)),
+        hidden_projects: stored.hidden_projects.clone().unwrap_or_default(),
+        indexed_config_dirs: claude_config_dirs(
+            &stored.claude_config_dir,
+            stored.claude_config_dirs.as_deref().unwrap_or_default(),
+        ),
         // Zero is "unset", not "no idle time at all": the column defaults to 0
         // and the setting is bounded to 1–240 minutes when the user does set it.
-        idle_gap_ms: if idle_minutes > 0 {
-            idle_minutes * 60 * 1000
+        idle_gap_ms: if stored.idle_gap_threshold_minutes > 0 {
+            stored.idle_gap_threshold_minutes * 60 * 1000
         } else {
             DEFAULT_IDLE_GAP_MS
         },
     }
 }
 
-/// Decode a JSON string array column, treating anything unusable as empty.
-fn decode_string_array(raw: &str) -> Vec<String> {
+/// Decode a JSON string array column the way `storage.decodeStringList` does:
+/// blank or unparseable is **nil** (`null` on the wire), a stored `[]` is an
+/// empty slice (`[]` on the wire).
+fn decode_string_list(raw: &str) -> Option<Vec<String>> {
     if raw.trim().is_empty() {
-        return Vec::new();
+        return None;
     }
-    serde_json::from_str::<Vec<String>>(raw).unwrap_or_else(|e| {
-        log::warn!("native settings: malformed string array {raw:?}: {e}");
-        Vec::new()
-    })
+    match serde_json::from_str::<Vec<String>>(raw) {
+        Ok(values) => Some(values),
+        Err(e) => {
+            log::warn!("native settings: malformed string array {raw:?}: {e}");
+            None
+        }
+    }
 }
 
 /// Every config dir Agento indexes, mirroring `config.ClaudeConfigDirs`:
@@ -222,6 +307,156 @@ fn absolute_dir(p: &str) -> Option<String> {
     Some(p.to_string())
 }
 
+// ─── GET /api/settings ────────────────────────────────────────────────────────
+
+/// What `GET /api/settings` answers with. Mirrors `api.settingsResponse`.
+#[derive(Debug, Clone, Serialize)]
+pub struct SettingsResponse {
+    pub settings: UserSettings,
+    /// Field name → the environment variable pinning it. Never nil on the Go
+    /// side (`make`d unconditionally), so an unlocked install ships `{}` rather
+    /// than `null` — and a `BTreeMap` because Go marshals map keys sorted.
+    pub locked: BTreeMap<String, String>,
+    pub model_from_env: bool,
+}
+
+/// `config.defaultModel`.
+const DEFAULT_MODEL: &str = "sonnet";
+
+/// Resolve the row into the answer `SettingsManager` gives, in its order:
+/// load the store, fill the two defaults, then apply the environment.
+///
+/// The manager does this once during startup wiring and holds it in memory; a
+/// ported read has no startup to hook into, so it redoes the resolution per
+/// request. That is not just equivalent, it is slightly fresher — a value saved
+/// through the Go server is visible to the very next native read.
+pub fn resolve(stored: UserSettings) -> SettingsResponse {
+    let mut settings = stored;
+    let locked = locked_fields();
+
+    // `SettingsManager.load` records whether the model was explicitly stored
+    // *before* filling the default, and `applyEnvOverrides` reads that flag.
+    let model_in_file = !settings.default_model.is_empty();
+    if settings.default_working_dir.is_empty() {
+        settings.default_working_dir = default_working_dir();
+    }
+    if settings.default_model.is_empty() {
+        settings.default_model = DEFAULT_MODEL.to_string();
+    }
+
+    // `applyEnvOverrides`. AGENTO_DEFAULT_MODEL locks the field;
+    // ANTHROPIC_DEFAULT_SONNET_MODEL is a soft default that only applies when
+    // the user has not chosen one, and neither locks nor is reported in
+    // `locked` — but both make the displayed model environment-derived.
+    let mut model_from_env = false;
+    if let Some(model) = env_value("AGENTO_DEFAULT_MODEL") {
+        settings.default_model = model;
+        model_from_env = true;
+    } else if let Some(sonnet) = env_value("ANTHROPIC_DEFAULT_SONNET_MODEL") {
+        if !model_in_file {
+            settings.default_model = sonnet;
+            model_from_env = true;
+        }
+    }
+    if let Some(dir) = env_value("AGENTO_WORKING_DIR") {
+        settings.default_working_dir = dir;
+    }
+    if let Some(url) = env_value("AGENTO_PUBLIC_URL") {
+        settings.public_url = url;
+    }
+    if let Some(dir) = claude_config_dir_from_env() {
+        settings.claude_config_dir = dir;
+    }
+
+    SettingsResponse {
+        settings,
+        locked,
+        model_from_env,
+    }
+}
+
+/// `SettingsManager.detectLockedFields`.
+///
+/// Go gates the first three on the matching `AppConfig` field also being
+/// non-empty, but each of those fields is populated from exactly this variable
+/// and nothing else, so the environment check alone is the same condition.
+/// `default_model` is the one to watch: its `AppConfig` field falls back to
+/// `ANTHROPIC_DEFAULT_SONNET_MODEL` and then to `"sonnet"`, so it is *always*
+/// non-empty — which is why the lock still turns only on `AGENTO_DEFAULT_MODEL`.
+fn locked_fields() -> BTreeMap<String, String> {
+    let mut locked = BTreeMap::new();
+    for (field, var) in [
+        ("default_model", "AGENTO_DEFAULT_MODEL"),
+        ("default_working_dir", "AGENTO_WORKING_DIR"),
+        ("public_url", "AGENTO_PUBLIC_URL"),
+    ] {
+        if env_value(var).is_some() {
+            locked.insert(field.to_string(), var.to_string());
+        }
+    }
+    // CLAUDE_CONFIG_DIR is Claude Code's own variable rather than one of ours,
+    // so its presence in the environment is the whole condition — and it is
+    // compared *normalized*, since a value of "   " is not a choice.
+    if claude_config_dir_from_env().is_some() {
+        locked.insert(
+            "claude_config_dir".to_string(),
+            "CLAUDE_CONFIG_DIR".to_string(),
+        );
+    }
+    locked
+}
+
+/// An environment variable, or `None` when unset **or empty** — Go's checks are
+/// all `os.Getenv(x) != ""`, so an exported-but-blank variable locks nothing.
+fn env_value(name: &str) -> Option<String> {
+    match std::env::var(name) {
+        Ok(v) if !v.is_empty() => Some(v),
+        _ => None,
+    }
+}
+
+/// `config.ClaudeConfigDirFromEnv`: the normalized value, or `None` when blank.
+fn claude_config_dir_from_env() -> Option<String> {
+    let normalized = normalize(&std::env::var("CLAUDE_CONFIG_DIR").unwrap_or_default());
+    (!normalized.is_empty()).then_some(normalized)
+}
+
+/// `config.DefaultWorkingDir`: `<temp>/agento/work`. The temp dir is resolved
+/// rather than hardcoded because Go's `os.TempDir` honours `TMPDIR`, and the
+/// value is shown to the user in the settings form.
+fn default_working_dir() -> String {
+    std::env::temp_dir()
+        .join("agento")
+        .join("work")
+        .to_string_lossy()
+        .into_owned()
+}
+
+// ─── The seam ─────────────────────────────────────────────────────────────────
+
+/// This module's entry in `native::ENDPOINTS`.
+pub const ENDPOINT: super::Endpoint = super::Endpoint {
+    name: "settings",
+    claims,
+    serve,
+};
+
+/// The read only. `PUT /api/settings` writes the row and then re-applies the
+/// process-wide snapshots and kicks off a rescan, none of which Rust can do
+/// while the Go server owns the database — so it stays with Go, and so does
+/// `/api/settings/claude-config-dirs`, which is a filesystem probe rather than
+/// a read of this row.
+fn claims(method: &Method, path: &str) -> bool {
+    method == Method::GET && path == "/api/settings"
+}
+
+fn serve(ctx: &super::Ctx, _req: &super::Request) -> Result<super::Answer, String> {
+    let conn = super::db::open_read_only(&ctx.db_path)?;
+    let body = super::gojson::to_vec(&resolve(load_stored(&conn)))
+        .map_err(|e| format!("encoding settings: {e}"))?;
+    Ok(super::Answer { body, probe: None })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -263,10 +498,120 @@ mod tests {
         assert_eq!(dirs, vec![default, "/var/lib/claude-work".to_string()]);
     }
 
+    /// A nil list is `null` and an empty one is `[]`, and only the stored `[]`
+    /// produces the second. Collapsing the two would change the wire for every
+    /// install that has never hidden a project.
     #[test]
-    fn a_malformed_settings_column_degrades_to_empty() {
-        assert!(decode_string_array("not json").is_empty());
-        assert!(decode_string_array("").is_empty());
-        assert_eq!(decode_string_array(r#"["/a","/b"]"#), vec!["/a", "/b"]);
+    fn a_malformed_settings_column_degrades_to_nil_not_empty() {
+        assert_eq!(decode_string_list("not json"), None);
+        assert_eq!(decode_string_list(""), None);
+        assert_eq!(decode_string_list("  "), None);
+        assert_eq!(decode_string_list("[]"), Some(Vec::new()));
+        assert_eq!(
+            decode_string_list(r#"["/a","/b"]"#),
+            Some(vec!["/a".to_string(), "/b".to_string()])
+        );
+    }
+
+    /// The whole envelope, encoded the way the handler encodes it. Key order is
+    /// the Go struct's declaration order; `locked` is `{}` rather than `null`.
+    #[test]
+    fn the_response_shape_is_the_go_envelope() {
+        let stored = UserSettings {
+            default_working_dir: "/tmp/agento/work".into(),
+            default_model: "opus".into(),
+            onboarding_complete: true,
+            appearance_font_size: 13,
+            appearance_font_family: "Inter".into(),
+            notification_settings: "{}".into(),
+            event_bus_worker_pool_size: 3,
+            hidden_projects: Some(vec!["/home/u/secret".into()]),
+            claude_config_dirs: Some(Vec::new()),
+            ..Default::default()
+        };
+        let body = super::super::gojson::to_vec(&SettingsResponse {
+            settings: stored,
+            locked: BTreeMap::new(),
+            model_from_env: false,
+        })
+        .expect("encode");
+
+        assert_eq!(
+            String::from_utf8(body).expect("utf8"),
+            concat!(
+                r#"{"settings":{"default_working_dir":"/tmp/agento/work","default_model":"opus","#,
+                r#""onboarding_complete":true,"appearance_dark_mode":false,"#,
+                r#""appearance_font_size":13,"appearance_font_family":"Inter","#,
+                r#""notification_settings":"{}","event_bus_worker_pool_size":3,"#,
+                r#""public_url":"","hidden_projects":["/home/u/secret"],"#,
+                r#""idle_gap_threshold_minutes":0,"claude_config_dir":"","#,
+                r#""claude_config_dirs":[]},"locked":{},"model_from_env":false}"#,
+                "\n"
+            )
+        );
+    }
+
+    /// A nil list must reach the wire as `null`, which is what an install with
+    /// no settings row at all produces.
+    #[test]
+    fn absent_lists_are_null_not_empty_arrays() {
+        let body = super::super::gojson::to_vec(&UserSettings::default()).expect("encode");
+        let json = String::from_utf8(body).expect("utf8");
+        assert!(json.contains(r#""hidden_projects":null"#), "{json}");
+        assert!(json.contains(r#""claude_config_dirs":null"#), "{json}");
+    }
+
+    /// The two defaults `SettingsManager.load` fills, and the flag that is set
+    /// only when the *environment* chose the model.
+    /// The two defaults `SettingsManager.load` fills, and the flag that is set
+    /// only when the *environment* chose the model.
+    ///
+    /// Guarded on the variables rather than asserted flat: these run on a
+    /// developer's machine, and one that exports `AGENTO_DEFAULT_MODEL` would
+    /// otherwise fail a test about the built-in default.
+    #[test]
+    fn an_empty_row_resolves_to_the_built_in_defaults() {
+        let resolved = resolve(UserSettings::default());
+
+        match env_value("AGENTO_DEFAULT_MODEL")
+            .or_else(|| env_value("ANTHROPIC_DEFAULT_SONNET_MODEL"))
+        {
+            Some(from_env) => {
+                assert_eq!(resolved.settings.default_model, from_env);
+                assert!(resolved.model_from_env);
+            }
+            None => {
+                assert_eq!(resolved.settings.default_model, DEFAULT_MODEL);
+                assert!(!resolved.model_from_env);
+            }
+        }
+
+        if env_value("AGENTO_WORKING_DIR").is_none() {
+            assert_eq!(resolved.settings.default_working_dir, default_working_dir());
+        }
+    }
+
+    /// A stored model is not overwritten by the soft default, and that is
+    /// exactly the case `modelInFile` exists to protect.
+    #[test]
+    fn a_stored_model_survives_and_is_not_environment_derived() {
+        let stored = UserSettings {
+            default_model: "haiku".into(),
+            ..Default::default()
+        };
+        let resolved = resolve(stored);
+        if env_value("AGENTO_DEFAULT_MODEL").is_none() {
+            assert_eq!(resolved.settings.default_model, "haiku");
+            assert!(!resolved.model_from_env);
+        }
+    }
+
+    #[test]
+    fn only_the_settings_read_is_claimed() {
+        assert!(claims(&Method::GET, "/api/settings"));
+        assert!(!claims(&Method::PUT, "/api/settings"));
+        // A filesystem probe, not a read of this row — it stays with Go.
+        assert!(!claims(&Method::GET, "/api/settings/claude-config-dirs"));
+        assert!(!claims(&Method::GET, "/api/settings/"));
     }
 }

--- a/desktop/src-tauri/src/native/version.rs
+++ b/desktop/src-tauri/src/native/version.rs
@@ -1,0 +1,263 @@
+//! `GET /api/version` and `GET /api/version/update-check`.
+//!
+//! Mirrors `handleVersion` and `handleUpdateCheck` (`internal/api/version.go`).
+//!
+//! Two things here are not obvious.
+//!
+//! **The build stamp is not stamped.** Go's `internal/build` variables are set
+//! by `-ldflags`, and only the Makefile does that. `desktop/scripts/build-sidecar.sh`
+//! builds with `-ldflags "-s -w"` and `scripts/parity-instance.sh` with no flags
+//! at all, so the sidecar the app ships — and the server the parity test diffs
+//! against — both serve the package defaults. [`VERSION`] and friends therefore
+//! read the same defaults, with an `option_env!` hook for the day the desktop
+//! bundle starts stamping itself. That day is the cut-over, when the Go binary
+//! that would have to agree is gone.
+//!
+//! **The update check is not the updater.** Go asks GitHub for the latest
+//! release and compares it, which is the self-updater — the one subsystem the
+//! handover explicitly excludes from the port, because Tauri's own updater
+//! replaces it. What is ported is the branch that answers *without* a network
+//! call: a build that names no published release short-circuits to
+//! `update_available: false`, and that is every build the desktop app ships.
+//! Anything else returns `Err` and falls back to the sidecar, which is the
+//! seam's documented way to leave a case with Go. See [`update_check`].
+
+use axum::http::Method;
+use serde::Serialize;
+
+/// `build.Version`. Unstamped is `"dev"`, exactly as the Go package declares it.
+pub const VERSION: &str = match option_env!("AGENTO_BUILD_VERSION") {
+    Some(v) => v,
+    None => "dev",
+};
+
+/// `build.CommitSHA`.
+pub const COMMIT_SHA: &str = match option_env!("AGENTO_BUILD_COMMIT") {
+    Some(v) => v,
+    None => "unknown",
+};
+
+/// `build.BuildDate`.
+pub const BUILD_DATE: &str = match option_env!("AGENTO_BUILD_DATE") {
+    Some(v) => v,
+    None => "unknown",
+};
+
+/// `GET /api/version`.
+///
+/// Go builds this from a `map[string]string`, and **Go marshals map keys
+/// sorted** — so the wire order is alphabetical rather than the order the
+/// literal is written in. The fields below are declared in that order for that
+/// reason; re-grouping them "logically" would change the response.
+#[derive(Debug, Clone, Serialize)]
+pub struct VersionResponse {
+    pub build_date: &'static str,
+    pub commit: &'static str,
+    pub version: &'static str,
+}
+
+/// `GET /api/version/update-check`, for a build that names no published
+/// release. Same story on the ordering: a `map[string]interface{}` in Go.
+#[derive(Debug, Clone, Serialize)]
+pub struct UpdateCheckResponse {
+    pub current_version: &'static str,
+    pub latest_version: &'static str,
+    pub release_url: &'static str,
+    pub update_available: bool,
+}
+
+pub fn version() -> VersionResponse {
+    VersionResponse {
+        build_date: BUILD_DATE,
+        commit: COMMIT_SHA,
+        version: VERSION,
+    }
+}
+
+/// The update check, or `None` when answering it would need the release lookup.
+///
+/// `None` is not a failure — it is the honest answer that this build's version
+/// names a published release, and comparing against GitHub's is the updater's
+/// job. The caller turns it into an `Err` so the request forwards to Go.
+pub fn update_check() -> Option<UpdateCheckResponse> {
+    if !is_dev_build(VERSION) {
+        return None;
+    }
+    Some(UpdateCheckResponse {
+        current_version: VERSION,
+        latest_version: "",
+        release_url: "",
+        update_available: false,
+    })
+}
+
+/// `build.IsDevBuild`: whether a version names a local working tree rather than
+/// a published release.
+///
+/// The `git describe` case is why this is a shape check and not a semver parse.
+/// `v0.8.0-21-gc325de6-dirty` *is* valid semver, and semver ranks a prerelease
+/// **below** the release it precedes — so the published v0.8.0 would compare as
+/// newer than a build 21 commits past it, and the banner would offer the
+/// developer an update to code they already have.
+///
+/// A genuine prerelease tag such as `v1.0.0-rc.1` is deliberately not a dev
+/// build: those are published, and their users should be offered updates.
+pub fn is_dev_build(version: &str) -> bool {
+    let v = version.trim().strip_prefix('v').unwrap_or(version.trim());
+    if v.is_empty() || v == "dev" || v == "unknown" {
+        return true;
+    }
+    if v.ends_with("-dirty") {
+        return true;
+    }
+    has_git_describe_suffix(v)
+}
+
+/// Go's `-\d+-g[0-9a-f]{7,40}$`, hand-matched because nothing else in this
+/// crate wants a regex engine.
+///
+/// The last `-g` is the only candidate: everything after it must be lowercase
+/// hex, and `g` is not a hex digit, so there is no earlier match to prefer.
+fn has_git_describe_suffix(v: &str) -> bool {
+    let Some(marker) = v.rfind("-g") else {
+        return false;
+    };
+    let sha = &v[marker + 2..];
+    if !(7..=40).contains(&sha.len())
+        || !sha
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+    {
+        return false;
+    }
+    let head = &v[..marker];
+    let Some(dash) = head.rfind('-') else {
+        return false;
+    };
+    let count = &head[dash + 1..];
+    !count.is_empty() && count.bytes().all(|b| b.is_ascii_digit())
+}
+
+// ─── The seam ─────────────────────────────────────────────────────────────────
+
+/// This module's entry in `native::ENDPOINTS`.
+pub const ENDPOINT: super::Endpoint = super::Endpoint {
+    name: "version",
+    claims,
+    serve,
+};
+
+fn claims(method: &Method, path: &str) -> bool {
+    method == Method::GET && (path == "/api/version" || path == "/api/version/update-check")
+}
+
+fn serve(_ctx: &super::Ctx, req: &super::Request) -> Result<super::Answer, String> {
+    let body = match req.path {
+        "/api/version" => {
+            super::gojson::to_vec(&version()).map_err(|e| format!("encoding version: {e}"))?
+        }
+        "/api/version/update-check" => match update_check() {
+            Some(answer) => {
+                super::gojson::to_vec(&answer).map_err(|e| format!("encoding update check: {e}"))?
+            }
+            // Deliberate: the release lookup is the self-updater, which the
+            // desktop app replaces with Tauri's own. Falling back keeps Go's
+            // answer — including its 502 when GitHub is unreachable — rather
+            // than inventing one.
+            None => {
+                return Err(format!(
+                    "update check for released build {VERSION:?} needs the release lookup"
+                ))
+            }
+        },
+        other => return Err(format!("{other} is not a version read")),
+    };
+    Ok(super::Answer { body, probe: None })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_dev_build_is_recognised_in_every_shape_the_makefile_produces() {
+        // The case the shape check exists for: valid semver that must not be
+        // compared against a release.
+        assert!(is_dev_build("v0.8.0-21-gc325de6-dirty"));
+        assert!(is_dev_build("v0.8.0-dirty"));
+        assert!(is_dev_build("v0.8.0-21-gc325de6"));
+        assert!(is_dev_build(
+            "v1.2.3-4-g0123456789abcdef0123456789abcdef01234567"
+        ));
+        assert!(is_dev_build("0.8.0-21-gc325de6-dirty"));
+
+        assert!(is_dev_build("dev"));
+        assert!(is_dev_build("unknown"));
+        assert!(is_dev_build(""));
+        assert!(is_dev_build("  "));
+    }
+
+    #[test]
+    fn a_published_release_is_not_a_dev_build() {
+        assert!(!is_dev_build("v0.8.0"));
+        assert!(!is_dev_build("0.8.0"));
+        // Published prereleases still get update offers.
+        assert!(!is_dev_build("v1.0.0-rc.1"));
+        // Too short, too long, and not hex: none of these is a describe suffix.
+        assert!(!is_dev_build("v1.0.0-4-gabc"));
+        assert!(!is_dev_build("v1.0.0-4-gzzzzzzz"));
+        assert!(!is_dev_build("v1.0.0-gc325de6"));
+    }
+
+    /// Key order is alphabetical because Go builds the body from a map. This is
+    /// the whole reason the struct's fields are declared out of logical order.
+    #[test]
+    fn the_version_body_is_the_map_go_marshals() {
+        let body = super::super::gojson::to_vec(&version()).expect("encode");
+        assert_eq!(
+            String::from_utf8(body).expect("utf8"),
+            format!(
+                "{{\"build_date\":\"{BUILD_DATE}\",\"commit\":\"{COMMIT_SHA}\",\
+                 \"version\":\"{VERSION}\"}}\n"
+            )
+        );
+    }
+
+    /// The unstamped defaults are what both the bundled sidecar and the parity
+    /// server serve, so parity depends on them matching `internal/build`.
+    #[test]
+    fn the_unstamped_defaults_match_the_go_package() {
+        if option_env!("AGENTO_BUILD_VERSION").is_none() {
+            assert_eq!(VERSION, "dev");
+            assert_eq!(COMMIT_SHA, "unknown");
+            assert_eq!(BUILD_DATE, "unknown");
+        }
+    }
+
+    #[test]
+    fn the_update_check_short_circuits_for_a_dev_build() {
+        let answer = update_check().expect("an unstamped build short-circuits");
+        assert!(!answer.update_available);
+        assert_eq!(answer.latest_version, "");
+        assert_eq!(answer.release_url, "");
+        assert_eq!(answer.current_version, VERSION);
+
+        let body = super::super::gojson::to_vec(&answer).expect("encode");
+        assert_eq!(
+            String::from_utf8(body).expect("utf8"),
+            format!(
+                "{{\"current_version\":\"{VERSION}\",\"latest_version\":\"\",\
+                 \"release_url\":\"\",\"update_available\":false}}\n"
+            )
+        );
+    }
+
+    #[test]
+    fn both_version_reads_are_claimed_and_nothing_else_is() {
+        assert!(claims(&Method::GET, "/api/version"));
+        assert!(claims(&Method::GET, "/api/version/update-check"));
+        assert!(!claims(&Method::POST, "/api/version"));
+        assert!(!claims(&Method::GET, "/api/version/"));
+        assert!(!claims(&Method::GET, "/api/versions"));
+    }
+}

--- a/desktop/src-tauri/tests/parity_settings.rs
+++ b/desktop/src-tauri/tests/parity_settings.rs
@@ -1,0 +1,105 @@
+//! Live parity for the settings, monitoring and version reads: diff all four
+//! ported endpoints against a *running* Go server, byte for byte.
+//!
+//! The unit tests prove each envelope's shape. This proves the resolution — the
+//! settings manager's default-fill and env-override order, the monitoring
+//! manager's file-versus-environment precedence — matches over the instance's
+//! own row, file and environment.
+//!
+//! Ignored by default: it needs a real Agento instance and its database, and CI
+//! has neither.
+//!
+//! ```sh
+//! cd desktop && eval "$(./scripts/parity-instance.sh start)"
+//! (cd src-tauri && cargo test --test parity_settings -- --ignored --nocapture)
+//! ./scripts/parity-instance.sh stop
+//! ```
+//!
+//! **Never point this at the instance on :8990.** That is whatever binary the
+//! developer installed, which drifts behind the repo — a stale baseline makes a
+//! wrong port look verified, and a right one look broken.
+//!
+//! **Both configurations have a shape that diffs clean while proving nothing.**
+//! A settings row that has never been saved is all zeros, and a monitoring file
+//! that does not exist is the default — so seed the scratch instance before
+//! trusting a pass:
+//!
+//! - `PUT /api/settings` with a hidden project, a non-default idle threshold, a
+//!   font family and a `public_url`, so the string-list columns are exercised as
+//!   populated arrays rather than as `null`;
+//! - `PUT /api/monitoring` with `otlp_headers` populated, so the `omitempty` map
+//!   is exercised as present as well as absent.
+//!
+//! **The environment must be identical on both sides.** These endpoints read
+//! `AGENTO_*` and `OTEL_*` from the process, and `parity-instance.sh` starts the
+//! Go server from this shell — so the same shell running `cargo test` sees the
+//! same variables. Exporting one between `start` and the test would diverge the
+//! two for a reason that is not a bug.
+//!
+//! **Read-only.** These issue GETs and nothing else.
+
+mod parity_common;
+
+use parity_common::*;
+
+use agento_lib::native::{db, gojson, monitoring, settings, version};
+
+#[tokio::test]
+#[ignore = "needs a running Agento instance and its database"]
+async fn the_settings_read_matches_the_live_go_response() {
+    let db_path = live_db();
+    let conn = db::open_read_only(&db_path).expect("opening the parity database");
+    let stored = settings::load_stored(&conn);
+
+    let go = fetch("/api/settings").await;
+    let native = gojson::to_vec(&settings::resolve(stored)).expect("encode");
+    assert_identical("settings", &go, &native);
+
+    // An all-zero row diffs clean against an all-zero row. Assert the response
+    // carries something a save produced, so a pass means the resolution was
+    // actually exercised.
+    let body = String::from_utf8(go).expect("utf8");
+    assert!(
+        body.contains(r#""hidden_projects":["#) || body.contains(r#""claude_config_dirs":["#),
+        "the parity instance has never saved a settings list — both columns are \
+         null, which diffs clean and proves nothing. Seed it with PUT /api/settings \
+         (see this file's header).\n{body}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "needs a running Agento instance and its database"]
+async fn the_monitoring_read_matches_the_live_go_response() {
+    // The data dir is the database's parent — for the parity instance that is
+    // its scratch copy, which is the directory its `monitoring.json` lives in.
+    let db_path = live_db();
+    let data_dir = db_path.parent().expect("a data directory");
+
+    let go = fetch("/api/monitoring").await;
+    let native = gojson::to_vec(&monitoring::response(data_dir)).expect("encode");
+    assert_identical("monitoring", &go, &native);
+}
+
+#[tokio::test]
+#[ignore = "needs a running Agento instance and its database"]
+async fn the_version_reads_match_the_live_go_response() {
+    let go = fetch("/api/version").await;
+    let native = gojson::to_vec(&version::version()).expect("encode");
+    assert_identical("version", &go, &native);
+
+    // The update check is only ported for a build that names no published
+    // release; anything else falls back to Go and there is nothing to diff.
+    // `parity-instance.sh` builds with no `-ldflags`, so this is the live case.
+    match version::update_check() {
+        Some(answer) => {
+            let go = fetch("/api/version/update-check").await;
+            let native = gojson::to_vec(&answer).expect("encode");
+            assert_identical("version/update-check", &go, &native);
+        }
+        None => panic!(
+            "this binary is stamped as {:?}, so the update check falls back to Go \
+             and cannot be diffed. Build the test without AGENTO_BUILD_VERSION.",
+            version::VERSION
+        ),
+    }
+}


### PR DESCRIPTION
Closes #266

## What

`GET /api/settings`, `GET /api/monitoring`, `GET /api/version` and `GET /api/version/update-check` are answered by Rust.

## How

**`native/settings.rs`** — extended rather than duplicated, as the issue asks. `load_stored` is now the single `SELECT` over `user_settings`; `load` narrows it to `DataSettings` for the session reads and `resolve` applies `config.SettingsManager`'s order (record whether the model was stored → fill the two defaults → apply the environment). The string-list columns are `Option<Vec<String>>` because Go's `decodeStringList` returns **nil** for a blank or unparseable column and an empty slice for a stored `[]` — `null` versus `[]` on the wire.

**`native/monitoring.rs`** — the read, not the telemetry. `monitoring.json` plus the `OTEL_*` locks, with the manager's precedence reproduced exactly: any `OTEL_*` variable set means `Load` returns before touching the file, so the stored config is **ignored rather than merged**. A missing, unreadable or malformed file degrades to the default, which is where `current` is left in each of those cases.

**`native/version.rs`** — mirrors `internal/build`'s unstamped defaults (`dev`/`unknown`/`unknown`), behind `option_env!` hooks. That is not a shortcut: `build-sidecar.sh` builds with `-ldflags "-s -w"` and `parity-instance.sh` with none, so the bundled sidecar and the parity server both serve the defaults. Stamping Rust while Go is unstamped would be a parity failure by construction.

The update check is **half ported on purpose**. Go's branch for a build that names no published release needs no network and short-circuits to `update_available: false` — that is every build the desktop app ships, and it is native. The other branch asks GitHub for the latest release, which *is* the self-updater that Tauri's own updater replaces (handover §1), so it returns `Err` and forwards to Go. `is_dev_build` is ported faithfully, including the `git describe` shape check that a semver parse cannot do.

## Scope

Strictly the four reads. `PUT /api/settings` re-applies the process-wide snapshots and triggers a rescan, `PUT /api/monitoring` hot-reloads the OTel providers, `POST /api/monitoring/test` dials the collector over gRPC — all stay with Go, as does `/api/settings/claude-config-dirs`, which probes the filesystem rather than reading this row.

## Verification

- 288 unit tests green (`cargo test`), clippy clean at `-D warnings`, `cargo fmt` clean.
- `tests/parity_settings.rs` — live diff against a Go server built from this checkout, in **both** configurations:
  - stored: a seeded settings row (hidden projects, extra config dir, HTML-escapable `public_url` and font family) and a seeded `monitoring.json` with populated `otlp_headers` → settings 563 B, monitoring 280 B, version 60 B, update-check 88 B, all identical;
  - env-locked: `OTEL_*` plus `AGENTO_DEFAULT_MODEL` / `AGENTO_WORKING_DIR` / `AGENTO_PUBLIC_URL` / `CLAUDE_CONFIG_DIR` exported → settings 593 B, monitoring 431 B, all identical, with `env_locked: true`, both `locked` maps populated and `model_from_env: true`.

An empty settings row and an absent `monitoring.json` both diff clean while proving nothing, so the suite asserts the instance was seeded and its header says how.