### PR TITLE
feat(desktop): port the integration writes that own no live state (#277)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -146,7 +146,11 @@ src-tauri/src/
     version.rs   GET /api/version and /version/update-check (dev builds only)
     notifications.rs GET /api/notifications/settings (password masked) and /log
     integrations.rs GET /api/integrations, /{id}, /available-tools, /{id}/triggers —
-                 credentials are never selected and auth is a bool made in SQL
+                 credentials are never selected and auth is a bool made in SQL;
+                 plus POST /api/integrations and the trigger-rule writes (#277).
+                 PUT/DELETE /{id} stay with Go: they reload/stop the live MCP server
+    integration_credentials.rs the seven per-type validators, and the two failures
+                 whose Go error text is not reproducible (both forward)
     fs.rs        GET /api/fs — the working-dir picker's listing (Unix; forwards on Windows)
     gopath.rs    Go's filepath.Clean/Dir/Join, pinned to vectors generated from Go
     query.rs     one query parameter, read the way r.URL.Query().Get reads it

--- a/desktop/src-tauri/src/native/integration_credentials.rs
+++ b/desktop/src-tauri/src/native/integration_credentials.rs
@@ -111,8 +111,17 @@ where
     serde_json::from_str::<Option<T>>(raw.get())
         .map(Option::unwrap_or_default)
         .map_err(|e| {
+            // **The error is deliberately not included.** serde_json quotes the
+            // offending value, so a caller who sends
+            // `"credentials": "ghp_realtoken"` would have that token echoed into
+            // the message — which the seam logs on every forward. Go's own error
+            // names the type and never the value. The position is enough to
+            // debug with and carries nothing secret.
             WriteError::Fallback(format!(
-                "{kind} credentials do not decode ({e}); Go's json error text is not reproducible here"
+                "{kind} credentials do not decode at line {} column {}; \
+                 Go's json error text is not reproducible here, so this forwards",
+                e.line(),
+                e.column()
             ))
         })
 }
@@ -370,6 +379,12 @@ fn split_url(raw: &str) -> Result<(String, String), WriteError> {
         }
     }
 
+    // A leading `:` is `getScheme`'s own error (`missing protocol scheme`),
+    // not an empty scheme, so it must forward rather than answer.
+    if raw.starts_with(':') {
+        return Err(forward());
+    }
+
     // `url.Parse` takes the scheme only when what precedes the first ':' is a
     // valid scheme; otherwise the whole string is an opaque path and Scheme is
     // "". A bare `example.atlassian.net` therefore has no scheme and no host,
@@ -392,12 +407,26 @@ fn split_url(raw: &str) -> Result<(String, String), WriteError> {
         return Ok((scheme, String::new()));
     };
     let authority = authority.split(['/', '?', '#']).next().unwrap_or_default();
-    // Userinfo is not part of Host.
-    let host = match authority.rsplit_once('@') {
-        Some((_, host)) => host,
-        None => authority,
-    };
-    Ok((scheme, host.to_string()))
+
+    // Everything below is a shape `parseHost` has a rule for that this port
+    // does not reimplement — userinfo validation, IPv6 bracket matching,
+    // percent-escapes (which a host may not contain at all), and port syntax.
+    // **Forwarding is the only safe answer for these**, because the failure
+    // mode of guessing is not a wrong message but a wrong *acceptance*: Rust
+    // would create an integration whose `site_url` Go's own parser can never
+    // read, and being native the request never reaches Go to be refused.
+    if authority.contains(['@', '[', ']', '%']) {
+        return Err(forward());
+    }
+    // A `:` in the authority introduces a port, which Go requires to be digits
+    // — and to appear at most once.
+    if let Some((host, port)) = authority.split_once(':') {
+        if !port.chars().all(|c| c.is_ascii_digit()) {
+            return Err(forward());
+        }
+        return Ok((scheme, host.to_string()));
+    }
+    Ok((scheme, authority.to_string()))
 }
 
 /// A Go-compatible JSON string literal.
