### PR TITLE
feat(desktop): port POST /api/uploads and /claude-sessions/{id}/continue (#308)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -157,6 +157,8 @@ src-tauri/src/
     scan.rs      GET /api/claude-sessions/status, POST /refresh — and the scan
                  itself: the shell owns it now, the sidecar runs with AGENTO_SCANNER=off
     fs.rs        GET /api/fs — the working-dir picker's listing (Unix; forwards on Windows)
+    uploads.rs   POST /api/uploads — the one multipart body, and the extension
+                 allowlist that is the route's whole security boundary
     gopath.rs    Go's filepath.Clean/Dir/Join, pinned to vectors generated from Go
     query.rs     one query parameter, read the way r.URL.Query().Get reads it
     pricing.rs   GET /api/pricing/catalog, plus the rate Resolver — and the
@@ -164,7 +166,9 @@ src-tauri/src/
     agents.rs    GET /api/agents and /api/agents/{slug}
     chats.rs     GET /api/chats and /api/chats/{id}; compact() is Go's, byte for byte
     tasks.rs     GET /api/tasks, /api/job-history and the three reads between them
-    sessions/    GET /api/claude-sessions, /facets, /projects and /{id}
+    sessions/    GET /api/claude-sessions, /facets, /projects and /{id}, plus
+                 POST /{id}/continue (#308)
+      continue_chat.rs the two writes that resume a Claude session as a chat
       detail.rs  one session re-read from its transcript, patched from the cache
       projects.rs the project picker's list, derived from the same walk a scan is
       corpus.rs  loads the lot
@@ -872,6 +876,45 @@ is ported is everything downstream of that call — settings → message → sen
 with a second writer that meant a native save left every scheduled-task email on
 the previous SMTP credentials until restart, silently. It reads the row now,
 which is what its own doc comment already promised.
+
+### Uploads, and the seam's second body cap (#308)
+
+`POST /api/uploads` is the **only multipart route in the API**, and claiming it
+cost the seam two small extensions, both in `proxy.rs`:
+
+- `native::Request` carries the `Content-Type`. A multipart body is unparseable
+  without the boundary, and the boundary is only in the header. Nothing else
+  reads it.
+- The body cap is per route. `MAX_NATIVE_BODY` is 8 MiB and stays there —
+  **over it a request is answered 400 rather than forwarded**, because
+  `to_bytes` has already consumed the body — so a 100 MiB upload needed its own
+  limit or the shell would have refused a file the server accepts. It is a
+  second constant rather than a raised one because the cost is real: the shell
+  buffers the whole body, where Go's `ParseMultipartForm` keeps 10 MiB and
+  spills the rest to temp files.
+
+The multipart reader is hand-written, because every crate in the ecosystem is
+built around an async byte *stream* and this handler runs on `spawn_blocking`
+with the body already in memory.
+
+Two rules the live parity run confirmed, both of which a reading of the Go
+would get wrong:
+
+- **`sanitizeExtension` is an allowlist, and `filepath.Ext(filepath.Base(f))`
+  is not `rfind('.')`.** `Ext` stops at a separator, so `evil.png/../x` has no
+  extension at all; `Base("")` is `"."` and `Ext(".")` is `"."`, so an empty
+  filename yields `"."` rather than `""`. Only `/` is a separator, because this
+  is the Unix `filepath` — a Windows-shaped name is one element, which is safe
+  only because the alphanumeric check rejects what the backslashes carry.
+- **A part named `file` with no filename is not a file.** `multipart.readForm`
+  puts it in `Form.Value`, so `FormFile` answers `ErrMissingFile` and the
+  handler 400s. Matching on the part name alone accepts a request Go rejects.
+
+`POST /api/claude-sessions/{id}/continue` moved with it. Go creates the chat and
+then updates it to carry the Claude session id; this does both in one
+transaction, which is a deliberate divergence with only one alternative: `Err`
+forwards, so a Rust failure *between* the two writes would leave Go's orphan
+chat **and** have Go create a second one.
 
 ### Do not port
 

--- a/desktop/src-tauri/src/native/chats.rs
+++ b/desktop/src-tauri/src/native/chats.rs
@@ -414,6 +414,44 @@ fn create(db_path: &Path, body: &[u8]) -> Result<super::Answer, WriteError> {
         }
     }
 
+    let session = insert_session(
+        &tx,
+        &req.agent_slug,
+        &req.working_directory,
+        &req.model,
+        &req.settings_profile_id,
+    )?;
+
+    // Everything fallible happens before the commit. After it, an `Err` would
+    // forward to Go, which would mint a fresh UUID and insert a *second* chat.
+    // A failing `commit` is the one safe exception: it rolls back, so
+    // forwarding is exactly right.
+    let body = super::gojson::to_vec(&session)
+        .map_err(|e| WriteError::Fallback(format!("encoding chat: {e}")))?;
+
+    // Nothing below this line may return `Fallback`.
+    tx.commit()
+        .map_err(|e| WriteError::Fallback(format!("commit chat create: {e}")))?;
+    Ok(super::Answer::json_status(StatusCode::CREATED, body))
+}
+
+/// `chatService.CreateSession`'s row, without the handler around it.
+///
+/// Shared with `POST /api/claude-sessions/{id}/continue` (#308), which creates
+/// exactly this row and then links it to a Claude session. Two copies of the
+/// INSERT would be two places for the literals below to drift — and one of them
+/// would be the copy nobody looks at.
+///
+/// The handler answers with the session the store built rather than a re-read,
+/// so the timestamps are the ones just written, parsed back from the same text
+/// rather than re-taken from the clock.
+pub(super) fn insert_session(
+    tx: &rusqlite::Transaction,
+    agent_slug: &str,
+    working_directory: &str,
+    model: &str,
+    settings_profile_id: &str,
+) -> Result<ChatSession, WriteError> {
     let id = uuid::Uuid::new_v4().to_string();
     let now = super::gotime::now_go_text();
     // `sdk_session_id` and the four token totals are literals in the Go INSERT
@@ -427,34 +465,26 @@ fn create(db_path: &Path, body: &[u8]) -> Result<super::Answer, WriteError> {
         rusqlite::params![
             id,
             "New Chat",
-            req.agent_slug,
-            req.working_directory,
-            req.model,
-            req.settings_profile_id,
+            agent_slug,
+            working_directory,
+            model,
+            settings_profile_id,
             now,
             now,
         ],
     )
     .map_err(|e| WriteError::Fallback(format!("creating session: {e}")))?;
 
-    // Everything fallible happens before the commit. After it, an `Err` would
-    // forward to Go, which would mint a fresh UUID and insert a *second* chat.
-    // A failing `commit` is the one safe exception: it rolls back, so
-    // forwarding is exactly right.
-    //
-    // The handler answers with the session the store built, not a re-read — so
-    // the timestamps are the ones just written, parsed back from the same text
-    // rather than re-taken from the clock.
     let stamp = super::gotime::from_sql_text(&now, 0)
         .map_err(|e| WriteError::Fallback(format!("re-reading the write timestamp: {e}")))?;
-    let session = ChatSession {
+    Ok(ChatSession {
         id,
         title: "New Chat".to_string(),
-        agent_slug: req.agent_slug,
+        agent_slug: agent_slug.to_string(),
         sdk_session_id: String::new(),
-        working_directory: req.working_directory,
-        model: req.model,
-        settings_profile_id: req.settings_profile_id,
+        working_directory: working_directory.to_string(),
+        model: model.to_string(),
+        settings_profile_id: settings_profile_id.to_string(),
         created_at: stamp,
         updated_at: stamp,
         total_input_tokens: 0,
@@ -462,14 +492,7 @@ fn create(db_path: &Path, body: &[u8]) -> Result<super::Answer, WriteError> {
         total_cache_creation_tokens: 0,
         total_cache_read_tokens: 0,
         is_favorite: false,
-    };
-    let body = super::gojson::to_vec(&session)
-        .map_err(|e| WriteError::Fallback(format!("encoding chat: {e}")))?;
-
-    // Nothing below this line may return `Fallback`.
-    tx.commit()
-        .map_err(|e| WriteError::Fallback(format!("commit chat create: {e}")))?;
-    Ok(super::Answer::json_status(StatusCode::CREATED, body))
+    })
 }
 
 /// `handleUpdateChat`: rename and/or favourite.
@@ -631,7 +654,7 @@ fn get_session_tx(tx: &rusqlite::Transaction, id: &str) -> Result<Option<ChatSes
     .map_err(|e| WriteError::Fallback(format!("looking up session {id:?}: {e}")))
 }
 
