### PR TITLE
feat(desktop): port the session detail and project reads to Rust (#271)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -144,7 +144,10 @@ src-tauri/src/
     agents.rs    GET /api/agents and /api/agents/{slug}
     chats.rs     GET /api/chats and /api/chats/{id}; compact() is Go's, byte for byte
     tasks.rs     GET /api/tasks, /api/job-history and the three reads between them
-    sessions/    GET /api/claude-sessions and /facets; corpus.rs loads the lot
+    sessions/    GET /api/claude-sessions, /facets, /projects and /{id}
+      detail.rs  one session re-read from its transcript, patched from the cache
+      projects.rs the project picker's list, derived from the same walk a scan is
+      corpus.rs  loads the lot
     analytics/   GET /api/claude-analytics
       buckets.rs Go's time.Date/AddDate and the bucket walks, in the request's tz
       params.rs  from/to/project/tz, and the granularity the window picks
@@ -336,6 +339,25 @@ fast path was not.)
 body). Nothing read from SQLite can be either — SQLite stores NaN as NULL — but
 a *computed* average or ratio can be, so guard the division at the source
 rather than expecting the encoder to notice.
+
+### A JSON `null` is a zero value, not a type error
+
+Go's `json.Unmarshal` treats `null` as a no-op for every type in this codebase,
+so `{"parentUuid":null}` leaves `""` and returns **no error**. `serde` rejects
+it, and the consequences are wildly out of proportion to the cause: a rejected
+field fails its struct, a failed struct drops its whole event, and a dropped
+event is simply absent from a transcript with nothing to signal it.
+
+`gojson::null_is_zero_value` is the one answer, and every `#[serde(default)]`
+scalar in `native/insights/transcript.rs` and `native/notifications.rs` goes
+through it. This is not defensive padding — #271 added `uuid`/`parentUuid` to
+the transcript decoder and silently lost the **first user message of every
+conversation**, because `parentUuid` is `null` on exactly the event that starts
+one. The live diff caught it; no unit test would have, since the fixtures were
+all written by hand with the field present.
+
+Genuinely unparseable input still fails, which is also what Go does — so the
+null case and the malformed case need separate tests.
 
 ### The build stamp, and the half of `/version` that is not ported
 

--- a/desktop/src-tauri/src/native/chats.rs
+++ b/desktop/src-tauri/src/native/chats.rs
@@ -30,7 +30,7 @@ use std::path::Path;
 
 use axum::http::Method;
 use rusqlite::OptionalExtension;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
 
 use super::db;
@@ -124,17 +124,6 @@ fn is_zero(value: &i64) -> bool {
 
 fn is_false(value: &bool) -> bool {
     !*value
-}
-
-/// Deserialize the value as-is, including an explicit `null`.
-///
-/// `Option<Box<RawValue>>`'s own impl turns `null` into `None`, which would drop
-/// a key Go emits.
-fn captured_raw<'de, D>(deserializer: D) -> Result<Option<Box<RawValue>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    Box::<RawValue>::deserialize(deserializer).map(Some)
 }
 
 const SESSION_COLUMNS: &str =
