### PR TITLE
feat(desktop): port GET /api/settings/claude-config-dirs, and write the settings PUT

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -932,14 +932,16 @@ why `apply_data_settings` is three lines where Go's is thirty. The obstacle is
 the **sidecar**, which does hold one and is still serving routes that read it:
 
 - `notificationServiceImpl.UpdateSettings` is a read-modify-write over
-  `settingsMgr.Get()` that persists the **whole** `user_settings` row. So a
-  native settings save followed by any SMTP save through the unported
-  `PUT /api/notifications/settings` rewrites `hidden_projects`,
-  `idle_gap_threshold_minutes` and both config-dir columns from the sidecar's
-  boot-time copy. Reproduced against a Go server built from this checkout: a
-  row edited to `["…/native-wrote-this"]` / 42 read back
+  `settingsMgr.Get()` that persists the **whole** `user_settings` row, so a
+  native settings save followed by one SMTP save through Go rewrites
+  `hidden_projects`, `idle_gap_threshold_minutes` and both config-dir columns
+  from the sidecar's boot-time copy. Reproduced against a Go server built from
+  this checkout: a row edited to `["…/native-wrote-this"]` / 42 read back
   `["…/hidden-one"]` / 25 after one unrelated notification save, with no error
-  anywhere. That is silent, total reversion of the Data & Analytics tab.
+  anywhere — silent, total reversion of the Data & Analytics tab. #307 has
+  since taken `PUT /api/notifications/settings` native, and its write touches
+  one column precisely so it cannot do this; but the Go method is unchanged and
+  `Err` still forwards, so the path is narrowed, not closed.
 - `config.ResolveAgentClaudeDir` resolves each run's Claude account from
   `claudeDirs.runOverride`, so scheduled tasks (#275) and Telegram triggers —
   both still Go's — would keep authenticating as the previous account.

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -141,7 +141,9 @@ src-tauri/src/
       turn.rs    spawn, stream, and the AskUserQuestion continuation
       persist.rs what a finished turn writes, and what an interrupted one does not
       sse.rs     the frame bytes: raw pass-through vs the two synthetic events
-    settings.rs  GET /api/settings; also the preferences + config dirs a read is scoped to
+    settings.rs  GET /api/settings and /settings/claude-config-dirs (a filesystem
+                 probe); the preferences + config dirs a read is scoped to; and
+                 `update`, the PUT — written and tested, deliberately unclaimed
     monitoring.rs GET /api/monitoring — monitoring.json and the OTEL_* locks, no exporters
     version.rs   GET /api/version and /version/update-check (dev builds only)
     notifications/ the settings read (password masked), /log, the settings
@@ -583,7 +585,8 @@ the tools — and an `rmcp` adapter is one impl away.
 - **Envelopes, not bare records.** `GET /settings`, `/monitoring` and
   `/version/update-check` answer `{settings, locked, …}`. `locked` maps a field
   name to the *environment variable* that pinned it; a PUT changing a locked
-  field is rejected.
+  field is rejected — with a **400**, not the 409 the monitoring path answers,
+  because `locked` is not `EnvLockedError`.
 - **`GET /chats/{id}` returns an envelope, not a flattened session — and the
   wire order is `{messages, session}`.** The handler writes a `map[string]any`,
   and `encoding/json` sorts map keys, so the order it is spelled in is not the
@@ -915,6 +918,68 @@ then updates it to carry the Claude session id; this does both in one
 transaction, which is a deliberate divergence with only one alternative: `Err`
 forwards, so a Rust failure *between* the two writes would leave Go's orphan
 chat **and** have Go create a second one.
+
+### The settings write is written, tested and not claimed (#305)
+
+`GET /api/settings/claude-config-dirs` is native. `PUT /api/settings` is
+implemented in full — validation, the locked-field 400s, the row write, the
+rescan rules — and left out of `claims`, the way `migrate::apply` was in #274.
+
+The reason is **not** the one this file used to give. Rust holds no snapshot of
+these preferences at all: `settings::load` reads the row per request, which is
+why `apply_data_settings` is three lines where Go's is thirty. The obstacle is
+the **sidecar**, which does hold one and is still serving routes that read it:
+
+- `notificationServiceImpl.UpdateSettings` is a read-modify-write over
+  `settingsMgr.Get()` that persists the **whole** `user_settings` row. So a
+  native settings save followed by any SMTP save through the unported
+  `PUT /api/notifications/settings` rewrites `hidden_projects`,
+  `idle_gap_threshold_minutes` and both config-dir columns from the sidecar's
+  boot-time copy. Reproduced against a Go server built from this checkout: a
+  row edited to `["…/native-wrote-this"]` / 42 read back
+  `["…/hidden-one"]` / 25 after one unrelated notification save, with no error
+  anywhere. That is silent, total reversion of the Data & Analytics tab.
+- `config.ResolveAgentClaudeDir` resolves each run's Claude account from
+  `claudeDirs.runOverride`, so scheduled tasks (#275) and Telegram triggers —
+  both still Go's — would keep authenticating as the previous account.
+- `config.profiles` resolves `/api/claude-settings*` against the same snapshot.
+
+#274's rule decides it: *a route moves only when Rust can reproduce every effect
+it has*, and "the sidecar now agrees" is one of this route's effects. #289's
+flip worked because `AGENTO_SCANNER=off` switched the Go half off; there is no
+equivalent here, and forward-after-write is just the forward. It turns on with
+the cut-over that deletes the sidecar.
+
+Three things the write itself pins, each captured from a live Go server:
+
+- **The `PUT` response is the stored row, not a resolution of it.** `Update`
+  assigns the incoming struct to `m.settings` wholesale and the handler answers
+  `Get()`, so nothing is re-defaulted: a body sending `"default_model":""` is
+  answered `""` where the very next `GET` answers `"sonnet"`. `claude_config_dirs`
+  comes back `null` for a request that sent `[]`, because
+  `normalizeClaudeConfigDirs` collapses an empty list to a nil slice while `Save`
+  still writes `[]` — so the column reads back non-nil.
+- **A locked field is a 400, not the 409 the monitoring path uses.**
+  `SettingsManager` returns plain errors and the handler flattens every one of
+  them, so the validation failures are 400s too — not the service layer's 422.
+  Field order is Go's slice order (`default_model`, `default_working_dir`,
+  `public_url`, `claude_config_dir`), so a body conflicting on two reports the
+  first of *those*, not the first in the JSON. A **blank** incoming value is
+  never a conflict — the form posts every tab back — it is pinned instead.
+- **The scan trigger is `force_scan`, not `ensure_scan`.** Go calls
+  `Cache.EnsureScan`, which admits a scan outright; `ensure_scan` is `ensureFresh`
+  and asks the staleness markers first. The threshold branch would pass that gate,
+  but the config-dir branch would not — no marker records which dirs were walked —
+  and a newly added account would sit unindexed until the TTL.
+
+`claude-config-dirs`'s own trap is that `candidates` distinguishes nil from
+empty: a home directory that cannot be listed is `null`, one with nothing to
+suggest is `[]`. Its rules are pinned against a crafted home rather than the
+developer's, because the four exclusions that matter — a symlink to a good
+candidate (`os.ReadDir`'s `IsDir` does not follow), a `.claude*` dir with no
+`projects`, one whose `projects` is a file, and a plain file — do not exist on a
+real machine. `.claude.bak` and `.clauded` *are* candidates when they have a
+`projects` dir: the prefix is literal and the `projects` check is the only filter.
 
 ### Do not port
 

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -142,8 +142,9 @@ src-tauri/src/
       persist.rs what a finished turn writes, and what an interrupted one does not
       sse.rs     the frame bytes: raw pass-through vs the two synthetic events
     settings.rs  GET /api/settings and /settings/claude-config-dirs (a filesystem
-                 probe); the preferences + config dirs a read is scoped to; and
-                 `update`, the PUT — written and tested, deliberately unclaimed
+                 probe; Unix, forwards on Windows); the preferences + config dirs
+                 a read is scoped to; and `update`, the PUT — written and tested,
+                 deliberately unclaimed
     monitoring.rs GET /api/monitoring — monitoring.json and the OTEL_* locks, no exporters
     version.rs   GET /api/version and /version/update-check (dev builds only)
     notifications/ the settings read (password masked), /log, the settings

--- a/desktop/parity/claude_dirs_parity_test.go
+++ b/desktop/parity/claude_dirs_parity_test.go
@@ -1,0 +1,254 @@
+// Cross-language vectors for the Claude config-dir rules.
+//
+// `GET /api/settings/claude-config-dirs` answers two things a port has to get
+// exactly right, and neither is a row read:
+//
+//   - `indexed`, from `config.ClaudeConfigDirs` — the default dir, then the dir
+//     a run targets (CLAUDE_CONFIG_DIR beating the configured one, and a
+//     relative value being dropped rather than resolved), then the user's
+//     extras, deduplicated;
+//   - `candidates`, from `config.DiscoverCandidateClaudeDirs` — a filesystem
+//     probe whose rule is four clauses long and whose exclusions are the part a
+//     natural rewrite gets wrong.
+//
+// The exclusions are why this file exists rather than a hand-written Rust
+// literal. No real `$HOME` contains a `.claude*` symlink, a `.claude*` dir
+// without `projects`, one whose `projects` is a *file*, and a plain file with
+// the prefix — so the live parity diff structurally cannot re-verify them, and
+// an expectation transcribed by hand pins only what its author believed. Here
+// the layout is built from this file, the expectations are what Go's own
+// functions returned over it, and both languages assert against the result: a
+// change to Go's rule fails Go's own suite, and a Rust divergence fails Rust's.
+//
+// Regenerate (only from Go, and only when adding cases):
+//
+//	go test ./desktop/parity/ -run TestClaudeDirsVectors -update-golden
+//
+// Paths are recorded with a literal `$HOME` token because the home directory is
+// a fresh temp dir on every run; both readers substitute their own.
+//
+// Unix-shaped on purpose, exactly as `gopath_vectors.json` is:
+// `native/settings.rs` forwards this route on Windows, where `filepath`'s
+// volume handling is a different algorithm.
+package parity
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/shaharia-lab/agento/internal/config"
+)
+
+const claudeDirsVectorsFile = "claude_dirs_vectors.json"
+
+// homeToken stands in for the temp home directory the layout is built in.
+const homeToken = "$HOME"
+
+type claudeDirsSymlink struct {
+	Link   string `json:"link"`
+	Target string `json:"target"`
+}
+
+type claudeDirsLayout struct {
+	Dirs     []string            `json:"dirs"`
+	Files    []string            `json:"files"`
+	Symlinks []claudeDirsSymlink `json:"symlinks"`
+}
+
+type claudeDirsCase struct {
+	Name       string   `json:"name"`
+	Env        string   `json:"claude_config_dir_env"`
+	RunDir     string   `json:"run_dir"`
+	Extra      []string `json:"extra"`
+	Indexed    []string `json:"indexed"`
+	Candidates []string `json:"candidates"`
+}
+
+type claudeDirsVectors struct {
+	Comment []string         `json:"_comment"`
+	Layout  claudeDirsLayout `json:"layout"`
+	Cases   []claudeDirsCase `json:"cases"`
+}
+
+// claudeDirsFixture is the home directory both languages build: every clause of
+// the discovery rule exercised at once, including the four shapes that look
+// like candidates and are not.
+//
+// `.claude.bak` and `.clauded` are deliberately present *with* a `projects`
+// dir. Go's own comment claims the `projects` check "keeps .claude-backup and
+// .claude.bak out"; it does not — the prefix match is literal and `projects` is
+// the only other filter — and pinning the real answer is the point.
+var claudeDirsFixture = claudeDirsLayout{
+	Dirs: []string{
+		".claude/projects",
+		".claude-work/projects",
+		".claude.bak/projects",
+		".clauded/projects",
+		".claude-alpha/projects",
+		".claude-zeta/projects",
+		// A `.claude*` dir with no `projects` — the `.claude-backup` shape.
+		".claude-backup",
+		// The right shape under a name without the prefix.
+		"notclaude/projects",
+		".claude-projfile",
+	},
+	Files: []string{
+		// `projects` exists but is a file, not a directory.
+		".claude-projfile/projects",
+		// A plain file whose name has the prefix.
+		".claude-file",
+	},
+	Symlinks: []claudeDirsSymlink{
+		// `os.ReadDir`'s `DirEntry.IsDir` does not follow a symlink, so a link
+		// to a perfectly good candidate is not one.
+		{Link: ".claude-link", Target: ".claude-work"},
+	},
+}
+
+// claudeDirsCases are the configurations asked of the layout. Only the inputs
+// are written here; `Indexed` and `Candidates` are filled from Go.
+var claudeDirsCases = []claudeDirsCase{
+	{
+		Name:  "nothing configured: the default dir alone is indexed",
+		Extra: []string{},
+	},
+	{
+		Name:   "a configured run dir is indexed and so is not suggested",
+		RunDir: homeToken + "/.claude-zeta",
+		Extra:  []string{},
+	},
+	{
+		Name:  "extras follow the run dir, in the order they were given",
+		Extra: []string{homeToken + "/.claude-work", homeToken + "/.claude-alpha"},
+	},
+	{
+		Name:  "a duplicate, a trailing slash and a relative extra all collapse",
+		Extra: []string{homeToken + "/.claude-work/", homeToken + "/.claude-work", "relative/dir"},
+	},
+	{
+		// The run dir here is not one the server could install alongside this
+		// env value — the wiring resolves the environment into the settings
+		// before calling ApplyClaudeDirs — but the precedence itself is a rule
+		// both languages implement, and this is where it is pinned.
+		Name:   "CLAUDE_CONFIG_DIR beats the run dir it is given",
+		Env:    homeToken + "/.claude-alpha",
+		RunDir: homeToken + "/.claude-zeta",
+		Extra:  []string{},
+	},
+	{
+		Name:   "a relative CLAUDE_CONFIG_DIR is dropped, not resolved",
+		Env:    "relative/dir",
+		RunDir: homeToken + "/.claude-zeta",
+		Extra:  []string{},
+	},
+}
+
+func TestClaudeDirsVectors(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("vectors record the Unix rules; the Rust port forwards the route on Windows")
+	}
+
+	home := t.TempDir()
+	buildClaudeDirsFixture(t, home)
+	t.Setenv("HOME", home)
+	// ApplyClaudeDirs writes a process-wide snapshot; leave it as it was found.
+	t.Cleanup(func() { config.ApplyClaudeDirs("", nil) })
+
+	want := claudeDirsVectors{
+		Comment: []string{
+			"Cross-language parity vectors for config.ClaudeConfigDirs and",
+			"config.DiscoverCandidateClaudeDirs, Unix rules. Generated from Go, then",
+			"frozen. Read by desktop/parity/claude_dirs_parity_test.go (Go) and by",
+			"desktop/src-tauri/src/native/settings.rs (Rust). 'layout' is the home",
+			"directory both languages build; 'indexed' and 'candidates' are exactly what",
+			"Go answered over it, so a divergence fails one language against the other's",
+			"real output rather than against a belief about it.",
+			"$HOME stands for the temp home each side builds the layout in.",
+			"Regenerate with: go test ./desktop/parity/ -run TestClaudeDirsVectors -update-golden",
+		},
+		Layout: claudeDirsFixture,
+	}
+
+	for _, tc := range claudeDirsCases {
+		t.Setenv(config.ClaudeConfigDirEnvVar, expandHome(tc.Env, home))
+		config.ApplyClaudeDirs(expandHome(tc.RunDir, home), expandHomeAll(tc.Extra, home))
+
+		filled := tc
+		filled.Indexed = tokenizeHomeAll(config.ClaudeConfigDirs(), home)
+		filled.Candidates = tokenizeHomeAll(config.DiscoverCandidateClaudeDirs(), home)
+		want.Cases = append(want.Cases, filled)
+	}
+
+	encoded, err := json.MarshalIndent(want, "", "  ")
+	if err != nil {
+		t.Fatalf("encoding vectors: %v", err)
+	}
+	encoded = append(encoded, '\n')
+
+	if *updateGolden {
+		if err := os.WriteFile(claudeDirsVectorsFile, encoded, 0o600); err != nil {
+			t.Fatalf("writing %s: %v", claudeDirsVectorsFile, err)
+		}
+		t.Logf("wrote %s", claudeDirsVectorsFile)
+		return
+	}
+
+	frozen, err := os.ReadFile(claudeDirsVectorsFile)
+	if err != nil {
+		t.Fatalf("reading %s (regenerate with -update-golden): %v", claudeDirsVectorsFile, err)
+	}
+	if string(frozen) != string(encoded) {
+		t.Fatalf("%s is stale: this checkout's Go answers differently.\n"+
+			"Regenerate with -update-golden and check what moved — the Rust port in "+
+			"native/settings.rs reads the same file and will fail against it.",
+			claudeDirsVectorsFile)
+	}
+}
+
+// buildClaudeDirsFixture lays the fixture out under root. The Rust side builds
+// the same tree from the same JSON, which is what makes the two comparable.
+func buildClaudeDirsFixture(t *testing.T, root string) {
+	t.Helper()
+	for _, dir := range claudeDirsFixture.Dirs {
+		if err := os.MkdirAll(filepath.Join(root, dir), 0o750); err != nil {
+			t.Fatalf("creating %s: %v", dir, err)
+		}
+	}
+	for _, file := range claudeDirsFixture.Files {
+		if err := os.WriteFile(filepath.Join(root, file), nil, 0o600); err != nil {
+			t.Fatalf("creating %s: %v", file, err)
+		}
+	}
+	for _, link := range claudeDirsFixture.Symlinks {
+		if err := os.Symlink(filepath.Join(root, link.Target), filepath.Join(root, link.Link)); err != nil {
+			t.Fatalf("linking %s: %v", link.Link, err)
+		}
+	}
+}
+
+func expandHome(p, home string) string {
+	if p == "" {
+		return ""
+	}
+	return strings.ReplaceAll(p, homeToken, home)
+}
+
+func expandHomeAll(paths []string, home string) []string {
+	out := make([]string, 0, len(paths))
+	for _, p := range paths {
+		out = append(out, expandHome(p, home))
+	}
+	return out
+}
+
+func tokenizeHomeAll(paths []string, home string) []string {
+	out := make([]string, 0, len(paths))
+	for _, p := range paths {
+		out = append(out, strings.ReplaceAll(p, home, homeToken))
+	}
+	return out
+}

