### PR TITLE
feat(desktop): port the GitHub integration MCP server (#312)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -780,9 +780,15 @@ three by #310 and one by #312 — and all six inherit every one:
   `Arc`, not through it: `rmcp` memoizes one schema per input type and hands
   every route a clone, so an in-place edit would reach into a process-wide
   cache. The walk is structure-aware rather than a key sweep — all three are
-  legal property *names* too. `#[serde(deny_unknown_fields)]` is what produces
-  `additionalProperties: false`, which Go reflects onto every struct and its
-  server *validates* against.
+  legal property *names* too — and it follows every position `schemars` can put
+  a subschema in, including the ones nothing has reached yet
+  (`unevaluatedProperties`/`unevaluatedItems`, which 1.x emits for
+  `#[serde(flatten)]` under `deny_unknown_fields`, plus `if`/`then`/`else`,
+  `contains` and `dependentSchemas`): an unwalked keyword leaves a nested
+  `$schema`/`format`/`default` in a schema the model reads and nothing says so.
+  `#[serde(deny_unknown_fields)]` is what produces `additionalProperties:
+  false`, which Go reflects onto every struct and its server *validates*
+  against.
 - **The reflector divergence map is generated, and it is the file to read
   before porting an integration** (#312).
   `desktop/parity/jsonschema_reflect_vectors.json` reflects one reference struct
@@ -817,6 +823,18 @@ three by #310 and one by #312 — and all six inherit every one:
   differs: Go's `validating "arguments": …` against `rmcp`'s `failed to
   deserialize parameters: …`. It is a property of `new_tool`, so every ported
   tool has it; there is no missing conversion to add.
+
+  Nothing in this port implements it, though, and that is the part worth
+  knowing: `into_tool_argument_error` **prefix-matches a hardcoded string**
+  (`"failed to deserialize parameters:"`) against its own extractor's message,
+  so an `rmcp` upgrade rewording either half would flip all 62 ported tools to
+  protocol errors at once — which the CLI renders as "Tool result missing due
+  to internal error", nothing for the model to retry against.
+  `malformed_arguments_are_a_tool_error_rather_than_a_protocol_error`
+  (`native/integrations/github/tests_vectors.rs`) sends a missing field and an
+  unknown field and pins the **kind**, deliberately not the text. Every ported
+  integration inherits the property from `new_tool`, so one test covers all of
+  them; add another only if a port stops going through `new_tool`.
 - **A tool's name is not renameable.** `mcp__local-tools__current_time` is in
   agents' stored `capabilities.local` allowlists and in every `tool_use` block
   already written to `chat_messages`. `desktop/parity/local_tools_vectors.json`
@@ -906,12 +924,52 @@ Five things it brought that #313–#317 will want:
   `client.Do` fails, so `calling GitHub %s %s: request failed` is what the model
   reads there too — no divergence to invent. Every outbound call
   `tokio::select!`s on the token, because `rmcp` spawns handlers detached.
-- **`reqwest` gained `rustls-tls`.** Every hop this shell made was loopback
-  until now, so no TLS backend was configured and `https://api.github.com` would
-  have failed at runtime. rustls with bundled webpki roots, for the reasoning
-  already written on `lettre`: five release triples, no C toolchain.
+- **`reqwest` gained a TLS backend, and it reads the *platform* trust store.**
+  Every hop this shell made was loopback until now, so none was configured and
+  `https://api.github.com` would have failed at runtime. rustls rather than
+  `native-tls` for the reasoning already written on `lettre` (five release
+  triples, no C toolchain) — but `rustls-tls-native-roots`, **not** the
+  `rustls-tls` alias, which is a Mozilla snapshot compiled in. Go's `net/http`
+  reads the platform store, and the case bundled roots break is exactly the one
+  they are usually chosen for: a TLS-inspecting corporate proxy intercepts
+  `api.github.com` like anything else and its CA exists only in the system
+  store, so the web UI's integration would work and the desktop app's would
+  answer `request failed` with nothing to point at the cause. It costs no new
+  crate (`rustls-native-certs` was already in the tree through
+  `tauri-plugin-updater`'s `reqwest 0.13`) and still resolves to `ring`.
+  `lettre`'s webpki roots are #307's decision and are deliberately left alone.
+  One consequence to keep: `reqwest` loads the roots inside `build()` and
+  reports an unusable store as a **builder** error, where Go's `&http.Client{…}`
+  is a struct literal that cannot fail — so `client.rs` holds
+  `OnceLock<Option<Client>>` and answers `calling GitHub …: request failed`
+  rather than panicking inside a handler `rmcp` spawned detached.
+- **`reqwest` gained `gzip`.** Go's transport adds `Accept-Encoding: gzip` and
+  decompresses transparently, so every Go-side integration call is compressed
+  and every uncompressed one here was a silent divergence — most visibly
+  `get_pull_diff`, whose 10 MB cap is 10 MB of highly compressible text. The
+  fakes never compress, so no vector can see it. The cap semantics do not move:
+  reqwest decompresses in its service stack, so `bytes_stream()` yields
+  decompressed bytes and `read_capped` caps what Go's `io.LimitReader` over a
+  gunzipped `resp.Body` caps.
+- **The test seam is `#[cfg(test)]`, and should stay that way in #313–#317.**
+  `githubAPIBase` had to be *exported* on the Go side (`parity.go`) because
+  `desktop/parity` is a different package; both Rust callers are in-crate, so
+  `API_BASE`/`set_api_base` compile out of a shipped binary entirely. What they
+  are is a primitive for pointing every GitHub request — each bearing the
+  user's PAT — at an arbitrary host.
 
-Two divergences are pinned rather than reconciled, both in the vectors:
+One fact to have before the next port, because it is easy to assume the other
+way: **`tools/list` does not carry registration order.** Both SDKs sort by
+name — `rmcp`'s `ToolRouter::list_all` ends in
+`tools.sort_by(|a, b| a.name.cmp(&b.name))`, and `modelcontextprotocol/go-sdk`
+holds tools in a `featureSet` that lists by sorted key — which is why
+`github_vectors.json`'s `tools` array starts at `create_issue` rather than at
+`list_repos`. Registration order is still worth keeping in `SERVICES` order so
+the two `buildMCPServer`s read alike, and it is pinned by
+`an_empty_allowed_set_hosts_every_tool` against `GITHUB_TOOL_NAMES` — but a
+`tools/list` comparison is set equality, not an order assertion.
+
+Four divergences are pinned rather than reconciled, all in the vectors:
 
 - **`encoding/json`'s syntax-error vocabulary.** `trigger_workflow` parses a
   caller-supplied document, and Go's `invalid character 'o' in literal null
@@ -927,6 +985,35 @@ Two divergences are pinned rather than reconciled, both in the vectors:
   Carried by the vector's `rust_target` field. Unreachable with a real GitHub
   run id, and deliberately not reproduced — degrading Rust to match would be
   worse than the divergence.
+- **A zero-fraction float is an integer to Go and not to serde.** Same
+  mechanism, and far more reachable: that same `map[string]any` round trip
+  *validates* against the reflected schema, where JSON Schema counts `30.0` as
+  an `integer`, and re-marshals `float64(30)` back as `30`, so the typed decode
+  succeeds. `serde_json::from_value::<i64>(Number(30.0))` fails outright, and
+  `{"per_page": 30.0}` is something models emit — six of the twenty tools take
+  an integer. Accepting it would mean a newtype on 21 fields whose `JsonSchema`
+  has to be hand-written to stay inlined rather than lifted into `$defs`, which
+  is a schema risk taken for a wording difference, so it is pinned instead:
+  `rust_text` plus `rust_no_request`.
+- **A `.` or `..` path segment reaches a different endpoint.** `url::Url::parse`
+  — which `reqwest` builds every request through — applies WHATWG dot-segment
+  removal for http(s); Go's `net/http` does not normalize and `url.PathEscape`
+  leaves both alone, so `list_issues(owner: "..", repo: "..")` asks Go's GitHub
+  for `/repos/../../issues` (a 404) and would ask this one for `/issues` — *the
+  authenticated user's issues across every repository*, on a request carrying
+  the PAT. Escaping does not help; `%2E%2E` is collapsed too. `owner`, `repo`
+  and `workflow_id` are model-supplied and every tool result carries
+  attacker-authored GitHub content, so it is reachable under prompt injection,
+  and it applies to the write tools too. `reqwest` offers no unnormalized
+  target, so `client::absolute` compares the parsed path and query against the
+  ones the tool built and **refuses** rather than calling somewhere else —
+  answering the site's own `calling GitHub …: request failed`. Five vectors,
+  covering all three URL builders and both the read and the write path, carry
+  `rust_text` and `rust_no_request`. The comparison is exact rather than a `..`
+  scan, so anything else `url` normalizes is caught by construction; nothing
+  legitimate trips it, because `gourl`'s escaping already covers every byte in
+  `url`'s path and query encode sets. **#313–#317 each build URLs the same way
+  and need the same guard.**
 
 ### Things that will bite
 

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -119,6 +119,8 @@ src-tauri/src/
     permissions.rs / hooks.rs   the two callback round trips
     mcp.rs       loopback HTTP host for in-process MCP servers (rmcp, stateless)
     tool.rs      a tool is a function: derived schemas, runtime registration
+    schema_vectors.rs  tests only: which Go shapes schemars reproduces, and what
+                 a port must write for the ones it does not (#312)
     lenient.rs   Go's partial-decode semantics, which serde does not have
   native/        ported endpoints (phase 2+)
     active_time.rs the capped-gap rule, shared by the scanner and the pipeline
@@ -146,6 +148,12 @@ src-tauri/src/
     tools/       the local in-process tools MCP server (#310) — `internal/tools`
       mod.rs     the server name, the qualified `mcp__local-tools__…` names
       current_time.rs  time.LoadLocation and RFC1123/RFC3339, pinned to vectors
+    integrations/github/  the GitHub integration's MCP server (#312) — 20 tools
+      mod.rs     the server name, the allowed-set union and the service gates
+      client.rs  githubAPIBase, the two clients, the three read caps, the four
+                 failure sentences — and what a cancelled call answers
+      body.rs    json.Marshal over a Go map, and encoding/json's unmarshal errors
+      repos.rs / issues.rs / pulls.rs / actions.rs / releases.rs  one per service
     settings.rs  GET /api/settings and /settings/claude-config-dirs (a filesystem
                  probe; Unix, forwards on Windows); the preferences + config dirs
                  a read is scoped to; and `update`, the PUT — written and tested,
@@ -525,7 +533,7 @@ of the `Err` arms the cut-over has to turn into a real response.
 | 1 ✅ | Sidecar + proxy | — | done |
 | 2 ← | Pricing + analytics | `internal/pricing`, `internal/claudesessions` | Pure computation over JSONL + SQLite. No external deps. **In progress**: `/api/pricing/catalog`, `/api/claude-sessions`, `/api/claude-sessions/facets`, `/api/claude-analytics`, `/api/claude-sessions/insights/summary` and the agent reads are native and diff clean. |
 | 3 ← | Storage + tasks | `internal/storage`, `internal/scheduler` | **In progress (#274, #275).** `db.rs` is read-write, the 27 migrations are ported, and the writes whose every effect Rust owns are native — see below. The scheduler's *schedule computation* is ported and pinned (#275); its ownership is not, and is blocked — see below. |
-| 4 ← | Integrations | `internal/integrations`, `internal/trigger` | OAuth2 + MCP servers. Six of them: google, github, slack, jira, confluence, telegram, plus `internal/tools`. **How to host one is settled (#282)** — `claude::ToolServer`, see "Hosting a tool" below; do not invent a second way. **`internal/tools` is done (#310)** — `native/tools/`, and it is the worked example the six should be read against. WhatsApp is **not** among them — see below. |
+| 4 ← | Integrations | `internal/integrations`, `internal/trigger` | OAuth2 + MCP servers. Six of them: google, github, slack, jira, confluence, telegram, plus `internal/tools`. **How to host one is settled (#282)** — `claude::ToolServer`, see "Hosting a tool" below; do not invent a second way. **`internal/tools` is done (#310)** — `native/tools/`, and it is the worked example the six should be read against. **GitHub is done (#312)** — `native/integrations/github/`, the worked example for an *integration*; the registry that hosts it is #311. WhatsApp is **not** among them — see below. |
 | 5 ← | Agent execution | `internal/agent`, `internal/service` | **In progress (#276).** The chat SSE turn is native: `/messages`, `/input`, `/permission` and `/stop`, on top of the ported SDK. The scheduler's executor (#275) is the other caller and still Go's. |
 
 ### The session scanner (`src-tauri/src/native/scanner/`)
@@ -759,24 +767,48 @@ docs carry a full worked example.
 
 **The first real caller is `native/tools/` (#310)**, the local in-process server
 — one tool, no credentials — and it is the file to read before porting an
-integration. Three things it settled that all six inherit:
+integration. Four things are settled before the six integration ports —
+three by #310 and one by #312 — and all six inherit every one:
 
-- **`new_tool` strips `$schema`.** `schemars` stamps a dialect key on every
-  schema it generates and `google/jsonschema-go` stamps none, so a Rust-hosted
-  tool would put a field in front of the model that the same Go-hosted tool does
-  not have. It is stripped by replacing the `Arc`, not through it: `rmcp`
-  memoizes one schema per input type and hands every route a clone, so an
-  in-place edit would reach into a process-wide cache. What is left matches Go
-  key for key — `additionalProperties`, `properties`, `required`, `type` — **for
-  a flat struct of required scalars**, which is all #310 has and all the vectors
-  cover. `#[serde(deny_unknown_fields)]` is what produces the first of those,
-  which Go reflects onto every struct and its server *validates* against.
-  `$schema` is the first of a class, not the whole class: `schemars` and
-  `google/jsonschema-go` are known to diverge on `Option<T>`
-  (`"type":["string","null"]` vs an `omitempty` field that stays
-  `"type":"string"` and just leaves `required`), on nested structs (`$defs`/
-  `$ref` vs inlined) and on integer `"format"`. Get a nested/`Option` parity
-  vector in before the first integration port lands.
+- **`new_tool` normalizes the schema towards Go's** (`normalize_go_schema`).
+  Three keys are dropped, and all three are keys `jsonschema.For` can never
+  emit, so removing one can only move a Rust schema towards Go's: `$schema`
+  (the dialect key `schemars` stamps on everything), `format` (`"int64"` for an
+  `i64`; Go's `Schema.Format` is only ever filled by hand) and `default`
+  (`#[serde(default)]` is the shape that reproduces `omitempty`, and `schemars`
+  advertises the default value it implies). They are dropped by replacing the
+  `Arc`, not through it: `rmcp` memoizes one schema per input type and hands
+  every route a clone, so an in-place edit would reach into a process-wide
+  cache. The walk is structure-aware rather than a key sweep — all three are
+  legal property *names* too. `#[serde(deny_unknown_fields)]` is what produces
+  `additionalProperties: false`, which Go reflects onto every struct and its
+  server *validates* against.
+- **The reflector divergence map is generated, and it is the file to read
+  before porting an integration** (#312).
+  `desktop/parity/jsonschema_reflect_vectors.json` reflects one reference struct
+  covering every shape class through `jsonschema.For`, and
+  `src-tauri/src/claude/schema_vectors.rs` declares the corresponding Rust
+  shapes and pins, per shape, whether they match and what to write when they do
+  not. Two findings drive every port:
+  - **`jsonschema:"required,…"` is not a directive.** `jsonschema-go` reads the
+    whole tag as the property's *description*, `required,` prefix included, and
+    marks a field optional only on `omitempty`/`omitzero`. No params struct in
+    the six integrations writes either, so **every field of all 62 tools is
+    required** and every description the model reads begins with `required,`.
+    Copy the tag verbatim into the doc comment; "fixing" it changes the wire.
+  - **An optional Go field is `#[serde(default)] String`, never
+    `Option<String>`.** `omitempty` moves a field out of `required` and leaves
+    its type alone; an `Option` renders `["string","null"]`, which is a
+    different type in front of the model.
+
+  Three divergences are left standing, each unreachable from #312 and each
+  documented at its site with what a port must do instead: a Go slice renders
+  `["null","array"]` (nothing in the integrations takes a list — every
+  multi-value input is a comma-separated `string` through `splitCSV`), a nested
+  struct is inlined by Go and lifted to `$defs`/`$ref` by `schemars` (every
+  params struct is flat; flatten yours), and a sized or unsigned integer
+  reflects as bounds in Go and as a format in Rust (use `i64`, which is what a
+  Go `int` and `int64` both are).
 - **Malformed arguments are the same *kind* of failure, with different
   wording.** Both servers answer a missing field, an extra field, a wrong type
   or an absent `arguments` with a `CallToolResult` carrying `IsError`, never a
@@ -809,6 +841,92 @@ the allowlist it produced. An agent naming `local: [current_time]` and no
 built-ins has a non-empty `--allowedTools` and still gets no `--disallowedTools`;
 subtracting the allowlist from the twelve built-ins instead would deny all of
 them.
+
+### The GitHub integration (`native/integrations/github/`, #312)
+
+The first of the six, and the largest: twenty tools over five service groups,
+token auth only. It is the file to read beside `native/tools/` before porting
+#313–#317 — that one settles *how to host a tool*, this one settles *how to port
+an integration*.
+
+**Where it lives, and why there.** `native/integrations.rs` stays a file and
+gains one `pub mod github;` line; the port is `native/integrations/github/`.
+Rust admits a `foo.rs` beside a `foo/` directory, so this is the layout that
+moves nothing — the alternative was renaming a 1,400-line module to
+`integrations/mod.rs` for the same result. `ServiceConfig` is reused from it
+rather than redeclared.
+
+**It is the server, not the registry.** `Start(ctx, cfg)` refuses an
+unauthenticated integration, parses `config.GitHubCredentials` and then hosts;
+only the hosting is here. The first two read the `auth` and `credentials`
+columns, which `native/integrations.rs` deliberately never selects, so nothing
+in this shell can supply them yet. #311 owns `Start`/`Stop`/`Reload` and
+`PUT`/`DELETE /api/integrations/{id}`, and is where a credential is first read;
+`start_github_mcp_server` takes the token it will have by then. `auth.go`'s
+`ValidatePAT` is unported for the same reason — no caller, and dead code trips
+clippy.
+
+**The gating rule reads backwards, and it is the thing a port gets wrong.** A
+service registers when its row says `enabled`; within it, a tool registers when
+the union of *every enabled service's* `tools` list names it — **or when that
+union is empty**. So all-enabled-with-no-lists hosts all twenty, and one name
+anywhere narrows every service at once. Both halves are in the vectors.
+
+**Four surfaces are pinned, not one.** `desktop/parity/github_vectors.json` is
+taken from the real Go server over its real MCP transport, against a fake GitHub
+that **records the request each tool built**: the hosted tool set, each
+description and input schema, the request (method, encoded target, headers,
+body) and the result text of every success and every failure path. The request
+half is what pins the things no response reveals — `url.PathEscape` per segment,
+`url.Values.Encode`'s sorted keys and `+`-for-space, the per-page clamp, and
+`json.Marshal`'s sorted keys and HTML escaping in every request body. Regenerate
+with
+`go test ./desktop/parity/ -run TestGitHubVectors -update-github-vectors`.
+
+Five things it brought that #313–#317 will want:
+
+- **`gourl.rs` now has all three of `net/url`'s escaping modes.**
+  `url.PathEscape` is `encodePathSegment` and escapes `/ ; , ?`;
+  `url.QueryEscape` is `encodeQueryComponent` and escapes everything reserved
+  **plus a space as `+`**. `form_urlencoded` — already in the tree — matches
+  neither: it escapes `~` where Go does not and keeps `*` where Go does not.
+  `gourl::Values` is `url.Values` restricted to `Set`, which is all any
+  integration uses. All pinned in `gourl_vectors.json`.
+- **A request body is a `BTreeMap` through `gojson::to_vec_marshal`**
+  (`github/body.rs`), which is what reproduces `json.Marshal` over a Go map:
+  sorted keys and `\u003c`/`\u003e`/`\u0026`. Watch the conditions — Go writes
+  a key only when it is non-empty or true, so `draft: false` sends **no key**,
+  an all-empty update sends `{}` (and therefore still sends `Content-Type`), and
+  a `labels` string of only separators sends `null` rather than `[]`, because
+  `splitCSV` returns a nil slice.
+- **The response bytes never round-trip through a JSON value.** Every success
+  sentence interpolates GitHub's own body verbatim; decoding and re-encoding
+  would reorder its keys and respell its numbers.
+- **A cancelled call answers Go's own sentence.** In Go a cancelled `ctx` is how
+  `client.Do` fails, so `calling GitHub %s %s: request failed` is what the model
+  reads there too — no divergence to invent. Every outbound call
+  `tokio::select!`s on the token, because `rmcp` spawns handlers detached.
+- **`reqwest` gained `rustls-tls`.** Every hop this shell made was loopback
+  until now, so no TLS backend was configured and `https://api.github.com` would
+  have failed at runtime. rustls with bundled webpki roots, for the reasoning
+  already written on `lettre`: five release triples, no C toolchain.
+
+Two divergences are pinned rather than reconciled, both in the vectors:
+
+- **`encoding/json`'s syntax-error vocabulary.** `trigger_workflow` parses a
+  caller-supplied document, and Go's `invalid character 'o' in literal null
+  (expecting 'u')` has no `serde_json` equivalent. Every *well-formed* document
+  matches exactly — including `null` parsing to a nil map with no error, and a
+  null value decoding to `""` — and a *truncated* one matches too
+  (`unexpected end of JSON input`). The vector's `rust_text` field carries the
+  one that does not.
+- **The Go MCP SDK rounds an integer argument above 2^53.** `mcp/tool.go`
+  unmarshals `arguments` into a `map[string]any`, applies schema defaults and
+  re-marshals before the typed decode, so an `int64` reaches a Go handler
+  rounded; `rmcp` deserializes straight into the input struct and does not.
+  Carried by the vector's `rust_target` field. Unreachable with a real GitHub
+  run id, and deliberately not reproduced — degrading Rust to match would be
+  worse than the divergence.
 
 ### Things that will bite
 
@@ -2050,6 +2168,16 @@ right:
 - **An unknown task's job history is `200 []`, not a 404.** Go never checks the
   task exists before listing its runs, so this must be *answered* rather than
   forwarded; only `/api/tasks/{id}` and `/api/job-history/{id}` 404.
+
+**Phase 4 has started.** `internal/tools` (#310) and the **GitHub integration**
+(#312) are ported: `native/tools/` and `native/integrations/github/`, both built
+on the typed-tool layer #282 settled and both pinned by parity vectors taken
+from the running Go server rather than from its source. Neither is *hosted* yet
+— the registry that starts and stops an integration's server, and the credential
+read that feeds it, are #311 — so `chat/runner.rs` still refuses an agent whose
+capabilities name MCP tools. #312 also produced the reflector divergence map
+(`parity/jsonschema_reflect_vectors.json` + `claude/schema_vectors.rs`), which
+is the file to read before starting #313–#317.
 
 Nothing else is ported. Every endpoint not listed above — every write path, the
 per-session reads and every other read — still forwards to Go.

--- a/desktop/parity/github_parity_test.go
+++ b/desktop/parity/github_parity_test.go
@@ -1,0 +1,935 @@
+// Cross-language vectors for the GitHub integration MCP server
+// (`internal/integrations/github`, ported in #312 to
+// `desktop/src-tauri/src/native/integrations/github/`).
+//
+// Four things about that server have to match byte for byte, and none of them
+// is checkable from one language alone:
+//
+//   - **Which tools are hosted.** `buildAllowedSet` unions the `Tools` of every
+//     *enabled* service and each `register*` skips a tool the set does not name
+//     — except that an **empty** set registers everything, which is the rule a
+//     port gets backwards. The names travel in every agent's stored
+//     `capabilities.mcp` allowlist and in every `tool_use` block already written
+//     to `chat_messages`, so a missing or renamed tool is a silent break of
+//     agents that exist.
+//   - **The advertised schema.** `tools/list` hands the CLI what the CLI hands
+//     the model. It is reflected off the params struct by
+//     `google/jsonschema-go`, and `schemars` — the Rust reflector — does not
+//     agree with it by default. `jsonschema_reflect_vectors.json` is the map of
+//     where the two diverge and what a port must write instead; this file is
+//     where the twenty real schemas are pinned.
+//   - **The request each tool builds.** `url.PathEscape` per segment,
+//     `url.Values.Encode`'s sorted keys and `+`-for-space, the per-tool
+//     `per_page` clamp, and `json.Marshal`'s sorted map keys and HTML escaping
+//     in every request body. None of that is visible in a response, so the fake
+//     GitHub below records the request it received and the vectors carry it.
+//   - **The result text.** A tool's result is what the model reads and what
+//     gets persisted, and on the error path it is the *message* — `new_tool`
+//     and `mcp.AddTool` both pack a failed call into `CallToolResult` with
+//     `IsError` rather than raising a protocol error. The raw GitHub bytes are
+//     passed through verbatim, so a port that round-trips them through a JSON
+//     value would reorder keys and respell numbers.
+//
+// Everything here is taken from the **running server** over its real HTTP MCP
+// transport — `github.Start` builds it exactly as `cmd/web.go` does — so a
+// change to the registration path, the client or a sentence fails this test
+// rather than passing a stale belief through.
+//
+// The Rust half lives in
+// `desktop/src-tauri/src/native/integrations/github/tests_vectors.rs` and reads
+// this same file.
+//
+// Regenerate (only from Go, and only when adding cases):
+//
+//	go test ./desktop/parity/ -run TestGitHubVectors -update-github-vectors
+package parity
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	mcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/shaharia-lab/agento/internal/config"
+	"github.com/shaharia-lab/agento/internal/integrations/github"
+)
+
+const githubVectorsFile = "github_vectors.json"
+
+var updateGitHubVectors = flag.Bool("update-github-vectors", false,
+	"rewrite github_vectors.json from this Go toolchain")
+
+// githubParityToken is the personal access token every recorded request carries.
+// It is a fixture, not a secret — and recording the whole `Authorization` header
+// is deliberate: `Bearer ` versus GitHub's older `token ` prefix is exactly the
+// kind of thing a port gets wrong and no response would reveal.
+// A fixture, and gosec's pattern match is exactly right about the shape —
+// which is the point: it has to look like a PAT for the vectors to pin the
+// `Bearer ` prefix. It authenticates nothing.
+const githubParityToken = "parity-pat-token" //nolint:gosec // a test fixture, not a credential
+
+// githubParityID is the integration id, which is half of the server name
+// (`github-<id>`) and therefore half of every `mcp__github-<id>__<tool>` in an
+// agent's allowlist.
+const githubParityID = "gh-parity"
+
+type githubToolVector struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"input_schema"`
+}
+
+// githubRequestVector is what the fake GitHub saw. `Target` is
+// `URL.RequestURI()` — the encoded path plus the encoded, sorted query — which
+// is the one string that pins `url.PathEscape` and `url.Values.Encode`
+// together.
+type githubRequestVector struct {
+	Method        string `json:"method"`
+	Target        string `json:"target"`
+	Authorization string `json:"authorization"`
+	Accept        string `json:"accept"`
+	// Set only when the tool sent a body; `call` adds the header only then.
+	ContentType string `json:"content_type"`
+	Body        string `json:"body"`
+}
+
+// githubResponseScript is what the fake GitHub answered with. The Rust half
+// replays exactly this, so the two languages see the same bytes.
+type githubResponseScript struct {
+	Status int `json:"status"`
+	// Sent only when non-empty. The 302-with and 302-without pair is the whole
+	// of `getRedirectURL`'s contract.
+	Location string `json:"location,omitempty"`
+	Body     string `json:"body"`
+}
+
+type githubCallVector struct {
+	Case      string               `json:"case"`
+	Tool      string               `json:"tool"`
+	Arguments json.RawMessage      `json:"arguments"`
+	Response  githubResponseScript `json:"response"`
+	// nil when the tool failed before it made a request — the only such path is
+	// `trigger_workflow`'s inputs parse.
+	Request *githubRequestVector `json:"request"`
+	IsError bool                 `json:"is_error"`
+	Text    string               `json:"text"`
+	// Set only where Rust cannot reproduce Go's text and the difference is
+	// pinned rather than hidden. See `RustText`'s only users below: Go's
+	// `encoding/json` *syntax* errors come out of a hand-written scanner whose
+	// messages have no serde_json equivalent.
+	RustText string `json:"rust_text,omitempty"`
+	// Likewise for the request, and there is exactly one user: an integer
+	// argument above 2^53 arrives at a Go handler **rounded**, because
+	// `modelcontextprotocol/go-sdk` unmarshals `arguments` into a
+	// `map[string]any`, applies schema defaults and re-marshals before the
+	// typed decode (`mcp/tool.go`). `rmcp` deserializes straight into the
+	// input struct, so Rust keeps the exact value. Unreachable with real
+	// GitHub run ids, which are eleven digits.
+	RustTarget string `json:"rust_target,omitempty"`
+}
+
+type githubHostingVector struct {
+	Case     string                          `json:"case"`
+	Services map[string]config.ServiceConfig `json:"services"`
+	Tools    []string                        `json:"tools"`
+}
+
+type githubVectors struct {
+	Comment       []string              `json:"_comment"`
+	IntegrationID string                `json:"integration_id"`
+	ServerName    string                `json:"server_name"`
+	Version       string                `json:"version"`
+	Token         string                `json:"token"`
+	Tools         []githubToolVector    `json:"tools"`
+	Hosting       []githubHostingVector `json:"hosting"`
+	Calls         []githubCallVector    `json:"calls"`
+}
+
+// ─── The fake GitHub ─────────────────────────────────────────────────────────
+
+// fakeGitHub plays a scripted GitHub and records what it was asked.
+//
+// One handler for every path, because the point is not to model the API — it is
+// to capture the request the tool *built*. A router would have to agree with the
+// port about the shape of each path, which is precisely the thing under test.
+type fakeGitHub struct {
+	mu     sync.Mutex
+	script githubResponseScript
+	seen   *githubRequestVector
+}
+
+func (f *fakeGitHub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		body = nil
+	}
+	f.mu.Lock()
+	script := f.script
+	f.seen = &githubRequestVector{
+		Method:        r.Method,
+		Target:        r.URL.RequestURI(),
+		Authorization: r.Header.Get("Authorization"),
+		Accept:        r.Header.Get("Accept"),
+		ContentType:   r.Header.Get("Content-Type"),
+		Body:          string(body),
+	}
+	f.mu.Unlock()
+
+	if script.Location != "" {
+		w.Header().Set("Location", script.Location)
+	}
+	w.WriteHeader(script.Status)
+	_, _ = w.Write([]byte(script.Body))
+}
+
+// arm sets the next reply and forgets the last request.
+func (f *fakeGitHub) arm(script githubResponseScript) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.script = script
+	f.seen = nil
+}
+
+func (f *fakeGitHub) recorded() *githubRequestVector {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.seen
+}
+
+// ─── Standing the real server up ─────────────────────────────────────────────
+
+// githubSession starts the real integration for services and returns a client
+// session against it. `github.Start` is the app's own entry point, so the
+// authentication check, the credential parse, the server name and the tool
+// registration are all the shipped ones.
+func githubSession(
+	t *testing.T, ctx context.Context, services map[string]config.ServiceConfig,
+) *mcp.ClientSession {
+	t.Helper()
+
+	// gosec flags `GitHubCredentials` because the type has a `client_secret`
+	// field — the OAuth mode this integration does not use. The value marshaled
+	// here is the fixture above, and it reaches nothing but a loopback fake.
+	credentials, err := json.Marshal(config.GitHubCredentials{ //nolint:gosec // fixture credentials
+		AuthMode:            "pat",
+		PersonalAccessToken: githubParityToken,
+	})
+	if err != nil {
+		t.Fatalf("encoding credentials: %v", err)
+	}
+
+	cfg := &config.IntegrationConfig{
+		ID:          githubParityID,
+		Name:        "GitHub (parity)",
+		Type:        "github",
+		Enabled:     true,
+		Credentials: credentials,
+		// `IsAuthenticated` is "present and not the four bytes null"; a PAT
+		// integration stores the validated login here.
+		Auth:     json.RawMessage(`{"login":"octocat"}`),
+		Services: services,
+	}
+
+	serverCfg, err := github.Start(ctx, cfg)
+	if err != nil {
+		t.Fatalf("starting the github integration: %v", err)
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "parity", Version: "1"}, nil)
+	session, err := client.Connect(ctx,
+		&mcp.StreamableClientTransport{Endpoint: serverCfg.URL}, nil)
+	if err != nil {
+		t.Fatalf("connecting to %s: %v", serverCfg.URL, err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	return session
+}
+
+// allServices enables every service with an empty tool list, which is the
+// "empty allowed set registers everything" rule — the configuration the twenty
+// schemas and every call vector are taken under.
+func allServices() map[string]config.ServiceConfig {
+	return map[string]config.ServiceConfig{
+		"repos":         {Enabled: true},
+		"issues":        {Enabled: true},
+		"pull_requests": {Enabled: true},
+		"actions":       {Enabled: true},
+		"releases":      {Enabled: true},
+	}
+}
+
+// hostingCases pin the three gates that decide what a server hosts, each in the
+// shape a real integration row takes.
+var hostingCases = []githubHostingVector{
+	{Case: "every service enabled, no tool lists — an empty allowed set hosts everything",
+		Services: allServices()},
+	{Case: "no services at all", Services: map[string]config.ServiceConfig{}},
+	{Case: "a disabled service contributes neither its gate nor its tools",
+		Services: map[string]config.ServiceConfig{
+			"repos":  {Enabled: true, Tools: []string{"list_repos"}},
+			"issues": {Enabled: false, Tools: []string{"list_issues"}},
+		}},
+	{Case: "a non-empty allowed set is a filter across every enabled service",
+		Services: map[string]config.ServiceConfig{
+			"repos":         {Enabled: true, Tools: []string{"get_repo"}},
+			"issues":        {Enabled: true, Tools: []string{"create_issue", "update_issue"}},
+			"pull_requests": {Enabled: true, Tools: []string{"get_pull_diff"}},
+			"actions":       {Enabled: true, Tools: []string{"get_run_logs"}},
+			"releases":      {Enabled: true, Tools: []string{"list_tags"}},
+		}},
+	// The union is what makes this one non-obvious: `repos` names a tool that
+	// `issues` registers, so enabling `issues` with no list of its own does not
+	// widen the set — but the name from `repos` still admits `list_issues`.
+	{Case: "the allowed set is a union over services, not a per-service list",
+		Services: map[string]config.ServiceConfig{
+			"repos":  {Enabled: true, Tools: []string{"list_repos", "list_issues"}},
+			"issues": {Enabled: true},
+		}},
+	{Case: "a tool named by a disabled service is not allowed anywhere",
+		Services: map[string]config.ServiceConfig{
+			"repos":  {Enabled: true, Tools: []string{"list_repos"}},
+			"issues": {Enabled: true, Tools: nil},
+			"nope":   {Enabled: false, Tools: []string{"get_repo"}},
+		}},
+}
+
+// ─── The call cases ──────────────────────────────────────────────────────────
+
+// okBody is a response body deliberately hostile to a re-encode: keys out of
+// alphabetical order, a trailing-zero decimal, an integer too large for a
+// float64 to hold exactly, and interior whitespace. Go passes the bytes through
+// verbatim, so all four survive into the result text; a port that decoded to a
+// JSON value and re-encoded would change every one of them.
+const okBody = `[{"zebra":1,"id":10152021304050607,"rate":1.50, "name":"x"}]`
+
+func jsonArgs(t *testing.T, args map[string]any) json.RawMessage {
+	t.Helper()
+	encoded, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("encoding arguments: %v", err)
+	}
+	return encoded
+}
+
+// callCase is a call vector before the live run fills in what happened.
+type callCase struct {
+	name       string
+	tool       string
+	args       map[string]any
+	script     githubResponseScript
+	rustText   string
+	rustTarget string
+}
+
+func ok(body string) githubResponseScript {
+	return githubResponseScript{Status: http.StatusOK, Body: body}
+}
+
+func created(body string) githubResponseScript {
+	return githubResponseScript{Status: http.StatusCreated, Body: body}
+}
+
+// githubCallCases is the exercise: every tool at least once on its success
+// path, plus every distinct failure the client can produce.
+//
+// The argument maps are complete rather than minimal because **every field is
+// required** — `google/jsonschema-go` marks a field optional only on
+// `omitempty`/`omitzero`, and not one params struct in this integration carries
+// either, so the server refuses a call that omits a field. That is itself part
+// of the advertised surface, and it is why the empty-string and zero cases
+// below are written as explicit zeros rather than as absent keys.
+func githubCallCases() []callCase {
+	const owner, repo = "my org", "a/b"
+	return []callCase{
+		// ─── repos ───────────────────────────────────────────────────────────
+		{
+			name:   "list_repos/zero values take the default page size and omit page",
+			tool:   "list_repos",
+			args:   map[string]any{"visibility": "", "sort": "", "per_page": 0, "page": 0},
+			script: ok(okBody),
+		},
+		{
+			name: "list_repos/every filter set, and per_page over 100 falls back to 30",
+			tool: "list_repos",
+			args: map[string]any{
+				"visibility": "private", "sort": "full_name", "per_page": 101, "page": 3,
+			},
+			script: ok(okBody),
+		},
+		{
+			name:   "list_repos/per_page 100 is the largest value that survives the clamp",
+			tool:   "list_repos",
+			args:   map[string]any{"visibility": "", "sort": "", "per_page": 100, "page": 1},
+			script: ok(okBody),
+		},
+		{
+			name:   "list_repos/a negative per_page is a zero, not an error",
+			tool:   "list_repos",
+			args:   map[string]any{"visibility": "", "sort": "", "per_page": -5, "page": 0},
+			script: ok(okBody),
+		},
+		{
+			name:   "get_repo/a space and a slash in the segments, PathEscape'd",
+			tool:   "get_repo",
+			args:   map[string]any{"owner": owner, "repo": repo},
+			script: ok(`{"full_name":"my org/a/b"}`),
+		},
+		{
+			// `PathEscape` is `encodePathSegment`, which is not the
+			// `encodePath` `gourl::escape_path` already carries: a segment
+			// escapes `/ ; , ?` and leaves `$ & + : = @` alone. Both halves are
+			// here, plus multi-byte UTF-8, which becomes one `%XX` per byte in
+			// uppercase hex.
+			name:   "get_repo/the reserved bytes a segment keeps, the ones it escapes, and UTF-8",
+			tool:   "get_repo",
+			args:   map[string]any{"owner": "a$&+:=@b", "repo": "café;日本語,x?y"},
+			script: ok(`{"full_name":"x"}`),
+		},
+		{
+			name: "get_repo/a non-2xx status is the API's own body, verbatim",
+			tool: "get_repo",
+			args: map[string]any{"owner": "octocat", "repo": "ghost"},
+			script: githubResponseScript{
+				Status: http.StatusNotFound,
+				Body:   `{"message":"Not Found","status":"404"}`,
+			},
+		},
+		{
+			name:   "get_repo/a 500 with an empty body still names the status",
+			tool:   "get_repo",
+			args:   map[string]any{"owner": "octocat", "repo": "ghost"},
+			script: githubResponseScript{Status: http.StatusInternalServerError, Body: ""},
+		},
+		{
+			// The one query value a user really types. `+`, the space and `~`
+			// are the three bytes where Go's QueryEscape, WHATWG form encoding
+			// and RFC 3986 all disagree.
+			name: "search_code/QueryEscape, where a space is + and a tilde is not escaped",
+			tool: "search_code",
+			args: map[string]any{
+				// `~` and `*` are the two bytes where Go's `QueryEscape` and
+				// WHATWG form encoding disagree in *opposite* directions: Go
+				// keeps `~` and escapes `*`, `form_urlencoded` does the
+				// reverse. A port that reached for the crate already in the
+				// tree would get both wrong and neither would show up in a
+				// response.
+				"query": "repo:o/r func foo+bar ~x/y&z=1 *", "per_page": 0, "page": 0,
+			},
+			script: ok(`{"total_count":1,"items":[]}`),
+		},
+
+		// ─── issues ──────────────────────────────────────────────────────────
+		{
+			name: "list_issues/every filter, and the sorted query Values.Encode produces",
+			tool: "list_issues",
+			args: map[string]any{
+				"owner": "octocat", "repo": "hello-world",
+				"state": "all", "labels": "bug,help wanted", "sort": "updated",
+				"per_page": 50, "page": 2,
+			},
+			script: ok(okBody),
+		},
+		{
+			name: "list_issues/empty filters drop out of the query entirely",
+			tool: "list_issues",
+			args: map[string]any{
+				"owner": "octocat", "repo": "hello-world",
+				"state": "", "labels": "", "sort": "", "per_page": 0, "page": 0,
+			},
+			script: ok(okBody),
+		},
+		{
+			name:   "get_issue/the number is formatted with %d, not escaped",
+			tool:   "get_issue",
+			args:   map[string]any{"owner": "octocat", "repo": "hello-world", "number": 1347},
+			script: ok(`{"number":1347}`),
+		},
+		{
+			name: "create_issue/a full body, whose keys json.Marshal sorts",
+			tool: "create_issue",
+			args: map[string]any{
+				"owner": "octocat", "repo": "hello-world",
+				"title": "Found a bug", "body": "It <broke> & burned",
+				"labels": "bug, help wanted ,", "assignees": "octocat,hubot",
+			},
+			script: created(`{"number":1347}`),
+		},
+		{
+			name: "create_issue/only the required title reaches the body",
+			tool: "create_issue",
+			args: map[string]any{
+				"owner": "octocat", "repo": "hello-world",
+				"title": "Bare", "body": "", "labels": "", "assignees": "",
+			},
+			script: created(`{"number":1348}`),
+		},
+		{
+			// splitCSV returns a **nil** slice for a string that is all
+			// separators, and a nil slice marshals as `null` — not `[]`.
+			name: "create_issue/a labels string of only separators is a null, not an empty array",
+			tool: "create_issue",
+			args: map[string]any{
+				"owner": "octocat", "repo": "hello-world",
+				"title": "Bare", "body": "", "labels": " , , ", "assignees": "",
+			},
+			script: created(`{"number":1349}`),
+		},
+		{
+			name: "update_issue/every field set",
+			tool: "update_issue",
+			args: map[string]any{
+				"owner": "octocat", "repo": "hello-world", "number": 1347,
+				"title": "New", "body": "Text", "state": "closed", "labels": "bug",
+			},
+			script: ok(`{"number":1347,"state":"closed"}`),
+		},
+		{
+			// Nothing is unconditional in this body, so an all-empty update
+			// sends the two bytes `{}` — and still sends the Content-Type
+			// header, because `call` keys that on `body != nil`.
+			name: "update_issue/an empty update still sends a body, and it is {}",
+			tool: "update_issue",
+			args: map[string]any{
+				"owner": "octocat", "repo": "hello-world", "number": 1347,
+				"title": "", "body": "", "state": "", "labels": "",
+			},
+			script: ok(`{"number":1347}`),
+		},
+
+		// ─── pull_requests ───────────────────────────────────────────────────
+		{
+			name: "list_pulls/every filter",
+			tool: "list_pulls",
+			args: map[string]any{
+				"owner": "octocat", "repo": "hello-world",
+				"state": "open", "sort": "popularity", "base": "main",
+				"per_page": 10, "page": 0,
+			},
+			script: ok(okBody),
+		},
+		{
+			name:   "get_pull/the same %d path shape as get_issue",
+			tool:   "get_pull",
+			args:   map[string]any{"owner": "octocat", "repo": "hello-world", "number": 42},
+			script: ok(`{"number":42}`),
+		},
+		{
+			name: "create_pull/draft true adds the key; the three required fields are unconditional",
+			tool: "create_pull",
+			args: map[string]any{
+				"owner": "octocat", "repo": "hello-world",
+				"title": "A PR", "head": "feature", "base": "main",
+				"body": "Body & <b>", "draft": true,
+			},
+			script: created(`{"number":43}`),
+		},
+		{
+			// `if p.Draft` — false omits the key rather than sending `false`.
+			name: "create_pull/draft false omits the key entirely",
+			tool: "create_pull",
+			args: map[string]any{
+				"owner": "octocat", "repo": "hello-world",
+				"title": "A PR", "head": "feature", "base": "main",
+				"body": "", "draft": false,
+			},
+			script: created(`{"number":44}`),
+		},
+		{
+			// The only tool on `callRaw`: a caller-chosen Accept, a 10 MB cap
+			// and a body that is not JSON at all.
+			name:   "get_pull_diff/a non-JSON body under a caller-chosen Accept",
+			tool:   "get_pull_diff",
+			args:   map[string]any{"owner": "octocat", "repo": "hello-world", "number": 42},
+			script: ok("diff --git a/x b/x\n--- a/x\n+++ b/x\n@@ -1 +1 @@\n-a\n+b\n"),
+		},
+		{
+			name: "get_pull_diff/callRaw reports a non-2xx exactly as call does",
+			tool: "get_pull_diff",
+			args: map[string]any{"owner": "octocat", "repo": "hello-world", "number": 42},
+			script: githubResponseScript{
+				Status: http.StatusNotAcceptable, Body: `{"message":"Unsupported media type"}`,
+			},
+		},
+		{
+			name: "list_pull_comments/no filters at all beyond paging",
+			tool: "list_pull_comments",
+			args: map[string]any{
+				"owner": "octocat", "repo": "hello-world", "number": 42,
+				"per_page": 0, "page": 0,
+			},
+			script: ok(okBody),
+		},
+
+		// ─── actions ─────────────────────────────────────────────────────────
+		{
+			name: "list_workflows/paging only",
+			tool: "list_workflows",
+			args: map[string]any{
+				"owner": "octocat", "repo": "hello-world", "per_page": 0, "page": 0,
+			},
+			script: ok(okBody),
+		},
+		{
+			name: "list_workflow_runs/no workflow_id takes the repository-wide path",
+			tool: "list_workflow_runs",
+			args: map[string]any{
+				"owner": "octocat", "repo": "hello-world", "workflow_id": "",
+				"status": "completed", "branch": "main", "per_page": 0, "page": 0,
+			},
+			script: ok(okBody),
+		},
+		{
+			name: "list_workflow_runs/a workflow_id takes the per-workflow path and is PathEscape'd",
+			tool: "list_workflow_runs",
+			args: map[string]any{
+				"owner": "octocat", "repo": "hello-world", "workflow_id": "ci build.yml",
+				"status": "", "branch": "", "per_page": 0, "page": 0,
+			},
+			script: ok(okBody),
+		},
+		{
+			name: "trigger_workflow/inputs parse into a map[string]string and are sorted",
+			tool: "trigger_workflow",
+			args: map[string]any{
+				"owner": "octocat", "repo": "hello-world",
+				"workflow_id": "ci.yml", "ref": "main",
+				"inputs": `{"zebra":"z","alpha":"a"}`,
+			},
+			script: githubResponseScript{Status: http.StatusNoContent, Body: ""},
+		},
+		{
+			name: "trigger_workflow/no inputs at all sends only the ref",
+			tool: "trigger_workflow",
+			args: map[string]any{
+				"owner": "octocat", "repo": "hello-world",
+				"workflow_id": "ci.yml", "ref": "main", "inputs": "",
+			},
+			script: githubResponseScript{Status: http.StatusNoContent, Body: ""},
+		},
+		{
+			// A literal `null` unmarshals into a **nil map** without error, and
+			// a nil map marshals as `null`. The guard is `!= ""`, so this
+			// reaches the parse.
+			name: "trigger_workflow/a literal null parses to a nil map and is sent as null",
+			tool: "trigger_workflow",
+			args: map[string]any{
+				"owner": "octocat", "repo": "hello-world",
+				"workflow_id": "ci.yml", "ref": "main", "inputs": "null",
+			},
+			script: githubResponseScript{Status: http.StatusNoContent, Body: ""},
+		},
+		{
+			name: "trigger_workflow/an array is not a JSON object",
+			tool: "trigger_workflow",
+			args: map[string]any{
+				"owner": "octocat", "repo": "hello-world",
+				"workflow_id": "ci.yml", "ref": "main", "inputs": `["a","b"]`,
+			},
+			script: githubResponseScript{Status: http.StatusNoContent, Body: ""},
+		},
+		{
+			name: "trigger_workflow/a non-string value is not a map[string]string",
+			tool: "trigger_workflow",
+			args: map[string]any{
+				"owner": "octocat", "repo": "hello-world",
+				"workflow_id": "ci.yml", "ref": "main", "inputs": `{"a":1}`,
+			},
+			script: githubResponseScript{Status: http.StatusNoContent, Body: ""},
+		},
+		{
+			// The one place Rust cannot follow: `encoding/json`'s scanner has
+			// its own vocabulary of syntax errors, and serde_json's is
+			// different. Pinned as a divergence rather than papered over —
+			// see `rust_text`.
+			name: "trigger_workflow/a syntactically invalid payload — the one divergence",
+			tool: "trigger_workflow",
+			args: map[string]any{
+				"owner": "octocat", "repo": "hello-world",
+				"workflow_id": "ci.yml", "ref": "main", "inputs": `not json`,
+			},
+			script: githubResponseScript{Status: http.StatusNoContent, Body: ""},
+			// Hand-written, and the only value in this file that is: it is
+			// what `serde_json` says, so it is updated by editing this line
+			// rather than by regenerating from Go. The Rust test fails
+			// against it if serde's wording ever moves, which is the point.
+			rustText: "parsing workflow inputs (must be a JSON object): " +
+				"expected ident at line 1 column 2",
+		},
+		{
+			// Truncation is reproducible, so it is pinned: serde and
+			// encoding/json agree that an unterminated document ended early,
+			// and Go's wording is short enough to reproduce exactly.
+			name: "trigger_workflow/a truncated payload ends the same way in both languages",
+			tool: "trigger_workflow",
+			args: map[string]any{
+				"owner": "octocat", "repo": "hello-world",
+				"workflow_id": "ci.yml", "ref": "main", "inputs": `{"a":`,
+			},
+			script: githubResponseScript{Status: http.StatusNoContent, Body: ""},
+		},
+		{
+			name: "get_workflow_run/a run id inside float64's exact range",
+			tool: "get_workflow_run",
+			args: map[string]any{
+				"owner": "octocat", "repo": "hello-world", "run_id": 15678900123,
+			},
+			script: ok(`{"id":15678900123}`),
+		},
+		{
+			// The one place the *request* diverges, and it is the Go MCP SDK's
+			// doing rather than this integration's: `mcp/tool.go` unmarshals
+			// `arguments` into a `map[string]any`, applies schema defaults and
+			// re-marshals before the typed decode, so an `int64` above 2^53
+			// reaches the handler rounded. `rmcp` deserializes straight into
+			// the input struct and keeps the exact value. Pinned rather than
+			// reproduced — deliberately degrading Rust to match would be worse
+			// than the divergence, which no real GitHub run id can reach.
+			name: "get_workflow_run/a run id above 2^53 — the Go SDK rounds it, Rust does not",
+			tool: "get_workflow_run",
+			args: map[string]any{
+				"owner": "octocat", "repo": "hello-world", "run_id": 10152021304050607,
+			},
+			script:     ok(`{"id":10152021304050607}`),
+			rustTarget: "/repos/octocat/hello-world/actions/runs/10152021304050607",
+		},
+		{
+			name: "get_run_logs/a 302 with a Location is the answer",
+			tool: "get_run_logs",
+			args: map[string]any{"owner": "octocat", "repo": "hello-world", "run_id": 42},
+			script: githubResponseScript{
+				Status:   http.StatusFound,
+				Location: "https://objects.example.invalid/logs.zip?token=abc",
+				Body:     "",
+			},
+		},
+		{
+			name: "get_run_logs/a 301 is a redirect too",
+			tool: "get_run_logs",
+			args: map[string]any{"owner": "octocat", "repo": "hello-world", "run_id": 42},
+			script: githubResponseScript{
+				Status:   http.StatusMovedPermanently,
+				Location: "https://objects.example.invalid/logs.zip",
+				Body:     "",
+			},
+		},
+		{
+			name:   "get_run_logs/a 302 with no Location is its own sentence",
+			tool:   "get_run_logs",
+			args:   map[string]any{"owner": "octocat", "repo": "hello-world", "run_id": 42},
+			script: githubResponseScript{Status: http.StatusFound, Body: ""},
+		},
+		{
+			// getRedirectURL reads at most 512 bytes of a non-redirect body,
+			// which is a different cap from `call`'s 2 MiB — so the error text
+			// is truncated mid-JSON. 700 `x`s make the cut visible.
+			name: "get_run_logs/a non-redirect body is truncated at 512 bytes",
+			tool: "get_run_logs",
+			args: map[string]any{"owner": "octocat", "repo": "hello-world", "run_id": 42},
+			script: githubResponseScript{
+				Status: http.StatusInternalServerError,
+				Body:   `{"message":"` + strings.Repeat("x", 700) + `"}`,
+			},
+		},
+
+		// ─── releases ────────────────────────────────────────────────────────
+		{
+			name: "list_releases/paging only",
+			tool: "list_releases",
+			args: map[string]any{
+				"owner": "octocat", "repo": "hello-world", "per_page": 0, "page": 0,
+			},
+			script: ok(okBody),
+		},
+		{
+			name: "create_release/every optional key present",
+			tool: "create_release",
+			args: map[string]any{
+				"owner": "octocat", "repo": "hello-world", "tag_name": "v1.0.0",
+				"name": "Version 1.0.0", "body": "Notes & <em>more</em>",
+				"target_commitish": "main", "draft": true, "prerelease": true,
+				"generate_release_notes": true,
+			},
+			script: created(`{"id":1,"tag_name":"v1.0.0"}`),
+		},
+		{
+			name: "create_release/false booleans omit their keys",
+			tool: "create_release",
+			args: map[string]any{
+				"owner": "octocat", "repo": "hello-world", "tag_name": "v1.0.1",
+				"name": "", "body": "", "target_commitish": "",
+				"draft": false, "prerelease": false, "generate_release_notes": false,
+			},
+			script: created(`{"id":2,"tag_name":"v1.0.1"}`),
+		},
+		{
+			name: "list_tags/paging only",
+			tool: "list_tags",
+			args: map[string]any{
+				"owner": "octocat", "repo": "hello-world", "per_page": 0, "page": 0,
+			},
+			script: ok(okBody),
+		},
+	}
+}
+
+// ─── The generator ───────────────────────────────────────────────────────────
+
+func TestGitHubVectors(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	fake := &fakeGitHub{}
+	srv := httptest.NewServer(fake)
+	defer srv.Close()
+	restore := github.SetAPIBase(srv.URL)
+	defer restore()
+
+	want := githubVectors{
+		Comment: []string{
+			"Cross-language parity vectors for internal/integrations/github, the GitHub",
+			"integration's in-process MCP server. Generated from Go, then frozen. Read by",
+			"desktop/parity/github_parity_test.go (Go) and by",
+			"desktop/src-tauri/src/native/integrations/github/ (Rust). Every value is exactly",
+			"what Go produces, so a divergence fails one language against the other's real",
+			"output rather than against a belief about it.",
+			"'tools' and 'hosting' come from live tools/list calls against servers built by",
+			"github.Start; 'calls' come from live tools/call calls against a scripted fake",
+			"GitHub that records the request each tool built.",
+			"'token' is a fixture, not a secret: it is recorded so the Bearer prefix is pinned.",
+			"Regenerate with: go test ./desktop/parity/ -run TestGitHubVectors -update-github-vectors",
+		},
+		IntegrationID: githubParityID,
+		ServerName:    fmt.Sprintf("github-%s", githubParityID),
+		Version:       "1.0.0",
+		Token:         githubParityToken,
+	}
+
+	session := githubSession(t, ctx, allServices())
+	listed, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("tools/list: %v", err)
+	}
+	for _, tool := range listed.Tools {
+		schema, err := json.Marshal(tool.InputSchema)
+		if err != nil {
+			t.Fatalf("encoding %s's input schema: %v", tool.Name, err)
+		}
+		want.Tools = append(want.Tools, githubToolVector{
+			Name:        tool.Name,
+			Description: tool.Description,
+			InputSchema: schema,
+		})
+	}
+
+	for _, hosting := range hostingCases {
+		hosting.Tools = hostedTools(t, ctx, hosting.Services)
+		want.Hosting = append(want.Hosting, hosting)
+	}
+
+	for _, c := range githubCallCases() {
+		want.Calls = append(want.Calls, runCallCase(t, ctx, session, fake, c))
+	}
+
+	encoded, err := json.MarshalIndent(want, "", "  ")
+	if err != nil {
+		t.Fatalf("encoding vectors: %v", err)
+	}
+	encoded = append(encoded, '\n')
+
+	if *updateGitHubVectors {
+		if err := os.WriteFile(githubVectorsFile, encoded, 0o600); err != nil {
+			t.Fatalf("writing %s: %v", githubVectorsFile, err)
+		}
+		t.Logf("wrote %s", githubVectorsFile)
+		return
+	}
+
+	frozen, err := os.ReadFile(githubVectorsFile)
+	if err != nil {
+		t.Fatalf("reading %s (regenerate with -update-github-vectors): %v",
+			githubVectorsFile, err)
+	}
+	if string(frozen) != string(encoded) {
+		t.Fatalf("%s is stale: this Go toolchain produces different results.\n"+
+			"Regenerate with -update-github-vectors and check what moved — the Rust "+
+			"port in native/integrations/github/ reads the same file and will fail "+
+			"against it. A moved tool name, schema, request or sentence is not a "+
+			"cosmetic diff: the names are in every agent's stored allowlist and in "+
+			"every tool_use block already written, and the sentences are what the "+
+			"model reads.",
+			githubVectorsFile)
+	}
+}
+
+// hostedTools starts a server for services and asks it what it hosts.
+//
+// Sorted, because `tools/list` order is the registration order and the point
+// here is the *set*; the twenty-tool `tools` block above keeps the order.
+func hostedTools(
+	t *testing.T, ctx context.Context, services map[string]config.ServiceConfig,
+) []string {
+	t.Helper()
+	listed, err := githubSession(t, ctx, services).ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("tools/list: %v", err)
+	}
+	names := make([]string, 0, len(listed.Tools))
+	for _, tool := range listed.Tools {
+		names = append(names, tool.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// runCallCase arms the fake, makes one real tools/call and records everything
+// observable: the request the tool built, and the result the model would read.
+func runCallCase(
+	t *testing.T, ctx context.Context,
+	session *mcp.ClientSession, fake *fakeGitHub, c callCase,
+) githubCallVector {
+	t.Helper()
+
+	fake.arm(c.script)
+	args := jsonArgs(t, c.args)
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: c.tool, Arguments: args,
+	})
+	if err != nil {
+		t.Fatalf("%s: tools/call: %v", c.name, err)
+	}
+	if len(result.Content) != 1 {
+		t.Fatalf("%s: want exactly one content block, got %d", c.name, len(result.Content))
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("%s: want text content, got %T", c.name, result.Content[0])
+	}
+
+	// The credential must never reach the model, on either path.
+	if strings.Contains(text.Text, githubParityToken) {
+		t.Fatalf("%s: the token leaked into a tool result: %s", c.name, text.Text)
+	}
+
+	return githubCallVector{
+		Case:       c.name,
+		Tool:       c.tool,
+		Arguments:  args,
+		Response:   c.script,
+		Request:    fake.recorded(),
+		IsError:    result.IsError,
+		Text:       text.Text,
+		RustText:   c.rustText,
+		RustTarget: c.rustTarget,
+	}
+}

--- a/desktop/parity/github_parity_test.go
+++ b/desktop/parity/github_parity_test.go
@@ -137,6 +137,22 @@ type githubCallVector struct {
 	// input struct, so Rust keeps the exact value. Unreachable with real
 	// GitHub run ids, which are eleven digits.
 	RustTarget string `json:"rust_target,omitempty"`
+	// Set where Go made a request and Rust deliberately makes none. Two causes,
+	// both documented at their cases below and both carrying `RustText` for the
+	// sentence the model reads instead:
+	//
+	//   - a path holding a `.` or `..` segment. Go's `net/http` sends the path
+	//     verbatim, while `url::Url::parse` — which `reqwest` builds every
+	//     request through — applies WHATWG dot-segment removal, so
+	//     `/repos/../../issues` would leave as `/issues`: the *authenticated
+	//     user's* issues across every repository, on a request already carrying
+	//     the PAT. Escaping does not help, `%2E%2E` is collapsed too, and
+	//     `reqwest` offers no unnormalized target, so the port refuses the call
+	//     rather than reaching a different endpoint than Go would.
+	//   - a zero-fraction float for an integer field, which this SDK's
+	//     validate-and-re-marshal turns into an integer and `serde_json`
+	//     refuses, so no handler runs.
+	RustNoRequest bool `json:"rust_no_request,omitempty"`
 }
 
 type githubHostingVector struct {
@@ -324,12 +340,13 @@ func jsonArgs(t *testing.T, args map[string]any) json.RawMessage {
 
 // callCase is a call vector before the live run fills in what happened.
 type callCase struct {
-	name       string
-	tool       string
-	args       map[string]any
-	script     githubResponseScript
-	rustText   string
-	rustTarget string
+	name          string
+	tool          string
+	args          map[string]any
+	script        githubResponseScript
+	rustText      string
+	rustTarget    string
+	rustNoRequest bool
 }
 
 func ok(body string) githubResponseScript {
@@ -780,6 +797,115 @@ func githubCallCases() []callCase {
 			},
 			script: ok(okBody),
 		},
+
+		// ─── a zero-fraction float, which models do emit ─────────────────────
+		{
+			// `{"per_page": 30.0}` is accepted by Go and refused here, and the
+			// mechanism is the 2^53 case's: `mcp/tool.go` unmarshals
+			// `arguments` into a `map[string]any`, **validates** against the
+			// reflected schema — where JSON Schema counts a zero-fraction float
+			// as an `integer` — and re-marshals, so `float64(30)` is written
+			// back as `30` and the typed decode into `int` succeeds. `rmcp`
+			// deserializes straight into the input struct and
+			// `serde_json::from_value::<i64>(Number(30.0))` fails outright.
+			// More reachable than the 2^53 one: six of the twenty tools take an
+			// integer, and a model emitting `30.0` for one is ordinary.
+			//
+			// `json.RawMessage` because Go's encoder writes `float64(30)` as
+			// `30` — the literal has to survive into the `arguments` bytes for
+			// the case to be about anything.
+			//
+			// Scripted as a 404 for one reason: it makes both languages report
+			// an error, so the divergence needs no `rust_is_error` field
+			// alongside `rustText`/`rustNoRequest`. The status is never reached
+			// on the Rust side — the decode fails before a handler runs.
+			name: "list_repos/a zero-fraction float is an integer to Go and not to serde",
+			tool: "list_repos",
+			args: map[string]any{
+				"visibility": "", "sort": "",
+				"per_page": json.RawMessage("30.0"), "page": 0,
+			},
+			script: githubResponseScript{Status: http.StatusNotFound, Body: `{"message":"Not Found"}`},
+			rustText: "failed to deserialize parameters: invalid type: floating point `30.0`, " +
+				"expected i64",
+			rustNoRequest: true,
+		},
+
+		// ─── dot segments ────────────────────────────────────────────────────
+		//
+		// `owner`, `repo` and `workflow_id` are model-supplied and tool results
+		// carry attacker-authored GitHub content, so a `..` reaching a segment
+		// is reachable under prompt injection. Go sends it verbatim — neither
+		// `url.PathEscape` (`.` is unreserved) nor `net/http` normalizes — so
+		// `list_issues(owner: "..", repo: "..")` asks GitHub for
+		// `/repos/../../issues` and gets a 404. A URL library that resolved the
+		// segments would instead ask for `/issues`, which on a PAT-bearing
+		// request is *the authenticated user's issues across every repository*:
+		// scope confusion, not a cosmetic difference.
+		//
+		// These pin the request Go builds so a port cannot quietly build
+		// another. One per call shape — `call`, `call` with a body, `callRaw`
+		// and `getRedirectURL` — because each constructs its own URL, plus a
+		// single-dot case, which resolves to a *different* wrong path than `..`
+		// does. Note that adding `..` to `gourl_parity_test.go`'s segment
+		// inputs would catch none of it: `PathEscape("..")` is `".."` in both
+		// languages and the normalization happens downstream, in whatever
+		// builds the request.
+		//
+		// The `rustText` values below are hand-written, like the syntax-error
+		// one above: they are what the port answers, so they move by editing
+		// these lines rather than by regenerating from Go.
+		{
+			name:          "get_repo/dot segments are sent literally, not resolved",
+			tool:          "get_repo",
+			args:          map[string]any{"owner": "..", "repo": ".."},
+			script:        githubResponseScript{Status: http.StatusNotFound, Body: `{"message":"Not Found"}`},
+			rustText:      "calling GitHub GET /repos/../..: request failed",
+			rustNoRequest: true,
+		},
+		{
+			name:          "get_repo/a single dot segment is sent literally too",
+			tool:          "get_repo",
+			args:          map[string]any{"owner": ".", "repo": "hello-world"},
+			script:        githubResponseScript{Status: http.StatusNotFound, Body: `{"message":"Not Found"}`},
+			rustText:      "calling GitHub GET /repos/./hello-world: request failed",
+			rustNoRequest: true,
+		},
+		{
+			// The write path: a POST whose body is built and sent before the
+			// status is looked at, so the request lands whatever the answer is.
+			// Scripted as a 404 so both languages report an error and the only
+			// difference is the sentence.
+			name: "create_issue/dot segments reach the write path too",
+			args: map[string]any{
+				"owner": "..", "repo": "..",
+				"title": "Bare", "body": "", "labels": "", "assignees": "",
+			},
+			tool:          "create_issue",
+			script:        githubResponseScript{Status: http.StatusNotFound, Body: `{"message":"Not Found"}`},
+			rustText:      "calling GitHub POST /repos/../../issues: request failed",
+			rustNoRequest: true,
+		},
+		{
+			name:          "get_pull_diff/callRaw builds its own URL, and it is not resolved either",
+			tool:          "get_pull_diff",
+			args:          map[string]any{"owner": "..", "repo": "..", "number": 42},
+			script:        githubResponseScript{Status: http.StatusNotFound, Body: `{"message":"Not Found"}`},
+			rustText:      "calling GitHub GET /repos/../../pulls/42: request failed",
+			rustNoRequest: true,
+		},
+		{
+			// `getRedirectURL` is the third URL builder and words its failure
+			// differently — no method placeholder, because the method is a
+			// literal there.
+			name:   "get_run_logs/getRedirectURL builds the third URL, and it is not resolved either",
+			tool:   "get_run_logs",
+			args:   map[string]any{"owner": "..", "repo": "..", "run_id": 42},
+			script: githubResponseScript{Status: http.StatusNotFound, Body: `{"message":"Not Found"}`},
+			rustText: "fetching logs URL for run 42: " +
+				"calling GitHub GET /repos/../../actions/runs/42/logs: request failed",
+			rustNoRequest: true,
+		},
 	}
 }
 
@@ -874,8 +1000,13 @@ func TestGitHubVectors(t *testing.T) {
 
 // hostedTools starts a server for services and asks it what it hosts.
 //
-// Sorted, because `tools/list` order is the registration order and the point
-// here is the *set*; the twenty-tool `tools` block above keeps the order.
+// The point here is the *set*, and the sort only makes explicit what both SDKs
+// already do: `tools/list` answers in **name** order, not registration order —
+// this SDK keeps its tools in a `featureSet` that lists by sorted key, and
+// `rmcp`'s `ToolRouter::list_all` ends in `sort_by(|a, b| a.name.cmp(&b.name))`
+// — which is why the `tools` block above starts at `create_issue` rather than
+// at `list_repos`. Registration order is pinned on the Rust side instead, by
+// `an_empty_allowed_set_hosts_every_tool` against `GITHUB_TOOL_NAMES`.
 func hostedTools(
 	t *testing.T, ctx context.Context, services map[string]config.ServiceConfig,
 ) []string {
@@ -922,14 +1053,15 @@ func runCallCase(
 	}
 
 	return githubCallVector{
-		Case:       c.name,
-		Tool:       c.tool,
-		Arguments:  args,
-		Response:   c.script,
-		Request:    fake.recorded(),
-		IsError:    result.IsError,
-		Text:       text.Text,
-		RustText:   c.rustText,
-		RustTarget: c.rustTarget,
+		Case:          c.name,
+		Tool:          c.tool,
+		Arguments:     args,
+		Response:      c.script,
+		Request:       fake.recorded(),
+		IsError:       result.IsError,
+		Text:          text.Text,
+		RustText:      c.rustText,
+		RustTarget:    c.rustTarget,
+		RustNoRequest: c.rustNoRequest,
 	}
 }

--- a/desktop/parity/github_vectors.json
+++ b/desktop/parity/github_vectors.json
@@ -1964,6 +1964,158 @@
       },
       "is_error": false,
       "text": "Tags: [{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]"
+    },
+    {
+      "case": "list_repos/a zero-fraction float is an integer to Go and not to serde",
+      "tool": "list_repos",
+      "arguments": {
+        "page": 0,
+        "per_page": 30.0,
+        "sort": "",
+        "visibility": ""
+      },
+      "response": {
+        "status": 404,
+        "body": "{\"message\":\"Not Found\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/user/repos?per_page=30",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": true,
+      "text": "github API error: status 404: {\"message\":\"Not Found\"}",
+      "rust_text": "failed to deserialize parameters: invalid type: floating point `30.0`, expected i64",
+      "rust_no_request": true
+    },
+    {
+      "case": "get_repo/dot segments are sent literally, not resolved",
+      "tool": "get_repo",
+      "arguments": {
+        "owner": "..",
+        "repo": ".."
+      },
+      "response": {
+        "status": 404,
+        "body": "{\"message\":\"Not Found\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/repos/../..",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": true,
+      "text": "github API error: status 404: {\"message\":\"Not Found\"}",
+      "rust_text": "calling GitHub GET /repos/../..: request failed",
+      "rust_no_request": true
+    },
+    {
+      "case": "get_repo/a single dot segment is sent literally too",
+      "tool": "get_repo",
+      "arguments": {
+        "owner": ".",
+        "repo": "hello-world"
+      },
+      "response": {
+        "status": 404,
+        "body": "{\"message\":\"Not Found\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/repos/./hello-world",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": true,
+      "text": "github API error: status 404: {\"message\":\"Not Found\"}",
+      "rust_text": "calling GitHub GET /repos/./hello-world: request failed",
+      "rust_no_request": true
+    },
+    {
+      "case": "create_issue/dot segments reach the write path too",
+      "tool": "create_issue",
+      "arguments": {
+        "assignees": "",
+        "body": "",
+        "labels": "",
+        "owner": "..",
+        "repo": "..",
+        "title": "Bare"
+      },
+      "response": {
+        "status": 404,
+        "body": "{\"message\":\"Not Found\"}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/repos/../../issues",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "application/json",
+        "body": "{\"title\":\"Bare\"}"
+      },
+      "is_error": true,
+      "text": "github API error: status 404: {\"message\":\"Not Found\"}",
+      "rust_text": "calling GitHub POST /repos/../../issues: request failed",
+      "rust_no_request": true
+    },
+    {
+      "case": "get_pull_diff/callRaw builds its own URL, and it is not resolved either",
+      "tool": "get_pull_diff",
+      "arguments": {
+        "number": 42,
+        "owner": "..",
+        "repo": ".."
+      },
+      "response": {
+        "status": 404,
+        "body": "{\"message\":\"Not Found\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/repos/../../pulls/42",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3.diff",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": true,
+      "text": "github API error: status 404: {\"message\":\"Not Found\"}",
+      "rust_text": "calling GitHub GET /repos/../../pulls/42: request failed",
+      "rust_no_request": true
+    },
+    {
+      "case": "get_run_logs/getRedirectURL builds the third URL, and it is not resolved either",
+      "tool": "get_run_logs",
+      "arguments": {
+        "owner": "..",
+        "repo": "..",
+        "run_id": 42
+      },
+      "response": {
+        "status": 404,
+        "body": "{\"message\":\"Not Found\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/repos/../../actions/runs/42/logs",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": true,
+      "text": "fetching logs URL for run 42: github API error: status 404: {\"message\":\"Not Found\"}",
+      "rust_text": "fetching logs URL for run 42: calling GitHub GET /repos/../../actions/runs/42/logs: request failed",
+      "rust_no_request": true
     }
   ]
 }

--- a/desktop/parity/github_vectors.json
+++ b/desktop/parity/github_vectors.json
@@ -1,0 +1,1969 @@
+{
+  "_comment": [
+    "Cross-language parity vectors for internal/integrations/github, the GitHub",
+    "integration's in-process MCP server. Generated from Go, then frozen. Read by",
+    "desktop/parity/github_parity_test.go (Go) and by",
+    "desktop/src-tauri/src/native/integrations/github/ (Rust). Every value is exactly",
+    "what Go produces, so a divergence fails one language against the other's real",
+    "output rather than against a belief about it.",
+    "'tools' and 'hosting' come from live tools/list calls against servers built by",
+    "github.Start; 'calls' come from live tools/call calls against a scripted fake",
+    "GitHub that records the request each tool built.",
+    "'token' is a fixture, not a secret: it is recorded so the Bearer prefix is pinned.",
+    "Regenerate with: go test ./desktop/parity/ -run TestGitHubVectors -update-github-vectors"
+  ],
+  "integration_id": "gh-parity",
+  "server_name": "github-gh-parity",
+  "version": "1.0.0",
+  "token": "parity-pat-token",
+  "tools": [
+    {
+      "name": "create_issue",
+      "description": "Creates a new issue in a repository.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "assignees": {
+            "description": "Comma-separated usernames",
+            "type": "string"
+          },
+          "body": {
+            "description": "Issue body in Markdown",
+            "type": "string"
+          },
+          "labels": {
+            "description": "Comma-separated label names",
+            "type": "string"
+          },
+          "owner": {
+            "description": "required,Repository owner",
+            "type": "string"
+          },
+          "repo": {
+            "description": "required,Repository name",
+            "type": "string"
+          },
+          "title": {
+            "description": "required,Issue title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "title",
+          "body",
+          "labels",
+          "assignees"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "create_pull",
+      "description": "Creates a new pull request.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "base": {
+            "description": "required,Target branch name",
+            "type": "string"
+          },
+          "body": {
+            "description": "PR body in Markdown",
+            "type": "string"
+          },
+          "draft": {
+            "description": "Create as draft. Default: false",
+            "type": "boolean"
+          },
+          "head": {
+            "description": "required,Source branch name",
+            "type": "string"
+          },
+          "owner": {
+            "description": "required,Repository owner",
+            "type": "string"
+          },
+          "repo": {
+            "description": "required,Repository name",
+            "type": "string"
+          },
+          "title": {
+            "description": "required,Pull request title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "title",
+          "head",
+          "base",
+          "body",
+          "draft"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "create_release",
+      "description": "Creates a new release in a repository.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "description": "Release notes in Markdown",
+            "type": "string"
+          },
+          "draft": {
+            "description": "Create as draft",
+            "type": "boolean"
+          },
+          "generate_release_notes": {
+            "description": "Auto-generate notes",
+            "type": "boolean"
+          },
+          "name": {
+            "description": "Release name",
+            "type": "string"
+          },
+          "owner": {
+            "description": "required,Repository owner",
+            "type": "string"
+          },
+          "prerelease": {
+            "description": "Mark as pre-release",
+            "type": "boolean"
+          },
+          "repo": {
+            "description": "required,Repository name",
+            "type": "string"
+          },
+          "tag_name": {
+            "description": "required,Tag name",
+            "type": "string"
+          },
+          "target_commitish": {
+            "description": "Branch or commit SHA",
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "tag_name",
+          "name",
+          "body",
+          "target_commitish",
+          "draft",
+          "prerelease",
+          "generate_release_notes"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_issue",
+      "description": "Gets details of a specific issue by number.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "number": {
+            "description": "required,Issue number",
+            "type": "integer"
+          },
+          "owner": {
+            "description": "required,Repository owner",
+            "type": "string"
+          },
+          "repo": {
+            "description": "required,Repository name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "number"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_pull",
+      "description": "Gets details of a specific pull request by number.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "number": {
+            "description": "required,Pull request number",
+            "type": "integer"
+          },
+          "owner": {
+            "description": "required,Repository owner",
+            "type": "string"
+          },
+          "repo": {
+            "description": "required,Repository name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "number"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_pull_diff",
+      "description": "Gets the diff of a pull request.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "number": {
+            "description": "required,Pull request number",
+            "type": "integer"
+          },
+          "owner": {
+            "description": "required,Repository owner",
+            "type": "string"
+          },
+          "repo": {
+            "description": "required,Repository name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "number"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_repo",
+      "description": "Gets details of a specific repository by owner/name.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "owner": {
+            "description": "required,Repository owner",
+            "type": "string"
+          },
+          "repo": {
+            "description": "required,Repository name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner",
+          "repo"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_run_logs",
+      "description": "Gets the download URL for a workflow run's logs. The GitHub API returns a redirect to a time-limited download URL.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "owner": {
+            "description": "required,Repository owner",
+            "type": "string"
+          },
+          "repo": {
+            "description": "required,Repository name",
+            "type": "string"
+          },
+          "run_id": {
+            "description": "required,Workflow run ID",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "run_id"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_workflow_run",
+      "description": "Gets details of a specific workflow run.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "owner": {
+            "description": "required,Repository owner",
+            "type": "string"
+          },
+          "repo": {
+            "description": "required,Repository name",
+            "type": "string"
+          },
+          "run_id": {
+            "description": "required,Workflow run ID",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "run_id"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_issues",
+      "description": "Lists issues for a repository.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "labels": {
+            "description": "Comma-separated label names",
+            "type": "string"
+          },
+          "owner": {
+            "description": "required,Repository owner",
+            "type": "string"
+          },
+          "page": {
+            "description": "Page number. Default: 1",
+            "type": "integer"
+          },
+          "per_page": {
+            "description": "Results per page (max 100)",
+            "type": "integer"
+          },
+          "repo": {
+            "description": "required,Repository name",
+            "type": "string"
+          },
+          "sort": {
+            "description": "Sort: created, updated, comments",
+            "type": "string"
+          },
+          "state": {
+            "description": "Filter: open, closed, all. Default: open",
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "state",
+          "labels",
+          "sort",
+          "per_page",
+          "page"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_pull_comments",
+      "description": "Lists review comments on a pull request.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "number": {
+            "description": "required,Pull request number",
+            "type": "integer"
+          },
+          "owner": {
+            "description": "required,Repository owner",
+            "type": "string"
+          },
+          "page": {
+            "description": "Page number. Default: 1",
+            "type": "integer"
+          },
+          "per_page": {
+            "description": "Results per page (max 100)",
+            "type": "integer"
+          },
+          "repo": {
+            "description": "required,Repository name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "number",
+          "per_page",
+          "page"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_pulls",
+      "description": "Lists pull requests for a repository.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "base": {
+            "description": "Filter by base branch name",
+            "type": "string"
+          },
+          "owner": {
+            "description": "required,Repository owner",
+            "type": "string"
+          },
+          "page": {
+            "description": "Page number. Default: 1",
+            "type": "integer"
+          },
+          "per_page": {
+            "description": "Results per page (max 100)",
+            "type": "integer"
+          },
+          "repo": {
+            "description": "required,Repository name",
+            "type": "string"
+          },
+          "sort": {
+            "description": "Sort: created, updated, popularity",
+            "type": "string"
+          },
+          "state": {
+            "description": "Filter: open, closed, all",
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "state",
+          "sort",
+          "base",
+          "per_page",
+          "page"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_releases",
+      "description": "Lists releases for a repository.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "owner": {
+            "description": "required,Repository owner",
+            "type": "string"
+          },
+          "page": {
+            "description": "Page number. Default: 1",
+            "type": "integer"
+          },
+          "per_page": {
+            "description": "Results per page (max 100)",
+            "type": "integer"
+          },
+          "repo": {
+            "description": "required,Repository name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "per_page",
+          "page"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_repos",
+      "description": "Lists repositories for the authenticated user.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "page": {
+            "description": "Page number. Default: 1",
+            "type": "integer"
+          },
+          "per_page": {
+            "description": "Results per page (max 100). Default: 30",
+            "type": "integer"
+          },
+          "sort": {
+            "description": "Sort by: created, updated, pushed, full_name",
+            "type": "string"
+          },
+          "visibility": {
+            "description": "Filter by visibility: all, public, private",
+            "type": "string"
+          }
+        },
+        "required": [
+          "visibility",
+          "sort",
+          "per_page",
+          "page"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_tags",
+      "description": "Lists tags for a repository.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "owner": {
+            "description": "required,Repository owner",
+            "type": "string"
+          },
+          "page": {
+            "description": "Page number. Default: 1",
+            "type": "integer"
+          },
+          "per_page": {
+            "description": "Results per page (max 100)",
+            "type": "integer"
+          },
+          "repo": {
+            "description": "required,Repository name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "per_page",
+          "page"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_workflow_runs",
+      "description": "Lists workflow runs for a repository.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "branch": {
+            "description": "Filter by branch name",
+            "type": "string"
+          },
+          "owner": {
+            "description": "required,Repository owner",
+            "type": "string"
+          },
+          "page": {
+            "description": "Page number. Default: 1",
+            "type": "integer"
+          },
+          "per_page": {
+            "description": "Results per page (max 100)",
+            "type": "integer"
+          },
+          "repo": {
+            "description": "required,Repository name",
+            "type": "string"
+          },
+          "status": {
+            "description": "Filter: queued, in_progress, completed",
+            "type": "string"
+          },
+          "workflow_id": {
+            "description": "Workflow ID or file name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "workflow_id",
+          "status",
+          "branch",
+          "per_page",
+          "page"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_workflows",
+      "description": "Lists all workflows in a repository.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "owner": {
+            "description": "required,Repository owner",
+            "type": "string"
+          },
+          "page": {
+            "description": "Page number. Default: 1",
+            "type": "integer"
+          },
+          "per_page": {
+            "description": "Results per page (max 100)",
+            "type": "integer"
+          },
+          "repo": {
+            "description": "required,Repository name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "per_page",
+          "page"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "search_code",
+      "description": "Searches for code across GitHub repositories using a query string.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "page": {
+            "description": "Page number. Default: 1",
+            "type": "integer"
+          },
+          "per_page": {
+            "description": "Results per page (max 100). Default: 30",
+            "type": "integer"
+          },
+          "query": {
+            "description": "required,Search query",
+            "type": "string"
+          }
+        },
+        "required": [
+          "query",
+          "per_page",
+          "page"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "trigger_workflow",
+      "description": "Triggers a workflow dispatch event.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "inputs": {
+            "description": "JSON-encoded workflow inputs",
+            "type": "string"
+          },
+          "owner": {
+            "description": "required,Repository owner",
+            "type": "string"
+          },
+          "ref": {
+            "description": "required,Git ref (branch or tag)",
+            "type": "string"
+          },
+          "repo": {
+            "description": "required,Repository name",
+            "type": "string"
+          },
+          "workflow_id": {
+            "description": "required,Workflow ID or file name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "workflow_id",
+          "ref",
+          "inputs"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "update_issue",
+      "description": "Updates an existing issue.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "description": "New body in Markdown",
+            "type": "string"
+          },
+          "labels": {
+            "description": "Comma-separated label names",
+            "type": "string"
+          },
+          "number": {
+            "description": "required,Issue number",
+            "type": "integer"
+          },
+          "owner": {
+            "description": "required,Repository owner",
+            "type": "string"
+          },
+          "repo": {
+            "description": "required,Repository name",
+            "type": "string"
+          },
+          "state": {
+            "description": "New state: open or closed",
+            "type": "string"
+          },
+          "title": {
+            "description": "New title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner",
+          "repo",
+          "number",
+          "title",
+          "body",
+          "state",
+          "labels"
+        ],
+        "type": "object"
+      }
+    }
+  ],
+  "hosting": [
+    {
+      "case": "every service enabled, no tool lists — an empty allowed set hosts everything",
+      "services": {
+        "actions": {
+          "enabled": true,
+          "tools": null
+        },
+        "issues": {
+          "enabled": true,
+          "tools": null
+        },
+        "pull_requests": {
+          "enabled": true,
+          "tools": null
+        },
+        "releases": {
+          "enabled": true,
+          "tools": null
+        },
+        "repos": {
+          "enabled": true,
+          "tools": null
+        }
+      },
+      "tools": [
+        "create_issue",
+        "create_pull",
+        "create_release",
+        "get_issue",
+        "get_pull",
+        "get_pull_diff",
+        "get_repo",
+        "get_run_logs",
+        "get_workflow_run",
+        "list_issues",
+        "list_pull_comments",
+        "list_pulls",
+        "list_releases",
+        "list_repos",
+        "list_tags",
+        "list_workflow_runs",
+        "list_workflows",
+        "search_code",
+        "trigger_workflow",
+        "update_issue"
+      ]
+    },
+    {
+      "case": "no services at all",
+      "services": {},
+      "tools": []
+    },
+    {
+      "case": "a disabled service contributes neither its gate nor its tools",
+      "services": {
+        "issues": {
+          "enabled": false,
+          "tools": [
+            "list_issues"
+          ]
+        },
+        "repos": {
+          "enabled": true,
+          "tools": [
+            "list_repos"
+          ]
+        }
+      },
+      "tools": [
+        "list_repos"
+      ]
+    },
+    {
+      "case": "a non-empty allowed set is a filter across every enabled service",
+      "services": {
+        "actions": {
+          "enabled": true,
+          "tools": [
+            "get_run_logs"
+          ]
+        },
+        "issues": {
+          "enabled": true,
+          "tools": [
+            "create_issue",
+            "update_issue"
+          ]
+        },
+        "pull_requests": {
+          "enabled": true,
+          "tools": [
+            "get_pull_diff"
+          ]
+        },
+        "releases": {
+          "enabled": true,
+          "tools": [
+            "list_tags"
+          ]
+        },
+        "repos": {
+          "enabled": true,
+          "tools": [
+            "get_repo"
+          ]
+        }
+      },
+      "tools": [
+        "create_issue",
+        "get_pull_diff",
+        "get_repo",
+        "get_run_logs",
+        "list_tags",
+        "update_issue"
+      ]
+    },
+    {
+      "case": "the allowed set is a union over services, not a per-service list",
+      "services": {
+        "issues": {
+          "enabled": true,
+          "tools": null
+        },
+        "repos": {
+          "enabled": true,
+          "tools": [
+            "list_repos",
+            "list_issues"
+          ]
+        }
+      },
+      "tools": [
+        "list_issues",
+        "list_repos"
+      ]
+    },
+    {
+      "case": "a tool named by a disabled service is not allowed anywhere",
+      "services": {
+        "issues": {
+          "enabled": true,
+          "tools": null
+        },
+        "nope": {
+          "enabled": false,
+          "tools": [
+            "get_repo"
+          ]
+        },
+        "repos": {
+          "enabled": true,
+          "tools": [
+            "list_repos"
+          ]
+        }
+      },
+      "tools": [
+        "list_repos"
+      ]
+    }
+  ],
+  "calls": [
+    {
+      "case": "list_repos/zero values take the default page size and omit page",
+      "tool": "list_repos",
+      "arguments": {
+        "page": 0,
+        "per_page": 0,
+        "sort": "",
+        "visibility": ""
+      },
+      "response": {
+        "status": 200,
+        "body": "[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/user/repos?per_page=30",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Repositories: [{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]"
+    },
+    {
+      "case": "list_repos/every filter set, and per_page over 100 falls back to 30",
+      "tool": "list_repos",
+      "arguments": {
+        "page": 3,
+        "per_page": 101,
+        "sort": "full_name",
+        "visibility": "private"
+      },
+      "response": {
+        "status": 200,
+        "body": "[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/user/repos?page=3\u0026per_page=30\u0026sort=full_name\u0026visibility=private",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Repositories: [{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]"
+    },
+    {
+      "case": "list_repos/per_page 100 is the largest value that survives the clamp",
+      "tool": "list_repos",
+      "arguments": {
+        "page": 1,
+        "per_page": 100,
+        "sort": "",
+        "visibility": ""
+      },
+      "response": {
+        "status": 200,
+        "body": "[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/user/repos?page=1\u0026per_page=100",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Repositories: [{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]"
+    },
+    {
+      "case": "list_repos/a negative per_page is a zero, not an error",
+      "tool": "list_repos",
+      "arguments": {
+        "page": 0,
+        "per_page": -5,
+        "sort": "",
+        "visibility": ""
+      },
+      "response": {
+        "status": 200,
+        "body": "[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/user/repos?per_page=30",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Repositories: [{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]"
+    },
+    {
+      "case": "get_repo/a space and a slash in the segments, PathEscape'd",
+      "tool": "get_repo",
+      "arguments": {
+        "owner": "my org",
+        "repo": "a/b"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"full_name\":\"my org/a/b\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/repos/my%20org/a%2Fb",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Repository: {\"full_name\":\"my org/a/b\"}"
+    },
+    {
+      "case": "get_repo/the reserved bytes a segment keeps, the ones it escapes, and UTF-8",
+      "tool": "get_repo",
+      "arguments": {
+        "owner": "a$\u0026+:=@b",
+        "repo": "café;日本語,x?y"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"full_name\":\"x\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/repos/a$\u0026+:=@b/caf%C3%A9%3B%E6%97%A5%E6%9C%AC%E8%AA%9E%2Cx%3Fy",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Repository: {\"full_name\":\"x\"}"
+    },
+    {
+      "case": "get_repo/a non-2xx status is the API's own body, verbatim",
+      "tool": "get_repo",
+      "arguments": {
+        "owner": "octocat",
+        "repo": "ghost"
+      },
+      "response": {
+        "status": 404,
+        "body": "{\"message\":\"Not Found\",\"status\":\"404\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/repos/octocat/ghost",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": true,
+      "text": "github API error: status 404: {\"message\":\"Not Found\",\"status\":\"404\"}"
+    },
+    {
+      "case": "get_repo/a 500 with an empty body still names the status",
+      "tool": "get_repo",
+      "arguments": {
+        "owner": "octocat",
+        "repo": "ghost"
+      },
+      "response": {
+        "status": 500,
+        "body": ""
+      },
+      "request": {
+        "method": "GET",
+        "target": "/repos/octocat/ghost",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": true,
+      "text": "github API error: status 500: "
+    },
+    {
+      "case": "search_code/QueryEscape, where a space is + and a tilde is not escaped",
+      "tool": "search_code",
+      "arguments": {
+        "page": 0,
+        "per_page": 0,
+        "query": "repo:o/r func foo+bar ~x/y\u0026z=1 *"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"total_count\":1,\"items\":[]}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/search/code?per_page=30\u0026q=repo%3Ao%2Fr+func+foo%2Bbar+~x%2Fy%26z%3D1+%2A",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Search results: {\"total_count\":1,\"items\":[]}"
+    },
+    {
+      "case": "list_issues/every filter, and the sorted query Values.Encode produces",
+      "tool": "list_issues",
+      "arguments": {
+        "labels": "bug,help wanted",
+        "owner": "octocat",
+        "page": 2,
+        "per_page": 50,
+        "repo": "hello-world",
+        "sort": "updated",
+        "state": "all"
+      },
+      "response": {
+        "status": 200,
+        "body": "[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/repos/octocat/hello-world/issues?labels=bug%2Chelp+wanted\u0026page=2\u0026per_page=50\u0026sort=updated\u0026state=all",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Issues: [{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]"
+    },
+    {
+      "case": "list_issues/empty filters drop out of the query entirely",
+      "tool": "list_issues",
+      "arguments": {
+        "labels": "",
+        "owner": "octocat",
+        "page": 0,
+        "per_page": 0,
+        "repo": "hello-world",
+        "sort": "",
+        "state": ""
+      },
+      "response": {
+        "status": 200,
+        "body": "[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/repos/octocat/hello-world/issues?per_page=30",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Issues: [{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]"
+    },
+    {
+      "case": "get_issue/the number is formatted with %d, not escaped",
+      "tool": "get_issue",
+      "arguments": {
+        "number": 1347,
+        "owner": "octocat",
+        "repo": "hello-world"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"number\":1347}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/repos/octocat/hello-world/issues/1347",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Issue: {\"number\":1347}"
+    },
+    {
+      "case": "create_issue/a full body, whose keys json.Marshal sorts",
+      "tool": "create_issue",
+      "arguments": {
+        "assignees": "octocat,hubot",
+        "body": "It \u003cbroke\u003e \u0026 burned",
+        "labels": "bug, help wanted ,",
+        "owner": "octocat",
+        "repo": "hello-world",
+        "title": "Found a bug"
+      },
+      "response": {
+        "status": 201,
+        "body": "{\"number\":1347}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/repos/octocat/hello-world/issues",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "application/json",
+        "body": "{\"assignees\":[\"octocat\",\"hubot\"],\"body\":\"It \\u003cbroke\\u003e \\u0026 burned\",\"labels\":[\"bug\",\"help wanted\"],\"title\":\"Found a bug\"}"
+      },
+      "is_error": false,
+      "text": "Issue created: {\"number\":1347}"
+    },
+    {
+      "case": "create_issue/only the required title reaches the body",
+      "tool": "create_issue",
+      "arguments": {
+        "assignees": "",
+        "body": "",
+        "labels": "",
+        "owner": "octocat",
+        "repo": "hello-world",
+        "title": "Bare"
+      },
+      "response": {
+        "status": 201,
+        "body": "{\"number\":1348}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/repos/octocat/hello-world/issues",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "application/json",
+        "body": "{\"title\":\"Bare\"}"
+      },
+      "is_error": false,
+      "text": "Issue created: {\"number\":1348}"
+    },
+    {
+      "case": "create_issue/a labels string of only separators is a null, not an empty array",
+      "tool": "create_issue",
+      "arguments": {
+        "assignees": "",
+        "body": "",
+        "labels": " , , ",
+        "owner": "octocat",
+        "repo": "hello-world",
+        "title": "Bare"
+      },
+      "response": {
+        "status": 201,
+        "body": "{\"number\":1349}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/repos/octocat/hello-world/issues",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "application/json",
+        "body": "{\"labels\":null,\"title\":\"Bare\"}"
+      },
+      "is_error": false,
+      "text": "Issue created: {\"number\":1349}"
+    },
+    {
+      "case": "update_issue/every field set",
+      "tool": "update_issue",
+      "arguments": {
+        "body": "Text",
+        "labels": "bug",
+        "number": 1347,
+        "owner": "octocat",
+        "repo": "hello-world",
+        "state": "closed",
+        "title": "New"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"number\":1347,\"state\":\"closed\"}"
+      },
+      "request": {
+        "method": "PATCH",
+        "target": "/repos/octocat/hello-world/issues/1347",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "application/json",
+        "body": "{\"body\":\"Text\",\"labels\":[\"bug\"],\"state\":\"closed\",\"title\":\"New\"}"
+      },
+      "is_error": false,
+      "text": "Issue updated: {\"number\":1347,\"state\":\"closed\"}"
+    },
+    {
+      "case": "update_issue/an empty update still sends a body, and it is {}",
+      "tool": "update_issue",
+      "arguments": {
+        "body": "",
+        "labels": "",
+        "number": 1347,
+        "owner": "octocat",
+        "repo": "hello-world",
+        "state": "",
+        "title": ""
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"number\":1347}"
+      },
+      "request": {
+        "method": "PATCH",
+        "target": "/repos/octocat/hello-world/issues/1347",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "application/json",
+        "body": "{}"
+      },
+      "is_error": false,
+      "text": "Issue updated: {\"number\":1347}"
+    },
+    {
+      "case": "list_pulls/every filter",
+      "tool": "list_pulls",
+      "arguments": {
+        "base": "main",
+        "owner": "octocat",
+        "page": 0,
+        "per_page": 10,
+        "repo": "hello-world",
+        "sort": "popularity",
+        "state": "open"
+      },
+      "response": {
+        "status": 200,
+        "body": "[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/repos/octocat/hello-world/pulls?base=main\u0026per_page=10\u0026sort=popularity\u0026state=open",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Pull requests: [{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]"
+    },
+    {
+      "case": "get_pull/the same %d path shape as get_issue",
+      "tool": "get_pull",
+      "arguments": {
+        "number": 42,
+        "owner": "octocat",
+        "repo": "hello-world"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"number\":42}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/repos/octocat/hello-world/pulls/42",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Pull request: {\"number\":42}"
+    },
+    {
+      "case": "create_pull/draft true adds the key; the three required fields are unconditional",
+      "tool": "create_pull",
+      "arguments": {
+        "base": "main",
+        "body": "Body \u0026 \u003cb\u003e",
+        "draft": true,
+        "head": "feature",
+        "owner": "octocat",
+        "repo": "hello-world",
+        "title": "A PR"
+      },
+      "response": {
+        "status": 201,
+        "body": "{\"number\":43}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/repos/octocat/hello-world/pulls",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "application/json",
+        "body": "{\"base\":\"main\",\"body\":\"Body \\u0026 \\u003cb\\u003e\",\"draft\":true,\"head\":\"feature\",\"title\":\"A PR\"}"
+      },
+      "is_error": false,
+      "text": "Pull request created: {\"number\":43}"
+    },
+    {
+      "case": "create_pull/draft false omits the key entirely",
+      "tool": "create_pull",
+      "arguments": {
+        "base": "main",
+        "body": "",
+        "draft": false,
+        "head": "feature",
+        "owner": "octocat",
+        "repo": "hello-world",
+        "title": "A PR"
+      },
+      "response": {
+        "status": 201,
+        "body": "{\"number\":44}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/repos/octocat/hello-world/pulls",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "application/json",
+        "body": "{\"base\":\"main\",\"head\":\"feature\",\"title\":\"A PR\"}"
+      },
+      "is_error": false,
+      "text": "Pull request created: {\"number\":44}"
+    },
+    {
+      "case": "get_pull_diff/a non-JSON body under a caller-chosen Accept",
+      "tool": "get_pull_diff",
+      "arguments": {
+        "number": 42,
+        "owner": "octocat",
+        "repo": "hello-world"
+      },
+      "response": {
+        "status": 200,
+        "body": "diff --git a/x b/x\n--- a/x\n+++ b/x\n@@ -1 +1 @@\n-a\n+b\n"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/repos/octocat/hello-world/pulls/42",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3.diff",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Diff:\ndiff --git a/x b/x\n--- a/x\n+++ b/x\n@@ -1 +1 @@\n-a\n+b\n"
+    },
+    {
+      "case": "get_pull_diff/callRaw reports a non-2xx exactly as call does",
+      "tool": "get_pull_diff",
+      "arguments": {
+        "number": 42,
+        "owner": "octocat",
+        "repo": "hello-world"
+      },
+      "response": {
+        "status": 406,
+        "body": "{\"message\":\"Unsupported media type\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/repos/octocat/hello-world/pulls/42",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3.diff",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": true,
+      "text": "github API error: status 406: {\"message\":\"Unsupported media type\"}"
+    },
+    {
+      "case": "list_pull_comments/no filters at all beyond paging",
+      "tool": "list_pull_comments",
+      "arguments": {
+        "number": 42,
+        "owner": "octocat",
+        "page": 0,
+        "per_page": 0,
+        "repo": "hello-world"
+      },
+      "response": {
+        "status": 200,
+        "body": "[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/repos/octocat/hello-world/pulls/42/comments?per_page=30",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Comments: [{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]"
+    },
+    {
+      "case": "list_workflows/paging only",
+      "tool": "list_workflows",
+      "arguments": {
+        "owner": "octocat",
+        "page": 0,
+        "per_page": 0,
+        "repo": "hello-world"
+      },
+      "response": {
+        "status": 200,
+        "body": "[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/repos/octocat/hello-world/actions/workflows?per_page=30",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Workflows: [{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]"
+    },
+    {
+      "case": "list_workflow_runs/no workflow_id takes the repository-wide path",
+      "tool": "list_workflow_runs",
+      "arguments": {
+        "branch": "main",
+        "owner": "octocat",
+        "page": 0,
+        "per_page": 0,
+        "repo": "hello-world",
+        "status": "completed",
+        "workflow_id": ""
+      },
+      "response": {
+        "status": 200,
+        "body": "[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/repos/octocat/hello-world/actions/runs?branch=main\u0026per_page=30\u0026status=completed",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Workflow runs: [{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]"
+    },
+    {
+      "case": "list_workflow_runs/a workflow_id takes the per-workflow path and is PathEscape'd",
+      "tool": "list_workflow_runs",
+      "arguments": {
+        "branch": "",
+        "owner": "octocat",
+        "page": 0,
+        "per_page": 0,
+        "repo": "hello-world",
+        "status": "",
+        "workflow_id": "ci build.yml"
+      },
+      "response": {
+        "status": 200,
+        "body": "[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/repos/octocat/hello-world/actions/workflows/ci%20build.yml/runs?per_page=30",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Workflow runs: [{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]"
+    },
+    {
+      "case": "trigger_workflow/inputs parse into a map[string]string and are sorted",
+      "tool": "trigger_workflow",
+      "arguments": {
+        "inputs": "{\"zebra\":\"z\",\"alpha\":\"a\"}",
+        "owner": "octocat",
+        "ref": "main",
+        "repo": "hello-world",
+        "workflow_id": "ci.yml"
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      },
+      "request": {
+        "method": "POST",
+        "target": "/repos/octocat/hello-world/actions/workflows/ci.yml/dispatches",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "application/json",
+        "body": "{\"inputs\":{\"alpha\":\"a\",\"zebra\":\"z\"},\"ref\":\"main\"}"
+      },
+      "is_error": false,
+      "text": "Workflow dispatch triggered successfully."
+    },
+    {
+      "case": "trigger_workflow/no inputs at all sends only the ref",
+      "tool": "trigger_workflow",
+      "arguments": {
+        "inputs": "",
+        "owner": "octocat",
+        "ref": "main",
+        "repo": "hello-world",
+        "workflow_id": "ci.yml"
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      },
+      "request": {
+        "method": "POST",
+        "target": "/repos/octocat/hello-world/actions/workflows/ci.yml/dispatches",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "application/json",
+        "body": "{\"ref\":\"main\"}"
+      },
+      "is_error": false,
+      "text": "Workflow dispatch triggered successfully."
+    },
+    {
+      "case": "trigger_workflow/a literal null parses to a nil map and is sent as null",
+      "tool": "trigger_workflow",
+      "arguments": {
+        "inputs": "null",
+        "owner": "octocat",
+        "ref": "main",
+        "repo": "hello-world",
+        "workflow_id": "ci.yml"
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      },
+      "request": {
+        "method": "POST",
+        "target": "/repos/octocat/hello-world/actions/workflows/ci.yml/dispatches",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "application/json",
+        "body": "{\"inputs\":null,\"ref\":\"main\"}"
+      },
+      "is_error": false,
+      "text": "Workflow dispatch triggered successfully."
+    },
+    {
+      "case": "trigger_workflow/an array is not a JSON object",
+      "tool": "trigger_workflow",
+      "arguments": {
+        "inputs": "[\"a\",\"b\"]",
+        "owner": "octocat",
+        "ref": "main",
+        "repo": "hello-world",
+        "workflow_id": "ci.yml"
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      },
+      "request": null,
+      "is_error": true,
+      "text": "parsing workflow inputs (must be a JSON object): json: cannot unmarshal array into Go value of type map[string]string"
+    },
+    {
+      "case": "trigger_workflow/a non-string value is not a map[string]string",
+      "tool": "trigger_workflow",
+      "arguments": {
+        "inputs": "{\"a\":1}",
+        "owner": "octocat",
+        "ref": "main",
+        "repo": "hello-world",
+        "workflow_id": "ci.yml"
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      },
+      "request": null,
+      "is_error": true,
+      "text": "parsing workflow inputs (must be a JSON object): json: cannot unmarshal number into Go value of type string"
+    },
+    {
+      "case": "trigger_workflow/a syntactically invalid payload — the one divergence",
+      "tool": "trigger_workflow",
+      "arguments": {
+        "inputs": "not json",
+        "owner": "octocat",
+        "ref": "main",
+        "repo": "hello-world",
+        "workflow_id": "ci.yml"
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      },
+      "request": null,
+      "is_error": true,
+      "text": "parsing workflow inputs (must be a JSON object): invalid character 'o' in literal null (expecting 'u')",
+      "rust_text": "parsing workflow inputs (must be a JSON object): expected ident at line 1 column 2"
+    },
+    {
+      "case": "trigger_workflow/a truncated payload ends the same way in both languages",
+      "tool": "trigger_workflow",
+      "arguments": {
+        "inputs": "{\"a\":",
+        "owner": "octocat",
+        "ref": "main",
+        "repo": "hello-world",
+        "workflow_id": "ci.yml"
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      },
+      "request": null,
+      "is_error": true,
+      "text": "parsing workflow inputs (must be a JSON object): unexpected end of JSON input"
+    },
+    {
+      "case": "get_workflow_run/a run id inside float64's exact range",
+      "tool": "get_workflow_run",
+      "arguments": {
+        "owner": "octocat",
+        "repo": "hello-world",
+        "run_id": 15678900123
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"id\":15678900123}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/repos/octocat/hello-world/actions/runs/15678900123",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Workflow run: {\"id\":15678900123}"
+    },
+    {
+      "case": "get_workflow_run/a run id above 2^53 — the Go SDK rounds it, Rust does not",
+      "tool": "get_workflow_run",
+      "arguments": {
+        "owner": "octocat",
+        "repo": "hello-world",
+        "run_id": 10152021304050607
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"id\":10152021304050607}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/repos/octocat/hello-world/actions/runs/10152021304050608",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Workflow run: {\"id\":10152021304050607}",
+      "rust_target": "/repos/octocat/hello-world/actions/runs/10152021304050607"
+    },
+    {
+      "case": "get_run_logs/a 302 with a Location is the answer",
+      "tool": "get_run_logs",
+      "arguments": {
+        "owner": "octocat",
+        "repo": "hello-world",
+        "run_id": 42
+      },
+      "response": {
+        "status": 302,
+        "location": "https://objects.example.invalid/logs.zip?token=abc",
+        "body": ""
+      },
+      "request": {
+        "method": "GET",
+        "target": "/repos/octocat/hello-world/actions/runs/42/logs",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Logs download URL (time-limited zip archive): https://objects.example.invalid/logs.zip?token=abc"
+    },
+    {
+      "case": "get_run_logs/a 301 is a redirect too",
+      "tool": "get_run_logs",
+      "arguments": {
+        "owner": "octocat",
+        "repo": "hello-world",
+        "run_id": 42
+      },
+      "response": {
+        "status": 301,
+        "location": "https://objects.example.invalid/logs.zip",
+        "body": ""
+      },
+      "request": {
+        "method": "GET",
+        "target": "/repos/octocat/hello-world/actions/runs/42/logs",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Logs download URL (time-limited zip archive): https://objects.example.invalid/logs.zip"
+    },
+    {
+      "case": "get_run_logs/a 302 with no Location is its own sentence",
+      "tool": "get_run_logs",
+      "arguments": {
+        "owner": "octocat",
+        "repo": "hello-world",
+        "run_id": 42
+      },
+      "response": {
+        "status": 302,
+        "body": ""
+      },
+      "request": {
+        "method": "GET",
+        "target": "/repos/octocat/hello-world/actions/runs/42/logs",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": true,
+      "text": "fetching logs URL for run 42: redirect response missing Location header"
+    },
+    {
+      "case": "get_run_logs/a non-redirect body is truncated at 512 bytes",
+      "tool": "get_run_logs",
+      "arguments": {
+        "owner": "octocat",
+        "repo": "hello-world",
+        "run_id": 42
+      },
+      "response": {
+        "status": 500,
+        "body": "{\"message\":\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/repos/octocat/hello-world/actions/runs/42/logs",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": true,
+      "text": "fetching logs URL for run 42: github API error: status 500: {\"message\":\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    },
+    {
+      "case": "list_releases/paging only",
+      "tool": "list_releases",
+      "arguments": {
+        "owner": "octocat",
+        "page": 0,
+        "per_page": 0,
+        "repo": "hello-world"
+      },
+      "response": {
+        "status": 200,
+        "body": "[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/repos/octocat/hello-world/releases?per_page=30",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Releases: [{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]"
+    },
+    {
+      "case": "create_release/every optional key present",
+      "tool": "create_release",
+      "arguments": {
+        "body": "Notes \u0026 \u003cem\u003emore\u003c/em\u003e",
+        "draft": true,
+        "generate_release_notes": true,
+        "name": "Version 1.0.0",
+        "owner": "octocat",
+        "prerelease": true,
+        "repo": "hello-world",
+        "tag_name": "v1.0.0",
+        "target_commitish": "main"
+      },
+      "response": {
+        "status": 201,
+        "body": "{\"id\":1,\"tag_name\":\"v1.0.0\"}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/repos/octocat/hello-world/releases",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "application/json",
+        "body": "{\"body\":\"Notes \\u0026 \\u003cem\\u003emore\\u003c/em\\u003e\",\"draft\":true,\"generate_release_notes\":true,\"name\":\"Version 1.0.0\",\"prerelease\":true,\"tag_name\":\"v1.0.0\",\"target_commitish\":\"main\"}"
+      },
+      "is_error": false,
+      "text": "Release created: {\"id\":1,\"tag_name\":\"v1.0.0\"}"
+    },
+    {
+      "case": "create_release/false booleans omit their keys",
+      "tool": "create_release",
+      "arguments": {
+        "body": "",
+        "draft": false,
+        "generate_release_notes": false,
+        "name": "",
+        "owner": "octocat",
+        "prerelease": false,
+        "repo": "hello-world",
+        "tag_name": "v1.0.1",
+        "target_commitish": ""
+      },
+      "response": {
+        "status": 201,
+        "body": "{\"id\":2,\"tag_name\":\"v1.0.1\"}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/repos/octocat/hello-world/releases",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "application/json",
+        "body": "{\"tag_name\":\"v1.0.1\"}"
+      },
+      "is_error": false,
+      "text": "Release created: {\"id\":2,\"tag_name\":\"v1.0.1\"}"
+    },
+    {
+      "case": "list_tags/paging only",
+      "tool": "list_tags",
+      "arguments": {
+        "owner": "octocat",
+        "page": 0,
+        "per_page": 0,
+        "repo": "hello-world"
+      },
+      "response": {
+        "status": 200,
+        "body": "[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/repos/octocat/hello-world/tags?per_page=30",
+        "authorization": "Bearer parity-pat-token",
+        "accept": "application/vnd.github.v3+json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Tags: [{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]"
+    }
+  ]
+}

--- a/desktop/parity/gourl_parity_test.go
+++ b/desktop/parity/gourl_parity_test.go
@@ -64,6 +64,11 @@ type gourlVectors struct {
 	Comment    []string        `json:"_comment"`
 	RoutePath  []routePathCase `json:"route_path"`
 	EscapePath []escapeCase    `json:"escape_path"`
+	// `url.PathEscape` and `url.QueryEscape` — the other two arms of
+	// `shouldEscape`, added with #312 because every integration builds its
+	// paths with the first and its queries with the second.
+	PathEscape  []escapeCase `json:"path_escape"`
+	QueryEscape []escapeCase `json:"query_escape"`
 }
 
 // routePathInputs cover each branch of `url.setPath`'s canonical check: a path
@@ -117,6 +122,22 @@ var escapePathInputs = []string{
 	"~user", "a+b", "日本語", "a\x00b",
 }
 
+// segmentAndQueryInputs run through **both** `url.PathEscape` and
+// `url.QueryEscape`, so the two vector blocks are the same inputs under the two
+// modes and a reader can see where the arms part company at a glance.
+//
+// The reserved set is spelled out one byte at a time because that is exactly
+// where `shouldEscape` branches: a segment escapes `/ ; , ?` and keeps
+// `$ & + : = @`, a query escapes all ten. The three inputs after it are the
+// bytes an off-the-shelf encoder gets wrong — `~` (Go keeps it, WHATWG form
+// encoding escapes it), `*` (the reverse), and a space (`+` in a query,
+// `%20` in a segment).
+var segmentAndQueryInputs = []string{
+	"", "a-b", "a b", "a/b", "a%b", "$", "&", "+", ",", "/", ":", ";", "=", "?", "@",
+	"-_.~", "~user", "a*b", "repo:o/r func foo+bar", "café", "日本語",
+	"a\tb", "a\nb", "a\"b", "a<b>c", "a#b", "a\x00b",
+}
+
 func TestGoURLVectors(t *testing.T) {
 	want := gourlVectors{
 		Comment: []string{
@@ -138,6 +159,12 @@ func TestGoURLVectors(t *testing.T) {
 		// whole point, since RawPath is left empty here.
 		u := url.URL{Path: in}
 		want.EscapePath = append(want.EscapePath, escapeCase{Value: in, Want: u.EscapedPath()})
+	}
+	for _, in := range segmentAndQueryInputs {
+		want.PathEscape = append(want.PathEscape,
+			escapeCase{Value: in, Want: url.PathEscape(in)})
+		want.QueryEscape = append(want.QueryEscape,
+			escapeCase{Value: in, Want: url.QueryEscape(in)})
 	}
 
 	encoded, err := json.MarshalIndent(want, "", "  ")

--- a/desktop/parity/gourl_vectors.json
+++ b/desktop/parity/gourl_vectors.json
@@ -236,5 +236,225 @@
       "value": "a\u0000b",
       "want": "a%00b"
     }
+  ],
+  "path_escape": [
+    {
+      "value": "",
+      "want": ""
+    },
+    {
+      "value": "a-b",
+      "want": "a-b"
+    },
+    {
+      "value": "a b",
+      "want": "a%20b"
+    },
+    {
+      "value": "a/b",
+      "want": "a%2Fb"
+    },
+    {
+      "value": "a%b",
+      "want": "a%25b"
+    },
+    {
+      "value": "$",
+      "want": "$"
+    },
+    {
+      "value": "\u0026",
+      "want": "\u0026"
+    },
+    {
+      "value": "+",
+      "want": "+"
+    },
+    {
+      "value": ",",
+      "want": "%2C"
+    },
+    {
+      "value": "/",
+      "want": "%2F"
+    },
+    {
+      "value": ":",
+      "want": ":"
+    },
+    {
+      "value": ";",
+      "want": "%3B"
+    },
+    {
+      "value": "=",
+      "want": "="
+    },
+    {
+      "value": "?",
+      "want": "%3F"
+    },
+    {
+      "value": "@",
+      "want": "@"
+    },
+    {
+      "value": "-_.~",
+      "want": "-_.~"
+    },
+    {
+      "value": "~user",
+      "want": "~user"
+    },
+    {
+      "value": "a*b",
+      "want": "a%2Ab"
+    },
+    {
+      "value": "repo:o/r func foo+bar",
+      "want": "repo:o%2Fr%20func%20foo+bar"
+    },
+    {
+      "value": "café",
+      "want": "caf%C3%A9"
+    },
+    {
+      "value": "日本語",
+      "want": "%E6%97%A5%E6%9C%AC%E8%AA%9E"
+    },
+    {
+      "value": "a\tb",
+      "want": "a%09b"
+    },
+    {
+      "value": "a\nb",
+      "want": "a%0Ab"
+    },
+    {
+      "value": "a\"b",
+      "want": "a%22b"
+    },
+    {
+      "value": "a\u003cb\u003ec",
+      "want": "a%3Cb%3Ec"
+    },
+    {
+      "value": "a#b",
+      "want": "a%23b"
+    },
+    {
+      "value": "a\u0000b",
+      "want": "a%00b"
+    }
+  ],
+  "query_escape": [
+    {
+      "value": "",
+      "want": ""
+    },
+    {
+      "value": "a-b",
+      "want": "a-b"
+    },
+    {
+      "value": "a b",
+      "want": "a+b"
+    },
+    {
+      "value": "a/b",
+      "want": "a%2Fb"
+    },
+    {
+      "value": "a%b",
+      "want": "a%25b"
+    },
+    {
+      "value": "$",
+      "want": "%24"
+    },
+    {
+      "value": "\u0026",
+      "want": "%26"
+    },
+    {
+      "value": "+",
+      "want": "%2B"
+    },
+    {
+      "value": ",",
+      "want": "%2C"
+    },
+    {
+      "value": "/",
+      "want": "%2F"
+    },
+    {
+      "value": ":",
+      "want": "%3A"
+    },
+    {
+      "value": ";",
+      "want": "%3B"
+    },
+    {
+      "value": "=",
+      "want": "%3D"
+    },
+    {
+      "value": "?",
+      "want": "%3F"
+    },
+    {
+      "value": "@",
+      "want": "%40"
+    },
+    {
+      "value": "-_.~",
+      "want": "-_.~"
+    },
+    {
+      "value": "~user",
+      "want": "~user"
+    },
+    {
+      "value": "a*b",
+      "want": "a%2Ab"
+    },
+    {
+      "value": "repo:o/r func foo+bar",
+      "want": "repo%3Ao%2Fr+func+foo%2Bbar"
+    },
+    {
+      "value": "café",
+      "want": "caf%C3%A9"
+    },
+    {
+      "value": "日本語",
+      "want": "%E6%97%A5%E6%9C%AC%E8%AA%9E"
+    },
+    {
+      "value": "a\tb",
+      "want": "a%09b"
+    },
+    {
+      "value": "a\nb",
+      "want": "a%0Ab"
+    },
+    {
+      "value": "a\"b",
+      "want": "a%22b"
+    },
+    {
+      "value": "a\u003cb\u003ec",
+      "want": "a%3Cb%3Ec"
+    },
+    {
+      "value": "a#b",
+      "want": "a%23b"
+    },
+    {
+      "value": "a\u0000b",
+      "want": "a%00b"
+    }
   ]
 }

--- a/desktop/parity/jsonschema_reflect_parity_test.go
+++ b/desktop/parity/jsonschema_reflect_parity_test.go
@@ -1,0 +1,201 @@
+// The reflector divergence map: what `google/jsonschema-go` produces for each
+// Go shape a ported integration can contain, so the Rust side can say — per
+// shape — whether `schemars` agrees and, where it does not, what a port must
+// write instead.
+//
+// # Why this file exists at all
+//
+// A tool's input schema is not internal. `tools/list` hands it to the CLI and
+// the CLI hands it to the model, so it is part of the same wire surface as the
+// tool's name and its result text. #310 verified that surface for **a flat
+// struct of required scalars** — which is all `current_time` is — and left a
+// note on `new_tool`'s schema normalization naming the shapes the six ports
+// (#312–#317) would hit first. This is that note, generated rather than
+// written: every value below comes from `jsonschema.For` invoked the way
+// `mcp.AddTool` invokes it, on one reference struct covering every shape class.
+//
+// The Rust half lives in `desktop/src-tauri/src/claude/schema_vectors.rs`. It
+// declares the corresponding Rust shapes, runs them through
+// `claude::new_tool`'s normalization, and asserts per property either equality
+// or the *exact* divergence — so a `schemars` upgrade that changes one fails
+// there, and a `jsonschema-go` upgrade that changes one fails here.
+//
+// # Two findings that are load-bearing for every port
+//
+//   - **`jsonschema:"required,…"` is not a directive.** `jsonschema-go` reads
+//     the whole tag as the property's *description*, verbatim, `required,`
+//     prefix included — and marks a field optional only on `omitempty` /
+//     `omitzero`. Every params struct in `internal/integrations/` writes
+//     `jsonschema:"required,Repository owner"` and none writes `omitempty`, so
+//     **every field of every one of the 62 tools is required**, and the
+//     description the model reads begins with `required,`. A port that "fixed"
+//     either would change what the model sees.
+//   - **An optional Go field is not an `Option<T>`.** `omitempty` leaves a
+//     field out of `required` and does nothing to its `type`; `Option<T>` in
+//     Rust renders `"type": ["string","null"]`. The Rust shape that matches is
+//     `#[serde(default)] String`.
+//
+// Regenerate (only from Go, and only when adding cases):
+//
+//	go test ./desktop/parity/ -run TestJSONSchemaReflectVectors -update-jsonschema-reflect-vectors
+package parity
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"slices"
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+)
+
+const jsonschemaReflectVectorsFile = "jsonschema_reflect_vectors.json"
+
+var updateJSONSchemaReflectVectors = flag.Bool("update-jsonschema-reflect-vectors", false,
+	"rewrite jsonschema_reflect_vectors.json from this Go toolchain")
+
+// reflectNested is the nested struct case. Go **inlines** it at every use;
+// `schemars` lifts it into `$defs` and points a `$ref` at it.
+type reflectNested struct {
+	Name  string `json:"name" jsonschema:"The nested name"`
+	Count int    `json:"count,omitempty" jsonschema:"The nested count"`
+}
+
+// reflectReference covers every shape class a ported params struct can contain.
+//
+// It is one struct rather than one per case on purpose: `$defs`/`$ref` and
+// property ordering are properties of the *document*, not of a field, and a
+// per-field generator would not show them.
+type reflectReference struct {
+	// The shape #310 already verified: a required scalar carrying the
+	// `required,` tag every integration writes.
+	RequiredString string `json:"required_string" jsonschema:"required,A required string"`
+	// The same field made optional the only way Go has: `omitempty`. Note what
+	// does *not* change — the type.
+	OptionalString string `json:"optional_string,omitempty" jsonschema:"An optional string"`
+	// `omitzero` is the newer spelling and `jsonschema-go` honors both.
+	OmitZeroString string `json:"omitzero_string,omitzero" jsonschema:"An omitzero string"`
+	// Untagged: the property has no description at all, which is a distinct
+	// state from an empty one.
+	Untagged string `json:"untagged"`
+
+	Int   int     `json:"int" jsonschema:"A plain int"`
+	Int64 int64   `json:"int64" jsonschema:"An int64"`
+	Int32 int32   `json:"int32" jsonschema:"An int32"`
+	Uint  uint    `json:"uint" jsonschema:"A uint"`
+	Float float64 `json:"float" jsonschema:"A float64"`
+	Bool  bool    `json:"bool" jsonschema:"A bool"`
+
+	Strings     []string `json:"strings" jsonschema:"A string slice"`
+	StringsOmit []string `json:"strings_omitempty,omitempty" jsonschema:"An omitempty string slice"`
+
+	Nested    reflectNested  `json:"nested" jsonschema:"A nested struct"`
+	NestedPtr *reflectNested `json:"nested_ptr,omitempty" jsonschema:"A pointer to a nested struct"`
+	PtrString *string        `json:"ptr_string" jsonschema:"A pointer to a string"`
+
+	Map map[string]string `json:"map" jsonschema:"A map of strings"`
+
+	// `json:"-"` omits the property entirely.
+	Ignored string `json:"-"`
+	// An unexported field is omitted too — where a private Rust field is not,
+	// since `schemars` reflects the type rather than its visibility.
+	unexported string //nolint:unused // present so its absence is pinned
+}
+
+type reflectPropertyVector struct {
+	Name string `json:"name"`
+	// Whether the property is in the document's `required` list. Kept beside
+	// the property because "optional" is a property of the parent, not of the
+	// field's own schema — which is the whole point of the `Option<T>` note.
+	Required bool            `json:"required"`
+	Schema   json.RawMessage `json:"schema"`
+}
+
+type jsonschemaReflectVectors struct {
+	Comment []string `json:"_comment"`
+	// The whole document, exactly as `tools/list` would carry it.
+	Schema json.RawMessage `json:"schema"`
+	// The document's `required` list, in Go's order (declaration order).
+	Required []string `json:"required"`
+	// One entry per property, so a Rust assertion can name the shape it is
+	// about rather than indexing into the document.
+	Properties []reflectPropertyVector `json:"properties"`
+}
+
+func TestJSONSchemaReflectVectors(t *testing.T) {
+	// Exactly what `mcp.AddTool` does with the `In` type parameter: no options,
+	// no post-processing. `Resolve` is not applied, because it only compiles
+	// the schema for validation and does not change the bytes `tools/list`
+	// carries — `github_vectors.json` holds the resolved-and-served form for
+	// twenty real tools and agrees with this one.
+	schema, err := jsonschema.For[reflectReference](nil)
+	if err != nil {
+		t.Fatalf("reflecting the reference struct: %v", err)
+	}
+
+	document, err := json.Marshal(schema)
+	if err != nil {
+		t.Fatalf("encoding the reference schema: %v", err)
+	}
+
+	want := jsonschemaReflectVectors{
+		Comment: []string{
+			"The reflector divergence map: google/jsonschema-go's output for every Go shape",
+			"a ported integration params struct can contain. Generated from Go, then frozen.",
+			"Read by desktop/parity/jsonschema_reflect_parity_test.go (Go) and by",
+			"desktop/src-tauri/src/claude/schema_vectors.rs (Rust), which declares the",
+			"corresponding Rust shapes and asserts per property either equality or the exact",
+			"divergence — with the guidance a port needs written at its site.",
+			"Two rules every port depends on: a jsonschema tag is the description verbatim",
+			"(the 'required,' prefix included, and it is not a directive), and a field is",
+			"optional only when it carries omitempty or omitzero.",
+			"Regenerate with: go test ./desktop/parity/ -run TestJSONSchemaReflectVectors -update-jsonschema-reflect-vectors",
+		},
+		Schema:   document,
+		Required: slices.Clone(schema.Required),
+	}
+
+	// `PropertyOrder` is declaration order, which is also the order the custom
+	// marshaler renders `properties` in — so iterating it keeps the vectors in
+	// the order a reader of the Go struct expects.
+	for _, name := range schema.PropertyOrder {
+		encoded, err := json.Marshal(schema.Properties[name])
+		if err != nil {
+			t.Fatalf("encoding property %s: %v", name, err)
+		}
+		want.Properties = append(want.Properties, reflectPropertyVector{
+			Name:     name,
+			Required: slices.Contains(schema.Required, name),
+			Schema:   encoded,
+		})
+	}
+
+	encoded, err := json.MarshalIndent(want, "", "  ")
+	if err != nil {
+		t.Fatalf("encoding vectors: %v", err)
+	}
+	encoded = append(encoded, '\n')
+
+	if *updateJSONSchemaReflectVectors {
+		if err := os.WriteFile(jsonschemaReflectVectorsFile, encoded, 0o600); err != nil {
+			t.Fatalf("writing %s: %v", jsonschemaReflectVectorsFile, err)
+		}
+		t.Logf("wrote %s", jsonschemaReflectVectorsFile)
+		return
+	}
+
+	frozen, err := os.ReadFile(jsonschemaReflectVectorsFile)
+	if err != nil {
+		t.Fatalf("reading %s (regenerate with -update-jsonschema-reflect-vectors): %v",
+			jsonschemaReflectVectorsFile, err)
+	}
+	if string(frozen) != string(encoded) {
+		t.Fatalf("%s is stale: this google/jsonschema-go produces different results.\n"+
+			"Regenerate with -update-jsonschema-reflect-vectors and read what moved — "+
+			"the Rust half in claude/schema_vectors.rs reads the same file, and a shape "+
+			"that starts or stops diverging changes what every ported tool must be "+
+			"written as.",
+			jsonschemaReflectVectorsFile)
+	}
+}

--- a/desktop/parity/jsonschema_reflect_vectors.json
+++ b/desktop/parity/jsonschema_reflect_vectors.json
@@ -1,0 +1,344 @@
+{
+  "_comment": [
+    "The reflector divergence map: google/jsonschema-go's output for every Go shape",
+    "a ported integration params struct can contain. Generated from Go, then frozen.",
+    "Read by desktop/parity/jsonschema_reflect_parity_test.go (Go) and by",
+    "desktop/src-tauri/src/claude/schema_vectors.rs (Rust), which declares the",
+    "corresponding Rust shapes and asserts per property either equality or the exact",
+    "divergence — with the guidance a port needs written at its site.",
+    "Two rules every port depends on: a jsonschema tag is the description verbatim",
+    "(the 'required,' prefix included, and it is not a directive), and a field is",
+    "optional only when it carries omitempty or omitzero.",
+    "Regenerate with: go test ./desktop/parity/ -run TestJSONSchemaReflectVectors -update-jsonschema-reflect-vectors"
+  ],
+  "schema": {
+    "type": "object",
+    "properties": {
+      "required_string": {
+        "type": "string",
+        "description": "required,A required string"
+      },
+      "optional_string": {
+        "type": "string",
+        "description": "An optional string"
+      },
+      "omitzero_string": {
+        "type": "string",
+        "description": "An omitzero string"
+      },
+      "untagged": {
+        "type": "string"
+      },
+      "int": {
+        "type": "integer",
+        "description": "A plain int"
+      },
+      "int64": {
+        "type": "integer",
+        "description": "An int64"
+      },
+      "int32": {
+        "type": "integer",
+        "description": "An int32",
+        "minimum": -2147483648,
+        "maximum": 2147483647
+      },
+      "uint": {
+        "type": "integer",
+        "description": "A uint",
+        "minimum": 0
+      },
+      "float": {
+        "type": "number",
+        "description": "A float64"
+      },
+      "bool": {
+        "type": "boolean",
+        "description": "A bool"
+      },
+      "strings": {
+        "type": [
+          "null",
+          "array"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "description": "A string slice"
+      },
+      "strings_omitempty": {
+        "type": [
+          "null",
+          "array"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "description": "An omitempty string slice"
+      },
+      "nested": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The nested name"
+          },
+          "count": {
+            "type": "integer",
+            "description": "The nested count"
+          }
+        },
+        "description": "A nested struct",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      },
+      "nested_ptr": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The nested name"
+          },
+          "count": {
+            "type": "integer",
+            "description": "The nested count"
+          }
+        },
+        "description": "A pointer to a nested struct",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      },
+      "ptr_string": {
+        "type": [
+          "null",
+          "string"
+        ],
+        "description": "A pointer to a string"
+      },
+      "map": {
+        "type": "object",
+        "description": "A map of strings",
+        "additionalProperties": {
+          "type": "string"
+        }
+      }
+    },
+    "required": [
+      "required_string",
+      "untagged",
+      "int",
+      "int64",
+      "int32",
+      "uint",
+      "float",
+      "bool",
+      "strings",
+      "nested",
+      "ptr_string",
+      "map"
+    ],
+    "additionalProperties": false
+  },
+  "required": [
+    "required_string",
+    "untagged",
+    "int",
+    "int64",
+    "int32",
+    "uint",
+    "float",
+    "bool",
+    "strings",
+    "nested",
+    "ptr_string",
+    "map"
+  ],
+  "properties": [
+    {
+      "name": "required_string",
+      "required": true,
+      "schema": {
+        "type": "string",
+        "description": "required,A required string"
+      }
+    },
+    {
+      "name": "optional_string",
+      "required": false,
+      "schema": {
+        "type": "string",
+        "description": "An optional string"
+      }
+    },
+    {
+      "name": "omitzero_string",
+      "required": false,
+      "schema": {
+        "type": "string",
+        "description": "An omitzero string"
+      }
+    },
+    {
+      "name": "untagged",
+      "required": true,
+      "schema": {
+        "type": "string"
+      }
+    },
+    {
+      "name": "int",
+      "required": true,
+      "schema": {
+        "type": "integer",
+        "description": "A plain int"
+      }
+    },
+    {
+      "name": "int64",
+      "required": true,
+      "schema": {
+        "type": "integer",
+        "description": "An int64"
+      }
+    },
+    {
+      "name": "int32",
+      "required": true,
+      "schema": {
+        "type": "integer",
+        "description": "An int32",
+        "minimum": -2147483648,
+        "maximum": 2147483647
+      }
+    },
+    {
+      "name": "uint",
+      "required": true,
+      "schema": {
+        "type": "integer",
+        "description": "A uint",
+        "minimum": 0
+      }
+    },
+    {
+      "name": "float",
+      "required": true,
+      "schema": {
+        "type": "number",
+        "description": "A float64"
+      }
+    },
+    {
+      "name": "bool",
+      "required": true,
+      "schema": {
+        "type": "boolean",
+        "description": "A bool"
+      }
+    },
+    {
+      "name": "strings",
+      "required": true,
+      "schema": {
+        "type": [
+          "null",
+          "array"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "description": "A string slice"
+      }
+    },
+    {
+      "name": "strings_omitempty",
+      "required": false,
+      "schema": {
+        "type": [
+          "null",
+          "array"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "description": "An omitempty string slice"
+      }
+    },
+    {
+      "name": "nested",
+      "required": true,
+      "schema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The nested name"
+          },
+          "count": {
+            "type": "integer",
+            "description": "The nested count"
+          }
+        },
+        "description": "A nested struct",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "nested_ptr",
+      "required": false,
+      "schema": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The nested name"
+          },
+          "count": {
+            "type": "integer",
+            "description": "The nested count"
+          }
+        },
+        "description": "A pointer to a nested struct",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "ptr_string",
+      "required": true,
+      "schema": {
+        "type": [
+          "null",
+          "string"
+        ],
+        "description": "A pointer to a string"
+      }
+    },
+    {
+      "name": "map",
+      "required": true,
+      "schema": {
+        "type": "object",
+        "description": "A map of strings",
+        "additionalProperties": {
+          "type": "string"
+        }
+      }
+    }
+  ]
+}

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -134,6 +134,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-executor"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,6 +642,23 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -1876,10 +1905,10 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -3409,6 +3438,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3425,7 +3455,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -5058,12 +5087,17 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "bitflags 2.13.1",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -583,6 +583,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
 name = "chacha20"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1527,8 +1533,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1550,9 +1558,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1869,6 +1879,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2413,6 +2424,12 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "markup5ever"
@@ -3187,6 +3204,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.20",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3229,6 +3302,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -3319,16 +3401,21 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3338,6 +3425,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3544,6 +3632,7 @@ version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -5342,6 +5431,16 @@ name = "web-sys"
 version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -70,26 +70,45 @@ tokio = { version = "1", features = [
 # *reading* at the cap, which a `bytes()` that buffers the whole body first
 # would not.
 #
-# **`rustls-tls`, added with #312.** Until the integrations landed, every hop
+# **A TLS backend, added with #312.** Until the integrations landed, every hop
 # this client made was loopback (the Go sidecar, an in-process MCP server), so
-# no TLS backend was configured at all and a `https://api.github.com` request
-# would have failed at runtime with "URL scheme is not allowed". The reasoning
-# for *which* backend is the one already written on `lettre` below and it has
-# not changed: `native-tls` links the platform's OpenSSL/Schannel, the release
-# workflow builds five target triples, and the whole reason `rusqlite` is
-# `bundled` is that there is no C toolchain to arrange.
+# none was configured at all and a `https://api.github.com` request would have
+# failed at runtime with "URL scheme is not allowed". The reasoning for *which*
+# stack is the one already written on `lettre` below and it has not changed:
+# `native-tls` links the platform's OpenSSL/Schannel, the release workflow
+# builds five target triples, and the whole reason `rusqlite` is `bundled` is
+# that there is no C toolchain to arrange.
 #
-# `rustls-tls` is reqwest's **webpki-roots** spelling — Mozilla's root store
-# compiled in — rather than `rustls-tls-native-roots`, which reads the
-# platform's. Bundled roots for the same reason `lettre` uses them: an
-# integration that works on one developer's machine and fails on a user's
-# because their system store is arranged differently is a support problem with
-# nothing in the error to point at it, and the endpoints here are three public
-# SaaS APIs rather than anything behind a corporate MITM proxy. It also shares
-# `ring` with `lettre`, so no second crypto provider enters the tree.
+# **The root store is `rustls-tls-native-roots`, and that is a parity decision
+# rather than a build-system one.** `rustls-tls` is an alias for
+# `rustls-tls-webpki-roots` — a Mozilla snapshot compiled into the binary — and
+# Go's `net/http` reads the **platform** trust store on every OS. The
+# difference is not theoretical: a TLS-inspecting corporate proxy intercepts
+# `api.github.com` like anything else, and its CA exists only in the system
+# store, so bundled roots would give a user whose web UI integration works a
+# desktop one that answers `request failed` with nothing to point at the cause.
+# #313–#317 would each inherit that. `rustls-tls-native-roots` is equally pure
+# Rust and equally toolchain-free — `rustls-native-certs` reads files on Linux,
+# Security.framework on macOS and CryptoAPI on Windows, all through crates that
+# cross-compile the way everything else here does — so the `native-tls`
+# reasoning below (five triples, no C toolchain) is untouched by it, and it
+# still resolves to `ring`, so no second crypto provider enters the tree.
+# `lettre`'s bundled roots below are #307's decision and are left alone; SMTP to
+# a configured relay is not the same exposure as an API call through whatever
+# the machine's network does to it.
+#
+# `gzip` because Go's transport adds `Accept-Encoding: gzip` and decompresses
+# transparently, so every Go-side integration call is compressed and every
+# uncompressed one here was a silent bandwidth divergence — most visibly
+# `get_pull_diff`, whose 10 MB cap is 10 MB of highly compressible text. The
+# fakes never compress, so the vectors cannot see this either way. Note the cap
+# semantics do **not** move: reqwest decompresses in its service stack, so
+# `bytes_stream()` yields decompressed bytes and `read_capped` caps the same
+# thing Go's `io.LimitReader` over a gunzipped `resp.Body` does.
 reqwest = { version = "0.12", default-features = false, features = [
     "stream",
-    "rustls-tls",
+    "gzip",
+    "rustls-tls-native-roots",
 ] }
 
 # Control requests are correlated by a v4 UUID, and hook callbacks are

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -65,7 +65,32 @@ tokio = { version = "1", features = [
     "io-std",
     "sync",
 ] }
-reqwest = { version = "0.12", default-features = false, features = ["stream"] }
+# `stream` is for the proxy's SSE pass-through and for the byte-capped reads the
+# ported integrations do — Go's `io.LimitReader(resp.Body, 2*1024*1024)` stops
+# *reading* at the cap, which a `bytes()` that buffers the whole body first
+# would not.
+#
+# **`rustls-tls`, added with #312.** Until the integrations landed, every hop
+# this client made was loopback (the Go sidecar, an in-process MCP server), so
+# no TLS backend was configured at all and a `https://api.github.com` request
+# would have failed at runtime with "URL scheme is not allowed". The reasoning
+# for *which* backend is the one already written on `lettre` below and it has
+# not changed: `native-tls` links the platform's OpenSSL/Schannel, the release
+# workflow builds five target triples, and the whole reason `rusqlite` is
+# `bundled` is that there is no C toolchain to arrange.
+#
+# `rustls-tls` is reqwest's **webpki-roots** spelling — Mozilla's root store
+# compiled in — rather than `rustls-tls-native-roots`, which reads the
+# platform's. Bundled roots for the same reason `lettre` uses them: an
+# integration that works on one developer's machine and fails on a user's
+# because their system store is arranged differently is a support problem with
+# nothing in the error to point at it, and the endpoints here are three public
+# SaaS APIs rather than anything behind a corporate MITM proxy. It also shares
+# `ring` with `lettre`, so no second crypto provider enters the tree.
+reqwest = { version = "0.12", default-features = false, features = [
+    "stream",
+    "rustls-tls",
+] }
 
 # Control requests are correlated by a v4 UUID, and hook callbacks are
 # registered under one. Go generates them from crypto/rand by hand; the format

--- a/desktop/src-tauri/src/claude/mod.rs
+++ b/desktop/src-tauri/src/claude/mod.rs
@@ -62,6 +62,12 @@ pub mod messages;
 pub mod options;
 pub mod permissions;
 pub mod process;
+/// The reflector divergence map: which Go shapes `schemars` reproduces and what
+/// a port must write for the ones it does not. Tests only — it declares
+/// reference types and asserts them against
+/// `desktop/parity/jsonschema_reflect_vectors.json`, and nothing ships from it.
+#[cfg(test)]
+pub mod schema_vectors;
 pub mod session;
 pub mod sessions;
 pub mod tool;

--- a/desktop/src-tauri/src/claude/schema_vectors.rs
+++ b/desktop/src-tauri/src/claude/schema_vectors.rs
@@ -1,0 +1,400 @@
+//! The Rust half of the reflector divergence map —
+//! `desktop/parity/jsonschema_reflect_vectors.json`.
+//!
+//! #310 verified that a Rust-hosted tool's schema matches a Go-hosted one **for
+//! a flat struct of required scalars**, and left a note on
+//! [`super::tool::new_tool`] naming the shapes the six integration ports would
+//! hit first. This module is that note turned into a test: the Go half
+//! (`desktop/parity/jsonschema_reflect_parity_test.go`) reflects one reference
+//! struct covering every shape class through `jsonschema.For` — exactly as
+//! `mcp.AddTool` does — and this half declares the corresponding Rust shapes,
+//! runs them through [`super::new_tool`]'s normalization, and pins **per shape**
+//! whether the two agree and what a port must write when they do not.
+//!
+//! Read this before porting an integration. The answer for each shape is at its
+//! site in [`the_divergence_map`], and the summary is:
+//!
+//! | Go | write in Rust | why |
+//! |---|---|---|
+//! | `string` + `jsonschema:"…"` | `String` + doc comment | matches |
+//! | `string,omitempty` | `#[serde(default)] String` | an `Option<String>` renders `["string","null"]` |
+//! | `int` / `int64` | `i64` | matches, once the `format` keyword is dropped |
+//! | `int32` / `uint` | still `i64` | Go reflects bounds, `schemars` reflects a format; neither is the other |
+//! | `bool` | `bool` | matches |
+//! | `[]string` | `Vec<String>` **plus** a `null` in `type` | Go renders `["null","array"]` for every slice |
+//! | a nested struct | inline it | Go inlines, `schemars` lifts to `$defs`/`$ref` |
+//! | `map[string]string` | `BTreeMap<String, String>` | matches |
+//! | `*T` | nothing — no integration uses one | Go renders `["null", …]` |
+//!
+//! **None of the standing divergences is reachable from #312.** Every params
+//! struct in `internal/integrations/github/` is flat, carries no `omitempty`,
+//! and uses only `string`, `int`, `int64` and `bool` — which is why the twenty
+//! schemas in `github_vectors.json` match exactly. The map exists so #313–#317
+//! do not each rediscover the boundary.
+
+use std::collections::BTreeMap;
+
+use rmcp::model::CallToolResult;
+use rmcp::ServerHandler;
+use schemars::JsonSchema;
+use serde_json::{json, Value};
+
+use super::{new_tool, ToolServer};
+
+/// The nested struct case — `reflectNested` on the Go side.
+///
+/// `dead_code` is allowed rather than worked around: these types exist to be
+/// *reflected*, so nothing ever reads a field. Naming them `_name` would change
+/// the property names, which are the whole point.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct ReflectNested {
+    /// The nested name
+    name: String,
+    /// The nested count
+    #[serde(default)]
+    count: i64,
+}
+
+/// Every shape class, mirroring `reflectReference` field for field.
+///
+/// The field names are the Go `json:` names so the two documents can be
+/// compared property by property, and the doc comments are the Go
+/// `jsonschema:` tags verbatim — including the `required,` prefix, which is
+/// **not a directive**: `jsonschema-go` reads the whole tag as the description.
+#[allow(dead_code)] // reflected, never read — see `ReflectNested`
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct ReflectReference {
+    /// required,A required string
+    required_string: String,
+    /// An optional string
+    #[serde(default)]
+    optional_string: String,
+    /// An omitzero string
+    #[serde(default)]
+    omitzero_string: String,
+    untagged: String,
+
+    /// A plain int
+    int: i64,
+    /// An int64
+    int64: i64,
+    /// An int32
+    int32: i64,
+    /// A uint
+    uint: i64,
+    /// A float64
+    float: f64,
+    /// A bool
+    bool: bool,
+
+    /// A string slice
+    strings: Vec<String>,
+    /// An omitempty string slice
+    #[serde(default)]
+    strings_omitempty: Vec<String>,
+
+    /// A nested struct
+    nested: ReflectNested,
+    /// A pointer to a nested struct
+    #[serde(default)]
+    nested_ptr: Option<ReflectNested>,
+    /// A pointer to a string
+    ptr_string: Option<String>,
+
+    /// A map of strings
+    map: BTreeMap<String, String>,
+}
+
+/// The schema `tools/list` would advertise for [`ReflectReference`] — through
+/// [`new_tool`], so the normalization under test is the shipped one.
+fn rust_schema() -> Value {
+    let server = ToolServer::new("reflect").with_tool(new_tool(
+        "reflect",
+        "The reference struct.",
+        |_input: ReflectReference, _ct| async move { Ok(CallToolResult::success(vec![])) },
+    ));
+    let tool = server.get_tool("reflect").expect("registered");
+    serde_json::to_value(&*tool.input_schema).expect("schema")
+}
+
+#[derive(serde::Deserialize)]
+struct PropertyVector {
+    name: String,
+    required: bool,
+    schema: Value,
+}
+
+#[derive(serde::Deserialize)]
+struct Vectors {
+    required: Vec<String>,
+    properties: Vec<PropertyVector>,
+}
+
+fn vectors() -> Vectors {
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../parity/jsonschema_reflect_vectors.json"
+    );
+    let raw = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("reading {path}: {e} — regenerate it from Go"));
+    serde_json::from_str(&raw).expect("parsing the reflector vectors")
+}
+
+/// What a shape's Rust rendering is, relative to Go's.
+enum Verdict {
+    /// The two documents agree, so a port writes the Rust shape and stops.
+    Same,
+    /// They do not, and this is exactly what `schemars` produces. Pinned so a
+    /// `schemars` upgrade that changes it fails here rather than in a port.
+    Differs {
+        rust: Value,
+        /// Whether `schemars` puts the property in `required`. Spelled out
+        /// rather than inherited from Go, because one row differs *only* here:
+        /// a Go `*string` with no `omitempty` is **required**, and an
+        /// `Option<String>` is not — requiredness and nullability are one
+        /// decision in Rust and two in Go.
+        rust_required: bool,
+        /// What a port must write instead, or why nothing needs to change.
+        guidance: &'static str,
+    },
+}
+
+/// The map itself: one row per Go property, asserted against the frozen Go
+/// output *and* against this port's own reading of `schemars`.
+///
+/// A single test rather than one per shape, because the value being pinned is
+/// the *table* — "which shapes are safe" is the question a port asks, and a
+/// half-updated table would answer it wrongly while every individual test
+/// passed.
+#[test]
+fn the_divergence_map() {
+    use Verdict::{Differs, Same};
+
+    let v = vectors();
+    let rust = rust_schema();
+    let rust_properties = rust["properties"]
+        .as_object()
+        .expect("an object schema has properties");
+    let rust_required: Vec<String> = rust["required"]
+        .as_array()
+        .expect("required")
+        .iter()
+        .map(|name| name.as_str().expect("a string").to_string())
+        .collect();
+
+    // In the Go document's order — declaration order — so a reader can hold
+    // the two files side by side.
+    let verdicts: Vec<(&str, Verdict)> = vec![
+        // ── Scalars: the shape #310 already verified, plus the tag rule ──────
+        //
+        // The description is the Go tag **verbatim**. `required,` is part of
+        // the sentence the model reads, not a keyword `jsonschema-go` consumes,
+        // and every one of the 62 integration tools writes it that way.
+        ("required_string", Same),
+        // ── Optionality: the divergence a port is most likely to walk into ───
+        //
+        // Go's only way to make a field optional is `omitempty`/`omitzero`,
+        // which changes the parent's `required` list and nothing else. The
+        // matching Rust shape is `#[serde(default)] String` — an
+        // `Option<String>` would render `"type": ["string","null"]`, which is a
+        // *different type* in front of the model, not a different requiredness.
+        ("optional_string", Same),
+        ("omitzero_string", Same),
+        // An untagged field has no `description` at all, which is a distinct
+        // state from an empty one — so a port must leave the doc comment off
+        // rather than writing `///`.
+        ("untagged", Same),
+        // `i64` matches only because `new_tool` drops `schemars`'s `format`
+        // keyword; without that these rows would read `{"type":"integer",
+        // "format":"int64"}` against Go's bare `{"type":"integer"}`.
+        ("int", Same),
+        ("int64", Same),
+        // ── Sized and unsigned integers: no Rust shape matches ───────────────
+        (
+            "int32",
+            Differs {
+                rust: json!({"type": "integer", "description": "An int32"}),
+                rust_required: true,
+                guidance: "Go reflects an int32 as an integer bounded by \
+                           minimum/maximum and `schemars` reflects it as \
+                           `format: int32`, which the normalization drops — so \
+                           neither spelling reproduces the other. No \
+                           integration params struct uses a sized integer; use \
+                           `i64` for a Go `int` or `int64`, which is what they \
+                           all are.",
+            },
+        ),
+        (
+            "uint",
+            Differs {
+                rust: json!({"type": "integer", "description": "A uint"}),
+                rust_required: true,
+                guidance: "Go adds `minimum: 0` for an unsigned integer. Rust's \
+                           `u64` adds it too, but as an integer where Go's is a \
+                           float, so the documents still differ. Same answer: \
+                           no integration uses one.",
+            },
+        ),
+        ("float", Same),
+        ("bool", Same),
+        // ── Slices: Go admits a JSON null for every one of them ──────────────
+        (
+            "strings",
+            Differs {
+                rust: json!({
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "A string slice",
+                }),
+                rust_required: true,
+                guidance: "`jsonschema-go` renders every slice as \
+                           `[\"null\",\"array\"]`, because a Go nil slice \
+                           marshals as `null` and must therefore be accepted \
+                           back. `Vec<String>` renders a bare `array`. Nothing \
+                           in the six integrations takes a list — every \
+                           multi-value input is a comma-separated `string` \
+                           split by `splitCSV` — so this is documented rather \
+                           than reconciled; a port that needs one must add the \
+                           null itself.",
+            },
+        ),
+        (
+            "strings_omitempty",
+            Differs {
+                rust: json!({
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "An omitempty string slice",
+                }),
+                rust_required: false,
+                guidance: "Same as `strings`: `omitempty` moves the field out \
+                           of `required` and leaves the `null` in the type.",
+            },
+        ),
+        // ── Nested structs: Go inlines, schemars lifts ───────────────────────
+        (
+            "nested",
+            Differs {
+                rust: json!({
+                    "$ref": "#/$defs/ReflectNested",
+                    "description": "A nested struct",
+                }),
+                rust_required: true,
+                guidance: "`schemars` lifts a nested struct into `$defs` and \
+                           points a `$ref` at it; Go inlines it at every use. \
+                           `new_tool` deliberately does not de-reference — \
+                           inlining is a rewrite with real choices in it \
+                           (sibling keywords, recursion) and no caller needs it \
+                           yet: every params struct in the six integrations is \
+                           flat. A port that needs nesting must flatten the \
+                           struct instead.",
+            },
+        ),
+        (
+            "nested_ptr",
+            Differs {
+                rust: json!({
+                    "anyOf": [
+                        {"$ref": "#/$defs/ReflectNested"},
+                        {"type": "null"},
+                    ],
+                    "description": "A pointer to a nested struct",
+                }),
+                rust_required: false,
+                guidance: "The two divergences compounded: `$defs` for the \
+                           nesting and `anyOf` + `null` for the pointer, \
+                           against Go's inlined `[\"null\",\"object\"]`.",
+            },
+        ),
+        (
+            "ptr_string",
+            Differs {
+                rust: json!({
+                    "type": ["string", "null"],
+                    "description": "A pointer to a string",
+                }),
+                rust_required: false,
+                guidance: "Go orders the union `[\"null\",\"string\"]` and \
+                           `schemars` orders it `[\"string\",\"null\"]` — the \
+                           same JSON Schema, different bytes, and the Rust test \
+                           for a real tool compares documents. No integration \
+                           takes a pointer field; this row exists so the \
+                           ordering is on record.",
+            },
+        ),
+        // ── Maps: the one container that matches outright ────────────────────
+        ("map", Same),
+    ];
+
+    assert_eq!(
+        verdicts.len(),
+        v.properties.len(),
+        "every Go property needs a verdict — the map is the thing being pinned"
+    );
+
+    for ((name, verdict), want) in verdicts.into_iter().zip(&v.properties) {
+        assert_eq!(name, want.name, "the map is in the Go document's order");
+        let got = rust_properties
+            .get(name)
+            .unwrap_or_else(|| panic!("{name} is not in the Rust schema"));
+
+        // Requiredness is the parent's business in both languages, and it is
+        // the half `Option<T>` gets wrong: a `#[serde(default)] String` leaves
+        // `required` and keeps its type, which is exactly `omitempty`.
+        let is_required = rust_required.contains(&name.to_string());
+
+        match verdict {
+            Same => {
+                assert_eq!(
+                    is_required, want.required,
+                    "{name}: mapped as matching Go, and its requiredness no \
+                     longer does (Go's required list: {:?})",
+                    v.required
+                );
+                assert_eq!(
+                    got, &want.schema,
+                    "{name} was mapped as matching Go, and no longer does"
+                );
+            }
+            Differs {
+                rust,
+                rust_required: want_required,
+                guidance,
+            } => {
+                assert_eq!(
+                    is_required, want_required,
+                    "{name}: schemars no longer agrees with the map about \
+                     requiredness. Guidance on file: {guidance}"
+                );
+                assert_ne!(
+                    got, &want.schema,
+                    "{name} was mapped as diverging and now matches Go — \
+                     delete the row and its guidance: {guidance}"
+                );
+                assert_eq!(
+                    got, &rust,
+                    "{name}: schemars no longer produces what the map records. \
+                     Guidance on file: {guidance}"
+                );
+            }
+        }
+    }
+}
+
+/// The `$defs` block `schemars` adds and Go never has, asserted where a reader
+/// will look for it — the nested rows above only show the `$ref` side.
+#[test]
+fn a_nested_struct_leaves_a_defs_block_behind() {
+    let rust = rust_schema();
+    assert!(
+        rust.get("$defs").is_some(),
+        "the nested-struct divergence is a document-level one too: {rust}"
+    );
+    assert_eq!(rust["$defs"]["ReflectNested"]["type"], "object");
+    // …and no dialect key survived, on the nested schema either.
+    assert!(rust.get("$schema").is_none());
+    assert!(rust["$defs"]["ReflectNested"].get("$schema").is_none());
+}

--- a/desktop/src-tauri/src/claude/tool.rs
+++ b/desktop/src-tauri/src/claude/tool.rs
@@ -260,8 +260,26 @@ fn normalize_object(schema: &mut serde_json::Map<String, serde_json::Value>) -> 
     changed |= schema.remove("format").is_some();
     changed |= schema.remove("default").is_some();
 
-    // Positions holding a single subschema.
-    for key in ["items", "additionalProperties", "propertyNames", "not"] {
+    // Positions holding a single subschema. The last six are unreachable from
+    // the integrations as they stand — nothing there is conditional or uses
+    // `flatten` — but they are what a *future* one would hit, and the failure
+    // is silent: a nested `$schema`/`format`/`default` under an unwalked
+    // keyword survives into a schema the model reads and nothing says so.
+    // `unevaluatedProperties`/`unevaluatedItems` are what `schemars` 1.x emits
+    // for `#[serde(flatten)]` under `deny_unknown_fields`, which is on for every
+    // params struct in this port.
+    for key in [
+        "items",
+        "additionalProperties",
+        "propertyNames",
+        "not",
+        "unevaluatedProperties",
+        "unevaluatedItems",
+        "if",
+        "then",
+        "else",
+        "contains",
+    ] {
         if let Some(serde_json::Value::Object(child)) = schema.get_mut(key) {
             changed |= normalize_object(child);
         }
@@ -269,7 +287,13 @@ fn normalize_object(schema: &mut serde_json::Map<String, serde_json::Value>) -> 
     // Positions holding a map of name → subschema. `properties` is why this
     // walk is structure-aware: a tool may legitimately have a field called
     // `format`, and a blind key sweep would delete it.
-    for key in ["properties", "patternProperties", "$defs", "definitions"] {
+    for key in [
+        "properties",
+        "patternProperties",
+        "$defs",
+        "definitions",
+        "dependentSchemas",
+    ] {
         if let Some(serde_json::Value::Object(children)) = schema.get_mut(key) {
             for child in children.values_mut() {
                 if let serde_json::Value::Object(child) = child {

--- a/desktop/src-tauri/src/claude/tool.rs
+++ b/desktop/src-tauri/src/claude/tool.rs
@@ -181,43 +181,114 @@ where
         .description(description)
         .parameters::<In>()
         .into_tool_route();
-    strip_schema_dialect(&mut route.attr);
+    normalize_go_schema(&mut route.attr);
     ToolDef(route)
 }
 
-/// Drops the `$schema` dialect key `schemars` stamps on every generated schema.
+/// Makes a `schemars` schema say what `google/jsonschema-go` says, for the
+/// shapes where the difference is mechanical.
 ///
-/// Go's `google/jsonschema-go` emits none — a `tools/list` from `internal/tools`
-/// carries exactly `additionalProperties`, `properties`, `required` and `type` —
-/// and this schema does not travel alone: the CLI forwards it to the model as
-/// the tool's `input_schema`. Keeping the key would put a field in front of the
-/// model that the same tool hosted by the Go server does not have, on the one
-/// surface (#310–#317) where the two are meant to be indistinguishable.
+/// A tool's input schema is not internal: `tools/list` hands it to the CLI and
+/// the CLI hands it to the model as the tool's `input_schema`. Any key one
+/// reflector emits and the other does not is a field in front of the model that
+/// the same tool hosted by the Go server does not have — on the one surface
+/// (#310–#317) where the two are meant to be indistinguishable.
 ///
-/// `$schema` is the first of a class rather than the whole class. What is left
-/// is verified to match Go key for key **for a flat struct of required
-/// scalars**, which is what `current_time` is and all the parity vectors cover.
-/// `schemars` 1.2.2 and `google/jsonschema-go` are known to diverge on shapes
-/// the six integration ports will hit: an `Option<T>` renders as
-/// `"type": ["string","null"]` where a Go field with `omitempty` stays
-/// `"type":"string"` and merely drops out of `required`; a nested struct
-/// produces `$defs`/`$ref` where Go inlines; integers pick up a `"format"`.
-/// A parity vector for a nested/`Option` input is wanted before the first
-/// integration port lands, since this function's contract is "strip one key",
-/// not "reconcile two reflectors".
+/// Three removals, and they are the three that are safe to make blindly —
+/// each is a key `jsonschema.For` can **never** emit, so removing it can only
+/// move a Rust schema towards Go's and never away from it:
 ///
-/// Replaces the `Arc` rather than mutating through it, and that is not
-/// fussiness: `rmcp` memoizes one generated schema per input type and hands
-/// every `ToolRoute` a clone of the same `Arc`, so `get_mut` would refuse and an
+/// 1. **`$schema`** — the dialect key `schemars` stamps on every schema it
+///    generates. `jsonschema-go` emits none, ever.
+/// 2. **`format`** — `schemars` writes `"format": "int64"` for an `i64`,
+///    `"uint32"` for a `u32` and so on. `Schema.Format` exists on the Go side
+///    but only a hand-written schema fills it, and no Agento tool writes one.
+///    #312's twenty GitHub tools — six of which take an `int` or an `int64` —
+///    would otherwise diverge on every one of them.
+/// 3. **`default`** — `#[serde(default)]` is the Rust shape that reproduces
+///    Go's `omitempty` (see below), and `schemars` reads it as metadata worth
+///    advertising: a defaulted `String` field picks up `"default": ""`.
+///    `jsonschema.For` sets no defaults, so the field would otherwise be
+///    optional in both languages and *described* differently in one. Removing
+///    it here is what keeps `#[serde(default)]` the whole of the guidance
+///    rather than a two-attribute incantation every port has to remember.
+///
+/// The walk is **structure-aware, not a key sweep**: all three are perfectly
+/// ordinary property *names*, so they are removed only where a subschema sits,
+/// and recursion follows the positions `schemars` can put one in.
+///
+/// # What is deliberately not reconciled, and what a port must write instead
+///
+/// `desktop/parity/jsonschema_reflect_vectors.json` is the generated map of
+/// every shape class, with the Rust half in [`super::schema_vectors`]. Three
+/// divergences are left standing because the fix belongs in the *port*, where
+/// the intent is known, rather than in a rewriter that would have to guess:
+///
+/// - **`Option<T>` is not an optional Go field.** `schemars` renders
+///   `"type": ["string","null"]`; a Go field with `omitempty` keeps
+///   `"type":"string"` and merely leaves `required`. Write
+///   `#[serde(default)] field: String`, not `Option<String>`. (Not needed by
+///   #312 at all: no params struct in `internal/integrations/github/` carries
+///   `omitempty`, so every field of all twenty tools is required.)
+/// - **A nested struct is inlined by Go** and lifted into `$defs`/`$ref` by
+///   `schemars`. Every Go params struct in the six integrations is flat; a port
+///   that needs nesting has to inline it, and that work belongs to the port
+///   that needs it rather than to a general de-referencer here.
+/// - **A sized integer carries bounds in Go, not a format.** `int32` reflects
+///   as `minimum`/`maximum` and `uint` as `minimum: 0`. Use `i64` for a Go
+///   `int` or `int64` — which is what every integer field in the integrations
+///   is — and nothing has to be reconciled.
+///
+/// # Why the `Arc` is replaced rather than written through
+///
+/// `rmcp` memoizes one generated schema per input type and hands every
+/// `ToolRoute` a clone of the same `Arc`, so `get_mut` would refuse and an
 /// in-place edit would reach into a process-wide cache. The clone is one map,
 /// once per tool at start-up.
-fn strip_schema_dialect(tool: &mut Tool) {
-    if !tool.input_schema.contains_key("$schema") {
+fn normalize_go_schema(tool: &mut Tool) {
+    let mut schema = (*tool.input_schema).clone();
+    if !normalize_object(&mut schema) {
         return;
     }
-    let mut schema = (*tool.input_schema).clone();
-    schema.remove("$schema");
     tool.input_schema = std::sync::Arc::new(schema);
+}
+
+/// One subschema: drop the two keys, then recurse. Reports whether anything
+/// changed, so an already-clean schema keeps its memoized `Arc`.
+fn normalize_object(schema: &mut serde_json::Map<String, serde_json::Value>) -> bool {
+    let mut changed = schema.remove("$schema").is_some();
+    changed |= schema.remove("format").is_some();
+    changed |= schema.remove("default").is_some();
+
+    // Positions holding a single subschema.
+    for key in ["items", "additionalProperties", "propertyNames", "not"] {
+        if let Some(serde_json::Value::Object(child)) = schema.get_mut(key) {
+            changed |= normalize_object(child);
+        }
+    }
+    // Positions holding a map of name → subschema. `properties` is why this
+    // walk is structure-aware: a tool may legitimately have a field called
+    // `format`, and a blind key sweep would delete it.
+    for key in ["properties", "patternProperties", "$defs", "definitions"] {
+        if let Some(serde_json::Value::Object(children)) = schema.get_mut(key) {
+            for child in children.values_mut() {
+                if let serde_json::Value::Object(child) = child {
+                    changed |= normalize_object(child);
+                }
+            }
+        }
+    }
+    // Positions holding a list of subschemas.
+    for key in ["allOf", "anyOf", "oneOf", "prefixItems"] {
+        if let Some(serde_json::Value::Array(children)) = schema.get_mut(key) {
+            for child in children.iter_mut() {
+                if let serde_json::Value::Object(child) = child {
+                    changed |= normalize_object(child);
+                }
+            }
+        }
+    }
+    changed
 }
 
 /// An MCP server whose whole surface is a set of [`ToolDef`]s.
@@ -419,6 +490,51 @@ mod tests {
             schema.get("$schema").is_none(),
             "Go's reflected schemas carry no dialect key: {schema}"
         );
+    }
+
+    /// `jsonschema.For` never sets `Format`, so a `schemars` `"format"` is a
+    /// key the model would see from a Rust-hosted tool and not from the Go one.
+    /// Six of #312's twenty GitHub tools take an integer, so this is not a
+    /// corner.
+    #[test]
+    fn an_integer_carries_no_format_key() {
+        let server = ToolServer::new("calc").with_tool(add_tool());
+        let tool = server.get_tool("add").expect("the tool is registered");
+        let schema = serde_json::to_value(&*tool.input_schema).unwrap();
+        assert_eq!(schema["properties"]["a"]["type"], "integer");
+        assert!(
+            schema["properties"]["a"].get("format").is_none(),
+            "Go reflects an int64 as a bare integer: {schema}"
+        );
+    }
+
+    /// The reason the walk is structure-aware. `format` is a legal field name,
+    /// and a tool that has one must keep the property while still losing the
+    /// *keyword* on it.
+    #[test]
+    fn a_property_named_format_survives_the_normalization() {
+        #[allow(dead_code)] // reflected for its schema, never deserialized
+        #[derive(serde::Deserialize, JsonSchema)]
+        struct ExportInput {
+            /// The output format.
+            format: String,
+            /// How many rows.
+            limit: i64,
+        }
+
+        let server = ToolServer::new("export").with_tool(new_tool(
+            "export",
+            "Exports.",
+            |_input: ExportInput, _ct| async move { Ok(CallToolResult::success(vec![])) },
+        ));
+        let tool = server.get_tool("export").expect("registered");
+        let schema = serde_json::to_value(&*tool.input_schema).unwrap();
+        assert_eq!(schema["properties"]["format"]["type"], "string");
+        assert_eq!(
+            schema["properties"]["format"]["description"],
+            "The output format."
+        );
+        assert!(schema["properties"]["limit"].get("format").is_none());
     }
 
     #[test]

--- a/desktop/src-tauri/src/native/gourl.rs
+++ b/desktop/src-tauri/src/native/gourl.rs
@@ -49,13 +49,44 @@
 //! languages' tests, exactly as `gopath_vectors.json` is, so these functions are
 //! pinned to what Go does rather than to what this comment believes.
 
-/// Bytes Go's `escape(s, encodePath)` leaves alone.
+/// Which of `net/url`'s escaping modes a byte is being judged under.
 ///
-/// Transcribed from `shouldEscape` in `net/url/url.go`, `encodePath` arm:
-/// alphanumerics and the unreserved marks are never escaped; of the reserved
-/// set `$ & + , / : ; = ? @` a path may carry every one **except** `?`; and
-/// everything else — every byte over 0x7F included — is escaped.
-fn should_escape(c: u8) -> bool {
+/// Go's `shouldEscape` takes this as a parameter and the three arms genuinely
+/// differ — which is the whole reason this enum exists rather than one
+/// function. `escape_path` was the only mode until #312; the GitHub integration
+/// needs the other two, and reaching for the wrong one is invisible in a
+/// response.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Encoding {
+    /// `encodePath` — a whole path. What [`route_path`]'s canonical check runs
+    /// under.
+    Path,
+    /// `encodePathSegment` — what `url.PathEscape` uses, and what every
+    /// `url.PathEscape(p.Owner)` in `internal/integrations/` is.
+    PathSegment,
+    /// `encodeQueryComponent` — what `url.QueryEscape` uses, and therefore what
+    /// `url.Values.Encode` applies to every key and value.
+    QueryComponent,
+}
+
+/// Bytes Go's `escape(s, mode)` leaves alone.
+///
+/// Transcribed from `shouldEscape` in `net/url/url.go`: alphanumerics and the
+/// unreserved marks `-_.~` are never escaped in any mode, everything else —
+/// every byte over 0x7F included — always is, and the reserved set
+/// `$ & + , / : ; = ? @` is where the modes part company:
+///
+/// | mode | escapes, of the reserved set |
+/// |---|---|
+/// | `encodePath` | `?` |
+/// | `encodePathSegment` | `/ ; , ?` |
+/// | `encodeQueryComponent` | all of them |
+///
+/// The two that bite: a **query** escapes `~`'s neighbours but not `~` itself
+/// while escaping `*` (`form_urlencoded`, already in this tree, does the exact
+/// reverse), and a **path segment** escapes `/` where a whole path does not —
+/// which is what stops a repository named `a/b` from becoming two segments.
+fn should_escape(c: u8, mode: Encoding) -> bool {
     if c.is_ascii_alphanumeric() {
         return false;
     }
@@ -64,8 +95,12 @@ fn should_escape(c: u8) -> bool {
         // The RFC allows `: @ & = + $` in a path and reserves `/ ; ,` for
         // assigning meaning to individual segments; `net/url` manipulates the
         // path as a whole and so allows those three too. That leaves `?`.
-        b'$' | b'&' | b'+' | b',' | b'/' | b':' | b';' | b'=' | b'@' => false,
-        b'?' => true,
+        b'$' | b'&' | b'+' | b',' | b'/' | b':' | b';' | b'=' | b'?' | b'@' => match mode {
+            Encoding::Path => c == b'?',
+            Encoding::PathSegment => matches!(c, b'/' | b';' | b',' | b'?'),
+            // "The RFC reserves (so we must escape) everything."
+            Encoding::QueryComponent => true,
+        },
         _ => true,
     }
 }
@@ -76,7 +111,27 @@ fn should_escape(c: u8) -> bool {
 /// `encodeQueryComponent`, and using it here would make every path holding a
 /// space look non-canonical and flip [`route_path`] to the wrong branch.
 pub fn escape_path(s: &str) -> String {
-    escape_bytes(s.as_bytes())
+    escape_bytes(s.as_bytes(), Encoding::Path)
+}
+
+/// Go's `url.PathEscape` — `escape(s, encodePathSegment)`.
+///
+/// One segment, so `/` is escaped: this is what every
+/// `fmt.Sprintf("/repos/%s/%s", url.PathEscape(owner), url.PathEscape(repo))`
+/// in `internal/integrations/` relies on, and a repository literally named
+/// `a/b` is the case that shows it.
+pub fn path_escape(s: &str) -> String {
+    escape_bytes(s.as_bytes(), Encoding::PathSegment)
+}
+
+/// Go's `url.QueryEscape` — `escape(s, encodeQueryComponent)`, space included.
+///
+/// The space rule lives in `escape` rather than in `shouldEscape`: a space
+/// becomes `+`, not `%20`. That is the one byte where this and
+/// percent-encoding-by-the-RFC visibly disagree, and `url.Values.Encode` puts
+/// it in every search query a user types.
+pub fn query_escape(s: &str) -> String {
+    escape_bytes(s.as_bytes(), Encoding::QueryComponent)
 }
 
 /// The same function over bytes, which is what [`route_path`] needs.
@@ -85,11 +140,15 @@ pub fn escape_path(s: &str) -> String {
 /// canonical check has to run before anything demands UTF-8 — see
 /// [`route_path`]. The output is ASCII either way: every byte over 0x7F is
 /// escaped, so `char` is safe here for exactly the reason `should_escape` says.
-fn escape_bytes(bytes: &[u8]) -> String {
+fn escape_bytes(bytes: &[u8], mode: Encoding) -> String {
     const UPPERHEX: &[u8; 16] = b"0123456789ABCDEF";
     let mut out = String::with_capacity(bytes.len());
     for &c in bytes {
-        if should_escape(c) {
+        // Go tests this *before* `shouldEscape`, and only in this mode: a space
+        // is `+` in a query component and `%20` everywhere else.
+        if c == b' ' && mode == Encoding::QueryComponent {
+            out.push('+');
+        } else if should_escape(c, mode) {
             out.push('%');
             out.push(UPPERHEX[(c >> 4) as usize] as char);
             out.push(UPPERHEX[(c & 15) as usize] as char);
@@ -98,6 +157,50 @@ fn escape_bytes(bytes: &[u8]) -> String {
         }
     }
     out
+}
+
+/// Go's `url.Values`, restricted to the one shape every caller here uses.
+///
+/// `url.Values` is a `map[string][]string`, but every construction in
+/// `internal/integrations/` is a sequence of `q.Set(k, v)` — which *replaces* —
+/// so one value per key models it exactly, and a `BTreeMap` gives
+/// [`Values::encode`] the sorted-key iteration `Encode` performs explicitly.
+///
+/// The sorting is not cosmetic. It is what makes a request reproducible, which
+/// is what lets `desktop/parity/github_vectors.json` pin the encoded target of
+/// every paged tool.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Values(std::collections::BTreeMap<String, String>);
+
+impl Values {
+    /// An empty set of parameters — `url.Values{}`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// `Values.Set`: replaces whatever was under `key`.
+    pub fn set(&mut self, key: impl Into<String>, value: impl Into<String>) {
+        self.0.insert(key.into(), value.into());
+    }
+
+    /// `Values.Encode`: `k=v` pairs joined by `&`, keys sorted, both halves
+    /// through [`query_escape`].
+    ///
+    /// An empty set encodes to `""` — which the callers rely on, since they all
+    /// append it after a literal `?` and Go produces a bare trailing `?` in
+    /// exactly the same case.
+    pub fn encode(&self) -> String {
+        let mut out = String::new();
+        for (key, value) in &self.0 {
+            if !out.is_empty() {
+                out.push('&');
+            }
+            out.push_str(&query_escape(key));
+            out.push('=');
+            out.push_str(&query_escape(value));
+        }
+        out
+    }
 }
 
 /// Go's `unescape(s, encodePath)`: `%XX` becomes one byte, everything else is
@@ -160,7 +263,7 @@ pub fn route_path(raw: &str) -> Option<String> {
     // `url.setPath`: the escaping is canonical exactly when re-encoding the
     // decoded path reproduces what arrived, and that is when `RawPath` stays
     // empty and chi falls through to the decoded `URL.Path`.
-    if escape_bytes(&decoded) == raw {
+    if escape_bytes(&decoded, Encoding::Path) == raw {
         String::from_utf8(decoded).ok()
     } else {
         // Non-canonical: chi routes on `RawPath`, which is the request target
@@ -195,6 +298,8 @@ mod tests {
     struct Vectors {
         route_path: Vec<RoutePathCase>,
         escape_path: Vec<EscapeCase>,
+        path_escape: Vec<EscapeCase>,
+        query_escape: Vec<EscapeCase>,
     }
 
     fn vectors() -> Vectors {
@@ -236,6 +341,65 @@ mod tests {
                 case.value
             );
         }
+    }
+
+    /// The two modes every ported integration builds a request with.
+    #[test]
+    fn path_and_query_escaping_match_the_go_vectors() {
+        let v = vectors();
+        assert!(v.path_escape.len() >= 20, "vectors look truncated");
+        for case in v.path_escape {
+            assert_eq!(
+                path_escape(&case.value),
+                case.want,
+                "url.PathEscape({:?})",
+                case.value
+            );
+        }
+        for case in v.query_escape {
+            assert_eq!(
+                query_escape(&case.value),
+                case.want,
+                "url.QueryEscape({:?})",
+                case.value
+            );
+        }
+    }
+
+    /// The three bytes a reader is most likely to assume, spelled out here so
+    /// the rule is legible without opening the vectors — and because each is a
+    /// place an off-the-shelf encoder disagrees with Go.
+    #[test]
+    fn the_two_modes_disagree_exactly_where_go_says_they_do() {
+        // A segment escapes `/`; a whole path does not. This is what keeps a
+        // repository named `a/b` one segment.
+        assert_eq!(path_escape("a/b"), "a%2Fb");
+        assert_eq!(escape_path("a/b"), "a/b");
+        // A space is `+` in a query and `%20` in a segment.
+        assert_eq!(query_escape("a b"), "a+b");
+        assert_eq!(path_escape("a b"), "a%20b");
+        // `~` survives and `*` does not — `form_urlencoded` does the reverse.
+        assert_eq!(query_escape("~a*b"), "~a%2Ab");
+    }
+
+    /// `Values.Encode` sorts by key and escapes both halves, which is what
+    /// makes every paged GitHub request reproducible.
+    #[test]
+    fn values_encode_sorts_keys_and_escapes_both_halves() {
+        let mut values = Values::new();
+        values.set("per_page", "30");
+        values.set("q", "repo:o/r func foo");
+        values.set("labels", "bug,help wanted");
+        assert_eq!(
+            values.encode(),
+            "labels=bug%2Chelp+wanted&per_page=30&q=repo%3Ao%2Fr+func+foo"
+        );
+
+        // `Set` replaces, and an empty set is the empty string — the callers
+        // append it after a literal `?` either way.
+        values.set("per_page", "100");
+        assert!(values.encode().contains("per_page=100"));
+        assert_eq!(Values::new().encode(), "");
     }
 
     /// The four rows of the module header's table, spelled out so a reader of

--- a/desktop/src-tauri/src/native/integrations.rs
+++ b/desktop/src-tauri/src/native/integrations.rs
@@ -107,6 +107,19 @@
 //! only one of the orderings Go produces, which is why the live parity suite
 //! re-asks. See "Go itself is not always byte-stable" in `desktop/CLAUDE.md`.
 
+/// The GitHub integration's in-process MCP server (#312).
+///
+/// A submodule of a `.rs` module file rather than a sibling, which is the least
+/// disruptive of the two layouts: `native/integrations.rs` stays exactly where
+/// it is and keeps its history, and `native/integrations/github/` is where the
+/// six ports (#312–#317) collect. The alternative — moving this file to
+/// `native/integrations/mod.rs` — is a rename of a 1,400-line file for the same
+/// result.
+///
+/// Nothing here calls it. Hosting an integration's server is the registry's
+/// job, which is #311; this module still never reads a credential.
+pub mod github;
+
 use std::collections::BTreeMap;
 use std::path::Path;
 

--- a/desktop/src-tauri/src/native/integrations/github/actions.rs
+++ b/desktop/src-tauri/src/native/integrations/github/actions.rs
@@ -1,0 +1,254 @@
+//! `actions`, ported from `internal/integrations/github/actions.go`.
+//!
+//! Five tools, and the two that are unlike anything else in this integration:
+//!
+//! - `trigger_workflow` parses a **caller-supplied JSON document**, so
+//!   `encoding/json`'s own error wording reaches the model. See
+//!   [`super::body::parse_string_map`] for what is reproduced and the two
+//!   malformed-input cases that are not.
+//! - `get_run_logs` is the only user of the no-redirect client: the API answers
+//!   a 302 and the *header* is the answer.
+
+use schemars::JsonSchema;
+
+use crate::claude::{new_tool, CancellationToken, ToolDef};
+use crate::native::gourl::{path_escape, Values};
+
+use super::body::{parse_string_map, Body};
+use super::client::{set_paging, Client};
+use super::text_result;
+
+/// `list_workflows`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct ListWorkflowsInput {
+    /// required,Repository owner
+    owner: String,
+    /// required,Repository name
+    repo: String,
+    /// Results per page (max 100)
+    per_page: i64,
+    /// Page number. Default: 1
+    page: i64,
+}
+
+pub fn list_workflows(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "list_workflows",
+        "Lists all workflows in a repository.",
+        move |input: ListWorkflowsInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let mut query = Values::new();
+                set_paging(&mut query, input.per_page, input.page);
+                let path = format!(
+                    "/repos/{}/{}/actions/workflows?{}",
+                    path_escape(&input.owner),
+                    path_escape(&input.repo),
+                    query.encode()
+                );
+                let result = client.call(&ct, reqwest::Method::GET, &path, None).await?;
+                Ok(text_result(format!("Workflows: {result}")))
+            }
+        },
+    )
+}
+
+/// `listWorkflowRunsParams` — a named type in Go too, because
+/// `workflowRunsPath` takes it.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct ListWorkflowRunsInput {
+    /// required,Repository owner
+    owner: String,
+    /// required,Repository name
+    repo: String,
+    /// Workflow ID or file name
+    workflow_id: String,
+    /// Filter: queued, in_progress, completed
+    status: String,
+    /// Filter by branch name
+    branch: String,
+    /// Results per page (max 100)
+    per_page: i64,
+    /// Page number. Default: 1
+    page: i64,
+}
+
+pub fn list_workflow_runs(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "list_workflow_runs",
+        "Lists workflow runs for a repository.",
+        move |input: ListWorkflowRunsInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let mut query = Values::new();
+                if !input.status.is_empty() {
+                    query.set("status", &input.status);
+                }
+                if !input.branch.is_empty() {
+                    query.set("branch", &input.branch);
+                }
+                set_paging(&mut query, input.per_page, input.page);
+                // `workflowRunsPath`: a workflow id picks a different endpoint
+                // entirely rather than adding a parameter, and it is
+                // `PathEscape`'d because it may be a file name.
+                let path = if input.workflow_id.is_empty() {
+                    format!(
+                        "/repos/{}/{}/actions/runs?{}",
+                        path_escape(&input.owner),
+                        path_escape(&input.repo),
+                        query.encode()
+                    )
+                } else {
+                    format!(
+                        "/repos/{}/{}/actions/workflows/{}/runs?{}",
+                        path_escape(&input.owner),
+                        path_escape(&input.repo),
+                        path_escape(&input.workflow_id),
+                        query.encode()
+                    )
+                };
+                let result = client.call(&ct, reqwest::Method::GET, &path, None).await?;
+                Ok(text_result(format!("Workflow runs: {result}")))
+            }
+        },
+    )
+}
+
+/// `trigger_workflow`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct TriggerWorkflowInput {
+    /// required,Repository owner
+    owner: String,
+    /// required,Repository name
+    repo: String,
+    /// required,Workflow ID or file name
+    workflow_id: String,
+    /// required,Git ref (branch or tag)
+    #[serde(rename = "ref")]
+    git_ref: String,
+    /// JSON-encoded workflow inputs
+    inputs: String,
+}
+
+pub fn trigger_workflow(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "trigger_workflow",
+        "Triggers a workflow dispatch event.",
+        move |input: TriggerWorkflowInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let mut body = Body::new();
+                body.set("ref", input.git_ref.as_str());
+                if !input.inputs.is_empty() {
+                    // The parse failure is the **only** path in this
+                    // integration that answers without making a request, which
+                    // is why `github_vectors.json` carries a null `request` for
+                    // exactly these cases.
+                    let parsed = parse_string_map(&input.inputs).map_err(|e| {
+                        format!("parsing workflow inputs (must be a JSON object): {e}")
+                    })?;
+                    // A literal `null` parses to a **nil map** and Go stores it
+                    // anyway, so the request carries `"inputs":null`.
+                    body.set(
+                        "inputs",
+                        match parsed {
+                            Some(map) => serde_json::to_value(map)
+                                .map_err(|e| format!("marshaling request body: {e}"))?,
+                            None => serde_json::Value::Null,
+                        },
+                    );
+                }
+                let path = format!(
+                    "/repos/{}/{}/actions/workflows/{}/dispatches",
+                    path_escape(&input.owner),
+                    path_escape(&input.repo),
+                    path_escape(&input.workflow_id)
+                );
+                // The response body is discarded — the API answers 204 — so the
+                // sentence is a constant.
+                client
+                    .call(&ct, reqwest::Method::POST, &path, Some(body.encode()?))
+                    .await?;
+                Ok(text_result(
+                    "Workflow dispatch triggered successfully.".to_string(),
+                ))
+            }
+        },
+    )
+}
+
+/// `get_workflow_run` and `get_run_logs` share their input shape — `run_id` is
+/// an `int64` in Go, which is `i64` here and reflects to a bare `integer` once
+/// `new_tool` drops `schemars`'s `format` keyword.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct RunInput {
+    /// required,Repository owner
+    owner: String,
+    /// required,Repository name
+    repo: String,
+    /// required,Workflow run ID
+    run_id: i64,
+}
+
+pub fn get_workflow_run(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "get_workflow_run",
+        "Gets details of a specific workflow run.",
+        move |input: RunInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let path = format!(
+                    "/repos/{}/{}/actions/runs/{}",
+                    path_escape(&input.owner),
+                    path_escape(&input.repo),
+                    input.run_id
+                );
+                let result = client.call(&ct, reqwest::Method::GET, &path, None).await?;
+                Ok(text_result(format!("Workflow run: {result}")))
+            }
+        },
+    )
+}
+
+pub fn get_run_logs(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "get_run_logs",
+        "Gets the download URL for a workflow run's logs. \
+         The GitHub API returns a redirect to a time-limited download URL.",
+        move |input: RunInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let path = format!(
+                    "/repos/{}/{}/actions/runs/{}/logs",
+                    path_escape(&input.owner),
+                    path_escape(&input.repo),
+                    input.run_id
+                );
+                // The one tool that wraps its client error rather than
+                // returning it — so a 500 here reads
+                // `fetching logs URL for run 42: github API error: status 500: …`
+                // and the same 500 from any other tool does not.
+                let download_url = client
+                    .get_redirect_url(&ct, &path)
+                    .await
+                    .map_err(|e| format!("fetching logs URL for run {}: {e}", input.run_id))?;
+                Ok(text_result(format!(
+                    "Logs download URL (time-limited zip archive): {download_url}"
+                )))
+            }
+        },
+    )
+}

--- a/desktop/src-tauri/src/native/integrations/github/body.rs
+++ b/desktop/src-tauri/src/native/integrations/github/body.rs
@@ -1,0 +1,293 @@
+//! Request bodies, the way `internal/integrations/github` builds them.
+//!
+//! Four tools POST or PATCH a body — `create_issue`, `update_issue`,
+//! `create_pull`, `create_release` — and every one of them builds a
+//! `map[string]any` conditionally and hands it to `json.Marshal`. The bytes
+//! that produces are a parity surface even though nothing in a *response*
+//! reflects them, which is why `desktop/parity/github_vectors.json` records the
+//! body the fake GitHub received.
+//!
+//! Three properties come from `json.Marshal` over a Go map, and all three are
+//! reproduced by [`crate::native::gojson::to_vec_marshal`] over a `BTreeMap`:
+//!
+//! - **Keys are sorted.** `encoding/json` sorts map keys; `BTreeMap` iterates
+//!   sorted. A `struct` would have given declaration order, which is why this
+//!   is a map here as it is there.
+//! - **`<`, `>` and `&` are escaped** to `\u003c`, `\u003e`, `\u0026`. An issue
+//!   body or a PR description is Markdown a person wrote, so this fires
+//!   constantly — and `serde_json` on its own emits those three bytes
+//!   literally.
+//! - **A nil slice is `null`, not `[]`.** `splitCSV(" , , ")` returns nil, and
+//!   `body["labels"] = splitCSV(...)` stores it, so the request carries
+//!   `"labels":null`. See [`Body::set_csv`].
+//!
+//! And one comes from the *conditions*: a field is written only when it is
+//! non-empty or true, so `create_pull` with `draft: false` omits the key rather
+//! than sending `false`, and `update_issue` with nothing set sends `{}` —
+//! which still counts as "there is a body" and therefore still sends the
+//! `Content-Type` header.
+
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+use super::client::split_csv;
+
+/// A Go `map[string]any` under construction, keyed for `json.Marshal`'s order.
+#[derive(Default)]
+pub struct Body(BTreeMap<String, Value>);
+
+impl Body {
+    /// `body := map[string]any{}`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// An unconditional key — `map[string]any{"title": p.Title}`.
+    pub fn set(&mut self, key: &str, value: impl Into<Value>) {
+        self.0.insert(key.to_string(), value.into());
+    }
+
+    /// `if p.Body != "" { body["body"] = p.Body }`.
+    pub fn set_if_non_empty(&mut self, key: &str, value: &str) {
+        if !value.is_empty() {
+            self.set(key, value);
+        }
+    }
+
+    /// `if p.Draft { body["draft"] = true }` — note the value is the literal
+    /// `true`, so a false flag leaves no key at all.
+    pub fn set_if_true(&mut self, key: &str, value: bool) {
+        if value {
+            self.set(key, true);
+        }
+    }
+
+    /// `if p.Labels != "" { body["labels"] = splitCSV(p.Labels) }`.
+    ///
+    /// Two conditions, not one, and they disagree on exactly one input: a
+    /// string that is **non-empty but all separators**. `" , , "` passes the
+    /// gate and splits to a nil slice, so the key is present with the value
+    /// `null`. `[]` would be a different request.
+    pub fn set_csv(&mut self, key: &str, value: &str) {
+        if value.is_empty() {
+            return;
+        }
+        let parts = split_csv(value);
+        if parts.is_empty() {
+            self.set(key, Value::Null);
+        } else {
+            self.set(key, parts);
+        }
+    }
+
+    /// The bytes `json.Marshal` would produce.
+    ///
+    /// Infallible in practice — every value here is a string, a bool, a list of
+    /// strings or a map of strings — but the encoder's signature is fallible,
+    /// and its `Err` becomes the tool error the model reads.
+    pub fn encode(&self) -> Result<Vec<u8>, String> {
+        crate::native::gojson::to_vec_marshal(&self.0)
+            .map_err(|e| format!("marshaling request body: {e}"))
+    }
+}
+
+/// `json.Unmarshal([]byte(p.Inputs), &map[string]string)`, error text included.
+///
+/// `trigger_workflow` is the only tool that parses a *caller-supplied* JSON
+/// document, and Go's failure message reaches the model through
+/// `fmt.Errorf("parsing workflow inputs (must be a JSON object): %w", err)` —
+/// so `encoding/json`'s own wording is part of the interface.
+///
+/// Reproduced exactly for every **well-formed** document:
+///
+/// | input | answer |
+/// |---|---|
+/// | `{"a":"b"}` | the map |
+/// | `{}` | an empty map, which marshals as `{}` |
+/// | `null` | a **nil map**, no error — it marshals back as `null` |
+/// | `{"a":null}` | `{"a":""}`, because a JSON null is Go's zero value |
+/// | `[…]` / `5` / `"s"` / `true` | `cannot unmarshal <kind> into Go value of type map[string]string` |
+/// | `{"a":1}` | `cannot unmarshal <kind> into Go value of type string` |
+///
+/// **Two divergences, both on malformed input, both deliberate:**
+///
+/// 1. A **syntax** error. Go's scanner has its own vocabulary
+///    (`invalid character 'o' in literal null (expecting 'u')`) with no
+///    `serde_json` equivalent, and porting `encoding/json`'s scanner to
+///    reproduce a message would be a large amount of code for a string. The
+///    one exception is a *truncated* document, whose wording is short enough to
+///    reproduce and common enough to be worth it:
+///    `unexpected end of JSON input`. `github_vectors.json` pins both cases,
+///    the divergent one through its `rust_text` field.
+/// 2. A document with **several** badly-typed values reports the kind of
+///    whichever comes first, and "first" is document order in Go and sorted
+///    order here (`serde_json::Map` is a `BTreeMap` — deliberately, since
+///    that is what gives [`crate::native::gojson`] Go's map ordering). Only the
+///    *kind word* can differ, and only for an input with two wrong values of
+///    different types.
+pub fn parse_string_map(raw: &str) -> Result<Option<BTreeMap<String, String>>, String> {
+    let value: Value = serde_json::from_str(raw).map_err(|e| {
+        if e.classify() == serde_json::error::Category::Eof {
+            "unexpected end of JSON input".to_string()
+        } else {
+            e.to_string()
+        }
+    })?;
+
+    let object = match value {
+        // `json.Unmarshal` of a literal null into a map leaves the map nil and
+        // returns no error. The nil-ness survives: the caller stores it and
+        // `json.Marshal` writes `"inputs":null`.
+        Value::Null => return Ok(None),
+        Value::Object(object) => object,
+        other => {
+            return Err(format!(
+                "json: cannot unmarshal {} into Go value of type map[string]string",
+                go_kind(&other)
+            ))
+        }
+    };
+
+    let mut out = BTreeMap::new();
+    for (key, value) in object {
+        let text = match value {
+            Value::String(text) => text,
+            // A JSON null decodes into a Go string as the zero value.
+            Value::Null => String::new(),
+            other => {
+                return Err(format!(
+                    "json: cannot unmarshal {} into Go value of type string",
+                    go_kind(&other)
+                ))
+            }
+        };
+        out.insert(key, text);
+    }
+    Ok(Some(out))
+}
+
+/// The word `encoding/json` uses for a JSON value's kind in an unmarshal error.
+///
+/// `bool` rather than `boolean`, and one `number` for every numeric shape —
+/// these are `decodeState`'s literals, not JSON Schema's type names.
+fn go_kind(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn encoded(body: &Body) -> String {
+        String::from_utf8(body.encode().expect("encode")).expect("utf-8")
+    }
+
+    /// Sorted keys and HTML escaping, which is the whole of `json.Marshal` over
+    /// a Go map — and the reason `create_issue`'s body is not in field order.
+    #[test]
+    fn a_body_is_sorted_and_html_escaped() {
+        let mut body = Body::new();
+        body.set("title", "Found a bug");
+        body.set_if_non_empty("body", "It <broke> & burned");
+        body.set_csv("labels", "bug, help wanted ,");
+        assert_eq!(
+            encoded(&body),
+            concat!(
+                r#"{"body":"It \u003cbroke\u003e \u0026 burned","#,
+                r#""labels":["bug","help wanted"],"title":"Found a bug"}"#
+            )
+        );
+    }
+
+    /// The three conditions, each at the input that distinguishes it.
+    #[test]
+    fn a_key_appears_only_when_go_would_write_it() {
+        let mut body = Body::new();
+        body.set_if_non_empty("body", "");
+        body.set_if_true("draft", false);
+        body.set_csv("labels", "");
+        assert_eq!(encoded(&body), "{}", "an empty update is still a body");
+
+        let mut body = Body::new();
+        body.set_if_true("draft", true);
+        // Non-empty but all separators: the gate passes and the split is nil.
+        body.set_csv("labels", " , , ");
+        assert_eq!(encoded(&body), r#"{"draft":true,"labels":null}"#);
+    }
+
+    #[test]
+    fn well_formed_inputs_parse_the_way_go_parses_them() {
+        let map = |pairs: &[(&str, &str)]| {
+            Some(
+                pairs
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect::<BTreeMap<_, _>>(),
+            )
+        };
+        assert_eq!(
+            parse_string_map(r#"{"zebra":"z","alpha":"a"}"#),
+            Ok(map(&[("alpha", "a"), ("zebra", "z")]))
+        );
+        assert_eq!(parse_string_map("{}"), Ok(map(&[])));
+        // A literal null is a nil map, not an error and not an empty map — and
+        // the difference is visible in the request body.
+        assert_eq!(parse_string_map("null"), Ok(None));
+        assert_eq!(parse_string_map(r#"{"a":null}"#), Ok(map(&[("a", "")])));
+    }
+
+    #[test]
+    fn a_wrong_shape_is_gos_sentence() {
+        for (input, kind) in [
+            (r#"["a","b"]"#, "array"),
+            ("[]", "array"),
+            ("5", "number"),
+            (r#""s""#, "string"),
+            ("true", "bool"),
+        ] {
+            assert_eq!(
+                parse_string_map(input),
+                Err(format!(
+                    "json: cannot unmarshal {kind} into Go value of type map[string]string"
+                )),
+                "{input}"
+            );
+        }
+        for (input, kind) in [
+            (r#"{"a":1}"#, "number"),
+            (r#"{"a":true}"#, "bool"),
+            (r#"{"a":{"b":"c"}}"#, "object"),
+            (r#"{"a":[]}"#, "array"),
+        ] {
+            assert_eq!(
+                parse_string_map(input),
+                Err(format!(
+                    "json: cannot unmarshal {kind} into Go value of type string"
+                )),
+                "{input}"
+            );
+        }
+    }
+
+    /// The one syntax error worth reproducing: a truncated document says the
+    /// same thing in both languages, and it is the failure a hand-typed
+    /// argument actually produces.
+    #[test]
+    fn a_truncated_document_is_gos_sentence_too() {
+        for input in [r#"{"a":"#, "{", "[", r#"{"a""#] {
+            assert_eq!(
+                parse_string_map(input),
+                Err("unexpected end of JSON input".to_string()),
+                "{input}"
+            );
+        }
+    }
+}

--- a/desktop/src-tauri/src/native/integrations/github/client.rs
+++ b/desktop/src-tauri/src/native/integrations/github/client.rs
@@ -1,0 +1,525 @@
+//! The shared HTTP client, ported from `internal/integrations/github/tools.go`.
+//!
+//! Everything the twenty tools have in common: where the API is, how a request
+//! is authenticated and shaped, how much of a response is read, and the four
+//! sentences a failure can produce. None of it is visible in a tool's success
+//! text, which is why `desktop/parity/github_vectors.json` records the *request*
+//! the fake GitHub received as well as the answer.
+//!
+//! # The error strings are the interface
+//!
+//! `crate::claude::new_tool` packs an `Err(String)` into a `CallToolResult`
+//! with `is_error`, so every message below is **text the model reads and
+//! retries on** — the same contract `mcp.AddTool`'s `ToolHandlerFor` gives the
+//! Go side. They are reproduced byte for byte, including the two that look like
+//! oversights and are not:
+//!
+//! - `"calling GitHub %s %s: request failed"` deliberately drops the transport
+//!   error. A `reqwest`/`net/http` error can carry the URL, and the URL is
+//!   built from user input — so the wording is fixed and the cause is not
+//!   interpolated.
+//! - `github API error: status %d: %s` carries GitHub's own body **verbatim**.
+//!   That body is what tells the model whether it hit a permission problem or a
+//!   typo, and re-encoding it through a JSON value would reorder its keys.
+//!
+//! # Cancellation
+//!
+//! Go threads `ctx` into `http.NewRequestWithContext`, so a cancelled turn
+//! aborts the outbound call and `client.Do` returns an error — which the caller
+//! turns into `calling GitHub %s %s: request failed`. That is exactly what a
+//! cancelled call answers here, so the port needs no divergence: the
+//! `tokio::select!` arm produces the same sentence Go's cancelled `Do` does.
+//! (`crate::claude::tool` explains why the token has to be watched at all:
+//! `rmcp` spawns handlers detached, so a handler that ignores it keeps its
+//! socket open after the caller is gone.)
+
+use std::sync::{OnceLock, RwLock};
+use std::time::Duration;
+
+use reqwest::Method;
+use tokio_stream::StreamExt;
+
+use crate::claude::CancellationToken;
+
+/// `githubAPIBase`'s default — the root every path below is appended to.
+pub const DEFAULT_API_BASE: &str = "https://api.github.com";
+
+/// Go's `githubAPIBase`, a package variable "exposed as a variable so tests can
+/// redirect requests to a local server".
+///
+/// A `RwLock` rather than a `OnceLock` for that same reason: the parity suite
+/// points it at a loopback fake and puts it back. Reads are on every request
+/// and contention is nil, since nothing writes outside a test.
+static API_BASE: RwLock<Option<String>> = RwLock::new(None);
+
+/// Where requests go. [`DEFAULT_API_BASE`] unless [`set_api_base`] said
+/// otherwise.
+pub fn api_base() -> String {
+    match API_BASE.read() {
+        Ok(base) => base.clone().unwrap_or_else(|| DEFAULT_API_BASE.to_string()),
+        // A poisoned lock means a test panicked while holding it; answering the
+        // real API would then be the *worse* outcome, so fail loudly.
+        Err(poisoned) => poisoned
+            .into_inner()
+            .clone()
+            .unwrap_or_else(|| DEFAULT_API_BASE.to_string()),
+    }
+}
+
+/// Points every subsequent request at `base`; `None` restores the default.
+///
+/// Only the parity suite calls this. It is not per-integration configuration —
+/// GitHub Enterprise would need a per-row base, which the Go side does not have
+/// either.
+pub fn set_api_base(base: Option<String>) {
+    let mut guard = match API_BASE.write() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    *guard = base;
+}
+
+/// Serializes the tests that redirect [`API_BASE`].
+///
+/// The base is process-wide, as Go's package variable is, so two tests that
+/// point it at different fakes would race — and `cargo test` runs them in
+/// parallel where `go test` runs a package's tests in sequence. Every test that
+/// touches it takes this first.
+///
+/// `tokio`'s mutex rather than `std`'s: every holder awaits an HTTP round trip
+/// while holding it, which is exactly what `clippy::await_holding_lock` exists
+/// to refuse.
+#[cfg(test)]
+pub(super) async fn api_base_lock() -> tokio::sync::MutexGuard<'static, ()> {
+    static LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+    LOCK.lock().await
+}
+
+/// `ghHTTPClient` — 15 seconds, redirects followed.
+fn http_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .timeout(Duration::from_secs(15))
+            .build()
+            .expect("a reqwest client with a TLS backend")
+    })
+}
+
+/// `ghNoRedirectClient` — the same, with `CheckRedirect` returning
+/// `http.ErrUseLastResponse` so a 302's `Location` is readable.
+///
+/// A second client rather than a per-request policy because `reqwest` has no
+/// per-request one; Go's is a second client too.
+fn no_redirect_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .timeout(Duration::from_secs(15))
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .expect("a reqwest client with a TLS backend")
+    })
+}
+
+/// `call`'s cap: 2 MiB.
+const MAX_JSON_BYTES: usize = 2 * 1024 * 1024;
+/// `callRaw`'s cap: 10 MB, "to accommodate large PR diffs".
+const MAX_RAW_BYTES: usize = 10 * 1024 * 1024;
+/// `getRedirectURL`'s cap on the body it quotes back when the response was not
+/// a redirect after all. A *third* number, and the smallest by four orders of
+/// magnitude — so a 500 there is truncated mid-sentence where the same 500 from
+/// `call` is not.
+const MAX_REDIRECT_ERROR_BYTES: usize = 512;
+
+/// Go's `client` struct: a token and the requests made with it.
+///
+/// Cloned per call from the closure that captured it — the shape
+/// `crate::claude::tool`'s module docs describe — so it is deliberately cheap
+/// to clone and holds nothing else.
+#[derive(Clone)]
+pub struct Client {
+    token: String,
+}
+
+impl Client {
+    pub fn new(token: impl Into<String>) -> Self {
+        Self {
+            token: token.into(),
+        }
+    }
+
+    /// `call`: a JSON request whose body is returned as the raw response bytes.
+    ///
+    /// `body` is already-encoded bytes rather than a value, because Go passes
+    /// `map[string]any` to `json.Marshal` and the callers reproduce that with
+    /// [`super::body::Body`] — the encoding has to be Go's (sorted keys, HTML
+    /// escaping) and doing it here would hide that.
+    ///
+    /// The `Content-Type` header is set **only when there is a body**, which is
+    /// observable: `update_issue` with nothing to update still sends `{}` and
+    /// therefore still sends the header, while every GET sends neither.
+    pub async fn call(
+        &self,
+        ct: &CancellationToken,
+        method: Method,
+        path: &str,
+        body: Option<Vec<u8>>,
+    ) -> Result<String, String> {
+        let has_body = body.is_some();
+        let mut request = http_client()
+            .request(method.clone(), format!("{}{path}", api_base()))
+            .header("Authorization", format!("Bearer {}", self.token))
+            .header("Accept", "application/vnd.github.v3+json");
+        if has_body {
+            request = request.header("Content-Type", "application/json");
+        }
+        if let Some(body) = body {
+            request = request.body(body);
+        }
+
+        let response = send(ct, request, &request_failed(&method, path)).await?;
+        let status = response.status();
+        let text = read_capped(ct, response, MAX_JSON_BYTES).await?;
+        api_error_or(status, text)
+    }
+
+    /// `callRaw`: the same request under a caller-chosen `Accept`, no body, and
+    /// a 10 MB cap. One caller — `get_pull_diff`, whose response is a diff.
+    pub async fn call_raw(
+        &self,
+        ct: &CancellationToken,
+        method: Method,
+        path: &str,
+        accept: &str,
+    ) -> Result<String, String> {
+        let request = http_client()
+            .request(method.clone(), format!("{}{path}", api_base()))
+            .header("Authorization", format!("Bearer {}", self.token))
+            .header("Accept", accept);
+
+        let response = send(ct, request, &request_failed(&method, path)).await?;
+        let status = response.status();
+        let text = read_capped(ct, response, MAX_RAW_BYTES).await?;
+        api_error_or(status, text)
+    }
+
+    /// `getRedirectURL`: a GET that is *expected* to redirect, answering with
+    /// the `Location` header.
+    ///
+    /// Note the failure message shape, which is Go's and is not the one `call`
+    /// uses: `calling GitHub GET %s: request failed` has no method placeholder,
+    /// because the method is a literal there.
+    pub async fn get_redirect_url(
+        &self,
+        ct: &CancellationToken,
+        path: &str,
+    ) -> Result<String, String> {
+        let request = no_redirect_client()
+            .get(format!("{}{path}", api_base()))
+            .header("Authorization", format!("Bearer {}", self.token))
+            .header("Accept", "application/vnd.github.v3+json");
+
+        let response = send(
+            ct,
+            request,
+            &format!("calling GitHub GET {path}: request failed"),
+        )
+        .await?;
+
+        let status = response.status();
+        if status == reqwest::StatusCode::FOUND || status == reqwest::StatusCode::MOVED_PERMANENTLY
+        {
+            // `Header.Get` on an absent header is `""`, and a header whose
+            // value is the empty string is the same thing to Go — so both
+            // reach the same sentence.
+            let location = response
+                .headers()
+                .get(reqwest::header::LOCATION)
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .to_string();
+            if location.is_empty() {
+                return Err("redirect response missing Location header".to_string());
+            }
+            return Ok(location);
+        }
+
+        // Go ignores the read error here (`body, _ := io.ReadAll(...)`), so a
+        // truncated body still produces the status sentence rather than
+        // replacing it with `reading response`.
+        let text = read_capped(ct, response, MAX_REDIRECT_ERROR_BYTES)
+            .await
+            .unwrap_or_default();
+        Err(github_api_error(status, &text))
+    }
+}
+
+/// `fmt.Errorf("calling GitHub %s %s: request failed", method, path)`.
+fn request_failed(method: &Method, path: &str) -> String {
+    format!("calling GitHub {method} {path}: request failed")
+}
+
+/// `fmt.Errorf("github API error: status %d: %s", status, body)`.
+fn github_api_error(status: reqwest::StatusCode, body: &str) -> String {
+    format!("github API error: status {}: {body}", status.as_u16())
+}
+
+/// Go's `if resp.StatusCode < 200 || resp.StatusCode >= 300` — note it is a
+/// *range*, not `!= 200`, so the `204` a workflow dispatch answers is a success
+/// and a `304` would not be.
+fn api_error_or(status: reqwest::StatusCode, body: String) -> Result<String, String> {
+    if !(200..300).contains(&status.as_u16()) {
+        return Err(github_api_error(status, &body));
+    }
+    Ok(body)
+}
+
+/// Sends a request, racing the run's cancellation.
+///
+/// `failed` is passed in rather than built here because the two call shapes
+/// word it differently — see [`Client::get_redirect_url`].
+async fn send(
+    ct: &CancellationToken,
+    request: reqwest::RequestBuilder,
+    failed: &str,
+) -> Result<reqwest::Response, String> {
+    tokio::select! {
+        // Cancellation and a transport failure produce the same sentence, and
+        // that is not a shortcut: in Go a cancelled `ctx` *is* how `client.Do`
+        // fails, so this is the message that reaches the model there too.
+        () = ct.cancelled() => Err(failed.to_string()),
+        result = request.send() => result.map_err(|_| failed.to_string()),
+    }
+}
+
+/// `io.ReadAll(io.LimitReader(resp.Body, cap))`.
+///
+/// Streamed rather than buffered whole: the cap exists so a hostile or
+/// runaway response cannot be pulled into memory, and `bytes()` would read it
+/// all before there was anything to truncate.
+///
+/// **Lossy UTF-8**, which is the one place this is not literally Go. Go does
+/// `string(respBody)` on arbitrary bytes and a Go string holds them; a Rust
+/// `String` cannot, so invalid sequences become U+FFFD. Every GitHub response
+/// this reaches is JSON or a diff, both UTF-8 by definition, and the
+/// alternative — carrying `Vec<u8>` through to the `ContentBlock` — would only
+/// move the same conversion to the end of the pipe, where `rmcp` demands a
+/// `String` anyway.
+async fn read_capped(
+    ct: &CancellationToken,
+    response: reqwest::Response,
+    cap: usize,
+) -> Result<String, String> {
+    let mut body = Vec::new();
+    let mut stream = Box::pin(response.bytes_stream());
+    loop {
+        let chunk = tokio::select! {
+            () = ct.cancelled() => return Err("reading response: context canceled".to_string()),
+            chunk = stream.next() => chunk,
+        };
+        match chunk {
+            None => break,
+            Some(Ok(chunk)) => {
+                body.extend_from_slice(&chunk);
+                if body.len() >= cap {
+                    body.truncate(cap);
+                    break;
+                }
+            }
+            // `fmt.Errorf("reading response: %w", err)`. The cause *is*
+            // interpolated here, unlike the send failure: this error describes
+            // a body already in flight and cannot carry the request URL.
+            Some(Err(e)) => return Err(format!("reading response: {e}")),
+        }
+    }
+    Ok(String::from_utf8_lossy(&body).into_owned())
+}
+
+/// `splitCSV`: comma-separated, trimmed, empties dropped.
+///
+/// Returns a `Vec` that may be **empty**, and the callers must keep that
+/// distinct from a non-empty one: Go's nil slice marshals as `null`, so
+/// `labels: " , , "` sends `"labels":null` rather than `"labels":[]`. See
+/// [`super::body::Body::set_csv`].
+pub fn split_csv(s: &str) -> Vec<String> {
+    s.split(',')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+/// The per-page clamp and the page gate, which are **identical at all nine**
+/// paging tools — verified one by one against `repos.go`, `issues.go`,
+/// `pulls.go`, `actions.go` and `releases.go` rather than assumed from the
+/// first one.
+///
+/// `perPage <= 0 || perPage > 100` both fall back to 30, so a zero (the value
+/// an omitted-but-required field cannot be, since every field *is* required)
+/// and a 500 land in the same place. `page` is written only when positive, so
+/// the default page produces no `page` key at all rather than `page=1`.
+pub fn set_paging(values: &mut crate::native::gourl::Values, per_page: i64, page: i64) {
+    let per_page = if per_page <= 0 || per_page > 100 {
+        30
+    } else {
+        per_page
+    };
+    values.set("per_page", per_page.to_string());
+    if page > 0 {
+        values.set("page", page.to_string());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_csv_matches_gos_trimming() {
+        assert!(split_csv("").is_empty());
+        assert_eq!(split_csv("a"), ["a"]);
+        assert_eq!(split_csv("a,b,c"), ["a", "b", "c"]);
+        assert_eq!(split_csv("a, b , c"), ["a", "b", "c"]);
+        assert!(split_csv(",,,").is_empty());
+        assert_eq!(split_csv("  , a ,  "), ["a"]);
+    }
+
+    #[test]
+    fn the_clamp_is_the_same_at_every_paging_tool() {
+        let encode = |per_page, page| {
+            let mut values = crate::native::gourl::Values::new();
+            set_paging(&mut values, per_page, page);
+            values.encode()
+        };
+        assert_eq!(encode(0, 0), "per_page=30");
+        assert_eq!(encode(-5, 0), "per_page=30");
+        assert_eq!(encode(101, 0), "per_page=30");
+        assert_eq!(encode(100, 0), "per_page=100");
+        assert_eq!(encode(50, 2), "page=2&per_page=50");
+        // A page of 1 *is* written — the gate is `> 0`, not `> 1`.
+        assert_eq!(encode(0, 1), "page=1&per_page=30");
+    }
+
+    /// 2xx is a range, so the `204` a workflow dispatch answers is a success.
+    #[test]
+    fn success_is_the_2xx_range_rather_than_200() {
+        for code in [200u16, 201, 204, 299] {
+            let status = reqwest::StatusCode::from_u16(code).unwrap();
+            assert_eq!(api_error_or(status, "body".into()), Ok("body".to_string()));
+        }
+        for code in [199u16, 300, 301, 404, 500] {
+            let status = reqwest::StatusCode::from_u16(code).unwrap();
+            assert_eq!(
+                api_error_or(status, "b".into()),
+                Err(format!("github API error: status {code}: b"))
+            );
+        }
+    }
+
+    /// The base is a variable so the parity suite can redirect it, and putting
+    /// it back has to work — otherwise one test would leak into the next.
+    #[tokio::test]
+    async fn the_api_base_is_redirectable_and_restorable() {
+        let _guard = api_base_lock().await;
+        assert_eq!(api_base(), DEFAULT_API_BASE);
+        set_api_base(Some("http://127.0.0.1:1".to_string()));
+        assert_eq!(api_base(), "http://127.0.0.1:1");
+        set_api_base(None);
+        assert_eq!(api_base(), DEFAULT_API_BASE);
+    }
+
+    /// A distinctive token, so a leak is unmistakable in any assertion.
+    const SECRET: &str = "ghp-SUPER-SECRET-PERSONAL-ACCESS-TOKEN";
+
+    /// The whole reason the failure message drops the transport error.
+    ///
+    /// A `reqwest::Error`'s `Display` carries the URL it was building, and a
+    /// future edit that "helpfully" interpolated the cause would put the
+    /// request — and, one refactor later, a header — into text the model reads
+    /// and the transcript stores. Go's wording has the same property and this
+    /// asserts it rather than trusting it.
+    #[tokio::test]
+    async fn a_failed_call_names_neither_the_token_nor_the_cause() {
+        let _guard = api_base_lock().await;
+        // Port 1 on loopback: nothing listens, so the connect fails fast.
+        set_api_base(Some("http://127.0.0.1:1".to_string()));
+        let client = Client::new(SECRET);
+        let ct = CancellationToken::new();
+
+        let call = client
+            .call(&ct, Method::GET, "/repos/o/r", None)
+            .await
+            .expect_err("nothing is listening");
+        assert_eq!(call, "calling GitHub GET /repos/o/r: request failed");
+
+        let raw = client
+            .call_raw(&ct, Method::GET, "/repos/o/r", "text/plain")
+            .await
+            .expect_err("nothing is listening");
+        assert_eq!(raw, "calling GitHub GET /repos/o/r: request failed");
+
+        // `getRedirectURL`'s sentence has no method placeholder — the method is
+        // a literal there — so it is a different string, not the same one.
+        let redirect = client
+            .get_redirect_url(&ct, "/repos/o/r/logs")
+            .await
+            .expect_err("nothing is listening");
+        assert_eq!(
+            redirect,
+            "calling GitHub GET /repos/o/r/logs: request failed"
+        );
+
+        for message in [call, raw, redirect] {
+            assert!(
+                !message.contains(SECRET),
+                "a token reached the model: {message}"
+            );
+        }
+        set_api_base(None);
+    }
+
+    /// A cancelled call answers **Go's sentence**, and that is a port rather
+    /// than a choice: in Go a cancelled `ctx` is how `client.Do` fails, so
+    /// `calling GitHub %s %s: request failed` is what the model reads there
+    /// too.
+    #[tokio::test]
+    async fn a_cancelled_call_answers_what_a_cancelled_go_call_answers() {
+        let _guard = api_base_lock().await;
+        set_api_base(Some("http://127.0.0.1:1".to_string()));
+        let ct = CancellationToken::new();
+        ct.cancel();
+        assert_eq!(
+            Client::new(SECRET)
+                .call(&ct, Method::GET, "/user/repos", None)
+                .await,
+            Err("calling GitHub GET /user/repos: request failed".to_string())
+        );
+        set_api_base(None);
+    }
+
+    /// `io.LimitReader` truncates rather than failing, and it stops *reading* —
+    /// which is why the port streams instead of buffering the body and then
+    /// slicing it.
+    #[tokio::test]
+    async fn a_response_is_truncated_at_the_cap_rather_than_refused() {
+        let _guard = api_base_lock().await;
+        let oversized = MAX_JSON_BYTES + 4096;
+        let app = axum::Router::new().fallback(move || async move { "x".repeat(oversized) });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let base = format!("http://{}", listener.local_addr().expect("addr"));
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        set_api_base(Some(base));
+
+        let body = Client::new(SECRET)
+            .call(&CancellationToken::new(), Method::GET, "/big", None)
+            .await
+            .expect("a 200 is a success however long the body is");
+        assert_eq!(body.len(), MAX_JSON_BYTES);
+        set_api_base(None);
+    }
+}

--- a/desktop/src-tauri/src/native/integrations/github/client.rs
+++ b/desktop/src-tauri/src/native/integrations/github/client.rs
@@ -33,7 +33,9 @@
 //! `rmcp` spawns handlers detached, so a handler that ignores it keeps its
 //! socket open after the caller is gone.)
 
-use std::sync::{OnceLock, RwLock};
+use std::sync::OnceLock;
+#[cfg(test)]
+use std::sync::RwLock;
 use std::time::Duration;
 
 use reqwest::Method;
@@ -47,36 +49,53 @@ pub const DEFAULT_API_BASE: &str = "https://api.github.com";
 /// Go's `githubAPIBase`, a package variable "exposed as a variable so tests can
 /// redirect requests to a local server".
 ///
-/// A `RwLock` rather than a `OnceLock` for that same reason: the parity suite
-/// points it at a loopback fake and puts it back. Reads are on every request
-/// and contention is nil, since nothing writes outside a test.
+/// **Test-only, where Go's is not, and deliberately.** The seam is "point every
+/// GitHub request — bearing the user's personal access token — at an arbitrary
+/// host", so it should not exist in a shipped binary. Go had no choice:
+/// `desktop/parity` is a different package, so `internal/integrations/github/`
+/// had to export `SetAPIBase` to be redirectable at all. Both callers here are
+/// in-crate, so `#[cfg(test)]` costs nothing and compiles the whole thing out —
+/// which is what [`api_base_lock`] below already does, for the same reason.
+/// #313–#317 each add their own seam and should follow this.
+///
+/// A `RwLock` rather than a `OnceLock` because a test points it at a loopback
+/// fake and then puts it back.
+#[cfg(test)]
 static API_BASE: RwLock<Option<String>> = RwLock::new(None);
 
-/// Where requests go. [`DEFAULT_API_BASE`] unless [`set_api_base`] said
+/// Where requests go — [`DEFAULT_API_BASE`] unless [`set_api_base`] said
 /// otherwise.
-pub fn api_base() -> String {
-    match API_BASE.read() {
-        Ok(base) => base.clone().unwrap_or_else(|| DEFAULT_API_BASE.to_string()),
-        // A poisoned lock means a test panicked while holding it; answering the
-        // real API would then be the *worse* outcome, so fail loudly.
-        Err(poisoned) => poisoned
-            .into_inner()
-            .clone()
-            .unwrap_or_else(|| DEFAULT_API_BASE.to_string()),
-    }
+///
+/// A poisoned lock means a test panicked between taking the write guard and
+/// dropping it, three lines later. There is no recovery that is not a lie about
+/// which server the next request reaches, and the caller is a test either way,
+/// so this panics rather than guessing.
+#[cfg(test)]
+fn api_base() -> String {
+    API_BASE
+        .read()
+        .expect("the github API base lock is poisoned")
+        .clone()
+        .unwrap_or_else(|| DEFAULT_API_BASE.to_string())
+}
+
+/// Where requests go. There is one answer in a shipped binary, because nothing
+/// outside a test can move it — see [`API_BASE`].
+#[cfg(not(test))]
+fn api_base() -> String {
+    DEFAULT_API_BASE.to_string()
 }
 
 /// Points every subsequent request at `base`; `None` restores the default.
 ///
-/// Only the parity suite calls this. It is not per-integration configuration —
-/// GitHub Enterprise would need a per-row base, which the Go side does not have
-/// either.
-pub fn set_api_base(base: Option<String>) {
-    let mut guard = match API_BASE.write() {
-        Ok(guard) => guard,
-        Err(poisoned) => poisoned.into_inner(),
-    };
-    *guard = base;
+/// Only tests call this, and only tests *can* — see [`API_BASE`]. It is not
+/// per-integration configuration: GitHub Enterprise would need a per-row base,
+/// which the Go side does not have either.
+#[cfg(test)]
+pub(super) fn set_api_base(base: Option<String>) {
+    *API_BASE
+        .write()
+        .expect("the github API base lock is poisoned") = base;
 }
 
 /// Serializes the tests that redirect [`API_BASE`].
@@ -96,14 +115,26 @@ pub(super) async fn api_base_lock() -> tokio::sync::MutexGuard<'static, ()> {
 }
 
 /// `ghHTTPClient` — 15 seconds, redirects followed.
-fn http_client() -> &'static reqwest::Client {
-    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
-    CLIENT.get_or_init(|| {
-        reqwest::Client::builder()
-            .timeout(Duration::from_secs(15))
-            .build()
-            .expect("a reqwest client with a TLS backend")
-    })
+///
+/// `Option`, because building one can fail here where Go's cannot.
+/// `&http.Client{Timeout: …}` is a struct literal and the trust store is not
+/// consulted until the handshake, so a machine with an unusable one fails
+/// *per request*; `reqwest` reads the platform roots inside `build()` (see
+/// `Cargo.toml` on `rustls-tls-native-roots`) and reports an empty store as a
+/// builder error. That has to reach the model as Go's own
+/// `calling GitHub …: request failed` — a handshake that cannot complete is a
+/// transport failure there too — rather than as a panic inside a handler
+/// `rmcp` spawned detached.
+fn http_client() -> Option<&'static reqwest::Client> {
+    static CLIENT: OnceLock<Option<reqwest::Client>> = OnceLock::new();
+    CLIENT
+        .get_or_init(|| {
+            reqwest::Client::builder()
+                .timeout(Duration::from_secs(15))
+                .build()
+                .ok()
+        })
+        .as_ref()
 }
 
 /// `ghNoRedirectClient` — the same, with `CheckRedirect` returning
@@ -111,15 +142,17 @@ fn http_client() -> &'static reqwest::Client {
 ///
 /// A second client rather than a per-request policy because `reqwest` has no
 /// per-request one; Go's is a second client too.
-fn no_redirect_client() -> &'static reqwest::Client {
-    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
-    CLIENT.get_or_init(|| {
-        reqwest::Client::builder()
-            .timeout(Duration::from_secs(15))
-            .redirect(reqwest::redirect::Policy::none())
-            .build()
-            .expect("a reqwest client with a TLS backend")
-    })
+fn no_redirect_client() -> Option<&'static reqwest::Client> {
+    static CLIENT: OnceLock<Option<reqwest::Client>> = OnceLock::new();
+    CLIENT
+        .get_or_init(|| {
+            reqwest::Client::builder()
+                .timeout(Duration::from_secs(15))
+                .redirect(reqwest::redirect::Policy::none())
+                .build()
+                .ok()
+        })
+        .as_ref()
 }
 
 /// `call`'s cap: 2 MiB.
@@ -167,8 +200,10 @@ impl Client {
         body: Option<Vec<u8>>,
     ) -> Result<String, String> {
         let has_body = body.is_some();
+        let failed = request_failed(&method, path);
         let mut request = http_client()
-            .request(method.clone(), format!("{}{path}", api_base()))
+            .ok_or_else(|| failed.clone())?
+            .request(method, absolute(path, &failed)?)
             .header("Authorization", format!("Bearer {}", self.token))
             .header("Accept", "application/vnd.github.v3+json");
         if has_body {
@@ -178,7 +213,7 @@ impl Client {
             request = request.body(body);
         }
 
-        let response = send(ct, request, &request_failed(&method, path)).await?;
+        let response = send(ct, request, &failed).await?;
         let status = response.status();
         let text = read_capped(ct, response, MAX_JSON_BYTES).await?;
         api_error_or(status, text)
@@ -193,12 +228,14 @@ impl Client {
         path: &str,
         accept: &str,
     ) -> Result<String, String> {
+        let failed = request_failed(&method, path);
         let request = http_client()
-            .request(method.clone(), format!("{}{path}", api_base()))
+            .ok_or_else(|| failed.clone())?
+            .request(method, absolute(path, &failed)?)
             .header("Authorization", format!("Bearer {}", self.token))
             .header("Accept", accept);
 
-        let response = send(ct, request, &request_failed(&method, path)).await?;
+        let response = send(ct, request, &failed).await?;
         let status = response.status();
         let text = read_capped(ct, response, MAX_RAW_BYTES).await?;
         api_error_or(status, text)
@@ -215,17 +252,14 @@ impl Client {
         ct: &CancellationToken,
         path: &str,
     ) -> Result<String, String> {
+        let failed = format!("calling GitHub GET {path}: request failed");
         let request = no_redirect_client()
-            .get(format!("{}{path}", api_base()))
+            .ok_or_else(|| failed.clone())?
+            .get(absolute(path, &failed)?)
             .header("Authorization", format!("Bearer {}", self.token))
             .header("Accept", "application/vnd.github.v3+json");
 
-        let response = send(
-            ct,
-            request,
-            &format!("calling GitHub GET {path}: request failed"),
-        )
-        .await?;
+        let response = send(ct, request, &failed).await?;
 
         let status = response.status();
         if status == reqwest::StatusCode::FOUND || status == reqwest::StatusCode::MOVED_PERMANENTLY
@@ -233,12 +267,19 @@ impl Client {
             // `Header.Get` on an absent header is `""`, and a header whose
             // value is the empty string is the same thing to Go — so both
             // reach the same sentence.
+            //
+            // `from_utf8_lossy` over the raw bytes rather than `to_str()`,
+            // which refuses anything non-ASCII: Go's `Header.Get` hands back
+            // whatever bytes arrived, so a `Location` carrying a non-ASCII
+            // byte — a redirect to a signed URL through a host with a
+            // percent-decoding proxy in front of it, say — succeeds there and
+            // would have become `redirect response missing Location header`
+            // here, which is a sentence about a header that is present.
             let location = response
                 .headers()
                 .get(reqwest::header::LOCATION)
-                .and_then(|value| value.to_str().ok())
-                .unwrap_or_default()
-                .to_string();
+                .map(|value| String::from_utf8_lossy(value.as_bytes()).into_owned())
+                .unwrap_or_default();
             if location.is_empty() {
                 return Err("redirect response missing Location header".to_string());
             }
@@ -258,6 +299,57 @@ impl Client {
 /// `fmt.Errorf("calling GitHub %s %s: request failed", method, path)`.
 fn request_failed(method: &Method, path: &str) -> String {
     format!("calling GitHub {method} {path}: request failed")
+}
+
+/// The URL a request to `path` goes to — or `failed`, if this port cannot build
+/// the request Go builds.
+///
+/// # Why this exists, and why it refuses instead of correcting
+///
+/// Go appends `path` to `githubAPIBase`, hands the string to
+/// `http.NewRequestWithContext`, and `net/http` writes `URL.RequestURI()` on
+/// the wire **verbatim**. Nothing normalizes: `url.PathEscape` leaves `.` and
+/// `..` alone (both are unreserved), and `net/url` does not remove dot
+/// segments. So `list_issues(owner: "..", repo: "..")` asks GitHub for
+/// `/repos/../../issues` and gets a 404.
+///
+/// `reqwest` builds every request through `url::Url::parse`, which applies
+/// WHATWG dot-segment removal for http(s). The same call would leave as
+/// `/issues` — on a request already carrying the user's PAT, that is *the
+/// authenticated user's issues across every repository* in place of one
+/// repository's. `owner`, `repo` and `workflow_id` are model-supplied and every
+/// tool result carries attacker-authored GitHub content, so it is reachable
+/// under prompt injection, and it applies to the write tools too. Escaping the
+/// dots is not a fix — `%2E%2E` is collapsed as well.
+///
+/// `reqwest` offers no way to send an unnormalized target, so the faithful
+/// option is to **refuse**: the model reads the sentence a transport failure
+/// produces rather than the answer to a question it did not ask. Pinned in
+/// `desktop/parity/github_vectors.json` as `rust_no_request` plus `rust_text`,
+/// alongside the 2^53 divergence — five cases, covering all three URL builders.
+///
+/// # Why the whole target is compared rather than `..` scanned for
+///
+/// An exact comparison catches anything else `url` normalizes, now or after an
+/// upgrade, instead of the one shape known today. Nothing legitimate trips it,
+/// and that is a property of `gourl`'s escaping rather than luck: Go's
+/// `encodePathSegment` escapes every byte in `url`'s path encode set (space,
+/// `"`, `#`, `<`, `>`, `?`, `` ` ``, `{`, `}`) and its `encodeQueryComponent`
+/// every byte in the query one, so there is nothing left for `url` to
+/// percent-encode; existing `%XX` escapes are passed through with their case
+/// intact, so Go's uppercase hex survives; and a path with no `?` compares
+/// `""` against `query()`'s `None`. Host, scheme and port are not compared at
+/// all, so `url`'s default-port and case normalization cannot reach this.
+/// Verified against all 50 call vectors, `+`-encoded spaces and multi-byte
+/// UTF-8 among them.
+fn absolute(path: &str, failed: &str) -> Result<reqwest::Url, String> {
+    let url =
+        reqwest::Url::parse(&format!("{}{path}", api_base())).map_err(|_| failed.to_string())?;
+    let (want_path, want_query) = path.split_once('?').unwrap_or((path, ""));
+    if url.path() != want_path || url.query().unwrap_or("") != want_query {
+        return Err(failed.to_string());
+    }
+    Ok(url)
 }
 
 /// `fmt.Errorf("github API error: status %d: %s", status, body)`.
@@ -415,6 +507,67 @@ mod tests {
                 Err(format!("github API error: status {code}: b"))
             );
         }
+    }
+
+    /// The dot-segment guard, at the unit rather than at the vector: what it
+    /// refuses, and — the half that would bite — everything it must not.
+    ///
+    /// `github_vectors.json` covers this end to end for all 50 calls; this
+    /// covers the shapes a *future* tool could build that no vector has yet,
+    /// which is where a guard like this normally goes wrong.
+    #[test]
+    fn dot_segments_are_refused_and_nothing_else_is() {
+        let ok = |path: &str| {
+            absolute(path, "no").unwrap_or_else(|_| panic!("{path} is a legitimate path"))
+        };
+
+        // `url` resolves every one of these into a different endpoint than Go
+        // calls, and escaping the dots does not help — `%2E%2E` is collapsed
+        // too, so there is nothing to encode our way out of.
+        for path in [
+            "/repos/../../issues",
+            "/repos/./x/issues",
+            "/repos/%2E%2E/%2E%2E/issues",
+            "/repos/o/r/..",
+        ] {
+            assert_eq!(
+                absolute(path, "refused"),
+                Err("refused".to_string()),
+                "{path}"
+            );
+        }
+
+        // Everything `gourl` can emit. `PathEscape` already escapes every byte
+        // in `url`'s path encode set and `QueryEscape` every byte in its query
+        // one, so there is nothing left for `url` to re-encode; percent-escapes
+        // keep Go's uppercase hex; a space is `+` in a query and `%20` in a
+        // segment; and a path with no `?` has no query on either side.
+        assert_eq!(ok("/user/repos?per_page=30").path(), "/user/repos");
+        assert_eq!(ok("/repos/o/r").query(), None);
+        assert_eq!(
+            ok("/search/code?q=repo%3Ao%2Fr+func+foo%2Bbar+~x%2Fy%26z%3D1+%2A&per_page=30").query(),
+            Some("q=repo%3Ao%2Fr+func+foo%2Bbar+~x%2Fy%26z%3D1+%2A&per_page=30")
+        );
+        assert_eq!(
+            ok("/repos/my%20org/a%2Fb").path(),
+            "/repos/my%20org/a%2Fb",
+            "uppercase hex survives, and so does an escaped slash"
+        );
+        assert_eq!(
+            ok("/repos/a$&+:=@b/caf%C3%A9%3B%E6%97%A5%E6%9C%AC%E8%AA%9E%2Cx%3Fy").path(),
+            "/repos/a$&+:=@b/caf%C3%A9%3B%E6%97%A5%E6%9C%AC%E8%AA%9E%2Cx%3Fy",
+            "the reserved bytes a segment keeps are not re-encoded"
+        );
+        // A dot *inside* a segment is not a dot segment, and neither is one
+        // inside a query value — only the path is resolved.
+        assert_eq!(
+            ok("/repos/o/r/actions/workflows/ci.yml").path(),
+            "/repos/o/r/actions/workflows/ci.yml"
+        );
+        assert_eq!(
+            ok("/repos/o/r/issues?labels=..%2F..&per_page=30").query(),
+            Some("labels=..%2F..&per_page=30")
+        );
     }
 
     /// The base is a variable so the parity suite can redirect it, and putting

--- a/desktop/src-tauri/src/native/integrations/github/issues.rs
+++ b/desktop/src-tauri/src/native/integrations/github/issues.rs
@@ -1,0 +1,205 @@
+//! `issues`, ported from `internal/integrations/github/issues.go`.
+//!
+//! Four tools, and the two writers are where `json.Marshal`'s key sorting and
+//! HTML escaping first become observable — see [`super::body`].
+
+use schemars::JsonSchema;
+
+use crate::claude::{new_tool, CancellationToken, ToolDef};
+use crate::native::gourl::{path_escape, Values};
+
+use super::body::Body;
+use super::client::{set_paging, Client};
+use super::text_result;
+
+/// `list_issues`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct ListIssuesInput {
+    /// required,Repository owner
+    owner: String,
+    /// required,Repository name
+    repo: String,
+    /// Filter: open, closed, all. Default: open
+    state: String,
+    /// Comma-separated label names
+    labels: String,
+    /// Sort: created, updated, comments
+    sort: String,
+    /// Results per page (max 100)
+    per_page: i64,
+    /// Page number. Default: 1
+    page: i64,
+}
+
+pub fn list_issues(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "list_issues",
+        "Lists issues for a repository.",
+        move |input: ListIssuesInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let mut query = Values::new();
+                if !input.state.is_empty() {
+                    query.set("state", &input.state);
+                }
+                // Passed through whole, not split: `splitCSV` is only for
+                // request *bodies*. GitHub takes the comma-separated form here,
+                // and `Values.Encode` escapes the comma to `%2C`.
+                if !input.labels.is_empty() {
+                    query.set("labels", &input.labels);
+                }
+                if !input.sort.is_empty() {
+                    query.set("sort", &input.sort);
+                }
+                set_paging(&mut query, input.per_page, input.page);
+                let path = format!(
+                    "/repos/{}/{}/issues?{}",
+                    path_escape(&input.owner),
+                    path_escape(&input.repo),
+                    query.encode()
+                );
+                let result = client.call(&ct, reqwest::Method::GET, &path, None).await?;
+                Ok(text_result(format!("Issues: {result}")))
+            }
+        },
+    )
+}
+
+/// `get_issue`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct GetIssueInput {
+    /// required,Repository owner
+    owner: String,
+    /// required,Repository name
+    repo: String,
+    /// required,Issue number
+    number: i64,
+}
+
+pub fn get_issue(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "get_issue",
+        "Gets details of a specific issue by number.",
+        move |input: GetIssueInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                // `%d`, not `PathEscape`: the number is already a number, and
+                // Go interpolates it directly.
+                let path = format!(
+                    "/repos/{}/{}/issues/{}",
+                    path_escape(&input.owner),
+                    path_escape(&input.repo),
+                    input.number
+                );
+                let result = client.call(&ct, reqwest::Method::GET, &path, None).await?;
+                Ok(text_result(format!("Issue: {result}")))
+            }
+        },
+    )
+}
+
+/// `create_issue`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct CreateIssueInput {
+    /// required,Repository owner
+    owner: String,
+    /// required,Repository name
+    repo: String,
+    /// required,Issue title
+    title: String,
+    /// Issue body in Markdown
+    body: String,
+    /// Comma-separated label names
+    labels: String,
+    /// Comma-separated usernames
+    assignees: String,
+}
+
+pub fn create_issue(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "create_issue",
+        "Creates a new issue in a repository.",
+        move |input: CreateIssueInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                // `title` is unconditional; everything else is conditional. So
+                // the minimal request is exactly `{"title":"…"}`.
+                let mut body = Body::new();
+                body.set("title", input.title.as_str());
+                body.set_if_non_empty("body", &input.body);
+                body.set_csv("labels", &input.labels);
+                body.set_csv("assignees", &input.assignees);
+                let path = format!(
+                    "/repos/{}/{}/issues",
+                    path_escape(&input.owner),
+                    path_escape(&input.repo)
+                );
+                let result = client
+                    .call(&ct, reqwest::Method::POST, &path, Some(body.encode()?))
+                    .await?;
+                Ok(text_result(format!("Issue created: {result}")))
+            }
+        },
+    )
+}
+
+/// `update_issue`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct UpdateIssueInput {
+    /// required,Repository owner
+    owner: String,
+    /// required,Repository name
+    repo: String,
+    /// required,Issue number
+    number: i64,
+    /// New title
+    title: String,
+    /// New body in Markdown
+    body: String,
+    /// New state: open or closed
+    state: String,
+    /// Comma-separated label names
+    labels: String,
+}
+
+pub fn update_issue(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "update_issue",
+        "Updates an existing issue.",
+        move |input: UpdateIssueInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                // Nothing is unconditional here, so an update with every field
+                // empty sends the two bytes `{}` — and, because there *is* a
+                // body, still sends `Content-Type: application/json`.
+                let mut body = Body::new();
+                body.set_if_non_empty("title", &input.title);
+                body.set_if_non_empty("body", &input.body);
+                body.set_if_non_empty("state", &input.state);
+                body.set_csv("labels", &input.labels);
+                let path = format!(
+                    "/repos/{}/{}/issues/{}",
+                    path_escape(&input.owner),
+                    path_escape(&input.repo),
+                    input.number
+                );
+                let result = client
+                    .call(&ct, reqwest::Method::PATCH, &path, Some(body.encode()?))
+                    .await?;
+                Ok(text_result(format!("Issue updated: {result}")))
+            }
+        },
+    )
+}

--- a/desktop/src-tauri/src/native/integrations/github/mod.rs
+++ b/desktop/src-tauri/src/native/integrations/github/mod.rs
@@ -1,0 +1,311 @@
+//! The GitHub integration's in-process MCP server, ported from
+//! `internal/integrations/github/`.
+//!
+//! Twenty tools across five service groups, over a personal access token read
+//! from the integration row. It is the largest of the six integrations and the
+//! only one with no OAuth, which is why it went first (#312).
+//!
+//! ## What has to match Go, and what checks it
+//!
+//! Four surfaces, all pinned by `desktop/parity/github_vectors.json` — taken
+//! from the **running Go server** over its real MCP transport, against a fake
+//! GitHub that records the request each tool built:
+//!
+//! 1. **Which tools are hosted**, which is [`build_allowed_set`] and
+//!    [`service_enabled`] below. The names are in every agent's stored
+//!    `capabilities.mcp` allowlist as `mcp__github-<id>__<tool>` and in every
+//!    `tool_use` block already written to `chat_messages`.
+//! 2. **The advertised schema**, which comes from each input struct.
+//! 3. **The request each tool builds** — path escaping, query encoding, the
+//!    per-page clamp, and the exact bytes of every request body.
+//! 4. **The result text**, success and failure alike: a tool's error is
+//!    `CallToolResult` content with `is_error`, so the message is what the
+//!    model reads and retries on.
+//!
+//! ## The gating rule, which reads backwards
+//!
+//! A service is registered when its row says `enabled`. Within an enabled
+//! service, a tool is registered when the **union of every enabled service's
+//! `tools` list** contains its name — *or when that union is empty*. So an
+//! integration whose services are all enabled with no tool lists hosts all
+//! twenty, and one that names a single tool anywhere narrows every service at
+//! once. Both halves are Go's `if len(allowed) > 0 && !allowed[name] { return }`
+//! and both are in the vectors, because "an empty allowlist means everything"
+//! is the rule a port gets backwards.
+//!
+//! ## Where this stops, and what #311 adds
+//!
+//! `Start(ctx, cfg)` does three things before `buildMCPServer`: it refuses an
+//! unauthenticated integration, parses `config.GitHubCredentials` out of the
+//! row, and hands the server to `StartInProcessMCPServer`. Only the third is
+//! here. The first two read the `integrations` row's `auth` and `credentials`
+//! columns — which `native/integrations.rs` deliberately **never selects**, so
+//! there is nothing in this shell yet to read them from. #311 owns the registry
+//! (`Start`/`Stop`/`Reload` and the `PUT`/`DELETE` routes) and is where a
+//! credential is first read; [`start_github_mcp_server`] takes the token it
+//! will have by then.
+//!
+//! For the same reason `auth.go`'s `ValidatePAT` is **not ported**. It exists
+//! to answer `POST /api/integrations/{id}/auth`, which is unported, and a
+//! function with no caller is dead code clippy would reject. #311 — or whichever
+//! issue claims that route — is where it lands.
+
+pub mod actions;
+pub mod body;
+pub mod client;
+pub mod issues;
+pub mod pulls;
+pub mod releases;
+pub mod repos;
+
+#[cfg(test)]
+mod tests_vectors;
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use rmcp::model::{CallToolResult, ContentBlock};
+
+use crate::claude::{tool_server, InProcessMcpServer, Result, ToolDef};
+
+use super::ServiceConfig;
+use client::Client;
+
+/// The five service groups, in the order `buildMCPServer` gates them.
+///
+/// Order is observable: it is `tools/list`'s order, and therefore the order the
+/// model reads the tool set in.
+pub const SERVICES: &[&str] = &["repos", "issues", "pull_requests", "actions", "releases"];
+
+/// Every tool this integration can host, in registration order — which is
+/// `SERVICES` order, then each `register*Tools` function's own order.
+///
+/// The frontend carries its own copy for the allowlist picker, as the web UI
+/// does; this is the list the server actually registers.
+pub const GITHUB_TOOL_NAMES: &[&str] = &[
+    "list_repos",
+    "get_repo",
+    "search_code",
+    "list_issues",
+    "get_issue",
+    "create_issue",
+    "update_issue",
+    "list_pulls",
+    "get_pull",
+    "create_pull",
+    "get_pull_diff",
+    "list_pull_comments",
+    "list_workflows",
+    "list_workflow_runs",
+    "trigger_workflow",
+    "get_workflow_run",
+    "get_run_logs",
+    "list_releases",
+    "create_release",
+    "list_tags",
+];
+
+/// `fmt.Sprintf("github-%s", cfg.ID)` — the server's name, and the half of
+/// `mcp__github-<id>__<tool>` that is not the tool.
+pub fn server_name(integration_id: &str) -> String {
+    format!("github-{integration_id}")
+}
+
+/// `buildAllowedSet`: the union of every **enabled** service's `Tools`.
+///
+/// A `BTreeSet` rather than a map of bools, since the only question asked of it
+/// is membership — plus emptiness, which is what makes it an allowlist or a
+/// no-op.
+pub fn build_allowed_set(services: &BTreeMap<String, ServiceConfig>) -> BTreeSet<String> {
+    let mut allowed = BTreeSet::new();
+    for service in services.values() {
+        if !service.enabled {
+            continue;
+        }
+        for tool in service.tools.iter().flat_map(|tools| tools.iter()) {
+            allowed.insert(tool.clone());
+        }
+    }
+    allowed
+}
+
+/// `serviceEnabled`: present **and** enabled. An absent service is not enabled,
+/// which is how an integration configured before a service existed keeps
+/// working.
+pub fn service_enabled(services: &BTreeMap<String, ServiceConfig>, name: &str) -> bool {
+    services.get(name).is_some_and(|service| service.enabled)
+}
+
+/// Every tool `buildMCPServer` would register for `services`, over `token`.
+///
+/// Separate from [`start_github_mcp_server`] so the tool set can be inspected
+/// without binding a port — which is what the parity assertions on the hosted
+/// set do, and what #311 will want when it reports an integration's live tools.
+pub fn github_tools(services: &BTreeMap<String, ServiceConfig>, token: &str) -> Vec<ToolDef> {
+    let allowed = build_allowed_set(services);
+    let client = Client::new(token);
+    let mut tools = Vec::new();
+
+    // `len(allowed) > 0 && !allowed[name]` — so an empty set admits everything.
+    let mut push = |service: &str, name: &str, tool: fn(&Client) -> ToolDef| {
+        if !service_enabled(services, service) {
+            return;
+        }
+        if !allowed.is_empty() && !allowed.contains(name) {
+            return;
+        }
+        tools.push(tool(&client));
+    };
+
+    push("repos", "list_repos", repos::list_repos);
+    push("repos", "get_repo", repos::get_repo);
+    push("repos", "search_code", repos::search_code);
+
+    push("issues", "list_issues", issues::list_issues);
+    push("issues", "get_issue", issues::get_issue);
+    push("issues", "create_issue", issues::create_issue);
+    push("issues", "update_issue", issues::update_issue);
+
+    push("pull_requests", "list_pulls", pulls::list_pulls);
+    push("pull_requests", "get_pull", pulls::get_pull);
+    push("pull_requests", "create_pull", pulls::create_pull);
+    push("pull_requests", "get_pull_diff", pulls::get_pull_diff);
+    push(
+        "pull_requests",
+        "list_pull_comments",
+        pulls::list_pull_comments,
+    );
+
+    push("actions", "list_workflows", actions::list_workflows);
+    push("actions", "list_workflow_runs", actions::list_workflow_runs);
+    push("actions", "trigger_workflow", actions::trigger_workflow);
+    push("actions", "get_workflow_run", actions::get_workflow_run);
+    push("actions", "get_run_logs", actions::get_run_logs);
+
+    push("releases", "list_releases", releases::list_releases);
+    push("releases", "create_release", releases::create_release);
+    push("releases", "list_tags", releases::list_tags);
+
+    tools
+}
+
+/// Starts the integration's server on a random loopback port — the third of
+/// `Start`'s three steps, and see the module header for why it is the only one.
+///
+/// The listener stops when the returned handle is dropped, which is what stands
+/// in for Go's `ctx`: dropping it cancels every in-flight tool call's token, and
+/// each of them watches it, so an outbound GitHub request does not outlive the
+/// server.
+pub async fn start_github_mcp_server(
+    integration_id: &str,
+    services: &BTreeMap<String, ServiceConfig>,
+    token: &str,
+) -> Result<InProcessMcpServer> {
+    tool_server(&server_name(integration_id), github_tools(services, token)).await
+}
+
+/// Go's `textResult`, shared by all twenty tools.
+///
+/// One text block, no structured content — `mcp.CallToolResult{Content:
+/// []mcp.Content{&mcp.TextContent{Text: text}}}` with the `any` return left
+/// `nil`.
+pub(crate) fn text_result(text: String) -> CallToolResult {
+    CallToolResult::success(vec![ContentBlock::text(text)])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::native::gojson::GoList;
+
+    fn service(enabled: bool, tools: &[&str]) -> ServiceConfig {
+        ServiceConfig {
+            enabled,
+            tools: Some(GoList(tools.iter().map(|t| t.to_string()).collect())),
+        }
+    }
+
+    fn names(services: &BTreeMap<String, ServiceConfig>) -> Vec<String> {
+        github_tools(services, "token")
+            .iter()
+            .map(|tool| tool.name().to_string())
+            .collect()
+    }
+
+    /// The server name is half of every qualified tool name in an agent's
+    /// stored allowlist. Spelled out rather than derived, because a test that
+    /// rebuilt it from the format string would pass through a rename.
+    #[test]
+    fn the_qualified_name_is_the_one_already_on_disk() {
+        assert_eq!(server_name("abc123"), "github-abc123");
+        assert_eq!(
+            format!("mcp__{}__{}", server_name("abc123"), "list_repos"),
+            "mcp__github-abc123__list_repos"
+        );
+    }
+
+    /// Every service enabled with no tool list hosts everything — the half of
+    /// the rule that reads backwards.
+    #[test]
+    fn an_empty_allowed_set_hosts_every_tool() {
+        let services: BTreeMap<String, ServiceConfig> = SERVICES
+            .iter()
+            .map(|name| (name.to_string(), service(true, &[])))
+            .collect();
+        assert_eq!(names(&services), GITHUB_TOOL_NAMES);
+        assert!(build_allowed_set(&services).is_empty());
+    }
+
+    /// …and one name anywhere narrows every service at once, because the set is
+    /// a union rather than a per-service list.
+    #[test]
+    fn one_named_tool_narrows_every_enabled_service() {
+        let mut services: BTreeMap<String, ServiceConfig> = SERVICES
+            .iter()
+            .map(|name| (name.to_string(), service(true, &[])))
+            .collect();
+        services.insert("repos".to_string(), service(true, &["get_repo"]));
+        assert_eq!(names(&services), ["get_repo"]);
+
+        // A tool named by one service admits it in whichever service registers
+        // it — `list_issues` here is named under `repos`.
+        services.insert(
+            "repos".to_string(),
+            service(true, &["get_repo", "list_issues"]),
+        );
+        assert_eq!(names(&services), ["get_repo", "list_issues"]);
+    }
+
+    /// A disabled service contributes neither its gate nor its names.
+    #[test]
+    fn a_disabled_service_is_invisible_in_both_directions() {
+        let services = BTreeMap::from([
+            ("repos".to_string(), service(true, &["list_repos"])),
+            // Disabled, so `get_repo` is not allowed anywhere…
+            ("issues".to_string(), service(false, &["get_repo"])),
+        ]);
+        assert_eq!(names(&services), ["list_repos"]);
+        assert!(!service_enabled(&services, "issues"));
+        // …and an unknown service name is simply not enabled.
+        assert!(!service_enabled(&services, "nope"));
+    }
+
+    #[test]
+    fn no_services_at_all_hosts_nothing() {
+        assert!(names(&BTreeMap::new()).is_empty());
+    }
+
+    /// A `null` tools column is a nil Go slice, which contributes no names —
+    /// and is therefore an *empty* allowed set, not a filter.
+    #[test]
+    fn a_null_tools_column_is_not_a_filter() {
+        let services = BTreeMap::from([(
+            "repos".to_string(),
+            ServiceConfig {
+                enabled: true,
+                tools: None,
+            },
+        )]);
+        assert!(build_allowed_set(&services).is_empty());
+        assert_eq!(names(&services), ["list_repos", "get_repo", "search_code"]);
+    }
+}

--- a/desktop/src-tauri/src/native/integrations/github/mod.rs
+++ b/desktop/src-tauri/src/native/integrations/github/mod.rs
@@ -72,12 +72,19 @@ use client::Client;
 
 /// The five service groups, in the order `buildMCPServer` gates them.
 ///
-/// Order is observable: it is `tools/list`'s order, and therefore the order the
-/// model reads the tool set in.
+/// Registration order is **not** what the model reads the tool set in: both
+/// SDKs sort `tools/list` by name — `rmcp`'s `ToolRouter::list_all` ends in
+/// `tools.sort_by(|a, b| a.name.cmp(&b.name))`, and the Go SDK holds its tools
+/// in a `featureSet` that lists by sorted key — which is why
+/// `github_vectors.json`'s `tools` array starts at `create_issue` rather than at
+/// `list_repos`. The order here is Go's registration order all the same, so the
+/// two `buildMCPServer`s can be read side by side, and it is pinned against
+/// [`GITHUB_TOOL_NAMES`] by `an_empty_allowed_set_hosts_every_tool`.
 pub const SERVICES: &[&str] = &["repos", "issues", "pull_requests", "actions", "releases"];
 
 /// Every tool this integration can host, in registration order — which is
-/// `SERVICES` order, then each `register*Tools` function's own order.
+/// `SERVICES` order, then each `register*Tools` function's own order. See
+/// [`SERVICES`] for why that is not the order `tools/list` answers in.
 ///
 /// The frontend carries its own copy for the allowlist picker, as the web UI
 /// does; this is the list the server actually registers.

--- a/desktop/src-tauri/src/native/integrations/github/pulls.rs
+++ b/desktop/src-tauri/src/native/integrations/github/pulls.rs
@@ -1,0 +1,237 @@
+//! `pull_requests`, ported from `internal/integrations/github/pulls.go`.
+//!
+//! Five tools, and one of them — `get_pull_diff` — is the only caller anywhere
+//! in this integration of `callRaw`: a caller-chosen `Accept`, a 10 MB cap
+//! rather than 2 MiB, and a response that is not JSON at all.
+
+use schemars::JsonSchema;
+
+use crate::claude::{new_tool, CancellationToken, ToolDef};
+use crate::native::gourl::{path_escape, Values};
+
+use super::body::Body;
+use super::client::{set_paging, Client};
+use super::text_result;
+
+/// `list_pulls`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct ListPullsInput {
+    /// required,Repository owner
+    owner: String,
+    /// required,Repository name
+    repo: String,
+    /// Filter: open, closed, all
+    state: String,
+    /// Sort: created, updated, popularity
+    sort: String,
+    /// Filter by base branch name
+    base: String,
+    /// Results per page (max 100)
+    per_page: i64,
+    /// Page number. Default: 1
+    page: i64,
+}
+
+pub fn list_pulls(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "list_pulls",
+        "Lists pull requests for a repository.",
+        move |input: ListPullsInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let mut query = Values::new();
+                if !input.state.is_empty() {
+                    query.set("state", &input.state);
+                }
+                if !input.sort.is_empty() {
+                    query.set("sort", &input.sort);
+                }
+                if !input.base.is_empty() {
+                    query.set("base", &input.base);
+                }
+                set_paging(&mut query, input.per_page, input.page);
+                let path = format!(
+                    "/repos/{}/{}/pulls?{}",
+                    path_escape(&input.owner),
+                    path_escape(&input.repo),
+                    query.encode()
+                );
+                let result = client.call(&ct, reqwest::Method::GET, &path, None).await?;
+                Ok(text_result(format!("Pull requests: {result}")))
+            }
+        },
+    )
+}
+
+/// `get_pull`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct GetPullInput {
+    /// required,Repository owner
+    owner: String,
+    /// required,Repository name
+    repo: String,
+    /// required,Pull request number
+    number: i64,
+}
+
+pub fn get_pull(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "get_pull",
+        "Gets details of a specific pull request by number.",
+        move |input: GetPullInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let path = pull_path(&input.owner, &input.repo, input.number);
+                let result = client.call(&ct, reqwest::Method::GET, &path, None).await?;
+                Ok(text_result(format!("Pull request: {result}")))
+            }
+        },
+    )
+}
+
+/// `create_pull`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct CreatePullInput {
+    /// required,Repository owner
+    owner: String,
+    /// required,Repository name
+    repo: String,
+    /// required,Pull request title
+    title: String,
+    /// required,Source branch name
+    head: String,
+    /// required,Target branch name
+    base: String,
+    /// PR body in Markdown
+    body: String,
+    /// Create as draft. Default: false
+    draft: bool,
+}
+
+pub fn create_pull(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "create_pull",
+        "Creates a new pull request.",
+        move |input: CreatePullInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let mut body = Body::new();
+                body.set("title", input.title.as_str());
+                body.set("head", input.head.as_str());
+                body.set("base", input.base.as_str());
+                body.set_if_non_empty("body", &input.body);
+                // `if p.Draft`, so `draft: false` sends no key at all rather
+                // than `"draft":false`.
+                body.set_if_true("draft", input.draft);
+                let path = format!(
+                    "/repos/{}/{}/pulls",
+                    path_escape(&input.owner),
+                    path_escape(&input.repo)
+                );
+                let result = client
+                    .call(&ct, reqwest::Method::POST, &path, Some(body.encode()?))
+                    .await?;
+                Ok(text_result(format!("Pull request created: {result}")))
+            }
+        },
+    )
+}
+
+/// `get_pull_diff`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct GetPullDiffInput {
+    /// required,Repository owner
+    owner: String,
+    /// required,Repository name
+    repo: String,
+    /// required,Pull request number
+    number: i64,
+}
+
+pub fn get_pull_diff(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "get_pull_diff",
+        "Gets the diff of a pull request.",
+        move |input: GetPullDiffInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                // The same path `get_pull` uses — only the `Accept` differs,
+                // which is how the REST API returns a diff instead of JSON.
+                let path = pull_path(&input.owner, &input.repo, input.number);
+                let result = client
+                    .call_raw(
+                        &ct,
+                        reqwest::Method::GET,
+                        &path,
+                        "application/vnd.github.v3.diff",
+                    )
+                    .await?;
+                // The one result sentence with a newline rather than a space.
+                Ok(text_result(format!("Diff:\n{result}")))
+            }
+        },
+    )
+}
+
+/// `list_pull_comments`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct ListPullCommentsInput {
+    /// required,Repository owner
+    owner: String,
+    /// required,Repository name
+    repo: String,
+    /// required,Pull request number
+    number: i64,
+    /// Results per page (max 100)
+    per_page: i64,
+    /// Page number. Default: 1
+    page: i64,
+}
+
+pub fn list_pull_comments(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "list_pull_comments",
+        "Lists review comments on a pull request.",
+        move |input: ListPullCommentsInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let mut query = Values::new();
+                set_paging(&mut query, input.per_page, input.page);
+                let path = format!(
+                    "/repos/{}/{}/pulls/{}/comments?{}",
+                    path_escape(&input.owner),
+                    path_escape(&input.repo),
+                    input.number,
+                    query.encode()
+                );
+                let result = client.call(&ct, reqwest::Method::GET, &path, None).await?;
+                Ok(text_result(format!("Comments: {result}")))
+            }
+        },
+    )
+}
+
+/// The path `get_pull` and `get_pull_diff` share, spelled once because they are
+/// the same request under two `Accept` headers.
+fn pull_path(owner: &str, repo: &str, number: i64) -> String {
+    format!(
+        "/repos/{}/{}/pulls/{number}",
+        path_escape(owner),
+        path_escape(repo)
+    )
+}

--- a/desktop/src-tauri/src/native/integrations/github/releases.rs
+++ b/desktop/src-tauri/src/native/integrations/github/releases.rs
@@ -1,0 +1,133 @@
+//! `releases`, ported from `internal/integrations/github/releases.go`.
+//!
+//! Three tools. `create_release` is the widest conditional body in the
+//! integration — one unconditional key and six that appear only when set —
+//! which makes it the case that shows `json.Marshal`'s sorting most clearly.
+
+use schemars::JsonSchema;
+
+use crate::claude::{new_tool, CancellationToken, ToolDef};
+use crate::native::gourl::{path_escape, Values};
+
+use super::body::Body;
+use super::client::{set_paging, Client};
+use super::text_result;
+
+/// `list_releases` and `list_tags` share their input shape: owner, repo and
+/// paging, with the same three descriptions.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct PagedRepoInput {
+    /// required,Repository owner
+    owner: String,
+    /// required,Repository name
+    repo: String,
+    /// Results per page (max 100)
+    per_page: i64,
+    /// Page number. Default: 1
+    page: i64,
+}
+
+pub fn list_releases(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "list_releases",
+        "Lists releases for a repository.",
+        move |input: PagedRepoInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let path = paged_repo_path(&input, "releases");
+                let result = client.call(&ct, reqwest::Method::GET, &path, None).await?;
+                Ok(text_result(format!("Releases: {result}")))
+            }
+        },
+    )
+}
+
+pub fn list_tags(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "list_tags",
+        "Lists tags for a repository.",
+        move |input: PagedRepoInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let path = paged_repo_path(&input, "tags");
+                let result = client.call(&ct, reqwest::Method::GET, &path, None).await?;
+                Ok(text_result(format!("Tags: {result}")))
+            }
+        },
+    )
+}
+
+/// `createReleaseParams` — a named type in Go too, because `buildReleaseBody`
+/// takes it.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct CreateReleaseInput {
+    /// required,Repository owner
+    owner: String,
+    /// required,Repository name
+    repo: String,
+    /// required,Tag name
+    tag_name: String,
+    /// Release name
+    name: String,
+    /// Release notes in Markdown
+    body: String,
+    /// Branch or commit SHA
+    target_commitish: String,
+    /// Create as draft
+    draft: bool,
+    /// Mark as pre-release
+    prerelease: bool,
+    /// Auto-generate notes
+    generate_release_notes: bool,
+}
+
+pub fn create_release(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "create_release",
+        "Creates a new release in a repository.",
+        move |input: CreateReleaseInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                // `buildReleaseBody`, in its order — which does not survive
+                // into the request, since `json.Marshal` sorts the keys.
+                let mut body = Body::new();
+                body.set("tag_name", input.tag_name.as_str());
+                body.set_if_non_empty("name", &input.name);
+                body.set_if_non_empty("body", &input.body);
+                body.set_if_non_empty("target_commitish", &input.target_commitish);
+                body.set_if_true("draft", input.draft);
+                body.set_if_true("prerelease", input.prerelease);
+                body.set_if_true("generate_release_notes", input.generate_release_notes);
+                let path = format!(
+                    "/repos/{}/{}/releases",
+                    path_escape(&input.owner),
+                    path_escape(&input.repo)
+                );
+                let result = client
+                    .call(&ct, reqwest::Method::POST, &path, Some(body.encode()?))
+                    .await?;
+                Ok(text_result(format!("Release created: {result}")))
+            }
+        },
+    )
+}
+
+/// `/repos/{owner}/{repo}/{collection}?{paging}` — the shape both list tools
+/// build, differing only in the last segment.
+fn paged_repo_path(input: &PagedRepoInput, collection: &str) -> String {
+    let mut query = Values::new();
+    set_paging(&mut query, input.per_page, input.page);
+    format!(
+        "/repos/{}/{}/{collection}?{}",
+        path_escape(&input.owner),
+        path_escape(&input.repo),
+        query.encode()
+    )
+}

--- a/desktop/src-tauri/src/native/integrations/github/repos.rs
+++ b/desktop/src-tauri/src/native/integrations/github/repos.rs
@@ -1,0 +1,136 @@
+//! `repos`, ported from `internal/integrations/github/repos.go`.
+//!
+//! Three tools. Each is the shape every tool in this module tree takes, so the
+//! comments that would repeat verbatim on the other seventeen live here:
+//!
+//! - The input struct's field names are the Go `json:` tags and its doc
+//!   comments are the Go `jsonschema:` tags **verbatim**, `required,` prefix
+//!   included. That prefix is not a directive — `google/jsonschema-go` reads
+//!   the whole tag as the description — so it is a sentence the model reads and
+//!   dropping it would change the advertised surface. See
+//!   `crate::claude::schema_vectors` for the generated proof.
+//! - Every field is a plain `String` / `i64` / `bool`, never an `Option`: no
+//!   params struct in this integration carries `omitempty`, so **every field is
+//!   required** and the model must send all of them. An `Option` would render
+//!   `["string","null"]` and change the schema.
+//! - `deny_unknown_fields` is what emits `"additionalProperties": false`, which
+//!   Go's reflector sets on every struct and its server validates against.
+//! - The credential is captured by the closure and **cloned per call**, outside
+//!   the async block — the `Fn` requirement `crate::claude::tool`'s module docs
+//!   spell out.
+
+use schemars::JsonSchema;
+
+use crate::claude::{new_tool, CancellationToken, ToolDef};
+use crate::native::gourl::{path_escape, Values};
+
+use super::client::{set_paging, Client};
+use super::text_result;
+
+/// `list_repos`.
+#[allow(dead_code)] // read through serde, never constructed in Rust
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct ListReposInput {
+    /// Filter by visibility: all, public, private
+    visibility: String,
+    /// Sort by: created, updated, pushed, full_name
+    sort: String,
+    /// Results per page (max 100). Default: 30
+    per_page: i64,
+    /// Page number. Default: 1
+    page: i64,
+}
+
+pub fn list_repos(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "list_repos",
+        "Lists repositories for the authenticated user.",
+        move |input: ListReposInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let mut query = Values::new();
+                // Both filters are dropped when empty, so the default request
+                // carries `per_page` alone.
+                if !input.visibility.is_empty() {
+                    query.set("visibility", &input.visibility);
+                }
+                if !input.sort.is_empty() {
+                    query.set("sort", &input.sort);
+                }
+                set_paging(&mut query, input.per_page, input.page);
+                let path = format!("/user/repos?{}", query.encode());
+                let result = client.call(&ct, reqwest::Method::GET, &path, None).await?;
+                Ok(text_result(format!("Repositories: {result}")))
+            }
+        },
+    )
+}
+
+/// `get_repo`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct GetRepoInput {
+    /// required,Repository owner
+    owner: String,
+    /// required,Repository name
+    repo: String,
+}
+
+pub fn get_repo(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "get_repo",
+        "Gets details of a specific repository by owner/name.",
+        move |input: GetRepoInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                // `url.PathEscape`, not the whole-path encoding: a repository
+                // named `a/b` has to stay one segment.
+                let path = format!(
+                    "/repos/{}/{}",
+                    path_escape(&input.owner),
+                    path_escape(&input.repo)
+                );
+                let result = client.call(&ct, reqwest::Method::GET, &path, None).await?;
+                Ok(text_result(format!("Repository: {result}")))
+            }
+        },
+    )
+}
+
+/// `search_code`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct SearchCodeInput {
+    /// required,Search query
+    query: String,
+    /// Results per page (max 100). Default: 30
+    per_page: i64,
+    /// Page number. Default: 1
+    page: i64,
+}
+
+pub fn search_code(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "search_code",
+        "Searches for code across GitHub repositories using a query string.",
+        move |input: SearchCodeInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let mut query = Values::new();
+                // Unconditional, unlike every other filter here: an empty
+                // search still sends `q=`.
+                query.set("q", &input.query);
+                set_paging(&mut query, input.per_page, input.page);
+                let path = format!("/search/code?{}", query.encode());
+                let result = client.call(&ct, reqwest::Method::GET, &path, None).await?;
+                Ok(text_result(format!("Search results: {result}")))
+            }
+        },
+    )
+}