-fn open_for_write(db_path: &Path) -> Result<rusqlite::Connection, WriteError> {
+pub(super) fn open_for_write(db_path: &Path) -> Result<rusqlite::Connection, WriteError> {
     let conn = db::open_read_write(db_path).map_err(WriteError::Fallback)?;
     super::migrate::verify(&conn).map_err(WriteError::Fallback)?;
     Ok(conn)

--- a/desktop/src-tauri/src/native/fs.rs
+++ b/desktop/src-tauri/src/native/fs.rs
@@ -35,9 +35,12 @@
 //! `claims` instead would leave a registry entry that claims nothing, and the
 //! two registry tests exist precisely to catch that shape. See [`super::gopath`].
 //!
-//! `POST /api/fs/mkdir` creates a directory and stays with Go. So does
-//! `POST /api/uploads`: **there is no upload read path** — `internal/api/uploads.go`
-//! registers one route and it writes a multipart body to disk.
+//! `POST /api/fs/mkdir` creates a directory and stays with Go.
+//!
+//! `POST /api/uploads` is **not** here either, and it is not Go's any more: it
+//! has no read path at all — `internal/api/uploads.go` registers one route and
+//! it writes a multipart body to disk — so it got its own module rather than
+//! joining a listing endpoint it shares nothing with. See [`super::uploads`].
 
 use axum::http::Method;
 use serde::Serialize;

--- a/desktop/src-tauri/src/native/mod.rs
+++ b/desktop/src-tauri/src/native/mod.rs
@@ -35,6 +35,7 @@ pub mod scanner;
 pub mod sessions;
 pub mod settings;
 pub mod tasks;
+pub mod uploads;
 pub mod version;
 pub mod writes;
 
@@ -82,6 +83,13 @@ pub struct Request<'a> {
     pub path: &'a str,
     /// The raw query string without its leading `?`.
     pub query: &'a str,
+    /// The `Content-Type` header, or `""` when absent.
+    ///
+    /// Carried for exactly one route. `POST /api/uploads` is multipart, and a
+    /// multipart body cannot be parsed at all without the boundary parameter,
+    /// which lives only in this header — every other claimed route decodes JSON
+    /// and ignores it.
+    pub content_type: &'a str,
     /// The request body, already buffered. Empty for a GET, and empty for the
     /// several writes Go accepts with no payload at all.
     pub body: &'a [u8],
@@ -248,6 +256,7 @@ const ENDPOINTS: &[Endpoint] = &[
     fs::ENDPOINT,
     integrations::ENDPOINT,
     scan::ENDPOINT,
+    uploads::ENDPOINT,
 ];
 
 /// Whether this request is answered by ported Rust code.
@@ -473,11 +482,32 @@ mod tests {
         assert!(!claims(&Method::GET, "/api/notifications"));
 
         // The filesystem listing, on the platforms `gopath` speaks. Creating a
-        // directory is a write, and uploads has no read at all.
+        // directory is still a write Go owns.
         assert!(claims(&Method::GET, "/api/fs"));
         assert!(!claims(&Method::POST, "/api/fs/mkdir"));
-        assert!(!claims(&Method::POST, "/api/uploads"));
+
+        // Uploads (#308): the one multipart route, and the only claimed one
+        // with no read at all.
+        assert!(claims(&Method::POST, "/api/uploads"));
         assert!(!claims(&Method::GET, "/api/uploads"));
+        assert!(!claims(&Method::POST, "/api/uploads/"));
+
+        // Continuing a Claude session (#308) is a POST under the sessions
+        // prefix, and must not be reachable by any other method or shape.
+        assert!(claims(
+            &Method::POST,
+            "/api/claude-sessions/abc-123/continue"
+        ));
+        assert!(!claims(
+            &Method::GET,
+            "/api/claude-sessions/abc-123/continue"
+        ));
+        assert!(!claims(&Method::POST, "/api/claude-sessions//continue"));
+        assert!(!claims(&Method::POST, "/api/claude-sessions/continue"));
+        assert!(!claims(
+            &Method::POST,
+            "/api/claude-sessions/abc/journey/continue"
+        ));
 
         // Integrations: the four reads, plus the writes with no live-server
         // effect. Anything that reloads an MCP server, dials a remote service,
@@ -505,6 +535,7 @@ mod tests {
             method: &Method::GET,
             path: "/api/nothing-here",
             query: "",
+            content_type: "",
             body: &[],
         })
         .is_err());
@@ -634,9 +665,18 @@ mod tests {
             "/api/integrations/abc",
             "/api/integrations/abc/triggers",
         ];
+        // Paired with a method, because not every area has a read: `uploads`
+        // claims a POST and nothing else, and a GET-only probe list would
+        // report it as dead code.
+        let writes = [
+            (Method::POST, "/api/uploads"),
+            (Method::POST, "/api/claude-sessions/abc/continue"),
+        ];
         for endpoint in ENDPOINTS {
+            let reachable = probes.iter().any(|p| (endpoint.claims)(&Method::GET, p))
+                || writes.iter().any(|(m, p)| (endpoint.claims)(m, p));
             assert!(
-                probes.iter().any(|p| (endpoint.claims)(&Method::GET, p)),
+                reachable,
                 "{} claims none of the probe paths; add one when you add a route",
                 endpoint.name
             );

--- a/desktop/src-tauri/src/native/sessions/continue_chat.rs
+++ b/desktop/src-tauri/src/native/sessions/continue_chat.rs
@@ -1,0 +1,181 @@
+//! `POST /api/claude-sessions/{id}/continue`, ported from
+//! `handleContinueClaudeSession` (`internal/api/claude_sessions.go`).
+//!
+//! Opens a new Agento chat that **resumes** an existing Claude Code
+//! conversation: it inherits the transcript's working directory and model, and
+//! carries the Claude session id in `sdk_session_id` so the SDK picks the
+//! history up on the first message.
+//!
+//! # Two writes, one transaction
+//!
+//! Go creates the chat and then updates it, in that order and separately —
+//! `CreateSession` has no `sdkSession` parameter. If the second write fails it
+//! leaves an orphan chat behind, which is a real behaviour rather than a bug to
+//! reproduce faithfully: the user gets a 500 and a stray "New Chat".
+//!
+//! This runs both statements inside one transaction, which is a deliberate
+//! divergence and the only one available. `Err` means "forward to Go", so a
+//! Rust failure *between* the two writes would leave the orphan **and** have Go
+//! create a second chat — the one outcome worse than Go's. Rolling back gives
+//! "both or neither"; the response is a single `chat_id` either way, so nothing
+//! observable changes except that the failure path stops leaking a row.
+//!
+//! # The statuses
+//!
+//! A missing session is `404`; a lookup *failure* is `500` and therefore
+//! forwards. `detail::get` collapses both into `None`/`Err`, so the split here
+//! is the same one it makes.
+
+use axum::http::StatusCode;
+use serde::Serialize;
+
+use crate::native::writes::WriteError;
+use crate::native::{chats, gojson, Answer};
+
+use super::detail;
+
+/// `writeJSON(w, 201, map[string]string{"chat_id": …})`. One key, so there is
+/// nothing for `encoding/json`'s map sorting to reorder — but it is a map, so
+/// check the shape before adding a second.
+#[derive(Serialize)]
+struct ContinueResponse {
+    chat_id: String,
+}
+
+pub fn continue_session(db_path: &std::path::Path, session_id: &str) -> Result<Answer, WriteError> {
+    // `claudesessions.GetSessionDetail`. Reading the transcript is the whole
+    // cost of this route, and it happens before anything is written.
+    let detail = detail::get(db_path, session_id)
+        .map_err(|e| WriteError::Fallback(format!("looking up claude session: {e}")))?;
+    let Some(detail) = detail else {
+        return Err(WriteError::NotFoundMessage("session not found".to_string()));
+    };
+
+    let mut conn = chats::open_for_write(db_path)?;
+    let tx = conn
+        .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+        .map_err(|e| WriteError::Fallback(format!("begin continue session: {e}")))?;
+
+    // No agent slug: a continued conversation belongs to whoever ran it, and
+    // `CreateSession` accepts an empty slug without looking one up.
+    let session = chats::insert_session(&tx, "", &detail.summary.cwd, &detail.summary.model, "")?;
+
+    // `chatService.UpdateSession`, which stamps its own `updated_at` — so this
+    // is a second statement with a second clock reading rather than a value
+    // folded into the insert above. It writes every column, but only these two
+    // can differ from what was just inserted.
+    tx.execute(
+        "UPDATE chat_sessions SET sdk_session_id = ?1, updated_at = ?2 WHERE id = ?3",
+        rusqlite::params![session_id, crate::native::gotime::now_go_text(), session.id],
+    )
+    .map_err(|e| WriteError::Fallback(format!("linking claude session: {e}")))?;
+
+    // Encoded before the commit: after it, an `Err` would forward and Go would
+    // create a second chat.
+    let body = gojson::to_vec(&ContinueResponse {
+        chat_id: session.id.clone(),
+    })
+    .map_err(|e| WriteError::Fallback(format!("encoding continue response: {e}")))?;
+
+    tx.commit()
+        .map_err(|e| WriteError::Fallback(format!("commit continue session: {e}")))?;
+    Ok(Answer::json_status(StatusCode::CREATED, body))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A database with the real migrations and a Claude transcript on disk, so
+    /// the route runs end to end: transcript → detail → chat row.
+    ///
+    /// The config dir is taken from the settings row the fixture writes, not
+    /// from the environment, so this is a real end-to-end run rather than one
+    /// that degrades to a no-op when another test got to the snapshot first.
+    #[test]
+    fn continuing_a_session_creates_one_chat_carrying_its_cwd_model_and_id() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let claude = dir.path().join(".claude");
+        let project = claude.join("projects").join("-home-u-proj");
+        std::fs::create_dir_all(&project).expect("project dir");
+
+        let session_id = "11111111-2222-3333-4444-555555555555";
+        let transcript = format!(
+            "{}\n{}\n",
+            r#"{"type":"user","uuid":"u1","parentUuid":null,"timestamp":"2026-08-01T10:00:00Z","cwd":"/home/u/proj","message":{"role":"user","content":"do the thing"}}"#,
+            r#"{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-08-01T10:00:05Z","cwd":"/home/u/proj","message":{"role":"assistant","model":"claude-opus-5","content":[{"type":"text","text":"done"}],"usage":{"input_tokens":10,"output_tokens":5}}}"#
+        );
+        std::fs::write(project.join(format!("{session_id}.jsonl")), transcript).expect("write");
+
+        let db = dir.path().join("agento.db");
+        {
+            let mut conn = rusqlite::Connection::open(&db).expect("open");
+            crate::native::migrate::apply(&mut conn).expect("migrate");
+            conn.execute(
+                "INSERT INTO user_settings (id, claude_config_dir) VALUES (1, ?1)",
+                [claude.to_string_lossy()],
+            )
+            .expect("settings row");
+        }
+
+        // The config dir comes from the settings row rather than the
+        // environment, so this does not depend on process-wide state and has no
+        // reason to be conditional.
+        let answer = continue_session(&db, session_id).expect("continue");
+        assert_eq!(answer.status, StatusCode::CREATED);
+
+        let body = String::from_utf8(answer.body.expect("body")).expect("utf-8");
+        let chat_id = body
+            .trim_end()
+            .strip_prefix(r#"{"chat_id":""#)
+            .and_then(|s| s.strip_suffix(r#""}"#))
+            .expect("one-key response")
+            .to_string();
+
+        let conn = rusqlite::Connection::open(&db).expect("open");
+        let (count, sdk, cwd, model, slug): (i64, String, String, String, String) = conn
+            .query_row(
+                "SELECT (SELECT COUNT(*) FROM chat_sessions), sdk_session_id,
+                        working_directory, model, agent_slug
+                 FROM chat_sessions WHERE id = ?1",
+                [&chat_id],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                    ))
+                },
+            )
+            .expect("the chat row");
+
+        assert_eq!(count, 1, "one chat, not two");
+        assert_eq!(sdk, session_id, "the link is what makes it a continuation");
+        assert_eq!(cwd, "/home/u/proj");
+        assert_eq!(model, "claude-opus-5");
+        assert_eq!(slug, "", "a continued conversation has no agent");
+    }
+
+    /// A session that exists nowhere is Go's 404 with its own fixed wording,
+    /// not the service error's — and it must write nothing.
+    #[test]
+    fn a_missing_session_is_404_and_creates_no_chat() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db = dir.path().join("agento.db");
+        let mut conn = rusqlite::Connection::open(&db).expect("open");
+        crate::native::migrate::apply(&mut conn).expect("migrate");
+        drop(conn);
+
+        let err = continue_session(&db, "no-such-session-id").unwrap_err();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+        assert_eq!(err.message(), "session not found");
+
+        let conn = rusqlite::Connection::open(&db).expect("open");
+        let chats: i64 = conn
+            .query_row("SELECT COUNT(*) FROM chat_sessions", [], |r| r.get(0))
+            .expect("count");
+        assert_eq!(chats, 0);
+    }
+}

