### PR TITLE
test(desktop): cover the permission round trip, and compact embedded RawValues (#298)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -1015,9 +1015,20 @@ for that chat** and forward otherwise. Go then answers — correctly, because it
 is the side that has the session.
 
 Five rules that are silent when broken, all pinned by `tests/chat_turn.rs` —
-**except** the deny-with-the-user's-text half of `AskUserQuestion`, which is
-reached only through a `can_use_tool` control request the fake CLI does not yet
-issue. That gap is #298; do not read the list below as fully covered.
+including, since #298, the deny-with-the-user's-text half of `AskUserQuestion`.
+That one was the gap the claim used to paper over: the suite drove
+`AskUserQuestion` as an assistant `tool_use` block, which reaches
+`extract_ask_user_question` and the post-result continuation and **not the
+permission handler at all**. The fake CLI issues a real `can_use_tool` control
+request now, and the assertion is on what the SDK wrote *back* — the whole
+observable effect of that round trip is a `control_response`, so the fake CLI
+logs every stdin line and the tests read it. Reverting the deny to an allow
+leaves every frame unchanged and fails only there.
+
+Covered with it: `wrap_permission_handler`'s allowlist (a tool the agent does not
+name is denied **without a prompt** — the absence is the assertion), the
+`AskUserQuestion` bypass of that allowlist, and the `permission_request` frame
+with its allow and deny answers.
 
 - **`result` is not terminal.** With an `AskUserQuestion` pending the same
   subprocess carries on, so one HTTP request spans several turns and several
@@ -1058,6 +1069,24 @@ never saved settings ran on the SDK default rather than `sonnet` — two differe
 strings — and one who exported `AGENTO_DEFAULT_MODEL` had it silently ignored.
 `resolve` is the documented mirror of `Get()`, and every other caller in the port
 already goes through it.