--- a/desktop/src-tauri/src/native/integrations/github/tests_vectors.rs
+++ b/desktop/src-tauri/src/native/integrations/github/tests_vectors.rs
@@ -1,0 +1,438 @@
+//! The Rust half of `desktop/parity/github_vectors.json`.
+//!
+//! The Go half (`desktop/parity/github_parity_test.go`) stands the **real**
+//! integration up through `github.Start`, points `githubAPIBase` at an
+//! `httptest.Server` that plays a scripted GitHub and records what it was
+//! asked, and writes down four things per case: the tool set hosted, the
+//! advertised schema, the request the tool built, and the result the model
+//! would read.
+//!
+//! This half replays the same script through the same three layers — an axum
+//! server on loopback standing in for `httptest`, the real
+//! [`start_github_mcp_server`](super::start_github_mcp_server), and a real
+//! `tools/call` over the MCP HTTP transport — and asserts all four. Nothing is
+//! stubbed: a change to the client, to a path, to a body or to a sentence fails
+//! here.
+//!
+//! Two fields carry a *pinned divergence* rather than a match, each documented
+//! at its use below and in the Go generator: `rust_text` (Go's
+//! `encoding/json` syntax-error vocabulary) and `rust_target` (the Go MCP SDK
+//! rounds an integer argument above 2^53 before the handler sees it).
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::{HeaderMap, Method, StatusCode, Uri};
+use axum::response::{IntoResponse, Response};
+use rmcp::ServerHandler;
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::client::{api_base_lock, set_api_base};
+use super::{github_tools, server_name, start_github_mcp_server, GITHUB_TOOL_NAMES, SERVICES};
+use crate::claude::ToolServer;
+use crate::native::gojson::GoList;
+use crate::native::integrations::ServiceConfig;
+
+// ─── The vectors ─────────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct ToolVector {
+    name: String,
+    description: String,
+    input_schema: Value,
+}
+
+#[derive(Deserialize)]
+struct HostingVector {
+    case: String,
+    services: BTreeMap<String, GoServiceConfig>,
+    tools: Vec<String>,
+}
+
+/// `config.ServiceConfig` as the Go generator marshals it. Converted rather
+/// than deserialized straight into [`ServiceConfig`], because that type's
+/// `tools` is a [`GoList`] whose job is nil-versus-empty fidelity on the *write
+/// path* — here the vector is plain JSON and a nil list is simply `null`.
+#[derive(Deserialize)]
+struct GoServiceConfig {
+    enabled: bool,
+    tools: Option<Vec<String>>,
+}
+
+#[derive(Deserialize)]
+struct RequestVector {
+    method: String,
+    target: String,
+    authorization: String,
+    accept: String,
+    content_type: String,
+    body: String,
+}
+
+#[derive(Deserialize)]
+struct ResponseScript {
+    status: u16,
+    #[serde(default)]
+    location: String,
+    body: String,
+}
+
+#[derive(Deserialize)]
+struct CallVector {
+    case: String,
+    tool: String,
+    arguments: Value,
+    response: ResponseScript,
+    /// Absent when the tool answered without making a request — only
+    /// `trigger_workflow`'s inputs parse does that.
+    request: Option<RequestVector>,
+    is_error: bool,
+    text: String,
+    /// See the module header: a pinned divergence, not a match.
+    #[serde(default)]
+    rust_text: String,
+    #[serde(default)]
+    rust_target: String,
+}
+
+#[derive(Deserialize)]
+struct Vectors {
+    integration_id: String,
+    server_name: String,
+    token: String,
+    tools: Vec<ToolVector>,
+    hosting: Vec<HostingVector>,
+    calls: Vec<CallVector>,
+}
+
+fn vectors() -> Vectors {
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../parity/github_vectors.json");
+    let raw = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("reading {path}: {e} — regenerate it from Go"));
+    serde_json::from_str(&raw).expect("parsing the github vectors")
+}
+
+fn services(from: &BTreeMap<String, GoServiceConfig>) -> BTreeMap<String, ServiceConfig> {
+    from.iter()
+        .map(|(name, service)| {
+            (
+                name.clone(),
+                ServiceConfig {
+                    enabled: service.enabled,
+                    tools: service.tools.clone().map(GoList),
+                },
+            )
+        })
+        .collect()
+}
+
+/// Every service enabled with no tool list — the configuration the twenty
+/// schemas and every call vector were taken under.
+fn all_services() -> BTreeMap<String, ServiceConfig> {
+    SERVICES
+        .iter()
+        .map(|name| {
+            (
+                name.to_string(),
+                ServiceConfig {
+                    enabled: true,
+                    tools: None,
+                },
+            )
+        })
+        .collect()
+}
+
+// ─── The advertised surface ──────────────────────────────────────────────────
+
+/// The server name, every tool name, its description and its reflected input
+/// schema — all taken from a live `tools/list` against the Go server.
+///
+/// The schema is compared as a `Value` rather than as bytes, for #310's reason:
+/// JSON object order is meaningful to neither the CLI nor `schemars`, while a
+/// key present on one side and not the other is exactly what value equality
+/// catches. `$schema`, `format` and `default` are three such keys — see
+/// `crate::claude::tool`'s `normalize_go_schema`.
+#[test]
+fn the_advertised_surface_matches_the_go_vectors() {
+    let v = vectors();
+    assert_eq!(v.server_name, server_name(&v.integration_id));
+    assert_eq!(
+        v.tools.len(),
+        GITHUB_TOOL_NAMES.len(),
+        "vectors look partial"
+    );
+
+    let server =
+        ToolServer::new(&v.server_name).with_tools(github_tools(&all_services(), &v.token));
+    assert_eq!(
+        server.tool_names(),
+        v.tools.iter().map(|t| t.name.clone()).collect::<Vec<_>>(),
+        "the hosted tool set — and its order, which is what tools/list carries"
+    );
+
+    for want in &v.tools {
+        let tool = server
+            .get_tool(&want.name)
+            .unwrap_or_else(|| panic!("{} is not registered", want.name));
+        assert_eq!(
+            tool.description.as_deref(),
+            Some(want.description.as_str()),
+            "{}'s description is what the model reads",
+            want.name
+        );
+        assert_eq!(
+            serde_json::to_value(&*tool.input_schema).expect("schema"),
+            want.input_schema,
+            "{}'s input schema is what the model is steered by",
+            want.name
+        );
+    }
+}
+
+/// The gating rule, in every shape the Go generator recorded — including the
+/// one that reads backwards, where an empty allowed set hosts everything.
+#[test]
+fn the_hosted_tool_set_matches_the_go_vectors() {
+    let v = vectors();
+    assert!(v.hosting.len() >= 5, "vectors look partial");
+    for case in &v.hosting {
+        let mut hosted: Vec<String> = github_tools(&services(&case.services), &v.token)
+            .iter()
+            .map(|tool| tool.name().to_string())
+            .collect();
+        // The Go vector sorts, because what it records is the *set*; the order
+        // is asserted by the twenty-tool block above.
+        hosted.sort();
+        assert_eq!(hosted, case.tools, "hosting case: {}", case.case);
+    }
+}
+
+// ─── The fake GitHub ─────────────────────────────────────────────────────────
+
+/// What the fake was asked, in the shape the Go generator recorded it.
+#[derive(Default)]
+struct Recorded {
+    method: String,
+    target: String,
+    authorization: String,
+    accept: String,
+    content_type: String,
+    body: String,
+}
+
+#[derive(Default)]
+struct Fake {
+    status: u16,
+    location: String,
+    body: String,
+    seen: Option<Recorded>,
+}
+
+#[derive(Clone, Default)]
+struct FakeState(Arc<Mutex<Fake>>);
+
+impl FakeState {
+    fn arm(&self, script: &ResponseScript) {
+        let mut fake = self.0.lock().expect("fake lock");
+        fake.status = script.status;
+        fake.location.clone_from(&script.location);
+        fake.body.clone_from(&script.body);
+        fake.seen = None;
+    }
+}
+
+/// One handler for every path, exactly as the Go fake does it: the point is to
+/// capture the request the tool *built*, and a router would have to agree with
+/// this port about each path's shape — which is the thing under test.
+async fn serve_fake(
+    State(state): State<FakeState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    let header = |name: &str| {
+        headers
+            .get(name)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default()
+            .to_string()
+    };
+
+    let (status, location, reply) = {
+        let mut fake = state.0.lock().expect("fake lock");
+        fake.seen = Some(Recorded {
+            method: method.to_string(),
+            // `URL.RequestURI()`: the encoded path plus the encoded query.
+            target: uri
+                .path_and_query()
+                .map(|pq| pq.as_str().to_string())
+                .unwrap_or_default(),
+            authorization: header("authorization"),
+            accept: header("accept"),
+            content_type: header("content-type"),
+            body: String::from_utf8_lossy(&body).into_owned(),
+        });
+        (fake.status, fake.location.clone(), fake.body.clone())
+    };
+
+    let mut response = (
+        StatusCode::from_u16(status).expect("a scripted status"),
+        reply,
+    )
+        .into_response();
+    if !location.is_empty() {
+        response.headers_mut().insert(
+            axum::http::header::LOCATION,
+            location.parse().expect("a scripted Location"),
+        );
+    }
+    response
+}
+
+// ─── The calls ───────────────────────────────────────────────────────────────
+
+/// Every call vector, driven end to end.
+///
+/// One test rather than one per case, because [`set_api_base`] is process-wide
+/// — as Go's `githubAPIBase` is — and `cargo test` runs tests in parallel where
+/// `go test` runs a package's in sequence. [`api_base_lock`] is what keeps this
+/// from racing `client`'s own base test.
+#[tokio::test]
+async fn every_call_matches_the_go_vectors() {
+    let v = vectors();
+    assert!(v.calls.len() >= 40, "vectors look partial");
+
+    let state = FakeState::default();
+    let app = axum::Router::new()
+        .fallback(serve_fake)
+        .with_state(state.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind the fake");
+    let base = format!("http://{}", listener.local_addr().expect("addr"));
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    let _guard = api_base_lock().await;
+    set_api_base(Some(base));
+
+    let server = start_github_mcp_server(&v.integration_id, &all_services(), &v.token)
+        .await
+        .expect("start the github server");
+
+    for case in &v.calls {
+        state.arm(&case.response);
+        let result = call_tool(&server, &case.tool, &case.arguments).await;
+
+        // The credential must never reach the model, on either path.
+        assert!(
+            !result.text.contains(&v.token),
+            "{}: the token leaked into a tool result: {}",
+            case.case,
+            result.text
+        );
+
+        let want_text = if case.rust_text.is_empty() {
+            &case.text
+        } else {
+            &case.rust_text
+        };
+        assert_eq!(result.text, *want_text, "{}: result text", case.case);
+        assert_eq!(result.is_error, case.is_error, "{}: is_error", case.case);
+
+        let seen = state.0.lock().expect("fake lock").seen.take();
+        match (&case.request, seen) {
+            (None, seen) => assert!(
+                seen.is_none(),
+                "{}: Go made no request and this one did",
+                case.case
+            ),
+            (Some(_), None) => panic!("{}: Go made a request and this one did not", case.case),
+            (Some(want), Some(got)) => {
+                let want_target = if case.rust_target.is_empty() {
+                    &want.target
+                } else {
+                    &case.rust_target
+                };
+                assert_eq!(got.method, want.method, "{}: method", case.case);
+                assert_eq!(got.target, *want_target, "{}: request target", case.case);
+                assert_eq!(
+                    got.authorization, want.authorization,
+                    "{}: the Bearer prefix and the token",
+                    case.case
+                );
+                assert_eq!(got.accept, want.accept, "{}: Accept", case.case);
+                assert_eq!(
+                    got.content_type, want.content_type,
+                    "{}: Content-Type is sent only when there is a body",
+                    case.case
+                );
+                assert_eq!(got.body, want.body, "{}: request body", case.case);
+            }
+        }
+    }
+
+    set_api_base(None);
+}
+
+struct ToolAnswer {
+    text: String,
+    is_error: bool,
+}
+
+/// One `tools/call` over the server's own HTTP transport, sent the way the CLI
+/// sends it — including the bearer token the handle's config carries.
+async fn call_tool(
+    server: &crate::claude::InProcessMcpServer,
+    name: &str,
+    arguments: &Value,
+) -> ToolAnswer {
+    let payload = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": name, "arguments": arguments},
+    });
+
+    let mut request = reqwest::Client::new()
+        .post(server.url())
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream");
+    for (header, value) in &server.config().headers {
+        request = request.header(header, value);
+    }
+    let response = request
+        .body(payload.to_string())
+        .send()
+        .await
+        .expect("send tools/call");
+    let body: Value =
+        serde_json::from_str(&response.text().await.expect("text")).expect("a JSON-RPC reply");
+
+    // A failing tool is never a protocol error — the convention `new_tool`
+    // ports from `mcp.AddTool`, and the Go generator asserts the same thing by
+    // reading `result.Content` unconditionally.
+    assert!(
+        body.get("error").is_none(),
+        "{name}: a tool must not raise a protocol error: {body}"
+    );
+    let content = body["result"]["content"]
+        .as_array()
+        .unwrap_or_else(|| panic!("{name}: no content array: {body}"));
+    assert_eq!(content.len(), 1, "{name}: want exactly one content block");
+    assert_eq!(content[0]["type"], "text");
+
+    ToolAnswer {
+        text: content[0]["text"]
+            .as_str()
+            .unwrap_or_else(|| panic!("{name}: content is not text: {body}"))
+            .to_string(),
+        is_error: body["result"]["isError"].as_bool().unwrap_or(false),
+    }
+}

