### PR TITLE
feat(desktop): port the filesystem listing to Rust (#268)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -137,6 +137,8 @@ src-tauri/src/
     monitoring.rs GET /api/monitoring — monitoring.json and the OTEL_* locks, no exporters
     version.rs   GET /api/version and /version/update-check (dev builds only)
     notifications.rs GET /api/notifications/settings (password masked) and /log
+    fs.rs        GET /api/fs — the working-dir picker's listing (Unix; forwards on Windows)
+    gopath.rs    Go's filepath.Clean/Dir/Join, pinned to vectors generated from Go
     pricing.rs   GET /api/pricing/catalog, plus the rate Resolver
     agents.rs    GET /api/agents and /api/agents/{slug}
     chats.rs     GET /api/chats and /api/chats/{id}; compact() is Go's, byte for byte
@@ -258,7 +260,11 @@ only a byte comparison catches all four.
    the first "identical" meant nothing until two agents were created through it.
 4. Prove it three ways:
    - a fixture both languages build, compared against a golden file Go wrote
-     (`desktop/parity/`, `go test ./desktop/parity/ -update-golden`). Build the
+     (`desktop/parity/`, `go test ./desktop/parity/ -update-golden`). A shared
+     *primitive* rather than a response takes the vector form instead —
+     `gopath_vectors.json` records what Go's `filepath.Clean`/`Dir`/`Join`
+     answer and both languages assert against it, which is how #268 found a
+     doubled separator the Rust `Clean` produced. Build the
      fixture with **no ties on any sort key** — see below; a tie makes the
      golden flaky in Go before Rust ever sees it, which is why
      `TestAnalyticsFixtureHasNoTiesOnAnySortKey` asserts the property;

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -139,6 +139,7 @@ src-tauri/src/
     notifications.rs GET /api/notifications/settings (password masked) and /log
     fs.rs        GET /api/fs — the working-dir picker's listing (Unix; forwards on Windows)
     gopath.rs    Go's filepath.Clean/Dir/Join, pinned to vectors generated from Go
+    query.rs     one query parameter, read the way r.URL.Query().Get reads it
     pricing.rs   GET /api/pricing/catalog, plus the rate Resolver
     agents.rs    GET /api/agents and /api/agents/{slug}
     chats.rs     GET /api/chats and /api/chats/{id}; compact() is Go's, byte for byte

--- a/desktop/parity/gopath_parity_test.go
+++ b/desktop/parity/gopath_parity_test.go
@@ -1,0 +1,132 @@
+// Cross-language vectors for Go's `path/filepath`.
+//
+// `GET /api/fs` is a thin wrapper around `filepath.Clean`, `filepath.Dir` and
+// `filepath.Join`, so porting the endpoint means porting those three — and they
+// are subtler than they look. `Clean` resolves `..` against a *lexical* root
+// rather than the filesystem, so it keeps leading `..` on a relative path and
+// drops them on a rooted one; `Dir` is `Clean` of everything before the last
+// separator, which turns a bare name into `.`; `Join` cleans its result, so
+// `Join("/a", "../b")` escapes upward.
+//
+// Every one of those is a path the picker would then hand to the user as a
+// directory to work in, so a divergence is not cosmetic. This half asserts Go
+// still produces what the frozen file records; the other half lives in
+// desktop/src-tauri/src/native/gopath.rs and asserts Rust produces the same.
+//
+// Regenerate (only from Go, and only when adding cases):
+//
+//	go test ./desktop/parity/ -run TestGoPathVectors -update-gopath-vectors
+//
+// The vectors are Unix-shaped on purpose: `native/gopath.rs` implements the
+// Unix rules and `native/fs.rs` does not claim the route on Windows, where
+// `filepath.Clean`'s volume-name handling is a different algorithm.
+package parity
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+const gopathVectorsFile = "gopath_vectors.json"
+
+var updateGoPathVectors = flag.Bool("update-gopath-vectors", false,
+	"rewrite gopath_vectors.json from this Go toolchain")
+
+type gopathVectors struct {
+	Comment []string `json:"_comment"`
+	Clean   []struct {
+		Value string `json:"value"`
+		Want  string `json:"want"`
+	} `json:"clean"`
+	Dir []struct {
+		Value string `json:"value"`
+		Want  string `json:"want"`
+	} `json:"dir"`
+	Join []struct {
+		Elems []string `json:"elems"`
+		Want  string   `json:"want"`
+	} `json:"join"`
+}
+
+// cleanAndDirInputs covers each branch of Clean's loop: the rooted and
+// unrooted `..` cases, repeated and trailing separators, a lone `.`, and the
+// empty string — which is `.` rather than `""`, and is the one case a
+// split-and-rejoin implementation gets wrong.
+var cleanAndDirInputs = []string{
+	"", ".", "..", "...", "/", "//", "///", "/.", "/..", "/../..",
+	"a", "a/", "a//b", "a/./b", "a/../b", "a/..", "a/../..",
+	"./a", "../a", "../../a", "/a/../..", "/a/b/../c/", "/../a",
+	"/home/u/.claude/", "/home//u/./.claude", "/home/u/x/../.claude",
+	"~", "~/foo", "/a/b/c/../../d", "foo/bar/..", "/a//b//c", "a/b/./../c",
+	".hidden", "/.hidden/", "/a/b/..", "/a/b/../..", "/a/b/../../..",
+}
+
+// joinInputs include the pairs `Join`'s own cleaning makes surprising: an empty
+// element is skipped entirely, and `..` in the second element escapes the first.
+var joinInputs = [][]string{
+	{"/a", "b"}, {"/", "b"}, {"", "b"}, {"a", ""}, {"/a/", "b"},
+	{"a", "../b"}, {"/a", ".."}, {"/a/b", "../.."}, {"/", ".."},
+	{"/home/u", ".claude"}, {"/a", "b/c"}, {".", "a"}, {"..", "a"},
+}
+
+func TestGoPathVectors(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("vectors record the Unix rules; the Rust port does not claim the route on Windows")
+	}
+
+	want := gopathVectors{
+		Comment: []string{
+			"Cross-language parity vectors for Go's path/filepath, Unix rules.",
+			"Generated from Go, then frozen. Read by desktop/parity/gopath_parity_test.go",
+			"(Go) and by desktop/src-tauri/src/native/gopath.rs (Rust). 'want' is exactly",
+			"what Go produces, so a divergence fails one language against the other's",
+			"real output rather than against a belief about it.",
+			"Regenerate with: go test ./desktop/parity/ -run TestGoPathVectors -update-gopath-vectors",
+		},
+	}
+	for _, in := range cleanAndDirInputs {
+		want.Clean = append(want.Clean, struct {
+			Value string `json:"value"`
+			Want  string `json:"want"`
+		}{in, filepath.Clean(in)})
+		want.Dir = append(want.Dir, struct {
+			Value string `json:"value"`
+			Want  string `json:"want"`
+		}{in, filepath.Dir(in)})
+	}
+	for _, elems := range joinInputs {
+		want.Join = append(want.Join, struct {
+			Elems []string `json:"elems"`
+			Want  string   `json:"want"`
+		}{elems, filepath.Join(elems...)})
+	}
+
+	encoded, err := json.MarshalIndent(want, "", "  ")
+	if err != nil {
+		t.Fatalf("encoding vectors: %v", err)
+	}
+	encoded = append(encoded, '\n')
+
+	if *updateGoPathVectors {
+		if err := os.WriteFile(gopathVectorsFile, encoded, 0o600); err != nil {
+			t.Fatalf("writing %s: %v", gopathVectorsFile, err)
+		}
+		t.Logf("wrote %s", gopathVectorsFile)
+		return
+	}
+
+	frozen, err := os.ReadFile(gopathVectorsFile)
+	if err != nil {
+		t.Fatalf("reading %s (regenerate with -update-gopath-vectors): %v", gopathVectorsFile, err)
+	}
+	if string(frozen) != string(encoded) {
+		t.Fatalf("%s is stale: this Go toolchain produces different results.\n"+
+			"Regenerate with -update-gopath-vectors and check what moved — the Rust "+
+			"port in native/gopath.rs reads the same file and will fail against it.",
+			gopathVectorsFile)
+	}
+}

