### PR TITLE
fix(desktop): echo the CLI's tool input back as bytes, not as a re-encoded Value (#342)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -1555,6 +1555,28 @@ into `{"a":1,"z":1.5}` — sorted and respelled, with nothing to signal it.
 literal bytes rather than `json.dumps`: Python normalises `1.50` to `1.5` and
 adds spaces, so a byte-exactness test cannot go through it.
 
+**The same rule holds in the other direction, on the input the tool actually
+runs with** (#342). `can_use_tool`'s allow arm echoes the CLI's own tool input
+back as `updatedInput`, and that echo used to go through a `serde_json::Value` —
+so the CLI ran a re-sorted, re-spelled payload, on the *allow* path. Go's
+`process.go` is `resp["updatedInput"] = envelope.Request.Input`, a
+`json.RawMessage`, echoed verbatim. `PermissionResult::Allow::updated_input` is
+therefore `Option<Box<RawValue>>` rather than a `Value` — bytes for both the
+echo and a handler's rewrite — which cost no call site, since every handler in
+the tree returns `PermissionResult::allow()`. Two consequences worth knowing:
+`PermissionResult`'s `PartialEq` is hand-written, because `RawValue` has none and
+byte equality is the only comparison the type can honestly offer; and
+`write_control_success_raw` builds the two control-response envelopes as structs
+whose **field order is the wire order**, spelled to match what `encoding/json`
+does to Go's `map[string]any` (`response` before `type`; `request_id` before
+`response` before `subtype`).
+
+Both halves are pinned by asserting the **whole** `"updatedInput":…` substring of
+the raw logged line — a per-key assertion passes against a reordered, respelled
+object, which is why `tests/claude_sdk.rs` grew a `logged_line` beside
+`logged_message`, and why the fake CLI now logs the stdin bytes it received
+rather than a `json.dumps` of the decoded object.
+
 **A disconnect has to be raced explicitly, not inferred.** The permission
 handler is awaited *inline on the SDK's reader task*, so while it is parked no
 events arrive and the stream loop has nothing to send — a closed tab is

--- a/desktop/src-tauri/src/claude/permissions.rs
+++ b/desktop/src-tauri/src/claude/permissions.rs
@@ -108,13 +108,22 @@ pub struct PermissionContext {
 /// Go models the behaviour as a string whose zero value is a usage error; Rust
 /// makes the same distinction by making the enum have no default, so a handler
 /// cannot accidentally return "unset" and have it read as an allow.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub enum PermissionResult {
     Allow {
         /// Replaces the tool input before execution. `None` echoes the CLI's
         /// original input back verbatim — the CLI expects the input it should
         /// actually run, so this field is always sent.
-        updated_input: Option<serde_json::Value>,
+        ///
+        /// JSON **bytes**, not a `serde_json::Value`, because this is the input
+        /// the tool executes with. `serde_json` is built here without
+        /// `preserve_order`, so a `Value` round trip sorts the object's keys
+        /// and respells its numbers — on the *allow* path, the one where the
+        /// user said yes. Go's field is a `map[string]any` and its echo is a
+        /// `json.RawMessage`; one raw type covers both, and it is a superset
+        /// rather than a divergence, since a handler that wants Go's sorting
+        /// can serialise a map to get it.
+        updated_input: Option<Box<RawValue>>,
         /// Persistent permission mutations to apply.
         updated_permissions: Vec<PermissionUpdate>,
     },
@@ -124,6 +133,42 @@ pub enum PermissionResult {
         /// Stops the agent entirely after this tool call.
         interrupt: bool,
     },
+}
+
+/// Written out rather than derived because `RawValue` has no `PartialEq`.
+///
+/// Two updated inputs are equal when their **bytes** are, which is the only
+/// comparison this type can honestly offer: the whole reason the field is raw
+/// is that `{"z":1.50,"a":1}` and `{"a":1,"z":1.5}` are different answers here.
+impl PartialEq for PermissionResult {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                PermissionResult::Allow {
+                    updated_input: a_input,
+                    updated_permissions: a_perms,
+                },
+                PermissionResult::Allow {
+                    updated_input: b_input,
+                    updated_permissions: b_perms,
+                },
+            ) => {
+                a_input.as_deref().map(RawValue::get) == b_input.as_deref().map(RawValue::get)
+                    && a_perms == b_perms
+            }
+            (
+                PermissionResult::Deny {
+                    message: a_message,
+                    interrupt: a_interrupt,
+                },
+                PermissionResult::Deny {
+                    message: b_message,
+                    interrupt: b_interrupt,
+                },
+            ) => a_message == b_message && a_interrupt == b_interrupt,
+            _ => false,
+        }
+    }
 }
 
 impl PermissionResult {

--- a/desktop/src-tauri/src/claude/process.rs
+++ b/desktop/src-tauri/src/claude/process.rs
@@ -38,6 +38,7 @@ use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex as StdMutex, RwLock};
 
