### PR TITLE
feat(desktop): port the Confluence integration MCP server (#317)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -1134,11 +1134,24 @@ Four things that will recur in #313–#316:
   site URL that works. The base is therefore parsed on its own and its *rendered*
   path is the expected prefix; only the tool's suffix is compared against the
   bytes it built, which is sound because that half is fully `gourl`-encoded.
-  Three base shapes leave no sound comparison and `validate_site_url` refuses
-  them at `Start` instead — one `url` cannot parse, one carrying its own `?` or
-  `#`, and one holding a dot segment of its own. The last two Go accepts, so all
-  three are pinned as `rust_error` divergences; refusing to host is visible and
-  logged, where the alternative is silently moving every request.
+- **Comparing two `url`-parsed values is blind to the base, and that is a
+  credential leak, not a tidiness point.** `url` treats `\` as an authority
+  separator for a special scheme; `net/url` does not, and rejects the userinfo
+  that results — so `https://evil.com\@acme.atlassian.net` is a parse error to Go
+  (nothing hosted) and host `evil.com` to `url`. Both sides of the guard would
+  then say `evil.com` and every tool would send the user's `Basic` credentials
+  there. `validate_site_url` therefore checks the base itself, once, at `Start`:
+  the host `url` resolved against the one `go_host` resolved (through `url` on
+  both sides, so case, IDN and the default port are not false differences), and
+  `url`'s rendering of the base path against Go's `escape(Path, encodePath)` —
+  which also covers Go escaping `\ ^ | [ ]` where `url` does not, and subsumes
+  the dot-segment case rather than special-casing it. Two more shapes have no
+  sound comparison at all and go with them: a base `url` cannot parse, and one
+  carrying its own `?` or `#`. Go accepts several of these, so each is pinned as
+  a `rust_error` divergence — refusing to host is logged and visible, where the
+  alternative is a request somewhere else. **#313–#316 inherit this**: any
+  integration whose API base comes out of the row needs the base validated, not
+  just the suffix.
 - **`SetBasicAuth` is `reqwest`'s `basic_auth`.** Both are
   `Basic base64(user + ":" + pass)` with standard (not URL-safe) alphabet. The
   vectors pin the encoded header rather than trusting that, because nothing in a

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -1134,24 +1134,40 @@ Four things that will recur in #313–#316:
   site URL that works. The base is therefore parsed on its own and its *rendered*
   path is the expected prefix; only the tool's suffix is compared against the
   bytes it built, which is sound because that half is fully `gourl`-encoded.
-- **Comparing two `url`-parsed values is blind to the base, and that is a
-  credential leak, not a tidiness point.** `url` treats `\` as an authority
-  separator for a special scheme; `net/url` does not, and rejects the userinfo
-  that results — so `https://evil.com\@acme.atlassian.net` is a parse error to Go
-  (nothing hosted) and host `evil.com` to `url`. Both sides of the guard would
-  then say `evil.com` and every tool would send the user's `Basic` credentials
-  there. `validate_site_url` therefore checks the base itself, once, at `Start`:
-  the host `url` resolved against the one `go_host` resolved (through `url` on
-  both sides, so case, IDN and the default port are not false differences), and
-  `url`'s rendering of the base path against Go's `escape(Path, encodePath)` —
-  which also covers Go escaping `\ ^ | [ ]` where `url` does not, and subsumes
-  the dot-segment case rather than special-casing it. Two more shapes have no
-  sound comparison at all and go with them: a base `url` cannot parse, and one
-  carrying its own `?` or `#`. Go accepts several of these, so each is pinned as
-  a `rust_error` divergence — refusing to host is logged and visible, where the
-  alternative is a request somewhere else. **#313–#316 inherit this**: any
-  integration whose API base comes out of the row needs the base validated, not
-  just the suffix.
+- **The base needs its own validation, and the authority half must be an
+  allowlist rather than a comparison.** This is where getting it wrong sends the
+  user's credentials to somebody else, so it is worth stating the shape of the
+  argument. Comparing the host `url` resolved against the host `net/url` would
+  have resolved catches only a disagreement about where the authority *ends*;
+  where the two read the same substring and *interpret* it differently, the
+  comparison is a tautology — it is the same parser on the same bytes. There are
+  at least three interpretation gaps, each of which grafts the site onto an
+  attacker's domain from a string that reads as the legitimate one:
+  `evil.com\@acme.atlassian.net` (Go: `invalid userinfo`; `url`: host
+  `evil.com`), `acme.atlassian.net%2Eevil.com` (Go: `invalid URL escape`; `url`:
+  `acme.atlassian.net.evil.com`), and a NO-BREAK SPACE between two labels (Go
+  keeps it literally; `url` IDNA-maps it and joins them). `parseHost` is itself
+  an allowlist — `integration_credentials::split_url` says so, having enumerated
+  every ASCII byte through it — so `validate_site_url` uses one too, and a
+  narrower one, because that module may forward what it is unsure of and this
+  one may not: ASCII letters, digits, `.`, `-`, `_`, optional numeric port,
+  applied to the **whole** authority so `@` and `\` are out. Nothing in that set
+  is transformed by either parser, so agreement is by construction. It refuses
+  four things Go serves — userinfo, an IPv6 literal, a non-ASCII host (which
+  Go's own IDNA-blind resolver cannot dial either) and a percent escape — each a
+  logged non-start.
+- **The path half compares against `EscapedPath()`, not against
+  `escape(Path, encodePath)`.** The second is only the first's *fallback*: Go
+  prefers the raw text whenever it is `validEncoded`, whose allowlist admits
+  `! $ & ' ( ) * + , ; = : @ [ ] %` regardless of `shouldEscape`. So `/a!b` and
+  `/a%2Fb` are sent verbatim and `url` renders them identically — comparing
+  against `escape` alone refuses a base that works. `gourl::valid_encoded_path`
+  is that rule; #316 needs it for Jira. The true refusals it keeps are `\` (Go
+  `%5C`, `url` `/`), `^`, `|` and the dot segments. Two more shapes have no
+  sound comparison at all: a base `url` cannot parse, and one carrying its own
+  `?` or `#`. Every refusal Go would have served is pinned as a `rust_error`
+  divergence. **#313–#316 inherit all of this**: any integration whose API base
+  comes out of the row needs the base validated, not just the tool's suffix.
 - **`SetBasicAuth` is `reqwest`'s `basic_auth`.** Both are
   `Basic base64(user + ":" + pass)` with standard (not URL-safe) alphabet. The
   vectors pin the encoded header rather than trusting that, because nothing in a

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -1120,15 +1120,25 @@ Four things that will recur in #313–#316:
   because `Start` refuses a plaintext URL before it builds anything:
   `internal/integrations/confluence/parity.go`'s `StartAtSiteURL` is `Start` with
   that one line removed, and it is exported for the same reason `SetAPIBase` is.
-- **The dot-segment guard needs the *raw* base.** `client::absolute` is
-  `github::client::absolute`'s reasoning verbatim — `url::Url::parse` applies
+- **The dot-segment guard compares only the half a tool built.** `client::absolute`
+  is `github::client::absolute`'s reasoning verbatim — `url::Url::parse` applies
   WHATWG dot-segment removal and Go's `net/http` does not, so
   `get_page(page_id: "..")` would reach `/wiki/api/v2/` (the space listing) on a