--- a/desktop/parity/gopath_vectors.json
+++ b/desktop/parity/gopath_vectors.json
@@ -1,0 +1,403 @@
+{
+  "_comment": [
+    "Cross-language parity vectors for Go's path/filepath, Unix rules.",
+    "Generated from Go, then frozen. Read by desktop/parity/gopath_parity_test.go",
+    "(Go) and by desktop/src-tauri/src/native/gopath.rs (Rust). 'want' is exactly",
+    "what Go produces, so a divergence fails one language against the other's",
+    "real output rather than against a belief about it.",
+    "Regenerate with: go test ./desktop/parity/ -run TestGoPathVectors -update-gopath-vectors"
+  ],
+  "clean": [
+    {
+      "value": "",
+      "want": "."
+    },
+    {
+      "value": ".",
+      "want": "."
+    },
+    {
+      "value": "..",
+      "want": ".."
+    },
+    {
+      "value": "...",
+      "want": "..."
+    },
+    {
+      "value": "/",
+      "want": "/"
+    },
+    {
+      "value": "//",
+      "want": "/"
+    },
+    {
+      "value": "///",
+      "want": "/"
+    },
+    {
+      "value": "/.",
+      "want": "/"
+    },
+    {
+      "value": "/..",
+      "want": "/"
+    },
+    {
+      "value": "/../..",
+      "want": "/"
+    },
+    {
+      "value": "a",
+      "want": "a"
+    },
+    {
+      "value": "a/",
+      "want": "a"
+    },
+    {
+      "value": "a//b",
+      "want": "a/b"
+    },
+    {
+      "value": "a/./b",
+      "want": "a/b"
+    },
+    {
+      "value": "a/../b",
+      "want": "b"
+    },
+    {
+      "value": "a/..",
+      "want": "."
+    },
+    {
+      "value": "a/../..",
+      "want": ".."
+    },
+    {
+      "value": "./a",
+      "want": "a"
+    },
+    {
+      "value": "../a",
+      "want": "../a"
+    },
+    {
+      "value": "../../a",
+      "want": "../../a"
+    },
+    {
+      "value": "/a/../..",
+      "want": "/"
+    },
+    {
+      "value": "/a/b/../c/",
+      "want": "/a/c"
+    },
+    {
+      "value": "/../a",
+      "want": "/a"
+    },
+    {
+      "value": "/home/u/.claude/",
+      "want": "/home/u/.claude"
+    },
+    {
+      "value": "/home//u/./.claude",
+      "want": "/home/u/.claude"
+    },
+    {
+      "value": "/home/u/x/../.claude",
+      "want": "/home/u/.claude"
+    },
+    {
+      "value": "~",
+      "want": "~"
+    },
+    {
+      "value": "~/foo",
+      "want": "~/foo"
+    },
+    {
+      "value": "/a/b/c/../../d",
+      "want": "/a/d"
+    },
+    {
+      "value": "foo/bar/..",
+      "want": "foo"
+    },
+    {
+      "value": "/a//b//c",
+      "want": "/a/b/c"
+    },
+    {
+      "value": "a/b/./../c",
+      "want": "a/c"
+    },
+    {
+      "value": ".hidden",
+      "want": ".hidden"
+    },
+    {
+      "value": "/.hidden/",
+      "want": "/.hidden"
+    },
+    {
+      "value": "/a/b/..",
+      "want": "/a"
+    },
+    {
+      "value": "/a/b/../..",
+      "want": "/"
+    },
+    {
+      "value": "/a/b/../../..",
+      "want": "/"
+    }
+  ],
+  "dir": [
+    {
+      "value": "",
+      "want": "."
+    },
+    {
+      "value": ".",
+      "want": "."
+    },
+    {
+      "value": "..",
+      "want": "."
+    },
+    {
+      "value": "...",
+      "want": "."
+    },
+    {
+      "value": "/",
+      "want": "/"
+    },
+    {
+      "value": "//",
+      "want": "/"
+    },
+    {
+      "value": "///",
+      "want": "/"
+    },
+    {
+      "value": "/.",
+      "want": "/"
+    },
+    {
+      "value": "/..",
+      "want": "/"
+    },
+    {
+      "value": "/../..",
+      "want": "/"
+    },
+    {
+      "value": "a",
+      "want": "."
+    },
+    {
+      "value": "a/",
+      "want": "a"
+    },
+    {
+      "value": "a//b",
+      "want": "a"
+    },
+    {
+      "value": "a/./b",
+      "want": "a"
+    },
+    {
+      "value": "a/../b",
+      "want": "."
+    },
+    {
+      "value": "a/..",
+      "want": "a"
+    },
+    {
+      "value": "a/../..",
+      "want": "."
+    },
+    {
+      "value": "./a",
+      "want": "."
+    },
+    {
+      "value": "../a",
+      "want": ".."
+    },
+    {
+      "value": "../../a",
+      "want": "../.."
+    },
+    {
+      "value": "/a/../..",
+      "want": "/"
+    },
+    {
+      "value": "/a/b/../c/",
+      "want": "/a/c"
+    },
+    {
+      "value": "/../a",
+      "want": "/"
+    },
+    {
+      "value": "/home/u/.claude/",
+      "want": "/home/u/.claude"
+    },
+    {
+      "value": "/home//u/./.claude",
+      "want": "/home/u"
+    },
+    {
+      "value": "/home/u/x/../.claude",
+      "want": "/home/u"
+    },
+    {
+      "value": "~",
+      "want": "."
+    },
+    {
+      "value": "~/foo",
+      "want": "~"
+    },
+    {
+      "value": "/a/b/c/../../d",
+      "want": "/a"
+    },
+    {
+      "value": "foo/bar/..",
+      "want": "foo/bar"
+    },
+    {
+      "value": "/a//b//c",
+      "want": "/a/b"
+    },
+    {
+      "value": "a/b/./../c",
+      "want": "a"
+    },
+    {
+      "value": ".hidden",
+      "want": "."
+    },
+    {
+      "value": "/.hidden/",
+      "want": "/.hidden"
+    },
+    {
+      "value": "/a/b/..",
+      "want": "/a/b"
+    },
+    {
+      "value": "/a/b/../..",
+      "want": "/a"
+    },
+    {
+      "value": "/a/b/../../..",
+      "want": "/"
+    }
+  ],
+  "join": [
+    {
+      "elems": [
+        "/a",
+        "b"
+      ],
+      "want": "/a/b"
+    },
+    {
+      "elems": [
+        "/",
+        "b"
+      ],
+      "want": "/b"
+    },
+    {
+      "elems": [
+        "",
+        "b"
+      ],
+      "want": "b"
+    },
+    {
+      "elems": [
+        "a",
+        ""
+      ],
+      "want": "a"
+    },
+    {
+      "elems": [
+        "/a/",
+        "b"
+      ],
+      "want": "/a/b"
+    },
+    {
+      "elems": [
+        "a",
+        "../b"
+      ],
+      "want": "b"
+    },
+    {
+      "elems": [
+        "/a",
+        ".."
+      ],
+      "want": "/"
+    },
+    {
+      "elems": [
+        "/a/b",
+        "../.."
+      ],
+      "want": "/"
+    },
+    {
+      "elems": [
+        "/",
+        ".."
+      ],
+      "want": "/"
+    },
+    {
+      "elems": [
+        "/home/u",
+        ".claude"
+      ],
+      "want": "/home/u/.claude"
+    },
+    {
+      "elems": [
+        "/a",
+        "b/c"
+      ],
+      "want": "/a/b/c"
+    },
+    {
+      "elems": [
+        ".",
+        "a"
+      ],
+      "want": "a"
+    },
+    {
+      "elems": [
+        "..",
+        "a"
+      ],
+      "want": "../a"
+    }
+  ]
+}