--- a/desktop/parity/claude_dirs_vectors.json
+++ b/desktop/parity/claude_dirs_vectors.json
@@ -1,0 +1,141 @@
+{
+  "_comment": [
+    "Cross-language parity vectors for config.ClaudeConfigDirs and",
+    "config.DiscoverCandidateClaudeDirs, Unix rules. Generated from Go, then",
+    "frozen. Read by desktop/parity/claude_dirs_parity_test.go (Go) and by",
+    "desktop/src-tauri/src/native/settings.rs (Rust). 'layout' is the home",
+    "directory both languages build; 'indexed' and 'candidates' are exactly what",
+    "Go answered over it, so a divergence fails one language against the other's",
+    "real output rather than against a belief about it.",
+    "$HOME stands for the temp home each side builds the layout in.",
+    "Regenerate with: go test ./desktop/parity/ -run TestClaudeDirsVectors -update-golden"
+  ],
+  "layout": {
+    "dirs": [
+      ".claude/projects",
+      ".claude-work/projects",
+      ".claude.bak/projects",
+      ".clauded/projects",
+      ".claude-alpha/projects",
+      ".claude-zeta/projects",
+      ".claude-backup",
+      "notclaude/projects",
+      ".claude-projfile"
+    ],
+    "files": [
+      ".claude-projfile/projects",
+      ".claude-file"
+    ],
+    "symlinks": [
+      {
+        "link": ".claude-link",
+        "target": ".claude-work"
+      }
+    ]
+  },
+  "cases": [
+    {
+      "name": "nothing configured: the default dir alone is indexed",
+      "claude_config_dir_env": "",
+      "run_dir": "",
+      "extra": [],
+      "indexed": [
+        "$HOME/.claude"
+      ],
+      "candidates": [
+        "$HOME/.claude-alpha",
+        "$HOME/.claude-work",
+        "$HOME/.claude-zeta",
+        "$HOME/.claude.bak",
+        "$HOME/.clauded"
+      ]
+    },
+    {
+      "name": "a configured run dir is indexed and so is not suggested",
+      "claude_config_dir_env": "",
+      "run_dir": "$HOME/.claude-zeta",
+      "extra": [],
+      "indexed": [
+        "$HOME/.claude",
+        "$HOME/.claude-zeta"
+      ],
+      "candidates": [
+        "$HOME/.claude-alpha",
+        "$HOME/.claude-work",
+        "$HOME/.claude.bak",
+        "$HOME/.clauded"
+      ]
+    },
+    {
+      "name": "extras follow the run dir, in the order they were given",
+      "claude_config_dir_env": "",
+      "run_dir": "",
+      "extra": [
+        "$HOME/.claude-work",
+        "$HOME/.claude-alpha"
+      ],
+      "indexed": [
+        "$HOME/.claude",
+        "$HOME/.claude-work",
+        "$HOME/.claude-alpha"
+      ],
+      "candidates": [
+        "$HOME/.claude-zeta",
+        "$HOME/.claude.bak",
+        "$HOME/.clauded"
+      ]
+    },
+    {
+      "name": "a duplicate, a trailing slash and a relative extra all collapse",
+      "claude_config_dir_env": "",
+      "run_dir": "",
+      "extra": [
+        "$HOME/.claude-work/",
+        "$HOME/.claude-work",
+        "relative/dir"
+      ],
+      "indexed": [
+        "$HOME/.claude",
+        "$HOME/.claude-work"
+      ],
+      "candidates": [
+        "$HOME/.claude-alpha",
+        "$HOME/.claude-zeta",
+        "$HOME/.claude.bak",
+        "$HOME/.clauded"
+      ]
+    },
+    {
+      "name": "CLAUDE_CONFIG_DIR beats the run dir it is given",
+      "claude_config_dir_env": "$HOME/.claude-alpha",
+      "run_dir": "$HOME/.claude-zeta",
+      "extra": [],
+      "indexed": [
+        "$HOME/.claude",
+        "$HOME/.claude-alpha"
+      ],
+      "candidates": [
+        "$HOME/.claude-work",
+        "$HOME/.claude-zeta",
+        "$HOME/.claude.bak",
+        "$HOME/.clauded"
+      ]
+    },
+    {
+      "name": "a relative CLAUDE_CONFIG_DIR is dropped, not resolved",
+      "claude_config_dir_env": "relative/dir",
+      "run_dir": "$HOME/.claude-zeta",
+      "extra": [],
+      "indexed": [
+        "$HOME/.claude",
+        "$HOME/.claude-zeta"
+      ],
+      "candidates": [
+        "$HOME/.claude-alpha",
+        "$HOME/.claude-work",
+        "$HOME/.claude.bak",
+        "$HOME/.clauded"
+      ]
+    }
+  ]
+}