-  request carrying the token. The difference is that the expected target cannot
-  be the `path` argument: it is whatever follows the authority in
-  `site_url + path`, recovered from the concatenated string *before* parsing,
-  since parsing is the thing being detected. A site URL whose authority is
-  followed by `?` or `#` has no faithful answer and is refused.
+  request carrying the token. What differs is what the expected target is
+  compared *against*. GitHub's base is a fixed, already-encoded string, so there
+  the whole target is the `path` argument. A site URL is per row and
+  **user-typed**, so it need not be encoded at all:
+  `https://intranet.example.com/my atlassian` is one Go accepts and sends as
+  `/my%20atlassian/…` through `EscapedPath`, and `url` encodes it identically —
+  so comparing against the raw concatenation would refuse every call against a
+  site URL that works. The base is therefore parsed on its own and its *rendered*
+  path is the expected prefix; only the tool's suffix is compared against the
+  bytes it built, which is sound because that half is fully `gourl`-encoded.
+  Three base shapes leave no sound comparison and `validate_site_url` refuses
+  them at `Start` instead — one `url` cannot parse, one carrying its own `?` or
+  `#`, and one holding a dot segment of its own. The last two Go accepts, so all
+  three are pinned as `rust_error` divergences; refusing to host is visible and
+  logged, where the alternative is silently moving every request.
 - **`SetBasicAuth` is `reqwest`'s `basic_auth`.** Both are
   `Basic base64(user + ":" + pass)` with standard (not URL-safe) alphabet. The
   vectors pin the encoded header rather than trusting that, because nothing in a

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -600,7 +600,7 @@ of the `Err` arms the cut-over has to turn into a real response.
 | 1 ✅ | Sidecar + proxy | — | done |
 | 2 ← | Pricing + analytics | `internal/pricing`, `internal/claudesessions` | Pure computation over JSONL + SQLite. No external deps. **In progress**: `/api/pricing/catalog`, `/api/claude-sessions`, `/api/claude-sessions/facets`, `/api/claude-analytics`, `/api/claude-sessions/insights/summary` and the agent reads are native and diff clean. |
 | 3 ← | Storage + tasks | `internal/storage`, `internal/scheduler` | **In progress (#274, #275).** `db.rs` is read-write, the 27 migrations are ported, and the writes whose every effect Rust owns are native — see below. The scheduler's *schedule computation* is ported and pinned (#275); its ownership is not, and is blocked — see below. |
-| 4 ← | Integrations | `internal/integrations`, `internal/trigger` | OAuth2 + MCP servers. Six of them: google, github, slack, jira, confluence, telegram, plus `internal/tools`. **How to host one is settled (#282)** — `claude::ToolServer`, see "Hosting a tool" below; do not invent a second way. **`internal/tools` is done (#310)** — `native/tools/`, and it is the worked example the six should be read against. **GitHub is done (#312)** — `native/integrations/github/`, the worked example for an *integration*. **The registry is done (#311)** — `native/integrations/registry.rs` plus `PUT`/`DELETE /api/integrations/{id}`, and the sidecar now runs with `AGENTO_INTEGRATIONS=off:<the types the shell hosts>`, so every type has exactly one owner. #313–#317 are each "add a starter **and its name to `HOSTED_TYPES`**", which is the one list both processes are configured from. WhatsApp is **not** among them — but Go still hosts its rows, because its starter opens a live connection rather than just a port; see below. |
+| 4 ← | Integrations | `internal/integrations`, `internal/trigger` | OAuth2 + MCP servers. Six of them: google, github, slack, jira, confluence, telegram, plus `internal/tools`. **How to host one is settled (#282)** — `claude::ToolServer`, see "Hosting a tool" below; do not invent a second way. **`internal/tools` is done (#310)** — `native/tools/`, and it is the worked example the six should be read against. **GitHub is done (#312)** — `native/integrations/github/`, the worked example for an *integration*. **The registry is done (#311)** — `native/integrations/registry.rs` plus `PUT`/`DELETE /api/integrations/{id}`, and the sidecar now runs with `AGENTO_INTEGRATIONS=off:<the types the shell hosts>`, so every type has exactly one owner. **Confluence is done (#317)** — `native/integrations/confluence/`, the smallest of the six and the one that shows what an integration adds over #312: a per-row API base, basic auth, and a `Start` check that is a decision. #313–#316 are each "add a starter **and its name to `HOSTED_TYPES`**", which is the one list both processes are configured from. WhatsApp is **not** among them — but Go still hosts its rows, because its starter opens a live connection rather than just a port; see below. |
 | 5 ← | Agent execution | `internal/agent`, `internal/service` | **In progress (#276).** The chat SSE turn is native: `/messages`, `/input`, `/permission` and `/stop`, on top of the ported SDK. The scheduler's executor (#275) is the other caller and still Go's. |
 
 ### The session scanner (`src-tauri/src/native/scanner/`)
@@ -813,7 +813,7 @@ Consequences, each load-bearing:
   equally unbounded), and it means the only ceiling on the drain is the slowest
   handler. `github::client` sets 15s and nothing holds a long-lived stream
   (`legacy_session_mode: false` makes the stream `GET` a `405`), so today the
-  bound is real. A handler added by #313–#317 with no client timeout would fail
+  bound is real. A handler added by #313–#316 with no client timeout would fail
   no test while leaving a revoked credential answering `tools/call` for as long
   as its socket stays open. Set the timeout on the client, not on the drain.
 - **Go's `ServeStdioMCP` / `SelfAsStdioMCPServer` are not ported**, and
@@ -942,7 +942,7 @@ them.
 
 The first of the six, and the largest: twenty tools over five service groups,
 token auth only. It is the file to read beside `native/tools/` before porting
-#313–#317 — that one settles *how to host a tool*, this one settles *how to port
+#313–#316 — that one settles *how to host a tool*, this one settles *how to port
 an integration*.
 
 **Where it lives, and why there.** `native/integrations.rs` stays a file and
@@ -980,7 +980,7 @@ half is what pins the things no response reveals — `url.PathEscape` per segmen
 with
 `go test ./desktop/parity/ -run TestGitHubVectors -update-github-vectors`.
 
-Five things it brought that #313–#317 will want:
+Five things it brought that #313–#316 will want:
 
 - **`gourl.rs` now has all three of `net/url`'s escaping modes.**
   `url.PathEscape` is `encodePathSegment` and escapes `/ ; , ?`;
@@ -1030,7 +1030,7 @@ Five things it brought that #313–#317 will want:
   reqwest decompresses in its service stack, so `bytes_stream()` yields
   decompressed bytes and `read_capped` caps what Go's `io.LimitReader` over a
   gunzipped `resp.Body` caps.
-- **The test seam is `#[cfg(test)]`, and should stay that way in #313–#317.**
+- **The test seam is `#[cfg(test)]`, and should stay that way in #313–#316.**
   `githubAPIBase` had to be *exported* on the Go side (`parity.go`) because
   `desktop/parity` is a different package; both Rust callers are in-crate, so
   `API_BASE`/`set_api_base` compile out of a shipped binary entirely. What they
@@ -1091,8 +1091,67 @@ Four divergences are pinned rather than reconciled, all in the vectors:
   `rust_text` and `rust_no_request`. The comparison is exact rather than a `..`
   scan, so anything else `url` normalizes is caught by construction; nothing
   legitimate trips it, because `gourl`'s escaping already covers every byte in
-  `url`'s path and query encode sets. **#313–#317 each build URLs the same way
-  and need the same guard.**
+  `url`'s path and query encode sets. **#313–#316 each build URLs the same way
+  and need the same guard**; #317 has it, with the base recovered from the
+  concatenated string because a site URL is per row.
+
+### The Confluence integration (`native/integrations/confluence/`, #317)
+
+The second of the six and the smallest: six tools in one service group
+(`content`), over an Atlassian site URL, account email and API token. Read it
+after `native/integrations/github/` — that one settles how to port an
+integration, this one is what an integration adds when its API is not GitHub's.
+
+**Five surfaces are pinned, not four.** `desktop/parity/confluence_vectors.json`
+carries the four #312 established — hosted tool set, schema, request, result
+text — plus `ValidateSiteURL` per input, because that is the one piece of
+`Start` that is a *decision* rather than plumbing: it is what stops an `http://`
+site URL carrying the user's API token in a `Basic` header over plaintext.
+Regenerate with
+`go test ./desktop/parity/ -run TestConfluenceVectors -update-confluence-vectors`.
+
+Four things that will recur in #313–#316:
+
+- **The test seam is a parameter, not a static.** GitHub has one API root, so
+  `githubAPIBase` is a package variable and the Rust side gates a `RwLock` behind
+  `#[cfg(test)]`. A Confluence base comes out of the row, so it is a field on
+  `Client` and a parity run simply constructs one against loopback — nothing
+  test-only ships at all, which is the narrower answer. Go still needs a seam,
+  because `Start` refuses a plaintext URL before it builds anything:
+  `internal/integrations/confluence/parity.go`'s `StartAtSiteURL` is `Start` with
+  that one line removed, and it is exported for the same reason `SetAPIBase` is.
+- **The dot-segment guard needs the *raw* base.** `client::absolute` is
+  `github::client::absolute`'s reasoning verbatim — `url::Url::parse` applies
+  WHATWG dot-segment removal and Go's `net/http` does not, so
+  `get_page(page_id: "..")` would reach `/wiki/api/v2/` (the space listing) on a
+  request carrying the token. The difference is that the expected target cannot
+  be the `path` argument: it is whatever follows the authority in
+  `site_url + path`, recovered from the concatenated string *before* parsing,
+  since parsing is the thing being detected. A site URL whose authority is
+  followed by `?` or `#` has no faithful answer and is refused.
+- **`SetBasicAuth` is `reqwest`'s `basic_auth`.** Both are
+  `Basic base64(user + ":" + pass)` with standard (not URL-safe) alphabet. The
+  vectors pin the encoded header rather than trusting that, because nothing in a
+  response reveals it.
+- **`net/url`'s parse failures are classified, not quoted.** `ValidateSiteURL`
+  asks `url.Parse` two questions (scheme, host) and Go answers a *third* case —
+  the parse itself failing — with `net/url`'s vocabulary, `%q`-quoted over the
+  caller's input. That wording is not reproducible past printable ASCII, and it
+  is a **log line**: `Start`'s error is logged by the registry and never reaches
+  a response or the model. So the port reproduces the two refusals exactly,
+  reproduces the *classification* of the two parse failures a stored site URL can
+  reach (a control character; a scheme-less URL whose first path segment holds a
+  colon) under its own wording, and `confluence_vectors.json` carries both as
+  `rust_error` divergences. `go_scheme` and `go_host` are `net/url`'s own
+  `getScheme` and authority split, written out rather than delegated to
+  `url::Url::parse` — which refuses strings `url.Parse` accepts and would answer
+  "invalid" where Go answers "not HTTPS".
+
+Two smaller notes. The nested request bodies (`create_page`, `update_page`) go
+through `gojson::to_vec_marshal` over `serde_json::json!`, which sorts at *every*
+level and HTML-escapes — and unlike #312's, this fires on every real call, since
+a page body is XHTML. And the client timeout is **30 seconds**, not GitHub's 15;
+it is per API and it is what bounds a graceful shutdown.
 
 ### The integration registry, and the port's second ownership flip (#311)
 
@@ -1143,7 +1202,7 @@ the sidecar still serves, and the sidecar is still shipped.
 must cover it (`a_hosted_type_always_has_a_starter`), and `hosting_env_value`
 renders it into what `sidecar.rs` sets. That shape was chosen over a constant
 hardcoded on both sides because of which failure it makes impossible: the shell
-is the process that *knows* what it hosts, so #313–#317 each add one string in
+is the process that *knows* what it hosts, so #313–#316 each add one string in
 one place. The failure being designed against is a Rust slack starter landing
 while Go is never told to stop hosting slack — two processes on one integration —
 and its mirror is the WhatsApp bug above. A hardcoded Go list would have to be
@@ -1162,13 +1221,14 @@ asserts both halves, the fallback and the untouched row.
 run uses: `runner.go` reads the integration row afresh per run, builds a
 throwaway server and records nothing. Gating it would have broken every
 integration-using chat, scheduled task and Telegram trigger the sidecar still
-serves — which is most of them, since five of the six types are #313–#317's.
+serves — which is most of them, since four of the six types are #313–#316's.
 The Go tests assert both halves, because the switch is only safe while that
 asymmetry holds.
 
 Two consequences worth knowing before touching this:
 
-- **Only `github` has a starter here, and Go still hosts the rest.** A type not
+- **Only `github` (#312) and `confluence` (#317) have starters here, and Go
+  still hosts the rest.** A type not
   in `HOSTED_TYPES` reaches this module's own unregistered-type path — `no
   starter registered for integration type "slack"`, logged and never surfaced —
   but in practice it does not reach it at all, because the writes decline it
@@ -1519,9 +1579,10 @@ path cannot try to answer a chat turn with a `Vec<u8>`.
 **The four routes share a process-local registry, so they moved together** —
 `/messages` puts a session in, the others look one up. But not every chat *can*
 run natively: an agent whose tools come from an integration this build cannot
-host still needs #313–#317, and `runner::build_options` refuses those before any
-subprocess exists. (Two halves of that refusal are gone — the **local** server
-(#310) and any agent naming only **github** integrations (#311). `build_options`
+host still needs #313–#316, and `runner::build_options` refuses those before any
+subprocess exists. (Parts of that refusal are gone — the **local** server (#310)
+and any agent naming only integrations in `HOSTED_TYPES`: **github** since #311,
+**confluence** since #317. `build_options`
 starts each of them, and is `async` for that reason, returning the listener
 handles alongside the options because dropping one stops its server.) That would strand `/stop` for a chat still running on Go, so
 the three steering routes answer natively **only when Rust holds a live session
@@ -2132,7 +2193,7 @@ precede it.
 
 **The blocker, verified.** The flip needs Rust to *run* a task, and
 `chat/runner.rs::build_options` still refuses an agent whose capabilities name
-an MCP server this build cannot host — five of the six providers (#313–#317). For a chat that is safe — the three steering routes forward
+an MCP server this build cannot host — four of the six providers (#313–#316). For a chat that is safe — the three steering routes forward
 and Go answers, because Go holds the session. **For a scheduled task there is no
 second implementation behind it**: with the sidecar not scheduling, a task Rust
 cannot run does not fail, it *silently never runs*, and the job history has no
@@ -2630,10 +2691,13 @@ the sidecar runs with `AGENTO_INTEGRATIONS=off:<the types the shell hosts>` so
 every type has a single owner — the second ownership flip after the scan's, and
 the one that had to be *per type*, since `whatsapp`'s starter opens a live
 connection the sidecar's own endpoints read. `chat/runner.rs` therefore refuses
-only an agent naming an integration Rust cannot host, which is the five types
-#313–#317 cover. #312 also produced the reflector divergence map
+only an agent naming an integration Rust cannot host, which is the four types
+#313–#316 cover. #312 also produced the reflector divergence map
 (`parity/jsonschema_reflect_vectors.json` + `claude/schema_vectors.rs`), which
-is the file to read before starting #313–#317.
+is the file to read before starting #313–#316. **#317 followed** — the
+Confluence integration, `native/integrations/confluence/`, six tools pinned by
+`parity/confluence_vectors.json`; it is the second worked example and the
+smaller one to read first.
 
 Nothing else is ported. Every endpoint not listed above — every write path, the
 per-session reads and every other read — still forwards to Go.

--- a/desktop/parity/confluence_parity_test.go
+++ b/desktop/parity/confluence_parity_test.go
@@ -121,8 +121,13 @@ type confluenceResponseScript struct {
 }
 
 type confluenceCallVector struct {
-	Case      string                   `json:"case"`
-	Tool      string                   `json:"tool"`
+	Case string `json:"case"`
+	Tool string `json:"tool"`
+	// The path appended to the fake's own URL to make this case's site URL,
+	// empty for the fake's root. A site URL is per row, so the base is part of
+	// every request a tool builds — and the only part that is not already
+	// percent-encoded, since a person typed it.
+	BasePath  string                   `json:"base_path,omitempty"`
 	Arguments json.RawMessage          `json:"arguments"`
 	Response  confluenceResponseScript `json:"response"`
 	// nil when the tool answered without making a request. No Confluence tool
@@ -356,6 +361,51 @@ var confluenceSiteURLCases = []struct {
 		input:     "https://acme.atlassian.net/\n",
 		rustError: "invalid site URL: it holds a control character",
 	},
+	{
+		// `getScheme` errors on a leading colon rather than answering "no
+		// scheme", so this is a parse failure too.
+		name:      "a leading colon is a parse failure, worded differently",
+		input:     ":acme.atlassian.net",
+		rustError: "invalid site URL: its first path segment holds a colon",
+	},
+	{
+		// `Parse` cuts the fragment and `parse` cuts the query **before** the
+		// relative-path colon check, so a colon in either is not a colon in the
+		// first path segment. Both fall through to the scheme refusal.
+		name:  "a colon in the query is not a colon in the first path segment",
+		input: "acme.atlassian.net?x:y",
+	},
+	{
+		name:  "a colon in the fragment is not one either",
+		input: "acme.atlassian.net#x:y",
+	},
+	{
+		// A user-typed site URL need not be percent-encoded: Go sends
+		// `/my%20atlassian/...` via `EscapedPath`, and `url` encodes it
+		// identically, so this is accepted on both sides and the request the
+		// tools build matches. The call vectors below exercise it live.
+		name:  "an unencoded base path is accepted — both sides encode it the same way",
+		input: "https://intranet.example.com/my atlassian",
+	},
+	{
+		// The three shapes `client::Client::absolute` cannot work behind, all
+		// refused at Start rather than at every call. Go accepts the last two
+		// and hosts six tools; this port declines to host, which is the safe
+		// direction and is why each carries a rustError.
+		name:      "a port url::Url cannot represent is refused before it is hosted",
+		input:     "https://acme.atlassian.net:99999",
+		rustError: "invalid site URL: it is not a URL this build can send a request to",
+	},
+	{
+		name:      "a base carrying its own query leaves the path open",
+		input:     "https://acme.atlassian.net?a=b",
+		rustError: "invalid site URL: a query or fragment leaves the path open",
+	},
+	{
+		name:      "a base holding a dot segment would move every request",
+		input:     "https://acme.atlassian.net/a/../b",
+		rustError: "invalid site URL: it holds a dot segment",
+	},
 }
 
 // ─── The call cases ──────────────────────────────────────────────────────────
@@ -369,8 +419,11 @@ const confluenceOKBody = `{"results":[{"zebra":1,"id":10152021304050607,"rate":1
 
 // confluenceCallCase is a call vector before the live run fills in what happened.
 type confluenceCallCase struct {
-	name          string
-	tool          string
+	name string
+	tool string
+	// Appended to the fake's URL to make the site URL this case runs against;
+	// empty means the fake's own root.
+	basePath      string
 	args          map[string]any
 	script        confluenceResponseScript
 	rustText      string
@@ -595,6 +648,77 @@ func confluenceCallCases() []confluenceCallCase {
 			rustText:      "calling confluence API: request failed",
 			rustNoRequest: true,
 		},
+		// ─── a site URL with a base path of its own ──────────────────────────
+		//
+		// Every case above runs against a bare `http://127.0.0.1:port`, which
+		// hides the half of the request that is *not* built by a tool. A real
+		// Atlassian site URL is `https://acme.atlassian.net`, but a self-hosted
+		// one carries a path, and that path is user-typed and therefore not
+		// necessarily encoded. Go sends `EscapedPath()`; `url::Url::parse`
+		// encodes the same bytes the same way — so the two agree on the wire and
+		// a port that compared against the *raw* string would refuse every one
+		// of these.
+		{
+			name:     "list_spaces/a site URL with a base path prefixes the target",
+			tool:     "list_spaces",
+			basePath: "/atlassian",
+			args:     map[string]any{"limit": 0},
+			script:   confluenceOK(confluenceOKBody),
+		},
+		{
+			name:     "get_page/an unencoded base path is escaped by both sides",
+			tool:     "get_page",
+			basePath: "/my atlassian",
+			args:     map[string]any{"page_id": "98765", "body_format": ""},
+			script:   confluenceOK(`{"title":"Home"}`),
+		},
+		{
+			name:     "update_page/a base path prefixes the write too",
+			tool:     "update_page",
+			basePath: "/atlassian",
+			args: map[string]any{
+				"page_id": "1", "title": "t", "body": "b", "version": 2,
+			},
+			script: confluenceResponseScript{Status: http.StatusOK, Body: `{"id":"1"}`},
+		},
+		{
+			// The guard has to keep firing behind a base it did not build.
+			name:          "get_space/a dot segment behind a base path is still refused",
+			tool:          "get_space",
+			basePath:      "/atlassian",
+			args:          map[string]any{"space_id": ".."},
+			script:        confluenceResponseScript{Status: 404, Body: `{"message":"Not Found"}`},
+			rustText:      "calling confluence API: request failed",
+			rustNoRequest: true,
+		},
+
+		// ─── a zero-fraction float, which models do emit ─────────────────────
+		//
+		// `modelcontextprotocol/go-sdk` unmarshals `arguments` into a
+		// `map[string]any`, validates it against the reflected schema — where
+		// JSON Schema counts `50.0` as an `integer` — and re-marshals before the
+		// typed decode, so the handler sees 50. `serde_json::from_value::<i64>`
+		// refuses outright, so no handler runs and no request is made. The same
+		// divergence #312 pinned, and reachable on a **write** here.
+		{
+			name:          "list_spaces/a zero-fraction float is an integer to Go and not to serde",
+			tool:          "list_spaces",
+			args:          map[string]any{"limit": json.RawMessage("50.0")},
+			script:        confluenceOK(confluenceOKBody),
+			rustText:      "failed to deserialize parameters: invalid type: floating point `50.0`, expected i64",
+			rustNoRequest: true,
+		},
+		{
+			name: "update_page/the same float reaches the write path, where Go bumps the version",
+			tool: "update_page",
+			args: map[string]any{
+				"page_id": "1", "title": "t", "body": "b",
+				"version": json.RawMessage("41.0"),
+			},
+			script:        confluenceResponseScript{Status: http.StatusOK, Body: `{"id":"1"}`},
+			rustText:      "failed to deserialize parameters: invalid type: floating point `41.0`, expected i64",
+			rustNoRequest: true,
+		},
 	}
 }
 
@@ -666,8 +790,17 @@ func TestConfluenceVectors(t *testing.T) {
 		want.Hosting = append(want.Hosting, hosting)
 	}
 
+	// One session per distinct site URL. Most cases run against the fake's own
+	// root; the base-path ones need a server whose credentials carry that base,
+	// because a site URL is not a per-call argument.
+	sessions := map[string]*mcp.ClientSession{"": session}
 	for _, c := range confluenceCallCases() {
-		want.Calls = append(want.Calls, runConfluenceCallCase(t, ctx, session, fake, c))
+		if _, ok := sessions[c.basePath]; !ok {
+			sessions[c.basePath] = confluenceSession(
+				t, ctx, srv.URL+c.basePath, confluenceAllServices())
+		}
+		want.Calls = append(want.Calls,
+			runConfluenceCallCase(t, ctx, sessions[c.basePath], fake, c))
 	}
 
 	encoded, err := json.MarshalIndent(want, "", "  ")
@@ -758,6 +891,7 @@ func runConfluenceCallCase(
 	return confluenceCallVector{
 		Case:          c.name,
 		Tool:          c.tool,
+		BasePath:      c.basePath,
 		Arguments:     args,
 		Response:      c.script,
 		Request:       fake.recorded(),

--- a/desktop/parity/confluence_parity_test.go
+++ b/desktop/parity/confluence_parity_test.go
@@ -416,7 +416,7 @@ var confluenceSiteURLCases = []struct {
 		// Basic credentials to evil.com.
 		name:      "a backslash before the userinfo is a different host to url and a parse error to Go",
 		input:     `https://evil.com\@acme.atlassian.net`,
-		rustError: "invalid site URL: net/url and url read a different host",
+		rustError: "invalid site URL: its host is not a plain ASCII hostname",
 	},
 	{
 		// Milder, same root: Go escapes `\\ ^ | [ ]` in a path and `url` does
@@ -448,7 +448,25 @@ var confluenceSiteURLCases = []struct {
 		// legitimate host and resolves to a stranger's.
 		name:      "a percent escape in the host decodes to a different domain under url",
 		input:     "https://acme.atlassian.net%2Eevil.com",
-		rustError: "invalid site URL: its host holds a percent escape",
+		rustError: "invalid site URL: its host is not a plain ASCII hostname",
+	},
+	{
+		// The third mechanism, and the one that shows why the rule has to be an
+		// allowlist rather than a comparison between the two parsers: that is a
+		// NO-BREAK SPACE. Go keeps the host literally and cannot resolve it;
+		// `url` IDNA-maps it, joining the two labels into one name somebody else
+		// owns.
+		name:      "a byte Go keeps literal and url IDNA-maps joins two labels into one host",
+		input:     "https://acme.atlassian.net\u00a0evil.com",
+		rustError: "invalid site URL: its host is not a plain ASCII hostname",
+	},
+	{
+		// Refused, and Go serves it. A site URL is not where credentials belong
+		// — the row carries email and API token in their own fields — and
+		// admitting userinfo is what lets a backslash hide in front of the `@`.
+		name:      "userinfo is refused, because it is where a backslash hides",
+		input:     "https://user:pw@acme.atlassian.net",
+		rustError: "invalid site URL: its host is not a plain ASCII hostname",
 	},
 }
 

--- a/desktop/parity/confluence_parity_test.go
+++ b/desktop/parity/confluence_parity_test.go
@@ -432,6 +432,24 @@ var confluenceSiteURLCases = []struct {
 		name:  "a pre-escaped base path is accepted, and so is the same path unescaped",
 		input: "https://intranet.example.com/a%20b",
 	},
+	{
+		// `EscapedPath` sends this verbatim even though `escape(Path,
+		// encodePath)` would render it `/a%21b`, because `validEncoded` admits
+		// `!`. A port comparing against `escape` alone would refuse a base that
+		// works — which is why gourl carries `valid_encoded_path`.
+		name:  "a base path validEncoded admits is sent verbatim, not re-escaped",
+		input: "https://intranet.example.com/a!b(c)[d]",
+	},
+	{
+		// The authority graft that a url-to-url comparison cannot see, because
+		// both parsers read the same substring and only disagree on what it
+		// means: `parseHost` rejects an escape that decodes to a byte it would
+		// have escaped, and `url` decodes them all. This reads as the
+		// legitimate host and resolves to a stranger's.
+		name:      "a percent escape in the host decodes to a different domain under url",
+		input:     "https://acme.atlassian.net%2Eevil.com",
+		rustError: "invalid site URL: its host holds a percent escape",
+	},
 }
 
 // ─── The call cases ──────────────────────────────────────────────────────────

--- a/desktop/parity/confluence_parity_test.go
+++ b/desktop/parity/confluence_parity_test.go
@@ -468,6 +468,21 @@ var confluenceSiteURLCases = []struct {
 		input:     "https://user:pw@acme.atlassian.net",
 		rustError: "invalid site URL: its host is not a plain ASCII hostname",
 	},
+	{
+		// Go's `Path` is arbitrary bytes, so a well-formed escape decoding to
+		// something that is not UTF-8 is a path it sends and `EscapedPath()`
+		// renders back unchanged; `url` agrees. Demanding UTF-8 between the
+		// decode and the re-escape would refuse it, which is why
+		// `gourl::unescape_path` answers bytes.
+		name:  "a base path whose escapes decode to non-UTF-8 is still served",
+		input: "https://acme.atlassian.net/a%FFb",
+	},
+	{
+		// A *malformed* escape is `setPath`'s own parse error, so both refuse.
+		name:      "a malformed escape in the base path is a parse failure",
+		input:     "https://acme.atlassian.net/a%zzb",
+		rustError: "invalid site URL: its path does not decode",
+	},
 }
 
 // ─── The call cases ──────────────────────────────────────────────────────────

--- a/desktop/parity/confluence_parity_test.go
+++ b/desktop/parity/confluence_parity_test.go
@@ -1,0 +1,769 @@
+// Cross-language vectors for the Confluence integration MCP server
+// (`internal/integrations/confluence`, ported in #317 to
+// `desktop/src-tauri/src/native/integrations/confluence/`).
+//
+// Five things about that server have to match byte for byte, and none of them is
+// checkable from one language alone:
+//
+//   - **Which tools are hosted.** `buildAllowedSet` unions the `Tools` of every
+//     *enabled* service and each `register*` skips a tool the set does not name
+//     — except that an **empty** set registers everything, which is the rule a
+//     port gets backwards. The names travel in every agent's stored
+//     `capabilities.mcp` allowlist and in every `tool_use` block already written
+//     to `chat_messages`, so a missing or renamed tool is a silent break of
+//     agents that exist.
+//   - **The advertised schema.** `tools/list` hands the CLI what the CLI hands
+//     the model. It is reflected off the params struct by
+//     `google/jsonschema-go`, and `schemars` — the Rust reflector — does not
+//     agree with it by default. `jsonschema_reflect_vectors.json` is the map of
+//     where the two diverge and what a port must write instead; this file is
+//     where the six real schemas are pinned.
+//   - **The request each tool builds.** `url.PathEscape` per segment,
+//     `url.QueryEscape` per query value (a space is `+`, not `%20`), the two
+//     `limit` clamps and their *different* fallbacks, and `json.Marshal`'s
+//     sorted map keys and HTML escaping in both request bodies — which matters
+//     more here than anywhere in #312, because a Confluence page body is XHTML
+//     and so escapes on every single call. None of that is visible in a
+//     response, so the fake Confluence below records the request it received.
+//   - **The result text.** A tool's result is what the model reads and what gets
+//     persisted, and on the error path it is the *message* — `new_tool` and
+//     `mcp.AddTool` both pack a failed call into `CallToolResult` with `IsError`
+//     rather than raising a protocol error. The raw Confluence bytes are passed
+//     through verbatim, so a port that round-tripped them through a JSON value
+//     would reorder keys and respell numbers.
+//   - **`ValidateSiteURL`.** The one piece of `Start` that is a decision rather
+//     than plumbing: it is what refuses a plaintext site URL before the API
+//     token is ever put in a `Basic` header. #277 pinned that Confluence's rule
+//     is deliberately *not* Jira's, so it is pinned here per input rather than
+//     described.
+//
+// Everything here is taken from the **running server** over its real HTTP MCP
+// transport — `confluence.StartAtSiteURL` is `confluence.Start` with only the
+// HTTPS check removed, so the authentication check, the credential parse, the
+// server name and the tool registration are all the shipped ones.
+//
+// The Rust half lives in
+// `desktop/src-tauri/src/native/integrations/confluence/tests_vectors.rs` and
+// reads this same file.
+//
+// Regenerate (only from Go, and only when adding cases):
+//
+//	go test ./desktop/parity/ -run TestConfluenceVectors -update-confluence-vectors
+package parity
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	mcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/shaharia-lab/agento/internal/config"
+	"github.com/shaharia-lab/agento/internal/integrations/confluence"
+)
+
+const confluenceVectorsFile = "confluence_vectors.json"
+
+var updateConfluenceVectors = flag.Bool("update-confluence-vectors", false,
+	"rewrite confluence_vectors.json from this Go toolchain")
+
+// The credentials every recorded request carries. Fixtures, not secrets — and
+// recording the whole `Authorization` header is deliberate: `SetBasicAuth` is
+// base64 of `email + ":" + apiToken`, and that a port used the same separator,
+// the same order and standard (not URL-safe) base64 is exactly the kind of thing
+// no response would reveal.
+const (
+	confluenceParityEmail = "parity@example.com"
+	// A fixture, and gosec's pattern match is right about the shape — which is
+	// the point. It authenticates nothing.
+	confluenceParityToken = "parity-confluence-api-token" //nolint:gosec // a test fixture, not a credential
+)
+
+// confluenceParityID is the integration id, and half of the server name
+// (`confluence-<id>`).
+const confluenceParityID = "cf-parity"
+
+type confluenceToolVector struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"input_schema"`
+}
+
+// confluenceRequestVector is what the fake Confluence saw. `Target` is
+// `URL.RequestURI()` — the encoded path plus the encoded query — which is the
+// one string that pins `url.PathEscape` and `url.QueryEscape` together.
+type confluenceRequestVector struct {
+	Method        string `json:"method"`
+	Target        string `json:"target"`
+	Authorization string `json:"authorization"`
+	Accept        string `json:"accept"`
+	// Set only when the tool sent a body; `callConfluence` adds the header only
+	// then.
+	ContentType string `json:"content_type"`
+	Body        string `json:"body"`
+}
+
+// confluenceResponseScript is what the fake answered with. The Rust half replays
+// exactly this, so the two languages see the same bytes.
+type confluenceResponseScript struct {
+	Status int    `json:"status"`
+	Body   string `json:"body"`
+}
+
+type confluenceCallVector struct {
+	Case      string                   `json:"case"`
+	Tool      string                   `json:"tool"`
+	Arguments json.RawMessage          `json:"arguments"`
+	Response  confluenceResponseScript `json:"response"`
+	// nil when the tool answered without making a request. No Confluence tool
+	// does — both bodies are built from strings that cannot fail to marshal —
+	// so this is nil only where the port itself declines, see RustNoRequest.
+	Request *confluenceRequestVector `json:"request"`
+	IsError bool                     `json:"is_error"`
+	Text    string                   `json:"text"`
+	// Set only where Rust cannot reproduce Go's text and the difference is
+	// pinned rather than hidden. One user: the dot-segment refusal below.
+	RustText string `json:"rust_text,omitempty"`
+	// Set where Go made a request and Rust deliberately makes none: a path
+	// holding a `.` or `..` segment. Go's `net/http` sends the path verbatim,
+	// while `url::Url::parse` — which `reqwest` builds every request through —
+	// applies WHATWG dot-segment removal, so `/wiki/api/v2/pages/..` would leave
+	// as `/wiki/api/v2/`: the space listing rather than one page, on a request
+	// already carrying the API token. Escaping does not help, `%2E%2E` is
+	// collapsed too, and `reqwest` offers no unnormalized target, so the port
+	// refuses the call rather than reaching a different endpoint than Go would.
+	RustNoRequest bool `json:"rust_no_request,omitempty"`
+}
+
+type confluenceHostingVector struct {
+	Case     string                          `json:"case"`
+	Services map[string]config.ServiceConfig `json:"services"`
+	Tools    []string                        `json:"tools"`
+}
+
+// confluenceSiteURLVector pins ValidateSiteURL per input: the cleaned value on
+// success, the message on refusal.
+type confluenceSiteURLVector struct {
+	Case  string `json:"case"`
+	Input string `json:"input"`
+	Clean string `json:"clean,omitempty"`
+	Error string `json:"error,omitempty"`
+	// Set where the port refuses the same input under different wording. One
+	// cause: `url.Parse` fails outright — a control character, a non-numeric
+	// port, a bad `%` escape in the host — and answers with `net/url`'s own
+	// vocabulary, `%q`-quoted over the caller's input. That is not reproducible
+	// and it is a **log line rather than an interface**: `Start`'s error is
+	// logged by the registry and never reaches a response or the model. The
+	// classification is what is pinned.
+	RustError string `json:"rust_error,omitempty"`
+}
+
+type confluenceVectors struct {
+	Comment       []string                  `json:"_comment"`
+	IntegrationID string                    `json:"integration_id"`
+	ServerName    string                    `json:"server_name"`
+	Version       string                    `json:"version"`
+	Email         string                    `json:"email"`
+	APIToken      string                    `json:"api_token"`
+	SiteURLs      []confluenceSiteURLVector `json:"site_urls"`
+	Tools         []confluenceToolVector    `json:"tools"`
+	Hosting       []confluenceHostingVector `json:"hosting"`
+	Calls         []confluenceCallVector    `json:"calls"`
+}
+
+// ─── The fake Confluence ─────────────────────────────────────────────────────
+
+// fakeConfluence plays a scripted Confluence and records what it was asked.
+//
+// One handler for every path, because the point is not to model the API — it is
+// to capture the request the tool *built*. A router would have to agree with the
+// port about the shape of each path, which is precisely the thing under test.
+type fakeConfluence struct {
+	mu     sync.Mutex
+	script confluenceResponseScript
+	seen   *confluenceRequestVector
+}
+
+func (f *fakeConfluence) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		body = nil
+	}
+	f.mu.Lock()
+	script := f.script
+	f.seen = &confluenceRequestVector{
+		Method:        r.Method,
+		Target:        r.URL.RequestURI(),
+		Authorization: r.Header.Get("Authorization"),
+		Accept:        r.Header.Get("Accept"),
+		ContentType:   r.Header.Get("Content-Type"),
+		Body:          string(body),
+	}
+	f.mu.Unlock()
+
+	w.WriteHeader(script.Status)
+	_, _ = w.Write([]byte(script.Body))
+}
+
+// arm sets the next reply and forgets the last request.
+func (f *fakeConfluence) arm(script confluenceResponseScript) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.script = script
+	f.seen = nil
+}
+
+func (f *fakeConfluence) recorded() *confluenceRequestVector {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.seen
+}
+
+// ─── Standing the real server up ─────────────────────────────────────────────
+
+// confluenceSession starts the real integration for services against siteURL and
+// returns a client session. `confluence.StartAtSiteURL` is `confluence.Start`
+// with only the HTTPS check removed, so the authentication check, the credential
+// parse, the server name and the tool registration are the shipped ones.
+func confluenceSession(
+	t *testing.T, ctx context.Context, siteURL string, services map[string]config.ServiceConfig,
+) *mcp.ClientSession {
+	t.Helper()
+
+	credentials, err := json.Marshal(config.AtlassianCredentials{
+		SiteURL:  siteURL,
+		Email:    confluenceParityEmail,
+		APIToken: confluenceParityToken,
+	})
+	if err != nil {
+		t.Fatalf("encoding credentials: %v", err)
+	}
+
+	cfg := &config.IntegrationConfig{
+		ID:          confluenceParityID,
+		Name:        "Confluence (parity)",
+		Type:        "confluence",
+		Enabled:     true,
+		Credentials: credentials,
+		// `IsAuthenticated` is "present and not the four bytes null"; a
+		// token-validated integration stores the outcome here.
+		Auth:     json.RawMessage(`{"validated":true}`),
+		Services: services,
+	}
+
+	serverCfg, err := confluence.StartAtSiteURL(ctx, cfg, siteURL)
+	if err != nil {
+		t.Fatalf("starting the confluence integration: %v", err)
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "parity", Version: "1"}, nil)
+	session, err := client.Connect(ctx,
+		&mcp.StreamableClientTransport{Endpoint: serverCfg.URL}, nil)
+	if err != nil {
+		t.Fatalf("connecting to %s: %v", serverCfg.URL, err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	return session
+}
+
+// confluenceAllServices enables the one service with an empty tool list, which
+// is the "empty allowed set registers everything" rule — the configuration the
+// six schemas and every call vector are taken under.
+func confluenceAllServices() map[string]config.ServiceConfig {
+	return map[string]config.ServiceConfig{"content": {Enabled: true}}
+}
+
+// confluenceHostingCases pin the gates that decide what a server hosts, each in
+// the shape a real integration row takes.
+var confluenceHostingCases = []confluenceHostingVector{
+	{Case: "the service enabled with no tool list — an empty allowed set hosts everything",
+		Services: confluenceAllServices()},
+	{Case: "no services at all", Services: map[string]config.ServiceConfig{}},
+	{Case: "the service disabled contributes neither its gate nor its tools",
+		Services: map[string]config.ServiceConfig{
+			"content": {Enabled: false, Tools: []string{"list_spaces"}},
+		}},
+	{Case: "a non-empty allowed set is a filter",
+		Services: map[string]config.ServiceConfig{
+			"content": {Enabled: true, Tools: []string{"get_page", "list_spaces"}},
+		}},
+	// The union half of the rule has no shape to take with one service, but an
+	// *unknown* service still contributes its names to the set — which is what
+	// makes the set a union rather than the enabled service's own list.
+	{Case: "an enabled but unknown service still narrows the one that exists",
+		Services: map[string]config.ServiceConfig{
+			"content": {Enabled: true},
+			"other":   {Enabled: true, Tools: []string{"update_page"}},
+		}},
+	{Case: "a tool named by a disabled service is not allowed anywhere",
+		Services: map[string]config.ServiceConfig{
+			"content": {Enabled: true, Tools: []string{"get_space"}},
+			"other":   {Enabled: false, Tools: []string{"create_page"}},
+		}},
+}
+
+// confluenceSiteURLCases exercise ValidateSiteURL, which is the gate that keeps
+// an API token off a plaintext connection.
+//
+// `rustError` marks the inputs where `url.Parse` itself fails and Go answers
+// with `net/url`'s vocabulary; see confluenceSiteURLVector.
+var confluenceSiteURLCases = []struct {
+	name      string
+	input     string
+	rustError string
+}{
+	{name: "https with no trailing slash is returned unchanged",
+		input: "https://acme.atlassian.net"},
+	{name: "every trailing slash is trimmed, not just the last",
+		input: "https://acme.atlassian.net///"},
+	{name: "a base path survives, minus its trailing slash",
+		input: "https://intranet.example.com/atlassian/"},
+	{name: "a port survives", input: "https://acme.atlassian.net:8443"},
+	{name: "the scheme is compared lower-cased, so this passes",
+		input: "HTTPS://acme.atlassian.net"},
+	{name: "plaintext is refused — the whole point of the check",
+		input: "http://acme.atlassian.net"},
+	{name: "a bare host has no scheme at all", input: "acme.atlassian.net"},
+	{name: "an empty string has no scheme either", input: ""},
+	{name: "another scheme is named in the message", input: "ftp://acme.atlassian.net"},
+	{name: "https with no authority has no host", input: "https:acme.atlassian.net"},
+	{name: "https with an empty authority has no host", input: "https://"},
+	{name: "an authority that is only userinfo has no host", input: "https://user@"},
+	{
+		// No scheme means a *relative* URL to `net/url`, and it refuses one
+		// whose first path segment holds a colon. The port classifies it the
+		// same way and words it its own way; see the site-URL note below.
+		name:      "a leading digit means no scheme, and then the colon is a parse failure",
+		input:     "1https://acme.atlassian.net",
+		rustError: "invalid site URL: its first path segment holds a colon",
+	},
+	{
+		// `url.Parse` rejects ASCII control characters outright, with a message
+		// built by `%q`-quoting the caller's input — Go string escaping this
+		// port does not reproduce. The refusal is what matters and it is
+		// reproduced; the sentence is pinned as a divergence.
+		name:      "a control character is a parse failure, worded differently",
+		input:     "https://acme.atlassian.net/\n",
+		rustError: "invalid site URL: it holds a control character",
+	},
+}
+
+// ─── The call cases ──────────────────────────────────────────────────────────
+
+// confluenceOKBody is a response body deliberately hostile to a re-encode: keys
+// out of alphabetical order, a trailing-zero decimal, an integer too large for a
+// float64 to hold exactly, and interior whitespace. Go passes the bytes through
+// verbatim, so all four survive into the result text; a port that decoded to a
+// JSON value and re-encoded would change every one of them.
+const confluenceOKBody = `{"results":[{"zebra":1,"id":10152021304050607,"rate":1.50, "name":"x"}]}`
+
+// confluenceCallCase is a call vector before the live run fills in what happened.
+type confluenceCallCase struct {
+	name          string
+	tool          string
+	args          map[string]any
+	script        confluenceResponseScript
+	rustText      string
+	rustNoRequest bool
+}
+
+func confluenceOK(body string) confluenceResponseScript {
+	return confluenceResponseScript{Status: http.StatusOK, Body: body}
+}
+
+// confluenceCallCases is the exercise: every tool at least once on its success
+// path, plus every distinct failure the client can produce.
+//
+// The argument maps are complete rather than minimal because **every field is
+// required** — `google/jsonschema-go` marks a field optional only on
+// `omitempty`/`omitzero`, and not one params struct in this integration carries
+// either, so the server refuses a call that omits a field. That is itself part of
+// the advertised surface, and it is why the empty-string and zero cases below are
+// written as explicit zeros rather than as absent keys.
+func confluenceCallCases() []confluenceCallCase {
+	return []confluenceCallCase{
+		// ─── list_spaces ─────────────────────────────────────────────────────
+		{
+			name:   "list_spaces/a zero limit takes the 50 fallback",
+			tool:   "list_spaces",
+			args:   map[string]any{"limit": 0},
+			script: confluenceOK(confluenceOKBody),
+		},
+		{
+			name:   "list_spaces/over 250 falls back too, rather than clamping to 250",
+			tool:   "list_spaces",
+			args:   map[string]any{"limit": 251},
+			script: confluenceOK(confluenceOKBody),
+		},
+		{
+			name:   "list_spaces/250 is the largest value that survives",
+			tool:   "list_spaces",
+			args:   map[string]any{"limit": 250},
+			script: confluenceOK(confluenceOKBody),
+		},
+		{
+			name:   "list_spaces/a negative limit is a zero, not an error",
+			tool:   "list_spaces",
+			args:   map[string]any{"limit": -5},
+			script: confluenceOK(confluenceOKBody),
+		},
+		{
+			name:   "list_spaces/a non-2xx status is the API's own body, verbatim",
+			tool:   "list_spaces",
+			args:   map[string]any{"limit": 1},
+			script: confluenceResponseScript{Status: 403, Body: `{"message":"Forbidden <you>"}`},
+		},
+		{
+			// The gate is the 2xx *range*, not `== 200`.
+			name:   "list_spaces/a 204 is a success, and its empty body is the result",
+			tool:   "list_spaces",
+			args:   map[string]any{"limit": 10},
+			script: confluenceResponseScript{Status: http.StatusNoContent, Body: ""},
+		},
+
+		// ─── get_space ───────────────────────────────────────────────────────
+		{
+			name:   "get_space/a plain id",
+			tool:   "get_space",
+			args:   map[string]any{"space_id": "123456"},
+			script: confluenceOK(`{"key":"DEV"}`),
+		},
+		{
+			// `PathEscape` is `encodePathSegment`, which escapes `/ ; , ?` and
+			// leaves `$ & + : = @` alone. Both halves are here, plus multi-byte
+			// UTF-8, which becomes one `%XX` per byte in uppercase hex.
+			name:   "get_space/the reserved bytes a segment keeps, the ones it escapes, and UTF-8",
+			tool:   "get_space",
+			args:   map[string]any{"space_id": "a$&+:=@b my space/x;y,z?q café日本語"},
+			script: confluenceOK(`{"key":"X"}`),
+		},
+
+		// ─── search_content ──────────────────────────────────────────────────
+		{
+			// `QueryEscape` is `encodeQueryComponent`: a space is `+`, not
+			// `%20`, and `=` and `&` are escaped. Real CQL is all three.
+			name: "search_content/CQL is query-escaped, so a space is a plus",
+			tool: "search_content",
+			args: map[string]any{
+				"cql": "space = DEV AND type = page AND title ~ \"a&b\"", "limit": 0,
+			},
+			script: confluenceOK(confluenceOKBody),
+		},
+		{
+			name:   "search_content/the fallback is 25 here, not list_spaces' 50",
+			tool:   "search_content",
+			args:   map[string]any{"cql": "type=page", "limit": 300},
+			script: confluenceOK(confluenceOKBody),
+		},
+		{
+			name:   "search_content/an empty CQL still sends the key",
+			tool:   "search_content",
+			args:   map[string]any{"cql": "", "limit": 7},
+			script: confluenceOK(confluenceOKBody),
+		},
+
+		// ─── get_page ────────────────────────────────────────────────────────
+		{
+			name:   "get_page/an empty body_format takes the storage default",
+			tool:   "get_page",
+			args:   map[string]any{"page_id": "98765", "body_format": ""},
+			script: confluenceOK(`{"title":"Home"}`),
+		},
+		{
+			name:   "get_page/an explicit format is passed through",
+			tool:   "get_page",
+			args:   map[string]any{"page_id": "98765", "body_format": "view"},
+			script: confluenceOK(`{"title":"Home"}`),
+		},
+		{
+			// The default is applied on **empty**, not on an unrecognized value
+			// — so garbage reaches Confluence and Confluence answers for it.
+			name:   "get_page/an unrecognized format is not corrected, only escaped",
+			tool:   "get_page",
+			args:   map[string]any{"page_id": "98765", "body_format": "storage view&x"},
+			script: confluenceResponseScript{Status: 400, Body: `{"message":"bad body-format"}`},
+		},
+
+		// ─── create_page ─────────────────────────────────────────────────────
+		{
+			// The body is XHTML, so `json.Marshal`'s HTML escaping fires on
+			// every real call — and the map is sorted at both levels.
+			name: "create_page/a nested body, sorted keys, and XHTML escaped",
+			tool: "create_page",
+			args: map[string]any{
+				"space_id":  "SPACE1",
+				"title":     "Release <1.0> & notes",
+				"body":      "<p>hi &amp; bye</p>",
+				"parent_id": "",
+			},
+			script: confluenceResponseScript{Status: http.StatusOK, Body: `{"id":"1"}`},
+		},
+		{
+			name: "create_page/a parent adds the one conditional key",
+			tool: "create_page",
+			args: map[string]any{
+				"space_id":  "SPACE1",
+				"title":     "Child",
+				"body":      "<p/>",
+				"parent_id": "424242",
+			},
+			script: confluenceResponseScript{Status: http.StatusOK, Body: `{"id":"2"}`},
+		},
+		{
+			name: "create_page/empty strings are still sent — only parent_id is conditional",
+			tool: "create_page",
+			args: map[string]any{
+				"space_id": "", "title": "", "body": "", "parent_id": "",
+			},
+			script: confluenceResponseScript{Status: 400, Body: `{"message":"spaceId required"}`},
+		},
+
+		// ─── update_page ─────────────────────────────────────────────────────
+		{
+			name: "update_page/the version is incremented, and the id is in both the path and the body",
+			tool: "update_page",
+			args: map[string]any{
+				"page_id": "98765", "title": "New title",
+				"body": "<p>v2 &lt;b&gt;</p>", "version": 41,
+			},
+			script: confluenceResponseScript{Status: http.StatusOK, Body: `{"id":"98765"}`},
+		},
+		{
+			name: "update_page/a zero version increments to one",
+			tool: "update_page",
+			args: map[string]any{
+				"page_id": "1", "title": "t", "body": "b", "version": 0,
+			},
+			script: confluenceResponseScript{Status: http.StatusOK, Body: `{"id":"1"}`},
+		},
+		{
+			name: "update_page/a negative version is not clamped",
+			tool: "update_page",
+			args: map[string]any{
+				"page_id": "1", "title": "t", "body": "b", "version": -3,
+			},
+			script: confluenceResponseScript{Status: 409, Body: `{"message":"version conflict"}`},
+		},
+		{
+			name: "update_page/an id needing escaping appears escaped in the path and raw in the body",
+			tool: "update_page",
+			args: map[string]any{
+				"page_id": "a/b c", "title": "t", "body": "b", "version": 2,
+			},
+			script: confluenceResponseScript{Status: http.StatusOK, Body: `{"id":"a/b c"}`},
+		},
+
+		// ─── the dot-segment refusal ─────────────────────────────────────────
+		{
+			// Go sends `/wiki/api/v2/spaces/..` verbatim and gets a 404; `url`
+			// would resolve it to `/wiki/api/v2/`, which is a *different
+			// endpoint* answering with a request that carries the API token.
+			name:          "get_space/a dot-dot segment reaches a different endpoint under url::Url",
+			tool:          "get_space",
+			args:          map[string]any{"space_id": ".."},
+			script:        confluenceResponseScript{Status: 404, Body: `{"message":"Not Found"}`},
+			rustText:      "calling confluence API: request failed",
+			rustNoRequest: true,
+		},
+		{
+			name:          "get_page/a single dot segment is sent literally too",
+			tool:          "get_page",
+			args:          map[string]any{"page_id": ".", "body_format": ""},
+			script:        confluenceResponseScript{Status: 404, Body: `{"message":"Not Found"}`},
+			rustText:      "calling confluence API: request failed",
+			rustNoRequest: true,
+		},
+		{
+			// The write path: a PUT whose body is built and sent before the
+			// status is looked at, so the request lands whatever the answer is.
+			name: "update_page/dot segments reach the write path too",
+			tool: "update_page",
+			args: map[string]any{
+				"page_id": "..", "title": "t", "body": "b", "version": 1,
+			},
+			script:        confluenceResponseScript{Status: 404, Body: `{"message":"Not Found"}`},
+			rustText:      "calling confluence API: request failed",
+			rustNoRequest: true,
+		},
+	}
+}
+
+// ─── The generator ───────────────────────────────────────────────────────────
+
+func TestConfluenceVectors(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	fake := &fakeConfluence{}
+	srv := httptest.NewServer(fake)
+	defer srv.Close()
+
+	want := confluenceVectors{
+		Comment: []string{
+			"Cross-language parity vectors for internal/integrations/confluence, the",
+			"Confluence integration's in-process MCP server. Generated from Go, then frozen.",
+			"Read by desktop/parity/confluence_parity_test.go (Go) and by",
+			"desktop/src-tauri/src/native/integrations/confluence/ (Rust). Every value is",
+			"exactly what Go produces, so a divergence fails one language against the other's",
+			"real output rather than against a belief about it.",
+			"'site_urls' come from confluence.ValidateSiteURL; 'tools' and 'hosting' from live",
+			"tools/list calls against servers built by confluence.StartAtSiteURL; 'calls' from",
+			"live tools/call calls against a scripted fake Confluence that records the request",
+			"each tool built.",
+			"'email' and 'api_token' are fixtures, not secrets: they are recorded so the",
+			"base64 of the Basic header is pinned.",
+			"Regenerate with: go test ./desktop/parity/ -run TestConfluenceVectors -update-confluence-vectors",
+		},
+		IntegrationID: confluenceParityID,
+		ServerName:    fmt.Sprintf("confluence-%s", confluenceParityID),
+		Version:       "1.0.0",
+		Email:         confluenceParityEmail,
+		APIToken:      confluenceParityToken,
+	}
+
+	for _, c := range confluenceSiteURLCases {
+		vector := confluenceSiteURLVector{
+			Case: c.name, Input: c.input, RustError: c.rustError,
+		}
+		clean, err := confluence.ValidateSiteURL(c.input)
+		if err != nil {
+			vector.Error = err.Error()
+		} else {
+			vector.Clean = clean
+		}
+		want.SiteURLs = append(want.SiteURLs, vector)
+	}
+
+	session := confluenceSession(t, ctx, srv.URL, confluenceAllServices())
+	listed, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("tools/list: %v", err)
+	}
+	for _, tool := range listed.Tools {
+		schema, err := json.Marshal(tool.InputSchema)
+		if err != nil {
+			t.Fatalf("encoding %s's input schema: %v", tool.Name, err)
+		}
+		want.Tools = append(want.Tools, confluenceToolVector{
+			Name:        tool.Name,
+			Description: tool.Description,
+			InputSchema: schema,
+		})
+	}
+
+	for _, hosting := range confluenceHostingCases {
+		hosting.Tools = confluenceHostedTools(t, ctx, srv.URL, hosting.Services)
+		want.Hosting = append(want.Hosting, hosting)
+	}
+
+	for _, c := range confluenceCallCases() {
+		want.Calls = append(want.Calls, runConfluenceCallCase(t, ctx, session, fake, c))
+	}
+
+	encoded, err := json.MarshalIndent(want, "", "  ")
+	if err != nil {
+		t.Fatalf("encoding vectors: %v", err)
+	}
+	encoded = append(encoded, '\n')
+
+	if *updateConfluenceVectors {
+		if err := os.WriteFile(confluenceVectorsFile, encoded, 0o600); err != nil {
+			t.Fatalf("writing %s: %v", confluenceVectorsFile, err)
+		}
+		t.Logf("wrote %s", confluenceVectorsFile)
+		return
+	}
+
+	frozen, err := os.ReadFile(confluenceVectorsFile)
+	if err != nil {
+		t.Fatalf("reading %s (regenerate with -update-confluence-vectors): %v",
+			confluenceVectorsFile, err)
+	}
+	if string(frozen) != string(encoded) {
+		t.Fatalf("%s is stale: this Go toolchain produces different results.\n"+
+			"Regenerate with -update-confluence-vectors and check what moved — the Rust "+
+			"port in native/integrations/confluence/ reads the same file and will fail "+
+			"against it. A moved tool name, schema, request or sentence is not a "+
+			"cosmetic diff: the names are in every agent's stored allowlist and in "+
+			"every tool_use block already written, and the sentences are what the "+
+			"model reads.",
+			confluenceVectorsFile)
+	}
+}
+
+// confluenceHostedTools starts a server for services and asks it what it hosts.
+//
+// The point here is the *set*, and the sort only makes explicit what both SDKs
+// already do: `tools/list` answers in **name** order, not registration order.
+// Registration order is pinned on the Rust side instead, by
+// `an_empty_allowed_set_hosts_every_tool` against `CONFLUENCE_TOOL_NAMES`.
+func confluenceHostedTools(
+	t *testing.T, ctx context.Context, siteURL string, services map[string]config.ServiceConfig,
+) []string {
+	t.Helper()
+	listed, err := confluenceSession(t, ctx, siteURL, services).ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("tools/list: %v", err)
+	}
+	names := make([]string, 0, len(listed.Tools))
+	for _, tool := range listed.Tools {
+		names = append(names, tool.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// runConfluenceCallCase arms the fake, makes one real tools/call and records
+// everything observable: the request the tool built, and the result the model
+// would read.
+func runConfluenceCallCase(
+	t *testing.T, ctx context.Context,
+	session *mcp.ClientSession, fake *fakeConfluence, c confluenceCallCase,
+) confluenceCallVector {
+	t.Helper()
+
+	fake.arm(c.script)
+	args := jsonArgs(t, c.args)
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: c.tool, Arguments: args,
+	})
+	if err != nil {
+		t.Fatalf("%s: tools/call: %v", c.name, err)
+	}
+	if len(result.Content) != 1 {
+		t.Fatalf("%s: want exactly one content block, got %d", c.name, len(result.Content))
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("%s: want text content, got %T", c.name, result.Content[0])
+	}
+
+	// The credentials must never reach the model, on either path.
+	for _, secret := range []string{confluenceParityToken, confluenceParityEmail} {
+		if strings.Contains(text.Text, secret) {
+			t.Fatalf("%s: a credential leaked into a tool result: %s", c.name, text.Text)
+		}
+	}
+
+	return confluenceCallVector{
+		Case:          c.name,
+		Tool:          c.tool,
+		Arguments:     args,
+		Response:      c.script,
+		Request:       fake.recorded(),
+		IsError:       result.IsError,
+		Text:          text.Text,
+		RustText:      c.rustText,
+		RustNoRequest: c.rustNoRequest,
+	}
+}

--- a/desktop/parity/confluence_parity_test.go
+++ b/desktop/parity/confluence_parity_test.go
@@ -404,7 +404,33 @@ var confluenceSiteURLCases = []struct {
 	{
 		name:      "a base holding a dot segment would move every request",
 		input:     "https://acme.atlassian.net/a/../b",
-		rustError: "invalid site URL: it holds a dot segment",
+		rustError: "invalid site URL: net/url and url encode its path differently",
+	},
+	{
+		// The case that distinguishes the two parsers on the **authority**, and
+		// the reason the host is compared at all. `url` treats `\\` as an
+		// authority separator for a special scheme, so it reads the host as
+		// `evil.com` and the rest as a path; `net/url` does not, and rejects the
+		// userinfo that leaves. Go therefore hosts nothing. A port that compared
+		// only url-parsed values would agree with itself and send the user's
+		// Basic credentials to evil.com.
+		name:      "a backslash before the userinfo is a different host to url and a parse error to Go",
+		input:     `https://evil.com\@acme.atlassian.net`,
+		rustError: "invalid site URL: net/url and url read a different host",
+	},
+	{
+		// Milder, same root: Go escapes `\\ ^ | [ ]` in a path and `url` does
+		// not, so this would reach `/a/b` on the right host instead of
+		// `/a%5Cb`.
+		name:      "a backslash in the base path is escaped by Go and converted by url",
+		input:     `https://acme.atlassian.net/a\b`,
+		rustError: "invalid site URL: net/url and url encode its path differently",
+	},
+	{
+		// Accepted, and the pair that shows the path comparison is against Go's
+		// *escaped* rendering rather than the raw text.
+		name:  "a pre-escaped base path is accepted, and so is the same path unescaped",
+		input: "https://intranet.example.com/a%20b",
 	},
 }
 

--- a/desktop/parity/confluence_vectors.json
+++ b/desktop/parity/confluence_vectors.json
@@ -129,7 +129,24 @@
       "case": "a base holding a dot segment would move every request",
       "input": "https://acme.atlassian.net/a/../b",
       "clean": "https://acme.atlassian.net/a/../b",
-      "rust_error": "invalid site URL: it holds a dot segment"
+      "rust_error": "invalid site URL: net/url and url encode its path differently"
+    },
+    {
+      "case": "a backslash before the userinfo is a different host to url and a parse error to Go",
+      "input": "https://evil.com\\@acme.atlassian.net",
+      "error": "invalid site URL: parse \"https://evil.com\\\\@acme.atlassian.net\": net/url: invalid userinfo",
+      "rust_error": "invalid site URL: net/url and url read a different host"
+    },
+    {
+      "case": "a backslash in the base path is escaped by Go and converted by url",
+      "input": "https://acme.atlassian.net/a\\b",
+      "clean": "https://acme.atlassian.net/a\\b",
+      "rust_error": "invalid site URL: net/url and url encode its path differently"
+    },
+    {
+      "case": "a pre-escaped base path is accepted, and so is the same path unescaped",
+      "input": "https://intranet.example.com/a%20b",
+      "clean": "https://intranet.example.com/a%20b"
     }
   ],
   "tools": [

--- a/desktop/parity/confluence_vectors.json
+++ b/desktop/parity/confluence_vectors.json
@@ -135,7 +135,7 @@
       "case": "a backslash before the userinfo is a different host to url and a parse error to Go",
       "input": "https://evil.com\\@acme.atlassian.net",
       "error": "invalid site URL: parse \"https://evil.com\\\\@acme.atlassian.net\": net/url: invalid userinfo",
-      "rust_error": "invalid site URL: net/url and url read a different host"
+      "rust_error": "invalid site URL: its host is not a plain ASCII hostname"
     },
     {
       "case": "a backslash in the base path is escaped by Go and converted by url",
@@ -157,7 +157,19 @@
       "case": "a percent escape in the host decodes to a different domain under url",
       "input": "https://acme.atlassian.net%2Eevil.com",
       "error": "invalid site URL: parse \"https://acme.atlassian.net%2Eevil.com\": invalid URL escape \"%2E\"",
-      "rust_error": "invalid site URL: its host holds a percent escape"
+      "rust_error": "invalid site URL: its host is not a plain ASCII hostname"
+    },
+    {
+      "case": "a byte Go keeps literal and url IDNA-maps joins two labels into one host",
+      "input": "https://acme.atlassian.net evil.com",
+      "clean": "https://acme.atlassian.net evil.com",
+      "rust_error": "invalid site URL: its host is not a plain ASCII hostname"
+    },
+    {
+      "case": "userinfo is refused, because it is where a backslash hides",
+      "input": "https://user:pw@acme.atlassian.net",
+      "clean": "https://user:pw@acme.atlassian.net",
+      "rust_error": "invalid site URL: its host is not a plain ASCII hostname"
     }
   ],
   "tools": [

--- a/desktop/parity/confluence_vectors.json
+++ b/desktop/parity/confluence_vectors.json
@@ -1,0 +1,873 @@
+{
+  "_comment": [
+    "Cross-language parity vectors for internal/integrations/confluence, the",
+    "Confluence integration's in-process MCP server. Generated from Go, then frozen.",
+    "Read by desktop/parity/confluence_parity_test.go (Go) and by",
+    "desktop/src-tauri/src/native/integrations/confluence/ (Rust). Every value is",
+    "exactly what Go produces, so a divergence fails one language against the other's",
+    "real output rather than against a belief about it.",
+    "'site_urls' come from confluence.ValidateSiteURL; 'tools' and 'hosting' from live",
+    "tools/list calls against servers built by confluence.StartAtSiteURL; 'calls' from",
+    "live tools/call calls against a scripted fake Confluence that records the request",
+    "each tool built.",
+    "'email' and 'api_token' are fixtures, not secrets: they are recorded so the",
+    "base64 of the Basic header is pinned.",
+    "Regenerate with: go test ./desktop/parity/ -run TestConfluenceVectors -update-confluence-vectors"
+  ],
+  "integration_id": "cf-parity",
+  "server_name": "confluence-cf-parity",
+  "version": "1.0.0",
+  "email": "parity@example.com",
+  "api_token": "parity-confluence-api-token",
+  "site_urls": [
+    {
+      "case": "https with no trailing slash is returned unchanged",
+      "input": "https://acme.atlassian.net",
+      "clean": "https://acme.atlassian.net"
+    },
+    {
+      "case": "every trailing slash is trimmed, not just the last",
+      "input": "https://acme.atlassian.net///",
+      "clean": "https://acme.atlassian.net"
+    },
+    {
+      "case": "a base path survives, minus its trailing slash",
+      "input": "https://intranet.example.com/atlassian/",
+      "clean": "https://intranet.example.com/atlassian"
+    },
+    {
+      "case": "a port survives",
+      "input": "https://acme.atlassian.net:8443",
+      "clean": "https://acme.atlassian.net:8443"
+    },
+    {
+      "case": "the scheme is compared lower-cased, so this passes",
+      "input": "HTTPS://acme.atlassian.net",
+      "clean": "HTTPS://acme.atlassian.net"
+    },
+    {
+      "case": "plaintext is refused — the whole point of the check",
+      "input": "http://acme.atlassian.net",
+      "error": "site URL must use HTTPS (got \"http\")"
+    },
+    {
+      "case": "a bare host has no scheme at all",
+      "input": "acme.atlassian.net",
+      "error": "site URL must use HTTPS (got \"\")"
+    },
+    {
+      "case": "an empty string has no scheme either",
+      "input": "",
+      "error": "site URL must use HTTPS (got \"\")"
+    },
+    {
+      "case": "another scheme is named in the message",
+      "input": "ftp://acme.atlassian.net",
+      "error": "site URL must use HTTPS (got \"ftp\")"
+    },
+    {
+      "case": "https with no authority has no host",
+      "input": "https:acme.atlassian.net",
+      "error": "site URL must include a hostname"
+    },
+    {
+      "case": "https with an empty authority has no host",
+      "input": "https://",
+      "error": "site URL must include a hostname"
+    },
+    {
+      "case": "an authority that is only userinfo has no host",
+      "input": "https://user@",
+      "error": "site URL must include a hostname"
+    },
+    {
+      "case": "a leading digit means no scheme, and then the colon is a parse failure",
+      "input": "1https://acme.atlassian.net",
+      "error": "invalid site URL: parse \"1https://acme.atlassian.net\": first path segment in URL cannot contain colon",
+      "rust_error": "invalid site URL: its first path segment holds a colon"
+    },
+    {
+      "case": "a control character is a parse failure, worded differently",
+      "input": "https://acme.atlassian.net/\n",
+      "error": "invalid site URL: parse \"https://acme.atlassian.net/\\n\": net/url: invalid control character in URL",
+      "rust_error": "invalid site URL: it holds a control character"
+    }
+  ],
+  "tools": [
+    {
+      "name": "create_page",
+      "description": "Creates a new Confluence page in a given space.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "description": "required,Page body content in Confluence storage format (XHTML)",
+            "type": "string"
+          },
+          "parent_id": {
+            "description": "Optional parent page ID to nest under",
+            "type": "string"
+          },
+          "space_id": {
+            "description": "required,The ID of the space to create the page in",
+            "type": "string"
+          },
+          "title": {
+            "description": "required,Title of the new page",
+            "type": "string"
+          }
+        },
+        "required": [
+          "space_id",
+          "title",
+          "body",
+          "parent_id"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_page",
+      "description": "Gets the content and metadata of a Confluence page by ID.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "body_format": {
+            "description": "Body format to return: storage or view (default: storage)",
+            "type": "string"
+          },
+          "page_id": {
+            "description": "required,The ID of the page to retrieve",
+            "type": "string"
+          }
+        },
+        "required": [
+          "page_id",
+          "body_format"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_space",
+      "description": "Gets details of a Confluence space by ID.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "space_id": {
+            "description": "required,The ID of the space to retrieve",
+            "type": "string"
+          }
+        },
+        "required": [
+          "space_id"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_spaces",
+      "description": "Lists Confluence spaces.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "limit": {
+            "description": "Maximum number of spaces to return (1-250)",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "limit"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "search_content",
+      "description": "Searches Confluence content using CQL (Confluence Query Language).",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "cql": {
+            "description": "required,CQL query string (e.g. 'space = DEV AND type = page')",
+            "type": "string"
+          },
+          "limit": {
+            "description": "Maximum number of results to return (1-250)",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "cql",
+          "limit"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "update_page",
+      "description": "Updates an existing Confluence page.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "description": "required,New page body content in Confluence storage format (XHTML)",
+            "type": "string"
+          },
+          "page_id": {
+            "description": "required,The ID of the page to update",
+            "type": "string"
+          },
+          "title": {
+            "description": "required,New title for the page",
+            "type": "string"
+          },
+          "version": {
+            "description": "required,Current version number of the page (incremented by 1 on update)",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "page_id",
+          "title",
+          "body",
+          "version"
+        ],
+        "type": "object"
+      }
+    }
+  ],
+  "hosting": [
+    {
+      "case": "the service enabled with no tool list — an empty allowed set hosts everything",
+      "services": {
+        "content": {
+          "enabled": true,
+          "tools": null
+        }
+      },
+      "tools": [
+        "create_page",
+        "get_page",
+        "get_space",
+        "list_spaces",
+        "search_content",
+        "update_page"
+      ]
+    },
+    {
+      "case": "no services at all",
+      "services": {},
+      "tools": []
+    },
+    {
+      "case": "the service disabled contributes neither its gate nor its tools",
+      "services": {
+        "content": {
+          "enabled": false,
+          "tools": [
+            "list_spaces"
+          ]
+        }
+      },
+      "tools": []
+    },
+    {
+      "case": "a non-empty allowed set is a filter",
+      "services": {
+        "content": {
+          "enabled": true,
+          "tools": [
+            "get_page",
+            "list_spaces"
+          ]
+        }
+      },
+      "tools": [
+        "get_page",
+        "list_spaces"
+      ]
+    },
+    {
+      "case": "an enabled but unknown service still narrows the one that exists",
+      "services": {
+        "content": {
+          "enabled": true,
+          "tools": null
+        },
+        "other": {
+          "enabled": true,
+          "tools": [
+            "update_page"
+          ]
+        }
+      },
+      "tools": [
+        "update_page"
+      ]
+    },
+    {
+      "case": "a tool named by a disabled service is not allowed anywhere",
+      "services": {
+        "content": {
+          "enabled": true,
+          "tools": [
+            "get_space"
+          ]
+        },
+        "other": {
+          "enabled": false,
+          "tools": [
+            "create_page"
+          ]
+        }
+      },
+      "tools": [
+        "get_space"
+      ]
+    }
+  ],
+  "calls": [
+    {
+      "case": "list_spaces/a zero limit takes the 50 fallback",
+      "tool": "list_spaces",
+      "arguments": {
+        "limit": 0
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"results\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/wiki/api/v2/spaces?limit=50",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Spaces: {\"results\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]}"
+    },
+    {
+      "case": "list_spaces/over 250 falls back too, rather than clamping to 250",
+      "tool": "list_spaces",
+      "arguments": {
+        "limit": 251
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"results\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/wiki/api/v2/spaces?limit=50",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Spaces: {\"results\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]}"
+    },
+    {
+      "case": "list_spaces/250 is the largest value that survives",
+      "tool": "list_spaces",
+      "arguments": {
+        "limit": 250
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"results\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/wiki/api/v2/spaces?limit=250",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Spaces: {\"results\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]}"
+    },
+    {
+      "case": "list_spaces/a negative limit is a zero, not an error",
+      "tool": "list_spaces",
+      "arguments": {
+        "limit": -5
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"results\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/wiki/api/v2/spaces?limit=50",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Spaces: {\"results\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]}"
+    },
+    {
+      "case": "list_spaces/a non-2xx status is the API's own body, verbatim",
+      "tool": "list_spaces",
+      "arguments": {
+        "limit": 1
+      },
+      "response": {
+        "status": 403,
+        "body": "{\"message\":\"Forbidden \u003cyou\u003e\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/wiki/api/v2/spaces?limit=1",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": true,
+      "text": "confluence API error (status 403): {\"message\":\"Forbidden \u003cyou\u003e\"}"
+    },
+    {
+      "case": "list_spaces/a 204 is a success, and its empty body is the result",
+      "tool": "list_spaces",
+      "arguments": {
+        "limit": 10
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      },
+      "request": {
+        "method": "GET",
+        "target": "/wiki/api/v2/spaces?limit=10",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Spaces: "
+    },
+    {
+      "case": "get_space/a plain id",
+      "tool": "get_space",
+      "arguments": {
+        "space_id": "123456"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"key\":\"DEV\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/wiki/api/v2/spaces/123456",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Space: {\"key\":\"DEV\"}"
+    },
+    {
+      "case": "get_space/the reserved bytes a segment keeps, the ones it escapes, and UTF-8",
+      "tool": "get_space",
+      "arguments": {
+        "space_id": "a$\u0026+:=@b my space/x;y,z?q café日本語"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"key\":\"X\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/wiki/api/v2/spaces/a$\u0026+:=@b%20my%20space%2Fx%3By%2Cz%3Fq%20caf%C3%A9%E6%97%A5%E6%9C%AC%E8%AA%9E",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Space: {\"key\":\"X\"}"
+    },
+    {
+      "case": "search_content/CQL is query-escaped, so a space is a plus",
+      "tool": "search_content",
+      "arguments": {
+        "cql": "space = DEV AND type = page AND title ~ \"a\u0026b\"",
+        "limit": 0
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"results\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/wiki/api/v2/search?cql=space+%3D+DEV+AND+type+%3D+page+AND+title+~+%22a%26b%22\u0026limit=25",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Search results: {\"results\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]}"
+    },
+    {
+      "case": "search_content/the fallback is 25 here, not list_spaces' 50",
+      "tool": "search_content",
+      "arguments": {
+        "cql": "type=page",
+        "limit": 300
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"results\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/wiki/api/v2/search?cql=type%3Dpage\u0026limit=25",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Search results: {\"results\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]}"
+    },
+    {
+      "case": "search_content/an empty CQL still sends the key",
+      "tool": "search_content",
+      "arguments": {
+        "cql": "",
+        "limit": 7
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"results\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/wiki/api/v2/search?cql=\u0026limit=7",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Search results: {\"results\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]}"
+    },
+    {
+      "case": "get_page/an empty body_format takes the storage default",
+      "tool": "get_page",
+      "arguments": {
+        "body_format": "",
+        "page_id": "98765"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"title\":\"Home\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/wiki/api/v2/pages/98765?body-format=storage",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Page: {\"title\":\"Home\"}"
+    },
+    {
+      "case": "get_page/an explicit format is passed through",
+      "tool": "get_page",
+      "arguments": {
+        "body_format": "view",
+        "page_id": "98765"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"title\":\"Home\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/wiki/api/v2/pages/98765?body-format=view",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Page: {\"title\":\"Home\"}"
+    },
+    {
+      "case": "get_page/an unrecognized format is not corrected, only escaped",
+      "tool": "get_page",
+      "arguments": {
+        "body_format": "storage view\u0026x",
+        "page_id": "98765"
+      },
+      "response": {
+        "status": 400,
+        "body": "{\"message\":\"bad body-format\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/wiki/api/v2/pages/98765?body-format=storage+view%26x",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": true,
+      "text": "confluence API error (status 400): {\"message\":\"bad body-format\"}"
+    },
+    {
+      "case": "create_page/a nested body, sorted keys, and XHTML escaped",
+      "tool": "create_page",
+      "arguments": {
+        "body": "\u003cp\u003ehi \u0026amp; bye\u003c/p\u003e",
+        "parent_id": "",
+        "space_id": "SPACE1",
+        "title": "Release \u003c1.0\u003e \u0026 notes"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"id\":\"1\"}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/wiki/api/v2/pages",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "application/json",
+        "body": "{\"body\":{\"representation\":\"storage\",\"value\":\"\\u003cp\\u003ehi \\u0026amp; bye\\u003c/p\\u003e\"},\"spaceId\":\"SPACE1\",\"status\":\"current\",\"title\":\"Release \\u003c1.0\\u003e \\u0026 notes\"}"
+      },
+      "is_error": false,
+      "text": "Page created: {\"id\":\"1\"}"
+    },
+    {
+      "case": "create_page/a parent adds the one conditional key",
+      "tool": "create_page",
+      "arguments": {
+        "body": "\u003cp/\u003e",
+        "parent_id": "424242",
+        "space_id": "SPACE1",
+        "title": "Child"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"id\":\"2\"}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/wiki/api/v2/pages",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "application/json",
+        "body": "{\"body\":{\"representation\":\"storage\",\"value\":\"\\u003cp/\\u003e\"},\"parentId\":\"424242\",\"spaceId\":\"SPACE1\",\"status\":\"current\",\"title\":\"Child\"}"
+      },
+      "is_error": false,
+      "text": "Page created: {\"id\":\"2\"}"
+    },
+    {
+      "case": "create_page/empty strings are still sent — only parent_id is conditional",
+      "tool": "create_page",
+      "arguments": {
+        "body": "",
+        "parent_id": "",
+        "space_id": "",
+        "title": ""
+      },
+      "response": {
+        "status": 400,
+        "body": "{\"message\":\"spaceId required\"}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/wiki/api/v2/pages",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "application/json",
+        "body": "{\"body\":{\"representation\":\"storage\",\"value\":\"\"},\"spaceId\":\"\",\"status\":\"current\",\"title\":\"\"}"
+      },
+      "is_error": true,
+      "text": "confluence API error (status 400): {\"message\":\"spaceId required\"}"
+    },
+    {
+      "case": "update_page/the version is incremented, and the id is in both the path and the body",
+      "tool": "update_page",
+      "arguments": {
+        "body": "\u003cp\u003ev2 \u0026lt;b\u0026gt;\u003c/p\u003e",
+        "page_id": "98765",
+        "title": "New title",
+        "version": 41
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"id\":\"98765\"}"
+      },
+      "request": {
+        "method": "PUT",
+        "target": "/wiki/api/v2/pages/98765",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "application/json",
+        "body": "{\"body\":{\"representation\":\"storage\",\"value\":\"\\u003cp\\u003ev2 \\u0026lt;b\\u0026gt;\\u003c/p\\u003e\"},\"id\":\"98765\",\"status\":\"current\",\"title\":\"New title\",\"version\":{\"number\":42}}"
+      },
+      "is_error": false,
+      "text": "Page updated: {\"id\":\"98765\"}"
+    },
+    {
+      "case": "update_page/a zero version increments to one",
+      "tool": "update_page",
+      "arguments": {
+        "body": "b",
+        "page_id": "1",
+        "title": "t",
+        "version": 0
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"id\":\"1\"}"
+      },
+      "request": {
+        "method": "PUT",
+        "target": "/wiki/api/v2/pages/1",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "application/json",
+        "body": "{\"body\":{\"representation\":\"storage\",\"value\":\"b\"},\"id\":\"1\",\"status\":\"current\",\"title\":\"t\",\"version\":{\"number\":1}}"
+      },
+      "is_error": false,
+      "text": "Page updated: {\"id\":\"1\"}"
+    },
+    {
+      "case": "update_page/a negative version is not clamped",
+      "tool": "update_page",
+      "arguments": {
+        "body": "b",
+        "page_id": "1",
+        "title": "t",
+        "version": -3
+      },
+      "response": {
+        "status": 409,
+        "body": "{\"message\":\"version conflict\"}"
+      },
+      "request": {
+        "method": "PUT",
+        "target": "/wiki/api/v2/pages/1",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "application/json",
+        "body": "{\"body\":{\"representation\":\"storage\",\"value\":\"b\"},\"id\":\"1\",\"status\":\"current\",\"title\":\"t\",\"version\":{\"number\":-2}}"
+      },
+      "is_error": true,
+      "text": "confluence API error (status 409): {\"message\":\"version conflict\"}"
+    },
+    {
+      "case": "update_page/an id needing escaping appears escaped in the path and raw in the body",
+      "tool": "update_page",
+      "arguments": {
+        "body": "b",
+        "page_id": "a/b c",
+        "title": "t",
+        "version": 2
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"id\":\"a/b c\"}"
+      },
+      "request": {
+        "method": "PUT",
+        "target": "/wiki/api/v2/pages/a%2Fb%20c",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "application/json",
+        "body": "{\"body\":{\"representation\":\"storage\",\"value\":\"b\"},\"id\":\"a/b c\",\"status\":\"current\",\"title\":\"t\",\"version\":{\"number\":3}}"
+      },
+      "is_error": false,
+      "text": "Page updated: {\"id\":\"a/b c\"}"
+    },
+    {
+      "case": "get_space/a dot-dot segment reaches a different endpoint under url::Url",
+      "tool": "get_space",
+      "arguments": {
+        "space_id": ".."
+      },
+      "response": {
+        "status": 404,
+        "body": "{\"message\":\"Not Found\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/wiki/api/v2/spaces/..",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": true,
+      "text": "confluence API error (status 404): {\"message\":\"Not Found\"}",
+      "rust_text": "calling confluence API: request failed",
+      "rust_no_request": true
+    },
+    {
+      "case": "get_page/a single dot segment is sent literally too",
+      "tool": "get_page",
+      "arguments": {
+        "body_format": "",
+        "page_id": "."
+      },
+      "response": {
+        "status": 404,
+        "body": "{\"message\":\"Not Found\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/wiki/api/v2/pages/.?body-format=storage",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": true,
+      "text": "confluence API error (status 404): {\"message\":\"Not Found\"}",
+      "rust_text": "calling confluence API: request failed",
+      "rust_no_request": true
+    },
+    {
+      "case": "update_page/dot segments reach the write path too",
+      "tool": "update_page",
+      "arguments": {
+        "body": "b",
+        "page_id": "..",
+        "title": "t",
+        "version": 1
+      },
+      "response": {
+        "status": 404,
+        "body": "{\"message\":\"Not Found\"}"
+      },
+      "request": {
+        "method": "PUT",
+        "target": "/wiki/api/v2/pages/..",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "application/json",
+        "body": "{\"body\":{\"representation\":\"storage\",\"value\":\"b\"},\"id\":\"..\",\"status\":\"current\",\"title\":\"t\",\"version\":{\"number\":2}}"
+      },
+      "is_error": true,
+      "text": "confluence API error (status 404): {\"message\":\"Not Found\"}",
+      "rust_text": "calling confluence API: request failed",
+      "rust_no_request": true
+    }
+  ]
+}

--- a/desktop/parity/confluence_vectors.json
+++ b/desktop/parity/confluence_vectors.json
@@ -91,6 +91,45 @@
       "input": "https://acme.atlassian.net/\n",
       "error": "invalid site URL: parse \"https://acme.atlassian.net/\\n\": net/url: invalid control character in URL",
       "rust_error": "invalid site URL: it holds a control character"
+    },
+    {
+      "case": "a leading colon is a parse failure, worded differently",
+      "input": ":acme.atlassian.net",
+      "error": "invalid site URL: parse \":acme.atlassian.net\": missing protocol scheme",
+      "rust_error": "invalid site URL: its first path segment holds a colon"
+    },
+    {
+      "case": "a colon in the query is not a colon in the first path segment",
+      "input": "acme.atlassian.net?x:y",
+      "error": "site URL must use HTTPS (got \"\")"
+    },
+    {
+      "case": "a colon in the fragment is not one either",
+      "input": "acme.atlassian.net#x:y",
+      "error": "site URL must use HTTPS (got \"\")"
+    },
+    {
+      "case": "an unencoded base path is accepted — both sides encode it the same way",
+      "input": "https://intranet.example.com/my atlassian",
+      "clean": "https://intranet.example.com/my atlassian"
+    },
+    {
+      "case": "a port url::Url cannot represent is refused before it is hosted",
+      "input": "https://acme.atlassian.net:99999",
+      "clean": "https://acme.atlassian.net:99999",
+      "rust_error": "invalid site URL: it is not a URL this build can send a request to"
+    },
+    {
+      "case": "a base carrying its own query leaves the path open",
+      "input": "https://acme.atlassian.net?a=b",
+      "clean": "https://acme.atlassian.net?a=b",
+      "rust_error": "invalid site URL: a query or fragment leaves the path open"
+    },
+    {
+      "case": "a base holding a dot segment would move every request",
+      "input": "https://acme.atlassian.net/a/../b",
+      "clean": "https://acme.atlassian.net/a/../b",
+      "rust_error": "invalid site URL: it holds a dot segment"
     }
   ],
   "tools": [
@@ -867,6 +906,149 @@
       "is_error": true,
       "text": "confluence API error (status 404): {\"message\":\"Not Found\"}",
       "rust_text": "calling confluence API: request failed",
+      "rust_no_request": true
+    },
+    {
+      "case": "list_spaces/a site URL with a base path prefixes the target",
+      "tool": "list_spaces",
+      "base_path": "/atlassian",
+      "arguments": {
+        "limit": 0
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"results\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/atlassian/wiki/api/v2/spaces?limit=50",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Spaces: {\"results\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]}"
+    },
+    {
+      "case": "get_page/an unencoded base path is escaped by both sides",
+      "tool": "get_page",
+      "base_path": "/my atlassian",
+      "arguments": {
+        "body_format": "",
+        "page_id": "98765"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"title\":\"Home\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/my%20atlassian/wiki/api/v2/pages/98765?body-format=storage",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Page: {\"title\":\"Home\"}"
+    },
+    {
+      "case": "update_page/a base path prefixes the write too",
+      "tool": "update_page",
+      "base_path": "/atlassian",
+      "arguments": {
+        "body": "b",
+        "page_id": "1",
+        "title": "t",
+        "version": 2
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"id\":\"1\"}"
+      },
+      "request": {
+        "method": "PUT",
+        "target": "/atlassian/wiki/api/v2/pages/1",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "application/json",
+        "body": "{\"body\":{\"representation\":\"storage\",\"value\":\"b\"},\"id\":\"1\",\"status\":\"current\",\"title\":\"t\",\"version\":{\"number\":3}}"
+      },
+      "is_error": false,
+      "text": "Page updated: {\"id\":\"1\"}"
+    },
+    {
+      "case": "get_space/a dot segment behind a base path is still refused",
+      "tool": "get_space",
+      "base_path": "/atlassian",
+      "arguments": {
+        "space_id": ".."
+      },
+      "response": {
+        "status": 404,
+        "body": "{\"message\":\"Not Found\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/atlassian/wiki/api/v2/spaces/..",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": true,
+      "text": "confluence API error (status 404): {\"message\":\"Not Found\"}",
+      "rust_text": "calling confluence API: request failed",
+      "rust_no_request": true
+    },
+    {
+      "case": "list_spaces/a zero-fraction float is an integer to Go and not to serde",
+      "tool": "list_spaces",
+      "arguments": {
+        "limit": 50.0
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"results\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/wiki/api/v2/spaces?limit=50",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Spaces: {\"results\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"name\":\"x\"}]}",
+      "rust_text": "failed to deserialize parameters: invalid type: floating point `50.0`, expected i64",
+      "rust_no_request": true
+    },
+    {
+      "case": "update_page/the same float reaches the write path, where Go bumps the version",
+      "tool": "update_page",
+      "arguments": {
+        "body": "b",
+        "page_id": "1",
+        "title": "t",
+        "version": 41.0
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"id\":\"1\"}"
+      },
+      "request": {
+        "method": "PUT",
+        "target": "/wiki/api/v2/pages/1",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1jb25mbHVlbmNlLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "application/json",
+        "body": "{\"body\":{\"representation\":\"storage\",\"value\":\"b\"},\"id\":\"1\",\"status\":\"current\",\"title\":\"t\",\"version\":{\"number\":42}}"
+      },
+      "is_error": false,
+      "text": "Page updated: {\"id\":\"1\"}",
+      "rust_text": "failed to deserialize parameters: invalid type: floating point `41.0`, expected i64",
       "rust_no_request": true
     }
   ]

--- a/desktop/parity/confluence_vectors.json
+++ b/desktop/parity/confluence_vectors.json
@@ -170,6 +170,17 @@
       "input": "https://user:pw@acme.atlassian.net",
       "clean": "https://user:pw@acme.atlassian.net",
       "rust_error": "invalid site URL: its host is not a plain ASCII hostname"
+    },
+    {
+      "case": "a base path whose escapes decode to non-UTF-8 is still served",
+      "input": "https://acme.atlassian.net/a%FFb",
+      "clean": "https://acme.atlassian.net/a%FFb"
+    },
+    {
+      "case": "a malformed escape in the base path is a parse failure",
+      "input": "https://acme.atlassian.net/a%zzb",
+      "error": "invalid site URL: parse \"https://acme.atlassian.net/a%zzb\": invalid URL escape \"%zz\"",
+      "rust_error": "invalid site URL: its path does not decode"
     }
   ],
   "tools": [

--- a/desktop/parity/confluence_vectors.json
+++ b/desktop/parity/confluence_vectors.json
@@ -147,6 +147,17 @@
       "case": "a pre-escaped base path is accepted, and so is the same path unescaped",
       "input": "https://intranet.example.com/a%20b",
       "clean": "https://intranet.example.com/a%20b"
+    },
+    {
+      "case": "a base path validEncoded admits is sent verbatim, not re-escaped",
+      "input": "https://intranet.example.com/a!b(c)[d]",
+      "clean": "https://intranet.example.com/a!b(c)[d]"
+    },
+    {
+      "case": "a percent escape in the host decodes to a different domain under url",
+      "input": "https://acme.atlassian.net%2Eevil.com",
+      "error": "invalid site URL: parse \"https://acme.atlassian.net%2Eevil.com\": invalid URL escape \"%2E\"",
+      "rust_error": "invalid site URL: its host holds a percent escape"
     }
   ],
   "tools": [

--- a/desktop/src-tauri/src/claude/schema_vectors.rs
+++ b/desktop/src-tauri/src/claude/schema_vectors.rs
@@ -29,8 +29,9 @@
 //! **None of the standing divergences is reachable from #312.** Every params
 //! struct in `internal/integrations/github/` is flat, carries no `omitempty`,
 //! and uses only `string`, `int`, `int64` and `bool` — which is why the twenty
-//! schemas in `github_vectors.json` match exactly. The map exists so #313–#317
-//! do not each rediscover the boundary.
+//! schemas in `github_vectors.json` match exactly, and #317's six in
+//! `confluence_vectors.json` with them. The map exists so #313–#316 do not each
+//! rediscover the boundary.
 
 use std::collections::BTreeMap;
 

--- a/desktop/src-tauri/src/native/chat/mod.rs
+++ b/desktop/src-tauri/src/native/chat/mod.rs
@@ -11,13 +11,13 @@
 //! button would silently do nothing.
 //!
 //! But not every chat *can* run here: an agent whose tools come from an
-//! integration needs one MCP server per provider, and this port has five of the
-//! six still to write (#313–#317), so `runner::build_options` refuses those and
-//! they keep running on the sidecar. Two halves of that refusal have gone —
-//! the **local** in-process server (#310) and, since #311, any agent whose
-//! `capabilities.mcp` names only **github** integrations — but each only shrinks
-//! the set of chats Go still holds; it does not empty it, and the argument here
-//! turns on the set being non-empty.
+//! integration needs one MCP server per provider, and this port has four of the
+//! six still to write (#313–#316), so `runner::build_options` refuses those and
+//! they keep running on the sidecar. Parts of that refusal have gone — the
+//! **local** in-process server (#310), then any agent whose `capabilities.mcp`
+//! names only hosted integrations (**github** since #311, **confluence** since
+//! #317) — but each only shrinks the set of chats Go still holds; it does not
+//! empty it, and the argument here turns on the set being non-empty.
 //! So the three steering routes are answered natively **only when Rust holds a
 //! live session for that chat**, and forward otherwise. Go then answers —
 //! correctly, because it is the side that has the session — and a chat with no

--- a/desktop/src-tauri/src/native/chat/runner.rs
+++ b/desktop/src-tauri/src/native/chat/runner.rs
@@ -23,12 +23,12 @@
 //!
 //! **#311 narrowed the `mcp` half rather than removing it.** An agent is served
 //! natively when *every* name in `capabilities.mcp` is an integration this build
-//! can host, which today means `github` (#312) and will mean the rest as
-//! #313–#317 land. Three things still forward, and [`mcp_plan`] is
-//! where each is decided:
+//! can host — `registry::HOSTED_TYPES`, which today means `github` (#312) and
+//! `confluence` (#317), and will mean the rest as #313–#316 land. Three things
+//! still forward, and [`mcp_plan`] is where each is decided:
 //!
-//! - **A name that is not a github integration.** A `slack` row has no Rust
-//!   starter; running the turn here would drop its tools.
+//! - **A name whose type is not hosted.** A `slack` row has no Rust starter;
+//!   running the turn here would drop its tools.
 //! - **A name with no integration row at all.** Go would still resolve it if
 //!   `mcps.yaml` names it, and this build reads no `mcps.yaml`.
 //! - **Any `mcp` capability at all when `<data dir>/mcps.yaml` exists.** That
@@ -388,7 +388,7 @@ fn mcp_plan(
         if !crate::native::integrations::registry::can_host(db_path, id)? {
             return Err(format!(
                 "agent uses MCP server {id:?}, which is not an integration this build \
-                 can host (#313–#317)"
+                 can host (#313–#316)"
             ));
         }
         servers.push(McpServerSpec {

--- a/desktop/src-tauri/src/native/gourl.rs
+++ b/desktop/src-tauri/src/native/gourl.rs
@@ -146,6 +146,17 @@ pub fn valid_encoded_path(s: &str) -> bool {
     })
 }
 
+/// [`escape_path`] over raw bytes.
+///
+/// A Go string is arbitrary bytes and `escape` is defined over them, so a
+/// caller that has just come out of [`unescape_path`] — which answers
+/// `Vec<u8>` for exactly that reason — must not have to demand UTF-8 first.
+/// `%FF` is a perfectly good path to Go, and `EscapedPath()` renders it back as
+/// `%FF`; requiring UTF-8 in between would refuse it.
+pub fn escape_path_bytes(bytes: &[u8]) -> String {
+    escape_bytes(bytes, Encoding::Path)
+}
+
 /// Go's `url.PathEscape` — `escape(s, encodePathSegment)`.
 ///
 /// One segment, so `/` is escaped: this is what every
@@ -310,6 +321,17 @@ mod tests {
     /// is the whole reason this function exists rather than a caller comparing
     /// against [`escape_path`]. Every byte here is one Go sends **verbatim**
     /// while `escape` would rewrite it.
+    /// [`escape_path_bytes`] is [`escape_path`] without the UTF-8 demand, and
+    /// the bytes that show it are the ones a `String` cannot hold.
+    #[test]
+    fn escaping_bytes_does_not_require_utf8() {
+        assert_eq!(escape_path_bytes(b"/a/b"), "/a/b");
+        assert_eq!(escape_path_bytes("/café".as_bytes()), "/caf%C3%A9");
+        // Not valid UTF-8, and a path Go both accepts and renders back.
+        assert_eq!(escape_path_bytes(b"/a\xffb"), "/a%FFb");
+        assert_eq!(escape_path_bytes(b"/\xff\xfe"), "/%FF%FE");
+    }
+
     #[test]
     fn valid_encoded_admits_what_escape_would_rewrite() {
         for raw in [

--- a/desktop/src-tauri/src/native/gourl.rs
+++ b/desktop/src-tauri/src/native/gourl.rs
@@ -114,6 +114,38 @@ pub fn escape_path(s: &str) -> String {
     escape_bytes(s.as_bytes(), Encoding::Path)
 }
 
+/// Go's `validEncoded(s, encodePath)` — whether `net/url` would send `s` as it
+/// stands rather than re-escaping it.
+///
+/// This is the half of `URL.EscapedPath()` that is easy to miss, and missing it
+/// makes a faithful-looking comparison wrong. `EscapedPath` does **not** simply
+/// return `escape(Path, encodePath)`: when the raw text differs from that and is
+/// *validly encoded*, the raw text wins. And `validEncoded`'s allowlist is wider
+/// than `should_escape`'s — it admits `! $ & ' ( ) * + , ; = : @ [ ] %`
+/// unconditionally, "not specified in RFC 3986 but left alone by modern
+/// browsers".
+///
+/// So `/a!b` is sent verbatim even though `escape` would render it `/a%21b`,
+/// and `/a%2Fb` is sent verbatim even though its decoded form re-escapes to
+/// `/a/b`. A caller comparing another parser's output against `escape` alone
+/// would call both of those a divergence when they are not one.
+///
+/// The one caller today is `native/integrations/confluence`, which uses it to
+/// decide whether a stored site URL is one this build can send where Go sends
+/// it; #316 needs the same question answered for Jira.
+pub fn valid_encoded_path(s: &str) -> bool {
+    s.bytes().all(|c| match c {
+        b'!' | b'$' | b'&' | b'\'' | b'(' | b')' | b'*' | b'+' | b',' | b';' | b'=' | b':'
+        | b'@' => true,
+        // "not specified in RFC 3986 but left alone by modern browsers"
+        b'[' | b']' => true,
+        // Percent-encoded, and `unescape` has the job of deciding whether it
+        // decodes at all.
+        b'%' => true,
+        _ => !should_escape(c, Encoding::Path),
+    })
+}
+
 /// Go's `url.PathEscape` — `escape(s, encodePathSegment)`.
 ///
 /// One segment, so `/` is escaped: this is what every
@@ -274,6 +306,37 @@ pub fn route_path(raw: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    /// `validEncoded`'s allowlist is wider than `should_escape`'s, and the gap
+    /// is the whole reason this function exists rather than a caller comparing
+    /// against [`escape_path`]. Every byte here is one Go sends **verbatim**
+    /// while `escape` would rewrite it.
+    #[test]
+    fn valid_encoded_admits_what_escape_would_rewrite() {
+        for raw in [
+            "/a!b",
+            "/a(b)c",
+            "/a[b]",
+            "/a'b",
+            "/a*b",
+            "/a%2Fb",
+            "/a/../b",
+            "/a:b@c",
+            "/a$b&c",
+            "/a+b,c;d=e",
+            "/plain",
+            "",
+        ] {
+            assert!(valid_encoded_path(raw), "{raw}");
+        }
+        // …and the bytes it refuses, which are the ones `EscapedPath` re-escapes.
+        for raw in [
+            "/a b", "/a\\b", "/a^b", "/a|b", "/a\"b", "/a<b>c", "/a`b", "/a{b}", "/a#b", "/a?b",
+            "/café",
+        ] {
+            assert!(!valid_encoded_path(raw), "{raw}");
+        }
+    }
+
     use super::*;
     use serde::Deserialize;
 

--- a/desktop/src-tauri/src/native/integration_credentials.rs
+++ b/desktop/src-tauri/src/native/integration_credentials.rs
@@ -361,6 +361,16 @@ fn validate_whatsapp(credentials: Option<&RawValue>) -> Result<(), WriteError> {
 /// forwarded, because those are exactly the inputs `url.Parse` rejects with a
 /// message of its own — and a wrong *acceptance* here would store a URL Go
 /// would have refused.
+///
+/// **This is the second of two places that reason about `net/url`'s rules, and
+/// they answer different questions.** Here the question is *create*: may this
+/// row be stored, and is forwarding to Go an option (it always is). In
+/// `native/integrations/confluence`, `validate_site_url` asks *start*: may a
+/// stored row be hosted — where there is nobody to forward to, so it decides
+/// everything itself and reproduces `getScheme` and the authority split
+/// outright. They agree on every realistic input and are deliberately not
+/// merged; #316 adds a third caller of the same Go rules with a *different*
+/// answer again, since Jira does not require HTTPS.
 fn split_url(raw: &str) -> Result<(String, String), WriteError> {
     let forward = || {
         WriteError::Fallback(format!(

--- a/desktop/src-tauri/src/native/integrations.rs
+++ b/desktop/src-tauri/src/native/integrations.rs
@@ -130,6 +130,7 @@
 /// [`registry`] calls it. Hosting an integration's server is the registry's
 /// job, and this module still never reads a credential — [`registry`] does,
 /// through a projection of its own that no response type can reach.
+pub mod confluence;
 pub mod github;
 
 /// The Start/Stop/Reload lifecycle, and the one place in the port that reads
@@ -475,16 +476,22 @@ fn segment(value: &str) -> Option<&str> {
 /// on the Go side. Returns the integration id the shell owes a reload for.
 ///
 /// `Reload` has seven callers in Go. Two are ported (`Update`, and `Delete` via
-/// `Stop`). Four more — the confluence, telegram, jira and slack validators —
-/// and `completeOAuth` are unaffected, because the switch is per type and every
-/// type they can reach is still Go's: `startProviderCallback` supports exactly
+/// `Stop`). Three more — the telegram, jira and slack validators — and
+/// `completeOAuth` are unaffected, because the switch is per type and every type
+/// they can reach is still Go's: `startProviderCallback` supports exactly
 /// `google` and `slack`, so an OAuth completion never concerns a type this
-/// process hosts. That leaves `validateGitHubPATAuth`, behind
-/// `POST /api/integrations/{id}/auth/validate`, as the one path that writes a
-/// credential for a hosted type and cannot tell anybody. Without this hook a
-/// GitHub integration is never hosted in the session it is set up in — create,
-/// `PUT` and `auth/validate` all leave it unauthenticated or unheard, and it
-/// appears only at the next boot's `start_all`.
+/// process hosts. That leaves `validateGitHubPATAuth` and, since #317,
+/// `validateConfluenceAuth` — both behind
+/// `POST /api/integrations/{id}/auth/validate` — as the paths that write a
+/// credential for a hosted type and cannot tell anybody. Without this hook such
+/// an integration is never hosted in the session it is set up in — create, `PUT`
+/// and `auth/validate` all leave it unauthenticated or unheard, and it appears
+/// only at the next boot's `start_all`.
+///
+/// The route predicate below is deliberately **type-blind**: it answers with the
+/// id for every integration, and `registry::reload_after_auth` reads the row's
+/// type through `can_host` before it does anything. So #313–#316 need not touch
+/// this — adding a string to `registry::HOSTED_TYPES` is what widens it.
 ///
 /// The reload runs **after** Go's answer, so the row is already written, and it
 /// is idempotent — the worst case is restarting a server that was about to be
@@ -1925,14 +1932,7 @@ mod tests {
     /// reload strands a socket and a paired client that never connects.
     #[test]
     fn a_write_for_a_type_the_sidecar_hosts_forwards_without_touching_the_row() {
-        for integration_type in [
-            "slack",
-            "whatsapp",
-            "telegram",
-            "jira",
-            "confluence",
-            "google",
-        ] {
+        for integration_type in ["slack", "whatsapp", "telegram", "jira", "google"] {
             let file = migrated();
             Connection::open(file.path())
                 .expect("open")

--- a/desktop/src-tauri/src/native/integrations/confluence/client.rs
+++ b/desktop/src-tauri/src/native/integrations/confluence/client.rs
@@ -206,13 +206,31 @@ impl Client {
     /// `url` normalizes in a tool's path — now or after an upgrade — is caught by
     /// construction.
     ///
-    /// [`super::validate_site_url`] has already refused the three base shapes
-    /// this cannot work behind: one `url` will not parse, one carrying its own
-    /// `?` or `#`, and one holding a dot segment of its own. The re-checks below
-    /// are cheap and keep the function total rather than trusting a caller.
+    /// # What this does not check, and who does
+    ///
+    /// Comparing two `url`-parsed values is blind to every place `url` and
+    /// `net/url` disagree about the **base** — most sharply the authority, where
+    /// `https://evil.com\@acme.atlassian.net` is a parse error to Go and host
+    /// `evil.com` to `url`. [`super::validate_site_url`] is the gate for those:
+    /// it runs once, at `Start`, and refuses a base whose host or path encoding
+    /// the two parsers read differently, so no `Client` should exist around one.
+    /// It is a per-call cost (a percent-decode and a re-encode) for a property
+    /// of a value that cannot change between calls, which is why it lives there
+    /// and not here.
+    ///
+    /// The three re-checks below are the cheap ones, kept so this function is
+    /// total rather than trusting its caller.
     fn absolute(&self, path: &str) -> Result<reqwest::Url, String> {
         let base = reqwest::Url::parse(&self.site_url).map_err(|_| REQUEST_FAILED.to_string())?;
         if base.query().is_some() || base.fragment().is_some() {
+            return Err(REQUEST_FAILED.to_string());
+        }
+        // A dot segment in the base collapses on *both* sides of the comparison
+        // below, so it is the one shape the comparison cannot see.
+        if super::base_path_of(&self.site_url)
+            .split('/')
+            .any(|segment| segment == "." || segment == "..")
+        {
             return Err(REQUEST_FAILED.to_string());
         }
         // `url` renders a base with no path of its own as `/`; the suffix

--- a/desktop/src-tauri/src/native/integrations/confluence/client.rs
+++ b/desktop/src-tauri/src/native/integrations/confluence/client.rs
@@ -179,54 +179,57 @@ impl Client {
     /// option is to **refuse**: the model reads the sentence a transport failure
     /// produces rather than the answer to a question it did not ask. This is
     /// `github::client::absolute`'s reasoning verbatim, and #313–#316 each need
-    /// it; the difference here is only that the base is a per-row site URL, so
-    /// the target Go would have sent is recovered from the concatenated string
-    /// rather than being the argument.
+    /// it.
     ///
-    /// # Why the whole target is compared rather than `..` scanned for
+    /// # What is compared, and why it is not the raw string
     ///
-    /// An exact comparison catches anything else `url` normalizes, now or after
-    /// an upgrade, instead of the one shape known today. Nothing legitimate
-    /// trips it, and that is a property of `gourl`'s escaping rather than luck:
-    /// `encodePathSegment` escapes every byte in `url`'s path encode set and
-    /// `encodeQueryComponent` every byte in its query one, so there is nothing
-    /// left for `url` to percent-encode; existing `%XX` escapes are passed
-    /// through with their case intact, so Go's uppercase hex survives; and a
-    /// path with no `?` compares `""` against `query()`'s `None`. Host, scheme
-    /// and port are not compared at all, so `url`'s default-port and case
-    /// normalization cannot reach this.
+    /// GitHub's base is a fixed, already-encoded string, so there the whole
+    /// target could be compared against the `path` argument. A site URL is
+    /// per row and **user-typed**, so it is not necessarily encoded:
+    /// `https://intranet.example.com/my atlassian` is one Go accepts, and both
+    /// `net/url`'s `EscapedPath` and `url` send it as `/my%20atlassian/…`. They
+    /// agree — but the raw text does not, so comparing against the raw
+    /// concatenation would refuse every call for a site URL that works.
     ///
-    /// A site URL is not the fixed string GitHub's base is, so the expected
-    /// target is whatever follows the authority in `site_url + path`. A site URL
-    /// carrying its own `?` or `#` before any path — which
-    /// [`super::validate_site_url`] admits, since it only checks the scheme and
-    /// the host — has no faithful answer and is refused here rather than sent
-    /// somewhere unintended.
+    /// So the base is parsed **on its own** and its rendered path is the
+    /// expected prefix; only the tool's own suffix is compared against the raw
+    /// bytes it built. That is sound because the suffix *is* fully encoded, and
+    /// not by luck: `encodePathSegment` escapes every byte in `url`'s path
+    /// encode set and `encodeQueryComponent` every byte in its query one, so
+    /// there is nothing left for `url` to percent-encode; existing `%XX` escapes
+    /// are passed through with their case intact, so Go's uppercase hex
+    /// survives; and a path with no `?` compares `""` against `query()`'s
+    /// `None`. Host, scheme and port are not compared at all, so `url`'s
+    /// default-port and case normalization cannot reach this.
+    ///
+    /// The comparison stays **exact** rather than a `..` scan, so anything else
+    /// `url` normalizes in a tool's path — now or after an upgrade — is caught by
+    /// construction.
+    ///
+    /// [`super::validate_site_url`] has already refused the three base shapes
+    /// this cannot work behind: one `url` will not parse, one carrying its own
+    /// `?` or `#`, and one holding a dot segment of its own. The re-checks below
+    /// are cheap and keep the function total rather than trusting a caller.
     fn absolute(&self, path: &str) -> Result<reqwest::Url, String> {
-        let full = format!("{}{path}", self.site_url);
-        let url = reqwest::Url::parse(&full).map_err(|_| REQUEST_FAILED.to_string())?;
-        let Some(target) = go_request_target(&full) else {
+        let base = reqwest::Url::parse(&self.site_url).map_err(|_| REQUEST_FAILED.to_string())?;
+        if base.query().is_some() || base.fragment().is_some() {
             return Err(REQUEST_FAILED.to_string());
+        }
+        // `url` renders a base with no path of its own as `/`; the suffix
+        // supplies that slash, so the prefix is empty.
+        let prefix = match base.path() {
+            "/" => "",
+            other => other,
         };
-        let (want_path, want_query) = target.split_once('?').unwrap_or((target, ""));
-        if url.path() != want_path || url.query().unwrap_or("") != want_query {
+
+        let url = reqwest::Url::parse(&format!("{}{path}", self.site_url))
+            .map_err(|_| REQUEST_FAILED.to_string())?;
+        let (want_path, want_query) = path.split_once('?').unwrap_or((path, ""));
+        if url.path() != format!("{prefix}{want_path}") || url.query().unwrap_or("") != want_query {
             return Err(REQUEST_FAILED.to_string());
         }
         Ok(url)
     }
-}
-
-/// What `net/http` would put on the request line for `full`: everything from the
-/// first `/` after the authority.
-///
-/// Recovered from the raw string rather than from a parsed URL precisely because
-/// parsing is what normalizes — the thing [`Client::absolute`] exists to detect.
-/// `None` when the authority is followed by a `?` or a `#` instead of a path,
-/// which no site URL this port should serve produces; the caller refuses.
-fn go_request_target(full: &str) -> Option<&str> {
-    let rest = full.split_once("://")?.1;
-    let start = rest.find(['/', '?', '#'])?;
-    rest[start..].starts_with('/').then(|| &rest[start..])
 }
 
 /// Sends a request, racing the run's cancellation.
@@ -395,10 +398,45 @@ mod tests {
         assert_eq!(url.query(), Some("limit=50"));
     }
 
+    /// A base `url` re-encodes is **not** a refusal, and this is the case that
+    /// a raw-string comparison gets wrong.
+    ///
+    /// A site URL is user-typed, so it need not be percent-encoded.
+    /// `net/url`'s `EscapedPath` and `url` both send `/my atlassian` as
+    /// `/my%20atlassian`, so Go and this port agree on the wire — but the raw
+    /// text does not match either of them, and comparing against it would answer
+    /// `request failed` for every call against a site URL that works.
+    #[test]
+    fn a_base_the_url_crate_re_encodes_is_still_served() {
+        for (site, prefix) in [
+            (
+                "https://intranet.example.com/my atlassian",
+                "/my%20atlassian",
+            ),
+            ("https://intranet.example.com/café", "/caf%C3%A9"),
+            ("https://intranet.example.com/a%20b", "/a%20b"),
+        ] {
+            let url = client(site)
+                .absolute("/wiki/api/v2/spaces?limit=50")
+                .unwrap_or_else(|_| panic!("{site} is a site URL Go serves"));
+            assert_eq!(url.path(), format!("{prefix}/wiki/api/v2/spaces"), "{site}");
+            assert_eq!(url.query(), Some("limit=50"), "{site}");
+        }
+    }
+
+    /// …and the dot-segment guard still fires behind such a base, because only
+    /// the tool's own suffix is compared against the bytes it built.
+    #[test]
+    fn the_guard_still_fires_behind_a_re_encoded_base() {
+        assert_eq!(
+            client("https://intranet.example.com/my atlassian").absolute("/wiki/api/v2/pages/.."),
+            Err(REQUEST_FAILED.to_string())
+        );
+    }
+
     /// A site URL whose authority is followed by a `?` or a `#` has no faithful
-    /// target, so it is refused rather than sent somewhere unintended.
-    /// `validate_site_url` admits it, because Go's only checks the scheme and
-    /// the host.
+    /// target. `validate_site_url` refuses it, and so does this — the function
+    /// stays total rather than trusting a caller.
     #[test]
     fn a_site_url_that_is_not_a_prefix_of_the_target_is_refused() {
         for site in [

--- a/desktop/src-tauri/src/native/integrations/confluence/client.rs
+++ b/desktop/src-tauri/src/native/integrations/confluence/client.rs
@@ -1,0 +1,478 @@
+//! The shared HTTP client, ported from `internal/integrations/confluence/tools.go`
+//! (`callConfluence`) and `validate.go` (`confluenceHTTPClient`).
+//!
+//! Everything the six tools have in common: how a request is authenticated and
+//! shaped, how much of a response is read, and the three sentences a failure can
+//! produce. None of it shows in a tool's success text, which is why
+//! `desktop/parity/confluence_vectors.json` records the *request* the fake
+//! Confluence received as well as the answer.
+//!
+//! # What is different from `github::client`, and it is not cosmetic
+//!
+//! - **The base is per integration, not per process.** GitHub has one API root
+//!   and a package variable pointing at it; a Confluence site URL comes out of
+//!   the row's credentials, so it is a field on [`Client`] and there is no
+//!   test-only seam to gate — a parity run simply constructs a client against a
+//!   loopback fake. (The Go side still needs one, because `Start` insists on
+//!   HTTPS before it ever builds the server; see
+//!   `internal/integrations/confluence/parity.go`.)
+//! - **Basic auth, not a bearer token.** `req.SetBasicAuth(email, apiToken)` is
+//!   `Authorization: Basic base64(email + ":" + apiToken)`, which is exactly what
+//!   `reqwest`'s `basic_auth` writes. The vectors pin the encoded header, so a
+//!   divergence in either implementation fails rather than shipping.
+//! - **The failure sentence names nothing.** `calling confluence API: request
+//!   failed` carries neither the method nor the URL, where GitHub's carries
+//!   both. That is Go's wording and the reason is the same there: the URL is
+//!   built from a site URL and model-supplied ids.
+//! - **The timeout is 30 seconds**, not GitHub's 15. Set on the client, which is
+//!   what bounds a graceful shutdown — see `desktop/CLAUDE.md` on why a handler
+//!   with no client timeout leaves a revoked credential answering `tools/call`.
+//!
+//! # Cancellation
+//!
+//! Go threads `ctx` into `http.NewRequestWithContext`, so a cancelled turn aborts
+//! the outbound call and `client.Do` returns an error — which becomes `calling
+//! confluence API: request failed`. That is what a cancelled call answers here
+//! too, so there is no divergence to invent. `crate::claude::tool` explains why
+//! the token has to be watched at all: `rmcp` spawns handlers detached, so a
+//! handler that ignores it keeps its socket open after the caller is gone.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use reqwest::Method;
+use tokio_stream::StreamExt;
+
+use crate::claude::CancellationToken;
+
+/// `maxResponseBytes`: 2 MiB, "keeping it small avoids flooding the LLM context".
+const MAX_RESPONSE_BYTES: usize = 2 * 1024 * 1024;
+
+/// `confluenceHTTPClient` — 30 seconds, redirects followed.
+///
+/// `Option`, because building one can fail here where Go's cannot.
+/// `&http.Client{Timeout: …}` is a struct literal and the trust store is not
+/// consulted until the handshake; `reqwest` reads the platform roots inside
+/// `build()` (see `Cargo.toml` on `rustls-tls-native-roots`) and reports an
+/// unusable store as a builder error. That has to reach the model as Go's own
+/// `calling confluence API: request failed` — a handshake that cannot complete
+/// is a transport failure there too — rather than as a panic inside a handler
+/// `rmcp` spawned detached.
+fn http_client() -> Option<&'static reqwest::Client> {
+    static CLIENT: OnceLock<Option<reqwest::Client>> = OnceLock::new();
+    CLIENT
+        .get_or_init(|| {
+            reqwest::Client::builder()
+                .timeout(Duration::from_secs(30))
+                .build()
+                .ok()
+        })
+        .as_ref()
+}
+
+/// `fmt.Errorf("calling confluence API: request failed")`, which is also what a
+/// cancelled call and a refused URL answer. See the module header.
+const REQUEST_FAILED: &str = "calling confluence API: request failed";
+
+/// Go's `client`-equivalent: the site URL and the credentials every request
+/// carries.
+///
+/// Cloned per call from the closure that captured it — the shape
+/// `crate::claude::tool`'s module docs describe — so it is deliberately cheap to
+/// clone and holds nothing else.
+#[derive(Clone)]
+pub struct Client {
+    site_url: String,
+    email: String,
+    api_token: String,
+}
+
+impl Client {
+    /// `site_url` is the value [`super::validate_site_url`] already cleaned:
+    /// HTTPS, a host, no trailing slash. Nothing here re-checks it, exactly as
+    /// nothing in `tools.go` does — `Start` is the one gate, and a parity run
+    /// deliberately bypasses it to point a client at loopback.
+    pub fn new(
+        site_url: impl Into<String>,
+        email: impl Into<String>,
+        api_token: impl Into<String>,
+    ) -> Self {
+        Self {
+            site_url: site_url.into(),
+            email: email.into(),
+            api_token: api_token.into(),
+        }
+    }
+
+    /// `callConfluence`: an authenticated request whose body is returned as the
+    /// raw response bytes.
+    ///
+    /// `path` is appended to the site URL, already escaped by its caller —
+    /// `gourl::path_escape` per segment, `gourl::query_escape` per query value —
+    /// because that is what `fmt.Sprintf` over `url.PathEscape` does on the Go
+    /// side. `body` is already-encoded bytes rather than a value: the encoding
+    /// has to be `json.Marshal`'s (sorted keys, HTML escaping) and doing it here
+    /// would hide that. See [`super::content`].
+    ///
+    /// The `Content-Type` header is set **only when there is a body** — Go's
+    /// `if body != nil` — so both GETs send `Accept` alone.
+    pub async fn call(
+        &self,
+        ct: &CancellationToken,
+        method: Method,
+        path: &str,
+        body: Option<Vec<u8>>,
+    ) -> Result<String, String> {
+        let has_body = body.is_some();
+        let mut request = http_client()
+            .ok_or_else(|| REQUEST_FAILED.to_string())?
+            .request(method, self.absolute(path)?)
+            // `req.SetBasicAuth(email, apiToken)`:
+            // `Basic base64(email + ":" + apiToken)`, which is what this writes.
+            .basic_auth(&self.email, Some(&self.api_token))
+            .header("Accept", "application/json");
+        if has_body {
+            request = request.header("Content-Type", "application/json");
+        }
+        if let Some(body) = body {
+            request = request.body(body);
+        }
+
+        let response = send(ct, request).await?;
+        let status = response.status();
+        let text = read_capped(ct, response).await?;
+        if !(200..300).contains(&status.as_u16()) {
+            // `fmt.Errorf("confluence API error (status %d): %s", …)` — the
+            // API's own body, **verbatim**. Decoding and re-encoding it would
+            // reorder its keys and respell its numbers, and that body is what
+            // tells the model whether it hit a permission problem or a typo.
+            return Err(format!(
+                "confluence API error (status {}): {text}",
+                status.as_u16()
+            ));
+        }
+        Ok(text)
+    }
+
+    /// The URL a request to `path` goes to — or [`REQUEST_FAILED`], if this port
+    /// cannot build the request Go builds.
+    ///
+    /// # Why this exists, and why it refuses instead of correcting
+    ///
+    /// Go concatenates the site URL and `path`, hands the string to
+    /// `http.NewRequestWithContext`, and `net/http` writes `URL.RequestURI()` on
+    /// the wire **verbatim**. Nothing normalizes: `url.PathEscape` leaves `.` and
+    /// `..` alone (both are unreserved) and `net/url` does not remove dot
+    /// segments, so `get_page(page_id: "..")` asks Confluence for
+    /// `/wiki/api/v2/pages/..` and gets a 404.
+    ///
+    /// `reqwest` builds every request through `url::Url::parse`, which applies
+    /// WHATWG dot-segment removal for http(s). The same call would leave as
+    /// `/wiki/api/v2/` — the space *listing* rather than one page, on a request
+    /// already carrying the user's API token. `page_id`, `space_id` and
+    /// `parent_id` are model-supplied and every tool result carries
+    /// attacker-authored wiki content, so it is reachable under prompt
+    /// injection, and it applies to `update_page`'s write too. Escaping the dots
+    /// is not a fix — `%2E%2E` is collapsed as well.
+    ///
+    /// `reqwest` offers no way to send an unnormalized target, so the faithful
+    /// option is to **refuse**: the model reads the sentence a transport failure
+    /// produces rather than the answer to a question it did not ask. This is
+    /// `github::client::absolute`'s reasoning verbatim, and #313–#316 each need
+    /// it; the difference here is only that the base is a per-row site URL, so
+    /// the target Go would have sent is recovered from the concatenated string
+    /// rather than being the argument.
+    ///
+    /// # Why the whole target is compared rather than `..` scanned for
+    ///
+    /// An exact comparison catches anything else `url` normalizes, now or after
+    /// an upgrade, instead of the one shape known today. Nothing legitimate
+    /// trips it, and that is a property of `gourl`'s escaping rather than luck:
+    /// `encodePathSegment` escapes every byte in `url`'s path encode set and
+    /// `encodeQueryComponent` every byte in its query one, so there is nothing
+    /// left for `url` to percent-encode; existing `%XX` escapes are passed
+    /// through with their case intact, so Go's uppercase hex survives; and a
+    /// path with no `?` compares `""` against `query()`'s `None`. Host, scheme
+    /// and port are not compared at all, so `url`'s default-port and case
+    /// normalization cannot reach this.
+    ///
+    /// A site URL is not the fixed string GitHub's base is, so the expected
+    /// target is whatever follows the authority in `site_url + path`. A site URL
+    /// carrying its own `?` or `#` before any path — which
+    /// [`super::validate_site_url`] admits, since it only checks the scheme and
+    /// the host — has no faithful answer and is refused here rather than sent
+    /// somewhere unintended.
+    fn absolute(&self, path: &str) -> Result<reqwest::Url, String> {
+        let full = format!("{}{path}", self.site_url);
+        let url = reqwest::Url::parse(&full).map_err(|_| REQUEST_FAILED.to_string())?;
+        let Some(target) = go_request_target(&full) else {
+            return Err(REQUEST_FAILED.to_string());
+        };
+        let (want_path, want_query) = target.split_once('?').unwrap_or((target, ""));
+        if url.path() != want_path || url.query().unwrap_or("") != want_query {
+            return Err(REQUEST_FAILED.to_string());
+        }
+        Ok(url)
+    }
+}
+
+/// What `net/http` would put on the request line for `full`: everything from the
+/// first `/` after the authority.
+///
+/// Recovered from the raw string rather than from a parsed URL precisely because
+/// parsing is what normalizes — the thing [`Client::absolute`] exists to detect.
+/// `None` when the authority is followed by a `?` or a `#` instead of a path,
+/// which no site URL this port should serve produces; the caller refuses.
+fn go_request_target(full: &str) -> Option<&str> {
+    let rest = full.split_once("://")?.1;
+    let start = rest.find(['/', '?', '#'])?;
+    rest[start..].starts_with('/').then(|| &rest[start..])
+}
+
+/// Sends a request, racing the run's cancellation.
+///
+/// Cancellation and a transport failure produce the same sentence, and that is
+/// not a shortcut: in Go a cancelled `ctx` *is* how `client.Do` fails, so this is
+/// the message that reaches the model there too.
+async fn send(
+    ct: &CancellationToken,
+    request: reqwest::RequestBuilder,
+) -> Result<reqwest::Response, String> {
+    tokio::select! {
+        () = ct.cancelled() => Err(REQUEST_FAILED.to_string()),
+        result = request.send() => result.map_err(|_| REQUEST_FAILED.to_string()),
+    }
+}
+
+/// `io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))`.
+///
+/// Streamed rather than buffered whole: the cap exists so a hostile or runaway
+/// response cannot be pulled into memory, and `bytes()` would read it all before
+/// there was anything to truncate.
+///
+/// **Lossy UTF-8**, the one place this is not literally Go. Go does
+/// `string(respBody)` on arbitrary bytes and a Go string holds them; a Rust
+/// `String` cannot, so invalid sequences become U+FFFD. Every Confluence
+/// response this reaches is JSON, and the alternative — carrying `Vec<u8>`
+/// through to the `ContentBlock` — would only move the same conversion to the
+/// end of the pipe, where `rmcp` demands a `String` anyway.
+async fn read_capped(
+    ct: &CancellationToken,
+    response: reqwest::Response,
+) -> Result<String, String> {
+    let mut body = Vec::new();
+    let mut stream = Box::pin(response.bytes_stream());
+    loop {
+        let chunk = tokio::select! {
+            () = ct.cancelled() => return Err("reading response: context canceled".to_string()),
+            chunk = stream.next() => chunk,
+        };
+        match chunk {
+            None => break,
+            Some(Ok(chunk)) => {
+                body.extend_from_slice(&chunk);
+                if body.len() >= MAX_RESPONSE_BYTES {
+                    body.truncate(MAX_RESPONSE_BYTES);
+                    break;
+                }
+            }
+            // `fmt.Errorf("reading response: %w", err)`. The cause *is*
+            // interpolated here, unlike the send failure: this error describes a
+            // body already in flight and cannot carry the request URL.
+            Some(Err(e)) => return Err(format!("reading response: {e}")),
+        }
+    }
+    Ok(String::from_utf8_lossy(&body).into_owned())
+}
+
+/// The `1-250` clamp both paging tools apply, with a per-tool fallback.
+///
+/// `limit <= 0 || limit > 250` falls back, so a zero (the value an
+/// omitted-but-required field cannot be, since every field *is* required) and a
+/// 500 land in the same place. The two callers disagree on the fallback —
+/// `list_spaces` uses 50 and `search_content` 25 — which is why it is a
+/// parameter rather than a constant.
+pub fn clamp_limit(limit: i64, fallback: i64) -> i64 {
+    if limit <= 0 || limit > 250 {
+        fallback
+    } else {
+        limit
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A distinctive token, so a leak is unmistakable in any assertion.
+    const SECRET: &str = "atlassian-SUPER-SECRET-API-TOKEN";
+
+    fn client(site_url: &str) -> Client {
+        Client::new(site_url, "person@example.com", SECRET)
+    }
+
+    #[test]
+    fn the_limit_clamp_is_gos() {
+        for (limit, fallback, want) in [
+            (0, 50, 50),
+            (-5, 50, 50),
+            (251, 50, 50),
+            (250, 50, 250),
+            (1, 50, 1),
+            (0, 25, 25),
+            (251, 25, 25),
+        ] {
+            assert_eq!(clamp_limit(limit, fallback), want, "{limit}/{fallback}");
+        }
+    }
+
+    /// The dot-segment guard, at the unit rather than at the vector: what it
+    /// refuses, and — the half that would bite — everything it must not.
+    ///
+    /// `confluence_vectors.json` covers this end to end for every call; this
+    /// covers the shapes a *future* tool could build that no vector has yet,
+    /// which is where a guard like this normally goes wrong.
+    #[test]
+    fn dot_segments_are_refused_and_nothing_else_is() {
+        let c = client("https://acme.atlassian.net");
+        let ok = |path: &str| {
+            c.absolute(path)
+                .unwrap_or_else(|_| panic!("{path} is a legitimate path"))
+        };
+
+        // `url` resolves every one of these into a different endpoint than Go
+        // calls, and escaping the dots does not help — `%2E%2E` is collapsed
+        // too, so there is nothing to encode our way out of.
+        for path in [
+            "/wiki/api/v2/pages/..",
+            "/wiki/api/v2/pages/.",
+            "/wiki/api/v2/pages/%2E%2E",
+            "/wiki/api/v2/spaces/../../..",
+        ] {
+            assert_eq!(c.absolute(path), Err(REQUEST_FAILED.to_string()), "{path}");
+        }
+
+        // Everything `gourl` can emit. `PathEscape` already escapes every byte
+        // in `url`'s path encode set and `QueryEscape` every byte in its query
+        // one, so there is nothing left for `url` to re-encode; percent-escapes
+        // keep Go's uppercase hex; a space is `+` in a query and `%20` in a
+        // segment; and a path with no `?` has no query on either side.
+        assert_eq!(
+            ok("/wiki/api/v2/spaces?limit=50").path(),
+            "/wiki/api/v2/spaces"
+        );
+        assert_eq!(ok("/wiki/api/v2/spaces/123").query(), None);
+        assert_eq!(
+            ok("/wiki/api/v2/search?cql=space+%3D+DEV+%26+type+%3D+page&limit=25").query(),
+            Some("cql=space+%3D+DEV+%26+type+%3D+page&limit=25")
+        );
+        assert_eq!(
+            ok("/wiki/api/v2/pages/my%20page%2Fid").path(),
+            "/wiki/api/v2/pages/my%20page%2Fid",
+            "uppercase hex survives, and so does an escaped slash"
+        );
+        // A dot *inside* a segment is not a dot segment, and neither is one
+        // inside a query value — only the path is resolved.
+        assert_eq!(
+            ok("/wiki/api/v2/pages/v1.2.3").path(),
+            "/wiki/api/v2/pages/v1.2.3"
+        );
+        assert_eq!(
+            ok("/wiki/api/v2/search?cql=..%2F..&limit=25").query(),
+            Some("cql=..%2F..&limit=25")
+        );
+    }
+
+    /// A site URL with its own base path is concatenated, not resolved — Go's
+    /// `fmt.Sprintf` has no notion of a base — so the guard has to accept it.
+    #[test]
+    fn a_site_url_with_a_base_path_is_still_a_prefix() {
+        let c = client("https://intranet.example.com/atlassian");
+        let url = c
+            .absolute("/wiki/api/v2/spaces?limit=50")
+            .expect("a base path is legitimate");
+        assert_eq!(url.path(), "/atlassian/wiki/api/v2/spaces");
+        assert_eq!(url.query(), Some("limit=50"));
+    }
+
+    /// A site URL whose authority is followed by a `?` or a `#` has no faithful
+    /// target, so it is refused rather than sent somewhere unintended.
+    /// `validate_site_url` admits it, because Go's only checks the scheme and
+    /// the host.
+    #[test]
+    fn a_site_url_that_is_not_a_prefix_of_the_target_is_refused() {
+        for site in [
+            "https://acme.atlassian.net?a=b",
+            "https://acme.atlassian.net#x",
+        ] {
+            assert_eq!(
+                client(site).absolute("/wiki/api/v2/spaces?limit=50"),
+                Err(REQUEST_FAILED.to_string()),
+                "{site}"
+            );
+        }
+    }
+
+    /// The whole reason the failure message names nothing.
+    ///
+    /// A `reqwest::Error`'s `Display` carries the URL it was building, and a
+    /// future edit that "helpfully" interpolated the cause would put the request
+    /// — and, one refactor later, a header — into text the model reads and the
+    /// transcript stores. Go's wording has the same property and this asserts it
+    /// rather than trusting it.
+    #[tokio::test]
+    async fn a_failed_call_names_neither_the_credentials_nor_the_cause() {
+        // Port 1 on loopback: nothing listens, so the connect fails fast.
+        let message = client("http://127.0.0.1:1")
+            .call(
+                &CancellationToken::new(),
+                Method::GET,
+                "/wiki/api/v2/spaces?limit=50",
+                None,
+            )
+            .await
+            .expect_err("nothing is listening");
+        assert_eq!(message, REQUEST_FAILED);
+        assert!(!message.contains(SECRET), "a token reached the model");
+        assert!(
+            !message.contains("person@example.com"),
+            "an email reached the model"
+        );
+    }
+
+    /// A cancelled call answers **Go's sentence**, and that is a port rather
+    /// than a choice: in Go a cancelled `ctx` is how `client.Do` fails.
+    #[tokio::test]
+    async fn a_cancelled_call_answers_what_a_cancelled_go_call_answers() {
+        let ct = CancellationToken::new();
+        ct.cancel();
+        assert_eq!(
+            client("http://127.0.0.1:1")
+                .call(&ct, Method::GET, "/wiki/api/v2/spaces?limit=50", None)
+                .await,
+            Err(REQUEST_FAILED.to_string())
+        );
+    }
+
+    /// `io.LimitReader` truncates rather than failing, and it stops *reading* —
+    /// which is why the port streams instead of buffering the body and then
+    /// slicing it.
+    #[tokio::test]
+    async fn a_response_is_truncated_at_the_cap_rather_than_refused() {
+        let oversized = MAX_RESPONSE_BYTES + 4096;
+        let app = axum::Router::new().fallback(move || async move { "x".repeat(oversized) });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let base = format!("http://{}", listener.local_addr().expect("addr"));
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+
+        let body = client(&base)
+            .call(&CancellationToken::new(), Method::GET, "/big", None)
+            .await
+            .expect("a 200 is a success however long the body is");
+        assert_eq!(body.len(), MAX_RESPONSE_BYTES);
+    }
+}

--- a/desktop/src-tauri/src/native/integrations/confluence/content.rs
+++ b/desktop/src-tauri/src/native/integrations/confluence/content.rs
@@ -1,0 +1,326 @@
+//! The `content` service's six tools, ported from
+//! `internal/integrations/confluence/tools.go`.
+//!
+//! Confluence has one service group, so this file is the whole tool surface.
+//! Each tool is the shape every ported tool takes, and the conventions behind it
+//! are `native/integrations/github/repos.rs`'s:
+//!
+//! - The input struct's field names are the Go `json:` tags and its doc comments
+//!   are the Go `jsonschema:` tags **verbatim**, `required,` prefix included.
+//!   That prefix is not a directive — `google/jsonschema-go` reads the whole tag
+//!   as the description — so it is a sentence the model reads and dropping it
+//!   would change the advertised surface. See `crate::claude::schema_vectors`
+//!   for the generated proof.
+//! - Every field is a plain `String` / `i64`, never an `Option`: no params
+//!   struct in this integration carries `omitempty`, so **every field is
+//!   required** and the model must send all of them. An `Option` would render
+//!   `["string","null"]` and change the schema.
+//! - `deny_unknown_fields` is what emits `"additionalProperties": false`, which
+//!   Go's reflector sets on every struct and its server validates against.
+//! - The credential is captured by the closure and **cloned per call**, outside
+//!   the async block — the `Fn` requirement `crate::claude::tool`'s module docs
+//!   spell out.
+//!
+//! # The two request bodies
+//!
+//! `create_page` and `update_page` build a `map[string]any` — nested, unlike
+//! anything in the GitHub port — and hand it to `json.Marshal`. Three properties
+//! of that encoding are reproduced by [`crate::native::gojson::to_vec_marshal`]
+//! over a `BTreeMap`, and all three are visible in the vectors:
+//!
+//! - **Keys are sorted, at every level.** `encoding/json` sorts map keys;
+//!   `BTreeMap` iterates sorted and `serde_json::Map` is one too, so the nested
+//!   `body` and `version` objects sort as well.
+//! - **`<`, `>` and `&` are escaped** to `\u003c`, `\u003e`, `\u0026`. A page
+//!   body is Confluence *storage format* — XHTML — so this fires on every single
+//!   `create_page`, and `serde_json` on its own emits those three bytes
+//!   literally.
+//! - **`parentId` is written only when non-empty**, which is Go's one condition
+//!   here; `update_page` has none and always sends all five keys.
+
+use schemars::JsonSchema;
+use serde_json::{json, Value};
+
+use crate::claude::{new_tool, CancellationToken, ToolDef};
+use crate::native::gourl::{path_escape, query_escape};
+
+use super::client::{clamp_limit, Client};
+use super::text_result;
+
+/// `json.Marshal(payload)` for a Go `map[string]any`.
+///
+/// Infallible in practice — every value here is a string, an integer or a map of
+/// those — but the encoder's signature is fallible, and Go's own
+/// `fmt.Errorf("marshaling request: %w", err)` is what the model would read, so
+/// the wording is kept.
+fn marshal(payload: &Value) -> Result<Vec<u8>, String> {
+    crate::native::gojson::to_vec_marshal(payload).map_err(|e| format!("marshaling request: {e}"))
+}
+
+/// `list_spaces`.
+#[allow(dead_code)] // read through serde, never constructed in Rust
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct ListSpacesInput {
+    /// Maximum number of spaces to return (1-250)
+    limit: i64,
+}
+
+pub fn list_spaces(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "list_spaces",
+        "Lists Confluence spaces.",
+        move |input: ListSpacesInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                // `fmt.Sprintf`, not `url.Values` — so the query is these two
+                // literal bytes and a decimal, with no escaping in play.
+                let limit = clamp_limit(input.limit, 50);
+                let path = format!("/wiki/api/v2/spaces?limit={limit}");
+                let result = client.call(&ct, reqwest::Method::GET, &path, None).await?;
+                Ok(text_result(format!("Spaces: {result}")))
+            }
+        },
+    )
+}
+
+/// `get_space`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct GetSpaceInput {
+    /// required,The ID of the space to retrieve
+    space_id: String,
+}
+
+pub fn get_space(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "get_space",
+        "Gets details of a Confluence space by ID.",
+        move |input: GetSpaceInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                // `url.PathEscape`, not the whole-path encoding: a space id
+                // holding a `/` has to stay one segment.
+                let path = format!("/wiki/api/v2/spaces/{}", path_escape(&input.space_id));
+                let result = client.call(&ct, reqwest::Method::GET, &path, None).await?;
+                Ok(text_result(format!("Space: {result}")))
+            }
+        },
+    )
+}
+
+/// `search_content`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct SearchContentInput {
+    /// required,CQL query string (e.g. 'space = DEV AND type = page')
+    cql: String,
+    /// Maximum number of results to return (1-250)
+    limit: i64,
+}
+
+pub fn search_content(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "search_content",
+        "Searches Confluence content using CQL (Confluence Query Language).",
+        move |input: SearchContentInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                // `url.QueryEscape`, which is `encodeQueryComponent`: a space
+                // becomes `+`, not `%20`. CQL is full of spaces and `=`, so the
+                // difference is on every real query.
+                let limit = clamp_limit(input.limit, 25);
+                let path = format!(
+                    "/wiki/api/v2/search?cql={}&limit={limit}",
+                    query_escape(&input.cql)
+                );
+                let result = client.call(&ct, reqwest::Method::GET, &path, None).await?;
+                Ok(text_result(format!("Search results: {result}")))
+            }
+        },
+    )
+}
+
+/// `get_page`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct GetPageInput {
+    /// required,The ID of the page to retrieve
+    page_id: String,
+    /// Body format to return: storage or view (default: storage)
+    body_format: String,
+}
+
+pub fn get_page(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "get_page",
+        "Gets the content and metadata of a Confluence page by ID.",
+        move |input: GetPageInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                // The default is applied on **empty**, not on an unrecognized
+                // value: anything else is passed through and Confluence answers
+                // for it.
+                let format = if input.body_format.is_empty() {
+                    "storage"
+                } else {
+                    &input.body_format
+                };
+                let path = format!(
+                    "/wiki/api/v2/pages/{}?body-format={}",
+                    path_escape(&input.page_id),
+                    query_escape(format)
+                );
+                let result = client.call(&ct, reqwest::Method::GET, &path, None).await?;
+                Ok(text_result(format!("Page: {result}")))
+            }
+        },
+    )
+}
+
+/// `create_page`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct CreatePageInput {
+    /// required,The ID of the space to create the page in
+    space_id: String,
+    /// required,Title of the new page
+    title: String,
+    /// required,Page body content in Confluence storage format (XHTML)
+    body: String,
+    /// Optional parent page ID to nest under
+    parent_id: String,
+}
+
+pub fn create_page(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "create_page",
+        "Creates a new Confluence page in a given space.",
+        move |input: CreatePageInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let mut payload = json!({
+                    "spaceId": input.space_id,
+                    "status": "current",
+                    "title": input.title,
+                    "body": {
+                        "representation": "storage",
+                        "value": input.body,
+                    },
+                });
+                // The one condition: an empty parent leaves no key at all,
+                // rather than sending `"parentId":""`.
+                if !input.parent_id.is_empty() {
+                    payload["parentId"] = Value::String(input.parent_id.clone());
+                }
+                let encoded = marshal(&payload)?;
+
+                let result = client
+                    .call(
+                        &ct,
+                        reqwest::Method::POST,
+                        "/wiki/api/v2/pages",
+                        Some(encoded),
+                    )
+                    .await?;
+                Ok(text_result(format!("Page created: {result}")))
+            }
+        },
+    )
+}
+
+/// `update_page`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct UpdatePageInput {
+    /// required,The ID of the page to update
+    page_id: String,
+    /// required,New title for the page
+    title: String,
+    /// required,New page body content in Confluence storage format (XHTML)
+    body: String,
+    /// required,Current version number of the page (incremented by 1 on update)
+    version: i64,
+}
+
+pub fn update_page(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "update_page",
+        "Updates an existing Confluence page.",
+        move |input: UpdatePageInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                // `params.Version + 1` on a Go `int`, which is 64-bit here — so
+                // this wraps where Go's wraps and the vectors pin it. No clamp
+                // and no validation: Confluence answers for whatever arrives.
+                let payload = json!({
+                    "id": input.page_id,
+                    "status": "current",
+                    "title": input.title,
+                    "body": {
+                        "representation": "storage",
+                        "value": input.body,
+                    },
+                    "version": {"number": input.version.wrapping_add(1)},
+                });
+                let encoded = marshal(&payload)?;
+
+                let path = format!("/wiki/api/v2/pages/{}", path_escape(&input.page_id));
+                let result = client
+                    .call(&ct, reqwest::Method::PUT, &path, Some(encoded))
+                    .await?;
+                Ok(text_result(format!("Page updated: {result}")))
+            }
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Sorted keys at every level and HTML escaping, which is the whole of
+    /// `json.Marshal` over a Go map — and the reason `create_page`'s body is not
+    /// in field order.
+    #[test]
+    fn a_body_is_sorted_and_html_escaped_at_every_level() {
+        let payload = json!({
+            "spaceId": "SPACE",
+            "status": "current",
+            "title": "Release <1.0> & notes",
+            "body": {"representation": "storage", "value": "<p>hi &amp; bye</p>"},
+        });
+        assert_eq!(
+            String::from_utf8(marshal(&payload).expect("encode")).expect("utf-8"),
+            concat!(
+                r#"{"body":{"representation":"storage","#,
+                r#""value":"\u003cp\u003ehi \u0026amp; bye\u003c/p\u003e"},"#,
+                r#""spaceId":"SPACE","status":"current","#,
+                r#""title":"Release \u003c1.0\u003e \u0026 notes"}"#
+            )
+        );
+    }
+
+    /// An integer is an integer, not a float — `version.number` is the only
+    /// number either body carries and a `30.0` there would be a different
+    /// request.
+    #[test]
+    fn a_version_number_is_spelled_as_an_integer() {
+        let payload = json!({"version": {"number": 41_i64.wrapping_add(1)}});
+        assert_eq!(
+            String::from_utf8(marshal(&payload).expect("encode")).expect("utf-8"),
+            r#"{"version":{"number":42}}"#
+        );
+    }
+}

--- a/desktop/src-tauri/src/native/integrations/confluence/mod.rs
+++ b/desktop/src-tauri/src/native/integrations/confluence/mod.rs
@@ -239,24 +239,36 @@ pub async fn start_confluence_mcp_server(
 /// disagree about the **base** — and the two do disagree, in one way that is a
 /// wrong path and one that is a different *host*:
 ///
-/// - **Authority.** `url` treats `\` as an authority separator for a special
-///   scheme; `net/url` does not, and rejects the userinfo that results. So
-///   `https://evil.com\@acme.atlassian.net` is a parse error to Go — nothing is
-///   hosted — while `url` reads the host as `evil.com` and the rest as a path.
-///   Both sides of `absolute`'s comparison would then say `evil.com`, and every
-///   tool would send the user's `Basic` credentials to it. So the host `url`
-///   resolved is compared against the one [`go_host`] resolved, through `url`
-///   on both sides so that case-folding, IDN and the default port cannot make a
-///   false difference.
-///   The comparison has teeth only where the two parsers **split** the
-///   authority differently, so it is paired with a flat refusal of a `%` in the
-///   raw authority — `net/url`'s `parseHost` decodes an escape and then rejects
-///   one that decoded to a byte it would have escaped (`%2E` is an error,
-///   `%C3%A9` is not), while `url` decodes them all. That gap is the same
-///   attack by another route: `https://acme.atlassian.net%2Eevil.com` is a
-///   parse error to Go and `acme.atlassian.net.evil.com` here. `split_url` in
-///   `native/integration_credentials.rs` forwards on the same byte for the same
-///   reason; there is nobody to forward to here, so it is a refusal.
+/// - **Authority — an allowlist, not a comparison.** This is where getting it
+///   wrong sends the user's `Basic` credentials to somebody else, and it is
+///   worth being explicit about why the obvious check does not work. Comparing
+///   the host `url` resolved against the host [`go_host`] resolved catches only
+///   a disagreement about where the authority *ends*; where the two read the
+///   same substring and *interpret* it differently the comparison is a
+///   tautology, because both sides are the same parser on the same bytes. And
+///   there are at least three interpretation gaps, each of which grafts the
+///   site onto an attacker's domain from a string that reads as the legitimate
+///   one:
+///
+///   | input | `net/url` | `url` |
+///   |---|---|---|
+///   | `evil.com\@acme.atlassian.net` | `invalid userinfo` | host `evil.com` |
+///   | `acme.atlassian.net%2Eevil.com` | `invalid URL escape` | host `acme.atlassian.net.evil.com` |
+///   | `acme.atlassian.net<U+00A0>evil.com` | that host, literally | IDNA-mapped |
+///
+///   `parseHost` is itself an allowlist — `split_url` in
+///   `native/integration_credentials.rs` says so, having enumerated every ASCII
+///   byte through it — so the sound shape here is an allowlist too, and a
+///   narrower one, because that module may forward what it is unsure of and
+///   this one may not. The rule is: ASCII letters, digits, `.`, `-` and `_`,
+///   with an optional `:`-separated numeric port. Nothing in that set is
+///   transformed by either parser, so agreement is by construction rather than
+///   by comparison.
+///
+///   It refuses four things Go serves, all deliberate and all logged
+///   non-starts: userinfo (`user:pw@host` — the row carries the credentials in
+///   their own fields), an IPv6 literal, a non-ASCII host (which Go's own
+///   IDNA-blind resolver cannot dial either), and a percent escape.
 /// - **Path encoding.** Go escapes `\ ^ |` in a path and `url` does not, and
 ///   `url` removes dot segments where `net/url` never does — so `/a\b` leaves
 ///   here as `/a/b` against Go's `/a%5Cb`, and `/a/../b` as `/b`. So `url`'s
@@ -336,33 +348,42 @@ pub fn validate_site_url(raw: &str) -> std::result::Result<String, String> {
     }
 
     let clean = raw.trim_end_matches('/');
+
     // The shapes `client::Client::absolute` cannot work behind. See the section
     // above for why each is refused here rather than per call.
+    //
+    // The authority goes first, ahead of even parsing the whole thing, because
+    // it is the one that decides *which server* the credentials reach — so it
+    // should be the sentence in the log whenever it applies, rather than
+    // whichever check happens to notice first.
+    //
+    // By allowlist rather than by comparison — see above for why a comparison
+    // between the two parsers cannot see an interpretation gap, and which three
+    // gaps this closes. The **whole** authority, userinfo included, rather than
+    // [`go_host`]'s post-`@` remainder: `@` and `\` are outside the set, and
+    // refusing them is what makes the two parsers agree on where the authority
+    // *ends* as well as on what it says. `evil.com\@acme.atlassian.net` has a
+    // perfectly plain host once the userinfo is stripped, which is the trap.
+    let authority = go_authority(rest);
+    let (host, port) = match authority.split_once(':') {
+        Some((host, port)) => (host, Some(port)),
+        None => (authority, None),
+    };
+    let plain_host = !host.is_empty()
+        && host
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'-' | b'_'));
+    // An empty port is Go's `Host` of `acme.atlassian.net:`, which dials 443 on
+    // both sides; anything else must be digits, as `validOptionalPort` requires.
+    let plain_port = port.is_none_or(|port| port.bytes().all(|b| b.is_ascii_digit()));
+    if !plain_host || !plain_port {
+        return Err("invalid site URL: its host is not a plain ASCII hostname".to_string());
+    }
+
     let parsed = reqwest::Url::parse(clean)
         .map_err(|_| "invalid site URL: it is not a URL this build can send a request to")?;
     if parsed.query().is_some() || parsed.fragment().is_some() {
         return Err("invalid site URL: a query or fragment leaves the path open".to_string());
-    }
-
-    // The host, which is the one disagreement that would send a credential
-    // somewhere else. Both sides go through `url` so that a lower-cased scheme,
-    // an IDN host or an explicit `:443` is not a false difference — what is
-    // being compared is *which host each parser found*, not how it spells one.
-    let authority = go_host(rest);
-    // The comparison below can only see a *split* the two parsers disagree on.
-    // Where they read the same substring and interpret it differently it is a
-    // tautology — and a `%` in a host is exactly that case, since `parseHost`
-    // decodes an escape and then rejects one that decoded to a byte it would
-    // have escaped, while `url` decodes them all. `%2E` is the reachable one.
-    if authority.contains('%') {
-        return Err("invalid site URL: its host holds a percent escape".to_string());
-    }
-    let go_authority = reqwest::Url::parse(&format!("https://{authority}"))
-        .map_err(|_| "invalid site URL: its host is not one this build can send to")?;
-    if go_authority.host() != parsed.host()
-        || go_authority.port_or_known_default() != parsed.port_or_known_default()
-    {
-        return Err("invalid site URL: net/url and url read a different host".to_string());
     }
 
     // …and the path, which is a wrong endpoint on the right host.
@@ -425,18 +446,29 @@ fn go_scheme(raw: &str) -> (String, &str) {
     (String::new(), raw)
 }
 
+/// The whole authority `url.Parse` would take, userinfo and port included —
+/// everything between `//` and the first `/`, `?` or `#`.
+///
+/// Empty when there is no authority at all. Separate from [`go_host`] because
+/// the two checks want different halves: Go's own `u.Host == ""` question wants
+/// the host, and the allowlist in [`validate_site_url`] wants the userinfo too,
+/// since that is where a `\` hides.
+fn go_authority(rest: &str) -> &str {
+    let Some(authority) = rest.strip_prefix("//") else {
+        return "";
+    };
+    match authority.find(['/', '?', '#']) {
+        Some(end) => &authority[..end],
+        None => authority,
+    }
+}
+
 /// The host `url.Parse` would set, given everything after the scheme's colon.
 ///
 /// Empty unless an authority is present (`//…`), and empty for an authority that
 /// is only userinfo — both of which Go answers with `u.Host == ""`.
 fn go_host(rest: &str) -> &str {
-    let Some(authority) = rest.strip_prefix("//") else {
-        return "";
-    };
-    let authority = match authority.find(['/', '?', '#']) {
-        Some(end) => &authority[..end],
-        None => authority,
-    };
+    let authority = go_authority(rest);
     match authority.rfind('@') {
         Some(at) => &authority[at + 1..],
         None => authority,
@@ -571,34 +603,46 @@ mod tests {
         ] {
             assert_eq!(
                 validate_site_url(site),
-                Err("invalid site URL: net/url and url read a different host".to_string()),
+                Err("invalid site URL: its host is not a plain ASCII hostname".to_string()),
                 "{site}"
             );
         }
 
-        // The same graft by the other route: `parseHost` rejects a `%` escape
-        // that decodes to a byte it would have escaped, and `url` decodes them
-        // all — so this reads as the legitimate host and dials a stranger's.
+        // …and every other way the two parsers read a different host from the
+        // same bytes. The second is a percent escape `parseHost` rejects and
+        // `url` decodes; the third is a byte Go keeps literal and `url`
+        // IDNA-maps, which joins the two labels into one attacker-controlled
+        // name. All three read as the legitimate site.
         for site in [
             "https://acme.atlassian.net%2Eevil.com",
             "https://acme.atlassian.net%41x.com",
-            // Go accepts this one (a percent-encoded IDN host); refusing it is
-            // the cost of not being able to tell the two apart without
-            // reproducing `parseHost`, and it is a logged non-start.
+            "https://acme.atlassian.net\u{a0}evil.com",
+            "https://exämple.net",
+            // Refused with them, and Go serves all four: userinfo (the row
+            // carries the credentials in their own fields), an IPv6 literal, a
+            // percent-encoded IDN host, and a non-numeric port.
+            "https://user:pw@acme.atlassian.net",
+            "https://[::1]:8443",
             "https://caf%C3%A9.example.com",
+            "https://acme.atlassian.net:80x",
         ] {
             assert_eq!(
                 validate_site_url(site),
-                Err("invalid site URL: its host holds a percent escape".to_string()),
+                Err("invalid site URL: its host is not a plain ASCII hostname".to_string()),
                 "{site}"
             );
         }
 
-        // …and the legitimate userinfo it must not be confused with.
-        assert_eq!(
-            validate_site_url("https://user:pw@acme.atlassian.net"),
-            Ok("https://user:pw@acme.atlassian.net".to_string())
-        );
+        // …and the ordinary hosts the allowlist must not catch.
+        for site in [
+            "https://acme.atlassian.net",
+            "https://ACME.Atlassian.NET",
+            "https://acme.atlassian.net:8443",
+            "https://intranet_wiki.corp",
+            "https://wiki-1.corp.example.com",
+        ] {
+            assert_eq!(validate_site_url(site), Ok(site.to_string()), "{site}");
+        }
     }
 
     /// The path half of the same disagreement, plus what it must still admit.

--- a/desktop/src-tauri/src/native/integrations/confluence/mod.rs
+++ b/desktop/src-tauri/src/native/integrations/confluence/mod.rs
@@ -1,0 +1,436 @@
+//! The Confluence integration's in-process MCP server, ported from
+//! `internal/integrations/confluence/`.
+//!
+//! Six tools in one service group, over an Atlassian site URL, account email and
+//! API token read from the integration row. The smallest of the six integrations
+//! (#317), and the second ported after GitHub (#312) — which is the file to read
+//! first, since it settles *how to port an integration* and this one only adds
+//! what Atlassian does differently.
+//!
+//! ## What has to match Go, and what checks it
+//!
+//! Five surfaces, all pinned by `desktop/parity/confluence_vectors.json` — taken
+//! from the **running Go server** over its real MCP transport, against a fake
+//! Confluence that records the request each tool built:
+//!
+//! 1. **Which tools are hosted**, which is [`build_allowed_set`] and
+//!    [`service_enabled`] below. The names are in every agent's stored
+//!    `capabilities.mcp` allowlist as `mcp__<integration id>__<tool>` and in
+//!    every `tool_use` block already written to `chat_messages`.
+//! 2. **The advertised schema**, which comes from each input struct.
+//! 3. **The request each tool builds** — path escaping, query escaping, the
+//!    limit clamps, and the exact bytes of both request bodies.
+//! 4. **The result text**, success and failure alike: a tool's error is
+//!    `CallToolResult` content with `is_error`, so the message is what the model
+//!    reads and retries on.
+//! 5. **[`validate_site_url`]**, which is the one piece of `Start` that is a
+//!    *decision* rather than plumbing — it is what refuses a plaintext site URL,
+//!    and it runs before any credential is used.
+//!
+//! ## The gating rule, which reads backwards
+//!
+//! A service is registered when its row says `enabled`. Within an enabled
+//! service, a tool is registered when the **union of every enabled service's
+//! `tools` list** contains its name — *or when that union is empty*. So an
+//! integration whose one service is enabled with no tool list hosts all six, and
+//! one that names a single tool narrows it. Both halves are Go's
+//! `if len(allowed) == 0 || allowed[name]` and both are in the vectors, because
+//! "an empty allowlist means everything" is the rule a port gets backwards.
+//!
+//! Confluence has exactly one service (`content`), so the *union* half of the
+//! rule — one service's list narrowing another's — has no shape to take here.
+//! It is still written the same way as GitHub's, because `buildAllowedSet` is
+//! the same loop over `cfg.Services` in both packages and #316's Jira port has
+//! two services.
+//!
+//! ## Where `Start` stops and [`registry`](super::registry) begins
+//!
+//! `Start(ctx, cfg)` does four things before `buildMCPServer`: it refuses an
+//! unauthenticated integration, parses `config.AtlassianCredentials` out of the
+//! row, normalises the site URL, and hands the server to
+//! `StartInProcessMCPServer`. The first two read the `integrations` row's `auth`
+//! and `credentials` columns, which `native/integrations.rs` deliberately never
+//! selects — so they live in `native/integrations/registry.rs`, which owns the
+//! credential-carrying projection. The third is [`validate_site_url`], which is
+//! here because the rule is Confluence's (HTTPS-only; Jira's is deliberately
+//! different — see #277 and #316).
+//!
+//! `validate.go`'s `ValidateCredentials` is **not ported**: it answers
+//! `POST /api/integrations/{id}/auth/validate`, which dials Atlassian and stays
+//! with Go, so a port would be dead code clippy rejects. The route is still
+//! covered — `native::after_forward` fires
+//! [`reload_after_auth`](super::registry::reload_after_auth) on Go's 2xx, for
+//! every hosted type — because that handler writes `auth` and calls Go's
+//! `Reload`, which now reaches nothing for a type this shell hosts.
+
+pub mod client;
+pub mod content;
+
+#[cfg(test)]
+mod tests_vectors;
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use rmcp::model::{CallToolResult, ContentBlock};
+
+use crate::claude::{tool_server, InProcessMcpServer, Result, ToolDef};
+
+use super::ServiceConfig;
+use client::Client;
+
+/// The one service group. A slice rather than a constant string so it reads
+/// beside `github::SERVICES` and #316's two.
+pub const SERVICES: &[&str] = &["content"];
+
+/// Every tool this integration can host, in registration order — `SERVICES`
+/// order, then `registerSpaceTools`'s and `registerPageTools`'s own.
+///
+/// **Not** the order `tools/list` answers in: both SDKs sort by name — `rmcp`'s
+/// `ToolRouter::list_all` ends in `tools.sort_by(|a, b| a.name.cmp(&b.name))`,
+/// and `modelcontextprotocol/go-sdk` holds tools in a `featureSet` that lists by
+/// sorted key. Registration order is kept so the two `buildMCPServer`s can be
+/// read side by side, and it is pinned by `an_empty_allowed_set_hosts_every_tool`.
+pub const CONFLUENCE_TOOL_NAMES: &[&str] = &[
+    "list_spaces",
+    "get_space",
+    "search_content",
+    "get_page",
+    "create_page",
+    "update_page",
+];
+
+/// `fmt.Sprintf("confluence-%s", cfg.ID)` — `mcp.NewServer`'s implementation
+/// name.
+///
+/// Note this is **not** the prefix on a qualified tool name: that is the bare
+/// integration id, because `StartInProcessMCPServer(ctx, cfg.ID, …)` is what
+/// keys the `mcpServers` map. See `registry::allowed_tool_names`.
+pub fn server_name(integration_id: &str) -> String {
+    format!("confluence-{integration_id}")
+}
+
+/// The union of every **enabled** service's `Tools`.
+///
+/// A `BTreeSet` rather than a map of bools, since the only question asked of it
+/// is membership — plus emptiness, which is what makes it an allowlist or a
+/// no-op.
+pub fn build_allowed_set(services: &BTreeMap<String, ServiceConfig>) -> BTreeSet<String> {
+    let mut allowed = BTreeSet::new();
+    for service in services.values() {
+        if !service.enabled {
+            continue;
+        }
+        for tool in service.tools.iter().flat_map(|tools| tools.iter()) {
+            allowed.insert(tool.clone());
+        }
+    }
+    allowed
+}
+
+/// Present **and** enabled. An absent service is not enabled, which is how an
+/// integration configured before a service existed keeps working.
+pub fn service_enabled(services: &BTreeMap<String, ServiceConfig>, name: &str) -> bool {
+    services.get(name).is_some_and(|service| service.enabled)
+}
+
+/// Every tool `buildMCPServer` would register for `services`, over the given
+/// site and credentials.
+///
+/// Separate from [`start_confluence_mcp_server`] so the tool set can be
+/// inspected without binding a port — which is what the parity assertions on the
+/// hosted set do.
+pub fn confluence_tools(
+    services: &BTreeMap<String, ServiceConfig>,
+    site_url: &str,
+    email: &str,
+    api_token: &str,
+) -> Vec<ToolDef> {
+    let allowed = build_allowed_set(services);
+    let client = Client::new(site_url, email, api_token);
+    let mut tools = Vec::new();
+
+    // `len(allowed) == 0 || allowed[name]` — so an empty set admits everything.
+    let mut push = |service: &str, name: &str, tool: fn(&Client) -> ToolDef| {
+        if !service_enabled(services, service) {
+            return;
+        }
+        if !allowed.is_empty() && !allowed.contains(name) {
+            return;
+        }
+        tools.push(tool(&client));
+    };
+
+    push("content", "list_spaces", content::list_spaces);
+    push("content", "get_space", content::get_space);
+    push("content", "search_content", content::search_content);
+    push("content", "get_page", content::get_page);
+    push("content", "create_page", content::create_page);
+    push("content", "update_page", content::update_page);
+
+    tools
+}
+
+/// Starts the integration's server on a random loopback port.
+///
+/// The listener stops when the returned handle is dropped, which is what stands
+/// in for Go's `ctx`: dropping it cancels every in-flight tool call's token, and
+/// each of them watches it, so an outbound Confluence request does not outlive
+/// the server.
+pub async fn start_confluence_mcp_server(
+    integration_id: &str,
+    services: &BTreeMap<String, ServiceConfig>,
+    site_url: &str,
+    email: &str,
+    api_token: &str,
+) -> Result<InProcessMcpServer> {
+    tool_server(
+        &server_name(integration_id),
+        confluence_tools(services, site_url, email, api_token),
+    )
+    .await
+}
+
+/// `ValidateSiteURL`: HTTPS, a hostname, and no trailing slash.
+///
+/// The **only** validation `Start` performs beyond the credential parse, and the
+/// one that matters: it is what stops an `http://` site URL carrying the user's
+/// API token in a `Basic` header over plaintext. #277 pinned that Confluence's
+/// rule is *not* Jira's — Jira trims trailing slashes and re-marshals but does
+/// not require HTTPS — so the two must not be merged into a shared helper.
+///
+/// # Reproducing `net/url` without `net/url`
+///
+/// Go parses the raw string with `url.Parse` and then asks two questions of the
+/// result: is the scheme `https`, and is the host non-empty. `url::Url::parse`
+/// cannot stand in for that, because it *refuses* strings `url.Parse` accepts
+/// (a bare `foo`, `https:no-authority`) and so would answer "invalid" where Go
+/// answers "not HTTPS" — a different rejection reason for the same input, and
+/// one that would be a silently different log line. The two questions are
+/// therefore answered directly off the raw string, mirroring `net/url`'s own
+/// `getScheme` and its authority split:
+///
+/// - A scheme is the run of `ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )` before
+///   the first `:`, lower-cased. Anything else — a leading digit, an invalid
+///   byte, no colon at all — means *no scheme*, which is an empty one rather
+///   than an error, and reaches the same "must use HTTPS" refusal.
+/// - A host exists only when the scheme is followed by `//`, and is what remains
+///   of the authority after any `userinfo@`. `https:` and `https://` and
+///   `https://user@` all have none.
+///
+/// The returned value is `strings.TrimRight(rawURL, "/")` of the **raw** string,
+/// not of a re-rendered URL — so nothing is normalised, and
+/// `client::Client::absolute` is what catches a site URL this port cannot build
+/// Go's request from.
+///
+/// # The divergence, and why it is only a sentence
+///
+/// `url.Parse` fails outright on a few inputs — an ASCII control character, a
+/// scheme-less URL whose first path segment holds a colon, a non-numeric port, a
+/// bad `%` escape in the host — and answers `invalid site URL: parse "…": …`
+/// with `net/url`'s own vocabulary. That wording is not reproducible: it is
+/// `%q`-quoted Go string escaping over the caller's input, which agrees with
+/// Rust's `{:?}` for printable ASCII and then stops agreeing (`\x01` against
+/// `\u{1}`). It is also a **log line rather than an interface** — `Start`'s
+/// error is logged by the registry and never reaches a response or the model —
+/// which is the same trade `registry::github_token` makes on the credential
+/// blob, for the same reason and with the extra motive that Go's message quotes
+/// the caller's input back.
+///
+/// So the **classification** is reproduced and the sentence is not: the two
+/// failures reachable from a stored site URL are refused here too, each under
+/// this port's own `invalid site URL: …` wording, and
+/// `confluence_vectors.json` pins both as divergences rather than hiding them.
+/// The remaining `url.Parse` failures (a non-numeric port, a bad `%` escape in
+/// the host) are *accepted* here and refused at the first request instead, by
+/// [`client::Client::absolute`] — a refusal either way, and one the vectors do
+/// not need to enumerate because it never reaches a different endpoint.
+pub fn validate_site_url(raw: &str) -> std::result::Result<String, String> {
+    // `url.Parse`'s first act — `stringContainsCTLByte`, which is `< 0x20 ||
+    // == 0x7f`, exactly `is_ascii_control`. Reproduced because letting a control
+    // character through would hand `reqwest` a string Go never sends.
+    if raw.chars().any(|c| c.is_ascii_control()) {
+        return Err("invalid site URL: it holds a control character".to_string());
+    }
+
+    let (scheme, rest) = go_scheme(raw);
+    // A URL with no scheme is a *relative* one to `net/url`, and it refuses one
+    // whose first path segment holds a colon — because re-parsing the result
+    // would read that colon as a scheme. `1https://acme.atlassian.net` is the
+    // shape a person actually types, and without this it would fall through to
+    // the "must use HTTPS" refusal, which names the wrong problem.
+    if scheme.is_empty()
+        && !raw.starts_with("//")
+        && raw
+            .split('/')
+            .next()
+            .is_some_and(|first| first.contains(':'))
+    {
+        return Err("invalid site URL: its first path segment holds a colon".to_string());
+    }
+    if scheme != "https" {
+        // `%q` over a scheme is plain quoting — the charset `go_scheme` admits
+        // has nothing either language escapes — so `{:?}` is Go's rendering.
+        return Err(format!("site URL must use HTTPS (got {scheme:?})"));
+    }
+    if go_host(rest).is_empty() {
+        return Err("site URL must include a hostname".to_string());
+    }
+    Ok(raw.trim_end_matches('/').to_string())
+}
+
+/// `net/url`'s `getScheme`, lower-cased as `url.Parse` lower-cases it.
+///
+/// Answers `("", raw)` for anything without a valid scheme, which is what
+/// `getScheme` does for every case except a leading `:` — and that one is a
+/// parse error in Go, so it reaches the same refusal by a different route.
+fn go_scheme(raw: &str) -> (String, &str) {
+    for (i, c) in raw.char_indices() {
+        match c {
+            'a'..='z' | 'A'..='Z' => {}
+            '0'..='9' | '+' | '-' | '.' if i > 0 => {}
+            ':' if i > 0 => return (raw[..i].to_ascii_lowercase(), &raw[i + 1..]),
+            _ => return (String::new(), raw),
+        }
+    }
+    (String::new(), raw)
+}
+
+/// The host `url.Parse` would set, given everything after the scheme's colon.
+///
+/// Empty unless an authority is present (`//…`), and empty for an authority that
+/// is only userinfo — both of which Go answers with `u.Host == ""`.
+fn go_host(rest: &str) -> &str {
+    let Some(authority) = rest.strip_prefix("//") else {
+        return "";
+    };
+    let authority = match authority.find(['/', '?', '#']) {
+        Some(end) => &authority[..end],
+        None => authority,
+    };
+    match authority.rfind('@') {
+        Some(at) => &authority[at + 1..],
+        None => authority,
+    }
+}
+
+/// Go's `textResult`, shared by all six tools.
+///
+/// One text block, no structured content — `mcp.CallToolResult{Content:
+/// []mcp.Content{&mcp.TextContent{Text: text}}}` with the `any` return left
+/// `nil`.
+pub(crate) fn text_result(text: String) -> CallToolResult {
+    CallToolResult::success(vec![ContentBlock::text(text)])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::native::gojson::GoList;
+
+    fn service(enabled: bool, tools: &[&str]) -> ServiceConfig {
+        ServiceConfig {
+            enabled,
+            tools: Some(GoList(tools.iter().map(|t| t.to_string()).collect())),
+        }
+    }
+
+    fn names(services: &BTreeMap<String, ServiceConfig>) -> Vec<String> {
+        confluence_tools(services, "https://acme.atlassian.net", "e", "t")
+            .iter()
+            .map(|tool| tool.name().to_string())
+            .collect()
+    }
+
+    /// The implementation name, spelled out rather than derived — a test that
+    /// rebuilt it from the format string would pass through a rename.
+    #[test]
+    fn the_server_name_is_gos() {
+        assert_eq!(server_name("abc123"), "confluence-abc123");
+    }
+
+    /// The service enabled with no tool list hosts everything — the half of the
+    /// rule that reads backwards.
+    #[test]
+    fn an_empty_allowed_set_hosts_every_tool() {
+        let services = BTreeMap::from([("content".to_string(), service(true, &[]))]);
+        assert_eq!(names(&services), CONFLUENCE_TOOL_NAMES);
+        assert!(build_allowed_set(&services).is_empty());
+    }
+
+    /// …and one name narrows it.
+    #[test]
+    fn one_named_tool_narrows_the_service() {
+        let services = BTreeMap::from([(
+            "content".to_string(),
+            service(true, &["get_page", "list_spaces"]),
+        )]);
+        assert_eq!(names(&services), ["list_spaces", "get_page"]);
+    }
+
+    /// A disabled service contributes neither its gate nor its names — and a
+    /// second, unknown service is simply not enabled.
+    #[test]
+    fn a_disabled_service_is_invisible_in_both_directions() {
+        let services = BTreeMap::from([
+            ("content".to_string(), service(false, &["list_spaces"])),
+            ("nope".to_string(), service(true, &["get_page"])),
+        ]);
+        assert!(names(&services).is_empty());
+        assert!(!service_enabled(&services, "content"));
+        assert!(!service_enabled(&services, "missing"));
+    }
+
+    #[test]
+    fn no_services_at_all_hosts_nothing() {
+        assert!(names(&BTreeMap::new()).is_empty());
+    }
+
+    /// A `null` tools column is a nil Go slice, which contributes no names — and
+    /// is therefore an *empty* allowed set, not a filter.
+    #[test]
+    fn a_null_tools_column_is_not_a_filter() {
+        let services = BTreeMap::from([(
+            "content".to_string(),
+            ServiceConfig {
+                enabled: true,
+                tools: None,
+            },
+        )]);
+        assert!(build_allowed_set(&services).is_empty());
+        assert_eq!(names(&services), CONFLUENCE_TOOL_NAMES);
+    }
+
+    /// The scheme split, at the shapes `getScheme` distinguishes. Every one of
+    /// these is also a `validate_site_url` vector; this is the unit view of why.
+    #[test]
+    fn the_scheme_is_read_the_way_net_url_reads_it() {
+        for (raw, scheme) in [
+            ("https://acme.atlassian.net", "https"),
+            // `url.Parse` lower-cases the scheme, so this passes the gate.
+            ("HTTPS://acme.atlassian.net", "https"),
+            ("http://acme.atlassian.net", "http"),
+            ("ftp://acme", "ftp"),
+            // A scheme may hold digits, `+`, `-` and `.` after the first byte.
+            ("h2.c+x-y://acme", "h2.c+x-y"),
+            // No colon at all, a leading digit, and an invalid byte all mean
+            // *no scheme* rather than an error.
+            ("acme.atlassian.net", ""),
+            ("1https://acme", ""),
+            ("ht tps://acme", ""),
+            ("/wiki", ""),
+        ] {
+            assert_eq!(go_scheme(raw).0, scheme, "{raw}");
+        }
+    }
+
+    /// The host, at the shapes that make it empty — which is the second refusal.
+    #[test]
+    fn a_host_needs_an_authority_and_more_than_userinfo() {
+        assert_eq!(go_host("//acme.atlassian.net/wiki"), "acme.atlassian.net");
+        assert_eq!(go_host("//user:pw@acme:8443?x"), "acme:8443");
+        assert_eq!(go_host("//acme#frag"), "acme");
+        for rest in ["", "//", "//user@", "opaque", "/path"] {
+            assert!(go_host(rest).is_empty(), "{rest}");
+        }
+    }
+}

--- a/desktop/src-tauri/src/native/integrations/confluence/mod.rs
+++ b/desktop/src-tauri/src/native/integrations/confluence/mod.rs
@@ -261,9 +261,19 @@ pub async fn start_confluence_mcp_server(
 ///   byte through it — so the sound shape here is an allowlist too, and a
 ///   narrower one, because that module may forward what it is unsure of and
 ///   this one may not. The rule is: ASCII letters, digits, `.`, `-` and `_`,
-///   with an optional `:`-separated numeric port. Nothing in that set is
-///   transformed by either parser, so agreement is by construction rather than
-///   by comparison.
+///   with an optional `:`-separated numeric port.
+///
+///   **What that buys, stated exactly:** no character in the set is
+///   *transformed* by either parser, so no admitted host can be disguised as
+///   another — which is the property all three gaps above attack. It is not
+///   quite "the two dial the same address": WHATWG runs its IPv4 parser on any
+///   host whose last label is numeric, so `0x7f.1`, `127.1`, `010.0.0.1` and
+///   `2130706433` are literal names to `net/url` and addresses to `url`. That
+///   is left standing deliberately — none of them can be passed off as
+///   `acme.atlassian.net`, and Go's own outcome for them is a failed lookup
+///   rather than a working host, so nothing is redirected *away* from a host Go
+///   was reaching. Refusing an all-numeric final label would close it, at the
+///   cost of hostnames shaped like `1.2.3.4.5`.
 ///
 ///   It refuses four things Go serves, all deliberate and all logged
 ///   non-starts: userinfo (`user:pw@host` — the row carries the credentials in
@@ -393,10 +403,14 @@ pub fn validate_site_url(raw: &str) -> std::result::Result<String, String> {
         // tool's own leading slash and nothing before it.
         "/".to_string()
     } else {
-        // `setPath` decodes first and a bad escape is a parse error there, so
-        // this runs whichever branch of `EscapedPath` wins below.
+        // `setPath` decodes first and a **malformed** escape is a parse error
+        // there, so this gate runs whichever branch wins below. It is the
+        // `Option` alone: a well-formed escape decoding to bytes that are not
+        // UTF-8 is not an error to Go — `%FF` is a perfectly good path, and
+        // `EscapedPath()` renders it back as `%FF` — which is why
+        // `unescape_path` answers `Vec<u8>` and the fallback below escapes
+        // bytes rather than a `String`.
         let decoded = crate::native::gourl::unescape_path(raw_path)
-            .and_then(|bytes| String::from_utf8(bytes).ok())
             .ok_or("invalid site URL: its path does not decode")?;
         // `EscapedPath()`: the raw text when it is validly encoded, and the
         // re-escaped decode otherwise. Both branches are needed — see
@@ -404,7 +418,7 @@ pub fn validate_site_url(raw: &str) -> std::result::Result<String, String> {
         if crate::native::gourl::valid_encoded_path(raw_path) {
             raw_path.to_string()
         } else {
-            crate::native::gourl::escape_path(&decoded)
+            crate::native::gourl::escape_path_bytes(&decoded)
         }
     };
     if parsed.path() != go_path {
@@ -633,16 +647,43 @@ mod tests {
             );
         }
 
-        // …and the ordinary hosts the allowlist must not catch.
+        // …and the ordinary hosts the allowlist must not catch, including the
+        // shapes a self-hosted deployment actually takes: a single label, an
+        // IPv4 address, an underscore, a port and a base path.
         for site in [
             "https://acme.atlassian.net",
             "https://ACME.Atlassian.NET",
             "https://acme.atlassian.net:8443",
             "https://intranet_wiki.corp",
             "https://wiki-1.corp.example.com",
+            "https://confluence",
+            "https://10.0.0.5:8090/confluence",
+            "https://confluence.corp.local/wiki",
         ] {
             assert_eq!(validate_site_url(site), Ok(site.to_string()), "{site}");
         }
+    }
+
+    /// A base path whose escapes decode to bytes that are not UTF-8.
+    ///
+    /// Go's `Path` is arbitrary bytes, so `%FF` is a path it sends and
+    /// `EscapedPath()` renders back as `%FF`; `url` agrees. Demanding UTF-8
+    /// between the decode and the re-escape would refuse it, which is the rule
+    /// `gourl`'s own module docs state — `unescape_path` answers `Vec<u8>` for
+    /// exactly this reason.
+    #[test]
+    fn a_base_path_that_decodes_to_non_utf8_is_still_served() {
+        for site in [
+            "https://acme.atlassian.net/a%FFb",
+            "https://acme.atlassian.net/a%FF%FEb",
+        ] {
+            assert_eq!(validate_site_url(site), Ok(site.to_string()), "{site}");
+        }
+        // A *malformed* escape is a parse error to Go too, so that one refuses.
+        assert_eq!(
+            validate_site_url("https://acme.atlassian.net/a%zzb"),
+            Err("invalid site URL: its path does not decode".to_string())
+        );
     }
 
     /// The path half of the same disagreement, plus what it must still admit.

--- a/desktop/src-tauri/src/native/integrations/confluence/mod.rs
+++ b/desktop/src-tauri/src/native/integrations/confluence/mod.rs
@@ -248,28 +248,34 @@ pub async fn start_confluence_mcp_server(
 ///   resolved is compared against the one [`go_host`] resolved, through `url`
 ///   on both sides so that case-folding, IDN and the default port cannot make a
 ///   false difference.
-/// - **Path encoding.** Go escapes `\ ^ | [ ]` in a path and `url` does not,
-///   and `url` removes dot segments where `net/url` never does — so
-///   `/a\b` leaves here as `/a/b` against Go's `/a%5Cb`, and `/a/../b` as
-///   `/b`. So `url`'s rendering of the base path is compared against Go's
-///   `escape(Path, encodePath)`, which is [`crate::native::gourl::escape_path`].
-///   That subsumes the dot-segment case rather than special-casing it.
+///   The comparison has teeth only where the two parsers **split** the
+///   authority differently, so it is paired with a flat refusal of a `%` in the
+///   raw authority — `net/url`'s `parseHost` decodes an escape and then rejects
+///   one that decoded to a byte it would have escaped (`%2E` is an error,
+///   `%C3%A9` is not), while `url` decodes them all. That gap is the same
+///   attack by another route: `https://acme.atlassian.net%2Eevil.com` is a
+///   parse error to Go and `acme.atlassian.net.evil.com` here. `split_url` in
+///   `native/integration_credentials.rs` forwards on the same byte for the same
+///   reason; there is nobody to forward to here, so it is a refusal.
+/// - **Path encoding.** Go escapes `\ ^ |` in a path and `url` does not, and
+///   `url` removes dot segments where `net/url` never does — so `/a\b` leaves
+///   here as `/a/b` against Go's `/a%5Cb`, and `/a/../b` as `/b`. So `url`'s
+///   rendering of the base path is compared against **`EscapedPath()`**, not
+///   against `escape(Path, encodePath)`: the two are different, and the
+///   difference is a whole class of ordinary characters. See
+///   [`crate::native::gourl::valid_encoded_path`] — `/a!b` and `/a%2Fb` are both
+///   sent verbatim by Go even though `escape` would rewrite them, so comparing
+///   against `escape` alone would refuse a base that works.
 ///
 /// Two more shapes have no sound comparison at all and are refused with them: a
-/// base `url` cannot parse (a non-numeric or out-of-range port, a bad `%`
-/// escape), and a base carrying its own `?` or `#`, after which the
-/// concatenation is not a prefix of the target.
+/// base `url` cannot parse (a non-numeric or out-of-range port), and a base
+/// carrying its own `?` or `#`, after which the concatenation is not a prefix of
+/// the target.
 ///
 /// Note what is deliberately **not** required: that the base is already
 /// percent-encoded. `https://intranet.example.com/my atlassian` is a site URL Go
 /// accepts and sends as `/my%20atlassian/…` through `EscapedPath`, and `url`
-/// encodes it identically — the comparison above is against Go's *escaped*
-/// rendering, not against the raw text, so it is admitted.
-///
-/// The one shape this refuses and Go serves is a base path holding a
-/// pre-escaped reserved byte (`/a%2Fb`), where `EscapedPath` prefers the raw
-/// text over re-escaping `Path`. No Atlassian site URL takes that shape, and a
-/// refusal is a logged non-start rather than a request somewhere else.
+/// encodes it identically, so it is admitted.
 ///
 /// # The divergence, and why it is only a sentence
 ///
@@ -342,7 +348,16 @@ pub fn validate_site_url(raw: &str) -> std::result::Result<String, String> {
     // somewhere else. Both sides go through `url` so that a lower-cased scheme,
     // an IDN host or an explicit `:443` is not a false difference — what is
     // being compared is *which host each parser found*, not how it spells one.
-    let go_authority = reqwest::Url::parse(&format!("https://{}", go_host(rest)))
+    let authority = go_host(rest);
+    // The comparison below can only see a *split* the two parsers disagree on.
+    // Where they read the same substring and interpret it differently it is a
+    // tautology — and a `%` in a host is exactly that case, since `parseHost`
+    // decodes an escape and then rejects one that decoded to a byte it would
+    // have escaped, while `url` decodes them all. `%2E` is the reachable one.
+    if authority.contains('%') {
+        return Err("invalid site URL: its host holds a percent escape".to_string());
+    }
+    let go_authority = reqwest::Url::parse(&format!("https://{authority}"))
         .map_err(|_| "invalid site URL: its host is not one this build can send to")?;
     if go_authority.host() != parsed.host()
         || go_authority.port_or_known_default() != parsed.port_or_known_default()
@@ -357,10 +372,19 @@ pub fn validate_site_url(raw: &str) -> std::result::Result<String, String> {
         // tool's own leading slash and nothing before it.
         "/".to_string()
     } else {
+        // `setPath` decodes first and a bad escape is a parse error there, so
+        // this runs whichever branch of `EscapedPath` wins below.
         let decoded = crate::native::gourl::unescape_path(raw_path)
             .and_then(|bytes| String::from_utf8(bytes).ok())
             .ok_or("invalid site URL: its path does not decode")?;
-        crate::native::gourl::escape_path(&decoded)
+        // `EscapedPath()`: the raw text when it is validly encoded, and the
+        // re-escaped decode otherwise. Both branches are needed — see
+        // `gourl::valid_encoded_path`.
+        if crate::native::gourl::valid_encoded_path(raw_path) {
+            raw_path.to_string()
+        } else {
+            crate::native::gourl::escape_path(&decoded)
+        }
     };
     if parsed.path() != go_path {
         return Err("invalid site URL: net/url and url encode its path differently".to_string());
@@ -552,6 +576,24 @@ mod tests {
             );
         }
 
+        // The same graft by the other route: `parseHost` rejects a `%` escape
+        // that decodes to a byte it would have escaped, and `url` decodes them
+        // all — so this reads as the legitimate host and dials a stranger's.
+        for site in [
+            "https://acme.atlassian.net%2Eevil.com",
+            "https://acme.atlassian.net%41x.com",
+            // Go accepts this one (a percent-encoded IDN host); refusing it is
+            // the cost of not being able to tell the two apart without
+            // reproducing `parseHost`, and it is a logged non-start.
+            "https://caf%C3%A9.example.com",
+        ] {
+            assert_eq!(
+                validate_site_url(site),
+                Err("invalid site URL: its host holds a percent escape".to_string()),
+                "{site}"
+            );
+        }
+
         // …and the legitimate userinfo it must not be confused with.
         assert_eq!(
             validate_site_url("https://user:pw@acme.atlassian.net"),
@@ -590,6 +632,14 @@ mod tests {
             "https://intranet.example.com/a%20b",
             "https://intranet.example.com/café",
             "https://intranet.example.com/a+b:c@d",
+            // `EscapedPath` sends all of these verbatim even though `escape`
+            // would rewrite them, and `url` agrees — so comparing against
+            // `escape` alone would have refused a base that works.
+            "https://intranet.example.com/a!b",
+            "https://intranet.example.com/a(b)c",
+            "https://intranet.example.com/a[b]",
+            "https://intranet.example.com/a'b*c",
+            "https://intranet.example.com/a%2Fb",
         ] {
             assert_eq!(
                 validate_site_url(site),

--- a/desktop/src-tauri/src/native/integrations/confluence/mod.rs
+++ b/desktop/src-tauri/src/native/integrations/confluence/mod.rs
@@ -218,9 +218,34 @@ pub async fn start_confluence_mcp_server(
 ///   `https://user@` all have none.
 ///
 /// The returned value is `strings.TrimRight(rawURL, "/")` of the **raw** string,
-/// not of a re-rendered URL — so nothing is normalised, and
-/// `client::Client::absolute` is what catches a site URL this port cannot build
-/// Go's request from.
+/// not of a re-rendered URL — Go concatenates that string with every tool's
+/// path, so anything else would be a different request.
+///
+/// # The base has to be one this port can build Go's request from
+///
+/// Everything above is Go's. The last check is not, and it is what
+/// [`client::Client::absolute`] needs to be able to do its job: that guard
+/// compares the target `url::Url::parse` produced against the one Go would have
+/// sent, and it can only attribute a difference to the *tool's* path if the
+/// **base** survives `url` unchanged. Three shapes break that, and all three are
+/// refused here rather than at every call:
+///
+/// - A base `url` cannot parse at all — a non-numeric or out-of-range port, a
+///   bad `%` escape in the host. Go's `url.Parse` refuses most of these too, so
+///   this is mostly *closer* to Go than not checking; where Go accepts, the
+///   alternative is hosting six tools that answer `request failed` forever.
+/// - A base carrying its own `?` or `#`. The concatenation is then not a prefix
+///   of the target at all, and there is no faithful answer.
+/// - A base holding a `.` or `..` path segment. `url` collapses it and Go does
+///   not, which is [`client::Client::absolute`]'s whole subject — but a base is
+///   not model-supplied, so refusing to host is both safe and quiet, where
+///   letting it through would silently move every request to another endpoint.
+///
+/// Note what is deliberately **not** required: that the base is already
+/// percent-encoded. `https://intranet.example.com/my atlassian` is a site URL Go
+/// accepts and sends as `/my%20atlassian/…`, and `url` encodes it identically —
+/// so it is admitted, and `absolute` compares against `url`'s own rendering of
+/// the base rather than against the raw text.
 ///
 /// # The divergence, and why it is only a sentence
 ///
@@ -236,14 +261,11 @@ pub async fn start_confluence_mcp_server(
 /// blob, for the same reason and with the extra motive that Go's message quotes
 /// the caller's input back.
 ///
-/// So the **classification** is reproduced and the sentence is not: the two
-/// failures reachable from a stored site URL are refused here too, each under
-/// this port's own `invalid site URL: …` wording, and
-/// `confluence_vectors.json` pins both as divergences rather than hiding them.
-/// The remaining `url.Parse` failures (a non-numeric port, a bad `%` escape in
-/// the host) are *accepted* here and refused at the first request instead, by
-/// [`client::Client::absolute`] — a refusal either way, and one the vectors do
-/// not need to enumerate because it never reaches a different endpoint.
+/// So the **classification** is reproduced and the sentence is not: each refusal
+/// carries this port's own `invalid site URL: …` wording, and
+/// `confluence_vectors.json` pins every one as a `rust_error` divergence rather
+/// than hiding it — including the three above, which are refusals Go does not
+/// always make.
 pub fn validate_site_url(raw: &str) -> std::result::Result<String, String> {
     // `url.Parse`'s first act — `stringContainsCTLByte`, which is `< 0x20 ||
     // == 0x7f`, exactly `is_ascii_control`. Reproduced because letting a control
@@ -258,9 +280,16 @@ pub fn validate_site_url(raw: &str) -> std::result::Result<String, String> {
     // would read that colon as a scheme. `1https://acme.atlassian.net` is the
     // shape a person actually types, and without this it would fall through to
     // the "must use HTTPS" refusal, which names the wrong problem.
+    //
+    // The fragment and the query are cut first, because `net/url` cuts them
+    // first: `Parse` splits on `#` and `parse` splits on `?`, both *before* the
+    // check, so `acme?x:y` is a colon in the query and not in a path segment.
+    // The prefix test is `/`, not `//`, for the same reason it is in `parse` —
+    // a rooted path is not a relative reference.
+    let head = raw.split(['#', '?']).next().unwrap_or("");
     if scheme.is_empty()
-        && !raw.starts_with("//")
-        && raw
+        && !head.starts_with('/')
+        && head
             .split('/')
             .next()
             .is_some_and(|first| first.contains(':'))
@@ -275,7 +304,37 @@ pub fn validate_site_url(raw: &str) -> std::result::Result<String, String> {
     if go_host(rest).is_empty() {
         return Err("site URL must include a hostname".to_string());
     }
-    Ok(raw.trim_end_matches('/').to_string())
+
+    let clean = raw.trim_end_matches('/');
+    // The three shapes `client::Client::absolute` cannot work behind. See the
+    // section above for why each is refused here rather than per call.
+    let parsed = reqwest::Url::parse(clean)
+        .map_err(|_| "invalid site URL: it is not a URL this build can send a request to")?;
+    if parsed.query().is_some() || parsed.fragment().is_some() {
+        return Err("invalid site URL: a query or fragment leaves the path open".to_string());
+    }
+    if base_path_of(clean)
+        .split('/')
+        .any(|segment| segment == "." || segment == "..")
+    {
+        return Err("invalid site URL: it holds a dot segment".to_string());
+    }
+    Ok(clean.to_string())
+}
+
+/// The raw text of a site URL's path — everything from the `/` that ends the
+/// authority.
+///
+/// Raw rather than parsed, because the dot-segment check above exists precisely
+/// because parsing removes them.
+fn base_path_of(clean: &str) -> &str {
+    let Some(rest) = clean.split_once("://").map(|(_, rest)| rest) else {
+        return "";
+    };
+    match rest.find('/') {
+        Some(start) => &rest[start..],
+        None => "",
+    }
 }
 
 /// `net/url`'s `getScheme`, lower-cased as `url.Parse` lower-cases it.

--- a/desktop/src-tauri/src/native/integrations/confluence/mod.rs
+++ b/desktop/src-tauri/src/native/integrations/confluence/mod.rs
@@ -192,6 +192,16 @@ pub async fn start_confluence_mcp_server(
 
 /// `ValidateSiteURL`: HTTPS, a hostname, and no trailing slash.
 ///
+/// **The second of two places that reason about `net/url`'s rules.** The first
+/// is `native/integration_credentials.rs`'s `split_url`, and the difference is
+/// which question is being asked: there it is *create* — may this row be stored
+/// — and forwarding the whole request to Go is always available, so it decides
+/// only the shapes it is sure of. Here it is *start* — may a stored row be
+/// hosted — and there is nobody to forward to, so this reproduces `getScheme`
+/// and the authority split outright and answers every input. #316 adds a third
+/// caller of the same Go rules with a different answer again, since Jira does
+/// not require HTTPS.
+///
 /// The **only** validation `Start` performs beyond the credential parse, and the
 /// one that matters: it is what stops an `http://` site URL carrying the user's
 /// API token in a `Basic` header over plaintext. #277 pinned that Confluence's
@@ -221,31 +231,45 @@ pub async fn start_confluence_mcp_server(
 /// not of a re-rendered URL — Go concatenates that string with every tool's
 /// path, so anything else would be a different request.
 ///
-/// # The base has to be one this port can build Go's request from
+/// # The base has to be one this port can send where Go sends it
 ///
-/// Everything above is Go's. The last check is not, and it is what
-/// [`client::Client::absolute`] needs to be able to do its job: that guard
-/// compares the target `url::Url::parse` produced against the one Go would have
-/// sent, and it can only attribute a difference to the *tool's* path if the
-/// **base** survives `url` unchanged. Three shapes break that, and all three are
-/// refused here rather than at every call:
+/// Everything above is Go's. The checks that follow are not, and they are what
+/// [`client::Client::absolute`] rests on. That guard compares two `url`-parsed
+/// targets, so it is blind by construction to any place `url` and `net/url`
+/// disagree about the **base** — and the two do disagree, in one way that is a
+/// wrong path and one that is a different *host*:
 ///
-/// - A base `url` cannot parse at all — a non-numeric or out-of-range port, a
-///   bad `%` escape in the host. Go's `url.Parse` refuses most of these too, so
-///   this is mostly *closer* to Go than not checking; where Go accepts, the
-///   alternative is hosting six tools that answer `request failed` forever.
-/// - A base carrying its own `?` or `#`. The concatenation is then not a prefix
-///   of the target at all, and there is no faithful answer.
-/// - A base holding a `.` or `..` path segment. `url` collapses it and Go does
-///   not, which is [`client::Client::absolute`]'s whole subject — but a base is
-///   not model-supplied, so refusing to host is both safe and quiet, where
-///   letting it through would silently move every request to another endpoint.
+/// - **Authority.** `url` treats `\` as an authority separator for a special
+///   scheme; `net/url` does not, and rejects the userinfo that results. So
+///   `https://evil.com\@acme.atlassian.net` is a parse error to Go — nothing is
+///   hosted — while `url` reads the host as `evil.com` and the rest as a path.
+///   Both sides of `absolute`'s comparison would then say `evil.com`, and every
+///   tool would send the user's `Basic` credentials to it. So the host `url`
+///   resolved is compared against the one [`go_host`] resolved, through `url`
+///   on both sides so that case-folding, IDN and the default port cannot make a
+///   false difference.
+/// - **Path encoding.** Go escapes `\ ^ | [ ]` in a path and `url` does not,
+///   and `url` removes dot segments where `net/url` never does — so
+///   `/a\b` leaves here as `/a/b` against Go's `/a%5Cb`, and `/a/../b` as
+///   `/b`. So `url`'s rendering of the base path is compared against Go's
+///   `escape(Path, encodePath)`, which is [`crate::native::gourl::escape_path`].
+///   That subsumes the dot-segment case rather than special-casing it.
+///
+/// Two more shapes have no sound comparison at all and are refused with them: a
+/// base `url` cannot parse (a non-numeric or out-of-range port, a bad `%`
+/// escape), and a base carrying its own `?` or `#`, after which the
+/// concatenation is not a prefix of the target.
 ///
 /// Note what is deliberately **not** required: that the base is already
 /// percent-encoded. `https://intranet.example.com/my atlassian` is a site URL Go
-/// accepts and sends as `/my%20atlassian/…`, and `url` encodes it identically —
-/// so it is admitted, and `absolute` compares against `url`'s own rendering of
-/// the base rather than against the raw text.
+/// accepts and sends as `/my%20atlassian/…` through `EscapedPath`, and `url`
+/// encodes it identically — the comparison above is against Go's *escaped*
+/// rendering, not against the raw text, so it is admitted.
+///
+/// The one shape this refuses and Go serves is a base path holding a
+/// pre-escaped reserved byte (`/a%2Fb`), where `EscapedPath` prefers the raw
+/// text over re-escaping `Path`. No Atlassian site URL takes that shape, and a
+/// refusal is a logged non-start rather than a request somewhere else.
 ///
 /// # The divergence, and why it is only a sentence
 ///
@@ -306,19 +330,42 @@ pub fn validate_site_url(raw: &str) -> std::result::Result<String, String> {
     }
 
     let clean = raw.trim_end_matches('/');
-    // The three shapes `client::Client::absolute` cannot work behind. See the
-    // section above for why each is refused here rather than per call.
+    // The shapes `client::Client::absolute` cannot work behind. See the section
+    // above for why each is refused here rather than per call.
     let parsed = reqwest::Url::parse(clean)
         .map_err(|_| "invalid site URL: it is not a URL this build can send a request to")?;
     if parsed.query().is_some() || parsed.fragment().is_some() {
         return Err("invalid site URL: a query or fragment leaves the path open".to_string());
     }
-    if base_path_of(clean)
-        .split('/')
-        .any(|segment| segment == "." || segment == "..")
+
+    // The host, which is the one disagreement that would send a credential
+    // somewhere else. Both sides go through `url` so that a lower-cased scheme,
+    // an IDN host or an explicit `:443` is not a false difference — what is
+    // being compared is *which host each parser found*, not how it spells one.
+    let go_authority = reqwest::Url::parse(&format!("https://{}", go_host(rest)))
+        .map_err(|_| "invalid site URL: its host is not one this build can send to")?;
+    if go_authority.host() != parsed.host()
+        || go_authority.port_or_known_default() != parsed.port_or_known_default()
     {
-        return Err("invalid site URL: it holds a dot segment".to_string());
+        return Err("invalid site URL: net/url and url read a different host".to_string());
     }
+
+    // …and the path, which is a wrong endpoint on the right host.
+    let raw_path = base_path_of(clean);
+    let go_path = if raw_path.is_empty() {
+        // `url` renders a base with no path of its own as `/`; Go sends the
+        // tool's own leading slash and nothing before it.
+        "/".to_string()
+    } else {
+        let decoded = crate::native::gourl::unescape_path(raw_path)
+            .and_then(|bytes| String::from_utf8(bytes).ok())
+            .ok_or("invalid site URL: its path does not decode")?;
+        crate::native::gourl::escape_path(&decoded)
+    };
+    if parsed.path() != go_path {
+        return Err("invalid site URL: net/url and url encode its path differently".to_string());
+    }
+
     Ok(clean.to_string())
 }
 
@@ -327,7 +374,7 @@ pub fn validate_site_url(raw: &str) -> std::result::Result<String, String> {
 ///
 /// Raw rather than parsed, because the dot-segment check above exists precisely
 /// because parsing removes them.
-fn base_path_of(clean: &str) -> &str {
+pub(super) fn base_path_of(clean: &str) -> &str {
     let Some(rest) = clean.split_once("://").map(|(_, rest)| rest) else {
         return "";
     };
@@ -479,6 +526,76 @@ mod tests {
             ("/wiki", ""),
         ] {
             assert_eq!(go_scheme(raw).0, scheme, "{raw}");
+        }
+    }
+
+    /// The refusal that matters most: a base where `url` and `net/url` read a
+    /// **different host**, which is how the user's `Basic` credentials would
+    /// leave for somebody else's server.
+    ///
+    /// `url` treats `\` as an authority separator for a special scheme, so it
+    /// reads `evil.com` as the host and `@acme.atlassian.net` as a path;
+    /// `net/url` does not, and rejects the userinfo that leaves, so Go hosts
+    /// nothing at all. A guard that compared two url-parsed values would agree
+    /// with itself and send the request. Pinned as a vector too, but asserted
+    /// here as well because it is the one failure with a blast radius.
+    #[test]
+    fn a_base_the_two_parsers_read_as_different_hosts_is_refused() {
+        for site in [
+            r"https://evil.com\@acme.atlassian.net",
+            r"https://evil.com\@acme.atlassian.net/wiki",
+        ] {
+            assert_eq!(
+                validate_site_url(site),
+                Err("invalid site URL: net/url and url read a different host".to_string()),
+                "{site}"
+            );
+        }
+
+        // …and the legitimate userinfo it must not be confused with.
+        assert_eq!(
+            validate_site_url("https://user:pw@acme.atlassian.net"),
+            Ok("https://user:pw@acme.atlassian.net".to_string())
+        );
+    }
+
+    /// The path half of the same disagreement, plus what it must still admit.
+    ///
+    /// Go escapes `\ ^ | [ ]` in a path and `url` does not; `url` removes dot
+    /// segments and `net/url` never does. But an *unencoded* path is fine —
+    /// both render `/my atlassian` as `/my%20atlassian` — which is the whole
+    /// reason the comparison is against Go's escaped form rather than the raw
+    /// text.
+    #[test]
+    fn a_base_path_the_two_parsers_encode_differently_is_refused() {
+        for site in [
+            r"https://acme.atlassian.net/a\b",
+            "https://acme.atlassian.net/a^b",
+            "https://acme.atlassian.net/a|b",
+            "https://acme.atlassian.net/a/../b",
+            "https://acme.atlassian.net/./a",
+        ] {
+            assert_eq!(
+                validate_site_url(site),
+                Err("invalid site URL: net/url and url encode its path differently".to_string()),
+                "{site}"
+            );
+        }
+
+        for site in [
+            "https://acme.atlassian.net",
+            "https://acme.atlassian.net:8443",
+            "https://intranet.example.com/atlassian",
+            "https://intranet.example.com/my atlassian",
+            "https://intranet.example.com/a%20b",
+            "https://intranet.example.com/café",
+            "https://intranet.example.com/a+b:c@d",
+        ] {
+            assert_eq!(
+                validate_site_url(site),
+                Ok(site.to_string()),
+                "{site} is a site URL Go serves"
+            );
         }
     }
 

--- a/desktop/src-tauri/src/native/integrations/confluence/tests_vectors.rs
+++ b/desktop/src-tauri/src/native/integrations/confluence/tests_vectors.rs
@@ -17,13 +17,17 @@
 //! Three fields carry a *pinned divergence* rather than a match, each documented
 //! at its use below and in the Go generator:
 //!
-//! - `rust_error` — `net/url`'s parse-failure vocabulary, which is `%q`-quoted
-//!   Go string escaping over the caller's own input and reaches a log line
-//!   rather than the model. The refusal is reproduced; the sentence is not.
+//! - `rust_error` — the site-URL gate. Two kinds: `net/url`'s parse-failure
+//!   vocabulary (`%q`-quoted Go string escaping over the caller's own input,
+//!   reaching a log line rather than the model — the refusal is reproduced, the
+//!   sentence is not), and three bases Go accepts that this port refuses to host
+//!   because `client::Client::absolute` cannot work behind them.
 //! - `rust_text` — the dot-segment refusal, where this port answers the sentence
-//!   a transport failure produces rather than calling a different endpoint.
-//! - `rust_no_request` — the same case seen from the network: Go reached the
-//!   fake and this port never built the request.
+//!   a transport failure produces rather than calling a different endpoint; and
+//!   a zero-fraction float for an integer field, which the Go SDK re-marshals
+//!   into an integer and `serde_json` refuses.
+//! - `rust_no_request` — the same two cases seen from the network: Go reached
+//!   the fake and this port never built the request.
 //!
 //! Note there is **no `rust_target`**. #312 needed one because the Go MCP SDK
 //! rounds an integer argument above 2^53 before the handler sees it; the two
@@ -111,6 +115,11 @@ struct ResponseScript {
 struct CallVector {
     case: String,
     tool: String,
+    /// The path appended to the fake's URL to make this case's site URL, empty
+    /// for the fake's root. A site URL is per row, so a case that exercises a
+    /// base path needs its own server.
+    #[serde(default)]
+    base_path: String,
     arguments: Value,
     response: ResponseScript,
     request: Option<RequestVector>,
@@ -183,13 +192,29 @@ fn all_services() -> BTreeMap<String, ServiceConfig> {
 /// This is the check that keeps the user's API token off a plaintext connection,
 /// so the interesting assertion is the *accept* set — a port that admitted
 /// `http://` would still pass every other test in this file.
+/// `rust_error` is the whole answer wherever it is set, and it is set in two
+/// different situations — which is why it wins over both of the other fields
+/// rather than only over `error`:
+///
+/// - Go refused and this port refuses under different wording (`net/url`'s parse
+///   vocabulary), and
+/// - Go **accepted** and this port refuses, for the three bases
+///   `client::Client::absolute` cannot work behind. Those carry a `clean` value
+///   from Go and must still fail here.
 #[test]
 fn the_site_url_gate_matches_the_go_vectors() {
     let v = vectors();
-    assert!(v.site_urls.len() >= 10, "vectors look partial");
+    assert!(v.site_urls.len() >= 15, "vectors look partial");
     for case in &v.site_urls {
         let got = validate_site_url(&case.input);
-        if case.error.is_empty() {
+        if !case.rust_error.is_empty() {
+            assert_eq!(
+                got,
+                Err(case.rust_error.clone()),
+                "{}: a pinned divergence",
+                case.case
+            );
+        } else if case.error.is_empty() {
             assert_eq!(
                 got,
                 Ok(case.clean.clone()),
@@ -198,14 +223,7 @@ fn the_site_url_gate_matches_the_go_vectors() {
                 case.clean
             );
         } else {
-            // Where the wording diverges the vector says so; where it does not,
-            // Go's own sentence is the assertion.
-            let want = if case.rust_error.is_empty() {
-                &case.error
-            } else {
-                &case.rust_error
-            };
-            assert_eq!(got, Err(want.clone()), "{}: refusal", case.case);
+            assert_eq!(got, Err(case.error.clone()), "{}: refusal", case.case);
         }
     }
 }
@@ -387,19 +405,30 @@ async fn every_call_matches_the_go_vectors() {
         let _ = axum::serve(listener, app).await;
     });
 
-    let server = start_confluence_mcp_server(
-        &v.integration_id,
-        &all_services(),
-        &base,
-        &v.email,
-        &v.api_token,
-    )
-    .await
-    .expect("start the confluence server");
+    // One server per distinct site URL, as the Go generator opens one session
+    // per distinct base path. The site URL is a field on the client, not a
+    // per-call argument, so a base-path case cannot share the plain server.
+    let mut servers: BTreeMap<String, crate::claude::InProcessMcpServer> = BTreeMap::new();
+    for case in &v.calls {
+        if servers.contains_key(&case.base_path) {
+            continue;
+        }
+        let server = start_confluence_mcp_server(
+            &v.integration_id,
+            &all_services(),
+            &format!("{base}{}", case.base_path),
+            &v.email,
+            &v.api_token,
+        )
+        .await
+        .expect("start the confluence server");
+        servers.insert(case.base_path.clone(), server);
+    }
 
     for case in &v.calls {
+        let server = &servers[&case.base_path];
         state.arm(&case.response);
-        let result = call_tool(&server, &case.tool, &case.arguments).await;
+        let result = call_tool(server, &case.tool, &case.arguments).await;
 
         // The credentials must never reach the model, on either path.
         for secret in [&v.api_token, &v.email] {
@@ -411,13 +440,19 @@ async fn every_call_matches_the_go_vectors() {
             );
         }
 
-        let want_text = if case.rust_text.is_empty() {
-            &case.text
+        // Every text this port substitutes is a *failure* this port produces
+        // where Go produced something else, so `rust_text` carries `is_error`
+        // with it. That is not always Go's own flag: the zero-fraction-float
+        // cases script a 200, because what they pin is that Go went ahead —
+        // performing `update_page`'s write with the bumped version — while the
+        // decode here fails before any handler runs.
+        let (want_text, want_error) = if case.rust_text.is_empty() {
+            (&case.text, case.is_error)
         } else {
-            &case.rust_text
+            (&case.rust_text, true)
         };
         assert_eq!(result.text, *want_text, "{}: result text", case.case);
-        assert_eq!(result.is_error, case.is_error, "{}: is_error", case.case);
+        assert_eq!(result.is_error, want_error, "{}: is_error", case.case);
 
         let seen = state.0.lock().expect("fake lock").seen.take();
         let want_request = if case.rust_no_request {

--- a/desktop/src-tauri/src/native/integrations/confluence/tests_vectors.rs
+++ b/desktop/src-tauri/src/native/integrations/confluence/tests_vectors.rs
@@ -1,0 +1,531 @@
+//! The Rust half of `desktop/parity/confluence_vectors.json`.
+//!
+//! The Go half (`desktop/parity/confluence_parity_test.go`) stands the **real**
+//! integration up through `confluence.StartAtSiteURL` — `Start` with only its
+//! HTTPS check removed — against an `httptest.Server` that plays a scripted
+//! Confluence and records what it was asked, and writes down five things: what
+//! `ValidateSiteURL` answers per input, the tool set hosted, the advertised
+//! schema, the request each tool built, and the result the model would read.
+//!
+//! This half replays the same script through the same three layers — an axum
+//! server on loopback standing in for `httptest`, the real
+//! [`start_confluence_mcp_server`](super::start_confluence_mcp_server), and a
+//! real `tools/call` over the MCP HTTP transport — and asserts all five. Nothing
+//! is stubbed: a change to the client, to a path, to a body or to a sentence
+//! fails here.
+//!
+//! Three fields carry a *pinned divergence* rather than a match, each documented
+//! at its use below and in the Go generator:
+//!
+//! - `rust_error` — `net/url`'s parse-failure vocabulary, which is `%q`-quoted
+//!   Go string escaping over the caller's own input and reaches a log line
+//!   rather than the model. The refusal is reproduced; the sentence is not.
+//! - `rust_text` — the dot-segment refusal, where this port answers the sentence
+//!   a transport failure produces rather than calling a different endpoint.
+//! - `rust_no_request` — the same case seen from the network: Go reached the
+//!   fake and this port never built the request.
+//!
+//! Note there is **no `rust_target`**. #312 needed one because the Go MCP SDK
+//! rounds an integer argument above 2^53 before the handler sees it; the two
+//! integers here (`limit`, `version`) have no reachable value that large and no
+//! vector exercises one, so the field would have no user.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::{HeaderMap, Method, StatusCode, Uri};
+use axum::response::{IntoResponse, Response};
+use rmcp::ServerHandler;
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::{
+    confluence_tools, server_name, start_confluence_mcp_server, validate_site_url,
+    CONFLUENCE_TOOL_NAMES, SERVICES,
+};
+use crate::claude::ToolServer;
+use crate::native::gojson::GoList;
+use crate::native::integrations::ServiceConfig;
+
+// ─── The vectors ─────────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct SiteUrlVector {
+    case: String,
+    input: String,
+    /// The cleaned value, on the inputs Go accepts.
+    #[serde(default)]
+    clean: String,
+    /// Go's refusal, on the inputs it rejects.
+    #[serde(default)]
+    error: String,
+    /// This port's refusal, where the two disagree on the sentence but not on
+    /// the outcome. See the module header.
+    #[serde(default)]
+    rust_error: String,
+}
+
+#[derive(Deserialize)]
+struct ToolVector {
+    name: String,
+    description: String,
+    input_schema: Value,
+}
+
+#[derive(Deserialize)]
+struct HostingVector {
+    case: String,
+    services: BTreeMap<String, GoServiceConfig>,
+    tools: Vec<String>,
+}
+
+/// `config.ServiceConfig` as the Go generator marshals it. Converted rather than
+/// deserialized straight into [`ServiceConfig`], because that type's `tools` is a
+/// [`GoList`] whose job is nil-versus-empty fidelity on the *write path* — here
+/// the vector is plain JSON and a nil list is simply `null`.
+#[derive(Deserialize)]
+struct GoServiceConfig {
+    enabled: bool,
+    tools: Option<Vec<String>>,
+}
+
+#[derive(Deserialize)]
+struct RequestVector {
+    method: String,
+    target: String,
+    authorization: String,
+    accept: String,
+    content_type: String,
+    body: String,
+}
+
+#[derive(Deserialize)]
+struct ResponseScript {
+    status: u16,
+    body: String,
+}
+
+#[derive(Deserialize)]
+struct CallVector {
+    case: String,
+    tool: String,
+    arguments: Value,
+    response: ResponseScript,
+    request: Option<RequestVector>,
+    is_error: bool,
+    text: String,
+    #[serde(default)]
+    rust_text: String,
+    #[serde(default)]
+    rust_no_request: bool,
+}
+
+#[derive(Deserialize)]
+struct Vectors {
+    integration_id: String,
+    server_name: String,
+    email: String,
+    api_token: String,
+    site_urls: Vec<SiteUrlVector>,
+    tools: Vec<ToolVector>,
+    hosting: Vec<HostingVector>,
+    calls: Vec<CallVector>,
+}
+
+fn vectors() -> Vectors {
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../parity/confluence_vectors.json"
+    );
+    let raw = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("reading {path}: {e} — regenerate it from Go"));
+    serde_json::from_str(&raw).expect("parsing the confluence vectors")
+}
+
+fn services(from: &BTreeMap<String, GoServiceConfig>) -> BTreeMap<String, ServiceConfig> {
+    from.iter()
+        .map(|(name, service)| {
+            (
+                name.clone(),
+                ServiceConfig {
+                    enabled: service.enabled,
+                    tools: service.tools.clone().map(GoList),
+                },
+            )
+        })
+        .collect()
+}
+
+/// The one service enabled with no tool list — the configuration the six schemas
+/// and every call vector were taken under.
+fn all_services() -> BTreeMap<String, ServiceConfig> {
+    SERVICES
+        .iter()
+        .map(|name| {
+            (
+                name.to_string(),
+                ServiceConfig {
+                    enabled: true,
+                    tools: None,
+                },
+            )
+        })
+        .collect()
+}
+
+// ─── The site-URL gate ───────────────────────────────────────────────────────
+
+/// `ValidateSiteURL`, per input: what it accepts, what it returns, and what it
+/// refuses.
+///
+/// This is the check that keeps the user's API token off a plaintext connection,
+/// so the interesting assertion is the *accept* set — a port that admitted
+/// `http://` would still pass every other test in this file.
+#[test]
+fn the_site_url_gate_matches_the_go_vectors() {
+    let v = vectors();
+    assert!(v.site_urls.len() >= 10, "vectors look partial");
+    for case in &v.site_urls {
+        let got = validate_site_url(&case.input);
+        if case.error.is_empty() {
+            assert_eq!(
+                got,
+                Ok(case.clean.clone()),
+                "{}: Go accepted this and returned {:?}",
+                case.case,
+                case.clean
+            );
+        } else {
+            // Where the wording diverges the vector says so; where it does not,
+            // Go's own sentence is the assertion.
+            let want = if case.rust_error.is_empty() {
+                &case.error
+            } else {
+                &case.rust_error
+            };
+            assert_eq!(got, Err(want.clone()), "{}: refusal", case.case);
+        }
+    }
+}
+
+// ─── The advertised surface ──────────────────────────────────────────────────
+
+/// The server name, every tool name, its description and its reflected input
+/// schema — all taken from a live `tools/list` against the Go server.
+///
+/// The schema is compared as a `Value` rather than as bytes, for #310's reason:
+/// JSON object order is meaningful to neither the CLI nor `schemars`, while a
+/// key present on one side and not the other is exactly what value equality
+/// catches. `$schema`, `format` and `default` are three such keys — see
+/// `crate::claude::tool`'s `normalize_go_schema`.
+#[test]
+fn the_advertised_surface_matches_the_go_vectors() {
+    let v = vectors();
+    assert_eq!(v.server_name, server_name(&v.integration_id));
+    assert_eq!(
+        v.tools.len(),
+        CONFLUENCE_TOOL_NAMES.len(),
+        "vectors look partial"
+    );
+
+    let server = ToolServer::new(&v.server_name).with_tools(confluence_tools(
+        &all_services(),
+        "https://acme.atlassian.net",
+        &v.email,
+        &v.api_token,
+    ));
+    assert_eq!(
+        server.tool_names(),
+        v.tools.iter().map(|t| t.name.clone()).collect::<Vec<_>>(),
+        // Both sides are already name-sorted — `tool_names` goes through
+        // `ToolRouter::list_all`, which sorts, and the Go SDK's `featureSet`
+        // lists by sorted key — so this is set equality in a stable order, not
+        // an order assertion. *Registration* order is pinned by
+        // `super::tests::an_empty_allowed_set_hosts_every_tool` against
+        // `CONFLUENCE_TOOL_NAMES`.
+        "the hosted tool set, as tools/list answers it"
+    );
+
+    for want in &v.tools {
+        let tool = server
+            .get_tool(&want.name)
+            .unwrap_or_else(|| panic!("{} is not registered", want.name));
+        assert_eq!(
+            tool.description.as_deref(),
+            Some(want.description.as_str()),
+            "{}'s description is what the model reads",
+            want.name
+        );
+        assert_eq!(
+            serde_json::to_value(&*tool.input_schema).expect("schema"),
+            want.input_schema,
+            "{}'s input schema is what the model is steered by",
+            want.name
+        );
+    }
+}
+
+/// The gating rule, in every shape the Go generator recorded — including the one
+/// that reads backwards, where an empty allowed set hosts everything.
+#[test]
+fn the_hosted_tool_set_matches_the_go_vectors() {
+    let v = vectors();
+    assert!(v.hosting.len() >= 5, "vectors look partial");
+    for case in &v.hosting {
+        let mut hosted: Vec<String> = confluence_tools(
+            &services(&case.services),
+            "https://acme.atlassian.net",
+            &v.email,
+            &v.api_token,
+        )
+        .iter()
+        .map(|tool| tool.name().to_string())
+        .collect();
+        // The Go vector sorts, because what it records is the *set*; the order
+        // is asserted by the six-tool block above.
+        hosted.sort();
+        assert_eq!(hosted, case.tools, "hosting case: {}", case.case);
+    }
+}
+
+// ─── The fake Confluence ─────────────────────────────────────────────────────
+
+/// What the fake was asked, in the shape the Go generator recorded it.
+struct Recorded {
+    method: String,
+    target: String,
+    authorization: String,
+    accept: String,
+    content_type: String,
+    body: String,
+}
+
+#[derive(Default)]
+struct Fake {
+    status: u16,
+    body: String,
+    seen: Option<Recorded>,
+}
+
+#[derive(Clone, Default)]
+struct FakeState(Arc<Mutex<Fake>>);
+
+impl FakeState {
+    fn arm(&self, script: &ResponseScript) {
+        let mut fake = self.0.lock().expect("fake lock");
+        fake.status = script.status;
+        fake.body.clone_from(&script.body);
+        fake.seen = None;
+    }
+}
+
+/// One handler for every path, exactly as the Go fake does it: the point is to
+/// capture the request the tool *built*, and a router would have to agree with
+/// this port about each path's shape — which is the thing under test.
+async fn serve_fake(
+    State(state): State<FakeState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    let header = |name: &str| {
+        headers
+            .get(name)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default()
+            .to_string()
+    };
+
+    let (status, reply) = {
+        let mut fake = state.0.lock().expect("fake lock");
+        fake.seen = Some(Recorded {
+            method: method.to_string(),
+            // `URL.RequestURI()`: the encoded path plus the encoded query.
+            target: uri
+                .path_and_query()
+                .map(|pq| pq.as_str().to_string())
+                .unwrap_or_default(),
+            authorization: header("authorization"),
+            accept: header("accept"),
+            content_type: header("content-type"),
+            body: String::from_utf8_lossy(&body).into_owned(),
+        });
+        (fake.status, fake.body.clone())
+    };
+
+    (
+        StatusCode::from_u16(status).expect("a scripted status"),
+        reply,
+    )
+        .into_response()
+}
+
+// ─── The calls ───────────────────────────────────────────────────────────────
+
+/// Every call vector, driven end to end.
+///
+/// One test rather than one per case, because one server and one fake serve them
+/// all — and, unlike #312's, nothing here is process-wide: the site URL is a
+/// field on the client, so this can run in parallel with anything.
+#[tokio::test]
+async fn every_call_matches_the_go_vectors() {
+    let v = vectors();
+    assert!(v.calls.len() >= 18, "vectors look partial");
+
+    let state = FakeState::default();
+    let app = axum::Router::new()
+        .fallback(serve_fake)
+        .with_state(state.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind the fake");
+    let base = format!("http://{}", listener.local_addr().expect("addr"));
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    let server = start_confluence_mcp_server(
+        &v.integration_id,
+        &all_services(),
+        &base,
+        &v.email,
+        &v.api_token,
+    )
+    .await
+    .expect("start the confluence server");
+
+    for case in &v.calls {
+        state.arm(&case.response);
+        let result = call_tool(&server, &case.tool, &case.arguments).await;
+
+        // The credentials must never reach the model, on either path.
+        for secret in [&v.api_token, &v.email] {
+            assert!(
+                !result.text.contains(secret),
+                "{}: a credential leaked into a tool result: {}",
+                case.case,
+                result.text
+            );
+        }
+
+        let want_text = if case.rust_text.is_empty() {
+            &case.text
+        } else {
+            &case.rust_text
+        };
+        assert_eq!(result.text, *want_text, "{}: result text", case.case);
+        assert_eq!(result.is_error, case.is_error, "{}: is_error", case.case);
+
+        let seen = state.0.lock().expect("fake lock").seen.take();
+        let want_request = if case.rust_no_request {
+            // The dot-segment refusal: Go reached the fake, this port never
+            // built the request. Asserted as "and nothing was sent" rather than
+            // skipped, because sending *something* — the resolved path — is the
+            // outcome `client::Client::absolute` exists to prevent.
+            assert!(
+                seen.is_none(),
+                "{}: the refusal still reached the network: {:?}",
+                case.case,
+                seen.as_ref().map(|r| &r.target)
+            );
+            None
+        } else {
+            case.request.as_ref()
+        };
+        match (want_request, seen) {
+            (None, seen) => assert!(
+                seen.is_none(),
+                "{}: Go made no request and this one did",
+                case.case
+            ),
+            (Some(_), None) => panic!("{}: Go made a request and this one did not", case.case),
+            (Some(want), Some(got)) => {
+                assert_eq!(got.method, want.method, "{}: method", case.case);
+                assert_eq!(got.target, want.target, "{}: request target", case.case);
+                assert_eq!(
+                    got.authorization, want.authorization,
+                    "{}: the Basic prefix and the base64 of email:token",
+                    case.case
+                );
+                assert_eq!(got.accept, want.accept, "{}: Accept", case.case);
+                assert_eq!(
+                    got.content_type, want.content_type,
+                    "{}: Content-Type is sent only when there is a body",
+                    case.case
+                );
+                assert_eq!(got.body, want.body, "{}: request body", case.case);
+            }
+        }
+    }
+}
+
+struct ToolAnswer {
+    text: String,
+    is_error: bool,
+}
+
+/// One `tools/call` over the server's own HTTP transport, sent the way the CLI
+/// sends it — including the bearer token the handle's config carries.
+async fn rpc_call(
+    server: &crate::claude::InProcessMcpServer,
+    name: &str,
+    arguments: &Value,
+) -> Value {
+    let payload = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": name, "arguments": arguments},
+    });
+
+    let mut request = reqwest::Client::new()
+        .post(server.url())
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream");
+    for (header, value) in &server.config().headers {
+        request = request.header(header, value);
+    }
+    let response = request
+        .body(payload.to_string())
+        .send()
+        .await
+        .expect("send tools/call");
+    serde_json::from_str(&response.text().await.expect("text")).expect("a JSON-RPC reply")
+}
+
+/// [`rpc_call`]'s success shape: exactly one text block, and no protocol error.
+///
+/// A failing tool is never a protocol error — the convention `new_tool` ports
+/// from `mcp.AddTool`, and the Go generator asserts the same thing by reading
+/// `result.Content` unconditionally. Malformed *arguments* are the path that
+/// assertion really guards, and no vector sends those; the property is
+/// `new_tool`'s and is pinned once for every ported integration by
+/// `github::tests_vectors::malformed_arguments_are_a_tool_error_rather_than_a_protocol_error`.
+async fn call_tool(
+    server: &crate::claude::InProcessMcpServer,
+    name: &str,
+    arguments: &Value,
+) -> ToolAnswer {
+    let body = rpc_call(server, name, arguments).await;
+
+    assert!(
+        body.get("error").is_none(),
+        "{name}: a tool must not raise a protocol error: {body}"
+    );
+    let content = body["result"]["content"]
+        .as_array()
+        .unwrap_or_else(|| panic!("{name}: no content array: {body}"));
+    assert_eq!(content.len(), 1, "{name}: want exactly one content block");
+    assert_eq!(content[0]["type"], "text");
+
+    ToolAnswer {
+        text: content[0]["text"]
+            .as_str()
+            .unwrap_or_else(|| panic!("{name}: content is not text: {body}"))
+            .to_string(),
+        is_error: body["result"]["isError"].as_bool().unwrap_or(false),
+    }
+}

--- a/desktop/src-tauri/src/native/integrations/github/client.rs
+++ b/desktop/src-tauri/src/native/integrations/github/client.rs
@@ -56,7 +56,9 @@ pub const DEFAULT_API_BASE: &str = "https://api.github.com";
 /// had to export `SetAPIBase` to be redirectable at all. Both callers here are
 /// in-crate, so `#[cfg(test)]` costs nothing and compiles the whole thing out —
 /// which is what [`api_base_lock`] below already does, for the same reason.
-/// #313–#317 each add their own seam and should follow this.
+/// #313–#316 each add their own seam and should follow this; #317's is a
+/// constructor argument rather than a static, because a Confluence site URL is
+/// per row.
 ///
 /// A `RwLock` rather than a `OnceLock` because a test points it at a loopback
 /// fake and then puts it back.

--- a/desktop/src-tauri/src/native/integrations/registry.rs
+++ b/desktop/src-tauri/src/native/integrations/registry.rs
@@ -4,7 +4,8 @@
 //! Go keeps one long-lived in-process MCP server per enabled, authenticated
 //! integration: `Start` brings them all up at boot, `Reload` restarts one when
 //! its row changes, `Stop` tears one down when it is deleted. This module is
-//! that, for the types listed in [`HOSTED_TYPES`] — today `github` alone.
+//! that, for the types listed in [`HOSTED_TYPES`] — today `github` (#312) and
+//! `confluence` (#317).
 //!
 //! ## Why the ownership had to flip before the writes could move
 //!
@@ -43,7 +44,7 @@
 //! **The list is built here, by [`hosting_env_value`], from the same
 //! [`HOSTED_TYPES`] that [`hosts_type`] and the starter dispatch read.** That is
 //! the point of carrying it in the environment rather than hardcoding it on both
-//! sides: the shell is the process that knows what it hosts, so #313–#317 each
+//! sides: the shell is the process that knows what it hosts, so #313–#316 each
 //! add one string to one list and the two halves cannot drift. The failure mode
 //! being designed against is a Rust slack starter landing while Go is never told
 //! to stop hosting slack — two processes on one integration — and its mirror is
@@ -82,18 +83,21 @@
 //! ## What still reaches Go's `Reload` and not this one
 //!
 //! `Reload` has seven callers in Go and only two of them (`Update`, and
-//! `Delete` via `Stop`) are ported. Five run inside the sidecar and **four of
-//! them are fine because the gate is per type**: the confluence, telegram, jira
-//! and slack validators can only reach types Go still hosts, and so can
-//! `completeOAuth`, since `startProviderCallback` supports exactly `google` and
-//! `slack`. The seventh is `validateGitHubPATAuth`, behind
-//! `POST /api/integrations/{id}/auth/validate` — a credential written for a type
-//! *this* process hosts, by a handler that cannot tell it. Without a hook a
-//! GitHub integration would first be hosted at the next boot's [`start_all`], so
-//! the seam fires [`reload_after_auth`] after forwarding a 2xx for that one
-//! route (`native::after_forward`). The reload is idempotent and the response
-//! has already been produced, so doing it on the forward path costs nothing but
-//! a restart of a server that was about to be restarted anyway.
+//! `Delete` via `Stop`) are ported. Five run inside the sidecar. `completeOAuth`
+//! and the telegram, jira and slack validators are fine **because the gate is
+//! per type**: they can only reach types Go still hosts, and
+//! `startProviderCallback` supports exactly `google` and `slack`, so an OAuth
+//! completion never concerns a hosted one. The other two — `validateGitHubPATAuth`
+//! and, since #317, `validateConfluenceAuth` — write a credential for a type
+//! *this* process hosts, from a handler that cannot tell it. Without a hook such
+//! an integration would first be hosted at the next boot's [`start_all`], so the
+//! seam fires [`reload_after_auth`] after forwarding a 2xx for that one route
+//! (`native::after_forward`). That hook needs no per-type list of its own: it
+//! runs for every id on the route and [`reload_after_auth`] reads the row's type
+//! through [`can_host`], so #313–#316 are covered the moment they add their
+//! string to [`HOSTED_TYPES`]. The reload is idempotent and the response has
+//! already been produced, so doing it on the forward path costs nothing but a
+//! restart of a server that was about to be restarted anyway.
 //!
 //! ## Secrets
 //!
@@ -152,8 +156,8 @@ impl HostingRow {
 /// One list, read by three things that must agree: [`hosts_type`] (which the
 /// native `PUT`/`DELETE` consult before they touch a row), the starter dispatch
 /// in [`start_for_type`], and [`hosting_env_value`], which tells the Go sidecar
-/// which types to stop hosting. #313–#317 each add one string here.
-pub const HOSTED_TYPES: &[&str] = &["github"];
+/// which types to stop hosting. #313–#316 each add one string here.
+pub const HOSTED_TYPES: &[&str] = &["github", "confluence"];
 
 /// Whether this process hosts an integration of the given type.
 pub fn hosts_type(integration_type: &str) -> bool {
@@ -362,6 +366,7 @@ async fn start_one(row: &HostingRow, generation: u64) -> Result<(), String> {
 async fn start_for_type(row: &HostingRow) -> Result<InProcessMcpServer, String> {
     match row.integration_type.as_str() {
         "github" => start_github(&row.id, &row.services(), &row.credentials).await,
+        "confluence" => start_confluence(&row.id, &row.services(), &row.credentials).await,
         other => Err(format!(
             "no starter registered for integration type {other:?}"
         )),
@@ -431,6 +436,95 @@ fn github_token(id: &str, credentials: &str) -> Result<String, String> {
         })
 }
 
+/// `confluence.Start`'s first three steps — the auth check, the credential parse
+/// and the site-URL normalisation — followed by the fourth, which
+/// `native/integrations/confluence` owns.
+///
+/// The auth check is Go's `if !cfg.IsAuthenticated()` inside `Start`, which is
+/// redundant with the caller's own skip and is kept for the same reason Go keeps
+/// it: `StartFilteredServer` reaches a starter by a different path.
+///
+/// Note the order: the site URL is validated **before** the server is built and
+/// therefore before the token is captured into any closure, so a plaintext site
+/// URL never gets as far as a client that could send a `Basic` header over it.
+async fn start_confluence(
+    id: &str,
+    services: &BTreeMap<String, ServiceConfig>,
+    credentials: &str,
+) -> Result<InProcessMcpServer, String> {
+    let creds = atlassian_credentials("confluence", id, credentials)?;
+    let site_url = super::confluence::validate_site_url(&creds.site_url)
+        .map_err(|e| format!("invalid site URL for {id:?}: {e}"))?;
+    super::confluence::start_confluence_mcp_server(
+        id,
+        services,
+        &site_url,
+        &creds.email,
+        &creds.api_token,
+    )
+    .await
+    .map_err(|e| format!("starting in-process MCP server for {id:?}: {e}"))
+}
+
+/// `config.AtlassianCredentials` — the struct Confluence and Jira share.
+///
+/// Neither derives `Debug` nor `Serialize`, for [`HostingRow`]'s reason: a
+/// `{creds:?}` in a log line is the same leak with a longer fuse.
+///
+/// `kind` is the word Go's wrapper uses (`parsing confluence credentials for %q`
+/// against `parsing jira credentials for %q`) — the struct is shared and the
+/// sentence is not, so #316 passes `"jira"` to the same function.
+struct AtlassianCredentials {
+    site_url: String,
+    email: String,
+    api_token: String,
+}
+
+fn atlassian_credentials(
+    kind: &str,
+    id: &str,
+    credentials: &str,
+) -> Result<AtlassianCredentials, String> {
+    #[derive(Default, serde::Deserialize)]
+    #[serde(default)]
+    struct Raw {
+        #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+        site_url: String,
+        #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+        email: String,
+        #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+        api_token: String,
+    }
+
+    if credentials.is_empty() {
+        // Go's own `fmt.Errorf("credentials are empty")`, wrapped as `Start`
+        // wraps it.
+        return Err(format!(
+            "parsing {kind} credentials for {id:?}: credentials are empty"
+        ));
+    }
+    // Through `Option<T>`, because a literal `null` is a no-op to
+    // `json.Unmarshal` and a type error to serde — the rule
+    // `native/integration_credentials.rs` carries for the same columns.
+    serde_json::from_str::<Option<Raw>>(credentials)
+        .map(Option::unwrap_or_default)
+        .map(|raw| AtlassianCredentials {
+            site_url: raw.site_url,
+            email: raw.email,
+            api_token: raw.api_token,
+        })
+        .map_err(|e| {
+            // **The serde message is deliberately dropped**, for
+            // [`github_token`]'s reason: it quotes the offending value, so a
+            // malformed blob would put the API token itself into this log line.
+            format!(
+                "parsing {kind} credentials for {id:?}: does not decode at line {} column {}",
+                e.line(),
+                e.column()
+            )
+        })
+}
+
 // ─── The per-run server, which the hosting switch does not touch ──────────────
 
 /// `AllowedToolNames`: `mcp__<integration id>__<tool>`.
@@ -480,6 +574,7 @@ pub async fn start_filtered_server(
     let filtered = filter_config_tools(&row.services(), tools);
     match row.integration_type.as_str() {
         "github" => start_github(&row.id, &filtered, &row.credentials).await,
+        "confluence" => start_confluence(&row.id, &filtered, &row.credentials).await,
         other => Err(format!(
             "no starter registered for integration type {other:?}"
         )),
@@ -805,25 +900,19 @@ mod tests {
     /// two ways to put a credential on two open ports at once.
     #[test]
     fn the_sidecar_is_told_exactly_what_this_process_hosts() {
-        assert_eq!(hosting_env_value(), "off:github");
+        assert_eq!(hosting_env_value(), "off:github,confluence");
         assert_eq!(
             hosting_env_value(),
             format!("off:{}", HOSTED_TYPES.join(",")),
             "the switch must be built from the starter table, never written out"
         );
         assert!(hosts_type("github"));
-        // The five types #313–#317 still owe. Go must keep hosting every one of
+        assert!(hosts_type("confluence"));
+        // The four types #313–#316 still owe. Go must keep hosting every one of
         // them, and `whatsapp` is the reason this is a list at all: its starter
         // opens a live whatsmeow connection that its status, reconnect and QR
         // endpoints read out of a package global.
-        for unported in [
-            "slack",
-            "jira",
-            "telegram",
-            "confluence",
-            "google",
-            "whatsapp",
-        ] {
+        for unported in ["slack", "jira", "telegram", "google", "whatsapp"] {
             assert!(!hosts_type(unported), "{unported} is not hosted here");
             assert!(
                 !hosting_env_value().contains(unported),

--- a/desktop/src-tauri/src/native/schedule/mod.rs
+++ b/desktop/src-tauri/src/native/schedule/mod.rs
@@ -11,9 +11,9 @@
 //! `cmd/web.go` starts the sidecar's scheduler on every boot. Ownership moves
 //! in one commit that stops the sidecar scheduling — the #289 model — and that
 //! commit is blocked on `chat/runner.rs::build_options`, which still refuses an
-//! agent whose tools come from an integration this build cannot host — five of
-//! the six (#313–#317), since the local in-process server (#310) and github
-//! (#311) are no longer among them. A chat can forward to Go on that
+//! agent whose tools come from an integration this build cannot host — four of
+//! the six (#313–#316), since the local in-process server (#310), github (#311)
+//! and confluence (#317) are no longer among them. A chat can forward to Go on that
 //! refusal; a scheduled task with no Go scheduler behind it would simply never
 //! run, with nothing to say so. See "The scheduler: the computation moved, the
 //! ownership did not" in `desktop/CLAUDE.md`.

--- a/desktop/src-tauri/src/sidecar.rs
+++ b/desktop/src-tauri/src/sidecar.rs
@@ -80,7 +80,7 @@ pub async fn spawn(app: &AppHandle, port: u16) -> Result<Sidecar, String> {
         // feature: its starter opens a live whatsmeow WebSocket and registers
         // the client in a package global that the status, reconnect and QR
         // pairing endpoints read. Deriving the list from the starter table means
-        // #313–#317 each add one string in one place.
+        // #313–#316 each add one string in one place.
         //
         // It does **not** switch off `StartFilteredServer`, which is what an
         // agent run uses: that reads the integration row afresh per run and

--- a/internal/integrations/confluence/parity.go
+++ b/internal/integrations/confluence/parity.go
@@ -1,0 +1,65 @@
+package confluence
+
+import (
+	"context"
+	"fmt"
+
+	claude "github.com/shaharia-lab/claude-agent-sdk-go/claude"
+
+	"github.com/shaharia-lab/agento/internal/config"
+)
+
+// This file is the seam `desktop/parity/confluence_parity_test.go` builds its
+// cross-language vectors through, and it exists for exactly one reason: the
+// vectors have to come from the **real** server, not from a restatement of it.
+//
+// `desktop/parity` is a different package, so it can neither reach
+// `buildMCPServer` nor stand a server up against a local fake — `Start` insists
+// on an HTTPS site URL, and an `httptest.Server` is plaintext loopback. The
+// alternative — a generator that rebuilt the tool set from this package's source
+// — would freeze someone's reading of the code rather than the code, and the
+// whole point of the vectors is that a change here fails the Rust port in
+// `desktop/src-tauri/src/native/integrations/confluence/`.
+//
+// #312 did the same thing for GitHub, where the seam is a package variable
+// (`SetAPIBase`) because the base is process-wide there. A Confluence site URL
+// comes out of the row, so the seam is a parameter instead — which is the
+// narrower of the two: there is no process state to leave pointing somewhere
+// else, and nothing here can redirect a *live* integration.
+//
+// Nothing below changes behavior or wording: `Start` remains the only way the
+// app builds this server, and this is `Start` with one line removed.
+
+// StartAtSiteURL is [Start] against siteURL, skipping only ValidateSiteURL.
+//
+// Do not call outside tests. What it is is a primitive for pointing every
+// Confluence request in the process — each one bearing a user's API token in a
+// `Basic` header — at an arbitrary host over plaintext, which is precisely what
+// ValidateSiteURL exists to refuse. It is exported only because `desktop/parity`
+// is a different package and the vectors have to come from the real server; the
+// Rust port needs no equivalent concession, since `confluence_tools` already
+// takes the site URL as an argument and a test can pass loopback to it directly.
+//
+// The credential parse is deliberately still Go's own, so the `credentials`
+// column travels the shipped path; only the site URL is substituted.
+func StartAtSiteURL(
+	ctx context.Context, cfg *config.IntegrationConfig, siteURL string,
+) (claude.McpHTTPServer, error) {
+	if !cfg.IsAuthenticated() {
+		return claude.McpHTTPServer{}, fmt.Errorf("integration %q has no auth token", cfg.ID)
+	}
+
+	var creds config.AtlassianCredentials
+	if err := cfg.ParseCredentials(&creds); err != nil {
+		return claude.McpHTTPServer{}, fmt.Errorf("parsing confluence credentials for %q: %w", cfg.ID, err)
+	}
+
+	server := buildMCPServer(cfg, siteURL, creds.Email, creds.APIToken)
+
+	serverCfg, err := claude.StartInProcessMCPServer(ctx, cfg.ID, server)
+	if err != nil {
+		return claude.McpHTTPServer{}, fmt.Errorf("starting in-process MCP server for %q: %w", cfg.ID, err)
+	}
+
+	return serverCfg, nil
+}


### PR DESCRIPTION
Closes #317

## What

Ports `internal/integrations/confluence/` to `desktop/src-tauri/src/native/integrations/confluence/` — six tools in one service group (`content`), over an Atlassian site URL, account email and API token read from the integration row. `confluence` joins `registry::HOSTED_TYPES`, so the sidecar is started with `AGENTO_INTEGRATIONS=off:github,confluence` and this shell becomes the only process hosting it.

## Why

#282 settled how to host a tool and #312 settled how to port an integration. This is the second of the six and the smallest, so it is where the differences between GitHub's API and everything else show up cheaply — and it turned out to be where a whole class of problem lives that #312 could not have: **a per-row API base**.

## How

Five surfaces are pinned by `desktop/parity/confluence_vectors.json`, generated from the running Go server over its real MCP transport against a fake Confluence that records the request each tool built — the four #312 established (hosted tool set, schema, request, result text) plus `ValidateSiteURL` per input, because that check is the one piece of `Start` that is a decision rather than plumbing.

### The straightforward half

- **The test seam is a constructor argument, not a static.** A Confluence base is per row, so `Client` holds it and a parity run constructs one against loopback — nothing test-only ships. Go still needs a seam, since `Start` refuses plaintext before it builds anything: `internal/integrations/confluence/parity.go`'s `StartAtSiteURL` is `Start` with that one line removed.
- **`SetBasicAuth` is `reqwest`'s `basic_auth`.** The vectors pin the encoded header rather than trusting it, because no response reveals it.
- **Nested request bodies** go through `gojson::to_vec_marshal`, sorted at every level and HTML-escaped — which fires on every real call here, since a page body is XHTML.
- **30s client timeout**, not GitHub's 15; it is per API and it is what bounds a graceful shutdown.

### The half that took five rounds of review

`client::absolute` is `github::client::absolute`'s guard — `url::Url::parse` applies WHATWG dot-segment removal and Go's `net/http` does not — but a **per-row base** breaks the way #312 implemented it, in four distinct ways, each found by review and each verified against the real `net/url` before being fixed:

1. **A base `url` re-encodes was refused for every call.** A site URL is user-typed and need not be percent-encoded; `https://intranet.example.com/my atlassian` is one Go accepts and sends as `/my%20atlassian/…`. Comparing the parsed target against the raw concatenation answered `request failed` forever. The base is now parsed separately and only the tool's suffix compared against the bytes it built.
2. **Comparing two `url`-parsed values is blind to the base — and that is a credential leak.** `url` treats `\` as an authority separator; `net/url` rejects the userinfo that results. So `https://evil.com\@acme.atlassian.net` is a parse error to Go (nothing hosted) and host `evil.com` to `url`, and every tool would have sent `Authorization: Basic base64(email:api_token)` there.
3. **A host comparison could not close it either.** It only sees where the authority *ends*, never what it *says* — a tautology whenever the authority holds no `@` or `\`. Two more mechanisms graft the site onto an attacker's domain from a string that reads as the legitimate one: `acme.atlassian.net%2Eevil.com` (Go: `invalid URL escape`; `url`: `acme.atlassian.net.evil.com`) and a NO-BREAK SPACE between labels (Go keeps it literal; `url` IDNA-maps and joins them). So the authority is now an **allowlist**, as `parseHost` itself is: ASCII letters, digits, `.`, `-`, `_`, optional numeric port, over the whole authority so `@` and `\` are out.
4. **The path half compared against the wrong function.** `escape(Path, encodePath)` is only `EscapedPath()`'s fallback; Go prefers the raw text whenever it is `validEncoded`, whose allowlist admits `! $ & ' ( ) * + , ; = : @ [ ] %`. So Go sends `/a!b` and `/a%2Fb` verbatim and `url` renders them identically — the rule was refusing bases that work. `gourl` gains `valid_encoded_path` and `escape_path_bytes` (the latter because a Go path is arbitrary bytes: `%FF` is one Go serves).

Every refusal where Go would have served is pinned as a `rust_error` divergence rather than hidden: userinfo, an IPv6 literal, a non-ASCII host, a percent escape, a base with its own `?`/`#`, and a base dot segment. Each is a logged non-start, where the alternative is a request somewhere else. The one gap left standing is named at the site: WHATWG runs its IPv4 parser on a numeric final label, so `0x7f.1` is a name to `net/url` and an address to `url` — but it cannot be passed off as `acme.atlassian.net`, and Go's own outcome is a failed lookup.

**#313–#316 inherit all of this**: any integration whose API base comes out of the row must validate the base, not just the tool's suffix.

## Acceptance

- [x] Every tool under the same name and the same input schema, from a live `tools/list` against the Go server.
- [x] Result payloads match, success and failure alike, across 30 call vectors — including the API's own body passed through verbatim, and four that cross the site-URL/request boundary against a base-path site URL.
- [x] Credentials come from the stored row and appear in no response or log line: no `Debug`/`Serialize` on the credential struct, serde messages reduced to line/column, and both languages' vector runners assert the token and email never reach a tool result.
- [x] Cancellation, the 2 MiB cap and the 30s timeout ported.

## Verification

- `cargo test` — whole suite green, 26 new confluence tests plus new `gourl` coverage.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` — clean.
- `go test ./...` — clean; `golangci-lint` at CI's pinned v2.5.0 — 0 issues.
- Both CI workflows green on `6f2bf30`. (Two earlier runs showed `Code Analysis` red from GitHub returning 503/429 for `actions/download-artifact`; a rerun of the identical commit passed.)