+
+**An embedded raw value is compacted and HTML-escaped on the way out, and Go
+does it on the way *in*** (#298). `encoding/json` runs
+`compact(…, escapeHTML=true)` over a `Marshaler`'s output, so a nested
+`json.RawMessage` is whitespace-stripped and has `<`, `>`, `&` and U+2028/9
+escaped — while keeping its key order and number spelling. `serde_json` writes a
+`RawValue`'s bytes as-is through `write_raw_fragment`, which `GoFormatter` never
+sees. Two places that mattered:
+
+- the **synthetic SSE frames**: Go ships `{"question":"a \u0026 b"}` where Rust
+  shipped `{"question":"a & b"}`. `gojson::serialize_compacted` is attached to the
+  field rather than applied at each construction site, so a future one cannot
+  forget it;
+- the **stored `blocks` column**: Go compacts **on store**, not on emit — this
+  file and `persist.rs` both used to say the opposite — so writing the SDK's bytes
+  verbatim left the two implementations' databases different for the same input.
+  It was masked on read, because `chats::decode_blocks` compacts what it loads,
+  which is exactly why nothing noticed.
 
 **The `tool_use` input must never round-trip through a `serde_json::Value`.**
 The first version of `append_assistant_blocks` did, and turned `{"z":1.50,"a":1}`

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -809,7 +809,7 @@ docs carry a full worked example.
   order and number spelling**. A tool_use `input` of `{"z":1.50,"a":1}` ships
   exactly that; decoding it into a `serde_json::Value` and re-encoding would
   ship `{"a":1,"z":1.5}` — reordered and respelled, with nothing to signal it.
-  `native/chats.rs::compact` is the byte pass that avoids it.
+  `native/gojson.rs::compact` is the byte pass that avoids it.
 - **The project filter differs between endpoints.** `/claude-analytics` matches
   `decoded_path`; `/claude-sessions` matches `project_path` literally, which is
   the dash-encoded name for some sessions and a real path for others. Sending
@@ -1079,14 +1079,21 @@ escaped — while keeping its key order and number spelling. `serde_json` writes
 sees. Two places that mattered:
 
 - the **synthetic SSE frames**: Go ships `{"question":"a \u0026 b"}` where Rust
-  shipped `{"question":"a & b"}`. `gojson::serialize_compacted` is attached to the
-  field rather than applied at each construction site, so a future one cannot
-  forget it;
+  shipped `{"question":"a & b"}`;
 - the **stored `blocks` column**: Go compacts **on store**, not on emit — this
   file and `persist.rs` both used to say the opposite — so writing the SDK's bytes
   verbatim left the two implementations' databases different for the same input.
   It was masked on read, because `chats::decode_blocks` compacts what it loads,
   which is exactly why nothing noticed.
+
+**The rule lives on the field, not at the construction site**, at all four of
+them: the two SSE structs in `chat/turn.rs`, plus `chats::MessageBlock::input`
+and `sessions::detail::NormalizedBlock::input`. `MessageBlock` is why — it has
+*two* sinks, the column via `persist::append_message` and the wire via
+`GET /api/chats/{id}`, and it had two independent compaction points, one of which
+was simply missing. A third construction path would have been silently wrong the
+same way. The call-site `compact_raw`s are left as belt-and-braces; compaction is
+idempotent, so nothing moved when the field-level rule went in.
 
 **The `tool_use` input must never round-trip through a `serde_json::Value`.**
 The first version of `append_assistant_blocks` did, and turned `{"z":1.50,"a":1}`
@@ -1356,7 +1363,7 @@ Three things here are silent when wrong:
   **key order and number spelling preserved**. On disk everything goes through
   `json.MarshalIndent` over Go's `any`: keys *sorted*, every number a float64,
   two-space indent, `": "` after each key, no trailing newline
-  (`gojson::indent`, which is `Indent` — `MarshalIndent` is literally `Marshal`
+  (`gojson::indent_compact`, which is `Indent` — `MarshalIndent` is literally `Marshal`
   then `Indent`, so it decomposes rather than needing a second `Formatter`). And
   a profile created by `POST .../profiles` is neither: it is a **verbatim** byte
   copy of the current default's file.

--- a/desktop/src-tauri/src/claude/process.rs
+++ b/desktop/src-tauri/src/claude/process.rs
@@ -570,6 +570,13 @@ struct InboundControlRequest {
     // can_use_tool
     #[serde(default)]
     tool_name: String,
+    /// One bounded, known divergence: Go's SDK holds this as a `json.RawMessage`,
+    /// so an inbound `"input": null` captures the four bytes `null` and its
+    /// `omitempty` emits `"input":null` onward. A plain `Option` collapses that
+    /// to `None`, so the key is dropped instead. Recorded rather than fixed
+    /// because the CLI always sends an object here, and because `src/claude/` is
+    /// the SDK port and does not depend on `native::gojson`'s `captured_raw` —
+    /// which is otherwise exactly the helper for it.
     #[serde(default)]
     input: Option<Box<RawValue>>,
 

--- a/desktop/src-tauri/src/claude/process.rs
+++ b/desktop/src-tauri/src/claude/process.rs
@@ -570,13 +570,20 @@ struct InboundControlRequest {
     // can_use_tool
     #[serde(default)]
     tool_name: String,
-    /// One bounded, known divergence: Go's SDK holds this as a `json.RawMessage`,
-    /// so an inbound `"input": null` captures the four bytes `null` and its
-    /// `omitempty` emits `"input":null` onward. A plain `Option` collapses that
-    /// to `None`, so the key is dropped instead. Recorded rather than fixed
-    /// because the CLI always sends an object here, and because `src/claude/` is
-    /// the SDK port and does not depend on `native::gojson`'s `captured_raw` —
-    /// which is otherwise exactly the helper for it.
+    /// One bounded, known divergence, and only for an **explicit** `null` — an
+    /// absent key is dropped by both.
+    ///
+    /// Go's SDK holds this as a `json.RawMessage` (no `omitempty` here), so an
+    /// inbound `"input": null` captures the four bytes and survives to Agento's
+    /// own `permReq.Input` in `internal/api/chats.go`, *whose* `omitempty` tests
+    /// byte length and therefore emits `"input":null` on the `permission_request`
+    /// frame. A plain `Option` collapses it to `None` one layer earlier, so the
+    /// key is dropped instead.
+    ///
+    /// Recorded rather than fixed because the CLI always sends an object here,
+    /// and because `src/claude/` is the SDK port and does not depend on
+    /// `native::gojson`'s `captured_raw` — which is otherwise exactly the helper
+    /// for it.
     #[serde(default)]
     input: Option<Box<RawValue>>,
 

--- a/desktop/src-tauri/src/native/chat/persist.rs
+++ b/desktop/src-tauri/src/native/chat/persist.rs
@@ -142,12 +142,24 @@ fn truncate_title(content: &str, max: usize) -> String {
 ///
 /// # The `input` must never round-trip through a `Value`
 ///
-/// A `tool_use` input of `{"z":1.50,"a":1}` is stored verbatim by Go and
-/// re-emitted through `compact`, which preserves key order and number spelling.
-/// Decoding it into a `serde_json::Value` and re-encoding sorts the keys and
-/// drops the trailing zero — `{"a":1,"z":1.5}` — with nothing to signal it.
-/// This is not hypothetical: the first version of this function did exactly
-/// that, and `tests/chat_turn.rs` caught it. `RawValue` is what keeps the bytes.
+/// A `tool_use` input of `{"z":1.50,"a":1}` is stored by Go through `compact`,
+/// which preserves key order and number spelling. Decoding it into a
+/// `serde_json::Value` and re-encoding sorts the keys and drops the trailing
+/// zero — `{"a":1,"z":1.5}` — with nothing to signal it. This is not
+/// hypothetical: the first version of this function did exactly that, and
+/// `tests/chat_turn.rs` caught it. `RawValue` is what keeps the bytes.
+///
+/// # …and it is compacted **on store**, not on emit (#298)
+///
+/// This comment used to say Go stored the bytes verbatim and compacted them on
+/// the way out. It is the other way round: `chatService` marshals a struct
+/// holding a `json.RawMessage`, and `encoding/json` runs
+/// `compact(…, escapeHTML=true)` over a nested raw value as it marshals — so
+/// what reaches the column is already whitespace-stripped and has `<`, `>` and
+/// `&` escaped. Writing the SDK's bytes as-is left the two implementations'
+/// databases different for the same input. It was masked on read, since
+/// `chats::decode_blocks` compacts what it loads, which is exactly why nothing
+/// noticed.
 pub fn append_assistant_blocks(blocks: &mut Vec<MessageBlock>, raw: &[u8]) {
     #[derive(serde::Deserialize)]
     struct Envelope<'a> {
@@ -216,13 +228,16 @@ pub fn append_assistant_blocks(blocks: &mut Vec<MessageBlock>, raw: &[u8]) {
                     id: block.id.unwrap_or_default(),
                     name: block.name.unwrap_or_default(),
                     // `to_owned` on the borrowed raw copies the bytes, not a
-                    // parsed representation of them.
+                    // parsed representation of them — then `compact_raw` puts
+                    // them in the form Go's marshal would have stored, which is
+                    // where the column's bytes are decided.
                     input: block
                         .input
                         .map(|raw| serde_json::value::RawValue::from_string(raw.get().to_string()))
                         .transpose()
                         .ok()
-                        .flatten(),
+                        .flatten()
+                        .map(crate::native::gojson::compact_raw),
                 });
             }
             _ => {}
@@ -400,6 +415,65 @@ mod tests {
         assert_eq!(blocks[0].block_type, "thinking");
         assert_eq!(blocks[1].text, "hello");
         assert_eq!(blocks[2].name, "Bash");
+    }
+
+    /// The stored bytes are what Go's marshal would have written, not the SDK's
+    /// own (#298): whitespace stripped and `<`, `>`, `&` escaped, with the key
+    /// order and number spelling intact.
+    ///
+    /// Both halves matter and they pull in opposite directions — `compact` is
+    /// the one pass that does the first without doing what a `Value` round trip
+    /// would do to the second.
+    #[test]
+    fn a_stored_tool_use_input_is_compacted_the_way_gos_marshal_stores_one() {
+        let mut blocks = Vec::new();
+        append_assistant_blocks(
+            &mut blocks,
+            br#"{"message":{"content":[
+                {"type":"tool_use","id":"t1","name":"Bash","input":{ "z" : 1.50 , "cmd" : "ls & cat <f>" }}
+            ]}}"#,
+        );
+
+        // Exactly what Go writes for the same input — measured, not assumed:
+        // marshalling a struct holding this `json.RawMessage` yields
+        // `{"z":1.50,"cmd":"ls \u0026 cat \u003cf\u003e"}`.
+        let input = blocks[0].input.as_ref().expect("an input").get();
+        assert_eq!(input, r#"{"z":1.50,"cmd":"ls \u0026 cat \u003cf\u003e"}"#);
+    }
+
+    /// …and that is what lands in the column, since `append_message` marshals
+    /// the blocks. Asserted end to end because the read path compacts too, so a
+    /// verbatim write is invisible through the API — which is exactly why this
+    /// went unnoticed.
+    #[test]
+    fn the_blocks_column_holds_gos_bytes() {
+        let file = migrated();
+        let mut blocks = Vec::new();
+        append_assistant_blocks(
+            &mut blocks,
+            br#"{"message":{"content":[
+                {"type":"tool_use","id":"t1","name":"Bash","input":{ "z" : 1.50 , "cmd" : "a & b" }}
+            ]}}"#,
+        );
+        let state = TurnState {
+            assistant_text: "done".into(),
+            blocks,
+            ..Default::default()
+        };
+        commit(file.path(), &row(), "q", &state, true).expect("commit");
+
+        let conn = Connection::open(file.path()).expect("open");
+        let stored: String = conn
+            .query_row(
+                "SELECT blocks FROM chat_messages WHERE role = 'assistant'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("row");
+        assert!(
+            stored.contains(r#""input":{"z":1.50,"cmd":"a \u0026 b"}"#),
+            "{stored}"
+        );
     }
 
     #[test]

--- a/desktop/src-tauri/src/native/chat/turn.rs
+++ b/desktop/src-tauri/src/native/chat/turn.rs
@@ -53,8 +53,15 @@ use super::sse;
 const NOTIFY_CAPACITY: usize = 4;
 
 /// The synthetic event announcing an `AskUserQuestion`.
+///
+/// Go builds this frame with `json.Marshal` over a struct holding a
+/// `json.RawMessage`, and `encoding/json` compacts and HTML-escapes a nested
+/// raw value on the way out. `serde_json` writes one verbatim, so the SDK's own
+/// spacing and an unescaped `&` would ship where Go ships neither (#298) — hence
+/// `serialize_compacted` on the field rather than at each construction site.
 #[derive(Serialize)]
 struct UserInputRequired<'a> {
+    #[serde(serialize_with = "crate::native::gojson::serialize_compacted")]
     input: &'a RawValue,
 }
 
