### PR TITLE
perf(desktop): load user_settings once per turn, and name which resolver each field uses (#340)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -1526,6 +1526,43 @@ strings — and one who exported `AGENTO_DEFAULT_MODEL` had it silently ignored.
 `resolve` is the documented mirror of `Get()`, and every other caller in the port
 already goes through it.
 
+**One `user_settings` read per turn, and the two resolutions on top of it are not
+the same** (#340). Go needs no equivalent: `settingsMgr.Get()` is an in-memory
+snapshot, so the config dir and the default model are free reads of one value.
+This port has no manager, so each consumer opened its own read-only connection
+and decoded the same row — twice for an ordinary turn, three times for one pinned
+to a named settings profile, on the latency path of every message. #299 removed
+the eager *model* read; it did not remove the config-dir one, and the PR should
+not be read as having done so.
+
+`runner::TurnSettings` is the shared load: a `OnceLock` over the **stored** row,
+carried on `RunSpec` and shared with the `no_agent_model` closure via an `Arc`.
+The value is not that it saves a connection — it is that **two consumers of one
+row with different fields is the shape that drifts**, which is what #339's review
+found when one of them read `load_stored` where Go reads the resolved settings
+and the other already went through `resolve`. Putting the two accessors side by
+side makes the asymmetry legible, and it is a real asymmetry rather than an
+oversight:
+
+- `default_model()` is `settingsMgr.Get().DefaultModel`, so it goes through
+  `settings::resolve`.
+- `run_config_dir()` is `config.ClaudeRunConfigDir`, which reads
+  `claudeDirs.runOverride` — the value `ApplyClaudeDirs` **stored** — and applies
+  `CLAUDE_CONFIG_DIR` itself, ahead of it. Handing it the *resolved* row instead
+  would diverge for a `CLAUDE_CONFIG_DIR` that is set but not absolute: `resolve`
+  overwrites the field with it, `absolute_dir` then rejects it, and a stored
+  absolute dir Go would have used is skipped for the default.
+
+So the shared thing is the stored row, and `resolve` is applied where Go applies
+it and nowhere else. Two other properties are pinned by counting loads rather
+than argued: a turn reads the row **at most once** however many fields it wants,
+and an agent carrying an **absolute** `claude_config_dir` reads it **zero** times
+— `ResolveAgentClaudeDir` returns before `ClaudeRunConfigDir` for the same
+reason. An unreadable database is still `None` rather than a zero row, so the
+model stays `""` (i.e. "set no model option") rather than becoming `resolve`'s
+`"sonnet"`: a database this process cannot open is not a user who never saved
+settings.
+
 **An embedded raw value is compacted and HTML-escaped on the way out, and Go
 does it on the way *in*** (#298). `encoding/json` runs
 `compact(…, escapeHTML=true)` over a `Marshaler`'s output, so a nested

--- a/desktop/src-tauri/src/native/chat/runner.rs
+++ b/desktop/src-tauri/src/native/chat/runner.rs
@@ -63,6 +63,122 @@ const ALL_BUILT_IN_TOOLS: &[&str] = &[
     "NotebookEdit",
 ];
 
+/// The `user_settings` row a turn reads — **at most once**, however many of its
+/// fields are wanted (#340).
+///
+/// Go has no equivalent because it needs none: `settingsMgr.Get()` is an
+/// in-memory snapshot, so `ClaudeRunConfigDir` and `DefaultModel` are free reads
+/// of one value. This port has no manager, so each consumer used to open its own
+/// read-only connection and decode the same row — twice for an ordinary turn,
+/// three times for one pinned to a named settings profile, on the latency path
+/// of every message, for a value that changes about never.
+///
+/// The cost was not really the connection. It is that **two consumers of one row
+/// with different fields is the shape that drifts**: #339's review found that one
+/// of them read `load_stored` where Go reads the resolved settings, while the
+/// other already went through `resolve`. One load makes that impossible to get
+/// wrong twice — and it puts the two resolutions side by side, which is what
+/// makes the asymmetry below legible rather than accidental.
+///
+/// **Each accessor names the Go function it mirrors, and they do not agree**:
+///
+/// - [`Self::default_model`] is `settingsMgr.Get().DefaultModel`, so it goes
+///   through `settings::resolve` — that is what fills `"sonnet"` when nothing is
+///   stored and what applies `AGENTO_DEFAULT_MODEL` /
+///   `ANTHROPIC_DEFAULT_SONNET_MODEL`.
+/// - [`Self::run_config_dir`] is `config.ClaudeRunConfigDir`, which reads
+///   `claudeDirs.runOverride` — the value `ApplyClaudeDirs` **stored**, not the
+///   resolved settings — and applies `CLAUDE_CONFIG_DIR` itself, ahead of it.
+///   Passing it the resolved row instead would diverge for a
+///   `CLAUDE_CONFIG_DIR` that is set but not absolute: `resolve` overwrites the
+///   field with it, `absolute_dir` then rejects it, and a stored absolute dir Go
+///   would have used is skipped for the default.
+///
+/// So the shared thing is the **stored row**; `resolve` is a pure function
+/// applied where Go applies it, and nowhere else.
+pub struct TurnSettings {
+    /// `None` when there is no database to read — the case the unit tests use
+    /// to prove a branch never looked.
+    db_path: Option<std::path::PathBuf>,
+    /// `None` *inside* the lock means the row could not be read. That is
+    /// distinct from a zero row: both resolvers degrade to their own defaults
+    /// on it rather than to `resolve`'s, which is what the two separate reads
+    /// did and is why an unreadable database still yields "no model option"
+    /// rather than `"sonnet"`.
+    row: std::sync::OnceLock<Option<crate::native::settings::UserSettings>>,
+    /// Observability, so a test can assert "at most once" rather than assuming
+    /// it. A `OnceLock` makes over-reading unrepresentable; this makes
+    /// *under*-reading — a branch that should never have looked — visible.
+    loads: std::sync::atomic::AtomicUsize,
+}
+
+impl TurnSettings {
+    /// The settings behind `db_path`, read on first use.
+    pub fn from_db(db_path: impl Into<std::path::PathBuf>) -> Self {
+        Self {
+            db_path: Some(db_path.into()),
+            row: std::sync::OnceLock::new(),
+            loads: std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+
+    /// No database: every field is its zero value, and nothing is opened.
+    pub fn none() -> Self {
+        Self {
+            db_path: None,
+            row: std::sync::OnceLock::new(),
+            loads: std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+
+    /// The stored row, loaded once. An unreadable database is `None`, not a
+    /// failure: a turn that cannot see the settings still runs, on whatever
+    /// each resolver's own fallback is.
+    fn stored(&self) -> Option<&crate::native::settings::UserSettings> {
+        self.row
+            .get_or_init(|| {
+                self.loads.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                let db_path = self.db_path.as_deref()?;
+                let conn = crate::native::db::open_read_only(db_path).ok()?;
+                Some(crate::native::settings::load_stored(&conn))
+            })
+            .as_ref()
+    }
+
+    /// `settingsMgr.Get().DefaultModel` — see the type's docs for why this one
+    /// goes through `resolve` and [`Self::run_config_dir`] does not.
+    ///
+    /// No row at all answers `""`, which `build_options` reads as "set no model
+    /// option" rather than as a failure. Deliberately *not* `resolve`'s
+    /// `"sonnet"`: a database this process cannot open is not a user who has
+    /// never saved settings, and the turn is better off on the SDK's own
+    /// default than on a value invented from a read that did not happen.
+    pub(crate) fn default_model(&self) -> String {
+        let Some(row) = self.stored() else {
+            return String::new();
+        };
+        crate::native::settings::resolve(row.clone())
+            .settings
+            .default_model
+    }
+
+    /// `config.ClaudeRunConfigDir`: `CLAUDE_CONFIG_DIR`, else the stored global
+    /// setting, else the default.
+    fn run_config_dir(&self) -> String {
+        let stored = self
+            .stored()
+            .map_or("", |row| row.claude_config_dir.as_str());
+        crate::native::settings::run_config_dir(stored)
+    }
+
+    /// How many times the row was actually read. The acceptance criterion of
+    /// #340 is a number, so it is asserted rather than argued.
+    #[cfg(test)]
+    fn loads(&self) -> usize {
+        self.loads.load(std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
 /// What the chat service knows about the turn before the subprocess starts.
 pub struct RunSpec {
     /// The agent, or `None` for a chat with no agent slug — which Go models as
@@ -83,6 +199,9 @@ pub struct RunSpec {
     /// no-agent branch, so an eager value is work whose result is thrown away.
     /// Called at most once, in the one arm below that needs it.
     pub no_agent_model: Box<dyn Fn() -> String + Send + Sync>,
+    /// The `user_settings` row, shared by every consumer in this file *and* by
+    /// the closure above — hence the `Arc`. See [`TurnSettings`].
+    pub settings: std::sync::Arc<TurnSettings>,
     pub working_dir: String,
     pub settings_profile_id: String,
     /// `Some` resumes an existing CLI session; `None` pins a new one to the
@@ -129,7 +248,7 @@ pub async fn build_options(
             .with_setting_sources(["project"]);
     }
 
-    let config_dir = resolve_agent_config_dir(spec.agent.as_ref());
+    let config_dir = resolve_agent_config_dir(spec.agent.as_ref(), &spec.settings);
     if config_dir != crate::native::settings::default_claude_config_dir()
         || std::env::var("CLAUDE_CONFIG_DIR").is_ok_and(|v| !v.is_empty())
     {
@@ -138,7 +257,7 @@ pub async fn build_options(
         opts = opts.with_env([("CLAUDE_CONFIG_DIR", config_dir.clone())]);
     }
 
-    if let Some(path) = settings_file_in(&config_dir, &spec.settings_profile_id) {
+    if let Some(path) = settings_file_in(&config_dir, &spec.settings_profile_id, &spec.settings) {
         // Only name a file that exists: a config dir Claude Code has never
         // written has no settings.json, and `--settings` on a missing path is
         // an error rather than a no-op.
@@ -448,11 +567,14 @@ fn wrap_permission_handler(inner: PermissionHandler, allowed: Vec<String>) -> Pe
 
 /// `ResolveAgentClaudeDir`: the agent's own override when it is absolute,
 /// otherwise the run default.
-fn resolve_agent_config_dir(agent: Option<&Agent>) -> String {
+fn resolve_agent_config_dir(agent: Option<&Agent>, settings: &TurnSettings) -> String {
     if let Some(agent) = agent {
         if !agent.claude_config_dir.is_empty() {
             let normalized = crate::native::settings::normalize(&agent.claude_config_dir);
             if let Some(dir) = crate::native::settings::absolute_dir(&normalized) {
+                // An absolute per-agent override answers outright, and the
+                // settings row is never touched — `ResolveAgentClaudeDir`
+                // returns before `ClaudeRunConfigDir` for the same reason.
                 return dir;
             }
         }
@@ -460,17 +582,7 @@ fn resolve_agent_config_dir(agent: Option<&Agent>) -> String {
     // A relative override is discarded rather than honoured: the subprocess
     // resolves it against its own cwd — inside the user's repo — and would read
     // it as trusted config.
-    crate::native::settings::run_config_dir(&stored_config_dir())
-}
-
-fn stored_config_dir() -> String {
-    let Some(db_path) = crate::paths::database_path() else {
-        return String::new();
-    };
-    let Ok(conn) = crate::native::db::open_read_only(&db_path) else {
-        return String::new();
-    };
-    crate::native::settings::load_stored(&conn).claude_config_dir
+    settings.run_config_dir()
 }
 
 /// `config.LoadProfileFilePathIn` plus the caller's `os.Stat`: the settings file
@@ -491,7 +603,7 @@ fn stored_config_dir() -> String {
 /// so a chat or task pinned to a named profile ran with **no `--settings` at
 /// all** while the Go server passed the recorded path — the same class of silent
 /// wrong-account failure #242 existed for.
-fn settings_file_in(config_dir: &str, profile_id: &str) -> Option<String> {
+fn settings_file_in(config_dir: &str, profile_id: &str, settings: &TurnSettings) -> Option<String> {
     // Go reads the index with `LoadProfilesMetadata()`, which resolves
     // `ClaudeSettingsProfilesPath()` — the **run default** dir, not `config_dir`.
     // That asymmetry is deliberate upstream and load-bearing here: profiles are
@@ -500,12 +612,13 @@ fn settings_file_in(config_dir: &str, profile_id: &str) -> Option<String> {
     // follows its own dir. Reading the index out of the override would silently
     // find nothing and hand the run the wrong account's settings.
     //
-    // Resolved only for a *named* profile: the unnamed fallback reads no index,
-    // and this opens the database.
+    // Resolved only for a *named* profile: the unnamed fallback reads no index.
+    // It costs nothing now — this is the same `TurnSettings` the config dir came
+    // from, so it is the row already in hand rather than a third connection.
     let index_dir = if profile_id.is_empty() {
         String::new()
     } else {
-        crate::native::settings::run_config_dir(&stored_config_dir())
+        settings.run_config_dir()
     };
     settings_file_from(config_dir, &index_dir, profile_id)
 }
@@ -668,6 +781,7 @@ mod tests {
                     counter.fetch_add(1, Ordering::SeqCst);
                     "no-agent-model".to_string()
                 }),
+                settings: std::sync::Arc::new(TurnSettings::none()),
                 working_dir: String::new(),
                 settings_profile_id: String::new(),
                 resume_session_id: None,
@@ -683,6 +797,7 @@ mod tests {
         RunSpec {
             agent: Some(agent_with(caps)),
             no_agent_model: Box::new(String::new),
+            settings: std::sync::Arc::new(TurnSettings::none()),
             working_dir: String::new(),
             settings_profile_id: String::new(),
             resume_session_id: None,
@@ -743,6 +858,109 @@ mod tests {
             "an agent's empty model is not a request for the session's or the user's"
         );
         assert_eq!(calls.load(Ordering::SeqCst), 0);
+    }
+
+    /// A settings row on disk, migrated and empty.
+    fn settings_db() -> tempfile::NamedTempFile {
+        let file = tempfile::NamedTempFile::new().expect("temp file");
+        let mut conn = rusqlite::Connection::open(file.path()).expect("open");
+        crate::native::migrate::apply(&mut conn).expect("migrate");
+        drop(conn);
+        file
+    }
+
+    /// #340's acceptance, and the only form it can take: a number.
+    ///
+    /// Three consumers with different fields — the config dir, the settings
+    /// profile's index dir, and the no-agent model — used to open a read-only
+    /// connection each, on the latency path of every message.
+    #[tokio::test]
+    async fn a_turn_reads_the_settings_row_at_most_once() {
+        let file = settings_db();
+        let settings = std::sync::Arc::new(TurnSettings::from_db(file.path()));
+
+        let mut spec = spec_for(Capabilities::default());
+        spec.settings = std::sync::Arc::clone(&settings);
+        // A *named* profile is what reaches the index dir; the unnamed fallback
+        // reads no index at all.
+        spec.settings_profile_id = "work".into();
+
+        let (_opts, servers) = build_options(&spec, no_op_handler())
+            .await
+            .expect("options");
+        assert!(servers.is_empty(), "no agent named a local tool");
+
+        // And the fourth consumer, which an agent chat never reaches — asked
+        // here so the count covers every field a turn can want.
+        let _ = settings.default_model();
+
+        assert_eq!(
+            settings.loads(),
+            1,
+            "the settings row was read more than once for one turn"
+        );
+    }
+
+    /// The zero case, which is the other half of the same rule: an absolute
+    /// per-agent override answers outright, so nothing opens the database at
+    /// all. `ResolveAgentClaudeDir` returns before `ClaudeRunConfigDir` for
+    /// exactly this reason.
+    #[tokio::test]
+    async fn an_absolute_per_agent_override_never_reads_the_settings_row() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let mut agent = agent_with(Capabilities::default());
+        agent.claude_config_dir = dir.path().to_string_lossy().into_owned();
+
+        // A path that cannot be opened: a read would still answer, so only the
+        // counter can tell "did not need it" from "needed it and got nothing".
+        let settings = std::sync::Arc::new(TurnSettings::from_db(
+            "/nonexistent/agento/definitely-not-a-db",
+        ));
+        let mut spec = spec_for(Capabilities::default());
+        spec.agent = Some(agent);
+        spec.settings = std::sync::Arc::clone(&settings);
+
+        let (_opts, _servers) = build_options(&spec, no_op_handler())
+            .await
+            .expect("options");
+
+        assert_eq!(settings.loads(), 0);
+    }
+
+    /// The precedence itself, unchanged: an absolute per-agent override wins,
+    /// and anything else defers to `ClaudeRunConfigDir`.
+    ///
+    /// The second and third assertions are identities rather than literals, so
+    /// they hold whether or not the developer running them exports
+    /// `CLAUDE_CONFIG_DIR` — and they still fail if the fall-through arm stops
+    /// going through the shared row.
+    #[test]
+    fn the_config_dir_precedence_is_override_then_the_run_dir() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let absolute = dir.path().to_string_lossy().into_owned();
+        let file = settings_db();
+        let settings = TurnSettings::from_db(file.path());
+
+        let mut agent = agent_with(Capabilities::default());
+        agent.claude_config_dir = absolute.clone();
+        assert_eq!(
+            resolve_agent_config_dir(Some(&agent), &settings),
+            absolute,
+            "an absolute per-agent override is the run's dir"
+        );
+
+        // A relative override is discarded rather than honoured: the subprocess
+        // would resolve it against its own cwd, inside the user's repo.
+        agent.claude_config_dir = "relative/dir".into();
+        assert_eq!(
+            resolve_agent_config_dir(Some(&agent), &settings),
+            settings.run_config_dir()
+        );
+
+        assert_eq!(
+            resolve_agent_config_dir(None, &settings),
+            settings.run_config_dir()
+        );
     }
 
     /// The one branch that does need it — and it is asked exactly once.

--- a/desktop/src-tauri/src/native/chat/turn.rs
+++ b/desktop/src-tauri/src/native/chat/turn.rs
@@ -133,7 +133,10 @@ pub async fn run(
     };
     let (row, agent) = loaded;
 
-    let no_agent_model = no_agent_model_for(&db_path, &row.model);
+    // One `user_settings` read per turn, shared by the no-agent model below and
+    // by the config-dir resolution inside `build_options` (#340).
+    let settings = Arc::new(runner::TurnSettings::from_db(&db_path));
+    let no_agent_model = no_agent_model_for(Arc::clone(&settings), &row.model);
 
     let (notify_tx, notify_rx) = mpsc::channel::<Notify>(NOTIFY_CAPACITY);
     let (input_tx, input_rx) = mpsc::channel::<String>(1);
@@ -152,6 +155,7 @@ pub async fn run(
     let spec = RunSpec {
         agent,
         no_agent_model,
+        settings,
         working_dir: row.working_dir.clone(),
         settings_profile_id: row.settings_profile_id.clone(),
         resume_session_id: Some(row.sdk_session_id.clone()).filter(|s| !s.is_empty()),
@@ -599,36 +603,21 @@ fn sse_response(body: Body) -> Response<Body> {
 /// (`resolveAgentConfig` returns the agent's config outright otherwise).
 /// Resolving eagerly opened a read-only connection and loaded the settings row
 /// on every turn of every agent chat, to throw the answer away.
+///
+/// It reads through the turn's shared [`runner::TurnSettings`] rather than
+/// opening its own connection (#340) — that type carries the `resolve` rule this
+/// function used to carry, and carries it beside the config dir's, which is the
+/// other consumer of the same row.
 fn no_agent_model_for(
-    db_path: &std::path::Path,
+    settings: Arc<runner::TurnSettings>,
     session_model: &str,
 ) -> Box<dyn Fn() -> String + Send + Sync> {
     if session_model.is_empty() {
-        let db_path = db_path.to_path_buf();
-        Box::new(move || default_model(&db_path))
+        Box::new(move || settings.default_model())
     } else {
         let model = session_model.to_string();
         Box::new(move || model.clone())
     }
-}
-
-/// `settingsMgr.Get().DefaultModel`.
-///
-/// **`resolve`, not `load_stored`.** Go reads the *resolved* settings, and
-/// `SettingsManager.load` fills `"sonnet"` when nothing is stored before
-/// `applyEnvOverrides` applies `AGENTO_DEFAULT_MODEL` /
-/// `ANTHROPIC_DEFAULT_SONNET_MODEL`. The raw `SELECT` has neither, so a user who
-/// had never saved settings ran on the SDK's own default instead of `sonnet`,
-/// and one who exported `AGENTO_DEFAULT_MODEL` had it silently ignored —
-/// `settings::resolve` is the documented mirror of `Get()` and every other
-/// caller in the port already goes through it.
-fn default_model(db_path: &std::path::Path) -> String {
-    let Ok(conn) = crate::native::db::open_read_only(db_path) else {
-        return String::new();
-    };
-    crate::native::settings::resolve(crate::native::settings::load_stored(&conn))
-        .settings
-        .default_model
 }
 
 #[cfg(test)]
@@ -643,8 +632,10 @@ mod tests {
     fn a_session_model_is_used_verbatim_and_never_touches_the_database() {
         // A path that does not exist: if the row's model were ignored and the
         // settings read anyway, opening it would fail and this would be `""`.
-        let nowhere = std::path::Path::new("/nonexistent/agento/definitely-not-a-db");
-        let resolve = no_agent_model_for(nowhere, "session-model");
+        let settings = Arc::new(runner::TurnSettings::from_db(
+            "/nonexistent/agento/definitely-not-a-db",
+        ));
+        let resolve = no_agent_model_for(Arc::clone(&settings), "session-model");
         assert_eq!(resolve(), "session-model");
         // Idempotent — `build_options` calls it once, but nothing enforces that.
         assert_eq!(resolve(), "session-model");
@@ -672,7 +663,7 @@ mod tests {
         // Nothing stored: the raw column is empty and `resolve` fills Go's
         // default, so reading the row directly would have answered `""`.
         assert_eq!(
-            no_agent_model_for(file.path(), "")(),
+            no_agent_model_for(Arc::new(runner::TurnSettings::from_db(file.path())), "")(),
             from_env
                 .clone()
                 .unwrap_or_else(|| crate::native::settings::DEFAULT_MODEL.to_string())
@@ -689,7 +680,7 @@ mod tests {
         // `AGENTO_DEFAULT_MODEL`, which is `modelInFile`'s whole point.
         let hard_override = crate::native::settings::env_value("AGENTO_DEFAULT_MODEL");
         assert_eq!(
-            no_agent_model_for(file.path(), "")(),
+            no_agent_model_for(Arc::new(runner::TurnSettings::from_db(file.path())), "")(),
             hard_override.unwrap_or_else(|| "stored-model".to_string())
         );
     }
@@ -698,8 +689,10 @@ mod tests {
     /// option" rather than as a failure — the turn still runs.
     #[test]
     fn an_unreadable_database_yields_no_model_rather_than_an_error() {
-        let nowhere = std::path::Path::new("/nonexistent/agento/definitely-not-a-db");
-        assert_eq!(no_agent_model_for(nowhere, "")(), "");
+        let settings = Arc::new(runner::TurnSettings::from_db(
+            "/nonexistent/agento/definitely-not-a-db",
+        ));
+        assert_eq!(no_agent_model_for(settings, "")(), "");
     }
 
     #[test]


### PR DESCRIPTION
## What

`runner::build_options` called `resolve_agent_config_dir(spec.agent.as_ref())` unconditionally, and unless the agent carried an **absolute** `claude_config_dir` override that fell through to `stored_config_dir()`, which opened its own read-only connection and loaded the `user_settings` row. `settings_file_in` opened a **third** for a chat pinned to a named settings profile. That is the common case — most agents set no override — so every turn of every chat did it, on the latency path of every message, for a value that changes about never. It also re-derived the database path from `crate::paths::database_path()` rather than using the `db_path` the turn already has, so the reads could not even share a handle.

#299 stopped `turn::run` resolving the user's default *model* eagerly. It did not remove these, and that PR should not be read as having done so.

## How

`runner::TurnSettings` is the shared load: a `OnceLock` over the **stored** row, carried on `RunSpec` and shared with the `no_agent_model` closure via an `Arc`, built in `turn::run` from the `db_path` the turn already has.

The connection was never the real cost. **Two consumers of one row with different fields is the shape that drifts** — #339's review found one of them reading `load_stored` where Go reads the resolved settings, while the other already went through `resolve`. One load puts both resolutions side by side, where the asymmetry is legible instead of accidental. And it *is* a real asymmetry:

| accessor | mirrors | resolution |
|---|---|---|
| `default_model()` | `settingsMgr.Get().DefaultModel` | through `settings::resolve` — `"sonnet"` when nothing is stored, plus `AGENTO_DEFAULT_MODEL` / `ANTHROPIC_DEFAULT_SONNET_MODEL` |
| `run_config_dir()` | `config.ClaudeRunConfigDir` | the **stored** value, with `CLAUDE_CONFIG_DIR` applied ahead of it by `settings::run_config_dir` itself |

The issue's "read through `settings::resolve`, never `load_stored`" is applied to the model but **deliberately not to the config dir**, because there it would be a behaviour change rather than a fix. `ClaudeRunConfigDir` reads `claudeDirs.runOverride` — the value `ApplyClaudeDirs` *stored* — and does the env layer itself. Handing it the resolved row instead diverges for a `CLAUDE_CONFIG_DIR` that is set but **not absolute**: `resolve` overwrites the field with it, `absolute_dir` then rejects it, and a stored absolute dir Go *would* have used is skipped for the default. So the shared thing is the stored row, and `resolve` is a pure function applied where Go applies it and nowhere else.

Behaviour is otherwise unchanged, including the edges: an unreadable database is `None` rather than a zero row, so the model stays `""` — which `build_options` reads as "set no model option" — instead of becoming `resolve`'s `"sonnet"`. A database this process cannot open is not a user who never saved settings.

## Tests

Three new, all counting loads rather than arguing:

- `a_turn_reads_the_settings_row_at_most_once` — a turn with a *named* settings profile plus the model consumer touches all four call sites and reads the row exactly once.
- `an_absolute_per_agent_override_never_reads_the_settings_row` — the zero case. The `TurnSettings` points at a path that cannot be opened, so only the counter can tell "did not need it" from "needed it and got nothing".
- `the_config_dir_precedence_is_override_then_the_run_dir` — absolute override wins, relative override is discarded, no agent defers. The last two are asserted as **identities** against `run_config_dir()` rather than as literals, so they hold whether or not the developer running them exports `CLAUDE_CONFIG_DIR`, and still fail if the fall-through arm stops going through the shared row.

The three existing `#299` tests are unchanged in intent; `turn.rs`'s three go through `TurnSettings::from_db` instead of a bare path.

## Quality

`cargo fmt --check` pass · `cargo clippy --all-targets -D warnings` pass · `cargo test` green (760 unit, 0 failures).

Closes #340