### PR TITLE
feat(desktop): host the local tools MCP server natively (#310)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -767,9 +767,24 @@ integration. Three things it settled that all six inherit:
   not have. It is stripped by replacing the `Arc`, not through it: `rmcp`
   memoizes one schema per input type and hands every route a clone, so an
   in-place edit would reach into a process-wide cache. What is left matches Go
-  key for key — `additionalProperties`, `properties`, `required`, `type` — and
-  `#[serde(deny_unknown_fields)]` is what produces the first of those, which Go
-  reflects onto every struct and its server *validates* against.
+  key for key — `additionalProperties`, `properties`, `required`, `type` — **for
+  a flat struct of required scalars**, which is all #310 has and all the vectors
+  cover. `#[serde(deny_unknown_fields)]` is what produces the first of those,
+  which Go reflects onto every struct and its server *validates* against.
+  `$schema` is the first of a class, not the whole class: `schemars` and
+  `google/jsonschema-go` are known to diverge on `Option<T>`
+  (`"type":["string","null"]` vs an `omitempty` field that stays
+  `"type":"string"` and just leaves `required`), on nested structs (`$defs`/
+  `$ref` vs inlined) and on integer `"format"`. Get a nested/`Option` parity
+  vector in before the first integration port lands.
+- **Malformed arguments are the same *kind* of failure, with different
+  wording.** Both servers answer a missing field, an extra field, a wrong type
+  or an absent `arguments` with a `CallToolResult` carrying `IsError`, never a
+  JSON-RPC error — `rmcp`'s `into_tool_argument_error` converts its own
+  extractor's `INVALID_PARAMS` for exactly this. Only the text the model reads
+  differs: Go's `validating "arguments": …` against `rmcp`'s `failed to
+  deserialize parameters: …`. It is a property of `new_tool`, so every ported
+  tool has it; there is no missing conversion to add.
 - **A tool's name is not renameable.** `mcp__local-tools__current_time` is in
   agents' stored `capabilities.local` allowlists and in every `tool_use` block
   already written to `chat_messages`. `desktop/parity/local_tools_vectors.json`
@@ -783,8 +798,10 @@ integration. Three things it settled that all six inherit:
 - **The listener is per turn, not per process.** Go starts its one server in
   `cmd/web.go` and shares it; here the handle *is* the lifetime, so
   `build_options` starts one and hands it back, and `turn.rs` drops it **after**
-  `session.close()` — dropping it first would cancel a `tools/call` the
-  subprocess is still waiting on.
+  `session.close()`, since dropping the listener cancels every handler's token.
+  `close` does not wait for the subprocess — it flips a flag and fires a
+  oneshot — so the ordering is best-effort rather than a barrier; the stream has
+  already ended by then, so no `tools/call` should be outstanding either way.
 
 One Go rule that only becomes visible once local tools exist:
 `appendDisallowedTools` keys on the agent's **explicit built-in list**, not on

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -138,10 +138,14 @@ src-tauri/src/
     writes.rs    what a write may answer, and what it hands back to Go
     chat/        the SSE turn and the three routes that steer it (#276)
       live.rs    the process-local live-session registry — why the four move together
-      runner.rs  an agent's config as SDK options; refuses what it cannot supply
+      runner.rs  an agent's config as SDK options; starts the local tools server
+                 (#310) and refuses only what it still cannot supply
       turn.rs    spawn, stream, and the AskUserQuestion continuation
       persist.rs what a finished turn writes, and what an interrupted one does not
       sse.rs     the frame bytes: raw pass-through vs the two synthetic events
+    tools/       the local in-process tools MCP server (#310) — `internal/tools`
+      mod.rs     the server name, the qualified `mcp__local-tools__…` names
+      current_time.rs  time.LoadLocation and RFC1123/RFC3339, pinned to vectors
     settings.rs  GET /api/settings and /settings/claude-config-dirs (a filesystem
                  probe; Unix, forwards on Windows); the preferences + config dirs
                  a read is scoped to; and `update`, the PUT — written and tested,
@@ -521,7 +525,7 @@ of the `Err` arms the cut-over has to turn into a real response.
 | 1 ✅ | Sidecar + proxy | — | done |
 | 2 ← | Pricing + analytics | `internal/pricing`, `internal/claudesessions` | Pure computation over JSONL + SQLite. No external deps. **In progress**: `/api/pricing/catalog`, `/api/claude-sessions`, `/api/claude-sessions/facets`, `/api/claude-analytics`, `/api/claude-sessions/insights/summary` and the agent reads are native and diff clean. |
 | 3 ← | Storage + tasks | `internal/storage`, `internal/scheduler` | **In progress (#274, #275).** `db.rs` is read-write, the 27 migrations are ported, and the writes whose every effect Rust owns are native — see below. The scheduler's *schedule computation* is ported and pinned (#275); its ownership is not, and is blocked — see below. |
-| 4 | Integrations | `internal/integrations`, `internal/trigger` | OAuth2 + MCP servers. Six of them: google, github, slack, jira, confluence, telegram, plus `internal/tools`. **How to host one is settled (#282)** — `claude::ToolServer`, see "Hosting a tool" below; do not invent a second way. WhatsApp is **not** among them — see below. |
+| 4 ← | Integrations | `internal/integrations`, `internal/trigger` | OAuth2 + MCP servers. Six of them: google, github, slack, jira, confluence, telegram, plus `internal/tools`. **How to host one is settled (#282)** — `claude::ToolServer`, see "Hosting a tool" below; do not invent a second way. **`internal/tools` is done (#310)** — `native/tools/`, and it is the worked example the six should be read against. WhatsApp is **not** among them — see below. |
 | 5 ← | Agent execution | `internal/agent`, `internal/service` | **In progress (#276).** The chat SSE turn is native: `/messages`, `/input`, `/permission` and `/stop`, on top of the ported SDK. The scheduler's executor (#275) is the other caller and still Go's. |
 
 ### The session scanner (`src-tauri/src/native/scanner/`)
@@ -752,6 +756,42 @@ async move { … } }`. Moving it in makes the closure `FnOnce`. There is no
 `&self` to read from either: `ToolServer` is one shared type holding nothing
 integration-specific, so capture is the only channel. `claude/tool.rs`'s module
 docs carry a full worked example.
+
+**The first real caller is `native/tools/` (#310)**, the local in-process server
+— one tool, no credentials — and it is the file to read before porting an
+integration. Three things it settled that all six inherit:
+
+- **`new_tool` strips `$schema`.** `schemars` stamps a dialect key on every
+  schema it generates and `google/jsonschema-go` stamps none, so a Rust-hosted
+  tool would put a field in front of the model that the same Go-hosted tool does
+  not have. It is stripped by replacing the `Arc`, not through it: `rmcp`
+  memoizes one schema per input type and hands every route a clone, so an
+  in-place edit would reach into a process-wide cache. What is left matches Go
+  key for key — `additionalProperties`, `properties`, `required`, `type` — and
+  `#[serde(deny_unknown_fields)]` is what produces the first of those, which Go
+  reflects onto every struct and its server *validates* against.
+- **A tool's name is not renameable.** `mcp__local-tools__current_time` is in
+  agents' stored `capabilities.local` allowlists and in every `tool_use` block
+  already written to `chat_messages`. `desktop/parity/local_tools_vectors.json`
+  pins the server name, the tool names, the descriptions and the schemas, taken
+  from a **live `tools/list`** against the Go server rather than from its source;
+  it also pins `current_time`'s answer text across seventeen zones and two
+  instants, because that text lands in a stored `tool_result` and depends on the
+  tz database's abbreviations (`+0545`, `-05`) agreeing between Go's tzdata and
+  `chrono-tz`'s. Regenerate with
+  `go test ./desktop/parity/ -run TestLocalToolsVectors -update-local-tools-vectors`.
+- **The listener is per turn, not per process.** Go starts its one server in
+  `cmd/web.go` and shares it; here the handle *is* the lifetime, so
+  `build_options` starts one and hands it back, and `turn.rs` drops it **after**
+  `session.close()` — dropping it first would cancel a `tools/call` the
+  subprocess is still waiting on.
+
+One Go rule that only becomes visible once local tools exist:
+`appendDisallowedTools` keys on the agent's **explicit built-in list**, not on
+the allowlist it produced. An agent naming `local: [current_time]` and no
+built-ins has a non-empty `--allowedTools` and still gets no `--disallowedTools`;
+subtracting the allowlist from the twelve built-ins instead would deny all of
+them.
 
 ### Things that will bite
 
@@ -1007,9 +1047,12 @@ path cannot try to answer a chat turn with a `Vec<u8>`.
 
 **The four routes share a process-local registry, so they moved together** —
 `/messages` puts a session in, the others look one up. But not every chat *can*
-run natively: an agent whose tools come from an integration or the local MCP
-server needs #277/#282, and `runner::build_options` refuses those before any
-subprocess exists. That would strand `/stop` for a chat still running on Go, so
+run natively: an agent whose tools come from an **integration** still needs
+#311–#317, and `runner::build_options` refuses those before any subprocess
+exists. (The **local** server was the other half of that refusal and is gone —
+#310; `build_options` starts it, and is `async` for that reason, returning the
+listener handle alongside the options because dropping the handle stops the
+server.) That would strand `/stop` for a chat still running on Go, so
 the three steering routes answer natively **only when Rust holds a live session
 for that chat** and forward otherwise. Go then answers — correctly, because it
 is the side that has the session.
@@ -1546,23 +1589,24 @@ lines nothing could check until the flip. It follows the flip; it does not
 precede it.
 
 **The blocker, verified.** The flip needs Rust to *run* a task, and
-`chat/runner.rs::build_options` refuses any agent whose capabilities name the
-local in-process MCP server or an MCP server (#277/#282/#310–#317). For a chat
-that is safe — the three steering routes forward and Go answers, because Go
-holds the session. **For a scheduled task there is no second implementation
-behind it**: with the sidecar not scheduling, a task Rust cannot run does not
-fail, it *silently never runs*, and the job history has no row to show for it.
-That is the one property the whole port has relied on, absent.
+`chat/runner.rs::build_options` refuses any agent whose capabilities name an MCP
+server (#311–#317). For a chat that is safe — the three steering routes forward
+and Go answers, because Go holds the session. **For a scheduled task there is no
+second implementation behind it**: with the sidecar not scheduling, a task Rust
+cannot run does not fail, it *silently never runs*, and the job history has no
+row to show for it. That is the one property the whole port has relied on,
+absent.
 
 How much it strands: an agent is runnable natively only if its allowlist is
-built-ins only. Against 12 built-ins there are 61 integration tools across the
-six supported providers, plus `internal/tools`' local server, plus anything in
+built-ins plus local tools. Against 12 built-ins and `internal/tools`' one there
+are 61 integration tools across the six supported providers, plus anything in
 `mcps.yaml` — none of which Rust can supply, and the scheduled task that fetches
-a calendar or triages issues is the archetype rather than the edge. One of the
-two agents Agento *ships* (`agents/hello-world.yaml`) names `local:
-current_time` and would be stranded. (Neither `~/.agento` nor
-`~/.agento-desktop-dev` has an agent, task or integration on this machine, so
-that is the structural count, not a measured one.)
+a calendar or triages issues is the archetype rather than the edge. #310 moved
+one of the two agents Agento *ships* (`agents/hello-world.yaml`, which names
+`local: current_time`) off that list; the other side of the count is unchanged.
+(Neither `~/.agento` nor `~/.agento-desktop-dev` has an agent, task or
+integration on this machine, so that is the structural count, not a measured
+one.)
 
 There is also no escape hatch that keeps Go executing: the API has no
 "run this task now" route, so a Rust-owned timer has nothing to call. Adding one

--- a/desktop/parity/local_tools_parity_test.go
+++ b/desktop/parity/local_tools_parity_test.go
@@ -1,0 +1,200 @@
+// Cross-language vectors for the local in-process tools MCP server
+// (`internal/tools`, ported in #310 to `desktop/src-tauri/src/native/tools/`).
+//
+// Two things about that server have to match byte for byte, and neither is
+// checkable from one language alone:
+//
+//   - **The advertised surface.** The server name, the tool names and the
+//     reflected input schemas are what `tools/list` hands the CLI, which hands
+//     the schema to the model. `mcp__local-tools__current_time` is also in every
+//     agent's stored `capabilities.local` allowlist and in every `tool_use`
+//     block already written to `chat_messages`, so a rename is not a rename —
+//     it is a silent break of agents that exist. The vectors are taken from the
+//     **running server** over its real HTTP transport rather than from the
+//     source, so a change to the registration path fails here.
+//   - **The answer text.** `current_time`'s sentence is what ends up in a stored
+//     `tool_result`. It is `time.RFC1123` plus `time.RFC3339` in a named zone,
+//     so it depends on the tz database's *abbreviations* — Asia/Kathmandu is
+//     `+0545`, Etc/GMT+5 is `-05` — which Go reads from its own tzdata and Rust
+//     reads from `chrono-tz`'s. That is exactly the kind of agreement that
+//     cannot be assumed.
+//
+// The Rust half lives in `desktop/src-tauri/src/native/tools/` and reads this
+// same file.
+//
+// Regenerate (only from Go, and only when adding cases):
+//
+//	go test ./desktop/parity/ -run TestLocalToolsVectors -update-local-tools-vectors
+package parity
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"os"
+	"testing"
+	"time"
+
+	mcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/shaharia-lab/agento/internal/tools"
+)
+
+const localToolsVectorsFile = "local_tools_vectors.json"
+
+var updateLocalToolsVectors = flag.Bool("update-local-tools-vectors", false,
+	"rewrite local_tools_vectors.json from this Go toolchain")
+
+type localToolVector struct {
+	Name          string          `json:"name"`
+	QualifiedName string          `json:"qualified_name"`
+	Description   string          `json:"description"`
+	InputSchema   json.RawMessage `json:"input_schema"`
+}
+
+type currentTimeVector struct {
+	Timezone string `json:"timezone"`
+	At       string `json:"at"`
+	Want     string `json:"want,omitempty"`
+	Error    string `json:"error,omitempty"`
+}
+
+type localToolsVectors struct {
+	Comment     []string            `json:"_comment"`
+	ServerName  string              `json:"server_name"`
+	Tools       []localToolVector   `json:"tools"`
+	CurrentTime []currentTimeVector `json:"current_time"`
+}
+
+// currentTimeInstants are two UTC instants six months apart, so every zone below
+// is recorded on both sides of its DST rule — which is the only way an
+// abbreviation table can be checked rather than sampled.
+var currentTimeInstants = []string{
+	"2026-08-16T21:07:34Z",
+	"2026-01-16T21:07:34Z",
+}
+
+// currentTimeZones cover each shape a zone abbreviation takes, plus every branch
+// of time.LoadLocation that produces a *different sentence*:
+//
+//   - alphabetic abbreviations, fixed (Asia/Tokyo) and seasonal (America/New_York)
+//   - numeric abbreviations with minutes (Asia/Kathmandu, Pacific/Chatham) and
+//     without (Etc/GMT+5, America/Sao_Paulo) — the ones a naive %z would get wrong
+//   - a zone whose winter offset is exactly zero (Europe/London), where RFC3339
+//     renders `Z` rather than `+00:00`
+//   - the two short-circuits before any lookup: "" and "UTC"
+//   - the two failures, which are not the same message: an unknown name, and a
+//     name Go rejects as a path traversal
+//
+// "Local" is deliberately absent: it resolves to the machine's zone, so a vector
+// for it would record this machine rather than the contract.
+var currentTimeZones = []string{
+	"", "UTC", "EST",
+	"America/New_York", "America/Sao_Paulo", "Asia/Tokyo", "Asia/Kolkata",
+	"Asia/Kathmandu", "Australia/Lord_Howe", "Etc/GMT+5", "Europe/London",
+	"Pacific/Chatham",
+	"utc", "Nowhere/Bad", "..", "a/../b", "/etc/localtime",
+}
+
+// listTools dials the real server the way the CLI does and returns what it
+// advertises.
+func listTools(t *testing.T) []*mcp.Tool {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cfg, err := tools.StartLocalMCPServer(ctx)
+	if err != nil {
+		t.Fatalf("starting the local tools server: %v", err)
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "parity", Version: "1"}, nil)
+	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{Endpoint: cfg.ServerCfg.URL}, nil)
+	if err != nil {
+		t.Fatalf("connecting to %s: %v", cfg.ServerCfg.URL, err)
+	}
+	defer func() { _ = session.Close() }()
+
+	listed, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("tools/list: %v", err)
+	}
+	return listed.Tools
+}
+
+func TestLocalToolsVectors(t *testing.T) {
+	want := localToolsVectors{
+		Comment: []string{
+			"Cross-language parity vectors for internal/tools, the local in-process MCP server.",
+			"Generated from Go, then frozen. Read by desktop/parity/local_tools_parity_test.go",
+			"(Go) and by desktop/src-tauri/src/native/tools/ (Rust). Every value is exactly what",
+			"Go produces, so a divergence fails one language against the other's real output",
+			"rather than against a belief about it.",
+			"'tools' is taken from a live tools/list over the server's own HTTP transport.",
+			"'current_time' is FormatCurrentTime at a fixed instant, since time.Now() would",
+			"pin one moment on one machine.",
+			"Regenerate with: go test ./desktop/parity/ -run TestLocalToolsVectors -update-local-tools-vectors",
+		},
+		ServerName: tools.LocalMCPServerName,
+	}
+
+	cfg := &tools.LocalMCPConfig{}
+	for _, tool := range listTools(t) {
+		schema, err := json.Marshal(tool.InputSchema)
+		if err != nil {
+			t.Fatalf("encoding %s's input schema: %v", tool.Name, err)
+		}
+		want.Tools = append(want.Tools, localToolVector{
+			Name:          tool.Name,
+			QualifiedName: cfg.AllowedToolName(tool.Name),
+			Description:   tool.Description,
+			InputSchema:   schema,
+		})
+	}
+
+	for _, at := range currentTimeInstants {
+		instant, err := time.Parse(time.RFC3339, at)
+		if err != nil {
+			t.Fatalf("parsing %q: %v", at, err)
+		}
+		for _, tz := range currentTimeZones {
+			vector := currentTimeVector{Timezone: tz, At: at}
+			text, err := tools.FormatCurrentTime(tz, instant)
+			if err != nil {
+				vector.Error = err.Error()
+			} else {
+				vector.Want = text
+			}
+			want.CurrentTime = append(want.CurrentTime, vector)
+		}
+	}
+
+	encoded, err := json.MarshalIndent(want, "", "  ")
+	if err != nil {
+		t.Fatalf("encoding vectors: %v", err)
+	}
+	encoded = append(encoded, '\n')
+
+	if *updateLocalToolsVectors {
+		if err := os.WriteFile(localToolsVectorsFile, encoded, 0o600); err != nil {
+			t.Fatalf("writing %s: %v", localToolsVectorsFile, err)
+		}
+		t.Logf("wrote %s", localToolsVectorsFile)
+		return
+	}
+
+	frozen, err := os.ReadFile(localToolsVectorsFile)
+	if err != nil {
+		t.Fatalf("reading %s (regenerate with -update-local-tools-vectors): %v",
+			localToolsVectorsFile, err)
+	}
+	if string(frozen) != string(encoded) {
+		t.Fatalf("%s is stale: this Go toolchain produces different results.\n"+
+			"Regenerate with -update-local-tools-vectors and check what moved — the Rust "+
+			"port in native/tools/ reads the same file and will fail against it. A moved "+
+			"tool name or server name is not a cosmetic diff: it is in every agent's stored "+
+			"allowlist and in every tool_use block already written.",
+			localToolsVectorsFile)
+	}
+}

--- a/desktop/parity/local_tools_parity_test.go
+++ b/desktop/parity/local_tools_parity_test.go
@@ -25,6 +25,11 @@
 // Regenerate (only from Go, and only when adding cases):
 //
 //	go test ./desktop/parity/ -run TestLocalToolsVectors -update-local-tools-vectors
+//
+// Regenerate on a case-sensitive filesystem: the `"utc"` case asserts that the
+// lookup is case-sensitive, and on a case-insensitive one (macOS's default) the
+// zoneinfo file for `UTC` is found under that name, so the case would record a
+// success where Linux and the Rust port record an error.
 package parity
 
 import (
@@ -34,6 +39,16 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	// Every case below is a time.LoadLocation call, and Windows declares no
+	// platformZoneSources at all — so without this, regenerating there (or in a
+	// minimal container) would write a vector file in which all 34 cases are
+	// errors, and the Rust suite plus Linux CI would fail against it. Same
+	// reasoning, and the same fallback-not-override property, as
+	// internal/scheduler/schedule_vectors_test.go: the system database still
+	// wins where it exists, so a genuine tzdata disagreement fails loudly here
+	// rather than being papered over.
+	_ "time/tzdata"
 
 	mcp "github.com/modelcontextprotocol/go-sdk/mcp"
 

--- a/desktop/parity/local_tools_vectors.json
+++ b/desktop/parity/local_tools_vectors.json
@@ -1,0 +1,206 @@
+{
+  "_comment": [
+    "Cross-language parity vectors for internal/tools, the local in-process MCP server.",
+    "Generated from Go, then frozen. Read by desktop/parity/local_tools_parity_test.go",
+    "(Go) and by desktop/src-tauri/src/native/tools/ (Rust). Every value is exactly what",
+    "Go produces, so a divergence fails one language against the other's real output",
+    "rather than against a belief about it.",
+    "'tools' is taken from a live tools/list over the server's own HTTP transport.",
+    "'current_time' is FormatCurrentTime at a fixed instant, since time.Now() would",
+    "pin one moment on one machine.",
+    "Regenerate with: go test ./desktop/parity/ -run TestLocalToolsVectors -update-local-tools-vectors"
+  ],
+  "server_name": "local-tools",
+  "tools": [
+    {
+      "name": "current_time",
+      "qualified_name": "mcp__local-tools__current_time",
+      "description": "Returns the current date and time for a given IANA timezone (e.g. UTC, America/New_York, Asia/Tokyo). Defaults to UTC.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "timezone": {
+            "description": "IANA timezone name, e.g. UTC or America/New_York. Defaults to UTC.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "timezone"
+        ],
+        "type": "object"
+      }
+    }
+  ],
+  "current_time": [
+    {
+      "timezone": "",
+      "at": "2026-08-16T21:07:34Z",
+      "want": "Current time in UTC: Sun, 16 Aug 2026 21:07:34 UTC (ISO 8601: 2026-08-16T21:07:34Z)"
+    },
+    {
+      "timezone": "UTC",
+      "at": "2026-08-16T21:07:34Z",
+      "want": "Current time in UTC: Sun, 16 Aug 2026 21:07:34 UTC (ISO 8601: 2026-08-16T21:07:34Z)"
+    },
+    {
+      "timezone": "EST",
+      "at": "2026-08-16T21:07:34Z",
+      "want": "Current time in EST: Sun, 16 Aug 2026 16:07:34 EST (ISO 8601: 2026-08-16T16:07:34-05:00)"
+    },
+    {
+      "timezone": "America/New_York",
+      "at": "2026-08-16T21:07:34Z",
+      "want": "Current time in America/New_York: Sun, 16 Aug 2026 17:07:34 EDT (ISO 8601: 2026-08-16T17:07:34-04:00)"
+    },
+    {
+      "timezone": "America/Sao_Paulo",
+      "at": "2026-08-16T21:07:34Z",
+      "want": "Current time in America/Sao_Paulo: Sun, 16 Aug 2026 18:07:34 -03 (ISO 8601: 2026-08-16T18:07:34-03:00)"
+    },
+    {
+      "timezone": "Asia/Tokyo",
+      "at": "2026-08-16T21:07:34Z",
+      "want": "Current time in Asia/Tokyo: Mon, 17 Aug 2026 06:07:34 JST (ISO 8601: 2026-08-17T06:07:34+09:00)"
+    },
+    {
+      "timezone": "Asia/Kolkata",
+      "at": "2026-08-16T21:07:34Z",
+      "want": "Current time in Asia/Kolkata: Mon, 17 Aug 2026 02:37:34 IST (ISO 8601: 2026-08-17T02:37:34+05:30)"
+    },
+    {
+      "timezone": "Asia/Kathmandu",
+      "at": "2026-08-16T21:07:34Z",
+      "want": "Current time in Asia/Kathmandu: Mon, 17 Aug 2026 02:52:34 +0545 (ISO 8601: 2026-08-17T02:52:34+05:45)"
+    },
+    {
+      "timezone": "Australia/Lord_Howe",
+      "at": "2026-08-16T21:07:34Z",
+      "want": "Current time in Australia/Lord_Howe: Mon, 17 Aug 2026 07:37:34 +1030 (ISO 8601: 2026-08-17T07:37:34+10:30)"
+    },
+    {
+      "timezone": "Etc/GMT+5",
+      "at": "2026-08-16T21:07:34Z",
+      "want": "Current time in Etc/GMT+5: Sun, 16 Aug 2026 16:07:34 -05 (ISO 8601: 2026-08-16T16:07:34-05:00)"
+    },
+    {
+      "timezone": "Europe/London",
+      "at": "2026-08-16T21:07:34Z",
+      "want": "Current time in Europe/London: Sun, 16 Aug 2026 22:07:34 BST (ISO 8601: 2026-08-16T22:07:34+01:00)"
+    },
+    {
+      "timezone": "Pacific/Chatham",
+      "at": "2026-08-16T21:07:34Z",
+      "want": "Current time in Pacific/Chatham: Mon, 17 Aug 2026 09:52:34 +1245 (ISO 8601: 2026-08-17T09:52:34+12:45)"
+    },
+    {
+      "timezone": "utc",
+      "at": "2026-08-16T21:07:34Z",
+      "error": "unknown timezone \"utc\": unknown time zone utc"
+    },
+    {
+      "timezone": "Nowhere/Bad",
+      "at": "2026-08-16T21:07:34Z",
+      "error": "unknown timezone \"Nowhere/Bad\": unknown time zone Nowhere/Bad"
+    },
+    {
+      "timezone": "..",
+      "at": "2026-08-16T21:07:34Z",
+      "error": "unknown timezone \"..\": time: invalid location name"
+    },
+    {
+      "timezone": "a/../b",
+      "at": "2026-08-16T21:07:34Z",
+      "error": "unknown timezone \"a/../b\": time: invalid location name"
+    },
+    {
+      "timezone": "/etc/localtime",
+      "at": "2026-08-16T21:07:34Z",
+      "error": "unknown timezone \"/etc/localtime\": time: invalid location name"
+    },
+    {
+      "timezone": "",
+      "at": "2026-01-16T21:07:34Z",
+      "want": "Current time in UTC: Fri, 16 Jan 2026 21:07:34 UTC (ISO 8601: 2026-01-16T21:07:34Z)"
+    },
+    {
+      "timezone": "UTC",
+      "at": "2026-01-16T21:07:34Z",
+      "want": "Current time in UTC: Fri, 16 Jan 2026 21:07:34 UTC (ISO 8601: 2026-01-16T21:07:34Z)"
+    },
+    {
+      "timezone": "EST",
+      "at": "2026-01-16T21:07:34Z",
+      "want": "Current time in EST: Fri, 16 Jan 2026 16:07:34 EST (ISO 8601: 2026-01-16T16:07:34-05:00)"
+    },
+    {
+      "timezone": "America/New_York",
+      "at": "2026-01-16T21:07:34Z",
+      "want": "Current time in America/New_York: Fri, 16 Jan 2026 16:07:34 EST (ISO 8601: 2026-01-16T16:07:34-05:00)"
+    },
+    {
+      "timezone": "America/Sao_Paulo",
+      "at": "2026-01-16T21:07:34Z",
+      "want": "Current time in America/Sao_Paulo: Fri, 16 Jan 2026 18:07:34 -03 (ISO 8601: 2026-01-16T18:07:34-03:00)"
+    },
+    {
+      "timezone": "Asia/Tokyo",
+      "at": "2026-01-16T21:07:34Z",
+      "want": "Current time in Asia/Tokyo: Sat, 17 Jan 2026 06:07:34 JST (ISO 8601: 2026-01-17T06:07:34+09:00)"
+    },
+    {
+      "timezone": "Asia/Kolkata",
+      "at": "2026-01-16T21:07:34Z",
+      "want": "Current time in Asia/Kolkata: Sat, 17 Jan 2026 02:37:34 IST (ISO 8601: 2026-01-17T02:37:34+05:30)"
+    },
+    {
+      "timezone": "Asia/Kathmandu",
+      "at": "2026-01-16T21:07:34Z",
+      "want": "Current time in Asia/Kathmandu: Sat, 17 Jan 2026 02:52:34 +0545 (ISO 8601: 2026-01-17T02:52:34+05:45)"
+    },
+    {
+      "timezone": "Australia/Lord_Howe",
+      "at": "2026-01-16T21:07:34Z",
+      "want": "Current time in Australia/Lord_Howe: Sat, 17 Jan 2026 08:07:34 +11 (ISO 8601: 2026-01-17T08:07:34+11:00)"
+    },
+    {
+      "timezone": "Etc/GMT+5",
+      "at": "2026-01-16T21:07:34Z",
+      "want": "Current time in Etc/GMT+5: Fri, 16 Jan 2026 16:07:34 -05 (ISO 8601: 2026-01-16T16:07:34-05:00)"
+    },
+    {
+      "timezone": "Europe/London",
+      "at": "2026-01-16T21:07:34Z",
+      "want": "Current time in Europe/London: Fri, 16 Jan 2026 21:07:34 GMT (ISO 8601: 2026-01-16T21:07:34Z)"
+    },
+    {
+      "timezone": "Pacific/Chatham",
+      "at": "2026-01-16T21:07:34Z",
+      "want": "Current time in Pacific/Chatham: Sat, 17 Jan 2026 10:52:34 +1345 (ISO 8601: 2026-01-17T10:52:34+13:45)"
+    },
+    {
+      "timezone": "utc",
+      "at": "2026-01-16T21:07:34Z",
+      "error": "unknown timezone \"utc\": unknown time zone utc"
+    },
+    {
+      "timezone": "Nowhere/Bad",
+      "at": "2026-01-16T21:07:34Z",
+      "error": "unknown timezone \"Nowhere/Bad\": unknown time zone Nowhere/Bad"
+    },
+    {
+      "timezone": "..",
+      "at": "2026-01-16T21:07:34Z",
+      "error": "unknown timezone \"..\": time: invalid location name"
+    },
+    {
+      "timezone": "a/../b",
+      "at": "2026-01-16T21:07:34Z",
+      "error": "unknown timezone \"a/../b\": time: invalid location name"
+    },
+    {
+      "timezone": "/etc/localtime",
+      "at": "2026-01-16T21:07:34Z",
+      "error": "unknown timezone \"/etc/localtime\": time: invalid location name"
+    }
+  ]
+}

--- a/desktop/src-tauri/src/claude/tool.rs
+++ b/desktop/src-tauri/src/claude/tool.rs
@@ -194,6 +194,18 @@ where
 /// model that the same tool hosted by the Go server does not have, on the one
 /// surface (#310–#317) where the two are meant to be indistinguishable.
 ///
+/// `$schema` is the first of a class rather than the whole class. What is left
+/// is verified to match Go key for key **for a flat struct of required
+/// scalars**, which is what `current_time` is and all the parity vectors cover.
+/// `schemars` 1.2.2 and `google/jsonschema-go` are known to diverge on shapes
+/// the six integration ports will hit: an `Option<T>` renders as
+/// `"type": ["string","null"]` where a Go field with `omitempty` stays
+/// `"type":"string"` and merely drops out of `required`; a nested struct
+/// produces `$defs`/`$ref` where Go inlines; integers pick up a `"format"`.
+/// A parity vector for a nested/`Option` input is wanted before the first
+/// integration port lands, since this function's contract is "strip one key",
+/// not "reconcile two reflectors".
+///
 /// Replaces the `Arc` rather than mutating through it, and that is not
 /// fussiness: `rmcp` memoizes one generated schema per input type and hands
 /// every `ToolRoute` a clone of the same `Arc`, so `get_mut` would refuse and an

--- a/desktop/src-tauri/src/claude/tool.rs
+++ b/desktop/src-tauri/src/claude/tool.rs
@@ -176,12 +176,36 @@ where
                 .unwrap_or_else(|message| CallToolResult::error(vec![ContentBlock::text(message)]))
         }
     };
-    ToolDef(
-        call.name(name)
-            .description(description)
-            .parameters::<In>()
-            .into_tool_route(),
-    )
+    let mut route = call
+        .name(name)
+        .description(description)
+        .parameters::<In>()
+        .into_tool_route();
+    strip_schema_dialect(&mut route.attr);
+    ToolDef(route)
+}
+
+/// Drops the `$schema` dialect key `schemars` stamps on every generated schema.
+///
+/// Go's `google/jsonschema-go` emits none — a `tools/list` from `internal/tools`
+/// carries exactly `additionalProperties`, `properties`, `required` and `type` —
+/// and this schema does not travel alone: the CLI forwards it to the model as
+/// the tool's `input_schema`. Keeping the key would put a field in front of the
+/// model that the same tool hosted by the Go server does not have, on the one
+/// surface (#310–#317) where the two are meant to be indistinguishable.
+///
+/// Replaces the `Arc` rather than mutating through it, and that is not
+/// fussiness: `rmcp` memoizes one generated schema per input type and hands
+/// every `ToolRoute` a clone of the same `Arc`, so `get_mut` would refuse and an
+/// in-place edit would reach into a process-wide cache. The clone is one map,
+/// once per tool at start-up.
+fn strip_schema_dialect(tool: &mut Tool) {
+    if !tool.input_schema.contains_key("$schema") {
+        return;
+    }
+    let mut schema = (*tool.input_schema).clone();
+    schema.remove("$schema");
+    tool.input_schema = std::sync::Arc::new(schema);
 }
 
 /// An MCP server whose whole surface is a set of [`ToolDef`]s.
@@ -369,6 +393,20 @@ mod tests {
             .map(|v| v.as_str().unwrap().to_string())
             .collect();
         assert!(required.contains(&"a".to_string()) && required.contains(&"b".to_string()));
+    }
+
+    /// `schemars` stamps a `$schema` dialect key on everything it generates and
+    /// `google/jsonschema-go` stamps none, so the key would be a field the model
+    /// sees from a Rust-hosted tool and not from the same Go-hosted one.
+    #[test]
+    fn the_schema_carries_no_dialect_key() {
+        let server = ToolServer::new("calc").with_tool(add_tool());
+        let tool = server.get_tool("add").expect("the tool is registered");
+        let schema = serde_json::to_value(&*tool.input_schema).unwrap();
+        assert!(
+            schema.get("$schema").is_none(),
+            "Go's reflected schemas carry no dialect key: {schema}"
+        );
     }
 
     #[test]

--- a/desktop/src-tauri/src/native/chat/runner.rs
+++ b/desktop/src-tauri/src/native/chat/runner.rs
@@ -756,6 +756,27 @@ mod tests {
         assert!(!opts.strict_mcp_config);
     }
 
+    /// `local: []` — **present but empty** — is the distinction `GoList` exists
+    /// to preserve, and it decides whether the agent gets twelve built-ins or
+    /// none. Go's `len(caps.Local) > 0` makes an empty list the same as an
+    /// absent one on both counts: no listener, and still "names no tools at
+    /// all", so all the built-ins.
+    #[tokio::test]
+    async fn a_present_but_empty_local_list_is_the_same_as_none() {
+        let spec = spec_for(Capabilities {
+            built_in: None,
+            local: Some(vec![].into()),
+            mcp: None,
+        });
+        let (opts, local) = build_options(&spec, no_op_handler())
+            .await
+            .expect("options");
+        assert!(local.is_none());
+        assert!(opts.mcp_servers.is_empty());
+        assert!(!opts.strict_mcp_config);
+        assert_eq!(opts.allowed_tools.len(), ALL_BUILT_IN_TOOLS.len());
+    }
+
     #[test]
     fn thinking_defaults_to_adaptive() {
         assert_eq!(thinking_mode(None), "adaptive");

--- a/desktop/src-tauri/src/native/chat/runner.rs
+++ b/desktop/src-tauri/src/native/chat/runner.rs
@@ -5,23 +5,28 @@
 //!
 //! Go resolves three kinds of tool: the built-ins, the **local** in-process MCP
 //! server (`internal/tools`), and one MCP server per configured **integration**
-//! (`internal/integrations`). Rust has neither of the latter two — they are
-//! #277's and #282's — and an agent whose capabilities name them would get a
-//! subprocess with the tools silently missing, which is a worse answer than the
-//! sidecar's.
+//! (`internal/integrations`). The first two are here; the third is not, and an
+//! agent whose capabilities name an MCP server would get a subprocess with the
+//! tools silently missing, which is a worse answer than the sidecar's.
 //!
-//! So [`build_options`] refuses: an agent with `local` or `mcp` capabilities
-//! returns `Err`, the seam forwards, and Go runs that chat exactly as before.
-//! This is the same "a route moves only when Rust reproduces every effect" rule
-//! #274 established, applied per *agent* rather than per route — which is why
+//! So [`build_options`] refuses: an agent with `mcp` capabilities returns
+//! `Err`, the seam forwards, and Go runs that chat exactly as before. This is
+//! the same "a route moves only when Rust reproduces every effect" rule #274
+//! established, applied per *agent* rather than per route — which is why
 //! `chat::stream` also forwards `/input`, `/permission` and `/stop` for any chat
 //! it does not itself hold a live session for. Without that, a chat running on
 //! Go would have its stop button claimed by a Rust registry that never saw it.
+//!
+//! The `local` half of that refusal is gone as of #310: [`build_options`] starts
+//! the local tools server itself and hands back the handle, because the
+//! listener's life is the handle's — see [`crate::native::tools`]. That is what
+//! makes this function `async`.
 
 use rusqlite::OptionalExtension;
 
 use crate::claude::options::Options;
 use crate::claude::permissions::PermissionHandler;
+use crate::claude::InProcessMcpServer;
 use crate::native::agents::{Agent, Capabilities};
 
 /// Every built-in tool, as `allBuiltInTools` lists them. Order is Go's, because
@@ -73,19 +78,21 @@ pub struct RunSpec {
 /// Build the SDK options for one chat turn.
 ///
 /// `Err` means "this port cannot run this chat" and forwards to Go — never a
-/// user-visible failure.
-pub fn build_options(
+/// user-visible failure. Every failure here happens before a subprocess exists,
+/// including the one that binds a port: a local tools server that failed to
+/// start is dropped on the way out, so forwarding leaves nothing behind.
+///
+/// The second half of the pair is the **local tools listener**, `Some` only for
+/// an agent that named a local tool. The caller owns it, and dropping it stops
+/// the server — so it has to outlive the subprocess that dials it.
+pub async fn build_options(
     spec: &RunSpec,
     permission_handler: PermissionHandler,
-) -> Result<Options, String> {
+) -> Result<(Options, Option<InProcessMcpServer>), String> {
     let caps = spec.agent.as_ref().map(|a| &a.capabilities);
     if let Some(caps) = caps {
-        if capability_count(caps.local.as_ref()) > 0
-            || caps.mcp.as_ref().is_some_and(|m| !m.is_empty())
-        {
-            return Err(
-                "agent uses local or MCP tools, which are not ported yet (#277/#282)".to_string(),
-            );
+        if caps.mcp.as_ref().is_some_and(|m| !m.is_empty()) {
+            return Err("agent uses MCP tools, which are not ported yet (#311–#317)".to_string());
         }
     }
 
@@ -154,14 +161,28 @@ pub fn build_options(
 
     opts = opts.with_thinking(thinking_mode(spec.agent.as_ref()));
 
-    let allowed = allowed_tools(caps);
+    // `resolveToolsAndMCP`'s order is the `--allowedTools` argument's order, so
+    // it is part of the command line: built-ins first, then the local server's
+    // qualified names.
+    let mut allowed = allowed_tools(caps);
+    let local_tools;
+    (opts, local_tools) = start_local_tools(opts, caps, &mut allowed).await?;
+
     if !allowed.is_empty() {
         opts = opts.with_allowed_tools(allowed.iter().cloned());
-        // Go explicitly disallows every built-in that was not selected, so an
-        // allowlist is a denylist too.
+    }
+    // `appendDisallowedTools` keys on the agent's **explicit built-in list**,
+    // not on the allowlist it produced. The difference only shows once local
+    // tools exist: an agent naming `local: [current_time]` and no built-ins has
+    // a non-empty allowlist and still gets no `--disallowedTools` from Go, where
+    // subtracting the allowlist from the built-ins would deny all twelve.
+    if let Some(selected) = caps
+        .and_then(|c| c.built_in.as_deref())
+        .filter(|list| !list.is_empty())
+    {
         let disallowed: Vec<String> = ALL_BUILT_IN_TOOLS
             .iter()
-            .filter(|t| !allowed.iter().any(|a| a == *t))
+            .filter(|t| !selected.iter().any(|s| s == *t))
             .map(|t| (*t).to_string())
             .collect();
         if !disallowed.is_empty() {
@@ -170,7 +191,49 @@ pub fn build_options(
     }
 
     opts = opts.with_permission_handler(wrap_permission_handler(permission_handler, allowed));
-    Ok(opts)
+    Ok((opts, local_tools))
+}
+
+/// `resolveLocalTools`: register the in-process server and qualify the names the
+/// agent asked for.
+///
+/// Two rules ported exactly, both of which look like oversights until they are
+/// not:
+///
+/// - **The names are not checked against what the server hosts.** An agent
+///   naming a local tool that no longer exists gets `mcp__local-tools__gone` in
+///   its allowlist and a model that cannot call it, rather than a run that
+///   refuses to start. That is Go's behaviour and it is the kinder failure.
+/// - **`--strict-mcp-config` travels with the server**, because Go adds it
+///   whenever it registers any MCP server at all. Without it the CLI would also
+///   load the user's own `.mcp.json`, so an agent's allowlist would stop being
+///   the whole story about what it can reach.
+///
+/// The server is started **only** for an agent that named a local tool, which
+/// is `len(caps.Local) > 0` on the Go side. Go has one server per process and
+/// simply does not reference it otherwise; here not starting it is the same
+/// thing, minus a bound port.
+async fn start_local_tools(
+    opts: Options,
+    caps: Option<&Capabilities>,
+    allowed: &mut Vec<String>,
+) -> Result<(Options, Option<InProcessMcpServer>), String> {
+    let Some(local) = caps.and_then(|c| c.local.as_deref()) else {
+        return Ok((opts, None));
+    };
+    if local.is_empty() {
+        return Ok((opts, None));
+    }
+
+    let server = crate::native::tools::start_local_mcp_server()
+        .await
+        .map_err(|e| format!("starting local MCP server: {e}"))?;
+    let opts = opts
+        .with_mcp_server(crate::native::tools::LOCAL_MCP_SERVER_NAME, server.config())
+        .map_err(|e| format!("registering the local MCP server: {e}"))?
+        .with_strict_mcp_config();
+    allowed.extend(crate::native::tools::allowed_tool_names(local.iter()));
+    Ok((opts, Some(server)))
 }
 
 fn capability_count(list: Option<&crate::native::gojson::GoList<String>>) -> usize {
@@ -458,6 +521,19 @@ mod tests {
         )
     }
 
+    /// A `RunSpec` for an agent with `caps`, when the test is about the tools
+    /// rather than about the model.
+    fn spec_for(caps: Capabilities) -> RunSpec {
+        RunSpec {
+            agent: Some(agent_with(caps)),
+            no_agent_model: Box::new(String::new),
+            working_dir: String::new(),
+            settings_profile_id: String::new(),
+            resume_session_id: None,
+            chat_id: "c1".into(),
+        }
+    }
+
     fn no_op_handler() -> PermissionHandler {
         std::sync::Arc::new(|_, _, _| {
             Box::pin(async { crate::claude::permissions::PermissionResult::allow() })
@@ -469,12 +545,15 @@ mod tests {
     /// outright and never reads the user's default. Resolving it eagerly opened
     /// a second read-only SQLite connection and loaded the settings row on every
     /// turn, to discard the answer.
-    #[test]
-    fn an_agent_chat_never_resolves_the_no_agent_model() {
+    #[tokio::test]
+    async fn an_agent_chat_never_resolves_the_no_agent_model() {
         let mut agent = agent_with(Capabilities::default());
         agent.model = "agent-model".into();
         let (spec, calls) = spec_with(Some(agent));
-        let opts = build_options(&spec, no_op_handler()).expect("options");
+        let (opts, local) = build_options(&spec, no_op_handler())
+            .await
+            .expect("options");
+        assert!(local.is_none(), "no agent named a local tool");
 
         assert_eq!(opts.model, "agent-model");
         assert_eq!(
@@ -490,12 +569,15 @@ mod tests {
     /// `agentCfg.Model != ""`, so an agent with an empty one runs with **no
     /// model option at all** — the session's model and the user's default are
     /// never consulted for it.
-    #[test]
-    fn an_agent_with_no_model_runs_with_none_rather_than_the_no_agent_model() {
+    #[tokio::test]
+    async fn an_agent_with_no_model_runs_with_none_rather_than_the_no_agent_model() {
         let mut agent = agent_with(Capabilities::default());
         agent.model = String::new();
         let (spec, calls) = spec_with(Some(agent));
-        let opts = build_options(&spec, no_op_handler()).expect("options");
+        let (opts, local) = build_options(&spec, no_op_handler())
+            .await
+            .expect("options");
+        assert!(local.is_none(), "no agent named a local tool");
 
         // `with_model` is never called, so the SDK's own default stands —
         // which is what Go's `defaultOptions()` leaves in place too.
@@ -508,10 +590,13 @@ mod tests {
     }
 
     /// The one branch that does need it — and it is asked exactly once.
-    #[test]
-    fn a_chat_with_no_agent_resolves_its_model_once() {
+    #[tokio::test]
+    async fn a_chat_with_no_agent_resolves_its_model_once() {
         let (spec, calls) = spec_with(None);
-        let opts = build_options(&spec, no_op_handler()).expect("options");
+        let (opts, local) = build_options(&spec, no_op_handler())
+            .await
+            .expect("options");
+        assert!(local.is_none(), "no agent named a local tool");
 
         assert_eq!(opts.model, "no-agent-model");
         assert_eq!(calls.load(Ordering::SeqCst), 1);
@@ -558,51 +643,117 @@ mod tests {
         assert!(allowed_tools(None).is_empty());
     }
 
-    /// The boundary this port draws: an agent needing tools Rust cannot supply
-    /// forwards, rather than running with them silently missing.
-    #[test]
-    fn an_agent_needing_mcp_refuses_to_build_options() {
+    /// The boundary this port still draws: an agent needing tools Rust cannot
+    /// supply forwards, rather than running with them silently missing. Since
+    /// #310 that is **integration/MCP tools only**.
+    #[tokio::test]
+    async fn an_agent_needing_mcp_refuses_to_build_options() {
         let mut mcp = BTreeMap::new();
         mcp.insert(
             "github".to_string(),
             crate::native::agents::McpCapability { tools: None },
         );
-        let spec = RunSpec {
-            agent: Some(agent_with(Capabilities {
-                built_in: None,
-                local: None,
-                mcp: Some(mcp.into()),
-            })),
-            no_agent_model: Box::new(String::new),
-            working_dir: String::new(),
-            settings_profile_id: String::new(),
-            resume_session_id: None,
-            chat_id: "c1".into(),
-        };
-        let handler: PermissionHandler = std::sync::Arc::new(|_, _, _| {
-            Box::pin(async { crate::claude::permissions::PermissionResult::allow() })
+        let spec = spec_for(Capabilities {
+            built_in: None,
+            local: None,
+            mcp: Some(mcp.into()),
         });
-        assert!(build_options(&spec, handler).is_err());
+        assert!(build_options(&spec, no_op_handler()).await.is_err());
     }
 
-    #[test]
-    fn an_agent_needing_local_tools_also_refuses() {
-        let spec = RunSpec {
-            agent: Some(agent_with(Capabilities {
-                built_in: None,
-                local: Some(vec!["now".into()].into()),
-                mcp: None,
-            })),
-            no_agent_model: Box::new(String::new),
-            working_dir: String::new(),
-            settings_profile_id: String::new(),
-            resume_session_id: None,
-            chat_id: "c1".into(),
-        };
-        let handler: PermissionHandler = std::sync::Arc::new(|_, _, _| {
-            Box::pin(async { crate::claude::permissions::PermissionResult::allow() })
+    /// The whole of #310: an agent naming a local tool builds options rather
+    /// than forwarding, and what it builds is Go's — the server registered
+    /// under `local-tools`, the qualified name in the allowlist, and
+    /// `--strict-mcp-config` alongside so the user's own `.mcp.json` cannot add
+    /// to what the agent may reach.
+    #[tokio::test]
+    async fn an_agent_naming_a_local_tool_runs_natively() {
+        let spec = spec_for(Capabilities {
+            built_in: None,
+            local: Some(vec!["current_time".into()].into()),
+            mcp: None,
         });
-        assert!(build_options(&spec, handler).is_err());
+        let (opts, local) = build_options(&spec, no_op_handler())
+            .await
+            .expect("a local tool is supplied natively now");
+
+        let server = local.expect("the listener is handed back, because dropping it stops it");
+        let registered = opts
+            .mcp_servers
+            .get("local-tools")
+            .expect("registered under the name the CLI prefixes with");
+        assert_eq!(registered["type"], "http");
+        assert_eq!(registered["url"], server.url());
+        assert!(opts.strict_mcp_config);
+        assert_eq!(
+            opts.allowed_tools,
+            vec!["mcp__local-tools__current_time".to_string()]
+        );
+    }
+
+    /// `appendDisallowedTools` keys on the agent's explicit built-in list, and
+    /// this agent has none — so Go sends no `--disallowedTools` even though its
+    /// allowlist is non-empty. Subtracting the allowlist from the built-ins
+    /// instead would deny all twelve and change what the agent can do.
+    #[tokio::test]
+    async fn naming_only_a_local_tool_disallows_nothing() {
+        let spec = spec_for(Capabilities {
+            built_in: None,
+            local: Some(vec!["current_time".into()].into()),
+            mcp: None,
+        });
+        let (opts, _local) = build_options(&spec, no_op_handler())
+            .await
+            .expect("options");
+        assert!(
+            opts.disallowed_tools.is_empty(),
+            "Go disallows nothing here: {:?}",
+            opts.disallowed_tools
+        );
+    }
+
+    /// Built-ins first, then the local server's qualified names — the order Go
+    /// appends them in, which is the order they reach `--allowedTools`. The
+    /// denylist is still the complement of the *built-in* list.
+    #[tokio::test]
+    async fn built_ins_and_local_tools_share_one_allowlist_in_gos_order() {
+        let spec = spec_for(Capabilities {
+            built_in: Some(vec!["Read".into(), "Bash".into()].into()),
+            local: Some(vec!["current_time".into(), "gone".into()].into()),
+            mcp: None,
+        });
+        let (opts, _local) = build_options(&spec, no_op_handler())
+            .await
+            .expect("options");
+
+        assert_eq!(
+            opts.allowed_tools,
+            vec![
+                "Read".to_string(),
+                "Bash".to_string(),
+                "mcp__local-tools__current_time".to_string(),
+                // A local tool the server does not host is still qualified —
+                // Go never checks, and a run that refused to start would be the
+                // worse failure.
+                "mcp__local-tools__gone".to_string(),
+            ]
+        );
+        assert!(!opts.disallowed_tools.contains(&"Read".to_string()));
+        assert!(opts.disallowed_tools.contains(&"Write".to_string()));
+        assert_eq!(opts.disallowed_tools.len(), ALL_BUILT_IN_TOOLS.len() - 2);
+    }
+
+    /// No local tools means no listener and no MCP server — a port bound for an
+    /// agent that never dials it is a leak, not a no-op.
+    #[tokio::test]
+    async fn an_agent_naming_no_local_tools_binds_nothing() {
+        let spec = spec_for(Capabilities::default());
+        let (opts, local) = build_options(&spec, no_op_handler())
+            .await
+            .expect("options");
+        assert!(local.is_none());
+        assert!(opts.mcp_servers.is_empty());
+        assert!(!opts.strict_mcp_config);
     }
 
     #[test]

--- a/desktop/src-tauri/src/native/chat/turn.rs
+++ b/desktop/src-tauri/src/native/chat/turn.rs
@@ -159,7 +159,12 @@ pub async fn run(
     };
     // Refuses for an agent whose tools this port cannot supply — before any
     // subprocess exists, so forwarding is safe.
-    let options = runner::build_options(&spec, handler)?;
+    //
+    // `local_tools` is the in-process MCP listener the CLI will dial for an
+    // agent that named one, and it is **not** an unused binding: dropping it
+    // stops the listener, so it has to be moved into the stream task and
+    // released only once the subprocess is gone.
+    let (options, local_tools) = runner::build_options(&spec, handler).await?;
 
     // The subprocess starts here, and these are the last two `Err`s. Both are
     // still safe to forward, but for different reasons and neither is obvious:
@@ -205,6 +210,11 @@ pub async fn run(
         // than there is the difference.
         drop(guard);
         session.close();
+        // After `close`, and explicitly rather than at the end of the block:
+        // the CLI can be mid-`tools/call` when the stream ends, and dropping
+        // the listener cancels every handler's token. Ordering it before
+        // `close` would cancel a tool call the subprocess is still waiting on.
+        drop(local_tools);
 
         // The commit is detached from the request on purpose, so a client that
         // disconnected mid-stream still has its turn persisted. Errors are

--- a/desktop/src-tauri/src/native/chat/turn.rs
+++ b/desktop/src-tauri/src/native/chat/turn.rs
@@ -211,9 +211,12 @@ pub async fn run(
         drop(guard);
         session.close();
         // After `close`, and explicitly rather than at the end of the block:
-        // the CLI can be mid-`tools/call` when the stream ends, and dropping
-        // the listener cancels every handler's token. Ordering it before
-        // `close` would cancel a tool call the subprocess is still waiting on.
+        // dropping the listener cancels every handler's token, so the shutdown
+        // signal is already in flight before the listener goes. `close` only
+        // flips a flag and fires a oneshot — it does not wait for the
+        // subprocess — so this is ordering rather than a barrier; but the
+        // stream has ended by here, so no `tools/call` should be outstanding
+        // either way.
         drop(local_tools);
 
         // The commit is detached from the request on purpose, so a client that

--- a/desktop/src-tauri/src/native/mod.rs
+++ b/desktop/src-tauri/src/native/mod.rs
@@ -38,6 +38,7 @@ pub mod schedule;
 pub mod sessions;
 pub mod settings;
 pub mod tasks;
+pub mod tools;
 pub mod uploads;
 pub mod version;
 pub mod writes;

--- a/desktop/src-tauri/src/native/schedule/mod.rs
+++ b/desktop/src-tauri/src/native/schedule/mod.rs
@@ -11,10 +11,11 @@
 //! `cmd/web.go` starts the sidecar's scheduler on every boot. Ownership moves
 //! in one commit that stops the sidecar scheduling — the #289 model — and that
 //! commit is blocked on `chat/runner.rs::build_options`, which refuses any agent
-//! whose tools come from an integration or the local MCP server. A chat can
-//! forward to Go on that refusal; a scheduled task with no Go scheduler behind
-//! it would simply never run, with nothing to say so. See "The scheduler: the
-//! computation moved, the ownership did not" in `desktop/CLAUDE.md`.
+//! whose tools come from an integration (#311–#317) — the local in-process
+//! server is no longer among them (#310). A chat can forward to Go on that
+//! refusal; a scheduled task with no Go scheduler behind it would simply never
+//! run, with nothing to say so. See "The scheduler: the computation moved, the
+//! ownership did not" in `desktop/CLAUDE.md`.
 //!
 //! Porting this half now is worth it because it is the half that is
 //! *verifiable* before ownership moves, and the half most likely to be subtly

--- a/desktop/src-tauri/src/native/tools/current_time.rs
+++ b/desktop/src-tauri/src/native/tools/current_time.rs
@@ -1,0 +1,185 @@
+//! `current_time`, ported from `internal/tools/current_time.go`.
+//!
+//! One tool, and every line of it is a parity surface: the input schema steers
+//! what the model sends, and the text it answers with is what ends up in a
+//! stored `tool_result` block. `desktop/parity/local_tools_vectors.json` is
+//! generated from the Go implementation and read by both languages' tests, so
+//! neither half can drift without the other failing.
+
+use chrono::{DateTime, SecondsFormat, Utc};
+use chrono_tz::Tz;
+use rmcp::model::{CallToolResult, ContentBlock};
+use schemars::JsonSchema;
+
+use crate::claude::{new_tool, CancellationToken, ToolDef};
+
+/// Go's `time.RFC1123`, `"Mon, 02 Jan 2006 15:04:05 MST"`.
+///
+/// `%Z` is the zone *abbreviation* in both languages, and it is not always
+/// alphabetic: the IANA database spells Asia/Kathmandu's as `+0545` and
+/// Etc/GMT+5's as `-05`, which Go prints verbatim and `chrono-tz` reproduces
+/// because it carries the same strings. That is exactly the kind of thing the
+/// vectors pin rather than assume.
+const RFC1123: &str = "%a, %d %b %Y %H:%M:%S %Z";
+
+/// The tool's input.
+///
+/// Two attributes carry Go's struct tags rather than being stylistic:
+///
+/// - The doc comment is the field description, which is what
+///   `jsonschema:"IANA timezone name, …"` does on `currentTimeParams`.
+/// - `deny_unknown_fields` is what emits `"additionalProperties": false`.
+///   Go's `google/jsonschema-go` sets it for every reflected struct and the
+///   `modelcontextprotocol/go-sdk` server *validates* against it, so an extra
+///   argument is refused there; without this it would be silently accepted here.
+///
+/// The field is a plain `String`, not an `Option`, because that is what puts
+/// `timezone` in the schema's `required` list — again matching Go, where the
+/// field carries no `omitempty` and is therefore required. It means the
+/// `timezone == ""` branch below is reachable only for an explicit empty
+/// string, which is true of Go too.
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CurrentTimeInput {
+    /// IANA timezone name, e.g. UTC or America/New_York. Defaults to UTC.
+    timezone: String,
+}
+
+/// The `current_time` tool, as `registry.go` registers it.
+///
+/// The name and the description are byte-for-byte Go's: the name becomes
+/// `mcp__local-tools__current_time` in an agent's allowlist and in every stored
+/// `tool_use` block, and the description is what the model reads when deciding
+/// to call it.
+pub fn tool() -> ToolDef {
+    new_tool(
+        "current_time",
+        "Returns the current date and time for a given IANA timezone \
+         (e.g. UTC, America/New_York, Asia/Tokyo). Defaults to UTC.",
+        |input: CurrentTimeInput, _ct: CancellationToken| async move {
+            format_current_time(&input.timezone, Utc::now())
+                .map(|text| CallToolResult::success(vec![ContentBlock::text(text)]))
+        },
+    )
+}
+
+/// `getCurrentTime`'s whole body, with the clock passed in.
+///
+/// Split out for the same reason Go's `FormatCurrentTime` is exported: a
+/// vector generated against `time.Now()` would be a vector of one instant on
+/// one machine. `Err` is the message the *model* reads — see
+/// [`crate::claude::new_tool`] for why a tool's error is text rather than a
+/// protocol failure.
+pub fn format_current_time(timezone: &str, now: DateTime<Utc>) -> Result<String, String> {
+    let tz = if timezone.is_empty() { "UTC" } else { timezone };
+    // Go: `fmt.Errorf("unknown timezone %q: %w", tz, err)`. `{tz:?}` stands in
+    // for `%q`, the way `wrap_permission_handler`'s deny message already does —
+    // the two agree on every byte an IANA name can contain.
+    let loc = load_location(tz).map_err(|e| format!("unknown timezone {tz:?}: {e}"))?;
+    let local = now.with_timezone(&loc);
+    Ok(format!(
+        "Current time in {tz}: {} (ISO 8601: {})",
+        local.format(RFC1123),
+        // Go's `time.RFC3339` is `2006-01-02T15:04:05Z07:00`: seconds, no
+        // fraction, and a literal `Z` at zero offset.
+        local.to_rfc3339_opts(SecondsFormat::Secs, true),
+    ))
+}
+
+/// `time.LoadLocation`, including the two answers it gives before it ever looks
+/// at the tz database.
+///
+/// The order is Go's and each step is observable:
+///
+/// 1. `""` and `"UTC"` resolve without a lookup — so `UTC` works even where the
+///    database does not.
+/// 2. `"Local"` is the machine's zone. `chrono-tz` has no such name, so it is
+///    resolved through `iana-time-zone` (already in the tree for the scheduler,
+///    which needs the same answer for `CRON_TZ=Local`). A machine whose zone
+///    cannot be named falls through to the unknown-zone error rather than to a
+///    silently different clock.
+/// 3. A name containing `..`, or beginning with a separator, is rejected with a
+///    **different message** — `time: invalid location name` — because Go treats
+///    it as a path-traversal attempt rather than as a missing zone. Reproducing
+///    only the second message would make a rejected traversal read as a typo.
+fn load_location(name: &str) -> Result<Tz, String> {
+    if name.is_empty() || name == "UTC" {
+        return Ok(Tz::UTC);
+    }
+    if name == "Local" {
+        return iana_time_zone::get_timezone()
+            .ok()
+            .and_then(|zone| zone.parse::<Tz>().ok())
+            .ok_or_else(|| format!("unknown time zone {name}"));
+    }
+    if name.contains("..") || name.starts_with('/') || name.starts_with('\\') {
+        return Err("time: invalid location name".to_string());
+    }
+    name.parse::<Tz>()
+        .map_err(|_| format!("unknown time zone {name}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn at(rfc3339: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(rfc3339)
+            .expect("a fixed instant")
+            .with_timezone(&Utc)
+    }
+
+    /// The exact bytes Go produces, spelled out once so the shape of the answer
+    /// is legible here rather than only in the vector file.
+    #[test]
+    fn the_answer_is_gos_sentence() {
+        assert_eq!(
+            format_current_time("UTC", at("2026-08-16T21:07:34Z")).unwrap(),
+            "Current time in UTC: Sun, 16 Aug 2026 21:07:34 UTC \
+             (ISO 8601: 2026-08-16T21:07:34Z)"
+        );
+    }
+
+    /// An empty string is UTC, and the sentence names `UTC` rather than the
+    /// empty string — Go substitutes before it formats.
+    #[test]
+    fn an_empty_timezone_is_utc_and_is_named_utc() {
+        assert_eq!(
+            format_current_time("", at("2026-08-16T21:07:34Z")).unwrap(),
+            format_current_time("UTC", at("2026-08-16T21:07:34Z")).unwrap()
+        );
+    }
+
+    /// The two failures are *different sentences*, which is the whole reason
+    /// `load_location` reproduces `LoadLocation`'s pre-checks.
+    #[test]
+    fn the_two_failure_messages_are_not_interchangeable() {
+        assert_eq!(
+            format_current_time("Nowhere/Bad", at("2026-08-16T21:07:34Z")).unwrap_err(),
+            "unknown timezone \"Nowhere/Bad\": unknown time zone Nowhere/Bad"
+        );
+        assert_eq!(
+            format_current_time("..", at("2026-08-16T21:07:34Z")).unwrap_err(),
+            "unknown timezone \"..\": time: invalid location name"
+        );
+        assert_eq!(
+            format_current_time("/etc/passwd", at("2026-08-16T21:07:34Z")).unwrap_err(),
+            "unknown timezone \"/etc/passwd\": time: invalid location name"
+        );
+        // Lookup is case-sensitive in Go, and `utc` is not the short-circuit.
+        assert_eq!(
+            format_current_time("utc", at("2026-08-16T21:07:34Z")).unwrap_err(),
+            "unknown timezone \"utc\": unknown time zone utc"
+        );
+    }
+
+    /// `Local` resolves rather than erroring, which is `LoadLocation`'s second
+    /// short-circuit. The value is the machine's, so only the shape is asserted.
+    #[test]
+    fn local_is_a_zone_rather_than_a_typo() {
+        let answer = format_current_time("Local", at("2026-08-16T21:07:34Z"));
+        if let Ok(text) = answer {
+            assert!(text.starts_with("Current time in Local: "), "{text}");
+        }
+    }
+}

--- a/desktop/src-tauri/src/native/tools/current_time.rs
+++ b/desktop/src-tauri/src/native/tools/current_time.rs
@@ -95,9 +95,25 @@ pub fn format_current_time(timezone: &str, now: DateTime<Utc>) -> Result<String,
 ///    database does not.
 /// 2. `"Local"` is the machine's zone. `chrono-tz` has no such name, so it is
 ///    resolved through `iana-time-zone` (already in the tree for the scheduler,
-///    which needs the same answer for `CRON_TZ=Local`). A machine whose zone
-///    cannot be named falls through to the unknown-zone error rather than to a
-///    silently different clock.
+///    which needs the same answer for `CRON_TZ=Local`). **This is the one
+///    deliberate divergence from Go**, and it is a divergence rather than a
+///    port: `time.LoadLocation("Local")` never fails — a machine whose zone Go
+///    cannot determine gets `time.Local` with the *name* `UTC` and a UTC
+///    offset, so Go answers with a clock rather than an error. Here the same
+///    machine gets `unknown timezone "Local": unknown time zone Local`.
+///
+///    Two failures reach that branch and only one of them is Go's: the zone
+///    genuinely cannot be named (where Go answers UTC), or `iana-time-zone`
+///    names a zone `chrono-tz` does not carry (where Go reads the system
+///    database and answers *correctly*). Falling back to UTC would match Go in
+///    the first case and, in the second, label a UTC clock `Current time in
+///    Local:` on a machine that is hours away from it — the failure mode with
+///    nothing to show for it. An explicit error is preferred over both, since
+///    every other timezone this tool takes is named outright and `Local` is the
+///    only input whose answer depends on the host.
+///
+///    No parity vector covers it, for the same reason: a vector for `Local`
+///    would record this machine rather than the contract.
 /// 3. A name containing `..`, or beginning with a separator, is rejected with a
 ///    **different message** — `time: invalid location name` — because Go treats
 ///    it as a path-traversal attempt rather than as a missing zone. Reproducing
@@ -174,11 +190,15 @@ mod tests {
     }
 
     /// `Local` resolves rather than erroring, which is `LoadLocation`'s second
-    /// short-circuit. The value is the machine's, so only the shape is asserted.
+    /// short-circuit. The value is the machine's, so only the shape is
+    /// asserted — but the *precondition* is what is gated on, not the result:
+    /// gating on `Ok` would let a `load_location("Local")` that always failed
+    /// pass this test silently, which is the one thing it exists to catch.
     #[test]
     fn local_is_a_zone_rather_than_a_typo() {
-        let answer = format_current_time("Local", at("2026-08-16T21:07:34Z"));
-        if let Ok(text) = answer {
+        if iana_time_zone::get_timezone().is_ok_and(|zone| zone.parse::<Tz>().is_ok()) {
+            let text = format_current_time("Local", at("2026-08-16T21:07:34Z"))
+                .expect("Local resolves where the machine can name a zone chrono-tz carries");
             assert!(text.starts_with("Current time in Local: "), "{text}");
         }
     }

--- a/desktop/src-tauri/src/native/tools/mod.rs
+++ b/desktop/src-tauri/src/native/tools/mod.rs
@@ -31,6 +31,26 @@
 //! `mcp.Implementation` says `1.0.0`, [`crate::claude::ToolServer`] reports the
 //! SDK's. Neither reaches the CLI's transcript, and there is deliberately no
 //! second way to build a server just to carry a different string.
+//!
+//! ## Malformed arguments: same kind, different wording
+//!
+//! This is a property of [`crate::claude::new_tool`], not of `current_time`, so
+//! every ported tool inherits it. For all four malformed-input classes — a
+//! missing field, an extra field (`deny_unknown_fields`), a wrong type, and an
+//! absent `arguments` object — the **kind** of failure already matches Go: the
+//! `modelcontextprotocol/go-sdk` server returns a `CallToolResult` with
+//! `IsError` rather than a JSON-RPC error, and `rmcp`'s
+//! `into_tool_argument_error` intercepts exactly the `INVALID_PARAMS` its own
+//! `Parameters` extractor raises and converts it to `CallToolResult::error`.
+//! Acceptance is therefore identical: the same inputs are refused on both
+//! sides, and the model gets something it can retry against either way.
+//!
+//! What differs is the **message text** the model reads: Go says
+//! `validating "arguments": …`, `rmcp` says `failed to deserialize parameters:
+//! …`, each followed by its own reflector's account of what was wrong. Neither
+//! is reachable from the vectors, which drive `format_current_time` directly,
+//! so it is written down here rather than pinned — and it is a wording
+//! difference, not a missing conversion to go and add.
 
 mod current_time;
 

--- a/desktop/src-tauri/src/native/tools/mod.rs
+++ b/desktop/src-tauri/src/native/tools/mod.rs
@@ -1,0 +1,311 @@
+//! The local in-process tools MCP server, ported from `internal/tools`.
+//!
+//! This is the first real caller of the typed-tool layer #282 settled
+//! ([`crate::claude::new_tool`] / [`crate::claude::tool_server`]), and it is
+//! deliberately the smallest one: no OAuth, no network, no credentials — one
+//! tool over the machine clock. Everything the six integrations will need is
+//! exercised here except the credential capture.
+//!
+//! ## What has to match Go exactly, and why
+//!
+//! The server's **name** is the prefix the CLI puts on every tool it hosts:
+//! `local-tools` makes `current_time` reachable as
+//! `mcp__local-tools__current_time`. That string is in the agent's stored
+//! `capabilities.local` allowlist *and* in every `tool_use` block already
+//! written to `chat_messages`, so renaming either half silently breaks agents
+//! that exist. [`allowed_tool_name`] is the one place the two are joined,
+//! exactly as `LocalMCPConfig.AllowedToolName` is on the Go side.
+//!
+//! ## One departure from Go, and it is invisible on the wire
+//!
+//! Go starts this server **once per process** (`cmd/web.go`, `cmd/ask.go`) and
+//! hands every run the same `McpHTTPServer`. Here the listener's life is its
+//! handle's — the rule the whole SDK port runs on — so
+//! [`start_local_mcp_server`] is called per turn and the handle is held by the
+//! turn's stream task. Nothing observable follows from that: the URL is
+//! argv-only, it is never stored, and a per-turn port closes when the
+//! subprocess it was started for is gone. What it buys is that a crashed or
+//! forwarded turn leaks no bound port.
+//!
+//! The other difference is the version in the initialize handshake — Go's
+//! `mcp.Implementation` says `1.0.0`, [`crate::claude::ToolServer`] reports the
+//! SDK's. Neither reaches the CLI's transcript, and there is deliberately no
+//! second way to build a server just to carry a different string.
+
+mod current_time;
+
+/// Re-exported for the parity vectors, which drive the formatting directly at a
+/// fixed instant. [`local_tools`] is how the tool itself is reached.
+pub use current_time::format_current_time;
+
+use crate::claude::{tool_server, InProcessMcpServer, Result, ToolDef};
+
+/// The MCP server name every local tool is hosted under — `LocalMCPServerName`.
+///
+/// Load-bearing: it is half of every qualified tool name in an agent allowlist
+/// and in every stored `tool_use` block.
+pub const LOCAL_MCP_SERVER_NAME: &str = "local-tools";
+
+/// Every tool this server registers, in registration order — `ToolNames`.
+///
+/// The frontend carries its own copy (`desktop/src/views/AgentsView.tsx`), as
+/// the web UI does; this is the list the server actually hosts.
+pub const LOCAL_TOOL_NAMES: &[&str] = &["current_time"];
+
+/// The fully qualified name the CLI knows a local tool by, and the string an
+/// agent's allowlist has to contain — `LocalMCPConfig.AllowedToolName`.
+pub fn allowed_tool_name(tool_name: &str) -> String {
+    format!("mcp__{LOCAL_MCP_SERVER_NAME}__{tool_name}")
+}
+
+/// [`allowed_tool_name`] over a subset — `LocalMCPConfig.AllowedToolNames`.
+///
+/// Note what it does **not** do: it never checks that the name is one this
+/// server registers. Go does not either, and that is the behaviour to keep —
+/// an agent naming a local tool that no longer exists gets a qualified name in
+/// its allowlist and a model that cannot call it, rather than a run that fails
+/// to start.
+pub fn allowed_tool_names<I, S>(names: I) -> Vec<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    names
+        .into_iter()
+        .map(|name| allowed_tool_name(name.as_ref()))
+        .collect()
+}
+
+/// Every local tool, as `StartLocalMCPServer` registers them.
+pub fn local_tools() -> Vec<ToolDef> {
+    vec![current_time::tool()]
+}
+
+/// Starts the local tools server on a random loopback port —
+/// `StartLocalMCPServer`.
+///
+/// The listener stops when the returned handle is dropped, so the caller owns
+/// its lifetime; see the module docs for why that is per-turn here and
+/// per-process in Go.
+pub async fn start_local_mcp_server() -> Result<InProcessMcpServer> {
+    tool_server(LOCAL_MCP_SERVER_NAME, local_tools()).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The string an existing agent's allowlist and every stored `tool_use`
+    /// block already contains. Spelled out rather than derived, because a test
+    /// that rebuilt it from the constants would pass through a rename.
+    #[test]
+    fn the_qualified_name_is_the_one_already_on_disk() {
+        assert_eq!(
+            allowed_tool_name("current_time"),
+            "mcp__local-tools__current_time"
+        );
+        assert_eq!(
+            allowed_tool_names(["current_time"]),
+            vec!["mcp__local-tools__current_time".to_string()]
+        );
+    }
+
+    /// Go appends a qualified name for whatever the agent asked for, registered
+    /// or not.
+    #[test]
+    fn an_unregistered_name_is_still_qualified() {
+        assert_eq!(
+            allowed_tool_names(["nope"]),
+            vec!["mcp__local-tools__nope".to_string()]
+        );
+        assert!(allowed_tool_names(Vec::<String>::new()).is_empty());
+    }
+
+    #[test]
+    fn the_server_hosts_exactly_the_named_tools() {
+        let server =
+            crate::claude::ToolServer::new(LOCAL_MCP_SERVER_NAME).with_tools(local_tools());
+        assert_eq!(server.tool_names(), LOCAL_TOOL_NAMES);
+    }
+
+    /// One `tools/call` over the real transport, which is the only way to see
+    /// the bytes the CLI will see.
+    #[tokio::test]
+    async fn a_call_over_the_wire_answers_gos_sentence() {
+        let server = start_local_mcp_server().await.expect("start");
+        let mut request = reqwest::Client::new()
+            .post(server.url())
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream");
+        for (name, value) in &server.config().headers {
+            request = request.header(name, value);
+        }
+        let response = request
+            .body(
+                r#"{"jsonrpc":"2.0","id":1,"method":"tools/call",
+                    "params":{"name":"current_time","arguments":{"timezone":"UTC"}}}"#,
+            )
+            .send()
+            .await
+            .expect("send");
+        let body: serde_json::Value =
+            serde_json::from_str(&response.text().await.expect("text")).expect("json");
+
+        let text = body["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap_or_else(|| panic!("no text content: {body}"));
+        assert!(text.starts_with("Current time in UTC: "), "{text}");
+        assert!(text.contains(" (ISO 8601: "), "{text}");
+        assert_eq!(body["result"]["content"][0]["type"], "text");
+    }
+
+    /// A bad zone is a **tool** error the model can retry on, never a JSON-RPC
+    /// one — the convention `new_tool` ports from `mcp.AddTool`.
+    #[tokio::test]
+    async fn a_bad_timezone_is_a_tool_error_not_a_protocol_error() {
+        let server = start_local_mcp_server().await.expect("start");
+        let mut request = reqwest::Client::new()
+            .post(server.url())
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream");
+        for (name, value) in &server.config().headers {
+            request = request.header(name, value);
+        }
+        let response = request
+            .body(
+                r#"{"jsonrpc":"2.0","id":1,"method":"tools/call",
+                    "params":{"name":"current_time","arguments":{"timezone":"Nowhere/Bad"}}}"#,
+            )
+            .send()
+            .await
+            .expect("send");
+        let body: serde_json::Value =
+            serde_json::from_str(&response.text().await.expect("text")).expect("json");
+
+        assert!(body.get("error").is_none(), "{body}");
+        assert_eq!(body["result"]["isError"], true);
+        assert_eq!(
+            body["result"]["content"][0]["text"],
+            "unknown timezone \"Nowhere/Bad\": unknown time zone Nowhere/Bad"
+        );
+    }
+
+    // ─── The Go vectors ───────────────────────────────────────────────────────
+    //
+    // `desktop/parity/local_tools_vectors.json` is generated from the Go
+    // implementation and asserted against it by
+    // `desktop/parity/local_tools_parity_test.go`. These read the same file, so
+    // a change on either side fails the other language.
+
+    #[derive(serde::Deserialize)]
+    struct ToolVector {
+        name: String,
+        qualified_name: String,
+        description: String,
+        input_schema: serde_json::Value,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct CurrentTimeVector {
+        timezone: String,
+        at: String,
+        #[serde(default)]
+        want: String,
+        #[serde(default)]
+        error: String,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct Vectors {
+        server_name: String,
+        tools: Vec<ToolVector>,
+        current_time: Vec<CurrentTimeVector>,
+    }
+
+    fn vectors() -> Vectors {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../parity/local_tools_vectors.json"
+        );
+        let raw = std::fs::read_to_string(path)
+            .unwrap_or_else(|e| panic!("reading {path}: {e} — regenerate it from Go"));
+        serde_json::from_str(&raw).expect("parsing local tools vectors")
+    }
+
+    /// The advertised surface: the server name, every tool name, its
+    /// description, and the reflected input schema — all taken from a live
+    /// `tools/list` against the Go server.
+    ///
+    /// The schema is compared as a value rather than as bytes because JSON
+    /// object order is not meaningful to the CLI or to `schemars`; what is
+    /// meaningful is that no key appears on one side and not the other, which
+    /// is what value equality checks. `$schema` is exactly such a key —
+    /// `schemars` stamps one and `google/jsonschema-go` does not, which is why
+    /// [`crate::claude::new_tool`] strips it.
+    #[test]
+    fn the_advertised_surface_matches_the_go_vectors() {
+        use rmcp::ServerHandler;
+
+        let v = vectors();
+        assert_eq!(v.server_name, LOCAL_MCP_SERVER_NAME);
+        assert!(!v.tools.is_empty(), "vectors look truncated");
+
+        let server =
+            crate::claude::ToolServer::new(LOCAL_MCP_SERVER_NAME).with_tools(local_tools());
+        assert_eq!(
+            server.tool_names(),
+            v.tools.iter().map(|t| t.name.clone()).collect::<Vec<_>>(),
+            "the hosted tool set is not Go's"
+        );
+
+        for want in &v.tools {
+            let tool = server
+                .get_tool(&want.name)
+                .unwrap_or_else(|| panic!("{} is not registered", want.name));
+            assert_eq!(
+                tool.description.as_deref(),
+                Some(want.description.as_str()),
+                "{}'s description is what the model reads",
+                want.name
+            );
+            assert_eq!(
+                serde_json::to_value(&*tool.input_schema).expect("schema"),
+                want.input_schema,
+                "{}'s input schema is what the model is steered by",
+                want.name
+            );
+            assert_eq!(allowed_tool_name(&want.name), want.qualified_name);
+        }
+    }
+
+    /// The answer text, including the two failure sentences — every one of them
+    /// a byte Go produced.
+    #[test]
+    fn current_time_matches_the_go_vectors() {
+        let v = vectors();
+        assert!(v.current_time.len() >= 20, "vectors look truncated");
+        for case in v.current_time {
+            let at = chrono::DateTime::parse_from_rfc3339(&case.at)
+                .unwrap_or_else(|e| panic!("vector instant {:?}: {e}", case.at))
+                .with_timezone(&chrono::Utc);
+            let got = format_current_time(&case.timezone, at);
+            if case.error.is_empty() {
+                assert_eq!(
+                    got.as_deref(),
+                    Ok(case.want.as_str()),
+                    "current_time({:?}, {})",
+                    case.timezone,
+                    case.at
+                );
+            } else {
+                assert_eq!(
+                    got.as_ref().err().map(String::as_str),
+                    Some(case.error.as_str()),
+                    "current_time({:?}, {})",
+                    case.timezone,
+                    case.at
+                );
+            }
+        }
+    }
+}

--- a/desktop/src-tauri/tests/chat_turn.rs
+++ b/desktop/src-tauri/tests/chat_turn.rs
@@ -60,9 +60,9 @@ fn migrated_with_chat(id: &str) -> tempfile::NamedTempFile {
 ///
 /// That is what makes `wrap_permission_handler` wrap the handler at all: an
 /// empty allowlist returns the inner one unwrapped, so a test that skipped the
-/// agent would exercise the bypass rather than the allowlist. `built_in` only —
-/// `runner::build_options` refuses an agent whose tools come from a local or MCP
-/// server, and would forward the whole turn to Go.
+/// agent would exercise the bypass rather than the allowlist. `built_in` only,
+/// so the allowlist is exactly the one tool — the local server has its own
+/// fixture below, and an agent naming an MCP server still forwards to Go.
 fn migrated_with_allowlisted_agent(id: &str) -> tempfile::NamedTempFile {
     let file = tempfile::NamedTempFile::new().expect("temp file");
     let mut conn = rusqlite::Connection::open(file.path()).expect("open");
@@ -75,6 +75,30 @@ fn migrated_with_allowlisted_agent(id: &str) -> tempfile::NamedTempFile {
     conn.execute(
         "INSERT INTO chat_sessions (id, title, agent_slug, created_at, updated_at)
          VALUES (?1, 'New Chat', 'gated', '2026-01-01 00:00:00 +0000 UTC', '2026-01-01 00:00:00 +0000 UTC')",
+        [id],
+    )
+    .expect("seed chat");
+    file
+}
+
+/// The same, plus an agent whose capabilities name the **local** in-process MCP
+/// server (#310) rather than a built-in.
+///
+/// That is the case `runner::build_options` used to refuse outright, so before
+/// #310 a chat on this agent forwarded to Go and none of the turn machinery ran
+/// at all.
+fn migrated_with_local_tool_agent(id: &str) -> tempfile::NamedTempFile {
+    let file = tempfile::NamedTempFile::new().expect("temp file");
+    let mut conn = rusqlite::Connection::open(file.path()).expect("open");
+    agento_lib::native::migrate::apply(&mut conn).expect("migrate");
+    conn.execute(
+        "INSERT INTO agents (slug, name, capabilities) VALUES ('clock', 'Clock', ?1)",
+        [r#"{"local":["current_time"]}"#],
+    )
+    .expect("seed agent");
+    conn.execute(
+        "INSERT INTO chat_sessions (id, title, agent_slug, created_at, updated_at)
+         VALUES (?1, 'New Chat', 'clock', '2026-01-01 00:00:00 +0000 UTC', '2026-01-01 00:00:00 +0000 UTC')",
         [id],
     )
     .expect("seed chat");
@@ -1079,4 +1103,123 @@ async fn collect_with_timeout(
     .await
     .expect("the turn should end rather than park on a wait nothing satisfies")
     .expect("body")
+}
+
+// ─── The local in-process tools server (#310) ─────────────────────────────────
+
+/// Drive one turn against a database the caller seeded, and collect its body.
+///
+/// [`run_turn`] makes its own agent-less chat; this is the same thing for the
+/// tests whose whole subject is *which agent* the chat names.
+async fn run_turn_on(
+    cli: &Path,
+    file: &tempfile::NamedTempFile,
+    chat_id: &str,
+    content: &str,
+) -> String {
+    let _env = env_lock().lock().await;
+    std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", cli);
+
+    let response = agento_lib::native::chat::turn::run(
+        file.path().to_path_buf(),
+        chat_id.to_string(),
+        content.to_string(),
+    )
+    .await
+    .expect("the turn should stream rather than forward");
+
+    assert_eq!(response.status(), 200);
+    let collected = collect_with_timeout(response).await;
+    String::from_utf8(collected.to_bytes().to_vec()).expect("utf8")
+}
+
+/// The acceptance criterion of #310, end to end: an agent whose only tool is
+/// the local in-process MCP server runs **natively**, and the tool it calls is
+/// really answered by this process.
+///
+/// The fake CLI does what the real one does with `--mcp-config`: it reads the
+/// server's URL and headers out of its own argv and dials the loopback
+/// listener. That makes this the one test covering the whole chain at once —
+/// `build_options` starting the server, `Options::build_args` putting it on the
+/// command line, the bearer token travelling in `headers`, the stateless
+/// transport answering a bare `tools/call`, and the answer text coming back as
+/// a `tool_result` the turn stores.
+///
+/// Before #310 none of it ran: `build_options` refused this agent and the whole
+/// turn forwarded to Go.
+#[tokio::test]
+async fn a_chat_using_a_local_tool_runs_natively_end_to_end() {
+    let Some(_) = python3() else {
+        eprintln!("skipping: no python3");
+        return;
+    };
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cli = fake_cli(
+        dir.path(),
+        r#"
+    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack(req.get("request_id") or msg.get("request_id"))
+    elif msg.get("type") == "user":
+        import urllib.request
+        # `--mcp-config` is inline JSON in argv, exactly as the real CLI reads
+        # it. A KeyError or a ValueError here is the assertion: it means the
+        # server was never registered under the name the CLI prefixes with.
+        cfg = json.loads(sys.argv[sys.argv.index("--mcp-config") + 1])
+        server = cfg["mcpServers"]["local-tools"]
+        headers = {"Content-Type": "application/json",
+                   "Accept": "application/json, text/event-stream"}
+        headers.update(server.get("headers") or {})
+        call = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                           "params": {"name": "current_time",
+                                      "arguments": {"timezone": "Asia/Tokyo"}}}).encode()
+        reply = json.loads(urllib.request.urlopen(
+            urllib.request.Request(server["url"], data=call, headers=headers)).read().decode())
+        text = reply["result"]["content"][0]["text"]
+        say({"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "id": "t1",
+             "name": "mcp__local-tools__current_time",
+             "input": {"timezone": "Asia/Tokyo"}}]}})
+        say({"type": "user", "message": {"content": [
+            {"type": "tool_result", "tool_use_id": "t1", "content": text}]}})
+        say({"type": "assistant", "message": {"content": [
+            {"type": "text", "text": text}]}})
+        say({"type": "result", "subtype": "success", "is_error": False,
+             "result": text, "session_id": "sdk-local",
+             "usage": {"input_tokens": 1, "output_tokens": 2}})
+"#,
+    );
+
+    let id = unique_id("localtool");
+    let file = migrated_with_local_tool_agent(&id);
+    let body = run_turn_on(&cli, &file, &id, "what time is it in Tokyo?").await;
+
+    // The tool really ran in this process: only the local server could have
+    // produced this sentence, and only from Go's format string.
+    assert!(
+        body.contains("Current time in Asia/Tokyo: "),
+        "the local tool was never reached; body was: {body}"
+    );
+    assert!(body.contains("(ISO 8601: "), "body was: {body}");
+
+    // The block that gets stored carries the qualified name — the string that
+    // is already in existing agents' allowlists and in transcripts on disk.
+    let detail = chats::get(file.path(), &id)
+        .expect("get")
+        .expect("chat exists");
+    let assistant = detail
+        .messages
+        .iter()
+        .find(|m| m.role == "assistant")
+        .expect("assistant message");
+    let names: Vec<&str> = assistant
+        .blocks
+        .iter()
+        .map(|b| b.name.as_str())
+        .filter(|n| !n.is_empty())
+        .collect();
+    assert_eq!(
+        names,
+        vec!["mcp__local-tools__current_time"],
+        "renaming either half of this breaks every agent that already names it"
+    );
 }

--- a/internal/tools/current_time.go
+++ b/internal/tools/current_time.go
@@ -13,31 +13,45 @@ type currentTimeParams struct {
 	Timezone string `json:"timezone" jsonschema:"IANA timezone name, e.g. UTC or America/New_York. Defaults to UTC."`
 }
 
-// getCurrentTime returns the current time in the requested timezone.
-func getCurrentTime(
-	_ context.Context, _ *mcp.CallToolRequest, params *currentTimeParams,
-) (*mcp.CallToolResult, any, error) {
-	tz := params.Timezone
+// FormatCurrentTime renders the current_time tool's answer for tz at now.
+//
+// It is the whole body of the tool handler, with the clock passed in, and it is
+// exported so desktop/parity can generate cross-language vectors from the real
+// implementation rather than from a restatement of it — a vector taken against
+// time.Now() would pin one instant on one machine. The returned error is the
+// text the model reads: mcp.AddTool packs a handler error into
+// CallToolResult.Content with IsError set.
+func FormatCurrentTime(tz string, now time.Time) (string, error) {
 	if tz == "" {
 		tz = "UTC"
 	}
 
 	loc, err := time.LoadLocation(tz)
 	if err != nil {
-		return nil, nil, fmt.Errorf("unknown timezone %q: %w", tz, err)
+		return "", fmt.Errorf("unknown timezone %q: %w", tz, err)
 	}
 
-	now := time.Now().In(loc)
+	local := now.In(loc)
+	return fmt.Sprintf(
+		"Current time in %s: %s (ISO 8601: %s)",
+		tz,
+		local.Format(time.RFC1123),
+		local.Format(time.RFC3339),
+	), nil
+}
+
+// getCurrentTime returns the current time in the requested timezone.
+func getCurrentTime(
+	_ context.Context, _ *mcp.CallToolRequest, params *currentTimeParams,
+) (*mcp.CallToolResult, any, error) {
+	text, err := FormatCurrentTime(params.Timezone, time.Now())
+	if err != nil {
+		return nil, nil, err
+	}
+
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
-			&mcp.TextContent{
-				Text: fmt.Sprintf(
-					"Current time in %s: %s (ISO 8601: %s)",
-					tz,
-					now.Format(time.RFC1123),
-					now.Format(time.RFC3339),
-				),
-			},
+			&mcp.TextContent{Text: text},
 		},
 	}, nil, nil
 }

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -26,7 +26,6 @@ func (c *LocalMCPConfig) AllowedToolName(toolName string) string {
 }
 
 // AllowedToolNames returns the fully qualified names for a subset of local tools.
-// If names is empty, returns qualified names for all tools.
 func (c *LocalMCPConfig) AllowedToolNames(names []string) []string {
 	result := make([]string, 0, len(names))
 	for _, name := range names {


### PR DESCRIPTION
## Summary

- Ports `internal/tools` — Agento's local in-process MCP server, the one an agent's `capabilities.local` allowlist points at — onto the `rmcp` typed-tool layer #282 chose. This is that layer's first real caller.
- Narrows `runner.rs`'s blanket refusal from *"local or MCP tools"* to **integration/MCP tools only** (#311–#317), so a chat naming a local tool no longer forwards to the Go sidecar.
- A chat turn using `current_time` now runs natively end to end: the CLI reads `--mcp-config` from argv, dials the loopback listener with its bearer token, and the resulting `tool_use` block is stored under the qualified name.
- Wire names are pinned cross-language: the server registers as `local-tools`, the tool resolves as `mcp__local-tools__current_time`.

## Changes

**The port**
- `desktop/src-tauri/src/native/tools/mod.rs` (new) — the server: `LOCAL_MCP_SERVER_NAME`, `allowed_tool_name(s)`, `local_tools()`, `start_local_mcp_server()`.
- `desktop/src-tauri/src/native/tools/current_time.rs` (new) — the tool: the `schemars` input struct, `format_current_time` with the clock injected, and `load_location` porting `time.LoadLocation`'s three pre-lookup branches.
- `desktop/src-tauri/src/native/chat/runner.rs` — `build_options` is now `async` and returns the listener handle alongside `Options`; refusal narrowed; `--strict-mcp-config` registered.
- `desktop/src-tauri/src/native/chat/turn.rs` — holds the listener handle until after `session.close()`.

**Parity surface**
- `desktop/parity/local_tools_vectors.json` + `local_tools_parity_test.go` (new) — generated by starting the **real** `tools.StartLocalMCPServer`, connecting an MCP client over its own HTTP transport, and recording the live `tools/list` (server name, tool name, qualified name, description, reflected input schema), plus `FormatCurrentTime` across 17 timezones × 2 instants including both failure sentences. Both languages' tests read that one file; Go's half byte-compares the regenerated version, so a Go-side change fails Go's own suite.
- `internal/tools/current_time.go` — `FormatCurrentTime(tz, now)` extracted and exported purely so the vectors are generated from the real implementation rather than a restatement of it. Output and wrapped error text unchanged.

**Two divergences the vectors exposed**
- `desktop/src-tauri/src/claude/tool.rs` — `schemars` stamps `"$schema": ".../draft/2020-12/schema"` on every generated schema; `google/jsonschema-go` stamps none. That key travels to the model as part of `input_schema`, so `new_tool` now strips it — by *replacing* the `Arc`, because `rmcp` memoizes one schema per input type and hands every route a clone (an in-place `Arc::get_mut` silently refuses, which is how it was caught).
- `runner.rs` — Go's `appendDisallowedTools` keys on `caps.BuiltIn`, **not** on the produced allowlist. An agent naming only `local: [current_time]` therefore gets no `--disallowedTools`; the old Rust code subtracted the allowlist from the twelve built-ins and would have denied all of them. Fixed and pinned by a test.

## Testing

- [x] `cargo test` — 700 lib + 17 `claude_sdk` + 14 `chat_turn` + 7 `scanner_roundtrip` + 2 doc-tests, **0 failed**
- [x] `cargo clippy --all-targets -- -D warnings` — clean; `cargo fmt --check` — clean
- [x] `make test` (Go) — passes, including the new `TestLocalToolsVectors`
- [x] `golangci-lint run` on every file this PR touches — **0 issues** (the findings the local binary reports are pre-existing, in untouched files, and are the known v2.12.2-local vs v2.5.0-CI pin drift)
- [x] Live: `claude_mcp_live` against the real Claude Code CLI — the CLI connects and lists tools with `$schema` stripped
- [x] Live parity instance seeded with a `local: [current_time]` agent, a chat, and messages carrying a `mcp__local-tools__current_time` `tool_use` block with unsorted keys and `1.50`: `parity_agents` and `parity_chats` both **byte-identical** (267/267, 234/234, 709/709 bytes)
- [x] All 4 CI checks green on the first commit

## Review round

A full review returned APPROVE with no MUST FIX. The second commit applies both SHOULD FIXes and every actionable CONSIDER:

- **`desktop/parity` now embeds `time/tzdata`.** The vector test drives 34 `time.LoadLocation` calls and Windows declares no `platformZoneSources`, so there every lookup fails — and regenerating on such a machine would write a vector file where all 34 cases are errors, breaking Linux CI. `internal/scheduler` already solved this one directory over. Regenerating with the import in place reproduces the committed file byte for byte.
- **`schedule/mod.rs`'s ownership blocker no longer says a local tool strands a scheduled task** — that sentence is the stated reasoning behind the blocker and was updated everywhere else in the first commit.
- **A "known gap" this PR originally claimed does not exist.** `rmcp`'s `into_tool_argument_error` intercepts its own extractor's `INVALID_PARAMS`, so a malformed argument already produces the same *kind* of failure Go produces (`CallToolResult` + `IsError`, never a JSON-RPC error), and acceptance is identical for all four malformed-input classes. Only the validator's wording differs (`validating "arguments": …` vs `failed to deserialize parameters: …`), and that is a property of `new_tool` rather than of `current_time`. The docs now say so.
- **`strip_schema_dialect`'s "matches Go key for key" is narrowed** to a flat struct of required scalars, naming the three `schemars` vs `jsonschema-go` divergences the integration ports will hit first (`Option<T>` nullable unions, `$defs`/`$ref` vs inlining, integer `format`). A nested/`Option` parity vector is wanted before #311 lands.
- Plus: `turn.rs`'s drop ordering restated as ordering rather than a barrier; a vacuous `Local` test regated on its precondition; a present-but-empty `local` list pinned as equivalent to an absent one; a `registry.go` comment that promised the opposite of the code deleted.

### Remaining divergences, documented at their sites
- `load_location("Local")` returns an error where Go falls back to UTC — kept as a **chosen** divergence, not parity: two distinct failures reach that branch, and a UTC fallback would print `Current time in Local:` over a clock hours off in the second (`iana-time-zone` naming a zone `chrono-tz` lacks, where Go reads the system database and answers correctly).
- The listener is per-turn rather than per-process as in Go (handle lifetime is the SDK port's rule); the URL is argv-only and never stored.
- `initialize`'s `serverInfo.version` is the SDK's rather than Go's hardcoded `1.0.0` — protocol metadata that never reaches a transcript.

## Related

Closes #310
Unblocked by #282 (which chose `rmcp`, PR #325).

---
🤖 Implemented by [Claude Code](https://claude.com/claude-code) via `implement-issue` workflow