+use serde::Serialize;
 use serde_json::value::RawValue;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::{mpsc, oneshot, Mutex};
@@ -48,7 +49,7 @@ use super::hooks::{build_hooks_for_initialize, HookRegistry};
 use super::init_types::decode_initialize_response;
 use super::messages::{error_event, message_type, parse_line, system_subtype, Event};
 use super::options::{thinking, Options};
-use super::permissions::{PermissionContext, PermissionResult};
+use super::permissions::{PermissionContext, PermissionResult, PermissionUpdate};
 use super::SDK_VERSION;
 
 /// Capacity of the event channel, matching Go's `make(chan Event, 32)`.
@@ -101,7 +102,12 @@ pub(crate) struct Shared {
 
 impl Shared {
     /// Serialises `value` as a JSON line and sends it to stdin.
-    pub(crate) async fn write(&self, value: &serde_json::Value) -> Result<()> {
+    ///
+    /// Generic over `Serialize` rather than taking a `serde_json::Value`, so a
+    /// caller that must not re-spell what it forwards can hand over a struct
+    /// carrying a `RawValue`. Routing that through a `Value` first would sort
+    /// its keys and respell its numbers — see `write_control_success_raw`.
+    pub(crate) async fn write<T: serde::Serialize + ?Sized>(&self, value: &T) -> Result<()> {
         let mut line = serde_json::to_vec(value)
             .map_err(|e| Error::wrap("encoding a message for stdin", e))?;
         line.push(b'\n');
@@ -617,19 +623,53 @@ async fn write_control_success(
     request_id: &str,
     payload: Option<serde_json::Value>,
 ) {
-    let mut response = serde_json::json!({
-        "subtype": "success",
-        "request_id": request_id,
-    });
-    if let Some(payload) = payload {
-        response["response"] = payload;
+    // Go builds this payload as a `map[string]any` too, so going through a
+    // `Value` here loses nothing: both sort the keys. Only the caller that
+    // forwards bytes it did not author needs the raw form below.
+    let raw = payload.and_then(|p| serde_json::value::to_raw_value(&p).ok());
+    write_control_success_raw(shared, request_id, raw.as_deref()).await;
+}
+
+/// The same, for a payload that is already JSON bytes and must stay them.
+///
+/// The two envelope structs exist so nothing on this path is rebuilt from a
+/// `serde_json::Value`. Their **field order is the wire order**, and it is
+/// spelled to match Go: `process.go` builds both envelopes as `map[string]any`,
+/// and `encoding/json` sorts map keys — hence `response` before `type`, and
+/// `request_id` before `response` before `subtype`. Reordering a field here
+/// changes the bytes the CLI receives.
+async fn write_control_success_raw(shared: &Shared, request_id: &str, payload: Option<&RawValue>) {
+    #[derive(Serialize)]
+    struct Body<'a> {
+        request_id: &'a str,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        response: Option<&'a RawValue>,
+        subtype: &'static str,
     }
+
+    #[derive(Serialize)]
+    struct Line<'a> {
+        response: Body<'a>,
+        #[serde(rename = "type")]
+        kind: &'static str,
+    }
+
     let _ = shared
-        .write(&serde_json::json!({
-            "type": "control_response",
-            "response": response,
-        }))
+        .write(&Line {
+            response: Body {
+                request_id,
+                response: payload,
+                subtype: "success",
+            },
+            kind: "control_response",
+        })
         .await;
+}
+
+/// `omitempty` for a bool: Go drops `false`, and only sets `interrupt` at all
+/// when it is true.
+fn is_false(b: &bool) -> bool {
+    !*b
 }
 
 /// Handles one inbound `control_request` and writes exactly one response.
@@ -665,12 +705,6 @@ pub(crate) async fn handle_control_request(
                 .and_then(|r| serde_json::from_value(r).ok())
                 .unwrap_or_default();
 
-            let original_input = envelope
-                .request
-                .input
-                .as_ref()
-                .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw.get()).ok());
-
             let input_for_handler = envelope
                 .request
                 .input
@@ -684,37 +718,79 @@ pub(crate) async fn handle_control_request(
             )
             .await;
 
-            let payload = match result {
+            // Both arms are serialised to bytes here rather than to a
+            // `serde_json::Value`, because the allow arm carries the tool input
+            // the CLI is about to *execute*: a `Value` is a `BTreeMap` without
+            // `preserve_order`, so a round trip sorts the keys, respells the
+            // numbers (`1.50` → `1.5`) and truncates a decimal beyond f64. Go
+            // echoes `envelope.Request.Input` — a `json.RawMessage` — verbatim.
+            //
+            // Field order is the wire order and matches Go's sorted
+            // `map[string]any`: behavior < updatedInput < updatedPermissions,
+            // and behavior < interrupt < message.
+            let payload = match &result {
                 PermissionResult::Allow {
                     updated_input,
                     updated_permissions,
                 } => {
-                    let mut response = serde_json::json!({ "behavior": "allow" });
-                    // The CLI expects the input it should actually run; when
-                    // the handler does not rewrite it, echo the original back
-                    // verbatim.
-                    response["updatedInput"] = updated_input
-                        .or(original_input)
-                        .unwrap_or(serde_json::Value::Null);
-                    if !updated_permissions.is_empty() {
-                        response["updatedPermissions"] =
-                            serde_json::to_value(&updated_permissions).unwrap_or_default();
+                    #[derive(Serialize)]
+                    struct AllowResponse<'a> {
+                        behavior: &'static str,
+                        /// Always sent, `null` included: the CLI expects the
+                        /// input it should actually run, and Go marshals a nil
+                        /// `json.RawMessage` as `null` rather than dropping it.
+                        #[serde(rename = "updatedInput")]
+                        updated_input: Option<&'a RawValue>,
+                        #[serde(
+                            rename = "updatedPermissions",
+                            skip_serializing_if = "<[_]>::is_empty"
+                        )]
+                        updated_permissions: &'a [PermissionUpdate],
                     }
-                    response
+
+                    serde_json::value::to_raw_value(&AllowResponse {
+                        behavior: "allow",
+                        // When the handler does not rewrite it, echo the
+                        // original back — the same bytes, not the same value.
+                        updated_input: updated_input
+                            .as_deref()
+                            .or(envelope.request.input.as_deref()),
+                        updated_permissions,
+                    })
                 }
                 PermissionResult::Deny { message, interrupt } => {
-                    let mut response = serde_json::json!({
-                        "behavior": "deny",
-                        "message": message,
-                    });
-                    if interrupt {
-                        response["interrupt"] = serde_json::Value::Bool(true);
+                    #[derive(Serialize)]
+                    struct DenyResponse<'a> {
+                        behavior: &'static str,
+                        #[serde(skip_serializing_if = "is_false")]
+                        interrupt: bool,
+                        message: &'a str,
                     }
-                    response
+
+                    serde_json::value::to_raw_value(&DenyResponse {
+                        behavior: "deny",
+                        interrupt: *interrupt,
+                        message,
+                    })
                 }
             };
 
-            write_control_success(shared, request_id, Some(payload)).await;
+            // A failed encode is not a reason to leave the CLI waiting: every
+            // inbound control_request must be answered, and an unanswered one
+            // hangs it with no error on either side.
+            match payload {
+                Ok(payload) => {
+                    write_control_success_raw(shared, request_id, Some(&payload)).await;
+                }
+                Err(e) => {
+                    write_control_error(
+                        shared,
+                        request_id,
+                        &format!("encoding the permission response: {e}"),
+                    )
+                    .await;
+                }
+            }
         }
 
         "hook_callback" => {

--- a/desktop/src-tauri/tests/claude_sdk.rs
+++ b/desktop/src-tauri/tests/claude_sdk.rs
@@ -58,6 +58,15 @@ def record(entry):
         log.write(json.dumps(entry) + "\n")
         log.flush()
 
+def record_raw(text):
+    # Stdin is logged as the bytes that arrived, not as a re-encode of the
+    # decoded object: json.loads/json.dumps sorts nothing but does respell
+    # numbers (1.50 -> 1.5), and byte fidelity of what the SDK writes is
+    # exactly what some of these tests are about.
+    with lock:
+        log.write(text + "\n")
+        log.flush()
+
 def say(obj):
     sys.stdout.write(json.dumps(obj) + "\n")
     sys.stdout.flush()
@@ -91,7 +100,7 @@ for line in sys.stdin:
         msg = json.loads(line)
     except Exception:
         continue
-    record(msg)
+    record_raw(line)
     req = msg.get("request") or {{}}
 {emit}
 "#,
@@ -155,6 +164,24 @@ fn logged_message(log_path: &Path, kind: &str) -> Option<serde_json::Value> {
     raw.lines()
         .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
         .find(|v| v.get("type").and_then(|t| t.as_str()) == Some(kind))
+}
+
+/// The same line, **unparsed**.
+///
+/// A `serde_json::Value` cannot answer a question about bytes: it sorts an
+/// object's keys and respells its numbers, so a test that decodes first can
+/// only ever assert what the port would produce even when it is wrong.
+fn logged_line(log_path: &Path, kind: &str) -> Option<String> {
+    let raw = std::fs::read_to_string(log_path).ok()?;
+    raw.lines()
+        .find(|l| {
+            serde_json::from_str::<serde_json::Value>(l)
+                .ok()
+                .and_then(|v| v.get("type").and_then(|t| t.as_str()).map(str::to_owned))
+                .as_deref()
+                == Some(kind)
+        })
+        .map(str::to_owned)
 }
 
 fn options_for(exe: &Path) -> Options {
@@ -523,6 +550,104 @@ async fn an_allow_echoes_the_original_input_back_verbatim() {
         tokio::time::sleep(Duration::from_millis(20)).await;
     }
     panic!("the SDK never answered the permission request; a missing reply hangs the CLI");
+}
+
+#[tokio::test]
+async fn the_echoed_input_keeps_its_key_order_and_number_spelling() {
+    if python3().is_none() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("stdin.jsonl");
+    // Written to stdout as raw bytes rather than through json.dumps, which
+    // would respell 1.50 before the SDK ever saw it.
+    let exe = fake_cli(
+        dir.path(),
+        &log,
+        r#"    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack_now(msg.get("request_id"))
+    elif msg.get("type") == "user":
+        sys.stdout.write('{"type":"control_request","request_id":"perm-4","request":{"subtype":"can_use_tool","tool_name":"Write","input":{"z":1.50,"a":1}}}' + "\n")
+        sys.stdout.flush()"#,
+    );
+
+    let handler: claude::PermissionHandler =
+        std::sync::Arc::new(|_, _, _| Box::pin(async { PermissionResult::allow() }));
+
+    let opts = options_for(&exe)
+        .with_default_permissions()
+        .with_permission_handler(handler);
+    let _stream = query("write it", opts).await;
+
+    for _ in 0..250 {
+        if let Some(reply) = logged_line(&log, "control_response") {
+            // The whole substring, not one key's value: the defect this pins is
+            // a reordered key and a respelled number, and a per-key assertion
+            // passes against both. `serde_json` is built without
+            // `preserve_order`, so decoding the input into a `Value` and
+            // re-encoding it would ship {"a":1,"z":1.5} — a different payload
+            // for the tool to actually execute, on the path where the user said
+            // yes.
+            assert!(
+                reply.contains(r#""updatedInput":{"z":1.50,"a":1}"#),
+                "the echoed input was rewritten: {reply}"
+            );
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("the SDK never answered the permission request");
+}
+
+#[tokio::test]
+async fn a_handler_that_rewrites_the_input_beats_the_echo() {
+    if python3().is_none() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("stdin.jsonl");
+    let exe = fake_cli(
+        dir.path(),
+        &log,
+        r#"    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack_now(msg.get("request_id"))
+    elif msg.get("type") == "user":
+        sys.stdout.write('{"type":"control_request","request_id":"perm-5","request":{"subtype":"can_use_tool","tool_name":"Write","input":{"path":"/etc/passwd"}}}' + "\n")
+        sys.stdout.flush()"#,
+    );
+
+    let handler: claude::PermissionHandler = std::sync::Arc::new(|_, _, _| {
+        Box::pin(async {
+            PermissionResult::Allow {
+                updated_input: Some(
+                    serde_json::value::RawValue::from_string(r#"{"path":"/tmp/safe"}"#.to_owned())
+                        .unwrap(),
+                ),
+                updated_permissions: Vec::new(),
+            }
+        })
+    });
+
+    let opts = options_for(&exe)
+        .with_default_permissions()
+        .with_permission_handler(handler);
+    let _stream = query("write it", opts).await;
+
+    for _ in 0..250 {
+        if let Some(reply) = logged_line(&log, "control_response") {
+            assert!(
+                reply.contains(r#""updatedInput":{"path":"/tmp/safe"}"#),
+                "the rewrite lost to the echo: {reply}"
+            );
+            assert!(
+                !reply.contains("/etc/passwd"),
+                "the original input survived the rewrite: {reply}"
+            );
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("the SDK never answered the permission request");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What

`handle_control_request`'s `can_use_tool` arm decoded the CLI's own tool input into a `serde_json::Value` and re-encoded it as `updatedInput` on the allow path. `serde_json` is built here without `preserve_order`, so a `Value::Object` is a `BTreeMap`: keys are sorted and numbers respelled (`1.50` → `1.5`, `1e3` → `1000.0`), and a decimal beyond `f64` precision is silently truncated.

Go echoes the bytes verbatim — `claude-agent-sdk-go/claude/process.go` is `resp["updatedInput"] = envelope.Request.Input`, a `json.RawMessage`.

## Why this one is worse than the others

Every previous instance was cosmetic to the eye: #276 respelled an SSE frame, #298 respelled the stored `blocks` column. This one is **the input the tool actually executes with** — on the *allow* path, i.e. the one where the user said yes.

## How

- **`PermissionResult::Allow::updated_input` is now `Option<Box<RawValue>>`.** No call site moved: every handler in the tree returns `PermissionResult::allow()` (`None`, the echo case). It is a *superset* of Go's `map[string]any` rather than a divergence — a handler that wants Go's key sorting can serialise a map to get it.
- The allow and deny payloads are `#[derive(Serialize)]` structs serialised straight to bytes. **Field order is wire order**, spelled to match what `encoding/json` does to Go's `map[string]any`: `behavior` < `updatedInput` < `updatedPermissions`, and `behavior` < `interrupt` < `message`.
- `write_control_success_raw` does the same for the two envelopes (`response` before `type`; `request_id` before `response` before `subtype`), so nothing on this path is rebuilt from a `Value`. The `Value`-taking `write_control_success` stays for the acknowledge-only callers, whose payloads Go also builds as maps — going through a `Value` there loses nothing.
- `Shared::write` is generic over `Serialize`, so a struct carrying a `RawValue` reaches stdin without a `Value` in between.
- `PermissionResult`'s `PartialEq` is hand-written: `RawValue` has none, and byte equality is the only comparison this type can honestly offer — the whole reason the field is raw is that `{"z":1.50,"a":1}` and `{"a":1,"z":1.5}` are different answers.
- An encode failure answers with a `control_response` **error** rather than nothing. Every inbound `control_request` must be answered; a missing reply hangs the CLI with no error on either side.

## Tests

Two new cases in `tests/claude_sdk.rs`:

- `the_echoed_input_keeps_its_key_order_and_number_spelling` — a `can_use_tool` whose input is `{"z":1.50,"a":1}` is answered with `"updatedInput":{"z":1.50,"a":1}`.
- `a_handler_that_rewrites_the_input_beats_the_echo` — a rewrite still wins, and the original does not survive.

Both assert the **whole** `"updatedInput":…` substring of the raw logged line. A per-key assertion (what the existing `an_allow_echoes_the_original_input_back_verbatim` does) passes against a reordered, respelled object, which is exactly why this was invisible. That needed two harness changes:

- `logged_line` beside `logged_message` — a `serde_json::Value` cannot answer a question about bytes;
- the fake CLI logs the **stdin bytes it received** rather than a `json.dumps` of the decoded object, because Python respells `1.50` too. Existing assertions are unaffected: the logged line is the same JSON, just unparsed.

**Verified negatively.** Reinstating the `Value` round trip fails the new test with the exact defect:

```
the echoed input was rewritten: {"response":{"request_id":"perm-4","response":{"behavior":"allow","updatedInput":{"a":1,"z":1.5}},"subtype":"success"},"type":"control_response"}
```

## Quality

`cargo fmt --check` pass · `cargo clippy --all-targets -D warnings` pass · `cargo test` green (757 unit + 19 `claude_sdk`, 0 failures).

`desktop/CLAUDE.md` records the rule beside the existing "`tool_use` input must never round-trip through a `serde_json::Value`" paragraph, which this was the last site still violating.

Closes #342