### PR TITLE
refactor(desktop): resolve the fallback model lazily, and dedup error_json (#299)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -1034,16 +1034,30 @@ issue. That gap is #298; do not read the list below as fully covered.
   the session row is still written: `updated_at`, the token totals, and on a
   first message a title derived from a message that was never stored.
 
-**The model a turn runs is the agent's or the fallback's — never both** (#299).
-`resolveAgentConfig` branches on whether the chat **names an agent**, not on
-whether that agent has a model: it returns the agent's config outright, and
+**The model a turn runs is the agent's or the no-agent branch's — never both**
+(#299). `resolveAgentConfig` branches on whether the chat **names an agent**, not
+on whether that agent has a model: it returns the agent's config outright, and
 `runner.go` then sets a model only when `agentCfg.Model != ""`. So an agent with
-an empty model runs with **no model option at all**, and the session's model and
-the user's default are read only in the no-agent branch. `RunSpec.fallback_model`
-is a closure for that reason — resolving it eagerly opened a second read-only
-SQLite connection and loaded the settings row on every turn of every agent chat,
-to throw the answer away, *and* treated an agent's empty model as a request for a
-default it would never have got from Go.
+an empty model gets **no model option from Agento at all** — the SDK's own
+default (`claude-sonnet-4-6`, the same constant in both SDKs) is what reaches the
+CLI — and the session's model and the user's default are read only in the
+no-agent branch. `RunSpec.no_agent_model` is a closure for that reason: resolving
+it eagerly loaded the settings row on every turn of every agent chat to throw the
+answer away, *and* treated an agent's empty model as a request for a default Go
+would never have given it.
+
+It is named for the branch and not for the fallback because
+`Options::fallback_model` already means something else in the same function — the
+CLI's `--fallback-model`, for when the *primary* model is unavailable.
+
+**Read the user's default through `settings::resolve`, never `load_stored`.** Go
+reads `settingsMgr.Get()`, and `SettingsManager.load` fills `"sonnet"` when
+nothing is stored *before* `applyEnvOverrides` applies `AGENTO_DEFAULT_MODEL` /
+`ANTHROPIC_DEFAULT_SONNET_MODEL`. The raw `SELECT` has neither: a user who had
+never saved settings ran on the SDK default rather than `sonnet` — two different
+strings — and one who exported `AGENTO_DEFAULT_MODEL` had it silently ignored.
+`resolve` is the documented mirror of `Get()`, and every other caller in the port
+already goes through it.
 
 **The `tool_use` input must never round-trip through a `serde_json::Value`.**
 The first version of `append_assistant_blocks` did, and turned `{"z":1.50,"a":1}`

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -1034,6 +1034,17 @@ issue. That gap is #298; do not read the list below as fully covered.
   the session row is still written: `updated_at`, the token totals, and on a
   first message a title derived from a message that was never stored.
 
+**The model a turn runs is the agent's or the fallback's — never both** (#299).
+`resolveAgentConfig` branches on whether the chat **names an agent**, not on
+whether that agent has a model: it returns the agent's config outright, and
+`runner.go` then sets a model only when `agentCfg.Model != ""`. So an agent with
+an empty model runs with **no model option at all**, and the session's model and
+the user's default are read only in the no-agent branch. `RunSpec.fallback_model`
+is a closure for that reason — resolving it eagerly opened a second read-only
+SQLite connection and loaded the settings row on every turn of every agent chat,
+to throw the answer away, *and* treated an agent's empty model as a request for a
+default it would never have got from Go.
+
 **The `tool_use` input must never round-trip through a `serde_json::Value`.**
 The first version of `append_assistant_blocks` did, and turned `{"z":1.50,"a":1}`
 into `{"a":1,"z":1.5}` — sorted and respelled, with nothing to signal it.

--- a/desktop/src-tauri/src/native/chat/runner.rs
+++ b/desktop/src-tauri/src/native/chat/runner.rs
@@ -50,13 +50,18 @@ pub struct RunSpec {
     /// The model a chat with **no agent** runs: `session.model`, or the user's
     /// default when the session has none.
     ///
+    /// Named for the branch rather than for the fallback, because
+    /// [`crate::claude::options::Options::fallback_model`] already means
+    /// something else in this very function — the CLI's `--fallback-model`, used
+    /// when the *primary* model is unavailable.
+    ///
     /// A closure, because computing it opens a second read-only SQLite
     /// connection and loads the settings row — and Go never does that for a
     /// chat that names an agent. `resolveAgentConfig` returns the agent's own
     /// config outright in that case and the default is only read in the
     /// no-agent branch, so an eager value is work whose result is thrown away.
     /// Called at most once, in the one arm below that needs it.
-    pub fallback_model: Box<dyn Fn() -> String + Send + Sync>,
+    pub no_agent_model: Box<dyn Fn() -> String + Send + Sync>,
     pub working_dir: String,
     pub settings_profile_id: String,
     /// `Some` resumes an existing CLI session; `None` pins a new one to the
@@ -129,7 +134,7 @@ pub fn build_options(
     // from the one Go picks.
     let model = match spec.agent.as_ref() {
         Some(agent) => agent.model.clone(),
-        None => (spec.fallback_model)(),
+        None => (spec.no_agent_model)(),
     };
     if !model.is_empty() {
         opts = opts.with_model(model);
@@ -440,7 +445,7 @@ mod tests {
         (
             RunSpec {
                 agent,
-                fallback_model: Box::new(move || {
+                no_agent_model: Box::new(move || {
                     counter.fetch_add(1, Ordering::SeqCst);
                     "fallback-model".to_string()
                 }),
@@ -568,7 +573,7 @@ mod tests {
                 local: None,
                 mcp: Some(mcp.into()),
             })),
-            fallback_model: Box::new(String::new),
+            no_agent_model: Box::new(String::new),
             working_dir: String::new(),
             settings_profile_id: String::new(),
             resume_session_id: None,
@@ -588,7 +593,7 @@ mod tests {
                 local: Some(vec!["now".into()].into()),
                 mcp: None,
             })),
-            fallback_model: Box::new(String::new),
+            no_agent_model: Box::new(String::new),
             working_dir: String::new(),
             settings_profile_id: String::new(),
             resume_session_id: None,

--- a/desktop/src-tauri/src/native/chat/runner.rs
+++ b/desktop/src-tauri/src/native/chat/runner.rs
@@ -47,8 +47,16 @@ pub struct RunSpec {
     /// The agent, or `None` for a chat with no agent slug — which Go models as
     /// a synthesized config carrying only a model.
     pub agent: Option<Agent>,
-    /// `session.model`, or the user's default when the session has none.
-    pub fallback_model: String,
+    /// The model a chat with **no agent** runs: `session.model`, or the user's
+    /// default when the session has none.
+    ///
+    /// A closure, because computing it opens a second read-only SQLite
+    /// connection and loads the settings row — and Go never does that for a
+    /// chat that names an agent. `resolveAgentConfig` returns the agent's own
+    /// config outright in that case and the default is only read in the
+    /// no-agent branch, so an eager value is work whose result is thrown away.
+    /// Called at most once, in the one arm below that needs it.
+    pub fallback_model: Box<dyn Fn() -> String + Send + Sync>,
     pub working_dir: String,
     pub settings_profile_id: String,
     /// `Some` resumes an existing CLI session; `None` pins a new one to the
@@ -112,12 +120,17 @@ pub fn build_options(
 
     opts = opts.with_claude_executable(claude_executable());
 
-    let model = spec
-        .agent
-        .as_ref()
-        .map(|a| a.model.clone())
-        .filter(|m| !m.is_empty())
-        .unwrap_or_else(|| spec.fallback_model.clone());
+    // `resolveAgentConfig` branches on whether the **chat names an agent**, not
+    // on whether that agent has a model: it returns the agent's config outright,
+    // and `runner.go` then sets a model only when `agentCfg.Model != ""`. So an
+    // agent with an empty model runs with **no model option at all** — neither
+    // the session's nor the user's default is consulted for it, and treating the
+    // fallback as a general default would run such an agent on a different model
+    // from the one Go picks.
+    let model = match spec.agent.as_ref() {
+        Some(agent) => agent.model.clone(),
+        None => (spec.fallback_model)(),
+    };
     if !model.is_empty() {
         opts = opts.with_model(model);
     }
@@ -396,6 +409,7 @@ pub fn load(
 mod tests {
     use super::*;
     use std::collections::BTreeMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn agent_with(caps: Capabilities) -> Agent {
         Agent {
@@ -409,6 +423,93 @@ mod tests {
             capabilities: caps,
             claude_config_dir: String::new(),
         }
+    }
+
+    /// A `RunSpec` whose fallback records whether it was ever asked for.
+    ///
+    /// The count is the point: #299 is about *not* resolving it, and a test that
+    /// only checked the resulting model would pass with the work still being
+    /// done on every turn.
+    /// Note the models below are all distinct from [`DEFAULT_MODEL`], which is
+    /// what `Options::default()` already carries — `agent_with`'s happens to be
+    /// exactly that string, so a test reusing it could not tell "we set the
+    /// model" from "we never called `with_model`".
+    fn spec_with(agent: Option<Agent>) -> (RunSpec, std::sync::Arc<AtomicUsize>) {
+        let calls = std::sync::Arc::new(AtomicUsize::new(0));
+        let counter = std::sync::Arc::clone(&calls);
+        (
+            RunSpec {
+                agent,
+                fallback_model: Box::new(move || {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    "fallback-model".to_string()
+                }),
+                working_dir: String::new(),
+                settings_profile_id: String::new(),
+                resume_session_id: None,
+                chat_id: "c1".into(),
+            },
+            calls,
+        )
+    }
+
+    fn no_op_handler() -> PermissionHandler {
+        std::sync::Arc::new(|_, _, _| {
+            Box::pin(async { crate::claude::permissions::PermissionResult::allow() })
+        })
+    }
+
+    /// The whole of #299: a chat that names an agent never asks for the
+    /// fallback, because Go's `resolveAgentConfig` returns the agent's config
+    /// outright and never reads the user's default. Resolving it eagerly opened
+    /// a second read-only SQLite connection and loaded the settings row on every
+    /// turn, to discard the answer.
+    #[test]
+    fn an_agent_chat_never_resolves_the_fallback_model() {
+        let mut agent = agent_with(Capabilities::default());
+        agent.model = "agent-model".into();
+        let (spec, calls) = spec_with(Some(agent));
+        let opts = build_options(&spec, no_op_handler()).expect("options");
+
+        assert_eq!(opts.model, "agent-model");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            0,
+            "the fallback was resolved for a chat that cannot use it"
+        );
+    }
+
+    /// The other half of the same rule, and a real parity fix rather than a
+    /// cleanup: Go branches on whether the chat **names an agent**, not on
+    /// whether that agent has a model. `runner.go` sets a model only when
+    /// `agentCfg.Model != ""`, so an agent with an empty one runs with **no
+    /// model option at all** — the session's model and the user's default are
+    /// never consulted for it.
+    #[test]
+    fn an_agent_with_no_model_runs_with_none_rather_than_the_fallback() {
+        let mut agent = agent_with(Capabilities::default());
+        agent.model = String::new();
+        let (spec, calls) = spec_with(Some(agent));
+        let opts = build_options(&spec, no_op_handler()).expect("options");
+
+        // `with_model` is never called, so the SDK's own default stands —
+        // which is what Go's `defaultOptions()` leaves in place too.
+        assert_eq!(
+            opts.model,
+            crate::claude::options::DEFAULT_MODEL,
+            "an agent's empty model is not a request for the session's or the user's"
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+    }
+
+    /// The one branch that does need it — and it is asked exactly once.
+    #[test]
+    fn a_chat_with_no_agent_resolves_the_fallback_once() {
+        let (spec, calls) = spec_with(None);
+        let opts = build_options(&spec, no_op_handler()).expect("options");
+
+        assert_eq!(opts.model, "fallback-model");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 
     #[test]
@@ -467,7 +568,7 @@ mod tests {
                 local: None,
                 mcp: Some(mcp.into()),
             })),
-            fallback_model: String::new(),
+            fallback_model: Box::new(String::new),
             working_dir: String::new(),
             settings_profile_id: String::new(),
             resume_session_id: None,
@@ -487,7 +588,7 @@ mod tests {
                 local: Some(vec!["now".into()].into()),
                 mcp: None,
             })),
-            fallback_model: String::new(),
+            fallback_model: Box::new(String::new),
             working_dir: String::new(),
             settings_profile_id: String::new(),
             resume_session_id: None,

--- a/desktop/src-tauri/src/native/chat/runner.rs
+++ b/desktop/src-tauri/src/native/chat/runner.rs
@@ -430,7 +430,7 @@ mod tests {
         }
     }
 
-    /// A `RunSpec` whose fallback records whether it was ever asked for.
+    /// A `RunSpec` whose no-agent model records whether it was ever asked for.
     ///
     /// The count is the point: #299 is about *not* resolving it, and a test that
     /// only checked the resulting model would pass with the work still being
@@ -447,7 +447,7 @@ mod tests {
                 agent,
                 no_agent_model: Box::new(move || {
                     counter.fetch_add(1, Ordering::SeqCst);
-                    "fallback-model".to_string()
+                    "no-agent-model".to_string()
                 }),
                 working_dir: String::new(),
                 settings_profile_id: String::new(),
@@ -465,12 +465,12 @@ mod tests {
     }
 
     /// The whole of #299: a chat that names an agent never asks for the
-    /// fallback, because Go's `resolveAgentConfig` returns the agent's config
+    /// no-agent model, because Go's `resolveAgentConfig` returns the agent's config
     /// outright and never reads the user's default. Resolving it eagerly opened
     /// a second read-only SQLite connection and loaded the settings row on every
     /// turn, to discard the answer.
     #[test]
-    fn an_agent_chat_never_resolves_the_fallback_model() {
+    fn an_agent_chat_never_resolves_the_no_agent_model() {
         let mut agent = agent_with(Capabilities::default());
         agent.model = "agent-model".into();
         let (spec, calls) = spec_with(Some(agent));
@@ -480,7 +480,7 @@ mod tests {
         assert_eq!(
             calls.load(Ordering::SeqCst),
             0,
-            "the fallback was resolved for a chat that cannot use it"
+            "the no-agent model was resolved for a chat that cannot use it"
         );
     }
 
@@ -491,7 +491,7 @@ mod tests {
     /// model option at all** — the session's model and the user's default are
     /// never consulted for it.
     #[test]
-    fn an_agent_with_no_model_runs_with_none_rather_than_the_fallback() {
+    fn an_agent_with_no_model_runs_with_none_rather_than_the_no_agent_model() {
         let mut agent = agent_with(Capabilities::default());
         agent.model = String::new();
         let (spec, calls) = spec_with(Some(agent));
@@ -509,11 +509,11 @@ mod tests {
 
     /// The one branch that does need it — and it is asked exactly once.
     #[test]
-    fn a_chat_with_no_agent_resolves_the_fallback_once() {
+    fn a_chat_with_no_agent_resolves_its_model_once() {
         let (spec, calls) = spec_with(None);
         let opts = build_options(&spec, no_op_handler()).expect("options");
 
-        assert_eq!(opts.model, "fallback-model");
+        assert_eq!(opts.model, "no-agent-model");
         assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 

--- a/desktop/src-tauri/src/native/chat/turn.rs
+++ b/desktop/src-tauri/src/native/chat/turn.rs
@@ -39,6 +39,7 @@ use crate::claude::messages::Event;
 use crate::claude::permissions::{PermissionContext, PermissionResult};
 use crate::claude::session::Session;
 
+use super::error_json;
 use super::live::{registry, LiveSession};
 use super::runner::{self, RunSpec};
 use super::sse;
@@ -121,10 +122,17 @@ pub async fn run(
     };
     let (row, agent) = loaded;
 
-    let fallback_model = if row.model.is_empty() {
-        default_model(&db_path)
+    // Deliberately *not* resolved here: `runner::build_options` calls this only
+    // for a chat with no agent, which is the only branch Go reads the user's
+    // default in. Resolving eagerly opened a second read-only connection and
+    // loaded the settings row on every turn of every agent chat, to throw the
+    // answer away.
+    let fallback_model: Box<dyn Fn() -> String + Send + Sync> = if row.model.is_empty() {
+        let db_path = db_path.clone();
+        Box::new(move || default_model(&db_path))
     } else {
-        row.model.clone()
+        let model = row.model.clone();
+        Box::new(move || model.clone())
     };
 
     let (notify_tx, notify_rx) = mpsc::channel::<Notify>(NOTIFY_CAPACITY);
@@ -567,21 +575,6 @@ fn sse_response(body: Body) -> Response<Body> {
         .header(header::CONNECTION, "keep-alive")
         .header("X-Accel-Buffering", "no")
         .body(body)
-        .unwrap_or_else(|_| Response::new(Body::empty()))
-}
-
-/// A JSON error answered *before* the SSE headers — which is the only window in
-/// which an HTTP status can still say anything.
-fn error_json(status: StatusCode, message: &str) -> Response<Body> {
-    #[derive(Serialize)]
-    struct ErrorBody<'a> {
-        error: &'a str,
-    }
-    let body = crate::native::gojson::to_vec(&ErrorBody { error: message }).unwrap_or_default();
-    Response::builder()
-        .status(status)
-        .header(header::CONTENT_TYPE, "application/json")
-        .body(Body::from(body))
         .unwrap_or_else(|_| Response::new(Body::empty()))
 }
 

--- a/desktop/src-tauri/src/native/chat/turn.rs
+++ b/desktop/src-tauri/src/native/chat/turn.rs
@@ -122,18 +122,7 @@ pub async fn run(
     };
     let (row, agent) = loaded;
 
-    // Deliberately *not* resolved here: `runner::build_options` calls this only
-    // for a chat with no agent, which is the only branch Go reads the user's
-    // default in. Resolving eagerly opened a second read-only connection and
-    // loaded the settings row on every turn of every agent chat, to throw the
-    // answer away.
-    let fallback_model: Box<dyn Fn() -> String + Send + Sync> = if row.model.is_empty() {
-        let db_path = db_path.clone();
-        Box::new(move || default_model(&db_path))
-    } else {
-        let model = row.model.clone();
-        Box::new(move || model.clone())
-    };
+    let no_agent_model = no_agent_model_for(&db_path, &row.model);
 
     let (notify_tx, notify_rx) = mpsc::channel::<Notify>(NOTIFY_CAPACITY);
     let (input_tx, input_rx) = mpsc::channel::<String>(1);
@@ -151,7 +140,7 @@ pub async fn run(
 
     let spec = RunSpec {
         agent,
-        fallback_model,
+        no_agent_model,
         working_dir: row.working_dir.clone(),
         settings_profile_id: row.settings_profile_id.clone(),
         resume_session_id: Some(row.sdk_session_id.clone()).filter(|s| !s.is_empty()),
@@ -578,16 +567,98 @@ fn sse_response(body: Body) -> Response<Body> {
         .unwrap_or_else(|_| Response::new(Body::empty()))
 }
 
+/// The closure `RunSpec::no_agent_model` carries.
+///
+/// Deliberately *not* resolved here: `runner::build_options` calls it only for a
+/// chat with no agent, which is the only branch Go reads the user's default in
+/// (`resolveAgentConfig` returns the agent's config outright otherwise).
+/// Resolving eagerly opened a read-only connection and loaded the settings row
+/// on every turn of every agent chat, to throw the answer away.
+fn no_agent_model_for(
+    db_path: &std::path::Path,
+    session_model: &str,
+) -> Box<dyn Fn() -> String + Send + Sync> {
+    if session_model.is_empty() {
+        let db_path = db_path.to_path_buf();
+        Box::new(move || default_model(&db_path))
+    } else {
+        let model = session_model.to_string();
+        Box::new(move || model.clone())
+    }
+}
+
+/// `settingsMgr.Get().DefaultModel`.
+///
+/// **`resolve`, not `load_stored`.** Go reads the *resolved* settings, and
+/// `SettingsManager.load` fills `"sonnet"` when nothing is stored before
+/// `applyEnvOverrides` applies `AGENTO_DEFAULT_MODEL` /
+/// `ANTHROPIC_DEFAULT_SONNET_MODEL`. The raw `SELECT` has neither, so a user who
+/// had never saved settings ran on the SDK's own default instead of `sonnet`,
+/// and one who exported `AGENTO_DEFAULT_MODEL` had it silently ignored —
+/// `settings::resolve` is the documented mirror of `Get()` and every other
+/// caller in the port already goes through it.
 fn default_model(db_path: &std::path::Path) -> String {
     let Ok(conn) = crate::native::db::open_read_only(db_path) else {
         return String::new();
     };
-    crate::native::settings::load_stored(&conn).default_model
+    crate::native::settings::resolve(crate::native::settings::load_stored(&conn))
+        .settings
+        .default_model
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The branch the three `runner.rs` tests cannot reach: they stub the
+    /// closure, so nothing checked which one `turn::run` builds. Inverting this
+    /// condition would ship green and run every no-agent chat on the wrong
+    /// model.
+    #[test]
+    fn a_session_model_is_used_verbatim_and_never_touches_the_database() {
+        // A path that does not exist: if the row's model were ignored and the
+        // settings read anyway, opening it would fail and this would be `""`.
+        let nowhere = std::path::Path::new("/nonexistent/agento/definitely-not-a-db");
+        let resolve = no_agent_model_for(nowhere, "session-model");
+        assert_eq!(resolve(), "session-model");
+        // Idempotent — `build_options` calls it once, but nothing enforces that.
+        assert_eq!(resolve(), "session-model");
+    }
+
+    /// The other arm reads the settings, and does so through `resolve` — which
+    /// is what fills `"sonnet"` for a user who has never saved settings, exactly
+    /// as `SettingsManager.load` does before Go reads it.
+    #[test]
+    fn an_empty_session_model_resolves_the_users_default() {
+        let file = tempfile::NamedTempFile::new().expect("temp file");
+        let mut conn = rusqlite::Connection::open(file.path()).expect("open");
+        crate::native::migrate::apply(&mut conn).expect("migrate");
+        drop(conn);
+
+        // Nothing stored: the raw column is empty and `resolve` fills Go's
+        // default, so reading the row directly would have answered `""`.
+        assert_eq!(
+            no_agent_model_for(file.path(), "")(),
+            crate::native::settings::DEFAULT_MODEL
+        );
+
+        let conn = rusqlite::Connection::open(file.path()).expect("open");
+        conn.execute(
+            "INSERT INTO user_settings (id, default_model) VALUES (1, 'stored-model')
+             ON CONFLICT(id) DO UPDATE SET default_model = 'stored-model'",
+            [],
+        )
+        .expect("store a model");
+        assert_eq!(no_agent_model_for(file.path(), "")(), "stored-model");
+    }
+
+    /// An unreadable database is `""`, which `build_options` reads as "no model
+    /// option" rather than as a failure — the turn still runs.
+    #[test]
+    fn an_unreadable_database_yields_no_model_rather_than_an_error() {
+        let nowhere = std::path::Path::new("/nonexistent/agento/definitely-not-a-db");
+        assert_eq!(no_agent_model_for(nowhere, "")(), "");
+    }
 
     #[test]
     fn an_ask_user_question_tool_use_is_found() {

--- a/desktop/src-tauri/src/native/chat/turn.rs
+++ b/desktop/src-tauri/src/native/chat/turn.rs
@@ -635,11 +635,22 @@ mod tests {
         crate::native::migrate::apply(&mut conn).expect("migrate");
         drop(conn);
 
+        // Guarded on the variables rather than asserted flat, the way
+        // `settings.rs`'s own default test is: these run on a developer's
+        // machine, and `resolve` applies `AGENTO_DEFAULT_MODEL` /
+        // `ANTHROPIC_DEFAULT_SONNET_MODEL` — which is the very behaviour this
+        // function gained, so asserting flat would fail for exactly the users
+        // it was fixed for.
+        let from_env = crate::native::settings::env_value("AGENTO_DEFAULT_MODEL")
+            .or_else(|| crate::native::settings::env_value("ANTHROPIC_DEFAULT_SONNET_MODEL"));
+
         // Nothing stored: the raw column is empty and `resolve` fills Go's
         // default, so reading the row directly would have answered `""`.
         assert_eq!(
             no_agent_model_for(file.path(), "")(),
-            crate::native::settings::DEFAULT_MODEL
+            from_env
+                .clone()
+                .unwrap_or_else(|| crate::native::settings::DEFAULT_MODEL.to_string())
         );
 
         let conn = rusqlite::Connection::open(file.path()).expect("open");
@@ -649,7 +660,13 @@ mod tests {
             [],
         )
         .expect("store a model");
-        assert_eq!(no_agent_model_for(file.path(), "")(), "stored-model");
+        // A stored model survives the *soft* default but not a hard
+        // `AGENTO_DEFAULT_MODEL`, which is `modelInFile`'s whole point.
+        let hard_override = crate::native::settings::env_value("AGENTO_DEFAULT_MODEL");
+        assert_eq!(
+            no_agent_model_for(file.path(), "")(),
+            hard_override.unwrap_or_else(|| "stored-model".to_string())
+        );
     }
 
     /// An unreadable database is `""`, which `build_options` reads as "no model

--- a/desktop/src-tauri/src/native/settings.rs
+++ b/desktop/src-tauri/src/native/settings.rs
@@ -328,7 +328,11 @@ pub struct SettingsResponse {
 }
 
 /// `config.defaultModel`.
-const DEFAULT_MODEL: &str = "sonnet";
+/// Go's `defaultModel` (`internal/config/settings.go`), which
+/// `SettingsManager.load` fills in when nothing is stored — before
+/// `applyEnvOverrides` runs. Public so a caller that resolves the model through
+/// [`resolve`] can assert against the same constant rather than a literal.
+pub const DEFAULT_MODEL: &str = "sonnet";
 
 /// Resolve the row into the answer `SettingsManager` gives, in its order:
 /// load the store, fill the two defaults, then apply the environment.

--- a/desktop/src-tauri/src/native/settings.rs
+++ b/desktop/src-tauri/src/native/settings.rs
@@ -332,7 +332,7 @@ pub struct SettingsResponse {
 /// `SettingsManager.load` fills in when nothing is stored — before
 /// `applyEnvOverrides` runs. Public so a caller that resolves the model through
 /// [`resolve`] can assert against the same constant rather than a literal.
-pub const DEFAULT_MODEL: &str = "sonnet";
+pub(crate) const DEFAULT_MODEL: &str = "sonnet";
 
 /// Resolve the row into the answer `SettingsManager` gives, in its order:
 /// load the store, fill the two defaults, then apply the environment.
@@ -419,7 +419,7 @@ fn locked_fields() -> BTreeMap<String, String> {
 
 /// An environment variable, or `None` when unset **or empty** — Go's checks are
 /// all `os.Getenv(x) != ""`, so an exported-but-blank variable locks nothing.
-fn env_value(name: &str) -> Option<String> {
+pub(crate) fn env_value(name: &str) -> Option<String> {
     match std::env::var(name) {
         Ok(v) if !v.is_empty() => Some(v),
         _ => None,


### PR DESCRIPTION
Closes #299

Both items from the issue, plus a parity divergence the first one turned up.

## 1 — The fallback model is resolved lazily

`turn::run` called `default_model(&db_path)` on every turn where `chat_sessions.model` is empty, opening a second read-only SQLite connection and loading the settings row — including for agent chats, where the value was then discarded. `RunSpec.no_agent_model` is a `Box<dyn Fn() -> String + Send + Sync>` now (renamed: `Options::fallback_model` already means the CLI's `--fallback-model` in the same function), called at most once and only in the branch that can use it.

### …and it is not purely a cleanup

The issue calls both items non-behavioural. The first one is not, and doing it properly is what surfaced why.

Go's `resolveAgentConfig` (`internal/service/chat_service.go:279`) branches on whether the chat **names an agent**, not on whether that agent has a model — it returns the agent's config outright — and `internal/agent/runner.go:250` then sets a model only when `agentCfg.Model != ""`. Verified the whole chain: `resolveAgentConfig` → `agent.StartSession` → that `if`.

| chat | Go | Rust before | Rust now |
|---|---|---|---|
| agent with a model | the agent's | the agent's | the agent's |
| **agent with an empty model** | **no model option at all** | session model, else the user's default | **no model option at all** |
| no agent, session model set | the session's | the session's | the session's |
| no agent, no session model | the user's default | the user's default | the user's default |

So the port treated an agent's empty model as a request for a default Go would never have given it — a different model from the one Go picks, silently. `build_options` matches on the **agent** rather than on its model now, which is the laziness and the fix in one line.

## 2 — `error_json` is one copy

It and its nested `ErrorBody` were duplicated verbatim in `native/chat/turn.rs` and `native/chat/mod.rs`. `turn.rs` uses the one in `chat/mod.rs`; a private item in a parent module is already visible to its children, so no visibility changed.

## Acceptance

- Three tests in `runner.rs` **count the closure's calls** rather than only checking the resulting model — a test that asserted the model alone would pass with the work still being done on every turn. An agent chat resolves it **0** times, a no-agent chat exactly **1**.
- The empty-agent-model case asserts `opts.model == DEFAULT_MODEL`, i.e. `with_model` was never called. The test models are deliberately distinct from `DEFAULT_MODEL`, because `Options::default()` already carries it and the existing `agent_with` helper's model is *exactly* that string — so a test reusing it could not tell "we set the model" from "we never called `with_model`".
- Local gates green: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo build --release`, `npm run build`, `go test ./desktop/...`, golangci-lint at the CI-pinned v2.5.0.


## 3 — The user's default is *resolved*, not read raw

Found in review, and it is the last row of the table above. `default_model` read `load_stored` — the raw `SELECT` — where Go reads `settingsMgr.Get()`. `SettingsManager.load` fills `"sonnet"` when nothing is stored, *before* `applyEnvOverrides` applies `AGENTO_DEFAULT_MODEL` / `ANTHROPIC_DEFAULT_SONNET_MODEL`. Consequences for a chat with no agent and no session model:

| | Go | Rust before |
|---|---|---|
| nothing ever saved | `sonnet` | `claude-sonnet-4-6` (the SDK default, a different string) |
| `AGENTO_DEFAULT_MODEL` exported | honoured | **ignored** |

`settings::resolve` is the documented mirror of `Get()` and every other caller in the port already goes through it. Pre-existing — the eager version called the same function — but this PR is the audit of exactly this resolution.

## What this PR does *not* remove

`build_options` still calls `resolve_agent_config_dir` unconditionally, which falls through to `stored_config_dir()` and opens its own read-only connection to load the same `user_settings` row unless the agent carries an absolute override. So the per-turn settings read is **narrowed, not eliminated** — what went away is the redundant second one. Filed as **#340**, which also notes that two consumers of one row with different fields is the shape that drifts: it is how one of them ended up on `load_stored` and the other on `resolve`.

## Review

**APPROVE with one follow-up.** The reviewer traced the Go chain independently at every link and confirmed the parity claim, then found the `load_stored` divergence above (fixed here), that the closure-selection branch had no coverage (now extracted as `no_agent_model_for` and tested on all three arms), the `fallback_model` name collision (renamed), and that "no model option at all" needed a clause saying the SDK default is what reaches the CLI (added).

Worth recording: an empty agent model is not reachable through any supported write path — create, update, the YAML import and the column default all fill `claude-sonnet-4-6` — so the parity fix is cheap insurance rather than a live bug. The `load_stored` one is reachable today by anyone who has not saved settings.