### PR TITLE
fix(desktop): match routes on the path chi routes on, not the raw target (#294)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -168,6 +168,7 @@ src-tauri/src/
     uploads.rs   POST /api/uploads — the one multipart body, and the extension
                  allowlist that is the route's whole security boundary
     gopath.rs    Go's filepath.Clean/Dir/Join, pinned to vectors generated from Go
+    gourl.rs     the path chi routes on — Go decodes only canonical escaping
     query.rs     one query parameter, read the way r.URL.Query().Get reads it
     pricing.rs   GET /api/pricing/catalog, plus the rate Resolver — and the
                  three rate writes (#306): add and correct are not one upsert
@@ -264,6 +265,34 @@ Two properties, both load-bearing:
 `no_two_endpoints_claim_the_same_request` guards the one thing a registry can
 get wrong that a match statement could not: two modules claiming one path, where
 the first listed silently wins and the other's tests keep passing.
+
+**Every `claims` function matches on the path *chi* routes on, not on the raw
+request target** (#294). They are different strings, and which one Go uses is a
+property of `url.setPath` rather than of the request: `net/http` decodes the
+target into a `url.URL` before any handler runs, and `chi`'s `Mux.routeHTTP`
+then routes on `RawPath` when it is set and on the decoded `Path` when it is
+not — so **Go decodes exactly when the escaping is canonical**.
+
+| request target | chi's segment |
+|---|---|
+| `/api/agents/a%2Db` | `a%2Db` — `-` needs no escaping, so the encoding does not round-trip |
+| `/api/agents/a%20b` | `a b` — a space *must* be escaped, so it does |
+| `/api/agents/caf%C3%A9` | `café` |
+| `/api/agents/a%2Fb` | `a%2Fb` — which is what keeps a one-segment route one segment |
+
+`native/gourl.rs` is that rule, applied once in `proxy.rs` where `path` is
+derived, so no module's `slug_of`/`id_of` has to know about it and none of the
+five can drift apart. Both a blanket decode and a blanket raw match are wrong,
+in opposite directions, on rows of that table. A target whose escaping is
+malformed, or whose decoded path is not UTF-8, has **no** route path: the first
+is a 400 `net/http` answers before any handler and the second is a string Rust
+cannot carry, so both forward and Go answers. `desktop/parity/gourl_vectors.json`
+records what a live chi router actually did, not what the rule says it should.
+
+While every claimed route was a read this was invisible — a miss produced `Err`
+and forwarded, and Go answered correctly. It stopped being invisible when #274
+and #276 claimed writes: `agents::update` *answers* 404 and `chats::patch`
+answers `chat not found` for a request Go would have applied to a real row.
 
 `AGENTO_DESKTOP_NATIVE` steers the whole seam:
 

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -283,11 +283,16 @@ not — so **Go decodes exactly when the escaping is canonical**.
 `native/gourl.rs` is that rule, applied once in `proxy.rs` where `path` is
 derived, so no module's `slug_of`/`id_of` has to know about it and none of the
 five can drift apart. Both a blanket decode and a blanket raw match are wrong,
-in opposite directions, on rows of that table. A target whose escaping is
-malformed, or whose decoded path is not UTF-8, has **no** route path: the first
-is a 400 `net/http` answers before any handler and the second is a string Rust
-cannot carry, so both forward and Go answers. `desktop/parity/gourl_vectors.json`
-records what a live chi router actually did, not what the rule says it should.
+in opposite directions, on rows of that table — and canonicality is a property
+of the **whole** path, so one non-canonical escape anywhere leaves every segment
+raw. A target whose escaping is malformed, or whose escaping is canonical *and*
+whose decoded path is not UTF-8, has **no** route path: the first is a 400
+`net/http` answers before any handler and the second is a string Rust cannot
+carry, so both forward and Go answers. The order of those two checks is
+load-bearing — `/api/agents/%ff` decodes to the same unrepresentable byte as
+`%FF` but is not canonical, so chi routes on the raw target, which is plain
+ASCII. `desktop/parity/gourl_vectors.json` records what a live chi router
+actually did, not what the rule says it should.
 
 While every claimed route was a read this was invisible — a miss produced `Err`
 and forwarded, and Go answered correctly. It stopped being invisible when #274

--- a/desktop/parity/gourl_parity_test.go
+++ b/desktop/parity/gourl_parity_test.go
@@ -70,6 +70,12 @@ var routePathInputs = []string{
 	"/api/agents/a%2db",
 	"/api/agents/a%20b",
 	"/api/agents/caf%C3%A9",
+	// The lowercase sibling of the row above: same bytes, non-canonical, so chi
+	// routes on the raw target instead. It is also the case that proves the
+	// canonical check must run on *bytes* — `%ff` decodes to something Rust
+	// cannot hold, but the string chi routes on is plain ASCII.
+	"/api/agents/caf%c3%a9",
+	"/api/agents/%ff",
 	"/api/agents/a%2Fb",
 	"/api/agents/a%3Fb",
 	"/api/agents/a+b",
@@ -81,6 +87,10 @@ var routePathInputs = []string{
 	"/api/chats/a%20b/messages",
 	"/api/tasks/a%20b/run",
 	"/api/integrations/a%20b/triggers",
+	// The rule's least obvious consequence: canonicality is a property of the
+	// **whole** path, so one non-canonical escape anywhere leaves every segment
+	// raw — `r%201` included, even though on its own it would have decoded.
+	"/api/integrations/a%2Db/triggers/r%201",
 	"/api/claude-sessions/a%20b/insights",
 	"/api/agents/",
 	"/api/agents/a%2",

--- a/desktop/parity/gourl_parity_test.go
+++ b/desktop/parity/gourl_parity_test.go
@@ -1,0 +1,181 @@
+// Cross-language vectors for the path a chi route actually matches on.
+//
+// Every claim function in `desktop/src-tauri/src/native/` matches on a path
+// string, and until #294 that string was the raw request target. Go's router
+// never sees that: `net/http` parses the URI into a `url.URL` first, and chi's
+// `Mux.routeHTTP` then routes on `RawPath` when it is set and on `Path` when it
+// is not — so Go's segment is the *encoded* one for `/api/agents/a%2Db` and the
+// *decoded* one for `/api/agents/a%20b`. Which of the two is a property of
+// `url.setPath`, not of the request, and it is not guessable by reading either
+// package's documentation.
+//
+// This half asserts Go still produces what the frozen file records; the other
+// half lives in desktop/src-tauri/src/native/gourl.rs and asserts Rust produces
+// the same. `route_path` is derived by asking chi itself rather than by
+// reimplementing its rule here, so the vectors record the router's behavior
+// rather than this test's belief about it.
+//
+// Regenerate (only from Go, and only when adding cases):
+//
+//	go test ./desktop/parity/ -run TestGoURLVectors -update-gourl-vectors
+package parity
+
+import (
+	"encoding/json"
+	"flag"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+const gourlVectorsFile = "gourl_vectors.json"
+
+var updateGoURLVectors = flag.Bool("update-gourl-vectors", false,
+	"rewrite gourl_vectors.json from this Go toolchain")
+
+type routePathCase struct {
+	Raw string `json:"raw"`
+	// Go's `URL.Path`, or null when `ParseRequestURI` rejected the target.
+	Path *string `json:"path"`
+	// Go's `URL.RawPath` — empty unless the escaping is non-canonical.
+	RawPath *string `json:"raw_path"`
+	// What chi routes on, observed from a live router rather than derived.
+	RoutePath *string `json:"route_path"`
+}
+
+type escapeCase struct {
+	Value string `json:"value"`
+	Want  string `json:"want"`
+}
+
+type gourlVectors struct {
+	Comment    []string        `json:"_comment"`
+	RoutePath  []routePathCase `json:"route_path"`
+	EscapePath []escapeCase    `json:"escape_path"`
+}
+
+// routePathInputs cover each branch of `url.setPath`'s canonical check: a path
+// needing no escaping at all, an escape that round-trips (space, non-ASCII,
+// `?`), an escape that does not (`%2D` for a byte that needs none, lowercase
+// hex), an encoded separator — which is what stops a one-segment route from
+// becoming a two-segment miss — and the malformed forms Go answers 400 to.
+var routePathInputs = []string{
+	"/api/agents/my-agent",
+	"/api/agents/a-b",
+	"/api/agents/a%2Db",
+	"/api/agents/a%2db",
+	"/api/agents/a%20b",
+	"/api/agents/caf%C3%A9",
+	"/api/agents/a%2Fb",
+	"/api/agents/a%3Fb",
+	"/api/agents/a+b",
+	"/api/agents/a%2Bb",
+	"/api/agents/%7Euser",
+	"/api/agents/~user",
+	"/api/agents/a%25b",
+	"/api/chats/11111111-2222-3333-4444-555555555555",
+	"/api/chats/a%20b/messages",
+	"/api/tasks/a%20b/run",
+	"/api/integrations/a%20b/triggers",
+	"/api/claude-sessions/a%20b/insights",
+	"/api/agents/",
+	"/api/agents/a%2",
+	"/api/agents/a%",
+	"/api/agents/a%zz",
+}
+
+// escapePathInputs pin `escape(s, encodePath)` itself, which is the half of the
+// rule that decides *whether* the escaping was canonical. Uppercase hex and the
+// reserved bytes a path may carry unescaped are both load-bearing: get either
+// wrong and every escaped path looks non-canonical, so the decode branch that
+// #294 exists to add never runs.
+var escapePathInputs = []string{
+	"", "a-b", "a b", "café", "a?b", "a/b", "$&+,/:;=@", "-_.~",
+	"a%b", "a\tb", "a\"b", "a<b>c", "a#b", "a[b]", "a{b}",
+	"~user", "a+b", "日本語", "a\x00b",
+}
+
+func TestGoURLVectors(t *testing.T) {
+	want := gourlVectors{
+		Comment: []string{
+			"Cross-language parity vectors for the path chi routes on.",
+			"Generated from Go, then frozen. Read by desktop/parity/gourl_parity_test.go",
+			"(Go) and by desktop/src-tauri/src/native/gourl.rs (Rust). 'route_path' is",
+			"observed from a live chi router, so a divergence fails one language against",
+			"the router's real behavior rather than against a belief about it.",
+			"Regenerate with: go test ./desktop/parity/ -run TestGoURLVectors -update-gourl-vectors",
+		},
+	}
+
+	for _, raw := range routePathInputs {
+		want.RoutePath = append(want.RoutePath, observeRoutePath(raw))
+	}
+	for _, in := range escapePathInputs {
+		// `url.URL{Path: in}.EscapedPath()` is `escape(in, encodePath)` for any
+		// input whose default encoding is what we are asking for — which is the
+		// whole point, since RawPath is left empty here.
+		u := url.URL{Path: in}
+		want.EscapePath = append(want.EscapePath, escapeCase{Value: in, Want: u.EscapedPath()})
+	}
+
+	encoded, err := json.MarshalIndent(want, "", "  ")
+	if err != nil {
+		t.Fatalf("encoding vectors: %v", err)
+	}
+	encoded = append(encoded, '\n')
+
+	if *updateGoURLVectors {
+		if err := os.WriteFile(gourlVectorsFile, encoded, 0o600); err != nil {
+			t.Fatalf("writing %s: %v", gourlVectorsFile, err)
+		}
+		t.Logf("wrote %s", gourlVectorsFile)
+		return
+	}
+
+	frozen, err := os.ReadFile(gourlVectorsFile)
+	if err != nil {
+		t.Fatalf("reading %s (regenerate with -update-gourl-vectors): %v", gourlVectorsFile, err)
+	}
+	if string(frozen) != string(encoded) {
+		t.Fatalf("%s is stale: this Go toolchain or chi version produces different results.\n"+
+			"Regenerate with -update-gourl-vectors and check what moved — the Rust "+
+			"port in native/gourl.rs reads the same file and will fail against it.",
+			gourlVectorsFile)
+	}
+}
+
+// observeRoutePath asks a real chi router what string it routed on, rather than
+// deriving it from `RawPath != "" ? RawPath : Path` — that expression is chi's
+// *current* implementation, and observing it instead means a chi upgrade that
+// changes the rule fails this test rather than silently agreeing with a stale
+// Rust port.
+//
+// A root wildcard is the way to read it back: chi matches `/*` against its
+// routing path and `URLParam(r, "*")` is the remainder, so `"/" + remainder` is
+// the whole string the tree walked — for any target, including the ones no real
+// route in the app would match.
+func observeRoutePath(raw string) routePathCase {
+	out := routePathCase{Raw: raw}
+
+	// What `net/http` does with the target before any handler runs. A parse
+	// failure is a 400 from inside the server, so there is no route path at all.
+	u, err := url.ParseRequestURI(raw)
+	if err != nil {
+		return out
+	}
+	path, rawPath := u.Path, u.RawPath
+	out.Path, out.RawPath = &path, &rawPath
+
+	r := chi.NewRouter()
+	r.Get("/*", func(w http.ResponseWriter, r *http.Request) {
+		routed := "/" + chi.URLParam(r, "*")
+		out.RoutePath = &routed
+	})
+
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, raw, nil))
+	return out
+}

--- a/desktop/parity/gourl_parity_test.go
+++ b/desktop/parity/gourl_parity_test.go
@@ -40,6 +40,14 @@ var updateGoURLVectors = flag.Bool("update-gourl-vectors", false,
 type routePathCase struct {
 	Raw string `json:"raw"`
 	// Go's `URL.Path`, or null when `ParseRequestURI` rejected the target.
+	//
+	// **Context only, never assert on it.** A Go string is arbitrary bytes and
+	// `json.Marshal` substitutes U+FFFD for the invalid ones, so the `%ff` row
+	// records `/api/agents/�` rather than the byte chi saw. It stays
+	// deterministic on both sides — Go compares marshaled bytes and Rust only
+	// interpolates this into a failure message — but a Go-side assertion on
+	// `Path` would not hold for that row. `route_path` is the field with the
+	// answer, and it is ASCII whenever it is non-null.
 	Path *string `json:"path"`
 	// Go's `URL.RawPath` — empty unless the escaping is non-canonical.
 	RawPath *string `json:"raw_path"`

--- a/desktop/parity/gourl_vectors.json
+++ b/desktop/parity/gourl_vectors.json
@@ -45,6 +45,18 @@
       "route_path": "/api/agents/café"
     },
     {
+      "raw": "/api/agents/caf%c3%a9",
+      "path": "/api/agents/café",
+      "raw_path": "/api/agents/caf%c3%a9",
+      "route_path": "/api/agents/caf%c3%a9"
+    },
+    {
+      "raw": "/api/agents/%ff",
+      "path": "/api/agents/\ufffd",
+      "raw_path": "/api/agents/%ff",
+      "route_path": "/api/agents/%ff"
+    },
+    {
       "raw": "/api/agents/a%2Fb",
       "path": "/api/agents/a/b",
       "raw_path": "/api/agents/a%2Fb",
@@ -109,6 +121,12 @@
       "path": "/api/integrations/a b/triggers",
       "raw_path": "",
       "route_path": "/api/integrations/a b/triggers"
+    },
+    {
+      "raw": "/api/integrations/a%2Db/triggers/r%201",
+      "path": "/api/integrations/a-b/triggers/r 1",
+      "raw_path": "/api/integrations/a%2Db/triggers/r%201",
+      "route_path": "/api/integrations/a%2Db/triggers/r%201"
     },
     {
       "raw": "/api/claude-sessions/a%20b/insights",

--- a/desktop/parity/gourl_vectors.json
+++ b/desktop/parity/gourl_vectors.json
@@ -1,0 +1,222 @@
+{
+  "_comment": [
+    "Cross-language parity vectors for the path chi routes on.",
+    "Generated from Go, then frozen. Read by desktop/parity/gourl_parity_test.go",
+    "(Go) and by desktop/src-tauri/src/native/gourl.rs (Rust). 'route_path' is",
+    "observed from a live chi router, so a divergence fails one language against",
+    "the router's real behavior rather than against a belief about it.",
+    "Regenerate with: go test ./desktop/parity/ -run TestGoURLVectors -update-gourl-vectors"
+  ],
+  "route_path": [
+    {
+      "raw": "/api/agents/my-agent",
+      "path": "/api/agents/my-agent",
+      "raw_path": "",
+      "route_path": "/api/agents/my-agent"
+    },
+    {
+      "raw": "/api/agents/a-b",
+      "path": "/api/agents/a-b",
+      "raw_path": "",
+      "route_path": "/api/agents/a-b"
+    },
+    {
+      "raw": "/api/agents/a%2Db",
+      "path": "/api/agents/a-b",
+      "raw_path": "/api/agents/a%2Db",
+      "route_path": "/api/agents/a%2Db"
+    },
+    {
+      "raw": "/api/agents/a%2db",
+      "path": "/api/agents/a-b",
+      "raw_path": "/api/agents/a%2db",
+      "route_path": "/api/agents/a%2db"
+    },
+    {
+      "raw": "/api/agents/a%20b",
+      "path": "/api/agents/a b",
+      "raw_path": "",
+      "route_path": "/api/agents/a b"
+    },
+    {
+      "raw": "/api/agents/caf%C3%A9",
+      "path": "/api/agents/café",
+      "raw_path": "",
+      "route_path": "/api/agents/café"
+    },
+    {
+      "raw": "/api/agents/a%2Fb",
+      "path": "/api/agents/a/b",
+      "raw_path": "/api/agents/a%2Fb",
+      "route_path": "/api/agents/a%2Fb"
+    },
+    {
+      "raw": "/api/agents/a%3Fb",
+      "path": "/api/agents/a?b",
+      "raw_path": "",
+      "route_path": "/api/agents/a?b"
+    },
+    {
+      "raw": "/api/agents/a+b",
+      "path": "/api/agents/a+b",
+      "raw_path": "",
+      "route_path": "/api/agents/a+b"
+    },
+    {
+      "raw": "/api/agents/a%2Bb",
+      "path": "/api/agents/a+b",
+      "raw_path": "/api/agents/a%2Bb",
+      "route_path": "/api/agents/a%2Bb"
+    },
+    {
+      "raw": "/api/agents/%7Euser",
+      "path": "/api/agents/~user",
+      "raw_path": "/api/agents/%7Euser",
+      "route_path": "/api/agents/%7Euser"
+    },
+    {
+      "raw": "/api/agents/~user",
+      "path": "/api/agents/~user",
+      "raw_path": "",
+      "route_path": "/api/agents/~user"
+    },
+    {
+      "raw": "/api/agents/a%25b",
+      "path": "/api/agents/a%b",
+      "raw_path": "",
+      "route_path": "/api/agents/a%b"
+    },
+    {
+      "raw": "/api/chats/11111111-2222-3333-4444-555555555555",
+      "path": "/api/chats/11111111-2222-3333-4444-555555555555",
+      "raw_path": "",
+      "route_path": "/api/chats/11111111-2222-3333-4444-555555555555"
+    },
+    {
+      "raw": "/api/chats/a%20b/messages",
+      "path": "/api/chats/a b/messages",
+      "raw_path": "",
+      "route_path": "/api/chats/a b/messages"
+    },
+    {
+      "raw": "/api/tasks/a%20b/run",
+      "path": "/api/tasks/a b/run",
+      "raw_path": "",
+      "route_path": "/api/tasks/a b/run"
+    },
+    {
+      "raw": "/api/integrations/a%20b/triggers",
+      "path": "/api/integrations/a b/triggers",
+      "raw_path": "",
+      "route_path": "/api/integrations/a b/triggers"
+    },
+    {
+      "raw": "/api/claude-sessions/a%20b/insights",
+      "path": "/api/claude-sessions/a b/insights",
+      "raw_path": "",
+      "route_path": "/api/claude-sessions/a b/insights"
+    },
+    {
+      "raw": "/api/agents/",
+      "path": "/api/agents/",
+      "raw_path": "",
+      "route_path": "/api/agents/"
+    },
+    {
+      "raw": "/api/agents/a%2",
+      "path": null,
+      "raw_path": null,
+      "route_path": null
+    },
+    {
+      "raw": "/api/agents/a%",
+      "path": null,
+      "raw_path": null,
+      "route_path": null
+    },
+    {
+      "raw": "/api/agents/a%zz",
+      "path": null,
+      "raw_path": null,
+      "route_path": null
+    }
+  ],
+  "escape_path": [
+    {
+      "value": "",
+      "want": ""
+    },
+    {
+      "value": "a-b",
+      "want": "a-b"
+    },
+    {
+      "value": "a b",
+      "want": "a%20b"
+    },
+    {
+      "value": "café",
+      "want": "caf%C3%A9"
+    },
+    {
+      "value": "a?b",
+      "want": "a%3Fb"
+    },
+    {
+      "value": "a/b",
+      "want": "a/b"
+    },
+    {
+      "value": "$\u0026+,/:;=@",
+      "want": "$\u0026+,/:;=@"
+    },
+    {
+      "value": "-_.~",
+      "want": "-_.~"
+    },
+    {
+      "value": "a%b",
+      "want": "a%25b"
+    },
+    {
+      "value": "a\tb",
+      "want": "a%09b"
+    },
+    {
+      "value": "a\"b",
+      "want": "a%22b"
+    },
+    {
+      "value": "a\u003cb\u003ec",
+      "want": "a%3Cb%3Ec"
+    },
+    {
+      "value": "a#b",
+      "want": "a%23b"
+    },
+    {
+      "value": "a[b]",
+      "want": "a%5Bb%5D"
+    },
+    {
+      "value": "a{b}",
+      "want": "a%7Bb%7D"
+    },
+    {
+      "value": "~user",
+      "want": "~user"
+    },
+    {
+      "value": "a+b",
+      "want": "a+b"
+    },
+    {
+      "value": "日本語",
+      "want": "%E6%97%A5%E6%9C%AC%E8%AA%9E"
+    },
+    {
+      "value": "a\u0000b",
+      "want": "a%00b"
+    }
+  ]
+}

--- a/desktop/src-tauri/src/native/gourl.rs
+++ b/desktop/src-tauri/src/native/gourl.rs
@@ -76,13 +76,18 @@ fn should_escape(c: u8) -> bool {
 /// `encodeQueryComponent`, and using it here would make every path holding a
 /// space look non-canonical and flip [`route_path`] to the wrong branch.
 pub fn escape_path(s: &str) -> String {
-    let bytes = s.as_bytes();
-    if !bytes.iter().copied().any(should_escape) {
-        return s.to_string();
-    }
+    escape_bytes(s.as_bytes())
+}
 
+/// The same function over bytes, which is what [`route_path`] needs.
+///
+/// A Go string is arbitrary bytes and `escape` is defined over them, so the
+/// canonical check has to run before anything demands UTF-8 — see
+/// [`route_path`]. The output is ASCII either way: every byte over 0x7F is
+/// escaped, so `char` is safe here for exactly the reason `should_escape` says.
+fn escape_bytes(bytes: &[u8]) -> String {
     const UPPERHEX: &[u8; 16] = b"0123456789ABCDEF";
-    let mut out = String::with_capacity(s.len());
+    let mut out = String::with_capacity(bytes.len());
     for &c in bytes {
         if should_escape(c) {
             out.push('%');
@@ -138,20 +143,28 @@ pub fn unescape_path(s: &str) -> Option<Vec<u8>> {
 ///   on it, so Go answers 400 from inside `net/http` and never reaches a
 ///   handler. Forwarding is how that 400 gets produced — reproducing it here
 ///   would mean reproducing the server's error page too.
-/// - the decoded path is not UTF-8 (`/api/agents/%FF`). Go carries it happily;
-///   Rust cannot put it in a `&str`, and every claim function and bound
-///   parameter downstream wants one. Rather than lossily converting — which
-///   would look up a *different* slug than Go looks up — the request forwards
-///   and Go answers it correctly.
+/// - the escaping is canonical **and** the decoded path is not UTF-8
+///   (`/api/agents/%FF`). Go carries it happily; Rust cannot put it in a `&str`,
+///   and every claim function and bound parameter downstream wants one. Rather
+///   than lossily converting — which would look up a *different* slug than Go
+///   looks up — the request forwards and Go answers it correctly.
+///
+/// **The canonical check runs on bytes, before anything demands UTF-8**, and the
+/// order is load-bearing: `/api/agents/%ff` decodes to the same unrepresentable
+/// byte as `/api/agents/%FF`, but its escaping is *not* canonical, so chi routes
+/// on the raw target — which is plain ASCII and perfectly carryable. Demanding
+/// UTF-8 first would forfeit that route path for no reason, and would make the
+/// case impossible to add to the vectors.
 pub fn route_path(raw: &str) -> Option<String> {
     let decoded = unescape_path(raw)?;
-    let decoded = String::from_utf8(decoded).ok()?;
     // `url.setPath`: the escaping is canonical exactly when re-encoding the
     // decoded path reproduces what arrived, and that is when `RawPath` stays
     // empty and chi falls through to the decoded `URL.Path`.
-    if escape_path(&decoded) == raw {
-        Some(decoded)
+    if escape_bytes(&decoded) == raw {
+        String::from_utf8(decoded).ok()
     } else {
+        // Non-canonical: chi routes on `RawPath`, which is the request target
+        // this was called with and therefore already a `&str`.
         Some(raw.to_string())
     }
 }
@@ -269,14 +282,22 @@ mod tests {
     }
 
     #[test]
-    fn a_non_utf8_path_forwards_rather_than_being_mangled() {
-        // Go routes `%FF` as a one-byte segment. Rust cannot carry it in a
-        // `&str`, and a lossy conversion would look up a different slug — so
-        // this forwards and Go answers.
+    fn a_non_utf8_path_forwards_only_when_that_is_what_chi_routes_on() {
+        // `%FF` is canonical, so chi routes on the *decoded* path: one byte Rust
+        // cannot carry in a `&str`, and a lossy conversion would look up a
+        // different slug. Forwarding is the only right answer.
         assert_eq!(route_path("/api/agents/%FF"), None);
         assert_eq!(
             unescape_path("/api/agents/%FF"),
             Some(b"/api/agents/\xff".to_vec())
+        );
+
+        // `%ff` decodes to the same byte and is *not* canonical, so chi routes
+        // on the raw target — plain ASCII, and perfectly carryable. Testing
+        // UTF-8 before the canonical check would forfeit this one for nothing.
+        assert_eq!(
+            route_path("/api/agents/%ff").as_deref(),
+            Some("/api/agents/%ff")
         );
     }
 

--- a/desktop/src-tauri/src/native/gourl.rs
+++ b/desktop/src-tauri/src/native/gourl.rs
@@ -1,0 +1,309 @@
+//! Go's `net/url` path encoding, and the path chi actually routes on.
+//!
+//! # Why the seam needs this at all
+//!
+//! Every claim function in `native/` matches on `Request::path`, and until #294
+//! that was `req.uri().path()` — the **raw** request target, byte for byte off
+//! the wire. Go's router does not see that string. `net/http` parses the URI
+//! into a `url.URL` before any handler runs, and `chi` then routes on
+//!
+//! ```text
+//! RawPath != "" ? RawPath : Path
+//! ```
+//!
+//! (`Mux.routeHTTP`), handing whatever it captured to `chi.URLParam` **without
+//! decoding it further**. So the question "is Go's path segment the encoded one
+//! or the decoded one?" has no single answer — it depends on `RawPath`, and
+//! `url.setPath` sets `RawPath` only when the *default* encoding of the decoded
+//! path differs from what arrived:
+//!
+//! | request target | `URL.Path` | `RawPath` | chi's segment |
+//! |---|---|---|---|
+//! | `/api/agents/a-b`      | `/api/agents/a-b`   | `""`                  | `a-b` |
+//! | `/api/agents/a%2Db`    | `/api/agents/a-b`   | `/api/agents/a%2Db`   | `a%2Db` |
+//! | `/api/agents/a%20b`    | `/api/agents/a b`   | `""`                  | `a b` |
+//! | `/api/agents/caf%C3%A9`| `/api/agents/café`  | `""`                  | `café` |
+//! | `/api/agents/a%2Fb`    | `/api/agents/a/b`   | `/api/agents/a%2Fb`   | `a%2Fb` |
+//!
+//! Read as a rule: **Go decodes exactly when the escaping is canonical.** A
+//! space or a non-ASCII byte *has* to be percent-encoded to travel, so its
+//! encoding round-trips and Go hands the handler the decoded text; `%2D` for a
+//! character that needs no escaping does not round-trip, so Go hands over the
+//! escaped text unchanged.
+//!
+//! Matching on the raw path therefore agreed with Go on the second and fifth
+//! rows and disagreed on the third and fourth. While every claimed route was a
+//! read that was invisible — a miss produced `Err` and forwarded, and Go
+//! answered correctly — but #274 and #276 claimed writes, so `agents::update`
+//! now *answers* 404 and `chats::patch` answers `chat not found` for a request
+//! Go would have applied to a real row.
+//!
+//! [`route_path`] is that whole rule in one function, applied once in
+//! `proxy.rs` where `native::Request` is built, so no module's claim function
+//! has to know about it and none of them can drift apart.
+//!
+//! There is no injection risk in either spelling — every id reaches SQLite as a
+//! bound parameter — so this is a correctness fix, not a security one.
+//!
+//! `desktop/parity/gourl_vectors.json` is generated from Go and read by both
+//! languages' tests, exactly as `gopath_vectors.json` is, so these functions are
+//! pinned to what Go does rather than to what this comment believes.
+
+/// Bytes Go's `escape(s, encodePath)` leaves alone.
+///
+/// Transcribed from `shouldEscape` in `net/url/url.go`, `encodePath` arm:
+/// alphanumerics and the unreserved marks are never escaped; of the reserved
+/// set `$ & + , / : ; = ? @` a path may carry every one **except** `?`; and
+/// everything else — every byte over 0x7F included — is escaped.
+fn should_escape(c: u8) -> bool {
+    if c.is_ascii_alphanumeric() {
+        return false;
+    }
+    match c {
+        b'-' | b'_' | b'.' | b'~' => false,
+        // The RFC allows `: @ & = + $` in a path and reserves `/ ; ,` for
+        // assigning meaning to individual segments; `net/url` manipulates the
+        // path as a whole and so allows those three too. That leaves `?`.
+        b'$' | b'&' | b'+' | b',' | b'/' | b':' | b';' | b'=' | b'@' => false,
+        b'?' => true,
+        _ => true,
+    }
+}
+
+/// Go's `escape(s, encodePath)`.
+///
+/// Uppercase hex, and **no `+` for space** — that substitution belongs to
+/// `encodeQueryComponent`, and using it here would make every path holding a
+/// space look non-canonical and flip [`route_path`] to the wrong branch.
+pub fn escape_path(s: &str) -> String {
+    let bytes = s.as_bytes();
+    if !bytes.iter().copied().any(should_escape) {
+        return s.to_string();
+    }
+
+    const UPPERHEX: &[u8; 16] = b"0123456789ABCDEF";
+    let mut out = String::with_capacity(s.len());
+    for &c in bytes {
+        if should_escape(c) {
+            out.push('%');
+            out.push(UPPERHEX[(c >> 4) as usize] as char);
+            out.push(UPPERHEX[(c & 15) as usize] as char);
+        } else {
+            out.push(c as char);
+        }
+    }
+    out
+}
+
+/// Go's `unescape(s, encodePath)`: `%XX` becomes one byte, everything else is
+/// carried through.
+///
+/// `None` is Go's `EscapeError`, which `url.ParseRequestURI` returns and
+/// `net/http` turns into a **400 before any handler runs**. `+` is left as `+`,
+/// because the plus-is-space rule is `encodeQueryComponent`'s.
+///
+/// Bytes rather than a `String`: a Go string is arbitrary bytes and `%FF` is a
+/// perfectly routable path to Go. Deciding what to do about one that is not
+/// UTF-8 is [`route_path`]'s job.
+pub fn unescape_path(s: &str) -> Option<Vec<u8>> {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            if i + 2 >= bytes.len() {
+                return None;
+            }
+            let hi = (bytes[i + 1] as char).to_digit(16)?;
+            let lo = (bytes[i + 2] as char).to_digit(16)?;
+            out.push(((hi << 4) | lo) as u8);
+            i += 3;
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    Some(out)
+}
+
+/// The path chi routes on, given the raw request target's path.
+///
+/// `RawPath != "" ? RawPath : Path`, with `RawPath` derived the way
+/// `url.setPath` derives it — see the module header for the table this produces.
+///
+/// `None` means **forward**, for either of two reasons, and both are the seam
+/// working as designed rather than a gap:
+///
+/// - the escaping is malformed (`/api/agents/a%2`). `url.ParseRequestURI` fails
+///   on it, so Go answers 400 from inside `net/http` and never reaches a
+///   handler. Forwarding is how that 400 gets produced — reproducing it here
+///   would mean reproducing the server's error page too.
+/// - the decoded path is not UTF-8 (`/api/agents/%FF`). Go carries it happily;
+///   Rust cannot put it in a `&str`, and every claim function and bound
+///   parameter downstream wants one. Rather than lossily converting — which
+///   would look up a *different* slug than Go looks up — the request forwards
+///   and Go answers it correctly.
+pub fn route_path(raw: &str) -> Option<String> {
+    let decoded = unescape_path(raw)?;
+    let decoded = String::from_utf8(decoded).ok()?;
+    // `url.setPath`: the escaping is canonical exactly when re-encoding the
+    // decoded path reproduces what arrived, and that is when `RawPath` stays
+    // empty and chi falls through to the decoded `URL.Path`.
+    if escape_path(&decoded) == raw {
+        Some(decoded)
+    } else {
+        Some(raw.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Deserialize)]
+    struct RoutePathCase {
+        raw: String,
+        /// Go's `URL.Path`, or `null` when `ParseRequestURI` rejected the target.
+        path: Option<String>,
+        /// Go's `URL.RawPath`.
+        raw_path: Option<String>,
+        /// What `chi.URLParam` would capture: `RawPath` if set, else `Path`.
+        route_path: Option<String>,
+    }
+
+    #[derive(Deserialize)]
+    struct EscapeCase {
+        value: String,
+        want: String,
+    }
+
+    #[derive(Deserialize)]
+    struct Vectors {
+        route_path: Vec<RoutePathCase>,
+        escape_path: Vec<EscapeCase>,
+    }
+
+    fn vectors() -> Vectors {
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../parity/gourl_vectors.json");
+        let raw = std::fs::read_to_string(path)
+            .unwrap_or_else(|e| panic!("reading {path}: {e} — regenerate it from Go"));
+        serde_json::from_str(&raw).expect("parsing gourl vectors")
+    }
+
+    /// The whole point of the file: Rust is asserted against what Go actually
+    /// produced, not against what this port believes Go produces.
+    #[test]
+    fn route_path_matches_the_go_vectors() {
+        let v = vectors();
+        assert!(v.route_path.len() >= 20, "vectors look truncated");
+        for case in v.route_path {
+            // `route_path: null` is a target `url.ParseRequestURI` rejects, so
+            // Go answers 400 from inside `net/http` and never routes it at all.
+            // The non-UTF-8 case cannot appear here — a JSON string is UTF-8 by
+            // construction — so it has its own test below.
+            assert_eq!(
+                route_path(&case.raw),
+                case.route_path,
+                "route_path({:?}) — Go: Path={:?} RawPath={:?}",
+                case.raw,
+                case.path,
+                case.raw_path
+            );
+        }
+    }
+
+    #[test]
+    fn escape_path_matches_the_go_vectors() {
+        for case in vectors().escape_path {
+            assert_eq!(
+                escape_path(&case.value),
+                case.want,
+                "escape({:?}, encodePath)",
+                case.value
+            );
+        }
+    }
+
+    /// The four rows of the module header's table, spelled out so a reader of
+    /// this file can see the rule without opening the vectors.
+    #[test]
+    fn the_rule_is_decode_when_the_escaping_is_canonical() {
+        // Non-canonical: `-` needs no escaping, so Go keeps the escaped form.
+        assert_eq!(
+            route_path("/api/agents/a%2Db").as_deref(),
+            Some("/api/agents/a%2Db")
+        );
+        // Canonical: a space and a non-ASCII byte must be escaped to travel, so
+        // Go hands the handler the decoded text. This is the pair the raw path
+        // got wrong.
+        assert_eq!(
+            route_path("/api/agents/a%20b").as_deref(),
+            Some("/api/agents/a b")
+        );
+        assert_eq!(
+            route_path("/api/agents/caf%C3%A9").as_deref(),
+            Some("/api/agents/café")
+        );
+        // An encoded separator keeps the raw form, which is what stops it from
+        // splitting into two segments and turning a one-segment route into a
+        // miss.
+        assert_eq!(
+            route_path("/api/agents/a%2Fb").as_deref(),
+            Some("/api/agents/a%2Fb")
+        );
+        // Nothing to decode: unchanged, and the overwhelmingly common case.
+        assert_eq!(
+            route_path("/api/agents/my-agent").as_deref(),
+            Some("/api/agents/my-agent")
+        );
+    }
+
+    #[test]
+    fn a_malformed_escape_has_no_route_path() {
+        // `ParseRequestURI` fails on each of these, so Go answers 400 from
+        // inside `net/http`. `None` forwards, which is how that 400 is produced.
+        assert_eq!(route_path("/api/agents/a%2"), None);
+        assert_eq!(route_path("/api/agents/a%"), None);
+        assert_eq!(route_path("/api/agents/a%zz"), None);
+    }
+
+    #[test]
+    fn a_non_utf8_path_forwards_rather_than_being_mangled() {
+        // Go routes `%FF` as a one-byte segment. Rust cannot carry it in a
+        // `&str`, and a lossy conversion would look up a different slug — so
+        // this forwards and Go answers.
+        assert_eq!(route_path("/api/agents/%FF"), None);
+        assert_eq!(
+            unescape_path("/api/agents/%FF"),
+            Some(b"/api/agents/\xff".to_vec())
+        );
+    }
+
+    #[test]
+    fn plus_is_not_a_space_in_a_path() {
+        // `encodeQueryComponent`'s rule, not `encodePath`'s. If it leaked in,
+        // every path holding a `+` would decode wrong *and* re-encode
+        // differently, flipping the canonical check.
+        assert_eq!(
+            route_path("/api/agents/a+b").as_deref(),
+            Some("/api/agents/a+b")
+        );
+        assert_eq!(escape_path("a b"), "a%20b");
+    }
+
+    #[test]
+    fn escaping_is_uppercase_hex() {
+        // Lowercase would make every escaped path look non-canonical, so
+        // `route_path` would stop decoding the very cases it exists for.
+        assert_eq!(escape_path("café"), "caf%C3%A9");
+        assert_eq!(escape_path("a?b"), "a%3Fb");
+    }
+
+    #[test]
+    fn the_reserved_bytes_a_path_may_carry_are_not_escaped() {
+        // `?` is the only member of the reserved set `encodePath` escapes.
+        assert_eq!(escape_path("$&+,/:;=@"), "$&+,/:;=@");
+        assert_eq!(escape_path("-_.~"), "-_.~");
+    }
+}

--- a/desktop/src-tauri/src/native/mod.rs
+++ b/desktop/src-tauri/src/native/mod.rs
@@ -601,6 +601,21 @@ mod tests {
             &route("/api/claude-sessions/a%20b/continue")
         ));
 
+        // Canonicality is a property of the **whole** path, not of a segment:
+        // one non-canonical escape anywhere leaves every segment raw, `r%201`
+        // included, even though on its own it would have decoded. This is the
+        // case a future `slug_of`/`route_of` change is most likely to get
+        // wrong, and it is why the rule is applied to the path rather than to
+        // each id.
+        assert_eq!(
+            route("/api/integrations/a%2Db/triggers/r%201"),
+            "/api/integrations/a%2Db/triggers/r%201"
+        );
+        assert!(claims(
+            &Method::PUT,
+            &route("/api/integrations/a%2Db/triggers/r%201")
+        ));
+
         // A malformed target has no route path at all: `url.ParseRequestURI`
         // rejects it, so Go answers 400 from inside `net/http` and the proxy
         // forwards rather than inventing one.

--- a/desktop/src-tauri/src/native/mod.rs
+++ b/desktop/src-tauri/src/native/mod.rs
@@ -23,6 +23,7 @@ pub mod fs;
 pub mod gojson;
 pub mod gopath;
 pub mod gotime;
+pub mod gourl;
 pub mod insights;
 pub mod integration_credentials;
 pub mod integrations;
@@ -556,6 +557,54 @@ mod tests {
             "/api/integrations/abc/webhook/status"
         ));
         assert!(!claims(&Method::GET, "/api/integrations/abc/whatsapp/qr"));
+    }
+
+    /// #294: what every `claims` function above matches on is the path **chi**
+    /// routes on, not the raw request target.
+    ///
+    /// `proxy.rs` runs `gourl::route_path` once before this registry is asked
+    /// anything, so the property worth pinning here is that both spellings a
+    /// percent-encoded id can arrive in reach `claims` the way Go's router would
+    /// deliver them — including the one where the right answer is *not* to
+    /// decode.
+    #[test]
+    fn a_claim_matches_on_the_path_chi_would_route_on() {
+        let route = |raw: &str| gourl::route_path(raw).expect("a routable target");
+
+        // Canonical escaping: Go decodes, so `agents::slug_of` extracts `a b`,
+        // and the row `agents::update` looks up is the one Go updates. Matching
+        // the raw target claimed `a%20b` and answered 404 for a live agent.
+        assert_eq!(route("/api/agents/a%20b"), "/api/agents/a b");
+        assert!(claims(&Method::PUT, &route("/api/agents/a%20b")));
+
+        // Non-canonical: `-` needs no escaping, so Go keeps the escaped form and
+        // so must this. The issue's own example, and the case already correct.
+        assert_eq!(route("/api/agents/a%2Db"), "/api/agents/a%2Db");
+        assert!(claims(&Method::PUT, &route("/api/agents/a%2Db")));
+
+        // An encoded separator stays encoded, which is what keeps a one-segment
+        // route one segment. A blanket decode — the obvious fix — would make
+        // this `/api/agents/a/b`, `slug_of` would reject it, and a PUT Go
+        // applies would forward instead of being claimed.
+        assert_eq!(route("/api/agents/a%2Fb"), "/api/agents/a%2Fb");
+        assert!(claims(&Method::PUT, &route("/api/agents/a%2Fb")));
+
+        // The same rule reaches every module's segment, not just agents'.
+        assert!(claims(&Method::GET, &route("/api/chats/a%20b")));
+        assert!(claims(&Method::GET, &route("/api/tasks/a%20b")));
+        assert!(claims(
+            &Method::PUT,
+            &route("/api/integrations/a%20b/triggers/r%201")
+        ));
+        assert!(claims(
+            &Method::POST,
+            &route("/api/claude-sessions/a%20b/continue")
+        ));
+
+        // A malformed target has no route path at all: `url.ParseRequestURI`
+        // rejects it, so Go answers 400 from inside `net/http` and the proxy
+        // forwards rather than inventing one.
+        assert!(gourl::route_path("/api/agents/a%2").is_none());
     }
 
     #[test]

--- a/desktop/src-tauri/src/proxy.rs
+++ b/desktop/src-tauri/src/proxy.rs
@@ -233,6 +233,14 @@ async fn handle(State(state): State<ProxyState>, req: Request<Body>) -> Response
     // It returns before the access log on purpose: handing out an embedded file
     // is static serving, not an application operation, and one page load is
     // dozens of them.
+    //
+    // `path` here is the **raw** request target, and stays raw for both halves
+    // of this `if` and for the access line below. The asset lookup is a file
+    // this binary embeds, so nothing about Go's router is involved in finding
+    // one; the API gate is raw because reaching a divergence would need a
+    // percent-escape inside the `/api` prefix itself (`/%61pi/agents`), which no
+    // client sends and which `dispatch` would answer identically anyway. The log
+    // is raw because it should record what arrived, not what matched.
     if !is_api_path(&path) {
         #[cfg(not(debug_assertions))]
         {
@@ -295,7 +303,48 @@ async fn handle(State(state): State<ProxyState>, req: Request<Body>) -> Response
 /// Split out of [`handle`] so the access line has exactly one call site. There
 /// are eight-odd ways out of here, and logging at each of them is the shape
 /// that drifts: the next port adds a ninth and quietly stops being recorded.
-async fn dispatch(state: ProxyState, req: Request<Body>, path: String) -> (Response<Body>, Served) {
+async fn dispatch(
+    state: ProxyState,
+    req: Request<Body>,
+    raw_path: String,
+) -> (Response<Body>, Served) {
+    // From here on, the path every claim function sees is the one **chi** would
+    // route on, not the raw request target (#294). They are not the same string:
+    // `net/http` decodes the target into `url.URL` before any handler runs, and
+    // chi routes on `RawPath` when the escaping is non-canonical and on the
+    // decoded `Path` when it is not — so `/api/agents/a%2Db` is `a%2Db` to Go
+    // and `/api/agents/a%20b` is `a b`. Matching on the raw target got the
+    // second class wrong, which was invisible while every claimed route was a
+    // read (a miss forwarded and Go answered) and is not now that #274 and #276
+    // claim writes: `agents::update` would *answer* 404 for a row Go updates.
+    //
+    // Doing it once here rather than in each module's `slug_of`/`id_of` is what
+    // stops the five of them drifting apart — and it is also the only place
+    // that can see the whole path, which is what the rule is about: one
+    // non-canonical escape anywhere leaves every segment raw.
+    let path = match native::gourl::route_path(&raw_path) {
+        Some(path) => path,
+        // No route path at all: either the escaping is malformed, in which case
+        // `url.ParseRequestURI` fails and Go answers 400 from inside
+        // `net/http`, or it is canonical and the decoded path is not UTF-8, so
+        // Rust cannot carry the string chi routes on. Forwarding is how both get
+        // the answer Go would have given — `Forwarded` rather than
+        // `NativeFailedForwarded` because no native handler was tried.
+        //
+        // Logged because every other fallback here says why it fell back, and
+        // these two conditions are the hardest of the lot to reproduce from a
+        // bug report.
+        None => {
+            log::debug!(
+                "no route path for {raw_path}: malformed escape or a non-UTF-8 decoded path, forwarding"
+            );
+            return (
+                forward_or_bad_gateway(&state, req, &raw_path).await,
+                Served::Forwarded,
+            );
+        }
+    };
+
     // The streaming half of the seam (#276). Checked before the buffered one
     // because a chat turn must never be collected into a `Vec<u8>`: it is the
     // one response whose whole point is arriving in pieces.


### PR DESCRIPTION
Closes #294

## What

`native::Request::path` — the string every `claims` function in `native/` matches on — is now the path **chi** routes on, rather than the raw request target off the wire. The rule lives in one new module, `native/gourl.rs`, applied once in `proxy.rs::dispatch`.

## Why

`req.uri().path()` is the undecoded target. Go's router never sees it: `net/http` parses the URI into a `url.URL` before any handler runs, and chi's `Mux.routeHTTP` routes on `RawPath` when it is set and on the decoded `Path` when it is not.

**Deviation from the issue's HOW, and the reason for it.** #294 proposed "percent-decode the segment", on the premise that Go's chi reads `r.URL.Path`. Measured against chi v5.3.1 (`observeRoutePath` in the new Go test drives a real router):

| request target | `URL.Path` | `RawPath` | chi's segment |
|---|---|---|---|
| `/api/agents/a%2Db` | `/api/agents/a-b` | set | `a%2Db` |
| `/api/agents/a%20b` | `/api/agents/a b` | `""` | `a b` |
| `/api/agents/caf%C3%A9` | `/api/agents/café` | `""` | `café` |
| `/api/agents/caf%c3%a9` | `/api/agents/café` | set | `caf%c3%a9` |
| `/api/agents/a%2Fb` | `/api/agents/a/b` | set | `a%2Fb` |

So **Go decodes exactly when the escaping is canonical** — `url.setPath` leaves `RawPath` empty only when re-encoding the decoded path reproduces what arrived. The issue's own example (`a%2Db`) is the one case where Rust already agreed; the real divergence is spaces and non-ASCII. And a blanket decode would be wrong in the other direction: `/api/agents/a%2Fb` would become two segments, `slug_of` would reject it, and a `PUT` Go applies would forward instead of being claimed.

Canonicality is also a property of the **whole path**, not of a segment: one non-canonical escape anywhere leaves every segment raw, so `/api/integrations/a%2Db/triggers/r%201` routes with `r%201` still encoded.

The consequence is the one the issue describes: while every claimed route was a read this was invisible (a miss forwarded and Go answered), but #274 and #276 claimed writes, so `agents::update` *answers* 404 and `chats::patch` answers `chat not found` for a request Go would have applied.

No injection risk in either spelling — every id reaches SQLite as a bound parameter, and Go's chi hands its own handlers the identical string.

## How

- **`native/gourl.rs`** — `escape_path`/`escape_bytes` (Go's `escape(s, encodePath)`), `unescape_path` (Go's `unescape`), and `route_path`.
- **`proxy.rs::dispatch`** — one call, before either registry is asked anything. Doing it here rather than in each module's `slug_of`/`id_of` is what stops the five drifting apart, and it is the only place that can see the whole path — which is what the rule is about. `handle` keeps the raw target for the asset lookup, the API gate and the access line, each justified in a comment.
- **`None` means forward**, for two reasons that are both the seam working as designed: a malformed escape (`/api/agents/a%2`) is a 400 `net/http` answers before any handler, and a *canonical* escape whose decoded path is not UTF-8 is a string Rust cannot carry. **The canonical check runs on bytes, before anything demands UTF-8**, and the order is load-bearing: `%ff` decodes to the same unrepresentable byte as `%FF` but is not canonical, so chi routes on the raw target — plain ASCII and perfectly carryable.
- **`desktop/parity/gourl_vectors.json`** — generated from Go and read by both languages, the third verification layer in its vector form (the shape #268 established for `gopath.rs`). `route_path` is **observed from a live chi router**, not derived from `RawPath != "" ? RawPath : Path`, so a chi upgrade that changes the rule fails the test rather than silently agreeing with a stale port.
- **`desktop/CLAUDE.md`** — the rule, the table, and why both a blanket decode and a blanket raw match are wrong.

## Acceptance

- `route_path` matches Go's answer on 25 targets covering every branch of the canonical check, both hex cases, an encoded separator, a mixed-canonicality multi-segment path, and the malformed forms.
- `native::tests::a_claim_matches_on_the_path_chi_would_route_on` ties the rule to the registry: agents, chats, tasks, integration trigger rules and session continue all claim the decoded path for a canonical escape, the raw one for `%2F`, and the whole raw path for the mixed case.
- Local gates green on the rebased head: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo build --release`, `npm run build`, `go test ./desktop/...`, `go vet ./desktop/...`, and golangci-lint at the CI-pinned v2.5.0.

## Review

Automated review returned **APPROVE** with four `consider` findings; all four were applied and re-verified (`escape_bytes` ordering, two vector gaps plus the mixed-canonicality case, a `debug` log on the forward arm, and the `is_api_path` comment), plus a note that the vectors' `path` field is lossy for `%ff` and is context rather than an assertion.

Rebased onto `desktop` after #333 split `handle` into `handle` + `dispatch`; the route-path derivation moved into `dispatch` accordingly, and the access line deliberately still records the raw target.