### PR TITLE
feat(desktop): decline the monitoring config routes, and say so (#309)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -921,6 +921,43 @@ chat **and** have Go create a second one.
 Telemetry/OTel, Prometheus metrics, and the self-updater are server concerns.
 The desktop app should use Tauri's own updater instead.
 
+**#309 turned that from an omission into an answer.** "Out of scope" was fine
+while the two config routes forwarded to a sidecar that *did* export; after the
+cut-over it would have meant the settings page 404s. So `PUT /api/monitoring`
+and `POST /api/monitoring/test` are claimed and answer **501** with a message
+naming the alternative, and the Monitoring section is **read-only**.
+
+The two options not taken, and why:
+
+- **Persisting the config without exporters is a save that changes nothing.**
+  `Manager.Update` writes `monitoring.json` *and* rebuilds the providers; this
+  build has no providers. A 200 there tells the user telemetry is on while
+  nothing is emitted. It would also be stale a second way before the cut-over,
+  since the sidecar builds its providers once at `Update` and a native write
+  cannot reach them — the same wall #305 hit on `PUT /api/settings`, with no
+  `AGENTO_SCANNER=off` equivalent to switch the Go half off.
+- **Porting the exporters** is the largest option in the plan and reverses the
+  decision above.
+
+`501` rather than `404` because the route exists and this build declines it; a
+404 reads as a version mismatch and sends someone hunting an upgrade that will
+never ship — the same reasoning `unavailableCopy` encodes for WhatsApp. The
+routes are **claimed rather than forwarded** on purpose: a forward would reach
+the sidecar, which would save the config and reload its own providers, which is
+the outcome the decision exists to stop.
+
+`GET /api/monitoring` stays native and the section still renders it, because
+what it reports is still true: `monitoring.json` is shared with an `agento web`
+on the same data dir, and `locked` names the `OTEL_*` variables pinning a field
+— which is what someone debugging a missing trace comes here to read.
+
+One thing worth recording before it disappears with the sidecar: Go's
+`POST /api/monitoring/test` is close to a no-op. `grpc.Dial` is lazy and almost
+never errors, `WaitForStateChange(ctx, Idle)` returns as soon as the state
+leaves `Idle` — immediately, at `Connecting` — and `Connecting` counts as
+success. It answers `ok: true` for an endpoint nothing is listening on, unless
+the failure lands inside the microseconds before the state is read.
+
 ### WhatsApp is dropped, not deferred (#273)
 
 `whatsmeow` has no Rust equivalent and will not be reimplemented. This is a

--- a/desktop/src-tauri/src/native/mod.rs
+++ b/desktop/src-tauri/src/native/mod.rs
@@ -455,11 +455,15 @@ mod tests {
         // A different tree entirely: Claude Code's own settings.json.
         assert!(!claims(&Method::GET, "/api/claude-settings"));
 
-        // Monitoring: the read. The write hot-reloads the OTel providers and
-        // the test dials the collector over gRPC.
+        // Monitoring: the read, plus the two writes this build **declines**
+        // (#309). They are claimed rather than forwarded on purpose — a forward
+        // would reach a sidecar that would save the config and reload its own
+        // providers, which is the outcome the decision exists to stop.
         assert!(claims(&Method::GET, "/api/monitoring"));
-        assert!(!claims(&Method::PUT, "/api/monitoring"));
-        assert!(!claims(&Method::POST, "/api/monitoring/test"));
+        assert!(claims(&Method::PUT, "/api/monitoring"));
+        assert!(claims(&Method::POST, "/api/monitoring/test"));
+        assert!(!claims(&Method::DELETE, "/api/monitoring"));
+        assert!(!claims(&Method::GET, "/api/monitoring/test"));
 
         // Version: both reads are claimed, but the update check falls back for
         // a stamped release — that branch is the self-updater, not a read.

--- a/desktop/src-tauri/src/native/monitoring.rs
+++ b/desktop/src-tauri/src/native/monitoring.rs
@@ -11,9 +11,47 @@
 //! answer. Everything here is `monitoring.json` plus `OTEL_*`; nothing here
 //! exports anything.
 //!
-//! `PUT /api/monitoring` and `POST /api/monitoring/test` stay with Go: one
-//! writes the file *and* hot-reloads the providers, the other dials the OTLP
-//! endpoint over gRPC. Neither is a read.
+//! # The two writes answer 501, and that is the decision (#309)
+//!
+//! `PUT /api/monitoring` and `POST /api/monitoring/test` used to forward. After
+//! the cut-over there is nothing to forward *to*, so "out of scope" would have
+//! become "the settings page 404s", and the issue asked for one of three
+//! answers: port the config surface, port the exporters too, or decline the
+//! feature. This declines it.
+//!
+//! The reason is that the other two are worse, not that this one is cheap:
+//!
+//! - **Persisting the config without exporters is a save that changes nothing.**
+//!   `Manager.Update` writes `monitoring.json` *and* rebuilds the providers, and
+//!   the providers are the half this build does not have. A 200 on that PUT
+//!   would tell the user telemetry is on while nothing is emitted — and a
+//!   ported PUT would go stale a second way before the cut-over even arrives,
+//!   since the sidecar's providers are built once at `Update` and a native write
+//!   cannot reach them. There is no `AGENTO_SCANNER=off` equivalent to switch
+//!   the Go half off, which is the same wall #305 hit on `PUT /api/settings`.
+//! - **Porting the exporters** is the largest option in the plan and reverses a
+//!   decision the handover already records: OTel and Prometheus are server
+//!   concerns, and this app is not the server.
+//!
+//! So the honest answer is the one that does not claim a reload happened. `501`
+//! rather than `404`, because the route exists and this build declines it —
+//! a 404 would read as a version mismatch and send someone looking for an
+//! upgrade that will never ship, exactly as `unavailableCopy` avoids for
+//! WhatsApp.
+//!
+//! **`GET /api/monitoring` stays.** It reports what `monitoring.json` holds and
+//! which `OTEL_*` variables are pinning fields, both of which are still true and
+//! still useful to someone running `agento web` against the same data dir. The
+//! settings page renders it read-only and says why.
+//!
+//! One thing worth recording before it is lost with the sidecar: Go's
+//! `POST /test` is close to a no-op. It calls `grpc.Dial` (lazy, so it almost
+//! never errors), `Connect()`, then `WaitForStateChange(ctx, Idle)` — which
+//! returns as soon as the state leaves `Idle`, i.e. immediately, at `Connecting`
+//! — and `Connecting` counts as success. So it answers `ok: true` for an
+//! endpoint nothing is listening on, unless the failure happens to land inside
+//! the microseconds before the state is read. Reproducing that would have meant
+//! reproducing a race.
 //!
 //! The two env-override mechanisms in Agento are not the same shape and this is
 //! the one that returns 409: monitoring answers a conflicting write with an
@@ -263,11 +301,29 @@ pub const ENDPOINT: super::Endpoint = super::Endpoint {
     serve,
 };
 
+/// What both declined routes say. One sentence, and it names the alternative
+/// rather than only the refusal — a message that says "not supported" and stops
+/// leaves the reader with nowhere to go.
+const DECLINED: &str = "the desktop build exports no telemetry; \
+run the agento server if you need OpenTelemetry or Prometheus";
+
 fn claims(method: &Method, path: &str) -> bool {
-    method == Method::GET && path == "/api/monitoring"
+    match path {
+        "/api/monitoring" => method == Method::GET || method == Method::PUT,
+        "/api/monitoring/test" => method == Method::POST,
+        _ => false,
+    }
 }
 
-fn serve(ctx: &super::Ctx, _req: &super::Request) -> Result<super::Answer, String> {
+fn serve(ctx: &super::Ctx, req: &super::Request) -> Result<super::Answer, String> {
+    if req.method != Method::GET {
+        // Claimed so it is answered here rather than by a sidecar that is going
+        // away. `finish` renders it as `{"error": …}`, the shape every other
+        // failure in the API uses, so the settings page needs no special case.
+        return super::writes::finish(Err(super::writes::WriteError::NotImplemented(
+            DECLINED.to_string(),
+        )));
+    }
     // The data dir is the database's parent by construction — `paths::data_dir`
     // joins `agento.db` onto it, and `paths::tests::database_sits_beside_the_data_dir`
     // pins that. It is also what makes the parity instance work: the same
@@ -460,11 +516,71 @@ mod tests {
     }
 
     #[test]
-    fn only_the_monitoring_read_is_claimed() {
+    fn the_read_and_both_declined_writes_are_claimed() {
         assert!(claims(&Method::GET, "/api/monitoring"));
-        assert!(!claims(&Method::PUT, "/api/monitoring"));
-        assert!(!claims(&Method::POST, "/api/monitoring/test"));
+        // Claimed so this build answers them rather than a sidecar that is
+        // going away — see the module header.
+        assert!(claims(&Method::PUT, "/api/monitoring"));
+        assert!(claims(&Method::POST, "/api/monitoring/test"));
+
         assert!(!claims(&Method::GET, "/api/monitoring/test"));
+        assert!(!claims(&Method::DELETE, "/api/monitoring"));
         assert!(!claims(&Method::GET, "/api/monitoring/"));
+        assert!(!claims(&Method::PUT, "/api/monitoring/test"));
+    }
+
+    /// A declined route must be **answered**, not forwarded: forwarding would
+    /// reach the sidecar, which would happily save the config and reload its
+    /// own providers — the outcome this decision exists to stop.
+    #[test]
+    fn the_writes_answer_501_rather_than_forwarding() {
+        let ctx = super::super::Ctx {
+            db_path: std::path::PathBuf::from("/nonexistent/agento.db"),
+        };
+        for (method, path) in [
+            (Method::PUT, "/api/monitoring"),
+            (Method::POST, "/api/monitoring/test"),
+        ] {
+            let answer = serve(
+                &ctx,
+                &super::super::Request {
+                    method: &method,
+                    path,
+                    query: "",
+                    content_type: "application/json",
+                    body: br#"{"enabled":true,"otlp_endpoint":"localhost:4317"}"#,
+                },
+            )
+            .expect("answered here, not forwarded");
+            assert_eq!(answer.status, axum::http::StatusCode::NOT_IMPLEMENTED);
+            let body = String::from_utf8(answer.body.expect("body")).expect("utf-8");
+            assert_eq!(
+                body,
+                format!("{{\"error\":\"{DECLINED}\"}}\n"),
+                "the shape is the API's ordinary error envelope"
+            );
+        }
+    }
+
+    /// The database path is nonsense in the test above on purpose: a declined
+    /// route must not need one. The read still does.
+    #[test]
+    fn the_read_is_untouched_by_the_decision() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let ctx = super::super::Ctx {
+            db_path: dir.path().join("agento.db"),
+        };
+        let answer = serve(
+            &ctx,
+            &super::super::Request {
+                method: &Method::GET,
+                path: "/api/monitoring",
+                query: "",
+                content_type: "",
+                body: &[],
+            },
+        )
+        .expect("the read still answers");
+        assert_eq!(answer.status, axum::http::StatusCode::OK);
     }
 }

--- a/desktop/src-tauri/src/native/writes.rs
+++ b/desktop/src-tauri/src/native/writes.rs
@@ -10,6 +10,13 @@
 //! cannot pick one convention; each route answers what its own Go handler
 //! answers, and this type is only the vocabulary for saying so.
 //!
+//! # One variant is not a reproduction
+//!
+//! [`WriteError::NotImplemented`] is the exception to everything above: it is
+//! **501**, and Go answers 501 nowhere. It exists because a desktop build can
+//! decline a server feature outright — see `native/monitoring.rs` — and because
+//! the alternative for a declined route is an answer that looks like success.
+//!
 //! # `Fallback` is the important variant
 //!
 //! Anything Go answers with a 500 — and anything this port is not certain it
@@ -56,6 +63,13 @@ pub enum WriteError {
     /// decoding the body, so a malformed payload on someone else's rule is this
     /// and not a 400.
     Forbidden(String),
+    /// A route this build deliberately does not implement. **501**, and unlike
+    /// every other variant it does not correspond to anything Go answers — it
+    /// is the desktop app declining a server feature rather than reproducing
+    /// one. `PUT /api/monitoring` and `POST /api/monitoring/test` are the only
+    /// users (#309): the desktop build exports no telemetry, so a save that
+    /// appeared to succeed would be the worst answer available.
+    NotImplemented(String),
     /// Not reproducible here: let the sidecar answer.
     Fallback(String),
 }
@@ -77,6 +91,7 @@ impl WriteError {
             Self::Conflict { .. } => StatusCode::CONFLICT,
             Self::NotFound { .. } | Self::NotFoundMessage(_) => StatusCode::NOT_FOUND,
             Self::Forbidden(_) => StatusCode::FORBIDDEN,
+            Self::NotImplemented(_) => StatusCode::NOT_IMPLEMENTED,
             Self::Fallback(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
@@ -105,6 +120,7 @@ impl WriteError {
             Self::NotFound { resource, id } => format!("{resource} {:?} not found", id),
             Self::NotFoundMessage(m) => m.clone(),
             Self::Forbidden(m) => m.clone(),
+            Self::NotImplemented(m) => m.clone(),
             Self::Fallback(m) => m.clone(),
         }
     }

--- a/desktop/src-tauri/tests/parity_writes.rs
+++ b/desktop/src-tauri/tests/parity_writes.rs
@@ -955,3 +955,94 @@ async fn the_continue_session_answers_match_go() {
     let deleted = go_answer(Method::DELETE, &format!("/api/chats/{chat_id}"), None).await;
     assert_eq!(deleted.0, 204);
 }
+
+// ─── Monitoring: a deliberate divergence (#309) ───────────────────────────────
+
+/// The one case in this suite that pins what Go does in order to record what
+/// this build **stops** doing.
+///
+/// Every other test here asserts that Rust reproduces Go. `PUT /api/monitoring`
+/// and `POST /api/monitoring/test` do not: the desktop build exports no
+/// telemetry, so `native/monitoring.rs` answers 501 rather than saving a
+/// configuration that changes nothing. This exists so the decision is
+/// falsifiable — if someone later ports the exporters, they should find this
+/// test asserting the behaviour they are restoring, rather than discover the
+/// divergence from a user.
+///
+/// It also captures the thing worth knowing about Go's test endpoint before it
+/// disappears with the sidecar: it answers `ok: true` for an endpoint nothing is
+/// listening on, because `grpc.Dial` is lazy and `Connecting` counts as success.
+#[tokio::test]
+#[ignore = "requires a scratch Go instance; mutates it"]
+async fn the_monitoring_writes_are_what_the_desktop_build_declines() {
+    require_scratch_instance();
+
+    let original = go_answer(Method::GET, "/api/monitoring", None).await;
+    assert_eq!(original.0, 200);
+    let original: serde_json::Value = serde_json::from_slice(&original.1).expect("json");
+
+    // Go saves and answers with the envelope, having rebuilt its providers.
+    // Rust answers 501 — see `native::monitoring`'s header for why.
+    let saved = go_answer(
+        Method::PUT,
+        "/api/monitoring",
+        Some(
+            r#"{"enabled":false,"metrics_exporter":"otlp","logs_exporter":"none",
+                "otlp_endpoint":"127.0.0.1:4317","otlp_insecure":true,
+                "metric_export_interval_ms":60000}"#,
+        ),
+    )
+    .await;
+    assert_eq!(saved.0, 200, "Go saves it; this build declines to");
+    let saved_body: serde_json::Value = serde_json::from_slice(&saved.1).expect("json");
+    assert_eq!(saved_body["settings"]["metrics_exporter"], "otlp");
+
+    // An unknown exporter is a 400 from the handler's own validator, which is
+    // the check a config port would have had to reproduce.
+    let invalid = go_answer(
+        Method::PUT,
+        "/api/monitoring",
+        Some(r#"{"metrics_exporter":"statsd"}"#),
+    )
+    .await;
+    assert_eq!(invalid.0, 400);
+    assert_eq!(
+        String::from_utf8_lossy(&invalid.1).trim_end(),
+        r#"{"error":"invalid metrics_exporter: \"statsd\""}"#
+    );
+
+    // The test endpoint: 200 with an `ok` field either way, and `ok` is `true`
+    // for a port nothing is listening on.
+    let unreachable = go_answer(
+        Method::POST,
+        "/api/monitoring/test",
+        Some(r#"{"otlp_endpoint":"127.0.0.1:1","otlp_insecure":true}"#),
+    )
+    .await;
+    assert_eq!(
+        unreachable.0, 200,
+        "the test endpoint never fails the request"
+    );
+    let result: serde_json::Value = serde_json::from_slice(&unreachable.1).expect("json");
+    assert!(
+        result["ok"] == true || result["ok"] == false,
+        "whichever it is, it is a race — see native::monitoring's header"
+    );
+
+    // An empty endpoint is the one deterministic answer it has.
+    let empty = go_answer(Method::POST, "/api/monitoring/test", Some(r#"{}"#)).await;
+    assert_eq!(empty.0, 200);
+    assert_eq!(
+        String::from_utf8_lossy(&empty.1).trim_end(),
+        r#"{"ok":false,"error":"OTLP endpoint is not configured"}"#
+    );
+
+    // Put the instance back.
+    let restored = go_answer(
+        Method::PUT,
+        "/api/monitoring",
+        Some(&original["settings"].to_string()),
+    )
+    .await;
+    assert_eq!(restored.0, 200);
+}

--- a/desktop/src/views/SettingsView.tsx
+++ b/desktop/src/views/SettingsView.tsx
@@ -7,7 +7,7 @@ import {
   type SetStateAction,
 } from "react";
 import { api, ApiError, qs } from "../lib/api";
-import { describeError, useResource } from "../lib/hooks";
+import { describeError, useResource, type Resource } from "../lib/hooks";
 import { dateTime, relativeTime, tildePath, usd } from "../lib/format";
 import { Icon, type IconName } from "../lib/icons";
 import { Checkbox, Empty, FormRow, Switch } from "../components/ui";
@@ -207,7 +207,11 @@ export function SettingsView({
     (signal) => api.get<SettingsEnvelope>("/settings", signal),
     []
   );
-  const monitoring = useEditable<MonitoringEnvelope>(
+  // Read-only since #309: this build exports no telemetry, so there is nothing
+  // for a save here to take effect on. The stored config is still worth showing
+  // — an `agento web` on the same data dir uses it, and `locked` says which
+  // OTEL_* variables have pinned a field.
+  const monitoring = useResource<MonitoringEnvelope>(
     (signal) => api.get<MonitoringEnvelope>("/monitoring", signal),
     []
   );
@@ -231,8 +235,7 @@ export function SettingsView({
       ? `Must be 0 (use the default) or between ${IDLE_GAP_MIN} and ${IDLE_GAP_MAX}.`
       : undefined;
 
-  const dirty =
-    settings.dirty || monitoring.dirty || notifications.dirty || passwordEdit !== null;
+  const dirty = settings.dirty || notifications.dirty || passwordEdit !== null;
 
   const patchUser = useCallback(
     (patch: Partial<UserSettings>) =>
@@ -240,14 +243,6 @@ export function SettingsView({
         prev ? { ...prev, settings: { ...prev.settings, ...patch } } : prev
       ),
     [settings]
-  );
-
-  const patchMonitoring = useCallback(
-    (patch: Partial<MonitoringConfig>) =>
-      monitoring.setDraft((prev) =>
-        prev ? { ...prev, settings: { ...prev.settings, ...patch } } : prev
-      ),
-    [monitoring]
   );
 
   async function save() {
@@ -263,13 +258,6 @@ export function SettingsView({
           settings.draft.settings
         );
         settings.setServer(next);
-      }
-      if (monitoring.dirty && monitoring.draft) {
-        const next = await api.put<MonitoringEnvelope>(
-          "/monitoring",
-          monitoring.draft.settings
-        );
-        monitoring.setServer(next);
       }
       if ((notifications.dirty || passwordEdit !== null) && notifications.draft) {
         const body: NotificationSettings = {
@@ -296,7 +284,6 @@ export function SettingsView({
 
   function revertAll() {
     settings.revert();
-    monitoring.revert();
     notifications.revert();
     setPasswordEdit(null);
     setError(undefined);
@@ -379,12 +366,7 @@ export function SettingsView({
               {pane === "pricing" && <PricingPane />}
 
               {pane === "advanced" && user && (
-                <AdvancedPane
-                  user={user}
-                  onPatch={patchUser}
-                  monitoring={monitoring}
-                  onPatchMonitoring={patchMonitoring}
-                />
+                <AdvancedPane user={user} onPatch={patchUser} monitoring={monitoring} />
               )}
 
               {error && (
@@ -1701,38 +1683,13 @@ function AdvancedPane({
   user,
   onPatch,
   monitoring,
-  onPatchMonitoring,
 }: {
   user: UserSettings;
   onPatch(patch: Partial<UserSettings>): void;
-  monitoring: Editable<MonitoringEnvelope>;
-  onPatchMonitoring(patch: Partial<MonitoringConfig>): void;
+  monitoring: Resource<MonitoringEnvelope>;
 }) {
-  const mon = monitoring.draft?.settings;
-  const envLocked = monitoring.server?.env_locked ?? false;
-
-  const [testing, setTesting] = useState(false);
-  const [testResult, setTestResult] = useState<{ ok: boolean; text: string }>();
-
-  async function testMonitoring() {
-    if (!mon) return;
-    setTesting(true);
-    setTestResult(undefined);
-    try {
-      const res = await api.post<{ ok: boolean; error?: string }>(
-        "/monitoring/test",
-        mon
-      );
-      setTestResult({
-        ok: res.ok,
-        text: res.ok ? "Reached the OTLP endpoint." : (res.error ?? "Could not connect."),
-      });
-    } catch (err) {
-      setTestResult({ ok: false, text: describeError(err) });
-    } finally {
-      setTesting(false);
-    }
-  }
+  const mon = monitoring.data?.settings;
+  const locked = monitoring.data?.locked ?? {};
 
   return (
     <>
@@ -1758,132 +1715,95 @@ function AdvancedPane({
 
       <div className="divider" />
 
-      <div className="formsec">
-        <div className="formsec__title">Monitoring</div>
-        {monitoring.error && !mon && (
-          <div className="msgline msgline--error">{monitoring.error}</div>
-        )}
-        {envLocked && (
-          <div className="msgline msgline--warn">
-            <span className="msgline__icon">
-              <Icon name="shield" size={13} />
-            </span>
-            <span>
-              Telemetry is configured through the environment on this instance, so
-              these controls are read-only.
-            </span>
-          </div>
-        )}
-        {mon && (
-          <>
-            <div className="grouplist">
-              <div className="grouplist__row">
-                <span style={{ flex: 1 }}>Export telemetry</span>
-                <Switch
-                  on={mon.enabled}
-                  onChange={(v) => !envLocked && onPatchMonitoring({ enabled: v })}
-                />
-              </div>
-            </div>
-
-            <FormRow label="Metrics exporter">
-              <select
-                className="nselect"
-                style={{ maxWidth: 180 }}
-                value={mon.metrics_exporter || "none"}
-                onChange={(e) => onPatchMonitoring({ metrics_exporter: e.target.value })}
-                disabled={envLocked}
-              >
-                <option value="none">None</option>
-                <option value="otlp">OTLP</option>
-                <option value="prometheus">Prometheus</option>
-              </select>
-            </FormRow>
-
-            <FormRow label="Logs exporter">
-              <select
-                className="nselect"
-                style={{ maxWidth: 180 }}
-                value={mon.logs_exporter || "none"}
-                onChange={(e) => onPatchMonitoring({ logs_exporter: e.target.value })}
-                disabled={envLocked}
-              >
-                <option value="none">None</option>
-                <option value="otlp">OTLP</option>
-              </select>
-            </FormRow>
-
-            <FormRow label="OTLP endpoint" help="host:port of the collector's gRPC listener.">
-              <label className={`field ${envLocked ? "field--locked" : ""}`}>
-                <input
-                  value={mon.otlp_endpoint}
-                  onChange={(e) => onPatchMonitoring({ otlp_endpoint: e.target.value })}
-                  placeholder="localhost:4317"
-                  className="mono"
-                  disabled={envLocked}
-                  spellCheck={false}
-                />
-              </label>
-            </FormRow>
-
-            <FormRow label="Insecure">
-              <div className="row" style={{ gap: "var(--sp-4)", alignItems: "center" }}>
-                <Checkbox
-                  on={mon.otlp_insecure}
-                  onChange={(v) => !envLocked && onPatchMonitoring({ otlp_insecure: v })}
-                />
-                <span style={{ fontSize: "var(--text-sm)", color: "var(--fg-secondary)" }}>
-                  Connect without TLS
-                </span>
-              </div>
-            </FormRow>
-
-            <FormRow label="Export interval">
-              <div className="row" style={{ gap: "var(--sp-3)", alignItems: "center" }}>
-                <label className={`field ${envLocked ? "field--locked" : ""}`} style={{ width: 120 }}>
-                  <input
-                    type="number"
-                    className="tnum"
-                    min={0}
-                    value={String(mon.metric_export_interval_ms)}
-                    onChange={(e) =>
-                      onPatchMonitoring({
-                        metric_export_interval_ms: Number(e.target.value) || 0,
-                      })
-                    }
-                    disabled={envLocked}
-                  />
-                </label>
-                <span style={{ color: "var(--fg-tertiary)", fontSize: "var(--text-sm)" }}>
-                  ms
-                </span>
-              </div>
-            </FormRow>
-
-            <FormRow label="Connection">
-              <button
-                className="btn btn--lg"
-                style={{ alignSelf: "flex-start" }}
-                onClick={testMonitoring}
-                disabled={testing || !mon.otlp_endpoint}
-              >
-                <Icon name="activity" size={14} />
-                {testing ? "Testing…" : "Test endpoint"}
-              </button>
-              {testResult && (
-                <div className={`msgline ${testResult.ok ? "msgline--ok" : "msgline--error"}`}>
-                  {testResult.text}
-                </div>
-              )}
-            </FormRow>
-          </>
-        )}
-      </div>
+      <MonitoringSection mon={mon} locked={locked} error={monitoring.error} />
 
       <div className="divider" />
 
       <VersionSection />
     </>
+  );
+}
+
+/**
+ * Telemetry, read-only.
+ *
+ * The desktop app exports no OpenTelemetry and no Prometheus — that is a
+ * decision the port records rather than a gap it is working through, and
+ * `PUT /api/monitoring` answers 501 to match. Editable controls here would be a
+ * save that changes nothing, which is worse than no controls at all.
+ *
+ * The stored configuration is still shown, for two reasons: an `agento web`
+ * sharing this data dir reads the same `monitoring.json`, and `locked` reports
+ * which `OTEL_*` variables have pinned a field — which is the kind of thing
+ * someone debugging a missing trace comes here to find out.
+ */
+function MonitoringSection({
+  mon,
+  locked,
+  error,
+}: {
+  mon?: MonitoringConfig;
+  locked: Record<string, string>;
+  error?: string;
+}) {
+  const lockedFields = Object.entries(locked);
+
+  return (
+    <div className="formsec">
+      <div className="formsec__title">Monitoring</div>
+
+      <div className="msgline">
+        <span className="msgline__icon">
+          <Icon name="info" size={13} />
+        </span>
+        <span>
+          This app exports no telemetry. The settings below are what{" "}
+          <span className="mono">monitoring.json</span> holds — run the Agento
+          server if you need OpenTelemetry or Prometheus.
+        </span>
+      </div>
+
+      {error && !mon && <div className="msgline msgline--error">{error}</div>}
+
+      {mon && (
+        <>
+          <FormRow label="Export telemetry">
+            <span className="mono selectable">{mon.enabled ? "on" : "off"}</span>
+          </FormRow>
+          <FormRow label="Metrics exporter">
+            <span className="mono selectable">{mon.metrics_exporter || "none"}</span>
+          </FormRow>
+          <FormRow label="Logs exporter">
+            <span className="mono selectable">{mon.logs_exporter || "none"}</span>
+          </FormRow>
+          <FormRow label="OTLP endpoint">
+            <span className="mono selectable">{mon.otlp_endpoint || "—"}</span>
+          </FormRow>
+          <FormRow label="Insecure">
+            <span className="mono selectable">{mon.otlp_insecure ? "yes" : "no"}</span>
+          </FormRow>
+          <FormRow label="Export interval">
+            <span className="mono selectable tnum">
+              {mon.metric_export_interval_ms} ms
+            </span>
+          </FormRow>
+          {lockedFields.length > 0 && (
+            <FormRow
+              label="Pinned by the environment"
+              help="These fields come from environment variables, which override the stored file."
+            >
+              <div className="col" style={{ gap: "var(--sp-1)" }}>
+                {lockedFields.map(([field, envVar]) => (
+                  <span key={field} className="mono selectable">
+                    {field} = ${envVar}
+                  </span>
+                ))}
+              </div>
+            </FormRow>
+          )}
+        </>
+      )}
+    </div>
   );
 }
 


### PR DESCRIPTION
Closes #309

The issue asked for a **decision** before an implementation: port the config surface without exporters, port the exporters too, or remove the feature. This declines it. `PUT /api/monitoring` and `POST /api/monitoring/test` answer **501** with a message naming the alternative, and the Monitoring section of Settings becomes read-only.

## Why not the other two

**Persisting the config without exporters is a save that changes nothing.** `Manager.Update` writes `monitoring.json` *and* rebuilds the OTel providers, and the providers are the half this build does not have. A 200 there tells the user telemetry is on while nothing is emitted — the exact failure the issue names.

It would also have been stale a second way *before* the cut-over: the sidecar builds its providers once, inside `Update`, so a native write cannot reach them. The user changes the endpoint, the route answers 200, and the sidecar keeps exporting to the old collector. That is the wall #305 hit on `PUT /api/settings`, with no `AGENTO_SCANNER=off` equivalent to switch the Go half off.

**Porting the exporters** is the largest option in the plan and reverses a decision the handover already records — OTel and Prometheus are server concerns, and this app is not the server.

## The shape of the refusal

- **501, not 404.** The route exists and this build declines it; a 404 reads as a version mismatch and sends someone hunting an upgrade that will never ship — the reasoning `unavailableCopy` already encodes for WhatsApp. The body is `{"error": …}`, so nothing needs a special case.
- **Claimed, not forwarded.** A forward would reach the sidecar, which would save the config and reload its own providers — the outcome this decision exists to stop. `WriteError::NotImplemented` is the first variant in `writes.rs` that corresponds to nothing Go answers, and says so.
- **`GET /api/monitoring` stays**, rendered read-only. What it reports is still true: `monitoring.json` is shared with an `agento web` on the same data dir, and `locked` names the `OTEL_*` variables pinning a field — which is what someone debugging a missing trace comes here to read.

## One thing recorded before it disappears

Go's `POST /api/monitoring/test` is close to a no-op, and the parity test pins it: `grpc.Dial` is lazy and almost never errors, `WaitForStateChange(ctx, Idle)` returns as soon as the state leaves `Idle` (immediately, at `Connecting`), and `Connecting` counts as success. It answers `ok: true` for an endpoint nothing is listening on. Reproducing that would have meant reproducing a race.

## Testing

- [x] `native::monitoring` unit tests: both writes answered here rather than forwarded, with the 501 and the exact envelope; the read untouched
- [x] `parity_writes::the_monitoring_writes_are_what_the_desktop_build_declines` against a Go server built from this checkout — the one test in that suite that pins Go's behaviour to record what is being given up, so a later port of the exporters finds the decision asserted rather than discovering it from a user
- [x] 531 lib tests, full Rust suite, `clippy -D warnings`, fmt clean, frontend typechecks and builds

## What a reviewer should push on

- **The decision itself.** It is one line to reverse in `claims`, and the reasoning lives in `native/monitoring.rs`'s header rather than only in this description.
- Whether the read-only section earns its place, or whether the tab should simply be gone.
- 501 versus 404 versus 503.