### PR TITLE
fix(desktop): a null inside a JSON array is a zero value, not a type error (#295)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -451,6 +451,26 @@ conversation**, because `parentUuid` is `null` on exactly the event that starts
 one. The live diff caught it; no unit test would have, since the fixtures were
 all written by hand with the field present.
 
+**`serde` only consults the rule where it is attached, so a container needs its
+own** (#295). `null_is_zero_value` covers the *field*: `{"ids":null}` was
+already `None` while `{"ids":[null]}` stayed a type error, and Go answers `[""]`
+to the second with no error at all. `null_elements_are_zero_values` is that one
+level down, `null_map_values_are_zero_values` is the same for a `null` object
+*value* (`{"mcp":{"s":null}}` is the zero struct to Go), and both keep the outer
+`Option` so the nil-versus-empty distinction is untouched. They are on
+`BulkDeleteRequest.ids` in `chats.rs` and `tasks.rs` and on all three of
+`Capabilities`' lists plus its MCP map. On a *read* this class of bug degrades
+to a fallback; on the writes #274 claimed it is a **400 or 422 for a request Go
+applies**.
+
+One thing those helpers deliberately do **not** fix, pinned in
+`gojson.rs::a_nested_struct_from_an_array_is_a_known_over_accept`: serde builds
+a struct from a JSON *array*, positionally, so `{"mcp":{"s":[]}}` is a zero
+`McpCapability` here and a 400 to Go. `writes::decode_body` guards that shape at
+the body level (#274) and nothing checks it for a value *inside* the body. It is
+an over-accept — the direction that creates rows Go refuses — and it predates
+#295.
+
 Genuinely unparseable input still fails, which is also what Go does — so the
 null case and the malformed case need separate tests.
 

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -454,22 +454,35 @@ all written by hand with the field present.
 **`serde` only consults the rule where it is attached, so a container needs its
 own** (#295). `null_is_zero_value` covers the *field*: `{"ids":null}` was
 already `None` while `{"ids":[null]}` stayed a type error, and Go answers `[""]`
-to the second with no error at all. `null_elements_are_zero_values` is that one
-level down, `null_map_values_are_zero_values` is the same for a `null` object
-*value* (`{"mcp":{"s":null}}` is the zero struct to Go), and both keep the outer
-`Option` so the nil-versus-empty distinction is untouched. They are on
-`BulkDeleteRequest.ids` in `chats.rs` and `tasks.rs` and on all three of
-`Capabilities`' lists plus its MCP map. On a *read* this class of bug degrades
-to a fallback; on the writes #274 claimed it is a **400 or 422 for a request Go
-applies**.
+to the second with no error at all. `gojson::GoList<T>` is that one level down
+and `gojson::GoMap<V>` is the same for a `null` object *value*
+(`{"mcp":{"s":null}}` is the zero struct to Go); both keep the outer `Option`, so
+the nil-versus-empty distinction is untouched, and a newtype serializes as its
+inner value, so no response byte moves. They are on `BulkDeleteRequest.ids`
+(`chats.rs`, `tasks.rs`), on all three of `Capabilities`' lists plus its MCP map,
+and on `ServiceConfig.tools`, `CreateIntegrationRequest.services` and the trigger
+rule's two filter lists. On a *read* this class of bug degrades to a fallback; on
+the writes #274 claimed it is a **400 for a request Go applies**.
 
-One thing those helpers deliberately do **not** fix, pinned in
-`gojson.rs::a_nested_struct_from_an_array_is_a_known_over_accept`: serde builds
-a struct from a JSON *array*, positionally, so `{"mcp":{"s":[]}}` is a zero
-`McpCapability` here and a 400 to Go. `writes::decode_body` guards that shape at
-the body level (#274) and nothing checks it for a value *inside* the body. It is
-an over-accept — the direction that creates rows Go refuses — and it predates
-#295.
+**They are types rather than `deserialize_with` functions, and that is the whole
+lesson of #295.** Functions were the first version. `serde`'s derive makes a
+field carrying `deserialize_with` **required** — the `missing_field` path that
+lets a bare `Option` default to `None` is not generated — so every call site had
+to add `#[serde(default)]`. That attribute also feeds the derive's `visit_seq`
+arm, which rejects a short array only for fields with **no** default: adding it
+turned `{"capabilities":[]}` and `{"capabilities":{"mcp":{"s":[]}}}` from the 400
+Go answers into a created agent. A fix for a `null` would have shipped a widened
+**over-accept** — the one direction this port must not move in, because `Err`
+means forward and nothing errors when Rust accepts what Go refuses. A type needs
+no attribute at all, so the struct stays exactly as strict about its own shape.
+Pinned by `a_container_default_would_have_widened_the_struct_from_array_over_accept`.
+
+What is left standing, pinned by
+`a_full_length_positional_array_is_a_known_over_accept`: serde builds a struct
+from a **full-length** JSON array, positionally, so `{"capabilities":[[...],null,null]}`
+is accepted and Go answers 400. `writes::decode_body` guards that shape at the
+body level (#274) and nothing checks it for a value *inside* the body. It
+predates #295 and is tracked as **#337**.
 
 Genuinely unparseable input still fails, which is also what Go does — so the
 null case and the malformed case need separate tests.

--- a/desktop/src-tauri/src/native/agents.rs
+++ b/desktop/src-tauri/src/native/agents.rs
@@ -65,16 +65,29 @@ pub struct Agent {
 /// an empty one (`[]`) on the wire and the stored JSON carries whichever the
 /// writer produced. Round-tripping the distinction is the only way the bytes
 /// match.
+///
+/// The three lists and the map additionally decode a `null` **inside** them as
+/// the zero value (#295). `Option` alone covers `"built_in": null`; it does
+/// nothing for `"built_in": [null]`, which Go reads as `[""]` with no error and
+/// `serde` rejects outright — a 400 for a request Go applies. `#[serde(default)]`
+/// on the struct restores the missing-field behaviour that `deserialize_with`
+/// would otherwise take away.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
 pub struct Capabilities {
+    #[serde(deserialize_with = "super::gojson::null_elements_are_zero_values")]
     pub built_in: Option<Vec<String>>,
+    #[serde(deserialize_with = "super::gojson::null_elements_are_zero_values")]
     pub local: Option<Vec<String>>,
+    #[serde(deserialize_with = "super::gojson::null_map_values_are_zero_values")]
     pub mcp: Option<BTreeMap<String, McpCapability>>,
 }
 
 /// Which tools from one MCP server an agent may use.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
 pub struct McpCapability {
+    #[serde(deserialize_with = "super::gojson::null_elements_are_zero_values")]
     pub tools: Option<Vec<String>>,
 }
 
@@ -642,6 +655,39 @@ mod tests {
             zeta.contains(r#""mcp":{"github":{"tools":["list_prs"]}}"#),
             "{zeta}"
         );
+    }
+
+    /// A `null` **inside** a capability list or the MCP map is the zero value,
+    /// not a type error (#295). Go answers `[""]` and `{"tools":null}` with no
+    /// error at all, so rejecting these was a 422 for an agent Go creates.
+    ///
+    /// Asserted through `AgentRequest`, which is the only way these bodies
+    /// arrive, and on the *stored* JSON, since that is what a later read serves.
+    #[test]
+    fn a_null_inside_capabilities_is_a_zero_value_rather_than_a_422() {
+        let body = br#"{"name":"N","slug":"n","capabilities":{
+            "built_in":[null,"Read"],
+            "local":[null],
+            "mcp":{"quiet":null,"github":{"tools":[null]}}
+        }}"#;
+        let req: AgentRequest = serde_json::from_slice(body).expect("a body Go accepts");
+        let caps = req.capabilities.expect("capabilities");
+
+        assert_eq!(caps.built_in, Some(vec![String::new(), "Read".into()]));
+        assert_eq!(caps.local, Some(vec![String::new()]));
+        let mcp = caps.mcp.expect("mcp");
+        // A null map value is the zero struct — every field at its own zero.
+        assert_eq!(mcp["quiet"].tools, None);
+        assert_eq!(mcp["github"].tools, Some(vec![String::new()]));
+
+        // And the nil-versus-empty distinction is untouched by any of it.
+        let bare: AgentRequest =
+            serde_json::from_slice(br#"{"capabilities":{"built_in":null,"local":[]}}"#)
+                .expect("nil and empty");
+        let caps = bare.capabilities.expect("capabilities");
+        assert_eq!(caps.built_in, None);
+        assert_eq!(caps.local, Some(Vec::new()));
+        assert!(caps.mcp.is_none());
     }
 
     #[test]

--- a/desktop/src-tauri/src/native/agents.rs
+++ b/desktop/src-tauri/src/native/agents.rs
@@ -30,7 +30,6 @@
 //!   its default arm. This port does not reproduce 500s: it detects the case,
 //!   writes nothing, and forwards, so Go produces its own answer.
 
-use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use axum::http::{Method, StatusCode};
@@ -38,6 +37,7 @@ use rusqlite::OptionalExtension;
 use serde::{Deserialize, Serialize};
 
 use super::db;
+use super::gojson::{GoList, GoMap};
 use super::writes::{decode_body, finish, WriteError};
 
 /// One agent. Mirrors `config.AgentConfig`.
@@ -66,29 +66,24 @@ pub struct Agent {
 /// writer produced. Round-tripping the distinction is the only way the bytes
 /// match.
 ///
-/// The three lists and the map additionally decode a `null` **inside** them as
-/// the zero value (#295). `Option` alone covers `"built_in": null`; it does
-/// nothing for `"built_in": [null]`, which Go reads as `[""]` with no error and
-/// `serde` rejects outright — a 400 for a request Go applies. `#[serde(default)]`
-/// on the struct restores the missing-field behaviour that `deserialize_with`
-/// would otherwise take away.
+/// [`GoList`] and [`GoMap`] carry one further rule: a `null` **inside** a list
+/// or the map is the zero value (#295). `Option` alone covers
+/// `"built_in": null`; it does nothing for `"built_in": [null]`, which Go reads
+/// as `[""]` with no error and plain `Vec<String>` rejects — a 400 for a
+/// request Go applies. They are types rather than `deserialize_with` functions
+/// precisely so this struct needs no `#[serde(default)]`, which would also make
+/// it accept `{"capabilities":[]}` — see [`GoList`]'s header.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 pub struct Capabilities {
-    #[serde(deserialize_with = "super::gojson::null_elements_are_zero_values")]
-    pub built_in: Option<Vec<String>>,
-    #[serde(deserialize_with = "super::gojson::null_elements_are_zero_values")]
-    pub local: Option<Vec<String>>,
-    #[serde(deserialize_with = "super::gojson::null_map_values_are_zero_values")]
-    pub mcp: Option<BTreeMap<String, McpCapability>>,
+    pub built_in: Option<GoList<String>>,
+    pub local: Option<GoList<String>>,
+    pub mcp: Option<GoMap<McpCapability>>,
 }
 
 /// Which tools from one MCP server an agent may use.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 pub struct McpCapability {
-    #[serde(deserialize_with = "super::gojson::null_elements_are_zero_values")]
-    pub tools: Option<Vec<String>>,
+    pub tools: Option<GoList<String>>,
 }
 
 const COLUMNS: &str = "SELECT slug, name, description, model, thinking, permission_mode,
@@ -657,39 +652,6 @@ mod tests {
         );
     }
 
-    /// A `null` **inside** a capability list or the MCP map is the zero value,
-    /// not a type error (#295). Go answers `[""]` and `{"tools":null}` with no
-    /// error at all, so rejecting these was a 422 for an agent Go creates.
-    ///
-    /// Asserted through `AgentRequest`, which is the only way these bodies
-    /// arrive, and on the *stored* JSON, since that is what a later read serves.
-    #[test]
-    fn a_null_inside_capabilities_is_a_zero_value_rather_than_a_422() {
-        let body = br#"{"name":"N","slug":"n","capabilities":{
-            "built_in":[null,"Read"],
-            "local":[null],
-            "mcp":{"quiet":null,"github":{"tools":[null]}}
-        }}"#;
-        let req: AgentRequest = serde_json::from_slice(body).expect("a body Go accepts");
-        let caps = req.capabilities.expect("capabilities");
-
-        assert_eq!(caps.built_in, Some(vec![String::new(), "Read".into()]));
-        assert_eq!(caps.local, Some(vec![String::new()]));
-        let mcp = caps.mcp.expect("mcp");
-        // A null map value is the zero struct — every field at its own zero.
-        assert_eq!(mcp["quiet"].tools, None);
-        assert_eq!(mcp["github"].tools, Some(vec![String::new()]));
-
-        // And the nil-versus-empty distinction is untouched by any of it.
-        let bare: AgentRequest =
-            serde_json::from_slice(br#"{"capabilities":{"built_in":null,"local":[]}}"#)
-                .expect("nil and empty");
-        let caps = bare.capabilities.expect("capabilities");
-        assert_eq!(caps.built_in, None);
-        assert_eq!(caps.local, Some(Vec::new()));
-        assert!(caps.mcp.is_none());
-    }
-
     #[test]
     fn the_field_order_is_gos_declaration_order() {
         let file = fixture();
@@ -717,6 +679,39 @@ mod tests {
         .expect("insert");
 
         assert!(list(file.path()).is_err());
+
+        // A stored `[]` is refused too, and that is not incidental: it is the
+        // shape a `#[serde(default)]` on `Capabilities` would have turned into
+        // an *empty* allowlist — an agent whose tools are unknown served as an
+        // agent with none. Neither implementation can write such a column
+        // today, which is exactly why the guard has to be a test rather than an
+        // observation.
+        let file = tempfile::NamedTempFile::new().expect("temp file");
+        let conn = rusqlite::Connection::open(file.path()).expect("open");
+        conn.execute_batch(SCHEMA).expect("schema");
+        conn.execute(
+            "INSERT INTO agents (slug, name, capabilities) VALUES ('arr', 'Arr', '[]')",
+            [],
+        )
+        .expect("insert");
+        assert!(
+            list(file.path()).is_err(),
+            "a stored [] must not read as an empty allowlist"
+        );
+
+        // A *full-length* positional array is still accepted, by serde's
+        // `visit_seq`. That one predates #295 and is deferred to #337; it is
+        // asserted here so the boundary between the two is recorded rather than
+        // rediscovered.
+        let file = tempfile::NamedTempFile::new().expect("temp file");
+        let conn = rusqlite::Connection::open(file.path()).expect("open");
+        conn.execute_batch(SCHEMA).expect("schema");
+        conn.execute(
+            r#"INSERT INTO agents (slug, name, capabilities) VALUES ('arr', 'Arr', '[["Read"],null,null]')"#,
+            [],
+        )
+        .expect("insert");
+        assert!(list(file.path()).is_ok(), "known over-accept, see #337");
     }
 
     // ─── Writes ───────────────────────────────────────────────────────────────
@@ -734,6 +729,65 @@ mod tests {
 
     fn stored(file: &tempfile::NamedTempFile, slug: &str) -> Option<Agent> {
         get(file.path(), slug).expect("get")
+    }
+
+    /// A `null` **inside** a capability list or the MCP map is the zero value,
+    /// not a type error (#295). Go answers `[""]` and the zero `MCPCapability`
+    /// with no error at all, so rejecting these was a **400** — `decode_body`'s
+    /// `InvalidBody`, since the typed decode is what failed — for an agent Go
+    /// creates.
+    ///
+    /// Driven through `create` and read back from the row, because the stored
+    /// JSON is what a later read serves and because that is the path the
+    /// `Value` shape-check sits in front of.
+    #[test]
+    fn a_null_inside_capabilities_is_a_zero_value_rather_than_a_400() {
+        let file = migrated();
+        let body = br#"{"name":"N","slug":"n","capabilities":{
+            "built_in":[null,"Read"],
+            "local":[null],
+            "mcp":{"quiet":null,"github":{"tools":[null]}}
+        }}"#;
+        let answer = create(file.path(), body).expect("a body Go accepts");
+        assert_eq!(answer.status, StatusCode::CREATED);
+
+        let caps = stored(&file, "n").expect("stored").capabilities;
+        assert_eq!(
+            caps.built_in,
+            Some(vec![String::new(), "Read".into()].into())
+        );
+        assert_eq!(caps.local, Some(vec![String::new()].into()));
+        let mcp = caps.mcp.expect("mcp");
+        // A null map value is the zero struct — every field at its own zero.
+        assert!(mcp["quiet"].tools.is_none());
+        assert_eq!(mcp["github"].tools, Some(vec![String::new()].into()));
+    }
+
+    /// The nil-versus-empty distinction is untouched by any of it, and a
+    /// wrongly-typed element still fails — which is Go's answer too.
+    #[test]
+    fn nil_empty_and_wrongly_typed_capabilities_are_unmoved() {
+        let file = migrated();
+        create(
+            file.path(),
+            br#"{"name":"B","slug":"b","capabilities":{"built_in":null,"local":[]}}"#,
+        )
+        .expect("nil and empty");
+        let caps = stored(&file, "b").expect("stored").capabilities;
+        assert!(caps.built_in.is_none());
+        assert_eq!(caps.local, Some(Vec::new().into()));
+        assert!(caps.mcp.is_none());
+
+        // And the shapes Go refuses are still refused here — including the
+        // array a `#[serde(default)]` on `Capabilities` would have accepted.
+        for body in [
+            &br#"{"name":"C","slug":"c","capabilities":{"built_in":[1]}}"#[..],
+            &br#"{"name":"C","slug":"c","capabilities":[]}"#[..],
+            &br#"{"name":"C","slug":"c","capabilities":{"mcp":{"s":[]}}}"#[..],
+        ] {
+            let err = create(file.path(), body).unwrap_err();
+            assert_eq!(err.status(), StatusCode::BAD_REQUEST, "{:?}", err);
+        }
     }
 
     #[test]

--- a/desktop/src-tauri/src/native/chat/runner.rs
+++ b/desktop/src-tauri/src/native/chat/runner.rs
@@ -155,7 +155,7 @@ pub fn build_options(
     Ok(opts)
 }
 
-fn capability_count(list: Option<&Vec<String>>) -> usize {
+fn capability_count(list: Option<&crate::native::gojson::GoList<String>>) -> usize {
     list.map(|l| l.len()).unwrap_or(0)
 }
 
@@ -167,7 +167,7 @@ fn allowed_tools(caps: Option<&Capabilities>) -> Vec<String> {
         return Vec::new();
     };
     if capability_count(caps.built_in.as_ref()) > 0 {
-        return caps.built_in.clone().unwrap_or_default();
+        return caps.built_in.as_deref().cloned().unwrap_or_default();
     }
     if capability_count(caps.local.as_ref()) == 0 && caps.mcp.as_ref().is_none_or(|m| m.is_empty())
     {
@@ -414,7 +414,7 @@ mod tests {
     #[test]
     fn an_explicit_built_in_list_wins() {
         let caps = Capabilities {
-            built_in: Some(vec!["Read".into(), "Bash".into()]),
+            built_in: Some(vec!["Read".into(), "Bash".into()].into()),
             local: None,
             mcp: None,
         };
@@ -436,13 +436,13 @@ mod tests {
         mcp.insert(
             "github".to_string(),
             crate::native::agents::McpCapability {
-                tools: Some(vec!["list_prs".into()]),
+                tools: Some(vec!["list_prs".into()].into()),
             },
         );
         let caps = Capabilities {
             built_in: None,
             local: None,
-            mcp: Some(mcp),
+            mcp: Some(mcp.into()),
         };
         assert!(allowed_tools(Some(&caps)).is_empty());
     }
@@ -465,7 +465,7 @@ mod tests {
             agent: Some(agent_with(Capabilities {
                 built_in: None,
                 local: None,
-                mcp: Some(mcp),
+                mcp: Some(mcp.into()),
             })),
             fallback_model: String::new(),
             working_dir: String::new(),
@@ -484,7 +484,7 @@ mod tests {
         let spec = RunSpec {
             agent: Some(agent_with(Capabilities {
                 built_in: None,
-                local: Some(vec!["now".into()]),
+                local: Some(vec!["now".into()].into()),
                 mcp: None,
             })),
             fallback_model: String::new(),

--- a/desktop/src-tauri/src/native/chats.rs
+++ b/desktop/src-tauri/src/native/chats.rs
@@ -380,8 +380,7 @@ struct PatchChatRequest {
 struct BulkDeleteRequest {
     /// A `null` element is `""` to Go, not an error (#295) — and an empty id
     /// simply matches no row, exactly as Go's does.
-    #[serde(deserialize_with = "super::gojson::null_elements_are_zero_values")]
-    ids: Option<Vec<String>>,
+    ids: Option<super::gojson::GoList<String>>,
 }
 
 /// Go's `maxQueryLimit`, reused as the bulk-delete cap.

--- a/desktop/src-tauri/src/native/chats.rs
+++ b/desktop/src-tauri/src/native/chats.rs
@@ -378,6 +378,9 @@ struct PatchChatRequest {
 #[derive(Debug, Default, Deserialize)]
 #[serde(default)]
 struct BulkDeleteRequest {
+    /// A `null` element is `""` to Go, not an error (#295) — and an empty id
+    /// simply matches no row, exactly as Go's does.
+    #[serde(deserialize_with = "super::gojson::null_elements_are_zero_values")]
     ids: Option<Vec<String>>,
 }
 
@@ -1128,6 +1131,24 @@ mod tests {
 
         // An id that does not exist is not an error here, unlike the single
         // delete — the statement simply matches nothing.
+        let remaining = list(file.path()).expect("list");
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].id, keep);
+    }
+
+    /// A `null` element is `""` to Go — no error — and an empty id simply
+    /// matches no row, so the other two are still deleted. Reverting the
+    /// deserializer makes this a 400 for a request Go applies (#295).
+    #[test]
+    fn a_null_id_is_an_empty_string_rather_than_a_400() {
+        let file = migrated();
+        let a = created_id(&create(file.path(), b"{}").expect("a"));
+        let keep = created_id(&create(file.path(), b"{}").expect("keep"));
+
+        let payload = format!(r#"{{"ids":["{a}",null]}}"#);
+        let answer = bulk_delete(file.path(), payload.as_bytes()).expect("bulk");
+        assert_eq!(answer.status, StatusCode::NO_CONTENT);
+
         let remaining = list(file.path()).expect("list");
         assert_eq!(remaining.len(), 1);
         assert_eq!(remaining[0].id, keep);

--- a/desktop/src-tauri/src/native/gojson.rs
+++ b/desktop/src-tauri/src/native/gojson.rs
@@ -225,8 +225,8 @@ where
     Ok(Option::<T>::deserialize(deserializer)?.unwrap_or_default())
 }
 
-/// The same rule one level down: a `null` **element** of an array is the
-/// element type's zero value (#295).
+/// A JSON array decoded Go's way: a `null` **element** is the element type's
+/// zero value (#295).
 ///
 /// [`null_is_zero_value`] covers the field itself and stops there, because
 /// `serde` only consults it where it is attached — so `{"ids":null}` was
@@ -234,46 +234,100 @@ where
 /// `[""]` to the second with no error at all. On a *write* route that
 /// difference is a 400 for a request Go applies.
 ///
-/// The outer `Option` is kept, because it is the nil-versus-empty distinction
-/// Go puts on the wire: `null` stays `None` and `[]` stays `Some(vec![])`.
+/// # Why this is a type and not a `deserialize_with` function
 ///
-/// Reachable only by a hand-crafted body — no client sends one — which is why
-/// this is fidelity rather than a live bug. Genuinely unparseable elements
-/// (`{"ids":[1]}`) still fail, which is also what Go does.
-pub fn null_elements_are_zero_values<'de, D, T>(deserializer: D) -> Result<Option<Vec<T>>, D::Error>
+/// It was a function first, and that was a **regression**. `serde`'s derive
+/// makes a field carrying `deserialize_with` *required* — the `missing_field`
+/// path that lets a bare `Option` default to `None` is not generated — so every
+/// call site had to add `#[serde(default)]`. That attribute also feeds the
+/// derive's `visit_seq` arm, which errors with `invalid length` only for fields
+/// that have **no** default: adding it turned `{"capabilities":[]}` and
+/// `{"capabilities":{"mcp":{"s":[]}}}` from the 400 Go answers into a created
+/// agent. Widening an over-accept is the one direction this port must not move
+/// in, and the fix for a null shipped inside it.
+///
+/// A type carries the rule instead. `Option<GoList<T>>` needs no attribute at
+/// all: missing is `None`, `null` is `None`, and the struct stays as strict
+/// about its own shape as it was before. See
+/// `a_container_default_would_have_widened_the_struct_from_array_over_accept`.
+///
+/// Serialization is unchanged — a newtype struct serializes as its inner value
+/// — so no response byte moves. Genuinely unparseable elements (`{"ids":[1]}`)
+/// still fail, which is also what Go does.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct GoList<T>(pub Vec<T>);
+
+impl<'de, T> serde::Deserialize<'de> for GoList<T>
 where
-    D: serde::Deserializer<'de>,
     T: serde::Deserialize<'de> + Default,
 {
-    use serde::Deserialize;
-    Ok(Option::<Vec<Option<T>>>::deserialize(deserializer)?
-        .map(|items| items.into_iter().map(Option::unwrap_or_default).collect()))
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Self(
+            Vec::<Option<T>>::deserialize(deserializer)?
+                .into_iter()
+                .map(Option::unwrap_or_default)
+                .collect(),
+        ))
+    }
 }
 
-/// And the same rule for a `null` **value** of an object (#295).
+impl<T> std::ops::Deref for GoList<T> {
+    type Target = Vec<T>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> From<Vec<T>> for GoList<T> {
+    fn from(values: Vec<T>) -> Self {
+        Self(values)
+    }
+}
+
+/// The same rule for a `null` **value** of a JSON object (#295).
 ///
 /// `{"mcp":{"s":null}}` is `{"s":{"tools":null}}` to Go — the zero struct, no
-/// error — and a type error to `serde`. Exactly [`null_elements_are_zero_values`]
-/// with a map in place of the array, and it sits beside it because a struct
-/// carrying both shapes is only faithful when both are covered.
-pub fn null_map_values_are_zero_values<'de, D, V>(
-    deserializer: D,
-) -> Result<Option<std::collections::BTreeMap<String, V>>, D::Error>
+/// error — and a type error to `serde`. Exactly [`GoList`] with a map in place
+/// of the array, and it sits beside it because a struct carrying both shapes is
+/// only faithful when both are covered.
+///
+/// `BTreeMap<String, V>` rather than a generic map: Go marshals map keys sorted,
+/// so every map on this wire is a `BTreeMap` already, and generalising over the
+/// key and container would cost inference at every call site for no caller.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct GoMap<V>(pub std::collections::BTreeMap<String, V>);
+
+impl<'de, V> serde::Deserialize<'de> for GoMap<V>
 where
-    D: serde::Deserializer<'de>,
     V: serde::Deserialize<'de> + Default,
 {
-    use serde::Deserialize;
-    Ok(
-        Option::<std::collections::BTreeMap<String, Option<V>>>::deserialize(deserializer)?.map(
-            |entries| {
-                entries
-                    .into_iter()
-                    .map(|(k, v)| (k, v.unwrap_or_default()))
-                    .collect()
-            },
-        ),
-    )
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Self(
+            std::collections::BTreeMap::<String, Option<V>>::deserialize(deserializer)?
+                .into_iter()
+                .map(|(key, value)| (key, value.unwrap_or_default()))
+                .collect(),
+        ))
+    }
+}
+
+impl<V> std::ops::Deref for GoMap<V> {
+    type Target = std::collections::BTreeMap<String, V>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<V> From<std::collections::BTreeMap<String, V>> for GoMap<V> {
+    fn from(entries: std::collections::BTreeMap<String, V>) -> Self {
+        Self(entries)
+    }
 }
 
 /// Deserialize a value as-is, including an explicit `null`.
@@ -653,15 +707,21 @@ mod tests {
     #[derive(Debug, Default, serde::Deserialize)]
     #[serde(default)]
     struct Listy {
-        #[serde(deserialize_with = "null_elements_are_zero_values")]
-        ids: Option<Vec<String>>,
+        ids: Option<GoList<String>>,
     }
 
+    /// Deliberately **without** `#[serde(default)]` — `Default` is derived
+    /// because `GoMap` needs it, which is a different thing. These two stand for
+    /// the structs #295 must not loosen: `Capabilities` and `McpCapability`.
     #[derive(Debug, Default, serde::Deserialize)]
-    #[serde(default)]
-    struct Mappy {
-        #[serde(deserialize_with = "null_map_values_are_zero_values")]
-        mcp: Option<std::collections::BTreeMap<String, Listy>>,
+    struct Inner {
+        ids: Option<GoList<String>>,
+    }
+
+    #[derive(Debug, serde::Deserialize)]
+    struct Strict {
+        mcp: Option<GoMap<Inner>>,
+        other: Option<String>,
     }
 
     /// Every answer here was measured against `encoding/json` rather than
@@ -673,6 +733,7 @@ mod tests {
             serde_json::from_str::<Listy>(body)
                 .unwrap_or_else(|e| panic!("{body}: {e}"))
                 .ids
+                .map(|list| list.0)
         };
 
         // The case #295 is about: Go answers [""] with no error.
@@ -693,54 +754,90 @@ mod tests {
     /// field at *its* zero — so the nesting has to survive.
     #[test]
     fn a_null_map_value_is_the_values_zero_value() {
-        let parsed: Mappy = serde_json::from_str(r#"{"mcp":{"s":null}}"#).expect("null value");
+        let parsed: Strict =
+            serde_json::from_str(r#"{"mcp":{"s":null},"other":null}"#).expect("null value");
         let mcp = parsed.mcp.expect("a map");
         assert_eq!(mcp.len(), 1);
-        assert_eq!(mcp["s"].ids, None);
+        assert!(mcp["s"].ids.is_none());
 
         // And the two rules compose: a null element inside a null-able map
         // value.
-        let parsed: Mappy =
-            serde_json::from_str(r#"{"mcp":{"s":{"ids":[null]}}}"#).expect("nested null");
+        let parsed: Strict = serde_json::from_str(r#"{"mcp":{"s":{"ids":[null]}},"other":null}"#)
+            .expect("nested null");
         assert_eq!(
-            parsed.mcp.expect("a map")["s"].ids,
-            Some(vec![String::new()])
+            parsed.mcp.expect("a map")["s"].ids.as_deref(),
+            Some(&vec![String::new()])
         );
+    }
 
-        assert!(serde_json::from_str::<Mappy>(r#"{"mcp":null}"#)
-            .expect("null map")
-            .mcp
-            .is_none());
+    /// A field of either type needs **no** `#[serde(default)]`, which is the
+    /// whole reason they are types. `Strict` has no container attribute and
+    /// still accepts a missing field.
+    #[test]
+    fn a_missing_field_needs_no_default_attribute() {
+        let parsed: Strict = serde_json::from_str(r#"{}"#).expect("both fields missing");
+        assert!(parsed.mcp.is_none());
+        assert!(parsed.other.is_none());
+    }
+
+    /// The regression these types exist to avoid, pinned so it cannot come
+    /// back.
+    ///
+    /// The first version of #295 used `deserialize_with` functions, which make
+    /// a field **required** — so every call site had to add
+    /// `#[serde(default)]`. That attribute also feeds the derive's `visit_seq`
+    /// arm, which rejects a short array only for fields with no default: it
+    /// turned `{"capabilities":[]}` from the 400 Go answers into a created
+    /// agent. Widening an over-accept is the one direction this port must not
+    /// move in, and it would have shipped inside a fix for a `null`.
+    #[test]
+    fn a_container_default_would_have_widened_the_struct_from_array_over_accept() {
+        // Without the attribute — what `Capabilities` looks like now — an array
+        // is still refused, exactly as Go refuses it.
+        assert!(serde_json::from_str::<Strict>(r#"[]"#).is_err());
+        assert!(serde_json::from_str::<Strict>(r#"{"mcp":{"s":[]}}"#).is_err());
+
+        // With it, both are accepted. `Listy` carries `#[serde(default)]` for
+        // its own reasons (`{}` is a legal bulk-delete body), which is why the
+        // helpers were free there and not here.
+        assert!(serde_json::from_str::<Listy>(r#"[]"#).is_ok());
+    }
+
+    /// A full-length array **is** still accepted, by serde's positional
+    /// `visit_seq`, and Go refuses it — deferred to #337, not introduced here.
+    /// Recorded so the next reader finds it rather than rediscovering it.
+    #[test]
+    fn a_full_length_positional_array_is_a_known_over_accept() {
+        let parsed: Strict = serde_json::from_str(r#"[{"s":{"ids":["x"]}},"y"]"#)
+            .expect("serde builds a struct from a sequence positionally");
+        assert_eq!(parsed.other.as_deref(), Some("y"));
     }
 
     /// The half that must *not* change: `null` is a zero value, but a wrong
     /// **type** is still an error — to Go as much as to serde. Without this the
-    /// helpers would read as "accept anything".
+    /// types would read as "accept anything".
     #[test]
     fn a_wrongly_typed_element_still_fails() {
         assert!(serde_json::from_str::<Listy>(r#"{"ids":[1]}"#).is_err());
         assert!(serde_json::from_str::<Listy>(r#"{"ids":[{}]}"#).is_err());
         assert!(serde_json::from_str::<Listy>(r#"{"ids":"a"}"#).is_err());
-        assert!(serde_json::from_str::<Mappy>(r#"{"mcp":[]}"#).is_err());
-        assert!(serde_json::from_str::<Mappy>(r#"{"mcp":{"s":1}}"#).is_err());
+        assert!(serde_json::from_str::<Strict>(r#"{"mcp":{"s":1}}"#).is_err());
     }
 
-    /// A **nested** struct still deserializes from a JSON array, positionally,
-    /// and Go does not — `{"mcp":{"s":[]}}` is a 400 to `encoding/json` and a
-    /// zero-valued `McpCapability` here.
-    ///
-    /// Pinned rather than fixed, and deliberately: this is the quirk
-    /// `writes::decode_body` guards at the **body** level (#274, where
-    /// `POST /api/agents` with `["My Agent"]` would have created an agent), and
-    /// nothing checks it for a value *inside* the body. It predates #295 — the
-    /// helpers above change nothing about it — and it is an over-accept, the
-    /// direction that creates rows Go refuses, so it is its own issue rather
-    /// than a line snuck in here. The assertion exists so the next reader finds
-    /// it recorded rather than rediscovering it.
+    /// Serialization is untouched: a newtype struct serializes as its inner
+    /// value, so no response byte moves.
     #[test]
-    fn a_nested_struct_from_an_array_is_a_known_over_accept() {
-        let parsed: Mappy = serde_json::from_str(r#"{"mcp":{"s":[]}}"#)
-            .expect("serde builds a struct from a sequence positionally");
-        assert_eq!(parsed.mcp.expect("a map")["s"].ids, None);
+    fn the_types_serialize_as_their_inner_value() {
+        assert_eq!(
+            String::from_utf8(to_vec_marshal(&GoList(vec!["a", "b"])).expect("encode"))
+                .expect("utf-8"),
+            r#"["a","b"]"#
+        );
+        let mut map = std::collections::BTreeMap::new();
+        map.insert("k".to_string(), 1u8);
+        assert_eq!(
+            String::from_utf8(to_vec_marshal(&GoMap(map)).expect("encode")).expect("utf-8"),
+            r#"{"k":1}"#
+        );
     }
 }

--- a/desktop/src-tauri/src/native/gojson.rs
+++ b/desktop/src-tauri/src/native/gojson.rs
@@ -225,6 +225,57 @@ where
     Ok(Option::<T>::deserialize(deserializer)?.unwrap_or_default())
 }
 
+/// The same rule one level down: a `null` **element** of an array is the
+/// element type's zero value (#295).
+///
+/// [`null_is_zero_value`] covers the field itself and stops there, because
+/// `serde` only consults it where it is attached — so `{"ids":null}` was
+/// already `None` while `{"ids":[null]}` was a type error, and Go answers
+/// `[""]` to the second with no error at all. On a *write* route that
+/// difference is a 400 for a request Go applies.
+///
+/// The outer `Option` is kept, because it is the nil-versus-empty distinction
+/// Go puts on the wire: `null` stays `None` and `[]` stays `Some(vec![])`.
+///
+/// Reachable only by a hand-crafted body — no client sends one — which is why
+/// this is fidelity rather than a live bug. Genuinely unparseable elements
+/// (`{"ids":[1]}`) still fail, which is also what Go does.
+pub fn null_elements_are_zero_values<'de, D, T>(deserializer: D) -> Result<Option<Vec<T>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de> + Default,
+{
+    use serde::Deserialize;
+    Ok(Option::<Vec<Option<T>>>::deserialize(deserializer)?
+        .map(|items| items.into_iter().map(Option::unwrap_or_default).collect()))
+}
+
+/// And the same rule for a `null` **value** of an object (#295).
+///
+/// `{"mcp":{"s":null}}` is `{"s":{"tools":null}}` to Go — the zero struct, no
+/// error — and a type error to `serde`. Exactly [`null_elements_are_zero_values`]
+/// with a map in place of the array, and it sits beside it because a struct
+/// carrying both shapes is only faithful when both are covered.
+pub fn null_map_values_are_zero_values<'de, D, V>(
+    deserializer: D,
+) -> Result<Option<std::collections::BTreeMap<String, V>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    V: serde::Deserialize<'de> + Default,
+{
+    use serde::Deserialize;
+    Ok(
+        Option::<std::collections::BTreeMap<String, Option<V>>>::deserialize(deserializer)?.map(
+            |entries| {
+                entries
+                    .into_iter()
+                    .map(|(k, v)| (k, v.unwrap_or_default()))
+                    .collect()
+            },
+        ),
+    )
+}
+
 /// Deserialize a value as-is, including an explicit `null`.
 ///
 /// `Option<Box<RawValue>>`'s own impl turns `null` into `None`, which would drop
@@ -595,5 +646,101 @@ mod tests {
             compact(r#"{ "k" : "ünïcödé 😀" }"#),
             r#"{"k":"ünïcödé 😀"}"#
         );
+    }
+
+    // ─── #295: a `null` inside a container ───────────────────────────────────
+
+    #[derive(Debug, Default, serde::Deserialize)]
+    #[serde(default)]
+    struct Listy {
+        #[serde(deserialize_with = "null_elements_are_zero_values")]
+        ids: Option<Vec<String>>,
+    }
+
+    #[derive(Debug, Default, serde::Deserialize)]
+    #[serde(default)]
+    struct Mappy {
+        #[serde(deserialize_with = "null_map_values_are_zero_values")]
+        mcp: Option<std::collections::BTreeMap<String, Listy>>,
+    }
+
+    /// Every answer here was measured against `encoding/json` rather than
+    /// reasoned about — the nil-versus-empty rows in particular, which is the
+    /// distinction the outer `Option` exists to keep.
+    #[test]
+    fn a_null_array_element_is_the_elements_zero_value() {
+        let ids = |body: &str| {
+            serde_json::from_str::<Listy>(body)
+                .unwrap_or_else(|e| panic!("{body}: {e}"))
+                .ids
+        };
+
+        // The case #295 is about: Go answers [""] with no error.
+        assert_eq!(ids(r#"{"ids":[null]}"#), Some(vec![String::new()]));
+        assert_eq!(
+            ids(r#"{"ids":["a",null,"b"]}"#),
+            Some(vec!["a".into(), String::new(), "b".into()])
+        );
+
+        // The nil-versus-empty distinction the outer `Option` carries, unmoved.
+        assert_eq!(ids(r#"{"ids":null}"#), None);
+        assert_eq!(ids(r#"{}"#), None);
+        assert_eq!(ids(r#"{"ids":[]}"#), Some(Vec::new()));
+        assert_eq!(ids(r#"{"ids":["a"]}"#), Some(vec!["a".into()]));
+    }
+
+    /// A `null` map value is the value type's zero, which for a struct is every
+    /// field at *its* zero — so the nesting has to survive.
+    #[test]
+    fn a_null_map_value_is_the_values_zero_value() {
+        let parsed: Mappy = serde_json::from_str(r#"{"mcp":{"s":null}}"#).expect("null value");
+        let mcp = parsed.mcp.expect("a map");
+        assert_eq!(mcp.len(), 1);
+        assert_eq!(mcp["s"].ids, None);
+
+        // And the two rules compose: a null element inside a null-able map
+        // value.
+        let parsed: Mappy =
+            serde_json::from_str(r#"{"mcp":{"s":{"ids":[null]}}}"#).expect("nested null");
+        assert_eq!(
+            parsed.mcp.expect("a map")["s"].ids,
+            Some(vec![String::new()])
+        );
+
+        assert!(serde_json::from_str::<Mappy>(r#"{"mcp":null}"#)
+            .expect("null map")
+            .mcp
+            .is_none());
+    }
+
+    /// The half that must *not* change: `null` is a zero value, but a wrong
+    /// **type** is still an error — to Go as much as to serde. Without this the
+    /// helpers would read as "accept anything".
+    #[test]
+    fn a_wrongly_typed_element_still_fails() {
+        assert!(serde_json::from_str::<Listy>(r#"{"ids":[1]}"#).is_err());
+        assert!(serde_json::from_str::<Listy>(r#"{"ids":[{}]}"#).is_err());
+        assert!(serde_json::from_str::<Listy>(r#"{"ids":"a"}"#).is_err());
+        assert!(serde_json::from_str::<Mappy>(r#"{"mcp":[]}"#).is_err());
+        assert!(serde_json::from_str::<Mappy>(r#"{"mcp":{"s":1}}"#).is_err());
+    }
+
+    /// A **nested** struct still deserializes from a JSON array, positionally,
+    /// and Go does not — `{"mcp":{"s":[]}}` is a 400 to `encoding/json` and a
+    /// zero-valued `McpCapability` here.
+    ///
+    /// Pinned rather than fixed, and deliberately: this is the quirk
+    /// `writes::decode_body` guards at the **body** level (#274, where
+    /// `POST /api/agents` with `["My Agent"]` would have created an agent), and
+    /// nothing checks it for a value *inside* the body. It predates #295 — the
+    /// helpers above change nothing about it — and it is an over-accept, the
+    /// direction that creates rows Go refuses, so it is its own issue rather
+    /// than a line snuck in here. The assertion exists so the next reader finds
+    /// it recorded rather than rediscovering it.
+    #[test]
+    fn a_nested_struct_from_an_array_is_a_known_over_accept() {
+        let parsed: Mappy = serde_json::from_str(r#"{"mcp":{"s":[]}}"#)
+            .expect("serde builds a struct from a sequence positionally");
+        assert_eq!(parsed.mcp.expect("a map")["s"].ids, None);
     }
 }

--- a/desktop/src-tauri/src/native/integrations.rs
+++ b/desktop/src-tauri/src/native/integrations.rs
@@ -144,13 +144,14 @@ pub struct ScrubbedIntegration {
 }
 
 /// One enabled service of an integration. Mirrors `config.ServiceConfig`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ServiceConfig {
     #[serde(default, deserialize_with = "super::gojson::null_is_zero_value")]
     pub enabled: bool,
     /// A nil slice is `null` and an empty one is `[]`; the stored value decides.
+    /// A `null` **element** is `""`, which is Go's answer too (#295).
     #[serde(default)]
-    pub tools: Option<Vec<String>>,
+    pub tools: Option<super::gojson::GoList<String>>,
 }
 
 /// One tool an enabled, authenticated integration exposes. Mirrors
@@ -273,7 +274,7 @@ pub fn available_tools(db_path: &Path) -> Result<Vec<AvailableTool>, String> {
             if !service.enabled {
                 continue;
             }
-            for tool_name in service.tools.iter().flatten() {
+            for tool_name in service.tools.iter().flat_map(|tools| tools.iter()) {
                 tools.push(AvailableTool {
                     integration_id: cfg.id.clone(),
                     integration_name: cfg.name.clone(),
@@ -498,7 +499,9 @@ struct CreateIntegrationRequest {
     /// what keeps the two distinguishable.
     #[serde(deserialize_with = "super::gojson::captured_raw")]
     credentials: Option<Box<RawValue>>,
-    services: Option<BTreeMap<String, ServiceConfig>>,
+    /// A `null` **value** is the zero `ServiceConfig` to Go, not an error
+    /// (#295) — the same rule `Capabilities.mcp` carries.
+    services: Option<super::gojson::GoMap<ServiceConfig>>,
 }
 
 /// `handleCreateIntegration` → `integrationService.Create`.
@@ -568,7 +571,7 @@ fn create(db_path: &Path, body: &[u8]) -> Result<super::Answer, WriteError> {
         enabled: req.enabled,
         id,
         name: req.name,
-        services: Some(services),
+        services: Some(services.0),
         integration_type: req.integration_type,
         updated_at: parse_written(&now)?,
     };
@@ -587,8 +590,9 @@ struct TriggerRuleRequest {
     enabled: bool,
     #[serde(deserialize_with = "super::gojson::null_is_zero_value")]
     filter_prefix: String,
-    filter_keywords: Option<Vec<String>>,
-    filter_chat_ids: Option<Vec<String>>,
+    /// A `null` element is `""` to Go, not an error (#295).
+    filter_keywords: Option<super::gojson::GoList<String>>,
+    filter_chat_ids: Option<super::gojson::GoList<String>>,
 }
 
 /// `handleCreateTriggerRule` → `triggerService.CreateRule`.
@@ -630,8 +634,8 @@ fn create_trigger_rule(
         agent_slug: req.agent_slug,
         enabled: req.enabled,
         filter_prefix: req.filter_prefix,
-        filter_keywords: req.filter_keywords,
-        filter_chat_ids: req.filter_chat_ids,
+        filter_keywords: req.filter_keywords.map(|list| list.0),
+        filter_chat_ids: req.filter_chat_ids.map(|list| list.0),
         created_at: stamp,
         updated_at: stamp,
     };
@@ -675,8 +679,8 @@ fn update_trigger_rule(
         agent_slug: req.agent_slug,
         enabled: req.enabled,
         filter_prefix: req.filter_prefix,
-        filter_keywords: req.filter_keywords,
-        filter_chat_ids: req.filter_chat_ids,
+        filter_keywords: req.filter_keywords.map(|list| list.0),
+        filter_chat_ids: req.filter_chat_ids.map(|list| list.0),
         created_at: existing.created_at,
         updated_at: parse_written(&now)?,
     };
@@ -1206,6 +1210,67 @@ mod tests {
             body_of(&answer)
         );
         assert_eq!(stored(&file, "SELECT services FROM integrations"), "{}");
+    }
+
+    /// The write surface carries the same containers `Capabilities` does, so it
+    /// carries the same rule (#295): a `null` service value is the zero
+    /// `ServiceConfig` to Go and a `null` tool is `""`, both with no error.
+    #[test]
+    fn a_null_inside_services_is_a_zero_value_rather_than_a_400() {
+        let file = migrated();
+        let answer = create(
+            file.path(),
+            br#"{"name":"W","type":"telegram","credentials":{"bot_token":"t"},
+                 "services":{"quiet":null,"loud":{"enabled":true,"tools":[null,"send"]}}}"#,
+        )
+        .expect("a body Go accepts");
+        assert_eq!(answer.status, axum::http::StatusCode::CREATED);
+
+        let stored_services = stored(&file, "SELECT services FROM integrations");
+        assert!(
+            stored_services.contains(r#""quiet":{"enabled":false,"tools":null}"#),
+            "{stored_services}"
+        );
+        assert!(
+            stored_services.contains(r#""tools":["","send"]"#),
+            "{stored_services}"
+        );
+
+        // A whole services map that is `null` is still nil, not `{}` — the
+        // nil-versus-empty distinction is untouched.
+        let file = migrated();
+        create(
+            file.path(),
+            br#"{"name":"W","type":"telegram","credentials":{"bot_token":"t"},"services":null}"#,
+        )
+        .expect("null map");
+        assert_eq!(stored(&file, "SELECT services FROM integrations"), "{}");
+
+        // And a wrongly-typed value still fails, which is Go's answer too.
+        let file = migrated();
+        assert!(create(
+            file.path(),
+            br#"{"name":"W","type":"telegram","credentials":{"bot_token":"t"},"services":{"s":1}}"#,
+        )
+        .is_err());
+    }
+
+    /// The trigger rule's two filter lists, same rule.
+    #[test]
+    fn a_null_filter_element_is_an_empty_string_rather_than_a_400() {
+        let file = migrated();
+        seed_integration(&file, "int-1");
+
+        let created = create_trigger_rule(
+            file.path(),
+            "int-1",
+            br#"{"name":"R","agent_slug":"a","filter_keywords":[null,"x"],"filter_chat_ids":[null]}"#,
+        )
+        .expect("a body Go accepts");
+        assert_eq!(created.status, axum::http::StatusCode::CREATED);
+        let body = body_of(&created);
+        assert!(body.contains(r#""filter_keywords":["","x"]"#), "{body}");
+        assert!(body.contains(r#""filter_chat_ids":[""]"#), "{body}");
     }
 
     /// Jira is the only type that rewrites what it stores.

--- a/desktop/src-tauri/src/native/integrations.rs
+++ b/desktop/src-tauri/src/native/integrations.rs
@@ -150,7 +150,13 @@ pub struct ServiceConfig {
     pub enabled: bool,
     /// A nil slice is `null` and an empty one is `[]`; the stored value decides.
     /// A `null` **element** is `""`, which is Go's answer too (#295).
-    #[serde(default)]
+    ///
+    /// **No `#[serde(default)]`, deliberately.** It carried one until #295 made
+    /// it redundant — `Option<GoList<_>>` gets `None` from `missing_field`
+    /// without it — and its only remaining effect was the derive's `visit_seq`
+    /// arm, which admits an array with as many elements as the struct has
+    /// defaulted fields. That is what made `{"services":{"s":[]}}` a 201 where
+    /// Go answers 400. See [`super::gojson::GoList`].
     pub tools: Option<super::gojson::GoList<String>>,
 }
 
@@ -1246,13 +1252,22 @@ mod tests {
         .expect("null map");
         assert_eq!(stored(&file, "SELECT services FROM integrations"), "{}");
 
-        // And a wrongly-typed value still fails, which is Go's answer too.
-        let file = migrated();
-        assert!(create(
-            file.path(),
-            br#"{"name":"W","type":"telegram","credentials":{"bot_token":"t"},"services":{"s":1}}"#,
-        )
-        .is_err());
+        // And a wrongly-typed value still fails, which is Go's answer too —
+        // including the positional arrays that `#[serde(default)]` on `tools`
+        // used to admit. Dropping that attribute (redundant once `tools` is a
+        // `GoList`) is what closes them.
+        for services in [r#"{"s":1}"#, r#"{"s":[]}"#, r#"{"s":[true]}"#] {
+            let file = migrated();
+            let body = format!(
+                r#"{{"name":"W","type":"telegram","credentials":{{"bot_token":"t"}},"services":{services}}}"#
+            );
+            let err = create(file.path(), body.as_bytes()).unwrap_err();
+            assert_eq!(
+                err.status(),
+                axum::http::StatusCode::BAD_REQUEST,
+                "{services}"
+            );
+        }
     }
 
     /// The trigger rule's two filter lists, same rule.

--- a/desktop/src-tauri/src/native/tasks.rs
+++ b/desktop/src-tauri/src/native/tasks.rs
@@ -479,6 +479,9 @@ fn serve_read(ctx: &super::Ctx, req: &super::Request) -> Result<super::Answer, S
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(default)]
 struct BulkDeleteRequest {
+    /// A `null` element is `""` to Go, not an error (#295) — and an empty id
+    /// simply matches no row, exactly as Go's does.
+    #[serde(deserialize_with = "super::gojson::null_elements_are_zero_values")]
     ids: Option<Vec<String>>,
 }
 
@@ -892,6 +895,17 @@ mod tests {
             bulk_delete_job_history(file.path(), br#"{"ids":["j1","j3","nope"]}"#).expect("bulk");
         assert_eq!(answer.status, StatusCode::NO_CONTENT);
         assert_eq!(history_ids(&file), vec!["j2"]);
+    }
+
+    /// A `null` element is `""` to Go — no error — and an empty id matches no
+    /// row, so `j1` still goes. Reverting the deserializer makes this a 400 for
+    /// a request Go applies (#295).
+    #[test]
+    fn a_null_id_is_an_empty_string_rather_than_a_400() {
+        let file = migrated_with_history();
+        let answer = bulk_delete_job_history(file.path(), br#"{"ids":["j1",null]}"#).expect("bulk");
+        assert_eq!(answer.status, StatusCode::NO_CONTENT);
+        assert_eq!(history_ids(&file), vec!["j2", "j3"]);
     }
 
     #[test]

--- a/desktop/src-tauri/src/native/tasks.rs
+++ b/desktop/src-tauri/src/native/tasks.rs
@@ -481,8 +481,7 @@ fn serve_read(ctx: &super::Ctx, req: &super::Request) -> Result<super::Answer, S
 struct BulkDeleteRequest {
     /// A `null` element is `""` to Go, not an error (#295) — and an empty id
     /// simply matches no row, exactly as Go's does.
-    #[serde(deserialize_with = "super::gojson::null_elements_are_zero_values")]
-    ids: Option<Vec<String>>,
+    ids: Option<super::gojson::GoList<String>>,
 }
 
 /// Go's `maxQueryLimit`, reused as the bulk-delete cap.


### PR DESCRIPTION
Closes #295

## What

Two types in `gojson.rs` — `GoList<T>` and `GoMap<V>` — decode a `null` **inside** a JSON container as the zero value, the way `encoding/json` does. Applied to `BulkDeleteRequest.ids` (`chats.rs`, `tasks.rs`), all four containers in `Capabilities`/`McpCapability`, and the claimed integration writes (`ServiceConfig.tools`, `CreateIntegrationRequest.services`, the trigger rule's two filter lists).

## Why

`gojson::null_is_zero_value` is attached to fields, and `serde` only consults it where it is attached — so it covered `{"ids":null}` and stopped there. Measured against `encoding/json`:

| body | Go | Rust before |
|---|---|---|
| `{"ids":[null]}` | `[""]`, no error | type error → `InvalidBody` → **400** |
| `{"ids":["a",null,"b"]}` | `["a","","b"]`, no error | 400 |
| `{"capabilities":{"built_in":[null]}}` | `[""]`, no error | 400 |
| `{"capabilities":{"mcp":{"s":null}}}` | `{"s":{"tools":null}}`, no error | 400 |
| `{"services":{"slack":null}}` | zero `ServiceConfig`, no error | 400 |
| `{"ids":[1]}` | error | error ✔ |

Reachable only by a hand-crafted request, which is why #293 recorded it rather than fixing it — but that PR makes the null-fidelity argument in three places, and these are the shapes it does not cover. While every claimed route was a read this degraded to a fallback; on the writes #274 and #277 claimed it is a rejection of a request Go applies.

## Why types, and not `deserialize_with` functions

This is the substantive thing the PR learned, and it was caught in review after the first version shipped it.

`serde`'s derive makes a field carrying `deserialize_with` **required** — the `missing_field` path that lets a bare `Option` default to `None` is not generated — so every call site had to add `#[serde(default)]`. That attribute also feeds the derive's `visit_seq` arm, which rejects a short array **only for fields with no default**. Measured on the first version:

| body | before the PR | first version | Go |
|---|---|---|---|
| `{"capabilities":[]}` | 400 | **201, agent created** | 400 |
| `{"capabilities":{"mcp":{"s":[]}}}` | 400 | **201, agent created** | 400 |

A fix for a `null` would have shipped a widened **over-accept** — the one direction this port must not move in, because `Err` means forward and nothing errors when Rust accepts what Go refuses. A type needs no attribute at all, so `Capabilities` and `McpCapability` now carry none and are exactly as strict about their own shape as before. Pinned by `a_container_default_would_have_widened_the_struct_from_array_over_accept`.

## Scope note

The issue lists the array case. The **map-value** case (`{"mcp":{"s":null}}`) is the identical divergence one line away in the same struct, and the integration writes carry the same containers — fixing three of `Capabilities`' four would leave it unfaithful, and the same argument applies verbatim to `integrations.rs`. Both are included.

## How

- `GoList<T>` / `GoMap<V>` with hand-written `Deserialize`, plus `Deref` and `From` so call sites read unchanged.
- Both **keep the outer `Option`**, because that is the nil-versus-empty distinction Go puts on the wire: `null` stays `None`, `[]` stays `Some(vec![])`.
- A newtype **serializes as its inner value**, so every read is byte-identical. Pinned by `the_types_serialize_as_their_inner_value`.
- `ServiceConfig` gains a `Default` derive (`GoMap` requires it); its zero is Go's zero.

## Acceptance

- `gojson`'s tests pin each type against answers measured from `encoding/json`, including the nil-versus-empty rows, the wrongly-typed rows that must still fail, and the two over-accept boundaries.
- Five call-site tests — `chats`, `tasks`, `agents` (through `create()` and the stored row) and two in `integrations` — assert the end-to-end effect, and **all seven behaviour tests go red when `GoList`/`GoMap` are reduced to pass-throughs** (verified).
- The read-side guard pins that a stored `[]` must not read as an *empty* allowlist.
- Local gates green: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (664 lib), `cargo build --release`, `npm run build`, `go test ./desktop/...`, `go vet ./desktop/...`, golangci-lint at the CI-pinned v2.5.0.

## Deferred, recorded rather than fixed

`serde` builds a nested struct from a **full-length** JSON array, positionally, so `{"capabilities":[["Read"],null,null]}` is accepted here and Go answers 400. That is `writes::decode_body`'s #274 quirk one level deeper — `decode_body` guards the body, nothing checks a value *inside* it. It predates this change and is an **over-accept**, so it is its own issue: **#337**. Pinned by `a_full_length_positional_array_is_a_known_over_accept` and noted in `desktop/CLAUDE.md`.

## Review

Automated review returned **REQUEST CHANGES** on the first version, for the over-accept above; all findings were applied and the rework re-verified.