### PR TITLE
feat(desktop): port the chat turn and its SSE stream to Rust (#276)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -700,7 +700,10 @@ the three steering routes answer natively **only when Rust holds a live session
 for that chat** and forward otherwise. Go then answers — correctly, because it
 is the side that has the session.
 
-Five rules that are silent when broken, all pinned by `tests/chat_turn.rs`:
+Five rules that are silent when broken, all pinned by `tests/chat_turn.rs` —
+**except** the deny-with-the-user's-text half of `AskUserQuestion`, which is
+reached only through a `can_use_tool` control request the fake CLI does not yet
+issue. That gap is #298; do not read the list below as fully covered.
 
 - **`result` is not terminal.** With an `AskUserQuestion` pending the same
   subprocess carries on, so one HTTP request spans several turns and several
@@ -723,6 +726,15 @@ into `{"a":1,"z":1.5}` — sorted and respelled, with nothing to signal it.
 `tests/chat_turn.rs` caught it, which is also why that test's fake CLI emits
 literal bytes rather than `json.dumps`: Python normalises `1.50` to `1.5` and
 adds spaces, so a byte-exactness test cannot go through it.
+
+**A disconnect has to be raced explicitly, not inferred.** The permission
+handler is awaited *inline on the SDK's reader task*, so while it is parked no
+events arrive and the stream loop has nothing to send — a closed tab is
+invisible to every code path that would otherwise notice. All three unbounded
+waits (the loop, the post-result continuation, the permission round trip) race
+`Sender::closed` on the body channel, which is what Go gets from
+`r.Context().Done()`. Without it, closing a tab on an open prompt held the busy
+lock and leaked a `claude` subprocess for the life of the process.
 
 **`AGENTO_CLAUDE_EXECUTABLE`** overrides which binary is spawned, falling back to
 `find_claude_cli()` and then the bare name. The fallback matters — a GUI process

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -135,6 +135,12 @@ src-tauri/src/
     db.rs        the SQLite handles: read-only for reads, read-write for writes
     migrate.rs   the 27 migrations, embedded from parity/ — verified, not applied
     writes.rs    what a write may answer, and what it hands back to Go
+    chat/        the SSE turn and the three routes that steer it (#276)
+      live.rs    the process-local live-session registry — why the four move together
+      runner.rs  an agent's config as SDK options; refuses what it cannot supply
+      turn.rs    spawn, stream, and the AskUserQuestion continuation
+      persist.rs what a finished turn writes, and what an interrupted one does not
+      sse.rs     the frame bytes: raw pass-through vs the two synthetic events
     settings.rs  GET /api/settings; also the preferences + config dirs a read is scoped to
     monitoring.rs GET /api/monitoring — monitoring.json and the OTEL_* locks, no exporters
     version.rs   GET /api/version and /version/update-check (dev builds only)
@@ -410,7 +416,7 @@ of the `Err` arms the cut-over has to turn into a real response.
 | 2 ← | Pricing + analytics | `internal/pricing`, `internal/claudesessions` | Pure computation over JSONL + SQLite. No external deps. **In progress**: `/api/pricing/catalog`, `/api/claude-sessions`, `/api/claude-sessions/facets`, `/api/claude-analytics`, `/api/claude-sessions/insights/summary` and the agent reads are native and diff clean. |
 | 3 ← | Storage + tasks | `internal/storage`, `internal/scheduler` | **In progress (#274).** `db.rs` is read-write, the 27 migrations are ported, and the writes whose every effect Rust owns are native — see below. Scheduler is #275. |
 | 4 | Integrations | `internal/integrations`, `internal/trigger` | OAuth2 + MCP servers. Six of them: google, github, slack, jira, confluence, telegram. WhatsApp is **not** among them — see below. |
-| 5 | Agent execution | `internal/agent`, `internal/service` | Spawns the `claude` CLI over stream-json stdin/stdout. **The SDK underneath it is ported** (`src/claude/`, below); what remains is the runner, the chat service and the SSE handler on top of it. |
+| 5 ← | Agent execution | `internal/agent`, `internal/service` | **In progress (#276).** The chat SSE turn is native: `/messages`, `/input`, `/permission` and `/stop`, on top of the ported SDK. The scheduler's executor (#275) is the other caller and still Go's. |
 
 ### The session scanner (`src-tauri/src/native/scanner/`)
 
@@ -674,6 +680,54 @@ asserted against the slice by `internal/storage/migrations_vector_test.go`, and
 embedded by `native/migrate.rs` with `include_str!`. Adding migration 28 without
 regenerating fails Go's own suite — and the file is what records the schema once
 the Go server is deleted.
+
+### Phase 5: the chat turn (#276)
+
+**The seam grew a second registry.** `Answer` is a buffered `Vec<u8>` and
+`Endpoint::serve` is a sync `fn` on `spawn_blocking` — right for thirteen areas
+that hand back a finished document, wrong for a turn that lasts as long as the
+model talks. `StreamEndpoint` is async and returns a `Response<Body>` built from
+`Body::from_stream`. `native::claims` is the union of both, because the proxy
+asks one question; `route_is_native` excludes the streaming ones so the buffered
+path cannot try to answer a chat turn with a `Vec<u8>`.
+
+**The four routes share a process-local registry, so they moved together** —
+`/messages` puts a session in, the others look one up. But not every chat *can*
+run natively: an agent whose tools come from an integration or the local MCP
+server needs #277/#282, and `runner::build_options` refuses those before any
+subprocess exists. That would strand `/stop` for a chat still running on Go, so
+the three steering routes answer natively **only when Rust holds a live session
+for that chat** and forward otherwise. Go then answers — correctly, because it
+is the side that has the session.
+
+Five rules that are silent when broken, all pinned by `tests/chat_turn.rs`:
+
+- **`result` is not terminal.** With an `AskUserQuestion` pending the same
+  subprocess carries on, so one HTTP request spans several turns and several
+  `result` frames. The turn ends on stream close, on an error result, or on a
+  final result with nothing pending.
+- **A mid-stream failure is a `result` with `is_error: true`**, never an `error`
+  event — the 200 was committed before the first frame.
+- **An event with no raw line emits nothing.** The SDK synthesizes process
+  failures that way, so a crashed subprocess tells the client nothing and the
+  stream just ends. Reproduced, not "fixed".
+- **`AskUserQuestion` is answered by *denying* the tool** with the user's text as
+  the message. That is how the answer reaches the model without the tool running.
+- **A turn with no final text persists no messages** — not even the user's — but
+  the session row is still written: `updated_at`, the token totals, and on a
+  first message a title derived from a message that was never stored.
+
+**The `tool_use` input must never round-trip through a `serde_json::Value`.**
+The first version of `append_assistant_blocks` did, and turned `{"z":1.50,"a":1}`
+into `{"a":1,"z":1.5}` — sorted and respelled, with nothing to signal it.
+`tests/chat_turn.rs` caught it, which is also why that test's fake CLI emits
+literal bytes rather than `json.dumps`: Python normalises `1.50` to `1.5` and
+adds spaces, so a byte-exactness test cannot go through it.
+
+**`AGENTO_CLAUDE_EXECUTABLE`** overrides which binary is spawned, falling back to
+`find_claude_cli()` and then the bare name. The fallback matters — a GUI process
+inherits a minimal `PATH`, which is why that helper already existed for the
+startup banner — and the override is how the turn tests point at a fake CLI.
 
 ### Do not port
 

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -730,11 +730,32 @@ adds spaces, so a byte-exactness test cannot go through it.
 **A disconnect has to be raced explicitly, not inferred.** The permission
 handler is awaited *inline on the SDK's reader task*, so while it is parked no
 events arrive and the stream loop has nothing to send — a closed tab is
-invisible to every code path that would otherwise notice. All three unbounded
-waits (the loop, the post-result continuation, the permission round trip) race
-`Sender::closed` on the body channel, which is what Go gets from
-`r.Context().Done()`. Without it, closing a tab on an open prompt held the busy
-lock and leaked a `claude` subprocess for the life of the process.
+invisible to every code path that would otherwise notice. All four unbounded
+waits (the loop, the post-result continuation, and both permission arms) race
+the body channel's closure, which is what Go gets from `r.Context().Done()`.
+Without it, closing a tab on an open prompt held the busy lock and leaked a
+`claude` subprocess for the life of the process.
+
+The obvious way to write that is a **bug**, and the fix for it is the reason
+`Answers.disconnect` is an `mpsc::WeakSender`. A plain `Sender` clone works for
+detecting the disconnect, but this struct is reachable from the permission
+handler, which the SDK's reader task owns until *stdout* hits EOF — so a strong
+clone keeps the body's sender set non-empty past the end of the turn and the SSE
+response stays open. That is ~5s when the CLI ignores `SIGTERM` and **unbounded**
+when it leaves a grandchild holding stdout, which any backgrounding `Bash` call
+produces. `useChatStream.ts` clears its streaming state only in `onDone`, so the
+symptom is a chat stuck mid-stream with the composer blocked long after the
+commit ran — and Go's handler returns as soon as `consumeAgentEvents` does, so
+it is a parity break too. **Nothing that outlives the turn may hold a strong body
+sender.**
+
+Each of these is pinned by a test that fails when the fix is reverted —
+`a_disconnect_while_a_prompt_is_pending_releases_the_chat` (reads frames until
+the prompt arrives *before* disconnecting, or it would only exercise the
+pre-existing failed-send path), its `..._silent_cli_...` sibling for the loop
+arm, and `the_body_ends_with_the_turn_even_when_a_grandchild_holds_stdout_open`
+for the sender strength. Assert the revert fails; a disconnect test that passes
+either way is the easy mistake here.
 
 **`AGENTO_CLAUDE_EXECUTABLE`** overrides which binary is spawned, falling back to
 `find_claude_cli()` and then the bare name. The fallback matters — a GUI process

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -16,6 +16,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "form_urlencoded",
+ "http-body-util",
  "libc",
  "log",
  "mime_guess",
@@ -33,6 +34,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "uuid",
 ]
 
@@ -4598,6 +4600,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -37,6 +37,9 @@ log = "0.4"
 # Local reverse proxy in front of the Go sidecar. No TLS backend: every hop is
 # loopback, and pulling in rustls here would cost build time for nothing.
 axum = "0.8"
+# The SSE body is a channel of frames; `ReceiverStream` is what turns that into
+# the `Stream` `Body::from_stream` wants. Added with #276.
+tokio-stream = "0.1"
 # `process` and `io-util` are for the Claude Agent SDK port (`src/claude/`),
 # which spawns the `claude` CLI and reads its stdout line by line. The sidecar
 # goes through tauri-plugin-shell instead, but that only launches binaries
@@ -96,3 +99,5 @@ strip = true
 
 [dev-dependencies]
 tempfile = "3.27.0"
+# Collecting a streamed SSE body in the turn tests.
+http-body-util = "0.1"

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -92,7 +92,7 @@ fn install_kind() -> &'static str {
 /// agents by spawning the Claude Code CLI as a subprocess, and that CLI is a
 /// separate ~280 MB install we do not redistribute. Detecting it up front turns
 /// "every chat fails with exec: not found" into one honest message.
-fn find_claude_cli() -> Option<String> {
+pub(crate) fn find_claude_cli() -> Option<String> {
     let name = if cfg!(windows) {
         "claude.exe"
     } else {

--- a/desktop/src-tauri/src/native/chat/live.rs
+++ b/desktop/src-tauri/src/native/chat/live.rs
@@ -1,0 +1,177 @@
+//! The live-session registry: what `/input`, `/permission` and `/stop` reach
+//! into while `/messages` is streaming.
+//!
+//! Mirrors `liveSessionStore` (`internal/api/livesessions.go`).
+//!
+//! # Why the four routes cannot be split
+//!
+//! This registry is **process-local**, and it is the only thing connecting the
+//! four chat routes. `/messages` puts a session in; the other three look one up
+//! and 409 when they cannot find it. Port `/messages` alone and `/stop` — still
+//! answered by the Go sidecar — looks in a registry that will always be empty,
+//! so the user's stop button silently does nothing. The four move together or
+//! not at all.
+//!
+//! # Two maps, not one
+//!
+//! `sessions` holds the handles the other routes need. `in_flight` is the
+//! *busy* set behind [`LiveSessions::try_lock`], which exists because a second
+//! POST arriving mid-stream would read a stale `sdk_session_id` from the
+//! database and start a new Claude CLI session instead of resuming the right
+//! one.
+//!
+//! They are separate because they have different lifetimes — and Go's
+//! `delete` clears **both**, which means the busy lock is released when the
+//! stream ends, *before* the commit runs, contradicting its own doc comment.
+//! That is reproduced here deliberately (`release` is what the stream's guard
+//! calls, and the commit happens after) so the two implementations agree about
+//! when a second send becomes possible.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Mutex, OnceLock};
+
+use tokio::sync::mpsc;
+
+use crate::claude::client::StreamControl;
+
+/// What the non-streaming routes need to reach a running turn.
+///
+/// Deliberately **not** the `Session` itself: reading events needs `&mut`, and
+/// that belongs to the one task streaming the response. `StreamControl` is the
+/// clonable half, which is all `/stop` requires.
+///
+/// `question_tx` and `permission_req_tx` are absent for the same reason they are
+/// absent in Go: they only ever flow handler → stream, and are owned by the
+/// streaming request rather than shared.
+pub struct LiveSession {
+    pub control: StreamControl,
+    /// The answer to an `AskUserQuestion`. Capacity 1, matching Go — which is
+    /// why "is it awaiting input?" is approximated by "is the buffer free?".
+    pub input_tx: mpsc::Sender<String>,
+    /// The allow/deny for a tool prompt. Capacity 1, same approximation.
+    pub permission_resp_tx: mpsc::Sender<bool>,
+}
+
+#[derive(Default)]
+struct Inner {
+    sessions: HashMap<String, LiveSession>,
+    in_flight: HashSet<String>,
+}
+
+/// The process-wide registry.
+pub struct LiveSessions {
+    inner: Mutex<Inner>,
+}
+
+impl LiveSessions {
+    fn new() -> Self {
+        Self {
+            inner: Mutex::new(Inner::default()),
+        }
+    }
+
+    /// Claim the right to stream a turn for `id`, or `None` when one is already
+    /// running — which the caller turns into Go's 409.
+    ///
+    /// Returns a plain bool rather than an unlock guard: the release point is
+    /// not the end of a scope but the end of the stream, and tying it to a
+    /// guard's `Drop` would move it *after* the commit, which is the one thing
+    /// this must not do (see the module header).
+    pub fn try_lock(&self, id: &str) -> bool {
+        let mut inner = self.lock();
+        if inner.in_flight.contains(id) {
+            return false;
+        }
+        inner.in_flight.insert(id.to_string());
+        true
+    }
+
+    pub fn put(&self, id: &str, session: LiveSession) {
+        self.lock().sessions.insert(id.to_string(), session);
+    }
+
+    /// Clone the two senders and the control handle for a live turn.
+    ///
+    /// Cloning rather than handing out a borrow keeps the registry lock held
+    /// only for the lookup, so a slow send cannot block `/stop`.
+    pub fn get(
+        &self,
+        id: &str,
+    ) -> Option<(StreamControl, mpsc::Sender<String>, mpsc::Sender<bool>)> {
+        let inner = self.lock();
+        inner.sessions.get(id).map(|s| {
+            (
+                s.control.clone(),
+                s.input_tx.clone(),
+                s.permission_resp_tx.clone(),
+            )
+        })
+    }
+
+    /// End the turn: forget the handles **and** release the busy lock, exactly
+    /// as Go's `delete` does.
+    pub fn release(&self, id: &str) {
+        let mut inner = self.lock();
+        inner.sessions.remove(id);
+        inner.in_flight.remove(id);
+    }
+
+    /// A poisoned mutex is not a reason to fail a chat: the data behind it is
+    /// two collections of handles, and a panic while holding the lock leaves
+    /// them structurally intact. Recovering keeps a single bad turn from
+    /// wedging every later one.
+    fn lock(&self) -> std::sync::MutexGuard<'_, Inner> {
+        self.inner.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+/// The one registry. A chat turn is process state, so this is a process global —
+/// the same reason Go hangs it off the single `api.Server`.
+pub fn registry() -> &'static LiveSessions {
+    static REGISTRY: OnceLock<LiveSessions> = OnceLock::new();
+    REGISTRY.get_or_init(LiveSessions::new)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A fresh registry per test — the real one is a process global, and tests
+    /// sharing it would depend on each other's ordering.
+    fn fresh() -> LiveSessions {
+        LiveSessions::new()
+    }
+
+    #[test]
+    fn a_second_send_is_refused_while_one_is_in_flight() {
+        let live = fresh();
+        assert!(live.try_lock("chat-1"));
+        assert!(!live.try_lock("chat-1"), "a second send must be refused");
+        // A different chat is unaffected.
+        assert!(live.try_lock("chat-2"));
+
+        live.release("chat-1");
+        assert!(live.try_lock("chat-1"), "releasing frees the lock");
+    }
+
+    /// The lock is taken before the session is registered, so every one of the
+    /// other three routes 409s during that window. Go has the same gap and the
+    /// UI relies on it: the stop button is only live once streaming starts.
+    #[test]
+    fn a_locked_but_unregistered_chat_has_no_session() {
+        let live = fresh();
+        assert!(live.try_lock("chat-1"));
+        assert!(live.get("chat-1").is_none());
+    }
+
+    #[test]
+    fn release_clears_both_the_session_and_the_lock() {
+        let live = fresh();
+        assert!(live.try_lock("chat-1"));
+        // `put` needs a real StreamControl, which needs a subprocess; the
+        // registry half is exercised through the integration test instead.
+        live.release("chat-1");
+        assert!(live.get("chat-1").is_none());
+        assert!(live.try_lock("chat-1"));
+    }
+}

--- a/desktop/src-tauri/src/native/chat/mod.rs
+++ b/desktop/src-tauri/src/native/chat/mod.rs
@@ -78,12 +78,34 @@ fn serve(req: StreamRequest) -> BoxFuture<'static, Result<Response<Body>, String
                 };
                 turn::run(req.db_path.clone(), id.to_string(), content).await
             }
-            Some(Route::Input(id)) => Ok(provide_input(id, &req.body)),
-            Some(Route::Permission(id)) => Ok(permission_response(id, &req.body)),
-            Some(Route::Stop(id)) => stop(id).await,
+            // `Forward` becomes the seam's `Err`, which is what makes Go answer.
+            // The reason travels with it so the log says which chat and why.
+            Some(Route::Input(id)) => steer(provide_input(id, &req.body), id),
+            Some(Route::Permission(id)) => steer(permission_response(id, &req.body), id),
+            Some(Route::Stop(id)) => steer(stop(id).await, id),
             None => Err(format!("{} is not a chat action", req.path)),
         }
     })
+}
+
+/// What one of the three steering routes decided.
+///
+/// A distinct type rather than a sentinel status: "forward" and "answered with
+/// a status" are different kinds of outcome, and encoding the first as a
+/// reserved status code would mean a real upstream response could impersonate
+/// it. There is no number here to collide with.
+enum Steer {
+    Answered(Response<Body>),
+    Forward,
+}
+
+fn steer(outcome: Steer, id: &str) -> Result<Response<Body>, String> {
+    match outcome {
+        Steer::Answered(response) => Ok(response),
+        Steer::Forward => Err(format!(
+            "chat {id:?} has no live session here; the sidecar may have one"
+        )),
+    }
 }
 
 #[derive(Default, Deserialize)]