--- a/desktop/src-tauri/src/native/integrations/github/tests_vectors.rs
+++ b/desktop/src-tauri/src/native/integrations/github/tests_vectors.rs
@@ -14,10 +14,19 @@
 //! stubbed: a change to the client, to a path, to a body or to a sentence fails
 //! here.
 //!
-//! Two fields carry a *pinned divergence* rather than a match, each documented
-//! at its use below and in the Go generator: `rust_text` (Go's
-//! `encoding/json` syntax-error vocabulary) and `rust_target` (the Go MCP SDK
-//! rounds an integer argument above 2^53 before the handler sees it).
+//! Three fields carry a *pinned divergence* rather than a match, across four
+//! causes, each documented at its use below and in the Go generator:
+//!
+//! - `rust_text` — Go's `encoding/json` syntax-error vocabulary; the
+//!   dot-segment refusal; and `rmcp`'s wording for an argument it will not
+//!   decode.
+//! - `rust_target` — the Go MCP SDK rounds an integer argument above 2^53
+//!   before the handler sees it.
+//! - `rust_no_request` — Go reached the fake and this port did not: a path
+//!   holding a `.` or `..` segment, which [`super::client::absolute`] refuses
+//!   because `url` would resolve it into a different endpoint than Go calls,
+//!   and a zero-fraction float, which the Go SDK re-marshals into an integer
+//!   and `serde_json` refuses.
 
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
@@ -96,6 +105,11 @@ struct CallVector {
     rust_text: String,
     #[serde(default)]
     rust_target: String,
+    /// Go made a request and this port deliberately makes none — a path
+    /// carrying a `.` or `..` segment, which `super::client::absolute` refuses
+    /// rather than let `url` resolve into a different endpoint.
+    #[serde(default)]
+    rust_no_request: bool,
 }
 
 #[derive(Deserialize)]