@@ -415,6 +444,10 @@ fn json_string(s: &str) -> String {
             '\n' => out.push_str("\\n"),
             '\r' => out.push_str("\\r"),
             '\t' => out.push_str("\\t"),
+            // Go uses the shorthand for these two and `\u00XX` for the rest,
+            // so the generic control-character arm below must not catch them.
+            '\u{8}' => out.push_str("\\b"),
+            '\u{c}' => out.push_str("\\f"),
             '<' => out.push_str("\\u003c"),
             '>' => out.push_str("\\u003e"),
             '&' => out.push_str("\\u0026"),
@@ -576,6 +609,83 @@ mod tests {
         assert!(
             matches!(e, WriteError::Fallback(_)),
             "a type mismatch must forward, since Go's json error text names Go types"
+        );
+    }
+
+    /// Accepting a URL Go would refuse is worse than forwarding one it would
+    /// accept: the row is created natively, so Go never sees the request and
+    /// never gets to say no — leaving a stored `site_url` its own parser cannot
+    /// read.
+    #[test]
+    fn every_url_shape_this_port_is_unsure_of_forwards_rather_than_accepting() {
+        // Each of these is an error from `url.Parse`, not a validation failure.
+        for url in [
+            "https://x.net:abc",     // invalid port
+            "https://x.net:80:90",   // two ports
+            "https://ex%41mple.net", // a host may not carry an escape
+            "https://[::1",          // unmatched bracket
+            "https://a\\\\b@x.net",  // invalid userinfo
+            "https://a[b@x.net",     // invalid userinfo
+            "://x.net",              // `missing protocol scheme`
+        ] {
+            let creds = format!(r#"{{"site_url":"{url}","email":"e","api_token":"t"}}"#);
+            for kind in ["confluence", "jira"] {
+                let e = validate(kind, Some(&raw(&creds))).expect_err("must not be accepted");
+                assert!(
+                    matches!(e, WriteError::Fallback(_)),
+                    "{kind} {url:?} answered {:?} instead of forwarding",
+                    e.message()
+                );
+            }
+        }
+    }
+
+    /// …but an ordinary port is not a shape to be unsure of, and must not make
+    /// the host look empty.
+    #[test]
+    fn a_numeric_port_is_understood_and_not_forwarded() {
+        assert!(validate(
+            "jira",
+            Some(&raw(
+                r#"{"site_url":"http://x.net:8080/","email":"e","api_token":"t"}"#
+            ))
+        )
+        .is_ok());
+        assert!(validate(
+            "confluence",
+            Some(&raw(
+                r#"{"site_url":"https://x.net:8443","email":"e","api_token":"t"}"#
+            ))
+        )
+        .is_ok());
+    }
+
+    /// `encoding/json` uses the two-character escapes for `0x08`/`0x0c` and
+    /// `\u00XX` for every other control character.
+    #[test]
+    fn backspace_and_formfeed_use_gos_shorthand() {
+        // `encoding/json` emits the two-character form for these two, and
+        // `\u00XX` for the other control characters — so a single `< 0x20` arm
+        // would be wrong for exactly this pair.
+        assert_eq!(json_string("a\u{8}b"), r#""a\bb""#);
+        assert_eq!(json_string("a\u{c}b"), r#""a\fb""#);
+        assert_eq!(json_string("a\u{1}b"), r#""a\u0001b""#);
+        // The ones serde also gets right, kept so the whole table is in one
+        // place.
+        assert_eq!(json_string("a\nb\tc\rd"), r#""a\nb\tc\rd""#);
+    }
+
+    /// The forward reason is logged by the seam, so it must not carry the
+    /// caller's bytes — serde_json's own message quotes the offending value.
+    #[test]
+    fn a_bad_credentials_blob_never_puts_the_secret_in_the_error() {
+        let e = validate("google", Some(&raw(r#""ghp_SUPERSECRETVALUE""#)))
+            .expect_err("a string is not a credentials object");
+        assert!(matches!(e, WriteError::Fallback(_)));
+        assert!(
+            !e.message().contains("ghp_SUPERSECRETVALUE"),
+            "the credential must not reach the log: {}",
+            e.message()
         );
     }
 }

--- a/desktop/src-tauri/src/native/integration_credentials.rs
+++ b/desktop/src-tauri/src/native/integration_credentials.rs
@@ -1,0 +1,581 @@
+//! Credential validation for `POST /api/integrations`.
+//!
+//! Mirrors `validateIntegrationCredentials` and the seven per-type validators
+//! it dispatches to (`internal/service/integration_service.go`).
+//!
+//! # Why this is a module of its own
+//!
+//! It is the one part of the integration write path that is pure logic with no
+//! SQL, and it is where the parity risk concentrates: seven types, each with its
+//! own required fields and its own **exact** error strings, all of which ship to
+//! the client as a 422 body.
+//!
+//! # Where the port deliberately gives up
+//!
+//! Two of Go's failure paths embed an error string this port cannot reproduce,
+//! and both **forward** rather than guess:
+//!
+//! - A credentials blob that is present but does not unmarshal. Go ships
+//!   `invalid google credentials: ` plus `encoding/json`'s own message, which
+//!   names Go types (`json: cannot unmarshal number into Go struct field
+//!   GoogleCredentials.client_id of type string`). There is no Rust spelling of
+//!   that.
+//! - A `site_url` that `net/url` rejects outright, whose message comes from
+//!   `url.Parse`.
+//!
+//! Both are `Fallback`, so Go answers them exactly. Everything else — the far
+//! commoner "you left a field blank" — is reproduced here.
+//!
+//! # The three traps
+//!
+//! 1. **Empty and `null` are different.** Go tests `len(cfg.Credentials) == 0`,
+//!    which is true only when the key is *absent*. A literal `"credentials":
+//!    null` is four bytes, so it unmarshals to the zero value and reports the
+//!    *field* error rather than "credentials are empty". Hence
+//!    [`super::gojson::captured_raw`] on the request field, and hence
+//!    `null_is_zero_value` on every string below — `{"client_id": null}` is `""`
+//!    to Go and a type error to serde.
+//! 2. **Jira rewrites what it stores.** It trims the trailing slash and calls
+//!    `SetCredentials`, which re-marshals the *struct* — so unknown keys the
+//!    caller sent are silently dropped and the three known ones are re-emitted
+//!    in declaration order. Confluence does not do this, despite sharing the
+//!    credential type. Reproduced in [`validate`]'s return value.
+//! 3. **Confluence demands HTTPS; Jira accepts either.** Same struct, two
+//!    different URL rules, and two different messages.
+
+use serde::Deserialize;
+use serde_json::value::RawValue;
+
+use super::gojson::null_is_zero_value;
+use super::writes::WriteError;
+
+const FIELD_CREDENTIALS: &str = "credentials";
+const FIELD_SITE_URL: &str = "credentials.site_url";
+const FIELD_BOT_TOKEN: &str = "credentials.bot_token";
+
+/// Validate an integration's credentials for its type.
+///
+/// `Ok(Some(json))` means the stored credentials must be **replaced** with
+/// `json` — only Jira does this. `Ok(None)` means store what the caller sent,
+/// byte for byte.
+pub fn validate(
+    integration_type: &str,
+    credentials: Option<&RawValue>,
+) -> Result<Option<String>, WriteError> {
+    match integration_type {
+        "google" => validate_google(credentials).map(|()| None),
+        "confluence" => validate_confluence(credentials).map(|()| None),
+        "telegram" => validate_telegram(credentials).map(|()| None),
+        "jira" => validate_jira(credentials).map(Some),
+        "github" => validate_github(credentials).map(|()| None),
+        "slack" => validate_slack(credentials).map(|()| None),
+        "whatsapp" => validate_whatsapp(credentials).map(|()| None),
+        // Go's `default` arm: any other type just needs *something*. Note it
+        // checks length only — it never looks at the content.
+        _ => {
+            if raw_is_absent(credentials) {
+                return Err(WriteError::validation(
+                    FIELD_CREDENTIALS,
+                    "credentials are required",
+                ));
+            }
+            Ok(None)
+        }
+    }
+}
+
+/// `len(cfg.Credentials) == 0` — absent, not `null`.
+fn raw_is_absent(credentials: Option<&RawValue>) -> bool {
+    credentials.map(|c| c.get().is_empty()).unwrap_or(true)
+}
+
+/// `cfg.ParseCredentials(&creds)`.
+///
+/// The empty case is Go's own `fmt.Errorf("credentials are empty")`, which is a
+/// fixed string and so reproducible. A real unmarshal failure is not, and
+/// forwards.
+fn parse<T>(kind: &str, credentials: Option<&RawValue>) -> Result<T, WriteError>
+where
+    T: for<'de> Deserialize<'de> + Default,
+{
+    let Some(raw) = credentials.filter(|c| !c.get().is_empty()) else {
+        return Err(WriteError::validation(
+            FIELD_CREDENTIALS,
+            format!("invalid {kind} credentials: credentials are empty"),
+        ));
+    };
+    // Through `Option<T>` rather than straight to `T`: a literal `null` is a
+    // *type error* to serde but leaves the zero value in Go, so a direct
+    // deserialize would forward `"credentials": null` instead of reporting the
+    // first missing field the way Go does.
+    serde_json::from_str::<Option<T>>(raw.get())
+        .map(Option::unwrap_or_default)
+        .map_err(|e| {
+            WriteError::Fallback(format!(
+                "{kind} credentials do not decode ({e}); Go's json error text is not reproducible here"
+            ))
+        })
+}
+
+#[derive(Default, Deserialize)]
+#[serde(default)]
+struct GoogleCredentials {
+    #[serde(deserialize_with = "null_is_zero_value")]
+    client_id: String,
+    #[serde(deserialize_with = "null_is_zero_value")]
+    client_secret: String,
+}
+
+fn validate_google(credentials: Option<&RawValue>) -> Result<(), WriteError> {
+    let creds: GoogleCredentials = parse("google", credentials)?;
+    if creds.client_id.is_empty() {
+        return Err(WriteError::validation(
+            "credentials.client_id",
+            "client_id is required",
+        ));
+    }
+    if creds.client_secret.is_empty() {
+        return Err(WriteError::validation(
+            "credentials.client_secret",
+            "client_secret is required",
+        ));
+    }
+    Ok(())
+}
+
+/// `config.AtlassianCredentials`, shared by Confluence and Jira.
+#[derive(Default, Deserialize)]
+#[serde(default)]
+struct AtlassianCredentials {
+    #[serde(deserialize_with = "null_is_zero_value")]
+    site_url: String,
+    #[serde(deserialize_with = "null_is_zero_value")]
+    email: String,
+    #[serde(deserialize_with = "null_is_zero_value")]
+    api_token: String,
+}
+
+fn validate_confluence(credentials: Option<&RawValue>) -> Result<(), WriteError> {
+    let creds: AtlassianCredentials = parse("confluence", credentials)?;
+    if creds.site_url.is_empty() {
+        return Err(WriteError::validation(
+            FIELD_SITE_URL,
+            "site_url is required",
+        ));
+    }
+    // `confluence.ValidateSiteURL`: HTTPS only, and a hostname is required.
+    let (scheme, host) = split_url(&creds.site_url)?;
+    if scheme != "https" {
+        return Err(WriteError::validation(
+            FIELD_SITE_URL,
+            // Go's `%q`. A scheme is ASCII, so this is a plain quoted string.
+            format!("site URL must use HTTPS (got {scheme:?})"),
+        ));
+    }
+    if host.is_empty() {
+        return Err(WriteError::validation(
+            FIELD_SITE_URL,
+            "site URL must include a hostname",
+        ));
+    }
+    atlassian_tail(&creds)
+}
+
+/// Jira's own URL rule, plus the normalization Confluence does not do.
+fn validate_jira(credentials: Option<&RawValue>) -> Result<String, WriteError> {
+    let mut creds: AtlassianCredentials = parse("jira", credentials)?;
+    if creds.site_url.is_empty() {
+        return Err(WriteError::validation(
+            FIELD_SITE_URL,
+            "site_url is required",
+        ));
+    }
+    let (scheme, host) = split_url(&creds.site_url)?;
+    if (scheme != "https" && scheme != "http") || host.is_empty() {
+        return Err(WriteError::validation(
+            FIELD_SITE_URL,
+            "site_url must be a valid http or https URL",
+        ));
+    }
+    // `strings.TrimRight(creds.SiteURL, "/")` — every trailing slash, not one.
+    creds.site_url = creds.site_url.trim_end_matches('/').to_string();
+    atlassian_tail(&creds)?;
+    // `cfg.SetCredentials(creds)` re-marshals the struct: declaration order, no
+    // `omitempty` on any of the three, and anything else the caller sent is
+    // gone. This is the stored value from here on.
+    Ok(format!(
+        r#"{{"site_url":{},"email":{},"api_token":{}}}"#,
+        json_string(&creds.site_url),
+        json_string(&creds.email),
+        json_string(&creds.api_token),
+    ))
+}
+
+/// The email/api_token checks both Atlassian validators end with, in order.
+fn atlassian_tail(creds: &AtlassianCredentials) -> Result<(), WriteError> {
+    if creds.email.is_empty() {
+        return Err(WriteError::validation(
+            "credentials.email",
+            "email is required",
+        ));
+    }
+    if creds.api_token.is_empty() {
+        return Err(WriteError::validation(
+            "credentials.api_token",
+            "api_token is required",
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Default, Deserialize)]
+#[serde(default)]
+struct TelegramCredentials {
+    #[serde(deserialize_with = "null_is_zero_value")]
+    bot_token: String,
+}
+
+fn validate_telegram(credentials: Option<&RawValue>) -> Result<(), WriteError> {
+    let creds: TelegramCredentials = parse("telegram", credentials)?;
+    if creds.bot_token.is_empty() {
+        return Err(WriteError::validation(
+            FIELD_BOT_TOKEN,
+            "bot_token is required",
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Default, Deserialize)]
+#[serde(default)]
+struct GitHubCredentials {
+    #[serde(deserialize_with = "null_is_zero_value")]
+    auth_mode: String,
+    #[serde(deserialize_with = "null_is_zero_value")]
+    personal_access_token: String,
+}
+
+fn validate_github(credentials: Option<&RawValue>) -> Result<(), WriteError> {
+    let creds: GitHubCredentials = parse("github", credentials)?;
+    // Note this rejects `oauth` and `app` even though the struct carries fields
+    // for both — the upstream comment says only `pat` is wired up.
+    if creds.auth_mode != "pat" {
+        return Err(WriteError::validation(
+            "credentials.auth_mode",
+            "only 'pat' auth mode is currently supported",
+        ));
+    }
+    if creds.personal_access_token.is_empty() {
+        return Err(WriteError::validation(
+            "credentials.personal_access_token",
+            "personal_access_token is required",
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Default, Deserialize)]
+#[serde(default)]
+struct SlackCredentials {
+    #[serde(deserialize_with = "null_is_zero_value")]
+    auth_mode: String,
+    #[serde(deserialize_with = "null_is_zero_value")]
+    bot_token: String,
+    #[serde(deserialize_with = "null_is_zero_value")]
+    client_id: String,
+    #[serde(deserialize_with = "null_is_zero_value")]
+    client_secret: String,
+}
+
+fn validate_slack(credentials: Option<&RawValue>) -> Result<(), WriteError> {
+    let creds: SlackCredentials = parse("slack", credentials)?;
+    match creds.auth_mode.as_str() {
+        "bot_token" => {
+            if creds.bot_token.is_empty() {
+                return Err(WriteError::validation(
+                    FIELD_BOT_TOKEN,
+                    "bot_token is required",
+                ));
+            }
+        }
+        "oauth" => {
+            if creds.client_id.is_empty() {
+                return Err(WriteError::validation(
+                    "credentials.client_id",
+                    "client_id is required",
+                ));
+            }
+            if creds.client_secret.is_empty() {
+                return Err(WriteError::validation(
+                    "credentials.client_secret",
+                    "client_secret is required",
+                ));
+            }
+        }
+        // Covers the empty string too, which is what an absent `auth_mode` is.
+        _ => {
+            return Err(WriteError::validation(
+                "credentials.auth_mode",
+                "auth_mode must be 'bot_token' or 'oauth'",
+            ))
+        }
+    }
+    Ok(())
+}
+
+#[derive(Default, Deserialize)]
+#[serde(default)]
+struct WhatsAppCredentials {
+    #[serde(deserialize_with = "null_is_zero_value")]
+    #[allow(dead_code)] // Parsed only to reproduce Go's decode check.
+    phone: String,
+}
+
+/// WhatsApp pairs by QR, so credentials are **optional** — absent is valid.
+///
+/// Kept despite the desktop app dropping WhatsApp (#273) for the same reason
+/// `native/integrations.rs` still lists a `whatsapp` row: this is the API, not
+/// the picker, and diverging from Go here would be a divergence for no gain.
+fn validate_whatsapp(credentials: Option<&RawValue>) -> Result<(), WriteError> {
+    if raw_is_absent(credentials) {
+        return Ok(());
+    }
+    let _: WhatsAppCredentials = parse("whatsapp", credentials)?;
+    Ok(())
+}
+
+/// Scheme and host as `net/url` would report them, or `Fallback` when this port
+/// is not confident it agrees with Go.
+///
+/// Only the shapes an Atlassian site URL actually takes are decided here.
+/// Anything carrying a space, a control character or a malformed `%` escape is
+/// forwarded, because those are exactly the inputs `url.Parse` rejects with a
+/// message of its own — and a wrong *acceptance* here would store a URL Go
+/// would have refused.
+fn split_url(raw: &str) -> Result<(String, String), WriteError> {
+    let forward = || {
+        WriteError::Fallback(format!(
+            "site_url {raw:?} needs net/url's own parse result; forwarding"
+        ))
+    };
+    if raw.chars().any(|c| c.is_control() || c == ' ') {
+        return Err(forward());
+    }
+    for (i, b) in raw.bytes().enumerate() {
+        if b == b'%' {
+            let rest = raw.as_bytes().get(i + 1..i + 3).unwrap_or(b"");
+            if rest.len() != 2 || !rest.iter().all(|c| c.is_ascii_hexdigit()) {
+                return Err(forward());
+            }
+        }
+    }
+
+    // `url.Parse` takes the scheme only when what precedes the first ':' is a
+    // valid scheme; otherwise the whole string is an opaque path and Scheme is
+    // "". A bare `example.atlassian.net` therefore has no scheme and no host,
+    // which is why it fails the HTTPS check rather than the hostname one.
+    let Some((scheme, rest)) = raw.split_once(':') else {
+        return Ok((String::new(), String::new()));
+    };
+    let valid_scheme = !scheme.is_empty()
+        && scheme.starts_with(|c: char| c.is_ascii_alphabetic())
+        && scheme
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.'));
+    if !valid_scheme {
+        return Ok((String::new(), String::new()));
+    }
+    // Go lowercases the scheme.
+    let scheme = scheme.to_ascii_lowercase();
+    // Without `//` the remainder is opaque and Host stays empty.
+    let Some(authority) = rest.strip_prefix("//") else {
+        return Ok((scheme, String::new()));
+    };
+    let authority = authority.split(['/', '?', '#']).next().unwrap_or_default();
+    // Userinfo is not part of Host.
+    let host = match authority.rsplit_once('@') {
+        Some((_, host)) => host,
+        None => authority,
+    };
+    Ok((scheme, host.to_string()))
+}
+
+/// A Go-compatible JSON string literal.
+///
+/// `encoding/json` escapes `<`, `>` and `&` by default, which serde does not —
+/// and these values are re-marshalled into the stored column, so the escaping
+/// has to match or the bytes differ.
+fn json_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '<' => out.push_str("\\u003c"),
+            '>' => out.push_str("\\u003e"),
+            '&' => out.push_str("\\u0026"),
+            '\u{2028}' => out.push_str("\\u2028"),
+            '\u{2029}' => out.push_str("\\u2029"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn raw(s: &str) -> Box<RawValue> {
+        RawValue::from_string(s.to_string()).expect("valid JSON")
+    }
+
+    fn err(integration_type: &str, creds: &str) -> WriteError {
+        validate(integration_type, Some(&raw(creds))).expect_err("expected a validation failure")
+    }
+
+    fn message(integration_type: &str, creds: &str) -> String {
+        err(integration_type, creds).message()
+    }
+
+    /// An **absent** blob is "credentials are empty"; a literal `null` is four
+    /// bytes to Go, so it decodes to the zero value and reports the first
+    /// missing field instead. Getting these the same way round is the whole
+    /// reason the request field uses `captured_raw`.
+    #[test]
+    fn absent_credentials_and_null_credentials_fail_differently() {
+        let absent = validate("google", None).expect_err("absent must fail");
+        assert!(
+            absent.message().contains("credentials are empty"),
+            "{}",
+            absent.message()
+        );
+        assert!(
+            message("google", "null").contains("client_id is required"),
+            "a literal null is a zero value to Go, not an absent blob"
+        );
+        // `{}` behaves like `null` for the same reason.
+        assert!(message("google", "{}").contains("client_id is required"));
+    }
+
+    #[test]
+    fn each_type_reports_its_own_first_missing_field() {
+        assert!(message("google", r#"{"client_id":"a"}"#).contains("client_secret is required"));
+        assert!(message("telegram", "{}").contains("bot_token is required"));
+        assert!(message("github", r#"{"auth_mode":"oauth"}"#)
+            .contains("only 'pat' auth mode is currently supported"));
+        assert!(message("github", r#"{"auth_mode":"pat"}"#)
+            .contains("personal_access_token is required"));
+        assert!(message("slack", r#"{"auth_mode":"bot_token"}"#).contains("bot_token is required"));
+        assert!(message("slack", r#"{"auth_mode":"oauth"}"#).contains("client_id is required"));
+        assert!(message("slack", "{}").contains("auth_mode must be 'bot_token' or 'oauth'"));
+        // An unknown type checks length only, never content.
+        assert!(validate("madeup", Some(&raw(r#"{"anything":1}"#))).is_ok());
+        assert!(validate("madeup", None)
+            .expect_err("absent")
+            .message()
+            .contains("credentials are required"));
+    }
+
+    /// A JSON `null` in a string field is `""` to Go and a type error to serde.
+    #[test]
+    fn a_null_string_field_is_the_zero_value_not_an_error() {
+        assert!(message("telegram", r#"{"bot_token":null}"#).contains("bot_token is required"));
+    }
+
+    /// Confluence is HTTPS-only and quotes the scheme it got; Jira takes either
+    /// and has one message for every URL failure.
+    #[test]
+    fn the_two_atlassian_types_have_different_url_rules() {
+        assert!(message("confluence", r#"{"site_url":"http://x.net"}"#)
+            .contains(r#"site URL must use HTTPS (got "http")"#));
+        // No scheme at all: Go reports an empty scheme, not a missing hostname.
+        assert!(message("confluence", r#"{"site_url":"x.atlassian.net"}"#)
+            .contains(r#"site URL must use HTTPS (got "")"#));
+        assert!(message("confluence", r#"{"site_url":"https:"}"#)
+            .contains("site URL must include a hostname"));
+
+        // Jira accepts http.
+        assert!(validate(
+            "jira",
+            Some(&raw(
+                r#"{"site_url":"http://x.net","email":"e","api_token":"t"}"#
+            ))
+        )
+        .is_ok());
+        assert!(message("jira", r#"{"site_url":"ftp://x.net"}"#)
+            .contains("site_url must be a valid http or https URL"));
+    }
+
+    /// Jira rewrites the stored blob; confluence stores what it was given.
+    #[test]
+    fn jira_normalises_and_reserialises_but_confluence_does_not() {
+        let stored = validate(
+            "jira",
+            Some(&raw(
+                r#"{"email":"e@x","extra":"dropped","site_url":"https://x.net///","api_token":"t"}"#,
+            )),
+        )
+        .expect("valid")
+        .expect("jira replaces the stored credentials");
+        // Declaration order, every trailing slash gone, unknown key dropped.
+        assert_eq!(
+            stored,
+            r#"{"site_url":"https://x.net","email":"e@x","api_token":"t"}"#
+        );
+
+        let unchanged = validate(
+            "confluence",
+            Some(&raw(
+                r#"{"site_url":"https://x.net/","email":"e","api_token":"t"}"#,
+            )),
+        )
+        .expect("valid");
+        assert!(
+            unchanged.is_none(),
+            "confluence must store the caller's bytes verbatim, trailing slash and all"
+        );
+    }
+
+    /// Go's `encoding/json` escapes these; the re-marshalled Jira blob has to
+    /// match byte for byte.
+    #[test]
+    fn the_reserialised_blob_uses_gos_html_escaping() {
+        let stored = validate(
+            "jira",
+            Some(&raw(
+                r#"{"site_url":"https://x.net","email":"a&b<c>d","api_token":"t"}"#,
+            )),
+        )
+        .expect("valid")
+        .expect("replaced");
+        assert_eq!(
+            stored,
+            r#"{"site_url":"https://x.net","email":"a\u0026b\u003cc\u003ed","api_token":"t"}"#,
+            "serde would emit these three unescaped; encoding/json does not"
+        );
+    }
+
+    /// WhatsApp is the one type where absent credentials are fine.
+    #[test]
+    fn whatsapp_allows_absent_credentials() {
+        assert!(validate("whatsapp", None).is_ok());
+        assert!(validate("whatsapp", Some(&raw(r#"{"phone":"+1"}"#))).is_ok());
+    }
+
+    /// A blob that does not decode forwards rather than inventing Go's message.
+    #[test]
+    fn an_undecodable_blob_forwards() {
+        let e = err("google", r#"{"client_id":123}"#);
+        assert!(
+            matches!(e, WriteError::Fallback(_)),
+            "a type mismatch must forward, since Go's json error text names Go types"
+        );
+    }
+}

--- a/desktop/src-tauri/src/native/integration_credentials.rs
+++ b/desktop/src-tauri/src/native/integration_credentials.rs
@@ -408,24 +408,41 @@ fn split_url(raw: &str) -> Result<(String, String), WriteError> {
     };
     let authority = authority.split(['/', '?', '#']).next().unwrap_or_default();
 
-    // Everything below is a shape `parseHost` has a rule for that this port
-    // does not reimplement — userinfo validation, IPv6 bracket matching,
-    // percent-escapes (which a host may not contain at all), and port syntax.
-    // **Forwarding is the only safe answer for these**, because the failure
-    // mode of guessing is not a wrong message but a wrong *acceptance*: Rust
-    // would create an integration whose `site_url` Go's own parser can never
-    // read, and being native the request never reaches Go to be refused.
+    // Everything below is a rule `parseHost` has that this port does not
+    // reimplement — userinfo validation, IPv6 bracket matching, percent-escapes
+    // (a host may not carry one at all) and port syntax. **Forwarding is the
+    // only safe answer**, because the failure mode of guessing is not a wrong
+    // message but a wrong *acceptance*: Rust would create an integration whose
+    // `site_url` Go's own parser can never read, and being native the request
+    // never reaches Go to be refused.
     if authority.contains(['@', '[', ']', '%']) {
         return Err(forward());
     }
-    // A `:` in the authority introduces a port, which Go requires to be digits
-    // — and to appear at most once.
-    if let Some((host, port)) = authority.split_once(':') {
+    // `parseHost` enforces an **allowlist**, not a blocklist, so this has to be
+    // spelled the same way round. Enumerating every ASCII byte through
+    // `url.Parse` in host position, Go rejects exactly `\`, `^`, `` ` ``, `{`,
+    // `|` and `}` with `invalid character … in host name`, and accepts the rest
+    // of the printable set — including `!"$&'()*+,-.;<=>_~`, which look
+    // rejectable and are not. Bytes at or above 0x80 pass through unchanged, so
+    // a non-ASCII host such as `exämple.net` is Go's to accept.
+    const HOST_PUNCT: &[u8] = b":!\"$&'()*+,-.;<=>_~";
+    if authority
+        .bytes()
+        .any(|b| b < 0x80 && !b.is_ascii_alphanumeric() && !HOST_PUNCT.contains(&b))
+    {
+        return Err(forward());
+    }
+    // A `:` introduces a port, which Go requires to be digits.
+    if let Some((_, port)) = authority.split_once(':') {
         if !port.chars().all(|c| c.is_ascii_digit()) {
             return Err(forward());
         }
-        return Ok((scheme, host.to_string()));
     }
+    // The **whole authority**, port included: both Go validators test `u.Host`,
+    // which keeps the port. Returning only the pre-colon part made
+    // `https://:8080` — a valid `Host` of `:8080` to Go — look like no host at
+    // all and answer 422. Emptiness is the only thing the callers test, so
+    // including the port changes nothing else.
     Ok((scheme, authority.to_string()))
 }
 
@@ -638,6 +655,55 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// `parseHost` enforces an allowlist, so the guard has to be one too.
+    ///
+    /// These six are the *complete* set of ASCII characters Go rejects in a
+    /// host. A guard built from shapes rather than from Go's own table missed
+    /// every one of them — testing `split_url` directly keeps the JSON escaping
+    /// of the outer credentials blob out of the way.
+    #[test]
+    fn the_six_characters_go_rejects_in_a_host_all_forward() {
+        for bad in ['\\', '^', '`', '{', '|', '}'] {
+            let url = format!("https://x.net{bad}a");
+            assert!(
+                split_url(&url).is_err(),
+                "{url:?} was accepted, but url.Parse rejects it"
+            );
+        }
+    }
+
+    /// The other side of the allowlist: punctuation that *looks* rejectable but
+    /// which Go accepts must not forward, or the port over-refuses.
+    #[test]
+    fn the_punctuation_go_allows_in_a_host_is_not_forwarded() {
+        for ok in [
+            '!', '"', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '<', '=', '>', '_', '~',
+        ] {
+            let url = format!("https://x.net{ok}a");
+            let (scheme, host) = split_url(&url)
+                .unwrap_or_else(|e| panic!("{url:?} forwarded, but Go accepts it: {e:?}"));
+            assert_eq!(scheme, "https");
+            assert_eq!(host, format!("x.net{ok}a"));
+        }
+        // Non-ASCII passes through unchanged in Go, so it must here too.
+        let (_, host) = split_url("https://ex\u{e4}mple.net").expect("non-ascii host");
+        assert_eq!(host, "ex\u{e4}mple.net");
+    }
+
+    /// Both Go validators test `u.Host`, which **includes the port** — so an
+    /// empty hostname with a valid port is not an empty host.
+    #[test]
+    fn a_port_with_no_hostname_is_still_a_host() {
+        let (_, host) = split_url("https://:8080").expect("valid to Go");
+        assert_eq!(
+            host, ":8080",
+            "Go reads Host as \":8080\", which is not empty"
+        );
+        // …and the whole authority is the host, port included.
+        let (_, host) = split_url("https://x.net:8443/wiki").expect("valid");
+        assert_eq!(host, "x.net:8443");
     }
 
     /// …but an ordinary port is not a shape to be unsure of, and must not make

--- a/desktop/src-tauri/src/native/integration_credentials.rs
+++ b/desktop/src-tauri/src/native/integration_credentials.rs
@@ -410,7 +410,7 @@ fn split_url(raw: &str) -> Result<(String, String), WriteError> {
 
     // Everything below is a rule `parseHost` has that this port does not
     // reimplement — userinfo validation, IPv6 bracket matching, percent-escapes
-    // (a host may not carry one at all) and port syntax. **Forwarding is the
+    // (Go accepts some and rejects others) and port syntax. **Forwarding is the
     // only safe answer**, because the failure mode of guessing is not a wrong
     // message but a wrong *acceptance*: Rust would create an integration whose
     // `site_url` Go's own parser can never read, and being native the request
@@ -637,13 +637,19 @@ mod tests {
     fn every_url_shape_this_port_is_unsure_of_forwards_rather_than_accepting() {
         // Each of these is an error from `url.Parse`, not a validation failure.
         for url in [
-            "https://x.net:abc",     // invalid port
-            "https://x.net:80:90",   // two ports
-            "https://ex%41mple.net", // a host may not carry an escape
-            "https://[::1",          // unmatched bracket
-            "https://a\\\\b@x.net",  // invalid userinfo
-            "https://a[b@x.net",     // invalid userinfo
-            "://x.net",              // `missing protocol scheme`
+            "https://x.net:abc",   // invalid port
+            "https://x.net:80:90", // two ports
+            // Go rejects an escape whose first hex digit is below 8; it
+            // *accepts* `%25` (host `x%net`) and valid multi-byte sequences
+            // such as `%C3%A9` (host `xénet`). This port forwards all of them
+            // rather than encoding that rule — deliberately, but do not
+            // "correct" the guard toward "a host may never carry an escape",
+            // which is not Go's rule.
+            "https://ex%41mple.net",
+            "https://[::1",         // unmatched bracket
+            "https://a\\\\b@x.net", // invalid userinfo
+            "https://a[b@x.net",    // invalid userinfo
+            "://x.net",             // `missing protocol scheme`
         ] {
             let creds = format!(r#"{{"site_url":"{url}","email":"e","api_token":"t"}}"#);
             for kind in ["confluence", "jira"] {

--- a/desktop/src-tauri/src/native/integrations.rs
+++ b/desktop/src-tauri/src/native/integrations.rs
@@ -1,11 +1,45 @@
-//! The integration reads: `GET /api/integrations`, `GET /api/integrations/{id}`,
-//! `GET /api/integrations/available-tools` and
-//! `GET /api/integrations/{id}/triggers`.
+//! The integration reads, plus the writes that have no effect outside the
+//! database: `GET /api/integrations`, `GET /api/integrations/{id}`,
+//! `GET /api/integrations/available-tools`,
+//! `GET|POST /api/integrations/{id}/triggers`,
+//! `PUT|DELETE /api/integrations/{id}/triggers/{rid}` and
+//! `POST /api/integrations`.
 //!
 //! Mirrors `handleListIntegrations`, `handleGetIntegration`,
-//! `handleAvailableTools` (`internal/api/integrations.go`) and
-//! `handleListTriggerRules` (`internal/api/trigger_rules.go`) over
-//! `SQLiteIntegrationStore` and `SQLiteTriggerStore`.
+//! `handleAvailableTools`, `handleCreateIntegration`
+//! (`internal/api/integrations.go`) and the trigger-rule handlers
+//! (`internal/api/trigger_rules.go`) over `SQLiteIntegrationStore` and
+//! `SQLiteTriggerStore`.
+//!
+//! ## Which writes moved, and the rule that decided it (#277)
+//!
+//! A route moves only when Rust reproduces **every** effect it has, and the
+//! integration writes split cleanly on that test:
+//!
+//! - `PUT /api/integrations/{id}` calls `registry.Reload(id)` and `DELETE`
+//!   calls `registry.Stop(id)` — they restart the **live in-process MCP
+//!   server**. Rust has none to restart until #282, so both stay with Go. A
+//!   native write there would persist the row and leave the running integration
+//!   on stale config: an integration still using a token the user just revoked,
+//!   with a 200 saying it worked.
+//! - `POST /api/integrations` touches no registry at all. That was verified
+//!   against the whole of `integrationService.Create` rather than inferred from
+//!   its siblings, which is the point — `Create` and `Update` look alike and
+//!   differ exactly here.
+//! - The trigger-rule writes are safe for a different reason: the dispatcher
+//!   calls `ListRules` **per inbound message**
+//!   (`internal/trigger/dispatcher.go`), so there is no cached rule set for a
+//!   native write to leave stale.
+//!
+//! ## A create is the one native path that handles a secret
+//!
+//! Everything below the "Secrets" note is about never *reading* credentials.
+//! That cannot hold for a create, because the caller supplies them in the
+//! request body and they have to reach the column. So `create` carries them as
+//! a borrowed `RawValue` from decode to `INSERT` — never through
+//! `serde_json::Value`, which would reorder the keys and respell any number —
+//! and the response is still built from [`ScrubbedIntegration`], which has no
+//! field to leak them through.
 //!
 //! ## Secrets
 //!
@@ -71,8 +105,10 @@ use std::path::Path;
 use axum::http::Method;
 use rusqlite::OptionalExtension;
 use serde::{Deserialize, Serialize};
+use serde_json::value::RawValue;
 
 use super::gotime::GoTime;
+use super::writes::{decode_body, finish, WriteError};
 
 /// One integration as `scrubIntegration` renders it.
 ///
@@ -263,31 +299,54 @@ pub fn list_trigger_rules(
         )
         .map_err(|e| format!("preparing trigger rule list: {e}"))?;
     let rows = stmt
-        .query_map([integration_id], |row| {
-            let enabled: i64 = row.get(4)?;
-            let keywords: String = row.get(6)?;
-            let chat_ids: String = row.get(7)?;
-            let created_at: String = row.get(8)?;
-            let updated_at: String = row.get(9)?;
-            Ok(TriggerRule {
-                id: row.get(0)?,
-                integration_id: row.get(1)?,
-                name: row.get(2)?,
-                agent_slug: row.get(3)?,
-                enabled: enabled != 0,
-                filter_prefix: row.get(5)?,
-                filter_keywords: super::gojson::decode_string_list(&keywords),
-                filter_chat_ids: super::gojson::decode_string_list(&chat_ids),
-                created_at: super::gotime::from_sql_text(&created_at, 8)?,
-                updated_at: super::gotime::from_sql_text(&updated_at, 9)?,
-            })
-        })
+        .query_map([integration_id], scan_trigger_rule)
         .map_err(|e| format!("listing trigger rules: {e}"))?;
     let mut out = Vec::new();
     for row in rows {
         out.push(row.map_err(|e| format!("scanning trigger rule: {e}"))?);
     }
     Ok(out)
+}
+
+/// The projection both rule reads share, so the by-id lookup the write path
+/// needs cannot drift from the list.
+const TRIGGER_RULE_COLUMNS: &str = "SELECT id, integration_id, name, agent_slug, enabled,
+                    filter_prefix, filter_keywords, filter_chat_ids,
+                    created_at, updated_at
+             FROM trigger_rules";
+
+fn scan_trigger_rule(row: &rusqlite::Row<'_>) -> rusqlite::Result<TriggerRule> {
+    let enabled: i64 = row.get(4)?;
+    let keywords: String = row.get(6)?;
+    let chat_ids: String = row.get(7)?;
+    let created_at: String = row.get(8)?;
+    let updated_at: String = row.get(9)?;
+    Ok(TriggerRule {
+        id: row.get(0)?,
+        integration_id: row.get(1)?,
+        name: row.get(2)?,
+        agent_slug: row.get(3)?,
+        enabled: enabled != 0,
+        filter_prefix: row.get(5)?,
+        filter_keywords: super::gojson::decode_string_list(&keywords),
+        filter_chat_ids: super::gojson::decode_string_list(&chat_ids),
+        created_at: super::gotime::from_sql_text(&created_at, 8)?,
+        updated_at: super::gotime::from_sql_text(&updated_at, 9)?,
+    })
+}
+
+/// One rule by its own id, regardless of which integration owns it — the
+/// ownership comparison is the caller's, because Go's is what produces the 403.
+fn trigger_rule_by_id(
+    conn: &rusqlite::Connection,
+    rule_id: &str,
+) -> rusqlite::Result<Option<TriggerRule>> {
+    conn.query_row(
+        &format!("{TRIGGER_RULE_COLUMNS} WHERE id = ?1"),
+        [rule_id],
+        scan_trigger_rule,
+    )
+    .optional()
 }
 
 // ─── The seam ─────────────────────────────────────────────────────────────────
@@ -304,9 +363,11 @@ enum Route<'a> {
     AvailableTools,
     Get(&'a str),
     Triggers(&'a str),
+    /// `{id}/triggers/{rid}` — the rule routes that take a rule id.
+    Trigger(&'a str, &'a str),
 }
 
-/// Match the four reads and nothing else.
+/// Match the reads, plus the write routes that share their paths.
 ///
 /// `available-tools` is checked before the `{id}` arm because it is a single
 /// segment in the same position, exactly as chi's own route table orders them.
@@ -323,6 +384,12 @@ fn route_of(path: &str) -> Option<Route<'_>> {
     if let Some(id) = rest.strip_suffix("/triggers") {
         return segment(id).map(Route::Triggers);
     }
+    if let Some((id, tail)) = rest.split_once("/triggers/") {
+        return match (segment(id), segment(tail)) {
+            (Some(id), Some(rid)) => Some(Route::Trigger(id, rid)),
+            _ => None,
+        };
+    }
     segment(rest).map(Route::Get)
 }
 
@@ -333,12 +400,48 @@ fn segment(value: &str) -> Option<&str> {
     Some(value)
 }
 
+/// Which of this module's routes are native, by method.
+///
+/// **The integration `{id}` writes are deliberately absent.** `PUT` calls
+/// `registry.Reload(id)` and `DELETE` calls `registry.Stop(id)`
+/// (`internal/service/integration_service.go`), which start and stop the *live
+/// in-process MCP server* for that integration. Rust has no MCP server to
+/// reload until #282, so a native write would persist the row and leave the
+/// running integration on stale config — the failure would show up as an
+/// integration that keeps using a revoked token, with nothing in the response
+/// to suggest it. `POST /api/integrations` is safe because `Create` is a pure
+/// row write: it never touches the registry, which was verified against the
+/// whole function rather than assumed from its siblings.
+///
+/// The trigger-rule writes are safe for a different reason: the dispatcher
+/// calls `ListRules` **per inbound message** (`internal/trigger/dispatcher.go`),
+/// so there is no cached rule set for a native write to leave stale.
 fn claims(method: &Method, path: &str) -> bool {
-    method == Method::GET && route_of(path).is_some()
+    match route_of(path) {
+        Some(Route::List) => method == Method::GET || method == Method::POST,
+        Some(Route::AvailableTools) | Some(Route::Get(_)) => method == Method::GET,
+        Some(Route::Triggers(_)) => method == Method::GET || method == Method::POST,
+        Some(Route::Trigger(..)) => method == Method::PUT || method == Method::DELETE,
+        None => false,
+    }
 }
 
 fn serve(ctx: &super::Ctx, req: &super::Request) -> Result<super::Answer, String> {
     let db = &ctx.db_path;
+    if req.method != Method::GET {
+        return match route_of(req.path) {
+            Some(Route::List) => finish(create(db, req.body)),
+            Some(Route::Triggers(id)) => finish(create_trigger_rule(db, id, req.body)),
+            Some(Route::Trigger(id, rid)) if req.method == Method::PUT => {
+                finish(update_trigger_rule(db, id, rid, req.body))
+            }
+            Some(Route::Trigger(id, rid)) => finish(delete_trigger_rule(db, id, rid)),
+            _ => Err(format!(
+                "{} {} is not an integration write",
+                req.method, req.path
+            )),
+        };
+    }
     let body = match route_of(req.path) {
         Some(Route::List) => {
             super::gojson::to_vec(&list(db)?).map_err(|e| format!("encoding integrations: {e}"))?
@@ -358,9 +461,335 @@ fn serve(ctx: &super::Ctx, req: &super::Request) -> Result<super::Answer, String
         Some(Route::Triggers(id)) => super::gojson::to_vec(&list_trigger_rules(db, id)?)
             .map_err(|e| format!("encoding trigger rules: {e}"))?,
 
-        None => return Err(format!("{} is not an integration read", req.path)),
+        // `claims` never admits a GET here — chi has no such route, so Go 405s
+        // and forwarding is what reproduces that.
+        Some(Route::Trigger(..)) | None => {
+            return Err(format!("{} is not an integration read", req.path))
+        }
     };
     Ok(super::Answer::json(body))
+}
+
+// ─── Writes ───────────────────────────────────────────────────────────────────
+
+/// `CreateIntegrationRequest`.
+#[derive(Default, Deserialize)]
+#[serde(default)]
+struct CreateIntegrationRequest {
+    #[serde(deserialize_with = "super::gojson::null_is_zero_value")]
+    name: String,
+    #[serde(
+        rename = "type",
+        deserialize_with = "super::gojson::null_is_zero_value"
+    )]
+    integration_type: String,
+    #[serde(deserialize_with = "super::gojson::null_is_zero_value")]
+    enabled: bool,
+    /// `json.RawMessage`, so a literal `null` is four bytes rather than absent —
+    /// which changes which validation error the caller gets. `captured_raw` is
+    /// what keeps the two distinguishable.
+    #[serde(deserialize_with = "super::gojson::captured_raw")]
+    credentials: Option<Box<RawValue>>,
+    services: Option<BTreeMap<String, ServiceConfig>>,
+}
+
+/// `handleCreateIntegration` → `integrationService.Create`.
+///
+/// Order is load-bearing and is Go's: name, then type, then credentials. A
+/// request missing all three reports `name`.
+fn create(db_path: &Path, body: &[u8]) -> Result<super::Answer, WriteError> {
+    let req = decode_body::<CreateIntegrationRequest>(body)?;
+
+    if req.name.is_empty() {
+        return Err(WriteError::validation("name", "name is required"));
+    }
+    if req.integration_type.is_empty() {
+        return Err(WriteError::validation("type", "type is required"));
+    }
+
+    let credentials = match super::integration_credentials::validate(
+        &req.integration_type,
+        req.credentials.as_deref(),
+    )? {
+        // Jira rewrites what it stores; everyone else stores the caller's bytes.
+        Some(normalized) => normalized,
+        None => req
+            .credentials
+            .as_ref()
+            .map(|c| c.get().to_string())
+            .unwrap_or_default(),
+    };
+
+    let id = uuid::Uuid::new_v4().to_string();
+    // One timestamp for both columns, as Go takes one `now`.
+    let now = super::gotime::now_go_text();
+    // `if cfg.Services == nil { cfg.Services = make(...) }` — so an absent
+    // `services` is stored and echoed as `{}`, never as `null`.
+    let services = req.services.unwrap_or_default();
+    let services_json = super::gojson::to_vec_marshal(&services)
+        .map_err(|e| WriteError::Fallback(format!("marshaling services: {e}")))?;
+    let services_json = String::from_utf8(services_json)
+        .map_err(|e| WriteError::Fallback(format!("services json is not utf-8: {e}")))?;
+
+    let conn = open_for_write(db_path)?;
+    conn.execute(
+        "INSERT INTO integrations (id, name, type, enabled, credentials, auth, services, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+         ON CONFLICT(id) DO UPDATE SET
+            name = excluded.name, type = excluded.type, enabled = excluded.enabled,
+            credentials = excluded.credentials, auth = excluded.auth,
+            services = excluded.services, updated_at = excluded.updated_at",
+        rusqlite::params![
+            &id,
+            &req.name,
+            &req.integration_type,
+            i64::from(req.enabled),
+            &credentials,
+            // `authJSON` stays nil on create: nothing is authenticated yet.
+            None::<String>,
+            &services_json,
+            &now,
+            &now,
+        ],
+    )
+    .map_err(|e| WriteError::Fallback(format!("saving integration: {e}")))?;
+
+    let created = ScrubbedIntegration {
+        authenticated: false,
+        created_at: parse_written(&now)?,
+        enabled: req.enabled,
+        id,
+        name: req.name,
+        services: Some(services),
+        integration_type: req.integration_type,
+        updated_at: parse_written(&now)?,
+    };
+    encode_created(&created)
+}
+
+/// `CreateTriggerRuleRequest` / `UpdateTriggerRuleRequest` — identical shapes.
+#[derive(Default, Deserialize)]
+#[serde(default)]
+struct TriggerRuleRequest {
+    #[serde(deserialize_with = "super::gojson::null_is_zero_value")]
+    name: String,
+    #[serde(deserialize_with = "super::gojson::null_is_zero_value")]
+    agent_slug: String,
+    #[serde(deserialize_with = "super::gojson::null_is_zero_value")]
+    enabled: bool,
+    #[serde(deserialize_with = "super::gojson::null_is_zero_value")]
+    filter_prefix: String,
+    filter_keywords: Option<Vec<String>>,
+    filter_chat_ids: Option<Vec<String>>,
+}
+
+/// `handleCreateTriggerRule` → `triggerService.CreateRule`.
+fn create_trigger_rule(
+    db_path: &Path,
+    integration_id: &str,
+    body: &[u8],
+) -> Result<super::Answer, WriteError> {
+    let req = decode_body::<TriggerRuleRequest>(body)?;
+
+    // `validateTriggerRule` checks agent_slug first, and integration_id second —
+    // the latter can only be empty if the path had an empty segment, which
+    // `route_of` already refuses, but the order is kept so the reasoning is
+    // visible rather than assumed.
+    if req.agent_slug.is_empty() {
+        return Err(WriteError::validation(
+            "agent_slug",
+            "agent_slug is required",
+        ));
+    }
+
+    let conn = open_for_write(db_path)?;
+    if !integration_exists(&conn, integration_id)? {
+        return Err(WriteError::NotFound {
+            resource: "integration".to_string(),
+            id: integration_id.to_string(),
+        });
+    }
+
+    // One `now` for both columns and for the response: Go takes a single
+    // `time.Now()` and writes it to both, so two calls here could store a rule
+    // whose `created_at` and `updated_at` differ by a nanosecond.
+    let now = super::gotime::now_go_text();
+    let stamp = parse_written(&now)?;
+    let rule = TriggerRule {
+        id: uuid::Uuid::new_v4().to_string(),
+        integration_id: integration_id.to_string(),
+        name: req.name,
+        agent_slug: req.agent_slug,
+        enabled: req.enabled,
+        filter_prefix: req.filter_prefix,
+        filter_keywords: req.filter_keywords,
+        filter_chat_ids: req.filter_chat_ids,
+        created_at: stamp,
+        updated_at: stamp,
+    };
+    insert_rule(&conn, &rule, &now)?;
+    encode_created(&rule)
+}
+
+/// `handleUpdateTriggerRule`.
+///
+/// The ownership check comes **before** the body is decoded, so a malformed
+/// payload aimed at another integration's rule is a 403 rather than a 400.
+fn update_trigger_rule(
+    db_path: &Path,
+    integration_id: &str,
+    rule_id: &str,
+    body: &[u8],
+) -> Result<super::Answer, WriteError> {
+    let conn = open_for_write(db_path)?;
+    let existing = load_rule(&conn, rule_id)?;
+    if existing.integration_id != integration_id {
+        return Err(WriteError::Forbidden(
+            "rule does not belong to this integration".to_string(),
+        ));
+    }
+
+    let req = decode_body::<TriggerRuleRequest>(body)?;
+    if req.agent_slug.is_empty() {
+        return Err(WriteError::validation(
+            "agent_slug",
+            "agent_slug is required",
+        ));
+    }
+
+    // `UpdateRule` keeps the stored id, integration and creation time and
+    // replaces everything else — a field the caller omitted is cleared, not kept.
+    let now = super::gotime::now_go_text();
+    let rule = TriggerRule {
+        id: existing.id,
+        integration_id: existing.integration_id,
+        name: req.name,
+        agent_slug: req.agent_slug,
+        enabled: req.enabled,
+        filter_prefix: req.filter_prefix,
+        filter_keywords: req.filter_keywords,
+        filter_chat_ids: req.filter_chat_ids,
+        created_at: existing.created_at,
+        updated_at: parse_written(&now)?,
+    };
+
+    conn.execute(
+        "UPDATE trigger_rules SET
+            name = ?1, agent_slug = ?2, enabled = ?3,
+            filter_prefix = ?4, filter_keywords = ?5, filter_chat_ids = ?6,
+            updated_at = ?7
+         WHERE id = ?8",
+        rusqlite::params![
+            &rule.name,
+            &rule.agent_slug,
+            i64::from(rule.enabled),
+            &rule.filter_prefix,
+            &marshal_list(&rule.filter_keywords)?,
+            &marshal_list(&rule.filter_chat_ids)?,
+            &now,
+            &rule.id,
+        ],
+    )
+    .map_err(|e| WriteError::Fallback(format!("updating trigger rule: {e}")))?;
+
+    let body = super::gojson::to_vec(&rule)
+        .map_err(|e| WriteError::Fallback(format!("encoding trigger rule: {e}")))?;
+    Ok(super::Answer::json(body))
+}
+
+/// `handleDeleteTriggerRule`. 204, and the same ownership check.
+fn delete_trigger_rule(
+    db_path: &Path,
+    integration_id: &str,
+    rule_id: &str,
+) -> Result<super::Answer, WriteError> {
+    let conn = open_for_write(db_path)?;
+    let existing = load_rule(&conn, rule_id)?;
+    if existing.integration_id != integration_id {
+        return Err(WriteError::Forbidden(
+            "rule does not belong to this integration".to_string(),
+        ));
+    }
+    conn.execute("DELETE FROM trigger_rules WHERE id = ?1", [rule_id])
+        .map_err(|e| WriteError::Fallback(format!("deleting trigger rule: {e}")))?;
+    Ok(super::Answer::no_content())
+}
+
+fn insert_rule(
+    conn: &rusqlite::Connection,
+    rule: &TriggerRule,
+    now: &str,
+) -> Result<(), WriteError> {
+    conn.execute(
+        "INSERT INTO trigger_rules
+            (id, integration_id, name, agent_slug, enabled,
+             filter_prefix, filter_keywords, filter_chat_ids, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+        rusqlite::params![
+            &rule.id,
+            &rule.integration_id,
+            &rule.name,
+            &rule.agent_slug,
+            i64::from(rule.enabled),
+            &rule.filter_prefix,
+            &marshal_list(&rule.filter_keywords)?,
+            &marshal_list(&rule.filter_chat_ids)?,
+            now,
+            now,
+        ],
+    )
+    .map_err(|e| WriteError::Fallback(format!("creating trigger rule: {e}")))?;
+    Ok(())
+}
+
+/// `json.Marshal` of a `[]string`: `null` when nil, `[]` when empty.
+fn marshal_list(value: &Option<Vec<String>>) -> Result<String, WriteError> {
+    let bytes = super::gojson::to_vec_marshal(value)
+        .map_err(|e| WriteError::Fallback(format!("marshaling filter list: {e}")))?;
+    String::from_utf8(bytes)
+        .map_err(|e| WriteError::Fallback(format!("filter list is not utf-8: {e}")))
+}
+
+fn load_rule(conn: &rusqlite::Connection, rule_id: &str) -> Result<TriggerRule, WriteError> {
+    trigger_rule_by_id(conn, rule_id)
+        .map_err(|e| WriteError::Fallback(format!("looking up trigger rule: {e}")))?
+        .ok_or_else(|| WriteError::NotFound {
+            resource: "trigger_rule".to_string(),
+            id: rule_id.to_string(),
+        })
+}
+
+fn integration_exists(conn: &rusqlite::Connection, id: &str) -> Result<bool, WriteError> {
+    conn.query_row("SELECT 1 FROM integrations WHERE id = ?1", [id], |_| {
+        Ok(true)
+    })
+    .optional()
+    .map_err(|e| WriteError::Fallback(format!("looking up integration: {e}")))
+    .map(|found| found.unwrap_or(false))
+}
+
+/// Re-read a timestamp this process just formatted.
+///
+/// The stored text is the source of truth for both the column and the response,
+/// so parsing it back is what keeps them identical rather than merely equal.
+fn parse_written(text: &str) -> Result<GoTime, WriteError> {
+    GoTime::parse_go_string(text)
+        .map_err(|e| WriteError::Fallback(format!("re-reading written timestamp: {e}")))
+}
+
+fn open_for_write(db_path: &Path) -> Result<rusqlite::Connection, WriteError> {
+    let conn = super::db::open_read_write(db_path).map_err(WriteError::Fallback)?;
+    super::migrate::verify(&conn).map_err(WriteError::Fallback)?;
+    Ok(conn)
+}
+
+fn encode_created<T: Serialize>(value: &T) -> Result<super::Answer, WriteError> {
+    let body = super::gojson::to_vec(value)
+        .map_err(|e| WriteError::Fallback(format!("encoding created row: {e}")))?;
+    Ok(super::Answer::json_status(
+        axum::http::StatusCode::CREATED,
+        body,
+    ))
 }
 
 #[cfg(test)]
@@ -654,17 +1083,29 @@ mod tests {
     }
 
     #[test]
-    fn only_the_four_reads_are_claimed() {
+    fn the_reads_and_the_portable_writes_are_claimed_and_nothing_else_is() {
         assert!(claims(&Method::GET, "/api/integrations"));
         assert!(claims(&Method::GET, "/api/integrations/available-tools"));
         assert!(claims(&Method::GET, "/api/integrations/abc"));
         assert!(claims(&Method::GET, "/api/integrations/abc/triggers"));
 
-        // Writes.
-        assert!(!claims(&Method::POST, "/api/integrations"));
+        // The writes that moved (#277).
+        assert!(claims(&Method::POST, "/api/integrations"));
+        assert!(claims(&Method::POST, "/api/integrations/abc/triggers"));
+        assert!(claims(&Method::PUT, "/api/integrations/abc/triggers/r1"));
+        assert!(claims(&Method::DELETE, "/api/integrations/abc/triggers/r1"));
+
+        // The integration `{id}` writes did NOT move: `PUT` reloads and
+        // `DELETE` stops the live in-process MCP server, which Rust has no way
+        // to do until #282. Claiming either would persist the row and leave the
+        // running integration on stale config.
         assert!(!claims(&Method::PUT, "/api/integrations/abc"));
         assert!(!claims(&Method::DELETE, "/api/integrations/abc"));
-        assert!(!claims(&Method::POST, "/api/integrations/abc/triggers"));
+
+        // A rule id is one segment, and the collection has no PUT/DELETE.
+        assert!(!claims(&Method::PUT, "/api/integrations/abc/triggers"));
+        assert!(!claims(&Method::POST, "/api/integrations/abc/triggers/r1"));
+        assert!(!claims(&Method::PUT, "/api/integrations/abc/triggers/r1/x"));
 
         // Reads that stay with Go, each for its own reason — see the header.
         assert!(!claims(&Method::GET, "/api/integrations/abc/auth/status"));
@@ -679,5 +1120,224 @@ mod tests {
         ));
         assert!(!claims(&Method::GET, "/api/integrations/abc/triggers/rid"));
         assert!(!claims(&Method::GET, "/api/integrations/"));
+    }
+
+    // ─── Writes ───────────────────────────────────────────────────────────────
+
+    /// A database with the real schema, so the write path runs against the
+    /// same tables and the same `schema_migrations` row the app has.
+    fn migrated() -> tempfile::NamedTempFile {
+        let file = tempfile::NamedTempFile::new().expect("temp file");
+        let mut conn = Connection::open(file.path()).expect("open");
+        super::super::migrate::apply(&mut conn).expect("migrate");
+        file
+    }
+
+    fn body_of(answer: &super::super::Answer) -> String {
+        String::from_utf8(answer.body.clone().expect("a body")).expect("utf-8")
+    }
+
+    fn stored(file: &tempfile::NamedTempFile, sql: &str) -> String {
+        Connection::open(file.path())
+            .expect("open")
+            .query_row(sql, [], |row| row.get::<_, String>(0))
+            .expect("query")
+    }
+
+    #[test]
+    fn creating_an_integration_answers_201_and_stores_the_row() {
+        let file = migrated();
+        let answer = create(
+            file.path(),
+            br#"{"name":"Work","type":"telegram","enabled":true,
+                 "credentials":{"bot_token":"t"}}"#,
+        )
+        .expect("create should succeed");
+
+        assert_eq!(answer.status, axum::http::StatusCode::CREATED);
+        let body = body_of(&answer);
+        // Alphabetical, because Go builds the response as a map.
+        assert!(
+            body.starts_with(r#"{"authenticated":false,"created_at":"#),
+            "{body}"
+        );
+        assert!(body.contains(r#""name":"Work""#), "{body}");
+        assert!(body.contains(r#""type":"telegram""#), "{body}");
+        // The secret is never echoed.
+        assert!(
+            !body.contains("bot_token"),
+            "credentials must not be in the response: {body}"
+        );
+        // …but it is stored, verbatim: a create is the one native path that
+        // necessarily handles a secret, because the caller supplies it.
+        assert_eq!(
+            stored(&file, "SELECT credentials FROM integrations"),
+            r#"{"bot_token":"t"}"#
+        );
+    }
+
+    /// `if cfg.Services == nil { cfg.Services = make(...) }`, so an omitted
+    /// `services` is `{}` in both the column and the response — never `null`.
+    #[test]
+    fn an_omitted_services_map_becomes_an_empty_object_not_null() {
+        let file = migrated();
+        let answer = create(
+            file.path(),
+            br#"{"name":"W","type":"telegram","credentials":{"bot_token":"t"}}"#,
+        )
+        .expect("create");
+        assert!(
+            body_of(&answer).contains(r#""services":{}"#),
+            "{}",
+            body_of(&answer)
+        );
+        assert_eq!(stored(&file, "SELECT services FROM integrations"), "{}");
+    }
+
+    /// Jira is the only type that rewrites what it stores.
+    #[test]
+    fn creating_a_jira_integration_stores_the_renormalised_credentials() {
+        let file = migrated();
+        create(
+            file.path(),
+            br#"{"name":"J","type":"jira","credentials":
+                 {"email":"e","extra":"dropped","site_url":"https://x.net//","api_token":"t"}}"#,
+        )
+        .expect("create");
+        assert_eq!(
+            stored(&file, "SELECT credentials FROM integrations"),
+            r#"{"site_url":"https://x.net","email":"e","api_token":"t"}"#,
+            "jira trims the trailing slashes, re-marshals in declaration order and drops unknown keys"
+        );
+    }
+
+    #[test]
+    fn name_is_checked_before_type_and_type_before_credentials() {
+        let file = migrated();
+        let err = create(file.path(), br#"{}"#).expect_err("empty body");
+        assert!(
+            err.message().contains("name is required"),
+            "{}",
+            err.message()
+        );
+        let err = create(file.path(), br#"{"name":"W"}"#).expect_err("no type");
+        assert!(
+            err.message().contains("type is required"),
+            "{}",
+            err.message()
+        );
+        let err =
+            create(file.path(), br#"{"name":"W","type":"telegram"}"#).expect_err("no credentials");
+        assert!(
+            err.message().contains("credentials are empty"),
+            "{}",
+            err.message()
+        );
+    }
+
+    fn seed_integration(file: &tempfile::NamedTempFile, id: &str) {
+        Connection::open(file.path())
+            .expect("open")
+            .execute(
+                "INSERT INTO integrations (id, name, type, enabled, credentials, services,
+                                           created_at, updated_at)
+                 VALUES (?1, 'n', 'telegram', 1, '{}', '{}', '2026-01-01 00:00:00 +0000 UTC',
+                         '2026-01-01 00:00:00 +0000 UTC')",
+                [id],
+            )
+            .expect("seed");
+    }
+
+    #[test]
+    fn a_trigger_rule_round_trips_through_create_update_and_delete() {
+        let file = migrated();
+        seed_integration(&file, "int-1");
+
+        let created = create_trigger_rule(
+            file.path(),
+            "int-1",
+            br#"{"name":"R","agent_slug":"a","enabled":true,"filter_keywords":["x"]}"#,
+        )
+        .expect("create rule");
+        assert_eq!(created.status, axum::http::StatusCode::CREATED);
+        let body = body_of(&created);
+        assert!(body.contains(r#""agent_slug":"a""#), "{body}");
+        assert!(body.contains(r#""filter_keywords":["x"]"#), "{body}");
+        // A `TriggerRule` is a struct in Go, so this order is declaration order.
+        assert!(body.starts_with(r#"{"id":"#), "{body}");
+
+        let id = stored(&file, "SELECT id FROM trigger_rules");
+
+        // An omitted field is cleared, not preserved — `UpdateRule` replaces.
+        let updated = update_trigger_rule(file.path(), "int-1", &id, br#"{"agent_slug":"b"}"#)
+            .expect("update rule");
+        assert_eq!(updated.status, axum::http::StatusCode::OK);
+        let body = body_of(&updated);
+        assert!(body.contains(r#""agent_slug":"b""#), "{body}");
+        assert!(
+            body.contains(r#""name":"""#),
+            "an omitted name is cleared: {body}"
+        );
+        // A nil Go slice is `null`; an omitted keyword list is nil, not `[]`.
+        assert!(body.contains(r#""filter_keywords":null"#), "{body}");
+
+        let deleted = delete_trigger_rule(file.path(), "int-1", &id).expect("delete rule");
+        assert_eq!(deleted.status, axum::http::StatusCode::NO_CONTENT);
+        assert!(deleted.body.is_none(), "a 204 carries no body at all");
+    }
+
+    /// The ownership check runs before the body is decoded, so a malformed
+    /// payload aimed at another integration's rule is 403 and not 400.
+    #[test]
+    fn a_rule_owned_by_another_integration_is_403_before_the_body_is_read() {
+        let file = migrated();
+        seed_integration(&file, "int-1");
+        seed_integration(&file, "int-2");
+        let created =
+            create_trigger_rule(file.path(), "int-1", br#"{"agent_slug":"a"}"#).expect("create");
+        assert_eq!(created.status, axum::http::StatusCode::CREATED);
+        let id = stored(&file, "SELECT id FROM trigger_rules");
+
+        for body in [&br#"{"agent_slug":"b"}"#[..], b"not json at all"] {
+            let err = update_trigger_rule(file.path(), "int-2", &id, body)
+                .expect_err("wrong integration");
+            assert_eq!(
+                err.status(),
+                axum::http::StatusCode::FORBIDDEN,
+                "body: {body:?}"
+            );
+            assert_eq!(err.message(), "rule does not belong to this integration");
+        }
+
+        let err = delete_trigger_rule(file.path(), "int-2", &id).expect_err("wrong integration");
+        assert_eq!(err.status(), axum::http::StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn a_missing_rule_is_404_and_a_missing_integration_is_too() {
+        let file = migrated();
+        let err = update_trigger_rule(file.path(), "int-1", "nope", br#"{"agent_slug":"a"}"#)
+            .expect_err("missing rule");
+        assert_eq!(err.status(), axum::http::StatusCode::NOT_FOUND);
+        assert_eq!(err.message(), r#"trigger_rule "nope" not found"#);
+
+        let err = create_trigger_rule(file.path(), "ghost", br#"{"agent_slug":"a"}"#)
+            .expect_err("missing integration");
+        assert_eq!(err.status(), axum::http::StatusCode::NOT_FOUND);
+        assert_eq!(err.message(), r#"integration "ghost" not found"#);
+    }
+
+    #[test]
+    fn a_rule_without_an_agent_slug_is_422() {
+        let file = migrated();
+        seed_integration(&file, "int-1");
+        let err = create_trigger_rule(file.path(), "int-1", br#"{"name":"R"}"#)
+            .expect_err("no agent_slug");
+        assert_eq!(err.status(), axum::http::StatusCode::UNPROCESSABLE_ENTITY);
+        assert!(
+            err.message().contains("agent_slug is required"),
+            "{}",
+            err.message()
+        );
     }
 }

--- a/desktop/src-tauri/src/native/integrations.rs
+++ b/desktop/src-tauri/src/native/integrations.rs
@@ -36,10 +36,18 @@
 //! Everything below the "Secrets" note is about never *reading* credentials.
 //! That cannot hold for a create, because the caller supplies them in the
 //! request body and they have to reach the column. So `create` carries them as
-//! a borrowed `RawValue` from decode to `INSERT` — never through
-//! `serde_json::Value`, which would reorder the keys and respell any number —
-//! and the response is still built from [`ScrubbedIntegration`], which has no
-//! field to leak them through.
+//! a borrowed `RawValue` from decode to `INSERT`, and the response is still
+//! built from [`ScrubbedIntegration`], which has no field to leak them through.
+//!
+//! **That guarantee is not local to this module.** It also depends on
+//! `writes::decode_body` deserializing from the request's *original bytes*
+//! rather than from the `serde_json::Value` it shape-checks with — going
+//! through the `Value` sorts keys and respells numbers, so the captured
+//! `RawValue` would be a re-serialization and Go's verbatim column would
+//! differ on every blob with more than one key. `decode_body` has its own test
+//! for this; the one here asserts the stored bytes end to end. Both use a
+//! multi-key blob deliberately: a single-key one is a fixed point of the broken
+//! round trip and proves nothing.
 //!
 //! ## Secrets
 //!
@@ -1147,10 +1155,14 @@ mod tests {
     #[test]
     fn creating_an_integration_answers_201_and_stores_the_row() {
         let file = migrated();
+        // A **multi-key** blob, out of alphabetical order, with a trailing-zero
+        // decimal and interior whitespace. A single-key blob is a fixed point of
+        // a `serde_json::Value` round trip, so it would pass even if the bytes
+        // were being rebuilt — which is exactly the hole review found here.
         let answer = create(
             file.path(),
             br#"{"name":"Work","type":"telegram","enabled":true,
-                 "credentials":{"bot_token":"t"}}"#,
+                 "credentials":{"zebra":"z", "bot_token":"t","rate":1.50}}"#,
         )
         .expect("create should succeed");
 
@@ -1172,7 +1184,9 @@ mod tests {
         // necessarily handles a secret, because the caller supplies it.
         assert_eq!(
             stored(&file, "SELECT credentials FROM integrations"),
-            r#"{"bot_token":"t"}"#
+            r#"{"zebra":"z", "bot_token":"t","rate":1.50}"#,
+            "Go stores the RawMessage verbatim: key order, `1.50` and the space \
+             after the first comma all survive"
         );
     }
 

--- a/desktop/src-tauri/src/native/mod.rs
+++ b/desktop/src-tauri/src/native/mod.rs
@@ -23,6 +23,7 @@ pub mod gojson;
 pub mod gopath;
 pub mod gotime;
 pub mod insights;
+pub mod integration_credentials;
 pub mod integrations;
 pub mod migrate;
 pub mod monitoring;
@@ -447,14 +448,18 @@ mod tests {
         assert!(!claims(&Method::POST, "/api/uploads"));
         assert!(!claims(&Method::GET, "/api/uploads"));
 
-        // Integrations: the four reads. Everything that writes, dials a remote
-        // service, or reads in-memory OAuth state stays with Go.
+        // Integrations: the four reads, plus the writes with no live-server
+        // effect. Anything that reloads an MCP server, dials a remote service,
+        // or reads in-memory OAuth state stays with Go.
         assert!(claims(&Method::GET, "/api/integrations"));
         assert!(claims(&Method::GET, "/api/integrations/available-tools"));
         assert!(claims(&Method::GET, "/api/integrations/abc"));
         assert!(claims(&Method::GET, "/api/integrations/abc/triggers"));
-        assert!(!claims(&Method::POST, "/api/integrations"));
+        assert!(claims(&Method::POST, "/api/integrations"));
+        assert!(claims(&Method::PUT, "/api/integrations/abc/triggers/r1"));
+        // Still Go's: these start and stop the live MCP server (#282).
         assert!(!claims(&Method::PUT, "/api/integrations/abc"));
+        assert!(!claims(&Method::DELETE, "/api/integrations/abc"));
         assert!(!claims(&Method::GET, "/api/integrations/abc/auth/status"));
         assert!(!claims(
             &Method::GET,

--- a/desktop/src-tauri/src/native/writes.rs
+++ b/desktop/src-tauri/src/native/writes.rs
@@ -186,9 +186,21 @@ pub fn decode_body<T: serde::de::DeserializeOwned>(body: &[u8]) -> Result<T, Wri
         // rather than what the client sent, and
         // `integrations.credentials` is stored verbatim by Go, so the two
         // databases would diverge on every blob with more than one key.
-        serde_json::Value::Object(_) => {
-            serde_json::from_slice(body).map_err(|_| WriteError::InvalidBody)
-        }
+        serde_json::Value::Object(_) => serde_json::from_slice(body).or_else(|_| {
+            // Falling back to the `Value` restores Go's answer for the one
+            // shape the strict path rejects and Go does not: **duplicate keys**.
+            // `encoding/json` takes the last occurrence; serde's derived impl
+            // errors with `duplicate field`, which would have been a 400 where
+            // Go answers 200 and creates the row. The `Value` already collapsed
+            // them last-wins, so decoding from it is exactly Go's result.
+            //
+            // This can only *add* back acceptance, never remove it: a body both
+            // paths reject is still `InvalidBody`. The cost is that a
+            // duplicate-key request loses byte-verbatim raw capture — which is
+            // the right trade, since the alternative is refusing a request Go
+            // would have honoured.
+            serde_json::from_value(value).map_err(|_| WriteError::InvalidBody)
+        }),
         // Go's no-op: the zero value, and the handler validates it.
         serde_json::Value::Null => {
             serde_json::from_value(serde_json::Value::Object(serde_json::Map::new()))
@@ -225,6 +237,37 @@ mod tests {
             decoded.blob.expect("present").get(),
             r#"{"zebra":"z", "alpha":"a","rate":1.50,"n":1e3}"#,
             "key order, number spelling and interior whitespace must all survive"
+        );
+    }
+
+    /// `encoding/json` accepts duplicate keys and keeps the **last**; serde's
+    /// derived impl errors with `duplicate field`. Deserializing from the raw
+    /// bytes made that a 400 where Go answers 200 and creates the row, so the
+    /// helper falls back to the collapsed `Value`.
+    #[test]
+    fn duplicate_keys_take_the_last_value_as_go_does() {
+        #[derive(serde::Deserialize)]
+        struct Body {
+            #[serde(default)]
+            s: String,
+        }
+        let decoded: Body =
+            decode_body(br#"{"s":"first","s":"last-wins"}"#).expect("Go accepts this");
+        assert_eq!(decoded.s, "last-wins");
+    }
+
+    /// The fallback must not widen what is accepted beyond it.
+    #[test]
+    fn a_body_both_paths_reject_is_still_malformed() {
+        #[derive(Debug, serde::Deserialize)]
+        struct Body {
+            #[serde(default)]
+            #[allow(dead_code)] // Only the decode outcome is under test.
+            n: u8,
+        }
+        assert_eq!(
+            decode_body::<Body>(br#"{"n":"not a number"}"#).unwrap_err(),
+            WriteError::InvalidBody
         );
     }
 

--- a/desktop/src-tauri/src/native/writes.rs
+++ b/desktop/src-tauri/src/native/writes.rs
@@ -186,20 +186,29 @@ pub fn decode_body<T: serde::de::DeserializeOwned>(body: &[u8]) -> Result<T, Wri
         // rather than what the client sent, and
         // `integrations.credentials` is stored verbatim by Go, so the two
         // databases would diverge on every blob with more than one key.
-        serde_json::Value::Object(_) => serde_json::from_slice(body).or_else(|_| {
-            // Falling back to the `Value` restores Go's answer for the one
-            // shape the strict path rejects and Go does not: **duplicate keys**.
-            // `encoding/json` takes the last occurrence; serde's derived impl
-            // errors with `duplicate field`, which would have been a 400 where
-            // Go answers 200 and creates the row. The `Value` already collapsed
-            // them last-wins, so decoding from it is exactly Go's result.
+        serde_json::Value::Object(_) => serde_json::from_slice(body).map_err(|_| {
+            // The strict path refuses one shape Go accepts — **duplicate keys**.
+            // serde's derived impl errors with `duplicate field`;
+            // `encoding/json` takes the last occurrence.
             //
-            // This can only *add* back acceptance, never remove it: a body both
-            // paths reject is still `InvalidBody`. The cost is that a
-            // duplicate-key request loses byte-verbatim raw capture — which is
-            // the right trade, since the alternative is refusing a request Go
-            // would have honoured.
-            serde_json::from_value(value).map_err(|_| WriteError::InvalidBody)
+            // The tempting repair is to decode the already-collapsed `Value`,
+            // but that is a *superset* of Go rather than a match: Go validates
+            // **every** occurrence, while the `Value` retained only the last. So
+            // `{"count":"notanumber","count":1}` is a 400 to Go and would decode
+            // cleanly here — an over-accept, which on `POST /api/integrations`
+            // means creating a row Go would have refused. It would also lose
+            // byte-verbatim raw capture, since the value came from the `Value`.
+            //
+            // Forwarding is exact in both directions and costs nothing: Go
+            // answers the well-typed duplicates and 400s the ill-typed ones. Safe
+            // because `decode_body` runs before any mutation in every caller.
+            if serde_json::from_value::<T>(value).is_ok() {
+                WriteError::Fallback(
+                    "duplicate keys: Go validates every occurrence, so only it can answer".into(),
+                )
+            } else {
+                WriteError::InvalidBody
+            }
         }),
         // Go's no-op: the zero value, and the handler validates it.
         serde_json::Value::Null => {
@@ -240,20 +249,52 @@ mod tests {
         );
     }
 
-    /// `encoding/json` accepts duplicate keys and keeps the **last**; serde's
-    /// derived impl errors with `duplicate field`. Deserializing from the raw
-    /// bytes made that a 400 where Go answers 200 and creates the row, so the
-    /// helper falls back to the collapsed `Value`.
+    /// Duplicate keys forward, because only Go can answer them.
+    ///
+    /// `encoding/json` keeps the **last** occurrence but type-checks **every**
+    /// one, so `{"n":"x","n":1}` is a 400 to Go even though the surviving value
+    /// is fine. serde's derived impl refuses duplicates outright, and the
+    /// collapsed `Value` has already thrown away the occurrences Go would have
+    /// judged — so neither local path can reproduce the answer. Handing it over
+    /// is exact in both directions.
     #[test]
-    fn duplicate_keys_take_the_last_value_as_go_does() {
-        #[derive(serde::Deserialize)]
+    fn duplicate_keys_forward_rather_than_being_guessed_at() {
+        #[derive(Debug, serde::Deserialize)]
         struct Body {
             #[serde(default)]
+            #[allow(dead_code)]
             s: String,
+            #[serde(default)]
+            #[allow(dead_code)]
+            n: u8,
         }
-        let decoded: Body =
-            decode_body(br#"{"s":"first","s":"last-wins"}"#).expect("Go accepts this");
-        assert_eq!(decoded.s, "last-wins");
+        // Go would accept this one…
+        assert!(matches!(
+            decode_body::<Body>(br#"{"s":"first","s":"last-wins"}"#).unwrap_err(),
+            WriteError::Fallback(_)
+        ));
+        // …and 400 this one, because the *first* occurrence does not fit `u8`.
+        // Both forward, so Go makes that distinction rather than this helper.
+        assert!(matches!(
+            decode_body::<Body>(br#"{"n":999,"n":7}"#).unwrap_err(),
+            WriteError::Fallback(_)
+        ));
+    }
+
+    /// Ordinary bodies must not touch the duplicate path — verbatim capture
+    /// still has to come from the strict decode.
+    #[test]
+    fn a_body_without_duplicates_never_takes_the_forward_path() {
+        #[derive(serde::Deserialize)]
+        struct Body {
+            #[serde(default, deserialize_with = "super::super::gojson::captured_raw")]
+            blob: Option<Box<serde_json::value::RawValue>>,
+        }
+        let decoded: Body = decode_body(br#"{"blob":{"z":"z", "a":"a","r":1.50}}"#).expect("ok");
+        assert_eq!(
+            decoded.blob.expect("present").get(),
+            r#"{"z":"z", "a":"a","r":1.50}"#
+        );
     }
 
     /// The fallback must not widen what is accepted beyond it.

--- a/desktop/src-tauri/src/native/writes.rs
+++ b/desktop/src-tauri/src/native/writes.rs
@@ -175,8 +175,19 @@ pub fn decode_body<T: serde::de::DeserializeOwned>(body: &[u8]) -> Result<T, Wri
     let value: serde_json::Value =
         serde_json::from_slice(body).map_err(|_| WriteError::InvalidBody)?;
     match value {
+        // Deserialize from the **original bytes**, not from the `Value` just
+        // parsed. The `Value` is only a shape check.
+        //
+        // This is load-bearing for any field that captures raw JSON: serde_json
+        // is built without `preserve_order`, so a `Value::Object` is a
+        // `BTreeMap` — going through it sorts keys, respells numbers (`1.50` →
+        // `1.5`, `1e3` → `1000.0`) and strips interior whitespace. A
+        // `Box<RawValue>` field would then capture the *re-serialized* value
+        // rather than what the client sent, and
+        // `integrations.credentials` is stored verbatim by Go, so the two
+        // databases would diverge on every blob with more than one key.
         serde_json::Value::Object(_) => {
-            serde_json::from_value(value).map_err(|_| WriteError::InvalidBody)
+            serde_json::from_slice(body).map_err(|_| WriteError::InvalidBody)
         }
         // Go's no-op: the zero value, and the handler validates it.
         serde_json::Value::Null => {
@@ -190,6 +201,32 @@ pub fn decode_body<T: serde::de::DeserializeOwned>(body: &[u8]) -> Result<T, Wri
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A field that captures raw JSON must capture what the **client sent**,
+    /// not a re-serialization of it.
+    ///
+    /// `decode_body` shape-checks through a `serde_json::Value`, and serde_json
+    /// here has no `preserve_order` — so deserializing *from that `Value`*
+    /// silently sorted keys, respelled `1.50` as `1.5` and dropped interior
+    /// whitespace. `integrations.credentials` is stored verbatim by Go, so that
+    /// was a byte divergence on every blob with more than one key. Deserializing
+    /// from the original bytes is what fixes it, and this pins it at the level
+    /// the bug lived at rather than only at the one call site that noticed.
+    #[test]
+    fn a_captured_raw_field_keeps_the_bytes_the_client_sent() {
+        #[derive(serde::Deserialize)]
+        struct Body {
+            #[serde(default, deserialize_with = "super::super::gojson::captured_raw")]
+            blob: Option<Box<serde_json::value::RawValue>>,
+        }
+        let body = br#"{"blob":{"zebra":"z", "alpha":"a","rate":1.50,"n":1e3}}"#;
+        let decoded: Body = decode_body(body).expect("decodes");
+        assert_eq!(
+            decoded.blob.expect("present").get(),
+            r#"{"zebra":"z", "alpha":"a","rate":1.50,"n":1e3}"#,
+            "key order, number spelling and interior whitespace must all survive"
+        );
+    }
 
     /// These strings ship. `service.ValidationError.Error()` uses `%q`, which
     /// is Go's quoted form — so the field name arrives in quotes, and a port

--- a/desktop/src-tauri/src/native/writes.rs
+++ b/desktop/src-tauri/src/native/writes.rs
@@ -50,6 +50,12 @@ pub enum WriteError {
     /// [`WriteError::NotFound`] — which would render `chat "abc" not found` —
     /// is the wrong shape, and `BadRequest` is the wrong *status*.
     NotFoundMessage(String),
+    /// A 403 with a fixed message, written by the handler rather than raised by
+    /// the service. The trigger-rule routes use it for a rule that exists but
+    /// belongs to a different integration — note they check that *before*
+    /// decoding the body, so a malformed payload on someone else's rule is this
+    /// and not a 400.
+    Forbidden(String),
     /// Not reproducible here: let the sidecar answer.
     Fallback(String),
 }
@@ -70,6 +76,7 @@ impl WriteError {
             Self::Validation { .. } => StatusCode::UNPROCESSABLE_ENTITY,
             Self::Conflict { .. } => StatusCode::CONFLICT,
             Self::NotFound { .. } | Self::NotFoundMessage(_) => StatusCode::NOT_FOUND,
+            Self::Forbidden(_) => StatusCode::FORBIDDEN,
             Self::Fallback(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
@@ -97,6 +104,7 @@ impl WriteError {
             // `service.NotFoundError.Error()`.
             Self::NotFound { resource, id } => format!("{resource} {:?} not found", id),
             Self::NotFoundMessage(m) => m.clone(),
+            Self::Forbidden(m) => m.clone(),
             Self::Fallback(m) => m.clone(),
         }
     }

--- a/desktop/src-tauri/tests/parity_writes.rs
+++ b/desktop/src-tauri/tests/parity_writes.rs
@@ -378,7 +378,13 @@ async fn the_integration_write_answers_match_go() {
     let created = go_answer(
         Method::POST,
         "/api/integrations",
-        Some(r#"{"name":"Parity Writes","type":"telegram","credentials":{"bot_token":"tok"}}"#),
+        // Multi-key, out of order, with a trailing-zero decimal and interior
+        // whitespace: a single-key blob is a fixed point of a `Value` round
+        // trip and would prove nothing about verbatim storage.
+        Some(
+            r#"{"name":"Parity Writes","type":"telegram",
+                 "credentials":{"zebra":"z", "bot_token":"tok","rate":1.50}}"#,
+        ),
     )
     .await;
     assert_eq!(created.0, 201, "create must be 201, got {}", created.0);

--- a/desktop/src-tauri/tests/parity_writes.rs
+++ b/desktop/src-tauri/tests/parity_writes.rs
@@ -312,3 +312,165 @@ async fn the_job_history_delete_answers_match_go() {
         );
     }
 }
+
+// ─── Integrations and trigger rules (#277) ────────────────────────────────────
+
+/// Pin Go's answers for the integration writes that moved, and for the two that
+/// deliberately did not.
+///
+/// The per-type credential validators are where this port's parity risk
+/// concentrates — seven types, each with its own required fields and its own
+/// exact 422 wording — so the messages are asserted verbatim rather than by
+/// status alone.
+#[tokio::test]
+#[ignore = "requires a scratch Go instance; mutates it"]
+async fn the_integration_write_answers_match_go() {
+    require_scratch_instance();
+
+    // A missing name is a 422 from the service, and it is checked before type.
+    let no_name = go_answer(
+        Method::POST,
+        "/api/integrations",
+        Some(r#"{"type":"telegram"}"#),
+    )
+    .await;
+    assert_eq!(no_name.0, 422);
+    assert_eq!(
+        String::from_utf8_lossy(&no_name.1).trim_end(),
+        r#"{"error":"validation error for \"name\": name is required"}"#
+    );
+
+    let no_type = go_answer(Method::POST, "/api/integrations", Some(r#"{"name":"n"}"#)).await;
+    assert_eq!(no_type.0, 422);
+    assert_eq!(
+        String::from_utf8_lossy(&no_type.1).trim_end(),
+        r#"{"error":"validation error for \"type\": type is required"}"#
+    );
+
+    // An **absent** credentials blob is "credentials are empty"…
+    let absent = go_answer(
+        Method::POST,
+        "/api/integrations",
+        Some(r#"{"name":"n","type":"telegram"}"#),
+    )
+    .await;
+    assert_eq!(absent.0, 422);
+    assert_eq!(
+        String::from_utf8_lossy(&absent.1).trim_end(),
+        r#"{"error":"validation error for \"credentials\": invalid telegram credentials: credentials are empty"}"#
+    );
+
+    // …but a literal `null` is four bytes, so it decodes to the zero value and
+    // reports the missing *field* instead. This pair is the whole reason the
+    // port captures the raw blob rather than letting serde fold null into None.
+    let null_creds = go_answer(
+        Method::POST,
+        "/api/integrations",
+        Some(r#"{"name":"n","type":"telegram","credentials":null}"#),
+    )
+    .await;
+    assert_eq!(null_creds.0, 422);
+    assert_eq!(
+        String::from_utf8_lossy(&null_creds.1).trim_end(),
+        r#"{"error":"validation error for \"credentials.bot_token\": bot_token is required"}"#
+    );
+
+    let created = go_answer(
+        Method::POST,
+        "/api/integrations",
+        Some(r#"{"name":"Parity Writes","type":"telegram","credentials":{"bot_token":"tok"}}"#),
+    )
+    .await;
+    assert_eq!(created.0, 201, "create must be 201, got {}", created.0);
+    println!("create: {}", String::from_utf8_lossy(&created.1));
+    let body: serde_json::Value = serde_json::from_slice(&created.1).expect("json");
+    let id = body["id"].as_str().expect("an id").to_string();
+    // An omitted services map is `{}`, never null, and no secret is echoed.
+    assert_eq!(body["services"], serde_json::json!({}));
+    assert_eq!(body["authenticated"], false);
+    assert!(
+        body.get("credentials").is_none(),
+        "credentials must be scrubbed"
+    );
+
+    // ── Trigger rules ──
+    let rule = go_answer(
+        Method::POST,
+        &format!("/api/integrations/{id}/triggers"),
+        Some(r#"{"name":"R","agent_slug":"a","enabled":true}"#),
+    )
+    .await;
+    assert_eq!(rule.0, 201, "rule create must be 201");
+    let rule_body: serde_json::Value = serde_json::from_slice(&rule.1).expect("json");
+    let rid = rule_body["id"].as_str().expect("a rule id").to_string();
+
+    // An omitted field is cleared by an update, not preserved.
+    let updated = go_answer(
+        Method::PUT,
+        &format!("/api/integrations/{id}/triggers/{rid}"),
+        Some(r#"{"agent_slug":"b"}"#),
+    )
+    .await;
+    assert_eq!(updated.0, 200);
+    let updated_body: serde_json::Value = serde_json::from_slice(&updated.1).expect("json");
+    assert_eq!(updated_body["agent_slug"], "b");
+    assert_eq!(updated_body["name"], "", "an omitted name is cleared");
+
+    // A rule id that exists but belongs elsewhere is 403 — and the check runs
+    // before the body is decoded, so garbage still gets 403 rather than 400.
+    let other = go_answer(
+        Method::POST,
+        "/api/integrations",
+        Some(r#"{"name":"Other","type":"telegram","credentials":{"bot_token":"t2"}}"#),
+    )
+    .await;
+    let other_id = serde_json::from_slice::<serde_json::Value>(&other.1).expect("json")["id"]
+        .as_str()
+        .expect("id")
+        .to_string();
+    for body in [r#"{"agent_slug":"c"}"#, "not json at all"] {
+        let forbidden = go_answer(
+            Method::PUT,
+            &format!("/api/integrations/{other_id}/triggers/{rid}"),
+            Some(body),
+        )
+        .await;
+        assert_eq!(forbidden.0, 403, "body {body:?} must still be 403");
+        assert_eq!(
+            String::from_utf8_lossy(&forbidden.1).trim_end(),
+            r#"{"error":"rule does not belong to this integration"}"#
+        );
+    }
+
+    let missing = go_answer(
+        Method::PUT,
+        &format!("/api/integrations/{id}/triggers/no-such-rule"),
+        Some(r#"{"agent_slug":"c"}"#),
+    )
+    .await;
+    assert_eq!(missing.0, 404);
+    assert_eq!(
+        String::from_utf8_lossy(&missing.1).trim_end(),
+        r#"{"error":"trigger_rule \"no-such-rule\" not found"}"#
+    );
+
+    let deleted = go_answer(
+        Method::DELETE,
+        &format!("/api/integrations/{id}/triggers/{rid}"),
+        None,
+    )
+    .await;
+    assert_eq!(deleted.0, 204);
+    assert!(deleted.1.is_empty(), "204 carries no body");
+
+    // Clean up through Go, which is also the side that owns these deletes.
+    for cleanup in [&id, &other_id] {
+        let gone = go_answer(
+            Method::DELETE,
+            &format!("/api/integrations/{cleanup}"),
+            None,
+        )
+        .await;
+        assert_eq!(gone.0, 204, "integration delete must be 204");
+    }
+}


### PR DESCRIPTION
Closes #277

Revalidating #277's HOW against the code found that most of its scope is blocked by **#282**, which the issue does not list as a blocker — its stated blockers (#269, #274) are both merged, so it looked ready. Rather than half-port it, this moves the subset that is genuinely unblocked and states the rest. Scope finding written up on the issue: shaharia-lab/agento#277 (comment).

## What moved

| Route | Why it is safe |
|---|---|
| `POST /api/integrations` | `integrationService.Create` is validation → uuid → timestamps → `store.Save`. **No registry call** — verified against the whole function, which matters because `Create` and `Update` look alike and differ exactly here. |
| `POST /{id}/triggers` | Pure row write. |
| `PUT /{id}/triggers/{rid}` | Pure row write. |
| `DELETE /{id}/triggers/{rid}` | Pure row write. The dispatcher calls `ListRules` **per inbound message** (`dispatcher.go:168`), so there is no cached rule set for a native write to leave stale — this is what makes rule writes portable while integration writes are not. |

## What deliberately did not

- `PUT /{id}` → `registry.Reload(id)`; `DELETE /{id}` → `registry.Stop(id)`. These restart the **live in-process MCP server**. Rust has none until #282, so a native write would persist the row and leave the integration running on stale config — still using a token the user just revoked, with a 200 saying it worked.
- OAuth (`auth/start|status|validate`): in-memory flow state, must open the user's **real browser**, and writes credentials Go's MCP servers consume. All three move together or not at all — the #276 live-registry lesson.
- Webhooks: Telegram network calls, and the secret authenticates Go's **root-mounted** inbound handler.
- `POST /webhooks/telegram/{id}` + `internal/trigger/`: the dispatcher runs an agent using the integration's credentials, which this port deliberately never reads (#272).

## The credential validators are where the parity risk is

Seven types, each with its own required fields and its own **exact** 422 wording, all of which ship to the client. Two of Go's failure paths embed a string with no Rust spelling — `encoding/json`'s unmarshal error (it names Go types) and `url.Parse`'s — so both **forward** rather than guess. Everything else is reproduced:

- **Absent and `null` credentials fail differently.** Go tests `len(cfg.Credentials) == 0`, true only when the key is *absent*; a literal `null` is four bytes, decodes to the zero value, and reports the missing *field*. `gojson::captured_raw` keeps them distinguishable, and decoding through `Option<T>` stops serde erroring where Go does not — wire-format rule 4, which bit once here and was caught by its own test.
- **Jira rewrites what it stores**: trims trailing slashes and re-marshals the struct, so unknown keys the caller sent are dropped and the three known ones come back in declaration order. **Confluence, sharing the credential type, does not** — and is HTTPS-only where Jira takes either.

## A create is the first native path that handles a secret

Unavoidably: the caller supplies it. It travels as a borrowed `RawValue` from decode to `INSERT` — never through `serde_json::Value`, which would reorder keys and respell numbers — and the response is still built from `ScrubbedIntegration`, which has no field to leak it through. A test asserts the stored bytes are verbatim and the response contains no `bot_token`.

`WriteError` gains `Forbidden` for the 403 the rule routes answer when a rule belongs to another integration — checked **before** the body is decoded, so a malformed payload there is 403 and not 400. Both are asserted.

## Verification

- 459 lib + 9 `chat_turn` + 17 `claude_sdk` + 7 `scanner_roundtrip` = **492 pass**; `clippy --all-targets -D warnings` and `fmt --check` clean; release build succeeds.
- 8 new write tests run against a **really migrated** database, not a hand-rolled schema.
- The two pre-existing tests asserting these routes were *not* native were updated — that is the check that would catch an accidental claim, so it is worth noting they had to change.
- `tests/parity_writes.rs` gains a case pinning Go's own answers for all of the above, including the absent-vs-`null` pair. As ever it is `#[ignore]`d and needs a scratch instance, so **CI does not run it**.