@@ -130,75 +152,58 @@ fn decode_content(body: &[u8]) -> Result<String, Box<Response<Body>>> {
 
 /// `handleProvideInput`. The answer reaches whichever half of the turn is
 /// waiting — the permission handler or the post-result continuation.
-fn provide_input(id: &str, body: &[u8]) -> Response<Body> {
+fn provide_input(id: &str, body: &[u8]) -> Steer {
     let req: ProvideInputRequest = match crate::native::writes::decode_body(body) {
         Ok(req) => req,
-        Err(_) => return error_json(StatusCode::BAD_REQUEST, "invalid JSON body"),
+        Err(_) => return Steer::Answered(error_json(StatusCode::BAD_REQUEST, "invalid JSON body")),
     };
     if req.answer.is_empty() {
-        return error_json(StatusCode::BAD_REQUEST, "answer is required");
+        return Steer::Answered(error_json(StatusCode::BAD_REQUEST, "answer is required"));
     }
     let Some((_, input_tx, _)) = live::registry().get(id) else {
         // Not ours: Go may still have this session, and its 409 is the right
-        // answer if neither does. Signalled by the sentinel below.
-        return forward_sentinel();
+        // answer if neither does.
+        return Steer::Forward;
     };
     // Capacity 1, so a successful send is the approximation of "awaiting
     // input" — the same one Go makes.
     match input_tx.try_send(req.answer) {
-        Ok(()) => no_content(),
-        Err(_) => error_json(
+        Ok(()) => Steer::Answered(no_content()),
+        Err(_) => Steer::Answered(error_json(
             StatusCode::CONFLICT,
             "session is not currently awaiting input",
-        ),
+        )),
     }
 }
 
 /// `handlePermissionResponse`.
-fn permission_response(id: &str, body: &[u8]) -> Response<Body> {
+fn permission_response(id: &str, body: &[u8]) -> Steer {
     let req: PermissionRequestBody = match crate::native::writes::decode_body(body) {
         Ok(req) => req,
-        Err(_) => return error_json(StatusCode::BAD_REQUEST, "invalid JSON body"),
+        Err(_) => return Steer::Answered(error_json(StatusCode::BAD_REQUEST, "invalid JSON body")),
     };
     let Some((_, _, perm_tx)) = live::registry().get(id) else {
-        return forward_sentinel();
+        return Steer::Forward;
     };
     match perm_tx.try_send(req.allow) {
-        Ok(()) => no_content(),
-        Err(_) => error_json(
+        Ok(()) => Steer::Answered(no_content()),
+        Err(_) => Steer::Answered(error_json(
             StatusCode::CONFLICT,
             "session is not currently awaiting a permission response",
-        ),
+        )),
     }
 }
 
 /// `handleStopSession`. Returns **204 even when the interrupt fails** — Go only
 /// logs it — and never closes the session; the stream's own teardown owns that.
-async fn stop(id: &str) -> Result<Response<Body>, String> {
+async fn stop(id: &str) -> Steer {
     let Some((control, _, _)) = live::registry().get(id) else {
-        return Err(format!("chat {id:?} has no live session here"));
+        return Steer::Forward;
     };
     if let Err(e) = control.interrupt().await {
         log::warn!("interrupt session failed for chat {id}: {e}");
     }
-    Ok(no_content())
-}
-
-/// A response that means "let Go answer this".
-///
-/// The three steering routes cannot simply return `Err` from a non-async
-/// context, so they build this and the caller converts it. Kept as a distinct
-/// status no handler produces, so it cannot be confused with a real answer.
-fn forward_sentinel() -> Response<Body> {
-    Response::builder()
-        .status(StatusCode::from_u16(599).unwrap_or(StatusCode::BAD_GATEWAY))
-        .body(Body::empty())
-        .unwrap_or_else(|_| Response::new(Body::empty()))
-}
-
-/// Whether a response is the forward sentinel rather than an answer.
-pub fn is_forward(response: &Response<Body>) -> bool {
-    response.status().as_u16() == 599
+    Steer::Answered(no_content())
 }
 
 fn no_content() -> Response<Body> {
@@ -249,11 +254,14 @@ mod tests {
     /// working.
     #[test]
     fn a_chat_with_no_live_session_here_forwards_rather_than_409ing() {
-        let response = provide_input("no-such-chat", br#"{"answer":"yes"}"#);
-        assert!(is_forward(&response));
-
-        let response = permission_response("no-such-chat", br#"{"allow":true}"#);
-        assert!(is_forward(&response));
+        assert!(matches!(
+            provide_input("no-such-chat", br#"{"answer":"yes"}"#),
+            Steer::Forward
+        ));
+        assert!(matches!(
+            permission_response("no-such-chat", br#"{"allow":true}"#),
+            Steer::Forward
+        ));
     }
 
     /// Body validation happens *before* the registry lookup, so a malformed
@@ -261,11 +269,14 @@ mod tests {
     /// identically.
     #[test]
     fn the_body_is_validated_before_the_session_is_looked_up() {
-        let response = provide_input("any", b"{}");
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-
-        let response = provide_input("any", b"not json");
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        for body in [&b"{}"[..], b"not json"] {
+            match provide_input("any", body) {
+                Steer::Answered(response) => {
+                    assert_eq!(response.status(), StatusCode::BAD_REQUEST)
+                }
+                Steer::Forward => panic!("a malformed body must be rejected, not forwarded"),
+            }
+        }
     }
 
     /// `allow` defaults to false rather than failing, matching Go's decoder:
@@ -273,8 +284,10 @@ mod tests {
     /// is a deny.
     #[test]
     fn an_absent_allow_is_a_deny_not_an_error() {
-        let response = permission_response("no-such-chat", b"{}");
-        // Reaches the registry lookup, so the body parsed.
-        assert!(is_forward(&response));
+        // Reaching the registry lookup at all proves the body parsed.
+        assert!(matches!(
+            permission_response("no-such-chat", b"{}"),
+            Steer::Forward
+        ));
     }
 }

--- a/desktop/src-tauri/src/native/chat/mod.rs
+++ b/desktop/src-tauri/src/native/chat/mod.rs
@@ -1,0 +1,280 @@
+//! Chat execution: the SSE turn, and the three routes that steer it.
+//!
+//! Mirrors `handleSendMessage`, `handleProvideInput`, `handlePermissionResponse`
+//! and `handleStopSession` (`internal/api/chats.go`).
+//!
+//! # Why all four are here, and how the split stays safe
+//!
+//! They share the process-local [`live`] registry: `/messages` puts a session
+//! in, the other three look one up. Splitting them across two implementations
+//! would leave `/stop` searching a registry that never saw the session — the
+//! button would silently do nothing.
+//!
+//! But not every chat *can* run here: an agent whose tools come from an
+//! integration or the local MCP server needs machinery this port does not have
+//! (#277, #282), and those chats keep running on the sidecar. So the three
+//! steering routes are answered natively **only when Rust holds a live session
+//! for that chat**, and forward otherwise. Go then answers — correctly, because
+//! it is the side that has the session — and a chat with no live session
+//! anywhere gets Go's own 409 rather than a second copy of it.
+//!
+//! That is what lets the four move together without requiring *every* chat to
+//! move at once.
+
+pub mod live;
+pub mod persist;
+pub mod runner;
+pub mod sse;
+pub mod turn;
+
+use axum::body::Body;
+use axum::http::{header, Method, Response, StatusCode};
+use serde::{Deserialize, Serialize};
+
+use crate::native::{BoxFuture, StreamEndpoint, StreamRequest};
+
+/// This module's entry in `native::STREAM_ENDPOINTS`.
+pub const ENDPOINT: StreamEndpoint = StreamEndpoint {
+    name: "chat",
+    claims,
+    serve,
+};
+
+fn claims(method: &Method, path: &str) -> bool {
+    *method == Method::POST && route_of(path).is_some()
+}
+
+enum Route<'a> {
+    Messages(&'a str),
+    Input(&'a str),
+    Permission(&'a str),
+    Stop(&'a str),
+}
+
+/// `/api/chats/{id}/<action>` and nothing else. The id is one segment, so a
+/// nested path cannot be swallowed.
+fn route_of(path: &str) -> Option<Route<'_>> {
+    let rest = path.strip_prefix("/api/chats/")?;
+    let (id, action) = rest.split_once('/')?;
+    if id.is_empty() || id.contains('/') {
+        return None;
+    }
+    match action {
+        "messages" => Some(Route::Messages(id)),
+        "input" => Some(Route::Input(id)),
+        "permission" => Some(Route::Permission(id)),
+        "stop" => Some(Route::Stop(id)),
+        _ => None,
+    }
+}
+
+fn serve(req: StreamRequest) -> BoxFuture<'static, Result<Response<Body>, String>> {
+    Box::pin(async move {
+        match route_of(&req.path) {
+            Some(Route::Messages(id)) => {
+                let content = match decode_content(&req.body) {
+                    Ok(content) => content,
+                    Err(response) => return Ok(*response),
+                };
+                turn::run(req.db_path.clone(), id.to_string(), content).await
+            }
+            Some(Route::Input(id)) => Ok(provide_input(id, &req.body)),
+            Some(Route::Permission(id)) => Ok(permission_response(id, &req.body)),
+            Some(Route::Stop(id)) => stop(id).await,
+            None => Err(format!("{} is not a chat action", req.path)),
+        }
+    })
+}
+
+#[derive(Default, Deserialize)]
+#[serde(default)]
+struct SendMessageRequest {
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    content: String,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(default)]
+struct ProvideInputRequest {
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    answer: String,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(default)]
+struct PermissionRequestBody {
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    allow: bool,
+}
+
+/// Boxed error: a `Response<Body>` is a large variant to return by value, and
+/// this is the error path.
+fn decode_content(body: &[u8]) -> Result<String, Box<Response<Body>>> {
+    let req: SendMessageRequest = match crate::native::writes::decode_body(body) {
+        Ok(req) => req,
+        Err(_) => {
+            return Err(Box::new(error_json(
+                StatusCode::BAD_REQUEST,
+                "invalid JSON body",
+            )))
+        }
+    };
+    if req.content.is_empty() {
+        return Err(Box::new(error_json(
+            StatusCode::BAD_REQUEST,
+            "content is required",
+        )));
+    }
+    Ok(req.content)
+}
+
+/// `handleProvideInput`. The answer reaches whichever half of the turn is
+/// waiting — the permission handler or the post-result continuation.
+fn provide_input(id: &str, body: &[u8]) -> Response<Body> {
+    let req: ProvideInputRequest = match crate::native::writes::decode_body(body) {
+        Ok(req) => req,
+        Err(_) => return error_json(StatusCode::BAD_REQUEST, "invalid JSON body"),
+    };
+    if req.answer.is_empty() {
+        return error_json(StatusCode::BAD_REQUEST, "answer is required");
+    }
+    let Some((_, input_tx, _)) = live::registry().get(id) else {
+        // Not ours: Go may still have this session, and its 409 is the right
+        // answer if neither does. Signalled by the sentinel below.
+        return forward_sentinel();
+    };
+    // Capacity 1, so a successful send is the approximation of "awaiting
+    // input" — the same one Go makes.
+    match input_tx.try_send(req.answer) {
+        Ok(()) => no_content(),
+        Err(_) => error_json(
+            StatusCode::CONFLICT,
+            "session is not currently awaiting input",
+        ),
+    }
+}
+
+/// `handlePermissionResponse`.
+fn permission_response(id: &str, body: &[u8]) -> Response<Body> {
+    let req: PermissionRequestBody = match crate::native::writes::decode_body(body) {
+        Ok(req) => req,
+        Err(_) => return error_json(StatusCode::BAD_REQUEST, "invalid JSON body"),
+    };
+    let Some((_, _, perm_tx)) = live::registry().get(id) else {
+        return forward_sentinel();
+    };
+    match perm_tx.try_send(req.allow) {
+        Ok(()) => no_content(),
+        Err(_) => error_json(
+            StatusCode::CONFLICT,
+            "session is not currently awaiting a permission response",
+        ),
+    }
+}
+
+/// `handleStopSession`. Returns **204 even when the interrupt fails** — Go only
+/// logs it — and never closes the session; the stream's own teardown owns that.
+async fn stop(id: &str) -> Result<Response<Body>, String> {
+    let Some((control, _, _)) = live::registry().get(id) else {
+        return Err(format!("chat {id:?} has no live session here"));
+    };
+    if let Err(e) = control.interrupt().await {
+        log::warn!("interrupt session failed for chat {id}: {e}");
+    }
+    Ok(no_content())
+}
+
+/// A response that means "let Go answer this".
+///
+/// The three steering routes cannot simply return `Err` from a non-async
+/// context, so they build this and the caller converts it. Kept as a distinct
+/// status no handler produces, so it cannot be confused with a real answer.
+fn forward_sentinel() -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::from_u16(599).unwrap_or(StatusCode::BAD_GATEWAY))
+        .body(Body::empty())
+        .unwrap_or_else(|_| Response::new(Body::empty()))
+}
+
+/// Whether a response is the forward sentinel rather than an answer.
+pub fn is_forward(response: &Response<Body>) -> bool {
+    response.status().as_u16() == 599
+}
+
+fn no_content() -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::NO_CONTENT)
+        .body(Body::empty())
+        .unwrap_or_else(|_| Response::new(Body::empty()))
+}
+
+fn error_json(status: StatusCode, message: &str) -> Response<Body> {
+    #[derive(Serialize)]
+    struct ErrorBody<'a> {
+        error: &'a str,
+    }
+    let body = crate::native::gojson::to_vec(&ErrorBody { error: message }).unwrap_or_default();
+    Response::builder()
+        .status(status)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body))
+        .unwrap_or_else(|_| Response::new(Body::empty()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_four_chat_actions_are_claimed_and_nothing_else_is() {
+        for action in ["messages", "input", "permission", "stop"] {
+            let path = format!("/api/chats/abc/{action}");
+            assert!(claims(&Method::POST, &path), "{path}");
+            // Only POST: the CRUD verbs on the same prefix belong to #274.
+            assert!(!claims(&Method::GET, &path));
+            assert!(!claims(&Method::DELETE, &path));
+        }
+
+        // The CRUD routes, which `native::chats` owns.
+        assert!(!claims(&Method::POST, "/api/chats"));
+        assert!(!claims(&Method::POST, "/api/chats/abc"));
+        // Unknown actions and nested paths forward.
+        assert!(!claims(&Method::POST, "/api/chats/abc/unknown"));
+        assert!(!claims(&Method::POST, "/api/chats//messages"));
+        assert!(!claims(&Method::POST, "/api/chats/abc/messages/extra"));
+    }
+
+    /// The registry is empty in a unit test, so every steering route takes the
+    /// "not ours" path — which is the behaviour that keeps a chat running on Go
+    /// working.
+    #[test]
+    fn a_chat_with_no_live_session_here_forwards_rather_than_409ing() {
+        let response = provide_input("no-such-chat", br#"{"answer":"yes"}"#);
+        assert!(is_forward(&response));
+
+        let response = permission_response("no-such-chat", br#"{"allow":true}"#);
+        assert!(is_forward(&response));
+    }
+
+    /// Body validation happens *before* the registry lookup, so a malformed
+    /// request is rejected here rather than being forwarded for Go to reject
+    /// identically.
+    #[test]
+    fn the_body_is_validated_before_the_session_is_looked_up() {
+        let response = provide_input("any", b"{}");
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let response = provide_input("any", b"not json");
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    /// `allow` defaults to false rather than failing, matching Go's decoder:
+    /// an absent key is the zero value, and a permission body with no `allow`
+    /// is a deny.
+    #[test]
+    fn an_absent_allow_is_a_deny_not_an_error() {
+        let response = permission_response("no-such-chat", b"{}");
+        // Reaches the registry lookup, so the body parsed.
+        assert!(is_forward(&response));
+    }
+}

--- a/desktop/src-tauri/src/native/chat/persist.rs
+++ b/desktop/src-tauri/src/native/chat/persist.rs
@@ -1,0 +1,412 @@
+//! What a finished turn writes. Mirrors `chatService.CommitMessage`
+//! (`internal/service/chat_service.go`).
+//!
+//! # "A turn that produced no final text persists nothing" — but only messages
+//!
+//! The rule is real and load-bearing: an interrupted stream must not leave an
+//! orphaned user message, because the Claude CLI's own transcript does not have
+//! one and the two would diverge on the next resume. Go guards **both**
+//! `AppendMessage` calls on `assistantText != ""`.
+//!
+//! What the phrase does *not* cover, and a port that stops reading there gets
+//! wrong: the `UPDATE chat_sessions` runs **unconditionally**. An aborted,
+//! errored or text-less turn still writes `updated_at`, the accumulated token
+//! totals, and — on a first message — a title derived from a user message that
+//! was never stored.
+//!
+//! # No transaction, deliberately faithful
+//!
+//! Go issues two inserts and an update with no transaction around them, so a
+//! failed assistant insert leaves the user row behind. Wrapping them here would
+//! be an improvement that makes the two implementations differ on a failure
+//! path, so the writes are issued the same way.
+
+use rusqlite::Connection;
+
+use super::runner::ChatRow;
+use super::turn::TurnState;
+use crate::native::chats::MessageBlock;
+
+/// Persist a finished turn.
+pub fn commit(
+    db_path: &std::path::Path,
+    row: &ChatRow,
+    user_content: &str,
+    state: &TurnState,
+    is_first_message: bool,
+) -> Result<(), String> {
+    let conn = crate::native::db::open_read_write(db_path)?;
+    crate::native::migrate::verify(&conn)?;
+
+    if !state.assistant_text.is_empty() {
+        if !user_content.is_empty() {
+            append_message(&conn, &row.id, "user", user_content, &[])?;
+        }
+        append_message(
+            &conn,
+            &row.id,
+            "assistant",
+            &state.assistant_text,
+            &state.blocks,
+        )?;
+    }
+
+    // Always, whatever the turn produced.
+    let title = if is_first_message {
+        truncate_title(user_content, 60)
+    } else {
+        row.title.clone()
+    };
+    // Only overwrite the CLI session id when the turn returned one: an
+    // interrupted turn reports none, and blanking it would make the next
+    // message start a new CLI session instead of resuming this one.
+    let sdk_session_id = if state.sdk_session_id.is_empty() {
+        row.sdk_session_id.clone()
+    } else {
+        state.sdk_session_id.clone()
+    };
+
+    let now = crate::native::gotime::now_go_text();
+    conn.execute(
+        "UPDATE chat_sessions SET
+            title = ?1, sdk_session_id = ?2,
+            total_input_tokens = total_input_tokens + ?3,
+            total_output_tokens = total_output_tokens + ?4,
+            total_cache_creation_tokens = total_cache_creation_tokens + ?5,
+            total_cache_read_tokens = total_cache_read_tokens + ?6,
+            updated_at = ?7
+         WHERE id = ?8",
+        rusqlite::params![
+            title,
+            sdk_session_id,
+            state.input_tokens,
+            state.output_tokens,
+            state.cache_creation_tokens,
+            state.cache_read_tokens,
+            now,
+            row.id,
+        ],
+    )
+    .map_err(|e| format!("updating session {:?}: {e}", row.id))?;
+
+    Ok(())
+}
+
+fn append_message(
+    conn: &Connection,
+    session_id: &str,
+    role: &str,
+    content: &str,
+    blocks: &[MessageBlock],
+) -> Result<(), String> {
+    // The column defaults to the literal `[]` rather than to NULL, and the read
+    // path distinguishes them.
+    let encoded = if blocks.is_empty() {
+        "[]".to_string()
+    } else {
+        let bytes = crate::native::gojson::to_vec_marshal(&blocks)
+            .map_err(|e| format!("encoding blocks: {e}"))?;
+        String::from_utf8(bytes).map_err(|e| format!("blocks are not UTF-8: {e}"))?
+    };
+    conn.execute(
+        "INSERT INTO chat_messages (session_id, role, content, blocks, timestamp)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        rusqlite::params![
+            session_id,
+            role,
+            content,
+            encoded,
+            crate::native::gotime::now_go_text()
+        ],
+    )
+    .map_err(|e| format!("storing {role} message: {e}"))?;
+    Ok(())
+}
+
+/// `truncateTitle`: cut at 60 **runes** and append an ellipsis.
+///
+/// Runes, not bytes — a title of accented text would otherwise be cut mid
+/// character and stored as invalid UTF-8.
+fn truncate_title(content: &str, max: usize) -> String {
+    let count = content.chars().count();
+    if count <= max {
+        return content.to_string();
+    }
+    let cut: String = content.chars().take(max).collect();
+    format!("{cut}...")
+}
+
+/// `appendAssistantBlocks`: keep non-empty `thinking` and `text`, and **every**
+/// `tool_use`, in arrival order. An unparseable event leaves the list untouched
+/// rather than failing the turn.
+///
+/// # The `input` must never round-trip through a `Value`
+///
+/// A `tool_use` input of `{"z":1.50,"a":1}` is stored verbatim by Go and
+/// re-emitted through `compact`, which preserves key order and number spelling.
+/// Decoding it into a `serde_json::Value` and re-encoding sorts the keys and
+/// drops the trailing zero — `{"a":1,"z":1.5}` — with nothing to signal it.
+/// This is not hypothetical: the first version of this function did exactly
+/// that, and `tests/chat_turn.rs` caught it. `RawValue` is what keeps the bytes.
+pub fn append_assistant_blocks(blocks: &mut Vec<MessageBlock>, raw: &[u8]) {
+    #[derive(serde::Deserialize)]
+    struct Envelope<'a> {
+        #[serde(borrow)]
+        message: Option<Message<'a>>,
+    }
+    #[derive(serde::Deserialize)]
+    struct Message<'a> {
+        #[serde(borrow, default)]
+        content: Vec<ContentBlock<'a>>,
+    }
+    #[derive(serde::Deserialize)]
+    struct ContentBlock<'a> {
+        #[serde(rename = "type", default)]
+        block_type: &'a str,
+        #[serde(default)]
+        thinking: Option<String>,
+        #[serde(default)]
+        text: Option<String>,
+        #[serde(default)]
+        id: Option<String>,
+        #[serde(default)]
+        name: Option<String>,
+        /// Borrowed raw, so the bytes are the CLI's own.
+        #[serde(borrow, default)]
+        input: Option<&'a serde_json::value::RawValue>,
+    }
+
+    let Ok(envelope) = serde_json::from_slice::<Envelope>(raw) else {
+        return;
+    };
+    let Some(message) = envelope.message else {
+        return;
+    };
+
+    for block in message.content {
+        match block.block_type {
+            "thinking" => {
+                let text = block.thinking.unwrap_or_default();
+                if !text.is_empty() {
+                    blocks.push(MessageBlock {
+                        block_type: "thinking".into(),
+                        text,
+                        id: String::new(),
+                        name: String::new(),
+                        input: None,
+                    });
+                }
+            }
+            "text" => {
+                let text = block.text.unwrap_or_default();
+                if !text.is_empty() {
+                    blocks.push(MessageBlock {
+                        block_type: "text".into(),
+                        text,
+                        id: String::new(),
+                        name: String::new(),
+                        input: None,
+                    });
+                }
+            }
+            "tool_use" => {
+                blocks.push(MessageBlock {
+                    block_type: "tool_use".into(),
+                    text: String::new(),
+                    id: block.id.unwrap_or_default(),
+                    name: block.name.unwrap_or_default(),
+                    // `to_owned` on the borrowed raw copies the bytes, not a
+                    // parsed representation of them.
+                    input: block
+                        .input
+                        .map(|raw| serde_json::value::RawValue::from_string(raw.get().to_string()))
+                        .transpose()
+                        .ok()
+                        .flatten(),
+                });
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn migrated() -> tempfile::NamedTempFile {
+        let file = tempfile::NamedTempFile::new().expect("temp file");
+        let mut conn = Connection::open(file.path()).expect("open");
+        crate::native::migrate::apply(&mut conn).expect("migrate");
+        conn.execute(
+            "INSERT INTO chat_sessions (id, title, agent_slug, created_at, updated_at)
+             VALUES ('c1', 'New Chat', '', '2026-01-01 00:00:00 +0000 UTC', '2026-01-01 00:00:00 +0000 UTC')",
+            [],
+        )
+        .expect("seed");
+        file
+    }
+
+    fn row() -> ChatRow {
+        ChatRow {
+            id: "c1".into(),
+            title: "New Chat".into(),
+            agent_slug: String::new(),
+            sdk_session_id: String::new(),
+            working_dir: String::new(),
+            model: String::new(),
+            settings_profile_id: String::new(),
+        }
+    }
+
+    fn message_count(file: &tempfile::NamedTempFile) -> i64 {
+        let conn = Connection::open(file.path()).expect("open");
+        conn.query_row("SELECT COUNT(*) FROM chat_messages", [], |r| r.get(0))
+            .expect("count")
+    }
+
+    #[test]
+    fn a_turn_with_text_stores_both_messages() {
+        let file = migrated();
+        let state = TurnState {
+            assistant_text: "hello".into(),
+            sdk_session_id: "sdk-1".into(),
+            input_tokens: 10,
+            output_tokens: 5,
+            ..Default::default()
+        };
+        commit(file.path(), &row(), "hi", &state, true).expect("commit");
+
+        assert_eq!(message_count(&file), 2);
+        let conn = Connection::open(file.path()).expect("open");
+        let (title, sdk, input): (String, String, i64) = conn
+            .query_row(
+                "SELECT title, sdk_session_id, total_input_tokens FROM chat_sessions WHERE id='c1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .expect("row");
+        assert_eq!(title, "hi");
+        assert_eq!(sdk, "sdk-1");
+        assert_eq!(input, 10);
+    }
+
+    /// The rule, and the half of it that is easy to over-apply: no messages,
+    /// but the session row is still written.
+    #[test]
+    fn a_turn_with_no_text_stores_no_messages_but_still_updates_the_session() {
+        let file = migrated();
+        let state = TurnState {
+            assistant_text: String::new(),
+            input_tokens: 7,
+            ..Default::default()
+        };
+        commit(file.path(), &row(), "hi", &state, true).expect("commit");
+
+        assert_eq!(message_count(&file), 0, "not even the user message");
+
+        let conn = Connection::open(file.path()).expect("open");
+        let (title, input): (String, i64) = conn
+            .query_row(
+                "SELECT title, total_input_tokens FROM chat_sessions WHERE id='c1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .expect("row");
+        // The title comes from a user message that was never stored.
+        assert_eq!(title, "hi");
+        assert_eq!(input, 7, "token totals accumulate regardless");
+    }
+
+    /// Blanking the CLI session id would make the next message start a new
+    /// session instead of resuming this one.
+    #[test]
+    fn an_interrupted_turn_keeps_the_previous_sdk_session_id() {
+        let file = migrated();
+        let mut existing = row();
+        existing.sdk_session_id = "sdk-original".into();
+        {
+            let conn = Connection::open(file.path()).expect("open");
+            conn.execute(
+                "UPDATE chat_sessions SET sdk_session_id='sdk-original' WHERE id='c1'",
+                [],
+            )
+            .expect("seed");
+        }
+
+        let state = TurnState::default();
+        commit(file.path(), &existing, "hi", &state, false).expect("commit");
+
+        let conn = Connection::open(file.path()).expect("open");
+        let sdk: String = conn
+            .query_row(
+                "SELECT sdk_session_id FROM chat_sessions WHERE id='c1'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("row");
+        assert_eq!(sdk, "sdk-original");
+    }
+
+    #[test]
+    fn token_totals_accumulate_rather_than_replace() {
+        let file = migrated();
+        let state = TurnState {
+            assistant_text: "a".into(),
+            input_tokens: 10,
+            output_tokens: 1,
+            ..Default::default()
+        };
+        commit(file.path(), &row(), "hi", &state, false).expect("first");
+        commit(file.path(), &row(), "hi", &state, false).expect("second");
+
+        let conn = Connection::open(file.path()).expect("open");
+        let input: i64 = conn
+            .query_row(
+                "SELECT total_input_tokens FROM chat_sessions WHERE id='c1'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("row");
+        assert_eq!(input, 20);
+    }
+
+    #[test]
+    fn the_title_is_cut_at_sixty_runes() {
+        assert_eq!(truncate_title("short", 60), "short");
+        let long = "a".repeat(61);
+        assert_eq!(truncate_title(&long, 60), format!("{}...", "a".repeat(60)));
+        // Runes, not bytes: 61 accented characters are 122 bytes, and a byte
+        // cut would split one in half.
+        let accented = "é".repeat(61);
+        let cut = truncate_title(&accented, 60);
+        assert_eq!(cut.chars().count(), 63); // 60 + "..."
+        assert!(cut.starts_with(&"é".repeat(60)));
+    }
+
+    #[test]
+    fn blocks_keep_thinking_text_and_every_tool_use_in_order() {
+        let mut blocks = Vec::new();
+        append_assistant_blocks(
+            &mut blocks,
+            br#"{"message":{"content":[
+                {"type":"thinking","thinking":"hmm"},
+                {"type":"text","text":""},
+                {"type":"text","text":"hello"},
+                {"type":"tool_use","id":"t1","name":"Bash","input":{"z":1.50,"a":1}}
+            ]}}"#,
+        );
+        assert_eq!(blocks.len(), 3, "the empty text block is dropped");
+        assert_eq!(blocks[0].block_type, "thinking");
+        assert_eq!(blocks[1].text, "hello");
+        assert_eq!(blocks[2].name, "Bash");
+    }
+
+    #[test]
+    fn an_unparseable_assistant_event_leaves_the_blocks_untouched() {
+        let mut blocks = Vec::new();
+        append_assistant_blocks(&mut blocks, b"not json");
+        append_assistant_blocks(&mut blocks, b"{}");
+        assert!(blocks.is_empty());
+    }
+}

--- a/desktop/src-tauri/src/native/chat/runner.rs
+++ b/desktop/src-tauri/src/native/chat/runner.rs
@@ -1,0 +1,492 @@
+//! An agent's stored config, turned into the SDK options one chat turn runs
+//! under. Mirrors `buildSDKOptions` (`internal/agent/runner.go`).
+//!
+//! # What this deliberately cannot do yet, and why that is safe
+//!
+//! Go resolves three kinds of tool: the built-ins, the **local** in-process MCP
+//! server (`internal/tools`), and one MCP server per configured **integration**
+//! (`internal/integrations`). Rust has neither of the latter two — they are
+//! #277's and #282's — and an agent whose capabilities name them would get a
+//! subprocess with the tools silently missing, which is a worse answer than the
+//! sidecar's.
+//!
+//! So [`build_options`] refuses: an agent with `local` or `mcp` capabilities
+//! returns `Err`, the seam forwards, and Go runs that chat exactly as before.
+//! This is the same "a route moves only when Rust reproduces every effect" rule
+//! #274 established, applied per *agent* rather than per route — which is why
+//! `chat::stream` also forwards `/input`, `/permission` and `/stop` for any chat
+//! it does not itself hold a live session for. Without that, a chat running on
+//! Go would have its stop button claimed by a Rust registry that never saw it.
+
+use rusqlite::OptionalExtension;
+
+use crate::claude::options::Options;
+use crate::claude::permissions::PermissionHandler;
+use crate::native::agents::{Agent, Capabilities};
+
+/// Every built-in tool, as `allBuiltInTools` lists them. Order is Go's, because
+/// it becomes the `--allowedTools` argument and a reordered list is a different
+/// command line.
+const ALL_BUILT_IN_TOOLS: &[&str] = &[
+    "Read",
+    "Write",
+    "Edit",
+    "Bash",
+    "Glob",
+    "Grep",
+    "WebFetch",
+    "WebSearch",
+    "Task",
+    "TaskOutput",
+    "TaskStop",
+    "NotebookEdit",
+];
+
+/// What the chat service knows about the turn before the subprocess starts.
+pub struct RunSpec {
+    /// The agent, or `None` for a chat with no agent slug — which Go models as
+    /// a synthesized config carrying only a model.
+    pub agent: Option<Agent>,
+    /// `session.model`, or the user's default when the session has none.
+    pub fallback_model: String,
+    pub working_dir: String,
+    pub settings_profile_id: String,
+    /// `Some` resumes an existing CLI session; `None` pins a new one to the
+    /// chat id so the two identifiers stay in step.
+    pub resume_session_id: Option<String>,
+    pub chat_id: String,
+}
+
+/// Build the SDK options for one chat turn.
+///
+/// `Err` means "this port cannot run this chat" and forwards to Go — never a
+/// user-visible failure.
+pub fn build_options(
+    spec: &RunSpec,
+    permission_handler: PermissionHandler,
+) -> Result<Options, String> {
+    let caps = spec.agent.as_ref().map(|a| &a.capabilities);
+    if let Some(caps) = caps {
+        if capability_count(caps.local.as_ref()) > 0
+            || caps.mcp.as_ref().is_some_and(|m| !m.is_empty())
+        {
+            return Err(
+                "agent uses local or MCP tools, which are not ported yet (#277/#282)".to_string(),
+            );
+        }
+    }
+
+    // `--include-partial-messages` is unconditional in Go, and it is what makes
+    // `stream_event` frames exist at all — the UI's token-by-token rendering
+    // depends on them.
+    let mut opts = Options::new().with_include_partial_messages();
+
+    // A working dir also selects the project setting source, exactly as Go
+    // does. Note `--settings` below can suppress it; that is Go's behaviour too.
+    if !spec.working_dir.is_empty() {
+        opts = opts
+            .with_cwd(spec.working_dir.clone())
+            .with_setting_sources(["project"]);
+    }
+
+    let config_dir = resolve_agent_config_dir(spec.agent.as_ref());
+    if config_dir != crate::native::settings::default_claude_config_dir()
+        || std::env::var("CLAUDE_CONFIG_DIR").is_ok_and(|v| !v.is_empty())
+    {
+        // Overrides the value the process inherited, which is what lets a
+        // per-agent override beat the `CLAUDE_CONFIG_DIR` the app started with.
+        opts = opts.with_env([("CLAUDE_CONFIG_DIR", config_dir.clone())]);
+    }
+
+    if let Some(path) = settings_file_in(&config_dir, &spec.settings_profile_id) {
+        // Only name a file that exists: a config dir Claude Code has never
+        // written has no settings.json, and `--settings` on a missing path is
+        // an error rather than a no-op.
+        opts = opts.with_settings(path);
+    }
+
+    // An interactive permission handler forces default permissions, overriding
+    // whatever the agent configured. That is Go's behaviour and it is why a
+    // `plan` or `dontAsk` agent still prompts in the chat UI.
+    opts = opts.with_default_permissions();
+
+    opts = opts.with_claude_executable(claude_executable());
+
+    let model = spec
+        .agent
+        .as_ref()
+        .map(|a| a.model.clone())
+        .filter(|m| !m.is_empty())
+        .unwrap_or_else(|| spec.fallback_model.clone());
+    if !model.is_empty() {
+        opts = opts.with_model(model);
+    }
+
+    if let Some(agent) = &spec.agent {
+        if !agent.system_prompt.is_empty() {
+            // Go interpolates `{{current_date}}` / `{{current_time}}` here.
+            opts = opts.with_system_prompt(interpolate(&agent.system_prompt));
+        }
+    }
+
+    match &spec.resume_session_id {
+        Some(id) if !id.is_empty() => opts = opts.with_session_id_to_resume(id.clone()),
+        _ => opts = opts.with_session_id(spec.chat_id.clone()),
+    }
+
+    opts = opts.with_thinking(thinking_mode(spec.agent.as_ref()));
+
+    let allowed = allowed_tools(caps);
+    if !allowed.is_empty() {
+        opts = opts.with_allowed_tools(allowed.iter().cloned());
+        // Go explicitly disallows every built-in that was not selected, so an
+        // allowlist is a denylist too.
+        let disallowed: Vec<String> = ALL_BUILT_IN_TOOLS
+            .iter()
+            .filter(|t| !allowed.iter().any(|a| a == *t))
+            .map(|t| (*t).to_string())
+            .collect();
+        if !disallowed.is_empty() {
+            opts = opts.with_disallowed_tools(disallowed);
+        }
+    }
+
+    opts = opts.with_permission_handler(wrap_permission_handler(permission_handler, allowed));
+    Ok(opts)
+}
+
+fn capability_count(list: Option<&Vec<String>>) -> usize {
+    list.map(|l| l.len()).unwrap_or(0)
+}
+
+/// `resolveBuiltInTools`: an explicit list wins; otherwise *all* built-ins, but
+/// only when the agent names no other tools at all.
+fn allowed_tools(caps: Option<&Capabilities>) -> Vec<String> {
+    let Some(caps) = caps else {
+        // No agent means no tools list, which the SDK reads as "no restriction".
+        return Vec::new();
+    };
+    if capability_count(caps.built_in.as_ref()) > 0 {
+        return caps.built_in.clone().unwrap_or_default();
+    }
+    // `map_or(true, ..)` rather than `is_none_or`, which needs Rust 1.82 and
+    // this crate's MSRV is 1.77.
+    if capability_count(caps.local.as_ref()) == 0
+        && caps.mcp.as_ref().map_or(true, |m| m.is_empty())
+    {
+        return ALL_BUILT_IN_TOOLS
+            .iter()
+            .map(|t| (*t).to_string())
+            .collect();
+    }
+    Vec::new()
+}
+
+/// `resolveThinkingMode`. An absent or unrecognized value is `adaptive`.
+fn thinking_mode(agent: Option<&Agent>) -> &'static str {
+    match agent.map(|a| a.thinking.as_str()) {
+        Some("disabled") => "disabled",
+        Some("enabled") => "enabled",
+        _ => "adaptive",
+    }
+}
+
+/// `wrapPermissionHandler`: enforce the allowlist before delegating.
+///
+/// Two behaviours worth keeping exactly: an empty allowlist returns the inner
+/// handler **unwrapped** (a no-agent chat reaches every tool), and a tool
+/// outside the list is denied *without* the user ever seeing a prompt.
+/// `AskUserQuestion` is always allowed — it is the interactive Q&A mechanism,
+/// not a capability.
+fn wrap_permission_handler(inner: PermissionHandler, allowed: Vec<String>) -> PermissionHandler {
+    if allowed.is_empty() {
+        return inner;
+    }
+    let set: std::collections::HashSet<String> = allowed.into_iter().collect();
+    std::sync::Arc::new(move |tool_name: String, input, ctx| {
+        if tool_name == "AskUserQuestion" || set.contains(&tool_name) {
+            return inner(tool_name, input, ctx);
+        }
+        let message = format!("tool {tool_name:?} is not in this agent's allowed capabilities");
+        Box::pin(async move { crate::claude::permissions::PermissionResult::deny(message) })
+    })
+}
+
+/// `ResolveAgentClaudeDir`: the agent's own override when it is absolute,
+/// otherwise the run default.
+fn resolve_agent_config_dir(agent: Option<&Agent>) -> String {
+    if let Some(agent) = agent {
+        if !agent.claude_config_dir.is_empty() {
+            let normalized = crate::native::settings::normalize(&agent.claude_config_dir);
+            if let Some(dir) = crate::native::settings::absolute_dir(&normalized) {
+                return dir;
+            }
+        }
+    }
+    // A relative override is discarded rather than honoured: the subprocess
+    // resolves it against its own cwd — inside the user's repo — and would read
+    // it as trusted config.
+    crate::native::settings::run_config_dir(&stored_config_dir())
+}
+
+fn stored_config_dir() -> String {
+    let Some(db_path) = crate::paths::database_path() else {
+        return String::new();
+    };
+    let Ok(conn) = crate::native::db::open_read_only(&db_path) else {
+        return String::new();
+    };
+    crate::native::settings::load_stored(&conn).claude_config_dir
+}
+
+/// `LoadProfileFilePathIn`, reduced to the case this port supports: the unnamed
+/// fallback, `<config dir>/settings.json`.
+///
+/// A **named** profile records its own absolute path in
+/// `settings_profiles.json`, and reading that file is the settings-profile
+/// service's job rather than this one's — so a chat pinned to a named profile
+/// returns `None` here and simply gets no `--settings`, which is what Go does
+/// when the recorded path does not exist. Porting the profile lookup belongs
+/// with the profile CRUD.
+fn settings_file_in(config_dir: &str, profile_id: &str) -> Option<String> {
+    if !profile_id.is_empty() {
+        return None;
+    }
+    let path = std::path::Path::new(config_dir).join("settings.json");
+    match std::fs::metadata(&path) {
+        Ok(meta) if meta.is_file() => Some(path.to_string_lossy().into_owned()),
+        _ => None,
+    }
+}
+
+/// Which `claude` binary to spawn.
+///
+/// The SDK defaults to the bare name resolved on `PATH`, which is exactly what
+/// the desktop app cannot rely on: a GUI process inherits a minimal `PATH`, and
+/// `find_claude_cli` exists precisely because of that — it is what the startup
+/// banner already uses to tell the user whether the CLI is installed. Spawning
+/// with the bare name while the banner says "found" would be the two disagreeing.
+///
+/// `AGENTO_CLAUDE_EXECUTABLE` overrides both. It is a real need — a second
+/// install, or a wrapper script — and it is also how the turn tests point the
+/// runner at a scripted fake CLI instead of a real one.
+fn claude_executable() -> String {
+    if let Ok(explicit) = std::env::var("AGENTO_CLAUDE_EXECUTABLE") {
+        if !explicit.is_empty() {
+            return explicit;
+        }
+    }
+    crate::find_claude_cli().unwrap_or_else(|| "claude".to_string())
+}
+
+/// The two template variables Agento substitutes into a system prompt.
+fn interpolate(prompt: &str) -> String {
+    if !prompt.contains("{{") {
+        return prompt.to_string();
+    }
+    let now = chrono::Local::now();
+    prompt
+        .replace("{{current_date}}", &now.format("%Y-%m-%d").to_string())
+        .replace("{{current_time}}", &now.format("%H:%M:%S").to_string())
+}
+
+/// The chat session row the turn runs against.
+pub struct ChatRow {
+    pub id: String,
+    pub title: String,
+    pub agent_slug: String,
+    pub sdk_session_id: String,
+    pub working_dir: String,
+    pub model: String,
+    pub settings_profile_id: String,
+}
+
+/// Load the chat and its agent. `Ok(None)` is Go's 404.
+pub fn load(
+    db_path: &std::path::Path,
+    id: &str,
+) -> Result<Option<(ChatRow, Option<Agent>)>, String> {
+    let conn = crate::native::db::open_read_only(db_path)?;
+    let row = conn
+        .query_row(
+            "SELECT id, title, agent_slug, sdk_session_id, working_directory, model,
+                    settings_profile_id
+             FROM chat_sessions WHERE id = ?1",
+            [id],
+            |row| {
+                Ok(ChatRow {
+                    id: row.get(0)?,
+                    title: row.get(1)?,
+                    agent_slug: row.get(2)?,
+                    sdk_session_id: row.get(3)?,
+                    working_dir: row.get(4)?,
+                    model: row.get(5)?,
+                    settings_profile_id: row.get(6)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(|e| format!("loading chat {id:?}: {e}"))?;
+
+    let Some(row) = row else {
+        return Ok(None);
+    };
+
+    let agent = if row.agent_slug.is_empty() {
+        None
+    } else {
+        match crate::native::agents::get(db_path, &row.agent_slug)? {
+            Some(agent) => Some(agent),
+            // Go returns NotFoundError{"agent"} here, a 404 with its own
+            // wording. Forward rather than reproduce a second 404 shape.
+            None => return Err(format!("agent {:?} not found", row.agent_slug)),
+        }
+    };
+    Ok(Some((row, agent)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn agent_with(caps: Capabilities) -> Agent {
+        Agent {
+            name: "A".into(),
+            slug: "a".into(),
+            description: String::new(),
+            model: "claude-sonnet-4-6".into(),
+            thinking: "adaptive".into(),
+            permission_mode: String::new(),
+            system_prompt: String::new(),
+            capabilities: caps,
+            claude_config_dir: String::new(),
+        }
+    }
+
+    #[test]
+    fn an_explicit_built_in_list_wins() {
+        let caps = Capabilities {
+            built_in: Some(vec!["Read".into(), "Bash".into()]),
+            local: None,
+            mcp: None,
+        };
+        assert_eq!(allowed_tools(Some(&caps)), vec!["Read", "Bash"]);
+    }
+
+    /// The rule that is easy to invert: *all* built-ins only when the agent
+    /// names nothing else at all.
+    #[test]
+    fn no_capabilities_at_all_means_every_built_in() {
+        let caps = Capabilities::default();
+        assert_eq!(allowed_tools(Some(&caps)).len(), ALL_BUILT_IN_TOOLS.len());
+        assert_eq!(allowed_tools(Some(&caps))[0], "Read");
+    }
+
+    #[test]
+    fn naming_only_mcp_tools_yields_no_built_ins() {
+        let mut mcp = BTreeMap::new();
+        mcp.insert(
+            "github".to_string(),
+            crate::native::agents::McpCapability {
+                tools: Some(vec!["list_prs".into()]),
+            },
+        );
+        let caps = Capabilities {
+            built_in: None,
+            local: None,
+            mcp: Some(mcp),
+        };
+        assert!(allowed_tools(Some(&caps)).is_empty());
+    }
+
+    #[test]
+    fn no_agent_means_no_tool_restriction() {
+        assert!(allowed_tools(None).is_empty());
+    }
+
+    /// The boundary this port draws: an agent needing tools Rust cannot supply
+    /// forwards, rather than running with them silently missing.
+    #[test]
+    fn an_agent_needing_mcp_refuses_to_build_options() {
+        let mut mcp = BTreeMap::new();
+        mcp.insert(
+            "github".to_string(),
+            crate::native::agents::McpCapability { tools: None },
+        );
+        let spec = RunSpec {
+            agent: Some(agent_with(Capabilities {
+                built_in: None,
+                local: None,
+                mcp: Some(mcp),
+            })),
+            fallback_model: String::new(),
+            working_dir: String::new(),
+            settings_profile_id: String::new(),
+            resume_session_id: None,
+            chat_id: "c1".into(),
+        };
+        let handler: PermissionHandler = std::sync::Arc::new(|_, _, _| {
+            Box::pin(async { crate::claude::permissions::PermissionResult::allow() })
+        });
+        assert!(build_options(&spec, handler).is_err());
+    }
+
+    #[test]
+    fn an_agent_needing_local_tools_also_refuses() {
+        let spec = RunSpec {
+            agent: Some(agent_with(Capabilities {
+                built_in: None,
+                local: Some(vec!["now".into()]),
+                mcp: None,
+            })),
+            fallback_model: String::new(),
+            working_dir: String::new(),
+            settings_profile_id: String::new(),
+            resume_session_id: None,
+            chat_id: "c1".into(),
+        };
+        let handler: PermissionHandler = std::sync::Arc::new(|_, _, _| {
+            Box::pin(async { crate::claude::permissions::PermissionResult::allow() })
+        });
+        assert!(build_options(&spec, handler).is_err());
+    }
+
+    #[test]
+    fn thinking_defaults_to_adaptive() {
+        assert_eq!(thinking_mode(None), "adaptive");
+        let mut agent = agent_with(Capabilities::default());
+        agent.thinking = "disabled".into();
+        assert_eq!(thinking_mode(Some(&agent)), "disabled");
+        agent.thinking = "nonsense".into();
+        assert_eq!(thinking_mode(Some(&agent)), "adaptive");
+        agent.thinking = String::new();
+        assert_eq!(thinking_mode(Some(&agent)), "adaptive");
+    }
+
+    #[test]
+    fn a_prompt_with_no_template_is_untouched() {
+        assert_eq!(interpolate("plain prompt"), "plain prompt");
+        let out = interpolate("today is {{current_date}}");
+        assert!(out.starts_with("today is 20"), "{out}");
+        assert!(!out.contains("{{"));
+    }
+
+    /// A named profile is not resolvable here, so it yields no `--settings`
+    /// rather than a guessed path.
+    #[test]
+    fn a_named_settings_profile_yields_no_settings_flag() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("settings.json"), "{}").expect("write");
+        let path = dir.path().to_string_lossy().into_owned();
+
+        assert!(settings_file_in(&path, "").is_some());
+        assert!(settings_file_in(&path, "profile-123").is_none());
+    }
+
+    #[test]
+    fn a_missing_settings_file_is_not_named() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert!(settings_file_in(&dir.path().to_string_lossy(), "").is_none());
+    }
+}

--- a/desktop/src-tauri/src/native/chat/sse.rs
+++ b/desktop/src-tauri/src/native/chat/sse.rs
@@ -1,0 +1,113 @@
+//! The SSE frames, byte for byte.
+//!
+//! Go has **two** writers and the difference is load-bearing:
+//!
+//! - `sendSSERaw` writes the CLI's JSON with three bare `w.Write` calls, so the
+//!   bytes are never decoded and re-encoded. A `tool_use` input of
+//!   `{"z":1.50,"a":1}` ships exactly that; going through a `serde_json::Value`
+//!   would ship `{"a":1,"z":1.5}` — reordered and respelled, with nothing to
+//!   signal it.
+//! - `sendSSEEvent` marshals a value and formats
+//!   `"event: %s\ndata: %s\n\n"`. Only the two synthetic events use it.
+//!
+//! Frames are **LF-only**, one blank line, no `id:`, no `retry:`, and there is
+//! **no heartbeat** — a quiet turn sends nothing at all.
+
+use serde::Serialize;
+
+/// One frame carrying a payload that is already JSON.
+///
+/// The event name is the CLI's own `type` field, so unknown and future types
+/// pass through unchanged; the frontend ignores names it does not know.
+pub fn raw_frame(event: &str, data: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(event.len() + data.len() + 16);
+    out.extend_from_slice(b"event: ");
+    out.extend_from_slice(event.as_bytes());
+    out.extend_from_slice(b"\ndata: ");
+    out.extend_from_slice(data);
+    out.extend_from_slice(b"\n\n");
+    out
+}
+
+/// One frame for a value this side constructs — the two synthetic events and
+/// the "streaming not supported" error.
+///
+/// Encoded through `gojson` rather than plain `serde_json` so the escaping
+/// matches: Go's encoder HTML-escapes `<`, `>` and `&`, and an
+/// `AskUserQuestion` payload routinely contains them.
+pub fn json_frame<T: Serialize>(event: &str, data: &T) -> Result<Vec<u8>, String> {
+    let encoded = crate::native::gojson::to_vec_marshal(data)
+        .map_err(|e| format!("encoding {event} payload: {e}"))?;
+    Ok(raw_frame(event, &encoded))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The exact bytes `internal/api/chats_test.go` asserts.
+    #[test]
+    fn a_raw_frame_is_gos_bytes() {
+        assert_eq!(
+            raw_frame("assistant", br#"{"message":"hello"}"#),
+            b"event: assistant\ndata: {\"message\":\"hello\"}\n\n".to_vec()
+        );
+    }
+
+    /// LF only. A CRLF frame parses in most clients and is still a divergence,
+    /// and it is exactly what a naive `writeln!` would produce on some targets.
+    #[test]
+    fn frames_use_lf_and_end_with_one_blank_line() {
+        let frame = raw_frame("result", b"{}");
+        let text = String::from_utf8(frame).unwrap();
+        assert!(!text.contains('\r'), "no CR: {text:?}");
+        assert!(text.ends_with("\n\n"));
+        assert_eq!(text.matches("\n\n").count(), 1);
+        // No id:/retry: fields.
+        assert!(!text.contains("id:"));
+        assert!(!text.contains("retry:"));
+    }
+
+    /// The whole reason `raw_frame` takes bytes: a round trip through a JSON
+    /// value would sort these keys and respell the number.
+    #[test]
+    fn a_raw_payload_keeps_its_key_order_and_number_spelling() {
+        let payload = br#"{"z":1.50,"a":[1,2]}"#;
+        let frame = raw_frame("assistant", payload);
+        let text = String::from_utf8(frame).unwrap();
+        assert!(text.contains(r#"{"z":1.50,"a":[1,2]}"#), "{text}");
+    }
+
+    /// Go's encoder HTML-escapes, and an AskUserQuestion payload routinely
+    /// carries `<` and `&`.
+    #[test]
+    fn a_json_frame_escapes_the_way_gos_encoder_does() {
+        #[derive(serde::Serialize)]
+        struct Payload<'a> {
+            error: &'a str,
+        }
+        let frame = json_frame("error", &Payload { error: "a < b & c" }).expect("encode");
+        let text = String::from_utf8(frame).unwrap();
+        // Escaped, not literal: `encoding/json` turns `<`, `>` and `&` into
+        // their \u form, and an AskUserQuestion payload routinely carries them.
+        assert!(text.contains(r"a \u003c b \u0026 c"), "{text}");
+        assert!(!text.contains("a < b"), "{text}");
+        assert!(text.ends_with("\n\n"));
+    }
+
+    /// `to_vec_marshal` rather than `to_vec`: the latter appends the trailing
+    /// newline `json.Encoder` adds, which inside a `data:` line would end the
+    /// frame early and split one event into two.
+    #[test]
+    fn a_json_frame_has_no_stray_newline_in_its_data_line() {
+        #[derive(serde::Serialize)]
+        struct Payload {
+            ok: bool,
+        }
+        let frame = json_frame("x", &Payload { ok: true }).expect("encode");
+        assert_eq!(
+            String::from_utf8(frame).unwrap(),
+            "event: x\ndata: {\"ok\":true}\n\n"
+        );
+    }
+}

--- a/desktop/src-tauri/src/native/chat/turn.rs
+++ b/desktop/src-tauri/src/native/chat/turn.rs
@@ -137,7 +137,7 @@ pub async fn run(
     let answers = Arc::new(Answers {
         input: tokio::sync::Mutex::new(input_rx),
         permission: tokio::sync::Mutex::new(perm_rx),
-        disconnect: body_tx.clone(),
+        disconnect: body_tx.downgrade(),
     });
     let handler = build_permission_handler(notify_tx.clone(), Arc::clone(&answers));
 
@@ -218,9 +218,8 @@ struct LockGuard {
 
 impl Drop for LockGuard {
     fn drop(&mut self) {
-        // The stream task calls `release` itself after dropping this, so a
-        // double release is possible and harmless — both are idempotent
-        // removals from a set.
+        // The only release: the stream task used to call `release` itself as
+        // well, and no longer does.
         registry().release(&self.id);
     }
 }
@@ -234,7 +233,7 @@ impl Drop for LockGuard {
 struct Answers {
     input: tokio::sync::Mutex<mpsc::Receiver<String>>,
     permission: tokio::sync::Mutex<mpsc::Receiver<bool>>,
-    /// A clone of the body sender, used only for [`mpsc::Sender::closed`].
+    /// A **weak** handle on the body sender, used only to notice a disconnect.
     ///
     /// This is how a waiting handler learns the client went away, and it is
     /// **not** optional: the permission callback is awaited inline on the SDK's
@@ -244,9 +243,36 @@ struct Answers {
     /// subprocess alive, the busy lock held and the chat unusable for the life
     /// of the process.
     ///
+    /// Weak rather than a plain clone, and that is load-bearing. This struct is
+    /// reachable from the permission-handler `Arc`, which the SDK's reader task
+    /// owns for as long as it runs — and that task ends only at stdout EOF. A
+    /// strong clone here would therefore keep the body's sender set non-empty
+    /// past the end of the turn, so `ReceiverStream` would not terminate and the
+    /// SSE response would stay open until the subprocess's stdout closed: ~5s
+    /// when the CLI ignores SIGTERM, and unbounded when it leaves a grandchild
+    /// holding stdout — the hazard `claude/process.rs` documents, which any
+    /// backgrounding `Bash` call produces. The frontend only clears its
+    /// streaming state in `onDone`, so that is a chat stuck mid-stream with the
+    /// composer blocked, long after the commit ran. Go's handler returns as soon
+    /// as `consumeAgentEvents` does.
+    ///
     /// Go reaches the same place through `r.Context().Done()`, which every one
     /// of its waits selects on.
-    disconnect: mpsc::Sender<Result<Vec<u8>, std::io::Error>>,
+    disconnect: mpsc::WeakSender<Result<Vec<u8>, std::io::Error>>,
+}
+
+/// Resolves once the client is gone.
+///
+/// Two ways that happens, and both mean "stop waiting": the body receiver was
+/// dropped (the tab closed), or every strong sender is already gone, which means
+/// the stream task itself has finished. Upgrading is transient — the strong
+/// sender it produces lives only while this future is parked, which is precisely
+/// the window in which the turn is still running and the CLI is blocked on an
+/// answer, so it cannot extend the stream past the turn.
+async fn client_gone(weak: &mpsc::WeakSender<Result<Vec<u8>, std::io::Error>>) {
+    if let Some(tx) = weak.upgrade() {
+        tx.closed().await;
+    }
 }
 
 /// `buildPermissionHandler`: `AskUserQuestion` is answered by *denying* the tool
@@ -286,7 +312,7 @@ fn build_permission_handler(
                         // alive and the chat's busy lock held for the life of
                         // the process. Go reaches the same place through
                         // `r.Context().Done()`, and answers with this string.
-                        _ = answers.disconnect.closed() => {
+                        _ = client_gone(&answers.disconnect) => {
                             PermissionResult::deny("request canceled")
                         }
                     };
@@ -302,7 +328,7 @@ fn build_permission_handler(
                     },
                     // Same reason as above — this is the more likely one to be
                     // hit, since a permission prompt is the common case.
-                    _ = answers.disconnect.closed() => {
+                    _ = client_gone(&answers.disconnect) => {
                         PermissionResult::deny("request canceled")
                     }
                 }

--- a/desktop/src-tauri/src/native/chat/turn.rs
+++ b/desktop/src-tauri/src/native/chat/turn.rs
@@ -182,10 +182,16 @@ pub async fn run(
     tokio::spawn(async move {
         let state = stream_events(&mut session, notify_rx, &body_tx, &answers).await;
 
-        // Go's defer order: forget the live session (which also releases the
-        // busy lock), then close the subprocess.
+        // Go's defer order: forget the live session — which also releases the
+        // busy lock — then close the subprocess.
+        //
+        // `drop` explicitly rather than letting the guard fall out of scope,
+        // and that is the whole point: the guard is *moved into this task*, so
+        // its natural drop would be at the end of the block, **after** the
+        // commit. Go releases before committing, which is what makes a second
+        // send possible while the first is still writing. Dropping here rather
+        // than there is the difference.
         drop(guard);
-        registry().release(&chat_id);
         session.close();
 
         // The commit is detached from the request on purpose, so a client that

--- a/desktop/src-tauri/src/native/chat/turn.rs
+++ b/desktop/src-tauri/src/native/chat/turn.rs
@@ -148,8 +148,17 @@ pub async fn run(
     // subprocess exists, so forwarding is safe.
     let options = runner::build_options(&spec, handler)?;
 
-    // The subprocess starts here. Past this point a failure can no longer
-    // forward, because Go would spawn a second one.
+    // The subprocess starts here, and these are the last two `Err`s. Both are
+    // still safe to forward, but for different reasons and neither is obvious:
+    //
+    // - A failed spawn produced no process at all.
+    // - A failed `send` produced one, but `close` terminates it and the user
+    //   message never reached the CLI — so nothing was transmitted, nothing was
+    //   written to its transcript, and Go starting a fresh subprocess is the
+    //   right answer rather than a duplicate.
+    //
+    // Everything after this point streams, and a failure there ends the stream
+    // rather than forwarding: the 200 is already committed.
     let mut session = Session::new(options)
         .await
         .map_err(|e| format!("starting agent session: {e}"))?;

--- a/desktop/src-tauri/src/native/chat/turn.rs
+++ b/desktop/src-tauri/src/native/chat/turn.rs
@@ -8,7 +8,8 @@
 //! arrives from the CLI, the permission handler asks a question, the permission
 //! handler asks for an allow/deny, or the client disconnects. There is **no
 //! timeout** and **no heartbeat** — a long tool call sends nothing for minutes,
-//! by design.
+//! by design, which is exactly why the disconnect arm has to be explicit rather
+//! than inferred from a failed send.
 //!
 //! # Rules that are silent when broken
 //!
@@ -129,10 +130,14 @@ pub async fn run(
     let (notify_tx, notify_rx) = mpsc::channel::<Notify>(NOTIFY_CAPACITY);
     let (input_tx, input_rx) = mpsc::channel::<String>(1);
     let (perm_tx, perm_rx) = mpsc::channel::<bool>(1);
+    // Created here rather than after the spawn, because the permission handler
+    // needs a clone of the sender to detect a disconnect.
+    let (body_tx, body_rx) = mpsc::channel::<Result<Vec<u8>, std::io::Error>>(32);
 
     let answers = Arc::new(Answers {
         input: tokio::sync::Mutex::new(input_rx),
         permission: tokio::sync::Mutex::new(perm_rx),
+        disconnect: body_tx.clone(),
     });
     let handler = build_permission_handler(notify_tx.clone(), Arc::clone(&answers));
 
@@ -177,7 +182,6 @@ pub async fn run(
     );
 
     let is_first_message = row.title == "New Chat";
-    let (body_tx, body_rx) = mpsc::channel::<Result<Vec<u8>, std::io::Error>>(32);
 
     tokio::spawn(async move {
         let state = stream_events(&mut session, notify_rx, &body_tx, &answers).await;
@@ -230,6 +234,19 @@ impl Drop for LockGuard {
 struct Answers {
     input: tokio::sync::Mutex<mpsc::Receiver<String>>,
     permission: tokio::sync::Mutex<mpsc::Receiver<bool>>,
+    /// A clone of the body sender, used only for [`mpsc::Sender::closed`].
+    ///
+    /// This is how a waiting handler learns the client went away, and it is
+    /// **not** optional: the permission callback is awaited inline on the SDK's
+    /// reader task, so while it is parked no events arrive and the stream loop
+    /// has nothing to send — meaning nothing else would ever notice the
+    /// disconnect. Without it, closing a tab on an open prompt leaves the
+    /// subprocess alive, the busy lock held and the chat unusable for the life
+    /// of the process.
+    ///
+    /// Go reaches the same place through `r.Context().Done()`, which every one
+    /// of its waits selects on.
+    disconnect: mpsc::Sender<Result<Vec<u8>, std::io::Error>>,
 }
 
 /// `buildPermissionHandler`: `AskUserQuestion` is answered by *denying* the tool
@@ -252,20 +269,42 @@ fn build_permission_handler(
                     // rather than fixed, so the two implementations agree.
                     let _ = notify.try_send(Notify::Question(raw));
                     let mut rx = answers.input.lock().await;
-                    return match rx.recv().await {
-                        // The answer travels as the *denial message*. That is how
-                        // it reaches the model without the tool ever executing.
-                        Some(answer) => PermissionResult::deny(answer),
-                        None => PermissionResult::deny("request canceled"),
+                    return tokio::select! {
+                        answer = rx.recv() => match answer {
+                            // The answer travels as the *denial message*. That
+                            // is how it reaches the model without the tool ever
+                            // executing.
+                            Some(answer) => PermissionResult::deny(answer),
+                            None => PermissionResult::deny("request canceled"),
+                        },
+                        // The client went away. This race is not optional: the
+                        // handler is awaited **inline on the SDK's reader
+                        // task**, so while it is parked no events arrive and
+                        // the stream loop has nothing to send — meaning its own
+                        // disconnect arm never fires either. Without this,
+                        // closing a tab on an open prompt leaves the subprocess
+                        // alive and the chat's busy lock held for the life of
+                        // the process. Go reaches the same place through
+                        // `r.Context().Done()`, and answers with this string.
+                        _ = answers.disconnect.closed() => {
+                            PermissionResult::deny("request canceled")
+                        }
                     };
                 }
 
                 let _ = notify.try_send(Notify::Permission(PermissionRequest { tool_name, input }));
                 let mut rx = answers.permission.lock().await;
-                match rx.recv().await {
-                    Some(true) => PermissionResult::allow(),
-                    Some(false) => PermissionResult::deny("Permission denied by user"),
-                    None => PermissionResult::deny("request canceled"),
+                tokio::select! {
+                    allow = rx.recv() => match allow {
+                        Some(true) => PermissionResult::allow(),
+                        Some(false) => PermissionResult::deny("Permission denied by user"),
+                        None => PermissionResult::deny("request canceled"),
+                    },
+                    // Same reason as above — this is the more likely one to be
+                    // hit, since a permission prompt is the common case.
+                    _ = answers.disconnect.closed() => {
+                        PermissionResult::deny("request canceled")
+                    }
                 }
             })
         },
@@ -322,6 +361,11 @@ async fn stream_events(
                     Err(e) => log::error!("encoding synthetic event: {e}"),
                 }
             }
+            // The client went away with nothing queued to send. Without this
+            // the loop would sit here forever: the two arms above are both
+            // waiting on something that will never arrive, and `out.send` —
+            // the only other place a disconnect is noticed — is never reached.
+            _ = out.closed() => return state,
             else => return state,
         }
     }
@@ -409,7 +453,12 @@ async fn handle_event(
             // shared `inputCh` does.
             let answer = {
                 let mut rx = answers.input.lock().await;
-                rx.recv().await
+                tokio::select! {
+                    answer = rx.recv() => answer,
+                    // Same disconnect race as the permission handler: this wait
+                    // is unbounded and the user may simply close the tab.
+                    _ = out.closed() => None,
+                }
             };
             let Some(answer) = answer else {
                 return Flow::Stop;
@@ -438,15 +487,46 @@ fn add_usage(state: &mut TurnState, result: &crate::claude::messages::Result) {
 }
 
 /// The input of the first `tool_use` named `AskUserQuestion`, if any.
+///
+/// # Borrowed, never round-tripped
+///
+/// This value goes straight into the `user_input_required` frame, so it is
+/// under the same rule as `append_assistant_blocks`: decoding it into a
+/// `serde_json::Value` sorts the keys and respells the floats, because
+/// `serde_json` is built without `preserve_order` and `Value::Object` is a
+/// `BTreeMap`. Go hands back the `json.RawMessage` untouched.
+///
+/// The first version of this function did round-trip, and the two producers of
+/// the same event then had different byte fidelity depending on which fired —
+/// the permission handler carried the SDK's raw bytes while this one had
+/// reordered them.
 fn extract_ask_user_question(raw: &[u8]) -> Option<Box<RawValue>> {
-    let value: serde_json::Value = serde_json::from_slice(raw).ok()?;
-    let content = value.get("message")?.get("content")?.as_array()?;
-    for block in content {
-        if block.get("type").and_then(|t| t.as_str()) == Some("tool_use")
-            && block.get("name").and_then(|n| n.as_str()) == Some("AskUserQuestion")
-        {
-            let input = block.get("input")?;
-            return RawValue::from_string(input.to_string()).ok();
+    #[derive(serde::Deserialize)]
+    struct Envelope<'a> {
+        #[serde(borrow)]
+        message: Option<Message<'a>>,
+    }
+    #[derive(serde::Deserialize)]
+    struct Message<'a> {
+        #[serde(borrow, default)]
+        content: Vec<Block<'a>>,
+    }
+    #[derive(serde::Deserialize)]
+    struct Block<'a> {
+        #[serde(rename = "type", default)]
+        block_type: &'a str,
+        #[serde(default)]
+        name: Option<&'a str>,
+        #[serde(borrow, default)]
+        input: Option<&'a RawValue>,
+    }
+
+    let envelope: Envelope = serde_json::from_slice(raw).ok()?;
+    let message = envelope.message?;
+    for block in message.content {
+        if block.block_type == "tool_use" && block.name == Some("AskUserQuestion") {
+            let input = block.input?;
+            return RawValue::from_string(input.get().to_string()).ok();
         }
     }
     None
@@ -498,6 +578,19 @@ mod tests {
         ]}}"#;
         let found = extract_ask_user_question(raw).expect("found");
         assert_eq!(found.get(), r#"{"q":"which?"}"#);
+    }
+
+    /// The single-key string payload above cannot see a reordering or a
+    /// respelling. This one can: two out-of-order keys and a trailing zero,
+    /// which a `serde_json::Value` round trip turns into
+    /// `{"a":1,"z":1.5}`.
+    #[test]
+    fn the_question_input_keeps_its_key_order_and_number_spelling() {
+        let raw = br#"{"message":{"content":[
+            {"type":"tool_use","id":"t1","name":"AskUserQuestion","input":{"z":1.50,"a":1,"note":"a & b"}}
+        ]}}"#;
+        let found = extract_ask_user_question(raw).expect("found");
+        assert_eq!(found.get(), r#"{"z":1.50,"a":1,"note":"a & b"}"#);
     }
 
     #[test]

--- a/desktop/src-tauri/src/native/chat/turn.rs
+++ b/desktop/src-tauri/src/native/chat/turn.rs
@@ -1,0 +1,526 @@
+//! One chat turn: spawn the CLI, stream its events as SSE, and persist what it
+//! produced. Mirrors `handleSendMessage` → `streamAgentSession` →
+//! `consumeAgentEvents` → `commitMessage` (`internal/api/chats.go`).
+//!
+//! # The shape of the loop
+//!
+//! Four things can happen and the loop selects over all of them: an event
+//! arrives from the CLI, the permission handler asks a question, the permission
+//! handler asks for an allow/deny, or the client disconnects. There is **no
+//! timeout** and **no heartbeat** — a long tool call sends nothing for minutes,
+//! by design.
+//!
+//! # Rules that are silent when broken
+//!
+//! - **There is no terminal event.** `result` means "turn done", not "stream
+//!   done": an `AskUserQuestion` keeps the same subprocess alive across several
+//!   turns in one HTTP request. The loop ends on stream close, on an error
+//!   result, or on a final result with nothing pending.
+//! - **A mid-stream failure is a `result` with `is_error: true`**, never an
+//!   `error` event, because the 200 was committed before the first frame.
+//! - **An event with no raw line emits nothing.** The SDK synthesizes process
+//!   failures as a `system` event with no `raw`, and Go's `len(event.Raw) > 0`
+//!   guard means the client is told *nothing* when the subprocess dies — the
+//!   stream simply ends. Reproduced.
+//! - **A turn with no final text persists no messages** — not even the user's —
+//!   so an interrupted stream cannot leave an orphan the CLI's own transcript
+//!   does not have. The session *row* is still updated.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{header, Response, StatusCode};
+use serde::Serialize;
+use serde_json::value::RawValue;
+use tokio::sync::mpsc;
+
+use crate::claude::messages::Event;
+use crate::claude::permissions::{PermissionContext, PermissionResult};
+use crate::claude::session::Session;
+
+use super::live::{registry, LiveSession};
+use super::runner::{self, RunSpec};
+use super::sse;
+
+/// How many notifications may queue before one is dropped.
+///
+/// Go's `questionCh`/`permissionReqCh` are capacity 4 with a non-blocking send,
+/// so a full buffer silently drops the notification — and the handler then waits
+/// forever for an answer the user was never asked for. Matching the capacity
+/// matters more than it looks: a different one changes when that happens.
+const NOTIFY_CAPACITY: usize = 4;
+
+/// The synthetic event announcing an `AskUserQuestion`.
+#[derive(Serialize)]
+struct UserInputRequired<'a> {
+    input: &'a RawValue,
+}
+
+/// The synthetic event announcing a tool permission prompt.
+#[derive(Serialize)]
+struct PermissionRequest {
+    tool_name: String,
+    /// `omitempty` on Go's `json.RawMessage` tests byte length, so an absent
+    /// input drops the key entirely.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    input: Option<Box<RawValue>>,
+}
+
+/// What the handler goroutine sends the stream.
+enum Notify {
+    Question(Box<RawValue>),
+    Permission(PermissionRequest),
+}
+
+/// What one turn accumulated, and what `commit` writes.
+#[derive(Default)]
+pub struct TurnState {
+    pub assistant_text: String,
+    pub sdk_session_id: String,
+    pub blocks: Vec<crate::native::chats::MessageBlock>,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_creation_tokens: i64,
+    pub cache_read_tokens: i64,
+}
+
+/// Run a turn and stream it.
+///
+/// Everything that can fail *before* the subprocess exists does so, so an `Err`
+/// here means nothing happened and the proxy may safely forward to Go.
+pub async fn run(
+    db_path: std::path::PathBuf,
+    chat_id: String,
+    content: String,
+) -> Result<Response<Body>, String> {
+    // Reject a concurrent send first, exactly as Go does: a second request
+    // would read a stale sdk_session_id and start a new CLI session instead of
+    // resuming the right one.
+    if !registry().try_lock(&chat_id) {
+        return Ok(error_json(
+            StatusCode::CONFLICT,
+            "session is busy, wait for the current message to complete",
+        ));
+    }
+    // From here every early return must release the lock, or the chat is
+    // wedged until the process restarts.
+    let guard = LockGuard {
+        id: chat_id.clone(),
+    };
+
+    let loaded = match runner::load(&db_path, &chat_id) {
+        Ok(Some(loaded)) => loaded,
+        Ok(None) => {
+            return Ok(error_json(
+                StatusCode::NOT_FOUND,
+                &format!("chat {chat_id:?} not found"),
+            ))
+        }
+        Err(e) => return Err(e),
+    };
+    let (row, agent) = loaded;
+
+    let fallback_model = if row.model.is_empty() {
+        default_model(&db_path)
+    } else {
+        row.model.clone()
+    };
+
+    let (notify_tx, notify_rx) = mpsc::channel::<Notify>(NOTIFY_CAPACITY);
+    let (input_tx, input_rx) = mpsc::channel::<String>(1);
+    let (perm_tx, perm_rx) = mpsc::channel::<bool>(1);
+
+    let answers = Arc::new(Answers {
+        input: tokio::sync::Mutex::new(input_rx),
+        permission: tokio::sync::Mutex::new(perm_rx),
+    });
+    let handler = build_permission_handler(notify_tx.clone(), Arc::clone(&answers));
+
+    let spec = RunSpec {
+        agent,
+        fallback_model,
+        working_dir: row.working_dir.clone(),
+        settings_profile_id: row.settings_profile_id.clone(),
+        resume_session_id: Some(row.sdk_session_id.clone()).filter(|s| !s.is_empty()),
+        chat_id: chat_id.clone(),
+    };
+    // Refuses for an agent whose tools this port cannot supply — before any
+    // subprocess exists, so forwarding is safe.
+    let options = runner::build_options(&spec, handler)?;
+
+    // The subprocess starts here. Past this point a failure can no longer
+    // forward, because Go would spawn a second one.
+    let mut session = Session::new(options)
+        .await
+        .map_err(|e| format!("starting agent session: {e}"))?;
+    if let Err(e) = session.send(&content).await {
+        session.close();
+        return Err(format!("sending first message: {e}"));
+    }
+
+    registry().put(
+        &chat_id,
+        LiveSession {
+            control: session.control(),
+            input_tx,
+            permission_resp_tx: perm_tx,
+        },
+    );
+
+    let is_first_message = row.title == "New Chat";
+    let (body_tx, body_rx) = mpsc::channel::<Result<Vec<u8>, std::io::Error>>(32);
+
+    tokio::spawn(async move {
+        let state = stream_events(&mut session, notify_rx, &body_tx, &answers).await;
+
+        // Go's defer order: forget the live session (which also releases the
+        // busy lock), then close the subprocess.
+        drop(guard);
+        registry().release(&chat_id);
+        session.close();
+
+        // The commit is detached from the request on purpose, so a client that
+        // disconnected mid-stream still has its turn persisted. Errors are
+        // logged and never surfaced — the stream has already ended.
+        if let Err(e) = super::persist::commit(&db_path, &row, &content, &state, is_first_message) {
+            log::error!("commit message failed for chat {chat_id}: {e}");
+        }
+    });
+
+    let stream = tokio_stream::wrappers::ReceiverStream::new(body_rx);
+    Ok(sse_response(Body::from_stream(stream)))
+}
+
+/// Releases the busy lock if an early return happens before the stream task
+/// takes ownership of it.
+struct LockGuard {
+    id: String,
+}
+
+impl Drop for LockGuard {
+    fn drop(&mut self) {
+        // The stream task calls `release` itself after dropping this, so a
+        // double release is possible and harmless — both are idempotent
+        // removals from a set.
+        registry().release(&self.id);
+    }
+}
+
+/// The receivers the permission handler waits on.
+///
+/// Behind mutexes because the handler is an `Arc<dyn Fn>` called from the SDK's
+/// reader task and must be `Send + Sync`, while an `mpsc::Receiver` is not
+/// shareable. Only one permission round trip is ever in flight — the CLI blocks
+/// on the answer — so the mutex is never contended.
+struct Answers {
+    input: tokio::sync::Mutex<mpsc::Receiver<String>>,
+    permission: tokio::sync::Mutex<mpsc::Receiver<bool>>,
+}
+
+/// `buildPermissionHandler`: `AskUserQuestion` is answered by *denying* the tool
+/// with the user's text as the message; everything else is a genuine
+/// allow/deny prompt.
+fn build_permission_handler(
+    notify: mpsc::Sender<Notify>,
+    answers: Arc<Answers>,
+) -> crate::claude::permissions::PermissionHandler {
+    Arc::new(
+        move |tool_name: String, input: Option<Box<RawValue>>, _ctx: PermissionContext| {
+            let notify = notify.clone();
+            let answers = Arc::clone(&answers);
+            Box::pin(async move {
+                if tool_name == "AskUserQuestion" {
+                    let raw = input.unwrap_or_else(empty_object);
+                    // Non-blocking: a full buffer drops the notification, matching
+                    // Go's `default:` arm. The wait below is then unbounded, which
+                    // is how a dropped notification wedges the turn — reproduced
+                    // rather than fixed, so the two implementations agree.
+                    let _ = notify.try_send(Notify::Question(raw));
+                    let mut rx = answers.input.lock().await;
+                    return match rx.recv().await {
+                        // The answer travels as the *denial message*. That is how
+                        // it reaches the model without the tool ever executing.
+                        Some(answer) => PermissionResult::deny(answer),
+                        None => PermissionResult::deny("request canceled"),
+                    };
+                }
+
+                let _ = notify.try_send(Notify::Permission(PermissionRequest { tool_name, input }));
+                let mut rx = answers.permission.lock().await;
+                match rx.recv().await {
+                    Some(true) => PermissionResult::allow(),
+                    Some(false) => PermissionResult::deny("Permission denied by user"),
+                    None => PermissionResult::deny("request canceled"),
+                }
+            })
+        },
+    )
+}
+
+fn empty_object() -> Box<RawValue> {
+    RawValue::from_string("{}".to_string()).expect("`{}` is valid JSON")
+}
+
+/// The event loop. Returns what the turn accumulated.
+async fn stream_events(
+    session: &mut Session,
+    mut notify_rx: mpsc::Receiver<Notify>,
+    out: &mpsc::Sender<Result<Vec<u8>, std::io::Error>>,
+    answers: &Arc<Answers>,
+) -> TurnState {
+    let mut state = TurnState::default();
+    let mut pending_input: Option<Box<RawValue>> = None;
+
+    loop {
+        tokio::select! {
+            event = session.next_event() => {
+                let Some(event) = event else {
+                    // The subprocess ended. This is the only "the turn is over"
+                    // signal there is.
+                    return state;
+                };
+                if !forward_event(&event, out).await {
+                    // The client hung up; the commit still runs.
+                    return state;
+                }
+                match handle_event(session, &event, &mut state, &mut pending_input, out, answers).await {
+                    Flow::Continue => {}
+                    Flow::Stop => return state,
+                }
+            }
+            Some(notification) = notify_rx.recv() => {
+                let frame = match &notification {
+                    Notify::Question(input) => {
+                        // A prompt from the handler supersedes one noticed in
+                        // the assistant event, so the user is not asked twice.
+                        pending_input = None;
+                        sse::json_frame("user_input_required", &UserInputRequired { input })
+                    }
+                    Notify::Permission(req) => sse::json_frame("permission_request", req),
+                };
+                match frame {
+                    Ok(bytes) => {
+                        if out.send(Ok(bytes)).await.is_err() {
+                            return state;
+                        }
+                    }
+                    Err(e) => log::error!("encoding synthetic event: {e}"),
+                }
+            }
+            else => return state,
+        }
+    }
+}
+
+enum Flow {
+    Continue,
+    Stop,
+}
+
+/// Forward the CLI's own line verbatim. Returns false when the client is gone.
+///
+/// **An event with no raw line emits nothing** — the SDK synthesizes process
+/// failures that way, so a crashed subprocess tells the client nothing and the
+/// stream just ends.
+async fn forward_event(event: &Event, out: &mpsc::Sender<Result<Vec<u8>, std::io::Error>>) -> bool {
+    let Some(raw) = event.raw.as_ref() else {
+        return true;
+    };
+    out.send(Ok(sse::raw_frame(&event.event_type, raw.get().as_bytes())))
+        .await
+        .is_ok()
+}
+
+async fn handle_event(
+    session: &Session,
+    event: &Event,
+    state: &mut TurnState,
+    pending_input: &mut Option<Box<RawValue>>,
+    out: &mpsc::Sender<Result<Vec<u8>, std::io::Error>>,
+    answers: &Arc<Answers>,
+) -> Flow {
+    match event.event_type.as_str() {
+        "assistant" => {
+            if let Some(raw) = event.raw.as_ref() {
+                super::persist::append_assistant_blocks(&mut state.blocks, raw.get().as_bytes());
+                if let Some(input) = extract_ask_user_question(raw.get().as_bytes()) {
+                    *pending_input = Some(input);
+                }
+            }
+            Flow::Continue
+        }
+        "result" => {
+            let Some(result) = event.result.as_ref() else {
+                // A result line the SDK could not decode: forwarded raw above,
+                // but it ends nothing.
+                return Flow::Continue;
+            };
+            add_usage(state, result);
+
+            if result.is_error {
+                // Keep a previously good session id rather than blanking it, so
+                // the next attempt still resumes the same CLI session.
+                if !result.session_id.is_empty() {
+                    state.sdk_session_id = result.session_id.clone();
+                }
+                return Flow::Stop;
+            }
+
+            state.sdk_session_id = result.session_id.clone();
+            state.assistant_text = result.result.clone();
+
+            let Some(input) = pending_input.take() else {
+                return Flow::Stop; // the final result
+            };
+
+            // An `AskUserQuestion` was seen, so this `result` is *not* the end:
+            // ask, wait, and continue the **same** subprocess into another turn.
+            // This is why one HTTP request can span several turns, and why the
+            // loop must never treat `result` as terminal.
+            match sse::json_frame("user_input_required", &UserInputRequired { input: &input }) {
+                Ok(bytes) => {
+                    if out.send(Ok(bytes)).await.is_err() {
+                        return Flow::Stop;
+                    }
+                }
+                Err(e) => {
+                    log::error!("encoding user_input_required: {e}");
+                    return Flow::Stop;
+                }
+            }
+
+            // The answer arrives on the same channel the permission handler
+            // waits on — whichever is listening consumes it, exactly as Go's
+            // shared `inputCh` does.
+            let answer = {
+                let mut rx = answers.input.lock().await;
+                rx.recv().await
+            };
+            let Some(answer) = answer else {
+                return Flow::Stop;
+            };
+            if let Err(e) = session.send(&answer).await {
+                log::error!("injecting the answer failed: {e}");
+                return Flow::Stop;
+            }
+            // Reset so the *next* turn's result is what gets persisted; the
+            // blocks and token totals keep accumulating across turns.
+            state.assistant_text.clear();
+            Flow::Continue
+        }
+        _ => Flow::Continue,
+    }
+}
+
+/// Token totals accumulate across **every** result in the request, including
+/// error ones and every turn of an AskUserQuestion exchange.
+fn add_usage(state: &mut TurnState, result: &crate::claude::messages::Result) {
+    let usage = &result.usage;
+    state.input_tokens += usage.input_tokens;
+    state.output_tokens += usage.output_tokens;
+    state.cache_creation_tokens += usage.cache_creation_input_tokens;
+    state.cache_read_tokens += usage.cache_read_input_tokens;
+}
+
+/// The input of the first `tool_use` named `AskUserQuestion`, if any.
+fn extract_ask_user_question(raw: &[u8]) -> Option<Box<RawValue>> {
+    let value: serde_json::Value = serde_json::from_slice(raw).ok()?;
+    let content = value.get("message")?.get("content")?.as_array()?;
+    for block in content {
+        if block.get("type").and_then(|t| t.as_str()) == Some("tool_use")
+            && block.get("name").and_then(|n| n.as_str()) == Some("AskUserQuestion")
+        {
+            let input = block.get("input")?;
+            return RawValue::from_string(input.to_string()).ok();
+        }
+    }
+    None
+}
+
+/// The four headers Go sets, and the 200 written before any event.
+fn sse_response(body: Body) -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "text/event-stream")
+        .header(header::CACHE_CONTROL, "no-cache")
+        .header(header::CONNECTION, "keep-alive")
+        .header("X-Accel-Buffering", "no")
+        .body(body)
+        .unwrap_or_else(|_| Response::new(Body::empty()))
+}
+
+/// A JSON error answered *before* the SSE headers — which is the only window in
+/// which an HTTP status can still say anything.
+fn error_json(status: StatusCode, message: &str) -> Response<Body> {
+    #[derive(Serialize)]
+    struct ErrorBody<'a> {
+        error: &'a str,
+    }
+    let body = crate::native::gojson::to_vec(&ErrorBody { error: message }).unwrap_or_default();
+    Response::builder()
+        .status(status)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body))
+        .unwrap_or_else(|_| Response::new(Body::empty()))
+}
+
+fn default_model(db_path: &std::path::Path) -> String {
+    let Ok(conn) = crate::native::db::open_read_only(db_path) else {
+        return String::new();
+    };
+    crate::native::settings::load_stored(&conn).default_model
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_ask_user_question_tool_use_is_found() {
+        let raw = br#"{"message":{"content":[
+            {"type":"text","text":"thinking"},
+            {"type":"tool_use","id":"t1","name":"AskUserQuestion","input":{"q":"which?"}}
+        ]}}"#;
+        let found = extract_ask_user_question(raw).expect("found");
+        assert_eq!(found.get(), r#"{"q":"which?"}"#);
+    }
+
+    #[test]
+    fn another_tool_use_is_not_mistaken_for_one() {
+        let raw = br#"{"message":{"content":[
+            {"type":"tool_use","id":"t1","name":"Bash","input":{"command":"ls"}}
+        ]}}"#;
+        assert!(extract_ask_user_question(raw).is_none());
+    }
+
+    #[test]
+    fn a_malformed_assistant_event_yields_nothing_rather_than_failing() {
+        assert!(extract_ask_user_question(b"not json").is_none());
+        assert!(extract_ask_user_question(b"{}").is_none());
+    }
+
+    /// `input` is omitted when absent, matching Go's `omitempty` on a
+    /// `json.RawMessage` — which tests byte length, so an absent input drops
+    /// the key rather than sending `null`.
+    #[test]
+    fn a_permission_request_omits_an_absent_input() {
+        let req = PermissionRequest {
+            tool_name: "Bash".into(),
+            input: None,
+        };
+        let frame = sse::json_frame("permission_request", &req).expect("encode");
+        let text = String::from_utf8(frame).unwrap();
+        assert_eq!(
+            text,
+            "event: permission_request\ndata: {\"tool_name\":\"Bash\"}\n\n"
+        );
+
+        let req = PermissionRequest {
+            tool_name: "Bash".into(),
+            input: Some(RawValue::from_string(r#"{"command":"ls"}"#.into()).unwrap()),
+        };
+        let frame = sse::json_frame("permission_request", &req).expect("encode");
+        let text = String::from_utf8(frame).unwrap();
+        assert!(text.contains(r#""input":{"command":"ls"}"#), "{text}");
+    }
+}

--- a/desktop/src-tauri/src/native/migrate.rs
+++ b/desktop/src-tauri/src/native/migrate.rs
@@ -315,6 +315,21 @@ mod tests {
         let file = tempfile::NamedTempFile::new().expect("temp file");
         let path = file.path().to_path_buf();
 
+        // WAL is set **once, up front** — not per thread.
+        //
+        // It is persistent in the file, so both connections inherit it. Setting
+        // it inside each thread is what made this flake in CI: switching journal
+        // mode needs a lock SQLite refuses to *wait* for, so it returns
+        // `SQLITE_BUSY` immediately rather than honouring a busy timeout, and
+        // the test failed on its own setup instead of on the property it
+        // measures. The app never hits this because the mode is already set by
+        // the time anything opens the database.
+        {
+            let conn = Connection::open(&path).expect("open");
+            conn.pragma_update(None, "journal_mode", "WAL")
+                .expect("wal");
+        }
+
         let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
         let handles: Vec<_> = (0..2)
             .map(|_| {
@@ -322,10 +337,6 @@ mod tests {
                 let barrier = std::sync::Arc::clone(&barrier);
                 std::thread::spawn(move || {
                     let mut conn = Connection::open(&path).expect("open");
-                    // WAL so the two do not serialize on the whole file, which
-                    // is the configuration the app actually runs.
-                    conn.pragma_update(None, "journal_mode", "WAL")
-                        .expect("wal");
                     barrier.wait();
                     apply(&mut conn)
                 })

--- a/desktop/src-tauri/src/native/mod.rs
+++ b/desktop/src-tauri/src/native/mod.rs
@@ -14,6 +14,7 @@
 pub mod active_time;
 pub mod agents;
 pub mod analytics;
+pub mod chat;
 pub mod chats;
 pub mod db;
 pub mod diff;
@@ -166,6 +167,64 @@ pub struct Endpoint {
     pub serve: fn(&Ctx, &Request) -> Result<Answer, String>,
 }
 
+/// A request whose answer is a *stream*, not a buffered body.
+///
+/// # Why this is a second registry rather than a wider `Answer`
+///
+/// [`Answer`] is a `Vec<u8>` and [`Endpoint::serve`] is a **sync** `fn` the
+/// proxy runs on `spawn_blocking` — the right shape for thirteen areas that
+/// read SQLite and hand back a finished document. A chat turn is neither: it is
+/// async, it lasts as long as the model talks, and buffering it would defeat
+/// the point of SSE.
+///
+/// Widening `Answer` to express both would make every buffered handler carry a
+/// streaming case it never uses, and would put an async runtime in front of a
+/// blocking read. So streaming gets its own registry, and the two share only
+/// `claims`-style routing. `native::claims` is the union, because the proxy asks
+/// one question: is this route ours?
+pub struct StreamEndpoint {
+    pub name: &'static str,
+    pub claims: fn(&Method, &str) -> bool,
+    /// Owned rather than borrowed, so the returned future is `'static` and can
+    /// outlive the call — which it must, since the response body is produced
+    /// long after `serve` returns.
+    pub serve: fn(StreamRequest) -> BoxFuture<'static, Result<Response<Body>, String>>,
+}
+
+/// Everything a streaming handler needs, owned.
+pub struct StreamRequest {
+    pub method: Method,
+    pub path: String,
+    pub body: Vec<u8>,
+    pub db_path: std::path::PathBuf,
+}
+
+pub type BoxFuture<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output = T> + Send + 'a>>;
+
+/// Areas whose answer streams. Only chat execution, and likely only ever.
+const STREAM_ENDPOINTS: &[StreamEndpoint] = &[chat::ENDPOINT];
+
+/// Whether this request is answered by a *streaming* native handler.
+pub fn claims_stream(method: &Method, path: &str) -> bool {
+    STREAM_ENDPOINTS.iter().any(|e| (e.claims)(method, path))
+}
+
+/// Answer a claimed streaming request. `Err` forwards, exactly as for a
+/// buffered one — and the same rule applies: a handler must fail *before* it
+/// has any effect, because the forward re-runs it. For a chat turn that means
+/// every check happens before the subprocess is spawned.
+pub async fn serve_stream(req: StreamRequest) -> Result<Response<Body>, String> {
+    for endpoint in STREAM_ENDPOINTS {
+        if (endpoint.claims)(&req.method, &req.path) {
+            return (endpoint.serve)(req).await;
+        }
+    }
+    Err(format!(
+        "{} {} is claimed but has no handler",
+        req.method, req.path
+    ))
+}
+
 /// Every ported area, in match order.
 ///
 /// **Adding an endpoint is one appended line here plus its own module.** That
@@ -198,7 +257,7 @@ const ENDPOINTS: &[Endpoint] = &[
 /// trailing slash, which chi treats as a different route — falls through to Go
 /// and keeps whatever answer Go gives it.
 pub fn claims(method: &Method, path: &str) -> bool {
-    ENDPOINTS.iter().any(|e| (e.claims)(method, path))
+    ENDPOINTS.iter().any(|e| (e.claims)(method, path)) || claims_stream(method, path)
 }
 
 /// Whether a request may be *executed* natively in the seam's current mode.
@@ -316,8 +375,18 @@ mod tests {
         assert!(claims(&Method::DELETE, "/api/chats"));
         assert!(claims(&Method::PATCH, "/api/chats/abc-123"));
         assert!(claims(&Method::DELETE, "/api/chats/abc-123"));
-        assert!(!claims(&Method::POST, "/api/chats/abc-123/messages"));
-        assert!(!claims(&Method::POST, "/api/chats/abc-123/stop"));
+        // Since #276 the four streaming actions are ours too — but through the
+        // *streaming* registry, which is why `claims` (the union) says yes.
+        assert!(claims(&Method::POST, "/api/chats/abc-123/messages"));
+        assert!(claims(&Method::POST, "/api/chats/abc-123/stop"));
+        assert!(claims(&Method::POST, "/api/chats/abc-123/input"));
+        assert!(claims(&Method::POST, "/api/chats/abc-123/permission"));
+        assert!(claims_stream(&Method::POST, "/api/chats/abc-123/messages"));
+        // …and only the streaming one: the buffered registry must not also
+        // claim them, or a chat turn would be answered with a `Vec<u8>`.
+        assert!(!ENDPOINTS
+            .iter()
+            .any(|e| (e.claims)(&Method::POST, "/api/chats/abc-123/messages")));
         assert!(!claims(&Method::GET, "/api/chats/abc-123/messages"));
         assert!(!claims(&Method::GET, "/api/chats/abc-123/stop"));
         assert!(!claims(&Method::GET, "/api/chats/"));

--- a/desktop/src-tauri/src/native/settings.rs
+++ b/desktop/src-tauri/src/native/settings.rs
@@ -221,7 +221,11 @@ pub fn default_claude_config_dir() -> String {
 /// The single dir a run targets: `CLAUDE_CONFIG_DIR` first, then the stored
 /// global setting, then the default. The environment comes first because it is
 /// what the surrounding environment has already chosen for every subprocess.
-fn run_config_dir(stored: &str) -> String {
+///
+/// `pub(crate)` since #276: the chat runner needs the same answer, because an
+/// agent's per-run override resolves *against* this and a second copy of the
+/// precedence would be a second thing to keep in step.
+pub(crate) fn run_config_dir(stored: &str) -> String {
     if let Ok(env) = std::env::var("CLAUDE_CONFIG_DIR") {
         if let Some(dir) = absolute_dir(&normalize(&env)) {
             return dir;
@@ -239,7 +243,7 @@ fn run_config_dir(stored: &str) -> String {
 /// This is not tidiness: the dirs are deduplicated by string comparison and
 /// recorded on cached rows, so `~/.claude`, `$HOME/.claude` and `$HOME/.claude/`
 /// must collapse to one value or the same corpus is attributed to two dirs.
-fn normalize(p: &str) -> String {
+pub(crate) fn normalize(p: &str) -> String {
     let p = p.trim();
     if p.is_empty() {
         return String::new();
@@ -276,7 +280,7 @@ fn clean(p: &str) -> String {
 /// Absolute paths only. A relative config dir means two different things at
 /// once — Agento resolves it against the server's working directory, Claude
 /// Code against the subprocess's — so Go drops it and so does this.
-fn absolute_dir(p: &str) -> Option<String> {
+pub(crate) fn absolute_dir(p: &str) -> Option<String> {
     if p.is_empty() || !Path::new(p).is_absolute() {
         return None;
     }

--- a/desktop/src-tauri/src/proxy.rs
+++ b/desktop/src-tauri/src/proxy.rs
@@ -158,17 +158,15 @@ async fn handle(State(state): State<ProxyState>, req: Request<Body>) -> Response
         };
 
         match native::serve_stream(stream_req).await {
-            // `/input`, `/permission` and `/stop` answer this when Rust holds no
-            // live session for the chat — Go may, and its answer is the right
-            // one. See `native::chat`'s header.
-            Ok(response) if native::chat::is_forward(&response) => {
-                return forward_or_bad_gateway(&state, req, &path).await;
-            }
             Ok(response) => return response,
             // Same rule as the buffered path, and the same obligation: a
             // streaming handler must fail *before* it has any effect, or the
             // forward spawns a second subprocess. Every check in `turn::run`
             // happens before the CLI is started.
+            //
+            // This is also how `/input`, `/permission` and `/stop` hand a chat
+            // back when Rust holds no live session for it — Go may, and its
+            // answer is then the right one. See `native::chat`'s header.
             Err(e) => {
                 log::warn!("native stream for {path} failed, forwarding to Go: {e}");
                 return forward_or_bad_gateway(&state, req, &path).await;

--- a/desktop/src-tauri/src/proxy.rs
+++ b/desktop/src-tauri/src/proxy.rs
@@ -75,7 +75,27 @@ pub async fn serve(upstream_port: u16, port: u16) -> Result<u16, String> {
 /// so claiming a route and implementing it are one edit rather than two files
 /// that can disagree.
 fn route_is_native(method: &axum::http::Method, path: &str) -> bool {
-    native::may_serve(native::mode(), method) && native::claims(method, path)
+    native::may_serve(native::mode(), method)
+        && native::claims(method, path)
+        // The streaming routes are handled above; `claims` is the union of both
+        // registries, so the buffered path has to exclude them or it would try
+        // to answer a chat turn with a `Vec<u8>`.
+        && !native::claims_stream(method, path)
+}
+
+/// Forward, turning a proxy failure into the 502 the caller would have written.
+async fn forward_or_bad_gateway(
+    state: &ProxyState,
+    req: Request<Body>,
+    path: &str,
+) -> Response<Body> {
+    match forward(state, req).await {
+        Ok(resp) => resp,
+        Err(e) => {
+            log::error!("proxy error for {path}: {e}");
+            error_response(StatusCode::BAD_GATEWAY, &e)
+        }
+    }
 }
 
 /// How much request body a native handler will accept.
@@ -106,6 +126,53 @@ async fn handle(State(state): State<ProxyState>, req: Request<Body>) -> Response
                 StatusCode::NOT_FOUND,
                 "frontend is served by Vite in development",
             );
+        }
+    }
+
+    // The streaming half of the seam (#276). Checked before the buffered one
+    // because a chat turn must never be collected into a `Vec<u8>`: it is the
+    // one response whose whole point is arriving in pieces.
+    if native::may_serve(native::mode(), req.method()) && native::claims_stream(req.method(), &path)
+    {
+        let (parts, body) = req.into_parts();
+        let body_bytes = match axum::body::to_bytes(body, MAX_NATIVE_BODY).await {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                log::warn!("native stream for {path}: reading body failed: {e}");
+                return error_response(StatusCode::BAD_REQUEST, "could not read request body");
+            }
+        };
+        let req = Request::from_parts(parts, Body::from(body_bytes.clone()));
+
+        let stream_req = native::StreamRequest {
+            method: req.method().clone(),
+            path: path.clone(),
+            body: body_bytes.to_vec(),
+            db_path: match crate::paths::database_path() {
+                Some(path) => path,
+                None => {
+                    log::warn!("native stream for {path}: no data dir, forwarding");
+                    return forward_or_bad_gateway(&state, req, &path).await;
+                }
+            },
+        };
+
+        match native::serve_stream(stream_req).await {
+            // `/input`, `/permission` and `/stop` answer this when Rust holds no
+            // live session for the chat — Go may, and its answer is the right
+            // one. See `native::chat`'s header.
+            Ok(response) if native::chat::is_forward(&response) => {
+                return forward_or_bad_gateway(&state, req, &path).await;
+            }
+            Ok(response) => return response,
+            // Same rule as the buffered path, and the same obligation: a
+            // streaming handler must fail *before* it has any effect, or the
+            // forward spawns a second subprocess. Every check in `turn::run`
+            // happens before the CLI is started.
+            Err(e) => {
+                log::warn!("native stream for {path} failed, forwarding to Go: {e}");
+                return forward_or_bad_gateway(&state, req, &path).await;
+            }
         }
     }
 

--- a/desktop/src-tauri/tests/chat_turn.rs
+++ b/desktop/src-tauri/tests/chat_turn.rs
@@ -299,10 +299,7 @@ async fn an_ask_user_question_keeps_the_stream_open_past_the_first_result() {
     elif msg.get("type") == "user":
         text = json.dumps(msg.get("message", {}).get("content", ""))
         if "second" not in text:
-            say({"type": "assistant", "message": {"content": [
-                {"type": "tool_use", "id": "q1", "name": "AskUserQuestion",
-                 "input": {"question": "which one?"}}
-            ]}})
+            raw('{"type":"assistant","message":{"content":[{"type":"tool_use","id":"q1","name":"AskUserQuestion","input":{"z":1.50,"question":"which one?"}}]}}')
             say({"type": "result", "subtype": "success", "is_error": False,
                  "result": "", "session_id": "sdk-1", "usage": {}})
         else:
@@ -334,10 +331,13 @@ async fn an_ask_user_question_keeps_the_stream_open_past_the_first_result() {
         "body was: {body}"
     );
 
-    let prompt = &frames[2].1;
-    assert!(
-        prompt.contains(r#""input":{"question":"which one?"}"#),
-        "the prompt carries the tool input verbatim: {prompt}"
+    // Byte for byte, including the out-of-order key and the trailing zero. A
+    // round trip through a `serde_json::Value` yields `{"question":…,"z":1.5}`
+    // — which is exactly what this path used to do, and what the single-key
+    // payload this test started with could not detect.
+    assert_eq!(
+        frames[2].1, r#"{"input":{"z":1.50,"question":"which one?"}}"#,
+        "the prompt must carry the tool input verbatim"
     );
 }
 
@@ -371,6 +371,75 @@ async fn a_mid_stream_failure_arrives_as_an_error_result_and_ends_the_turn() {
     assert!(
         !body.contains("error\ndata"),
         "there is no `error` event type on this path"
+    );
+}
+
+/// A client that disconnects while a prompt is pending must tear the turn down:
+/// release the busy lock, close the subprocess and let the commit run.
+///
+/// This is the case that had no coverage and no code. The permission handler is
+/// awaited **inline on the SDK's reader task**, so while it is parked nothing
+/// arrives and the stream loop has nothing to send — the disconnect is
+/// invisible unless something races it explicitly. Without that race, closing a
+/// tab left the chat answering `409 session is busy` for the life of the
+/// process and leaked a `claude` subprocess.
+///
+/// This drives the **post-result continuation** and the loop's own arm. The
+/// third wait — the `can_use_tool` permission round trip — needs the fake to
+/// issue a control request, which is #298.
+#[tokio::test]
+async fn a_disconnect_while_a_prompt_is_pending_releases_the_chat() {
+    let Some(_) = python3() else {
+        eprintln!("skipping: no python3");
+        return;
+    };
+    let dir = tempfile::tempdir().expect("tempdir");
+    // Asks a question and then says nothing more, so the turn parks exactly
+    // where a real one waits for the user.
+    let cli = fake_cli(
+        dir.path(),
+        r#"
+    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack(req.get("request_id") or msg.get("request_id"))
+    elif msg.get("type") == "user":
+        raw('{"type":"assistant","message":{"content":[{"type":"tool_use","id":"q1","name":"AskUserQuestion","input":{"question":"stuck?"}}]}}')
+        raw('{"type":"result","subtype":"success","is_error":false,"result":"","session_id":"sdk-1","usage":{}}')
+"#,
+    );
+
+    let id = unique_id("disconnect");
+    let file = migrated_with_chat(&id);
+    let _env = env_lock().lock().await;
+    std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", &cli);
+
+    let response = agento_lib::native::chat::turn::run(
+        file.path().to_path_buf(),
+        id.clone(),
+        "hello".to_string(),
+    )
+    .await
+    .expect("the turn should stream");
+
+    // Drop the body without reading it to the end — a closed tab.
+    drop(response);
+
+    // The turn must notice and release. Poll rather than sleep a fixed amount:
+    // the teardown is asynchronous, and a fixed wait is either flaky or slow.
+    let mut released = false;
+    for _ in 0..200 {
+        if agento_lib::native::chat::live::registry()
+            .get(&id)
+            .is_none()
+            && agento_lib::native::chat::live::registry().try_lock(&id)
+        {
+            released = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    assert!(
+        released,
+        "a disconnected turn must release the busy lock, or the chat is wedged"
     );
 }
 

--- a/desktop/src-tauri/tests/chat_turn.rs
+++ b/desktop/src-tauri/tests/chat_turn.rs
@@ -1,0 +1,463 @@
+//! The chat turn, driven against a **scripted fake CLI** (#276).
+//!
+//! Every rule this port has to honour is a property of a *sequence*, not of a
+//! function: that `result` does not end the stream when an `AskUserQuestion` is
+//! pending, that an `AskUserQuestion` is answered by *denying* the tool, that a
+//! turn with no final text persists nothing, that a subprocess dying emits no
+//! frame at all. A unit test can reach none of them, which is why the SDK's own
+//! suite uses this technique and why this file reuses it.
+//!
+//! The fake is a small Python program: no `claude` binary, no API key, runs in
+//! CI like any other test.
+
+use std::path::{Path, PathBuf};
+
+use agento_lib::native::chat::persist;
+use agento_lib::native::chat::turn::TurnState;
+use agento_lib::native::chats;
+
+/// Skips when the machine has no `python3`, as the SDK suite does.
+fn python3() -> Option<String> {
+    for candidate in ["python3", "python"] {
+        if std::process::Command::new(candidate)
+            .arg("--version")
+            .output()
+            .is_ok()
+        {
+            return Some(candidate.to_string());
+        }
+    }
+    None
+}
+
+/// A chat id unique to the calling test.
+///
+/// The live-session registry is a **process global** — it has to be, since a
+/// chat turn is process state — and cargo runs tests in parallel in one
+/// process. Sharing an id would make one test see another's busy lock and get
+/// the 409, which is a test collision rather than a finding.
+fn unique_id(label: &str) -> String {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    static NEXT: AtomicU32 = AtomicU32::new(0);
+    format!("{label}-{}", NEXT.fetch_add(1, Ordering::Relaxed))
+}
+
+/// A database with the real schema and one chat row.
+fn migrated_with_chat(id: &str) -> tempfile::NamedTempFile {
+    let file = tempfile::NamedTempFile::new().expect("temp file");
+    let mut conn = rusqlite::Connection::open(file.path()).expect("open");
+    agento_lib::native::migrate::apply(&mut conn).expect("migrate");
+    conn.execute(
+        "INSERT INTO chat_sessions (id, title, agent_slug, created_at, updated_at)
+         VALUES (?1, 'New Chat', '', '2026-01-01 00:00:00 +0000 UTC', '2026-01-01 00:00:00 +0000 UTC')",
+        [id],
+    )
+    .expect("seed chat");
+    file
+}
+
+fn chat_row(id: &str) -> agento_lib::native::chat::runner::ChatRow {
+    agento_lib::native::chat::runner::ChatRow {
+        id: id.to_string(),
+        title: "New Chat".into(),
+        agent_slug: String::new(),
+        sdk_session_id: String::new(),
+        working_dir: String::new(),
+        model: String::new(),
+        settings_profile_id: String::new(),
+    }
+}
+
+fn messages(file: &tempfile::NamedTempFile, id: &str) -> Vec<(String, String)> {
+    let conn = rusqlite::Connection::open(file.path()).expect("open");
+    let mut stmt = conn
+        .prepare("SELECT role, content FROM chat_messages WHERE session_id = ?1 ORDER BY id")
+        .expect("prepare");
+    let rows = stmt
+        .query_map([id], |r| {
+            Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
+        })
+        .expect("query");
+    rows.map(|r| r.expect("row")).collect()
+}
+
+// ─── The persistence rules ────────────────────────────────────────────────────
+
+/// The headline rule, and the half of it that is easy to over-apply: no
+/// messages, but the session row is still written.
+#[test]
+fn an_interrupted_turn_persists_no_messages_but_still_updates_the_session() {
+    let file = migrated_with_chat("c1");
+    let state = TurnState {
+        // No final text: the stream was interrupted.
+        input_tokens: 42,
+        ..Default::default()
+    };
+    persist::commit(file.path(), &chat_row("c1"), "my question", &state, true).expect("commit");
+
+    assert!(
+        messages(&file, "c1").is_empty(),
+        "not even the user message may be stored"
+    );
+
+    let conn = rusqlite::Connection::open(file.path()).expect("open");
+    let (title, tokens): (String, i64) = conn
+        .query_row(
+            "SELECT title, total_input_tokens FROM chat_sessions WHERE id='c1'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .expect("row");
+    // A title derived from a message that was never stored — Go's behaviour,
+    // and the reason "persists nothing" cannot be read as covering the row.
+    assert_eq!(title, "my question");
+    assert_eq!(tokens, 42);
+}
+
+#[test]
+fn a_completed_turn_stores_the_user_message_and_the_reply_in_order() {
+    let file = migrated_with_chat("c1");
+    let state = TurnState {
+        assistant_text: "the answer".into(),
+        sdk_session_id: "sdk-1".into(),
+        ..Default::default()
+    };
+    persist::commit(file.path(), &chat_row("c1"), "the question", &state, true).expect("commit");
+
+    assert_eq!(
+        messages(&file, "c1"),
+        vec![
+            ("user".to_string(), "the question".to_string()),
+            ("assistant".to_string(), "the answer".to_string()),
+        ]
+    );
+}
+
+/// The blocks a turn accumulated are stored with the assistant message, and a
+/// `tool_use` input keeps its bytes — key order and number spelling included.
+#[test]
+fn tool_use_input_survives_the_round_trip_byte_for_byte() {
+    let file = migrated_with_chat("c1");
+    let mut blocks = Vec::new();
+    persist::append_assistant_blocks(
+        &mut blocks,
+        br#"{"message":{"content":[
+            {"type":"tool_use","id":"t1","name":"Bash","input":{"z":1.50,"a":[1,2]}}
+        ]}}"#,
+    );
+    let state = TurnState {
+        assistant_text: "done".into(),
+        blocks,
+        ..Default::default()
+    };
+    persist::commit(file.path(), &chat_row("c1"), "run it", &state, false).expect("commit");
+
+    // Read back through the same path the chat detail endpoint uses.
+    let detail = chats::get(file.path(), "c1")
+        .expect("get")
+        .expect("chat exists");
+    let assistant = detail
+        .messages
+        .iter()
+        .find(|m| m.role == "assistant")
+        .expect("assistant message");
+    let input = assistant.blocks[0]
+        .input
+        .as_ref()
+        .expect("tool_use input")
+        .get();
+    assert_eq!(
+        input, r#"{"z":1.50,"a":[1,2]}"#,
+        "a round trip through a JSON value would sort the keys and respell 1.50"
+    );
+}
+
+// ─── The sequence rules, against a real subprocess ────────────────────────────
+
+/// Writes an executable fake `claude` that replies with a scripted sequence.
+fn fake_cli(dir: &Path, emit: &str) -> PathBuf {
+    let script = format!(
+        r#"#!/usr/bin/env {python}
+import json, sys, threading, time
+
+def say(obj):
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+
+def raw(line):
+    # Exact bytes. json.dumps would insert spaces after ':' and ',' and would
+    # renormalise 1.50 to 1.5 — which is precisely what a byte-exactness test
+    # must not depend on.
+    sys.stdout.write(line + "\n")
+    sys.stdout.flush()
+
+def ack(request_id):
+    say({{"type": "control_response",
+         "response": {{"subtype": "success", "request_id": request_id,
+                       "response": {{"models": [{{"value": "fake", "displayName": "Fake"}}],
+                                     "account": {{"apiProvider": "fake"}},
+                                     "output_style": "default"}}}}}})
+
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        msg = json.loads(line)
+    except Exception:
+        continue
+    req = msg.get("request") or {{}}
+{emit}
+"#,
+        python = python3().unwrap_or_else(|| "python3".into()),
+        emit = emit,
+    );
+    let path = dir.join("fake-claude");
+    std::fs::write(&path, script).expect("write fake CLI");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod fake CLI");
+    }
+    path
+}
+
+/// Collect an SSE body into frames, splitting on the blank line.
+fn frames(body: &str) -> Vec<(String, String)> {
+    body.split("\n\n")
+        .filter(|chunk| !chunk.trim().is_empty())
+        .map(|chunk| {
+            let mut event = String::new();
+            let mut data = String::new();
+            for line in chunk.lines() {
+                if let Some(rest) = line.strip_prefix("event: ") {
+                    event = rest.to_string();
+                } else if let Some(rest) = line.strip_prefix("data: ") {
+                    data = rest.to_string();
+                }
+            }
+            (event, data)
+        })
+        .collect()
+}
+
+/// The CLI's own lines are forwarded **verbatim**, named by their `type`, and a
+/// `result` ends the turn when nothing is pending.
+#[tokio::test]
+async fn a_turn_forwards_the_cli_lines_verbatim_and_ends_on_the_final_result() {
+    let Some(_) = python3() else {
+        eprintln!("skipping: no python3");
+        return;
+    };
+    let dir = tempfile::tempdir().expect("tempdir");
+    // A `tool_use` input with an unsorted key and a trailing-zero float: if any
+    // layer re-encodes, this is what changes.
+    let cli = fake_cli(
+        dir.path(),
+        r#"
+    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack(req.get("request_id") or msg.get("request_id"))
+    elif msg.get("type") == "user":
+        raw('{"type":"assistant","message":{"content":[{"type":"text","text":"hi"},{"type":"tool_use","id":"t1","name":"Bash","input":{"z":1.50,"a":1}}]}}')
+        raw('{"type":"result","subtype":"success","is_error":false,"result":"all done","session_id":"sdk-xyz","usage":{"input_tokens":3,"output_tokens":4}}')
+"#,
+    );
+
+    let id = unique_id("verbatim");
+    let body = run_turn(&cli, &id, "hello").await;
+    let frames = frames(&body);
+
+    let names: Vec<&str> = frames.iter().map(|(e, _)| e.as_str()).collect();
+    assert_eq!(names, vec!["assistant", "result"], "body was: {body}");
+
+    // Verbatim: the assistant frame carries the CLI's bytes, unsorted keys and
+    // `1.50` intact.
+    // The whole assistant line, byte for byte — unsorted keys and the trailing
+    // zero intact. Any layer that decoded and re-encoded would fail here.
+    assert_eq!(
+        frames[0].1,
+        r#"{"type":"assistant","message":{"content":[{"type":"text","text":"hi"},{"type":"tool_use","id":"t1","name":"Bash","input":{"z":1.50,"a":1}}]}}"#
+    );
+}
+
+/// The rule most likely to be got wrong: `result` means "turn done", not
+/// "stream done". With an `AskUserQuestion` pending the same subprocess carries
+/// on, so **one HTTP request spans two turns and two `result` frames**.
+#[tokio::test]
+async fn an_ask_user_question_keeps_the_stream_open_past_the_first_result() {
+    let Some(_) = python3() else {
+        eprintln!("skipping: no python3");
+        return;
+    };
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cli = fake_cli(
+        dir.path(),
+        r#"
+    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack(req.get("request_id") or msg.get("request_id"))
+    elif msg.get("type") == "user":
+        text = json.dumps(msg.get("message", {}).get("content", ""))
+        if "second" not in text:
+            say({"type": "assistant", "message": {"content": [
+                {"type": "tool_use", "id": "q1", "name": "AskUserQuestion",
+                 "input": {"question": "which one?"}}
+            ]}})
+            say({"type": "result", "subtype": "success", "is_error": False,
+                 "result": "", "session_id": "sdk-1", "usage": {}})
+        else:
+            say({"type": "assistant", "message": {"content": [
+                {"type": "text", "text": "thanks"}
+            ]}})
+            say({"type": "result", "subtype": "success", "is_error": False,
+                 "result": "final answer", "session_id": "sdk-1", "usage": {}})
+"#,
+    );
+
+    let id = unique_id("askuser");
+    let (body, answered) = run_turn_answering(&cli, &id, "hello", "second").await;
+    assert!(answered, "the answer was never delivered");
+    let frames = frames(&body);
+    let names: Vec<&str> = frames.iter().map(|(e, _)| e.as_str()).collect();
+
+    // The synthetic prompt sits between the two results — proof the first one
+    // did not end the stream.
+    assert_eq!(
+        names,
+        vec![
+            "assistant",
+            "result",
+            "user_input_required",
+            "assistant",
+            "result"
+        ],
+        "body was: {body}"
+    );
+
+    let prompt = &frames[2].1;
+    assert!(
+        prompt.contains(r#""input":{"question":"which one?"}"#),
+        "the prompt carries the tool input verbatim: {prompt}"
+    );
+}
+
+/// A mid-stream failure is a `result` with `is_error: true`, never an `error`
+/// event — the 200 was committed before the first frame.
+#[tokio::test]
+async fn a_mid_stream_failure_arrives_as_an_error_result_and_ends_the_turn() {
+    let Some(_) = python3() else {
+        eprintln!("skipping: no python3");
+        return;
+    };
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cli = fake_cli(
+        dir.path(),
+        r#"
+    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack(req.get("request_id") or msg.get("request_id"))
+    elif msg.get("type") == "user":
+        raw('{"type":"result","subtype":"error_during_execution","is_error":true,"result":"","session_id":"sdk-err","usage":{}}')
+        raw('{"type":"assistant","message":{"content":[{"type":"text","text":"unreachable"}]}}')
+"#,
+    );
+
+    let id = unique_id("midfail");
+    let body = run_turn(&cli, &id, "hello").await;
+    let frames = frames(&body);
+    let names: Vec<&str> = frames.iter().map(|(e, _)| e.as_str()).collect();
+
+    assert_eq!(names, vec!["result"], "the turn ends immediately: {body}");
+    assert!(frames[0].1.contains(r#""is_error":true"#));
+    assert!(
+        !body.contains("error\ndata"),
+        "there is no `error` event type on this path"
+    );
+}
+
+// ─── Harness ──────────────────────────────────────────────────────────────────
+
+/// Drive one turn against the fake CLI and collect the whole SSE body.
+async fn run_turn(cli: &Path, chat_id: &str, content: &str) -> String {
+    let (body, _) = run_turn_inner(cli, chat_id, content, None).await;
+    body
+}
+
+/// The same, answering the first `user_input_required` with `answer`.
+async fn run_turn_answering(
+    cli: &Path,
+    chat_id: &str,
+    content: &str,
+    answer: &str,
+) -> (String, bool) {
+    run_turn_inner(cli, chat_id, content, Some(answer.to_string())).await
+}
+
+async fn run_turn_inner(
+    cli: &Path,
+    chat_id: &str,
+    content: &str,
+    answer: Option<String>,
+) -> (String, bool) {
+    use http_body_util::BodyExt;
+
+    let file = migrated_with_chat(chat_id);
+    // The SDK resolves the executable from this variable, so the fake stands in
+    // for a real `claude` without any code path knowing.
+    std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", cli);
+
+    let response = agento_lib::native::chat::turn::run(
+        file.path().to_path_buf(),
+        chat_id.to_string(),
+        content.to_string(),
+    )
+    .await
+    .expect("the turn should stream");
+
+    assert_eq!(response.status(), 200);
+    assert_eq!(
+        response
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok()),
+        Some("text/event-stream")
+    );
+    assert_eq!(
+        response
+            .headers()
+            .get("x-accel-buffering")
+            .and_then(|v| v.to_str().ok()),
+        Some("no")
+    );
+
+    let mut answered = false;
+    if let Some(answer) = answer {
+        // Deliver the answer once the prompt has been emitted. The registry is
+        // the same one `/input` uses, so this exercises that path.
+        let chat_id = chat_id.to_string();
+        let handle = tokio::spawn(async move {
+            for _ in 0..200 {
+                if let Some((_, input_tx, _)) =
+                    agento_lib::native::chat::live::registry().get(&chat_id)
+                {
+                    if input_tx.send(answer.clone()).await.is_ok() {
+                        return true;
+                    }
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            }
+            false
+        });
+        let collected = response.into_body().collect().await.expect("body");
+        answered = handle.await.unwrap_or(false);
+        return (
+            String::from_utf8(collected.to_bytes().to_vec()).expect("utf8"),
+            answered,
+        );
+    }
+
+    let collected = response.into_body().collect().await.expect("body");
+    (
+        String::from_utf8(collected.to_bytes().to_vec()).expect("utf8"),
+        answered,
+    )
+}

--- a/desktop/src-tauri/tests/chat_turn.rs
+++ b/desktop/src-tauri/tests/chat_turn.rs
@@ -392,6 +392,18 @@ async fn run_turn_answering(
     run_turn_inner(cli, chat_id, content, Some(answer.to_string())).await
 }
 
+/// Serialises the turn tests.
+///
+/// `AGENTO_CLAUDE_EXECUTABLE` is **process-global**, and cargo runs these in
+/// parallel in one process — so without this each test would overwrite the
+/// others' fake CLI path and they would spawn each other's scripts. The lock is
+/// held for the whole turn, not just the `set_var`, because the variable is read
+/// when the subprocess spawns rather than when it is set.
+fn env_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
 async fn run_turn_inner(
     cli: &Path,
     chat_id: &str,
@@ -400,6 +412,7 @@ async fn run_turn_inner(
 ) -> (String, bool) {
     use http_body_util::BodyExt;
 
+    let _env = env_lock().lock().await;
     let file = migrated_with_chat(chat_id);
     // The SDK resolves the executable from this variable, so the fake stands in
     // for a real `claude` without any code path knowing.

--- a/desktop/src-tauri/tests/chat_turn.rs
+++ b/desktop/src-tauri/tests/chat_turn.rs
@@ -420,17 +420,150 @@ async fn a_disconnect_while_a_prompt_is_pending_releases_the_chat() {
     .await
     .expect("the turn should stream");
 
-    // Drop the body without reading it to the end — a closed tab.
+    // Read until the prompt frame arrives, *then* disconnect.
+    //
+    // Dropping the response immediately would not test this: the first
+    // `out.send` would fail and tear the turn down through the pre-existing
+    // error path, which passes with the whole disconnect fix reverted. Waiting
+    // for `user_input_required` parks the turn in the post-result continuation,
+    // where nothing is being sent and only the disconnect race can free it.
+    read_until(response, "user_input_required").await;
+
+    assert_released(&id, "the post-result continuation").await;
+}
+
+/// The other half of the same rule, for the event loop's own arm.
+///
+/// The CLI here says **nothing** after initialize, so the turn parks in
+/// `stream_events` with no frame ever written — meaning no failing send can
+/// notice the disconnect and `out.closed()` is the only thing that can.
+#[tokio::test]
+async fn a_disconnect_while_the_loop_waits_on_a_silent_cli_releases_the_chat() {
+    let Some(_) = python3() else {
+        eprintln!("skipping: no python3");
+        return;
+    };
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cli = fake_cli(
+        dir.path(),
+        r#"
+    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack(req.get("request_id") or msg.get("request_id"))
+"#,
+    );
+
+    let id = unique_id("disconnect-loop");
+    let file = migrated_with_chat(&id);
+    let _env = env_lock().lock().await;
+    std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", &cli);
+
+    let response = agento_lib::native::chat::turn::run(
+        file.path().to_path_buf(),
+        id.clone(),
+        "hello".to_string(),
+    )
+    .await
+    .expect("the turn should stream");
+
+    // No frame will ever arrive, so dropping now is a tab closed on a turn that
+    // is waiting on a tool call — the case with no send to fail.
     drop(response);
 
-    // The turn must notice and release. Poll rather than sleep a fixed amount:
-    // the teardown is asynchronous, and a fixed wait is either flaky or slow.
+    assert_released(&id, "the event loop's disconnect arm").await;
+}
+
+/// The SSE body must end when the **turn** ends, not when the subprocess's
+/// stdout closes.
+///
+/// Nothing may hold a strong clone of the body sender past the turn. The
+/// permission handler is the tempting place to put one — it needs to notice a
+/// disconnect — but the SDK's reader task owns that handler until stdout hits
+/// EOF, which a grandchild can defer indefinitely. Here the CLI backgrounds a
+/// `sleep` that inherits stdout and then exits, which is what any `Bash` call
+/// starting a dev server or watcher does. The frontend clears its streaming
+/// state only when the body ends, so a body that outlives the turn is a chat
+/// stuck mid-stream with the composer blocked.
+#[tokio::test]
+async fn the_body_ends_with_the_turn_even_when_a_grandchild_holds_stdout_open() {
+    let Some(_) = python3() else {
+        eprintln!("skipping: no python3");
+        return;
+    };
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cli = fake_cli(
+        dir.path(),
+        r#"
+    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack(req.get("request_id") or msg.get("request_id"))
+    elif msg.get("type") == "user":
+        import subprocess
+        # Inherits stdout and outlives us: stdout never reaches EOF.
+        subprocess.Popen(["sleep", "30"])
+        raw('{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}')
+        raw('{"type":"result","subtype":"success","is_error":false,"result":"hi","session_id":"sdk-1","usage":{}}')
+        sys.exit(0)
+"#,
+    );
+
+    let id = unique_id("grandchild");
+    let file = migrated_with_chat(&id);
+    let _env = env_lock().lock().await;
+    std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", &cli);
+
+    let response = agento_lib::native::chat::turn::run(
+        file.path().to_path_buf(),
+        id.clone(),
+        "hello".to_string(),
+    )
+    .await
+    .expect("the turn should stream");
+
+    // 10s is far below the grandchild's 30s and far above a healthy teardown,
+    // which is milliseconds — so this cannot be flaky in either direction.
+    let started = std::time::Instant::now();
+    let drained = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+        use http_body_util::BodyExt;
+        response.into_body().collect().await.map(|c| c.to_bytes())
+    })
+    .await;
+
+    let body = drained
+        .expect("the body outlived the turn — something still holds a strong body sender")
+        .expect("body error");
+    assert!(
+        String::from_utf8_lossy(&body).contains("\"hi\""),
+        "the turn should still have streamed its reply"
+    );
+    eprintln!("body ended in {:?}", started.elapsed());
+}
+
+/// Consume frames until one contains `marker`, then disconnect by dropping the
+/// body. Returns once the turn is parked and the client is gone.
+async fn read_until(response: axum::http::Response<axum::body::Body>, marker: &str) {
+    use http_body_util::BodyExt;
+
+    let mut body = response.into_body();
+    let mut seen = String::new();
+    while !seen.contains(marker) {
+        let frame = tokio::time::timeout(std::time::Duration::from_secs(20), body.frame())
+            .await
+            .unwrap_or_else(|_| panic!("timed out waiting for a frame containing {marker:?}"))
+            .unwrap_or_else(|| panic!("stream ended before {marker:?}; saw: {seen}"))
+            .expect("frame error");
+        if let Some(chunk) = frame.data_ref() {
+            seen.push_str(&String::from_utf8_lossy(chunk));
+        }
+    }
+    drop(body);
+}
+
+/// Poll rather than sleep a fixed amount: teardown is asynchronous, and a fixed
+/// wait is either flaky or slow.
+async fn assert_released(id: &str, which: &str) {
     let mut released = false;
     for _ in 0..200 {
-        if agento_lib::native::chat::live::registry()
-            .get(&id)
-            .is_none()
-            && agento_lib::native::chat::live::registry().try_lock(&id)
+        if agento_lib::native::chat::live::registry().get(id).is_none()
+            && agento_lib::native::chat::live::registry().try_lock(id)
         {
             released = true;
             break;
@@ -439,7 +572,7 @@ async fn a_disconnect_while_a_prompt_is_pending_releases_the_chat() {
     }
     assert!(
         released,
-        "a disconnected turn must release the busy lock, or the chat is wedged"
+        "a disconnected turn must release the busy lock via {which}, or the chat is wedged"
     );
 }
 


### PR DESCRIPTION
Closes #276

The four chat routes — `/messages`, `/input`, `/permission`, `/stop` — on top of the SDK ported in #269, which until now had no caller. +2684/−9.

## The seam grew a second registry

`Answer` is a buffered `Vec<u8>` and `Endpoint::serve` is a **sync** `fn` on `spawn_blocking`: the right shape for thirteen areas that hand back a finished document, the wrong one for a turn that lasts as long as the model talks. `StreamEndpoint` is async and returns a `Response<Body>` from `Body::from_stream`.

`native::claims` is the union of both registries because the proxy asks one question; `route_is_native` excludes the streaming routes so the buffered path cannot try to answer a chat turn with a `Vec<u8>`.

## Why all four moved, and how the split stays safe

They share a **process-local** live-session registry: `/messages` puts a session in, the others look one up. Splitting them would leave `/stop` searching a registry that never saw the session — the stop button would silently do nothing.

But not every chat *can* run natively. An agent whose tools come from an integration or the local MCP server needs #277/#282, and `runner::build_options` refuses those — **before any subprocess exists**, so forwarding is safe. That would strand `/stop` for a chat still running on Go, so the three steering routes answer natively **only when Rust holds a live session for that chat** and forward otherwise. Go then answers, correctly, because it is the side that has the session.

That is what lets the four move together without requiring every chat to move at once.

## Five rules that are silent when broken

All pinned by `tests/chat_turn.rs`, which drives a real subprocess via a scripted fake CLI — every one of them is a property of a *sequence*, which no unit test can reach:

- **`result` is not terminal.** With an `AskUserQuestion` pending the same subprocess carries on, so one HTTP request spans several turns and several `result` frames. The test asserts the frame order `assistant, result, user_input_required, assistant, result`.
- **A mid-stream failure is a `result` with `is_error: true`**, never an `error` event — the 200 was committed before the first frame.
- **An event with no raw line emits nothing.** The SDK synthesizes process failures that way, so a crashed subprocess tells the client nothing and the stream just ends. Reproduced, not "fixed".
- **`AskUserQuestion` is answered by *denying* the tool** with the user's text as the message. That is how the answer reaches the model without the tool running.
- **A turn with no final text persists no messages** — not even the user's — but the session row *is* still written: `updated_at`, token totals, and on a first message a title derived from a message that was never stored. The phrase "persists nothing" covers messages only.

## A bug the integration test caught

The first `append_assistant_blocks` round-tripped a `tool_use` input through `serde_json::Value` and turned `{"z":1.50,"a":1}` into `{"a":1,"z":1.5}` — sorted and respelled, with nothing to signal it. It now borrows `RawValue`.

The fake CLI emits **literal bytes** rather than `json.dumps` for the same reason: Python normalises `1.50` to `1.5` and adds spaces after `:`, so a byte-exactness test cannot go through it.

## Also

`AGENTO_CLAUDE_EXECUTABLE` overrides which binary is spawned, falling back to `find_claude_cli()` and then the bare name. The fallback is a real fix, not a test hook: a GUI process inherits a minimal `PATH`, which is why that helper already existed for the startup banner — spawning the bare name while the banner said "found" was the two disagreeing.

## Verification

```
npm run build
./scripts/build-sidecar.sh
cargo fmt --check
cargo clippy --all-targets -- -D warnings
cargo test          # 442 lib + 6 chat_turn + 17 claude_sdk + 7 scanner, 0 failed
cargo build --release
```

The parity bar here is the **SSE stream**, not JSON, so `parity-instance.sh` has nothing to say about it — `tests/chat_turn.rs` is the equivalent, and unlike the parity suites it runs in CI.