--- a/desktop/src-tauri/src/native/fs.rs
+++ b/desktop/src-tauri/src/native/fs.rs
@@ -19,6 +19,14 @@
 //! 3. **No traversal guard beyond `Clean`.** Go applies none, and adding one
 //!    here would refuse paths the sidecar serves.
 //!
+//! **One accepted divergence: a filename that is not valid UTF-8.** Both
+//! languages mangle it — Go's JSON encoder substitutes U+FFFD and so does
+//! `to_string_lossy` — but they count differently: Go emits one replacement per
+//! invalid *byte*, while Rust emits one per maximal invalid *subsequence*, so
+//! `\xe0\xa0` is two characters to Go and one here. Neither answer is a usable
+//! path, and reproducing Go's policy would mean hand-rolling the conversion for
+//! a case the picker cannot act on, so this is documented rather than fixed.
+//!
 //! **Answered on Unix only.** The endpoint is `filepath.Clean`/`Dir`/`Join`
 //! wrapped in a response, and Windows `filepath` strips a volume name before
 //! cleaning and accepts both separators — a different algorithm, with no Windows
@@ -120,13 +128,10 @@ pub fn list(raw_path: &str) -> Result<FsListResponse, String> {
     })
 }
 
-/// The `path` query parameter, read the way `r.URL.Query().Get` reads it:
-/// percent-decoded, and the first value when the key repeats.
+/// The `path` query parameter. No rule of its own on top of the decoding —
+/// `""` already means the home directory, which is what an absent key gives.
 pub fn path_param(query: &str) -> String {
-    form_urlencoded::parse(query.as_bytes())
-        .find(|(k, _)| k == "path")
-        .map(|(_, v)| v.into_owned())
-        .unwrap_or_default()
+    super::query::value(query, "path")
 }
 
 // ─── The seam ─────────────────────────────────────────────────────────────────

