### PR TITLE
docs(desktop): correct chat/mod.rs's blocker, and unpublish LOCAL_TOOL_NAMES

### DIFF
--- a/desktop/src-tauri/src/native/chat/mod.rs
+++ b/desktop/src-tauri/src/native/chat/mod.rs
@@ -11,12 +11,16 @@
 //! button would silently do nothing.
 //!
 //! But not every chat *can* run here: an agent whose tools come from an
-//! integration or the local MCP server needs machinery this port does not have
-//! (#277, #282), and those chats keep running on the sidecar. So the three
-//! steering routes are answered natively **only when Rust holds a live session
-//! for that chat**, and forward otherwise. Go then answers — correctly, because
-//! it is the side that has the session — and a chat with no live session
-//! anywhere gets Go's own 409 rather than a second copy of it.
+//! **integration** needs one MCP server per provider, which this port does not
+//! have (#311–#317), so `runner::build_options` refuses those and they keep
+//! running on the sidecar. The **local** in-process server was the other half of
+//! that refusal and is gone — `build_options` starts it itself and hands back
+//! the handle (#310) — but that only shrinks the set of chats Go still holds; it
+//! does not empty it, and the argument here turns on the set being non-empty.
+//! So the three steering routes are answered natively **only when Rust holds a
+//! live session for that chat**, and forward otherwise. Go then answers —
+//! correctly, because it is the side that has the session — and a chat with no
+//! live session anywhere gets Go's own 409 rather than a second copy of it.
 //!
 //! That is what lets the four move together without requiring *every* chat to
 //! move at once.

--- a/desktop/src-tauri/src/native/tools/mod.rs
+++ b/desktop/src-tauri/src/native/tools/mod.rs
@@ -66,12 +66,6 @@ use crate::claude::{tool_server, InProcessMcpServer, Result, ToolDef};
 /// and in every stored `tool_use` block.
 pub const LOCAL_MCP_SERVER_NAME: &str = "local-tools";
 
-/// Every tool this server registers, in registration order — `ToolNames`.
-///
-/// The frontend carries its own copy (`desktop/src/views/AgentsView.tsx`), as
-/// the web UI does; this is the list the server actually hosts.
-pub const LOCAL_TOOL_NAMES: &[&str] = &["current_time"];
-
 /// The fully qualified name the CLI knows a local tool by, and the string an
 /// agent's allowlist has to contain — `LocalMCPConfig.AllowedToolName`.
 pub fn allowed_tool_name(tool_name: &str) -> String {
@@ -97,6 +91,14 @@ where
 }
 
 /// Every local tool, as `StartLocalMCPServer` registers them.
+///
+/// This *is* the list — there is deliberately no second `&[&str]` of names
+/// beside it. Go's `LocalMCPConfig.ToolNames` is such a list, hand-copied from
+/// the `mcp.AddTool` calls above it and, as of #310, read by nothing; a Rust
+/// copy would be a third statement of the same truth, free to drift from the
+/// registration it claims to describe. What a caller actually wants —
+/// "what is hosted?" — is answered by [`crate::claude::ToolServer::tool_names`],
+/// which is derived from the registered set and so cannot disagree with it.
 pub fn local_tools() -> Vec<ToolDef> {
     vec![current_time::tool()]
 }
@@ -141,8 +143,26 @@ mod tests {
         assert!(allowed_tool_names(Vec::<String>::new()).is_empty());
     }
 
+    /// The hosted set, spelled out — for the reason
+    /// `the_qualified_name_is_the_one_already_on_disk` spells its string out: a
+    /// list rebuilt from the registration agrees with it by construction and so
+    /// could never notice a tool being renamed or dropped. It stays a fixture
+    /// local to this test rather than a constant of the module, because nothing
+    /// in the crate should be reading a hand-written copy of what
+    /// [`local_tools`] already is.
+    ///
+    /// It is not folded into the vector test below either, because that one
+    /// needs `desktop/parity/local_tools_vectors.json` on disk and answers a
+    /// different question — "does Rust host what Go hosts?" rather than "is
+    /// this still the set we think we wrote?".
+    ///
+    /// Both UIs carry their own copy of this list —
+    /// `desktop/src/views/AgentsView.tsx` and `frontend/src/types.ts` — so
+    /// adding a tool means editing them too; neither can be reached from here.
     #[test]
     fn the_server_hosts_exactly_the_named_tools() {
+        const LOCAL_TOOL_NAMES: &[&str] = &["current_time"];
+
         let server =
             crate::claude::ToolServer::new(LOCAL_MCP_SERVER_NAME).with_tools(local_tools());
         assert_eq!(server.tool_names(), LOCAL_TOOL_NAMES);


### PR DESCRIPTION
## Summary

Follow-up to #310 / PR #343. Two review findings were raised against that PR but it auto-merged before they landed. Documentation and test scope only — **no behaviour change**.

- `native/chat/mod.rs`'s module doc still asserts the opposite of what the code now does.
- `LOCAL_TOOL_NAMES` was a `pub const` with no reader outside its own test.

## Changes

**`desktop/src-tauri/src/native/chat/mod.rs`** — the module doc still says an agent whose tools come from "an integration or the local MCP server" needs machinery this port does not have (#277, #282). The local half is exactly what #310 removed: `runner::build_options` now starts the local server itself. #343 corrected the identical passage in `desktop/CLAUDE.md` and in `native/schedule/mod.rs` and missed this mirror — the copy a reader of the chat port hits first, and in this tree the module doc is the authority.

The paragraph's **argument is deliberately intact**, and now stated outright: moving one class of chat shrinks the set Go still holds without emptying it, which is what the live-session rule turns on. Integrations (#311–#317) are what still forward. The 409 sentence is untouched.

**`desktop/src-tauri/src/native/tools/mod.rs`** — `LOCAL_TOOL_NAMES` was a `pub const` whose only reference in the tree was its own test, while `local_tools()` builds its vector independently — a second copy of the truth, free to drift, and `pub` invited a future caller to trust it.

Checked against Go rather than assumed: `internal/tools/registry.go`'s `LocalMCPConfig.ToolNames` is *also* a hand-copy of the `mcp.AddTool` calls, and a tree-wide grep finds **no reader of it on either side** — so the Rust constant mirrored a field that is not load-bearing in Go either.

Deriving it would have been worse, not better: a `ToolDef` carries the name `new_tool` gave it, so a derived list agrees with the registration by construction and could never catch a rename — the same reasoning `the_qualified_name_is_the_one_already_on_disk` already documents for its spelled-out string. So the literal is now a fixture local to that test, and `local_tools()` gained a paragraph saying it *is* the list, pointing a would-be caller at `ToolServer::tool_names()`, which is derived from the registered set and cannot disagree with it.

## Testing

- [x] `go test ./...` — exit 0, no failures (zero Go files touched by this diff)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --no-fail-fast` — **741 passed, 0 failed**
- [x] `pre-commit run` — all applicable hooks pass (the four frontend hooks are gated on `^frontend/src/` and are no-ops here)

Go lint is unaffected: this diff touches no `.go` files.

## Related

Follow-up to #310, PR #343.

Separately filed while verifying: #344 — a session id under two project paths loses its PRs and its per-model sub-agent breakdown (pre-existing, from #257, unrelated to this diff).

---
🤖 Implemented by [Claude Code](https://claude.com/claude-code) via `implement-issue` workflow