@@ -283,74 +272,10 @@ fn decode_blocks(stored: &str) -> Vec<MessageBlock> {
 /// reordered and respelled, with nothing to signal it.
 ///
 /// In practice the column is already compact and escaped, because Go wrote it
-/// with `json.Marshal`; this makes a hand-edited or older row match too.
-fn compact_raw_json(raw: Box<RawValue>) -> Box<RawValue> {
-    let compacted = compact(raw.get());
-    if compacted == raw.get() {
-        return raw;
-    }
-    // Compacting valid JSON leaves valid JSON, so the fallback is unreachable —
-    // and keeping the original is the harmless direction if it ever is not.
-    RawValue::from_string(compacted).unwrap_or(raw)
-}
-
-fn compact(src: &str) -> String {
-    let bytes = src.as_bytes();
-    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
-    let mut in_string = false;
-    let mut escaped = false;
-    let mut i = 0;
-
-    while i < bytes.len() {
-        let byte = bytes[i];
-
-        // U+2028 (E2 80 A8) and U+2029 (E2 80 A9): valid JSON, invalid
-        // JavaScript, so Go escapes both.
-        if byte == 0xE2
-            && i + 2 < bytes.len()
-            && bytes[i + 1] == 0x80
-            && (bytes[i + 2] & !1) == 0xA8
-        {
-            out.extend_from_slice(if bytes[i + 2] == 0xA8 {
-                b"\\u2028"
-            } else {
-                b"\\u2029"
-            });
-            i += 3;
-            continue;
-        }
-
-        match byte {
-            b'<' => out.extend_from_slice(b"\\u003c"),
-            b'>' => out.extend_from_slice(b"\\u003e"),
-            b'&' => out.extend_from_slice(b"\\u0026"),
-            b' ' | b'\t' | b'\n' | b'\r' if !in_string => {}
-            _ => out.push(byte),
-        }
-
-        // Track string context so whitespace *inside* a string survives. The
-        // three escaped bytes above can never change it.
-        if in_string {
-            if escaped {
-                escaped = false;
-            } else if byte == b'\\' {
-                escaped = true;
-            } else if byte == b'"' {
-                in_string = false;
-            }
-        } else if byte == b'"' {
-            in_string = true;
-        }
-
-        i += 1;
-    }
-
-    // Unreachable: every byte dropped or inserted above is ASCII, and the one
-    // multi-byte sequence handled is replaced whole, so a valid `&str` in stays
-    // valid UTF-8 out. Returning the input uncompacted is the harmless
-    // direction if that ever stops being true.
-    String::from_utf8(out).unwrap_or_else(|_| src.to_string())
-}
+/// The chat message blocks are carried verbatim; the compaction and raw-capture
+/// helpers live in [`super::gojson`] because the session-detail port needs the
+/// same pair for `tool_use` inputs.
+use super::gojson::{captured_raw, compact_raw as compact_raw_json};
 
 // ─── The seam ─────────────────────────────────────────────────────────────────
 
@@ -672,47 +597,6 @@ mod tests {
         assert_eq!(
             encoded(&decode_blocks(&separators)).trim_end(),
             r#"[{"type":"text","text":"para1\u2028para2"},{"type":"tool_use","id":"t9","name":"N","input":{"sep":"a\u2028b\u2029c","emoji":"😀 ünïcödé"}}]"#
-        );
-    }
-
-    #[test]
-    fn compact_leaves_already_compact_json_untouched() {
-        let compact_json = r#"{"a":1,"b":[true,null],"s":"x y"}"#;
-        assert_eq!(compact(compact_json), compact_json);
-    }
-
-    /// Whitespace *inside* a string is content, not formatting.
-    #[test]
-    fn compact_keeps_whitespace_inside_strings() {
-        assert_eq!(
-            compact("{ \"k\" : \"a b\\tc\\n d\" }"),
-            "{\"k\":\"a b\\tc\\n d\"}"
-        );
-    }
-
-    /// A quote closes a string unless it is itself escaped — get that wrong and
-    /// every space after the first `\"` is stripped out of the payload.
-    #[test]
-    fn compact_tracks_escaped_quotes() {
-        assert_eq!(compact(r#"{"k":"a \" b"}"#), r#"{"k":"a \" b"}"#);
-        assert_eq!(compact(r#"{ "k" : "a \\" }"#), r#"{"k":"a \\"}"#);
-    }
-
-    #[test]
-    fn compact_escapes_the_characters_go_escapes() {
-        assert_eq!(compact(r#"{"k":"<&>"}"#), r#"{"k":"\u003c\u0026\u003e"}"#);
-        assert_eq!(
-            compact("{\"k\":\"a\u{2028}b\u{2029}c\"}"),
-            r#"{"k":"a\u2028b\u2029c"}"#
-        );
-    }
-
-    /// Multi-byte UTF-8 has to survive a byte-wise pass intact.
-    #[test]
-    fn compact_preserves_multibyte_content() {
-        assert_eq!(
-            compact(r#"{ "k" : "ünïcödé 😀" }"#),
-            r#"{"k":"ünïcödé 😀"}"#
         );
     }
 }

--- a/desktop/src-tauri/src/native/gojson.rs
+++ b/desktop/src-tauri/src/native/gojson.rs
@@ -37,6 +37,7 @@ use std::io;
 
 use serde::Serialize;
 use serde_json::ser::{Formatter, Serializer};
+use serde_json::value::RawValue;
 
 /// Encode exactly as the Go server's `writeJSON` does, newline included.
 pub fn to_vec<T>(value: &T) -> Result<Vec<u8>, serde_json::Error>
@@ -172,6 +173,119 @@ fn go_float(value: f64, fixed: String, exponential: String) -> String {
     }
 }
 
+// ─── `encoding/json`'s compact, for values carried verbatim ──────────────────
+//
+// A `json.RawMessage` is re-encoded by `Marshal` through `compact`, which
+// strips whitespace outside strings and HTML-escapes, and **changes nothing
+// else** — key order and number spelling survive. Any port that carries a
+// stored JSON value through to the wire needs this, so it lives beside the
+// encoder rather than in whichever module happened to need it first (chat
+// message blocks did; session-detail `tool_use` inputs do too).
+
+/// Decode a field the way Go does: a JSON `null` is the **zero value**, not a
+/// type error.
+///
+/// `json.Unmarshal` treats `null` as a no-op for every type Agento decodes, so
+/// `{"parentUuid":null}` leaves `""` and returns no error. `serde` rejects it,
+/// and the consequences are out of proportion to the cause: a rejected field
+/// fails its whole struct, a failed struct drops its whole event, and a dropped
+/// event is simply absent from a transcript with nothing to signal it. That is
+/// how the first user message of every conversation went missing from
+/// `GET /api/claude-sessions/{id}` in #271 — `parentUuid` is `null` on the
+/// event that starts one.
+///
+/// Genuinely unparseable input still fails, which is also what Go does.
+pub fn null_is_zero_value<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de> + Default,
+{
+    use serde::Deserialize;
+    Ok(Option::<T>::deserialize(deserializer)?.unwrap_or_default())
+}
+
+/// Deserialize a value as-is, including an explicit `null`.
+///
+/// `Option<Box<RawValue>>`'s own impl turns `null` into `None`, which would drop
+/// a key Go emits: `omitempty` on a `json.RawMessage` tests the byte length, and
+/// the four bytes of `null` are not empty.
+pub fn captured_raw<'de, D>(deserializer: D) -> Result<Option<Box<RawValue>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+    Box::<RawValue>::deserialize(deserializer).map(Some)
+}
+
+/// with `json.Marshal`; this makes a hand-edited or older row match too.
+pub fn compact_raw(raw: Box<RawValue>) -> Box<RawValue> {
+    let compacted = compact(raw.get());
+    if compacted == raw.get() {
+        return raw;
+    }
+    // Compacting valid JSON leaves valid JSON, so the fallback is unreachable —
+    // and keeping the original is the harmless direction if it ever is not.
+    RawValue::from_string(compacted).unwrap_or(raw)
+}
+
+pub fn compact(src: &str) -> String {
+    let bytes = src.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut i = 0;
+
+    while i < bytes.len() {
+        let byte = bytes[i];
+
+        // U+2028 (E2 80 A8) and U+2029 (E2 80 A9): valid JSON, invalid
+        // JavaScript, so Go escapes both.
+        if byte == 0xE2
+            && i + 2 < bytes.len()
+            && bytes[i + 1] == 0x80
+            && (bytes[i + 2] & !1) == 0xA8
+        {
+            out.extend_from_slice(if bytes[i + 2] == 0xA8 {
+                b"\\u2028"
+            } else {
+                b"\\u2029"
+            });
+            i += 3;
+            continue;
+        }
+
+        match byte {
+            b'<' => out.extend_from_slice(b"\\u003c"),
+            b'>' => out.extend_from_slice(b"\\u003e"),
+            b'&' => out.extend_from_slice(b"\\u0026"),
+            b' ' | b'\t' | b'\n' | b'\r' if !in_string => {}
+            _ => out.push(byte),
+        }
+
+        // Track string context so whitespace *inside* a string survives. The
+        // three escaped bytes above can never change it.
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                in_string = false;
+            }
+        } else if byte == b'"' {
+            in_string = true;
+        }
+
+        i += 1;
+    }
+
+    // Unreachable: every byte dropped or inserted above is ASCII, and the one
+    // multi-byte sequence handled is replaced whole, so a valid `&str` in stays
+    // valid UTF-8 out. Returning the input uncompacted is the harmless
+    // direction if that ever stops being true.
+    String::from_utf8(out).unwrap_or_else(|_| src.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -276,5 +390,45 @@ mod tests {
     fn non_finite_floats_become_null_where_go_would_fail_the_encode() {
         assert_eq!(encoded(&f64::NAN), "null");
         assert_eq!(encoded(&f64::INFINITY), "null");
+    }
+    #[test]
+    fn compact_leaves_already_compact_json_untouched() {
+        let compact_json = r#"{"a":1,"b":[true,null],"s":"x y"}"#;
+        assert_eq!(compact(compact_json), compact_json);
+    }
+
+    /// Whitespace *inside* a string is content, not formatting.
+    #[test]
+    fn compact_keeps_whitespace_inside_strings() {
+        assert_eq!(
+            compact("{ \"k\" : \"a b\\tc\\n d\" }"),
+            "{\"k\":\"a b\\tc\\n d\"}"
+        );
+    }
+
+    /// A quote closes a string unless it is itself escaped — get that wrong and
+    /// every space after the first `\"` is stripped out of the payload.
+    #[test]
+    fn compact_tracks_escaped_quotes() {
+        assert_eq!(compact(r#"{"k":"a \" b"}"#), r#"{"k":"a \" b"}"#);
+        assert_eq!(compact(r#"{ "k" : "a \\" }"#), r#"{"k":"a \\"}"#);
+    }
+
+    #[test]
+    fn compact_escapes_the_characters_go_escapes() {
+        assert_eq!(compact(r#"{"k":"<&>"}"#), r#"{"k":"\u003c\u0026\u003e"}"#);
+        assert_eq!(
+            compact("{\"k\":\"a\u{2028}b\u{2029}c\"}"),
+            r#"{"k":"a\u2028b\u2029c"}"#
+        );
+    }
+
+    /// Multi-byte UTF-8 has to survive a byte-wise pass intact.
+    #[test]
+    fn compact_preserves_multibyte_content() {
+        assert_eq!(
+            compact(r#"{ "k" : "ünïcödé 😀" }"#),
+            r#"{"k":"ünïcödé 😀"}"#
+        );
     }
 }

--- a/desktop/src-tauri/src/native/insights/transcript.rs
+++ b/desktop/src-tauri/src/native/insights/transcript.rs
@@ -39,39 +39,91 @@ use serde::Deserialize;
 /// One decoded line of a session JSONL file.
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct Event {
-    #[serde(default, rename = "type")]
+    #[serde(
+        default,
+        rename = "type",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub event_type: String,
-    #[serde(default)]
+    /// Identity of the event itself, and of the one it answers. Only the
+    /// session-detail view renders them — the counters and the journey work
+    /// from order — but they are decoded here because this is the one decoder
+    /// for the format.
+    #[serde(
+        default,
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
+    pub uuid: String,
+    #[serde(
+        default,
+        rename = "parentUuid",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
+    pub parent_uuid: String,
+    #[serde(
+        default,
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub timestamp: Option<DateTime<Utc>>,
     /// Set on every event of a sub-agent transcript, and on delegated events
     /// inside a parent transcript. **The check is deliberately left to each
     /// caller**: the flag means "delegated work, skip" in a parent transcript
     /// but carries no such meaning in a sub-agent's own.
-    #[serde(default, rename = "isSidechain")]
+    #[serde(
+        default,
+        rename = "isSidechain",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub is_sidechain: bool,
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub message: Option<Message>,
 
     /// Stamped by Claude Code at the *top level* of assistant events — never
     /// inside `message`, and never on user events. It names which skill's
     /// instructions were in context when the turn ran, so on a `Skill` tool
     /// call it names the **caller**, not the skill being invoked.
-    #[serde(default, rename = "attributionSkill")]
+    #[serde(
+        default,
+        rename = "attributionSkill",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub attribution_skill: String,
-    #[serde(default, rename = "attributionPlugin")]
+    #[serde(
+        default,
+        rename = "attributionPlugin",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub attribution_plugin: String,
-    #[serde(default, rename = "attributionAgent")]
+    #[serde(
+        default,
+        rename = "attributionAgent",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub attribution_agent: String,
     /// Decoded but deliberately **not counted**: these hold the last MCP tool
     /// touched and persist onto later, unrelated turns. MCP attribution comes
     /// from the `mcp__<server>__<tool>` block name instead, which is
     /// authoritative.
-    #[serde(default, rename = "attributionMcpServer")]
+    #[serde(
+        default,
+        rename = "attributionMcpServer",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub attribution_mcp_server: String,
-    #[serde(default, rename = "attributionMcpTool")]
+    #[serde(
+        default,
+        rename = "attributionMcpTool",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub attribution_mcp_tool: String,
     /// The reasoning-effort tier the turn ran at.
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub effort: String,
 
     // ── Fields the scanner reads (issue #270) ───────────────────────────────
@@ -80,47 +132,100 @@ pub struct Event {
     // the one decoder for this file format, and a second struct over the same
     // lines is how two readers of one format drift apart.
     /// First non-empty value wins — the session's working directory.
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub cwd: String,
-    #[serde(default, rename = "gitBranch")]
+    #[serde(
+        default,
+        rename = "gitBranch",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub git_branch: String,
 
     /// Title events carry no timestamp and no message — only these fields.
     /// Claude Code re-appends them on every resume, so last-in-file wins.
-    #[serde(default, rename = "customTitle")]
+    #[serde(
+        default,
+        rename = "customTitle",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub custom_title: String,
     /// Claude Code's own auto-title, distinct from a user rename.
-    #[serde(default, rename = "aiTitle")]
+    #[serde(
+        default,
+        rename = "aiTitle",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub ai_title: String,
 
     /// `pr-link`: the pull request a session produced. Unlike the other
     /// metadata events this one carries a **real** timestamp, which is why
     /// `bounds_session_time_range` has to exclude it explicitly.
-    #[serde(default, rename = "prNumber")]
+    #[serde(
+        default,
+        rename = "prNumber",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub pr_number: i64,
-    #[serde(default, rename = "prUrl")]
+    #[serde(
+        default,
+        rename = "prUrl",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub pr_url: String,
-    #[serde(default, rename = "prRepository")]
+    #[serde(
+        default,
+        rename = "prRepository",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub pr_repository: String,
 
     /// Session metadata events. Like the title events these carry no timestamp
     /// and are re-appended on every resume, so the last one in the file wins.
-    #[serde(default, rename = "agentName")]
+    #[serde(
+        default,
+        rename = "agentName",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub agent_name: String,
-    #[serde(default, rename = "permissionMode")]
+    #[serde(
+        default,
+        rename = "permissionMode",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub permission_mode: String,
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub mode: String,
-    #[serde(default, rename = "relocatedCwd")]
+    #[serde(
+        default,
+        rename = "relocatedCwd",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub relocated_cwd: String,
-    #[serde(default, rename = "worktreeSession")]
+    #[serde(
+        default,
+        rename = "worktreeSession",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub worktree_session: Option<WorktreeSession>,
 
     /// `system` events: the subtype selects the payload, and only
     /// `compact_boundary` carries compaction metadata.
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub subtype: String,
-    #[serde(default, rename = "compactMetadata")]
+    #[serde(
+        default,
+        rename = "compactMetadata",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub compact_metadata: Option<CompactMetadata>,
 }
 
@@ -128,15 +233,35 @@ pub struct Event {
 /// ran in, plus where it came from.
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct WorktreeSession {
-    #[serde(default, rename = "worktreeName")]
+    #[serde(
+        default,
+        rename = "worktreeName",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub worktree_name: String,
-    #[serde(default, rename = "worktreeBranch")]
+    #[serde(
+        default,
+        rename = "worktreeBranch",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub worktree_branch: String,
-    #[serde(default, rename = "originalBranch")]
+    #[serde(
+        default,
+        rename = "originalBranch",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub original_branch: String,
-    #[serde(default, rename = "originalCwd")]
+    #[serde(
+        default,
+        rename = "originalCwd",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub original_cwd: String,
-    #[serde(default, rename = "originalHeadCommit")]
+    #[serde(
+        default,
+        rename = "originalHeadCommit",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub original_head_commit: String,
 }
 
@@ -147,47 +272,136 @@ pub struct WorktreeSession {
 /// multiply-count it.
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct CompactMetadata {
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub trigger: String,
-    #[serde(default, rename = "preTokens")]
+    #[serde(
+        default,
+        rename = "preTokens",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub pre_tokens: i64,
-    #[serde(default, rename = "postTokens")]
+    #[serde(
+        default,
+        rename = "postTokens",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub post_tokens: i64,
-    #[serde(default, rename = "cumulativeDroppedTokens")]
+    #[serde(
+        default,
+        rename = "cumulativeDroppedTokens",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub cumulative_dropped_tokens: i64,
-    #[serde(default, rename = "durationMs")]
+    #[serde(
+        default,
+        rename = "durationMs",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub duration_ms: i64,
 }
 
 /// The message payload of a user or assistant event.
-#[derive(Debug, Clone, Default, Deserialize)]
+///
+/// `content` is carried **twice**, and both are load-bearing:
+///
+/// - as a `Value`, because it is a bare JSON string on some events and an array
+///   of blocks on others, and telling those apart is what the turn predicates
+///   do — every one of them wants a decoded tree;
+/// - as the original bytes, because a `tool_use` block's `input` reaches the
+///   wire verbatim in `GET /api/claude-sessions/{id}` (Go carries it as a
+///   `json.RawMessage`). A `Value` round trip sorts its keys and respells its
+///   numbers, so `{"z":1.50,"a":1}` would ship as `{"a":1,"z":1.5}` with
+///   nothing to signal it.
+///
+/// One decode produces both — the `Value` is parsed *from* the raw — so they
+/// cannot describe different content.
+#[derive(Debug, Clone, Default)]
 pub struct Message {
-    #[serde(default)]
     pub role: String,
-    #[serde(default)]
     pub model: String,
-    /// Left raw: it is a bare JSON string on some events and an array of
-    /// content blocks on others, and telling those apart is what the turn
-    /// predicates are about.
-    #[serde(default)]
     pub content: serde_json::Value,
-    #[serde(default)]
+    /// The same content, unparsed. `None` only when the key was absent.
+    pub content_raw: Option<Box<serde_json::value::RawValue>>,
     pub usage: Option<Usage>,
+}
+
+/// The wire shape `Message` is built from.
+#[derive(Deserialize)]
+struct MessageWire {
+    #[serde(
+        default,
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
+    role: String,
+    #[serde(
+        default,
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
+    model: String,
+    #[serde(default, deserialize_with = "crate::native::gojson::captured_raw")]
+    content: Option<Box<serde_json::value::RawValue>>,
+    #[serde(
+        default,
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
+    usage: Option<Usage>,
+}
+
+impl<'de> Deserialize<'de> for Message {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let wire = MessageWire::deserialize(deserializer)?;
+        // An unparseable content is `Null` rather than an error, matching a Go
+        // `json.RawMessage` that is held but never successfully decoded: the
+        // event still exists and its counters still run.
+        let content = wire
+            .content
+            .as_ref()
+            .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw.get()).ok())
+            .unwrap_or(serde_json::Value::Null);
+        Ok(Message {
+            role: wire.role,
+            model: wire.model,
+            content,
+            content_raw: wire.content,
+            usage: wire.usage,
+        })
+    }
 }
 
 /// Token counters attached to an assistant message.
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct Usage {
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub input_tokens: i64,
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub output_tokens: i64,
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub cache_creation_input_tokens: i64,
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub cache_read_input_tokens: i64,
     /// Absent on transcripts written before Claude Code emitted the split.
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub cache_creation: Option<CacheCreation>,
 }
 
@@ -196,9 +410,15 @@ pub struct Usage {
 /// which is the only reason the split is carried at all.
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct CacheCreation {
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub ephemeral_5m_input_tokens: i64,
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub ephemeral_1h_input_tokens: i64,
 }
 
@@ -226,22 +446,66 @@ pub fn split_cache_tiers(total: i64, nested_1h: i64) -> (i64, i64) {
 /// One block within a message's content array.
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct ContentBlock {
-    #[serde(default, rename = "type")]
+    #[serde(
+        default,
+        rename = "type",
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub block_type: String,
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub text: String,
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub thinking: String,
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub id: String,
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub name: String,
-    #[serde(default)]
-    pub input: serde_json::Value,
-    #[serde(default)]
+    /// Carried **raw**, never as a `serde_json::Value`. Go's `NormalizedBlock`
+    /// holds a `json.RawMessage`, so the stored key order and number spelling
+    /// reach the wire unchanged; decoding and re-encoding would sort the keys
+    /// and respell the numbers, with nothing to signal it.
+    #[serde(
+        default,
+        deserialize_with = "crate::native::gojson::captured_raw",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub input: Option<Box<serde_json::value::RawValue>>,
+    #[serde(
+        default,
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub tool_use_id: String,
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
     pub is_error: bool,
+}
+
+/// Decode array content into blocks **from the original bytes**, so a
+/// `tool_use` block's `input` keeps the key order and number spelling it was
+/// written with.
+///
+/// The `Value`-based sibling below cannot: its input has already been through a
+/// `serde_json::Value`, which sorts object keys and respells numbers. Both go
+/// through the same [`ContentBlock`], so this is one decoder with two entry
+/// points rather than two decoders — only the *source* differs, and only the
+/// consumer that puts `input` back on the wire needs this one.
+pub fn parse_content_blocks_raw(raw: &serde_json::value::RawValue) -> Vec<ContentBlock> {
+    // Go decodes the whole array or nothing.
+    serde_json::from_str::<Vec<ContentBlock>>(raw.get()).unwrap_or_default()
 }
 
 /// Decode array content into blocks. String content and anything undecodable

--- a/desktop/src-tauri/src/native/mod.rs
+++ b/desktop/src-tauri/src/native/mod.rs
@@ -183,12 +183,21 @@ mod tests {
         // Writes stay with Go until phase 3 moves the storage layer.
         assert!(!claims(&Method::POST, "/api/pricing/rates"));
         assert!(!claims(&Method::POST, "/api/claude-sessions/refresh"));
-        // Scan lifecycle stays with Go while the scanner does.
+        // Scan lifecycle stays with Go while the scanner does — and `status`
+        // and `refresh` are single segments, so the detail route has to exclude
+        // them by name rather than by shape.
         assert!(!claims(&Method::GET, "/api/claude-sessions/status"));
-        // Not a prefix match: an unported endpoint under the same namespace
-        // must not be swallowed. A session ID is a path segment, not a suffix.
-        assert!(!claims(&Method::GET, "/api/claude-sessions/abc-123"));
+        assert!(!claims(&Method::GET, "/api/claude-sessions/refresh"));
+        // The detail read is claimed, but only as a single segment — a nested
+        // path under the same namespace must not be swallowed.
+        assert!(claims(&Method::GET, "/api/claude-sessions/abc-123"));
+        assert!(claims(&Method::GET, "/api/claude-sessions/projects"));
         assert!(!claims(&Method::GET, "/api/claude-sessions/"));
+        assert!(!claims(&Method::PATCH, "/api/claude-sessions/abc-123"));
+        assert!(!claims(
+            &Method::GET,
+            "/api/claude-sessions/abc-123/journey"
+        ));
         assert!(claims(
             &Method::GET,
             "/api/claude-sessions/insights/summary"

--- a/desktop/src-tauri/src/native/notifications.rs
+++ b/desktop/src-tauri/src/native/notifications.rs
@@ -33,29 +33,12 @@
 use std::path::Path;
 
 use axum::http::Method;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 
 use super::db;
 use super::gotime::GoTime;
 
 // ─── GET /api/notifications/settings ──────────────────────────────────────────
-
-/// Decode a field the way Go does: a stored JSON `null` is the **zero value**,
-/// not a type error.
-///
-/// `json.Unmarshal` treats `null` as a no-op for every type here, so
-/// `{"provider":null}` leaves `SMTPConfig{}` and returns a 200. `serde` rejects
-/// it, and the seam would turn that into a silent fallback — the route stops
-/// being native with nothing to signal it. Genuinely unparsable text still
-/// fails, which is also what Go does. Same rule `scheduled_tasks.schedule_config`
-/// needed in PR #285; the column is hand-editable, so it is reachable.
-fn null_is_zero_value<'de, D, T>(deserializer: D) -> Result<T, D::Error>
-where
-    D: Deserializer<'de>,
-    T: Deserialize<'de> + Default,
-{
-    Ok(Option::<T>::deserialize(deserializer)?.unwrap_or_default())
-}
 
 /// SMTP connection parameters. Mirrors `notification.SMTPConfig`.
 ///
@@ -63,20 +46,20 @@ where
 /// unconfigured install — including `"port": 0`.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SmtpConfig {
-    #[serde(default, deserialize_with = "null_is_zero_value")]
+    #[serde(default, deserialize_with = "super::gojson::null_is_zero_value")]
     pub host: String,
-    #[serde(default, deserialize_with = "null_is_zero_value")]
+    #[serde(default, deserialize_with = "super::gojson::null_is_zero_value")]
     pub port: i64,
-    #[serde(default, deserialize_with = "null_is_zero_value")]
+    #[serde(default, deserialize_with = "super::gojson::null_is_zero_value")]
     pub username: String,
-    #[serde(default, deserialize_with = "null_is_zero_value")]
+    #[serde(default, deserialize_with = "super::gojson::null_is_zero_value")]
     pub password: String,
-    #[serde(default, deserialize_with = "null_is_zero_value")]
+    #[serde(default, deserialize_with = "super::gojson::null_is_zero_value")]
     pub from_address: String,
-    #[serde(default, deserialize_with = "null_is_zero_value")]
+    #[serde(default, deserialize_with = "super::gojson::null_is_zero_value")]
     pub to_addresses: String,
     /// "none", "starttls" or "ssl_tls".
-    #[serde(default, deserialize_with = "null_is_zero_value")]
+    #[serde(default, deserialize_with = "super::gojson::null_is_zero_value")]
     pub encryption: String,
 }
 
@@ -98,7 +81,7 @@ pub struct ScheduledTasksPreferences {
 /// Mirrors `notification.NotificationPreferences`.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NotificationPreferences {
-    #[serde(default, deserialize_with = "null_is_zero_value")]
+    #[serde(default, deserialize_with = "super::gojson::null_is_zero_value")]
     pub scheduled_tasks: ScheduledTasksPreferences,
 }
 
@@ -106,11 +89,11 @@ pub struct NotificationPreferences {
 /// `user_settings.notification_settings`.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NotificationSettings {
-    #[serde(default, deserialize_with = "null_is_zero_value")]
+    #[serde(default, deserialize_with = "super::gojson::null_is_zero_value")]
     pub enabled: bool,
-    #[serde(default, deserialize_with = "null_is_zero_value")]
+    #[serde(default, deserialize_with = "super::gojson::null_is_zero_value")]
     pub provider: SmtpConfig,
-    #[serde(default, deserialize_with = "null_is_zero_value")]
+    #[serde(default, deserialize_with = "super::gojson::null_is_zero_value")]
     pub preferences: NotificationPreferences,
 }
 

--- a/desktop/src-tauri/src/native/scanner/summary_file.rs
+++ b/desktop/src-tauri/src/native/scanner/summary_file.rs
@@ -225,7 +225,7 @@ impl TimeRange {
 }
 
 /// Sets cwd and git branch from the first event that has them.
-fn update_metadata_from_event(summary: &mut SessionSummary, ev: &Event) {
+pub(crate) fn update_metadata_from_event(summary: &mut SessionSummary, ev: &Event) {
     if summary.cwd.is_empty() && !ev.cwd.is_empty() {
         summary.cwd = ev.cwd.clone();
     }
@@ -274,7 +274,7 @@ fn process_summary_event(
 /// Claude Code re-appends every one of them on each resume, so unconditional
 /// assignment during a sequential read gives last-wins for free — which is the
 /// correct rule, since the final value is the current one.
-fn apply_session_metadata(summary: &mut SessionSummary, ev: &Event) {
+pub(crate) fn apply_session_metadata(summary: &mut SessionSummary, ev: &Event) {
     match ev.event_type.as_str() {
         "custom-title" => summary.native_title = ev.custom_title.clone(),
         "ai-title" => summary.ai_title = ev.ai_title.clone(),
@@ -297,7 +297,7 @@ fn apply_session_metadata(summary: &mut SessionSummary, ev: &Event) {
 ///
 /// Claude Code re-emits the event on every resume, so the same PR appears many
 /// times in one file; the earliest sighting keeps its timestamp.
-fn add_summary_pr_link(summary: &mut SessionSummary, ev: &Event) {
+pub(crate) fn add_summary_pr_link(summary: &mut SessionSummary, ev: &Event) {
     if ev.pr_url.is_empty() {
         return;
     }
@@ -319,7 +319,7 @@ fn add_summary_pr_link(summary: &mut SessionSummary, ev: &Event) {
 ///
 /// Only the `compact_boundary` subtype carries compaction metadata; every other
 /// system subtype is ignored here.
-fn add_summary_compaction(summary: &mut SessionSummary, ev: &Event) {
+pub(crate) fn add_summary_compaction(summary: &mut SessionSummary, ev: &Event) {
     if ev.subtype != "compact_boundary" {
         return;
     }
@@ -466,7 +466,7 @@ fn skill_name_from_path(path: &str) -> String {
 
 /// Truncates to `max` characters, appending an ellipsis — Go's
 /// `truncateRunes`, which counts runes rather than bytes.
-fn truncate_chars(s: &str, max: usize) -> String {
+pub(crate) fn truncate_chars(s: &str, max: usize) -> String {
     if s.chars().count() <= max {
         return s.to_string();
     }

--- a/desktop/src-tauri/src/native/sessions/detail.rs
+++ b/desktop/src-tauri/src/native/sessions/detail.rs
@@ -36,7 +36,6 @@
 //!    detail can therefore disagree about the preview of the same session, and
 //!    the detail's is the one the transcript just produced.
 
-use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use rusqlite::{Connection, OptionalExtension};
@@ -441,7 +440,15 @@ fn load_todos(config_dir: &str, session_id: &str) -> Vec<SessionTodo> {
 
 /// The handler's own work: the columns the transcript cannot carry.
 fn patch_from_cache(conn: &Connection, session_id: &str, detail: &mut SessionDetail) {
-    detail.summary.custom_title = scalar(conn, "custom_title", session_id).unwrap_or_default();
+    detail.summary.custom_title = conn
+        .query_row(
+            "SELECT custom_title FROM claude_session_cache WHERE session_id = ?1",
+            [session_id],
+            |r| r.get::<_, String>(0),
+        )
+        .optional()
+        .unwrap_or_default()
+        .unwrap_or_default();
     detail.summary.is_favorite = conn
         .query_row(
             "SELECT is_favorite FROM claude_session_cache WHERE session_id = ?1",
@@ -486,16 +493,6 @@ fn patch_from_cache(conn: &Connection, session_id: &str, detail: &mut SessionDet
         detail.summary.subagent_usage.cache_creation_tokens += sa.usage.cache_creation_tokens;
         detail.summary.subagent_usage.cache_read_tokens += sa.usage.cache_read_tokens;
     }
-}
-
-fn scalar(conn: &Connection, column: &str, session_id: &str) -> Option<String> {
-    conn.query_row(
-        &format!("SELECT {column} FROM claude_session_cache WHERE session_id = ?1"),
-        [session_id],
-        |r| r.get::<_, String>(0),
-    )
-    .optional()
-    .unwrap_or_default()
 }
 
 /// What `GetSummary` is consulted for. The four fields the handler copies, and
@@ -613,14 +610,256 @@ impl TimeRange {
     }
 }
 
-/// Placeholder so `BTreeMap` stays imported for the summary's by-model maps,
-/// which the detail leaves empty.
-#[allow(dead_code)]
-type ByModel = BTreeMap<String, TokenUsage>;
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A transcript with each shape the reader distinguishes, written to a
+    /// throwaway config dir so `find_session_file` and `load_todos` run for
+    /// real rather than being stubbed around.
+    fn corpus(session_id: &str, lines: &[&str], todos: Option<&str>) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let project = dir.path().join("projects").join("-home-u-proj");
+        std::fs::create_dir_all(&project).expect("project dir");
+        std::fs::write(
+            project.join(format!("{session_id}.jsonl")),
+            lines.join("\n"),
+        )
+        .expect("transcript");
+        if let Some(todos) = todos {
+            let todo_dir = dir.path().join("todos");
+            std::fs::create_dir_all(&todo_dir).expect("todos dir");
+            std::fs::write(
+                todo_dir.join(format!("{session_id}-agent-{session_id}.json")),
+                todos,
+            )
+            .expect("todos");
+        }
+        dir
+    }
+
+    const SESSION: &str = "s1";
+
+    /// The two counters, the two asymmetries, and the metadata the reader picks
+    /// up on the way past.
+    #[test]
+    fn the_reader_counts_turns_and_events_the_way_go_counts_them() {
+        let lines = [
+            r#"{"type":"user","uuid":"u1","parentUuid":null,"timestamp":"2026-08-01T10:00:00Z","cwd":"/home/u/proj","gitBranch":"main","message":{"role":"user","content":"do the thing"}}"#,
+            // A `tool_result` carrier: rendered, but not a turn.
+            r#"{"type":"user","uuid":"u2","timestamp":"2026-08-01T10:00:05Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1"}]}}"#,
+            // A sidechain *user* event is skipped entirely…
+            r#"{"type":"user","uuid":"u3","isSidechain":true,"timestamp":"2026-08-01T10:00:06Z","message":{"role":"user","content":"delegated"}}"#,
+            // …while a sidechain *assistant* event is not.
+            r#"{"type":"assistant","uuid":"a1","isSidechain":true,"timestamp":"2026-08-01T10:00:07Z","message":{"role":"assistant","model":"opus","content":[{"type":"text","text":"from a sub-agent"}],"usage":{"input_tokens":3,"output_tokens":4}}}"#,
+            r#"{"type":"assistant","uuid":"a2","timestamp":"2026-08-01T10:00:10Z","message":{"role":"assistant","model":"sonnet","content":[{"type":"text","text":"done"}],"usage":{"input_tokens":10,"output_tokens":20,"cache_creation_input_tokens":30,"cache_read_input_tokens":40}}}"#,
+            r#"{"type":"agent-name","agentName":"reviewer"}"#,
+            r#"{"type":"custom-title","customTitle":"a native title"}"#,
+        ];
+        let dir = corpus(SESSION, &lines, None);
+        let root = dir.path().to_string_lossy().into_owned();
+        let (config_dir, project_path, file) =
+            find_session_file(std::slice::from_ref(&root), SESSION).expect("found");
+        assert_eq!(config_dir, root);
+        // Whatever `DecodeProjectPath` makes of the encoded name — it consults
+        // the filesystem to place the dashes, and this fixture's project does
+        // not exist. The decoder has its own tests; this asserts the plumbing.
+        assert_eq!(
+            project_path,
+            crate::native::scanner::walk::decode_project_path("-home-u-proj")
+        );
+
+        let d = read_detail(&config_dir, SESSION, &project_path, &file).expect("detail");
+
+        // The sidechain user event is gone; everything else is rendered.
+        assert_eq!(
+            d.messages
+                .iter()
+                .map(|m| m.uuid.as_str())
+                .collect::<Vec<_>>(),
+            vec!["u1", "u2", "a1", "a2"],
+            "a sidechain user event is skipped and a sidechain assistant event is not"
+        );
+        // Four events counted, and only the genuine turns counted as messages.
+        assert_eq!(d.summary.event_count, 4);
+        assert_eq!(
+            d.summary.message_count, 3,
+            "u1 + a1 + a2; the carrier is not a turn"
+        );
+
+        // The first assistant model wins, even from a sidechain event.
+        assert_eq!(d.summary.model, "opus");
+        // Usage accumulates across both assistant events.
+        assert_eq!(d.summary.usage.input_tokens, 13);
+        assert_eq!(d.summary.usage.output_tokens, 24);
+        assert_eq!(d.summary.usage.cache_creation_tokens, 30);
+        assert_eq!(d.summary.usage.cache_read_tokens, 40);
+
+        assert_eq!(d.summary.cwd, "/home/u/proj");
+        assert_eq!(d.summary.git_branch, "main");
+        assert_eq!(d.summary.agent_name, "reviewer");
+        assert_eq!(d.summary.native_title, "a native title");
+        assert_eq!(d.summary.preview, "do the thing");
+        assert_eq!(
+            d.summary.start_time.0.to_rfc3339(),
+            "2026-08-01T10:00:00+00:00"
+        );
+        assert_eq!(
+            d.summary.last_activity.0.to_rfc3339(),
+            "2026-08-01T10:00:10+00:00"
+        );
+    }
+
+    /// `parentUuid: null` is on the event that *starts* a conversation, so
+    /// rejecting it drops the first user message — the regression the live diff
+    /// caught. Pinned here so a future decoder change fails in CI.
+    #[test]
+    fn an_event_with_a_null_parent_uuid_is_not_dropped() {
+        let lines = [
+            r#"{"type":"user","uuid":"u1","parentUuid":null,"timestamp":"2026-08-01T10:00:00Z","message":{"role":"user","content":"the first message"}}"#,
+        ];
+        let dir = corpus(SESSION, &lines, None);
+        let root = dir.path().to_string_lossy().into_owned();
+        let (c, p, f) = find_session_file(&[root], SESSION).expect("found");
+        let d = read_detail(&c, SESSION, &p, &f).expect("detail");
+        assert_eq!(
+            d.messages.len(),
+            1,
+            "a null parentUuid must not drop the event"
+        );
+        assert_eq!(d.summary.preview, "the first message");
+        assert_eq!(d.messages[0].parent_uuid, "");
+    }
+
+    /// Todos resolve under the session's **own** config dir, and a malformed
+    /// file is an empty list rather than a failure.
+    #[test]
+    fn todos_come_from_the_sessions_own_config_dir() {
+        let lines = [
+            r#"{"type":"user","uuid":"u1","timestamp":"2026-08-01T10:00:00Z","message":{"role":"user","content":"hi"}}"#,
+        ];
+        let dir = corpus(
+            SESSION,
+            &lines,
+            Some(r#"[{"content":"do it","status":"pending","activeForm":"doing it"}]"#),
+        );
+        let root = dir.path().to_string_lossy().into_owned();
+        assert_eq!(load_todos(&root, SESSION).len(), 1);
+        assert_eq!(load_todos(&root, SESSION)[0].content, "do it");
+
+        // A dir with no todos file, and an id that cannot become a path.
+        let empty = tempfile::tempdir().expect("temp dir");
+        assert!(load_todos(&empty.path().to_string_lossy(), SESSION).is_empty());
+        assert!(load_todos(&root, "../escape").is_empty());
+    }
+
+    /// `os.ReadDir` sorts, so a session id present under two project
+    /// directories resolves to the alphabetically first one — every time, and
+    /// the same one Go picks.
+    #[test]
+    fn a_duplicated_session_id_resolves_to_the_first_project_directory() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        for name in ["zzz-project", "aaa-project"] {
+            let p = dir.path().join("projects").join(name);
+            std::fs::create_dir_all(&p).expect("project dir");
+            std::fs::write(p.join(format!("{SESSION}.jsonl")), "").expect("transcript");
+        }
+        let root = dir.path().to_string_lossy().into_owned();
+        let (_, _, file) = find_session_file(&[root], SESSION).expect("found");
+        assert!(
+            file.to_string_lossy().contains("aaa-project"),
+            "expected the first directory by name, got {}",
+            file.display()
+        );
+    }
+
+    /// Fifteen positional columns onto a struct: two adjacent `TEXT` ones
+    /// swapped would compile and pass every other test in this file.
+    #[test]
+    fn every_subagent_column_lands_on_its_own_field() {
+        let conn = Connection::open_in_memory().expect("db");
+        conn.execute_batch(
+            "CREATE TABLE claude_subagent_cache (
+                parent_session_id TEXT, agent_id TEXT, agent_type TEXT, description TEXT,
+                tool_use_id TEXT, start_time DATETIME, last_activity DATETIME,
+                message_count INTEGER, event_count INTEGER,
+                input_tokens INTEGER, output_tokens INTEGER,
+                cache_creation_tokens INTEGER, cache_read_tokens INTEGER,
+                cache_creation_5m_tokens INTEGER, cache_creation_1h_tokens INTEGER, model TEXT);
+             INSERT INTO claude_subagent_cache VALUES
+               ('s1','agent-2','the-type','the-description','the-tool-use',
+                '2026-08-02 10:00:00 +0000 UTC','2026-08-02 10:05:00 +0000 UTC',
+                2, 9, 11, 22, 33, 44, 55, 66, 'the-model'),
+               ('s1','agent-1','t2','d2','tu2',
+                '2026-08-01 10:00:00 +0000 UTC','2026-08-01 10:05:00 +0000 UTC',
+                1, 3, 1, 2, 3, 4, 5, 6, 'm2'),
+               ('other','agent-3','','','',
+                '2026-08-03 10:00:00 +0000 UTC','2026-08-03 10:05:00 +0000 UTC',
+                1, 1, 7, 7, 7, 7, 7, 7, 'm3');",
+        )
+        .expect("schema");
+
+        let subagents = list_subagents(&conn, "s1");
+        // Ordered by start_time, and another session's rows are not included.
+        assert_eq!(
+            subagents
+                .iter()
+                .map(|s| s.agent_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["agent-1", "agent-2"]
+        );
+
+        let second = &subagents[1];
+        assert_eq!(second.agent_type, "the-type");
+        assert_eq!(second.description, "the-description");
+        assert_eq!(second.tool_use_id, "the-tool-use");
+        assert_eq!(second.message_count, 2);
+        assert_eq!(second.event_count, 9);
+        assert_eq!(second.usage.input_tokens, 11);
+        assert_eq!(second.usage.output_tokens, 22);
+        assert_eq!(second.usage.cache_creation_tokens, 33);
+        assert_eq!(second.usage.cache_read_tokens, 44);
+        assert_eq!(second.usage.cache_creation_5m_tokens, 55);
+        assert_eq!(second.usage.cache_creation_1h_tokens, 66);
+        assert_eq!(second.model, "the-model");
+    }
+
+    /// A missing table is an empty list, not a failure — the Go accessor logs
+    /// and returns `[]ClaudeSubagent{}`.
+    #[test]
+    fn an_unreadable_subagent_table_is_an_empty_list() {
+        let conn = Connection::open_in_memory().expect("db");
+        assert!(list_subagents(&conn, "s1").is_empty());
+    }
+
+    /// The embedded summary flattens into the same object rather than nesting
+    /// under a key — the one thing `#[serde(flatten)]` is here to do.
+    #[test]
+    fn the_summary_is_flattened_into_the_detail() {
+        let detail = SessionDetail {
+            summary: SessionSummary {
+                session_id: "s1".into(),
+                project_path: "/p".into(),
+                ..Default::default()
+            },
+            messages: Vec::new(),
+            todos: Vec::new(),
+            subagents: Vec::new(),
+        };
+        let json = String::from_utf8(crate::native::gojson::to_vec(&detail).expect("encode"))
+            .expect("utf8");
+        assert!(
+            json.starts_with(r#"{"session_id":"s1","project_path":"/p","#),
+            "{json}"
+        );
+        assert!(!json.contains(r#""summary":"#), "the summary must not nest");
+        // Empty collections are `[]`, matching the Go slices the handler always
+        // populates.
+        assert!(
+            json.contains(r#""messages":[],"todos":[],"subagents":[]}"#),
+            "{json}"
+        );
+    }
 
     #[test]
     fn a_session_id_that_could_become_a_path_is_rejected() {

--- a/desktop/src-tauri/src/native/sessions/detail.rs
+++ b/desktop/src-tauri/src/native/sessions/detail.rs
@@ -1,0 +1,717 @@
+//! `GET /api/claude-sessions/{id}` — one session's full message history.
+//!
+//! Mirrors `GetSessionDetail` / `readSessionDetail` (`internal/claudesessions/scanner.go`)
+//! and the patching `handleGetClaudeSession` does on top of it
+//! (`internal/api/claude_sessions.go`).
+//!
+//! **This is scanner work, not a SQLite read.** The detail re-reads the
+//! session's own JSONL every time, which is why it waited for the scanner port:
+//! the transcript carries the messages, the token counts and the session's own
+//! metadata, and reading it means the detail is correct even for a session the
+//! scanner has not reached yet.
+//!
+//! Four things come from the cache instead, and each for its own reason:
+//!
+//! - **`custom_title` and `is_favorite`** are the only two columns the user
+//!   typed. They are not in the transcript at all.
+//! - **The native and AI titles** are read *only as a fallback*, when the
+//!   transcript carried none. Reading them unconditionally would blank them for
+//!   a session Claude Code has just titled and the scanner has not re-read.
+//! - **Cost** is accumulated per assistant message during a scan and stored
+//!   (#188); a re-read has no per-message pricing context to recompute it from.
+//!   A session the scanner has not reached keeps the zero value, which the UI
+//!   shows as $0.00 rather than as a wrong figure.
+//! - **Sub-agents** live in sibling transcripts under `<session-id>/subagents/`,
+//!   so they come from `claude_subagent_cache` rather than from this file.
+//!
+//! Two asymmetries in `readSessionDetail` that look like bugs and are not, and
+//! which this reproduces exactly:
+//!
+//! 1. **A sidechain *user* event is skipped; a sidechain *assistant* event is
+//!    not.** Only `processDetailUserEvent` tests the flag, so delegated
+//!    assistant messages appear in `messages` — with `is_sidechain` never set,
+//!    because nothing assigns it.
+//! 2. **`preview` here is the first user message with any text**, which is a
+//!    weaker rule than the scanner's turn-aware preview. The list and the
+//!    detail can therefore disagree about the preview of the same session, and
+//!    the detail's is the one the transcript just produced.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use rusqlite::{Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use serde_json::value::RawValue;
+
+use super::summary::{SessionCost, SessionSummary, TokenUsage};
+use crate::native::insights::transcript::{self, Event};
+use crate::native::scanner::summary_file;
+use crate::native::{gopath, settings};
+
+/// `previewMaxRunes`.
+const PREVIEW_MAX_CHARS: usize = 120;
+
+/// One rendered conversation event. Mirrors `claudesessions.ClaudeMessage`.
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionMessage {
+    pub uuid: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub parent_uuid: String,
+    /// "user" or "assistant".
+    #[serde(rename = "type")]
+    pub message_type: String,
+    pub timestamp: crate::native::gotime::GoTime,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub role: String,
+    /// Plain text, for user messages.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub content: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub blocks: Vec<NormalizedBlock>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<TokenUsage>,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub git_branch: String,
+    /// Never set by the detail reader — see this module's header. Present
+    /// because the field is on the wire and `omitempty` hides it either way.
+    #[serde(skip_serializing_if = "is_false")]
+    pub is_sidechain: bool,
+    /// Reserved on the Go side too: the `progress` events that once nested here
+    /// no longer exist, so it is always absent.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub children: Vec<SessionMessage>,
+}
+
+/// A content block normalized to Agento's rendering format. Mirrors
+/// `claudesessions.NormalizedBlock`.
+///
+/// A thinking block's text lands in `text`, not in a `thinking` field — that is
+/// Agento's stored `MessageBlock` shape, and the frontend renders both the same
+/// way.
+#[derive(Debug, Clone, Serialize)]
+pub struct NormalizedBlock {
+    #[serde(rename = "type")]
+    pub block_type: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub text: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub id: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub name: String,
+    /// Carried verbatim through `compact`, so a stored `{"z":1.50,"a":1}` ships
+    /// exactly that rather than a re-sorted, re-spelled copy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input: Option<Box<RawValue>>,
+}
+
+/// One todo from the session's todo list. Mirrors `claudesessions.ClaudeTodo`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionTodo {
+    #[serde(default)]
+    pub content: String,
+    /// "completed", "in_progress" or "pending".
+    #[serde(default)]
+    pub status: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub active_form: String,
+}
+
+/// One delegated sub-agent run. Mirrors `claudesessions.ClaudeSubagent`.
+#[derive(Debug, Clone, Serialize)]
+pub struct Subagent {
+    pub agent_id: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub agent_type: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub description: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub tool_use_id: String,
+    pub start_time: crate::native::gotime::GoTime,
+    pub last_activity: crate::native::gotime::GoTime,
+    pub message_count: i64,
+    pub event_count: i64,
+    pub usage: TokenUsage,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub model: String,
+}
+
+/// The response body. Mirrors `claudesessions.ClaudeSessionDetail`, whose
+/// embedded `ClaudeSessionSummary` flattens into the same object — hence
+/// `#[serde(flatten)]` rather than a nested key.
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionDetail {
+    #[serde(flatten)]
+    pub summary: SessionSummary,
+    pub messages: Vec<SessionMessage>,
+    pub todos: Vec<SessionTodo>,
+    pub subagents: Vec<Subagent>,
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+/// Locate a session's transcript across every configured config dir.
+///
+/// Returns the **config dir** alongside the path, not just the path: the
+/// session's todo list lives under that same dir's `todos/`, and resolving it
+/// against the default dir would return another account's todos, or none.
+///
+/// The id is validated here because this is the one place it becomes a
+/// filesystem path — a route parameter containing `..` would otherwise walk out
+/// of the projects directory.
+pub fn find_session_file(dirs: &[String], session_id: &str) -> Option<(String, String, PathBuf)> {
+    if !is_valid_session_id(session_id) {
+        return None;
+    }
+    for dir in dirs {
+        let projects_dir = Path::new(dir).join("projects");
+        let Ok(entries) = std::fs::read_dir(&projects_dir) else {
+            continue;
+        };
+        // `os.ReadDir` returns entries **sorted by filename** and
+        // `std::fs::read_dir` does not. It decides which project directory wins
+        // when one session id exists under two of them — rare, but the answer
+        // has to be the same one every time and the same one Go gives.
+        let mut names: Vec<String> = entries
+            .flatten()
+            // `IsDir()` on the Go side, which reads the type bit and does not
+            // follow symlinks.
+            .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        for name in names {
+            let file = projects_dir.join(&name).join(format!("{session_id}.jsonl"));
+            if file.exists() {
+                return Some((
+                    dir.clone(),
+                    crate::native::scanner::walk::decode_project_path(&name),
+                    file,
+                ));
+            }
+        }
+    }
+    None
+}
+
+/// `validSessionID`: `^[a-zA-Z0-9_-]+$`.
+fn is_valid_session_id(id: &str) -> bool {
+    !id.is_empty()
+        && id
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+}
+
+/// Read one session's detail, or `None` when no config dir holds it.
+pub fn get(db_path: &Path, session_id: &str) -> Result<Option<SessionDetail>, String> {
+    let conn = crate::native::db::open_read_only(db_path)?;
+    let dirs = settings::load(&conn).indexed_config_dirs;
+
+    let Some((config_dir, project_path, file)) = find_session_file(&dirs, session_id) else {
+        return Ok(None);
+    };
+
+    let mut detail = read_detail(&config_dir, session_id, &project_path, &file)?;
+    patch_from_cache(&conn, session_id, &mut detail);
+    Ok(Some(detail))
+}
+
+/// `readSessionDetail`: the transcript, and only the transcript.
+fn read_detail(
+    config_dir: &str,
+    session_id: &str,
+    project_path: &str,
+    file: &Path,
+) -> Result<SessionDetail, String> {
+    let events = transcript::read(file)?;
+
+    let mut summary = SessionSummary {
+        session_id: session_id.to_string(),
+        project_path: project_path.to_string(),
+        ..Default::default()
+    };
+    let mut messages: Vec<SessionMessage> = Vec::new();
+    let mut range = TimeRange::default();
+
+    for ev in &events {
+        if ev.event_type == "file-history-snapshot" {
+            continue;
+        }
+        // The same denylist the summary read uses, so the detail's start/end
+        // cannot disagree with the list's for one session.
+        if summary_file::bounds_session_time_range(&ev.event_type) {
+            range.update(ev.timestamp);
+        }
+        summary_file::update_metadata_from_event(&mut summary, ev);
+        process_event(&mut summary, &mut messages, ev);
+    }
+
+    // Both default to the zero time when the transcript carried no bounding
+    // event at all, which is `0001-01-01T00:00:00Z` on the wire — Go's zero
+    // `time.Time`, not an omitted key.
+    summary.start_time = go_time(range.start);
+    summary.last_activity = go_time(range.last);
+    summary.preview = derive_preview(&messages);
+
+    Ok(SessionDetail {
+        summary,
+        messages,
+        todos: load_todos(config_dir, session_id),
+        subagents: Vec::new(),
+    })
+}
+
+fn process_event(summary: &mut SessionSummary, messages: &mut Vec<SessionMessage>, ev: &Event) {
+    match ev.event_type.as_str() {
+        "user" => process_user_event(summary, messages, ev),
+        "assistant" => process_assistant_event(summary, messages, ev),
+        // The detail reader walks the same file as the summary reader, so it
+        // collects the session's own metadata directly rather than reading it
+        // back from the cache.
+        "pr-link" => summary_file::add_summary_pr_link(summary, ev),
+        "system" => summary_file::add_summary_compaction(summary, ev),
+        _ => summary_file::apply_session_metadata(summary, ev),
+    }
+}
+
+fn process_user_event(
+    summary: &mut SessionSummary,
+    messages: &mut Vec<SessionMessage>,
+    ev: &Event,
+) {
+    // Sidechain user turns belong to delegated sub-agents, read separately.
+    if ev.is_sidechain {
+        return;
+    }
+    let content = ev
+        .message
+        .as_ref()
+        .map(|m| transcript::extract_text_content(&m.content))
+        .unwrap_or_default();
+
+    // Every event stays in the rendered list; only the counters distinguish
+    // genuine turns from `tool_result` carriers.
+    summary.event_count += 1;
+    if let Some(m) = &ev.message {
+        if transcript::is_user_turn_content(&m.content) {
+            summary.message_count += 1;
+        }
+    }
+
+    messages.push(SessionMessage {
+        uuid: ev.uuid.clone(),
+        parent_uuid: ev.parent_uuid.clone(),
+        message_type: "user".to_string(),
+        timestamp: go_time(ev.timestamp),
+        role: "user".to_string(),
+        content,
+        blocks: Vec::new(),
+        usage: None,
+        git_branch: ev.git_branch.clone(),
+        is_sidechain: false,
+        children: Vec::new(),
+    });
+}
+
+fn process_assistant_event(
+    summary: &mut SessionSummary,
+    messages: &mut Vec<SessionMessage>,
+    ev: &Event,
+) {
+    let mut msg = SessionMessage {
+        uuid: ev.uuid.clone(),
+        parent_uuid: ev.parent_uuid.clone(),
+        message_type: "assistant".to_string(),
+        timestamp: go_time(ev.timestamp),
+        role: "assistant".to_string(),
+        content: String::new(),
+        blocks: Vec::new(),
+        usage: None,
+        git_branch: ev.git_branch.clone(),
+        is_sidechain: false,
+        children: Vec::new(),
+    };
+
+    if let Some(m) = &ev.message {
+        if summary.model.is_empty() && !m.model.is_empty() {
+            summary.model = m.model.clone();
+        }
+        if let Some(u) = &m.usage {
+            let (five_min, one_hour) = u.split_cache_tiers();
+            let usage = TokenUsage {
+                input_tokens: u.input_tokens,
+                output_tokens: u.output_tokens,
+                cache_creation_tokens: u.cache_creation_input_tokens,
+                cache_creation_5m_tokens: five_min,
+                cache_creation_1h_tokens: one_hour,
+                cache_read_tokens: u.cache_read_input_tokens,
+            };
+            summary.usage.input_tokens += usage.input_tokens;
+            summary.usage.output_tokens += usage.output_tokens;
+            summary.usage.cache_creation_tokens += usage.cache_creation_tokens;
+            summary.usage.cache_creation_5m_tokens += usage.cache_creation_5m_tokens;
+            summary.usage.cache_creation_1h_tokens += usage.cache_creation_1h_tokens;
+            summary.usage.cache_read_tokens += usage.cache_read_tokens;
+            msg.usage = Some(usage);
+        }
+        msg.blocks = normalized_blocks(m.content_raw.as_deref());
+    }
+
+    summary.event_count += 1;
+    if let Some(m) = &ev.message {
+        if transcript::is_assistant_reply(&m.content) {
+            summary.message_count += 1;
+        }
+    }
+    messages.push(msg);
+}
+
+/// `populateAssistantBlocks` + `normalizeBlock`: only the three renderable
+/// types survive, and anything else is dropped rather than passed through.
+fn normalized_blocks(content: Option<&RawValue>) -> Vec<NormalizedBlock> {
+    let Some(content) = content else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for b in transcript::parse_content_blocks_raw(content) {
+        match b.block_type.as_str() {
+            "thinking" => out.push(NormalizedBlock {
+                block_type: "thinking".to_string(),
+                text: b.thinking,
+                id: String::new(),
+                name: String::new(),
+                input: None,
+            }),
+            "text" => out.push(NormalizedBlock {
+                block_type: "text".to_string(),
+                text: b.text,
+                id: String::new(),
+                name: String::new(),
+                input: None,
+            }),
+            "tool_use" => out.push(NormalizedBlock {
+                block_type: "tool_use".to_string(),
+                text: String::new(),
+                id: b.id,
+                name: b.name,
+                input: b.input.map(crate::native::gojson::compact_raw),
+            }),
+            _ => {}
+        }
+    }
+    out
+}
+
+/// `derivePreview`: the first user message carrying any text.
+///
+/// Deliberately weaker than the scanner's preview, which distinguishes a
+/// genuine turn from an injected wrapper. Both are Go's; they are two rules,
+/// not one rule applied twice.
+fn derive_preview(messages: &[SessionMessage]) -> String {
+    for msg in messages {
+        if msg.role == "user" && !msg.content.is_empty() {
+            return summary_file::truncate_chars(&msg.content, PREVIEW_MAX_CHARS);
+        }
+    }
+    String::new()
+}
+
+/// `loadTodos`: `<config dir>/todos/<id>-agent-<id>.json`, absent or malformed
+/// reading as none.
+fn load_todos(config_dir: &str, session_id: &str) -> Vec<SessionTodo> {
+    if !is_valid_session_id(session_id) {
+        return Vec::new();
+    }
+    let dir = if config_dir.is_empty() {
+        settings::default_claude_config_dir()
+    } else {
+        config_dir.to_string()
+    };
+    let path = gopath::join(&[
+        &dir,
+        "todos",
+        &format!("{session_id}-agent-{session_id}.json"),
+    ]);
+    let Ok(raw) = std::fs::read(&path) else {
+        return Vec::new();
+    };
+    serde_json::from_slice::<Vec<SessionTodo>>(&raw).unwrap_or_default()
+}
+
+/// The handler's own work: the columns the transcript cannot carry.
+fn patch_from_cache(conn: &Connection, session_id: &str, detail: &mut SessionDetail) {
+    detail.summary.custom_title = scalar(conn, "custom_title", session_id).unwrap_or_default();
+    detail.summary.is_favorite = conn
+        .query_row(
+            "SELECT is_favorite FROM claude_session_cache WHERE session_id = ?1",
+            [session_id],
+            |r| r.get::<_, i64>(0),
+        )
+        .optional()
+        .unwrap_or_default()
+        .is_some_and(|v| v != 0);
+
+    // Only as a fallback: reading these unconditionally would blank a title
+    // Claude Code has just written but the scanner has not re-read.
+    if detail.summary.native_title.is_empty() && detail.summary.ai_title.is_empty() {
+        if let Some((native, ai)) = conn
+            .query_row(
+                "SELECT native_title, ai_title FROM claude_session_cache WHERE session_id = ?1",
+                [session_id],
+                |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)),
+            )
+            .optional()
+            .unwrap_or_default()
+        {
+            detail.summary.native_title = native;
+            detail.summary.ai_title = ai;
+        }
+    }
+    detail.summary.display_title = super::summary::resolve_display_title(&detail.summary);
+
+    if let Some(cached) = cached_costs(conn, session_id) {
+        detail.summary.cost = cached.cost;
+        detail.summary.subagent_cost = cached.subagent_cost;
+        detail.summary.unpriced_models = cached.unpriced_models;
+        detail.summary.unpriced_tokens = cached.unpriced_tokens;
+    }
+
+    detail.subagents = list_subagents(conn, session_id);
+    detail.summary.subagent_count = detail.subagents.len() as i64;
+    detail.summary.subagent_usage = TokenUsage::default();
+    for sa in &detail.subagents {
+        detail.summary.subagent_usage.input_tokens += sa.usage.input_tokens;
+        detail.summary.subagent_usage.output_tokens += sa.usage.output_tokens;
+        detail.summary.subagent_usage.cache_creation_tokens += sa.usage.cache_creation_tokens;
+        detail.summary.subagent_usage.cache_read_tokens += sa.usage.cache_read_tokens;
+    }
+}
+
+fn scalar(conn: &Connection, column: &str, session_id: &str) -> Option<String> {
+    conn.query_row(
+        &format!("SELECT {column} FROM claude_session_cache WHERE session_id = ?1"),
+        [session_id],
+        |r| r.get::<_, String>(0),
+    )
+    .optional()
+    .unwrap_or_default()
+}
+
+/// What `GetSummary` is consulted for. The four fields the handler copies, and
+/// no more — the rest of the cached row would overwrite figures the transcript
+/// just produced.
+struct CachedCosts {
+    cost: SessionCost,
+    subagent_cost: SessionCost,
+    unpriced_models: Vec<String>,
+    unpriced_tokens: i64,
+}
+
+fn cached_costs(conn: &Connection, session_id: &str) -> Option<CachedCosts> {
+    let sql = format!(
+        "{}{}\n\tWHERE c.session_id = ?1",
+        super::summary::SUMMARY_COLUMNS,
+        super::summary::SUMMARY_SOURCE
+    );
+    let cached = conn
+        .query_row(&sql, [session_id], super::summary::scan)
+        .optional()
+        .unwrap_or_else(|e| {
+            log::warn!("native session detail: reading cached summary failed: {e}");
+            None
+        })?;
+    Some(CachedCosts {
+        cost: cached.cost,
+        subagent_cost: cached.subagent_cost,
+        unpriced_models: cached.unpriced_models,
+        unpriced_tokens: cached.unpriced_tokens,
+    })
+}
+
+/// `ListSubagents`: every delegated run, oldest first. An unreadable table is
+/// an empty list rather than a failure, matching the Go accessor.
+fn list_subagents(conn: &Connection, session_id: &str) -> Vec<Subagent> {
+    let sql = "SELECT agent_id, agent_type, description, tool_use_id,
+                      start_time, last_activity, message_count, event_count,
+                      input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+                      cache_creation_5m_tokens, cache_creation_1h_tokens, model
+               FROM claude_subagent_cache
+               WHERE parent_session_id = ?1
+               ORDER BY start_time";
+    let mut stmt = match conn.prepare(sql) {
+        Ok(stmt) => stmt,
+        Err(e) => {
+            log::warn!("native session detail: preparing sub-agent query failed: {e}");
+            return Vec::new();
+        }
+    };
+    let rows = stmt.query_map([session_id], |row| {
+        let start: String = row.get(4)?;
+        let last: String = row.get(5)?;
+        Ok(Subagent {
+            agent_id: row.get(0)?,
+            agent_type: row.get(1)?,
+            description: row.get(2)?,
+            tool_use_id: row.get(3)?,
+            start_time: parse_time(&start, 4)?,
+            last_activity: parse_time(&last, 5)?,
+            message_count: row.get(6)?,
+            event_count: row.get(7)?,
+            usage: TokenUsage {
+                input_tokens: row.get(8)?,
+                output_tokens: row.get(9)?,
+                cache_creation_tokens: row.get(10)?,
+                cache_read_tokens: row.get(11)?,
+                cache_creation_5m_tokens: row.get(12)?,
+                cache_creation_1h_tokens: row.get(13)?,
+            },
+            model: row.get(14)?,
+        })
+    });
+    match rows {
+        Ok(rows) => rows.filter_map(Result::ok).collect(),
+        Err(e) => {
+            log::warn!("native session detail: listing sub-agents failed: {e}");
+            Vec::new()
+        }
+    }
+}
+
+fn parse_time(text: &str, index: usize) -> rusqlite::Result<crate::native::gotime::GoTime> {
+    crate::native::gotime::GoTime::parse_any(text).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            index,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::other(e)),
+        )
+    })
+}
+
+/// A transcript timestamp as it travels, or the zero `time.Time` when absent.
+fn go_time(at: Option<chrono::DateTime<chrono::Utc>>) -> crate::native::gotime::GoTime {
+    at.map(|t| crate::native::gotime::GoTime(t.fixed_offset()))
+        .unwrap_or_default()
+}
+
+/// The start/last bounds of a transcript, as `timeRange` keeps them.
+#[derive(Default)]
+struct TimeRange {
+    start: Option<chrono::DateTime<chrono::Utc>>,
+    last: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+impl TimeRange {
+    fn update(&mut self, at: Option<chrono::DateTime<chrono::Utc>>) {
+        let Some(at) = at else { return };
+        if self.start.map_or(true, |s| at < s) {
+            self.start = Some(at);
+        }
+        if self.last.map_or(true, |l| at > l) {
+            self.last = Some(at);
+        }
+    }
+}
+
+/// Placeholder so `BTreeMap` stays imported for the summary's by-model maps,
+/// which the detail leaves empty.
+#[allow(dead_code)]
+type ByModel = BTreeMap<String, TokenUsage>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_session_id_that_could_become_a_path_is_rejected() {
+        assert!(is_valid_session_id("abc-123_DEF"));
+        assert!(!is_valid_session_id(""));
+        assert!(!is_valid_session_id("../../etc/passwd"));
+        assert!(!is_valid_session_id("abc/def"));
+        assert!(!is_valid_session_id("abc.jsonl"));
+    }
+
+    /// A `tool_use` input keeps the key order and number spelling it was
+    /// written with — the whole reason it travels as a `RawValue`.
+    #[test]
+    fn a_tool_use_input_is_carried_verbatim() {
+        let content = RawValue::from_string(
+            r#"[{"type":"tool_use","id":"t1","name":"Bash","input":{"z":1.50,"a":[1,2]}}]"#
+                .to_string(),
+        )
+        .expect("content");
+        let blocks = normalized_blocks(Some(&content));
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(
+            blocks[0].input.as_ref().map(|v| v.get()),
+            Some(r#"{"z":1.50,"a":[1,2]}"#)
+        );
+    }
+
+    /// `<`, `>` and `&` are escaped by `compact`, wherever they appear.
+    #[test]
+    fn a_tool_use_input_is_html_escaped_the_way_marshal_escapes() {
+        let content = RawValue::from_string(
+            r#"[{"type":"tool_use","id":"t","name":"Bash","input":{"cmd":"a < b && c"}}]"#
+                .to_string(),
+        )
+        .expect("content");
+        let blocks = normalized_blocks(Some(&content));
+        // `compact` escapes `<`, `>` and `&` wherever they appear, exactly as
+        // `json.Marshal` does — so the wire form is the escaped one.
+        assert_eq!(
+            blocks[0].input.as_ref().map(|v| v.get()),
+            Some(r#"{"cmd":"a \u003c b \u0026\u0026 c"}"#)
+        );
+    }
+
+    /// Thinking text lands in `text`, and an unrenderable block is dropped
+    /// rather than passed through with an empty type.
+    #[test]
+    fn only_the_three_renderable_block_types_survive() {
+        let content = RawValue::from_string(
+            r#"[{"type":"thinking","thinking":"hmm"},
+                {"type":"text","text":"hi"},
+                {"type":"tool_result","tool_use_id":"t1"}]"#
+                .to_string(),
+        )
+        .expect("content");
+        let blocks = normalized_blocks(Some(&content));
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(blocks[0].block_type, "thinking");
+        assert_eq!(blocks[0].text, "hmm");
+        assert_eq!(blocks[1].block_type, "text");
+    }
+
+    #[test]
+    fn the_preview_is_the_first_user_message_with_text() {
+        let msg = |role: &str, content: &str| SessionMessage {
+            uuid: String::new(),
+            parent_uuid: String::new(),
+            message_type: role.to_string(),
+            timestamp: Default::default(),
+            role: role.to_string(),
+            content: content.to_string(),
+            blocks: Vec::new(),
+            usage: None,
+            git_branch: String::new(),
+            is_sidechain: false,
+            children: Vec::new(),
+        };
+        // An empty user message is skipped, and an assistant one never counts.
+        let messages = vec![
+            msg("user", ""),
+            msg("assistant", "not this"),
+            msg("user", "the preview"),
+        ];
+        assert_eq!(derive_preview(&messages), "the preview");
+        assert_eq!(derive_preview(&[]), "");
+
+        let long = "x".repeat(200);
+        assert_eq!(
+            derive_preview(&[msg("user", &long)]).chars().count(),
+            PREVIEW_MAX_CHARS + 1,
+            "truncation appends one ellipsis"
+        );
+    }
+}

--- a/desktop/src-tauri/src/native/sessions/mod.rs
+++ b/desktop/src-tauri/src/native/sessions/mod.rs
@@ -24,7 +24,9 @@
 //! starts.
 
 pub mod corpus;
+pub mod detail;
 pub mod page;
+pub mod projects;
 pub mod query;
 pub mod summary;
 
@@ -39,11 +41,78 @@ pub const ENDPOINT: Endpoint = Endpoint {
     serve,
 };
 
-fn claims(method: &Method, path: &str) -> bool {
-    method == Method::GET && matches!(path, "/api/claude-sessions" | "/api/claude-sessions/facets")
+/// The four reads this area owns.
+///
+/// `{id}` is matched last and only as a **single** segment, so it cannot
+/// swallow `/facets`, `/projects`, `/insights/summary` (a different registry
+/// entry), `{id}/insights` or `{id}/journey`. `/status` and `/refresh` are
+/// deliberately absent — see [`serve`].
+enum Route<'a> {
+    List,
+    Facets,
+    Projects,
+    Detail(&'a str),
 }
 
+fn route_of(path: &str) -> Option<Route<'_>> {
+    match path {
+        "/api/claude-sessions" => return Some(Route::List),
+        "/api/claude-sessions/facets" => return Some(Route::Facets),
+        "/api/claude-sessions/projects" => return Some(Route::Projects),
+        _ => {}
+    }
+    let rest = path.strip_prefix("/api/claude-sessions/")?;
+    if rest.is_empty() || rest.contains('/') {
+        return None;
+    }
+    // The remaining literal siblings are not session ids. `insights` cannot
+    // appear here — `/insights/summary` has a slash and `{id}/insights` is two
+    // segments — but `status` and `refresh` are single segments that would
+    // otherwise be read as ids.
+    if matches!(rest, "status" | "refresh") {
+        return None;
+    }
+    Some(Route::Detail(rest))
+}
+
+fn claims(method: &Method, path: &str) -> bool {
+    method == Method::GET && route_of(path).is_some()
+}
+
+/// Answer one of the four reads.
+///
+/// **`/status` and `/refresh` are not here, and that is a decision rather than
+/// an omission.** Both are about the *scan*: `/status` reports
+/// `scan_in_progress`, `files_done` and `files_total`, which are in-memory
+/// state of the scanner running inside the Go sidecar, and `/refresh`
+/// invalidates the cache and starts one. Rust deliberately does not own
+/// scanning — `native/db.rs` opens the database **read-only** precisely so two
+/// processes never write one SQLite file — so a native `/status` could only
+/// answer `false`/`0`, which would be actively wrong while a Go scan runs and
+/// would blank the "Scanning ~/.claude… 412 / 1,373" the list shows during a
+/// first run. They move when the scanner is wired in, which is phase 3.
 fn serve(ctx: &Ctx, req: &Request) -> Result<Answer, String> {
+    if let Some(Route::Detail(id)) = route_of(req.path) {
+        return match detail::get(&ctx.db_path, id)? {
+            // Falling back lets Go answer its own 404 rather than this having
+            // to reproduce the body and the status.
+            None => Err(format!("claude session {id:?} not found")),
+            Some(d) => Ok(Answer {
+                body: gojson::to_vec(&d).map_err(|e| format!("encoding session detail: {e}"))?,
+                probe: None,
+            }),
+        };
+    }
+
+    if req.path == "/api/claude-sessions/projects" {
+        let projects = projects::list(&ctx.db_path, projects::include_hidden(req.query))?;
+        return Ok(Answer {
+            body: gojson::to_vec(&projects)
+                .map_err(|e| format!("encoding claude projects: {e}"))?,
+            probe: None,
+        });
+    }
+
     let q = query::SessionQuery::parse(req.query)?;
     let conn = db::open_read_only(&ctx.db_path)?;
     let data_settings = settings::load(&conn);

--- a/desktop/src-tauri/src/native/sessions/projects.rs
+++ b/desktop/src-tauri/src/native/sessions/projects.rs
@@ -108,6 +108,106 @@ pub fn include_hidden(raw_query: &str) -> bool {
 mod tests {
     use super::*;
 
+    /// A config dir with three projects, one of them delegating — so the
+    /// sub-agent exclusion, the fold by encoded name and the sort all have
+    /// something to do — plus a settings row hiding one of them.
+    fn corpus(hidden: &[&str]) -> (tempfile::TempDir, tempfile::NamedTempFile) {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let projects = dir.path().join("projects");
+        for (encoded, sessions) in [("-zzz", 1), ("-aaa", 2), ("-mmm", 1)] {
+            let p = projects.join(encoded);
+            std::fs::create_dir_all(&p).expect("project dir");
+            for i in 0..sessions {
+                std::fs::write(p.join(format!("s{encoded}-{i}.jsonl")), "").expect("transcript");
+            }
+        }
+        // A delegated transcript, which must not be counted as a session.
+        let sub = projects.join("-aaa").join("s-aaa-0").join("subagents");
+        std::fs::create_dir_all(&sub).expect("subagent dir");
+        std::fs::write(sub.join("agent-1.jsonl"), "").expect("subagent transcript");
+
+        let db = tempfile::NamedTempFile::new().expect("temp file");
+        let conn = rusqlite::Connection::open(db.path()).expect("open");
+        conn.execute_batch(
+            "CREATE TABLE user_settings (
+                id INTEGER PRIMARY KEY, default_working_dir TEXT NOT NULL DEFAULT '',
+                default_model TEXT NOT NULL DEFAULT '', onboarding_complete INTEGER NOT NULL DEFAULT 0,
+                appearance_dark_mode INTEGER NOT NULL DEFAULT 0, appearance_font_size INTEGER NOT NULL DEFAULT 0,
+                appearance_font_family TEXT NOT NULL DEFAULT '', notification_settings TEXT NOT NULL DEFAULT '{}',
+                event_bus_worker_pool_size INTEGER NOT NULL DEFAULT 3, public_url TEXT NOT NULL DEFAULT '',
+                hidden_projects TEXT NOT NULL DEFAULT '[]', idle_gap_threshold_minutes INTEGER NOT NULL DEFAULT 0,
+                claude_config_dir TEXT NOT NULL DEFAULT '', claude_config_dirs TEXT NOT NULL DEFAULT '[]');",
+        )
+        .expect("schema");
+        // The config dir under test is an *extra* dir; the default one is
+        // always indexed too, and on a developer's machine it is real — so the
+        // assertions below look for these projects rather than at the length.
+        conn.execute(
+            "INSERT INTO user_settings (id, hidden_projects, claude_config_dirs) VALUES (1, ?1, ?2)",
+            rusqlite::params![
+                serde_json::to_string(hidden).expect("json"),
+                serde_json::to_string(&[dir.path().to_string_lossy()]).expect("json"),
+            ],
+        )
+        .expect("settings row");
+        (dir, db)
+    }
+
+    fn decoded(encoded: &str) -> String {
+        crate::native::scanner::walk::decode_project_path(encoded)
+    }
+
+    fn find<'a>(projects: &'a [ClaudeProject], encoded: &str) -> Option<&'a ClaudeProject> {
+        projects.iter().find(|p| p.encoded_name == encoded)
+    }
+
+    /// Sessions are counted per project, delegated transcripts are not sessions,
+    /// and the result is sorted by decoded path.
+    #[test]
+    fn projects_are_counted_and_sorted_the_way_a_scan_publishes_them() {
+        let (_dir, db) = corpus(&[]);
+        let projects = list(db.path(), false).expect("projects");
+
+        assert_eq!(find(&projects, "-aaa").map(|p| p.session_count), Some(2));
+        assert_eq!(find(&projects, "-mmm").map(|p| p.session_count), Some(1));
+        assert_eq!(
+            find(&projects, "-zzz").map(|p| p.session_count),
+            Some(1),
+            "the sub-agent transcript must not be counted as a session"
+        );
+        assert!(
+            find(&projects, "subagents").is_none(),
+            "a subagents/ directory is not a project"
+        );
+
+        let paths: Vec<&str> = projects.iter().map(|p| p.decoded_path.as_str()).collect();
+        let mut sorted = paths.clone();
+        sorted.sort();
+        assert_eq!(paths, sorted, "sorted by decoded path");
+
+        assert!(projects.iter().all(|p| !p.hidden));
+    }
+
+    /// A hidden project is omitted entirely, and returned flagged only when the
+    /// caller asks — the settings tab's one exception.
+    #[test]
+    fn a_hidden_project_is_omitted_unless_asked_for() {
+        let hidden = decoded("-mmm");
+        let (_dir, db) = corpus(&[&hidden]);
+
+        let visible = list(db.path(), false).expect("projects");
+        assert!(
+            find(&visible, "-mmm").is_none(),
+            "a hidden project must not reach a picker"
+        );
+        assert!(find(&visible, "-aaa").is_some());
+
+        let all = list(db.path(), true).expect("projects");
+        let flagged = find(&all, "-mmm").expect("hidden project when asked for");
+        assert!(flagged.hidden);
+        assert!(!find(&all, "-aaa").expect("visible project").hidden);
+    }
+
     #[test]
     fn only_the_exact_literal_includes_hidden_projects() {
         assert!(include_hidden("include_hidden=true"));

--- a/desktop/src-tauri/src/native/sessions/projects.rs
+++ b/desktop/src-tauri/src/native/sessions/projects.rs
@@ -1,0 +1,163 @@
+//! `GET /api/claude-sessions/projects` — the project picker's list.
+//!
+//! Mirrors `handleListClaudeProjects` (`internal/api/claude_sessions.go`) over
+//! `ListProjects` / `projectsFromDiskFiles` (`internal/claudesessions/projects.go`).
+//!
+//! **Derived from the walk, not from the fallback.** Go serves this from the
+//! list its last scan published (`projectsFromDiskFiles` over the files the scan
+//! walked) and only falls back to a fresh directory walk before the first scan
+//! of the process. The published list is in-memory Go state that Rust cannot
+//! read, so this recomputes it — but from `walk_all_disk_files`, the *same*
+//! walk the scan derives from, rather than from Go's `walkProjects` fallback.
+//! The two disagree by design: the fallback counts distinct session ids and
+//! includes a readable-but-empty project directory with a count of zero, which
+//! the scan-derived list omits entirely.
+//!
+//! **Hidden projects are omitted, not flagged**, unless the caller asks. Every
+//! picker in the UI should offer only what the figures beside it cover; the one
+//! exception is the Data & Analytics settings tab, which cannot let you unhide
+//! a project it is not allowed to show you, so it passes `include_hidden=true`
+//! and reads the per-project `hidden` flag.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::Serialize;
+
+use crate::native::scanner::walk;
+use crate::native::{gopath, query, settings};
+
+/// One project directory. Mirrors `claudesessions.ClaudeProject`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ClaudeProject {
+    pub encoded_name: String,
+    pub decoded_path: String,
+    pub session_count: i64,
+    /// Set from the current settings rather than read from disk, and only ever
+    /// true in a response that asked for hidden projects.
+    pub hidden: bool,
+}
+
+/// `projectsFromDiskFiles` plus the handler's hidden filter.
+pub fn list(db_path: &Path, include_hidden: bool) -> Result<Vec<ClaudeProject>, String> {
+    let conn = crate::native::db::open_read_only(db_path)?;
+    let data_settings = settings::load(&conn);
+
+    let walked = walk::walk_all_disk_files(&data_settings.indexed_config_dirs);
+
+    // Keyed by the *encoded* directory name, so one project worked on under two
+    // config dirs folds into one entry — it is one project whichever account
+    // opened it. A `BTreeMap` because the result is sorted anyway and the key
+    // order makes the count stable.
+    let mut by_encoded: BTreeMap<String, (String, i64)> = BTreeMap::new();
+    for file in walked.files.values() {
+        // Sub-agent transcripts are not sessions: a session that delegated
+        // three times would otherwise be counted four.
+        if file.is_subagent {
+            continue;
+        }
+        let encoded = encoded_name(&file.file_path.to_string_lossy());
+        let entry = by_encoded
+            .entry(encoded)
+            .or_insert_with(|| (file.project_path.clone(), 0));
+        entry.1 += 1;
+    }
+
+    let mut projects: Vec<ClaudeProject> = by_encoded
+        .into_iter()
+        .map(
+            |(encoded_name, (decoded_path, session_count))| ClaudeProject {
+                encoded_name,
+                decoded_path,
+                session_count,
+                hidden: false,
+            },
+        )
+        .collect();
+    // `sortProjects`: by decoded path. Unstable on the Go side, but the key is
+    // unique per project so there are no ties to break.
+    projects.sort_by(|a, b| a.decoded_path.cmp(&b.decoded_path));
+
+    let hidden = &data_settings.hidden_projects;
+    Ok(projects
+        .into_iter()
+        .filter_map(|mut p| {
+            p.hidden = hidden.iter().any(|h| h == &p.decoded_path);
+            if p.hidden && !include_hidden {
+                return None;
+            }
+            Some(p)
+        })
+        .collect())
+}
+
+/// `filepath.Base(filepath.Dir(filePath))` — the project directory's own name,
+/// which is the encoded form Claude Code writes.
+fn encoded_name(file_path: &str) -> String {
+    let dir = gopath::dir(file_path);
+    dir.rsplit('/').next().unwrap_or(&dir).to_string()
+}
+
+/// `include_hidden=true`, and nothing else. Go compares the raw value against
+/// the literal string, so `1`, `yes` and `TRUE` all mean false.
+pub fn include_hidden(raw_query: &str) -> bool {
+    query::value(raw_query, "include_hidden") == "true"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_the_exact_literal_includes_hidden_projects() {
+        assert!(include_hidden("include_hidden=true"));
+        assert!(!include_hidden(""));
+        assert!(!include_hidden("include_hidden=1"));
+        assert!(!include_hidden("include_hidden=TRUE"));
+        assert!(!include_hidden("include_hidden=yes"));
+        assert!(!include_hidden("include_hidden=false"));
+    }
+
+    #[test]
+    fn the_encoded_name_is_the_project_directorys_own_name() {
+        assert_eq!(
+            encoded_name("/home/u/.claude/projects/-home-u-Projects-agento/abc.jsonl"),
+            "-home-u-Projects-agento"
+        );
+        // A sub-agent transcript sits two levels deeper; it is filtered out
+        // before this is called, but the answer is still its own directory.
+        assert_eq!(
+            encoded_name("/home/u/.claude/projects/-p/sess/subagents/agent-1.jsonl"),
+            "subagents"
+        );
+    }
+
+    /// Field order is the Go struct's declaration order, and `hidden` is always
+    /// present — it carries no `omitempty`, so a visible project ships `false`.
+    #[test]
+    fn the_project_shape_is_the_go_struct_order() {
+        let body = crate::native::gojson::to_vec(&vec![ClaudeProject {
+            encoded_name: "-home-u-x".to_string(),
+            decoded_path: "/home/u/x".to_string(),
+            session_count: 3,
+            hidden: false,
+        }])
+        .expect("encode");
+        assert_eq!(
+            String::from_utf8(body).expect("utf8"),
+            concat!(
+                r#"[{"encoded_name":"-home-u-x","decoded_path":"/home/u/x","#,
+                r#""session_count":3,"hidden":false}]"#,
+                "\n"
+            )
+        );
+    }
+
+    /// The handler builds with `make([]ClaudeProject, 0, …)`, so a corpus with
+    /// no visible project is `[]` rather than `null`.
+    #[test]
+    fn an_empty_result_is_an_empty_array() {
+        let body = crate::native::gojson::to_vec(&Vec::<ClaudeProject>::new()).expect("encode");
+        assert_eq!(String::from_utf8(body).expect("utf8"), "[]\n");
+    }
+}

--- a/desktop/src-tauri/src/native/sessions/summary.rs
+++ b/desktop/src-tauri/src/native/sessions/summary.rs
@@ -368,7 +368,7 @@ fn parse_time(text: &str, column: usize) -> rusqlite::Result<GoTime> {
 
 /// The label the UI renders. Agento's own rename wins, then Claude Code's
 /// native title, then its AI-generated one, then the first prompt.
-fn resolve_display_title(s: &SessionSummary) -> String {
+pub fn resolve_display_title(s: &SessionSummary) -> String {
     for candidate in [&s.custom_title, &s.native_title, &s.ai_title, &s.preview] {
         if !candidate.is_empty() {
             return candidate.clone();

--- a/desktop/src-tauri/src/native/settings.rs
+++ b/desktop/src-tauri/src/native/settings.rs
@@ -220,7 +220,7 @@ fn claude_config_dirs(run_override: &str, extra: &[String]) -> Vec<String> {
 
 /// `~/.claude`, or `/root/.claude` when there is no home — the fallback Go's
 /// `DefaultClaudeConfigDir` uses.
-fn default_claude_config_dir() -> String {
+pub fn default_claude_config_dir() -> String {
     paths::home()
         .unwrap_or_else(|| PathBuf::from("/root"))
         .join(".claude")

--- a/desktop/src-tauri/tests/parity_session_detail.rs
+++ b/desktop/src-tauri/tests/parity_session_detail.rs
@@ -1,0 +1,202 @@
+//! Live parity for `GET /api/claude-sessions/{id}` and
+//! `GET /api/claude-sessions/projects`: diff both against a *running* Go
+//! server, byte for byte.
+//!
+//! Ignored by default: it needs a real Agento instance and its database, and CI
+//! has neither.
+//!
+//! ```sh
+//! cd desktop && eval "$(./scripts/parity-instance.sh start)"
+//! (cd src-tauri && cargo test --test parity_session_detail -- --ignored --nocapture)
+//! ./scripts/parity-instance.sh stop
+//! ```
+//!
+//! **Never point this at the instance on :8990.** That is whatever binary the
+//! developer installed, which drifts behind the repo — a stale baseline makes a
+//! wrong port look verified, and a right one look broken.
+//!
+//! **No seeding needed, but coverage is not automatic.** The detail re-reads a
+//! real transcript, and the machine's corpus already contains every shape that
+//! matters — but only if the sessions this diffs are *varied*. The suite
+//! therefore walks the list endpoint and picks sessions by property rather than
+//! taking the first N: one with sub-agents, one with a custom title, one with a
+//! stored cost, one with linked PRs, plus the most recent and the largest. It
+//! asserts it found more than a handful, because a run over three trivial
+//! sessions would pass while proving very little.
+//!
+//! The shapes most likely to diverge, and which the picks above are chosen to
+//! reach:
+//!
+//! - a `tool_use` block's `input`, which must arrive with its stored key order
+//!   and number spelling (it travels as a `json.RawMessage`);
+//! - a session with delegated work, where `subagents`, `subagent_count` and
+//!   `subagent_usage` are patched in from the cache;
+//! - a session the scanner has priced, where `cost` and `subagent_cost` come
+//!   from the cache rather than from the re-read;
+//! - the embedded summary, which Go **flattens** into the same object.
+//!
+//! **Read-only.** These issue GETs and nothing else.
+
+mod parity_common;
+
+use std::collections::BTreeSet;
+
+use parity_common::*;
+
+use agento_lib::native::sessions::{detail, projects};
+use agento_lib::native::{gojson, query};
+
+/// Pull the whole list, following the cursor, so the picks below choose from
+/// the corpus rather than from its first page.
+async fn all_sessions() -> Vec<serde_json::Value> {
+    let mut out = Vec::new();
+    let mut cursor = String::new();
+    loop {
+        let path = if cursor.is_empty() {
+            "/api/claude-sessions?limit=200".to_string()
+        } else {
+            format!("/api/claude-sessions?limit=200&cursor={cursor}")
+        };
+        let body = fetch(&path).await;
+        let page: serde_json::Value = serde_json::from_slice(&body).expect("page json");
+        let items = page
+            .get("items")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        out.extend(items);
+        match page.get("next_cursor").and_then(|v| v.as_str()) {
+            Some(next) if !next.is_empty() && out.len() < 2_000 => {
+                cursor = form_urlencoded::byte_serialize(next.as_bytes()).collect()
+            }
+            _ => break,
+        }
+    }
+    out
+}
+
+fn id_of(session: &serde_json::Value) -> String {
+    session
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn nonzero(session: &serde_json::Value, key: &str) -> bool {
+    session.get(key).and_then(|v| v.as_i64()).unwrap_or(0) > 0
+}
+
+#[tokio::test]
+#[ignore = "needs a running Agento instance and its database"]
+async fn the_session_detail_matches_the_live_go_response() {
+    let db_path = live_db();
+    let sessions = all_sessions().await;
+    assert!(
+        sessions.len() >= 5,
+        "only {} sessions on the parity instance — too few to exercise the \
+         detail's shapes (see this file's header)",
+        sessions.len()
+    );
+
+    // Pick by property, not by position: each of these reaches a branch the
+    // others do not.
+    let mut picks: BTreeSet<String> = BTreeSet::new();
+    let pick_first = |pred: &dyn Fn(&serde_json::Value) -> bool, picks: &mut BTreeSet<String>| {
+        if let Some(s) = sessions.iter().find(|s| pred(s)) {
+            picks.insert(id_of(s));
+        }
+    };
+    pick_first(&|s| nonzero(s, "subagent_count"), &mut picks);
+    pick_first(
+        &|s| s.get("custom_title").and_then(|v| v.as_str()).is_some(),
+        &mut picks,
+    );
+    pick_first(
+        &|s| {
+            s.get("cost")
+                .and_then(|c| c.get("total_usd"))
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.0)
+                > 0.0
+        },
+        &mut picks,
+    );
+    pick_first(&|s| s.get("prs").is_some(), &mut picks);
+    pick_first(&|s| nonzero(s, "compaction_count"), &mut picks);
+    pick_first(&|s| !s.get("is_favorite").is_none(), &mut picks);
+    // The most recent, and the busiest, whatever else they are.
+    if let Some(s) = sessions.first() {
+        picks.insert(id_of(s));
+    }
+    if let Some(s) = sessions.iter().max_by_key(|s| {
+        s.get("event_count")
+            .and_then(|v| v.as_i64())
+            .unwrap_or_default()
+    }) {
+        picks.insert(id_of(s));
+    }
+
+    assert!(
+        picks.len() >= 4,
+        "only {} distinct sessions selected — the corpus does not cover enough \
+         shapes for this diff to mean much",
+        picks.len()
+    );
+
+    for id in &picks {
+        let go = fetch(&format!("/api/claude-sessions/{id}")).await;
+        let native = detail::get(&db_path, id)
+            .unwrap_or_else(|e| panic!("native detail for {id}: {e}"))
+            .unwrap_or_else(|| panic!("native detail for {id} was not found"));
+        assert_identical(
+            &format!("session {id}"),
+            &go,
+            &gojson::to_vec(&native).expect("encode"),
+        );
+    }
+    println!("diffed {} session details", picks.len());
+}
+
+#[tokio::test]
+#[ignore = "needs a running Agento instance and its database"]
+async fn the_projects_read_matches_the_live_go_response() {
+    let db_path = live_db();
+
+    for (case, include) in [("", false), ("include_hidden=true", true)] {
+        let path = if case.is_empty() {
+            "/api/claude-sessions/projects".to_string()
+        } else {
+            format!("/api/claude-sessions/projects?{case}")
+        };
+        let go = fetch(&path).await;
+        assert_eq!(
+            projects::include_hidden(case),
+            include,
+            "the query parser and the case disagree"
+        );
+        let native = gojson::to_vec(&projects::list(&db_path, include).expect("native projects"))
+            .expect("encode");
+        assert_identical(&format!("projects?{case}"), &go, &native);
+    }
+
+    // Two empty lists diff clean. The corpus this runs against has projects,
+    // and if it does not the diff proves nothing.
+    let go = fetch("/api/claude-sessions/projects").await;
+    let count = String::from_utf8(go)
+        .expect("utf8")
+        .matches("\"encoded_name\":")
+        .count();
+    assert!(
+        count >= 3,
+        "only {count} projects on the parity instance — too few for the sort \
+         and the fold-by-encoded-name to be exercised"
+    );
+
+    // The parser is Go's, so an unrecognised spelling must not opt in.
+    assert!(!projects::include_hidden("include_hidden=1"));
+    assert_eq!(
+        query::value("include_hidden=true", "include_hidden"),
+        "true"
+    );
+}


### PR DESCRIPTION
Closes #271

## What

`GET /api/claude-sessions/{id}` and `GET /api/claude-sessions/projects` are answered by Rust.

## Scope: two of the four, and why

The issue names four endpoints. Two are ported here; **`/status` and `/refresh` are not, and that is a decision rather than an omission** — deferred to #289 and cross-linked.

Both are about the *scan*, not about reading cached rows. `/status` reports `scan_in_progress`, `files_done` and `files_total`, which are in-memory state of the scanner running inside the Go sidecar; a native answer of `false`/`0` would be **actively wrong** while a Go scan runs and would blank the "Scanning ~/.claude… 412 / 1,373 transcripts" the list shows on a first run. `/refresh` invalidates the cache and starts a scan — a write. Rust deliberately does not own scanning: `native/db.rs` opens the database read-only precisely so two processes never write one SQLite file, and `desktop/CLAUDE.md` already records that wiring the scanner in (and with it retiring `freshness_probe`, which the issue's trap note calls out) belongs to phase 3.

## How

**`sessions/detail.rs`** re-reads the session's own transcript, so the detail is correct even for a session the scanner has not reached. Four things still come from the cache, each for its own reason: `custom_title` and `is_favorite` are the only columns the user typed; the native/AI titles are read **only as a fallback**, because reading them unconditionally would blank a title Claude Code has just written; `cost` is accumulated per assistant message during a scan (#188) and a re-read has no per-message pricing context; sub-agents live in sibling transcripts.

Two asymmetries in `readSessionDetail` are reproduced deliberately — a sidechain **user** event is skipped while a sidechain **assistant** event is not, and the detail's `preview` uses a weaker rule than the scanner's turn-aware one, so the list and the detail can legitimately disagree.

**`sessions/projects.rs`** derives the list from `walk_all_disk_files` — the *same* walk a scan publishes from — rather than from Go's cold-start `walkProjects` fallback, which counts distinct session ids and includes empty project directories. Go serves the published list, so matching the publisher is the faithful choice.

## Two shared pieces fell out

- `gojson` now hosts `compact`/`compact_raw` (they were private in `chats.rs`; a `tool_use` `input` needs the same verbatim carry) and the new `null_is_zero_value`.
- `transcript::Message` carries its content **twice** — as a `Value` for the turn predicates, and as the original bytes so a `tool_use` `input` reaches the wire with its stored key order and number spelling. One decode produces both, so they cannot describe different content.

## The bug the live diff caught

Adding `uuid`/`parentUuid` to the transcript decoder **silently dropped the first user message of every conversation**: `parentUuid` is `null` on exactly the event that starts one, and `serde` rejects `null` for a `String` where Go's `json.Unmarshal` leaves `""`. A rejected field fails its struct, a failed struct drops its event, and a dropped event is simply absent.

The diff caught it at byte 112 of a 700 KB response — the session's `preview` was the wrong user message. **No unit test would have**, because every hand-written fixture had the field present. Every `#[serde(default)]` scalar in the transcript decoder now goes through `null_is_zero_value`; genuinely unparseable input still fails, as it does in Go. Written up in `desktop/CLAUDE.md`.

Also fixed: `find_session_file` now sorts the project directories, because `os.ReadDir` sorts and `std::fs::read_dir` does not, and that order decides which directory wins a session id present in two.

## Verification

- 333 unit tests green, clippy clean at `-D warnings`, `cargo fmt` clean, `go test ./desktop/parity/` green.
- `tests/parity_session_detail.rs` — live diff against a Go server built from this checkout. Sessions are picked **by property** rather than by position (sub-agents, a stored cost, linked PRs, a custom title, the most recent, the busiest) and the suite asserts it found enough distinct ones to be worth running: 4 details, 702 KB / 670 KB / **2.9 MB** / 497 KB, all identical. Both `/projects` cases identical at 8145 B.
- **The whole parity corpus re-run**, because the shared transcript decoder changed: `parity_scanner` (926 + 920 recomputed rows), `parity_sessions`, `parity_insights`, `parity_analytics` — all green.