--- a/desktop/src-tauri/src/native/fs.rs
+++ b/desktop/src-tauri/src/native/fs.rs
@@ -1,0 +1,311 @@
+//! `GET /api/fs` — the directory listing behind the working-directory pickers.
+//!
+//! Mirrors `handleFSList` (`internal/api/filesystem.go`).
+//!
+//! **This reads the user's filesystem, so it must not widen what Go exposes.**
+//! Three deliberate narrowings travel with it, and dropping any one shows the
+//! user something the Go server would not have:
+//!
+//! 1. **Directories only.** `handleFSList` skips every non-directory entry, and
+//!    it decides with `DirEntry.IsDir()`, which reads the type bit `readdir`
+//!    returned and **does not follow symlinks**. A symlink pointing at a
+//!    directory is therefore *excluded*. Rust's `DirEntry::file_type()` has the
+//!    same semantics; `metadata()` does not — it follows, and using it would add
+//!    entries Go omits.
+//! 2. **`~` is expanded only when it is the whole path.** `""` and `"~"` become
+//!    the home directory; `"~/Projects"` does not. It stays literal, `Clean`
+//!    leaves it relative, and the read fails — which is Go's answer and the one
+//!    the frontend is written against.
+//! 3. **No traversal guard beyond `Clean`.** Go applies none, and adding one
+//!    here would refuse paths the sidecar serves.
+//!
+//! **Answered on Unix only.** The endpoint is `filepath.Clean`/`Dir`/`Join`
+//! wrapped in a response, and Windows `filepath` strips a volume name before
+//! cleaning and accepts both separators — a different algorithm, with no Windows
+//! machine in this loop to verify a port of it against. The route is still
+//! *claimed* there and [`serve`] returns `Err`, which the seam forwards: gating
+//! `claims` instead would leave a registry entry that claims nothing, and the
+//! two registry tests exist precisely to catch that shape. See [`super::gopath`].
+//!
+//! `POST /api/fs/mkdir` creates a directory and stays with Go. So does
+//! `POST /api/uploads`: **there is no upload read path** — `internal/api/uploads.go`
+//! registers one route and it writes a multipart body to disk.
+
+use axum::http::Method;
+use serde::Serialize;
+
+use super::gopath;
+use crate::paths;
+
+/// One listed directory. Mirrors `api.fsEntry`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct FsEntry {
+    pub name: String,
+    /// Always true: the handler filters everything else out. Kept because the
+    /// field is on the wire and the frontend reads it.
+    pub is_dir: bool,
+    pub path: String,
+}
+
+/// Mirrors `api.fsListResponse`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct FsListResponse {
+    pub path: String,
+    pub parent: String,
+    /// `make([]fsEntry, 0, …)` on the Go side, so an empty directory is `[]`
+    /// rather than `null` — the opposite of the notification log, and the
+    /// difference is whether the slice was preallocated.
+    pub entries: Vec<FsEntry>,
+}
+
+/// `handleFSList`.
+///
+/// Errors mean "fall back": Go answers 404 for a missing path, 400 for anything
+/// else unreadable and 500 when the home directory cannot be resolved, each with
+/// its own body. Reproducing those here would be three more strings to keep in
+/// step for no gain while the sidecar can answer them itself.
+pub fn list(raw_path: &str) -> Result<FsListResponse, String> {
+    // `""` and `"~"` — and nothing else — mean the home directory.
+    let expanded = if raw_path.is_empty() || raw_path == "~" {
+        paths::home()
+            .ok_or("could not determine home directory")?
+            .to_string_lossy()
+            .into_owned()
+    } else {
+        raw_path.to_string()
+    };
+
+    let clean = gopath::clean(&expanded);
+
+    let mut entries = Vec::new();
+    let reader =
+        std::fs::read_dir(&clean).map_err(|e| format!("cannot read directory {clean:?}: {e}"))?;
+    for entry in reader {
+        let entry = entry.map_err(|e| format!("reading an entry of {clean:?}: {e}"))?;
+        // `file_type`, never `metadata`: Go's `DirEntry.IsDir` does not follow
+        // symlinks, so a link to a directory is not listed.
+        let file_type = entry
+            .file_type()
+            .map_err(|e| format!("stat-ing an entry of {clean:?}: {e}"))?;
+        if !file_type.is_dir() {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().into_owned();
+        entries.push(FsEntry {
+            path: gopath::join(&[&clean, &name]),
+            name,
+            is_dir: true,
+        });
+    }
+
+    // `os.ReadDir` returns entries **sorted by filename**; `std::fs::read_dir`
+    // returns them in whatever order the directory yields. Without this the
+    // response is right and its order is not, which is the kind of diff that
+    // passes on a small directory and fails on a big one.
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+
+    // At the filesystem root `Dir` answers the root itself, and Go spells that
+    // out rather than relying on it.
+    let parent = gopath::dir(&clean);
+    let parent = if parent == clean {
+        clean.clone()
+    } else {
+        parent
+    };
+
+    Ok(FsListResponse {
+        path: clean,
+        parent,
+        entries,
+    })
+}
+
+/// The `path` query parameter, read the way `r.URL.Query().Get` reads it:
+/// percent-decoded, and the first value when the key repeats.
+pub fn path_param(query: &str) -> String {
+    form_urlencoded::parse(query.as_bytes())
+        .find(|(k, _)| k == "path")
+        .map(|(_, v)| v.into_owned())
+        .unwrap_or_default()
+}
+
+// ─── The seam ─────────────────────────────────────────────────────────────────
+
+/// This module's entry in `native::ENDPOINTS`.
+pub const ENDPOINT: super::Endpoint = super::Endpoint {
+    name: "fs",
+    claims,
+    serve,
+};
+
+/// The listing only. Platform-independent on purpose — see [`serve`].
+fn claims(method: &Method, path: &str) -> bool {
+    method == Method::GET && path == "/api/fs"
+}
+
+fn serve(_ctx: &super::Ctx, req: &super::Request) -> Result<super::Answer, String> {
+    // Windows `filepath` is a different algorithm and unverified here, so the
+    // request forwards. This is the seam's own mechanism for "cannot answer",
+    // and it keeps the platform decision in one readable place rather than
+    // making the route vanish from the registry.
+    if !cfg!(unix) {
+        return Err("the fs listing is not ported for Windows path semantics".to_string());
+    }
+    let listing = list(&path_param(req.query))?;
+    let body = super::gojson::to_vec(&listing).map_err(|e| format!("encoding fs listing: {e}"))?;
+    Ok(super::Answer { body, probe: None })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A directory tree with the three shapes the handler distinguishes: real
+    /// subdirectories, a plain file, and a symlink pointing at a directory.
+    fn tree() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let root = dir.path();
+        // Created out of alphabetical order so the sort is doing work.
+        for name in ["zulu", "alpha", "Mike", "bravo"] {
+            std::fs::create_dir(root.join(name)).expect("subdir");
+        }
+        std::fs::write(root.join("notes.txt"), b"x").expect("file");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(root.join("alpha"), root.join("link-to-alpha"))
+            .expect("symlink");
+        dir
+    }
+
+    fn names(listing: &FsListResponse) -> Vec<&str> {
+        listing.entries.iter().map(|e| e.name.as_str()).collect()
+    }
+
+    /// `os.ReadDir` sorts by filename; `std::fs::read_dir` does not. Byte order,
+    /// so an uppercase name sorts before every lowercase one.
+    #[test]
+    fn entries_are_sorted_by_name_the_way_read_dir_sorts() {
+        let dir = tree();
+        let listing = list(dir.path().to_str().expect("utf8 path")).expect("listing");
+        assert_eq!(names(&listing), vec!["Mike", "alpha", "bravo", "zulu"]);
+    }
+
+    /// Files are skipped, and so is a symlink to a directory — `DirEntry.IsDir`
+    /// reads the type bit rather than following the link, and `metadata()`
+    /// would have added an entry Go omits.
+    #[test]
+    fn files_and_symlinked_directories_are_both_excluded() {
+        let dir = tree();
+        let listing = list(dir.path().to_str().expect("utf8 path")).expect("listing");
+        assert!(!names(&listing).contains(&"notes.txt"));
+        assert!(
+            !names(&listing).contains(&"link-to-alpha"),
+            "a symlink to a directory must not be listed: {:?}",
+            names(&listing)
+        );
+    }
+
+    /// Every entry's path is `Join(clean, name)`, and `is_dir` is always true
+    /// because everything else was filtered out.
+    #[test]
+    fn each_entry_carries_its_joined_path() {
+        let dir = tree();
+        let root = dir.path().to_str().expect("utf8 path");
+        let listing = list(root).expect("listing");
+        for entry in &listing.entries {
+            assert!(entry.is_dir);
+            assert_eq!(entry.path, gopath::join(&[&listing.path, &entry.name]));
+        }
+    }
+
+    /// An empty directory is `[]`, not `null` — the Go slice is preallocated
+    /// with `make`, unlike the notification log's.
+    #[test]
+    fn an_empty_directory_is_an_empty_array() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let listing = list(dir.path().to_str().expect("utf8 path")).expect("listing");
+        assert!(listing.entries.is_empty());
+        let body = super::super::gojson::to_vec(&listing).expect("encode");
+        assert!(
+            String::from_utf8(body)
+                .expect("utf8")
+                .contains(r#""entries":[]"#),
+            "an empty listing must be [] rather than null"
+        );
+    }
+
+    /// Only the bare forms expand. `~/Projects` stays literal, `Clean` leaves it
+    /// relative, and the read fails — which is what Go answers.
+    #[test]
+    fn only_a_bare_tilde_and_the_empty_path_mean_home() {
+        let home = paths::home().expect("a home directory");
+        let home = home.to_string_lossy().into_owned();
+
+        for raw in ["", "~"] {
+            let listing = list(raw).expect("home listing");
+            assert_eq!(listing.path, gopath::clean(&home), "{raw:?}");
+        }
+
+        assert!(
+            list("~/definitely-not-a-real-directory").is_err(),
+            "a trailing-path tilde must not be expanded"
+        );
+    }
+
+    /// The root is its own parent, spelled out rather than left to `Dir`.
+    #[test]
+    fn the_filesystem_root_is_its_own_parent() {
+        let listing = list("/").expect("root listing");
+        assert_eq!(listing.path, "/");
+        assert_eq!(listing.parent, "/");
+    }
+
+    #[test]
+    fn a_nested_path_reports_its_cleaned_parent() {
+        let dir = tree();
+        let root = dir.path().to_str().expect("utf8 path");
+        // The `..` is resolved lexically before anything is read.
+        let listing = list(&format!("{root}/alpha/../bravo")).expect("listing");
+        assert_eq!(listing.path, format!("{root}/bravo"));
+        assert_eq!(listing.parent, root);
+    }
+
+    /// Field order is the Go struct's declaration order.
+    #[test]
+    fn the_response_shape_is_the_go_struct_order() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::fs::create_dir(dir.path().join("only")).expect("subdir");
+        let root = dir.path().to_str().expect("utf8 path");
+        let body = super::super::gojson::to_vec(&list(root).expect("listing")).expect("encode");
+        assert_eq!(
+            String::from_utf8(body).expect("utf8"),
+            format!(
+                "{{\"path\":\"{root}\",\"parent\":\"{}\",\
+                 \"entries\":[{{\"name\":\"only\",\"is_dir\":true,\"path\":\"{root}/only\"}}]}}\n",
+                gopath::dir(root)
+            )
+        );
+    }
+
+    #[test]
+    fn the_path_parameter_is_decoded_the_way_go_decodes_it() {
+        assert_eq!(path_param(""), "");
+        assert_eq!(path_param("path=/home/u"), "/home/u");
+        // Percent-decoded, including the separators a real path carries.
+        assert_eq!(path_param("path=%2Fhome%2Fu%20x"), "/home/u x");
+        // First value for a repeated key.
+        assert_eq!(path_param("path=/a&path=/b"), "/a");
+        assert_eq!(path_param("other=1&path=/a"), "/a");
+    }
+
+    #[test]
+    fn only_the_listing_is_claimed() {
+        assert!(claims(&Method::GET, "/api/fs"));
+        assert!(!claims(&Method::POST, "/api/fs"));
+        assert!(!claims(&Method::POST, "/api/fs/mkdir"));
+        assert!(!claims(&Method::GET, "/api/fs/mkdir"));
+        assert!(!claims(&Method::GET, "/api/fs/"));
+        // Uploads has no read at all — one route, and it writes.
+        assert!(!claims(&Method::POST, "/api/uploads"));
+        assert!(!claims(&Method::GET, "/api/uploads"));
+    }
+}

