### PR TITLE
docs(desktop): the JSON content-type guard is per-method, not per-request (#332)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -238,8 +238,11 @@ ground truth for wire formats — better than reading Go structs. **GET only.**
 Never write to it. For write-path testing, start your own instance with
 `AGENTO_DATA_DIR` pointed at a scratch directory.
 
-Every `/api` request needs `Content-Type: application/json` — the server's
-guard runs before the handler, even for GETs. `api.ts` does this for you.
+Every state-changing `/api` request needs `Content-Type: application/json` —
+`POST`, `PUT`, `PATCH`, `DELETE`; the server's guard (`isStateChanging` in
+`internal/server/guards.go`) runs before the handler and 415s without it,
+including on the payload-free endpoints. `GET`/`HEAD`/`OPTIONS` are untouched.
+`api.ts` does this for you.
 
 **Desktop, not web.** The UI deliberately diverges from the Agento web app:
 three resizable panes per section, 13px type, 26px rows, hairline borders,


### PR DESCRIPTION
## What

`desktop/CLAUDE.md:241-242` claimed:

> Every `/api` request needs `Content-Type: application/json` — the server's guard runs before the handler, **even for GETs**.

It does not. `requireJSONContentType` (`internal/server/guards.go:121`) returns early unless `isStateChanging(r.Method)` says so, and that is an allowlist of `POST`, `PUT`, `PATCH`, `DELETE`. `GET`, `HEAD` and `OPTIONS` pass with no header at all — asserted by `internal/server/guards_test.go`.

Replaced with the wording the issue proposed: it names `isStateChanging` and its file, lists the four methods, keeps the payload-free endpoints (the non-obvious part of the rule), and states that `GET`/`HEAD`/`OPTIONS` are untouched.

## Why

Harmless in the direction it errs — sending the header on a GET costs nothing — but it teaches the wrong model of the guard, and the wrong model is what #302 was about. An agent that believes the check is per-request rather than per-method has no way to predict which requests a change to `isStateChanging` affects.

## Scope

Docs only, on `desktop` — `desktop/CLAUDE.md` does not exist on `main`. No code, no tests. The `curl -H "Content-Type: application/json" … GET` example at line 236 is left alone: it is still correct (the header is simply not required there) and it is the ground-truth recipe, not a statement about the guard.

Closes #332