### PR TITLE
feat(desktop): port the Claude settings and settings-profile surface

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -146,6 +146,10 @@ src-tauri/src/
                  probe; Unix, forwards on Windows); the preferences + config dirs
                  a read is scoped to; and `update`, the PUT — written and tested,
                  deliberately unclaimed
+    claude_settings/ Claude Code's own settings.json and the profiles beside it (#304) —
+      mod.rs     the run config dir, Go's `any`/`MarshalIndent`/`Indent`, GET+PUT
+                 /api/claude-settings, and the request decoder that is NOT writes::decode_body
+      profiles.rs the seven profile routes and the settings_profiles.json index
     monitoring.rs GET /api/monitoring — monitoring.json and the OTEL_* locks, no exporters
     version.rs   GET /api/version and /version/update-check (dev builds only)
     notifications/ the settings read (password masked), /log, the settings
@@ -1106,6 +1110,85 @@ candidate (`os.ReadDir`'s `IsDir` does not follow), a `.claude*` dir with no
 `projects`, one whose `projects` is a file, and a plain file — do not exist on a
 real machine. `.claude.bak` and `.clauded` *are* candidates when they have a
 `projects` dir: the prefix is literal and the `projects` check is the only filter.
+
+### The Claude settings surface, where the state is files (#304)
+
+All nine routes — `GET`/`PUT /api/claude-settings` and the six profile ones —
+moved at once. **The reads could not be left behind, because one of them is a
+write**: `GET /api/claude-settings/profiles` runs `ensureDefaultProfileExists`,
+which seeds `settings_default.json` from the current `settings.json` and writes
+the index. `POST` and `PUT .../{id}/default` do the same; the per-profile
+`GET`/`PUT`/`DELETE` and `duplicate` deliberately do not, which is why a `GET` on
+an unknown id is a 404 rather than a list that has just been created.
+
+**The cache the issue warned about does not exist.** `ClaudeSettingsProfileService`
+holds one field — a logger — and every method calls
+`config.LoadProfilesMetadata`, an `os.ReadFile` per call; `appendSettingsOpts`
+re-reads it at the moment a run starts. Rather than argue that from the source,
+`a_native_write_is_visible_to_the_go_server_immediately` writes the index
+underneath a *running* Go server with this port's own encoder and then asks that
+server — so the claim is reproduced, not reasoned about. (#305 reached the
+opposite conclusion for `PUT /api/settings`, which really does re-apply
+process-wide snapshots and trigger a rescan. Different question, different
+answer — "does Go cache this?" has to be asked per surface.)
+
+Three things here are silent when wrong:
+
+- **The dir is the run default**, `config.ResolveAgentClaudeDir(nil)` —
+  `CLAUDE_CONFIG_DIR`, else the stored global setting, else `~/.claude` —
+  resolved from the settings row the way `native/settings.rs` resolves
+  everything else, and applied once at the seam so each handler takes a dir.
+  `PUT /api/claude-settings` writes the `settings.json` that `--settings`
+  resolves against on every run (#242); the wrong dir is not an error, it is a
+  run that quietly gets no settings.
+- **A named profile keeps the absolute path recorded in the index.** Only the
+  unnamed fallback follows the dir. Rebuilding `settings_<id>.json` from the id
+  would read a different file — possibly one that exists, with different
+  contents — so `detail` uses `file_path` verbatim.
+- **Three Go encodings meet, and they are not the same one.** On the wire a
+  `json.RawMessage` goes through `compact`: whitespace stripped, `<>&` escaped,
+  **key order and number spelling preserved**. On disk everything goes through
+  `json.MarshalIndent` over Go's `any`: keys *sorted*, every number a float64,
+  two-space indent, `": "` after each key, no trailing newline
+  (`gojson::indent`, which is `Indent` — `MarshalIndent` is literally `Marshal`
+  then `Indent`, so it decomposes rather than needing a second `Formatter`). And
+  a profile created by `POST .../profiles` is neither: it is a **verbatim** byte
+  copy of the current default's file.
+
+**`writes::decode_body` is wrong for this area, twice.** It shape-checks through
+a `serde_json::Value`, whose parser rejects a number outside float64's range —
+which would turn `{"settings":{"n":1e999}}` from Go's **422** into a 400, losing
+the one reachable `ValidationError` here — and it requires end of input, while a
+`json.Decoder` reads a *stream* and ignores whatever follows the first value.
+`claude_settings::decode_request` checks the first token instead: `{` decodes,
+`null` is Go's documented no-op zero value, anything else is the type error the
+handler turns into its 400. Duplicate keys still forward, for the reason
+`decode_body` documents.
+
+Statuses to get right, all verified against a live Go server rather than read off
+the service: the **create** handler folds every decode failure and an empty name
+into one `400 name is required` (its own check runs before the service, so the
+service's 422 is unreachable, and `["x"]` is *not* `invalid JSON body`); the
+**update** handler does use `invalid JSON body`; deleting the default profile is
+a `409` whose message says *"already exists"*, because it raises a
+`ConflictError`; and a rename onto another profile's slug is a 409 while
+**create** with the same name silently deduplicates to `-2`.
+
+What forwards rather than being guessed at, each before any mutation: a
+**non-ASCII profile name** (Go slugifies by Unicode category and then rejects the
+id it built, unless every character happened to be dropped — two answers from
+tables Rust's `char::is_alphabetic` does not match); a **relative** recorded path
+(`filepath.Abs` resolves it against the Go server's working directory, not ours);
+a document deeper than serde's 128-level recursion limit but inside Go's 10000
+(`json.Valid` is fine — `IgnoredAny` skips iteratively, and the 10000 cap is
+checked by hand — but a `Value` decode is not); and everything Go answers with a
+500.
+
+`tests/parity_claude_settings.rs` **refuses to run without `CLAUDE_CONFIG_DIR`**
+pointing somewhere other than `~/.claude`. `parity-instance.sh` copies the
+database and does nothing for the Claude config dir, and this suite overwrites
+`settings.json`. Exporting it before `start` is also what puts both
+implementations in one directory — a diff across two would mean nothing.
 
 ### Do not port
 

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -275,6 +275,14 @@ is logged and forwarded to Go rather than turned into a 500 — a ported route
 can only ever be as broken as an unported one. That is what makes flipping a
 route safe: the worst case is the behaviour the app had before.
 
+**The one place that property does not hold today is the guards** (#329): a
+natively-served request never reaches `internal/server/guards.go`, so neither
+`validateHost` nor `requireJSONContentType` applies to any ported route, and the
+guards' coverage shrinks with every endpoint the port claims. It has been true
+since #274 and it belongs with the proxy rather than with any one area, so it is
+tracked separately — but it is worth knowing while porting, because the surfaces
+being claimed now include `~/.claude/settings.json` and its `hooks` key.
+
 Because both implementations run at once, a ported route is verifiable:
 replay the same request against Rust and against Go and diff the JSON.
 **Byte-identical JSON is the bar** — the frontend is shared, so any
@@ -1113,8 +1121,8 @@ real machine. `.claude.bak` and `.clauded` *are* candidates when they have a
 
 ### The Claude settings surface, where the state is files (#304)
 
-All nine routes — `GET`/`PUT /api/claude-settings` and the six profile ones —
-moved at once. **The reads could not be left behind, because one of them is a
+All nine routes — `GET`/`PUT /api/claude-settings` and the seven profile ones
+(list, create, get, update, delete, duplicate, set-default) — moved at once. **The reads could not be left behind, because one of them is a
 write**: `GET /api/claude-settings/profiles` runs `ensureDefaultProfileExists`,
 which seeds `settings_default.json` from the current `settings.json` and writes
 the index. `POST` and `PUT .../{id}/default` do the same; the per-profile
@@ -1174,15 +1182,95 @@ a `409` whose message says *"already exists"*, because it raises a
 `ConflictError`; and a rename onto another profile's slug is a 409 while
 **create** with the same name silently deduplicates to `-2`.
 
-What forwards rather than being guessed at, each before any mutation: a
-**non-ASCII profile name** (Go slugifies by Unicode category and then rejects the
-id it built, unless every character happened to be dropped — two answers from
-tables Rust's `char::is_alphabetic` does not match); a **relative** recorded path
+What forwards rather than being guessed at: a **non-ASCII profile name** (Go
+slugifies by Unicode category and then rejects the id it built, unless every
+character happened to be dropped — two answers from tables Rust's
+`char::is_alphabetic` does not match); a **relative** recorded path
 (`filepath.Abs` resolves it against the Go server's working directory, not ours);
 a document deeper than serde's 128-level recursion limit but inside Go's 10000
 (`json.Valid` is fine — `IgnoredAny` skips iteratively, and the 10000 cap is
-checked by hand — but a `Value` decode is not); and everything Go answers with a
-500.
+checked by hand — but a `Value` decode is not); **bytes that are not UTF-8** (see
+below); and everything Go answers with a 500.
+
+**Why a forward is safe here is not "it happens before any mutation" — several
+do not.** `create` runs `ensureDefaultProfileExists`, which writes the index,
+*before* `slugify` reaches the non-ASCII forward; `put_settings` runs `MkdirAll`
+before its undecidable-value forward; `update`, `delete`, `duplicate` and
+`set_default` can forward after a profile file has already moved. What makes all
+of them safe is that **every step this surface takes before a forward is
+idempotent**: seeding no-ops on a non-empty index, `MkdirAll` no-ops on an
+existing dir, `deduplicateID` re-derives the same id from the same index,
+`moveProfileFile`'s "no file to move" branch tolerates Rust having already moved
+it, and every write is a whole-file truncate rather than an append or an
+increment. Go re-runs the whole handler and lands on the same state.
+
+That argument is load-bearing, and it is narrower than it looks: **a
+non-idempotent step added to this surface breaks the forward, not just itself.**
+An append to the index, a counter, a "create only if absent" check with an
+error, or a rename that does not tolerate its own output would each make a
+forward that follows it a double-apply. The one place the ordering was actually
+wrong is `update`, which reached `validatePathWithinDir` only in the closing
+`buildProfileDetail` — after the rename had moved the file and the index had been
+saved under the new id, so Go looked up the URL's old id and answered 404 where
+Go alone would have answered 500. That check is now hoisted to just after the
+lookup; the others validate up front already.
+
+**Go's JSON layer is not UTF-8-strict and serde's is.** For `{"a":"x\xffy"}`,
+`json.Valid` is true, `Unmarshal` into `any` succeeds with U+FFFD substituted,
+`MarshalIndent` writes the replacement character, and the encoder passes a
+`json.RawMessage` through byte for byte — all verified against the toolchain.
+serde_json splits: `ignore_str` does not validate (so `go_json_valid` agrees)
+but `parse_str` does, so every parse that materializes the string fails. Left
+unguarded that produced five *wrong answers* rather than five forwards — a 400
+where Go writes the file and answers 200, a `settings` key silently dropped from
+a 200, and a seeded `settings_default.json` that every later `create` byte-copies.
+`claude_settings::is_utf8` is the guard, applied at `decode_stream_head`,
+`go_any`, `decode_request` and the two file reads, and all of them forward.
+Reproducing Go's answer would mean reproducing where `encoding/json` puts the
+replacement character, which is a guess.
+
+**`json.Decoder.Decode` enforces the scanner's `maxNestingDepth` too**, not just
+`json.Valid`. A 10001-deep body errors `exceeded max depth` — including when the
+depth sits inside a field the struct ignores, which is where it bites: serde
+routes an unknown field to `IgnoredAny`, whose skip is iterative and counts
+nothing, so `{"name":"x","junk":[×10001]}` decoded here with `name == "x"` and
+answered **201** for a request Go refuses with `400 name is required`. The cap is
+checked on the body in `decode_request` and `decode_stream_head`.
+
+**A `json.Decoder` and `json.Unmarshal` are different readers, and this surface
+uses both.** `PUT /api/claude-settings` decodes a stream and then unmarshals
+*what the decode captured*, so `{"a":1} 1e999` is a 200 — `decode_stream_head`
+returns the first value's bytes for exactly that reason, and a port that
+re-scanned the whole body answered `400 invalid JSON settings`.
+`ensureDefaultProfileExists` is the other way round: it calls `json.Unmarshal` on
+a whole file, which rejects trailing content, so `{"a":1} junk` seeds `{}` there.
+Same bytes, two answers, and the seeding one propagates into every profile
+created afterwards.
+
+**The gap #276 left is closed with it.** `native/chat/runner.rs`'s
+`settings_file_in` used to return `None` for every non-empty `profile_id`,
+because resolving a named profile meant reading `settings_profiles.json` and
+that belonged with the profile CRUD. It has landed — `profiles::load` **is**
+`config.LoadProfilesMetadata` — so the runner now implements
+`LoadProfileFilePathIn` properly: a named id resolves to the path the index
+records, an unknown id falls back to the default profile's path, and only then
+to `<config dir>/settings.json`. Until then a chat or task pinned to a named
+settings profile ran with **no `--settings` at all** in the desktop app while
+the Go server passed the recorded path — the same class of silent wrong-account
+run #242 existed for. One asymmetry is deliberate and reproduced: Go reads the
+index with `LoadProfilesMetadata()`, which resolves the **run default** dir and
+not the `dir` argument, so an agent with its own `claude_config_dir` resolves its
+named profile against the global index while its *fallback* follows its own dir.
+
+**`GET .../profiles`'s shadow-mode diff proves nothing about seeding.** The proxy
+runs Rust first, so Go reads the index Rust just wrote: the two answers agree
+because the second call had nothing left to do, not because both would have
+seeded the same thing from an empty dir. A wrong `settings_default.json` diffs
+clean. It is deliberately *not* in `native::diff_exempt` — that list is for
+routes that cannot agree by construction, and these do agree; the agreement is
+merely uninformative. The unit tests and the file comparison in the parity suite
+are what actually pin seeding. Note too that shadow mode writes into whatever
+Claude config dir the developer is running with.
 
 `tests/parity_claude_settings.rs` **refuses to run without `CLAUDE_CONFIG_DIR`**
 pointing somewhere other than `~/.claude`. `parity-instance.sh` copies the
@@ -1506,3 +1594,15 @@ Use the isolated dev instance for write testing.
   (`decoded_path`) and `/claude-sessions` (`project_path`).
 - `/claude-sessions/projects` returns `decoded_path` identical to
   `encoded_name`, so the decode never actually happens for the picker.
+- The Claude settings surface writes with `os.WriteFile`, which truncates: a
+  crash between the truncate and the write leaves an empty
+  `settings_profiles.json`, orphaning every profile. A temp file plus `rename`
+  is byte-identical in final content and unobservable through the API. Not done
+  in the port alone, because then the desktop app and `agento web` would survive
+  a power cut differently.
+- `writeProfileSettings` and `moveProfileFile` are the only two places that touch
+  a recorded `file_path` without `validatePathWithinDir`, while `buildProfileDetail`,
+  `DeleteProfile`, `DuplicateProfile` and `SetDefaultProfile` all check. A
+  hand-edited index can therefore have an update write outside the settings dir.
+  The port reproduces this deliberately (adding the check would refuse a write Go
+  performs) and says so at both sites.

--- a/desktop/src-tauri/src/native/chat/runner.rs
+++ b/desktop/src-tauri/src/native/chat/runner.rs
@@ -236,24 +236,74 @@ fn stored_config_dir() -> String {
     crate::native::settings::load_stored(&conn).claude_config_dir
 }
 
-/// `LoadProfileFilePathIn`, reduced to the case this port supports: the unnamed
-/// fallback, `<config dir>/settings.json`.
+/// `config.LoadProfileFilePathIn` plus the caller's `os.Stat`: the settings file
+/// a run names with `--settings`, or `None` when there is none to name.
 ///
-/// A **named** profile records its own absolute path in
-/// `settings_profiles.json`, and reading that file is the settings-profile
-/// service's job rather than this one's — so a chat pinned to a named profile
-/// returns `None` here and simply gets no `--settings`, which is what Go does
-/// when the recorded path does not exist. Porting the profile lookup belongs
-/// with the profile CRUD.
+/// The two halves are separate rules and both matter (#242):
+///
+/// - **Which path.** An empty profile id is the unnamed fallback,
+///   `<config dir>/settings.json`, which follows the dir the run targets. A
+///   named profile keeps the **absolute path recorded in the index** — a
+///   profile is a file the user created and pointed at, so it is not rebuilt
+///   from the id. An id that matches nothing falls back to the *default*
+///   profile's path, and only then to `<config dir>/settings.json`.
+/// - **Whether to name it.** `--settings` on a missing path is an error rather
+///   than a no-op, so a path that is not a file is `None`.
+///
+/// Until this landed the runner returned `None` for every non-empty profile id,
+/// so a chat or task pinned to a named profile ran with **no `--settings` at
+/// all** while the Go server passed the recorded path — the same class of silent
+/// wrong-account failure #242 existed for.
 fn settings_file_in(config_dir: &str, profile_id: &str) -> Option<String> {
-    if !profile_id.is_empty() {
-        return None;
-    }
-    let path = std::path::Path::new(config_dir).join("settings.json");
+    // Go reads the index with `LoadProfilesMetadata()`, which resolves
+    // `ClaudeSettingsProfilesPath()` — the **run default** dir, not `config_dir`.
+    // That asymmetry is deliberate upstream and load-bearing here: profiles are
+    // a global CRUD surface, so an agent with its own `claude_config_dir` still
+    // resolves its named profile against the global index while its *fallback*
+    // follows its own dir. Reading the index out of the override would silently
+    // find nothing and hand the run the wrong account's settings.
+    //
+    // Resolved only for a *named* profile: the unnamed fallback reads no index,
+    // and this opens the database.
+    let index_dir = if profile_id.is_empty() {
+        String::new()
+    } else {
+        crate::native::settings::run_config_dir(&stored_config_dir())
+    };
+    settings_file_from(config_dir, &index_dir, profile_id)
+}
+
+/// [`settings_file_in`] with the index dir passed in, so the resolution can be
+/// driven over a scratch directory instead of the machine's real one.
+fn settings_file_from(config_dir: &str, index_dir: &str, profile_id: &str) -> Option<String> {
+    let path = profile_file_path_in(config_dir, index_dir, profile_id);
     match std::fs::metadata(&path) {
-        Ok(meta) if meta.is_file() => Some(path.to_string_lossy().into_owned()),
+        Ok(meta) if meta.is_file() => Some(path),
         _ => None,
     }
+}
+
+/// `config.LoadProfileFilePathIn`, path resolution only.
+fn profile_file_path_in(config_dir: &str, index_dir: &str, profile_id: &str) -> String {
+    let fallback = std::path::Path::new(config_dir)
+        .join("settings.json")
+        .to_string_lossy()
+        .into_owned();
+    if profile_id.is_empty() {
+        return fallback;
+    }
+    // `if err != nil { return fallback }` — an unreadable or malformed index is
+    // the fallback, not a failure.
+    let Ok(profiles) = crate::native::claude_settings::profiles::load(index_dir) else {
+        return fallback;
+    };
+    if let Some(profile) = profiles.iter().find(|p| p.id == profile_id) {
+        return profile.file_path.clone();
+    }
+    if let Some(profile) = profiles.iter().find(|p| p.is_default) {
+        return profile.file_path.clone();
+    }
+    fallback
 }
 
 /// Which `claude` binary to spawn.
@@ -469,21 +519,149 @@ mod tests {
         assert!(!out.contains("{{"));
     }
 
-    /// A named profile is not resolvable here, so it yields no `--settings`
-    /// rather than a guessed path.
-    #[test]
-    fn a_named_settings_profile_yields_no_settings_flag() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        std::fs::write(dir.path().join("settings.json"), "{}").expect("write");
-        let path = dir.path().to_string_lossy().into_owned();
-
-        assert!(settings_file_in(&path, "").is_some());
-        assert!(settings_file_in(&path, "profile-123").is_none());
+    /// Write a profiles index into `dir` and return its path prefix.
+    fn seed_index(
+        dir: &std::path::Path,
+        profiles: &[crate::native::claude_settings::profiles::Profile],
+    ) {
+        let bytes =
+            crate::native::claude_settings::profiles::encode_index(profiles).expect("encode");
+        std::fs::write(dir.join("settings_profiles.json"), bytes).expect("write index");
     }
 
+    fn profile(
+        id: &str,
+        file_path: &str,
+        is_default: bool,
+    ) -> crate::native::claude_settings::profiles::Profile {
+        crate::native::claude_settings::profiles::Profile {
+            id: id.to_string(),
+            name: id.to_string(),
+            file_path: file_path.to_string(),
+            is_default,
+        }
+    }
+
+    /// **A named profile resolves to the path the index records** — not to
+    /// `<dir>/settings.json`, and not to nothing. Before this was implemented a
+    /// run pinned to a named profile got no `--settings` at all while the Go
+    /// server passed the recorded path, which is a silent wrong-account run.
+    #[test]
+    fn a_named_settings_profile_resolves_to_its_recorded_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("settings.json"), "{}").expect("write");
+        // Deliberately *not* `settings_work.json`: the index is the authority,
+        // so a resolver that rebuilt the name from the id would miss this.
+        let recorded = dir.path().join("settings_renamed-since.json");
+        std::fs::write(&recorded, "{}").expect("write");
+        let recorded = recorded.to_string_lossy().into_owned();
+        seed_index(dir.path(), &[profile("work", &recorded, false)]);
+        let path = dir.path().to_string_lossy().into_owned();
+
+        assert_eq!(
+            settings_file_from(&path, &path, "work"),
+            Some(recorded.clone())
+        );
+        // The unnamed fallback still follows the *run* dir rather than the index.
+        assert_eq!(
+            settings_file_from(&path, &path, ""),
+            Some(
+                dir.path()
+                    .join("settings.json")
+                    .to_string_lossy()
+                    .into_owned()
+            )
+        );
+    }
+
+    /// An id the index does not carry falls back to the **default** profile, and
+    /// only then to `<dir>/settings.json`. Both branches are Go's.
+    #[test]
+    fn an_unknown_profile_id_falls_back_to_the_default_then_to_settings_json() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("settings.json"), "{}").expect("write");
+        let fallback = dir
+            .path()
+            .join("settings.json")
+            .to_string_lossy()
+            .into_owned();
+        let default_path = dir.path().join("settings_default.json");
+        std::fs::write(&default_path, "{}").expect("write");
+        let default_path = default_path.to_string_lossy().into_owned();
+        let path = dir.path().to_string_lossy().into_owned();
+
+        seed_index(dir.path(), &[profile("default", &default_path, true)]);
+        assert_eq!(
+            settings_file_from(&path, &path, "no-such-profile"),
+            Some(default_path)
+        );
+
+        // No default either: the unnamed fallback.
+        seed_index(dir.path(), &[profile("other", "/nowhere/x.json", false)]);
+        assert_eq!(
+            settings_file_from(&path, &path, "no-such-profile"),
+            Some(fallback.clone())
+        );
+
+        // No index at all is the same fallback, not a failure.
+        std::fs::remove_file(dir.path().join("settings_profiles.json")).expect("rm");
+        assert_eq!(settings_file_from(&path, &path, "anything"), Some(fallback));
+    }
+
+    /// The index lives in the **run default** dir even when the run targets an
+    /// agent's own `claude_config_dir`, because profiles are a global surface —
+    /// while the unnamed fallback follows the run's dir. `LoadProfileFilePathIn`
+    /// takes `dir` for the fallback and calls `LoadProfilesMetadata()`, which
+    /// does not.
+    #[test]
+    fn the_index_is_read_from_the_global_dir_and_the_fallback_from_the_runs() {
+        let global = tempfile::tempdir().expect("tempdir");
+        let agent = tempfile::tempdir().expect("tempdir");
+        let recorded = global.path().join("settings_work.json");
+        std::fs::write(&recorded, "{}").expect("write");
+        let recorded = recorded.to_string_lossy().into_owned();
+        seed_index(global.path(), &[profile("work", &recorded, false)]);
+        std::fs::write(agent.path().join("settings.json"), "{}").expect("write");
+
+        let agent_dir = agent.path().to_string_lossy().into_owned();
+        let global_dir = global.path().to_string_lossy().into_owned();
+        assert_eq!(
+            settings_file_from(&agent_dir, &global_dir, "work"),
+            Some(recorded)
+        );
+        assert_eq!(
+            settings_file_from(&agent_dir, &global_dir, ""),
+            Some(
+                agent
+                    .path()
+                    .join("settings.json")
+                    .to_string_lossy()
+                    .into_owned()
+            )
+        );
+    }
+
+    /// `--settings` on a missing path is an error rather than a no-op, so a
+    /// recorded path whose file has gone is named nothing at all.
     #[test]
     fn a_missing_settings_file_is_not_named() {
         let dir = tempfile::tempdir().expect("tempdir");
-        assert!(settings_file_in(&dir.path().to_string_lossy(), "").is_none());
+        assert!(settings_file_from(
+            &dir.path().to_string_lossy(),
+            &dir.path().to_string_lossy(),
+            ""
+        )
+        .is_none());
+
+        let path = dir.path().to_string_lossy().into_owned();
+        seed_index(
+            dir.path(),
+            &[profile(
+                "gone",
+                &format!("{path}/settings_gone.json"),
+                false,
+            )],
+        );
+        assert!(settings_file_from(&path, &path, "gone").is_none());
     }
 }

--- a/desktop/src-tauri/src/native/claude_settings/mod.rs
+++ b/desktop/src-tauri/src/native/claude_settings/mod.rs
@@ -1,0 +1,1134 @@
+//! Claude Code's own `settings.json`, and the named profiles beside it.
+//!
+//! `internal/api/claude_settings.go`, `internal/api/claude_settings_profiles.go`,
+//! `internal/service/claude_settings_profile_service.go` and
+//! `internal/config/profiles.go`, in Rust. Nine routes, all of them ported
+//! together — see [the cache question](#the-cache-question) below.
+//!
+//! # This is filesystem state, not SQLite
+//!
+//! Every other ported area reads rows. This one reads and writes files in a
+//! directory Claude Code owns, so the two things that decide correctness are the
+//! *path* and the *bytes*, and both are silent when wrong: a settings file
+//! written to the wrong dir is not an error, it is a run that quietly gets no
+//! settings (#242), and a profile file written with the wrong indentation is a
+//! diff in the user's own editor.
+//!
+//! ## The dir is the run default, and only the fallback follows it
+//!
+//! [`run_dir`] is `config.ResolveAgentClaudeDir(nil)` — `CLAUDE_CONFIG_DIR`,
+//! else the stored global setting, else `~/.claude`. Profiles are a **global**
+//! CRUD surface, so they live there rather than in any per-agent override.
+//!
+//! But that only decides where a *new* file is created. **A named profile keeps
+//! the absolute path recorded in `settings_profiles.json`**; only the unnamed
+//! fallback (`<dir>/settings.json`) is derived from the dir on every read. So
+//! moving the config dir must not silently repoint a named profile, and
+//! `profiles::detail_body` reads `file_path` verbatim rather than rebuilding it
+//! from the id. `a_named_profile_keeps_its_recorded_path` pins that.
+//!
+//! ## The bytes
+//!
+//! Three Go encodings meet here and they are not the same one:
+//!
+//! - **On the wire**, a `json.RawMessage` field is re-emitted through Go's
+//!   `compact` — whitespace stripped, `<`/`>`/`&` escaped, **key order and
+//!   number spelling preserved**. So a stored settings file is served with the
+//!   keys the user typed, in the order they typed them
+//!   ([`super::gojson::compact`]).
+//! - **On disk**, every file this surface writes goes through
+//!   `json.MarshalIndent(v, "", "  ")` after a round trip through Go's `any` —
+//!   which sorts object keys, respells every number as a float64 and escapes
+//!   HTML. [`marshal_indent`] is that pair, and [`super::gojson::indent`] is the
+//!   `Indent` half.
+//! - **The profile file created by `POST .../profiles`** is neither: it is the
+//!   current default profile's bytes copied **verbatim**. Reformatting it would
+//!   be a diff on a file the user did not ask to change.
+//!
+//! # The cache question
+//!
+//! The issue that asked for this port warned that `ClaudeSettingsProfileService`
+//! caches `settings_profiles.json` in memory, which would leave the sidecar —
+//! still the side that *runs agents* and resolves `--settings` on every turn —
+//! reading a stale index after a native write.
+//!
+//! **It does not cache.** `claudeSettingsProfileService` holds one field, a
+//! `*slog.Logger`; every one of its seven methods calls
+//! `config.LoadProfilesMetadata()`, which is an `os.ReadFile` per call. The
+//! agent runner is the same: `appendSettingsOpts` calls
+//! `config.LoadProfileFilePathIn`, which re-reads the file at the moment the run
+//! starts. There is no in-memory copy for a native write to invalidate, and
+//! reproduced evidence for that is in `tests/parity_claude_settings.rs`
+//! (`a_native_write_is_visible_to_the_go_server_immediately`), which writes the
+//! metadata file underneath a *running* Go server and then asks it.
+//!
+//! What Go does hold in memory is `config.claudeDirs`, the snapshot deciding
+//! *which* dir this is — and that is a different question, answered the way
+//! [`super::settings`] already answers it: by re-reading the settings row, which
+//! is the authority the snapshot itself is installed from.
+
+pub mod profiles;
+
+use std::io;
+use std::path::Path;
+
+use axum::http::Method;
+use serde::de::IgnoredAny;
+use serde::{Deserialize, Serialize};
+use serde_json::value::RawValue;
+use serde_json::Value;
+
+use super::writes::{finish, WriteError};
+use super::{gojson, gopath};
+
+// ─── Paths ────────────────────────────────────────────────────────────────────
+
+/// `config.ClaudeSettingsDirPath` → `config.ClaudeRunConfigDir`: the single dir
+/// a run targets when no agent overrides it.
+///
+/// Read from the settings row rather than from a startup snapshot, for the
+/// reason [`super::settings`] documents: a ported handler has no startup wiring
+/// to hook into, and the row is what the snapshot is installed from.
+pub fn run_dir(db_path: &Path) -> Result<String, String> {
+    let conn = super::db::open_read_only(db_path)?;
+    let stored = super::settings::load_stored(&conn);
+    Ok(super::settings::run_config_dir(&stored.claude_config_dir))
+}
+
+/// `config.ClaudeSettingsJSONPathIn`.
+pub fn settings_json_path(dir: &str) -> String {
+    gopath::join(&[dir, "settings.json"])
+}
+
+/// `config.ClaudeSettingsProfilesPath`.
+pub fn profiles_path(dir: &str) -> String {
+    gopath::join(&[dir, "settings_profiles.json"])
+}
+
+// ─── Filesystem, with Go's modes ──────────────────────────────────────────────
+
+/// `os.WriteFile(path, data, 0600)`.
+///
+/// The mode matters: these files carry API keys and hook commands, and
+/// `std::fs::write` would create them `0666 & ~umask`.
+pub fn write_file(path: &str, data: &[u8]) -> io::Result<()> {
+    use std::io::Write;
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(path)?;
+    file.write_all(data)
+}
+
+/// `os.MkdirAll(dir, 0700)`.
+pub fn mkdir_all(dir: &str) -> io::Result<()> {
+    let mut builder = std::fs::DirBuilder::new();
+    builder.recursive(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        builder.mode(0o700);
+    }
+    builder.create(dir)
+}
+
+// ─── Go's `any`, and the four ways its parse can end ──────────────────────────
+
+/// `encoding/json`'s `maxNestingDepth`. Its scanner refuses anything deeper, so
+/// `json.Valid` says **false** for a 10001-level document.
+const GO_MAX_NESTING_DEPTH: usize = 10000;
+
+/// `json.Valid`: one complete JSON value, trailing whitespace allowed and
+/// nothing else.
+///
+/// Two things about the implementation are deliberate:
+///
+/// - **`IgnoredAny` rather than `Value`.** Its skip is iterative, so
+///   `serde_json`'s 128-level recursion limit — which *does* stop a `Value`
+///   decode — never applies. That matters, because a nesting depth Go accepts
+///   must not read here as an invalid file: it would turn a 200 into a 500 on
+///   `GET /api/claude-settings` and an `exists: true` into an `exists: false` on
+///   a profile.
+/// - **The depth is then checked by hand**, because having no limit at all is
+///   the *other* wrong answer — Go's scanner stops at 10000 and a document past
+///   it is invalid to Go.
+pub fn go_json_valid(src: &[u8]) -> bool {
+    if nesting_depth_exceeds(src, GO_MAX_NESTING_DEPTH) {
+        return false;
+    }
+    let mut de = serde_json::Deserializer::from_slice(src);
+    IgnoredAny::deserialize(&mut de)
+        .and_then(|_| de.end())
+        .is_ok()
+}
+
+/// Whether any point in `src` nests deeper than `limit` containers.
+///
+/// A byte scan rather than a parse: this runs on input that may not be valid
+/// JSON at all, and an unbalanced closer simply cannot take the depth below
+/// zero.
+fn nesting_depth_exceeds(src: &[u8], limit: usize) -> bool {
+    let mut depth = 0usize;
+    let mut in_string = false;
+    let mut escaped = false;
+    for &byte in src {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match byte {
+            b'"' => in_string = true,
+            b'{' | b'[' => {
+                depth += 1;
+                if depth > limit {
+                    return true;
+                }
+            }
+            b'}' | b']' => depth = depth.saturating_sub(1),
+            _ => {}
+        }
+    }
+    false
+}
+
+/// `serde_json`'s recursion limit, told apart from a real syntax error.
+///
+/// Matched on the message because `Category` does not distinguish it: the
+/// alternative is `disable_recursion_limit`, which trades a wrong answer for a
+/// stack overflow. Pinned by `a_document_deeper_than_serdes_limit_forwards`.
+fn is_recursion_limit(e: &serde_json::Error) -> bool {
+    e.to_string().contains("recursion limit exceeded")
+}
+
+/// What `json.NewDecoder(body).Decode(&raw json.RawMessage)` followed by
+/// `json.Unmarshal(raw, &pretty any)` produces.
+#[derive(Debug)]
+pub enum Decoded {
+    /// A value Go's `any` can hold, with every number already widened to
+    /// float64 the way `encoding/json` widens them.
+    Value(Value),
+    /// `Decode` failed — no JSON value at the start of the body, or no body at
+    /// all. Both handlers answer 400 for this.
+    NotJson,
+    /// `Decode` succeeded (a `json.RawMessage` accepts any syntactically valid
+    /// value) but `Unmarshal` into `any` did not, because
+    /// `strconv.ParseFloat` reports a number out of float64's range. A
+    /// *different* 400 message, and on the profile path a 422 — so the two
+    /// cases cannot be collapsed.
+    NumberOutOfRange,
+    /// Neither parser is the authority. Forward.
+    Undecidable(String),
+}
+
+/// `json.NewDecoder(body).Decode(&raw json.RawMessage)`: the syntax half.
+///
+/// A `Decoder` reads a **stream**, so it stops at the end of the first value and
+/// ignores whatever follows — `{"a":1}trailing` is a successful decode in Go.
+/// `serde_json::from_slice` would reject it, which is why this drives the
+/// `Deserializer` by hand and never calls `end()`.
+///
+/// `Err(None)` is Go's decode error; `Err(Some(reason))` is a document this
+/// port's parser will not judge.
+pub fn decode_stream_head(body: &[u8]) -> Result<(), Option<String>> {
+    let mut de = serde_json::Deserializer::from_slice(body);
+    match IgnoredAny::deserialize(&mut de) {
+        Ok(_) => Ok(()),
+        Err(e) if is_recursion_limit(&e) => Err(Some(e.to_string())),
+        Err(_) => Err(None),
+    }
+}
+
+/// `json.NewDecoder(r.Body).Decode(&req)` for a request **struct**.
+///
+/// # Why this is not [`super::writes::decode_body`]
+///
+/// The shared helper is right for the SQLite writes it was built for, and wrong
+/// twice over here — both times observably:
+///
+/// - **It shape-checks through a `serde_json::Value`**, whose parser rejects a
+///   number outside float64's range. `{"settings":{"n":1e999}}` would then be a
+///   400, and Go answers **422**: the value rides in a `json.RawMessage`, which
+///   is not parsed until the service looks at it. That is the one reachable
+///   `ValidationError` on this surface, so losing it loses the case.
+/// - **It requires end of input.** A `json.Decoder` reads a *stream* and stops
+///   at the end of the first value, so `{"name":"x"} junk` is a successful
+///   decode in Go. `serde_json::from_slice` is not a stream and rejects it.
+///
+/// What is left is Go's own rule, which only needs the first token: an object
+/// decodes field by field, a `null` is the documented no-op leaving the zero
+/// value, and anything else — an array, a scalar, nothing at all — is the type
+/// error the handler turns into its 400.
+///
+/// Duplicate keys forward for the reason `decode_body` documents: `encoding/json`
+/// keeps the last occurrence but type-checks every one, and serde refuses them
+/// outright, so only Go can answer. Safe because this runs before any mutation.
+pub(crate) fn decode_request<T>(body: &[u8]) -> Result<T, WriteError>
+where
+    T: serde::de::DeserializeOwned + Default,
+{
+    match first_token(body) {
+        Some(b'{') => {
+            let mut de = serde_json::Deserializer::from_slice(body);
+            match T::deserialize(&mut de) {
+                Ok(req) => Ok(req),
+                Err(e) if e.to_string().starts_with("duplicate field") => {
+                    Err(WriteError::Fallback(e.to_string()))
+                }
+                Err(_) => Err(WriteError::InvalidBody),
+            }
+        }
+        Some(b'n') if trim_leading_space(body).starts_with(b"null") => Ok(T::default()),
+        _ => Err(WriteError::InvalidBody),
+    }
+}
+
+/// The first byte JSON considers significant, or `None` for a blank body.
+fn first_token(body: &[u8]) -> Option<u8> {
+    trim_leading_space(body).first().copied()
+}
+
+fn trim_leading_space(body: &[u8]) -> &[u8] {
+    let start = body
+        .iter()
+        .position(|b| !matches!(b, b' ' | b'\t' | b'\n' | b'\r'))
+        .unwrap_or(body.len());
+    &body[start..]
+}
+
+/// Both halves at once, for the callers whose Go original has no observable
+/// step between them.
+pub fn decode_go_any(body: &[u8]) -> Decoded {
+    match decode_stream_head(body) {
+        Ok(()) => go_any(body),
+        Err(None) => Decoded::NotJson,
+        Err(Some(reason)) => Decoded::Undecidable(reason),
+    }
+}
+
+/// `json.Unmarshal(raw, &v any)` for a body already known to be syntactically
+/// valid JSON.
+pub fn go_any(body: &[u8]) -> Decoded {
+    if !numbers_fit_float64(body) {
+        return Decoded::NumberOutOfRange;
+    }
+    let mut de = serde_json::Deserializer::from_slice(body);
+    match Value::deserialize(&mut de) {
+        Ok(value) => match widen_numbers(value) {
+            Some(value) => Decoded::Value(value),
+            None => Decoded::NumberOutOfRange,
+        },
+        // A `Value` decode *is* recursive, unlike the `IgnoredAny` skip above,
+        // so 129 levels stop it where Go carries on to 10000. That one is
+        // forwarded; an ordinary syntax error is Go's own decode failure, which
+        // `ensureDefaultProfileExists` handles by seeding an empty object.
+        Err(e) if is_recursion_limit(&e) => Decoded::Undecidable(e.to_string()),
+        Err(_) => Decoded::NotJson,
+    }
+}
+
+/// Whether every number literal in `src` survives `strconv.ParseFloat(s, 64)`.
+///
+/// Go decodes into `any`, which makes **every** number a float64 and fails the
+/// whole document when one does not fit — `1e999` is a 400, not an infinity.
+/// The check is done over the bytes rather than left to `serde_json`, because
+/// the two parsers do not agree on the boundary: `1e-999` underflows to `0`
+/// with no error in Go (verified against the Go toolchain), while serde_json
+/// raises `NumberOutOfRange` only for the overflow half. Overflow is the whole
+/// of Go's rule, so overflow is the whole of this one.
+fn numbers_fit_float64(src: &[u8]) -> bool {
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut i = 0;
+    while i < src.len() {
+        let byte = src[i];
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+        if byte == b'"' {
+            in_string = true;
+            i += 1;
+            continue;
+        }
+        // Outside a string, only a number token can begin with `-` or a digit —
+        // `true`, `false` and `null` contain neither, and `+`, `.`, `e` and `E`
+        // never start one.
+        if byte == b'-' || byte.is_ascii_digit() {
+            let start = i;
+            while i < src.len() && matches!(src[i], b'0'..=b'9' | b'-' | b'+' | b'.' | b'e' | b'E')
+            {
+                i += 1;
+            }
+            let token = std::str::from_utf8(&src[start..i]).unwrap_or("");
+            // A token this port cannot parse at all is one it will not judge —
+            // the `Value` decode below decides, and forwards if it cannot.
+            if let Ok(f) = token.parse::<f64>() {
+                if !f.is_finite() {
+                    return false;
+                }
+            }
+            continue;
+        }
+        i += 1;
+    }
+    true
+}
+
+/// Every number as a float64, which is the only numeric type Go's `any` has.
+///
+/// This is not cosmetic. `9007199254740993` round-trips through Go as
+/// `9007199254740992`, and serde_json would have kept it as a `u64` and written
+/// the odd value back. The file on disk would differ from the one Go writes for
+/// the same request.
+fn widen_numbers(value: Value) -> Option<Value> {
+    Some(match value {
+        Value::Number(n) => {
+            let f = n.as_f64()?;
+            Value::Number(serde_json::Number::from_f64(f)?)
+        }
+        Value::Array(items) => Value::Array(
+            items
+                .into_iter()
+                .map(widen_numbers)
+                .collect::<Option<Vec<_>>>()?,
+        ),
+        Value::Object(fields) => {
+            let mut out = serde_json::Map::new();
+            for (key, item) in fields {
+                out.insert(key, widen_numbers(item)?);
+            }
+            Value::Object(out)
+        }
+        other => other,
+    })
+}
+
+/// `json.MarshalIndent(v, "", "  ")`, which is `Marshal` followed by `Indent`.
+pub fn marshal_indent(value: &Value) -> Result<Vec<u8>, String> {
+    let compact =
+        gojson::to_vec_marshal(value).map_err(|e| format!("marshaling settings JSON: {e}"))?;
+    Ok(gojson::indent(&compact))
+}
+
+/// Carry stored bytes to the wire the way a `json.RawMessage` field does:
+/// through Go's `compact`, so key order and number spelling survive.
+pub fn raw_field(bytes: &[u8]) -> Option<Box<RawValue>> {
+    let text = std::str::from_utf8(bytes).ok()?;
+    RawValue::from_string(gojson::compact(text)).ok()
+}
+
+// ─── GET / PUT /api/claude-settings ───────────────────────────────────────────
+
+/// `api.claudeSettingsResponse`. `settings` is `omitempty` over a
+/// `json.RawMessage`, so the "no file" answer is `{"exists":false}` and not
+/// `{"exists":false,"settings":null}`.
+#[derive(Debug, Serialize)]
+struct ClaudeSettingsResponse {
+    exists: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    settings: Option<Box<RawValue>>,
+}
+
+/// `handleGetClaudeSettings`.
+///
+/// Takes the resolved dir rather than the database, so a unit test can drive it
+/// over a temp directory — [`run_dir`] is applied once at the seam.
+pub fn get_settings(dir: &str) -> Result<super::Answer, String> {
+    let path = settings_json_path(dir);
+    let data = match std::fs::read(&path) {
+        Ok(data) => data,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            let body = gojson::to_vec(&ClaudeSettingsResponse {
+                exists: false,
+                settings: None,
+            })
+            .map_err(|e| format!("encoding claude settings: {e}"))?;
+            return Ok(super::Answer::json(body));
+        }
+        // Go answers 500 here, and this port does not invent 500s.
+        Err(e) => return Err(format!("reading {path}: {e}")),
+    };
+
+    if !go_json_valid(&data) {
+        // Also a 500 in Go ("Claude settings file contains invalid JSON").
+        return Err(format!("{path} contains invalid JSON"));
+    }
+
+    let body = gojson::to_vec(&ClaudeSettingsResponse {
+        exists: true,
+        settings: raw_field(&data),
+    })
+    .map_err(|e| format!("encoding claude settings: {e}"))?;
+    Ok(super::Answer::json(body))
+}
+
+/// `handleUpdateClaudeSettings`.
+///
+/// **The path is the trap.** This writes `settings.json` inside the *run* config
+/// dir, which is the file `--settings` resolves against on every agent run
+/// (#242). Getting it wrong is silent: the run simply gets no settings.
+/// The step order is Go's, not a tidier one. `Decode` runs first, then the path
+/// is resolved, then `MkdirAll`, and only then is the value parsed into `any` —
+/// so a body carrying an out-of-range number is a 400 *after* the directory has
+/// been created. Creating a directory is the one effect here that is idempotent
+/// and invisible, but reordering it would still be a port that guessed.
+pub fn put_settings(dir: &str, body: &[u8]) -> Result<super::Answer, WriteError> {
+    // 1. `json.NewDecoder(r.Body).Decode(&incoming)` — `errInvalidJSONBody`.
+    decode_stream_head(body).map_err(|reason| match reason {
+        Some(reason) => WriteError::Fallback(reason),
+        None => WriteError::InvalidBody,
+    })?;
+
+    // 2. `config.ClaudeSettingsJSONPath()`, and 3. `os.MkdirAll(dir, 0700)`.
+    let path = settings_json_path(dir);
+    if let Err(e) = mkdir_all(dir) {
+        return Err(WriteError::Fallback(format!("creating {dir}: {e}")));
+    }
+
+    // 4. `json.Unmarshal(incoming, &pretty)` — the handler's own message, which
+    // is not `errInvalidJSONBody`.
+    let value = match go_any(body) {
+        Decoded::Value(value) => value,
+        Decoded::NumberOutOfRange => {
+            return Err(WriteError::BadRequest("invalid JSON settings".to_string()))
+        }
+        Decoded::Undecidable(reason) => return Err(WriteError::Fallback(reason)),
+        // Unreachable: step 1 established the syntax.
+        Decoded::NotJson => return Err(WriteError::InvalidBody),
+    };
+
+    let out = marshal_indent(&value).map_err(WriteError::Fallback)?;
+    if let Err(e) = write_file(&path, &out) {
+        return Err(WriteError::Fallback(format!("writing {path}: {e}")));
+    }
+
+    let answer = gojson::to_vec(&ClaudeSettingsResponse {
+        exists: true,
+        settings: raw_field(&out),
+    })
+    .map_err(|e| WriteError::Fallback(format!("encoding claude settings: {e}")))?;
+    Ok(super::Answer::json(answer))
+}
+
+// ─── The seam ─────────────────────────────────────────────────────────────────
+
+/// This module's entry in `native::ENDPOINTS`. One area, nine routes: the reads
+/// cannot be split from the writes here, because `GET .../profiles` *is* a write
+/// — `ensureDefaultProfileExists` seeds the index and the default profile file
+/// on first read.
+pub const ENDPOINT: super::Endpoint = super::Endpoint {
+    name: "claude-settings",
+    claims,
+    serve,
+};
+
+/// Which of the five chi routes a path is, if any.
+#[derive(Debug, PartialEq, Eq)]
+enum Route<'a> {
+    /// `/api/claude-settings`
+    Settings,
+    /// `/api/claude-settings/profiles`
+    Profiles,
+    /// `/api/claude-settings/profiles/{id}`
+    Profile(&'a str),
+    /// `/api/claude-settings/profiles/{id}/duplicate`
+    Duplicate(&'a str),
+    /// `/api/claude-settings/profiles/{id}/default`
+    Default(&'a str),
+}
+
+/// chi's `{id}` matches exactly one segment and never an empty one, so an id
+/// containing a slash is a different route and `/profiles/` is no route at all.
+fn route(path: &str) -> Option<Route<'_>> {
+    if path == "/api/claude-settings" {
+        return Some(Route::Settings);
+    }
+    let rest = path.strip_prefix("/api/claude-settings/profiles")?;
+    if rest.is_empty() {
+        return Some(Route::Profiles);
+    }
+    let rest = rest.strip_prefix('/')?;
+    let (id, action) = match rest.split_once('/') {
+        Some((id, action)) => (id, Some(action)),
+        None => (rest, None),
+    };
+    if id.is_empty() {
+        return None;
+    }
+    match action {
+        None => Some(Route::Profile(id)),
+        Some("duplicate") => Some(Route::Duplicate(id)),
+        Some("default") => Some(Route::Default(id)),
+        Some(_) => None,
+    }
+}
+
+fn claims(method: &Method, path: &str) -> bool {
+    match route(path) {
+        Some(Route::Settings) => matches!(*method, Method::GET | Method::PUT),
+        Some(Route::Profiles) => matches!(*method, Method::GET | Method::POST),
+        Some(Route::Profile(_)) => matches!(*method, Method::GET | Method::PUT | Method::DELETE),
+        Some(Route::Duplicate(_)) => *method == Method::POST,
+        Some(Route::Default(_)) => *method == Method::PUT,
+        None => false,
+    }
+}
+
+fn serve(ctx: &super::Ctx, req: &super::Request) -> Result<super::Answer, String> {
+    // Go's modes and Go's `filepath` are what this module writes with, and
+    // neither is verified on Windows — the same call `super::fs` makes.
+    if !cfg!(unix) {
+        return Err("the Claude settings surface is not ported for Windows".to_string());
+    }
+    // Resolved once, here: every handler below works inside one directory, and
+    // a failure to resolve it forwards before anything is written.
+    let dir = &run_dir(&ctx.db_path)?;
+    match (route(req.path), req.method) {
+        (Some(Route::Settings), &Method::GET) => get_settings(dir),
+        (Some(Route::Settings), &Method::PUT) => finish(put_settings(dir, req.body)),
+        (Some(Route::Profiles), &Method::GET) => finish(profiles::list(dir)),
+        (Some(Route::Profiles), &Method::POST) => finish(profiles::create(dir, req.body)),
+        (Some(Route::Profile(id)), &Method::GET) => finish(profiles::get(dir, id)),
+        (Some(Route::Profile(id)), &Method::PUT) => finish(profiles::update(dir, id, req.body)),
+        (Some(Route::Profile(id)), &Method::DELETE) => finish(profiles::delete(dir, id)),
+        (Some(Route::Duplicate(id)), &Method::POST) => finish(profiles::duplicate(dir, id)),
+        (Some(Route::Default(id)), &Method::PUT) => finish(profiles::set_default(dir, id)),
+        _ => Err(format!(
+            "{} {} is claimed but has no handler",
+            req.method, req.path
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::native::Answer;
+    use axum::http::StatusCode;
+
+    // ─── Routing ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn the_five_routes_are_claimed_and_their_neighbours_are_not() {
+        assert!(claims(&Method::GET, "/api/claude-settings"));
+        assert!(claims(&Method::PUT, "/api/claude-settings"));
+        assert!(claims(&Method::GET, "/api/claude-settings/profiles"));
+        assert!(claims(&Method::POST, "/api/claude-settings/profiles"));
+        assert!(claims(&Method::GET, "/api/claude-settings/profiles/work"));
+        assert!(claims(&Method::PUT, "/api/claude-settings/profiles/work"));
+        assert!(claims(
+            &Method::DELETE,
+            "/api/claude-settings/profiles/work"
+        ));
+        assert!(claims(
+            &Method::POST,
+            "/api/claude-settings/profiles/work/duplicate"
+        ));
+        assert!(claims(
+            &Method::PUT,
+            "/api/claude-settings/profiles/work/default"
+        ));
+
+        // Methods chi does not route.
+        assert!(!claims(&Method::POST, "/api/claude-settings"));
+        assert!(!claims(&Method::DELETE, "/api/claude-settings/profiles"));
+        assert!(!claims(&Method::POST, "/api/claude-settings/profiles/work"));
+        assert!(!claims(
+            &Method::GET,
+            "/api/claude-settings/profiles/work/duplicate"
+        ));
+        assert!(!claims(
+            &Method::POST,
+            "/api/claude-settings/profiles/work/default"
+        ));
+
+        // Shapes chi routes to nothing, plus the Agento settings row next door.
+        assert!(!claims(&Method::GET, "/api/claude-settings/"));
+        assert!(!claims(&Method::GET, "/api/claude-settings/profiles/"));
+        assert!(!claims(&Method::GET, "/api/claude-settings/profiles/a/b/c"));
+        assert!(!claims(
+            &Method::GET,
+            "/api/claude-settings/profiles/a/other"
+        ));
+        assert!(!claims(&Method::GET, "/api/settings"));
+        assert!(!claims(&Method::GET, "/api/claude-settings-profiles"));
+    }
+
+    #[test]
+    fn an_id_is_one_segment_and_never_empty() {
+        assert_eq!(
+            route("/api/claude-settings/profiles/default"),
+            Some(Route::Profile("default"))
+        );
+        assert_eq!(
+            route("/api/claude-settings/profiles/default/duplicate"),
+            Some(Route::Duplicate("default"))
+        );
+        assert_eq!(
+            route("/api/claude-settings/profiles/default/default"),
+            Some(Route::Default("default"))
+        );
+        assert_eq!(route("/api/claude-settings/profiles//duplicate"), None);
+    }
+
+    // ─── Paths ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn the_two_well_known_files_sit_in_the_dir() {
+        assert_eq!(settings_json_path("/h/.claude"), "/h/.claude/settings.json");
+        assert_eq!(
+            profiles_path("/h/.claude"),
+            "/h/.claude/settings_profiles.json"
+        );
+        // `filepath.Join` cleans, so a trailing separator does not double up.
+        assert_eq!(
+            settings_json_path("/h/.claude/"),
+            "/h/.claude/settings.json"
+        );
+    }
+
+    // ─── Go's `any` ───────────────────────────────────────────────────────────
+
+    /// The literals here are the Go toolchain's own answers, printed by a probe
+    /// over `json.Unmarshal` into `any` followed by `json.MarshalIndent`.
+    #[test]
+    fn marshal_indent_is_gos_marshal_indent() {
+        let cases: &[(&str, &str)] = &[
+            ("{}", "{}"),
+            ("[]", "[]"),
+            ("{\"a\":1}", "{\n  \"a\": 1\n}"),
+            (
+                r#"{"b":[1,2],"a":{"c":{}}}"#,
+                "{\n  \"a\": {\n    \"c\": {}\n  },\n  \"b\": [\n    1,\n    2\n  ]\n}",
+            ),
+            (
+                r#"{"x":"<script>&</script>"}"#,
+                "{\n  \"x\": \"\\u003cscript\\u003e\\u0026\\u003c/script\\u003e\"\n}",
+            ),
+            (
+                r#"{"n":1e3,"m":0.1,"big":9007199254740993}"#,
+                "{\n  \"big\": 9007199254740992,\n  \"m\": 0.1,\n  \"n\": 1000\n}",
+            ),
+            ("123", "123"),
+            (r#""str""#, r#""str""#),
+            ("null", "null"),
+            ("true", "true"),
+            (
+                r#"{"nested":{"deep":[{"k":"v"},[]]}}"#,
+                "{\n  \"nested\": {\n    \"deep\": [\n      {\n        \"k\": \"v\"\n      },\n      []\n    ]\n  }\n}",
+            ),
+        ];
+        for (src, want) in cases {
+            let value = match decode_go_any(src.as_bytes()) {
+                Decoded::Value(v) => v,
+                other => panic!("{src} decoded as {other:?}"),
+            };
+            let got = String::from_utf8(marshal_indent(&value).expect("marshal")).expect("utf8");
+            assert_eq!(&got, want, "src {src}");
+        }
+    }
+
+    /// A key that sorts after another in insertion order must come first on
+    /// disk, because Go marshals a `map[string]any` with its keys sorted. This
+    /// is also the canary for `serde_json/preserve_order` arriving through a
+    /// transitive dependency, which would silently flip it.
+    #[test]
+    fn object_keys_are_sorted_the_way_a_go_map_sorts_them() {
+        let value = match decode_go_any(br#"{"z":1,"A":2,"a":3,"0":4}"#) {
+            Decoded::Value(v) => v,
+            other => panic!("{other:?}"),
+        };
+        assert_eq!(
+            String::from_utf8(gojson::to_vec_marshal(&value).expect("marshal")).unwrap(),
+            r#"{"0":4,"A":2,"a":3,"z":1}"#
+        );
+    }
+
+    /// `json.NewDecoder(...).Decode` reads a stream: it stops at the end of the
+    /// first value and never looks at what follows. `from_slice` would 400 this.
+    #[test]
+    fn trailing_bytes_after_the_first_value_are_ignored_as_a_decoder_ignores_them() {
+        assert!(matches!(
+            decode_go_any(br#"{"a":1}trailing"#),
+            Decoded::Value(_)
+        ));
+    }
+
+    #[test]
+    fn an_empty_or_malformed_body_is_not_json() {
+        for body in [&b""[..], b"   ", b"{not json", b"{\"a\":", b"@"] {
+            assert!(
+                matches!(decode_go_any(body), Decoded::NotJson),
+                "body {body:?}"
+            );
+        }
+    }
+
+    /// Go's rule is `strconv.ParseFloat`'s: **overflow** fails the whole
+    /// document, underflow quietly becomes zero. Both halves verified against
+    /// the Go toolchain.
+    #[test]
+    fn only_an_overflowing_number_fails_the_way_go_fails() {
+        for body in [&b"1e999"[..], b"-1e999", br#"{"a":{"b":[1e999]}}"#] {
+            assert!(
+                matches!(decode_go_any(body), Decoded::NumberOutOfRange),
+                "body {body:?}"
+            );
+        }
+        // Underflow is a zero, not an error — and it marshals back as `0`.
+        for (body, want) in [
+            (&b"1e-999"[..], "0"),
+            (b"1e-324", "0"),
+            (b"0e-999", "0"),
+            (b"1e-320", "1e-320"),
+            (b"1e308", "1e+308"),
+            (b"1e21", "1e+21"),
+            (b"1e-7", "1e-7"),
+            (b"1e-6", "0.000001"),
+        ] {
+            let value = match decode_go_any(body) {
+                Decoded::Value(v) => v,
+                other => panic!("body {body:?} decoded as {other:?}"),
+            };
+            assert_eq!(
+                String::from_utf8(gojson::to_vec_marshal(&value).unwrap()).unwrap(),
+                want,
+                "body {body:?}"
+            );
+        }
+    }
+
+    /// A number *inside a string* is not a number token, so a string containing
+    /// `1e999` must not fail the document.
+    #[test]
+    fn a_number_shaped_string_is_not_a_number() {
+        assert!(matches!(
+            decode_go_any(br#"{"a":"1e999"}"#),
+            Decoded::Value(_)
+        ));
+        // …including one that ends in an escaped quote, which is where a naive
+        // string tracker loses its place.
+        assert!(matches!(
+            decode_go_any(br#"{"a":"x\"1e999","b":1}"#),
+            Decoded::Value(_)
+        ));
+    }
+
+    /// A `Value` decode stops at 128 levels and Go's at 10000. This port
+    /// answers neither way — it forwards, so Go gives whatever answer Go gives.
+    #[test]
+    fn a_document_deeper_than_serdes_limit_forwards() {
+        let deep = format!("{}{}", "[".repeat(200), "]".repeat(200));
+        assert!(matches!(
+            decode_go_any(deep.as_bytes()),
+            Decoded::Undecidable(_)
+        ));
+        // …but `json.Valid` still answers, because the skip is iterative. A
+        // port that used `Value` here would call a 5000-level settings file
+        // invalid and turn Go's 200 into a 500.
+        assert!(go_json_valid(deep.as_bytes()));
+    }
+
+    /// Go's scanner caps nesting at 10000, so having *no* limit is the other
+    /// wrong answer.
+    #[test]
+    fn json_valid_stops_where_gos_scanner_stops() {
+        let ok = format!("{}{}", "[".repeat(10000), "]".repeat(10000));
+        assert!(go_json_valid(ok.as_bytes()));
+        let too_deep = format!("{}{}", "[".repeat(10001), "]".repeat(10001));
+        assert!(!go_json_valid(too_deep.as_bytes()));
+        // Braces and brackets share the counter, and a bracket inside a string
+        // is not nesting.
+        assert!(go_json_valid(br#"{"a":"[[[[["}"#));
+    }
+
+    #[test]
+    fn json_valid_wants_one_whole_value_and_nothing_after_it() {
+        assert!(go_json_valid(b"{\"a\":1}"));
+        assert!(go_json_valid(b"  123  "));
+        assert!(!go_json_valid(b"{\"a\":1} junk"));
+        assert!(!go_json_valid(b""));
+        assert!(!go_json_valid(b"{"));
+    }
+
+    /// The wire form of a stored file: compacted and HTML-escaped, but with the
+    /// key order and number spelling the user typed left alone.
+    #[test]
+    fn a_stored_settings_file_reaches_the_wire_through_gos_compact() {
+        let raw = b"{\n  \"z\": 1.50,\n  \"a\": \"<b>\"\n}";
+        let body = gojson::to_vec(&ClaudeSettingsResponse {
+            exists: true,
+            settings: raw_field(raw),
+        })
+        .expect("encode");
+        assert_eq!(
+            String::from_utf8(body).unwrap(),
+            "{\"exists\":true,\"settings\":{\"z\":1.50,\"a\":\"\\u003cb\\u003e\"}}\n"
+        );
+    }
+
+    /// `omitempty` over a `json.RawMessage`: the absent case is two keys short
+    /// of the present one, not a `null`.
+    #[test]
+    fn a_missing_settings_file_omits_the_key_rather_than_nulling_it() {
+        let body = gojson::to_vec(&ClaudeSettingsResponse {
+            exists: false,
+            settings: None,
+        })
+        .expect("encode");
+        assert_eq!(String::from_utf8(body).unwrap(), "{\"exists\":false}\n");
+    }
+
+    // ─── The two write paths, over a temp dir ─────────────────────────────────
+
+    /// A settings dir with the given files, standing in for `~/.claude`.
+    pub(super) fn claude_dir() -> tempfile::TempDir {
+        tempfile::tempdir().expect("temp dir")
+    }
+
+    #[test]
+    fn writing_settings_pretty_prints_the_file_and_compacts_the_answer() {
+        let dir = claude_dir();
+        let path = settings_json_path(&dir.path().to_string_lossy());
+
+        let value = match decode_go_any(br#"{"z":1,"a":{"b":[1,2]}}"#) {
+            Decoded::Value(v) => v,
+            other => panic!("{other:?}"),
+        };
+        let out = marshal_indent(&value).expect("marshal");
+        write_file(&path, &out).expect("write");
+
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read"),
+            "{\n  \"a\": {\n    \"b\": [\n      1,\n      2\n    ]\n  },\n  \"z\": 1\n}"
+        );
+        let body = gojson::to_vec(&ClaudeSettingsResponse {
+            exists: true,
+            settings: raw_field(&out),
+        })
+        .expect("encode");
+        assert_eq!(
+            String::from_utf8(body).unwrap(),
+            "{\"exists\":true,\"settings\":{\"a\":{\"b\":[1,2]},\"z\":1}}\n"
+        );
+    }
+
+    /// The mode is part of the write: these files carry API keys and hook
+    /// commands, and `std::fs::write` would create them world-readable.
+    #[cfg(unix)]
+    #[test]
+    fn files_are_created_0600_and_directories_0700() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = claude_dir();
+        let dir = format!("{}/nested/.claude", root.path().to_string_lossy());
+        mkdir_all(&dir).expect("mkdir");
+        let path = settings_json_path(&dir);
+        write_file(&path, b"{}").expect("write");
+
+        let file = std::fs::metadata(&path).expect("stat").permissions().mode();
+        assert_eq!(file & 0o777, 0o600, "settings.json must be 0600");
+        let dir_mode = std::fs::metadata(&dir).expect("stat").permissions().mode();
+        assert_eq!(dir_mode & 0o777, 0o700, "the config dir must be 0700");
+    }
+
+    // ─── The two handlers, against the answers Go gave ────────────────────────
+    //
+    // Every literal below was recorded from a running Go server by
+    // `tests/parity_claude_settings.rs`. A write cannot be asked of both
+    // implementations at once, so the comparison lives across the two files.
+
+    fn body_of(answer: Answer) -> String {
+        String::from_utf8(answer.body.expect("a body")).expect("utf8")
+    }
+
+    /// The read, in both its states.
+    #[test]
+    fn the_settings_read_answers_what_go_answers() {
+        let root = claude_dir();
+        let dir = root.path().to_string_lossy().into_owned();
+
+        // No file at all.
+        assert_eq!(
+            body_of(get_settings(&dir).expect("read")),
+            "{\"exists\":false}\n"
+        );
+
+        // A file, carried through `compact` — key order and `1.50` intact,
+        // `<` escaped.
+        write_file(
+            &settings_json_path(&dir),
+            b"{\n  \"z\": 1.50,\n  \"tag\": \"<b>\"\n}",
+        )
+        .expect("write");
+        assert_eq!(
+            body_of(get_settings(&dir).expect("read")),
+            "{\"exists\":true,\"settings\":{\"z\":1.50,\"tag\":\"\\u003cb\\u003e\"}}\n"
+        );
+
+        // An unparseable file is a 500 in Go, and this port does not invent
+        // 500s — it forwards.
+        write_file(&settings_json_path(&dir), b"not json").expect("write");
+        assert!(get_settings(&dir).is_err());
+    }
+
+    /// The write: every status and message, and the file left behind.
+    #[test]
+    fn the_settings_write_answers_what_go_answers() {
+        let root = claude_dir();
+        let dir = root.path().to_string_lossy().into_owned();
+
+        for body in [&b""[..], b"   ", b"{not json"] {
+            let err = put_settings(&dir, body).unwrap_err();
+            assert_eq!(err.status(), StatusCode::BAD_REQUEST, "body {body:?}");
+            assert_eq!(err.message(), "invalid JSON body", "body {body:?}");
+        }
+
+        // The second parse has its own message — collapsing the two would be a
+        // wire divergence on a request that is a 400 either way.
+        let err = put_settings(&dir, br#"{"n":1e999}"#).unwrap_err();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(err.message(), "invalid JSON settings");
+
+        // Underflow is a zero, not an error.
+        assert_eq!(
+            body_of(put_settings(&dir, br#"{"tiny":1e-999}"#).expect("write")),
+            "{\"exists\":true,\"settings\":{\"tiny\":0}}\n"
+        );
+
+        // A `Decoder` stops at the first value.
+        assert_eq!(
+            body_of(put_settings(&dir, br#"{"trailing":true} and then some"#).expect("write")),
+            "{\"exists\":true,\"settings\":{\"trailing\":true}}\n"
+        );
+
+        // A scalar is a JSON value, so it is written as one.
+        assert_eq!(
+            body_of(put_settings(&dir, b"123").expect("write")),
+            "{\"exists\":true,\"settings\":123}\n"
+        );
+
+        // The round trip, in the response and on disk.
+        let answer = put_settings(&dir, br#"{"z":1,"a":{"b":[1,2]},"rate":1.50,"tag":"<b>"}"#)
+            .expect("write");
+        assert_eq!(answer.status, StatusCode::OK);
+        assert_eq!(
+            body_of(answer),
+            concat!(
+                "{\"exists\":true,\"settings\":{\"a\":{\"b\":[1,2]},\"rate\":1.5,",
+                "\"tag\":\"\\u003cb\\u003e\",\"z\":1}}\n"
+            )
+        );
+        assert_eq!(
+            std::fs::read_to_string(settings_json_path(&dir)).expect("settings.json"),
+            concat!(
+                "{\n",
+                "  \"a\": {\n",
+                "    \"b\": [\n",
+                "      1,\n",
+                "      2\n",
+                "    ]\n",
+                "  },\n",
+                "  \"rate\": 1.5,\n",
+                "  \"tag\": \"\\u003cb\\u003e\",\n",
+                "  \"z\": 1\n",
+                "}"
+            )
+        );
+    }
+
+    /// The two ways `decode_request` differs from the shared `decode_body`, both
+    /// of which a port that reused it would get wrong on this surface.
+    #[test]
+    fn the_request_decoder_is_gos_decoder_and_not_the_shared_one() {
+        #[derive(Debug, Default, Deserialize)]
+        #[serde(default)]
+        struct Probe {
+            name: String,
+            #[serde(deserialize_with = "gojson::captured_raw")]
+            settings: Option<Box<RawValue>>,
+        }
+
+        // 1. A number no float64 holds rides through untouched, because a
+        //    `json.RawMessage` is not parsed at decode time. `decode_body`'s
+        //    `Value` shape check rejects it, which would turn Go's 422 into a
+        //    400.
+        let decoded: Probe = decode_request(br#"{"settings":{"n":1e999}}"#).expect("decodes");
+        assert_eq!(
+            decoded.settings.as_deref().map(RawValue::get),
+            Some(r#"{"n":1e999}"#)
+        );
+
+        // 2. A `Decoder` stops at the first value; `from_slice` wants EOF.
+        let decoded: Probe = decode_request(br#"{"name":"x"} junk"#).expect("decodes");
+        assert_eq!(decoded.name, "x");
+
+        // Everything else is Go's rule: `null` is the zero value, an array or a
+        // scalar is a type error, and a blank body is one too.
+        for body in [&b"null"[..], b"  null  "] {
+            let zero: Probe = decode_request(body).expect("null is the zero value");
+            assert_eq!(zero.name, "");
+            assert!(zero.settings.is_none());
+        }
+        for body in [
+            &b""[..],
+            b"   ",
+            b"[]",
+            br#"["x"]"#,
+            b"123",
+            b"\"s\"",
+            b"nope",
+        ] {
+            assert_eq!(
+                decode_request::<Probe>(body).unwrap_err(),
+                WriteError::InvalidBody,
+                "body {body:?}"
+            );
+        }
+
+        // Duplicate keys forward: Go type-checks every occurrence and keeps the
+        // last, and serde can do neither.
+        assert!(matches!(
+            decode_request::<Probe>(br#"{"name":"a","name":"b"}"#).unwrap_err(),
+            WriteError::Fallback(_)
+        ));
+    }
+
+    /// The dir is created if it is not there, because a machine that has never
+    /// run Claude Code has no `~/.claude` — and `MkdirAll` runs *before* the
+    /// value is parsed, so it happens even on the request that then 400s.
+    #[test]
+    fn the_write_creates_the_config_dir_before_it_parses() {
+        let root = claude_dir();
+        let dir = format!("{}/never-used", root.path().to_string_lossy());
+
+        assert!(put_settings(&dir, br#"{"n":1e999}"#).is_err());
+        assert!(
+            std::path::Path::new(&dir).is_dir(),
+            "MkdirAll runs before the second parse, so the dir exists either way"
+        );
+
+        put_settings(&dir, br#"{"model":"opus"}"#).expect("write");
+        assert_eq!(
+            std::fs::read_to_string(settings_json_path(&dir)).expect("settings.json"),
+            "{\n  \"model\": \"opus\"\n}"
+        );
+    }
+}

--- a/desktop/src-tauri/src/native/claude_settings/mod.rs
+++ b/desktop/src-tauri/src/native/claude_settings/mod.rs
@@ -39,11 +39,20 @@
 //! - **On disk**, every file this surface writes goes through
 //!   `json.MarshalIndent(v, "", "  ")` after a round trip through Go's `any` —
 //!   which sorts object keys, respells every number as a float64 and escapes
-//!   HTML. [`marshal_indent`] is that pair, and [`super::gojson::indent`] is the
-//!   `Indent` half.
+//!   HTML. [`marshal_indent`] is that pair, and
+//!   [`super::gojson::indent_compact`] is the `Indent` half.
 //! - **The profile file created by `POST .../profiles`** is neither: it is the
 //!   current default profile's bytes copied **verbatim**. Reformatting it would
 //!   be a diff on a file the user did not ask to change.
+//!
+//! ## …and the bytes are not always UTF-8
+//!
+//! `encoding/json` never rejects a document for its bytes and serde_json does,
+//! which is not a boundary disagreement but a different answer to "is this
+//! JSON". Every path that parses or re-emits bytes here guards with
+//! [`is_utf8`] and **forwards**, because Go's answer — U+FFFD substituted at
+//! whatever offsets `encoding/json` chooses — is not something this port can
+//! reproduce, only defer to.
 //!
 //! # The cache question
 //!
@@ -111,6 +120,16 @@ pub fn profiles_path(dir: &str) -> String {
 ///
 /// The mode matters: these files carry API keys and hook commands, and
 /// `std::fs::write` would create them `0666 & ~umask`.
+///
+/// **Truncate-then-write, not temp-file-then-rename**, and that is a choice.
+/// `os.WriteFile` truncates, so a crash between the truncate and the write
+/// leaves an empty file — and for `settings_profiles.json` an empty index
+/// orphans every profile. An atomic replace would be strictly better *and*
+/// byte-identical in final content, so it costs no parity. It is not done here
+/// because the crash window belongs to the Go original too: fixing it in one
+/// implementation and not the other means the desktop app and `agento web`
+/// survive a power cut differently, which is a worse thing to debug than the
+/// window itself. It is on the upstream list in `desktop/CLAUDE.md`.
 pub fn write_file(path: &str, data: &[u8]) -> io::Result<()> {
     use std::io::Write;
     let mut options = std::fs::OpenOptions::new();
@@ -139,8 +158,36 @@ pub fn mkdir_all(dir: &str) -> io::Result<()> {
 // ─── Go's `any`, and the four ways its parse can end ──────────────────────────
 
 /// `encoding/json`'s `maxNestingDepth`. Its scanner refuses anything deeper, so
-/// `json.Valid` says **false** for a 10001-level document.
+/// `json.Valid` says **false** for a 10001-level document — and so does
+/// `json.Decoder.Decode`, which drives the same scanner.
 const GO_MAX_NESTING_DEPTH: usize = 10000;
+
+/// Whether `src` is UTF-8, which is the one place Go's JSON layer and serde's
+/// disagree about *validity* rather than about a boundary.
+///
+/// `encoding/json` never rejects a document for its bytes. `json.Valid` says
+/// true for `{"a":"x\xffy"}`, `Unmarshal` into `any` succeeds and substitutes
+/// U+FFFD, `MarshalIndent` writes the replacement character, and the encoder
+/// hands a `json.RawMessage` straight through byte for byte — all four verified
+/// against the Go toolchain. serde_json splits: its `ignore_str` does **not**
+/// validate, so [`go_json_valid`] agrees, but `parse_str` does, so every parse
+/// that actually materializes the string fails.
+///
+/// Left unguarded that produced five *wrong answers* rather than five forwards —
+/// a 400 where Go writes the file and answers 200, a seeded default profile
+/// whose bytes are not Go's, and a `settings` key silently missing from a 200.
+/// So every path that is about to parse or re-emit bytes checks this first and
+/// forwards, which is the only answer this port can be sure of: reproducing
+/// Go's substitution would mean reproducing where `encoding/json` puts the
+/// replacement character, and that is a guess.
+pub fn is_utf8(src: &[u8]) -> bool {
+    std::str::from_utf8(src).is_ok()
+}
+
+/// The `Fallback`/`Undecidable` reason every [`is_utf8`] guard reports.
+fn not_utf8_reason(what: &str) -> String {
+    format!("{what} is not UTF-8; Go substitutes U+FFFD and serde refuses to parse")
+}
 
 /// `json.Valid`: one complete JSON value, trailing whitespace allowed and
 /// nothing else.
@@ -237,12 +284,32 @@ pub enum Decoded {
 /// `serde_json::from_slice` would reject it, which is why this drives the
 /// `Deserializer` by hand and never calls `end()`.
 ///
+/// **It returns the first value's bytes**, and that is not a convenience. The
+/// caller's next step is `json.Unmarshal(raw, &any)` over exactly what `Decode`
+/// captured, so a port that handed it `body` again would be scanning bytes Go
+/// never looked at: `{"a":1} 1e999` is a 200 in Go and was a
+/// `400 invalid JSON settings` here, because [`numbers_fit_float64`] read the
+/// whole slice while the decode read only the head. One value in, one value on.
+///
 /// `Err(None)` is Go's decode error; `Err(Some(reason))` is a document this
 /// port's parser will not judge.
-pub fn decode_stream_head(body: &[u8]) -> Result<(), Option<String>> {
+pub fn decode_stream_head(body: &[u8]) -> Result<&[u8], Option<String>> {
+    // `json.Decoder` scans with `encoding/json`'s scanner, so the 10000-level
+    // cap applies to `Decode` exactly as it applies to `json.Valid`. Verified
+    // against Go 1.26.5: a 10001-deep body is `exceeded max depth`, which the
+    // handlers turn into their 400 — while serde's `ignore_value` is iterative
+    // and would have decoded it happily.
+    if nesting_depth_exceeds(body, GO_MAX_NESTING_DEPTH) {
+        return Err(None);
+    }
+    if !is_utf8(body) {
+        return Err(Some(not_utf8_reason("the request body")));
+    }
     let mut de = serde_json::Deserializer::from_slice(body);
-    match IgnoredAny::deserialize(&mut de) {
-        Ok(_) => Ok(()),
+    // `&RawValue` rather than `IgnoredAny`: its skip is the same iterative
+    // `ignore_value`, and it hands back the span that was skipped.
+    match <&RawValue>::deserialize(&mut de) {
+        Ok(raw) => Ok(raw.get().as_bytes()),
         Err(e) if is_recursion_limit(&e) => Err(Some(e.to_string())),
         Err(_) => Err(None),
     }
@@ -272,10 +339,31 @@ pub fn decode_stream_head(body: &[u8]) -> Result<(), Option<String>> {
 /// Duplicate keys forward for the reason `decode_body` documents: `encoding/json`
 /// keeps the last occurrence but type-checks every one, and serde refuses them
 /// outright, so only Go can answer. Safe because this runs before any mutation.
+///
+/// The two guards ahead of the decode are the two places serde and
+/// `encoding/json` disagree about the *body* rather than about a value:
+///
+/// - **Depth.** `Decode` drives `encoding/json`'s scanner, so it stops at 10000
+///   levels — including inside a field the struct ignores. serde routes an
+///   unknown field to `IgnoredAny`, whose skip is iterative and counts nothing,
+///   so `{"name":"x","junk":[×10001]}` decoded here with `name == "x"` and
+///   *created a profile Go refuses*, answering 201 where Go answers
+///   `400 name is required`. A state-changing divergence, which is why the
+///   check is on the body and not on the fields.
+/// - **UTF-8.** See [`is_utf8`]: Go substitutes U+FFFD into a `string` field
+///   and carries on, serde fails the decode. Forwarded rather than guessed.
 pub(crate) fn decode_request<T>(body: &[u8]) -> Result<T, WriteError>
 where
     T: serde::de::DeserializeOwned + Default,
 {
+    if nesting_depth_exceeds(body, GO_MAX_NESTING_DEPTH) {
+        // `json.Decoder`'s scanner stops at 10000, so this never reaches the
+        // struct's fields and the handler sees a zero-valued request.
+        return Err(WriteError::InvalidBody);
+    }
+    if !is_utf8(body) {
+        return Err(WriteError::Fallback(not_utf8_reason("the request body")));
+    }
     match first_token(body) {
         Some(b'{') => {
             let mut de = serde_json::Deserializer::from_slice(body);
@@ -309,7 +397,9 @@ fn trim_leading_space(body: &[u8]) -> &[u8] {
 /// step between them.
 pub fn decode_go_any(body: &[u8]) -> Decoded {
     match decode_stream_head(body) {
-        Ok(()) => go_any(body),
+        // The **first value's** bytes, not `body`: that is what Go's `Decode`
+        // captured and what its `Unmarshal` then sees.
+        Ok(first) => go_any(first),
         Err(None) => Decoded::NotJson,
         Err(Some(reason)) => Decoded::Undecidable(reason),
     }
@@ -318,6 +408,10 @@ pub fn decode_go_any(body: &[u8]) -> Decoded {
 /// `json.Unmarshal(raw, &v any)` for a body already known to be syntactically
 /// valid JSON.
 pub fn go_any(body: &[u8]) -> Decoded {
+    // Go parses these; serde refuses to. See [`is_utf8`].
+    if !is_utf8(body) {
+        return Decoded::Undecidable(not_utf8_reason("the value"));
+    }
     if !numbers_fit_float64(body) {
         return Decoded::NumberOutOfRange;
     }
@@ -424,14 +518,21 @@ fn widen_numbers(value: Value) -> Option<Value> {
 pub fn marshal_indent(value: &Value) -> Result<Vec<u8>, String> {
     let compact =
         gojson::to_vec_marshal(value).map_err(|e| format!("marshaling settings JSON: {e}"))?;
-    Ok(gojson::indent(&compact))
+    Ok(gojson::indent_compact(&compact))
 }
 
 /// Carry stored bytes to the wire the way a `json.RawMessage` field does:
 /// through Go's `compact`, so key order and number spelling survive.
-pub fn raw_field(bytes: &[u8]) -> Option<Box<RawValue>> {
-    let text = std::str::from_utf8(bytes).ok()?;
-    RawValue::from_string(gojson::compact(text)).ok()
+///
+/// `Result` rather than `Option` on purpose. Every caller puts this behind a
+/// `skip_serializing_if` or a nullable field, so a `None` here would not be an
+/// error — it would be a **200 with the `settings` key quietly missing**, which
+/// is exactly what non-UTF-8 bytes used to produce. Callers now have to say what
+/// a failure means, and all of them say "forward".
+pub fn raw_field(bytes: &[u8]) -> Result<Box<RawValue>, String> {
+    let text = std::str::from_utf8(bytes).map_err(|_| not_utf8_reason("the stored bytes"))?;
+    RawValue::from_string(gojson::compact(text))
+        .map_err(|e| format!("re-emitting stored JSON: {e}"))
 }
 
 // ─── GET / PUT /api/claude-settings ───────────────────────────────────────────
@@ -466,6 +567,13 @@ pub fn get_settings(dir: &str) -> Result<super::Answer, String> {
         Err(e) => return Err(format!("reading {path}: {e}")),
     };
 
+    // Go serves these bytes verbatim through its encoder; serde cannot build a
+    // `RawValue` from them. Forwarding is the only right answer — dropping the
+    // key would have been `{"exists":true}` where Go sends the whole document.
+    if !is_utf8(&data) {
+        return Err(not_utf8_reason(&path));
+    }
+
     if !go_json_valid(&data) {
         // Also a 500 in Go ("Claude settings file contains invalid JSON").
         return Err(format!("{path} contains invalid JSON"));
@@ -473,7 +581,7 @@ pub fn get_settings(dir: &str) -> Result<super::Answer, String> {
 
     let body = gojson::to_vec(&ClaudeSettingsResponse {
         exists: true,
-        settings: raw_field(&data),
+        settings: Some(raw_field(&data)?),
     })
     .map_err(|e| format!("encoding claude settings: {e}"))?;
     Ok(super::Answer::json(body))
@@ -491,7 +599,8 @@ pub fn get_settings(dir: &str) -> Result<super::Answer, String> {
 /// and invisible, but reordering it would still be a port that guessed.
 pub fn put_settings(dir: &str, body: &[u8]) -> Result<super::Answer, WriteError> {
     // 1. `json.NewDecoder(r.Body).Decode(&incoming)` — `errInvalidJSONBody`.
-    decode_stream_head(body).map_err(|reason| match reason {
+    // `incoming` is the first value only, and step 4 parses *that*, not `body`.
+    let incoming = decode_stream_head(body).map_err(|reason| match reason {
         Some(reason) => WriteError::Fallback(reason),
         None => WriteError::InvalidBody,
     })?;
@@ -504,14 +613,21 @@ pub fn put_settings(dir: &str, body: &[u8]) -> Result<super::Answer, WriteError>
 
     // 4. `json.Unmarshal(incoming, &pretty)` — the handler's own message, which
     // is not `errInvalidJSONBody`.
-    let value = match go_any(body) {
+    let value = match go_any(incoming) {
         Decoded::Value(value) => value,
         Decoded::NumberOutOfRange => {
             return Err(WriteError::BadRequest("invalid JSON settings".to_string()))
         }
         Decoded::Undecidable(reason) => return Err(WriteError::Fallback(reason)),
-        // Unreachable: step 1 established the syntax.
-        Decoded::NotJson => return Err(WriteError::InvalidBody),
+        // Step 1 captured a complete value and checked its bytes, so this means
+        // the two parsers disagree about what JSON is. Forward rather than pick
+        // a side: the arm that used to answer 400 here was reachable through
+        // non-UTF-8 bytes, where Go writes the file and answers 200.
+        Decoded::NotJson => {
+            return Err(WriteError::Fallback(
+                "the decoded value does not re-parse; only Go can say".to_string(),
+            ))
+        }
     };
 
     let out = marshal_indent(&value).map_err(WriteError::Fallback)?;
@@ -521,7 +637,7 @@ pub fn put_settings(dir: &str, body: &[u8]) -> Result<super::Answer, WriteError>
 
     let answer = gojson::to_vec(&ClaudeSettingsResponse {
         exists: true,
-        settings: raw_field(&out),
+        settings: Some(raw_field(&out).map_err(WriteError::Fallback)?),
     })
     .map_err(|e| WriteError::Fallback(format!("encoding claude settings: {e}")))?;
     Ok(super::Answer::json(answer))
@@ -769,6 +885,91 @@ mod tests {
             decode_go_any(br#"{"a":1}trailing"#),
             Decoded::Value(_)
         ));
+        // …and *nothing* downstream may look at them either. `{"a":1} 1e999` is
+        // a 200 in Go, because `Decode` hands `Unmarshal` only `{"a":1}`. This
+        // was a `400 invalid JSON settings` while the number scan read the whole
+        // body — the case the assertion above missed, because `trailing`
+        // contains no number.
+        assert!(matches!(
+            decode_go_any(br#"{"a":1} 1e999"#),
+            Decoded::Value(_)
+        ));
+        // The first value is also all that is *written*.
+        assert_eq!(
+            decode_stream_head(br#"{"a":1} 1e999"#).expect("decodes"),
+            br#"{"a":1}"#
+        );
+    }
+
+    /// **`json.Decoder` enforces the scanner's 10000-level cap.** Verified
+    /// against Go 1.26.5: a 10001-deep body is `exceeded max depth` — including
+    /// when the depth is inside a field the struct ignores, where serde's
+    /// iterative `IgnoredAny` skip counts nothing and would have decoded it.
+    #[test]
+    fn a_decode_stops_where_gos_scanner_stops() {
+        #[derive(Debug, Default, Deserialize)]
+        #[serde(default)]
+        struct Probe {
+            name: String,
+        }
+
+        // Depth 10001: the object plus 10000 arrays.
+        let too_deep = format!(
+            r#"{{"name":"x","junk":{}{}}}"#,
+            "[".repeat(10000),
+            "]".repeat(10000)
+        );
+        assert_eq!(
+            decode_request::<Probe>(too_deep.as_bytes()).unwrap_err(),
+            WriteError::InvalidBody,
+            "Go's Decode errors, so `name` never lands and the handler 400s"
+        );
+        assert!(matches!(
+            decode_go_any(too_deep.as_bytes()),
+            Decoded::NotJson
+        ));
+
+        // Depth 10000 exactly: Go decodes it, and so must this.
+        let deep_enough = format!(
+            r#"{{"name":"x","junk":{}{}}}"#,
+            "[".repeat(9999),
+            "]".repeat(9999)
+        );
+        let decoded: Probe = decode_request(deep_enough.as_bytes()).expect("Go decodes this");
+        assert_eq!(decoded.name, "x");
+    }
+
+    /// **Go's JSON layer is not UTF-8-strict and serde's is.** Every one of
+    /// these is `true`/`Ok` in Go — `json.Valid`, `Unmarshal` into `any`,
+    /// `MarshalIndent`, and the encoder's `json.RawMessage` passthrough — so
+    /// none of them may be a Rust *answer*. They forward.
+    #[test]
+    fn bytes_that_are_not_utf8_forward_rather_than_answering() {
+        let src = b"{\"a\":\"\xff\"}";
+
+        // `json.Valid` says true, and so does this — the skip does not validate.
+        assert!(go_json_valid(src));
+        // …but every parse that materializes the string forwards.
+        assert!(matches!(go_any(src), Decoded::Undecidable(_)));
+        assert!(matches!(decode_go_any(src), Decoded::Undecidable(_)));
+        assert!(
+            decode_stream_head(src).unwrap_err().is_some(),
+            "a forward, not Go's decode error"
+        );
+
+        #[derive(Debug, Default, Deserialize)]
+        #[serde(default)]
+        struct Probe {
+            #[serde(deserialize_with = "gojson::null_is_zero_value")]
+            a: String,
+        }
+        assert!(matches!(
+            decode_request::<Probe>(src).unwrap_err(),
+            WriteError::Fallback(_)
+        ));
+
+        // And the wire re-emission, which used to drop the key silently.
+        assert!(raw_field(src).is_err());
     }
 
     #[test]
@@ -875,7 +1076,7 @@ mod tests {
         let raw = b"{\n  \"z\": 1.50,\n  \"a\": \"<b>\"\n}";
         let body = gojson::to_vec(&ClaudeSettingsResponse {
             exists: true,
-            settings: raw_field(raw),
+            settings: raw_field(raw).ok(),
         })
         .expect("encode");
         assert_eq!(
@@ -921,7 +1122,7 @@ mod tests {
         );
         let body = gojson::to_vec(&ClaudeSettingsResponse {
             exists: true,
-            settings: raw_field(&out),
+            settings: raw_field(&out).ok(),
         })
         .expect("encode");
         assert_eq!(
@@ -987,6 +1188,17 @@ mod tests {
         // 500s — it forwards.
         write_file(&settings_json_path(&dir), b"not json").expect("write");
         assert!(get_settings(&dir).is_err());
+
+        // A file that is valid JSON to Go but not UTF-8. Go's `json.Valid`
+        // passes and its encoder ships the bytes verbatim, so the answer is
+        // `{"exists":true,"settings":{…}}`. serde cannot build that, and the
+        // old code dropped the key and answered `{"exists":true}` — a wrong
+        // answer where a forward was available.
+        write_file(&settings_json_path(&dir), b"{\"a\":\"\xff\"}").expect("write");
+        assert!(
+            get_settings(&dir).is_err(),
+            "non-UTF-8 settings must forward, not lose the `settings` key"
+        );
     }
 
     /// The write: every status and message, and the file left behind.
@@ -1013,11 +1225,31 @@ mod tests {
             "{\"exists\":true,\"settings\":{\"tiny\":0}}\n"
         );
 
-        // A `Decoder` stops at the first value.
+        // A `Decoder` stops at the first value — and so does everything after
+        // it, including the number scan. `1e999` past the first value is a 200.
         assert_eq!(
             body_of(put_settings(&dir, br#"{"trailing":true} and then some"#).expect("write")),
             "{\"exists\":true,\"settings\":{\"trailing\":true}}\n"
         );
+        assert_eq!(
+            body_of(put_settings(&dir, br#"{"trailing":true} 1e999"#).expect("write")),
+            "{\"exists\":true,\"settings\":{\"trailing\":true}}\n"
+        );
+
+        // Not UTF-8: Go writes the file with U+FFFD substituted and answers
+        // 200. This port cannot reproduce that, so it forwards rather than
+        // answering the 400 it used to.
+        assert!(matches!(
+            put_settings(&dir, b"{\"a\":\"\xff\"}").unwrap_err(),
+            WriteError::Fallback(_)
+        ));
+
+        // Deeper than the scanner's 10000 levels: `Decode` fails, so this is
+        // `errInvalidJSONBody` and not the second parse's message.
+        let too_deep = format!("{}{}", "[".repeat(10001), "]".repeat(10001));
+        let err = put_settings(&dir, too_deep.as_bytes()).unwrap_err();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(err.message(), "invalid JSON body");
 
         // A scalar is a JSON value, so it is written as one.
         assert_eq!(

--- a/desktop/src-tauri/src/native/claude_settings/profiles.rs
+++ b/desktop/src-tauri/src/native/claude_settings/profiles.rs
@@ -1,0 +1,1361 @@
+//! The seven profile routes: `service.claudeSettingsProfileService` and the
+//! `settings_profiles.json` index it keeps, in Rust.
+//!
+//! # A read here is a write
+//!
+//! `GET /api/claude-settings/profiles` calls `ensureDefaultProfileExists`, which
+//! seeds `settings_default.json` from the current `settings.json` and writes the
+//! index — so the very first list creates two files. `POST` and
+//! `PUT .../default` do the same; `GET/PUT/DELETE .../{id}` and `duplicate`
+//! deliberately do **not**, which is why a `GET` on a missing id is a 404 rather
+//! than a list that has just been seeded.
+//!
+//! That is also why this area could not be split into "the reads now, the writes
+//! later": there is no read here that does not write.
+//!
+//! It is also the one place `Mode::Diff`'s "never run a write" rule does not
+//! cover, since this *is* a `GET` — and it is harmless: the proxy runs Rust
+//! first and Go second, and seeding is idempotent, so Go's list finds the index
+//! Rust just wrote and re-seeds nothing. The two answers are the same bytes
+//! because the second call had nothing left to do.
+//!
+//! # Which errors are answers, and which are forwarded
+//!
+//! `httpErr` maps the service's three typed errors and turns everything else
+//! into a 500. Only four failures reach the wire from this file:
+//!
+//! | | |
+//! |---|---|
+//! | 400 `name is required` | the **handler's** own check on create — not the service's 422, because `handleCreateClaudeSettingsProfile` tests `err != nil \|\| req.Name == ""` before the service runs. A malformed body reaches it too, so `["x"]` is `name is required` and not `invalid JSON body`. |
+//! | 400 `invalid JSON body` | the update handler, which *does* use `errInvalidJSONBody`. |
+//! | 404 `profile "<id>" not found` | `NotFoundError`. |
+//! | 409 `profile with id "<id>" already exists` | `ConflictError` — used both for a rename collision **and** for deleting the default profile, where the wording is Go's and reads oddly. Reproduced, not improved. |
+//! | 422 `validation error for "settings": failed to parse settings JSON` | the one reachable `ValidationError`: `json.Valid` passes a number `strconv.ParseFloat` then rejects. |
+//!
+//! Everything else Go answers with a 500, so it forwards.
+//!
+//! # Two rules with no error to announce them
+//!
+//! - **A named profile keeps its recorded absolute path.** Every operation that
+//!   reads or removes a profile file uses `Profile::file_path` verbatim; only
+//!   create, rename and the seeded default *derive* one from the dir. Moving
+//!   the config dir must not silently repoint a profile at a file that is not
+//!   its own.
+//! - **`slugify` walks Unicode categories.** `unicode.IsLetter`/`IsDigit` keep
+//!   accented letters, which `safeProfileID` then rejects — so a non-ASCII name
+//!   is a 500 in Go unless every character happens to be dropped. Rust's
+//!   `char::is_alphabetic` is a *different* set (it includes `Nl` and
+//!   `Other_Alphabetic`), so rather than approximate the tables, any non-ASCII
+//!   name forwards. It forwards before anything is written, and Go then gives
+//!   whichever of the two answers is right.
+
+use axum::http::StatusCode;
+use serde::{Deserialize, Serialize};
+use serde_json::value::RawValue;
+use serde_json::Value;
+
+use super::super::writes::WriteError;
+use super::super::{gojson, gopath, Answer};
+use super::{
+    decode_request, go_any, go_json_valid, marshal_indent, mkdir_all, raw_field,
+    settings_json_path, Decoded,
+};
+
+// ─── The index ────────────────────────────────────────────────────────────────
+
+/// `config.ClaudeSettingsProfile`. Field order is the Go struct's, which is what
+/// decides the key order on the wire.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Profile {
+    #[serde(default, deserialize_with = "gojson::null_is_zero_value")]
+    pub id: String,
+    #[serde(default, deserialize_with = "gojson::null_is_zero_value")]
+    pub name: String,
+    #[serde(default, deserialize_with = "gojson::null_is_zero_value")]
+    pub file_path: String,
+    #[serde(default, deserialize_with = "gojson::null_is_zero_value")]
+    pub is_default: bool,
+}
+
+/// `config.ProfilesMetadata`, as read.
+#[derive(Debug, Default, Deserialize)]
+struct MetadataIn {
+    #[serde(default)]
+    profiles: Option<Vec<Profile>>,
+}
+
+/// `config.ProfilesMetadata`, as written.
+///
+/// A slice rather than an `Option`, because **no save path can produce a nil
+/// one**: `ensureDefaultProfileExists` assigns a one-element slice, create and
+/// duplicate append, and delete only runs once an index has been found — so the
+/// `{"profiles": null}` an untouched struct would marshal is unreachable here.
+/// Deleting the last profile *is* reachable and writes `[]`, which is the
+/// distinction that does travel.
+#[derive(Debug, Serialize)]
+struct MetadataOut<'a> {
+    profiles: &'a [Profile],
+}
+
+/// `config.LoadProfilesMetadata`. A missing file is an empty index, not an
+/// error; anything else Go answers with a 500, so it forwards.
+fn load(dir: &str) -> Result<Vec<Profile>, WriteError> {
+    let path = super::profiles_path(dir);
+    let data = match std::fs::read(&path) {
+        Ok(data) => data,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(WriteError::Fallback(format!("reading {path}: {e}"))),
+    };
+    // `json.Unmarshal` into a struct: a whole-file `null` is a no-op leaving the
+    // zero value, an array is a type error, an object is decoded.
+    let shape: Value = serde_json::from_slice(&data)
+        .map_err(|e| WriteError::Fallback(format!("parsing {path}: {e}")))?;
+    match shape {
+        Value::Null => Ok(Vec::new()),
+        Value::Object(_) => serde_json::from_slice::<MetadataIn>(&data)
+            .map(|m| m.profiles.unwrap_or_default())
+            .map_err(|e| WriteError::Fallback(format!("decoding {path}: {e}"))),
+        _ => Err(WriteError::Fallback(format!(
+            "{path} is not a profiles index"
+        ))),
+    }
+}
+
+/// The exact bytes `saveProfilesMetadata` puts in the file.
+///
+/// Public because the live parity suite compares them against an index the Go
+/// server wrote: the two processes share this file, so a formatting difference
+/// would make it churn every time they take turns.
+pub fn encode_index(profiles: &[Profile]) -> Result<Vec<u8>, String> {
+    let compact = gojson::to_vec_marshal(&MetadataOut { profiles })
+        .map_err(|e| format!("marshaling profiles index: {e}"))?;
+    Ok(gojson::indent(&compact))
+}
+
+/// `saveProfilesMetadata`: `MarshalIndent` into the file, mode 0600.
+fn save(dir: &str, profiles: &[Profile]) -> Result<(), WriteError> {
+    let path = super::profiles_path(dir);
+    if let Err(e) = mkdir_all(&gopath::dir(&path)) {
+        return Err(WriteError::Fallback(format!("creating {dir}: {e}")));
+    }
+    let data = encode_index(profiles).map_err(WriteError::Fallback)?;
+    super::write_file(&path, &data)
+        .map_err(|e| WriteError::Fallback(format!("writing {path}: {e}")))
+}
+
+/// `ensureDefaultProfileExists`: seed a "Default" profile from the current
+/// `settings.json` when the index is empty.
+fn ensure_default(dir: &str) -> Result<(), WriteError> {
+    if !load(dir)?.is_empty() {
+        return Ok(());
+    }
+    if let Err(e) = mkdir_all(dir) {
+        return Err(WriteError::Fallback(format!("creating {dir}: {e}")));
+    }
+
+    // An unreadable or unparseable settings.json seeds an empty object rather
+    // than failing — the profile has to exist either way.
+    let content = std::fs::read(settings_json_path(dir)).unwrap_or_else(|_| b"{}".to_vec());
+    let value = match go_any(&content) {
+        Decoded::Value(value) => value,
+        Decoded::NotJson | Decoded::NumberOutOfRange => Value::Object(serde_json::Map::new()),
+        // Go's parser would have succeeded; ours cannot say. Nothing but the
+        // directory has been touched, so forwarding is exact.
+        Decoded::Undecidable(reason) => return Err(WriteError::Fallback(reason)),
+    };
+    let out = marshal_indent(&value).map_err(WriteError::Fallback)?;
+
+    let file_path = gopath::join(&[dir, "settings_default.json"]);
+    super::write_file(&file_path, &out)
+        .map_err(|e| WriteError::Fallback(format!("writing {file_path}: {e}")))?;
+
+    save(
+        dir,
+        &[Profile {
+            id: "default".to_string(),
+            name: "Default".to_string(),
+            file_path,
+            is_default: true,
+        }],
+    )
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+fn find_index(profiles: &[Profile], id: &str) -> Option<usize> {
+    profiles.iter().position(|p| p.id == id)
+}
+
+fn not_found(id: &str) -> WriteError {
+    WriteError::NotFound {
+        resource: "profile".to_string(),
+        id: id.to_string(),
+    }
+}
+
+fn conflict(id: &str) -> WriteError {
+    WriteError::Conflict {
+        resource: "profile".to_string(),
+        id: id.to_string(),
+    }
+}
+
+/// `deduplicateID`: `base`, then `base-2`, `base-3`, …
+fn deduplicate_id(base: &str, profiles: &[Profile]) -> String {
+    let mut id = base.to_string();
+    let mut n = 2;
+    while find_index(profiles, &id).is_some() {
+        id = format!("{base}-{n}");
+        n += 1;
+    }
+    id
+}
+
+/// `slugify`, for the ASCII names it can be reproduced for — see the module
+/// header for why a non-ASCII one forwards instead.
+fn slugify(name: &str) -> Result<String, WriteError> {
+    if !name.is_ascii() {
+        return Err(WriteError::Fallback(format!(
+            "profile name {name:?} is not ASCII: Go slugifies by Unicode category"
+        )));
+    }
+    let mut slug = String::with_capacity(name.len());
+    let mut prev_dash = false;
+    for c in name.to_ascii_lowercase().chars() {
+        if c == ' ' || c == '-' {
+            // `reConsecutiveDashes` collapses the run afterwards; doing it here
+            // is the same string.
+            if !prev_dash {
+                slug.push('-');
+                prev_dash = true;
+            }
+        } else if c.is_ascii_alphanumeric() {
+            slug.push(c);
+            prev_dash = false;
+        }
+        // Everything else — including `_` — is dropped by `strings.Map`.
+    }
+    let trimmed = slug.trim_matches('-');
+    Ok(if trimmed.is_empty() {
+        "profile".to_string()
+    } else {
+        trimmed.to_string()
+    })
+}
+
+/// `resolveProfileFilePath`: `safeProfileID` first, so a tampered index cannot
+/// name a path outside the dir. An id that fails it is a 500 in Go.
+fn resolve_profile_file_path(dir: &str, id: &str) -> Result<String, WriteError> {
+    let safe = !id.is_empty()
+        && id
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-');
+    if !safe {
+        return Err(WriteError::Fallback(format!(
+            "invalid profile id {id:?}: contains disallowed characters"
+        )));
+    }
+    Ok(gopath::join(&[dir, &format!("settings_{id}.json")]))
+}
+
+/// `validatePathWithinDir`.
+///
+/// A **relative** recorded path forwards rather than being resolved: Go's
+/// `filepath.Abs` resolves it against the *server's* working directory, which is
+/// a different process's and unknowable here. Every path this surface writes is
+/// absolute, so this only fires on a hand-edited index.
+fn validate_path_within_dir(path: &str, dir: &str) -> Result<(), WriteError> {
+    if !path.starts_with('/') {
+        return Err(WriteError::Fallback(format!(
+            "profile file path {path:?} is relative; only the Go server knows its working directory"
+        )));
+    }
+    let abs = gopath::clean(path);
+    if !abs.starts_with(&format!("{dir}/")) {
+        return Err(WriteError::Fallback(format!(
+            "path {abs:?} escapes settings directory"
+        )));
+    }
+    Ok(())
+}
+
+/// `readDefaultProfileContent`: the current default profile's bytes, **verbatim**
+/// — the new profile is a copy, not a reformat.
+fn read_default_profile_content(profiles: &[Profile]) -> Vec<u8> {
+    match profiles.iter().find(|p| p.is_default) {
+        Some(p) => std::fs::read(&p.file_path).unwrap_or_else(|_| b"{}".to_vec()),
+        None => b"{}".to_vec(),
+    }
+}
+
+/// `syncDefaultToSettingsJSON`: copy the default profile's bytes over
+/// `settings.json`. A missing profile file syncs `{}` rather than failing.
+fn sync_default_to_settings_json(profile: &Profile, dir: &str) -> Result<(), String> {
+    let data = match std::fs::read(&profile.file_path) {
+        Ok(data) => data,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => b"{}".to_vec(),
+        Err(e) => return Err(format!("reading {}: {e}", profile.file_path)),
+    };
+    let path = settings_json_path(dir);
+    super::write_file(&path, &data).map_err(|e| format!("writing {path}: {e}"))
+}
+
+// ─── Responses ────────────────────────────────────────────────────────────────
+
+/// `service.ClaudeSettingsProfileDetail`: the embedded profile's four fields
+/// inlined ahead of its own two, which is how Go flattens an embedded struct.
+#[derive(Debug, Serialize)]
+struct ProfileDetail<'a> {
+    id: &'a str,
+    name: &'a str,
+    file_path: &'a str,
+    is_default: bool,
+    /// No `omitempty`, so a missing or unparseable file ships `null`.
+    settings: Option<Box<RawValue>>,
+    exists: bool,
+}
+
+/// `buildProfileDetail`.
+fn detail_body(profile: &Profile, dir: &str) -> Result<Vec<u8>, WriteError> {
+    validate_path_within_dir(&profile.file_path, dir)?;
+
+    let mut settings = None;
+    let mut exists = false;
+    if let Ok(data) = std::fs::read(&profile.file_path) {
+        // `json.Valid` only. An unparseable file is `exists: false` with a
+        // `null` payload — an answer, not an error.
+        if go_json_valid(&data) {
+            settings = raw_field(&data);
+            exists = true;
+        }
+    }
+
+    gojson::to_vec(&ProfileDetail {
+        id: &profile.id,
+        name: &profile.name,
+        file_path: &profile.file_path,
+        is_default: profile.is_default,
+        settings,
+        exists,
+    })
+    .map_err(|e| WriteError::Fallback(format!("encoding profile detail: {e}")))
+}
+
+fn profile_answer(status: StatusCode, profile: &Profile) -> Result<Answer, WriteError> {
+    let body = gojson::to_vec(profile)
+        .map_err(|e| WriteError::Fallback(format!("encoding profile: {e}")))?;
+    Ok(Answer::json_status(status, body))
+}
+
+// ─── The seven operations ─────────────────────────────────────────────────────
+
+/// `GET /api/claude-settings/profiles` — `ListProfiles`.
+pub fn list(dir: &str) -> Result<Answer, WriteError> {
+    ensure_default(dir)?;
+    let profiles = load(dir)?;
+    // Go returns an explicit empty slice for a nil one, so this is never `null`.
+    let body = gojson::to_vec(&profiles)
+        .map_err(|e| WriteError::Fallback(format!("encoding profiles: {e}")))?;
+    Ok(Answer::json(body))
+}
+
+/// `api.CreateProfileRequest`.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct CreateRequest {
+    #[serde(deserialize_with = "gojson::null_is_zero_value")]
+    name: String,
+}
+
+/// `POST /api/claude-settings/profiles` — `CreateProfile`.
+pub fn create(dir: &str, body: &[u8]) -> Result<Answer, WriteError> {
+    // The handler folds a decode failure and an empty name into one 400 with one
+    // message, so an array body says `name is required` rather than
+    // `invalid JSON body`.
+    let req: CreateRequest = match decode_request(body) {
+        Ok(req) => req,
+        Err(WriteError::InvalidBody) => {
+            return Err(WriteError::BadRequest("name is required".to_string()))
+        }
+        Err(other) => return Err(other),
+    };
+    if req.name.is_empty() {
+        return Err(WriteError::BadRequest("name is required".to_string()));
+    }
+
+    ensure_default(dir)?;
+    let mut profiles = load(dir)?;
+
+    let id = deduplicate_id(&slugify(&req.name)?, &profiles);
+    let content = read_default_profile_content(&profiles);
+    let file_path = resolve_profile_file_path(dir, &id)?;
+    super::write_file(&file_path, &content)
+        .map_err(|e| WriteError::Fallback(format!("writing {file_path}: {e}")))?;
+
+    let profile = Profile {
+        id,
+        name: req.name,
+        file_path,
+        is_default: false,
+    };
+    profiles.push(profile.clone());
+    save(dir, &profiles)?;
+    profile_answer(StatusCode::CREATED, &profile)
+}
+
+/// `GET /api/claude-settings/profiles/{id}` — `GetProfile`. No
+/// `ensureDefaultProfileExists`, so an id that does not exist is a 404 rather
+/// than a freshly seeded index.
+pub fn get(dir: &str, id: &str) -> Result<Answer, WriteError> {
+    let profiles = load(dir)?;
+    let idx = find_index(&profiles, id).ok_or_else(|| not_found(id))?;
+    Ok(Answer::json(detail_body(&profiles[idx], dir)?))
+}
+
+/// `api.UpdateProfileRequest`.
+///
+/// `Name` is a `*string`, so an absent key and an explicit `null` are both "do
+/// not rename" while `""` is a rename the service then ignores. `Settings` is a
+/// `json.RawMessage`, which Go hands the four bytes of a literal `null` — the
+/// service tests for exactly that string, so [`gojson::captured_raw`] has to
+/// keep it rather than folding it into `None`.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct UpdateRequest {
+    name: Option<String>,
+    #[serde(deserialize_with = "gojson::captured_raw")]
+    settings: Option<Box<RawValue>>,
+}
+
+/// `PUT /api/claude-settings/profiles/{id}` — `UpdateProfile`.
+pub fn update(dir: &str, id: &str, body: &[u8]) -> Result<Answer, WriteError> {
+    let req: UpdateRequest = decode_request(body)?;
+    let mut profiles = load(dir)?;
+    let idx = find_index(&profiles, id).ok_or_else(|| not_found(id))?;
+
+    // `validateSettingsJSON` runs before any filesystem mutation so a rename
+    // cannot land with the settings unwritten. Its `json.Valid` check cannot
+    // fail — the bytes came out of a decoder — but the *second* parse, into
+    // `any`, can, and Go reaches it only after the rename. Parsing here and
+    // reporting later keeps both: Go's state and Go's answer.
+    //
+    // Deciding it now is also what makes `Undecidable` safe to forward: an
+    // `Err` after the rename would send Go a request whose id no longer exists.
+    let settings = match req.settings.as_deref().map(RawValue::get) {
+        None => None,
+        Some("null") => None,
+        Some(raw) => {
+            if !go_json_valid(raw.as_bytes()) {
+                return Err(WriteError::validation(
+                    "settings",
+                    "settings must be valid JSON",
+                ));
+            }
+            match go_any(raw.as_bytes()) {
+                Decoded::Value(value) => Some(Ok(value)),
+                Decoded::NumberOutOfRange => Some(Err(())),
+                Decoded::NotJson => return Err(WriteError::InvalidBody),
+                Decoded::Undecidable(reason) => return Err(WriteError::Fallback(reason)),
+            }
+        }
+    };
+
+    if let Some(new_name) = req.name.as_deref() {
+        if !new_name.is_empty() && new_name != profiles[idx].name {
+            rename(&mut profiles, idx, id, new_name, dir)?;
+        }
+    }
+
+    match settings {
+        None => {}
+        // The deferred 422, raised where Go raises it — after the rename.
+        Some(Err(())) => {
+            return Err(WriteError::validation(
+                "settings",
+                "failed to parse settings JSON",
+            ))
+        }
+        Some(Ok(value)) => {
+            let out = marshal_indent(&value).map_err(WriteError::Fallback)?;
+            let path = profiles[idx].file_path.clone();
+            super::write_file(&path, &out)
+                .map_err(|e| WriteError::Fallback(format!("writing {path}: {e}")))?;
+            if profiles[idx].is_default {
+                // Go logs this failure and carries on, so the request still
+                // succeeds with settings.json left behind.
+                if let Err(e) = sync_default_to_settings_json(&profiles[idx], dir) {
+                    log::error!("native claude-settings: sync default profile failed: {e}");
+                }
+            }
+        }
+    }
+
+    save(dir, &profiles)?;
+    Ok(Answer::json(detail_body(&profiles[idx], dir)?))
+}
+
+/// `renameProfile` + `moveProfileFile`.
+///
+/// A rename collision is an explicit 409 rather than the auto-deduplication
+/// create and duplicate perform — the two really do differ.
+fn rename(
+    profiles: &mut [Profile],
+    idx: usize,
+    current_id: &str,
+    new_name: &str,
+    dir: &str,
+) -> Result<(), WriteError> {
+    let new_id = slugify(new_name)?;
+    if new_id != current_id {
+        if profiles
+            .iter()
+            .enumerate()
+            .any(|(i, p)| i != idx && p.id == new_id)
+        {
+            return Err(conflict(&new_id));
+        }
+        let new_file_path = resolve_profile_file_path(dir, &new_id)?;
+        // No file to move is not an error: the index is updated and the write
+        // that follows creates it at the new path.
+        if let Ok(data) = std::fs::read(&profiles[idx].file_path) {
+            super::write_file(&new_file_path, &data)
+                .map_err(|e| WriteError::Fallback(format!("writing {new_file_path}: {e}")))?;
+            // Go warns and continues if the old file cannot be removed.
+            let _ = std::fs::remove_file(&profiles[idx].file_path);
+        }
+        profiles[idx].id = new_id;
+        profiles[idx].file_path = new_file_path;
+    }
+    profiles[idx].name = new_name.to_string();
+    Ok(())
+}
+
+/// `DELETE /api/claude-settings/profiles/{id}` — `DeleteProfile`.
+pub fn delete(dir: &str, id: &str) -> Result<Answer, WriteError> {
+    let mut profiles = load(dir)?;
+    let idx = find_index(&profiles, id).ok_or_else(|| not_found(id))?;
+    if profiles[idx].is_default {
+        // `ConflictError` — so the message says "already exists" for a profile
+        // that cannot be deleted. Go's wording, kept.
+        return Err(conflict(id));
+    }
+
+    let file_path = profiles[idx].file_path.clone();
+    validate_path_within_dir(&file_path, dir)?;
+
+    profiles.remove(idx);
+    // The index is saved *before* the file is removed, and a failed removal is
+    // only logged — so a profile whose file survives is gone from the index.
+    save(dir, &profiles)?;
+    if let Err(e) = std::fs::remove_file(&file_path) {
+        log::warn!("native claude-settings: removing {file_path} failed: {e}");
+    }
+    Ok(Answer::no_content())
+}
+
+/// `POST /api/claude-settings/profiles/{id}/duplicate` — `DuplicateProfile`.
+pub fn duplicate(dir: &str, id: &str) -> Result<Answer, WriteError> {
+    let mut profiles = load(dir)?;
+    let idx = find_index(&profiles, id).ok_or_else(|| not_found(id))?;
+    validate_path_within_dir(&profiles[idx].file_path, dir)?;
+
+    let new_name = format!("Copy of {}", profiles[idx].name);
+    let new_id = deduplicate_id(&slugify(&new_name)?, &profiles);
+    let content = std::fs::read(&profiles[idx].file_path).unwrap_or_else(|_| b"{}".to_vec());
+    let file_path = resolve_profile_file_path(dir, &new_id)?;
+    super::write_file(&file_path, &content)
+        .map_err(|e| WriteError::Fallback(format!("writing {file_path}: {e}")))?;
+
+    let profile = Profile {
+        id: new_id,
+        name: new_name,
+        file_path,
+        is_default: false,
+    };
+    profiles.push(profile.clone());
+    save(dir, &profiles)?;
+    profile_answer(StatusCode::CREATED, &profile)
+}
+
+/// `PUT /api/claude-settings/profiles/{id}/default` — `SetDefaultProfile`.
+///
+/// The order is load-bearing: `settings.json` is overwritten **before** the
+/// index is saved, so a failure in between leaves the file synced to a profile
+/// the index does not yet call default.
+pub fn set_default(dir: &str, id: &str) -> Result<Answer, WriteError> {
+    ensure_default(dir)?;
+    let mut profiles = load(dir)?;
+
+    let mut found = None;
+    for (i, profile) in profiles.iter_mut().enumerate() {
+        profile.is_default = profile.id == id;
+        if profile.is_default {
+            found = Some(i);
+        }
+    }
+    let idx = found.ok_or_else(|| not_found(id))?;
+
+    validate_path_within_dir(&profiles[idx].file_path, dir)?;
+    sync_default_to_settings_json(&profiles[idx], dir)
+        .map_err(|e| WriteError::Fallback(format!("syncing settings.json: {e}")))?;
+    save(dir, &profiles)?;
+    profile_answer(StatusCode::OK, &profiles[idx])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A scratch config dir. The operations take a database path only to resolve
+    /// the dir, so these drive the helpers over a real directory and check the
+    /// files that land in it.
+    fn dir() -> tempfile::TempDir {
+        tempfile::tempdir().expect("temp dir")
+    }
+
+    fn path_of(root: &tempfile::TempDir) -> String {
+        root.path().to_string_lossy().into_owned()
+    }
+
+    fn read(path: &str) -> String {
+        std::fs::read_to_string(path).unwrap_or_else(|e| panic!("reading {path}: {e}"))
+    }
+
+    // ─── slugify and the id rules ─────────────────────────────────────────────
+
+    #[test]
+    fn slugify_matches_gos_map_collapse_and_trim() {
+        for (name, want) in [
+            ("Work", "work"),
+            ("My Profile", "my-profile"),
+            ("  leading", "leading"),
+            ("trailing  ", "trailing"),
+            ("Multiple   Spaces", "multiple-spaces"),
+            ("a--b", "a-b"),
+            ("---", "profile"),
+            ("", "profile"),
+            ("snake_case", "snakecase"),
+            ("Copy of Default", "copy-of-default"),
+            ("v1.2", "v12"),
+        ] {
+            assert_eq!(slugify(name).expect("ascii"), want, "name {name:?}");
+        }
+    }
+
+    /// Go keeps Unicode letters and then rejects the id it built, unless every
+    /// character happened to be dropped. Two different answers from one rule
+    /// this port does not reproduce, so it hands the name over.
+    #[test]
+    fn a_non_ascii_name_forwards_rather_than_guessing_a_slug() {
+        assert!(matches!(
+            slugify("Café").unwrap_err(),
+            WriteError::Fallback(_)
+        ));
+        assert!(matches!(slugify("™").unwrap_err(), WriteError::Fallback(_)));
+    }
+
+    #[test]
+    fn an_id_that_is_not_filename_safe_is_never_turned_into_a_path() {
+        let root = dir();
+        let d = path_of(&root);
+        assert_eq!(
+            resolve_profile_file_path(&d, "work-2").expect("safe"),
+            format!("{d}/settings_work-2.json")
+        );
+        for bad in ["", "../escape", "a/b", "a.b", "a b"] {
+            assert!(
+                matches!(
+                    resolve_profile_file_path(&d, bad).unwrap_err(),
+                    WriteError::Fallback(_)
+                ),
+                "id {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn duplicate_ids_get_a_numeric_suffix_starting_at_two() {
+        let mut profiles = Vec::new();
+        assert_eq!(deduplicate_id("work", &profiles), "work");
+        for id in ["work", "work-2"] {
+            profiles.push(Profile {
+                id: id.to_string(),
+                name: id.to_string(),
+                file_path: String::new(),
+                is_default: false,
+            });
+        }
+        assert_eq!(deduplicate_id("work", &profiles), "work-3");
+    }
+
+    #[test]
+    fn a_path_outside_the_dir_is_refused() {
+        assert!(validate_path_within_dir("/h/.claude/settings_a.json", "/h/.claude").is_ok());
+        // The dir itself is not "within" the dir — Go compares against
+        // `dir + "/"`, so the prefix has to be a real child.
+        assert!(validate_path_within_dir("/h/.claude", "/h/.claude").is_err());
+        assert!(validate_path_within_dir("/h/.claude-evil/x.json", "/h/.claude").is_err());
+        assert!(validate_path_within_dir("/h/.claude/../x.json", "/h/.claude").is_err());
+        // A relative path is Go's working directory's business, not ours.
+        assert!(matches!(
+            validate_path_within_dir("settings_a.json", "/h/.claude").unwrap_err(),
+            WriteError::Fallback(_)
+        ));
+    }
+
+    // ─── The index file ───────────────────────────────────────────────────────
+
+    /// The bytes are `json.MarshalIndent`'s, printed by a probe over the Go
+    /// struct: two-space indent, `": "` after each key, no trailing newline.
+    #[test]
+    fn the_index_is_written_the_way_go_writes_it() {
+        let root = dir();
+        let d = path_of(&root);
+        save(
+            &d,
+            &[Profile {
+                id: "default".to_string(),
+                name: "Default".to_string(),
+                file_path: "/h/.claude/settings_default.json".to_string(),
+                is_default: true,
+            }],
+        )
+        .expect("save");
+
+        assert_eq!(
+            read(&super::super::profiles_path(&d)),
+            concat!(
+                "{\n",
+                "  \"profiles\": [\n",
+                "    {\n",
+                "      \"id\": \"default\",\n",
+                "      \"name\": \"Default\",\n",
+                "      \"file_path\": \"/h/.claude/settings_default.json\",\n",
+                "      \"is_default\": true\n",
+                "    }\n",
+                "  ]\n",
+                "}"
+            )
+        );
+    }
+
+    /// Deleting the last profile leaves `[]`, not `null` — Go's slice is
+    /// non-nil after the re-slice, and the distinction is stored.
+    #[test]
+    fn an_emptied_index_is_an_empty_array() {
+        let root = dir();
+        let d = path_of(&root);
+        save(&d, &[]).expect("save");
+        assert_eq!(
+            read(&super::super::profiles_path(&d)),
+            "{\n  \"profiles\": []\n}"
+        );
+    }
+
+    #[test]
+    fn a_missing_index_is_empty_and_a_null_one_is_too() {
+        let root = dir();
+        let d = path_of(&root);
+        assert!(load(&d).expect("missing is empty").is_empty());
+
+        std::fs::write(super::super::profiles_path(&d), "null").expect("write");
+        assert!(load(&d).expect("null is the zero value").is_empty());
+
+        std::fs::write(super::super::profiles_path(&d), r#"{"profiles":null}"#).expect("write");
+        assert!(load(&d).expect("nil list").is_empty());
+
+        // An array where a struct belongs is a type error in Go: a 500, so it
+        // forwards rather than reading as empty.
+        std::fs::write(super::super::profiles_path(&d), "[]").expect("write");
+        assert!(matches!(load(&d).unwrap_err(), WriteError::Fallback(_)));
+    }
+
+    // ─── ensureDefaultProfileExists ───────────────────────────────────────────
+
+    #[test]
+    fn the_first_list_seeds_a_default_profile_from_settings_json() {
+        let root = dir();
+        let d = path_of(&root);
+        std::fs::write(settings_json_path(&d), r#"{"z":1,"a":{"b":2}}"#).expect("write");
+
+        ensure_default(&d).expect("seed");
+
+        // The seeded profile file is pretty-printed and key-sorted, because Go
+        // round-trips it through `any` before `MarshalIndent`.
+        assert_eq!(
+            read(&format!("{d}/settings_default.json")),
+            "{\n  \"a\": {\n    \"b\": 2\n  },\n  \"z\": 1\n}"
+        );
+        let profiles = load(&d).expect("load");
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(profiles[0].id, "default");
+        assert_eq!(profiles[0].name, "Default");
+        assert!(profiles[0].is_default);
+        assert_eq!(profiles[0].file_path, format!("{d}/settings_default.json"));
+
+        // Idempotent: a second call must not overwrite a profile the user has
+        // since edited.
+        std::fs::write(&profiles[0].file_path, "edited").expect("write");
+        ensure_default(&d).expect("second");
+        assert_eq!(read(&profiles[0].file_path), "edited");
+    }
+
+    #[test]
+    fn seeding_with_no_settings_json_writes_an_empty_object() {
+        let root = dir();
+        let d = path_of(&root);
+        ensure_default(&d).expect("seed");
+        assert_eq!(read(&format!("{d}/settings_default.json")), "{}");
+    }
+
+    /// An unparseable `settings.json` seeds `{}` rather than failing — the
+    /// profile has to exist either way.
+    #[test]
+    fn seeding_from_an_unparseable_settings_json_still_produces_a_profile() {
+        let root = dir();
+        let d = path_of(&root);
+        std::fs::write(settings_json_path(&d), "not json at all").expect("write");
+        ensure_default(&d).expect("seed");
+        assert_eq!(read(&format!("{d}/settings_default.json")), "{}");
+    }
+
+    // ─── The two path traps ───────────────────────────────────────────────────
+
+    /// **The named-profile trap.** The index records an absolute path; a read
+    /// must use it rather than rebuilding `settings_<id>.json` from the id. A
+    /// port that rebuilt would answer `exists: false` for a profile whose file
+    /// is right there.
+    #[test]
+    fn a_named_profile_keeps_its_recorded_path() {
+        let root = dir();
+        let d = path_of(&root);
+        let recorded = format!("{d}/settings_original-name.json");
+        std::fs::write(&recorded, r#"{"model":"opus"}"#).expect("write");
+
+        let profile = Profile {
+            id: "renamed-since".to_string(),
+            name: "Renamed Since".to_string(),
+            file_path: recorded.clone(),
+            is_default: false,
+        };
+        // The path the id *would* derive exists too, with different content —
+        // so a rebuild would silently answer with the wrong file rather than
+        // with nothing.
+        std::fs::write(
+            resolve_profile_file_path(&d, &profile.id).expect("safe"),
+            r#"{"model":"decoy"}"#,
+        )
+        .expect("write");
+
+        let body = String::from_utf8(detail_body(&profile, &d).expect("detail")).expect("utf8");
+        assert!(body.contains(r#""file_path":""#), "{body}");
+        assert!(
+            body.contains(&format!(r#""file_path":"{recorded}""#)),
+            "{body}"
+        );
+        assert!(body.contains(r#""settings":{"model":"opus"}"#), "{body}");
+        assert!(body.ends_with("\"exists\":true}\n"), "{body}");
+    }
+
+    /// **The settings.json trap.** Setting a default writes the profile's bytes
+    /// over `<run dir>/settings.json` — the file `--settings` resolves against
+    /// on every agent run (#242) — and nowhere else.
+    #[test]
+    fn setting_a_default_syncs_settings_json_in_the_same_dir() {
+        let root = dir();
+        let d = path_of(&root);
+        let file_path = format!("{d}/settings_work.json");
+        std::fs::write(&file_path, "{\n  \"model\": \"opus\"\n}").expect("write");
+
+        let profile = Profile {
+            id: "work".to_string(),
+            name: "Work".to_string(),
+            file_path,
+            is_default: true,
+        };
+        sync_default_to_settings_json(&profile, &d).expect("sync");
+
+        // Byte-for-byte the profile's file, not a re-encode of it.
+        assert_eq!(read(&settings_json_path(&d)), "{\n  \"model\": \"opus\"\n}");
+    }
+
+    /// A default profile whose file has been deleted syncs `{}` rather than
+    /// failing the request.
+    #[test]
+    fn syncing_a_missing_profile_file_writes_an_empty_object() {
+        let root = dir();
+        let d = path_of(&root);
+        let profile = Profile {
+            id: "gone".to_string(),
+            name: "Gone".to_string(),
+            file_path: format!("{d}/settings_gone.json"),
+            is_default: true,
+        };
+        sync_default_to_settings_json(&profile, &d).expect("sync");
+        assert_eq!(read(&settings_json_path(&d)), "{}");
+    }
+
+    // ─── Details ──────────────────────────────────────────────────────────────
+
+    /// The embedded struct's fields come first, and `settings` is `null` — not
+    /// absent — when the file cannot be read or does not parse.
+    #[test]
+    fn a_detail_for_a_missing_file_is_null_settings_and_exists_false() {
+        let root = dir();
+        let d = path_of(&root);
+        let profile = Profile {
+            id: "ghost".to_string(),
+            name: "Ghost".to_string(),
+            file_path: format!("{d}/settings_ghost.json"),
+            is_default: false,
+        };
+        let body = String::from_utf8(detail_body(&profile, &d).expect("detail")).expect("utf8");
+        assert_eq!(
+            body,
+            format!(
+                "{{\"id\":\"ghost\",\"name\":\"Ghost\",\"file_path\":\"{d}/settings_ghost.json\",\
+                 \"is_default\":false,\"settings\":null,\"exists\":false}}\n"
+            )
+        );
+
+        // An unparseable file is the same answer: the profile exists, its
+        // settings do not.
+        std::fs::write(&profile.file_path, "not json").expect("write");
+        let body = String::from_utf8(detail_body(&profile, &d).expect("detail")).expect("utf8");
+        assert!(
+            body.contains("\"settings\":null,\"exists\":false"),
+            "{body}"
+        );
+    }
+
+    /// A profile's stored bytes reach the wire through Go's `compact`: key order
+    /// and number spelling as the user typed them, HTML escaped.
+    #[test]
+    fn a_detail_carries_the_stored_bytes_rather_than_a_re_encoding() {
+        let root = dir();
+        let d = path_of(&root);
+        let profile = Profile {
+            id: "raw".to_string(),
+            name: "Raw".to_string(),
+            file_path: format!("{d}/settings_raw.json"),
+            is_default: false,
+        };
+        std::fs::write(&profile.file_path, "{\n  \"z\": 1.50,\n  \"a\": \"<b>\"\n}")
+            .expect("write");
+        let body = String::from_utf8(detail_body(&profile, &d).expect("detail")).expect("utf8");
+        // Compacted and HTML-escaped, but `1.50` is still `1.50` and `z` still
+        // comes first — the user's bytes, not a re-encoding of them.
+        assert!(
+            body.contains(r#""settings":{"z":1.50,"a":"\u003cb\u003e"},"exists":true"#),
+            "{body}"
+        );
+    }
+
+    /// The list is `[]` and never `null`, and the profile keys are Go's order.
+    #[test]
+    fn the_list_shape_is_gos() {
+        let empty: Vec<Profile> = Vec::new();
+        assert_eq!(
+            String::from_utf8(gojson::to_vec(&empty).expect("encode")).unwrap(),
+            "[]\n"
+        );
+        let one = vec![Profile {
+            id: "default".to_string(),
+            name: "Default".to_string(),
+            file_path: "/h/.claude/settings_default.json".to_string(),
+            is_default: true,
+        }];
+        assert_eq!(
+            String::from_utf8(gojson::to_vec(&one).expect("encode")).unwrap(),
+            "[{\"id\":\"default\",\"name\":\"Default\",\
+              \"file_path\":\"/h/.claude/settings_default.json\",\"is_default\":true}]\n"
+        );
+    }
+
+    // ─── Rename ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn renaming_moves_the_file_and_the_recorded_path() {
+        let root = dir();
+        let d = path_of(&root);
+        let old = format!("{d}/settings_before.json");
+        std::fs::write(&old, r#"{"a":1}"#).expect("write");
+        let mut profiles = vec![Profile {
+            id: "before".to_string(),
+            name: "Before".to_string(),
+            file_path: old.clone(),
+            is_default: false,
+        }];
+
+        rename(&mut profiles, 0, "before", "After", &d).expect("rename");
+
+        assert_eq!(profiles[0].id, "after");
+        assert_eq!(profiles[0].name, "After");
+        assert_eq!(profiles[0].file_path, format!("{d}/settings_after.json"));
+        assert_eq!(read(&profiles[0].file_path), r#"{"a":1}"#);
+        assert!(!std::path::Path::new(&old).exists(), "old file removed");
+    }
+
+    /// A rename whose slug collides is a **409**, not an auto-deduplicated id.
+    /// Create and duplicate deduplicate; this one refuses.
+    #[test]
+    fn a_rename_collision_is_409_and_moves_nothing() {
+        let root = dir();
+        let d = path_of(&root);
+        let mine = format!("{d}/settings_mine.json");
+        std::fs::write(&mine, "{}").expect("write");
+        let mut profiles = vec![
+            Profile {
+                id: "mine".to_string(),
+                name: "Mine".to_string(),
+                file_path: mine.clone(),
+                is_default: false,
+            },
+            Profile {
+                id: "taken".to_string(),
+                name: "Taken".to_string(),
+                file_path: format!("{d}/settings_taken.json"),
+                is_default: false,
+            },
+        ];
+
+        let err = rename(&mut profiles, 0, "mine", "Taken", &d).unwrap_err();
+        assert_eq!(err.status(), StatusCode::CONFLICT);
+        assert_eq!(err.message(), "profile with id \"taken\" already exists");
+        assert_eq!(profiles[0].id, "mine", "nothing moved");
+        assert!(std::path::Path::new(&mine).exists());
+    }
+
+    /// A rename whose slug is unchanged renames nothing on disk — `"My Work"`
+    /// and `"my work"` share a slug, so only the display name moves.
+    #[test]
+    fn a_rename_that_keeps_the_slug_only_changes_the_name() {
+        let root = dir();
+        let d = path_of(&root);
+        let path = format!("{d}/settings_my-work.json");
+        std::fs::write(&path, "{}").expect("write");
+        let mut profiles = vec![Profile {
+            id: "my-work".to_string(),
+            name: "My Work".to_string(),
+            file_path: path.clone(),
+            is_default: false,
+        }];
+
+        rename(&mut profiles, 0, "my-work", "my work", &d).expect("rename");
+        assert_eq!(profiles[0].name, "my work");
+        assert_eq!(profiles[0].file_path, path);
+        assert!(std::path::Path::new(&path).exists());
+    }
+
+    /// A profile whose file has already gone is renamed in the index alone —
+    /// Go's `moveProfileFile` returns early rather than failing.
+    #[test]
+    fn renaming_a_profile_with_no_file_updates_only_the_index() {
+        let root = dir();
+        let d = path_of(&root);
+        let mut profiles = vec![Profile {
+            id: "gone".to_string(),
+            name: "Gone".to_string(),
+            file_path: format!("{d}/settings_gone.json"),
+            is_default: false,
+        }];
+        rename(&mut profiles, 0, "gone", "Back", &d).expect("rename");
+        assert_eq!(profiles[0].id, "back");
+        assert_eq!(profiles[0].file_path, format!("{d}/settings_back.json"));
+        assert!(!std::path::Path::new(&profiles[0].file_path).exists());
+    }
+
+    // ─── Error vocabulary ─────────────────────────────────────────────────────
+
+    /// These strings are on the wire, so a paraphrase is a divergence. The 409
+    /// for "cannot delete the default profile" really does say "already exists".
+    #[test]
+    fn the_error_bodies_are_gos() {
+        assert_eq!(not_found("work").status(), StatusCode::NOT_FOUND);
+        assert_eq!(not_found("work").message(), "profile \"work\" not found");
+        assert_eq!(conflict("default").status(), StatusCode::CONFLICT);
+        assert_eq!(
+            conflict("default").message(),
+            "profile with id \"default\" already exists"
+        );
+        assert_eq!(
+            WriteError::validation("settings", "failed to parse settings JSON").message(),
+            "validation error for \"settings\": failed to parse settings JSON"
+        );
+    }
+
+    /// The create handler folds every decode failure into its own 400, so an
+    /// array body says `name is required` — the update handler, which uses
+    /// `errInvalidJSONBody`, says something else for the same body.
+    #[test]
+    fn a_bad_create_body_is_400_name_is_required() {
+        let root = dir();
+        let d = path_of(&root);
+        for body in [
+            &b""[..],
+            b"[]",
+            br#"["Sneaky"]"#,
+            b"{not json",
+            b"{}",
+            b"null",
+        ] {
+            let err = create(&d, body).unwrap_err();
+            assert_eq!(err.status(), StatusCode::BAD_REQUEST, "body {body:?}");
+            assert_eq!(err.message(), "name is required", "body {body:?}");
+        }
+    }
+
+    // ─── The whole surface, against the answers Go gave ───────────────────────
+    //
+    // Every status and every message below was recorded from a running Go
+    // server by `tests/parity_claude_settings.rs`. A write cannot be asked of
+    // both implementations at once, so the comparison lives across the two
+    // files: that suite pins what Go says, this one asserts Rust says it.
+
+    fn body_of(answer: Answer) -> String {
+        String::from_utf8(answer.body.expect("a body")).expect("utf8")
+    }
+
+    /// The lifecycle, driven end to end over a scratch dir.
+    #[test]
+    fn the_lifecycle_answers_match_the_answers_go_gave() {
+        let root = dir();
+        let d = path_of(&root);
+
+        // The first list seeds a default profile and answers with it.
+        let listed = list(&d).expect("list");
+        assert_eq!(listed.status, StatusCode::OK);
+        assert_eq!(
+            body_of(listed),
+            format!(
+                "[{{\"id\":\"default\",\"name\":\"Default\",\
+                 \"file_path\":\"{d}/settings_default.json\",\"is_default\":true}}]\n"
+            )
+        );
+
+        // create: 201, the slugified id, and not the default.
+        let created = create(&d, br#"{"name":"Parity Writes"}"#).expect("create");
+        assert_eq!(created.status, StatusCode::CREATED);
+        assert_eq!(
+            body_of(created),
+            format!(
+                "{{\"id\":\"parity-writes\",\"name\":\"Parity Writes\",\
+                 \"file_path\":\"{d}/settings_parity-writes.json\",\"is_default\":false}}\n"
+            )
+        );
+
+        // A second profile of the same name is deduplicated, not refused.
+        let again = create(&d, br#"{"name":"Parity Writes"}"#).expect("create");
+        assert!(body_of(again).contains("\"id\":\"parity-writes-2\""));
+
+        // get: a missing id is 404 with the service error's wording.
+        let err = get(&d, "parity-no-such-profile").unwrap_err();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+        assert_eq!(
+            err.message(),
+            "profile \"parity-no-such-profile\" not found"
+        );
+
+        // update: a malformed body is `invalid JSON body`, *not* the create
+        // handler's message.
+        let err = update(&d, "parity-writes", b"{not json").unwrap_err();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(err.message(), "invalid JSON body");
+
+        // …and a number no float64 holds is the one reachable 422.
+        let err = update(&d, "parity-writes", br#"{"settings":{"n":1e999}}"#).unwrap_err();
+        assert_eq!(err.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(
+            err.message(),
+            "validation error for \"settings\": failed to parse settings JSON"
+        );
+
+        // A settings write: the file is key-sorted and pretty-printed, and the
+        // detail carries the round trip rather than the request's bytes.
+        let updated = update(
+            &d,
+            "parity-writes",
+            br#"{"settings":{"z":1,"a":{"b":[1,2]}}}"#,
+        )
+        .expect("update");
+        assert_eq!(updated.status, StatusCode::OK);
+        assert!(
+            body_of(updated).contains(r#""settings":{"a":{"b":[1,2]},"z":1},"exists":true"#),
+            "the detail must show the stored round trip"
+        );
+
+        // A literal `null` settings is a no-op, not a clear.
+        let untouched = update(&d, "parity-writes", br#"{"settings":null}"#).expect("update");
+        assert!(body_of(untouched).contains(r#""settings":{"a":{"b":[1,2]},"z":1}"#));
+
+        // A rename onto another profile's slug is 409 — while *create* with the
+        // same name deduplicated.
+        let err = update(&d, "parity-writes-2", br#"{"name":"PARITY WRITES"}"#).unwrap_err();
+        assert_eq!(err.status(), StatusCode::CONFLICT);
+        assert_eq!(
+            err.message(),
+            "profile with id \"parity-writes\" already exists"
+        );
+
+        // A rename that moves takes the settings with it.
+        let renamed = update(&d, "parity-writes", br#"{"name":"Parity Renamed"}"#).expect("rename");
+        let renamed = body_of(renamed);
+        assert!(renamed.contains("\"id\":\"parity-renamed\""), "{renamed}");
+        assert!(
+            renamed.contains(&format!(
+                "\"file_path\":\"{d}/settings_parity-renamed.json\""
+            )),
+            "{renamed}"
+        );
+        assert!(
+            renamed.contains(r#""settings":{"a":{"b":[1,2]},"z":1}"#),
+            "{renamed}"
+        );
+
+        // update looks the profile up before anything else, so a missing one is
+        // a 404 whatever the body says.
+        assert_eq!(
+            update(&d, "parity-no-such-profile", br#"{"name":"x"}"#)
+                .unwrap_err()
+                .status(),
+            StatusCode::NOT_FOUND
+        );
+
+        // duplicate: 201, "Copy of <name>", never the default.
+        let copied = duplicate(&d, "parity-renamed").expect("duplicate");
+        assert_eq!(copied.status, StatusCode::CREATED);
+        let copied = body_of(copied);
+        assert!(
+            copied.contains(r#""id":"copy-of-parity-renamed""#),
+            "{copied}"
+        );
+        assert!(
+            copied.contains(r#""name":"Copy of Parity Renamed""#),
+            "{copied}"
+        );
+        assert!(copied.contains(r#""is_default":false"#), "{copied}");
+        assert_eq!(
+            duplicate(&d, "parity-no-such-profile")
+                .unwrap_err()
+                .status(),
+            StatusCode::NOT_FOUND
+        );
+
+        // default: 200, and settings.json becomes a byte copy of the profile.
+        let defaulted = set_default(&d, "parity-renamed").expect("set default");
+        assert_eq!(defaulted.status, StatusCode::OK);
+        assert!(body_of(defaulted).contains(r#""is_default":true"#));
+        assert_eq!(
+            read(&settings_json_path(&d)),
+            read(&format!("{d}/settings_parity-renamed.json")),
+            "settings.json must be a byte copy of the new default profile"
+        );
+        assert_eq!(
+            set_default(&d, "parity-no-such-profile")
+                .unwrap_err()
+                .status(),
+            StatusCode::NOT_FOUND
+        );
+
+        // delete: the default is refused with a ConflictError, whose wording is
+        // about existence rather than about deletion.
+        let err = delete(&d, "parity-renamed").unwrap_err();
+        assert_eq!(err.status(), StatusCode::CONFLICT);
+        assert_eq!(
+            err.message(),
+            "profile with id \"parity-renamed\" already exists"
+        );
+
+        let deleted = delete(&d, "copy-of-parity-renamed").expect("delete");
+        assert_eq!(deleted.status, StatusCode::NO_CONTENT);
+        assert!(deleted.body.is_none(), "204 carries no body");
+        assert!(
+            !std::path::Path::new(&format!("{d}/settings_copy-of-parity-renamed.json")).exists()
+        );
+        assert_eq!(
+            delete(&d, "parity-no-such-profile").unwrap_err().status(),
+            StatusCode::NOT_FOUND
+        );
+    }
+
+    /// A profile created before any settings exist copies the default's bytes
+    /// **verbatim**, rather than reformatting a file the user did not touch.
+    #[test]
+    fn a_new_profile_is_a_byte_copy_of_the_current_default() {
+        let root = dir();
+        let d = path_of(&root);
+        list(&d).expect("seed");
+        // Hand-edit the default's file so a reformat would be visible.
+        std::fs::write(
+            format!("{d}/settings_default.json"),
+            "{\n    \"z\": 1.50,\n    \"a\": 1\n}",
+        )
+        .expect("write");
+
+        create(&d, br#"{"name":"Copied"}"#).expect("create");
+        assert_eq!(
+            read(&format!("{d}/settings_copied.json")),
+            "{\n    \"z\": 1.50,\n    \"a\": 1\n}"
+        );
+    }
+
+    /// Updating the **default** profile syncs `settings.json` too, because that
+    /// is the file every agent run resolves `--settings` against.
+    #[test]
+    fn updating_the_default_profile_syncs_settings_json() {
+        let root = dir();
+        let d = path_of(&root);
+        list(&d).expect("seed");
+
+        update(&d, "default", br#"{"settings":{"model":"opus"}}"#).expect("update");
+        assert_eq!(read(&settings_json_path(&d)), "{\n  \"model\": \"opus\"\n}");
+
+        // …and updating a *non*-default one does not touch it.
+        create(&d, br#"{"name":"Other"}"#).expect("create");
+        update(&d, "other", br#"{"settings":{"model":"haiku"}}"#).expect("update");
+        assert_eq!(
+            read(&settings_json_path(&d)),
+            "{\n  \"model\": \"opus\"\n}",
+            "a non-default profile must not reach settings.json"
+        );
+    }
+
+    /// Deleting the last profile leaves the index as `[]`, and the next list
+    /// seeds a fresh default rather than answering with nothing.
+    #[test]
+    fn the_index_survives_being_emptied() {
+        let root = dir();
+        let d = path_of(&root);
+        list(&d).expect("seed");
+        create(&d, br#"{"name":"Only Other"}"#).expect("create");
+        // The default cannot go, so remove the other and then unset the default
+        // by pointing it at the survivor — which is what the UI does.
+        delete(&d, "only-other").expect("delete");
+        assert_eq!(load(&d).expect("load").len(), 1);
+    }
+
+    /// `{"name":null}` is a `*string` left nil, which the service reads as "do
+    /// not rename" — and `{"settings":null}` is the four bytes of a literal
+    /// null, which it reads as "do not write". Folding either into the other
+    /// would make an omitted key clear a profile's settings.
+    #[test]
+    fn a_null_name_and_a_null_settings_are_both_no_ops() {
+        let req: UpdateRequest =
+            decode_request(br#"{"name":null,"settings":null}"#).expect("decode");
+        assert!(req.name.is_none());
+        assert_eq!(req.settings.as_deref().map(RawValue::get), Some("null"));
+
+        let req: UpdateRequest = decode_request(b"{}").expect("decode");
+        assert!(req.name.is_none());
+        assert!(req.settings.is_none());
+
+        // A real payload survives verbatim — key order and number spelling
+        // included, since the file it writes is the user's.
+        let req: UpdateRequest =
+            decode_request(br#"{"settings":{"z":1.50,"a":1}}"#).expect("decode");
+        assert_eq!(
+            req.settings.as_deref().map(RawValue::get),
+            Some(r#"{"z":1.50,"a":1}"#)
+        );
+    }
+}

--- a/desktop/src-tauri/src/native/claude_settings/profiles.rs
+++ b/desktop/src-tauri/src/native/claude_settings/profiles.rs
@@ -14,10 +14,24 @@
 //! later": there is no read here that does not write.
 //!
 //! It is also the one place `Mode::Diff`'s "never run a write" rule does not
-//! cover, since this *is* a `GET` — and it is harmless: the proxy runs Rust
-//! first and Go second, and seeding is idempotent, so Go's list finds the index
-//! Rust just wrote and re-seeds nothing. The two answers are the same bytes
-//! because the second call had nothing left to do.
+//! cover, since this *is* a `GET` — and it is harmless in the sense that
+//! matters: the proxy runs Rust first and Go second, and seeding is idempotent,
+//! so Go's list finds the index Rust just wrote and re-seeds nothing.
+//!
+//! **But that is also why the diff proves nothing about seeding.** Because Rust
+//! runs first, Go is reading Rust's own output: the two answers agree because
+//! the second call had nothing left to do, not because both implementations
+//! would have seeded the same index from an empty dir. A wrong `settings_default.json`
+//! diffs clean here. The unit tests below are what actually pin seeding, and
+//! `tests/parity_claude_settings.rs` compares the *files* rather than only the
+//! responses for the same reason. Note also that shadow mode writes into
+//! whatever Claude config dir the developer is running with, which is the second
+//! reason the parity suite insists on a scratch `CLAUDE_CONFIG_DIR`.
+//!
+//! It is deliberately **not** in `native::diff_exempt`: that list is for routes
+//! whose answers cannot agree by construction, and these agree. The problem is
+//! that the agreement is uninformative, which is a caveat rather than an
+//! exemption.
 //!
 //! # Which errors are answers, and which are forwarded
 //!
@@ -99,7 +113,11 @@ struct MetadataOut<'a> {
 
 /// `config.LoadProfilesMetadata`. A missing file is an empty index, not an
 /// error; anything else Go answers with a 500, so it forwards.
-fn load(dir: &str) -> Result<Vec<Profile>, WriteError> {
+///
+/// Public because the agent runner needs it: `LoadProfileFilePathIn` resolves a
+/// named settings profile through this same index, and there is now exactly one
+/// reader of it.
+pub fn load(dir: &str) -> Result<Vec<Profile>, WriteError> {
     let path = super::profiles_path(dir);
     let data = match std::fs::read(&path) {
         Ok(data) => data,
@@ -129,7 +147,7 @@ fn load(dir: &str) -> Result<Vec<Profile>, WriteError> {
 pub fn encode_index(profiles: &[Profile]) -> Result<Vec<u8>, String> {
     let compact = gojson::to_vec_marshal(&MetadataOut { profiles })
         .map_err(|e| format!("marshaling profiles index: {e}"))?;
-    Ok(gojson::indent(&compact))
+    Ok(gojson::indent_compact(&compact))
 }
 
 /// `saveProfilesMetadata`: `MarshalIndent` into the file, mode 0600.
@@ -156,12 +174,31 @@ fn ensure_default(dir: &str) -> Result<(), WriteError> {
     // An unreadable or unparseable settings.json seeds an empty object rather
     // than failing — the profile has to exist either way.
     let content = std::fs::read(settings_json_path(dir)).unwrap_or_else(|_| b"{}".to_vec());
-    let value = match go_any(&content) {
-        Decoded::Value(value) => value,
-        Decoded::NotJson | Decoded::NumberOutOfRange => Value::Object(serde_json::Map::new()),
-        // Go's parser would have succeeded; ours cannot say. Nothing but the
-        // directory has been touched, so forwarding is exact.
-        Decoded::Undecidable(reason) => return Err(WriteError::Fallback(reason)),
+    // `ensureDefaultProfileExists` calls `json.Unmarshal(content, &pretty)`,
+    // which is **whole-input**: trailing content after the first value fails it
+    // (`Unmarshal([]byte("{\"a\":1} junk"))` is `invalid character 'j' after
+    // top-level value`, verified against the Go toolchain) and Go seeds `{}`.
+    // `go_any` deliberately never calls `de.end()` — right for a request body a
+    // `json.Decoder` reads, wrong for a file `Unmarshal` reads — so the rule is
+    // reapplied here. `go_json_valid` is exactly "one value, trailing
+    // whitespace only", so it is the rule rather than a second copy of it.
+    //
+    // This propagates if it is wrong: every later `create` byte-copies the
+    // seeded file, so a `{"a":1}` Go would never have written travels into
+    // every profile made afterwards.
+    let value = if !go_json_valid(&content) {
+        Value::Object(serde_json::Map::new())
+    } else {
+        match go_any(&content) {
+            Decoded::Value(value) => value,
+            Decoded::NotJson | Decoded::NumberOutOfRange => Value::Object(serde_json::Map::new()),
+            // Go's parser would have succeeded; ours cannot say — a document
+            // past serde's 128-level limit, or bytes that are not UTF-8, which
+            // Go decodes with a U+FFFD substitution this port will not guess.
+            // Nothing but the directory has been touched, so forwarding is
+            // exact.
+            Decoded::Undecidable(reason) => return Err(WriteError::Fallback(reason)),
+        }
     };
     let out = marshal_indent(&value).map_err(WriteError::Fallback)?;
 
@@ -322,10 +359,20 @@ fn detail_body(profile: &Profile, dir: &str) -> Result<Vec<u8>, WriteError> {
     let mut settings = None;
     let mut exists = false;
     if let Ok(data) = std::fs::read(&profile.file_path) {
+        // Go's `json.Valid` accepts bytes that are not UTF-8 and its encoder
+        // then ships them verbatim. serde cannot build a `RawValue` from them,
+        // so this would have answered `exists: true` with `settings: null`
+        // where Go sends the document. Forward instead.
+        if !super::is_utf8(&data) {
+            return Err(WriteError::Fallback(format!(
+                "{} is not UTF-8; Go serves those bytes verbatim",
+                profile.file_path
+            )));
+        }
         // `json.Valid` only. An unparseable file is `exists: false` with a
         // `null` payload — an answer, not an error.
         if go_json_valid(&data) {
-            settings = raw_field(&data);
+            settings = Some(raw_field(&data).map_err(WriteError::Fallback)?);
             exists = true;
         }
     }
@@ -433,6 +480,15 @@ pub fn update(dir: &str, id: &str, body: &[u8]) -> Result<Answer, WriteError> {
     let mut profiles = load(dir)?;
     let idx = find_index(&profiles, id).ok_or_else(|| not_found(id))?;
 
+    // Hoisted out of the closing `detail_body`, which is where it used to run.
+    // It forwards on a relative or out-of-dir recorded path — but by then the
+    // rename may have moved the file and `save` rewritten the index under the
+    // new id, so Go would look up the URL's *old* id, find nothing and answer
+    // 404 where Go alone would have answered 500. `delete`, `duplicate` and
+    // `set_default` all validate up front; this is the same rule, and it costs
+    // no parity because the check only ever decides forward-versus-answer.
+    validate_path_within_dir(&profiles[idx].file_path, dir)?;
+
     // `validateSettingsJSON` runs before any filesystem mutation so a rename
     // cannot land with the settings unwritten. Its `json.Valid` check cannot
     // fail — the bytes came out of a decoder — but the *second* parse, into
@@ -454,7 +510,15 @@ pub fn update(dir: &str, id: &str, body: &[u8]) -> Result<Answer, WriteError> {
             match go_any(raw.as_bytes()) {
                 Decoded::Value(value) => Some(Ok(value)),
                 Decoded::NumberOutOfRange => Some(Err(())),
-                Decoded::NotJson => return Err(WriteError::InvalidBody),
+                // `go_json_valid` just passed over the same bytes, so this is
+                // the two parsers disagreeing rather than a malformed request.
+                // Forward — answering 400 here would be inventing a status Go
+                // has no reason to send.
+                Decoded::NotJson => {
+                    return Err(WriteError::Fallback(
+                        "settings re-parse disagrees with json.Valid; only Go can say".to_string(),
+                    ))
+                }
                 Decoded::Undecidable(reason) => return Err(WriteError::Fallback(reason)),
             }
         }
@@ -477,6 +541,11 @@ pub fn update(dir: &str, id: &str, body: &[u8]) -> Result<Answer, WriteError> {
         }
         Some(Ok(value)) => {
             let out = marshal_indent(&value).map_err(WriteError::Fallback)?;
+            // Written without `validate_path_within_dir`, on purpose: Go's
+            // `writeProfileSettings` has no check either, so adding one here
+            // would refuse a write Go performs. The hoisted check above covers
+            // the recorded path this request arrived with; a path the *rename*
+            // produced is always `<dir>/settings_<id>.json`.
             let path = profiles[idx].file_path.clone();
             super::write_file(&path, &out)
                 .map_err(|e| WriteError::Fallback(format!("writing {path}: {e}")))?;
@@ -517,6 +586,12 @@ fn rename(
         let new_file_path = resolve_profile_file_path(dir, &new_id)?;
         // No file to move is not an error: the index is updated and the write
         // that follows creates it at the new path.
+        //
+        // Also no `validate_path_within_dir` — correct parity, not an oversight:
+        // Go's `moveProfileFile` reads the recorded path unchecked. The
+        // destination is safe by construction (`resolveProfileFilePath` runs
+        // `safeProfileID` first), so only the *source* is unvalidated, and it is
+        // a read.
         if let Ok(data) = std::fs::read(&profiles[idx].file_path) {
             super::write_file(&new_file_path, &data)
                 .map_err(|e| WriteError::Fallback(format!("writing {new_file_path}: {e}")))?;
@@ -819,6 +894,45 @@ mod tests {
         assert_eq!(read(&format!("{d}/settings_default.json")), "{}");
     }
 
+    /// **Seeding reads the file with `json.Unmarshal`, which is whole-input.**
+    /// Trailing content after the first value fails it, so Go seeds `{}` — where
+    /// a `json.Decoder`'s stream semantics would have seeded `{"a": 1}`. This
+    /// propagates: every later `create` byte-copies the seeded file.
+    #[test]
+    fn seeding_rejects_trailing_content_the_way_unmarshal_does() {
+        let root = dir();
+        let d = path_of(&root);
+        std::fs::write(settings_json_path(&d), r#"{"a":1} junk"#).expect("write");
+        ensure_default(&d).expect("seed");
+        assert_eq!(
+            read(&format!("{d}/settings_default.json")),
+            "{}",
+            "Unmarshal rejects trailing content, so Go seeds an empty object"
+        );
+
+        // …and the copy really does travel into the next profile.
+        create(&d, br#"{"name":"Copied"}"#).expect("create");
+        assert_eq!(read(&format!("{d}/settings_copied.json")), "{}");
+    }
+
+    /// A `settings.json` that is valid JSON to Go but not UTF-8: Go seeds the
+    /// document with U+FFFD substituted, which this port will not guess. It
+    /// forwards, having touched only the directory.
+    #[test]
+    fn seeding_from_a_non_utf8_settings_json_forwards() {
+        let root = dir();
+        let d = path_of(&root);
+        std::fs::write(settings_json_path(&d), b"{\"a\":\"\xff\"}").expect("write");
+        assert!(matches!(
+            ensure_default(&d).unwrap_err(),
+            WriteError::Fallback(_)
+        ));
+        assert!(
+            !std::path::Path::new(&format!("{d}/settings_default.json")).exists(),
+            "the forward must leave no seeded profile behind"
+        );
+    }
+
     // ─── The two path traps ───────────────────────────────────────────────────
 
     /// **The named-profile trap.** The index records an absolute path; a read
@@ -925,6 +1039,18 @@ mod tests {
         assert!(
             body.contains("\"settings\":null,\"exists\":false"),
             "{body}"
+        );
+
+        // A file that is valid JSON to Go but not UTF-8 is neither of those
+        // answers: `json.Valid` passes and Go ships the bytes verbatim, so a
+        // `settings: null, exists: false` here would be a wrong answer. Forward.
+        std::fs::write(&profile.file_path, b"{\"a\":\"\xff\"}").expect("write");
+        assert!(
+            matches!(
+                detail_body(&profile, &d).unwrap_err(),
+                WriteError::Fallback(_)
+            ),
+            "non-UTF-8 profile settings must forward"
         );
     }
 
@@ -1103,6 +1229,123 @@ mod tests {
             assert_eq!(err.status(), StatusCode::BAD_REQUEST, "body {body:?}");
             assert_eq!(err.message(), "name is required", "body {body:?}");
         }
+    }
+
+    /// **A body past the scanner's 10000-level cap creates nothing.** `Decode`
+    /// errors `exceeded max depth` in Go, so `req.Name` stays empty and the
+    /// handler answers `400 name is required`. serde routes the unknown `junk`
+    /// field to `IgnoredAny`, whose skip is iterative and counts no depth, so
+    /// this used to decode with `name == "x"` and answer **201** — writing
+    /// `settings_x.json` and appending to the index for a request Go refuses.
+    #[test]
+    fn a_create_deeper_than_gos_scanner_is_400_and_writes_nothing() {
+        let root = dir();
+        let d = path_of(&root);
+        let body = format!(
+            r#"{{"name":"x","junk":{}{}}}"#,
+            "[".repeat(10000),
+            "]".repeat(10000)
+        );
+
+        let err = create(&d, body.as_bytes()).unwrap_err();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(err.message(), "name is required");
+
+        // Not the profile, not the seeded default, not the index: the decode
+        // fails before `ensure_default` runs.
+        assert!(!std::path::Path::new(&format!("{d}/settings_x.json")).exists());
+        assert!(!std::path::Path::new(&super::super::profiles_path(&d)).exists());
+        assert!(!std::path::Path::new(&format!("{d}/settings_default.json")).exists());
+    }
+
+    /// The same cap on `update`, which is a **400** and not the 422 a
+    /// hand-written depth check inside `validateSettingsJSON` produced: Go's
+    /// `Decode` fails first, so the service never runs. The 128–10000 band
+    /// still forwards, which is the neighbouring case easy to lose.
+    #[test]
+    fn an_update_deeper_than_gos_scanner_is_400_and_the_band_below_forwards() {
+        let root = dir();
+        let d = path_of(&root);
+        list(&d).expect("seed");
+
+        let too_deep = format!(
+            r#"{{"settings":{}{}}}"#,
+            "[".repeat(10001),
+            "]".repeat(10001)
+        );
+        let err = update(&d, "default", too_deep.as_bytes()).unwrap_err();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(err.message(), "invalid JSON body");
+
+        // Past serde's 128-level limit but inside Go's 10000: neither parser is
+        // the authority, so it forwards.
+        let band = format!(r#"{{"settings":{}{}}}"#, "[".repeat(200), "]".repeat(200));
+        assert!(matches!(
+            update(&d, "default", band.as_bytes()).unwrap_err(),
+            WriteError::Fallback(_)
+        ));
+    }
+
+    /// **`update` validates the recorded path before it mutates anything.** It
+    /// used to reach `validate_path_within_dir` only in the closing
+    /// `detail_body` — after the rename had moved the file and `save` had
+    /// rewritten the index under the new id — so the forward sent Go a request
+    /// whose URL id no longer existed and Go answered 404 where Go alone would
+    /// have answered 500.
+    #[test]
+    fn update_validates_the_recorded_path_before_it_renames() {
+        let root = dir();
+        let d = path_of(&root);
+        let outside = dir();
+        let stray = format!("{}/settings_stray.json", path_of(&outside));
+        std::fs::write(&stray, "{}").expect("write");
+        save(
+            &d,
+            &[Profile {
+                id: "stray".to_string(),
+                name: "Stray".to_string(),
+                file_path: stray.clone(),
+                is_default: false,
+            }],
+        )
+        .expect("save");
+
+        assert!(matches!(
+            update(&d, "stray", br#"{"name":"Moved"}"#).unwrap_err(),
+            WriteError::Fallback(_)
+        ));
+
+        // The forward has to be exact, which means the id in the URL still
+        // resolves on Go's side.
+        let profiles = load(&d).expect("load");
+        assert_eq!(profiles[0].id, "stray", "the index must be untouched");
+        assert_eq!(profiles[0].file_path, stray);
+        assert!(
+            !std::path::Path::new(&format!("{d}/settings_moved.json")).exists(),
+            "nothing may have moved"
+        );
+    }
+
+    /// A body that is not UTF-8 forwards from every write on this surface: Go
+    /// substitutes U+FFFD into the decoded string and carries on, and where it
+    /// puts the replacement character is not something this port reproduces.
+    #[test]
+    fn a_non_utf8_body_forwards_from_create_and_update() {
+        let root = dir();
+        let d = path_of(&root);
+        list(&d).expect("seed");
+
+        assert!(matches!(
+            create(&d, b"{\"name\":\"x\xffy\"}").unwrap_err(),
+            WriteError::Fallback(_)
+        ));
+        assert!(matches!(
+            update(&d, "default", b"{\"settings\":{\"a\":\"\xff\"}}").unwrap_err(),
+            WriteError::Fallback(_)
+        ));
+        // Neither may have written anything.
+        assert!(!std::path::Path::new(&format!("{d}/settings_xy.json")).exists());
+        assert_eq!(read(&format!("{d}/settings_default.json")), "{}");
     }
 
     // ─── The whole surface, against the answers Go gave ───────────────────────

--- a/desktop/src-tauri/src/native/gojson.rs
+++ b/desktop/src-tauri/src/native/gojson.rs
@@ -307,6 +307,100 @@ pub fn compact(src: &str) -> String {
     String::from_utf8(out).unwrap_or_else(|_| src.to_string())
 }
 
+// ─── `encoding/json`'s Indent, for the files Go writes rather than serves ────
+
+/// `json.Indent` with an empty prefix, applied to compact Go-encoded JSON.
+///
+/// `json.MarshalIndent` is literally `Marshal` followed by `Indent`, so a port
+/// that already has [`to_vec_marshal`] gets the indented form by running this
+/// over its output rather than by growing a second `Formatter`. That is the
+/// faithful decomposition, and it is the one that keeps float spelling and HTML
+/// escaping in exactly one place.
+///
+/// The two rules that are easy to guess wrong, both taken from
+/// `encoding/json/indent.go`:
+///
+/// - **`:` becomes `": "`** — a colon *and a space*. Go adds spacing around
+///   punctuation on the way out, not while encoding.
+/// - **An empty object or array stays `{}` / `[]`.** The indent after an opening
+///   brace is *delayed* until a value actually follows, which is the whole point
+///   of the `need_indent` flag; writing the newline eagerly and trimming it back
+///   produces `{\n}` for `{}`.
+///
+/// This is Agento's settings files, not a response: the Claude settings profile
+/// surface writes `settings.json`, `settings_<slug>.json` and
+/// `settings_profiles.json` with `MarshalIndent` so a person can read them.
+pub fn indent(src: &[u8]) -> Vec<u8> {
+    let mut out: Vec<u8> = Vec::with_capacity(src.len() * 2);
+    let mut depth = 0usize;
+    let mut need_indent = false;
+    let mut in_string = false;
+    let mut escaped = false;
+
+    let newline = |out: &mut Vec<u8>, depth: usize| {
+        out.push(b'\n');
+        for _ in 0..depth {
+            out.extend_from_slice(b"  ");
+        }
+    };
+
+    for &byte in src {
+        // Punctuation inside a string is content, so the whole switch below is
+        // skipped for it — the same reason [`compact`] tracks string context.
+        if in_string {
+            out.push(byte);
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                in_string = false;
+            }
+            continue;
+        }
+        if byte == b'"' {
+            if need_indent {
+                need_indent = false;
+                depth += 1;
+                newline(&mut out, depth);
+            }
+            in_string = true;
+            out.push(byte);
+            continue;
+        }
+
+        if need_indent && byte != b'}' && byte != b']' {
+            need_indent = false;
+            depth += 1;
+            newline(&mut out, depth);
+        }
+
+        match byte {
+            b'{' | b'[' => {
+                need_indent = true;
+                out.push(byte);
+            }
+            b',' => {
+                out.push(byte);
+                newline(&mut out, depth);
+            }
+            b':' => out.extend_from_slice(b": "),
+            b'}' | b']' => {
+                if need_indent {
+                    // An empty object or array: suppress the delayed indent.
+                    need_indent = false;
+                } else {
+                    depth = depth.saturating_sub(1);
+                    newline(&mut out, depth);
+                }
+                out.push(byte);
+            }
+            _ => out.push(byte),
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/desktop/src-tauri/src/native/gojson.rs
+++ b/desktop/src-tauri/src/native/gojson.rs
@@ -330,7 +330,57 @@ pub fn compact(src: &str) -> String {
 /// This is Agento's settings files, not a response: the Claude settings profile
 /// surface writes `settings.json`, `settings_<slug>.json` and
 /// `settings_profiles.json` with `MarshalIndent` so a person can read them.
-pub fn indent(src: &[u8]) -> Vec<u8> {
+///
+/// # Precondition: the input is already compact
+///
+/// Named `indent_compact` because it is not `json.Indent`, which re-indents
+/// *any* well-formed JSON by discarding the whitespace it finds. This one only
+/// inserts, so pre-existing whitespace between tokens survives into the output
+/// and the result is wrong. That is not a limitation worth removing: the only
+/// callers hand it [`to_vec_marshal`]'s output, which is compact by
+/// construction, and `MarshalIndent` is defined as exactly that pair.
+pub fn indent_compact(src: &[u8]) -> Vec<u8> {
+    debug_assert!(
+        !has_whitespace_between_tokens(src),
+        "indent_compact needs Marshal's compact output; \
+         whitespace between tokens survives into the result"
+    );
+    indent_compact_inner(src)
+}
+
+/// Whether `src` carries whitespace outside a string — the precondition
+/// [`indent_compact`] asserts. Debug builds only, so the scan is free in
+/// release.
+#[cfg(debug_assertions)]
+fn has_whitespace_between_tokens(src: &[u8]) -> bool {
+    let mut in_string = false;
+    let mut escaped = false;
+    for &byte in src {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match byte {
+            b'"' => in_string = true,
+            b' ' | b'\t' | b'\n' | b'\r' => return true,
+            _ => {}
+        }
+    }
+    false
+}
+
+#[cfg(not(debug_assertions))]
+fn has_whitespace_between_tokens(_src: &[u8]) -> bool {
+    false
+}
+
+fn indent_compact_inner(src: &[u8]) -> Vec<u8> {
     let mut out: Vec<u8> = Vec::with_capacity(src.len() * 2);
     let mut depth = 0usize;
     let mut need_indent = false;

--- a/desktop/src-tauri/src/native/mod.rs
+++ b/desktop/src-tauri/src/native/mod.rs
@@ -16,6 +16,7 @@ pub mod agents;
 pub mod analytics;
 pub mod chat;
 pub mod chats;
+pub mod claude_settings;
 pub mod db;
 pub mod diff;
 pub mod fs;
@@ -250,6 +251,7 @@ const ENDPOINTS: &[Endpoint] = &[
     chats::ENDPOINT,
     tasks::ENDPOINT,
     settings::ENDPOINT,
+    claude_settings::ENDPOINT,
     monitoring::ENDPOINT,
     version::ENDPOINT,
     notifications::ENDPOINT,
@@ -452,8 +454,30 @@ mod tests {
         assert!(claims(&Method::GET, "/api/settings"));
         assert!(claims(&Method::GET, "/api/settings/claude-config-dirs"));
         assert!(!claims(&Method::PUT, "/api/settings"));
-        // A different tree entirely: Claude Code's own settings.json.
-        assert!(!claims(&Method::GET, "/api/claude-settings"));
+        // Claude Code's own settings.json and the profiles beside it: a
+        // different tree entirely, and since #304 all nine routes are ours —
+        // reads included, because `GET .../profiles` seeds the index and so is
+        // itself a write.
+        assert!(claims(&Method::GET, "/api/claude-settings"));
+        assert!(claims(&Method::PUT, "/api/claude-settings"));
+        assert!(claims(&Method::GET, "/api/claude-settings/profiles"));
+        assert!(claims(&Method::POST, "/api/claude-settings/profiles"));
+        assert!(claims(&Method::GET, "/api/claude-settings/profiles/work"));
+        assert!(claims(&Method::PUT, "/api/claude-settings/profiles/work"));
+        assert!(claims(
+            &Method::DELETE,
+            "/api/claude-settings/profiles/work"
+        ));
+        assert!(claims(
+            &Method::POST,
+            "/api/claude-settings/profiles/work/duplicate"
+        ));
+        assert!(claims(
+            &Method::PUT,
+            "/api/claude-settings/profiles/work/default"
+        ));
+        assert!(!claims(&Method::POST, "/api/claude-settings"));
+        assert!(!claims(&Method::GET, "/api/claude-settings/profiles/"));
 
         // Monitoring: the read, plus the two writes this build **declines**
         // (#309). They are claimed rather than forwarded on purpose — a forward
@@ -617,6 +641,9 @@ mod tests {
             "/api/job-history/abc-123",
             "/api/settings",
             "/api/settings/claude-config-dirs",
+            "/api/claude-settings",
+            "/api/claude-settings/profiles",
+            "/api/claude-settings/profiles/work",
             "/api/monitoring",
             "/api/version",
             "/api/version/update-check",
@@ -660,6 +687,9 @@ mod tests {
             "/api/job-history/abc-123",
             "/api/settings",
             "/api/settings/claude-config-dirs",
+            "/api/claude-settings",
+            "/api/claude-settings/profiles",
+            "/api/claude-settings/profiles/work",
             "/api/monitoring",
             "/api/version",
             "/api/version/update-check",

--- a/desktop/src-tauri/tests/parity_claude_settings.rs
+++ b/desktop/src-tauri/tests/parity_claude_settings.rs
@@ -1,0 +1,745 @@
+//! Live parity for the Claude settings surface (#304): all nine routes, diffed
+//! against a Go server built from **this** checkout.
+//!
+//! ```sh
+//! cd desktop
+//! export AGENTO_PARITY_WORKER=304
+//! export CLAUDE_CONFIG_DIR=/tmp/agento-parity-claude-304   # required — see below
+//! mkdir -p "$CLAUDE_CONFIG_DIR"
+//! eval "$(./scripts/parity-instance.sh start)"
+//! (cd src-tauri && cargo test --test parity_claude_settings -- --ignored --nocapture)
+//! ./scripts/parity-instance.sh stop
+//! ```
+//!
+//! # This suite writes, and what it writes is not in the database
+//!
+//! `parity-instance.sh` protects the *database* by copying it. It does nothing
+//! for `~/.claude`, and this surface writes there: `PUT /api/claude-settings`
+//! overwrites `settings.json`, and `PUT .../profiles/{id}/default` overwrites it
+//! with a profile's contents. Pointed at the default dir, this suite would
+//! rewrite the developer's real Claude Code configuration.
+//!
+//! So it **refuses to run** unless `CLAUDE_CONFIG_DIR` is exported and names
+//! something other than `~/.claude`. That variable is also the first thing
+//! `config.ClaudeRunConfigDir` consults, which is the second reason it is
+//! required: exporting it *before* `parity-instance.sh start` moves both
+//! implementations to one directory, and a diff across two directories would
+//! mean nothing.
+//!
+//! # One directory, so one case at a time
+//!
+//! Every case here mutates `settings.json` and `settings_profiles.json`, which
+//! the whole suite shares. `serial()` makes that safe under the default parallel
+//! runner rather than relying on `--test-threads=1` being remembered, and each
+//! case sets up what it needs instead of inheriting it from the case before —
+//! the first draft did not, and read a file a *previous* case had written while
+//! believing it was Go's.
+//!
+//! # Seeding, and why an empty pass proves nothing
+//!
+//! A machine with no profiles answers `GET .../profiles` with the one-element
+//! list it just seeded, and `GET /api/claude-settings` with `{"exists":false}`.
+//! Both diff clean against a port that does nothing, so every case creates its
+//! data through the Go server first and asserts the response is not that shape.
+//!
+//! # The comparison has two halves, as the write suites do
+//!
+//! A read is asked of both implementations and diffed byte for byte. A write
+//! cannot be — whichever runs first changes what the second would see — so Go's
+//! answers are pinned here as literals and the unit tests in
+//! `native/claude_settings/` assert the same literals against Rust. This half
+//! cannot be wrong about what Go does, because it asked.
+
+mod parity_common;
+
+use parity_common::*;
+
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use tokio::sync::{Mutex, MutexGuard};
+
+use agento_lib::native::claude_settings::{self, profiles, Decoded};
+use agento_lib::native::writes::finish;
+use agento_lib::native::Answer;
+
+use reqwest::Method;
+
+/// One case at a time: they share two files in one directory.
+///
+/// `tokio`'s mutex rather than `std`'s, because the guard is held across every
+/// `await` in a case — a blocking guard there is `clippy::await_holding_lock`,
+/// and it has no poisoning to recover from when a case fails.
+async fn serial() -> MutexGuard<'static, ()> {
+    static SERIAL: OnceLock<Mutex<()>> = OnceLock::new();
+    SERIAL.get_or_init(|| Mutex::new(())).lock().await
+}
+
+/// The scratch Claude config dir both sides are pointed at.
+///
+/// Asserted rather than defaulted: what this guards against is silent and
+/// destructive, and a default would make it easy to run without noticing.
+fn scratch_claude_dir() -> String {
+    let dir = std::env::var("CLAUDE_CONFIG_DIR").unwrap_or_default();
+    assert!(
+        !dir.trim().is_empty(),
+        "CLAUDE_CONFIG_DIR must be exported before `parity-instance.sh start`. \
+         This suite writes settings.json and profile files, and without it both \
+         implementations would target the developer's real ~/.claude."
+    );
+    let default = agento_lib::paths::home()
+        .expect("a home directory")
+        .join(".claude");
+    assert_ne!(
+        PathBuf::from(&dir),
+        default,
+        "CLAUDE_CONFIG_DIR must not be the real ~/.claude — this suite overwrites settings.json"
+    );
+    std::fs::create_dir_all(&dir).expect("creating the scratch Claude config dir");
+    dir
+}
+
+/// Enter a case: hold the serial lock, check the instance, and confirm Rust
+/// resolves the *same* run config dir the Go server was started with.
+///
+/// That last check is this port's first trap in one line. If `run_dir` picked a
+/// different directory every diff below would compare two unrelated files — and,
+/// worse, `PUT /api/claude-settings` would write `settings.json` somewhere no
+/// agent run reads it.
+async fn enter() -> (MutexGuard<'static, ()>, String) {
+    let guard = serial().await;
+    assert!(
+        std::env::var("AGENTO_LIVE_URL").is_ok(),
+        "parity_claude_settings mutates the filesystem and refuses to guess an \
+         instance. Run `eval \"$(./scripts/parity-instance.sh start)\"` first."
+    );
+    let dir = scratch_claude_dir();
+    assert_eq!(
+        claude_settings::run_dir(&live_db()).expect("resolving the run config dir"),
+        dir,
+        "the native run config dir must be the one the Go server was started with"
+    );
+    (guard, dir)
+}
+
+/// Unwrap a native answer's body, asserting its status on the way past.
+fn native_body(label: &str, answer: Result<Answer, String>, want_status: u16) -> Vec<u8> {
+    let answer = answer.unwrap_or_else(|e| panic!("{label}: native handler forwarded: {e}"));
+    assert_eq!(
+        answer.status.as_u16(),
+        want_status,
+        "{label}: native status"
+    );
+    answer.body.unwrap_or_default()
+}
+
+/// Create a profile through Go, returning its id.
+async fn create_profile(name: &str) -> String {
+    let (status, body) = send(
+        Method::POST,
+        "/api/claude-settings/profiles",
+        Some(&format!(r#"{{"name":"{name}"}}"#)),
+    )
+    .await;
+    assert_eq!(
+        status,
+        201,
+        "creating {name}: {}",
+        String::from_utf8_lossy(&body)
+    );
+    serde_json::from_slice::<serde_json::Value>(&body).expect("json")["id"]
+        .as_str()
+        .expect("an id")
+        .to_string()
+}
+
+async fn delete_profile(id: &str) {
+    let _ = send(
+        Method::DELETE,
+        &format!("/api/claude-settings/profiles/{id}"),
+        None,
+    )
+    .await;
+}
+
+// ─── The reads ────────────────────────────────────────────────────────────────
+
+/// `GET /api/claude-settings`, over a file Go wrote.
+#[tokio::test]
+#[ignore = "needs a running parity instance and a scratch CLAUDE_CONFIG_DIR"]
+async fn the_claude_settings_read_matches_the_live_go_response() {
+    let (_serial, dir) = enter().await;
+
+    let (status, _) = send(
+        Method::PUT,
+        "/api/claude-settings",
+        Some(r#"{"z":1,"model":"opus","env":{"B":"2","A":"1"},"tag":"<b>","rate":1.50}"#),
+    )
+    .await;
+    assert_eq!(status, 200, "seeding PUT /api/claude-settings");
+
+    let go = fetch("/api/claude-settings").await;
+    let body = String::from_utf8(go.clone()).expect("utf8");
+    assert!(
+        body.contains(r#""exists":true"#) && body.contains("\"model\""),
+        "the scratch dir has no settings.json — seeding failed, and an \
+         `{{\"exists\":false}}` answer diffs clean while proving nothing.\n{body}"
+    );
+
+    let native = native_body("claude-settings", claude_settings::get_settings(&dir), 200);
+    assert_identical("claude-settings", &go, &native);
+
+    // The path trap, checked against the filesystem rather than against a
+    // response: the file `--settings` resolves against is the one in the run
+    // config dir (#242), and it is the file this endpoint just wrote.
+    let on_disk = std::fs::read_to_string(format!("{dir}/settings.json")).expect("settings.json");
+    assert!(
+        on_disk.contains("\"model\": \"opus\""),
+        "PUT /api/claude-settings must write settings.json inside the run config dir\n{on_disk}"
+    );
+}
+
+/// The list and every profile's detail.
+#[tokio::test]
+#[ignore = "needs a running parity instance and a scratch CLAUDE_CONFIG_DIR"]
+async fn the_profile_reads_match_the_live_go_response() {
+    let (_serial, dir) = enter().await;
+
+    // Beyond the default the first list seeds, so this is not the one-element
+    // shape a port that does nothing also produces.
+    let a = create_profile("Parity Read A").await;
+    let b = create_profile("Parity Read B").await;
+    let missing = create_profile("Parity Read Missing").await;
+    let unparseable = create_profile("Parity Read Broken").await;
+
+    // …and one profile with real settings, so `settings` is a compacted
+    // document rather than `{}` for at least one row.
+    let (status, _) = send(
+        Method::PUT,
+        &format!("/api/claude-settings/profiles/{a}"),
+        Some(r#"{"settings":{"model":"opus","env":{"B":"2","A":"1"},"tag":"<b>"}}"#),
+    )
+    .await;
+    assert_eq!(status, 200, "seeding a profile's settings");
+
+    // The other two states of `settings`/`exists`, which a profile created
+    // through the API never reaches on its own: no file at all, and a file that
+    // is not JSON. Both are `{"settings":null,"exists":false}` — an *answer*,
+    // not an error — and a port that treated either as a failure would forward
+    // a request Go answers with a 200.
+    std::fs::remove_file(format!("{dir}/settings_{missing}.json")).expect("removing");
+    std::fs::write(format!("{dir}/settings_{unparseable}.json"), "not json").expect("writing");
+
+    let go = fetch("/api/claude-settings/profiles").await;
+    let listed: Vec<serde_json::Value> = serde_json::from_slice(&go).expect("json");
+    assert!(
+        listed.len() >= 3,
+        "fewer profiles than this case created — an almost empty list diffs \
+         clean and proves nothing: {}",
+        String::from_utf8_lossy(&go)
+    );
+
+    let native = native_body("profiles", finish(profiles::list(&dir)), 200);
+    assert_identical("claude-settings/profiles", &go, &native);
+
+    let mut with_settings = 0;
+    let mut without_settings = 0;
+    for profile in &listed {
+        let id = profile["id"].as_str().expect("an id");
+        let path = format!("/api/claude-settings/profiles/{id}");
+        let go = fetch(&path).await;
+        if String::from_utf8_lossy(&go).contains(r#""exists":true"#) {
+            with_settings += 1;
+        } else {
+            without_settings += 1;
+        }
+        let native = native_body(&path, finish(profiles::get(&dir, id)), 200);
+        assert_identical(&path, &go, &native);
+    }
+    assert!(
+        with_settings > 0 && without_settings > 0,
+        "both halves of the `settings`/`exists` pair must be exercised, \
+         got {with_settings} present and {without_settings} absent"
+    );
+
+    for id in [&a, &b, &missing, &unparseable] {
+        delete_profile(id).await;
+    }
+}
+
+/// The two files this surface writes are shared with the Go server, so the bytes
+/// Rust *would* write have to be the bytes Go *did* write — otherwise the files
+/// churn every time the two implementations take turns.
+#[tokio::test]
+#[ignore = "needs a running parity instance and a scratch CLAUDE_CONFIG_DIR"]
+async fn the_files_rust_writes_are_the_files_go_wrote() {
+    let (_serial, dir) = enter().await;
+
+    // Make Go write both, rather than trusting whatever an earlier case left —
+    // this case read its own suite's output the first time it was written.
+    let id = create_profile("Index Parity").await;
+    let (status, _) = send(
+        Method::PUT,
+        "/api/claude-settings",
+        Some(r#"{"z":1,"a":{"b":[1,2]},"rate":1.50,"tag":"<b>"}"#),
+    )
+    .await;
+    assert_eq!(status, 200);
+
+    let listed = fetch("/api/claude-settings/profiles").await;
+    let listed: Vec<profiles::Profile> = serde_json::from_slice(&listed).expect("profiles");
+    assert!(!listed.is_empty(), "no profiles to compare");
+
+    let go_index = std::fs::read(format!("{dir}/settings_profiles.json")).expect("the index");
+    let native = profiles::encode_index(&listed).expect("encode");
+    assert_identical("settings_profiles.json", &go_index, &native);
+
+    // The pretty-printed settings file, re-derived through the whole chain:
+    // Go's `any` (key sort, float widening), Go's `Marshal` (HTML escaping,
+    // float spelling) and Go's `Indent` (two spaces, `": "`, no trailing
+    // newline).
+    let go_settings = std::fs::read(format!("{dir}/settings.json")).expect("settings.json");
+    let value = match claude_settings::decode_go_any(&go_settings) {
+        Decoded::Value(value) => value,
+        other => panic!("Go wrote a settings.json this port cannot parse: {other:?}"),
+    };
+    let native = claude_settings::marshal_indent(&value).expect("marshal");
+    assert_identical("settings.json", &go_settings, &native);
+
+    delete_profile(&id).await;
+}
+
+// ─── Go's answers for the writes, pinned as literals ──────────────────────────
+
+/// `PUT /api/claude-settings`: the answers, and the file left behind.
+#[tokio::test]
+#[ignore = "needs a running parity instance and a scratch CLAUDE_CONFIG_DIR; it writes"]
+async fn the_claude_settings_write_answers_match_go() {
+    let (_serial, dir) = enter().await;
+
+    for body in ["", "   ", "{not json"] {
+        let (status, answer) = send(Method::PUT, "/api/claude-settings", Some(body)).await;
+        assert_eq!(status, 400, "body {body:?}");
+        assert_eq!(
+            String::from_utf8_lossy(&answer).trim_end(),
+            r#"{"error":"invalid JSON body"}"#,
+            "body {body:?}"
+        );
+    }
+
+    // Syntactically valid, but no float64 holds it — a *different* 400, raised
+    // by the second parse rather than by `Decode`.
+    let (status, answer) = send(Method::PUT, "/api/claude-settings", Some(r#"{"n":1e999}"#)).await;
+    assert_eq!(status, 400);
+    assert_eq!(
+        String::from_utf8_lossy(&answer).trim_end(),
+        r#"{"error":"invalid JSON settings"}"#
+    );
+
+    // Underflow is *not* out of range: Go's `ParseFloat` returns a zero for it,
+    // which is the half of the rule a port that leaned on serde_json's own
+    // `NumberOutOfRange` would get wrong.
+    let (status, answer) = send(
+        Method::PUT,
+        "/api/claude-settings",
+        Some(r#"{"tiny":1e-999}"#),
+    )
+    .await;
+    assert_eq!(
+        status, 200,
+        "an underflowing number is a zero, not an error"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&answer).trim_end(),
+        r#"{"exists":true,"settings":{"tiny":0}}"#
+    );
+
+    // A `Decoder` reads a stream, so bytes after the first value are not looked
+    // at. `serde_json::from_slice` would have rejected this.
+    let (status, answer) = send(
+        Method::PUT,
+        "/api/claude-settings",
+        Some(r#"{"trailing":true} and then some"#),
+    )
+    .await;
+    assert_eq!(status, 200, "trailing bytes are ignored by a json.Decoder");
+    assert_eq!(
+        String::from_utf8_lossy(&answer).trim_end(),
+        r#"{"exists":true,"settings":{"trailing":true}}"#
+    );
+
+    // A scalar is a JSON value, so it is accepted and written as one.
+    let (status, answer) = send(Method::PUT, "/api/claude-settings", Some("123")).await;
+    assert_eq!(status, 200, "a bare number is a JSON value Go accepts");
+    assert_eq!(
+        String::from_utf8_lossy(&answer).trim_end(),
+        r#"{"exists":true,"settings":123}"#
+    );
+
+    // The round trip: keys sorted, `1.50` respelled `1.5`, `<` escaped — in the
+    // response *and* in the file, which is two-space indented with no trailing
+    // newline.
+    let (status, answer) = send(
+        Method::PUT,
+        "/api/claude-settings",
+        Some(r#"{"z":1,"a":{"b":[1,2]},"rate":1.50,"tag":"<b>"}"#),
+    )
+    .await;
+    assert_eq!(status, 200);
+    assert_eq!(
+        String::from_utf8_lossy(&answer).trim_end(),
+        concat!(
+            "{\"exists\":true,\"settings\":{\"a\":{\"b\":[1,2]},\"rate\":1.5,",
+            "\"tag\":\"\\u003cb\\u003e\",\"z\":1}}"
+        ),
+        "the response is compacted, and `<` is escaped on the way out"
+    );
+    assert_eq!(
+        std::fs::read_to_string(format!("{dir}/settings.json")).expect("settings.json"),
+        concat!(
+            "{\n",
+            "  \"a\": {\n",
+            "    \"b\": [\n",
+            "      1,\n",
+            "      2\n",
+            "    ]\n",
+            "  },\n",
+            "  \"rate\": 1.5,\n",
+            "  \"tag\": \"\\u003cb\\u003e\",\n",
+            "  \"z\": 1\n",
+            "}"
+        ),
+        "the file is json.MarshalIndent's output"
+    );
+
+    // Leave something ordinary behind.
+    let (status, _) = send(
+        Method::PUT,
+        "/api/claude-settings",
+        Some(r#"{"model":"opus"}"#),
+    )
+    .await;
+    assert_eq!(status, 200);
+}
+
+/// Every profile write, and the exact status and body Go answers each with.
+#[tokio::test]
+#[ignore = "needs a running parity instance and a scratch CLAUDE_CONFIG_DIR; it writes"]
+async fn the_profile_write_answers_match_go() {
+    let (_serial, _dir) = enter().await;
+    for stale in ["parity-writes", "parity-writes-2", "parity-renamed"] {
+        delete_profile(stale).await;
+    }
+
+    // ── create ──
+    // A decode failure and an empty name are one 400 with one message, because
+    // the *handler* tests `err != nil || req.Name == ""` before the service
+    // runs — so the service's 422 for an empty name is unreachable, and an array
+    // body says `name is required` rather than `invalid JSON body`.
+    for body in ["", "[]", r#"["Sneaky"]"#, "{not json", "{}", "null"] {
+        let (status, answer) =
+            send(Method::POST, "/api/claude-settings/profiles", Some(body)).await;
+        assert_eq!(status, 400, "create body {body:?}");
+        assert_eq!(
+            String::from_utf8_lossy(&answer).trim_end(),
+            r#"{"error":"name is required"}"#,
+            "create body {body:?}"
+        );
+    }
+
+    let (status, created) = send(
+        Method::POST,
+        "/api/claude-settings/profiles",
+        Some(r#"{"name":"Parity Writes"}"#),
+    )
+    .await;
+    assert_eq!(status, 201, "create must be 201");
+    let profile: serde_json::Value = serde_json::from_slice(&created).expect("json");
+    assert_eq!(
+        profile["id"], "parity-writes",
+        "the id is the slugified name"
+    );
+    assert_eq!(profile["is_default"], false);
+    println!("create: {}", String::from_utf8_lossy(&created));
+
+    // A second profile with the same name is **deduplicated**, not refused —
+    // the opposite of what a rename onto the same slug does.
+    let (status, again) = send(
+        Method::POST,
+        "/api/claude-settings/profiles",
+        Some(r#"{"name":"Parity Writes"}"#),
+    )
+    .await;
+    assert_eq!(status, 201);
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&again).expect("json")["id"],
+        "parity-writes-2",
+        "create deduplicates the id and keeps the name"
+    );
+
+    // ── get ──
+    let (status, missing) = send(
+        Method::GET,
+        "/api/claude-settings/profiles/parity-no-such-profile",
+        None,
+    )
+    .await;
+    assert_eq!(status, 404);
+    assert_eq!(
+        String::from_utf8_lossy(&missing).trim_end(),
+        r#"{"error":"profile \"parity-no-such-profile\" not found"}"#
+    );
+
+    // ── update ──
+    let (status, bad_body) = send(
+        Method::PUT,
+        "/api/claude-settings/profiles/parity-writes",
+        Some("{not json"),
+    )
+    .await;
+    assert_eq!(status, 400);
+    assert_eq!(
+        String::from_utf8_lossy(&bad_body).trim_end(),
+        r#"{"error":"invalid JSON body"}"#,
+        "the update handler uses errInvalidJSONBody, unlike the create handler"
+    );
+
+    // An out-of-range number passes `json.Valid` and then fails the parse into
+    // `any`: the one reachable 422 on this surface.
+    let (status, out_of_range) = send(
+        Method::PUT,
+        "/api/claude-settings/profiles/parity-writes",
+        Some(r#"{"settings":{"n":1e999}}"#),
+    )
+    .await;
+    assert_eq!(status, 422, "a number out of float64 range is a 422");
+    assert_eq!(
+        String::from_utf8_lossy(&out_of_range).trim_end(),
+        r#"{"error":"validation error for \"settings\": failed to parse settings JSON"}"#
+    );
+
+    // A settings write, and the detail it answers with. The keys come back
+    // sorted because the file was written through `MarshalIndent` over `any`.
+    let (status, updated) = send(
+        Method::PUT,
+        "/api/claude-settings/profiles/parity-writes",
+        Some(r#"{"settings":{"z":1,"a":{"b":[1,2]}}}"#),
+    )
+    .await;
+    assert_eq!(status, 200);
+    let detail: serde_json::Value = serde_json::from_slice(&updated).expect("json");
+    assert_eq!(detail["exists"], true);
+    assert_eq!(detail["settings"].to_string(), r#"{"a":{"b":[1,2]},"z":1}"#);
+
+    // A literal `null` settings is a no-op, not a clear. Folding it into an
+    // absent key — or an absent key into an empty document — would silently
+    // erase a profile on a rename-only request.
+    let (status, untouched) = send(
+        Method::PUT,
+        "/api/claude-settings/profiles/parity-writes",
+        Some(r#"{"settings":null}"#),
+    )
+    .await;
+    assert_eq!(status, 200);
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&untouched).expect("json")["settings"]
+            .to_string(),
+        r#"{"a":{"b":[1,2]},"z":1}"#,
+        "a literal null settings must not clear the file"
+    );
+
+    // A rename whose slug collides with **another** profile is a 409. The
+    // collision is on the slug, so the names differ while the ids would not.
+    let (status, collision) = send(
+        Method::PUT,
+        "/api/claude-settings/profiles/parity-writes-2",
+        Some(r#"{"name":"PARITY WRITES"}"#),
+    )
+    .await;
+    assert_eq!(status, 409, "a rename collision is 409");
+    assert_eq!(
+        String::from_utf8_lossy(&collision).trim_end(),
+        r#"{"error":"profile with id \"parity-writes\" already exists"}"#
+    );
+
+    // A rename that does move: the id and the recorded path follow the slug,
+    // and the settings move with them rather than staying at the old path.
+    let (status, renamed) = send(
+        Method::PUT,
+        "/api/claude-settings/profiles/parity-writes",
+        Some(r#"{"name":"Parity Renamed"}"#),
+    )
+    .await;
+    assert_eq!(status, 200);
+    let renamed: serde_json::Value = serde_json::from_slice(&renamed).expect("json");
+    assert_eq!(renamed["id"], "parity-renamed");
+    assert!(renamed["file_path"]
+        .as_str()
+        .expect("a path")
+        .ends_with("/settings_parity-renamed.json"));
+    assert_eq!(
+        renamed["settings"].to_string(),
+        r#"{"a":{"b":[1,2]},"z":1}"#
+    );
+
+    let (status, _) = send(
+        Method::PUT,
+        "/api/claude-settings/profiles/parity-no-such-profile",
+        Some(r#"{"name":"x"}"#),
+    )
+    .await;
+    assert_eq!(status, 404, "update looks the profile up first");
+
+    // ── duplicate ──
+    let (status, copied) = send(
+        Method::POST,
+        "/api/claude-settings/profiles/parity-renamed/duplicate",
+        None,
+    )
+    .await;
+    assert_eq!(status, 201, "duplicate must be 201");
+    let copy: serde_json::Value = serde_json::from_slice(&copied).expect("json");
+    assert_eq!(copy["name"], "Copy of Parity Renamed");
+    assert_eq!(copy["id"], "copy-of-parity-renamed");
+    assert_eq!(copy["is_default"], false);
+
+    let (status, _) = send(
+        Method::POST,
+        "/api/claude-settings/profiles/parity-no-such-profile/duplicate",
+        None,
+    )
+    .await;
+    assert_eq!(status, 404);
+
+    // ── default ──
+    let (status, defaulted) = send(
+        Method::PUT,
+        "/api/claude-settings/profiles/parity-renamed/default",
+        Some("{}"),
+    )
+    .await;
+    assert_eq!(status, 200, "setting a default must be 200");
+    let defaulted: serde_json::Value = serde_json::from_slice(&defaulted).expect("json");
+    assert_eq!(defaulted["is_default"], true);
+
+    // The second path trap: it synced `settings.json` in the run config dir,
+    // byte for byte from the profile's own file.
+    let dir = scratch_claude_dir();
+    assert_eq!(
+        std::fs::read_to_string(format!("{dir}/settings.json")).expect("settings.json"),
+        std::fs::read_to_string(defaulted["file_path"].as_str().expect("path"))
+            .expect("profile file"),
+        "settings.json must be a byte copy of the new default profile"
+    );
+
+    let (status, _) = send(
+        Method::PUT,
+        "/api/claude-settings/profiles/parity-no-such-profile/default",
+        Some("{}"),
+    )
+    .await;
+    assert_eq!(status, 404);
+
+    // ── delete ──
+    // The default profile cannot be deleted, and Go says so with a
+    // `ConflictError` — whose wording is about existence, not about deletion.
+    let (status, refused) = send(
+        Method::DELETE,
+        "/api/claude-settings/profiles/parity-renamed",
+        None,
+    )
+    .await;
+    assert_eq!(status, 409, "deleting the default profile is 409");
+    assert_eq!(
+        String::from_utf8_lossy(&refused).trim_end(),
+        r#"{"error":"profile with id \"parity-renamed\" already exists"}"#
+    );
+
+    let (status, gone) = send(
+        Method::DELETE,
+        "/api/claude-settings/profiles/copy-of-parity-renamed",
+        None,
+    )
+    .await;
+    assert_eq!(status, 204, "delete must be 204");
+    assert!(gone.is_empty(), "204 carries no body");
+
+    let (status, _) = send(
+        Method::DELETE,
+        "/api/claude-settings/profiles/parity-no-such-profile",
+        None,
+    )
+    .await;
+    assert_eq!(status, 404);
+
+    // Hand the default back and clear this case's rows.
+    let (status, _) = send(
+        Method::PUT,
+        "/api/claude-settings/profiles/default/default",
+        Some("{}"),
+    )
+    .await;
+    assert_eq!(status, 200);
+    for cleanup in ["parity-renamed", "parity-writes-2"] {
+        delete_profile(cleanup).await;
+    }
+}
+
+// ─── The cache question, reproduced rather than reasoned about ────────────────
+
+/// **The evidence behind claiming the writes.**
+///
+/// The issue warned that `ClaudeSettingsProfileService` caches the index, which
+/// would leave the sidecar — still the side that runs agents and resolves
+/// `--settings` on every turn — reading a stale copy after a native write.
+///
+/// It does not. This writes `settings_profiles.json` *underneath a running Go
+/// server*, with this port's own encoder and no Go request in between, and then
+/// asks that same server. If the service held the index in memory the rename
+/// would be invisible to it; every method calls `config.LoadProfilesMetadata`,
+/// which is an `os.ReadFile` per call, so it is not.
+///
+/// The reads before the write are deliberate: a cache that was never populated
+/// would pass this for the wrong reason.
+#[tokio::test]
+#[ignore = "needs a running parity instance and a scratch CLAUDE_CONFIG_DIR; it writes"]
+async fn a_native_write_is_visible_to_the_go_server_immediately() {
+    let (_serial, dir) = enter().await;
+
+    let id = create_profile("Cache Evidence").await;
+
+    let before = fetch("/api/claude-settings/profiles").await;
+    assert!(
+        String::from_utf8_lossy(&before).contains(&format!("\"{id}\"")),
+        "the profile this case created is not in the list"
+    );
+    let _ = fetch(&format!("/api/claude-settings/profiles/{id}")).await;
+
+    let marker = "Renamed Behind The Server's Back";
+    let mut listed: Vec<profiles::Profile> = serde_json::from_slice(&before).expect("profiles");
+    for profile in &mut listed {
+        if profile.id == id {
+            profile.name = marker.to_string();
+        }
+    }
+    std::fs::write(
+        format!("{dir}/settings_profiles.json"),
+        profiles::encode_index(&listed).expect("encode"),
+    )
+    .expect("writing the index");
+
+    let after = fetch("/api/claude-settings/profiles").await;
+    assert!(
+        String::from_utf8_lossy(&after).contains(marker),
+        "the Go server did not see a write to settings_profiles.json — it caches \
+         the index after all, and these writes must not be claimed.\n{}",
+        String::from_utf8_lossy(&after)
+    );
+
+    // The per-profile read goes through the same load, so check that too.
+    let detail = fetch(&format!("/api/claude-settings/profiles/{id}")).await;
+    let detail: serde_json::Value = serde_json::from_slice(&detail).expect("json");
+    assert_eq!(detail["name"], marker);
+
+    delete_profile(&id).await;
+}

--- a/desktop/src-tauri/tests/parity_claude_settings.rs
+++ b/desktop/src-tauri/tests/parity_claude_settings.rs
@@ -685,6 +685,142 @@ async fn the_profile_write_answers_match_go() {
     }
 }
 
+// ─── The two places Go's JSON layer is not serde's ────────────────────────────
+
+/// **`encoding/json` is not UTF-8-strict and serde_json is**, and Go's answers
+/// here are the ones that make that a divergence rather than a curiosity: it
+/// serves invalid bytes verbatim, decodes them into `any` with U+FFFD
+/// substituted, and writes the substituted document back. None of that is
+/// reproducible in Rust, so every one of these must be a **forward** — the port
+/// answering at all would be answering wrongly.
+///
+/// This is the live half: it asks Go what it really does. The unit tests assert
+/// Rust forwards for each of the same inputs.
+#[tokio::test]
+#[ignore = "needs a running parity instance and a scratch CLAUDE_CONFIG_DIR; it writes"]
+async fn bytes_that_are_not_utf8_are_gos_to_answer() {
+    let (_serial, dir) = enter().await;
+
+    // ── the read of a file Go accepts and Rust cannot re-emit ──
+    let raw: &[u8] = b"{\"model\":\"opus\",\"tag\":\"x\xffy\"}";
+    std::fs::write(format!("{dir}/settings.json"), raw).expect("write");
+
+    let go = fetch("/api/claude-settings").await;
+    assert!(
+        go.windows(2).any(|w| w == b"\xff\"") || String::from_utf8_lossy(&go).contains("\u{fffd}"),
+        "Go is expected to ship the stored bytes through its encoder; it sent {}",
+        String::from_utf8_lossy(&go)
+    );
+    assert!(
+        String::from_utf8_lossy(&go).contains(r#""exists":true"#),
+        "Go answers 200 with the document, so a Rust `{{\"exists\":true}}` \
+         would be a wrong answer rather than a missing one"
+    );
+    assert!(
+        claude_settings::get_settings(&dir).is_err(),
+        "the native read must forward, not drop the `settings` key"
+    );
+
+    // ── the write Go performs and Rust cannot reproduce ──
+    let (status, answer) = send_raw(
+        Method::PUT,
+        "/api/claude-settings",
+        "application/json",
+        b"{\"tag\":\"x\xffy\"}".to_vec(),
+    )
+    .await;
+    assert_eq!(
+        status,
+        200,
+        "Go substitutes U+FFFD and writes the file: {}",
+        String::from_utf8_lossy(&answer)
+    );
+    assert!(matches!(
+        claude_settings::put_settings(&dir, b"{\"tag\":\"x\xffy\"}"),
+        Err(agento_lib::native::writes::WriteError::Fallback(_))
+    ));
+
+    // ── the same on a profile's own file ──
+    let id = create_profile("Parity Not Utf8").await;
+    std::fs::write(format!("{dir}/settings_{id}.json"), raw).expect("write");
+    let go = fetch(&format!("/api/claude-settings/profiles/{id}")).await;
+    assert!(
+        String::from_utf8_lossy(&go).contains(r#""exists":true"#),
+        "Go's `json.Valid` accepts these bytes, so the detail is `exists: true` \
+         with the document — not `settings: null`"
+    );
+    assert!(
+        finish(profiles::get(&dir, &id)).is_err(),
+        "the native detail must forward"
+    );
+    delete_profile(&id).await;
+
+    // Leave the shared dir holding something ordinary.
+    let (status, _) = send(
+        Method::PUT,
+        "/api/claude-settings",
+        Some(r#"{"model":"opus"}"#),
+    )
+    .await;
+    assert_eq!(status, 200);
+}
+
+/// **`json.Decoder.Decode` enforces `encoding/json`'s 10000-level cap**, even
+/// inside a field the request struct ignores — so a 10001-deep body never
+/// reaches `req.Name` and the create handler answers `400 name is required`.
+///
+/// serde routes an unknown field to `IgnoredAny`, whose skip is iterative and
+/// counts no depth, so this decoded with `name == "x"` and answered **201**:
+/// a profile file written and an index entry appended for a request Go refuses.
+/// The live half is here because the claim is about Go's scanner, not ours.
+#[tokio::test]
+#[ignore = "needs a running parity instance and a scratch CLAUDE_CONFIG_DIR; it writes"]
+async fn a_body_deeper_than_gos_scanner_creates_nothing() {
+    let (_serial, dir) = enter().await;
+
+    let body = format!(
+        r#"{{"name":"Parity Too Deep","junk":{}{}}}"#,
+        "[".repeat(10000),
+        "]".repeat(10000)
+    );
+    let (status, answer) = send(Method::POST, "/api/claude-settings/profiles", Some(&body)).await;
+    assert_eq!(status, 400, "Go's Decode stops at 10000 levels");
+    assert_eq!(
+        String::from_utf8_lossy(&answer).trim_end(),
+        r#"{"error":"name is required"}"#,
+        "the decode fails, so the handler sees an empty name"
+    );
+    assert!(
+        !std::path::Path::new(&format!("{dir}/settings_parity-too-deep.json")).exists(),
+        "Go wrote no profile file, so neither may the port"
+    );
+
+    // The port answers the same 400 — and, crucially, writes nothing either.
+    let native = native_body(
+        "create too deep",
+        finish(profiles::create(&dir, body.as_bytes())),
+        400,
+    );
+    assert_identical("create too deep", &answer, &native);
+    assert!(!std::path::Path::new(&format!("{dir}/settings_parity-too-deep.json")).exists());
+
+    // One level shallower is a real create in both, which is what makes the
+    // assertion above about the *cap* rather than about deep bodies generally.
+    let shallower = format!(
+        r#"{{"name":"Parity Deep Enough","junk":{}{}}}"#,
+        "[".repeat(9999),
+        "]".repeat(9999)
+    );
+    let (status, _) = send(
+        Method::POST,
+        "/api/claude-settings/profiles",
+        Some(&shallower),
+    )
+    .await;
+    assert_eq!(status, 201, "10000 levels is inside Go's cap");
+    delete_profile("parity-deep-enough").await;
+}
+
 // ─── The cache question, reproduced rather than reasoned about ────────────────
 
 /// **The evidence behind claiming the writes.**


### PR DESCRIPTION
## Summary

All nine routes are native — `GET`/`PUT /api/claude-settings` and the six profile ones. This is **filesystem state rather than SQLite**: `settings.json` and `settings_<slug>.json` in the run config dir, indexed by `settings_profiles.json`.

## The issue's cache premise is wrong, and it was settled by reproduction

The issue warned that "the service caches Go-side, so a native write leaves that cache stale". It does not. `claudeSettingsProfileService` holds exactly one field, a `*slog.Logger`; all seven methods call `config.LoadProfilesMetadata()`, which is an `os.ReadFile` per call, and `appendSettingsOpts` → `config.LoadProfileFilePathIn` re-reads the same file at the instant a run starts. There is nothing to invalidate.

I did not stop at reading the source. `a_native_write_is_visible_to_the_go_server_immediately` warms the Go server (list + per-profile read), writes `settings_profiles.json` underneath it **with this port's own encoder** and no Go request in between, then asks the same process — the rename is visible immediately, on both the list and the detail.

So all nine routes are claimed. **This is the opposite of #305's conclusion for `PUT /api/settings`**, which genuinely does re-apply process-wide snapshots. "Does Go cache this?" has to be asked per surface, not answered once for the branch.

Reads could not be split from writes regardless: `GET /api/claude-settings/profiles` runs `ensureDefaultProfileExists`, so the first list creates two files. That also makes it the one `GET` that `Mode::Diff`'s no-write rule does not cover — harmless, because the proxy runs Rust first and seeding is idempotent.

## Three divergences found during verification, each by a different half of the harness

- **`writes::decode_body` is wrong for this surface, twice.** It shape-checks through a `serde_json::Value`, whose parser rejects `1e999`, so `{"settings":{"n":1e999}}` came out **400 where Go answers 422**; and it requires EOF, while a `json.Decoder` reads a *stream* and accepts `{"name":"x"} junk`. `claude_settings::decode_request` checks the first token instead. My own unit test caught this after the live suite had already pinned Go's answer.
- **Go's number rule is `strconv.ParseFloat`'s — overflow only.** `1e-999` underflows to `0` with no error (verified against the toolchain), while serde_json's `NumberOutOfRange` covers both ends. The check is a byte scan of number tokens.
- **`json.Valid` needed `IgnoredAny`** (iterative skip, no 128-level recursion limit) plus a hand-written 10000-level cap, or a deeply nested settings file turned Go's 200 into a 500 and `exists:true` into `exists:false`.

## Both silent path traps are pinned

- **A named profile keeps its recorded absolute path.** `a_named_profile_keeps_its_recorded_path` puts a decoy at the id-derived path and asserts the recorded `file_path` wins — so moving the config dir cannot silently repoint it.
- **The dir is the run default** (`ResolveAgentClaudeDir` with no agent). Every live case asserts `run_dir(db) == CLAUDE_CONFIG_DIR`; `the_claude_settings_read_…` asserts the file landed there; and `setting_a_default_syncs_settings_json_in_the_same_dir` plus the live default case assert the byte copy into `<run dir>/settings.json` — the file `--settings` resolves against on every run (#242), where a wrong path is silent.

## Statuses verified live, not assumed

Create folds *every* decode failure and an empty name into `400 {"error":"name is required"}` — handler-level, so its 422 is unreachable and `["x"]` is not `invalid JSON body`. Update uses `invalid JSON body`. Deleting the default is a **409** reading "already exists" (`ConflictError`'s wording, reproduced). A rename onto another slug is 409, while create deduplicates to `-2`.

## What forwards, always before any mutation

A non-ASCII profile name (Go slugifies by Unicode category then rejects the id it built; `char::is_alphabetic` is a different set), a relative recorded path (`filepath.Abs` uses Go's cwd), documents past serde's 128-level recursion limit but inside Go's 10000, and every Go 500. None can produce a wrong answer.

## Changes

| File | Why |
|---|---|
| `native/claude_settings/mod.rs` | run-dir resolution, Go's `any`/`Marshal`/`Indent` chain, Go's stream decoder, `GET`/`PUT /api/claude-settings` |
| `native/claude_settings/profiles.rs` | the seven profile routes and the `settings_profiles.json` index — load/save, `ensureDefaultProfileExists`, slugify, dedupe, rename, path validation |
| `native/gojson.rs` | `indent()` — `encoding/json`'s `Indent`, so `MarshalIndent` decomposes into the existing `to_vec_marshal` plus this rather than needing a second `Formatter` |
| `native/mod.rs` | registers the endpoint; flips the `!claims(GET, "/api/claude-settings")` assertion and extends both registry-invariant probe lists |
| `tests/parity_claude_settings.rs` | six live-diff / answer-pinning cases |
| `desktop/CLAUDE.md` | layout entries and a "The Claude settings surface, where the state is files (#304)" section |

No Go source changed.

## Testing

- [x] `cargo test` (528 lib tests + 22 test binaries), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`
- [x] `make test`
- [x] Re-run green after rebasing onto `desktop` (which picked up #306, #307 and #308's own registry entries)
- [x] Live parity, `AGENTO_PARITY_WORKER=304`, Go built from this checkout, with a scratch `CLAUDE_CONFIG_DIR`. Seeded through the scratch server's own API: 5 profiles, one with real settings, one with its file deleted, one with a non-JSON file, plus several `PUT` payloads. **6/6 byte-identical** — `GET /api/claude-settings` (107 B), `/profiles` (701 B), all five profile details (146/225/165/186/183 B, covering both `exists:true` and `exists:false`), and the two files themselves (`settings_profiles.json` 358 B, `settings.json` 101 B).

**The parity suite refuses to run without a scratch `CLAUDE_CONFIG_DIR`.** `parity-instance.sh` copies the database but does nothing for `~/.claude`, and this surface overwrites `settings.json` — running it against the default dir would rewrite the developer's real Claude Code config.

## Related

Closes #304

---
🤖 Implemented by [Claude Code](https://claude.com/claude-code) via `implement-issue`