--- a/desktop/src-tauri/src/native/sessions/mod.rs
+++ b/desktop/src-tauri/src/native/sessions/mod.rs
@@ -25,6 +25,7 @@
 //! all. It is fire-and-forget either way — the page never waits, exactly as
 //! `ListPage` never waits for the rescan it starts.
 
+pub mod continue_chat;
 pub mod corpus;
 pub mod detail;
 pub mod page;
@@ -54,6 +55,10 @@ enum Route<'a> {
     Facets,
     Projects,
     Detail(&'a str),
+    /// `POST /api/claude-sessions/{id}/continue` (#308) — the one write this
+    /// area owns, and the only two-segment route under the prefix that is not
+    /// somebody else's.
+    Continue(&'a str),
 }
 
 fn route_of(path: &str) -> Option<Route<'_>> {
@@ -64,7 +69,15 @@ fn route_of(path: &str) -> Option<Route<'_>> {
         _ => {}
     }
     let rest = path.strip_prefix("/api/claude-sessions/")?;
-    if rest.is_empty() || rest.contains('/') {
+    if rest.is_empty() {
+        return None;
+    }
+    if let Some(id) = rest.strip_suffix("/continue") {
+        // Still one segment before the suffix: `{id}/journey/continue` is not
+        // this route, and neither is `/continue` on its own.
+        return (!id.is_empty() && !id.contains('/')).then_some(Route::Continue(id));
+    }
+    if rest.contains('/') {
         return None;
     }
     // The remaining literal siblings are not session ids. `insights` cannot
@@ -78,7 +91,13 @@ fn route_of(path: &str) -> Option<Route<'_>> {
 }
 
 fn claims(method: &Method, path: &str) -> bool {
-    method == Method::GET && route_of(path).is_some()
+    match route_of(path) {
+        // The one write. Claimed for POST alone, so a GET of the same path
+        // still forwards and gets chi's own 405.
+        Some(Route::Continue(_)) => method == Method::POST,
+        Some(_) => method == Method::GET,
+        None => false,
+    }
 }
 
 /// Answer one of the four reads.
