### PR TITLE
fix(desktop): reject an array where a nested struct belongs (#337)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -533,12 +533,41 @@ means forward and nothing errors when Rust accepts what Go refuses. A type needs
 no attribute at all, so the struct stays exactly as strict about its own shape.
 Pinned by `a_container_default_would_have_widened_the_struct_from_array_over_accept`.
 
-What is left standing, pinned by
-`a_full_length_positional_array_is_a_known_over_accept`: serde builds a struct
-from a **full-length** JSON array, positionally, so `{"capabilities":[[...],null,null]}`
-is accepted and Go answers 400. `writes::decode_body` guards that shape at the
-body level (#274) and nothing checks it for a value *inside* the body. It
-predates #295 and is tracked as **#337**.
+**`gojson::GoStruct<T>` is the third type, and it closes what those two left**
+(#337). serde builds a struct from a **full-length** JSON array, positionally, so
+`{"capabilities":[[...],null,null]}` was accepted and Go answers 400.
+`writes::decode_body` guards that shape at the *body* level (#274) and nothing
+checked it for a value *inside* the body — the one over-**accept** in the port,
+where every other decode divergence has been an over-reject. An over-reject is
+visible and `Err`-means-forward turns it into Go's own answer; an over-accept
+writes a row Go refuses, with nothing to report it.
+
+The accepted set was not uniform, which is what made it hard to see: the derive's
+`visit_seq` errors only when the array runs out of elements for a field with
+**no** default, so a struct accepted exactly "as many elements as it has fields
+without a default" — three for `Capabilities`, one for `McpCapability`, two for
+`ServiceConfig`, and **zero** for `SmtpConfig` and `ScheduledTasksPreferences`,
+whose every field carries `#[serde(default)]` because `deserialize_with` makes a
+field required. `{"provider":[]}` was a saved SMTP configuration.
+
+`deserialize_map` is the whole mechanism — `serde_json` answers it with
+`invalid type: sequence` for anything that is not `{`, and the visitor hands the
+`MapAccess` to `T`'s own derived impl, so the inner struct's strictness is
+untouched. It is a newtype, so it serializes as its inner value and **no response
+byte moves**; `null` and "missing" are still decided one level out by `Option`,
+and `GoMap<GoStruct<T>>` still maps a `null` value to the zero struct.
+
+**A field cannot protect itself, so the wrapper goes on the holder**:
+`AgentRequest.capabilities`, `Capabilities.mcp`'s values,
+`{Create,Update}IntegrationRequest.services`' values,
+`NotificationSettings.{provider,preferences}` and
+`NotificationPreferences.scheduled_tasks`. The stored `capabilities` column is
+read through it too, so a row neither implementation can write is refused rather
+than read as a real allowlist. `writes::decode_body`'s doc carries the **whole
+enumeration of write bodies** and which of them hold a nested struct, because a
+partial check reads as coverage it does not have. `a_full_length_positional_array`
+is inverted rather than deleted, on both the read side (`agents.rs`) and in
+`gojson.rs`.
 
 Genuinely unparseable input still fails, which is also what Go does — so the
 null case and the malformed case need separate tests.

--- a/desktop/src-tauri/src/native/agents.rs
+++ b/desktop/src-tauri/src/native/agents.rs
@@ -37,7 +37,7 @@ use rusqlite::OptionalExtension;
 use serde::{Deserialize, Serialize};
 
 use super::db;
-use super::gojson::{GoList, GoMap};
+use super::gojson::{GoList, GoMap, GoStruct};
 use super::writes::{decode_body, finish, WriteError};
 
 /// One agent. Mirrors `config.AgentConfig`.
@@ -73,11 +73,18 @@ pub struct Agent {
 /// request Go applies. They are types rather than `deserialize_with` functions
 /// precisely so this struct needs no `#[serde(default)]`, which would also make
 /// it accept `{"capabilities":[]}` — see [`GoList`]'s header.
+///
+/// [`GoStruct`] is the third rule (#337) and closes what those two left: serde
+/// builds a struct from a **full-length** JSON array, positionally, so
+/// `{"capabilities":[["Read"],null,null]}` was accepted here and 400 to Go. It
+/// wraps the `mcp` *value* rather than this struct, because a field cannot
+/// protect itself — `AgentRequest.capabilities` carries the wrapper for this
+/// one.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Capabilities {
     pub built_in: Option<GoList<String>>,
     pub local: Option<GoList<String>>,
-    pub mcp: Option<GoMap<McpCapability>>,
+    pub mcp: Option<GoMap<GoStruct<McpCapability>>>,
 }
 
 /// Which tools from one MCP server an agent may use.
@@ -131,13 +138,22 @@ fn scan(row: &rusqlite::Row<'_>) -> rusqlite::Result<Agent> {
         // Go fails the whole request on unparsable capabilities rather than
         // serving an agent whose tool allowlist is unknown. So does this: the
         // error reaches the proxy, which falls back to Go.
-        capabilities: serde_json::from_str(&capabilities).map_err(|e| {
-            rusqlite::Error::FromSqlConversionFailure(
-                7,
-                rusqlite::types::Type::Text,
-                Box::new(std::io::Error::other(format!("parsing capabilities: {e}"))),
-            )
-        })?,
+        //
+        // Through [`GoStruct`] (#337) so a stored *array* fails here too. Go's
+        // `json.Unmarshal` refuses one and this used to accept a full-length
+        // one positionally — reading `[["Read"],null,null]` as a real allowlist
+        // where Go fails the request. Neither implementation can write such a
+        // column, which is precisely why it has to be a type rather than an
+        // observation.
+        capabilities: serde_json::from_str::<GoStruct<Capabilities>>(&capabilities)
+            .map(|wrapped| wrapped.0)
+            .map_err(|e| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    7,
+                    rusqlite::types::Type::Text,
+                    Box::new(std::io::Error::other(format!("parsing capabilities: {e}"))),
+                )
+            })?,
         claude_config_dir: row.get(8)?,
     })
 }