@@ -171,7 +185,13 @@ fn the_advertised_surface_matches_the_go_vectors() {
     assert_eq!(
         server.tool_names(),
         v.tools.iter().map(|t| t.name.clone()).collect::<Vec<_>>(),
-        "the hosted tool set — and its order, which is what tools/list carries"
+        // Both sides are already name-sorted — `tool_names` goes through
+        // `ToolRouter::list_all`, which sorts, and the Go SDK's `featureSet`
+        // lists by sorted key — so this is set equality in a stable order, not
+        // an order assertion. *Registration* order is pinned by
+        // `super::tests::an_empty_allowed_set_hosts_every_tool` against
+        // `GITHUB_TOOL_NAMES`; see `super::SERVICES`.
+        "the hosted tool set, as tools/list answers it"
     );
 
     for want in &v.tools {
@@ -347,7 +367,22 @@ async fn every_call_matches_the_go_vectors() {
         assert_eq!(result.is_error, case.is_error, "{}: is_error", case.case);
 
         let seen = state.0.lock().expect("fake lock").seen.take();
-        match (&case.request, seen) {
+        let want_request = if case.rust_no_request {
+            // The dot-segment refusal: Go reached the fake, this port never
+            // built the request. Asserted as "and nothing was sent" rather than
+            // skipped, because sending *something* — the resolved path — is the
+            // outcome `absolute` exists to prevent.
+            assert!(
+                seen.is_none(),
+                "{}: the refusal still reached the network: {:?}",
+                case.case,
+                seen.as_ref().map(|r| &r.target)
+            );
+            None
+        } else {
+            case.request.as_ref()
+        };
+        match (want_request, seen) {
             (None, seen) => assert!(
                 seen.is_none(),
                 "{}: Go made no request and this one did",
@@ -381,18 +416,92 @@ async fn every_call_matches_the_go_vectors() {
     set_api_base(None);
 }
 
+/// A malformed argument is a **tool** error, not a protocol error.
+///
+/// `desktop/CLAUDE.md` promises that a missing, extra or wrong-typed field
+/// yields a `CallToolResult` carrying `IsError` — text the model can read and
+/// retry against — exactly as the Go server does, and never a JSON-RPC `error`.
+/// Nothing in this port implements that: it rests entirely on `rmcp`'s
+/// `into_tool_argument_error`, which **prefix-matches a hardcoded string**
+/// (`"failed to deserialize parameters:"`) against its own extractor's message
+/// (`handler/server/router/tool.rs`). An upgrade that reworded either half
+/// would silently flip all 62 ported tools to protocol errors, which the CLI
+/// renders as "Tool result missing due to internal error" — nothing to retry
+/// against, on every integration at once.
+///
+/// [`every_call_matches_the_go_vectors`] cannot notice: [`call_tool`] asserts
+/// the absence of an `error` member, but no vector ever sends bad arguments, so
+/// the assertion never runs on the path it guards. This sends them.
+///
+/// The **kind** is pinned, not the text: the wording divergence (Go's
+/// `validating "arguments": …` against `rmcp`'s `failed to deserialize
+/// parameters: …`) is already accepted and documented, and pinning it here
+/// would fail on a harmless rmcp rewording while still missing the real one.
+#[tokio::test]
+async fn malformed_arguments_are_a_tool_error_rather_than_a_protocol_error() {
+    let v = vectors();
+    // Nothing should reach the network — the decode fails before a handler
+    // runs — so the base points at a port with nothing behind it. If that ever
+    // stops being true this fails loudly instead of calling api.github.com.
+    let _guard = api_base_lock().await;
+    set_api_base(Some("http://127.0.0.1:1".to_string()));
+
+    let server = start_github_mcp_server(&v.integration_id, &all_services(), &v.token)
+        .await
+        .expect("start the github server");
+
+    for (case, arguments) in [
+        // `repo` is required — every field of all twenty tools is, since no Go
+        // params struct in this integration carries `omitempty`.
+        (
+            "a missing required field",
+            serde_json::json!({"owner": "octocat"}),
+        ),
+        // `deny_unknown_fields`, which is what emits `additionalProperties:
+        // false` — the key Go's reflector sets and its server validates on.
+        (
+            "an unknown field",
+            serde_json::json!({"owner": "octocat", "repo": "hello-world", "nope": 1}),
+        ),
+    ] {
+        let body = rpc_call(&server, "get_repo", &arguments).await;
+        assert!(
+            body.get("error").is_none(),
+            "{case}: raised a JSON-RPC error rather than a tool error: {body}"
+        );
+        assert_eq!(
+            body["result"]["isError"].as_bool(),
+            Some(true),
+            "{case}: want a tool error: {body}"
+        );
+        let content = body["result"]["content"]
+            .as_array()
+            .unwrap_or_else(|| panic!("{case}: no content array: {body}"));
+        assert_eq!(content.len(), 1, "{case}: want exactly one content block");
+        assert_eq!(content[0]["type"], "text");
+        assert!(
+            content[0]["text"].as_str().is_some_and(|t| !t.is_empty()),
+            "{case}: the model is handed an empty message: {body}"
+        );
+    }
+
+    set_api_base(None);
+}
+
 struct ToolAnswer {
     text: String,
     is_error: bool,
 }
 
 /// One `tools/call` over the server's own HTTP transport, sent the way the CLI
-/// sends it — including the bearer token the handle's config carries.
-async fn call_tool(
+/// sends it — including the bearer token the handle's config carries. Answers
+/// the raw JSON-RPC reply, so a caller can assert on the envelope as well as on
+/// the result.
+async fn rpc_call(
     server: &crate::claude::InProcessMcpServer,
     name: &str,
     arguments: &Value,
-) -> ToolAnswer {
+) -> Value {
     let payload = serde_json::json!({
         "jsonrpc": "2.0",
         "id": 1,
@@ -412,12 +521,22 @@ async fn call_tool(
         .send()
         .await
         .expect("send tools/call");
-    let body: Value =
-        serde_json::from_str(&response.text().await.expect("text")).expect("a JSON-RPC reply");
+    serde_json::from_str(&response.text().await.expect("text")).expect("a JSON-RPC reply")
+}
+
+/// [`rpc_call`]'s success shape: exactly one text block, and no protocol error.
+async fn call_tool(
+    server: &crate::claude::InProcessMcpServer,
+    name: &str,
+    arguments: &Value,
+) -> ToolAnswer {
+    let body = rpc_call(server, name, arguments).await;
 
     // A failing tool is never a protocol error — the convention `new_tool`
     // ports from `mcp.AddTool`, and the Go generator asserts the same thing by
-    // reading `result.Content` unconditionally.
+    // reading `result.Content` unconditionally. Malformed *arguments* are the
+    // path that assertion really guards, and no vector sends those; see
+    // [`malformed_arguments_are_a_tool_error_rather_than_a_protocol_error`].
     assert!(
         body.get("error").is_none(),
         "{name}: a tool must not raise a protocol error: {body}"

--- a/internal/integrations/github/parity.go
+++ b/internal/integrations/github/parity.go
@@ -18,6 +18,16 @@ package github
 // SetAPIBase points every outgoing GitHub request at base and returns a
 // function that restores the previous value.
 //
+// Do not call outside tests. What it is is a primitive for pointing every
+// GitHub request in the process — each one bearing a user's personal access
+// token — at an arbitrary host, so a caller anywhere in the running server
+// would be a credential-exfiltration seam rather than a misconfiguration. It is
+// exported only because `desktop/parity` is a different package and the vectors
+// have to come from the real server; the Rust port needs no equivalent
+// concession (both of its callers are in-crate) and gates the same seam behind
+// `#[cfg(test)]`, so it does not exist in a shipped desktop binary at all.
+// #313–#317 each add one of these: keep it as narrow as the language allows.
+//
 // The variable it writes is the same one this package's own tests redirect, and
 // it is a package global in Go for the same reason it is a `RwLock` static on
 // the Rust side: `client` is constructed per registration and the base is not

--- a/internal/integrations/github/parity.go
+++ b/internal/integrations/github/parity.go
@@ -1,0 +1,30 @@
+package github
+
+// This file is the seam `desktop/parity/github_parity_test.go` builds its
+// cross-language vectors through, and it exists for exactly one reason: the
+// vectors have to come from the **real** server, not from a restatement of it.
+//
+// `desktop/parity` is a different package, so it can neither reach
+// `githubAPIBase` nor stand a server up against a local fake without help. The
+// alternative — a generator that rebuilds the tool set from this package's
+// source — would freeze someone's reading of the code rather than the code, and
+// the whole point of the vectors is that a change here fails the Rust port in
+// `desktop/src-tauri/src/native/integrations/github/`.
+//
+// #310 did the same thing for the local tools server (`tools.FormatCurrentTime`).
+// Nothing below changes behavior or wording: `Start` remains the only way the
+// app builds this server.
+
+// SetAPIBase points every outgoing GitHub request at base and returns a
+// function that restores the previous value.
+//
+// The variable it writes is the same one this package's own tests redirect, and
+// it is a package global in Go for the same reason it is a `RwLock` static on
+// the Rust side: `client` is constructed per registration and the base is not
+// per-request state. Not safe for concurrent use with a live integration —
+// which is fine, because the only callers are tests that own the process.
+func SetAPIBase(base string) (restore func()) {
+	previous := githubAPIBase
+	githubAPIBase = base
+	return func() { githubAPIBase = previous }
+}


### PR DESCRIPTION
## Summary

- Ports `internal/integrations/github` — Agento's largest in-process MCP server, **20 tools across five service groups** — onto the `rmcp` typed-tool layer #282 settled. This is that layer's second caller and its first with credentials and a network.
- The parity bar is the whole payload, not just the schema: the advertised surface, **the request each tool builds**, and every result and error sentence are pinned to vectors taken from the **live Go server** — a real MCP client over the real HTTP transport, against a scripted fake GitHub that records what each tool sent.
- Lands the **reflector divergence map** #310 asked for before the integration ports start, so #313–#317 inherit it rather than each rediscovering where `schemars` and `google/jsonschema-go` disagree.
- Scope stops at the server. The registry lifecycle and the `PUT`/`DELETE` routes are **#311**; `runner.rs`'s MCP refusal is deliberately untouched.

## The finding

`jsonschema:"required,Repository owner"` **is not a directive.** `google/jsonschema-go` reads the whole tag as the property description and marks a field optional only on `omitempty`/`omitzero`. No struct in the integration has either — so every one of the 20 tools advertises descriptions that literally begin `required,`, and **every field of every tool is required**.

That is what the Go server has always sent the model, so it is what the port reproduces. It also collapses the `Option<T>` problem for #312 entirely: all fields are plain `String`/`i64`/`bool`. The vectors record it, so a Go-side fix has to move both languages at once and cannot be done silently.

## Changes

**The port** — `desktop/src-tauri/src/native/integrations/github/`
- `mod.rs` — server name (`github-<id>`), `build_allowed_set` / `service_enabled`, registration order, `start_github_mcp_server`. Keeps Go's `len(allowed) > 0` guard: an empty allowed set hosts everything.
- `client.rs` — the redirectable API base, the two 15s clients (one no-redirect), `call` / `call_raw` / `get_redirect_url`, the three read caps, `split_csv`, the per-tool paging clamp, cancellation.
- `body.rs` — `json.Marshal`-over-a-Go-map request bodies (key-sorted), and `encoding/json`'s unmarshal error vocabulary for `trigger_workflow`'s inputs.
- `{repos,issues,pulls,actions,releases}.rs` — the 20 tools, one module per service group.
- Response bytes are passed through **verbatim** — no `serde_json::Value` round trip — so a body with unsorted keys, an integer past 2^53 and `1.50` reaches the model exactly as Go sent it. The vectors assert on precisely such a body.

**Shared machinery**
- `native/gourl.rs` — `path_escape` (`encodePathSegment`) and `query_escape` (`encodeQueryComponent`, space → `+`) plus `gourl::Values`, whose `Encode` sorts keys as Go's does. `form_urlencoded` was **not** usable: it escapes `~` where Go does not and keeps `*` where Go does not. Both are now in `gourl_vectors.json`.
- `claude/tool.rs` — `strip_schema_dialect` becomes `normalize_go_schema`, dropping three keys the Go reflector can never emit: `$schema`, `format` (schemars' `int64`) and `default`. The walk is structure-aware rather than a key sweep — all three are legal property names, and there is a test for a field called `format`. The `Arc` is still **replaced**, never written through, for #310's reason.
- `Cargo.toml` — `reqwest` gains `rustls-tls`. Bundled roots over native roots so an integration cannot work on one machine and fail on another over a differently-arranged system store; `native-tls` rejected for the reason already written on `lettre` (five release triples, no C toolchain).

**Parity surface**
- `desktop/parity/github_vectors.json` + `github_parity_test.go` — 20 tool schemas, 6 hosting cases (disabled service, non-empty allowlist, empty-set-means-everything), 44 live call cases including non-2xx, a 302 with and without `Location`, and malformed workflow inputs. Regenerate with `-update-github-vectors`; otherwise byte-compared, so a Go-side change fails Go's own suite.
- `desktop/parity/jsonschema_reflect_vectors.json` + `jsonschema_reflect_parity_test.go` + `desktop/src-tauri/src/claude/schema_vectors.rs` — the divergence map, per shape class, pinning what a port must write instead.
- `internal/integrations/github/parity.go` — `SetAPIBase`, the only new Go export: a thin seam so the vectors come from `github.Start` rather than from a restatement of it, exactly as #310 did with `FormatCurrentTime`.

**Divergences kept, each documented at its site** (all unreachable from this issue): Go slice → `["null","array"]` vs bare `array` (no integration takes a list — every multi-value input is a CSV string); nested struct inlined vs `$defs`/`$ref` (every params struct is flat); sized/unsigned ints (use `i64`); pointer field ordering and required-ness; `encoding/json`'s syntax-error vocabulary; and the Go MCP SDK **rounding an integer argument above 2^53** through its `map[string]any` defaults pass, which `rmcp` does not — unreachable with real GitHub run ids, and degrading Rust to match would be worse.

**Not ported, by design:** `ValidatePAT`, and `Start`'s auth check and credential parse — they have no native caller until #311 reads credentials for the first time. Noted in the module doc naming that issue.

## Testing

- [x] `make test` — passes, including `TestGitHubVectors`, `TestJSONSchemaReflectVectors` and the extended `TestGoURLVectors`
- [x] `cargo test` — 728 lib + 41 integration + 2 doc, **0 failed**
- [x] `cargo clippy --all-targets -- -D warnings` — clean; `cargo fmt --check` — clean
- [x] `golangci-lint run` on both changed Go packages — **0 issues in this PR's files**. The one finding on `gourl_parity_test.go` is the identical pre-existing line on `origin/desktop`, untouched by this PR's hunks: the known local v2.12.2 vs CI-pinned v2.5.0 drift.
- [x] All three vector files regenerate **byte for byte**
- [x] Credentials: a test asserts a failing call's message carries no token

## Related

Closes #312
Unblocked by #282 (PR #325); builds on #310 (PR #343). Leaves #311 the registry and the routes.

---
🤖 Implemented by [Claude Code](https://claude.com/claude-code) via `implement-issue` workflow