--- a/desktop/src-tauri/src/native/gopath.rs
+++ b/desktop/src-tauri/src/native/gopath.rs
@@ -1,0 +1,224 @@
+//! Go's `path/filepath`, for the Unix rules.
+//!
+//! `GET /api/fs` is little more than `Clean`, `Dir` and `Join` wrapped in a
+//! response, so porting it means porting those — and they are not Rust's
+//! `std::path`. Three differences matter here:
+//!
+//! - **`Clean` resolves `..` lexically, not against the filesystem.** It keeps a
+//!   leading `..` on a relative path and *drops* one that would escape a rooted
+//!   path, so `Clean("/a/../..") == "/"`. Rust's `Path::components` keeps `..`
+//!   in both cases, deliberately, because it refuses to guess about symlinks.
+//! - **`Dir` is `Clean` of everything before the last separator**, so a bare
+//!   name answers `"."` and `Dir("/") == "/"`.
+//! - **`Join` cleans its result**, so `Join("/a", "../b") == "/b"` — an element
+//!   can escape the one before it.
+//!
+//! Every one of those produces a path the working-directory picker then offers
+//! the user, so a divergence is a real answer about the wrong directory rather
+//! than a cosmetic one. `desktop/parity/gopath_vectors.json` is generated from
+//! Go and read by both languages' tests, so these functions are pinned to what
+//! Go actually does rather than to what this comment believes.
+//!
+//! **Unix only.** Windows `filepath` is a different algorithm — a volume name is
+//! stripped before cleaning and both separators are accepted — and there is no
+//! Windows machine in this loop to verify it on. [`super::fs`] therefore still
+//! claims its route there but answers `Err`, so the request forwards to the
+//! sidecar.
+
+/// Go's `filepath.Clean`, transcribed from `path/filepath/path.go`.
+///
+/// The `lazybuf` in the original is an allocation optimization; the algorithm is
+/// the loop, and it is reproduced branch for branch rather than approximated by
+/// splitting on separators — a split-and-rejoin gets `""` (which is `"."`) and
+/// the rooted-`..` case wrong, and both reach this code from a user-typed path.
+pub fn clean(path: &str) -> String {
+    if path.is_empty() {
+        return ".".to_string();
+    }
+
+    let bytes = path.as_bytes();
+    let rooted = bytes[0] == b'/';
+    let n = bytes.len();
+
+    // Go's `lazybuf`: a fixed buffer plus a write cursor, kept rather than
+    // simplified to a `Vec` with `push`/`truncate`. The `..` branch below reads
+    // `buf[w]` — the byte *at* the cursor, one past the new end — which a
+    // truncating buffer cannot offer, and getting that wrong leaves a doubled
+    // separator on `Clean("/a/b/../c/")`. Found by the Go vectors, not by
+    // reading the source.
+    let mut buf = vec![0u8; n + 1];
+    let mut w = 0usize;
+    let mut r = 0usize;
+    let mut dotdot = 0usize;
+    if rooted {
+        buf[w] = b'/';
+        w += 1;
+        r = 1;
+        dotdot = 1;
+    }
+
+    while r < n {
+        if bytes[r] == b'/' {
+            // Empty path element.
+            r += 1;
+        } else if bytes[r] == b'.' && (r + 1 == n || bytes[r + 1] == b'/') {
+            // "." element.
+            r += 1;
+        } else if bytes[r] == b'.'
+            && r + 1 < n
+            && bytes[r + 1] == b'.'
+            && (r + 2 == n || bytes[r + 2] == b'/')
+        {
+            // ".." element: back up one, if we can.
+            r += 2;
+            if w > dotdot {
+                w -= 1;
+                while w > dotdot && buf[w] != b'/' {
+                    w -= 1;
+                }
+            } else if !rooted {
+                // Cannot back up: keep the "..". A rooted path has nowhere to
+                // go, so its ".." is dropped entirely — that is the asymmetry.
+                if w > 0 {
+                    buf[w] = b'/';
+                    w += 1;
+                }
+                buf[w] = b'.';
+                w += 1;
+                buf[w] = b'.';
+                w += 1;
+                dotdot = w;
+            }
+        } else {
+            // Real path element: add a separator if needed, then copy it.
+            if (rooted && w != 1) || (!rooted && w != 0) {
+                buf[w] = b'/';
+                w += 1;
+            }
+            while r < n && bytes[r] != b'/' {
+                buf[w] = bytes[r];
+                w += 1;
+                r += 1;
+            }
+        }
+    }
+
+    if w == 0 {
+        return ".".to_string();
+    }
+    buf.truncate(w);
+    // Every byte came from `path`, which is a `&str`, and the separators are
+    // ASCII — so the buffer is still valid UTF-8. Multi-byte sequences are
+    // copied whole by the element loop, which only ever stops on `/`.
+    String::from_utf8(buf).unwrap_or_else(|_| path.to_string())
+}
+
+/// Go's `filepath.Dir`: `Clean` of everything up to and including the last
+/// separator. A path with no separator answers `"."`, not `""`.
+pub fn dir(path: &str) -> String {
+    let bytes = path.as_bytes();
+    let mut i = bytes.len() as isize - 1;
+    while i >= 0 && bytes[i as usize] != b'/' {
+        i -= 1;
+    }
+    clean(&path[..(i + 1) as usize])
+}
+
+/// Go's `filepath.Join`: concatenate the non-empty elements with a separator,
+/// then `Clean` the result — which is why an element may escape the one before
+/// it, and why an empty element vanishes instead of leaving a `//`.
+pub fn join(elems: &[&str]) -> String {
+    let mut joined = String::new();
+    for elem in elems {
+        if elem.is_empty() {
+            continue;
+        }
+        if joined.is_empty() {
+            joined.push_str(elem);
+        } else {
+            joined.push('/');
+            joined.push_str(elem);
+        }
+    }
+    if joined.is_empty() {
+        return String::new();
+    }
+    clean(&joined)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Deserialize)]
+    struct Case {
+        value: String,
+        want: String,
+    }
+
+    #[derive(Deserialize)]
+    struct JoinCase {
+        elems: Vec<String>,
+        want: String,
+    }
+
+    #[derive(Deserialize)]
+    struct Vectors {
+        clean: Vec<Case>,
+        dir: Vec<Case>,
+        join: Vec<JoinCase>,
+    }
+
+    fn vectors() -> Vectors {
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../parity/gopath_vectors.json");
+        let raw = std::fs::read_to_string(path)
+            .unwrap_or_else(|e| panic!("reading {path}: {e} — regenerate it from Go"));
+        serde_json::from_str(&raw).expect("parsing gopath vectors")
+    }
+
+    /// The whole point of the file: Rust is asserted against what Go actually
+    /// produced, not against what this port believes Go produces.
+    #[test]
+    fn clean_matches_the_go_vectors() {
+        let v = vectors();
+        assert!(v.clean.len() >= 30, "vectors look truncated");
+        for case in v.clean {
+            assert_eq!(clean(&case.value), case.want, "Clean({:?})", case.value);
+        }
+    }
+
+    #[test]
+    fn dir_matches_the_go_vectors() {
+        for case in vectors().dir {
+            assert_eq!(dir(&case.value), case.want, "Dir({:?})", case.value);
+        }
+    }
+
+    #[test]
+    fn join_matches_the_go_vectors() {
+        for case in vectors().join {
+            let elems: Vec<&str> = case.elems.iter().map(String::as_str).collect();
+            assert_eq!(join(&elems), case.want, "Join({:?})", case.elems);
+        }
+    }
+
+    /// The two cases a split-and-rejoin implementation gets wrong, called out
+    /// so a future rewrite fails on them specifically rather than somewhere in
+    /// the vector loop.
+    #[test]
+    fn the_two_cases_a_naive_implementation_misses() {
+        // Empty is ".", not "".
+        assert_eq!(clean(""), ".");
+        // A rooted ".." has nowhere to go and is dropped; an unrooted one is kept.
+        assert_eq!(clean("/a/../.."), "/");
+        assert_eq!(clean("a/../.."), "..");
+    }
+
+    /// Multi-byte path elements survive the byte-level loop intact.
+    #[test]
+    fn non_ascii_elements_round_trip() {
+        assert_eq!(clean("/home/ü/Projekte/../.claude"), "/home/ü/.claude");
+        assert_eq!(join(&["/home/ü", "文档"]), "/home/ü/文档");
+    }
+}