@@ -236,7 +252,11 @@ struct AgentRequest {
     thinking: String,
     #[serde(deserialize_with = "super::gojson::null_is_zero_value")]
     system_prompt: String,
-    capabilities: Option<Capabilities>,
+    /// [`GoStruct`] so `{"capabilities":[["Read"],null,null]}` is the 400 Go
+    /// answers rather than a created agent (#337). The container
+    /// `#[serde(default)]` above is what makes the field itself optional; the
+    /// wrapper only decides what a *present* value may be shaped like.
+    capabilities: Option<GoStruct<Capabilities>>,
     #[serde(deserialize_with = "super::gojson::null_is_zero_value")]
     claude_config_dir: String,
 }
@@ -254,7 +274,7 @@ impl AgentRequest {
             thinking: self.thinking,
             permission_mode: String::new(),
             system_prompt: self.system_prompt,
-            capabilities: self.capabilities.unwrap_or_default(),
+            capabilities: self.capabilities.map(|c| c.0).unwrap_or_default(),
             claude_config_dir: self.claude_config_dir,
         }
     }
@@ -699,10 +719,12 @@ mod tests {
             "a stored [] must not read as an empty allowlist"
         );
 
-        // A *full-length* positional array is still accepted, by serde's
-        // `visit_seq`. That one predates #295 and is deferred to #337; it is
-        // asserted here so the boundary between the two is recorded rather than
-        // rediscovered.
+        // A *full-length* positional array used to be **accepted** here, by
+        // serde's `visit_seq` — the last shape #295 left standing, closed by
+        // `GoStruct` in #337. Inverted rather than deleted: this assertion is
+        // the boundary between the two changes, and it is the read half of the
+        // pair (`the_write_path_refuses_an_array_where_a_struct_belongs` is the
+        // write half).
         let file = tempfile::NamedTempFile::new().expect("temp file");
         let conn = rusqlite::Connection::open(file.path()).expect("open");
         conn.execute_batch(SCHEMA).expect("schema");
@@ -711,7 +733,10 @@ mod tests {
             [],
         )
         .expect("insert");
-        assert!(list(file.path()).is_ok(), "known over-accept, see #337");
+        assert!(
+            list(file.path()).is_err(),
+            "a stored full-length array must not read as an allowlist (#337)"
+        );
     }
 
     // ─── Writes ───────────────────────────────────────────────────────────────
@@ -788,6 +813,80 @@ mod tests {
             let err = create(file.path(), body).unwrap_err();
             assert_eq!(err.status(), StatusCode::BAD_REQUEST, "{:?}", err);
         }
+    }
+
+    /// #337, on the routes it can actually create a row on.
+    ///
+    /// The accepted set was **not uniform**, which is why every length is
+    /// listed rather than one representative: the derive's `visit_seq` errors
+    /// only when the array runs out of elements for a field with no default, so
+    /// `Capabilities` (three such fields) needed three and `McpCapability` (one)
+    /// needed one. Everything shorter was already the 400 Go answers — pinned
+    /// above — and everything at or past the length was a **created row Go
+    /// refuses**, which is an over-accept and the one direction this port must
+    /// not move in.
+    #[test]
+    fn the_write_path_refuses_an_array_where_a_struct_belongs() {
+        let file = migrated();
+        for body in [
+            // `Capabilities` at exactly its length, and past it.
+            &br#"{"name":"C","slug":"c","capabilities":[["Read"],null,null]}"#[..],
+            &br#"{"name":"C","slug":"c","capabilities":[["Read"],null,null,"extra"]}"#[..],
+            // `McpCapability` as a map value, at its length and past it.
+            &br#"{"name":"C","slug":"c","capabilities":{"mcp":{"g":[null]}}}"#[..],
+            &br#"{"name":"C","slug":"c","capabilities":{"mcp":{"g":[["x"],"extra"]}}}"#[..],
+        ] {
+            let err = create(file.path(), body).unwrap_err();
+            assert_eq!(
+                err.status(),
+                StatusCode::BAD_REQUEST,
+                "{}",
+                String::from_utf8_lossy(body)
+            );
+            // …and nothing was written. An over-accept is only interesting
+            // because of the row it leaves behind.
+            assert!(stored(&file, "c").is_none());
+        }
+
+        // The update path decodes the same body, so it refuses the same shapes.
+        create(file.path(), br#"{"name":"U","slug":"u"}"#).expect("create");
+        let err = update(
+            file.path(),
+            "u",
+            br#"{"name":"U","capabilities":[["Read"],null,null]}"#,
+        )
+        .unwrap_err();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    /// The other half, and the one a blunt fix would have broken: a **genuine**
+    /// array is still a genuine array. `built_in`, `local` and `mcp.*.tools` are
+    /// lists in Go too, so refusing arrays wholesale would have turned every
+    /// real agent into a 400.
+    #[test]
+    fn genuine_arrays_are_unaffected_by_the_struct_check() {
+        let file = migrated();
+        let answer = create(
+            file.path(),
+            br#"{"name":"G","slug":"g","capabilities":{
+                "built_in":["Read","Bash"],
+                "local":[],
+                "mcp":{"github":{"tools":["list_prs"]}}
+            }}"#,
+        )
+        .expect("a body Go accepts");
+        assert_eq!(answer.status, StatusCode::CREATED);
+
+        let caps = stored(&file, "g").expect("stored").capabilities;
+        assert_eq!(
+            caps.built_in,
+            Some(vec!["Read".into(), "Bash".into()].into())
+        );
+        assert_eq!(caps.local, Some(Vec::new().into()));
+        assert_eq!(
+            caps.mcp.expect("mcp")["github"].tools,
+            Some(vec!["list_prs".to_string()].into())
+        );
     }
 
     #[test]