@@ -63,8 +70,12 @@ struct UserInputRequired<'a> {
 struct PermissionRequest {
     tool_name: String,
     /// `omitempty` on Go's `json.RawMessage` tests byte length, so an absent
-    /// input drops the key entirely.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// input drops the key entirely — and a present one is compacted and
+    /// escaped, for the reason on [`UserInputRequired`].
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::native::gojson::serialize_compacted_option"
+    )]
     input: Option<Box<RawValue>>,
 }
 
@@ -712,6 +723,38 @@ mod tests {
     fn a_malformed_assistant_event_yields_nothing_rather_than_failing() {
         assert!(extract_ask_user_question(b"not json").is_none());
         assert!(extract_ask_user_question(b"{}").is_none());
+    }
+
+    /// An embedded raw value is **compacted and HTML-escaped** on the way into
+    /// a synthetic frame, because `encoding/json` does that to a nested
+    /// `json.RawMessage` as it marshals (#298).
+    ///
+    /// Every expected string here was produced by Go: marshalling a struct
+    /// holding `json.RawMessage(`{ "q" : "a & b <c>" }`)` yields
+    /// `{"question":{"q":"a \u0026 b \u003cc\u003e"}}` — spacing gone, the
+    /// three characters escaped, and the key order and number spelling intact.
+    #[test]
+    fn a_synthetic_frames_input_is_compacted_and_escaped_the_way_go_marshals_one() {
+        // Spacing stripped, `&` and `<`/`>` escaped, `1.50` and the key order
+        // untouched — the last two are what a `serde_json::Value` would break.
+        let raw = RawValue::from_string(r#"{ "z" : 1.50 , "a" : "x & y <z>" }"#.into()).unwrap();
+        let frame = sse::json_frame("user_input_required", &UserInputRequired { input: &raw })
+            .expect("encode");
+        assert_eq!(
+            String::from_utf8(frame).unwrap(),
+            "event: user_input_required\ndata: {\"input\":{\"z\":1.50,\"a\":\"x \\u0026 y \\u003cz\\u003e\"}}\n\n"
+        );
+
+        // The same on the permission frame, which carries its input optionally.
+        let req = PermissionRequest {
+            tool_name: "Bash".into(),
+            input: Some(RawValue::from_string(r#"{ "command" : "ls & pwd" }"#.into()).unwrap()),
+        };
+        let frame = sse::json_frame("permission_request", &req).expect("encode");
+        assert_eq!(
+            String::from_utf8(frame).unwrap(),
+            "event: permission_request\ndata: {\"tool_name\":\"Bash\",\"input\":{\"command\":\"ls \\u0026 pwd\"}}\n\n"
+        );
     }
 
     /// `input` is omitted when absent, matching Go's `omitempty` on a

--- a/desktop/src-tauri/src/native/chats.rs
+++ b/desktop/src-tauri/src/native/chats.rs
@@ -98,10 +98,19 @@ pub struct MessageBlock {
     /// distinguishes: `omitempty` on a `json.RawMessage` tests the byte length,
     /// and the four bytes of `null` are not empty. Plain `Option` would collapse
     /// them, so [`captured_raw`] takes the value however it arrives.
+    ///
+    /// **Emitted through Go's compact, stated on the field** (#298). This struct
+    /// has *two* sinks — the `blocks` column via `persist::append_message`, and
+    /// the wire via `GET /api/chats/{id}` — and it had two independent
+    /// compaction points, one of which was simply missing until #298. A third
+    /// construction path would have been silently wrong the same way, so the
+    /// rule lives in the type. The existing call-site `compact_raw`s are
+    /// belt-and-braces: compaction is idempotent.
     #[serde(
         default,
         deserialize_with = "captured_raw",
-        skip_serializing_if = "Option::is_none"
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "super::gojson::serialize_compacted_option"
     )]
     pub input: Option<Box<RawValue>>,
 }
@@ -257,25 +266,9 @@ fn decode_blocks(stored: &str) -> Vec<MessageBlock> {
     blocks
 }
 
-/// Re-encode a captured raw JSON value the way Go's `compact` does.
-///
-/// Marshaling a `json.RawMessage` runs `encoding/json`'s `compact` with HTML
-/// escaping on, which:
-///
-/// - drops whitespace *outside* strings,
-/// - escapes `<`, `>`, `&` and U+2028/U+2029 wherever they appear,
-/// - and **changes nothing else** — object keys keep the order they were stored
-///   in and numbers keep the digits they were stored with.
-///
-/// Those last two are why this is a byte pass rather than a decode/re-encode:
-/// a stored `{"z":1.50,"a":[1,2]}` stays `{"z":1.50,"a":[1,2]}` on the wire,
-/// while a `serde_json::Value` round trip would emit `{"a":[1,2],"z":1.5}` —
-/// reordered and respelled, with nothing to signal it.
-///
-/// In practice the column is already compact and escaped, because Go wrote it
-/// The chat message blocks are carried verbatim; the compaction and raw-capture
-/// helpers live in [`super::gojson`] because the session-detail port needs the
-/// same pair for `tool_use` inputs.
+// The compaction and raw-capture helpers live in `super::gojson` — see
+// `compact_raw` there for what Go's `compact` does and why it is a byte pass —
+// because the session-detail port needs the same pair for `tool_use` inputs.
 use super::gojson::{captured_raw, compact_raw as compact_raw_json};
 
 // ─── The seam ─────────────────────────────────────────────────────────────────

--- a/desktop/src-tauri/src/native/gojson.rs
+++ b/desktop/src-tauri/src/native/gojson.rs
@@ -354,6 +354,45 @@ pub fn compact_raw(raw: Box<RawValue>) -> Box<RawValue> {
     RawValue::from_string(compacted).unwrap_or(raw)
 }
 
+/// Serialize an **embedded** raw value the way `encoding/json` emits one.
+///
+/// `encoding/json` runs `compact(…, escapeHTML=true)` over a `Marshaler`'s
+/// output, so a `json.RawMessage` nested inside a marshalled value is
+/// whitespace-stripped **and** has `<`, `>`, `&` and U+2028/9 escaped — while
+/// keeping its key order and number spelling. `serde_json` writes a `RawValue`'s
+/// bytes as-is through `write_raw_fragment`, which [`GoFormatter`] never sees,
+/// so an unescaped `&` ships where Go ships `\u0026`.
+///
+/// Attached to the field rather than applied at each construction site, so a
+/// future one cannot forget it: the type says how it is emitted.
+pub fn serialize_compacted<S>(raw: &RawValue, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    use serde::ser::Error;
+    let compacted =
+        RawValue::from_string(compact(raw.get())).map_err(|e| S::Error::custom(e.to_string()))?;
+    compacted.serialize(serializer)
+}
+
+/// [`serialize_compacted`] for an optional field.
+///
+/// Only ever reached with `Some`, since every user pairs it with
+/// `skip_serializing_if = "Option::is_none"` — but `None` is written as `null`
+/// rather than unwrapped, so the two attributes stay independent.
+pub fn serialize_compacted_option<S>(
+    raw: &Option<Box<RawValue>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    match raw {
+        Some(raw) => serialize_compacted(raw, serializer),
+        None => serializer.serialize_none(),
+    }
+}
+
 pub fn compact(src: &str) -> String {
     let bytes = src.as_bytes();
     let mut out: Vec<u8> = Vec::with_capacity(bytes.len());

--- a/desktop/src-tauri/src/native/gojson.rs
+++ b/desktop/src-tauri/src/native/gojson.rs
@@ -343,7 +343,26 @@ where
     Box::<RawValue>::deserialize(deserializer).map(Some)
 }
 
-/// with `json.Marshal`; this makes a hand-edited or older row match too.
+/// Re-encode a captured raw JSON value the way Go's `compact` does.
+///
+/// Marshalling a `json.RawMessage` runs `encoding/json`'s `compact` with HTML
+/// escaping on, which:
+///
+/// - drops whitespace *outside* strings,
+/// - escapes `<`, `>`, `&` and U+2028/U+2029 wherever they appear,
+/// - and **changes nothing else** — object keys keep the order they were stored
+///   in and numbers keep the digits they were stored with.
+///
+/// Those last two are why this is a byte pass rather than a decode/re-encode: a
+/// stored `{"z":1.50,"a":[1,2]}` stays `{"z":1.50,"a":[1,2]}`, while a
+/// `serde_json::Value` round trip would give `{"a":[1,2],"z":1.5}` — reordered
+/// and respelled, with nothing to signal it.
+///
+/// **Both implementations write compacted bytes** — Go because `chatService`
+/// marshals through a `json.RawMessage`, and this port since #298, which is what
+/// that issue fixed. Applying it on read as well is what makes a hand-edited or
+/// pre-#298 row match too; compaction is idempotent, so the two are not in
+/// tension.
 pub fn compact_raw(raw: Box<RawValue>) -> Box<RawValue> {
     let compacted = compact(raw.get());
     if compacted == raw.get() {

--- a/desktop/src-tauri/src/native/gojson.rs
+++ b/desktop/src-tauri/src/native/gojson.rs
@@ -389,8 +389,17 @@ where
     S: serde::Serializer,
 {
     use serde::ser::Error;
+    let compacted = compact(raw.get());
+    // The no-op case is now the *only* case in practice — every construction
+    // site already compacts — so short-circuiting is what keeps this from
+    // costing an allocation and a full re-parse per `tool_use` input on every
+    // serialize, including a long transcript's worth on
+    // `GET /api/claude-sessions/{id}`. `compact_raw` has the same guard.
+    if compacted == raw.get() {
+        return raw.serialize(serializer);
+    }
     let compacted =
-        RawValue::from_string(compact(raw.get())).map_err(|e| S::Error::custom(e.to_string()))?;
+        RawValue::from_string(compacted).map_err(|e| S::Error::custom(e.to_string()))?;
     compacted.serialize(serializer)
 }
 

--- a/desktop/src-tauri/src/native/sessions/detail.rs
+++ b/desktop/src-tauri/src/native/sessions/detail.rs
@@ -98,8 +98,13 @@ pub struct NormalizedBlock {
     #[serde(skip_serializing_if = "String::is_empty")]
     pub name: String,
     /// Carried verbatim through `compact`, so a stored `{"z":1.50,"a":1}` ships
-    /// exactly that rather than a re-sorted, re-spelled copy.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// exactly that rather than a re-sorted, re-spelled copy — stated on the
+    /// field rather than at each construction site (#298), for the reason
+    /// `chats::MessageBlock::input` gives.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::native::gojson::serialize_compacted_option"
+    )]
     pub input: Option<Box<RawValue>>,
 }
 

--- a/desktop/src-tauri/tests/chat_turn.rs
+++ b/desktop/src-tauri/tests/chat_turn.rs
@@ -56,6 +56,31 @@ fn migrated_with_chat(id: &str) -> tempfile::NamedTempFile {
     file
 }
 
+/// The same, plus an agent whose capabilities name **one** built-in tool.
+///
+/// That is what makes `wrap_permission_handler` wrap the handler at all: an
+/// empty allowlist returns the inner one unwrapped, so a test that skipped the
+/// agent would exercise the bypass rather than the allowlist. `built_in` only —
+/// `runner::build_options` refuses an agent whose tools come from a local or MCP
+/// server, and would forward the whole turn to Go.
+fn migrated_with_allowlisted_agent(id: &str) -> tempfile::NamedTempFile {
+    let file = tempfile::NamedTempFile::new().expect("temp file");
+    let mut conn = rusqlite::Connection::open(file.path()).expect("open");
+    agento_lib::native::migrate::apply(&mut conn).expect("migrate");
+    conn.execute(
+        "INSERT INTO agents (slug, name, capabilities) VALUES ('gated', 'Gated', ?1)",
+        [r#"{"built_in":["Read"]}"#],
+    )
+    .expect("seed agent");
+    conn.execute(
+        "INSERT INTO chat_sessions (id, title, agent_slug, created_at, updated_at)
+         VALUES (?1, 'New Chat', 'gated', '2026-01-01 00:00:00 +0000 UTC', '2026-01-01 00:00:00 +0000 UTC')",
+        [id],
+    )
+    .expect("seed chat");
+    file
+}
+
 fn chat_row(id: &str) -> agento_lib::native::chat::runner::ChatRow {
     agento_lib::native::chat::runner::ChatRow {
         id: id.to_string(),
@@ -175,10 +200,24 @@ fn tool_use_input_survives_the_round_trip_byte_for_byte() {
 // ─── The sequence rules, against a real subprocess ────────────────────────────
 
 /// Writes an executable fake `claude` that replies with a scripted sequence.
+///
+/// Every stdin line is appended to `<dir>/stdin.jsonl`, which is what lets a
+/// test assert on what the SDK **wrote back** rather than only on the frames it
+/// emitted. The permission round trip is invisible without it: its whole
+/// observable effect on the CLI side is a `control_response`.
 fn fake_cli(dir: &Path, emit: &str) -> PathBuf {
     let script = format!(
         r#"#!/usr/bin/env {python}
 import json, sys, threading, time
+
+LOG = {log}
+_log = open(LOG, "a")
+_lock = threading.Lock()
+
+def record(entry):
+    with _lock:
+        _log.write(json.dumps(entry) + "\n")
+        _log.flush()
 
 def say(obj):
     sys.stdout.write(json.dumps(obj) + "\n")
@@ -206,10 +245,12 @@ for line in sys.stdin:
         msg = json.loads(line)
     except Exception:
         continue
+    record(msg)
     req = msg.get("request") or {{}}
 {emit}
 "#,
         python = python3().unwrap_or_else(|| "python3".into()),
+        log = serde_json::to_string(&stdin_log(dir).to_string_lossy()).unwrap(),
         emit = emit,
     );
     let path = dir.join("fake-claude");
@@ -221,6 +262,44 @@ for line in sys.stdin:
             .expect("chmod fake CLI");
     }
     path
+}
+
+/// Where [`fake_cli`] records the lines it was sent.
+fn stdin_log(dir: &Path) -> PathBuf {
+    dir.join("stdin.jsonl")
+}
+
+/// Everything the SDK wrote to the CLI, decoded, in order.
+fn written(dir: &Path) -> Vec<serde_json::Value> {
+    let Ok(raw) = std::fs::read_to_string(stdin_log(dir)) else {
+        return Vec::new();
+    };
+    raw.lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| serde_json::from_str(l).ok())
+        .collect()
+}
+
+/// The payload of the `control_response` answering `request_id`, polled until it
+/// appears — the SDK writes it from the reader task, after the frame the test
+/// was waiting on.
+async fn control_response_for(dir: &Path, request_id: &str) -> serde_json::Value {
+    for _ in 0..200 {
+        for line in written(dir) {
+            if line.get("type").and_then(|t| t.as_str()) != Some("control_response") {
+                continue;
+            }
+            let response = &line["response"];
+            if response.get("request_id").and_then(|r| r.as_str()) == Some(request_id) {
+                return response["response"].clone();
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    panic!(
+        "no control_response for {request_id:?}; wrote: {:?}",
+        written(dir)
+    );
 }
 
 /// Collect an SSE body into frames, splitting on the blank line.
@@ -301,18 +380,20 @@ async fn an_ask_user_question_keeps_the_stream_open_past_the_first_result() {
         if "second" not in text:
             raw('{"type":"assistant","message":{"content":[{"type":"tool_use","id":"q1","name":"AskUserQuestion","input":{"z":1.50,"question":"which one?"}}]}}')
             say({"type": "result", "subtype": "success", "is_error": False,
-                 "result": "", "session_id": "sdk-1", "usage": {}})
+                 "result": "", "session_id": "sdk-1",
+                 "usage": {"input_tokens": 3, "output_tokens": 4}})
         else:
             say({"type": "assistant", "message": {"content": [
                 {"type": "text", "text": "thanks"}
             ]}})
             say({"type": "result", "subtype": "success", "is_error": False,
-                 "result": "final answer", "session_id": "sdk-1", "usage": {}})
+                 "result": "final answer", "session_id": "sdk-1",
+                 "usage": {"input_tokens": 5, "output_tokens": 6}})
 "#,
     );
 
     let id = unique_id("askuser");
-    let (body, answered) = run_turn_answering(&cli, &id, "hello", "second").await;
+    let (body, answered, db) = run_turn_answering_keeping_db(&cli, &id, "hello", "second").await;
     assert!(answered, "the answer was never delivered");
     let frames = frames(&body);
     let names: Vec<&str> = frames.iter().map(|(e, _)| e.as_str()).collect();
@@ -338,6 +419,53 @@ async fn an_ask_user_question_keeps_the_stream_open_past_the_first_result() {
     assert_eq!(
         frames[2].1, r#"{"input":{"z":1.50,"question":"which one?"}}"#,
         "the prompt must carry the tool input verbatim"
+    );
+
+    // The multi-turn persistence claim, which the frame names alone could not
+    // reach (#298): blocks and token totals **accumulate** across the turns of
+    // one request, while `assistant_text` is reset — so the stored reply is the
+    // *second* turn's text, not both concatenated, and the row carries both
+    // turns' tokens.
+    let conn = rusqlite::Connection::open(db.path()).expect("open");
+    let stored: Vec<(String, String)> = conn
+        .prepare("SELECT role, content FROM chat_messages WHERE session_id = ?1 ORDER BY id")
+        .expect("prepare")
+        .query_map([&id], |r| Ok((r.get(0)?, r.get(1)?)))
+        .expect("query")
+        .map(|r| r.expect("row"))
+        .collect();
+    assert_eq!(
+        stored,
+        vec![
+            ("user".to_string(), "hello".to_string()),
+            ("assistant".to_string(), "final answer".to_string()),
+        ],
+        "one user message and the *last* turn's text, not both turns concatenated"
+    );
+
+    // Both `tool_use` blocks survive, in order — that is the accumulation half.
+    let blocks: String = conn
+        .query_row(
+            "SELECT blocks FROM chat_messages WHERE role = 'assistant'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("blocks");
+    assert!(blocks.contains(r#""name":"AskUserQuestion""#), "{blocks}");
+
+    let (input, output): (i64, i64) = conn
+        .query_row(
+            "SELECT total_input_tokens, total_output_tokens FROM chat_sessions WHERE id = ?1",
+            [&id],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .expect("totals");
+    // 3+5 and 4+6: **both** turns' usage, which is the accumulation. Resetting
+    // per turn the way `assistant_text` is reset would store 5 and 6.
+    assert_eq!(
+        (input, output),
+        (8, 10),
+        "token totals accumulate across the turns of one request"
     );
 }
 
@@ -580,18 +708,281 @@ async fn assert_released(id: &str, which: &str) {
 
 /// Drive one turn against the fake CLI and collect the whole SSE body.
 async fn run_turn(cli: &Path, chat_id: &str, content: &str) -> String {
-    let (body, _) = run_turn_inner(cli, chat_id, content, None).await;
+    let (body, _, _db) = run_turn_inner(cli, chat_id, content, None).await;
     body
 }
 
-/// The same, answering the first `user_input_required` with `answer`.
-async fn run_turn_answering(
+/// The same, answering the first `user_input_required` with `answer` — and
+/// keeping the database, so the caller can assert on what the turn **stored**
+/// rather than only on the frames it emitted.
+async fn run_turn_answering_keeping_db(
     cli: &Path,
     chat_id: &str,
     content: &str,
     answer: &str,
-) -> (String, bool) {
+) -> (String, bool, tempfile::NamedTempFile) {
     run_turn_inner(cli, chat_id, content, Some(answer.to_string())).await
+}
+
+// ─── The permission round trip (#298) ─────────────────────────────────────────
+//
+// Until now `tests/chat_turn.rs` drove `AskUserQuestion` as an assistant
+// `tool_use` block, which exercises `extract_ask_user_question` and the
+// post-result continuation — and *not* the permission handler. Everything below
+// goes through a real `can_use_tool` control request, which is the only way to
+// reach `build_permission_handler`, `wrap_permission_handler`, and the deny
+// that carries the user's answer back to the model.
+
+/// Drive a turn whose fake CLI issues a `can_use_tool`, answering the prompt
+/// through the live registry the way `/input` and `/permission` do.
+///
+/// Returns the body and the fake CLI's directory, so the caller can assert on
+/// both the frames and what was written back.
+async fn run_permission_turn(
+    dir: &Path,
+    cli: &Path,
+    file: &tempfile::NamedTempFile,
+    chat_id: &str,
+    answer: Answer,
+) -> String {
+    use http_body_util::BodyExt;
+
+    let _env = env_lock().lock().await;
+    std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", cli);
+
+    let response = agento_lib::native::chat::turn::run(
+        file.path().to_path_buf(),
+        chat_id.to_string(),
+        "hello".to_string(),
+    )
+    .await
+    .expect("the turn should stream");
+
+    let id = chat_id.to_string();
+    let deliver = tokio::spawn(async move {
+        for _ in 0..200 {
+            if let Some((_, input_tx, perm_tx)) =
+                agento_lib::native::chat::live::registry().get(&id)
+            {
+                let sent = match &answer {
+                    Answer::Text(text) => input_tx.send(text.clone()).await.is_ok(),
+                    Answer::Permission(allow) => perm_tx.send(*allow).await.is_ok(),
+                    Answer::None => return,
+                };
+                if sent {
+                    return;
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+    });
+
+    let collected = tokio::time::timeout(
+        std::time::Duration::from_secs(20),
+        response.into_body().collect(),
+    )
+    .await
+    .expect("the turn should end")
+    .expect("body");
+    deliver.abort();
+    let _ = dir;
+    String::from_utf8(collected.to_bytes().to_vec()).expect("utf8")
+}
+
+enum Answer {
+    /// `POST /input` — the `AskUserQuestion` reply.
+    Text(String),
+    /// `POST /permission` — the allow/deny for an ordinary tool.
+    Permission(bool),
+    /// Nothing is answered, because nothing should be asked.
+    None,
+}
+
+/// The headline rule `desktop/CLAUDE.md` listed as "pinned by
+/// `tests/chat_turn.rs`" and which nothing actually reached: **`AskUserQuestion`
+/// is answered by *denying* the tool with the user's text as the message.** That
+/// is how the answer gets to the model without the tool ever running.
+///
+/// Reverting `PermissionResult::deny(answer)` to an `allow` — the obvious
+/// "fix" — leaves every frame in this test unchanged and fails only on the
+/// written-back behaviour.
+#[tokio::test]
+async fn an_ask_user_question_is_answered_by_denying_the_tool_with_the_users_text() {
+    let Some(_) = python3() else {
+        eprintln!("skipping: no python3");
+        return;
+    };
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cli = fake_cli(
+        dir.path(),
+        r#"
+    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack(req.get("request_id") or msg.get("request_id"))
+    elif msg.get("type") == "user":
+        say({"type": "control_request", "request_id": "perm-1",
+             "request": {"subtype": "can_use_tool", "tool_name": "AskUserQuestion",
+                         "input": {"question": "which one?"}}})
+    elif msg.get("type") == "control_response":
+        say({"type": "result", "subtype": "success", "is_error": False,
+             "result": "done", "session_id": "sdk-1", "usage": {}})
+"#,
+    );
+
+    let id = unique_id("perm-ask");
+    let file = migrated_with_chat(&id);
+    let body = run_permission_turn(
+        dir.path(),
+        &cli,
+        &file,
+        &id,
+        Answer::Text("the second one".into()),
+    )
+    .await;
+
+    // The prompt reaches the client as the synthetic event, carrying the tool's
+    // own input.
+    let frames = frames(&body);
+    let names: Vec<&str> = frames.iter().map(|(e, _)| e.as_str()).collect();
+    assert!(
+        names.contains(&"user_input_required"),
+        "no prompt frame; body was: {body}"
+    );
+
+    // …and the answer goes back as a **denial**, not an allow.
+    let answered = control_response_for(dir.path(), "perm-1").await;
+    assert_eq!(answered["behavior"], "deny", "answered: {answered}");
+    assert_eq!(answered["message"], "the second one");
+}
+
+/// An ordinary tool is a genuine allow/deny prompt, answered through
+/// `/permission`. The frame is `permission_request` and it carries the tool's
+/// name.
+#[tokio::test]
+async fn an_ordinary_tool_prompts_for_permission_and_the_answer_is_written_back() {
+    let Some(_) = python3() else {
+        eprintln!("skipping: no python3");
+        return;
+    };
+
+    for (allow, want_behavior) in [(true, "allow"), (false, "deny")] {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cli = fake_cli(
+            dir.path(),
+            r#"
+    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack(req.get("request_id") or msg.get("request_id"))
+    elif msg.get("type") == "user":
+        say({"type": "control_request", "request_id": "perm-1",
+             "request": {"subtype": "can_use_tool", "tool_name": "Bash",
+                         "input": {"command": "ls"}}})
+    elif msg.get("type") == "control_response":
+        say({"type": "result", "subtype": "success", "is_error": False,
+             "result": "done", "session_id": "sdk-1", "usage": {}})
+"#,
+        );
+
+        let id = unique_id("perm-tool");
+        let file = migrated_with_chat(&id);
+        let body =
+            run_permission_turn(dir.path(), &cli, &file, &id, Answer::Permission(allow)).await;
+
+        let frames = frames(&body);
+        let prompt = frames
+            .iter()
+            .find(|(event, _)| event == "permission_request")
+            .unwrap_or_else(|| panic!("no permission_request frame; body was: {body}"));
+        assert_eq!(prompt.1, r#"{"tool_name":"Bash","input":{"command":"ls"}}"#);
+
+        let answered = control_response_for(dir.path(), "perm-1").await;
+        assert_eq!(answered["behavior"], want_behavior, "answered: {answered}");
+        if !allow {
+            // Go's own wording, which the frontend shows.
+            assert_eq!(answered["message"], "Permission denied by user");
+        }
+    }
+}
+
+/// `wrap_permission_handler`'s allowlist: a tool the agent does not name is
+/// denied **without the user ever seeing a prompt**.
+///
+/// The absence is the assertion, so this also proves the frame in the previous
+/// test was not incidental — and nothing answers here, because nothing should
+/// be asked.
+#[tokio::test]
+async fn a_tool_outside_the_agents_allowlist_is_denied_without_a_prompt() {
+    let Some(_) = python3() else {
+        eprintln!("skipping: no python3");
+        return;
+    };
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cli = fake_cli(
+        dir.path(),
+        r#"
+    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack(req.get("request_id") or msg.get("request_id"))
+    elif msg.get("type") == "user":
+        say({"type": "control_request", "request_id": "perm-1",
+             "request": {"subtype": "can_use_tool", "tool_name": "Bash",
+                         "input": {"command": "rm -rf /"}}})
+    elif msg.get("type") == "control_response":
+        say({"type": "result", "subtype": "success", "is_error": False,
+             "result": "done", "session_id": "sdk-1", "usage": {}})
+"#,
+    );
+
+    let id = unique_id("perm-gated");
+    let file = migrated_with_allowlisted_agent(&id);
+    let body = run_permission_turn(dir.path(), &cli, &file, &id, Answer::None).await;
+
+    assert!(
+        !body.contains("permission_request"),
+        "a tool outside the allowlist must not reach the user; body was: {body}"
+    );
+
+    let answered = control_response_for(dir.path(), "perm-1").await;
+    assert_eq!(answered["behavior"], "deny", "answered: {answered}");
+    assert_eq!(
+        answered["message"],
+        "tool \"Bash\" is not in this agent's allowed capabilities"
+    );
+}
+
+/// …and `AskUserQuestion` is exempt from that allowlist, because it is the
+/// interactive Q&A mechanism rather than a capability. The same agent, which
+/// names only `Read`, still prompts for it.
+#[tokio::test]
+async fn ask_user_question_bypasses_the_allowlist() {
+    let Some(_) = python3() else {
+        eprintln!("skipping: no python3");
+        return;
+    };
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cli = fake_cli(
+        dir.path(),
+        r#"
+    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack(req.get("request_id") or msg.get("request_id"))
+    elif msg.get("type") == "user":
+        say({"type": "control_request", "request_id": "perm-1",
+             "request": {"subtype": "can_use_tool", "tool_name": "AskUserQuestion",
+                         "input": {"question": "which?"}}})
+    elif msg.get("type") == "control_response":
+        say({"type": "result", "subtype": "success", "is_error": False,
+             "result": "done", "session_id": "sdk-1", "usage": {}})
+"#,
+    );
+
+    let id = unique_id("perm-bypass");
+    let file = migrated_with_allowlisted_agent(&id);
+    let body = run_permission_turn(dir.path(), &cli, &file, &id, Answer::Text("mine".into())).await;
+
+    assert!(
+        body.contains("user_input_required"),
+        "AskUserQuestion must reach the user even when the agent does not name it; body was: {body}"
+    );
+    let answered = control_response_for(dir.path(), "perm-1").await;
+    assert_eq!(answered["behavior"], "deny");
+    assert_eq!(answered["message"], "mine");
 }
 
 /// Serialises the turn tests.
@@ -611,7 +1002,7 @@ async fn run_turn_inner(
     chat_id: &str,
     content: &str,
     answer: Option<String>,
-) -> (String, bool) {
+) -> (String, bool, tempfile::NamedTempFile) {
     use http_body_util::BodyExt;
 
     let _env = env_lock().lock().await;
@@ -667,6 +1058,7 @@ async fn run_turn_inner(
         return (
             String::from_utf8(collected.to_bytes().to_vec()).expect("utf8"),
             answered,
+            file,
         );
     }
 
@@ -674,5 +1066,6 @@ async fn run_turn_inner(
     (
         String::from_utf8(collected.to_bytes().to_vec()).expect("utf8"),
         answered,
+        file,
     )
 }

--- a/desktop/src-tauri/tests/chat_turn.rs
+++ b/desktop/src-tauri/tests/chat_turn.rs
@@ -736,10 +736,9 @@ async fn run_turn_answering_keeping_db(
 /// Drive a turn whose fake CLI issues a `can_use_tool`, answering the prompt
 /// through the live registry the way `/input` and `/permission` do.
 ///
-/// Returns the body and the fake CLI's directory, so the caller can assert on
-/// both the frames and what was written back.
+/// Returns the body; the caller reads what was written back from the fake CLI's
+/// own directory with [`control_response_for`].
 async fn run_permission_turn(
-    dir: &Path,
     cli: &Path,
     file: &tempfile::NamedTempFile,
     chat_id: &str,
@@ -777,15 +776,17 @@ async fn run_permission_turn(
         }
     });
 
+    // Bounded for the same reason `collect_with_timeout` is — and for the
+    // `Answer::None` case the bound is the *point*: if a prompt is raised that
+    // should not have been, nothing ever answers it and the turn parks.
     let collected = tokio::time::timeout(
         std::time::Duration::from_secs(20),
         response.into_body().collect(),
     )
     .await
-    .expect("the turn should end")
+    .expect("the turn parked — if nothing was meant to be answered, a prompt was raised that should not have been")
     .expect("body");
     deliver.abort();
-    let _ = dir;
     String::from_utf8(collected.to_bytes().to_vec()).expect("utf8")
 }
 
@@ -830,14 +831,7 @@ async fn an_ask_user_question_is_answered_by_denying_the_tool_with_the_users_tex
 
     let id = unique_id("perm-ask");
     let file = migrated_with_chat(&id);
-    let body = run_permission_turn(
-        dir.path(),
-        &cli,
-        &file,
-        &id,
-        Answer::Text("the second one".into()),
-    )
-    .await;
+    let body = run_permission_turn(&cli, &file, &id, Answer::Text("the second one".into())).await;
 
     // The prompt reaches the client as the synthetic event, carrying the tool's
     // own input.
@@ -883,8 +877,7 @@ async fn an_ordinary_tool_prompts_for_permission_and_the_answer_is_written_back(
 
         let id = unique_id("perm-tool");
         let file = migrated_with_chat(&id);
-        let body =
-            run_permission_turn(dir.path(), &cli, &file, &id, Answer::Permission(allow)).await;
+        let body = run_permission_turn(&cli, &file, &id, Answer::Permission(allow)).await;
 
         let frames = frames(&body);
         let prompt = frames
@@ -932,7 +925,7 @@ async fn a_tool_outside_the_agents_allowlist_is_denied_without_a_prompt() {
 
     let id = unique_id("perm-gated");
     let file = migrated_with_allowlisted_agent(&id);
-    let body = run_permission_turn(dir.path(), &cli, &file, &id, Answer::None).await;
+    let body = run_permission_turn(&cli, &file, &id, Answer::None).await;
 
     assert!(
         !body.contains("permission_request"),
@@ -974,7 +967,7 @@ async fn ask_user_question_bypasses_the_allowlist() {
 
     let id = unique_id("perm-bypass");
     let file = migrated_with_allowlisted_agent(&id);
-    let body = run_permission_turn(dir.path(), &cli, &file, &id, Answer::Text("mine".into())).await;
+    let body = run_permission_turn(&cli, &file, &id, Answer::Text("mine".into())).await;
 
     assert!(
         body.contains("user_input_required"),
@@ -1003,8 +996,6 @@ async fn run_turn_inner(
     content: &str,
     answer: Option<String>,
 ) -> (String, bool, tempfile::NamedTempFile) {
-    use http_body_util::BodyExt;
-
     let _env = env_lock().lock().await;
     let file = migrated_with_chat(chat_id);
     // The SDK resolves the executable from this variable, so the fake stands in
@@ -1053,7 +1044,7 @@ async fn run_turn_inner(
             }
             false
         });
-        let collected = response.into_body().collect().await.expect("body");
+        let collected = collect_with_timeout(response).await;
         answered = handle.await.unwrap_or(false);
         return (
             String::from_utf8(collected.to_bytes().to_vec()).expect("utf8"),
@@ -1062,10 +1053,30 @@ async fn run_turn_inner(
         );
     }
 
-    let collected = response.into_body().collect().await.expect("body");
+    let collected = collect_with_timeout(response).await;
     (
         String::from_utf8(collected.to_bytes().to_vec()).expect("utf8"),
         answered,
         file,
     )
+}
+
+/// Collect a turn's body, bounded.
+///
+/// A hang rather than a failure is this suite's characteristic break — the turn
+/// parks on a wait nothing will satisfy — so an unbounded `collect` turns a
+/// regression into a CI job that sits until the runner's own limit and reports
+/// nothing useful. The bound is what makes it a test failure with a name.
+async fn collect_with_timeout(
+    response: axum::http::Response<axum::body::Body>,
+) -> http_body_util::Collected<axum::body::Bytes> {
+    use http_body_util::BodyExt;
+
+    tokio::time::timeout(
+        std::time::Duration::from_secs(20),
+        response.into_body().collect(),
+    )
+    .await
+    .expect("the turn should end rather than park on a wait nothing satisfies")
+    .expect("body")
 }


### PR DESCRIPTION
Closes #298

Both halves of the issue.

## 1 — The permission path had no coverage at all

`tests/chat_turn.rs` drove `AskUserQuestion` as an assistant `tool_use` block, which reaches `extract_ask_user_question` and the post-result continuation — and **not the permission handler**. `desktop/CLAUDE.md` listed the deny-with-the-user's-text rule among those "pinned by `tests/chat_turn.rs`". It was not.

The fake CLI issues a real `can_use_tool` control request now, and **logs every stdin line**, because the entire observable effect of that round trip on the CLI side is a `control_response` — frame assertions cannot see it.

| test | asserts |
|---|---|
| `an_ask_user_question_is_answered_by_denying_the_tool_with_the_users_text` | the `user_input_required` frame, and that the answer goes back as `{"behavior":"deny","message":"<the user's text>"}` |
| `an_ordinary_tool_prompts_for_permission_and_the_answer_is_written_back` | the `permission_request` frame with its input, and that allow **and** deny both reach the CLI — deny with Go's own `Permission denied by user` |
| `a_tool_outside_the_agents_allowlist_is_denied_without_a_prompt` | **no** frame, and the deny carrying `wrap_permission_handler`'s message. The absence is the assertion |
| `ask_user_question_bypasses_the_allowlist` | the same agent, which names only `Read`, still prompts for `AskUserQuestion` |

**All four confirmed to fail under the matching mutation** — turning the deny into an allow, dropping the `AskUserQuestion ||` from the allowlist check, and returning the inner handler unwrapped. The first is the one that matters: reverting `PermissionResult::deny(answer)` to an allow leaves **every frame unchanged**, which is precisely why the old frame-name assertions could never have caught it.

The multi-turn test now reads the database: one user message plus the **last** turn's text (not both concatenated), both `tool_use` blocks, and `3+5`/`4+6` tokens — the accumulation-vs-reset claim the frame names could not reach. The fake CLI reports per-turn usage so that assertion is real rather than `(0, 0)`.

## 2 — Embedded `RawValue`s skipped Go's compact + HTML-escape

`encoding/json` runs `compact(…, escapeHTML=true)` over a `Marshaler`'s output, so a nested `json.RawMessage` is whitespace-stripped and has `<`, `>`, `&` and U+2028/9 escaped — **while keeping its key order and number spelling**. `serde_json` writes a `RawValue`'s bytes as-is through `write_raw_fragment`, which `GoFormatter` never sees. Measured against Go, marshalling `json.RawMessage(`{ "z" : 1.50 , "a" : "a < b & c" }`)`:

```
Go:   {"z":1.50,"a":"a < b & c"}
Rust: { "z" : 1.50 , "a" : "a < b & c" }
```

- **The synthetic SSE frames.** `gojson::serialize_compacted` is attached to the *field* rather than applied at each construction site, so a future one cannot forget it — the type says how it is emitted.
- **The stored `blocks` column.** Go compacts **on store**, not on emit; this file and `persist.rs` both said the opposite. Writing the SDK's bytes verbatim left the two implementations' databases different for the same input, **masked on read** because `chats::decode_blocks` compacts what it loads — which is exactly why nothing noticed.

Both directions matter and pull against each other: `compact` strips whitespace and escapes without doing what a `serde_json::Value` round trip would do to key order and `1.50`.

## Acceptance

- Every expected byte string was measured from `encoding/json`, not reasoned about.
- The `chat_turn` suite was run **25×** with no failures and no hangs — the check this file's own history calls for, since a hang rather than a failure is its characteristic failure mode.
- `desktop/CLAUDE.md`'s coverage claim is corrected: it now says what the old test actually reached and what closed the gap.
- Local gates green: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo build --release`, `npm run build`, `go test ./desktop/...`, golangci-lint at the CI-pinned v2.5.0.