--- a/desktop/src-tauri/src/native/mod.rs
+++ b/desktop/src-tauri/src/native/mod.rs
@@ -25,6 +25,7 @@ pub mod insights;
 pub mod monitoring;
 pub mod notifications;
 pub mod pricing;
+pub mod query;
 pub mod scanner;
 pub mod sessions;
 pub mod settings;

--- a/desktop/src-tauri/src/native/mod.rs
+++ b/desktop/src-tauri/src/native/mod.rs
@@ -17,7 +17,9 @@ pub mod analytics;
 pub mod chats;
 pub mod db;
 pub mod diff;
+pub mod fs;
 pub mod gojson;
+pub mod gopath;
 pub mod gotime;
 pub mod insights;
 pub mod monitoring;
@@ -126,6 +128,7 @@ const ENDPOINTS: &[Endpoint] = &[
     monitoring::ENDPOINT,
     version::ENDPOINT,
     notifications::ENDPOINT,
+    fs::ENDPOINT,
 ];
 
 /// Whether this request is answered by ported Rust code.
@@ -258,6 +261,13 @@ mod tests {
         assert!(!claims(&Method::PUT, "/api/notifications/settings"));
         assert!(!claims(&Method::POST, "/api/notifications/test"));
         assert!(!claims(&Method::GET, "/api/notifications"));
+
+        // The filesystem listing, on the platforms `gopath` speaks. Creating a
+        // directory is a write, and uploads has no read at all.
+        assert!(claims(&Method::GET, "/api/fs"));
+        assert!(!claims(&Method::POST, "/api/fs/mkdir"));
+        assert!(!claims(&Method::POST, "/api/uploads"));
+        assert!(!claims(&Method::GET, "/api/uploads"));
     }
 
     #[test]