--- a/desktop/src-tauri/src/native/chat/runner.rs
+++ b/desktop/src-tauri/src/native/chat/runner.rs
@@ -1002,7 +1002,8 @@ mod tests {
             "github".to_string(),
             crate::native::agents::McpCapability {
                 tools: Some(vec!["list_prs".into()].into()),
-            },
+            }
+            .into(),
         );
         let caps = Capabilities {
             built_in: None,
@@ -1025,7 +1026,8 @@ mod tests {
             server.to_string(),
             crate::native::agents::McpCapability {
                 tools: tools.map(Into::into),
-            },
+            }
+            .into(),
         );
         Capabilities {
             built_in: None,
@@ -1099,7 +1101,7 @@ mod tests {
         if let Some(mcp) = mixed.mcp.as_mut() {
             mcp.0.insert(
                 "sl-1".to_string(),
-                crate::native::agents::McpCapability { tools: None },
+                crate::native::agents::McpCapability { tools: None }.into(),
             );
         }
         assert!(mcp_plan(Some(&mixed), Some(file.path()), false).is_err());

--- a/desktop/src-tauri/src/native/gojson.rs
+++ b/desktop/src-tauri/src/native/gojson.rs
@@ -330,6 +330,116 @@ impl<V> From<std::collections::BTreeMap<String, V>> for GoMap<V> {
     }
 }
 
+/// A nested struct that decodes from a JSON **object only**, as Go's does
+/// (#337).
+///
+/// # The shape this closes
+///
+/// `serde` builds a struct from a JSON *array*, positionally, and `encoding/json`
+/// answers `cannot unmarshal array into Go value of type …`.
+/// [`super::writes::decode_body`] guards that at the **body** level — #274 added
+/// the object check because `POST /api/agents` with `["My Agent"]` would
+/// otherwise have created an agent — but nothing checked a value *inside* the
+/// body:
+///
+/// ```json
+/// {"capabilities":[["Read"],null,null]}
+/// {"capabilities":{"mcp":{"g":[null]}}}
+/// ```
+///
+/// Both were accepted here and are 400 to Go. The accepted set was not even
+/// uniform, which is what made it hard to reason about: the derive's `visit_seq`
+/// errors only when the array runs out of elements for a field that has **no**
+/// default, so what a struct accepted was exactly "as many elements as it has
+/// fields without a default" — three for `Capabilities`, one for
+/// `McpCapability`, two for `ServiceConfig`, and *zero* for the notification
+/// structs, whose every field carries `#[serde(default)]`.
+///
+/// **This is the direction that matters.** Every other decode divergence in the
+/// port has been an over-*reject* — a request Go applies is refused, which is
+/// visible and safe, and which `Err`-means-forward turns into Go's own answer.
+/// This one is an over-*accept*: it writes a row Go refuses, so the two
+/// implementations' databases diverge with nothing to report it, and the
+/// fallback cannot help because nothing errors.
+///
+/// # Why a type, and not a `deserialize_with`
+///
+/// The same lesson [`GoList`] carries, and #336 proved it again by trying the
+/// other way for #295: `serde`'s derive makes a field carrying
+/// `deserialize_with` **required**, so every call site must add
+/// `#[serde(default)]` — and that attribute is exactly what opens the
+/// `visit_seq` arm. A fix applied to the field would widen the hole it was
+/// closing. A type needs no attribute at all.
+///
+/// # How it works, and what it costs
+///
+/// `deserialize_map` is the whole mechanism: `serde_json` answers it with
+/// `invalid type: sequence` for anything that is not `{`, and the visitor then
+/// hands the `MapAccess` to `T`'s own derived impl, so the inner struct's
+/// strictness, field names and `deserialize_with` rules are untouched.
+///
+/// Serialization is a newtype and therefore transparent, so **no response byte
+/// moves** — the wrapper is on request *and* response structs (`Capabilities` is
+/// both) and only the decode side can tell.
+///
+/// `null` and "missing" still work, because both are decided one level out:
+/// `Option<GoStruct<T>>` gets `None` from `visit_none` and from `missing_field`
+/// respectively, and `GoMap<GoStruct<T>>` maps a `null` **value** to the zero
+/// struct, which is #295's rule unchanged.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct GoStruct<T>(pub T);
+
+impl<'de, T> serde::Deserialize<'de> for GoStruct<T>
+where
+    T: serde::Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct ObjectOnly<T>(std::marker::PhantomData<T>);
+
+        impl<'de, T> serde::de::Visitor<'de> for ObjectOnly<T>
+        where
+            T: serde::Deserialize<'de>,
+        {
+            type Value = GoStruct<T>;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("a JSON object")
+            }
+
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                T::deserialize(serde::de::value::MapAccessDeserializer::new(map)).map(GoStruct)
+            }
+        }
+
+        deserializer.deserialize_map(ObjectOnly(std::marker::PhantomData))
+    }
+}
+
+impl<T> std::ops::Deref for GoStruct<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> std::ops::DerefMut for GoStruct<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T> From<T> for GoStruct<T> {
+    fn from(value: T) -> Self {
+        Self(value)
+    }
+}
+
 /// Deserialize a value as-is, including an explicit `null`.
 ///
 /// `Option<Box<RawValue>>`'s own impl turns `null` into `None`, which would drop
