### PR TITLE
feat(desktop): emit the service-layer log lines for the subsystems already ported (#335)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -2239,36 +2239,65 @@ line per `/api` request, emitted at the seam** in `proxy.rs::handle`: method,
 path, status, elapsed ms, and which implementation answered (`native`,
 `native-stream`, `forwarded`, `native-failed-forwarded`, `diff`).
 
-**Be precise about which Go log that is, because the gap is permanent and will
-otherwise be filed as a regression.** What is reproduced is Go's
+**Be precise about which Go log that is.** What is reproduced there is Go's
 `requestLogger` (`internal/server/server.go`) — method, path, status, duration —
 which Go writes at **debug for every method**, and which the seam promotes to
 info for the requests worth keeping. Go's *service-layer* `Info` lines are a
-different animal and are **not** reproduced: `integration_service.go` writes
-`"integration created", "id", …, "name", …`, `chat_service.go` writes
-`"chat sessions bulk deleted", "count", …`. `POST /api/integrations 201 12ms
-native` carries neither the entity nor the outcome, and no access line can say
-how many chats a bulk delete took. The seam sees a *request*, not an operation.
-Worse for coverage, the background `Info` lines have no request behind them at
-all — `scheduler.go`'s `"task scheduled"`, `executor.go`'s
+different animal and **could not be reproduced at the seam**: `POST
+/api/integrations 201 12ms native` carries neither the entity nor the outcome,
+and no access line can say how many chats a bulk delete took. The seam sees a
+*request*, not an operation.
+
+**#335 added them at the call sites, for the subsystems that are native today.**
+Sixteen lines, mirroring their Go counterpart's message and keys: the agent CRUD
+(#274), the chat CRUD and the turn's five (#276), the two job-history deletes
+(#274), `POST /api/integrations` plus the `{id}` writes and the three
+trigger-rule writes (#277, #347), and `POST /api/uploads` (#308).
+`writes::service_log_convention` is the rule — `message key=value`, every string
+value `{:?}`, `info` and **after** the effect — and it is a doc rather than a
+helper because the alternative is the rule restated sixteen times. Each line has
+a test: a `log` sink the write tests assert against
+(`writes::testlog`, and a second copy in `tests/chat_turn.rs`, which is a
+different crate), because a line with no test is a line that quietly stops being
+emitted — which for this half is the whole failure mode.
+
+Two of them carry user-authored text the access line does not, and both are
+deliberate on the same terms the agent slug in the path already is:
+`integration created … name=`, because a line that cannot say which integration
+was created is most of what it is for, and `file uploaded path=`, which is the
+*generated* destination under the uploads dir and which the response body
+returns anyway. Nothing logs a credential, a prompt or a message body.
+
+**What is still missing is missing by construction, and the list is the point.**
+The background `Info` lines have no request behind them at all —
+`scheduler.go`'s `"task scheduled"`, `executor.go`'s
 `"task execution completed"`, `trigger/dispatcher.go`'s `"trigger rule matched"`,
-and the notification handler's — so the seam cannot reach them by construction.
-They come from the sidecar today; when #278 removes it they will need their own
-call sites in the Rust code that replaced them, and that is a piece of work
-nobody has scheduled. Go's line also carries a `request_id`, which is the thing
+and the notification handler's — and they belong to subsystems the sidecar still
+owns, so a line here would log an event this process did not cause. The five
+`… validated` lines in `integration_service.go` belong to `ValidateTokenAuth`,
+i.e. the deferred `auth/*` routes; `PUT /api/settings`'s two are deferred with it
+(#305). They come from the sidecar today; **#278 is when this stops being
+optional**, because until then the sidecar still emits its own lines for what it
+still serves. That is why these land per subsystem as it is ported rather than as
+one pass. Go's line also carries a `request_id`, which is the thing
 that would let a `forwarded` line be matched against the sidecar's own record of
 the same request. Correlation is deliberately not attempted: it would mean
 minting an id here and threading a header through the forward, for a pairing
 only useful while both halves are running.
 
-At the seam and not in the handlers, for the reason the whole issue exists.
-`handle` is the one point every `/api` request passes through whether Rust,
-Go or a fallback answers it, so the record covers claimed and unclaimed routes
-alike and **cannot go selectively sparse as the port advances** — a line per
-handler would be fifteen edits that drift, and the sixteenth port would forget
-one. It is the same shape Go got from wrapping the router in `otelhttp` rather
-than instrumenting each handler. `dispatch` exists only so that the eight-odd
-return paths do not each need their own log call.
+**The access line is at the seam and not in the handlers, for the reason the
+whole issue exists.** `handle` is the one point every `/api` request passes
+through whether Rust, Go or a fallback answers it, so the record covers claimed
+and unclaimed routes alike and **cannot go selectively sparse as the port
+advances** — a line per handler would be fifteen edits that drift, and the
+sixteenth port would forget one. It is the same shape Go got from wrapping the
+router in `otelhttp` rather than instrumenting each handler. `dispatch` exists
+only so that the eight-odd return paths do not each need their own log call.
+
+The #335 lines are the ones that *have* to be per handler, and they accept that
+cost knowingly: only the handler knows the entity and the outcome, so there is no
+seam to put them at. Their protection against going sparse is a test per line
+rather than a single call site.
 
 Two rules there are deliberate and must survive anyone "improving" it:
 

--- a/desktop/src-tauri/src/native/agents.rs
+++ b/desktop/src-tauri/src/native/agents.rs
@@ -337,6 +337,9 @@ fn create(db_path: &Path, body: &[u8]) -> Result<super::Answer, WriteError> {
     let answer = encode(StatusCode::CREATED, &agent)?;
     tx.commit()
         .map_err(|e| WriteError::Fallback(format!("commit agent create: {e}")))?;
+    // `agentService.Create`'s own line, after the store call as Go's is — see
+    // `writes::service_log_convention`.
+    log::info!("agent created slug={:?}", agent.slug);
     Ok(answer)
 }
 
@@ -377,6 +380,7 @@ fn update(db_path: &Path, slug: &str, body: &[u8]) -> Result<super::Answer, Writ
     let answer = encode(StatusCode::OK, &agent)?;
     tx.commit()
         .map_err(|e| WriteError::Fallback(format!("commit agent update: {e}")))?;
+    log::info!("agent updated slug={slug:?}");
     Ok(answer)
 }
 
@@ -391,6 +395,7 @@ fn delete(db_path: &Path, slug: &str) -> Result<super::Answer, WriteError> {
         // its own 500, which is the behaviour the app has today.
         return Err(WriteError::Fallback(format!("agent {slug:?} not found")));
     }
+    log::info!("agent deleted slug={slug:?}");
     Ok(super::Answer::no_content())
 }
 
@@ -1091,5 +1096,28 @@ mod tests {
         assert!(!claims(&Method::PUT, "/api/agents"));
         assert!(!claims(&Method::DELETE, "/api/agents"));
         assert!(!claims(&Method::PATCH, "/api/agents/my-agent"));
+    }
+
+    /// #335: the access line says a `POST /api/agents` happened; only the
+    /// handler knows which agent. A line with no test is a line that quietly
+    /// stops being emitted, which for this half of #301 is the whole failure
+    /// mode.
+    #[test]
+    fn the_agent_writes_log_their_entity_and_outcome() {
+        crate::native::writes::testlog::install();
+        let file = migrated();
+
+        create(
+            file.path(),
+            br#"{"name":"Logged Agent","slug":"logged-agent"}"#,
+        )
+        .expect("create");
+        crate::native::writes::testlog::assert_info_once(r#"agent created slug="logged-agent""#);
+
+        update(file.path(), "logged-agent", br#"{"name":"Logged Agent 2"}"#).expect("update");
+        crate::native::writes::testlog::assert_info_once(r#"agent updated slug="logged-agent""#);
+
+        delete(file.path(), "logged-agent").expect("delete");
+        crate::native::writes::testlog::assert_info_once(r#"agent deleted slug="logged-agent""#);
     }
 }

--- a/desktop/src-tauri/src/native/chat/turn.rs
+++ b/desktop/src-tauri/src/native/chat/turn.rs
@@ -189,6 +189,10 @@ pub async fn run(
         session.close();
         return Err(format!("sending first message: {e}"));
     }
+    // `chatService.BeginMessage`'s own line, after `agent.StartSession` returns
+    // as Go's is — the subprocess exists and the first message reached it. See
+    // `writes::service_log_convention`.
+    log::info!("agent session started session_id={chat_id:?}");
 
     registry().put(
         &chat_id,
@@ -202,7 +206,7 @@ pub async fn run(
     let is_first_message = row.title == "New Chat";
 
     tokio::spawn(async move {
-        let state = stream_events(&mut session, notify_rx, &body_tx, &answers).await;
+        let state = stream_events(&mut session, &chat_id, notify_rx, &body_tx, &answers).await;
 
         // Go's defer order: forget the live session — which also releases the
         // busy lock — then close the subprocess.
@@ -227,8 +231,16 @@ pub async fn run(
         // The commit is detached from the request on purpose, so a client that
         // disconnected mid-stream still has its turn persisted. Errors are
         // logged and never surfaced — the stream has already ended.
-        if let Err(e) = super::persist::commit(&db_path, &row, &content, &state, is_first_message) {
-            log::error!("commit message failed for chat {chat_id}: {e}");
+        match super::persist::commit(&db_path, &row, &content, &state, is_first_message) {
+            // `chatService.CommitMessage`'s line, after the session update as
+            // Go's is. The id is the turn's own rather than the resolved
+            // fallback, which is what Go's caller passes.
+            Ok(()) => log::info!(
+                "message committed session_id={:?} sdk_session_id={:?}",
+                chat_id,
+                state.sdk_session_id
+            ),
+            Err(e) => log::error!("commit message failed for chat {chat_id}: {e}"),
         }
     });
 
@@ -370,6 +382,7 @@ fn empty_object() -> Box<RawValue> {
 /// The event loop. Returns what the turn accumulated.
 async fn stream_events(
     session: &mut Session,
+    chat_id: &str,
     mut notify_rx: mpsc::Receiver<Notify>,
     out: &mpsc::Sender<Result<Vec<u8>, std::io::Error>>,
     answers: &Arc<Answers>,
@@ -389,7 +402,7 @@ async fn stream_events(
                     // The client hung up; the commit still runs.
                     return state;
                 }
-                match handle_event(session, &event, &mut state, &mut pending_input, out, answers).await {
+                match handle_event(session, chat_id, &event, &mut state, &mut pending_input, out, answers).await {
                     Flow::Continue => {}
                     Flow::Stop => return state,
                 }
@@ -444,6 +457,7 @@ async fn forward_event(event: &Event, out: &mpsc::Sender<Result<Vec<u8>, std::io
 
 async fn handle_event(
     session: &Session,
+    chat_id: &str,
     event: &Event,
     state: &mut TurnState,
     pending_input: &mut Option<Box<RawValue>>,
@@ -456,6 +470,7 @@ async fn handle_event(
                 super::persist::append_assistant_blocks(&mut state.blocks, raw.get().as_bytes());
                 if let Some(input) = extract_ask_user_question(raw.get().as_bytes()) {
                     *pending_input = Some(input);
+                    log::info!("AskUserQuestion detected in stream session_id={chat_id:?}");
                 }
             }
             Flow::Continue
@@ -488,6 +503,12 @@ async fn handle_event(
             // ask, wait, and continue the **same** subprocess into another turn.
             // This is why one HTTP request can span several turns, and why the
             // loop must never treat `result` as terminal.
+            //
+            // `handlePendingUserInput`'s two lines bracket the wait, and only
+            // this path has them: the `Notify::Question` arm above is the
+            // *permission-handler* route to the same frame, which Go does not
+            // log either.
+            log::info!("sending user_input_required, waiting for answer session_id={chat_id:?}");
             match sse::json_frame("user_input_required", &UserInputRequired { input: &input }) {
                 Ok(bytes) => {
                     if out.send(Ok(bytes)).await.is_err() {
@@ -515,6 +536,7 @@ async fn handle_event(
             let Some(answer) = answer else {
                 return Flow::Stop;
             };
+            log::info!("received user answer, resuming session session_id={chat_id:?}");
             if let Err(e) = session.send(&answer).await {
                 log::error!("injecting the answer failed: {e}");
                 return Flow::Stop;

--- a/desktop/src-tauri/src/native/chats.rs
+++ b/desktop/src-tauri/src/native/chats.rs
@@ -427,6 +427,14 @@ fn create(db_path: &Path, body: &[u8]) -> Result<super::Answer, WriteError> {
     // Nothing below this line may return `Fallback`.
     tx.commit()
         .map_err(|e| WriteError::Fallback(format!("commit chat create: {e}")))?;
+    // `chatService.CreateSession`'s own line, with its three keys in Go's order
+    // — see `writes::service_log_convention`.
+    log::info!(
+        "chat session created session_id={:?} agent_slug={:?} settings_profile_id={:?}",
+        session.id,
+        req.agent_slug,
+        req.settings_profile_id
+    );
     Ok(super::Answer::json_status(StatusCode::CREATED, body))
 }
 
@@ -591,6 +599,7 @@ fn delete_one(db_path: &Path, id: &str) -> Result<super::Answer, WriteError> {
     if affected == 0 {
         return Err(WriteError::Fallback(format!("session {id:?} not found")));
     }
+    log::info!("chat session deleted session_id={id:?}");
     Ok(super::Answer::no_content())
 }
 
@@ -614,6 +623,10 @@ fn bulk_delete(db_path: &Path, body: &[u8]) -> Result<super::Answer, WriteError>
     conn.execute(&sql, rusqlite::params_from_iter(ids.iter()))
         .map_err(|e| WriteError::Fallback(format!("bulk deleting sessions: {e}")))?;
 
+    // Go's `count` is `len(ids)` — what was asked for, not what matched. An id
+    // that exists nowhere is not an error on this route, so the two numbers
+    // differ routinely and the line reports the request rather than the effect.
+    log::info!("chat sessions bulk deleted count={}", ids.len());
     Ok(super::Answer::no_content())
 }
 
@@ -1180,5 +1193,32 @@ mod tests {
         assert!(!claims(&Method::POST, "/api/chats/abc/permission"));
         assert!(!claims(&Method::POST, "/api/chats/abc/stop"));
         assert!(!claims(&Method::PATCH, "/api/chats"));
+    }
+
+    /// #335: the chat CRUD's own lines. `chat sessions bulk deleted count=` is
+    /// the clearest case for why the access line is not enough — `DELETE
+    /// /api/chats 204` cannot say how many.
+    #[test]
+    fn the_chat_writes_log_their_entity_and_outcome() {
+        crate::native::writes::testlog::install();
+        let file = migrated();
+
+        let id = created_id(&create(file.path(), b"{}").expect("create"));
+        crate::native::writes::testlog::assert_info_once(&format!(
+            r#"chat session created session_id="{id}" agent_slug="" settings_profile_id="""#
+        ));
+
+        delete_one(file.path(), &id).expect("delete");
+        crate::native::writes::testlog::assert_info_once(&format!(
+            r#"chat session deleted session_id="{id}""#
+        ));
+
+        let a = created_id(&create(file.path(), b"{}").expect("a"));
+        let b = created_id(&create(file.path(), b"{}").expect("b"));
+        // Three ids, two of which exist: Go's `count` is `len(ids)`, so the line
+        // reports what was asked for rather than what matched.
+        let payload = format!(r#"{{"ids":["{a}","{b}","never-existed"]}}"#);
+        bulk_delete(file.path(), payload.as_bytes()).expect("bulk");
+        crate::native::writes::testlog::assert_info_present("chat sessions bulk deleted count=3");
     }
 }

--- a/desktop/src-tauri/src/native/integrations.rs
+++ b/desktop/src-tauri/src/native/integrations.rs
@@ -674,6 +674,14 @@ fn create(db_path: &Path, body: &[u8]) -> Result<super::Answer, WriteError> {
         integration_type: req.integration_type,
         updated_at: parse_written(&now)?,
     };
+    // `integrationService.Create`'s own line. `name` is user-authored text the
+    // access line does not carry, and that is deliberate — see
+    // `writes::service_log_convention`.
+    log::info!(
+        "integration created id={:?} name={:?}",
+        created.id,
+        created.name
+    );
     encode_created(&created)
 }
 
@@ -810,6 +818,7 @@ fn update(db_path: &Path, id: &str, body: &[u8]) -> Result<super::Answer, WriteE
     };
     let body = super::gojson::to_vec(&updated)
         .map_err(|e| WriteError::Fallback(format!("encoding integration: {e}")))?;
+    log::info!("integration updated id={id:?}");
     Ok(super::Answer::json(body))
 }
 
@@ -836,6 +845,7 @@ fn delete(db_path: &Path, id: &str) -> Result<super::Answer, WriteError> {
 
     conn.execute("DELETE FROM integrations WHERE id = ?1", [id])
         .map_err(|e| WriteError::Fallback(format!("deleting integration: {e}")))?;
+    log::info!("integration deleted id={id:?}");
     Ok(super::Answer::no_content())
 }
 
@@ -961,6 +971,11 @@ fn create_trigger_rule(
         updated_at: stamp,
     };
     insert_rule(&conn, &rule, &now)?;
+    log::info!(
+        "trigger rule created id={:?} integration_id={:?}",
+        rule.id,
+        rule.integration_id
+    );
     encode_created(&rule)
 }
 
@@ -1027,6 +1042,7 @@ fn update_trigger_rule(
 
     let body = super::gojson::to_vec(&rule)
         .map_err(|e| WriteError::Fallback(format!("encoding trigger rule: {e}")))?;
+    log::info!("trigger rule updated id={rule_id:?}");
     Ok(super::Answer::json(body))
 }
 
@@ -1045,6 +1061,7 @@ fn delete_trigger_rule(
     }
     conn.execute("DELETE FROM trigger_rules WHERE id = ?1", [rule_id])
         .map_err(|e| WriteError::Fallback(format!("deleting trigger rule: {e}")))?;
+    log::info!("trigger rule deleted id={rule_id:?}");
     Ok(super::Answer::no_content())
 }
 
@@ -2138,5 +2155,67 @@ mod tests {
             "{}",
             err.message()
         );
+    }
+
+    /// #335: the integration and trigger-rule writes' own lines.
+    ///
+    /// `integration created … name=` is the one line here that carries
+    /// user-authored text the access line does not, and it is deliberate — a
+    /// line that cannot say which integration was created is most of what it is
+    /// for. See `writes::service_log_convention`.
+    #[test]
+    fn the_integration_writes_log_their_entity_and_outcome() {
+        crate::native::writes::testlog::install();
+        let file = migrated();
+
+        create(
+            file.path(),
+            br#"{"name":"Logged Bot","type":"telegram","credentials":{"bot_token":"t"}}"#,
+        )
+        .expect("create");
+        let created = crate::native::writes::testlog::matching(r#"name="Logged Bot""#);
+        assert_eq!(created.len(), 1, "{created:?}");
+        assert!(
+            created[0].starts_with("INFO integration created id=\""),
+            "{}",
+            created[0]
+        );
+
+        seed_full_integration(&file, "logged-int", None);
+        update(
+            file.path(),
+            "logged-int",
+            br#"{"name":"N","type":"github"}"#,
+        )
+        .expect("update");
+        crate::native::writes::testlog::assert_info_once(r#"integration updated id="logged-int""#);
+
+        delete(file.path(), "logged-int").expect("delete");
+        crate::native::writes::testlog::assert_info_once(r#"integration deleted id="logged-int""#);
+    }
+
+    /// The trigger-rule half, whose create line carries both ids as Go's does.
+    #[test]
+    fn the_trigger_rule_writes_log_their_entity_and_outcome() {
+        crate::native::writes::testlog::install();
+        let file = migrated();
+        seed_integration(&file, "rule-int");
+
+        create_trigger_rule(file.path(), "rule-int", br#"{"agent_slug":"a"}"#).expect("create");
+        let id = stored(&file, "SELECT id FROM trigger_rules");
+        crate::native::writes::testlog::assert_info_once(&format!(
+            r#"trigger rule created id="{id}" integration_id="rule-int""#
+        ));
+
+        update_trigger_rule(file.path(), "rule-int", &id, br#"{"agent_slug":"b"}"#)
+            .expect("update");
+        crate::native::writes::testlog::assert_info_once(&format!(
+            r#"trigger rule updated id="{id}""#
+        ));
+
+        delete_trigger_rule(file.path(), "rule-int", &id).expect("delete");
+        crate::native::writes::testlog::assert_info_once(&format!(
+            r#"trigger rule deleted id="{id}""#
+        ));
     }
 }

--- a/desktop/src-tauri/src/native/tasks.rs
+++ b/desktop/src-tauri/src/native/tasks.rs
@@ -517,6 +517,7 @@ fn delete_job_history(db_path: &Path, id: &str) -> Result<super::Answer, WriteEr
     tx.commit()
         .map_err(|e| WriteError::Fallback(format!("commit job history delete: {e}")))?;
 
+    log::info!("job history deleted id={id:?}");
     Ok(super::Answer::no_content())
 }
 
@@ -539,6 +540,8 @@ fn bulk_delete_job_history(db_path: &Path, body: &[u8]) -> Result<super::Answer,
     conn.execute(&sql, rusqlite::params_from_iter(ids.iter()))
         .map_err(|e| WriteError::Fallback(format!("bulk deleting job history: {e}")))?;
 
+    // `len(ids)`, as Go's is: what was asked for rather than what matched.
+    log::info!("job history bulk deleted count={}", ids.len());
     Ok(super::Answer::no_content())
 }
 
@@ -942,5 +945,18 @@ mod tests {
         assert!(!claims(&Method::POST, "/api/tasks/t1/pause"));
         assert!(!claims(&Method::POST, "/api/tasks/t1/resume"));
         assert!(!claims(&Method::DELETE, "/api/tasks/t1/job-history"));
+    }
+
+    /// #335: the two job-history deletes, which are all this module claims.
+    #[test]
+    fn the_job_history_deletes_log_their_entity_and_outcome() {
+        crate::native::writes::testlog::install();
+        let file = migrated_with_history();
+
+        delete_job_history(file.path(), "j1").expect("delete");
+        crate::native::writes::testlog::assert_info_once(r#"job history deleted id="j1""#);
+
+        bulk_delete_job_history(file.path(), br#"{"ids":["j2","j3"]}"#).expect("bulk");
+        crate::native::writes::testlog::assert_info_present("job history bulk deleted count=2");
     }
 }

--- a/desktop/src-tauri/src/native/uploads.rs
+++ b/desktop/src-tauri/src/native/uploads.rs
@@ -129,6 +129,17 @@ fn upload(content_type: &str, body: &[u8], upload_dir: &Path) -> Result<super::A
     })?;
 
     // Nothing below this line may fail.
+    //
+    // `handleUpload`'s own line, with Go's three keys. `path` is the generated
+    // destination under the uploads dir rather than the name the user typed,
+    // and the response body returns it anyway — see
+    // `writes::service_log_convention`.
+    log::info!(
+        "file uploaded path={:?} size={} extension={:?}",
+        dest,
+        part.content.len(),
+        ext
+    );
     Ok(super::Answer::json(answer))
 }
 
@@ -612,5 +623,29 @@ mod tests {
         assert!(!claims(&Method::GET, "/api/uploads"));
         assert!(!claims(&Method::POST, "/api/uploads/"));
         assert!(!claims(&Method::POST, "/api/upload"));
+    }
+
+    /// #335: `handleUpload`'s own line. The path is the generated destination
+    /// under the uploads dir, which the response body returns anyway.
+    #[test]
+    fn an_upload_logs_its_path_size_and_extension() {
+        crate::native::writes::testlog::install();
+        let dir = dir();
+        let target = dir.path().join("logged-uploads");
+        upload(
+            &content_type(),
+            &body(&[("file", Some("photo.PNG"), b"\x89PNG\r\n\x1a\ndata")]),
+            &target,
+        )
+        .expect("upload");
+
+        let found = crate::native::writes::testlog::matching("file uploaded path=");
+        let line = found
+            .iter()
+            .find(|line| line.contains("logged-uploads"))
+            .unwrap_or_else(|| panic!("no line for this upload: {found:?}"));
+        assert!(line.starts_with("INFO "), "{line}");
+        assert!(line.contains(r#"extension=".PNG""#), "{line}");
+        assert!(line.contains("size=12"), "{line}");
     }
 }

--- a/desktop/src-tauri/src/native/writes.rs
+++ b/desktop/src-tauri/src/native/writes.rs
@@ -275,6 +275,149 @@ pub fn decode_body<T: serde::de::DeserializeOwned>(body: &[u8]) -> Result<T, Wri
     }
 }
 
+// ─── The service-layer log lines (#335) ───────────────────────────────────────
+
+/// The convention every service-layer log line in `native/` follows.
+///
+/// Nothing calls this; it exists so the rule has one address that a call site
+/// can link to, the way the endpoint registry documents the seam. The
+/// alternative — the rule restated at fifteen call sites — is what #301's own
+/// argument against per-handler logging is about.
+///
+/// #301 ported Go's `requestLogger` — one access line per `/api` request, at the
+/// seam, so it cannot go selectively sparse as routes move. It deliberately
+/// stopped there, and #335 is the other half: **an access line carries neither
+/// the entity nor the outcome.** `POST /api/integrations 201 12ms native` does
+/// not say which integration, under what name; `DELETE /api/chats 204 3ms
+/// native` cannot say how many sessions a bulk delete took. Only the handler
+/// knows, so unlike the access line these *have* to live at the call sites — and
+/// that is why they land **per subsystem, as its Go counterpart is ported**
+/// rather than as one pass. A line for a service the sidecar still answers would
+/// log an event this process did not cause.
+///
+/// Four rules, so fifteen call sites read as one record:
+///
+/// 1. **`message key=value …`, mirroring Go's `slog` call**, with the same
+///    message string and the same keys in the same order. The message is what a
+///    reader greps for, and a renamed one silently reworded every historical
+///    line.
+/// 2. **Every string value is `{:?}`; numbers are `{}`.** Go's `slog` quotes only
+///    when it must, but half of these values are user-authored — an integration
+///    name, an upload's filename — and one containing a space or an `=` makes an
+///    unquoted line unparseable. Quoting always is the only rule that does not
+///    depend on the value.
+/// 3. **`info`, and after the effect.** The seam's split is failures at `warn`,
+///    writes at `info`, successful reads at `debug`; these are all writes. Go
+///    logs after the store call returns, so a line means it happened — logging
+///    before the commit would announce a write a rollback then discarded.
+/// 4. **The `#301` privacy rule still holds: no bodies, no headers, no query
+///    string.** Two of these lines carry user-authored text that the access line
+///    does not, and both are deliberate rather than overlooked, on the same terms
+///    as the agent slug already in the path: `integration created … name=…`,
+///    because a line that cannot say which integration was created is most of
+///    what it is for; and `file uploaded path=…`, which is the destination
+///    filename under the uploads dir — Go logs it and the response body returns
+///    it. Nothing here logs a credential, a prompt or a message body, and a line
+///    that wanted to would need to be argued here first.
+///
+/// What is **not** here, and why, so the gap is not read as an omission: the
+/// scheduler's job-start/complete lines (#275), the trigger dispatcher's
+/// match/run lines and the notification handler's are produced by background
+/// work with no request behind them, in a subsystem the sidecar still owns. The
+/// five `… validated` lines in `integration_service.go` belong to
+/// `ValidateTokenAuth`, which is the deferred `auth/*` route. `PUT /api/settings`
+/// is deferred too (#305). None of them can be written until their subsystem
+/// moves; #278 is when this stops being optional, because until then the sidecar
+/// still emits its own lines for what it still serves.
+pub mod service_log_convention {}
+
+/// A `log` sink the write tests assert against.
+///
+/// A log line with no test is a line that quietly stops being emitted, which for
+/// this half of #301 is the whole failure mode — the record going sparse without
+/// anyone noticing. Installed once per process because `log::set_boxed_logger`
+/// allows exactly one; tests filter by their own row's id, so the shared buffer
+/// does not make them order-dependent.
+#[cfg(test)]
+pub(crate) mod testlog {
+    use std::sync::{Mutex, Once, OnceLock};
+
+    static LINES: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+    static INIT: Once = Once::new();
+
+    struct Capture;
+
+    impl log::Log for Capture {
+        fn enabled(&self, _: &log::Metadata<'_>) -> bool {
+            true
+        }
+        fn log(&self, record: &log::Record<'_>) {
+            if let Ok(mut lines) = lines().lock() {
+                lines.push(format!("{} {}", record.level(), record.args()));
+            }
+        }
+        fn flush(&self) {}
+    }
+
+    fn lines() -> &'static Mutex<Vec<String>> {
+        LINES.get_or_init(Mutex::default)
+    }
+
+    /// Start capturing. Idempotent, and safe to call from every test.
+    pub(crate) fn install() {
+        INIT.call_once(|| {
+            let _ = log::set_boxed_logger(Box::new(Capture));
+            log::set_max_level(log::LevelFilter::Trace);
+        });
+    }
+
+    /// Every captured line containing `needle`, level prefix included.
+    pub(crate) fn matching(needle: &str) -> Vec<String> {
+        install();
+        lines()
+            .lock()
+            .map(|lines| {
+                lines
+                    .iter()
+                    .filter(|line| line.contains(needle))
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Assert at least one line was emitted at `INFO` matching `needle`.
+    ///
+    /// For the two `count=` lines, which carry no id: Go's carries only the
+    /// count, so a suite sharing one buffer cannot tell two tests' lines apart
+    /// and "exactly one" would be order-dependent rather than true.
+    #[track_caller]
+    pub(crate) fn assert_info_present(needle: &str) {
+        let found = matching(needle);
+        assert!(!found.is_empty(), "no line for {needle:?}");
+        for line in &found {
+            assert!(line.starts_with("INFO "), "a write logs at info: {line:?}");
+        }
+    }
+
+    /// Assert exactly one line was emitted at `INFO` matching `needle`. Only
+    /// safe for a line carrying an id unique to the calling test.
+    #[track_caller]
+    pub(crate) fn assert_info_once(needle: &str) {
+        let found = matching(needle);
+        assert_eq!(
+            found.len(),
+            1,
+            "expected one line for {needle:?}: {found:?}"
+        );
+        assert!(
+            found[0].starts_with("INFO "),
+            "a write logs at info: {:?}",
+            found[0]
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/desktop/src-tauri/tests/chat_turn.rs
+++ b/desktop/src-tauri/tests/chat_turn.rs
@@ -16,6 +16,69 @@ use agento_lib::native::chat::persist;
 use agento_lib::native::chat::turn::TurnState;
 use agento_lib::native::chats;
 
+/// The `log` sink the #335 assertions read.
+///
+/// A separate copy from `writes::testlog` because this is a different crate and
+/// that one is `#[cfg(test)]` on the library. Installed once per process, since
+/// `log::set_boxed_logger` allows exactly one.
+mod testlog {
+    use std::sync::{Mutex, Once, OnceLock};
+
+    static LINES: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+    static INIT: Once = Once::new();
+
+    struct Capture;
+
+    impl log::Log for Capture {
+        fn enabled(&self, _: &log::Metadata<'_>) -> bool {
+            true
+        }
+        fn log(&self, record: &log::Record<'_>) {
+            if let Ok(mut lines) = lines().lock() {
+                lines.push(format!("{} {}", record.level(), record.args()));
+            }
+        }
+        fn flush(&self) {}
+    }
+
+    fn lines() -> &'static Mutex<Vec<String>> {
+        LINES.get_or_init(Mutex::default)
+    }
+
+    pub fn install() {
+        INIT.call_once(|| {
+            let _ = log::set_boxed_logger(Box::new(Capture));
+            log::set_max_level(log::LevelFilter::Trace);
+        });
+    }
+
+    pub fn matching(needle: &str) -> Vec<String> {
+        install();
+        lines()
+            .lock()
+            .map(|lines| {
+                lines
+                    .iter()
+                    .filter(|line| line.contains(needle))
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// The commit runs in a task detached from the request, so its line can
+    /// arrive after the body has ended.
+    pub async fn wait_for(needle: &str) -> String {
+        for _ in 0..200 {
+            if let Some(line) = matching(needle).into_iter().next() {
+                return line;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        panic!("no log line matching {needle:?}");
+    }
+}
+
 /// Skips when the machine has no `python3`, as the SDK suite does.
 fn python3() -> Option<String> {
     for candidate in ["python3", "python"] {
@@ -1222,4 +1285,69 @@ async fn a_chat_using_a_local_tool_runs_natively_end_to_end() {
         vec!["mcp__local-tools__current_time"],
         "renaming either half of this breaks every agent that already names it"
     );
+}
+
+/// #335: the five service-layer lines one `AskUserQuestion` turn produces.
+///
+/// Driven through this suite rather than a unit test for the reason the whole
+/// file exists: every one of them is a property of a *sequence*. `agent session
+/// started` needs a live subprocess, the three `AskUserQuestion` lines need a
+/// result that is not the end of the stream, and `message committed` is emitted
+/// from the task detached from the request — so it can arrive after the body
+/// has, which is why it is awaited rather than read.
+#[tokio::test]
+async fn one_turn_emits_the_service_layer_lines_go_emits() {
+    let Some(_) = python3() else {
+        eprintln!("skipping: no python3");
+        return;
+    };
+    testlog::install();
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cli = fake_cli(
+        dir.path(),
+        r#"
+    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack(req.get("request_id") or msg.get("request_id"))
+    elif msg.get("type") == "user":
+        text = json.dumps(msg.get("message", {}).get("content", ""))
+        if "second" not in text:
+            raw('{"type":"assistant","message":{"content":[{"type":"tool_use","id":"q1","name":"AskUserQuestion","input":{"question":"which one?"}}]}}')
+            say({"type": "result", "subtype": "success", "is_error": False,
+                 "result": "", "session_id": "sdk-logged",
+                 "usage": {"input_tokens": 1, "output_tokens": 1}})
+        else:
+            say({"type": "assistant", "message": {"content": [
+                {"type": "text", "text": "thanks"}
+            ]}})
+            say({"type": "result", "subtype": "success", "is_error": False,
+                 "result": "final answer", "session_id": "sdk-logged",
+                 "usage": {"input_tokens": 1, "output_tokens": 1}})
+"#,
+    );
+
+    let id = unique_id("logged");
+    let (_body, answered, _db) = run_turn_answering_keeping_db(&cli, &id, "hello", "second").await;
+    assert!(answered, "the prompt was never answered");
+
+    // Each line carries the chat id, so a suite running in parallel cannot
+    // supply another test's.
+    for needle in [
+        format!(r#"agent session started session_id="{id}""#),
+        format!(r#"AskUserQuestion detected in stream session_id="{id}""#),
+        format!(r#"sending user_input_required, waiting for answer session_id="{id}""#),
+        format!(r#"received user answer, resuming session session_id="{id}""#),
+    ] {
+        let found = testlog::matching(&needle);
+        assert_eq!(found.len(), 1, "expected one {needle:?}: {found:?}");
+        assert!(found[0].starts_with("INFO "), "{}", found[0]);
+    }
+
+    // The commit is detached from the request, so this one is awaited.
+    let committed = testlog::wait_for(&format!(r#"message committed session_id="{id}""#)).await;
+    assert!(
+        committed.contains(r#"sdk_session_id="sdk-logged""#),
+        "{committed}"
+    );
+    assert!(committed.starts_with("INFO "), "{committed}");
 }


### PR DESCRIPTION
## What

#301 ported Go's `requestLogger` — one access line per `/api` request, emitted at the seam so it cannot go selectively sparse as routes move — and stopped there. That was structural, not scope-trimming:

1. **An access line carries neither the entity nor the outcome.** `POST /api/integrations 201 12ms native` does not say which integration or under what name; `DELETE /api/chats 204 3ms native` cannot say how many sessions a bulk delete took. A middleware cannot recover that — only the handler knows it.
2. **Several of those lines have no request behind them at all**, and those stay out (below).

This is the first half of the remainder: **sixteen lines at the call sites, for the subsystems that are native today.**

| subsystem | lines |
|---|---|
| agent CRUD (#274) | `agent created/updated/deleted slug=…` |
| chat CRUD (#274) | `chat session created session_id= agent_slug= settings_profile_id=`, `chat session deleted session_id=`, `chat sessions bulk deleted count=` |
| job history (#274) | `job history deleted id=`, `job history bulk deleted count=` |
| chat turn (#276) | `agent session started`, `AskUserQuestion detected in stream`, `sending user_input_required, waiting for answer`, `received user answer, resuming session`, `message committed` |
| integrations (#277, #347) | `integration created id= name=`, `integration updated/deleted id=`, `trigger rule created id= integration_id=`, `trigger rule updated/deleted id=` |
| uploads (#308) | `file uploaded path= size= extension=` |

Each mirrors its Go counterpart's message string and its keys, in Go's order.

## The convention lives in one place

`writes::service_log_convention` — a doc rather than a helper, because a helper that only formats a string buys indirection while the *rule* is what drifts:

- **`message key=value …`, mirroring the Go `slog` call.** The message is what a reader greps for; a renamed one silently rewords every historical line.
- **Every string value is `{:?}`, numbers are `{}`.** Go's `slog` quotes only when it must, but half these values are user-authored — an integration name, an upload's filename — and one containing a space or an `=` makes an unquoted line unparseable. Quoting always is the only rule that does not depend on the value.
- **`info`, and after the effect.** The seam's split is failures at `warn`, writes at `info`, successful reads at `debug`; these are all writes. Go logs after the store call returns, so a line means it happened — logging before the commit would announce a write a rollback then discarded.
- **#301's privacy rule still holds.**

## Two lines carry user-authored text, deliberately

On the same terms the agent slug in the path already is (#301 argues that one explicitly, and says a route that wanted to add more "would need to be argued here first" — so here it is):

- `integration created … name=…` — a line that cannot say *which* integration was created is most of what it is for.
- `file uploaded path=…` — the **generated** destination under the uploads dir (`<millis>-<uuid><ext>`), not the name the user typed, and the response body returns it anyway.

Nothing here logs a credential, a prompt or a message body.

## Every line has a test

`writes::testlog` is a `log` sink the write tests assert against, installed once per process; `tests/chat_turn.rs` carries a second copy because it is a different crate and the turn's five lines are properties of a *sequence* — `agent session started` needs a live subprocess, and `message committed` comes from the task detached from the request, so it is awaited rather than read.

**A line with no test is a line that quietly stops being emitted, which for this half is the whole failure mode.** The two `count=` lines are asserted as *present* rather than exactly-once: Go's carries only the count, so a suite sharing one buffer cannot tell two tests' lines apart and "exactly one" would be order-dependent rather than true.

## What is deliberately absent

Absent by construction, and the list is in the doc so the gap is not read as an omission:

- The **scheduler**'s job-start/complete lines, the **trigger dispatcher**'s match/run lines and the **notification handler**'s have no request behind them and belong to subsystems the sidecar still owns. A line here would log an event this process did not cause.
- The five `… validated` lines in `integration_service.go` belong to `ValidateTokenAuth`, i.e. the deferred `auth/*` routes. Rust's `integration_credentials::validate` is field-shape validation only and makes no network call, so it has no counterpart to log.
- `PUT /api/settings`'s two are deferred with the route (#305).

**#278 is when this stops being optional**, because until then the sidecar still emits its own lines for what it still serves. That is why these land per subsystem as it is ported, rather than as one pass.

Explicitly out of scope, unchanged: OpenTelemetry spans. #301 declined those and #309 declined the exporters; nothing here reopens either.

## Quality

`cargo fmt --check` pass · `cargo clippy --all-targets -D warnings` pass · `cargo test` green (775 unit + 15 `chat_turn`, 0 failures).

Closes #335