@@ -296,6 +306,7 @@ mod tests {
             "/api/version/update-check",
             "/api/notifications/settings",
             "/api/notifications/log",
+            "/api/fs",
         ];
         for path in paths {
             let owners: Vec<&str> = ENDPOINTS
@@ -332,6 +343,7 @@ mod tests {
             "/api/version/update-check",
             "/api/notifications/settings",
             "/api/notifications/log",
+            "/api/fs",
         ];
         for endpoint in ENDPOINTS {
             assert!(

--- a/desktop/src-tauri/src/native/notifications.rs
+++ b/desktop/src-tauri/src/native/notifications.rs
@@ -217,16 +217,10 @@ pub fn list_log(db_path: &Path, limit: i64) -> Result<Option<Vec<NotificationLog
 pub fn log_limit(query: &str) -> i64 {
     const DEFAULT_LIMIT: i64 = 50;
 
-    // `form_urlencoded`, not a `strip_prefix` scan: it is what `tasks.rs` uses
-    // and what reproduces `r.URL.Query().Get` — percent-decoded, and the *first*
-    // value for a repeated key. `tasks::parse_query_int` itself is not reusable
-    // here because it clamps to `MAX_QUERY_LIMIT`, which this handler does not.
-    let raw = form_urlencoded::parse(query.as_bytes())
-        .find(|(k, _)| k == "limit")
-        .map(|(_, v)| v.into_owned())
-        .unwrap_or_default();
-
-    match raw.parse::<i64>() {
+    // The decoding is shared (`super::query`); only the rule on top is this
+    // handler's. `tasks::parse_query_int` is not reusable here because it also
+    // clamps to `MAX_QUERY_LIMIT`, which this handler does not.
+    match super::query::value(query, "limit").parse::<i64>() {
         Ok(n) if n > 0 => n,
         _ => DEFAULT_LIMIT,
     }

--- a/desktop/src-tauri/src/native/query.rs
+++ b/desktop/src-tauri/src/native/query.rs
@@ -1,0 +1,58 @@
+//! Reading a query parameter the way Go's `r.URL.Query().Get` reads it.
+//!
+//! Two behaviours that a `strip_prefix` scan does not have, and both reach
+//! ported handlers from the frontend:
+//!
+//! - **Percent-decoding.** `?path=%2Fhome%2Fu` is `/home/u` to Go. A path
+//!   parameter carries separators and spaces, so this is routine rather than
+//!   exotic.
+//! - **First value for a repeated key.** `Get` returns `Values[key][0]`.
+//!
+//! It lives here rather than in one of the three modules that need it because
+//! it was written three times before it was written once — each handler layers
+//! its own rule on top (a clamp, a positive-only default, none at all), but the
+//! decoding underneath has to be Go's in all of them, and three copies of it
+//! are three chances for the next port to differ from its neighbours without
+//! anything failing.
+
+/// The first decoded value for `key`, or `""` when the key is absent — which is
+/// also what `Get` answers, so a caller cannot tell "absent" from "empty" and
+/// neither can Go's.
+pub fn value(query: &str, key: &str) -> String {
+    form_urlencoded::parse(query.as_bytes())
+        .find(|(k, _)| k == key)
+        .map(|(_, v)| v.into_owned())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_absent_key_is_the_empty_string() {
+        assert_eq!(value("", "limit"), "");
+        assert_eq!(value("other=1", "limit"), "");
+        // Present but empty is the same answer, exactly as `Get` gives.
+        assert_eq!(value("limit=", "limit"), "");
+    }
+
+    #[test]
+    fn values_are_percent_decoded() {
+        assert_eq!(value("path=%2Fhome%2Fu%20x", "path"), "/home/u x");
+        // …and so is the key, which is why a prefix scan is not equivalent.
+        assert_eq!(value("%70ath=/a", "path"), "/a");
+    }
+
+    #[test]
+    fn a_repeated_key_answers_with_its_first_value() {
+        assert_eq!(value("limit=7&limit=9", "limit"), "7");
+    }
+
+    /// A key that merely ends with the one asked for must not match.
+    #[test]
+    fn a_longer_key_is_not_a_match() {
+        assert_eq!(value("xlimit=7", "limit"), "");
+        assert_eq!(value("limits=7", "limit"), "");
+    }
+}

--- a/desktop/src-tauri/src/native/settings.rs
+++ b/desktop/src-tauri/src/native/settings.rs
@@ -264,37 +264,23 @@ fn normalize(p: &str) -> String {
     clean(&expanded.unwrap_or_else(|| p.to_string()))
 }
 
-/// `filepath.Clean` for the subset of paths a config dir can be: collapse
-/// repeated separators, resolve `.` and `..`, and drop a trailing separator.
+/// `filepath.Clean`, delegated to [`super::gopath::clean`].
+///
+/// This used to be a split-and-rejoin of its own, adequate for the subset of
+/// paths a config dir can be. #268 needed the real thing for `GET /api/fs` and
+/// pinned it to vectors generated from Go, which promptly found a case the
+/// local version also got wrong (`/a/b/../c/`). One implementation, checked
+/// against Go, rather than two that agree by inspection.
+///
+/// The empty guard stays here: `NormalizeClaudeConfigDir` answers `""` for a
+/// blank input so callers can tell "not set" from a real value, while
+/// `filepath.Clean("")` is `"."`. The caller above never reaches this with an
+/// empty string, but the guard is what makes that safe to stop checking.
 fn clean(p: &str) -> String {
     if p.is_empty() {
         return String::new();
     }
-    let rooted = p.starts_with('/');
-    let mut parts: Vec<&str> = Vec::new();
-    for part in p.split('/') {
-        match part {
-            "" | "." => continue,
-            ".." => {
-                if let Some(last) = parts.last() {
-                    if *last != ".." {
-                        parts.pop();
-                        continue;
-                    }
-                }
-                if !rooted {
-                    parts.push("..");
-                }
-            }
-            other => parts.push(other),
-        }
-    }
-    let joined = parts.join("/");
-    match (rooted, joined.is_empty()) {
-        (true, _) => format!("/{joined}"),
-        (false, true) => ".".to_string(),
-        (false, false) => joined,
-    }
+    super::gopath::clean(p)
 }
 
 /// Absolute paths only. A relative config dir means two different things at

--- a/desktop/src-tauri/src/native/tasks.rs
+++ b/desktop/src-tauri/src/native/tasks.rs
@@ -336,12 +336,7 @@ const DEFAULT_LIMIT: i64 = 50;
 /// falls back to the default rather than 400-ing, and anything above
 /// `maxQueryLimit` is clamped down to it.
 fn parse_query_int(query: &str, key: &str, default: i64) -> i64 {
-    // `r.URL.Query().Get` answers with the first value for a repeated key.
-    let raw = form_urlencoded::parse(query.as_bytes())
-        .find(|(k, _)| k == key)
-        .map(|(_, v)| v.into_owned())
-        .unwrap_or_default();
-
+    let raw = super::query::value(query, key);
     if raw.is_empty() {
         return default;
     }

--- a/desktop/src-tauri/tests/parity_fs.rs
+++ b/desktop/src-tauri/tests/parity_fs.rs
@@ -1,0 +1,118 @@
+//! Live parity for the filesystem listing: diff `GET /api/fs` against a
+//! *running* Go server, byte for byte.
+//!
+//! Ignored by default: it needs a real Agento instance, and CI has none.
+//!
+//! ```sh
+//! cd desktop && eval "$(./scripts/parity-instance.sh start)"
+//! (cd src-tauri && cargo test --test parity_fs -- --ignored --nocapture)
+//! ./scripts/parity-instance.sh stop
+//! ```
+//!
+//! **Never point this at the instance on :8990.** That is whatever binary the
+//! developer installed, which drifts behind the repo — a stale baseline makes a
+//! wrong port look verified, and a right one look broken.
+//!
+//! **This endpoint needs no seeding**, unlike every other parity suite here: it
+//! reads the real filesystem, which is already full of the shapes that matter.
+//! What it does need is *variety*, so the cases below deliberately include a
+//! directory with many entries (where an unsorted listing diverges but a small
+//! one might not), the home directory reached three ways, the filesystem root
+//! (its own parent), and paths carrying `.`, `..` and a trailing separator.
+//!
+//! The suite creates one throwaway tree under the system temp dir so the
+//! symlink and file cases are exercised even on a machine whose home directory
+//! happens to contain neither. That is the only thing it writes, and it removes
+//! it again.
+//!
+//! **Otherwise read-only.** It issues GETs and nothing else — no `POST /fs/mkdir`.
+//!
+//! Unix-only, like the port itself: the suite creates a symlink, and the route
+//! answers `Err` on Windows so there would be nothing to diff.
+
+#![cfg(unix)]
+
+mod parity_common;
+
+use parity_common::*;
+
+use agento_lib::native::{fs, gojson};
+
+/// Percent-encode a path for the query string. Only the characters a real path
+/// can carry that would otherwise change the parse.
+fn encode(path: &str) -> String {
+    form_urlencoded::Serializer::new(String::new())
+        .append_pair("path", path)
+        .finish()
+}
+
+#[tokio::test]
+#[ignore = "needs a running Agento instance"]
+async fn the_filesystem_listing_matches_the_live_go_response() {
+    let home = agento_lib::paths::home().expect("a home directory");
+    let home = home.to_string_lossy().into_owned();
+
+    // A tree the machine is not guaranteed to have otherwise: a subdirectory, a
+    // plain file and a symlink pointing at a directory — the last is the case
+    // `DirEntry.IsDir` excludes and `metadata()` would have included.
+    let scratch = tempfile::tempdir().expect("temp dir");
+    let root = scratch.path().to_string_lossy().into_owned();
+    for name in ["zulu", "alpha", "Mike"] {
+        std::fs::create_dir(scratch.path().join(name)).expect("subdir");
+    }
+    std::fs::write(scratch.path().join("notes.txt"), b"x").expect("file");
+    std::os::unix::fs::symlink(
+        scratch.path().join("alpha"),
+        scratch.path().join("link-to-alpha"),
+    )
+    .expect("symlink");
+    let empty = scratch.path().join("alpha").to_string_lossy().into_owned();
+
+    let cases = [
+        // The three spellings that mean the home directory, and the one that
+        // does not.
+        String::new(),
+        "~".to_string(),
+        home.clone(),
+        // Enough entries that an unsorted listing cannot pass by luck.
+        "/usr/lib".to_string(),
+        "/etc".to_string(),
+        // The root is its own parent.
+        "/".to_string(),
+        // Lexical cleaning: `.`, `..` and a trailing separator.
+        format!("{home}/"),
+        format!("{home}/./"),
+        format!("{home}/../{}", file_name(&home)),
+        // The throwaway tree, and one of its directories, which is empty —
+        // `[]` rather than `null`.
+        root.clone(),
+        empty,
+    ];
+
+    for path in &cases {
+        let go = fetch(&format!("/api/fs?{}", encode(path))).await;
+        let native = gojson::to_vec(&fs::list(path).unwrap_or_else(|e| {
+            panic!("native listing of {path:?} failed: {e}");
+        }))
+        .expect("encode");
+        assert_identical(&format!("fs?path={path}"), &go, &native);
+    }
+
+    // The listing of a directory with many entries is where sorting shows; if
+    // every case above happened to be tiny the suite would prove little.
+    let go = fetch(&format!("/api/fs?{}", encode("/usr/lib"))).await;
+    let entries = String::from_utf8(go)
+        .expect("utf8")
+        .matches("\"name\":")
+        .count();
+    assert!(
+        entries >= 10,
+        "/usr/lib listed {entries} directories — too few to exercise the sort. \
+         Pick a busier directory for this machine."
+    );
+}
+
+/// `filepath.Base` for the one use above.
+fn file_name(path: &str) -> String {
+    path.rsplit('/').next().unwrap_or(path).to_string()
+}


### PR DESCRIPTION
Closes #268

## What

`GET /api/fs` — the directory listing behind the working-directory pickers — is answered by Rust.

## Scope note

The issue names "`GET /api/fs/*` … and the upload read path", with sources `internal/api/fs.go` and `internal/api/uploads.go`. Checked against the router:

- the fs tree is `GET /api/fs` and `POST /api/fs/mkdir`; the file is `filesystem.go`, not `fs.go`. Only the first is a read.
- **uploads has no read path at all.** `uploads.go` registers exactly one route, `POST /api/uploads`, and it writes a multipart body to disk.

So this ports the one read that exists. `mkdir` and the upload stay with Go.

## How

**It reads the user's filesystem, so the port carries Go's narrowings rather than inventing its own:**

1. **Directories only, decided with `file_type()` and never `metadata()`.** `DirEntry.IsDir()` reads the type bit `readdir` returned and does not follow symlinks, so a symlink pointing at a directory is *excluded*. `metadata()` follows, and using it would have listed entries Go omits.
2. **`~` expands only when it is the whole path.** `""` and `"~"` are the home directory; `"~/Projects"` stays literal, `Clean` leaves it relative and the read fails — Go's answer, and the one the frontend is written against.
3. **No traversal guard beyond `Clean`.** Go applies none; adding one would refuse paths the sidecar serves.

`os.ReadDir` returns entries **sorted by filename** and `std::fs::read_dir` does not, so they are sorted explicitly — the kind of divergence that passes on a three-entry directory and fails on `/etc`.

## `native/gopath.rs`, and why it has cross-language vectors

The endpoint is `filepath.Clean`/`Dir`/`Join` wrapped in a response, and those are not Rust's `std::path`: `Clean` resolves `..` **lexically**, keeping a leading `..` on a relative path and dropping one that would escape a rooted path (`Clean("/a/../..") == "/"`), while `Path::components` keeps both. Every result is a path the picker then offers the user as somewhere to work, so this is not cosmetic.

`desktop/parity/gopath_vectors.json` is generated from Go (`go test ./desktop/parity/ -run TestGoPathVectors -update-gopath-vectors`) and asserted by **both** languages — the third parity layer the porting guide describes, in its vector form rather than its golden-response form.

**It found a bug immediately.** The first Rust `Clean` produced `/a//c` for `/a/b/../c/`: Go's back-up loop inspects `buf[w]` — the byte *at* the write cursor, one past the new end — which a `Vec` with `truncate` cannot offer. The implementation is now a faithful transcription of `lazybuf`. `native/settings.rs` carried its own split-and-rejoin `Clean` with the same defect and now delegates, so there is one implementation checked against Go rather than two that agree by inspection.

## Windows

`serve()` returns `Err` on Windows and the request forwards: `filepath` there strips a volume name before cleaning and accepts both separators — a different algorithm, with no Windows machine in this loop to verify a port of it against, guarding an endpoint that reads the filesystem. The route is still **claimed**, because a registry entry that claims nothing is exactly the shape `every_registered_endpoint_claims_something` and `no_two_endpoints_claim_the_same_request` exist to catch.

## Verification

- 320 unit tests green (`cargo test`), clippy clean at `-D warnings`, `cargo fmt` clean, `go test ./desktop/parity/` green, `golangci-lint ./desktop/...` 0 issues.
- Unit tests cover the sort, the excluded file and symlinked directory, `[]` for an empty directory, the tilde rules, the root as its own parent, and the query-parameter decoding.
- `tests/parity_fs.rs` — live diff against a Go server built from this checkout over **eleven** cases: `/etc` (8236 B) and `/usr/lib` (6393 B), large enough that an unsorted listing could not pass by luck; `/` (its own parent); an empty directory; all three spellings of the home directory; and paths carrying `.`, `..` and a trailing separator. All identical.

This endpoint is the one parity suite that needs no seeding — the filesystem already contains the shapes that matter — but it does need variety, and the suite asserts `/usr/lib` was busy enough to be worth diffing.