@@ -771,7 +881,7 @@ mod tests {
 
     // ─── #295: a `null` inside a container ───────────────────────────────────
 
-    #[derive(Debug, Default, serde::Deserialize)]
+    #[derive(Debug, Default, serde::Deserialize, serde::Serialize)]
     #[serde(default)]
     struct Listy {
         ids: Option<GoList<String>>,
@@ -870,14 +980,93 @@ mod tests {
         assert!(serde_json::from_str::<Listy>(r#"[]"#).is_ok());
     }
 
-    /// A full-length array **is** still accepted, by serde's positional
-    /// `visit_seq`, and Go refuses it — deferred to #337, not introduced here.
-    /// Recorded so the next reader finds it rather than rediscovering it.
+    /// A full-length array used to be **accepted**, by serde's positional
+    /// `visit_seq`, where Go refuses it. That was the last shape #295 left
+    /// standing, and #337 closed it with [`GoStruct`].
+    ///
+    /// Inverted rather than deleted: the assertion is the boundary between the
+    /// two changes, and `Strict` still stands for `Capabilities` — so the wrap
+    /// has to be applied *by the holder*, exactly as `AgentRequest` applies it.
+    /// `Strict` itself, unwrapped, is still built from a sequence, which is what
+    /// the second half asserts and what makes "a field cannot protect itself"
+    /// concrete.
     #[test]
-    fn a_full_length_positional_array_is_a_known_over_accept() {
-        let parsed: Strict = serde_json::from_str(r#"[{"s":{"ids":["x"]}},"y"]"#)
-            .expect("serde builds a struct from a sequence positionally");
+    fn a_full_length_positional_array_is_refused_once_the_holder_wraps_it() {
+        let body = r#"[{"s":{"ids":["x"]}},"y"]"#;
+
+        let wrapped = serde_json::from_str::<GoStruct<Strict>>(body);
+        assert!(
+            wrapped.is_err(),
+            "a JSON array must not build a struct (#337)"
+        );
+
+        // Unwrapped, serde still does it. This is not a wish — it is why the
+        // rule lives on the holder rather than on the struct.
+        let parsed: Strict =
+            serde_json::from_str(body).expect("serde still builds it positionally");
         assert_eq!(parsed.other.as_deref(), Some("y"));
+    }
+
+    /// Everything [`GoStruct`] must leave alone, which is most of its behaviour.
+    #[test]
+    fn a_wrapped_struct_keeps_every_rule_but_the_array_one() {
+        #[derive(Debug, Default, serde::Deserialize)]
+        struct Holder {
+            inner: Option<GoStruct<Inner>>,
+            map: Option<GoMap<GoStruct<Inner>>>,
+        }
+
+        // An object decodes, and the inner struct's own rules still apply —
+        // including #295's null element.
+        let parsed: Holder = serde_json::from_str(r#"{"inner":{"ids":[null]}}"#).expect("object");
+        assert_eq!(
+            parsed.inner.expect("inner").ids.as_deref(),
+            Some(&vec![String::new()])
+        );
+
+        // Missing and explicit `null` are decided one level out, by `Option`,
+        // so neither reaches the visitor.
+        let parsed: Holder = serde_json::from_str(r#"{}"#).expect("missing");
+        assert!(parsed.inner.is_none());
+        let parsed: Holder = serde_json::from_str(r#"{"inner":null}"#).expect("null");
+        assert!(parsed.inner.is_none());
+
+        // A `null` map **value** is still the zero struct (#295) — the wrapper
+        // sits inside `GoMap`, which resolves the null before it is reached.
+        let parsed: Holder = serde_json::from_str(r#"{"map":{"s":null}}"#).expect("null value");
+        assert!(parsed.map.expect("map")["s"].ids.is_none());
+
+        // And the shape it exists for, at both depths.
+        assert!(serde_json::from_str::<Holder>(r#"{"inner":[null]}"#).is_err());
+        assert!(serde_json::from_str::<Holder>(r#"{"map":{"s":[null]}}"#).is_err());
+
+        // A scalar is refused too, as it always was and as Go refuses it.
+        assert!(serde_json::from_str::<Holder>(r#"{"inner":"x"}"#).is_err());
+        assert!(serde_json::from_str::<Holder>(r#"{"inner":3}"#).is_err());
+    }
+
+    /// The wrapper is a **decode-time** rule: it is a newtype, so it serializes
+    /// as its inner value and no response byte moves. `Capabilities` is on both
+    /// sides of the wire, so this is load-bearing rather than incidental.
+    #[test]
+    fn a_wrapped_struct_serializes_as_its_inner_value() {
+        #[derive(serde::Serialize)]
+        struct Out {
+            inner: GoStruct<Listy>,
+        }
+
+        assert_eq!(
+            String::from_utf8(
+                to_vec_marshal(&Out {
+                    inner: GoStruct(Listy {
+                        ids: Some(GoList(vec!["a".to_string()])),
+                    }),
+                })
+                .expect("encode")
+            )
+            .expect("utf-8"),
+            r#"{"inner":{"ids":["a"]}}"#
+        );
     }
 
     /// The half that must *not* change: `null` is a zero value, but a wrong

--- a/desktop/src-tauri/src/native/integrations.rs
+++ b/desktop/src-tauri/src/native/integrations.rs
@@ -580,8 +580,27 @@ struct CreateIntegrationRequest {
     #[serde(deserialize_with = "super::gojson::captured_raw")]
     credentials: Option<Box<RawValue>>,
     /// A `null` **value** is the zero `ServiceConfig` to Go, not an error
-    /// (#295) — the same rule `Capabilities.mcp` carries.
-    services: Option<super::gojson::GoMap<ServiceConfig>>,
+    /// (#295) — the same rule `Capabilities.mcp` carries, and [`GoStruct`] is
+    /// the same third rule (#337): `{"services":{"s":[true,null]}}` filled a
+    /// `ServiceConfig` positionally where Go answers 400.
+    services: Option<super::gojson::GoMap<super::gojson::GoStruct<ServiceConfig>>>,
+}
+
+/// Drop the [`super::gojson::GoStruct`] wrappers a decoded `services` map
+/// carries.
+///
+/// The wrapper is a **decode-time** rule and serializes as its inner value, so
+/// the stored bytes and the response bytes are the same either way. Peeling it
+/// here is what keeps `ScrubbedIntegration` — a response type — free of a
+/// request-side concern.
+fn unwrap_services(
+    services: super::gojson::GoMap<super::gojson::GoStruct<ServiceConfig>>,
+) -> std::collections::BTreeMap<String, ServiceConfig> {
+    services
+        .0
+        .into_iter()
+        .map(|(name, service)| (name, service.0))
+        .collect()
 }
 
 /// `handleCreateIntegration` → `integrationService.Create`.
@@ -616,7 +635,7 @@ fn create(db_path: &Path, body: &[u8]) -> Result<super::Answer, WriteError> {
     let now = super::gotime::now_go_text();
     // `if cfg.Services == nil { cfg.Services = make(...) }` — so an absent
     // `services` is stored and echoed as `{}`, never as `null`.
-    let services = req.services.unwrap_or_default();
+    let services = unwrap_services(req.services.unwrap_or_default());
     let services_json = super::gojson::to_vec_marshal(&services)
         .map_err(|e| WriteError::Fallback(format!("marshaling services: {e}")))?;
     let services_json = String::from_utf8(services_json)
@@ -651,7 +670,7 @@ fn create(db_path: &Path, body: &[u8]) -> Result<super::Answer, WriteError> {
         enabled: req.enabled,
         id,
         name: req.name,
-        services: Some(services.0),
+        services: Some(services),
         integration_type: req.integration_type,
         updated_at: parse_written(&now)?,
     };
@@ -681,7 +700,9 @@ struct UpdateIntegrationRequest {
     /// Go stores this column verbatim. See `writes::decode_body`.
     #[serde(deserialize_with = "super::gojson::captured_raw")]
     credentials: Option<Box<RawValue>>,
-    services: Option<super::gojson::GoMap<ServiceConfig>>,
+    /// Same two rules as the create side's: `null` value is the zero struct
+    /// (#295), and an array where a struct belongs is a 400 (#337).
+    services: Option<super::gojson::GoMap<super::gojson::GoStruct<ServiceConfig>>>,
 }
 
 /// `handleUpdateIntegration` → `integrationService.Update`, then
@@ -783,7 +804,7 @@ fn update(db_path: &Path, id: &str, body: &[u8]) -> Result<super::Answer, WriteE
         enabled: req.enabled,
         id: id.to_string(),
         name: req.name,
-        services: req.services.map(|services| services.0),
+        services: req.services.map(unwrap_services),
         integration_type: req.integration_type,
         updated_at: parse_written(&now)?,
     };
@@ -1584,8 +1605,18 @@ mod tests {
         // And a wrongly-typed value still fails, which is Go's answer too —
         // including the positional arrays that `#[serde(default)]` on `tools`
         // used to admit. Dropping that attribute (redundant once `tools` is a
-        // `GoList`) is what closes them.
-        for services in [r#"{"s":1}"#, r#"{"s":[]}"#, r#"{"s":[true]}"#] {
+        // `GoList`) is what closes the short ones; `GoStruct` (#337) closes the
+        // rest. `ServiceConfig` has one field without a default, so `[true]`
+        // was already refused and `[true,null]` — its full length — was the
+        // shape that got through and stored a row Go answers 400 to.
+        for services in [
+            r#"{"s":1}"#,
+            r#"{"s":[]}"#,
+            r#"{"s":[true]}"#,
+            r#"{"s":[true,null]}"#,
+            r#"{"s":[true,["send"]]}"#,
+            r#"{"s":[true,null,"extra"]}"#,
+        ] {
             let file = migrated();
             let body = format!(
                 r#"{{"name":"W","type":"telegram","credentials":{{"bot_token":"t"}},"services":{services}}}"#

--- a/desktop/src-tauri/src/native/notifications/mod.rs
+++ b/desktop/src-tauri/src/native/notifications/mod.rs
@@ -55,6 +55,7 @@ use axum::http::Method;
 use serde::{Deserialize, Serialize};
 
 use super::db;
+use super::gojson::GoStruct;
 use super::gotime::GoTime;
 use super::writes::{decode_body, finish, WriteError};
 
@@ -92,9 +93,15 @@ pub struct SmtpConfig {
 /// plain `bool` would not.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ScheduledTasksPreferences {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// **No `#[serde(default)]`**: a bare `Option` already gets `None` from
+    /// `missing_field`, so the attribute was redundant — and its one remaining
+    /// effect was to feed the derive's `visit_seq` arm, which is #337's shape.
+    /// Belt-and-braces now that [`GoStruct`] wraps this at its one use site, but
+    /// #336 is the precedent: an attribute left behind after its field became
+    /// self-sufficient does nothing except open that arm.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub on_finished: Option<bool>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub on_failed: Option<bool>,
 }
 
@@ -102,7 +109,7 @@ pub struct ScheduledTasksPreferences {
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NotificationPreferences {
     #[serde(default, deserialize_with = "super::gojson::null_is_zero_value")]
-    pub scheduled_tasks: ScheduledTasksPreferences,
+    pub scheduled_tasks: GoStruct<ScheduledTasksPreferences>,
 }
 
 /// Mirrors `notification.NotificationSettings`, the shape stored in
@@ -111,10 +118,17 @@ pub struct NotificationPreferences {
 pub struct NotificationSettings {
     #[serde(default, deserialize_with = "super::gojson::null_is_zero_value")]
     pub enabled: bool,
+    /// [`GoStruct`] because these two are the *worst* case of #337, not a
+    /// borderline one: every field of `SmtpConfig` and of
+    /// `ScheduledTasksPreferences` carries `#[serde(default)]` — each needs one,
+    /// since `deserialize_with` makes a field required — and the derive's
+    /// `visit_seq` arm errors only for a field *without* a default. So the
+    /// accepted array length was **zero and upwards**, and `{"provider":[]}` was
+    /// a saved SMTP configuration here and a 400 to Go.
     #[serde(default, deserialize_with = "super::gojson::null_is_zero_value")]
-    pub provider: SmtpConfig,
+    pub provider: GoStruct<SmtpConfig>,
     #[serde(default, deserialize_with = "super::gojson::null_is_zero_value")]
-    pub preferences: NotificationPreferences,
+    pub preferences: GoStruct<NotificationPreferences>,
 }
 
 /// `service.maskedFieldSentinel`. Also what `PUT` reads back as "unchanged", so
@@ -263,7 +277,7 @@ fn update_settings(db_path: &Path, body: &[u8]) -> Result<super::Answer, WriteEr
     if incoming.provider.password == MASKED_FIELD_SENTINEL {
         let stored = decode_settings(&super::settings::load_stored(&conn).notification_settings)
             .map_err(|e| WriteError::Fallback(format!("loading existing settings: {e}")))?;
-        incoming.provider.password = stored.provider.password;
+        incoming.provider.password = stored.provider.0.password;
     }
 
     // `json.Marshal`, not the response encoder: this string is stored and read
@@ -499,7 +513,7 @@ mod tests {
             assert_eq!(settings.provider.port, 0, "{raw}");
             assert_eq!(
                 settings.preferences,
-                NotificationPreferences::default(),
+                GoStruct(NotificationPreferences::default()),
                 "{raw}"
             );
         }
@@ -680,6 +694,51 @@ mod tests {
 
         // …while the column holds the real one.
         assert!(stored_json(&file).contains(r#""password":"hunter2""#));
+    }
+
+    /// #337 on this route, which is the **worst** instance of it in the write
+    /// surface rather than a marginal one.
+    ///
+    /// Every field of `SmtpConfig` and of `ScheduledTasksPreferences` carries
+    /// `#[serde(default)]` — each needs one, since `deserialize_with` makes a
+    /// field required — and the derive's `visit_seq` arm errors only for a field
+    /// *without* a default. So the accepted array length was **zero and
+    /// upwards**: `{"provider":[]}` saved an SMTP configuration where Go answers
+    /// `cannot unmarshal array into Go struct field`.
+    #[test]
+    fn saving_settings_refuses_an_array_where_a_struct_belongs() {
+        for body in [
+            &br#"{"provider":[]}"#[..],
+            &br#"{"provider":["smtp.example.com",587]}"#[..],
+            &br#"{"preferences":[]}"#[..],
+            &br#"{"preferences":{"scheduled_tasks":[]}}"#[..],
+            &br#"{"preferences":{"scheduled_tasks":[true,false]}}"#[..],
+        ] {
+            let file = migrated();
+            let err = update_settings(file.path(), body).unwrap_err();
+            assert_eq!(
+                err.status(),
+                axum::http::StatusCode::BAD_REQUEST,
+                "{}",
+                String::from_utf8_lossy(body)
+            );
+            // Nothing was written: an over-accept only matters for the row it
+            // leaves behind.
+            assert!(
+                !stored_json(&file).contains("smtp.example.com"),
+                "{}",
+                String::from_utf8_lossy(body)
+            );
+        }
+
+        // The object forms all still save, including the `null`s #295 covers —
+        // the check is about the array shape and nothing else.
+        let file = migrated();
+        update_settings(
+            file.path(),
+            br#"{"enabled":true,"provider":null,"preferences":{"scheduled_tasks":null}}"#,
+        )
+        .expect("nulls are zero values, not arrays");
     }
 
     /// The sentinel round-trip. The UI never holds the real password, so a save

--- a/desktop/src-tauri/src/native/writes.rs
+++ b/desktop/src-tauri/src/native/writes.rs
@@ -184,6 +184,46 @@ pub fn finish(result: Result<super::Answer, WriteError>) -> Result<super::Answer
 ///   — a 422, not a 400. serde would reject it outright.
 ///
 /// Everything else — a number, a string, `true` — is a decode error in both.
+///
+/// # The same shape one level down (#337)
+///
+/// The array check above is at the **body** level and nothing here can reach
+/// inside one: `T` is opaque, and a recursive walk of the parsed `Value` would
+/// have to know which subtrees are structs and which are genuinely arrays, which
+/// is exactly the information the type carries and the `Value` does not. So the
+/// nested rule lives on the types, as [`super::gojson::GoStruct`], and this
+/// table is what makes "every write body" auditable rather than asserted. A
+/// partial check reads as coverage it does not have.
+///
+/// Every request body that reaches a typed decode, and what in it is a nested
+/// struct:
+///
+/// | body | nested struct | wrapped |
+/// |---|---|---|
+/// | `agents::AgentRequest` | `capabilities`, and `Capabilities.mcp`'s values | yes |
+/// | `integrations::CreateIntegrationRequest` | `services`' values | yes |
+/// | `integrations::UpdateIntegrationRequest` | `services`' values | yes |
+/// | `notifications::NotificationSettings` | `provider`, `preferences`, `NotificationPreferences.scheduled_tasks` | yes |
+/// | `integrations::TriggerRuleRequest` | — (two `GoList<String>`) | n/a |
+/// | `chats::CreateChatRequest`, `chats::PatchChatRequest` | — | n/a |
+/// | `chats::BulkDeleteRequest`, `tasks::BulkDeleteRequest` | — (`GoList<String>`) | n/a |
+/// | `pricing::RateRequest` | — (the bands are not expressible in a request) | n/a |
+/// | `sessions::update::UpdateRequest` | — | n/a |
+/// | `fs::MkdirRequest` | — | n/a |
+/// | `chat::{SendMessageRequest, ProvideInputRequest, PermissionRequestBody}` | — | n/a |
+/// | `claude_settings::profiles::{CreateRequest, UpdateRequest}` | — (`settings` is a `RawValue`, as Go's is) | n/a |
+/// | `settings::UserSettings` | — | route is `deferred` (#305) |
+///
+/// Two bodies deliberately have no struct at all and so no row here:
+/// `PUT /api/claude-settings` decodes into Go's `any` (`claude_settings::go_any`),
+/// and `POST /api/uploads` is multipart.
+///
+/// `settings::UserSettings` is the one row worth a caveat: it needs no wrapper
+/// because it holds no nested struct, but its `hidden_projects` and
+/// `claude_config_dirs` are plain `Vec<String>` rather than
+/// [`super::gojson::GoList`], so `[null]` is an over-*reject* there. That is
+/// #295's rule rather than this one, and the route still forwards, so it is
+/// recorded rather than changed.
 pub fn decode_body<T: serde::de::DeserializeOwned>(body: &[u8]) -> Result<T, WriteError> {
     if body.is_empty() {
         return Err(WriteError::InvalidBody);


### PR DESCRIPTION
## What

`serde` builds a struct from a JSON *array*, positionally, and Go does not. `writes::decode_body` guards that at the **body** level — #274 added the object check because `POST /api/agents` with `["My Agent"]` would otherwise have created an agent — but nothing checked a value *inside* the body.

## Why this one matters

Every other decode divergence in the port has been an over-**reject**: a request Go applies is refused, which is visible and safe, and which `Err`-means-forward turns into Go's own answer. This one is an over-**accept** — it writes a row Go refuses, so the two implementations' databases diverge with nothing to report it, and the fallback cannot help because nothing errors.

## The accepted set was not uniform

Which is what made it hard to reason about. The derive's `visit_seq` errors only when the array runs out of elements for a field with **no** default, so a struct accepted exactly "as many elements as it has fields without a default":

| struct | fields without a default | shortest array accepted | Go |
|---|---|---|---|
| `Capabilities` | 3 | `[["Read"],null,null]` | 400 |
| `McpCapability` | 1 | `[null]` | 400 |
| `ServiceConfig` | 1 (since #336) | `[true,null]` | 400 |
| `SmtpConfig` | **0** | `[]` | 400 |
| `ScheduledTasksPreferences` | **0** | `[]` | 400 |

The last two are the worst instances and were not in the issue's table: every field of `SmtpConfig` and `ScheduledTasksPreferences` carries `#[serde(default)]` — each *needs* one, since `deserialize_with` makes a field required — so the accepted array length was **zero and upwards**. `PUT /api/notifications/settings` with `{"provider":[]}` saved an SMTP configuration where Go answers `cannot unmarshal array into Go struct field`.

## How

`gojson::GoStruct<T>`, the issue's option 1 — a **type**, not a `deserialize_with`, for the reason #336 proved again: the derive makes a field carrying `deserialize_with` *required*, so every call site must add `#[serde(default)]`, and that attribute is exactly what opens the `visit_seq` arm. A fix applied to the field would widen the hole it was closing.

`deserialize_map` is the whole mechanism: `serde_json` answers it with `invalid type: sequence` for anything that is not `{`, and the visitor hands the `MapAccess` to `T`'s own derived impl, so the inner struct's strictness, field names and `deserialize_with` rules are untouched.

Three properties it must not disturb, all asserted:

- **It is a newtype, so it serializes as its inner value and no response byte moves.** Load-bearing rather than incidental — `Capabilities` and `NotificationSettings` are request *and* response types.
- **`null` and "missing" are decided one level out**, by `Option`, so neither reaches the visitor.
- **`GoMap<GoStruct<T>>` still maps a `null` value to the zero struct** — #295's rule, unchanged.

**A field cannot protect itself, so the wrapper goes on the holder**: `AgentRequest.capabilities`, `Capabilities.mcp`'s values, `{Create,Update}IntegrationRequest.services`' values, `NotificationSettings.{provider,preferences}`, `NotificationPreferences.scheduled_tasks`. The stored `capabilities` column is read through it too, so a row neither implementation can write is refused rather than read as a real allowlist.

### First, the redundant attributes

As the issue asks. `ScheduledTasksPreferences`' two `#[serde(default)]` are gone: a bare `Option` already gets `None` from `missing_field`, so they were redundant, and their one remaining effect was to feed the `visit_seq` arm. That is #336's lesson applied to the last site that still had it.

### Then, the enumeration

"The check is only worth having where it is complete, and a partial one reads as coverage it does not have." `writes::decode_body`'s doc now carries the **whole table** of request bodies that reach a typed decode and which of them hold a nested struct. Two bodies deliberately have no struct at all (`PUT /api/claude-settings` decodes into Go's `any`; `POST /api/uploads` is multipart), and one row carries a caveat rather than a change:

> `settings::UserSettings` needs no wrapper — it holds no nested struct — but its `hidden_projects` and `claude_config_dirs` are plain `Vec<String>` rather than `GoList`, so `[null]` is an over-*reject* there. That is #295's rule rather than this one, and the route still forwards (#305), so it is recorded rather than fixed here.

## Tests

- **The pin is inverted, not deleted**, on both sides: `agents.rs`'s stored-column case, and `gojson.rs`'s. The latter's second half still asserts that an **unwrapped** struct *is* built from a sequence — which is not a wish, it is what makes "the rule lives on the holder" concrete and would catch someone moving the wrapper onto the struct instead.
- **Per write route**, as the acceptance asks: `POST`/`PUT /api/agents`, `POST /api/integrations`, `PUT /api/notifications/settings`. Each asserts the 400 **and** that no row was written — an over-accept is only interesting because of the row it leaves behind — at the struct's exact length and past it.
- **Genuine arrays are unaffected**: `built_in`, `local`, `mcp.*.tools` and the integration `tools` still decode, which a blunt "refuse arrays" fix would have broken.
- **#295's null behaviour is unchanged**, re-asserted at every depth including a `null` map value inside a wrapped struct.
- `GoStruct`'s own unit tests cover the object/missing/null/scalar/array matrix and the transparent serialization.

## Quality

`cargo fmt --check` pass · `cargo clippy --all-targets -D warnings` pass · `cargo test` green (765 unit, 0 failures).

Closes #337