--- a/desktop/src-tauri/src/native/mod.rs
+++ b/desktop/src-tauri/src/native/mod.rs
@@ -445,13 +445,13 @@ mod tests {
         assert!(!claims(&Method::GET, "/api/tasks/"));
         assert!(!claims(&Method::GET, "/api/job-history/"));
 
-        // Settings: the row read. The write re-applies the process-wide
-        // snapshots and triggers a rescan, neither of which Rust can do while
-        // Go owns the database — and the config-dir editor probes the
-        // filesystem rather than reading this row.
+        // Settings: the row read and, since #305, the config-dir probe. The
+        // write is implemented in `settings::update` but stays unclaimed: the
+        // sidecar holds its own copy of these preferences in memory and is
+        // still serving routes that read it — see that module's `claims`.
         assert!(claims(&Method::GET, "/api/settings"));
+        assert!(claims(&Method::GET, "/api/settings/claude-config-dirs"));
         assert!(!claims(&Method::PUT, "/api/settings"));
-        assert!(!claims(&Method::GET, "/api/settings/claude-config-dirs"));
         // A different tree entirely: Claude Code's own settings.json.
         assert!(!claims(&Method::GET, "/api/claude-settings"));
 
@@ -612,6 +612,7 @@ mod tests {
             "/api/job-history",
             "/api/job-history/abc-123",
             "/api/settings",
+            "/api/settings/claude-config-dirs",
             "/api/monitoring",
             "/api/version",
             "/api/version/update-check",
@@ -654,6 +655,7 @@ mod tests {
             "/api/job-history",
             "/api/job-history/abc-123",
             "/api/settings",
+            "/api/settings/claude-config-dirs",
             "/api/monitoring",
             "/api/version",
             "/api/version/update-check",

--- a/desktop/src-tauri/src/native/scan.rs
+++ b/desktop/src-tauri/src/native/scan.rs
@@ -806,8 +806,11 @@ mod tests {
 
         // A home with no `.claude`, so the walk finds nothing to list.
         let home = tempfile::tempdir().expect("tempdir");
-        let previous_home = std::env::var_os("HOME");
-        std::env::set_var("HOME", home.path());
+        // RAII, not a trailing restore: a failed assertion panics past any
+        // epilogue, and `env_lock` recovers from poisoning — so a leaked `HOME`
+        // pointing at a `TempDir` this test already deleted would break every
+        // later `paths::home()` in the binary.
+        let _home_var = crate::paths::tests::EnvVar::set("HOME", home.path());
 
         let file = migrated();
         let conn = rusqlite::Connection::open(file.path()).expect("open");
@@ -881,10 +884,6 @@ mod tests {
             let mut s = state().lock().expect("lock");
             s.no_dirs_at = None;
             s.files_done = 0;
-        }
-        match previous_home {
-            Some(h) => std::env::set_var("HOME", h),
-            None => std::env::remove_var("HOME"),
         }
     }
 

--- a/desktop/src-tauri/src/native/settings.rs
+++ b/desktop/src-tauri/src/native/settings.rs
@@ -27,8 +27,10 @@ use std::path::{Path, PathBuf};
 
 use axum::http::Method;
 use rusqlite::{Connection, OptionalExtension};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
+use super::gojson::null_is_zero_value;
+use super::writes::WriteError;
 use crate::paths;
 
 /// The Data & Analytics preferences a session read depends on.
@@ -84,19 +86,37 @@ impl DataSettings {
 /// and a non-nil empty one for a stored `[]` — and a nil slice marshals as
 /// `null` while an empty one marshals as `[]`. The distinction is stored, so it
 /// travels.
-#[derive(Debug, Clone, Default, Serialize)]
+///
+/// It doubles as the `PUT` request body, because Go decodes the request into
+/// the very same `config.UserSettings` it answers with. The scalars go through
+/// [`null_is_zero_value`] for the reason every decoded Go struct here does — a
+/// JSON `null` is a no-op to `encoding/json`, so `{"public_url":null}` is a
+/// successful decode of the zero value and must not 400.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
 pub struct UserSettings {
+    #[serde(deserialize_with = "null_is_zero_value")]
     pub default_working_dir: String,
+    #[serde(deserialize_with = "null_is_zero_value")]
     pub default_model: String,
+    #[serde(deserialize_with = "null_is_zero_value")]
     pub onboarding_complete: bool,
+    #[serde(deserialize_with = "null_is_zero_value")]
     pub appearance_dark_mode: bool,
+    #[serde(deserialize_with = "null_is_zero_value")]
     pub appearance_font_size: i64,
+    #[serde(deserialize_with = "null_is_zero_value")]
     pub appearance_font_family: String,
+    #[serde(deserialize_with = "null_is_zero_value")]
     pub notification_settings: String,
+    #[serde(deserialize_with = "null_is_zero_value")]
     pub event_bus_worker_pool_size: i64,
+    #[serde(deserialize_with = "null_is_zero_value")]
     pub public_url: String,
     pub hidden_projects: Option<Vec<String>>,
+    #[serde(deserialize_with = "null_is_zero_value")]
     pub idle_gap_threshold_minutes: i64,
+    #[serde(deserialize_with = "null_is_zero_value")]
     pub claude_config_dir: String,
     pub claude_config_dirs: Option<Vec<String>>,
 }
@@ -412,6 +432,469 @@ fn default_working_dir() -> String {
         .into_owned()
 }
 
+// ─── GET /api/settings/claude-config-dirs ─────────────────────────────────────
+
+/// `api.claudeConfigDirsResponse`: what the config-dir editor is drawn from.
+///
+/// Not a read of the settings row — or not only one. `indexed` is the resolved
+/// union the scanner walks, but `candidates` is a **filesystem probe**, which is
+/// why #266 left this route with Go while taking `GET /api/settings`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ClaudeConfigDirsResponse {
+    /// The resolved set, default first. Never empty: the default dir is always
+    /// in it, so this ships an array rather than `null`.
+    pub indexed: Vec<String>,
+    /// Dirs that look like config dirs but are not configured yet.
+    ///
+    /// `Option` because Go distinguishes the two empties here and the
+    /// distinction reaches the wire: a home directory that cannot be listed
+    /// returns a **nil** slice (`null`), while one with nothing to suggest
+    /// returns `make([]string, 0, …)` (`[]`).
+    pub candidates: Option<Vec<String>>,
+    /// `default` is a Rust keyword, so the field is renamed rather than raw —
+    /// the wire name is Go's.
+    #[serde(rename = "default")]
+    pub default_dir: String,
+}
+
+/// `handleClaudeConfigDirs`.
+pub fn claude_config_dirs_response(conn: &Connection) -> ClaudeConfigDirsResponse {
+    let stored = load_stored(conn);
+    let indexed = claude_config_dirs(
+        &stored.claude_config_dir,
+        stored.claude_config_dirs.as_deref().unwrap_or_default(),
+    );
+    let candidates = discover_candidate_claude_dirs(&indexed);
+    ClaudeConfigDirsResponse {
+        indexed,
+        candidates,
+        default_dir: default_claude_config_dir(),
+    }
+}
+
+/// `config.DiscoverCandidateClaudeDirs`: config dirs sitting beside the default
+/// one that are not configured yet, so Settings can offer them instead of
+/// asking for a typed absolute path.
+///
+/// The rule is deliberately narrow, and each clause earns its place:
+///
+/// - a **sibling of the default dir** — anywhere else is added by hand, because
+///   suggesting is not discovering;
+/// - whose name starts with `.claude`;
+/// - which contains a `projects` **directory**. That is what keeps
+///   `.claude-backup` and `.claude.bak` out; they are the common shapes of a
+///   directory that merely looks like a config dir.
+///
+/// Two Go details that a natural Rust rewrite gets wrong: `os.ReadDir`'s
+/// `DirEntry.IsDir` does **not** follow symlinks (so a symlink to a directory is
+/// not a candidate) while the `projects` check is an `os.Stat`, which does; and
+/// a failed listing is a nil slice rather than an empty one.
+fn discover_candidate_claude_dirs(configured: &[String]) -> Option<Vec<String>> {
+    let parent = super::gopath::dir(&default_claude_config_dir());
+    let entries = std::fs::read_dir(&parent).ok()?;
+
+    let mut out: Vec<String> = Vec::new();
+    for entry in entries {
+        // Go's `os.ReadDir` returns whatever it read *plus* the error, and the
+        // handler discards both. A per-entry failure here is the same class of
+        // "we could not look", so it answers the same way rather than quietly
+        // suggesting a shorter list.
+        let entry = entry.ok()?;
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if !name.starts_with(".claude") {
+            continue;
+        }
+        match entry.file_type() {
+            Ok(t) if t.is_dir() => {}
+            _ => continue,
+        }
+        let candidate = super::gopath::join(&[&parent, &name]);
+        if configured.contains(&candidate) {
+            continue;
+        }
+        let projects = super::gopath::join(&[&candidate, "projects"]);
+        match std::fs::metadata(&projects) {
+            Ok(meta) if meta.is_dir() => {}
+            _ => continue,
+        }
+        out.push(candidate);
+    }
+    // `sort.Strings` is a byte-order sort, and so is `Vec<String>::sort`.
+    out.sort();
+    Some(out)
+}
+
+// ─── PUT /api/settings ────────────────────────────────────────────────────────
+//
+// Written, tested, and deliberately **not claimed** — see `claims` below for
+// why, and `desktop/CLAUDE.md`. What follows is `handleUpdateSettings` plus
+// `SettingsManager.Update`, `SQLiteSettingsStore.Save` and
+// `Server.applyDataSettings`, in Go's order.
+
+/// `config.{Min,Max}IdleGapThresholdMinutes`.
+const MIN_IDLE_GAP_MINUTES: i64 = 1;
+const MAX_IDLE_GAP_MINUTES: i64 = 240;
+
+/// `handleUpdateSettings`.
+///
+/// Every failure is a **400** carrying the error's own text: the handler writes
+/// `s.writeError(w, http.StatusBadRequest, err.Error())` for anything `Update`
+/// returns. That is not the 409 the monitoring path answers for an env-locked
+/// write, and it is not the 422 the service layer's `ValidationError` produces —
+/// `SettingsManager` returns plain `fmt.Errorf` values and the handler flattens
+/// them all to 400.
+pub fn update(db_path: &Path, body: &[u8]) -> Result<super::Answer, WriteError> {
+    update_with(db_path, body, super::scan::force_scan)
+}
+
+/// The handler, with the rescan as a parameter.
+///
+/// The seam exists for the tests: a scan walks the developer's real `~/.claude`,
+/// so a unit test of the *save* would otherwise spend minutes reading a corpus
+/// it has nothing to say about — and the trigger rules are worth asserting
+/// directly rather than inferring from a side effect.
+fn update_with(
+    db_path: &Path,
+    body: &[u8],
+    rescan: impl FnOnce(PathBuf),
+) -> Result<super::Answer, WriteError> {
+    // Decoded first, exactly as Go does: a malformed body is a 400 before the
+    // database is opened, let alone written.
+    let incoming: UserSettings = super::writes::decode_body(body)?;
+
+    let conn = super::db::open_read_write(db_path).map_err(WriteError::Fallback)?;
+    super::migrate::verify(&conn).map_err(WriteError::Fallback)?;
+
+    // `m.settings`, the manager's in-memory current value. Reconstructed rather
+    // than remembered: `resolve` is `load()` + `applyEnvOverrides`, which is
+    // precisely how the manager arrived at it during startup wiring.
+    let current = resolve(load_stored(&conn)).settings;
+    let previous_idle_gap = current.idle_gap_threshold_minutes;
+    let previous_dirs = claude_config_dirs(
+        &current.claude_config_dir,
+        current.claude_config_dirs.as_deref().unwrap_or_default(),
+    );
+
+    let saved = apply_update(incoming, &current)?;
+    save(&conn, &saved).map_err(WriteError::Fallback)?;
+    drop(conn);
+
+    apply_data_settings(db_path, &saved, previous_idle_gap, &previous_dirs, rescan);
+
+    // **The stored row, not a resolution of it.** `Update` assigns `incoming`
+    // wholesale to `m.settings` and the handler answers `Get()`, so no default
+    // is refilled: a `PUT` sending `"default_model":""` is answered with `""`,
+    // where the very next `GET` answers `"sonnet"`. Likewise a normalized-away
+    // dir list is `null` here and `[]` on the next read, because `Save` writes
+    // `[]` for a nil slice and `decodeStringList` reads that back as non-nil.
+    let model_from_env = model_from_env(&saved);
+    let body = super::gojson::to_vec(&SettingsResponse {
+        settings: saved,
+        locked: locked_fields(),
+        model_from_env,
+    })
+    .map_err(|e| WriteError::Fallback(format!("encoding settings: {e}")))?;
+    Ok(super::Answer::json(body))
+}
+
+/// `SettingsManager.Update` up to the point it persists: lock, validate,
+/// normalize. The order is Go's, and it is observable — a payload that both
+/// changes a locked field and carries an out-of-range threshold is answered
+/// with the lock message.
+fn apply_update(
+    mut incoming: UserSettings,
+    current: &UserSettings,
+) -> Result<UserSettings, WriteError> {
+    apply_locked_fields(&mut incoming, current)?;
+    validate_idle_gap_threshold(incoming.idle_gap_threshold_minutes)?;
+    validate_claude_config_dirs(&incoming, current)?;
+
+    incoming.claude_config_dir = normalize(&incoming.claude_config_dir);
+    incoming.claude_config_dirs = normalize_claude_config_dirs(&incoming.claude_config_dirs);
+    Ok(incoming)
+}
+
+/// `SettingsManager.applyLockedFields`: refuse a change to an env-locked field,
+/// and pin every locked field to what the environment chose.
+///
+/// **A blank incoming value is never a conflict.** The settings form posts the
+/// whole object back from every tab, so a client that does not know about a
+/// field must not be read as asking to clear it — it is pinned instead.
+///
+/// The field order is Go's slice order and is load-bearing: a body conflicting
+/// on two locked fields at once reports the first of these, not the first in
+/// the JSON.
+fn apply_locked_fields(
+    incoming: &mut UserSettings,
+    current: &UserSettings,
+) -> Result<(), WriteError> {
+    let locked = locked_fields();
+    for field in [
+        "default_model",
+        "default_working_dir",
+        "public_url",
+        "claude_config_dir",
+    ] {
+        let Some(env_var) = locked.get(field) else {
+            continue;
+        };
+        let (incoming_value, current_value) = match field {
+            "default_model" => (&mut incoming.default_model, &current.default_model),
+            "default_working_dir" => (
+                &mut incoming.default_working_dir,
+                &current.default_working_dir,
+            ),
+            "public_url" => (&mut incoming.public_url, &current.public_url),
+            _ => (&mut incoming.claude_config_dir, &current.claude_config_dir),
+        };
+        // `claude_config_dir` compares **normalized**, so `~/.claude` and
+        // `$HOME/.claude` are not read as a conflicting change; the other three
+        // are plain string equality.
+        let same = if field == "claude_config_dir" {
+            normalize(incoming_value) == normalize(current_value)
+        } else {
+            incoming_value == current_value
+        };
+        if !incoming_value.is_empty() && !same {
+            return Err(WriteError::BadRequest(format!(
+                "{field} is locked by environment variable {env_var}"
+            )));
+        }
+        incoming_value.clone_from(current_value);
+    }
+    Ok(())
+}
+
+/// `config.validateIdleGapThreshold`.
+///
+/// Zero is allowed and means "not chosen": the settings form for any other tab
+/// posts the whole object back, and a client that does not know about the field
+/// must not be read as asking for a zero-length sitting. Every reader resolves
+/// zero to the default.
+fn validate_idle_gap_threshold(minutes: i64) -> Result<(), WriteError> {
+    if minutes == 0 || (MIN_IDLE_GAP_MINUTES..=MAX_IDLE_GAP_MINUTES).contains(&minutes) {
+        return Ok(());
+    }
+    Err(WriteError::BadRequest(format!(
+        "idle_gap_threshold_minutes must be between {MIN_IDLE_GAP_MINUTES} and \
+         {MAX_IDLE_GAP_MINUTES} minutes, got {minutes}"
+    )))
+}
+
+/// `config.validateClaudeConfigDirs`.
+///
+/// **Only values the caller is actually changing are checked.** A directory that
+/// existed when it was stored can stop existing — an unmounted volume, or a
+/// `CLAUDE_CONFIG_DIR` exported in a shell profile that Claude Code has not
+/// created yet — and validating an unchanged value would then reject every save,
+/// including saves of unrelated fields, naming a field the user was not touching
+/// and (when env-locked) cannot even edit.
+fn validate_claude_config_dirs(
+    incoming: &UserSettings,
+    current: &UserSettings,
+) -> Result<(), WriteError> {
+    if normalize(&incoming.claude_config_dir) != normalize(&current.claude_config_dir) {
+        validate_claude_config_dir(&incoming.claude_config_dir)?;
+    }
+
+    let existing: Vec<String> = current
+        .claude_config_dirs
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .map(|d| normalize(d))
+        .collect();
+    for dir in incoming.claude_config_dirs.as_deref().unwrap_or_default() {
+        // Blank entries are dropped rather than rejected, so a half-filled row
+        // in the UI is not an error the user has to clear before saving
+        // anything else.
+        if dir.trim().is_empty() {
+            continue;
+        }
+        if existing.contains(&normalize(dir)) {
+            continue;
+        }
+        validate_claude_config_dir(dir)?;
+    }
+    Ok(())
+}
+
+/// `config.ValidateClaudeConfigDir`.
+///
+/// Go validates the **normalized** path and its messages quote that form, so
+/// `~/nope` is reported as the expanded path. A blank value is valid and means
+/// "use the default".
+fn validate_claude_config_dir(raw: &str) -> Result<(), WriteError> {
+    let normalized = normalize(raw);
+    if normalized.is_empty() {
+        return Ok(());
+    }
+    if !Path::new(&normalized).is_absolute() {
+        return Err(WriteError::BadRequest(format!(
+            "claude config dir must be an absolute path, got {normalized:?}"
+        )));
+    }
+    match std::fs::metadata(&normalized) {
+        Ok(meta) if meta.is_dir() => Ok(()),
+        Ok(_) => Err(WriteError::BadRequest(format!(
+            "claude config dir {normalized:?} is not a directory"
+        ))),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(WriteError::BadRequest(format!(
+            "claude config dir {normalized:?} does not exist"
+        ))),
+        // Go wraps the underlying `os.Stat` error and its text is the Go
+        // runtime's. Reproducing that is not possible, so this forwards rather
+        // than inventing a message the user would read — and it forwards before
+        // anything is written, which is what makes forwarding safe.
+        Err(e) => Err(WriteError::Fallback(format!(
+            "claude config dir {normalized:?} is not readable: {e}"
+        ))),
+    }
+}
+
+/// `config.normalizeClaudeConfigDirs`: normalize, drop blanks and duplicates.
+///
+/// An input that reduces to nothing becomes **nil**, not an empty slice, and the
+/// difference is on the wire — `Save` writes `[]` for both, but the `PUT`
+/// response is the in-memory value, so it ships `null`.
+fn normalize_claude_config_dirs(dirs: &Option<Vec<String>>) -> Option<Vec<String>> {
+    let dirs = dirs.as_deref()?;
+    if dirs.is_empty() {
+        return None;
+    }
+    let mut out: Vec<String> = Vec::with_capacity(dirs.len());
+    for dir in dirs {
+        let normalized = normalize(dir);
+        if normalized.is_empty() || out.contains(&normalized) {
+            continue;
+        }
+        out.push(normalized);
+    }
+    (!out.is_empty()).then_some(out)
+}
+
+/// `storage.SQLiteSettingsStore.Save`, one row, `id = 1`.
+///
+/// `encodeStringList` writes `[]` for a nil slice, which is why the column can
+/// read back non-nil after a `PUT` that sent `null`.
+fn save(conn: &Connection, settings: &UserSettings) -> Result<(), String> {
+    let notification_settings = if settings.notification_settings.is_empty() {
+        "{}"
+    } else {
+        &settings.notification_settings
+    };
+    conn.execute(
+        "INSERT INTO user_settings
+            (id, default_working_dir, default_model, onboarding_complete,
+             appearance_dark_mode, appearance_font_size, appearance_font_family,
+             notification_settings, event_bus_worker_pool_size, public_url,
+             hidden_projects, idle_gap_threshold_minutes,
+             claude_config_dir, claude_config_dirs)
+         VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+         ON CONFLICT(id) DO UPDATE SET
+            default_working_dir = excluded.default_working_dir,
+            default_model = excluded.default_model,
+            onboarding_complete = excluded.onboarding_complete,
+            appearance_dark_mode = excluded.appearance_dark_mode,
+            appearance_font_size = excluded.appearance_font_size,
+            appearance_font_family = excluded.appearance_font_family,
+            notification_settings = excluded.notification_settings,
+            event_bus_worker_pool_size = excluded.event_bus_worker_pool_size,
+            public_url = excluded.public_url,
+            hidden_projects = excluded.hidden_projects,
+            idle_gap_threshold_minutes = excluded.idle_gap_threshold_minutes,
+            claude_config_dir = excluded.claude_config_dir,
+            claude_config_dirs = excluded.claude_config_dirs",
+        rusqlite::params![
+            settings.default_working_dir,
+            settings.default_model,
+            i64::from(settings.onboarding_complete),
+            i64::from(settings.appearance_dark_mode),
+            settings.appearance_font_size,
+            settings.appearance_font_family,
+            notification_settings,
+            settings.event_bus_worker_pool_size,
+            settings.public_url,
+            encode_string_list(&settings.hidden_projects),
+            settings.idle_gap_threshold_minutes,
+            settings.claude_config_dir,
+            encode_string_list(&settings.claude_config_dirs),
+        ],
+    )
+    .map(|_| ())
+    .map_err(|e| format!("persisting settings: saving settings: {e}"))
+}
+
+/// `storage.encodeStringList`: a nil or empty list is the two bytes `[]`, so the
+/// `NOT NULL` column always holds valid JSON.
+fn encode_string_list(values: &Option<Vec<String>>) -> String {
+    match values {
+        Some(v) if !v.is_empty() => serde_json::to_string(v).unwrap_or_else(|_| "[]".to_string()),
+        _ => "[]".to_string(),
+    }
+}
+
+/// `Server.applyDataSettings`, minus the half Rust does not need.
+///
+/// Go installs the saved preferences into two process-wide snapshots
+/// (`claudesessions.dataSettings`, `config.claudeDirs`) because its readers have
+/// no settings dependency. **This port keeps no such snapshot**: every native
+/// reader calls [`load`] against the row it is already holding a connection to,
+/// so the write *is* the install. That is the whole reason this function is
+/// three lines rather than thirty.
+///
+/// What is left is the scan, and Go's rules for it: hiding a project takes
+/// effect on the next read because it is a filter over cached rows, while a new
+/// threshold or a newly added config dir is not — the durations are stored per
+/// transcript and a dir that was never walked has no rows to filter.
+///
+/// `force_scan`, not `ensure_scan`: Go calls `Cache.EnsureScan`, which admits a
+/// scan outright, where `ensure_scan` is `ensureFresh` and would ask the
+/// staleness markers first. The threshold branch would pass that gate anyway,
+/// but the config-dir branch would **not** — no marker records which dirs were
+/// walked — and a newly added account would then sit unindexed until the TTL.
+fn apply_data_settings(
+    db_path: &Path,
+    saved: &UserSettings,
+    previous_idle_gap: i64,
+    previous_dirs: &[String],
+    rescan: impl FnOnce(PathBuf),
+) {
+    if saved.idle_gap_threshold_minutes != previous_idle_gap {
+        log::info!(
+            "claude sessions: idle-gap threshold changed; recomputing durations \
+             (from {previous_idle_gap} to {})",
+            saved.idle_gap_threshold_minutes
+        );
+        rescan(db_path.to_path_buf());
+        return;
+    }
+    let dirs = claude_config_dirs(
+        &saved.claude_config_dir,
+        saved.claude_config_dirs.as_deref().unwrap_or_default(),
+    );
+    // Order-sensitive on purpose: it decides which dir wins a session present in
+    // two of them (`claim_session`), so a reorder is a real change.
+    if dirs != previous_dirs {
+        log::info!("claude sessions: config dirs changed; indexing {dirs:?}");
+        rescan(db_path.to_path_buf());
+    }
+}
+
+/// `SettingsManager.modelFromEnv`, recomputed from the row.
+///
+/// Go records this **once, at startup**, from the row as it was then. Nothing in
+/// the port observes that moment, so this answers the question a fresh boot on
+/// the current row would — the same convention [`resolve`] already uses for
+/// `GET /api/settings`, and the same one-case caveat: with only
+/// `ANTHROPIC_DEFAULT_SONNET_MODEL` set, a model stored *after* boot makes Go's
+/// flag stale-true while this says false.
+fn model_from_env(stored: &UserSettings) -> bool {
+    env_value("AGENTO_DEFAULT_MODEL").is_some()
+        || (env_value("ANTHROPIC_DEFAULT_SONNET_MODEL").is_some()
+            && stored.default_model.is_empty())
+}
+
 // ─── The seam ─────────────────────────────────────────────────────────────────
 
 /// This module's entry in `native::ENDPOINTS`.
@@ -421,19 +904,54 @@ pub const ENDPOINT: super::Endpoint = super::Endpoint {
     serve,
 };
 
-/// The read only. `PUT /api/settings` writes the row and then re-applies the
-/// process-wide snapshots and kicks off a rescan, none of which Rust can do
-/// while the Go server owns the database — so it stays with Go, and so does
-/// `/api/settings/claude-config-dirs`, which is a filesystem probe rather than
-/// a read of this row.
+/// The two reads. **`PUT /api/settings` is deliberately not among them**, even
+/// though [`update`] above implements it in full.
+///
+/// Not because Rust cannot do the write — it can, and the snapshot half is
+/// free here, since nothing in `native/` caches these preferences. Because the
+/// **Go sidecar** still holds `config.claudeDirs`, `claudesessions.dataSettings`
+/// and `SettingsManager.settings` in memory, and it is still serving routes that
+/// read all three. A native write updates the row underneath them:
+///
+/// - `PUT /api/notifications/settings` is Go's, and
+///   `notificationServiceImpl.UpdateSettings` is a read-modify-write over
+///   `settingsMgr.Get()` that persists the **whole** `user_settings` row. Saving
+///   an SMTP host after a native settings save therefore rewrites
+///   `hidden_projects`, `idle_gap_threshold_minutes` and both config-dir columns
+///   from the sidecar's boot-time copy — silent, total reversion of the Data &
+///   Analytics tab, reproduced against a live parity instance.
+/// - `internal/agent/runner.go` resolves each run's Claude account through
+///   `config.ResolveAgentClaudeDir`, i.e. `claudeDirs.runOverride`. Scheduled
+///   tasks (#275) and Telegram triggers still run in Go, so a changed
+///   `claude_config_dir` would keep authenticating them as the previous account.
+/// - `internal/config/profiles.go` resolves Claude settings profiles against the
+///   same snapshot, so `/api/claude-settings*` would read and write the old dir.
+///
+/// #274's rule decides it: *a route moves only when Rust can reproduce every
+/// effect it has*, and one of this route's effects is "the sidecar now agrees".
+/// There is no `AGENTO_SCANNER=off` equivalent to switch that half off the way
+/// #289 switched off the Go scanner, and no forward-after-write that is not just
+/// the forward. So the handler is written, unit-tested against Go's literal
+/// answers, and left unwired — exactly as `migrate::apply` was in #274 — and it
+/// turns on with the cut-over that removes the sidecar.
+///
+/// `/api/settings/claude-config-dirs` **is** claimed. #266 left it behind
+/// because it is a filesystem probe rather than a row read; the probe is the
+/// only new part, and the `indexed` half it shares with the row cannot disagree
+/// with Go's snapshot while Go still owns every write to it.
 fn claims(method: &Method, path: &str) -> bool {
-    method == Method::GET && path == "/api/settings"
+    method == Method::GET && matches!(path, "/api/settings" | "/api/settings/claude-config-dirs")
 }
 
-fn serve(ctx: &super::Ctx, _req: &super::Request) -> Result<super::Answer, String> {
+fn serve(ctx: &super::Ctx, req: &super::Request) -> Result<super::Answer, String> {
     let conn = super::db::open_read_only(&ctx.db_path)?;
-    let body = super::gojson::to_vec(&resolve(load_stored(&conn)))
-        .map_err(|e| format!("encoding settings: {e}"))?;
+    let body = if req.path == "/api/settings/claude-config-dirs" {
+        super::gojson::to_vec(&claude_config_dirs_response(&conn))
+            .map_err(|e| format!("encoding claude config dirs: {e}"))?
+    } else {
+        super::gojson::to_vec(&resolve(load_stored(&conn)))
+            .map_err(|e| format!("encoding settings: {e}"))?
+    };
     Ok(super::Answer::json(body))
 }
 
@@ -461,6 +979,9 @@ mod tests {
 
     #[test]
     fn the_default_dir_leads_and_duplicates_collapse() {
+        // `run_config_dir` reads `CLAUDE_CONFIG_DIR` and `paths::home` reads
+        // `HOME`, both of which the locked-field tests below swap.
+        let _env = crate::paths::tests::env_lock();
         let home = paths::home().expect("a home directory");
         let default = home.join(".claude").to_string_lossy().into_owned();
 
@@ -471,6 +992,7 @@ mod tests {
 
     #[test]
     fn extra_dirs_follow_the_default() {
+        let _env = crate::paths::tests::env_lock();
         let home = paths::home().expect("a home directory");
         let default = home.join(".claude").to_string_lossy().into_owned();
 
@@ -689,12 +1211,613 @@ mod tests {
         }
     }
 
+    // ─── GET /api/settings/claude-config-dirs ─────────────────────────────────
+
+    /// A home laid out to exercise every clause of the discovery rule at once,
+    /// including the three shapes that look like candidates and are not.
+    fn candidate_home() -> tempfile::TempDir {
+        let home = tempfile::tempdir().expect("tempdir");
+        let root = home.path();
+        for dir in [
+            ".claude",
+            ".claude-work",
+            ".claude.bak",
+            ".clauded",
+            ".claude-alpha",
+            ".claude-zeta",
+        ] {
+            std::fs::create_dir_all(root.join(dir).join("projects")).expect("candidate");
+        }
+        // A `.claude*` dir with no `projects` — the `.claude-backup` shape.
+        std::fs::create_dir_all(root.join(".claude-backup")).expect("backup");
+        // `projects` exists but is a file, not a directory.
+        std::fs::create_dir_all(root.join(".claude-projfile")).expect("projfile");
+        std::fs::write(root.join(".claude-projfile").join("projects"), "").expect("projects file");
+        // A plain file whose name has the prefix.
+        std::fs::write(root.join(".claude-file"), "").expect("file");
+        // The right shape under the wrong name.
+        std::fs::create_dir_all(root.join("notclaude").join("projects")).expect("notclaude");
+        // A *symlink* to a perfectly good candidate. `os.ReadDir`'s `IsDir` does
+        // not follow it, so Go does not suggest it — and neither may this.
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(root.join(".claude-work"), root.join(".claude-link"))
+            .expect("symlink");
+        home
+    }
+
+    /// Pinned to what a Go server built from this checkout answered over
+    /// exactly this layout, with `HOME` pointed at it.
+    ///
+    /// Every entry is a rule, and four of them are exclusions that a natural
+    /// rewrite gets wrong: the symlink (`IsDir` does not follow), the dir with
+    /// no `projects`, the one whose `projects` is a file, and the plain file.
+    /// `.claude.bak` and `.clauded` are *included* — the prefix is literal and
+    /// the `projects` check is the only filter, whatever the doc comment's
+    /// examples suggest.
     #[test]
-    fn only_the_settings_read_is_claimed() {
+    fn the_candidate_probe_matches_gos_discovery_rule() {
+        let _env = crate::paths::tests::env_lock();
+        let home = candidate_home();
+        let previous_home = std::env::var_os("HOME");
+        let previous_dir = std::env::var_os("CLAUDE_CONFIG_DIR");
+        std::env::set_var("HOME", home.path());
+        std::env::remove_var("CLAUDE_CONFIG_DIR");
+
+        let root = home.path().to_string_lossy().into_owned();
+        let indexed = claude_config_dirs("", &[]);
+        assert_eq!(indexed, vec![format!("{root}/.claude")]);
+        assert_eq!(
+            discover_candidate_claude_dirs(&indexed),
+            Some(vec![
+                format!("{root}/.claude-alpha"),
+                format!("{root}/.claude-work"),
+                format!("{root}/.claude-zeta"),
+                format!("{root}/.claude.bak"),
+                format!("{root}/.clauded"),
+            ]),
+            "`-` < `.` < `d` — sort.Strings is a byte-order sort"
+        );
+
+        // A configured dir is not a candidate: it is already in the set.
+        let indexed = claude_config_dirs(&format!("{root}/.claude-zeta"), &[]);
+        assert_eq!(
+            indexed,
+            vec![format!("{root}/.claude"), format!("{root}/.claude-zeta")],
+            "default first, then the run dir"
+        );
+        let candidates = discover_candidate_claude_dirs(&indexed).expect("listable");
+        assert!(!candidates.contains(&format!("{root}/.claude-zeta")));
+        assert!(candidates.contains(&format!("{root}/.claude-work")));
+
+        match previous_home {
+            Some(h) => std::env::set_var("HOME", h),
+            None => std::env::remove_var("HOME"),
+        }
+        if let Some(d) = previous_dir {
+            std::env::set_var("CLAUDE_CONFIG_DIR", d);
+        }
+    }
+
+    /// A home that cannot be listed is `null`, and one with nothing to suggest
+    /// is `[]`. Both reach the wire, and only the second is an empty array.
+    #[test]
+    fn an_unlistable_home_is_null_and_an_empty_one_is_an_empty_array() {
+        let _env = crate::paths::tests::env_lock();
+        let previous_home = std::env::var_os("HOME");
+
+        let empty = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("HOME", empty.path());
+        assert_eq!(discover_candidate_claude_dirs(&[]), Some(Vec::new()));
+
+        // `~/.claude`'s parent is the home directory, so a home that does not
+        // exist is the unlistable case.
+        std::env::set_var("HOME", empty.path().join("gone"));
+        assert_eq!(discover_candidate_claude_dirs(&[]), None);
+
+        match previous_home {
+            Some(h) => std::env::set_var("HOME", h),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    /// The envelope, byte for byte — including `default`, which is a Rust
+    /// keyword and so is the one field name a rename could quietly drop.
+    #[test]
+    fn the_config_dirs_envelope_is_gos() {
+        let body = super::super::gojson::to_vec(&ClaudeConfigDirsResponse {
+            indexed: vec!["/home/u/.claude".into(), "/home/u/.claude-work".into()],
+            candidates: Some(vec!["/home/u/.claude-alpha".into()]),
+            default_dir: "/home/u/.claude".into(),
+        })
+        .expect("encode");
+        assert_eq!(
+            String::from_utf8(body).expect("utf8"),
+            concat!(
+                r#"{"indexed":["/home/u/.claude","/home/u/.claude-work"],"#,
+                r#""candidates":["/home/u/.claude-alpha"],"default":"/home/u/.claude"}"#,
+                "\n"
+            )
+        );
+
+        let body = super::super::gojson::to_vec(&ClaudeConfigDirsResponse {
+            indexed: vec!["/home/u/.claude".into()],
+            candidates: None,
+            default_dir: "/home/u/.claude".into(),
+        })
+        .expect("encode");
+        assert!(String::from_utf8(body)
+            .expect("utf8")
+            .contains(r#""candidates":null"#));
+    }
+
+    // ─── PUT /api/settings ────────────────────────────────────────────────────
+    //
+    // Written but unclaimed, so there is no live diff to run against it. Every
+    // expectation below is instead a **literal captured from a Go server built
+    // from this checkout**, driven with the same request body — the convention
+    // #274 established for the write path.
+
+    fn migrated_db() -> tempfile::NamedTempFile {
+        let file = tempfile::NamedTempFile::new().expect("temp file");
+        let mut conn = rusqlite::Connection::open(file.path()).expect("open");
+        super::super::migrate::apply(&mut conn).expect("migrate");
+        file
+    }
+
+    /// These tests assert the *unlocked* answers. A developer whose shell
+    /// exports one of the four variables would otherwise fail them for a reason
+    /// that is not a bug.
+    fn nothing_is_locked() -> bool {
+        locked_fields().is_empty()
+    }
+
+    /// A `PUT`, with the rescan stubbed out — see [`put_recording_rescan`] for
+    /// the variant that asserts on it.
+    fn put(db: &std::path::Path, body: &str) -> (axum::http::StatusCode, String) {
+        put_recording_rescan(db, body).0
+    }
+
+    /// The same, reporting whether the save asked for a rescan.
+    fn put_recording_rescan(
+        db: &std::path::Path,
+        body: &str,
+    ) -> ((axum::http::StatusCode, String), bool) {
+        let mut rescanned = false;
+        let result = update_with(db, body.as_bytes(), |_| rescanned = true);
+        let answered = match super::super::writes::finish(result) {
+            Ok(answer) => (
+                answer.status,
+                String::from_utf8(answer.body.unwrap_or_default()).expect("utf8"),
+            ),
+            Err(reason) => panic!("forwarded rather than answered: {reason}"),
+        };
+        (answered, rescanned)
+    }
+
+    /// The whole happy path, byte for byte against Go.
+    ///
+    /// Note what is **not** in the answer: `Update` assigns the incoming struct
+    /// to `m.settings` wholesale and the handler answers `Get()`, so nothing is
+    /// re-defaulted — and `claude_config_dirs` comes back `null` for a request
+    /// that sent `[]`, because `normalizeClaudeConfigDirs` collapses an empty
+    /// list to a nil slice while `Save` still writes `[]` to the column.
+    #[test]
+    fn a_full_save_answers_gos_bytes() {
+        let _env = crate::paths::tests::env_lock();
+        if !nothing_is_locked() {
+            return;
+        }
+        let file = migrated_db();
+        let (status, body) = put(
+            file.path(),
+            concat!(
+                r#"{"default_working_dir":"/tmp/agento/work","default_model":"opus","#,
+                r#""onboarding_complete":true,"appearance_dark_mode":true,"#,
+                r#""appearance_font_size":13,"appearance_font_family":"Inter","#,
+                r#""notification_settings":"{\"enabled\":false}","event_bus_worker_pool_size":3,"#,
+                r#""public_url":"https://agento.example","#,
+                r#""hidden_projects":["/home/u/secret","/home/u/other"],"#,
+                r#""idle_gap_threshold_minutes":25,"claude_config_dir":"","#,
+                r#""claude_config_dirs":[]}"#
+            ),
+        );
+        assert_eq!(status, axum::http::StatusCode::OK);
+        assert_eq!(
+            body,
+            concat!(
+                r#"{"settings":{"default_working_dir":"/tmp/agento/work","default_model":"opus","#,
+                r#""onboarding_complete":true,"appearance_dark_mode":true,"#,
+                r#""appearance_font_size":13,"appearance_font_family":"Inter","#,
+                r#""notification_settings":"{\"enabled\":false}","event_bus_worker_pool_size":3,"#,
+                r#""public_url":"https://agento.example","#,
+                r#""hidden_projects":["/home/u/secret","/home/u/other"],"#,
+                r#""idle_gap_threshold_minutes":25,"claude_config_dir":"","#,
+                r#""claude_config_dirs":null},"locked":{},"model_from_env":false}"#,
+                "\n"
+            )
+        );
+
+        // …and the row it wrote reads back the way the next `GET` will read it:
+        // `[]` where the answer said `null`, and `{}` for a blank
+        // `notification_settings`.
+        let conn = rusqlite::Connection::open(file.path()).expect("open");
+        let stored = load_stored(&conn);
+        assert_eq!(stored.claude_config_dirs, Some(Vec::new()));
+        assert_eq!(
+            stored.hidden_projects,
+            Some(vec![
+                "/home/u/secret".to_string(),
+                "/home/u/other".to_string()
+            ]),
+            "the stored order is the order the client sent"
+        );
+        assert_eq!(stored.idle_gap_threshold_minutes, 25);
+    }
+
+    /// A partial body is not a patch: Go decodes into a zero-valued struct and
+    /// stores the lot, so every field the client omitted is cleared. An unknown
+    /// key is ignored and an explicit `null` is the zero value.
+    #[test]
+    fn an_omitted_field_is_cleared_and_a_null_is_its_zero_value() {
+        let _env = crate::paths::tests::env_lock();
+        if !nothing_is_locked() {
+            return;
+        }
+        let file = migrated_db();
+        let (status, body) = put(
+            file.path(),
+            r#"{"surprise":1,"public_url":null,"hidden_projects":null,"appearance_font_size":null,"idle_gap_threshold_minutes":7}"#,
+        );
+        assert_eq!(status, axum::http::StatusCode::OK);
+        assert_eq!(
+            body,
+            concat!(
+                r#"{"settings":{"default_working_dir":"","default_model":"","#,
+                r#""onboarding_complete":false,"appearance_dark_mode":false,"#,
+                r#""appearance_font_size":0,"appearance_font_family":"","#,
+                r#""notification_settings":"","event_bus_worker_pool_size":0,"#,
+                r#""public_url":"","hidden_projects":null,"#,
+                r#""idle_gap_threshold_minutes":7,"claude_config_dir":"","#,
+                r#""claude_config_dirs":null},"locked":{},"model_from_env":false}"#,
+                "\n"
+            )
+        );
+    }
+
+    /// Go's decoder is lenient about `null` and strict about everything else.
+    /// A `null` **body** is a documented no-op that reaches the handler as the
+    /// zero value and saves; an array is a decode error and 400s.
+    #[test]
+    fn a_null_body_saves_and_an_array_body_is_rejected() {
+        let _env = crate::paths::tests::env_lock();
+        if !nothing_is_locked() {
+            return;
+        }
+        let file = migrated_db();
+        let (status, body) = put(file.path(), "null");
+        assert_eq!(status, axum::http::StatusCode::OK);
+        assert!(body.contains(r#""idle_gap_threshold_minutes":0"#), "{body}");
+
+        let (status, body) = put(file.path(), r#"["x"]"#);
+        assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+        assert_eq!(body, "{\"error\":\"invalid JSON body\"}\n");
+
+        let (status, body) = put(file.path(), "not json");
+        assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+        assert_eq!(body, "{\"error\":\"invalid JSON body\"}\n");
+    }
+
+    /// Every rejection is a **400** carrying the error's own text — not the 409
+    /// the monitoring path answers for an env-locked write, and not the 422 the
+    /// service layer's `ValidationError` produces. `SettingsManager` returns
+    /// plain errors and the handler flattens them all.
+    #[test]
+    fn the_validation_failures_are_400s_with_gos_wording() {
+        let _env = crate::paths::tests::env_lock();
+        if !nothing_is_locked() {
+            return;
+        }
+        let file = migrated_db();
+        let scratch = tempfile::tempdir().expect("tempdir");
+        let missing = scratch.path().join("nope");
+        let not_a_dir = scratch.path().join("notadir");
+        std::fs::write(&not_a_dir, "").expect("file");
+
+        for (body, expected) in [
+            (
+                r#"{"idle_gap_threshold_minutes":500}"#.to_string(),
+                "idle_gap_threshold_minutes must be between 1 and 240 minutes, got 500".to_string(),
+            ),
+            (
+                r#"{"idle_gap_threshold_minutes":-1}"#.to_string(),
+                "idle_gap_threshold_minutes must be between 1 and 240 minutes, got -1".to_string(),
+            ),
+            (
+                r#"{"claude_config_dir":"relative/dir"}"#.to_string(),
+                "claude config dir must be an absolute path, got \\\"relative/dir\\\"".to_string(),
+            ),
+            (
+                format!(r#"{{"claude_config_dir":"{}"}}"#, missing.display()),
+                format!(
+                    "claude config dir \\\"{}\\\" does not exist",
+                    missing.display()
+                ),
+            ),
+            (
+                format!(r#"{{"claude_config_dir":"{}"}}"#, not_a_dir.display()),
+                format!(
+                    "claude config dir \\\"{}\\\" is not a directory",
+                    not_a_dir.display()
+                ),
+            ),
+            (
+                format!(r#"{{"claude_config_dirs":["{}"]}}"#, missing.display()),
+                format!(
+                    "claude config dir \\\"{}\\\" does not exist",
+                    missing.display()
+                ),
+            ),
+        ] {
+            let (status, answer) = put(file.path(), &body);
+            assert_eq!(status, axum::http::StatusCode::BAD_REQUEST, "{body}");
+            assert_eq!(answer, format!("{{\"error\":\"{expected}\"}}\n"), "{body}");
+        }
+
+        // Zero is "not chosen", not a zero-length sitting — the whole reason the
+        // bound starts at 1 and zero is still accepted.
+        let (status, _) = put(file.path(), r#"{"idle_gap_threshold_minutes":0}"#);
+        assert_eq!(status, axum::http::StatusCode::OK);
+    }
+
+    /// Nothing may be written before a rejection, or the forward-to-Go that an
+    /// `Err` triggers would apply the change twice. Here the failure is answered
+    /// rather than forwarded, but the invariant is the same one and it is
+    /// cheaper to pin than to re-derive.
+    #[test]
+    fn a_rejected_save_leaves_the_row_untouched() {
+        let _env = crate::paths::tests::env_lock();
+        if !nothing_is_locked() {
+            return;
+        }
+        let file = migrated_db();
+        put(file.path(), r#"{"public_url":"https://kept.example"}"#);
+        let (status, _) = put(
+            file.path(),
+            r#"{"public_url":"https://clobbered.example","idle_gap_threshold_minutes":9999}"#,
+        );
+        assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+
+        let conn = rusqlite::Connection::open(file.path()).expect("open");
+        assert_eq!(load_stored(&conn).public_url, "https://kept.example");
+    }
+
+    /// A dir already in the stored list is **not** re-validated, so an unmounted
+    /// volume cannot block a save of some unrelated field.
+    #[test]
+    fn an_unchanged_dir_is_not_revalidated_when_it_stops_existing() {
+        let _env = crate::paths::tests::env_lock();
+        if !nothing_is_locked() {
+            return;
+        }
+        let file = migrated_db();
+        let scratch = tempfile::tempdir().expect("tempdir");
+        let volume = scratch.path().join("volume");
+        std::fs::create_dir_all(&volume).expect("dir");
+
+        let listed = format!(r#"["{}"]"#, volume.display());
+        let (status, _) = put(
+            file.path(),
+            &format!(r#"{{"claude_config_dirs":{listed}}}"#),
+        );
+        assert_eq!(status, axum::http::StatusCode::OK);
+
+        std::fs::remove_dir(&volume).expect("unmount");
+        let (status, body) = put(
+            file.path(),
+            &format!(r#"{{"appearance_font_size":15,"claude_config_dirs":{listed}}}"#),
+        );
+        assert_eq!(
+            status,
+            axum::http::StatusCode::OK,
+            "an unchanged dir must not be re-validated: {body}"
+        );
+
+        // …but adding a *new* missing one still fails.
+        let (status, _) = put(
+            file.path(),
+            &format!(
+                r#"{{"claude_config_dirs":["{}","{}"]}}"#,
+                volume.display(),
+                scratch.path().join("brand-new").display()
+            ),
+        );
+        assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+    }
+
+    /// The `locked` map is a **400**, and it is the message Go writes.
+    ///
+    /// Three properties in one, because they share an environment: a blank
+    /// incoming value is pinned rather than treated as a request to clear;
+    /// `claude_config_dir` is compared *normalized*, so a trailing slash is not
+    /// a change; and the field order is Go's slice order, so a body conflicting
+    /// on two locked fields reports `public_url` rather than whichever came
+    /// first in the JSON.
+    #[test]
+    fn a_locked_field_is_a_400_and_a_blank_one_is_pinned() {
+        let _env = crate::paths::tests::env_lock();
+        let scratch = tempfile::tempdir().expect("tempdir");
+        let pinned = scratch.path().join("pinned");
+        let other = scratch.path().join("other");
+        std::fs::create_dir_all(&pinned).expect("dir");
+        std::fs::create_dir_all(&other).expect("dir");
+
+        let previous_url = std::env::var_os("AGENTO_PUBLIC_URL");
+        let previous_dir = std::env::var_os("CLAUDE_CONFIG_DIR");
+        std::env::set_var("AGENTO_PUBLIC_URL", "https://example.test");
+        std::env::set_var("CLAUDE_CONFIG_DIR", pinned.to_string_lossy().as_ref());
+
+        let file = migrated_db();
+        let (status, body) = put(
+            file.path(),
+            &format!(r#"{{"claude_config_dir":"{}"}}"#, other.display()),
+        );
+        assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+        assert_eq!(
+            body,
+            "{\"error\":\"claude_config_dir is locked by environment variable CLAUDE_CONFIG_DIR\"}\n"
+        );
+
+        let (status, body) = put(file.path(), r#"{"public_url":"https://other.test"}"#);
+        assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+        assert!(
+            body.contains("public_url is locked by environment variable AGENTO_PUBLIC_URL"),
+            "{body}"
+        );
+
+        // Both at once reports `public_url`: it comes first in Go's slice.
+        let (_, body) = put(
+            file.path(),
+            &format!(
+                r#"{{"public_url":"https://other.test","claude_config_dir":"{}"}}"#,
+                other.display()
+            ),
+        );
+        assert!(body.contains("public_url is locked"), "{body}");
+
+        // A trailing slash normalizes to the same dir, so it saves — and both
+        // locked fields come back pinned to what the environment chose.
+        let (status, body) = put(
+            file.path(),
+            &format!(r#"{{"claude_config_dir":"{}/"}}"#, pinned.display()),
+        );
+        assert_eq!(status, axum::http::StatusCode::OK, "{body}");
+        assert!(
+            body.contains(&format!(r#""claude_config_dir":"{}""#, pinned.display())),
+            "{body}"
+        );
+        assert!(
+            body.contains(r#""public_url":"https://example.test""#),
+            "{body}"
+        );
+        assert!(
+            body.contains(
+                r#""locked":{"claude_config_dir":"CLAUDE_CONFIG_DIR","public_url":"AGENTO_PUBLIC_URL"}"#
+            ),
+            "{body}"
+        );
+
+        // A blank value is pinned rather than read as "clear it".
+        let (status, body) = put(file.path(), r#"{"claude_config_dir":""}"#);
+        assert_eq!(status, axum::http::StatusCode::OK);
+        assert!(
+            body.contains(&format!(r#""claude_config_dir":"{}""#, pinned.display())),
+            "{body}"
+        );
+
+        match previous_url {
+            Some(v) => std::env::set_var("AGENTO_PUBLIC_URL", v),
+            None => std::env::remove_var("AGENTO_PUBLIC_URL"),
+        }
+        match previous_dir {
+            Some(v) => std::env::set_var("CLAUDE_CONFIG_DIR", v),
+            None => std::env::remove_var("CLAUDE_CONFIG_DIR"),
+        }
+    }
+
+    /// `applyDataSettings`'s three cases, which are not symmetrical.
+    ///
+    /// Hiding a project is a filter over cached rows and takes effect on the
+    /// next read, so it must **not** cost a corpus walk. A threshold change
+    /// must, because active duration is stored per transcript. Adding a config
+    /// dir must too, and for a different reason: that dir has never been walked,
+    /// so there are no rows to filter. Removing one needs no scan either, but
+    /// the comparison is on the resolved set, so it is one rule.
+    #[test]
+    fn only_a_threshold_or_a_config_dir_change_asks_for_a_rescan() {
+        let _env = crate::paths::tests::env_lock();
+        if !nothing_is_locked() {
+            return;
+        }
+        let file = migrated_db();
+        let scratch = tempfile::tempdir().expect("tempdir");
+        let extra = scratch.path().join("extra");
+        std::fs::create_dir_all(&extra).expect("dir");
+
+        // A first save that changes nothing about time or dirs.
+        let (_, rescanned) =
+            put_recording_rescan(file.path(), r#"{"public_url":"https://a.test"}"#);
+        assert!(!rescanned, "an ordinary save must not walk the corpus");
+
+        let (_, rescanned) = put_recording_rescan(
+            file.path(),
+            r#"{"hidden_projects":["/home/u/secret"],"public_url":"https://a.test"}"#,
+        );
+        assert!(!rescanned, "hiding a project is a filter, not a re-read");
+
+        let (_, rescanned) = put_recording_rescan(
+            file.path(),
+            r#"{"hidden_projects":["/home/u/secret"],"idle_gap_threshold_minutes":25}"#,
+        );
+        assert!(
+            rescanned,
+            "a moved threshold restates every stored duration"
+        );
+
+        let (_, rescanned) = put_recording_rescan(
+            file.path(),
+            &format!(
+                r#"{{"idle_gap_threshold_minutes":25,"claude_config_dirs":["{}"]}}"#,
+                extra.display()
+            ),
+        );
+        assert!(
+            rescanned,
+            "a dir that was never walked has no rows to filter"
+        );
+
+        // …and saving the very same thing again is free.
+        let (_, rescanned) = put_recording_rescan(
+            file.path(),
+            &format!(
+                r#"{{"idle_gap_threshold_minutes":25,"claude_config_dirs":["{}"]}}"#,
+                extra.display()
+            ),
+        );
+        assert!(!rescanned, "an unchanged save must cost nothing");
+    }
+
+    /// `normalizeClaudeConfigDirs`: normalize, drop blanks, drop duplicates, and
+    /// answer **nil** rather than `[]` when nothing survives.
+    #[test]
+    fn the_stored_dir_list_is_normalized_and_collapses_to_nil() {
+        assert_eq!(normalize_claude_config_dirs(&None), None);
+        assert_eq!(normalize_claude_config_dirs(&Some(Vec::new())), None);
+        assert_eq!(
+            normalize_claude_config_dirs(&Some(vec!["  ".into(), "".into()])),
+            None
+        );
+        assert_eq!(
+            normalize_claude_config_dirs(&Some(vec![
+                "/var/lib/claude/".into(),
+                "/var/lib/claude".into(),
+                " /var/lib/other ".into(),
+            ])),
+            Some(vec![
+                "/var/lib/claude".to_string(),
+                "/var/lib/other".to_string()
+            ])
+        );
+    }
+
+    #[test]
+    fn only_the_two_settings_reads_are_claimed() {
         assert!(claims(&Method::GET, "/api/settings"));
+        assert!(claims(&Method::GET, "/api/settings/claude-config-dirs"));
+        // The write is implemented but unwired: the Go sidecar's own snapshots
+        // would go stale behind it. See `claims` for the three routes that read
+        // them and the reversion the first of those causes.
         assert!(!claims(&Method::PUT, "/api/settings"));
-        // A filesystem probe, not a read of this row — it stays with Go.
-        assert!(!claims(&Method::GET, "/api/settings/claude-config-dirs"));
+        assert!(!claims(&Method::PUT, "/api/settings/claude-config-dirs"));
         assert!(!claims(&Method::GET, "/api/settings/"));
     }
 }

--- a/desktop/src-tauri/src/native/settings.rs
+++ b/desktop/src-tauri/src/native/settings.rs
@@ -230,12 +230,19 @@ fn claude_config_dirs(run_override: &str, extra: &[String]) -> Vec<String> {
 
 /// `~/.claude`, or `/root/.claude` when there is no home — the fallback Go's
 /// `DefaultClaudeConfigDir` uses.
+///
+/// Joined through [`super::gopath::join`] rather than `PathBuf::join` because
+/// Go's is `filepath.Join`, which **cleans**: with `HOME=/home//u` Go answers
+/// `/home/u/.claude` and a `PathBuf::join` would answer `/home//u/.claude`.
+/// Every other caller runs the result through [`normalize`] and so never saw
+/// the difference; `GET /api/settings/claude-config-dirs` puts it on the wire
+/// raw as `default`, where it would disagree with its own `indexed[0]`.
 pub fn default_claude_config_dir() -> String {
-    paths::home()
+    let home = paths::home()
         .unwrap_or_else(|| PathBuf::from("/root"))
-        .join(".claude")
         .to_string_lossy()
-        .into_owned()
+        .into_owned();
+    super::gopath::join(&[&home, ".claude"])
 }
 
 /// The single dir a run targets: `CLAUDE_CONFIG_DIR` first, then the stored
@@ -458,8 +465,18 @@ pub struct ClaudeConfigDirsResponse {
 }
 
 /// `handleClaudeConfigDirs`.
+///
+/// The row is read **through [`resolve`]**, not raw. Go answers `indexed` from
+/// the `config.claudeDirs` snapshot, which `ApplyClaudeDirs` installs from the
+/// *env-resolved* settings — and `applyEnvOverrides` overwrites
+/// `ClaudeConfigDir` with `ClaudeConfigDirFromEnv()` whenever that is non-blank,
+/// **including when the env value is relative**. So with a relative
+/// `CLAUDE_CONFIG_DIR` exported and an absolute value in the column, Go drops
+/// both (the env wins, then `absoluteDir` discards it) and falls back to the
+/// default dir; reading the raw row would drop only the env value and add a dir
+/// Go does not index.
 pub fn claude_config_dirs_response(conn: &Connection) -> ClaudeConfigDirsResponse {
-    let stored = load_stored(conn);
+    let stored = resolve(load_stored(conn)).settings;
     let indexed = claude_config_dirs(
         &stored.claude_config_dir,
         stored.claude_config_dirs.as_deref().unwrap_or_default(),
@@ -481,9 +498,15 @@ pub fn claude_config_dirs_response(conn: &Connection) -> ClaudeConfigDirsRespons
 /// - a **sibling of the default dir** — anywhere else is added by hand, because
 ///   suggesting is not discovering;
 /// - whose name starts with `.claude`;
-/// - which contains a `projects` **directory**. That is what keeps
-///   `.claude-backup` and `.claude.bak` out; they are the common shapes of a
-///   directory that merely looks like a config dir.
+/// - which contains a `projects` **directory** — the only filter beyond the
+///   prefix, and so the only thing that keeps a directory which merely *looks*
+///   like a config dir (the `.claude-backup` shape) out.
+///
+/// Go's own comment says the `projects` check "is what keeps `.claude-backup`
+/// and `.claude.bak` out". That is wrong about the second: the prefix match is
+/// literal, so `.claude.bak` **is** suggested whenever it has a `projects`
+/// directory — as the vectors below pin. Nothing distinguishes a name; only the
+/// `projects` directory does.
 ///
 /// Two Go details that a natural Rust rewrite gets wrong: `os.ReadDir`'s
 /// `DirEntry.IsDir` does **not** follow symlinks (so a symlink to a directory is
@@ -543,6 +566,16 @@ const MAX_IDLE_GAP_MINUTES: i64 = 240;
 /// write, and it is not the 422 the service layer's `ValidationError` produces —
 /// `SettingsManager` returns plain `fmt.Errorf` values and the handler flattens
 /// them all to 400.
+///
+/// One exception, and it is not a status: a failure of the machinery rather
+/// than of the request — opening the database, verifying the migrations, the
+/// `INSERT`, or encoding the answer — is a [`WriteError::Fallback`] and
+/// **forwards to Go** rather than answering at all, because those wrap driver
+/// and `os` errors whose Go text is not reproducible. The first three forward
+/// with nothing written, which is what makes forwarding safe; the encode
+/// happens after the row is saved, and forwarding there re-applies a `PUT`
+/// that replaces the whole row with the same values, so it is idempotent
+/// rather than merely harmless.
 pub fn update(db_path: &Path, body: &[u8]) -> Result<super::Answer, WriteError> {
     update_with(db_path, body, super::scan::force_scan)
 }
@@ -939,11 +972,33 @@ pub const ENDPOINT: super::Endpoint = super::Endpoint {
 /// because it is a filesystem probe rather than a row read; the probe is the
 /// only new part, and the `indexed` half it shares with the row cannot disagree
 /// with Go's snapshot while Go still owns every write to it.
+///
+/// It is claimed on **every** platform but answered only on Unix: [`serve`]
+/// forwards the probe on Windows, because it is `filepath` arithmetic and
+/// `native/gopath.rs` implements the Unix rules. Claiming platform-independently
+/// and refusing in `serve` is what `native/fs.rs` does, and it keeps the
+/// platform decision in one readable place rather than making the route vanish
+/// from the registry. Windows x86_64 is a shipped target
+/// (`.github/workflows/desktop-release.yml`) while desktop CI is ubuntu-only, so
+/// nothing else would catch it.
 fn claims(method: &Method, path: &str) -> bool {
     method == Method::GET && matches!(path, "/api/settings" | "/api/settings/claude-config-dirs")
 }
 
 fn serve(ctx: &super::Ctx, req: &super::Request) -> Result<super::Answer, String> {
+    // The config-dir probe is `filepath` arithmetic on the real filesystem, and
+    // this port implements the **Unix** `filepath` (see `native/gopath.rs`,
+    // whose vectors are Unix-shaped). On Windows `gopath::dir` finds no `/` in
+    // `C:\Users\u\.claude` and answers `"."`, so the probe would list the
+    // process working directory instead of `$HOME`, and `gopath::join` would
+    // build `C:\Users\u/.claude-work`, which no `configured` entry can match —
+    // silently empty suggestions at best, an outright wrong list at worst.
+    // Forwarding is the seam's own mechanism for "cannot answer", exactly as
+    // `native/fs.rs` does. `GET /api/settings` is a plain row read and is
+    // deliberately still answered.
+    if !cfg!(unix) && req.path == "/api/settings/claude-config-dirs" {
+        return Err("the config-dir probe is not ported for Windows path semantics".to_string());
+    }
     let conn = super::db::open_read_only(&ctx.db_path)?;
     let body = if req.path == "/api/settings/claude-config-dirs" {
         super::gojson::to_vec(&claude_config_dirs_response(&conn))
@@ -1213,88 +1268,122 @@ mod tests {
 
     // ─── GET /api/settings/claude-config-dirs ─────────────────────────────────
 
-    /// A home laid out to exercise every clause of the discovery rule at once,
-    /// including the three shapes that look like candidates and are not.
-    fn candidate_home() -> tempfile::TempDir {
-        let home = tempfile::tempdir().expect("tempdir");
-        let root = home.path();
-        for dir in [
-            ".claude",
-            ".claude-work",
-            ".claude.bak",
-            ".clauded",
-            ".claude-alpha",
-            ".claude-zeta",
-        ] {
-            std::fs::create_dir_all(root.join(dir).join("projects")).expect("candidate");
-        }
-        // A `.claude*` dir with no `projects` — the `.claude-backup` shape.
-        std::fs::create_dir_all(root.join(".claude-backup")).expect("backup");
-        // `projects` exists but is a file, not a directory.
-        std::fs::create_dir_all(root.join(".claude-projfile")).expect("projfile");
-        std::fs::write(root.join(".claude-projfile").join("projects"), "").expect("projects file");
-        // A plain file whose name has the prefix.
-        std::fs::write(root.join(".claude-file"), "").expect("file");
-        // The right shape under the wrong name.
-        std::fs::create_dir_all(root.join("notclaude").join("projects")).expect("notclaude");
-        // A *symlink* to a perfectly good candidate. `os.ReadDir`'s `IsDir` does
-        // not follow it, so Go does not suggest it — and neither may this.
-        #[cfg(unix)]
-        std::os::unix::fs::symlink(root.join(".claude-work"), root.join(".claude-link"))
-            .expect("symlink");
-        home
+    use crate::paths::tests::EnvVar;
+
+    /// `desktop/parity/claude_dirs_vectors.json`, generated from Go by
+    /// `desktop/parity/claude_dirs_parity_test.go`.
+    ///
+    /// A shared *primitive* rather than a response, so it takes the vector form
+    /// `desktop/CLAUDE.md`'s checklist names — the same arrangement
+    /// `gopath_vectors.json` uses. It has to be the vector form here: the four
+    /// exclusion shapes (a `.claude*` symlink, a `.claude*` dir with no
+    /// `projects`, one whose `projects` is a *file*, a plain file with the
+    /// prefix) exist in no real `$HOME`, so the live parity diff structurally
+    /// cannot re-verify them, and a hand-transcribed literal would pin only what
+    /// its author believed Go does. Both languages now assert against what Go
+    /// actually answered, and a change to Go's rule fails Go's own suite.
+    #[derive(Deserialize)]
+    struct DirVectorSymlink {
+        link: String,
+        target: String,
     }
 
-    /// Pinned to what a Go server built from this checkout answered over
-    /// exactly this layout, with `HOME` pointed at it.
+    #[derive(Deserialize)]
+    struct DirVectorLayout {
+        dirs: Vec<String>,
+        files: Vec<String>,
+        symlinks: Vec<DirVectorSymlink>,
+    }
+
+    #[derive(Deserialize)]
+    struct DirVectorCase {
+        name: String,
+        claude_config_dir_env: String,
+        run_dir: String,
+        extra: Vec<String>,
+        indexed: Vec<String>,
+        candidates: Vec<String>,
+    }
+
+    #[derive(Deserialize)]
+    struct DirVectors {
+        layout: DirVectorLayout,
+        cases: Vec<DirVectorCase>,
+    }
+
+    /// Baked in rather than read at run time: the file is a build input, and a
+    /// missing one should fail the compile rather than one test.
+    const DIR_VECTORS: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../parity/claude_dirs_vectors.json"
+    ));
+
+    /// The `$HOME` token the vectors record, since the home directory is a
+    /// fresh temp dir on both sides.
+    fn expand(path: &str, home: &str) -> String {
+        path.replace("$HOME", home)
+    }
+
+    fn expand_all(paths: &[String], home: &str) -> Vec<String> {
+        paths.iter().map(|p| expand(p, home)).collect()
+    }
+
+    /// Build the vectors' layout — the same tree the Go test built.
+    #[cfg(unix)]
+    fn build_layout(layout: &DirVectorLayout, root: &Path) {
+        for dir in &layout.dirs {
+            std::fs::create_dir_all(root.join(dir)).expect("layout dir");
+        }
+        for file in &layout.files {
+            std::fs::write(root.join(file), "").expect("layout file");
+        }
+        for link in &layout.symlinks {
+            std::os::unix::fs::symlink(root.join(&link.target), root.join(&link.link))
+                .expect("layout symlink");
+        }
+    }
+
+    /// Both halves of the endpoint, against Go's own answers over a home
+    /// directory built from the vectors.
     ///
-    /// Every entry is a rule, and four of them are exclusions that a natural
-    /// rewrite gets wrong: the symlink (`IsDir` does not follow), the dir with
-    /// no `projects`, the one whose `projects` is a file, and the plain file.
-    /// `.claude.bak` and `.clauded` are *included* — the prefix is literal and
-    /// the `projects` check is the only filter, whatever the doc comment's
-    /// examples suggest.
+    /// `#[cfg(unix)]` for the same reason the vectors are Unix-shaped and
+    /// [`serve`] forwards the route on Windows: the layout needs a symlink, and
+    /// the rule is `filepath` arithmetic this port implements for Unix only.
     #[test]
+    #[cfg(unix)]
     fn the_candidate_probe_matches_gos_discovery_rule() {
         let _env = crate::paths::tests::env_lock();
-        let home = candidate_home();
-        let previous_home = std::env::var_os("HOME");
-        let previous_dir = std::env::var_os("CLAUDE_CONFIG_DIR");
-        std::env::set_var("HOME", home.path());
-        std::env::remove_var("CLAUDE_CONFIG_DIR");
+        let vectors: DirVectors =
+            serde_json::from_str(DIR_VECTORS).expect("parsing claude dir vectors");
+        assert!(vectors.cases.len() >= 5, "vectors look truncated");
 
+        let home = tempfile::tempdir().expect("tempdir");
+        build_layout(&vectors.layout, home.path());
         let root = home.path().to_string_lossy().into_owned();
-        let indexed = claude_config_dirs("", &[]);
-        assert_eq!(indexed, vec![format!("{root}/.claude")]);
-        assert_eq!(
-            discover_candidate_claude_dirs(&indexed),
-            Some(vec![
-                format!("{root}/.claude-alpha"),
-                format!("{root}/.claude-work"),
-                format!("{root}/.claude-zeta"),
-                format!("{root}/.claude.bak"),
-                format!("{root}/.clauded"),
-            ]),
-            "`-` < `.` < `d` — sort.Strings is a byte-order sort"
-        );
+        let _home_var = EnvVar::set("HOME", home.path());
 
-        // A configured dir is not a candidate: it is already in the set.
-        let indexed = claude_config_dirs(&format!("{root}/.claude-zeta"), &[]);
-        assert_eq!(
-            indexed,
-            vec![format!("{root}/.claude"), format!("{root}/.claude-zeta")],
-            "default first, then the run dir"
-        );
-        let candidates = discover_candidate_claude_dirs(&indexed).expect("listable");
-        assert!(!candidates.contains(&format!("{root}/.claude-zeta")));
-        assert!(candidates.contains(&format!("{root}/.claude-work")));
+        for case in &vectors.cases {
+            let _dir_var = match case.claude_config_dir_env.as_str() {
+                "" => EnvVar::unset("CLAUDE_CONFIG_DIR"),
+                value => EnvVar::set("CLAUDE_CONFIG_DIR", expand(value, &root)),
+            };
 
-        match previous_home {
-            Some(h) => std::env::set_var("HOME", h),
-            None => std::env::remove_var("HOME"),
-        }
-        if let Some(d) = previous_dir {
-            std::env::set_var("CLAUDE_CONFIG_DIR", d);
+            let indexed = claude_config_dirs(
+                &expand(&case.run_dir, &root),
+                &expand_all(&case.extra, &root),
+            );
+            assert_eq!(
+                indexed,
+                expand_all(&case.indexed, &root),
+                "indexed — {}",
+                case.name
+            );
+            assert_eq!(
+                discover_candidate_claude_dirs(&indexed),
+                Some(expand_all(&case.candidates, &root)),
+                "candidates — {}",
+                case.name
+            );
         }
     }
 
@@ -1303,21 +1392,68 @@ mod tests {
     #[test]
     fn an_unlistable_home_is_null_and_an_empty_one_is_an_empty_array() {
         let _env = crate::paths::tests::env_lock();
-        let previous_home = std::env::var_os("HOME");
 
         let empty = tempfile::tempdir().expect("tempdir");
-        std::env::set_var("HOME", empty.path());
+        let _home_var = EnvVar::set("HOME", empty.path());
         assert_eq!(discover_candidate_claude_dirs(&[]), Some(Vec::new()));
 
         // `~/.claude`'s parent is the home directory, so a home that does not
         // exist is the unlistable case.
-        std::env::set_var("HOME", empty.path().join("gone"));
+        let _gone = EnvVar::set("HOME", empty.path().join("gone"));
         assert_eq!(discover_candidate_claude_dirs(&[]), None);
+    }
 
-        match previous_home {
-            Some(h) => std::env::set_var("HOME", h),
-            None => std::env::remove_var("HOME"),
-        }
+    /// `default` is `filepath.Join(home, ".claude")`, and `filepath.Join`
+    /// **cleans** — `PathBuf::join` does not. This is the one caller whose
+    /// output reaches the wire without passing through [`normalize`], so a
+    /// non-clean `HOME` would put a `default` on the wire that disagrees with
+    /// the `indexed[0]` beside it.
+    #[test]
+    fn the_default_dir_is_cleaned_like_filepath_join() {
+        let _env = crate::paths::tests::env_lock();
+        let _home_var = EnvVar::set("HOME", "/home//u/");
+        assert_eq!(default_claude_config_dir(), "/home/u/.claude");
+        assert_eq!(
+            claude_config_dirs("", &[]),
+            vec!["/home/u/.claude".to_string()],
+            "`default` and `indexed[0]` are the same dir and must be spelled alike"
+        );
+    }
+
+    /// `indexed` is resolved from the **env-resolved** settings, not the raw
+    /// row: `applyEnvOverrides` overwrites `claude_config_dir` with
+    /// `CLAUDE_CONFIG_DIR` whenever that is non-blank — *including when the env
+    /// value is relative* — and `ApplyClaudeDirs` installs what is left. So a
+    /// relative env value drops the stored dir with it, and reading the raw row
+    /// would index a dir Go does not.
+    #[test]
+    fn a_relative_env_dir_drops_the_stored_run_dir_too() {
+        let _env = crate::paths::tests::env_lock();
+        let home = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(home.path().join(".claude").join("projects")).expect("default dir");
+        let stored = home.path().join(".claude-work");
+        std::fs::create_dir_all(stored.join("projects")).expect("stored dir");
+
+        let _home_var = EnvVar::set("HOME", home.path());
+        let _dir_var = EnvVar::set("CLAUDE_CONFIG_DIR", "relative/dir");
+
+        let conn = fixture(Some(&format!(
+            "INSERT INTO user_settings (id, claude_config_dir) VALUES (1, '{}')",
+            stored.display()
+        )));
+        let response = claude_config_dirs_response(&conn);
+        assert_eq!(
+            response.indexed,
+            vec![home.path().join(".claude").to_string_lossy().into_owned()],
+            "the relative env value replaces the stored one before either is resolved"
+        );
+        assert!(
+            response
+                .candidates
+                .expect("listable")
+                .contains(&stored.to_string_lossy().into_owned()),
+            "and the dropped dir is offered as a candidate, exactly as Go offers it"
+        );
     }
 
     /// The envelope, byte for byte — including `default`, which is a Rust
@@ -1651,10 +1787,12 @@ mod tests {
         std::fs::create_dir_all(&pinned).expect("dir");
         std::fs::create_dir_all(&other).expect("dir");
 
-        let previous_url = std::env::var_os("AGENTO_PUBLIC_URL");
-        let previous_dir = std::env::var_os("CLAUDE_CONFIG_DIR");
-        std::env::set_var("AGENTO_PUBLIC_URL", "https://example.test");
-        std::env::set_var("CLAUDE_CONFIG_DIR", pinned.to_string_lossy().as_ref());
+        // RAII, not a trailing restore: a failed assertion below panics past
+        // any epilogue, and these two variables would then leak into the rest
+        // of the binary — where six other tests skip themselves when anything
+        // is locked, silently turning one failure into seven.
+        let _url_var = EnvVar::set("AGENTO_PUBLIC_URL", "https://example.test");
+        let _dir_var = EnvVar::set("CLAUDE_CONFIG_DIR", pinned.to_string_lossy().as_ref());
 
         let file = migrated_db();
         let (status, body) = put(
@@ -1713,15 +1851,6 @@ mod tests {
             body.contains(&format!(r#""claude_config_dir":"{}""#, pinned.display())),
             "{body}"
         );
-
-        match previous_url {
-            Some(v) => std::env::set_var("AGENTO_PUBLIC_URL", v),
-            None => std::env::remove_var("AGENTO_PUBLIC_URL"),
-        }
-        match previous_dir {
-            Some(v) => std::env::set_var("CLAUDE_CONFIG_DIR", v),
-            None => std::env::remove_var("CLAUDE_CONFIG_DIR"),
-        }
     }
 
     /// `applyDataSettings`'s three cases, which are not symmetrical.

--- a/desktop/src-tauri/src/paths.rs
+++ b/desktop/src-tauri/src/paths.rs
@@ -82,6 +82,54 @@ pub(crate) mod tests {
         LOCK.lock().unwrap_or_else(|e| e.into_inner())
     }
 
+    /// An environment variable swapped for the lifetime of the guard.
+    ///
+    /// Restoring in a trailing block at the end of the test is not enough: a
+    /// failed assertion panics past it, and [`env_lock`] deliberately recovers
+    /// from poisoning, so the swapped value **survives into every later test in
+    /// the same binary**. One real failure then becomes a cascade of unrelated
+    /// ones — or, worse, silences them, since several tests here skip
+    /// themselves when a variable is set. A `HOME` left pointing at a deleted
+    /// `TempDir` breaks every subsequent [`home`] read outright.
+    ///
+    /// Holding the guard alongside `env_lock()`'s is what makes the swap safe:
+    /// the lock serialises the tests, the guard bounds the swap to one of them.
+    pub(crate) struct EnvVar {
+        name: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVar {
+        /// Set `name`, remembering what was there.
+        pub(crate) fn set(name: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let guard = Self {
+                name,
+                previous: std::env::var_os(name),
+            };
+            std::env::set_var(name, value);
+            guard
+        }
+
+        /// Remove `name`, remembering what was there.
+        pub(crate) fn unset(name: &'static str) -> Self {
+            let guard = Self {
+                name,
+                previous: std::env::var_os(name),
+            };
+            std::env::remove_var(name);
+            guard
+        }
+    }
+
+    impl Drop for EnvVar {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.name, value),
+                None => std::env::remove_var(self.name),
+            }
+        }
+    }
+
     #[test]
     fn tilde_expands_like_the_go_resolver() {
         let _env = env_lock();

--- a/desktop/src-tauri/tests/parity_settings.rs
+++ b/desktop/src-tauri/tests/parity_settings.rs
@@ -25,8 +25,10 @@
 //! trusting a pass:
 //!
 //! - `PUT /api/settings` with a hidden project, a non-default idle threshold, a
-//!   font family and a `public_url`, so the string-list columns are exercised as
-//!   populated arrays rather than as `null`;
+//!   font family, a `public_url` and a second `claude_config_dirs` entry (any
+//!   existing absolute directory will do), so the string-list columns are
+//!   exercised as populated arrays rather than as `null` — and so the config-dir
+//!   read resolves a set with an order and a dedup in it rather than one entry;
 //! - `PUT /api/monitoring` with `otlp_headers` populated, so the `omitempty` map
 //!   is exercised as present as well as absent.
 //!
@@ -64,6 +66,43 @@ async fn the_settings_read_matches_the_live_go_response() {
         "the parity instance has never saved a settings list — both columns are \
          null, which diffs clean and proves nothing. Seed it with PUT /api/settings \
          (see this file's header).\n{body}"
+    );
+}
+
+/// The config-dir editor's source (#305).
+///
+/// Half a row read and half a **filesystem probe**, which is why #266 left it
+/// behind: `indexed` resolves the stored preferences the way `GET /api/settings`
+/// does, while `candidates` lists the home directory. Both halves are answered
+/// from the same process here, and the Go server runs from this shell — so the
+/// `HOME` and `CLAUDE_CONFIG_DIR` the two resolve against are the same ones.
+///
+/// The probe's *rules* are pinned by a unit test over a crafted home, because
+/// no developer's real one exercises the exclusions. What this adds is the
+/// resolution over whatever is actually there.
+#[tokio::test]
+#[ignore = "needs a running Agento instance and its database"]
+async fn the_claude_config_dirs_read_matches_the_live_go_response() {
+    let db_path = live_db();
+    let conn = db::open_read_only(&db_path).expect("opening the parity database");
+
+    let go = fetch("/api/settings/claude-config-dirs").await;
+    let native = gojson::to_vec(&settings::claude_config_dirs_response(&conn)).expect("encode");
+    assert_identical("settings/claude-config-dirs", &go, &native);
+
+    // A one-entry `indexed` is the answer an install that has configured
+    // nothing gives, and it diffs clean against itself while proving only that
+    // both sides can spell the default dir. Seed a second dir before trusting
+    // a pass — the order (default, run dir, extras) and the dedup are the parts
+    // that can be wrong.
+    let parsed: serde_json::Value = serde_json::from_slice(&go).expect("valid JSON");
+    let indexed = parsed["indexed"].as_array().map_or(0, Vec::len);
+    let candidates = parsed["candidates"].as_array().map_or(0, Vec::len);
+    assert!(
+        indexed > 1 || candidates > 0,
+        "the parity instance indexes exactly one config dir and has no candidate \
+         beside it, so this diffs the default dir against itself. Seed it with \
+         PUT /api/settings and a real `claude_config_dirs` entry (see the header).\n{parsed}"
     );
 }
 


### PR DESCRIPTION
## Summary

- `GET /api/settings/claude-config-dirs` is answered natively — the filesystem probe #266 left behind, byte-identical to a Go server built from this checkout.
- `PUT /api/settings` is fully written and unit-tested against literals captured from Go, but **deliberately left unclaimed**. The `migrate::apply` precedent from #274: written, verified, wired at the cut-over.
- `desktop/CLAUDE.md` gains the settings path's status code. The general wire-trap bullet says "validation errors are 422, conflicts 409 — not 400", and the settings path is a total exception to it: a locked-field rejection there is a plain **400**. The file did not previously state either way for this surface.

## Why the PUT does not move yet

Rust holds no snapshot of these preferences (`settings::load` reads the row per request), so the native half of `applyDataSettings` is free. **The sidecar's snapshot is the blocker, and it is not theoretical:**

- `notificationServiceImpl.UpdateSettings` is a read-modify-write over `settingsMgr.Get()` that persists the *whole* `user_settings` row. Reproduced against a Go server built from this checkout: writing `hidden_projects` and `idle_gap_threshold_minutes` directly (simulating a native PUT), then issuing one unrelated `PUT /api/notifications/settings` — still Go's — reverted both to the sidecar's boot values. Silently.
- `config.ResolveAgentClaudeDir` reads `claudeDirs.runOverride`, so scheduled tasks and Telegram triggers would keep authenticating as the previous Claude account.
- `internal/config/profiles.go` resolves the `/api/claude-settings*` surface against the same snapshot.

There is no `AGENTO_SCANNER=off` equivalent to switch the Go half off the way #289 did, and forward-after-write is just the forward — `Ctx` carries only `db_path`, and the freshness probe that knew the sidecar's URL was deleted in #289. So the handler ships written and off.

## Three Go behaviours the handler reproduces that a natural port gets wrong

All captured live, all pinned as literals in the unit tests:

- The PUT response is the stored row **unresolved** — `"default_model":""` stays `""`, and `claude_config_dirs: []` answers `null` while the column stores `[]`.
- Every failure is a **400** carrying the error's own text, in Go's field order (`public_url` beats `claude_config_dir` when both conflict), and a blank incoming value is pinned rather than treated as a clear.
- The rescan uses `force_scan` (= `Cache.EnsureScan`), not `ensure_scan` (= `ensureFresh`) — the config-dir branch has no staleness marker to pass the latter. It is injected as a parameter so the unit tests assert the three trigger rules directly instead of walking the real corpus.

`candidates` distinguishes nil (`null`, `$HOME` unlistable) from empty (`[]`). Its exclusions are pinned against a crafted home because the four that matter do not exist on a real machine: a symlink to a valid candidate (`os.ReadDir`'s `IsDir` does not follow), a `.claude*` dir with no `projects/`, one whose `projects` is a file, and a plain file. `.claude.bak` and `.clauded` *are* candidates when they have `projects/` — Go's own comment claims otherwise and is wrong.

## Changes

| File | Why |
|---|---|
| `desktop/src-tauri/src/native/settings.rs` | the config-dirs read, the unclaimed PUT, unit tests |
| `desktop/src-tauri/src/native/mod.rs` | registry claim assertions; the new route added to both probe lists |
| `desktop/parity/claude_dirs_parity_test.go` + `claude_dirs_vectors.json` | Go emits the discovery rule's answers over a crafted home; both languages assert the same file, so a Go change fails Go's own suite |
| `desktop/src-tauri/tests/parity_settings.rs` | live diff for the config-dirs read, plus a seeding guard so a thin corpus fails rather than diffing the default dir against itself |
| `desktop/CLAUDE.md` | layout entry, the decision record, the settings-path status code |

No production Go source changed.

## Testing

- [x] `make test` passes, including the new `desktop/parity/` vector test
- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`
- [x] Live parity, `AGENTO_PARITY_WORKER=305`, Go built from this checkout on a seeded scratch DB: `settings/claude-config-dirs` byte-identical; the three pre-existing settings tests still identical
- [x] A second Go instance with `HOME` pointed at a crafted candidate-rich home and `CLAUDE_CONFIG_DIR`/`AGENTO_PUBLIC_URL` exported: byte-identical — 4 candidates, 5 exclusions, both locked fields
- [x] Every PUT literal in the unit tests captured from that Go server: full save, partial/`null`-field save, `null` body, array body, malformed body, four validation messages, both locked-field 400s

## Review follow-ups folded in

- **The probe forwards on Windows.** `gopath` is Unix-only by documentation, and the claimed route called it unguarded on a shipped target: `gopath::dir` on a `C:\…` path returns `"."`, so the probe would have listed the process working directory instead of `$HOME`. Guarded the way `fs.rs` already guards its listing.
- `indexed` now resolves through `resolve()` rather than the raw row, so a *relative* `CLAUDE_CONFIG_DIR` drops the stored column the way Go's `applyEnvOverrides` does.
- The `default` field goes through `gopath::join`, which is `filepath.Join` and therefore cleans — a non-clean `HOME` no longer makes `default` and `indexed[0]` disagree.
- The candidate rule is pinned to a Go-generated vector file instead of a hand-transcribed literal.
- Env-swapping tests use an RAII guard, so one failure can no longer leak `AGENTO_PUBLIC_URL` and turn six other tests into vacuous passes.

## Related

Closes #305

---
🤖 Implemented by [Claude Code](https://claude.com/claude-code) via `implement-issue`