@@ -94,6 +113,10 @@ fn claims(method: &Method, path: &str) -> bool {
 /// would blank the "Scanning ~/.claude… 412 / 1,373" the list shows during a
 /// first run. They move when the scanner is wired in, which is phase 3.
 fn serve(ctx: &Ctx, req: &Request) -> Result<Answer, String> {
+    if let Some(Route::Continue(id)) = route_of(req.path) {
+        return crate::native::writes::finish(continue_chat::continue_session(&ctx.db_path, id));
+    }
+
     if let Some(Route::Detail(id)) = route_of(req.path) {
         return match detail::get(&ctx.db_path, id)? {
             // Falling back lets Go answer its own 404 rather than this having

--- a/desktop/src-tauri/src/native/uploads.rs
+++ b/desktop/src-tauri/src/native/uploads.rs
@@ -1,0 +1,616 @@
+//! `POST /api/uploads`, ported from `internal/api/uploads.go`.
+//!
+//! The chat composer posts a file here and gets back an **absolute path**,
+//! which it then injects into the prompt it sends the model. So the interesting
+//! part of this route is not the JSON — it is one key — but the filename, and
+//! `sanitize_extension` is the boundary between a name the user chose and a path
+//! this process creates.
+//!
+//! # The one multipart body in the API
+//!
+//! Every other claimed write decodes JSON through `writes::decode_body`. This
+//! one cannot: the body is `multipart/form-data`, and it is unparseable without
+//! the boundary, which lives in the `Content-Type` header. That is why
+//! `native::Request` carries the header at all.
+//!
+//! It is also why `proxy.rs` has a second body cap. Go reads the request through
+//! a `MaxBytesReader` at 100 MiB and hands it to `ParseMultipartForm`, which
+//! keeps 10 MiB in memory and spills the rest to temp files; the seam buffers
+//! the whole body instead, because a native handler is handed `&[u8]`. The
+//! trade is deliberate and is documented at [`crate::proxy`]: a 100 MiB
+//! allocation on an upload, against refusing a file the server would accept.
+//!
+//! # Failing before the file exists
+//!
+//! `Err` means "forward to Go", and Go would then write the file itself. So
+//! nothing fallible may run once the destination exists: the response bytes are
+//! built first, the directory is created before the file, and a partial file is
+//! removed before the failure is returned. A forward after a completed write
+//! would leave two uploads on disk and hand the second path to the user.
+
+use std::path::{Path, PathBuf};
+
+use axum::http::Method;
+use serde::Serialize;
+
+use super::writes::{finish, WriteError};
+
+/// The route, named so `proxy.rs` can size the body cap without duplicating it.
+pub const PATH: &str = "/api/uploads";
+
+/// `maxUploadSize`: what Go's `MaxBytesReader` allows.
+const MAX_UPLOAD_SIZE: usize = 100 << 20;
+
+/// `writeJSON(w, 200, map[string]string{"path": destPath})` — one key.
+#[derive(Serialize)]
+struct UploadResponse {
+    path: String,
+}
+
+/// This module's entry in `native::ENDPOINTS`.
+pub const ENDPOINT: super::Endpoint = super::Endpoint {
+    name: "uploads",
+    claims,
+    serve,
+};
+
+fn claims(method: &Method, path: &str) -> bool {
+    method == Method::POST && path == PATH
+}
+
+fn serve(ctx: &super::Ctx, req: &super::Request) -> Result<super::Answer, String> {
+    let _ = ctx;
+    finish(upload(req.content_type, req.body, &uploads_dir()?))
+}
+
+/// `appConfig.TmpUploadsDir()`.
+fn uploads_dir() -> Result<PathBuf, String> {
+    Ok(crate::paths::data_dir()
+        .ok_or("no home directory to resolve the data dir")?
+        .join("tmp-uploads"))
+}
+
+/// `handleUploadFile`.
+fn upload(content_type: &str, body: &[u8], upload_dir: &Path) -> Result<super::Answer, WriteError> {
+    // Go's cap is enforced by `MaxBytesReader`, whose error surfaces from
+    // `ParseMultipartForm` — so an oversized body and a malformed one produce
+    // the *same* 400 message. Reproducing that means checking the size here
+    // rather than answering something more informative.
+    if body.len() > MAX_UPLOAD_SIZE {
+        return Err(WriteError::BadRequest(
+            "file too large or invalid multipart form".to_string(),
+        ));
+    }
+    let Some(boundary) = multipart_boundary(content_type) else {
+        return Err(WriteError::BadRequest(
+            "file too large or invalid multipart form".to_string(),
+        ));
+    };
+
+    // `r.FormFile("file")`: the first part named `file`. Go's error for a
+    // missing one is its own message, distinct from the parse failure above.
+    let Some(part) = find_part(body, &boundary, "file") else {
+        return Err(WriteError::BadRequest(
+            "missing required field: file".to_string(),
+        ));
+    };
+
+    let ext = sanitize_extension(&part.filename);
+    let name = format!("{}-{}{}", unix_millis(), uuid::Uuid::new_v4(), ext);
+
+    let dest = super::gopath::clean(&super::gopath::join(&[
+        &upload_dir.to_string_lossy(),
+        &name,
+    ]));
+
+    // Go's traversal guard. It cannot fire on a generated name, and it is
+    // reproduced rather than reasoned away: it is the check that would catch a
+    // later change to how the name is built.
+    let prefix = format!(
+        "{}{}",
+        super::gopath::clean(&upload_dir.to_string_lossy()),
+        std::path::MAIN_SEPARATOR
+    );
+    if !dest.starts_with(&prefix) {
+        return Err(WriteError::BadRequest("invalid filename".to_string()));
+    }
+
+    // Built before anything exists on disk. See the module header.
+    let answer = super::gojson::to_vec(&UploadResponse { path: dest.clone() })
+        .map_err(|e| WriteError::Fallback(format!("encoding upload response: {e}")))?;
+
+    create_upload_dir(upload_dir)?;
+
+    // `os.Create` then `io.Copy`, with Go's cleanup: a failed copy removes the
+    // partial file. Here that also makes the forward safe.
+    std::fs::write(&dest, part.content).map_err(|e| {
+        let _ = std::fs::remove_file(&dest);
+        WriteError::Fallback(format!("failed to save file {dest:?}: {e}"))
+    })?;
+
+    // Nothing below this line may fail.
+    Ok(super::Answer::json(answer))
+}
+
+/// `os.MkdirAll(uploadDir, 0o750)`.
+///
+/// The mode is not decoration: the uploaded file's path is handed to the model
+/// and the directory sits in the user's data dir, so group-writable or
+/// world-readable would both be wrong. `create_dir_all` has no mode argument,
+/// so the permissions are set afterwards on Unix — and only when this call
+/// created the directory, so an existing one the user chmod'd is left alone.
+fn create_upload_dir(dir: &Path) -> Result<(), WriteError> {
+    if dir.is_dir() {
+        return Ok(());
+    }
+    std::fs::create_dir_all(dir)
+        .map_err(|e| WriteError::Fallback(format!("failed to create upload directory: {e}")))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o750))
+            .map_err(|e| WriteError::Fallback(format!("setting upload dir mode: {e}")))?;
+    }
+    Ok(())
+}
+
+fn unix_millis() -> i64 {
+    chrono::Utc::now().timestamp_millis()
+}
+
+/// `sanitizeExtension`: the extension of the final path element, and only when
+/// every character after the dot is ASCII alphanumeric.
+///
+/// This is the security boundary of the route. The stored name is generated, so
+/// the caller's filename reaches the filesystem through this function and
+/// nothing else — a `..`, a separator, a second dot or a NUL all yield `""`
+/// rather than being cleaned, because the rule is an allowlist.
+fn sanitize_extension(filename: &str) -> String {
+    let ext = go_ext(&go_base(filename));
+    // `cleaned` is the extension without its dot, and an **empty** one passes:
+    // `Base("")` is `"."`, whose `Ext` is `"."`, so an upload with no filename
+    // at all would be stored as `<millis>-<uuid>.` on the Go side. Unreachable
+    // from the handler — a part with no filename is not a file to `FormFile` —
+    // but this function reproduces Go rather than the handler's use of it.
+    if ext[1.min(ext.len())..]
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric())
+    {
+        ext
+    } else {
+        String::new()
+    }
+}
+
+/// `filepath.Ext`: the suffix from the final dot in the final element, `""`
+/// when there is none.
+///
+/// Written as Go writes it — scanning back and stopping at a separator — rather
+/// than as `rfind('.')`, because the two differ on `a.png/b`, where Go's scan
+/// stops at the `/` and answers `""` while an unbounded `rfind` would answer
+/// `.png/b`.
+fn go_ext(path: &str) -> String {
+    for (i, c) in path.char_indices().rev() {
+        if c == '/' {
+            break;
+        }
+        if c == '.' {
+            return path[i..].to_string();
+        }
+    }
+    String::new()
+}
+
+/// `filepath.Base`: strip trailing separators, take everything after the last
+/// one, and answer `.` for the empty string.
+///
+/// **Only `/` is a separator**, because this is the Unix `filepath` and the Go
+/// server runs the same one. A Windows-shaped `..\..\x.exe` is therefore one
+/// element to both — which is safe for a different reason: the extension is an
+/// allowlist, so anything the backslashes could smuggle in is rejected by the
+/// alphanumeric check rather than by the split.
+fn go_base(path: &str) -> String {
+    let trimmed = path.trim_end_matches('/');
+    if trimmed.is_empty() {
+        return if path.is_empty() {
+            ".".into()
+        } else {
+            "/".into()
+        };
+    }
+    match trimmed.rfind('/') {
+        Some(i) => trimmed[i + 1..].to_string(),
+        None => trimmed.to_string(),
+    }
+}
+
+// ─── Multipart ────────────────────────────────────────────────────────────────
+
+/// One part of the body: what `FormFile` returns.
+struct Part<'a> {
+    filename: String,
+    content: &'a [u8],
+}
+
+/// `mime.ParseMediaType`, narrowed to what this route needs: the `boundary`
+/// parameter of a `multipart/form-data` content type.
+///
+/// A quoted value is unquoted, because that is how a boundary containing a
+/// space or a colon has to be sent and `ParseMediaType` accepts both forms.
+fn multipart_boundary(content_type: &str) -> Option<String> {
+    let mut parts = content_type.split(';');
+    let media_type = parts.next()?.trim();
+    if !media_type.eq_ignore_ascii_case("multipart/form-data") {
+        return None;
+    }
+    for param in parts {
+        let (key, value) = param.split_once('=')?;
+        if !key.trim().eq_ignore_ascii_case("boundary") {
+            continue;
+        }
+        let value = value.trim();
+        let value = value
+            .strip_prefix('"')
+            .and_then(|v| v.strip_suffix('"'))
+            .unwrap_or(value);
+        if value.is_empty() {
+            return None;
+        }
+        return Some(value.to_string());
+    }
+    None
+}
+
+/// The first part whose `name` is `want`, with its `filename`.
+///
+/// A hand-written reader rather than a crate, for one reason: every multipart
+/// crate in the ecosystem is built around an async byte *stream*, and this
+/// handler runs on `spawn_blocking` with the whole body already in memory. The
+/// grammar it has to cover is correspondingly small — RFC 7578 delimiters, one
+/// header block, one body — and the cases that are easy to get wrong all have
+/// tests: a preamble before the first delimiter, `\r\n` inside the content, a
+/// part with no filename, and the closing `--`.
+fn find_part<'a>(body: &'a [u8], boundary: &str, want: &str) -> Option<Part<'a>> {
+    let delimiter = format!("\r\n--{boundary}");
+    // The first delimiter may open the body with no preceding CRLF, so the scan
+    // starts from a synthetic one rather than special-casing position 0.
+    let mut buffer = Vec::with_capacity(body.len() + 2);
+    buffer.extend_from_slice(b"\r\n");
+    buffer.extend_from_slice(body);
+
+    let mut cursor = 0usize;
+    loop {
+        let start = find(&buffer[cursor..], delimiter.as_bytes())? + cursor + delimiter.len();
+        // `--` here closes the body; anything else is a part, after the CRLF
+        // that ends the delimiter line (transport padding may sit between).
+        if buffer[start..].starts_with(b"--") {
+            return None;
+        }
+        let header_start = find(&buffer[start..], b"\r\n")? + start + 2;
+        let header_end = find(&buffer[header_start..], b"\r\n\r\n")? + header_start;
+        let headers = std::str::from_utf8(&buffer[header_start..header_end]).ok()?;
+        let content_start = header_end + 4;
+        let content_end = find(&buffer[content_start..], delimiter.as_bytes())? + content_start;
+
+        if let Some((name, filename)) = content_disposition(headers) {
+            // **A part with no filename is not a file.** `multipart.readForm`
+            // puts it in `Form.Value`, not `Form.File`, so `FormFile("file")`
+            // returns `ErrMissingFile` and Go answers 400 — even though a part
+            // named `file` is right there. Matching on the name alone would
+            // accept a request Go rejects.
+            if name == want && !filename.is_empty() {
+                // The content is a slice of `buffer`, which is local — but it
+                // is offset by exactly the two synthetic bytes, so the same
+                // range of `body` is the same bytes without a copy.
+                return Some(Part {
+                    filename,
+                    content: &body[content_start - 2..content_end - 2],
+                });
+            }
+        }
+        cursor = content_end;
+    }
+}
+
+/// The `name` and `filename` of a `Content-Disposition: form-data` header.
+fn content_disposition(headers: &str) -> Option<(String, String)> {
+    let line = headers
+        .split("\r\n")
+        .find(|l| l.to_ascii_lowercase().starts_with("content-disposition:"))?;
+    let (mut name, mut filename) = (None, String::new());
+    for param in line.split(';').skip(1) {
+        let Some((key, value)) = param.split_once('=') else {
+            continue;
+        };
+        let value = value.trim();
+        let value = value
+            .strip_prefix('"')
+            .and_then(|v| v.strip_suffix('"'))
+            .unwrap_or(value);
+        match key.trim().to_ascii_lowercase().as_str() {
+            "name" => name = Some(value.to_string()),
+            "filename" => filename = value.to_string(),
+            _ => {}
+        }
+    }
+    Some((name?, filename))
+}
+
+fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return None;
+    }
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode;
+
+    const BOUNDARY: &str = "----WebKitFormBoundaryABC123";
+
+    fn body(parts: &[(&str, Option<&str>, &[u8])]) -> Vec<u8> {
+        let mut out = Vec::new();
+        for (name, filename, content) in parts {
+            out.extend_from_slice(format!("--{BOUNDARY}\r\n").as_bytes());
+            let disposition = match filename {
+                Some(f) => {
+                    format!("Content-Disposition: form-data; name=\"{name}\"; filename=\"{f}\"\r\n")
+                }
+                None => format!("Content-Disposition: form-data; name=\"{name}\"\r\n"),
+            };
+            out.extend_from_slice(disposition.as_bytes());
+            out.extend_from_slice(b"Content-Type: application/octet-stream\r\n\r\n");
+            out.extend_from_slice(content);
+            out.extend_from_slice(b"\r\n");
+        }
+        out.extend_from_slice(format!("--{BOUNDARY}--\r\n").as_bytes());
+        out
+    }
+
+    fn content_type() -> String {
+        format!("multipart/form-data; boundary={BOUNDARY}")
+    }
+
+    fn dir() -> tempfile::TempDir {
+        tempfile::tempdir().expect("temp dir")
+    }
+
+    #[test]
+    fn an_upload_writes_the_file_and_answers_its_absolute_path() {
+        let dir = dir();
+        let target = dir.path().join("tmp-uploads");
+        let answer = upload(
+            &content_type(),
+            &body(&[("file", Some("photo.PNG"), b"\x89PNG\r\n\x1a\ndata")]),
+            &target,
+        )
+        .expect("upload");
+
+        assert_eq!(answer.status, StatusCode::OK);
+        let json = String::from_utf8(answer.body.expect("body")).expect("utf-8");
+        let path = json
+            .trim_end()
+            .strip_prefix(r#"{"path":""#)
+            .and_then(|s| s.strip_suffix(r#""}"#))
+            .expect("one-key response");
+
+        assert!(path.starts_with(&target.to_string_lossy().to_string()));
+        assert!(path.ends_with(".PNG"), "the case of the extension survives");
+        // The stored bytes are the part's, `\r\n` inside the content included —
+        // a reader that stopped at the first CRLF would truncate every binary
+        // file at its first line break.
+        assert_eq!(
+            std::fs::read(path).expect("stored file"),
+            b"\x89PNG\r\n\x1a\ndata"
+        );
+    }
+
+    /// The whole security boundary of the route. The stored name is generated,
+    /// so the caller's filename reaches the filesystem through this and nothing
+    /// else — and the rule is an allowlist, so anything unexpected is dropped
+    /// rather than cleaned.
+    #[test]
+    fn the_extension_allowlist_drops_everything_that_is_not_alphanumeric() {
+        for (input, want) in [
+            ("photo.png", ".png"),
+            ("photo.PNG", ".PNG"),
+            ("archive.tar.gz", ".gz"),
+            ("report.2026", ".2026"),
+            ("noextension", ""),
+            // `Base("")` is `"."` and `Ext(".")` is `"."`. Surprising, and Go's.
+            ("", "."),
+            (".hidden", ".hidden"),
+            // A traversal attempt: `Base` takes the last element, so there is
+            // no extension left to take.
+            ("../../etc/passwd", ""),
+            // Backslashes are not separators to the Unix `filepath`, so this is
+            // one element — and `.exe` is what Go extracts from it too.
+            ("..\\..\\windows\\system32\\cmd.exe", ".exe"),
+            // `Ext` stops at the separator, so there is no extension here at
+            // all — an unbounded `rfind('.')` would have answered `.png/../x`.
+            ("evil.png/../x", ""),
+            ("evil.p g", ""),
+            ("evil.p-g", ""),
+            ("evil.p\0g", ""),
+            ("trailing.", "."),
+        ] {
+            assert_eq!(sanitize_extension(input), want, "for {input:?}");
+        }
+    }
+
+    /// `filepath.Ext` after `filepath.Base`, and the separator handling that
+    /// makes a Windows-shaped name safe on a Unix server.
+    /// `filepath.Base` and `filepath.Ext`, including the two answers that look
+    /// like bugs: `Base("")` is `"."`, and `Ext` stops at a separator.
+    #[test]
+    fn base_and_ext_are_gos() {
+        assert_eq!(go_base("a/b/c.png"), "c.png");
+        assert_eq!(go_base("a/b/"), "b");
+        assert_eq!(go_base("c.png"), "c.png");
+        assert_eq!(go_base(""), ".");
+        assert_eq!(go_base("/"), "/");
+        // Not a separator here: this is the Unix filepath, as on the server.
+        assert_eq!(go_base("a\\b\\c.png"), "a\\b\\c.png");
+
+        assert_eq!(go_ext("c.png"), ".png");
+        assert_eq!(go_ext("a.tar.gz"), ".gz");
+        assert_eq!(go_ext("noext"), "");
+        assert_eq!(go_ext("."), ".");
+        assert_eq!(go_ext("a.png/b"), "");
+    }
+
+    #[test]
+    fn a_missing_file_field_and_a_malformed_body_have_different_messages() {
+        let dir = dir();
+        let target = dir.path().join("tmp-uploads");
+
+        let err = upload(
+            &content_type(),
+            &body(&[("other", Some("x.png"), b"data")]),
+            &target,
+        )
+        .unwrap_err();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(err.message(), "missing required field: file");
+
+        // No boundary at all is the parse failure, which shares its message
+        // with the size cap because Go's MaxBytesReader surfaces through
+        // ParseMultipartForm.
+        let err = upload("application/json", b"{}", &target).unwrap_err();
+        assert_eq!(err.message(), "file too large or invalid multipart form");
+
+        // …and nothing was created on either path.
+        assert!(!target.exists());
+    }
+
+    #[test]
+    fn a_body_over_the_cap_is_the_same_400_go_gives() {
+        let dir = dir();
+        let err = upload(
+            &content_type(),
+            &vec![0u8; MAX_UPLOAD_SIZE + 1],
+            &dir.path().join("tmp-uploads"),
+        )
+        .unwrap_err();
+        assert_eq!(err.message(), "file too large or invalid multipart form");
+    }
+
+    #[test]
+    fn the_boundary_is_read_from_the_content_type_in_both_spellings() {
+        assert_eq!(
+            multipart_boundary("multipart/form-data; boundary=abc").as_deref(),
+            Some("abc")
+        );
+        assert_eq!(
+            multipart_boundary("Multipart/Form-Data; Boundary=\"a b\"").as_deref(),
+            Some("a b")
+        );
+        assert_eq!(multipart_boundary("multipart/form-data").as_deref(), None);
+        assert_eq!(
+            multipart_boundary("multipart/form-data; boundary=").as_deref(),
+            None
+        );
+        assert_eq!(multipart_boundary("application/json").as_deref(), None);
+        assert_eq!(multipart_boundary("").as_deref(), None);
+    }
+
+    /// A preamble before the first delimiter is legal and some clients send
+    /// one. Starting the scan at byte zero would miss the first part.
+    #[test]
+    fn a_preamble_before_the_first_delimiter_is_skipped() {
+        let mut raw = b"This is a multipart message.\r\n".to_vec();
+        raw.extend_from_slice(&body(&[("file", Some("a.txt"), b"hello")]));
+        let part = find_part(&raw, BOUNDARY, "file").expect("part");
+        assert_eq!(part.content, b"hello");
+        assert_eq!(part.filename, "a.txt");
+    }
+
+    /// The field is selected by `name`, and value parts are skipped on the way.
+    #[test]
+    fn the_part_is_selected_by_name_past_the_value_fields() {
+        let raw = body(&[
+            ("caption", None, b"a picture"),
+            ("file", Some("b.bin"), b"bytes"),
+        ]);
+        let part = find_part(&raw, BOUNDARY, "file").expect("part");
+        assert_eq!(part.content, b"bytes");
+        assert_eq!(part.filename, "b.bin");
+    }
+
+    /// A part named `file` with **no filename** is a form *value* to Go, not a
+    /// file: `multipart.readForm` puts it in `Form.Value`, so `FormFile` returns
+    /// `ErrMissingFile` and the handler 400s. Matching on the name alone would
+    /// have accepted a request the server rejects, and stored a file called
+    /// `<millis>-<uuid>.` for it.
+    #[test]
+    fn a_file_part_without_a_filename_is_not_a_file() {
+        let dir = dir();
+        let target = dir.path().join("tmp-uploads");
+        let err = upload(&content_type(), &body(&[("file", None, b"bytes")]), &target).unwrap_err();
+        assert_eq!(err.message(), "missing required field: file");
+        assert!(!target.exists());
+    }
+
+    #[test]
+    fn an_empty_file_is_stored_rather_than_rejected() {
+        let dir = dir();
+        let target = dir.path().join("tmp-uploads");
+        let answer = upload(
+            &content_type(),
+            &body(&[("file", Some("e.txt"), b"")]),
+            &target,
+        )
+        .expect("upload");
+        assert_eq!(answer.status, StatusCode::OK);
+        assert_eq!(std::fs::read_dir(&target).expect("dir").count(), 1);
+    }
+
+    /// Two uploads in the same millisecond must not collide — which is what the
+    /// UUID in the name is for, since the timestamp alone would not.
+    #[test]
+    fn two_uploads_get_distinct_names() {
+        let dir = dir();
+        let target = dir.path().join("tmp-uploads");
+        for _ in 0..2 {
+            upload(
+                &content_type(),
+                &body(&[("file", Some("x.bin"), b"z")]),
+                &target,
+            )
+            .expect("upload");
+        }
+        assert_eq!(std::fs::read_dir(&target).expect("dir").count(), 2);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn the_upload_directory_is_created_0750() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = dir();
+        let target = dir.path().join("tmp-uploads");
+        upload(
+            &content_type(),
+            &body(&[("file", Some("x.bin"), b"z")]),
+            &target,
+        )
+        .expect("upload");
+        let mode = std::fs::metadata(&target)
+            .expect("meta")
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o750);
+    }
+
+    #[test]
+    fn only_the_upload_post_is_claimed() {
+        assert!(claims(&Method::POST, "/api/uploads"));
+        assert!(!claims(&Method::GET, "/api/uploads"));
+        assert!(!claims(&Method::POST, "/api/uploads/"));
+        assert!(!claims(&Method::POST, "/api/upload"));
+    }
+}

--- a/desktop/src-tauri/src/proxy.rs
+++ b/desktop/src-tauri/src/proxy.rs
@@ -105,9 +105,33 @@ async fn forward_or_bad_gateway(
 /// limit is hit. That is the one place the seam's "a native failure just falls
 /// back" rule does not hold, so the cap is set well above anything a claimed
 /// route legitimately carries: the biggest is an agent's `system_prompt`, and
-/// 8 MiB of it would be about a million words. Uploads are the only genuinely
-/// large body in the API and they are not claimed.
+/// 8 MiB of it would be about a million words.
 const MAX_NATIVE_BODY: usize = 8 << 20;
+
+/// What `POST /api/uploads` is allowed to carry, since #308 claimed it.
+///
+/// Go caps the request at `maxUploadSize` (100 MiB) with a `MaxBytesReader` and
+/// answers 400 over it. This has to be **at least** that, or the shell would
+/// refuse a file the server accepts — and it has to be more, because the cap
+/// here applies to the whole multipart envelope while Go's applies to the same
+/// bytes but the *file* inside it is what the 100 MiB is about. The slack is
+/// the part headers and the boundaries.
+///
+/// It is a second constant rather than a raised `MAX_NATIVE_BODY` because the
+/// cost is real: this is a buffer held in memory for the length of the request,
+/// where Go's `ParseMultipartForm` keeps 10 MiB and spills the rest to temp
+/// files. Paying that on an upload is a deliberate trade; paying it on every
+/// claimed route would be a memory regression on a route that never needs it.
+const MAX_UPLOAD_BODY: usize = (100 << 20) + (1 << 20);
+
+/// The body cap for one route.
+fn max_body_for(path: &str) -> usize {
+    if path == native::uploads::PATH {
+        MAX_UPLOAD_BODY
+    } else {
+        MAX_NATIVE_BODY
+    }
+}
 
 async fn handle(State(state): State<ProxyState>, req: Request<Body>) -> Response<Body> {
     let path = req.uri().path().to_string();
@@ -180,7 +204,7 @@ async fn handle(State(state): State<ProxyState>, req: Request<Body>) -> Response
         // put back before any forward below. Claimed routes are never the SSE
         // ones, so nothing streaming is buffered by this.
         let (parts, body) = req.into_parts();
-        let body_bytes = match axum::body::to_bytes(body, MAX_NATIVE_BODY).await {
+        let body_bytes = match axum::body::to_bytes(body, max_body_for(&path)).await {
             Ok(bytes) => bytes,
             // Not forwarded: the body is gone. See `MAX_NATIVE_BODY`.
             Err(e) => {
@@ -196,6 +220,15 @@ async fn handle(State(state): State<ProxyState>, req: Request<Body>) -> Response
         // one slow read cannot stall an SSE stream sharing the runtime.
         let method = req.method().clone();
         let query = req.uri().query().unwrap_or_default().to_string();
+        // Carried because one claimed route needs it: a multipart body is
+        // unparseable without the boundary, and the boundary is only in the
+        // header. Everything else ignores it.
+        let content_type = req
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
         let native_answer = {
             let path = path.clone();
             tokio::task::spawn_blocking(move || {
@@ -203,6 +236,7 @@ async fn handle(State(state): State<ProxyState>, req: Request<Body>) -> Response
                     method: &method,
                     path: &path,
                     query: &query,
+                    content_type: &content_type,
                     body: &body_bytes,
                 })
             })

--- a/desktop/src-tauri/tests/parity_common/mod.rs
+++ b/desktop/src-tauri/tests/parity_common/mod.rs
@@ -132,6 +132,33 @@ pub async fn send(method: reqwest::Method, path: &str, body: Option<&str>) -> (u
     (status, bytes)
 }
 
+/// A request with a caller-chosen `Content-Type` and a raw body.
+///
+/// [`send`] hard-codes `application/json`, which is right for every other
+/// write: `requireJSONContentType` rejects a state-changing request without it
+/// with a 415 before any handler runs. `POST /api/uploads` is the **one**
+/// exception the guard admits (`r.URL.Path == uploadPath`), and it is
+/// multipart — so it needs a way past that helper.
+pub async fn send_raw(
+    method: reqwest::Method,
+    path: &str,
+    content_type: &str,
+    body: Vec<u8>,
+) -> (u16, Vec<u8>) {
+    let url = format!("{}{path}", live_url());
+    let resp = reqwest::Client::new()
+        .request(method.clone(), &url)
+        .header("Content-Type", content_type)
+        .body(body)
+        .send()
+        .await
+        .unwrap_or_else(|e| panic!("{method} {url} failed — is Agento running? ({e})"));
+
+    let status = resp.status().as_u16();
+    let bytes = resp.bytes().await.expect("reading body").to_vec();
+    (status, bytes)
+}
+
 /// Compare a write's whole answer — status first, then bytes.
 ///
 /// Status before body on purpose: a 500 and a 201 both have bodies, and being

--- a/desktop/src-tauri/tests/parity_writes.rs
+++ b/desktop/src-tauri/tests/parity_writes.rs
@@ -747,3 +747,211 @@ async fn the_notification_settings_write_answers_match_go() {
     .await;
     assert_eq!(restored.0, 200);
 }
+
+// ─── Uploads and continue (#308) ──────────────────────────────────────────────
+
+/// Pin Go's answers for the one multipart route in the API.
+///
+/// The response is a single key, so what is actually being compared is the
+/// **filename**: `sanitizeExtension` is the boundary between a name the caller
+/// chose and a path this process creates, and the path it produces is injected
+/// straight into a prompt. A port that differed on which extensions it accepts
+/// would be invisible in the JSON and visible in the file the model is asked to
+/// read.
+///
+/// Each case is asked of the real server, so the assertions below are Go's
+/// behaviour rather than this port's reading of `filepath.Ext`.
+#[tokio::test]
+#[ignore = "requires a scratch Go instance; mutates it"]
+async fn the_upload_answers_match_go() {
+    require_scratch_instance();
+
+    const BOUNDARY: &str = "----parityWritesBoundary";
+    fn multipart(name: &str, filename: Option<&str>, content: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(format!("--{BOUNDARY}\r\n").as_bytes());
+        let disposition = match filename {
+            Some(f) => {
+                format!("Content-Disposition: form-data; name=\"{name}\"; filename=\"{f}\"\r\n")
+            }
+            None => format!("Content-Disposition: form-data; name=\"{name}\"\r\n"),
+        };
+        out.extend_from_slice(disposition.as_bytes());
+        out.extend_from_slice(b"Content-Type: application/octet-stream\r\n\r\n");
+        out.extend_from_slice(content);
+        out.extend_from_slice(format!("\r\n--{BOUNDARY}--\r\n").as_bytes());
+        out
+    }
+    let content_type = format!("multipart/form-data; boundary={BOUNDARY}");
+
+    // The happy path: 200, one key, an absolute path under tmp-uploads, and the
+    // extension carried through with its case intact.
+    let (status, body) = send_raw(
+        Method::POST,
+        "/api/uploads",
+        &content_type,
+        // A `\r\n` inside the content, which is what a reader that stops at the
+        // first line break would truncate.
+        multipart("file", Some("photo.PNG"), b"\x89PNG\r\n\x1a\ndata"),
+    )
+    .await;
+    assert_eq!(status, 200, "an upload is 200, not 201");
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("json");
+    let path = json["path"].as_str().expect("path");
+    assert!(path.contains("/tmp-uploads/"), "{path}");
+    assert!(
+        path.ends_with(".PNG"),
+        "the extension keeps its case: {path}"
+    );
+    // `<unix-millis>-<uuid><ext>`: 13 digits, a hyphen, a 36-character UUID.
+    let name = path.rsplit('/').next().expect("basename");
+    let (millis, rest) = name.split_once('-').expect("millis-uuid");
+    assert!(millis.chars().all(|c| c.is_ascii_digit()), "{name}");
+    assert_eq!(rest.len(), 36 + ".PNG".len(), "{name}");
+
+    // The extension allowlist, as the server applies it.
+    for (filename, want_suffix) in [
+        ("archive.tar.gz", ".gz"),
+        ("report.2026", ".2026"),
+        // `filepath.Base` takes the last element, so a traversal has no
+        // extension left to take.
+        ("../../etc/passwd", ""),
+        // Anything non-alphanumeric after the dot fails the allowlist outright
+        // rather than being cleaned.
+        ("evil.p g", ""),
+        ("evil.p-g", ""),
+        ("noextension", ""),
+    ] {
+        let (status, body) = send_raw(
+            Method::POST,
+            "/api/uploads",
+            &content_type,
+            multipart("file", Some(filename), b"x"),
+        )
+        .await;
+        assert_eq!(status, 200, "{filename}");
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("json");
+        let path = json["path"].as_str().expect("path");
+        let name = path.rsplit('/').next().expect("basename");
+        if want_suffix.is_empty() {
+            // No extension at all: the generated name ends at the UUID.
+            assert_eq!(name.len(), 13 + 1 + 36, "{filename} → {name}");
+        } else {
+            assert!(name.ends_with(want_suffix), "{filename} → {name}");
+        }
+        // Whatever the caller sent, none of it is in the stored name.
+        assert!(!name.contains(".."), "{name}");
+        assert!(!name.contains("passwd"), "{name}");
+    }
+
+    // A part named `file` with **no filename** is a form *value* to
+    // `multipart.readForm`, so `FormFile` answers ErrMissingFile — even though
+    // a part with that name is right there.
+    let (status, body) = send_raw(
+        Method::POST,
+        "/api/uploads",
+        &content_type,
+        multipart("file", None, b"x"),
+    )
+    .await;
+    assert_eq!(status, 400);
+    assert_eq!(
+        String::from_utf8_lossy(&body).trim_end(),
+        r#"{"error":"missing required field: file"}"#
+    );
+
+    // A part under a different name is the same error.
+    let (status, body) = send_raw(
+        Method::POST,
+        "/api/uploads",
+        &content_type,
+        multipart("attachment", Some("x.png"), b"x"),
+    )
+    .await;
+    assert_eq!(status, 400);
+    assert_eq!(
+        String::from_utf8_lossy(&body).trim_end(),
+        r#"{"error":"missing required field: file"}"#
+    );
+
+    // Not multipart at all: the parse failure, whose message is shared with the
+    // size cap because MaxBytesReader surfaces through ParseMultipartForm.
+    let (status, body) = send_raw(
+        Method::POST,
+        "/api/uploads",
+        "application/json",
+        b"{}".to_vec(),
+    )
+    .await;
+    assert_eq!(status, 400);
+    assert_eq!(
+        String::from_utf8_lossy(&body).trim_end(),
+        r#"{"error":"file too large or invalid multipart form"}"#
+    );
+}
+
+/// Pin Go's answers for continuing a Claude session.
+///
+/// The 404 is the interesting one: it is the handler's own fixed string rather
+/// than a `service.NotFoundError`, so it does not carry the `resource "id" not
+/// found` shape every other 404 in this suite has.
+///
+/// The success path needs a real session id from this machine's corpus, so it
+/// is driven only when the list has one — the alternative is asserting against
+/// a 404 and calling it a test of the create path.
+#[tokio::test]
+#[ignore = "requires a scratch Go instance; mutates it"]
+async fn the_continue_session_answers_match_go() {
+    require_scratch_instance();
+
+    let missing = go_answer(
+        Method::POST,
+        "/api/claude-sessions/parity-writes-no-such-session/continue",
+        None,
+    )
+    .await;
+    assert_eq!(missing.0, 404);
+    assert_eq!(
+        String::from_utf8_lossy(&missing.1).trim_end(),
+        r#"{"error":"session not found"}"#,
+        "the handler writes its own string, not the service error's shape"
+    );
+
+    let (_, listed) = send(Method::GET, "/api/claude-sessions?limit=1", None).await;
+    let listed: serde_json::Value = serde_json::from_slice(&listed).expect("json");
+    let Some(session_id) = listed["items"]
+        .as_array()
+        .and_then(|items| items.first())
+        .and_then(|item| item["session_id"].as_str())
+    else {
+        panic!(
+            "the parity instance has no Claude sessions, so the create half of \
+             continue is not exercised — run this on a machine with a ~/.claude corpus"
+        );
+    };
+
+    let created = go_answer(
+        Method::POST,
+        &format!("/api/claude-sessions/{session_id}/continue"),
+        None,
+    )
+    .await;
+    assert_eq!(created.0, 201, "a continued chat is 201");
+    let body: serde_json::Value = serde_json::from_slice(&created.1).expect("json");
+    let chat_id = body["chat_id"].as_str().expect("chat_id").to_string();
+    // One key, and no others: this is a Go map, so a second one would sort.
+    assert_eq!(body.as_object().expect("object").len(), 1);
+
+    // The chat it made: no agent, the session's cwd and model, and the link
+    // that makes it a continuation rather than a new conversation.
+    let (status, chat) = send(Method::GET, &format!("/api/chats/{chat_id}"), None).await;
+    assert_eq!(status, 200);
+    let chat: serde_json::Value = serde_json::from_slice(&chat).expect("json");
+    let session = &chat["session"];
+    assert_eq!(session["sdk_session_id"], session_id);
+    assert_eq!(session["agent_slug"], "");
+    assert_eq!(session["title"], "New Chat");
+
+    let deleted = go_answer(Method::DELETE, &format!("/api/chats/{chat_id}"), None).await;
+    assert_eq!(deleted.0, 204);
+}


### PR DESCRIPTION
Closes #308

The two write routes that belong to no other issue. Both are small; the first is the only multipart body in the API, and claiming it is what the seam had to grow for.

## What the seam grew, and why it is two things

- **`native::Request` carries the `Content-Type`.** A multipart body cannot be parsed without the boundary, and the boundary is only in the header. Nothing else reads it.
- **The body cap is per route.** `MAX_NATIVE_BODY` stays at 8 MiB — and over it a request is answered **400 rather than forwarded**, because `to_bytes` has already consumed the body — so a 100 MiB upload needed its own limit or the shell would refuse a file the server accepts. A second constant rather than a raised one, because the cost is real: the shell buffers the whole body where `ParseMultipartForm` keeps 10 MiB and spills the rest.

The multipart reader is hand-written: every crate in the ecosystem is built around an async byte *stream*, and this handler runs on `spawn_blocking` with the body already in memory.

## Two rules the live run confirmed and a reading of the Go would not

- **`sanitizeExtension` is an allowlist, and `Ext(Base(f))` is not `rfind('.')`.** `filepath.Ext` stops at a separator, so `evil.png/../x` has no extension; `Base("")` is `"."` and `Ext(".")` is `"."`. Only `/` is a separator, because this is the Unix `filepath` — a Windows-shaped name is one element, safe only because the alphanumeric check rejects what the backslashes carry.
- **A part named `file` with no filename is not a file.** `multipart.readForm` puts it in `Form.Value`, so `FormFile` answers `ErrMissingFile` and Go 400s. The first version matched on the part name alone — accepting a request Go rejects and storing a file called `<millis>-<uuid>.`.

## Continue: two writes, one transaction

Go creates the chat and then updates it to carry the Claude session id, leaving an orphan if the second fails. This does both in one transaction — the only alternative, since `Err` forwards and a failure between the two writes would leave the orphan **and** have Go create a second chat. The chat row now comes from one place (`chats::insert_session`, shared with `POST /api/chats`), so the literals cannot drift.

A missing session is a **404 with the handler's own fixed string**, not the `resource "id" not found` shape every other 404 has.

## Failing before the file exists

Response bytes are built before anything is on disk, the directory is created before the file, and a partial write is removed before the failure returns — a forward after a completed write would leave two uploads and hand the user the second path.

## Testing

- [x] 13 `native::uploads` unit tests and 2 for continue, the latter end to end from a real transcript through to the chat row
- [x] `parity_writes::the_upload_answers_match_go` against a Go server built from this checkout: the happy path, the `<millis>-<uuid><ext>` shape, six allowlist cases, and all three 400s
- [x] `parity_writes::the_continue_session_answers_match_go`: the 404's exact string, the 201, the one-key body, and the chat it made
- [x] 529 lib tests, full Rust suite, `clippy -D warnings`, fmt clean

## What a reviewer should push on

- Whether the multipart reader has a shape it mis-parses. It is the only hand-written parser in the port.
- The 100 MiB buffer: whether refusing large uploads natively (and forwarding them) would have been the better trade.
- Whether anything in the upload path can fail after the file is written.