### PR TITLE
feat(desktop): port the Jira integration MCP server (#316)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -1230,6 +1230,17 @@ per-call dot-segment guard). Read its header before porting anything else whose
 API base comes out of the row; #313–#315 do not need it, because theirs are
 constants.
 
+**The base's path prefix comes from whether it contributed any path *text*, not
+from what `url` rendered.** `url::Url::parse` gives both `https://x` and
+`https://x/` a `path()` of `/`, while Go concatenates raw text — so
+`https://x/` + `/rest/api/3/project` goes on the wire as `//rest/api/3/project`,
+empty first segment intact. Deriving the prefix from the rendered path made such
+a base refuse every call. It is reachable on Jira and not on Confluence, and the
+asymmetry is the same one twice: `validate_site_url` trims trailing slashes
+before `Base::new` sees them, while `jira.Start` trims nothing — and `Update`
+validates nothing on either, so a user retyping the URL in the edit form can
+store one.
+
 Four things in `tools.go` that look like mistakes, are Go's behaviour, and are
 pinned:
 

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -600,7 +600,7 @@ of the `Err` arms the cut-over has to turn into a real response.
 | 1 ✅ | Sidecar + proxy | — | done |
 | 2 ← | Pricing + analytics | `internal/pricing`, `internal/claudesessions` | Pure computation over JSONL + SQLite. No external deps. **In progress**: `/api/pricing/catalog`, `/api/claude-sessions`, `/api/claude-sessions/facets`, `/api/claude-analytics`, `/api/claude-sessions/insights/summary` and the agent reads are native and diff clean. |
 | 3 ← | Storage + tasks | `internal/storage`, `internal/scheduler` | **In progress (#274, #275).** `db.rs` is read-write, the 27 migrations are ported, and the writes whose every effect Rust owns are native — see below. The scheduler's *schedule computation* is ported and pinned (#275); its ownership is not, and is blocked — see below. |
-| 4 ← | Integrations | `internal/integrations`, `internal/trigger` | OAuth2 + MCP servers. Six of them: google, github, slack, jira, confluence, telegram, plus `internal/tools`. **How to host one is settled (#282)** — `claude::ToolServer`, see "Hosting a tool" below; do not invent a second way. **`internal/tools` is done (#310)** — `native/tools/`, and it is the worked example the six should be read against. **GitHub is done (#312)** — `native/integrations/github/`, the worked example for an *integration*. **The registry is done (#311)** — `native/integrations/registry.rs` plus `PUT`/`DELETE /api/integrations/{id}`, and the sidecar now runs with `AGENTO_INTEGRATIONS=off:<the types the shell hosts>`, so every type has exactly one owner. **Confluence is done (#317)** — `native/integrations/confluence/`, the smallest of the six and the one that shows what an integration adds over #312: a per-row API base, basic auth, and a `Start` check that is a decision. #313–#316 are each "add a starter **and its name to `HOSTED_TYPES`**", which is the one list both processes are configured from. WhatsApp is **not** among them — but Go still hosts its rows, because its starter opens a live connection rather than just a port; see below. |
+| 4 ← | Integrations | `internal/integrations`, `internal/trigger` | OAuth2 + MCP servers. Six of them: google, github, slack, jira, confluence, telegram, plus `internal/tools`. **How to host one is settled (#282)** — `claude::ToolServer`, see "Hosting a tool" below; do not invent a second way. **`internal/tools` is done (#310)** — `native/tools/`, and it is the worked example the six should be read against. **GitHub is done (#312)** — `native/integrations/github/`, the worked example for an *integration*. **The registry is done (#311)** — `native/integrations/registry.rs` plus `PUT`/`DELETE /api/integrations/{id}`, and the sidecar now runs with `AGENTO_INTEGRATIONS=off:<the types the shell hosts>`, so every type has exactly one owner. **Confluence is done (#317)** — `native/integrations/confluence/`, the smallest of the six and the one that shows what an integration adds over #312: a per-row API base, basic auth, and a `Start` check that is a decision. **Jira is done (#316)** — `native/integrations/jira/`, Confluence's twin, and the one that shows that a shared credential type does not mean shared behaviour: `jira.Start` validates nothing, so a bad base is answered per call instead of by refusing to host. #313–#315 are each "add a starter **and its name to `HOSTED_TYPES`**", which is the one list both processes are configured from. WhatsApp is **not** among them — but Go still hosts its rows, because its starter opens a live connection rather than just a port; see below. |
 | 5 ← | Agent execution | `internal/agent`, `internal/service` | **In progress (#276).** The chat SSE turn is native: `/messages`, `/input`, `/permission` and `/stop`, on top of the ported SDK. The scheduler's executor (#275) is the other caller and still Go's. |
 
 ### The session scanner (`src-tauri/src/native/scanner/`)
@@ -813,7 +813,7 @@ Consequences, each load-bearing:
   equally unbounded), and it means the only ceiling on the drain is the slowest
   handler. `github::client` sets 15s and nothing holds a long-lived stream
   (`legacy_session_mode: false` makes the stream `GET` a `405`), so today the
-  bound is real. A handler added by #313–#316 with no client timeout would fail
+  bound is real. A handler added by #313–#315 with no client timeout would fail
   no test while leaving a revoked credential answering `tools/call` for as long
   as its socket stays open. Set the timeout on the client, not on the drain.
 - **Go's `ServeStdioMCP` / `SelfAsStdioMCPServer` are not ported**, and
@@ -942,7 +942,7 @@ them.
 
 The first of the six, and the largest: twenty tools over five service groups,
 token auth only. It is the file to read beside `native/tools/` before porting
-#313–#316 — that one settles *how to host a tool*, this one settles *how to port
+#313–#315 — that one settles *how to host a tool*, this one settles *how to port
 an integration*.
 
 **Where it lives, and why there.** `native/integrations.rs` stays a file and
@@ -980,7 +980,7 @@ half is what pins the things no response reveals — `url.PathEscape` per segmen
 with
 `go test ./desktop/parity/ -run TestGitHubVectors -update-github-vectors`.
 
-Five things it brought that #313–#316 will want:
+Five things it brought that #313–#315 will want:
 
 - **`gourl.rs` now has all three of `net/url`'s escaping modes.**
   `url.PathEscape` is `encodePathSegment` and escapes `/ ; , ?`;
@@ -1030,7 +1030,7 @@ Five things it brought that #313–#316 will want:
   reqwest decompresses in its service stack, so `bytes_stream()` yields
   decompressed bytes and `read_capped` caps what Go's `io.LimitReader` over a
   gunzipped `resp.Body` caps.
-- **The test seam is `#[cfg(test)]`, and should stay that way in #313–#316.**
+- **The test seam is `#[cfg(test)]`, and should stay that way in #313–#315.**
   `githubAPIBase` had to be *exported* on the Go side (`parity.go`) because
   `desktop/parity` is a different package; both Rust callers are in-crate, so
   `API_BASE`/`set_api_base` compile out of a shipped binary entirely. What they
@@ -1091,9 +1091,9 @@ Four divergences are pinned rather than reconciled, all in the vectors:
   `rust_text` and `rust_no_request`. The comparison is exact rather than a `..`
   scan, so anything else `url` normalizes is caught by construction; nothing
   legitimate trips it, because `gourl`'s escaping already covers every byte in
-  `url`'s path and query encode sets. **#313–#316 each build URLs the same way
-  and need the same guard**; #317 has it, with the base recovered from the
-  concatenated string because a site URL is per row.
+  `url`'s path and query encode sets. **#313–#315 each build URLs the same way
+  and need the same guard**; #316 and #317 share `native/integrations/base_url.rs`,
+  which adds what a *per-row* base costs on top of it.
 
 ### The Confluence integration (`native/integrations/confluence/`, #317)
 
@@ -1110,7 +1110,7 @@ site URL carrying the user's API token in a `Basic` header over plaintext.
 Regenerate with
 `go test ./desktop/parity/ -run TestConfluenceVectors -update-confluence-vectors`.
 
-Four things that will recur in #313–#316:
+Four things that will recur in #313–#315:
 
 - **The test seam is a parameter, not a static.** GitHub has one API root, so
   `githubAPIBase` is a package variable and the Rust side gates a `RwLock` behind
@@ -1166,8 +1166,9 @@ Four things that will recur in #313–#316:
   `%5C`, `url` `/`), `^`, `|` and the dot segments. Two more shapes have no
   sound comparison at all: a base `url` cannot parse, and one carrying its own
   `?` or `#`. Every refusal Go would have served is pinned as a `rust_error`
-  divergence. **#313–#316 inherit all of this**: any integration whose API base
-  comes out of the row needs the base validated, not just the tool's suffix.
+  divergence. **Any integration whose API base comes out of the row inherits all
+  of this** — #316 is the first, through `native/integrations/base_url.rs`; #313–#315
+  have constant bases and need only the tool-suffix guard.
 - **`SetBasicAuth` is `reqwest`'s `basic_auth`.** Both are
   `Basic base64(user + ":" + pass)` with standard (not URL-safe) alphabet. The
   vectors pin the encoded header rather than trusting that, because nothing in a
@@ -1191,6 +1192,64 @@ through `gojson::to_vec_marshal` over `serde_json::json!`, which sorts at *every
 level and HTML-escapes — and unlike #312's, this fires on every real call, since
 a page body is XHTML. And the client timeout is **30 seconds**, not GitHub's 15;
 it is per API and it is what bounds a graceful shutdown.
+
+### The Jira integration (`native/integrations/jira/`, #316)
+
+Nine tools in one service group (`project_management`), over the **same**
+`config.AtlassianCredentials` Confluence uses. Read it beside
+`native/integrations/confluence/`: the two are twins, and every difference
+between them is #277's, deliberately preserved.
+
+| | Confluence | Jira |
+|---|---|---|
+| create-time validator | HTTPS only, keeps the raw value | http **or** https, trims trailing `/`, **re-marshals** |
+| inside `Start` | `ValidateSiteURL` again | **nothing at all** |
+| client timeout | 30s | 15s |
+| failure sentence | names nothing | names the method and the path |
+| `desktop/parity` seam | `StartAtSiteURL` needed | **none needed** |
+
+Two of those rows change the shape of the port:
+
+- **`jira.Start` validates nothing, so a bad base is answered per call rather
+  than by refusing to host.** Go hosts the server and advertises all nine tools
+  whatever the stored site URL says. Refusing to host would change the
+  *advertised tool set*, which is what every agent's stored `capabilities.mcp`
+  allowlist depends on — so `jira::client::Client` holds `Option<Base>` and
+  answers Go's own transport sentence when it is `None`. Confluence refuses at
+  `Start` because **Go refuses there too**. Same helper, opposite answers,
+  because the two Go packages differ. `jira_vectors.json`'s `site_urls` block
+  pins it from both ends: the tool set is unchanged and the call fails.
+- **No Go-side seam.** `Start` reads the site URL out of the credentials, so the
+  generator puts the `httptest.Server`'s URL there and calls the shipped
+  `jira.Start`. There is no `internal/integrations/jira/parity.go`, and that
+  absence is a consequence rather than an oversight.
+
+`native/integrations/base_url.rs` is #317's site-URL work extracted for the
+second caller — `Base::new` (the four base checks) and `Base::resolve` (the
+per-call dot-segment guard). Read its header before porting anything else whose
+API base comes out of the row; #313–#315 do not need it, because theirs are
+constants.
+
+Four things in `tools.go` that look like mistakes, are Go's behaviour, and are
+pinned:
+
+- **`list_projects` binds `*struct{}`** — the only tool in the six integrations
+  with no fields, so its schema is `{"type":"object","additionalProperties":false}`
+  with no `properties` key at all.
+- **`create_issue` runs `url.PathEscape` over the project key *inside the JSON
+  body***, and over nothing else, so a key holding a space is sent as `MY%20PROJ`.
+- **`update_issue` and `transition_issue` discard the response** and build their
+  result text from the arguments, so a 200 with a surprising body still reads as
+  success.
+- **`/rest/api/3/issue/` carries its trailing slash in the constant** while
+  `/rest/api/3/project` does not — same wire, two spellings.
+
+One divergence is pinned rather than reconciled, in the `site_urls` block: for a
+site URL `url.Parse` rejects, Go fails inside `http.NewRequestWithContext` and
+answers `creating request: parse "…": …` with `net/url`'s vocabulary and the
+stored site URL interpolated. This port refuses before building anything and
+answers the transport sentence — which is also the narrower of the two, since
+Go's puts the site URL into text the model reads and a `tool_result` stores.
 
 ### The integration registry, and the port's second ownership flip (#311)
 
@@ -1241,7 +1300,7 @@ the sidecar still serves, and the sidecar is still shipped.
 must cover it (`a_hosted_type_always_has_a_starter`), and `hosting_env_value`
 renders it into what `sidecar.rs` sets. That shape was chosen over a constant
 hardcoded on both sides because of which failure it makes impossible: the shell
-is the process that *knows* what it hosts, so #313–#316 each add one string in
+is the process that *knows* what it hosts, so #313–#315 each add one string in
 one place. The failure being designed against is a Rust slack starter landing
 while Go is never told to stop hosting slack — two processes on one integration —
 and its mirror is the WhatsApp bug above. A hardcoded Go list would have to be
@@ -1260,14 +1319,14 @@ asserts both halves, the fallback and the untouched row.
 run uses: `runner.go` reads the integration row afresh per run, builds a
 throwaway server and records nothing. Gating it would have broken every
 integration-using chat, scheduled task and Telegram trigger the sidecar still
-serves — which is most of them, since four of the six types are #313–#316's.
+serves — which is most of them, since three of the six types are #313–#315's.
 The Go tests assert both halves, because the switch is only safe while that
 asymmetry holds.
 
 Two consequences worth knowing before touching this:
 
-- **Only `github` (#312) and `confluence` (#317) have starters here, and Go
-  still hosts the rest.** A type not
+- **Only `github` (#312), `confluence` (#317) and `jira` (#316) have starters
+  here, and Go still hosts the rest.** A type not
   in `HOSTED_TYPES` reaches this module's own unregistered-type path — `no
   starter registered for integration type "slack"`, logged and never surfaced —
   but in practice it does not reach it at all, because the writes decline it
@@ -1618,10 +1677,10 @@ path cannot try to answer a chat turn with a `Vec<u8>`.
 **The four routes share a process-local registry, so they moved together** —
 `/messages` puts a session in, the others look one up. But not every chat *can*
 run natively: an agent whose tools come from an integration this build cannot
-host still needs #313–#316, and `runner::build_options` refuses those before any
+host still needs #313–#315, and `runner::build_options` refuses those before any
 subprocess exists. (Parts of that refusal are gone — the **local** server (#310)
 and any agent naming only integrations in `HOSTED_TYPES`: **github** since #311,
-**confluence** since #317. `build_options`
+**confluence** since #317, **jira** since #316. `build_options`
 starts each of them, and is `async` for that reason, returning the listener
 handles alongside the options because dropping one stops its server.) That would strand `/stop` for a chat still running on Go, so
 the three steering routes answer natively **only when Rust holds a live session
@@ -2232,7 +2291,7 @@ precede it.
 
 **The blocker, verified.** The flip needs Rust to *run* a task, and
 `chat/runner.rs::build_options` still refuses an agent whose capabilities name
-an MCP server this build cannot host — four of the six providers (#313–#316). For a chat that is safe — the three steering routes forward
+an MCP server this build cannot host — three of the six providers (#313–#315). For a chat that is safe — the three steering routes forward
 and Go answers, because Go holds the session. **For a scheduled task there is no
 second implementation behind it**: with the sidecar not scheduling, a task Rust
 cannot run does not fail, it *silently never runs*, and the job history has no
@@ -2730,13 +2789,14 @@ the sidecar runs with `AGENTO_INTEGRATIONS=off:<the types the shell hosts>` so
 every type has a single owner — the second ownership flip after the scan's, and
 the one that had to be *per type*, since `whatsapp`'s starter opens a live
 connection the sidecar's own endpoints read. `chat/runner.rs` therefore refuses
-only an agent naming an integration Rust cannot host, which is the four types
-#313–#316 cover. #312 also produced the reflector divergence map
+only an agent naming an integration Rust cannot host, which is the three types
+#313–#315 cover. #312 also produced the reflector divergence map
 (`parity/jsonschema_reflect_vectors.json` + `claude/schema_vectors.rs`), which
-is the file to read before starting #313–#316. **#317 followed** — the
-Confluence integration, `native/integrations/confluence/`, six tools pinned by
-`parity/confluence_vectors.json`; it is the second worked example and the
-smaller one to read first.
+is the file to read before starting #313–#315. **#317 and #316 followed** — the
+Confluence and Jira integrations, six and nine tools, pinned by
+`parity/confluence_vectors.json` and `parity/jira_vectors.json`. Read Confluence
+first (it is the smaller worked example) and then Jira, which is where a shared
+credential type turns out not to mean shared behaviour.
 
 Nothing else is ported. Every endpoint not listed above — every write path, the
 per-session reads and every other read — still forwards to Go.

--- a/desktop/parity/jira_parity_test.go
+++ b/desktop/parity/jira_parity_test.go
@@ -1,0 +1,810 @@
+// Cross-language vectors for the Jira integration MCP server
+// (`internal/integrations/jira`, ported in #316 to
+// `desktop/src-tauri/src/native/integrations/jira/`).
+//
+// Four things have to match byte for byte, none checkable from one language
+// alone: which tools are hosted, each advertised schema, the request each tool
+// builds, and the result text of every success and every failure. The reasoning
+// for each is in `confluence_parity_test.go`'s header and is not repeated.
+//
+// **This file needs no seam into the jira package, and that absence is the
+// point.** `confluence.Start` validates the site URL (HTTPS only) before it
+// builds anything, so `desktop/parity` had to be handed
+// `confluence.StartAtSiteURL` to stand a server up against a plaintext loopback
+// fake. `jira.Start` does not look at the site URL at all — it reads
+// `creds.SiteURL` and passes it to `buildMCPServer` — so putting the
+// `httptest.Server`'s URL in the credentials *is* the shipped path. #277 pinned
+// that the two validators differ deliberately; this is that difference showing up
+// as one fewer exported function.
+//
+// Jira-specific things pinned here that a port would otherwise get wrong:
+//
+//   - `list_projects` binds `*struct{}`, so its schema is an empty object. No
+//     other tool in the six integrations has no fields.
+//   - `create_issue` runs `url.PathEscape` over the project key **inside the JSON
+//     body**, and over nothing else.
+//   - `update_issue` and `transition_issue` build their result text from the
+//     *arguments* and discard the response.
+//   - `/rest/api/3/issue/` carries its trailing slash in the constant while
+//     `/rest/api/3/project` does not.
+//
+// The Rust half lives in
+// `desktop/src-tauri/src/native/integrations/jira/tests_vectors.rs` and reads this
+// same file.
+//
+// Regenerate (only from Go, and only when adding cases):
+//
+//	go test ./desktop/parity/ -run TestJiraVectors -update-jira-vectors
+package parity
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	mcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/shaharia-lab/agento/internal/config"
+	"github.com/shaharia-lab/agento/internal/integrations/jira"
+)
+
+const jiraVectorsFile = "jira_vectors.json"
+
+var updateJiraVectors = flag.Bool("update-jira-vectors", false,
+	"rewrite jira_vectors.json from this Go toolchain")
+
+// Fixtures, not secrets. Recorded so the base64 of the Basic header is pinned:
+// that a port used the same separator, the same order and standard (not URL-safe)
+// base64 is exactly what no response would reveal.
+const (
+	jiraParityEmail = "parity@example.com"
+	jiraParityToken = "parity-jira-api-token" //nolint:gosec // a test fixture, not a credential
+)
+
+// jiraParityID is the integration id, and half of the server name (`jira-<id>`).
+const jiraParityID = "jira-parity"
+
+type jiraToolVector struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"input_schema"`
+}
+
+// jiraRequestVector is what the fake Jira saw. `Target` is `URL.RequestURI()`.
+type jiraRequestVector struct {
+	Method        string `json:"method"`
+	Target        string `json:"target"`
+	Authorization string `json:"authorization"`
+	Accept        string `json:"accept"`
+	// Set only when the tool sent a body; `call` adds the header only then.
+	ContentType string `json:"content_type"`
+	Body        string `json:"body"`
+}
+
+type jiraResponseScript struct {
+	Status int    `json:"status"`
+	Body   string `json:"body"`
+}
+
+type jiraCallVector struct {
+	Case string `json:"case"`
+	Tool string `json:"tool"`
+	// The path appended to the fake's URL to make this case's site URL, empty
+	// for the fake's root. A site URL is per row, so the base is part of every
+	// request a tool builds — and the only part a person typed.
+	BasePath  string             `json:"base_path,omitempty"`
+	Arguments json.RawMessage    `json:"arguments"`
+	Response  jiraResponseScript `json:"response"`
+	Request   *jiraRequestVector `json:"request"`
+	IsError   bool               `json:"is_error"`
+	Text      string             `json:"text"`
+	// A pinned divergence rather than a match. Two users, both inherited from
+	// #312 and #317: the dot-segment refusal, and a zero-fraction float for an
+	// integer field, which this SDK re-marshals into an integer and `serde_json`
+	// refuses.
+	RustText string `json:"rust_text,omitempty"`
+	// Go made a request and this port deliberately makes none — the same two
+	// causes.
+	RustNoRequest bool `json:"rust_no_request,omitempty"`
+}
+
+type jiraHostingVector struct {
+	Case     string                          `json:"case"`
+	Services map[string]config.ServiceConfig `json:"services"`
+	Tools    []string                        `json:"tools"`
+}
+
+// jiraSiteURLVector pins that a site URL Go serves and this build cannot send a
+// request through leaves the **tool set** untouched, which is the property that
+// made Jira answer per call rather than refuse to host.
+type jiraSiteURLVector struct {
+	Case string `json:"case"`
+	// Substituted for the fake's URL wholesale, so this is an absolute URL and
+	// no request can reach the fake.
+	SiteURL string   `json:"site_url"`
+	Tools   []string `json:"tools"`
+	// What a tools/call answers on the Go side.
+	CallText string `json:"call_text"`
+	IsError  bool   `json:"is_error"`
+	// Set where the Rust port answers a different sentence, and there is one
+	// cause: for a site URL `url.Parse` itself rejects, Go fails inside
+	// `http.NewRequestWithContext` and answers `creating request: parse "…": …`
+	// — `net/url`'s own vocabulary, `%q`-quoted over the stored site URL. The
+	// port refuses before it builds anything and answers the transport sentence
+	// instead. Neither reaches the network, and the port's is the *narrower* of
+	// the two: Go's interpolates the site URL into text the model reads and a
+	// `tool_result` stores.
+	//
+	// The other two site URLs need no entry: Go gets as far as a DNS lookup that
+	// fails, so both languages answer `calling Jira GET …: request failed` for
+	// the same call by different routes.
+	RustCallText string `json:"rust_call_text,omitempty"`
+}
+
+type jiraVectors struct {
+	Comment       []string            `json:"_comment"`
+	IntegrationID string              `json:"integration_id"`
+	ServerName    string              `json:"server_name"`
+	Version       string              `json:"version"`
+	Email         string              `json:"email"`
+	APIToken      string              `json:"api_token"`
+	Tools         []jiraToolVector    `json:"tools"`
+	Hosting       []jiraHostingVector `json:"hosting"`
+	SiteURLs      []jiraSiteURLVector `json:"site_urls"`
+	Calls         []jiraCallVector    `json:"calls"`
+}
+
+// ─── The fake Jira ───────────────────────────────────────────────────────────
+
+// fakeJira plays a scripted Jira and records what it was asked. One handler for
+// every path, because the point is to capture the request the tool *built*.
+type fakeJira struct {
+	mu     sync.Mutex
+	script jiraResponseScript
+	seen   *jiraRequestVector
+}
+
+func (f *fakeJira) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		body = nil
+	}
+	f.mu.Lock()
+	script := f.script
+	f.seen = &jiraRequestVector{
+		Method:        r.Method,
+		Target:        r.URL.RequestURI(),
+		Authorization: r.Header.Get("Authorization"),
+		Accept:        r.Header.Get("Accept"),
+		ContentType:   r.Header.Get("Content-Type"),
+		Body:          string(body),
+	}
+	f.mu.Unlock()
+
+	w.WriteHeader(script.Status)
+	_, _ = w.Write([]byte(script.Body))
+}
+
+func (f *fakeJira) arm(script jiraResponseScript) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.script = script
+	f.seen = nil
+}
+
+func (f *fakeJira) recorded() *jiraRequestVector {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.seen
+}
+
+// ─── Standing the real server up ─────────────────────────────────────────────
+
+// jiraSession starts the real integration against siteURL and returns a client
+// session. `jira.Start` is the app's own entry point — no seam, because it does
+// not validate the site URL.
+func jiraSession(
+	t *testing.T, ctx context.Context, siteURL string, services map[string]config.ServiceConfig,
+) *mcp.ClientSession {
+	t.Helper()
+
+	credentials, err := json.Marshal(config.AtlassianCredentials{
+		SiteURL:  siteURL,
+		Email:    jiraParityEmail,
+		APIToken: jiraParityToken,
+	})
+	if err != nil {
+		t.Fatalf("encoding credentials: %v", err)
+	}
+
+	cfg := &config.IntegrationConfig{
+		ID:          jiraParityID,
+		Name:        "Jira (parity)",
+		Type:        "jira",
+		Enabled:     true,
+		Credentials: credentials,
+		// `IsAuthenticated` is "present and not the four bytes null"; a
+		// token-validated Jira integration stores the display name here.
+		Auth:     json.RawMessage(`{"display_name":"Parity"}`),
+		Services: services,
+	}
+
+	serverCfg, err := jira.Start(ctx, cfg)
+	if err != nil {
+		t.Fatalf("starting the jira integration: %v", err)
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "parity", Version: "1"}, nil)
+	session, err := client.Connect(ctx,
+		&mcp.StreamableClientTransport{Endpoint: serverCfg.URL}, nil)
+	if err != nil {
+		t.Fatalf("connecting to %s: %v", serverCfg.URL, err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	return session
+}
+
+// jiraAllServices enables the one service with an empty tool list — the "empty
+// allowed set registers everything" rule, and the configuration the nine schemas
+// and every call vector are taken under.
+func jiraAllServices() map[string]config.ServiceConfig {
+	return map[string]config.ServiceConfig{"project_management": {Enabled: true}}
+}
+
+var jiraHostingCases = []jiraHostingVector{
+	{Case: "the service enabled with no tool list — an empty allowed set hosts everything",
+		Services: jiraAllServices()},
+	{Case: "no services at all", Services: map[string]config.ServiceConfig{}},
+	{Case: "the service disabled contributes neither its gate nor its tools",
+		Services: map[string]config.ServiceConfig{
+			"project_management": {Enabled: false, Tools: []string{"get_issue"}},
+		}},
+	{Case: "a non-empty allowed set is a filter",
+		Services: map[string]config.ServiceConfig{
+			"project_management": {Enabled: true, Tools: []string{"get_issue", "add_comment"}},
+		}},
+	// The union half: an enabled service Jira does not know still contributes
+	// its names, so it narrows the one that exists.
+	{Case: "an enabled but unknown service still narrows the one that exists",
+		Services: map[string]config.ServiceConfig{
+			"project_management": {Enabled: true},
+			"other":              {Enabled: true, Tools: []string{"list_projects"}},
+		}},
+	{Case: "a tool named by a disabled service is not allowed anywhere",
+		Services: map[string]config.ServiceConfig{
+			"project_management": {Enabled: true, Tools: []string{"get_project"}},
+			"other":              {Enabled: false, Tools: []string{"create_issue"}},
+		}},
+}
+
+// jiraSiteURLCases are the site URLs `jira.Start` accepts without a glance and
+// the Rust port cannot send a request through.
+//
+// The assertion is the **tool set**, not the refusal: Go hosts all nine whatever
+// the base says, and the advertised set is what every agent's stored
+// `capabilities.mcp` allowlist depends on — so a port that refused to host would
+// break agents that exist. The Rust half asserts the same nine tools plus its own
+// per-call refusal.
+//
+// Each host is one that does not resolve, so Go's own answer is its transport
+// sentence and nothing leaves the machine.
+var jiraSiteURLCases = []struct {
+	name         string
+	siteURL      string
+	rustCallText string
+}{
+	{
+		// `url` treats `\` as an authority separator and `net/url` rejects the
+		// userinfo that leaves, so the two read a different host. Go's
+		// `http.NewRequestWithContext` fails on it outright.
+		name:         "a backslash before the userinfo, which url reads as a different host",
+		siteURL:      `https://evil.invalid\@jira.invalid`,
+		rustCallText: "calling Jira GET /rest/api/3/project: request failed",
+	},
+	{
+		// `parseHost` rejects a `%` escape that decodes to a byte it would have
+		// escaped; `url` decodes them all.
+		name:         "a percent escape in the host, which url decodes to another domain",
+		siteURL:      "https://jira.invalid%2Eevil.invalid",
+		rustCallText: "calling Jira GET /rest/api/3/project: request failed",
+	},
+	{
+		// Go sends the dot segments verbatim; `url` collapses them.
+		name:    "a dot segment in the base path, which url collapses",
+		siteURL: "https://jira.invalid/a/../b",
+	},
+	{
+		// Plaintext, which Confluence refuses at Start and Jira does not — the
+		// create-time validator accepts `http` for Jira. Nothing about this one
+		// diverges; it is here because it is the difference #277 pinned.
+		name:    "plaintext, which Jira's own validator allows and Confluence's does not",
+		siteURL: "http://jira.invalid",
+	},
+}
+
+// ─── The call cases ──────────────────────────────────────────────────────────
+
+// jiraOKBody is hostile to a re-encode: keys out of alphabetical order, a
+// trailing-zero decimal, an integer too large for a float64 to hold exactly, and
+// interior whitespace. Go passes the bytes through verbatim.
+const jiraOKBody = `{"issues":[{"zebra":1,"id":10152021304050607,"rate":1.50, "key":"PROJ-1"}]}`
+
+type jiraCallCase struct {
+	name          string
+	tool          string
+	basePath      string
+	args          map[string]any
+	script        jiraResponseScript
+	rustText      string
+	rustNoRequest bool
+}
+
+func jiraOK(body string) jiraResponseScript {
+	return jiraResponseScript{Status: http.StatusOK, Body: body}
+}
+
+// jiraCallCases is the exercise: every tool at least once on its success path,
+// plus every distinct failure the client can produce.
+//
+// The argument maps are complete rather than minimal because **every field is
+// required** — `jsonschema-go` marks a field optional only on
+// `omitempty`/`omitzero`, and no params struct here carries either.
+func jiraCallCases() []jiraCallCase {
+	return []jiraCallCase{
+		// ─── list_projects, the only tool with no arguments ───────────────────
+		{
+			name:   "list_projects/no arguments at all, because the Go handler binds *struct{}",
+			tool:   "list_projects",
+			args:   map[string]any{},
+			script: jiraOK(jiraOKBody),
+		},
+		{
+			name:   "list_projects/a non-2xx status is Jira's own body, verbatim",
+			tool:   "list_projects",
+			args:   map[string]any{},
+			script: jiraResponseScript{Status: 403, Body: `{"message":"Forbidden <you>"}`},
+		},
+		{
+			// The gate is the 2xx *range*, not `== 200`.
+			name:   "list_projects/a 204 is a success, and its empty body is the result",
+			tool:   "list_projects",
+			args:   map[string]any{},
+			script: jiraResponseScript{Status: http.StatusNoContent, Body: ""},
+		},
+
+		// ─── get_project ─────────────────────────────────────────────────────
+		{
+			name:   "get_project/a plain key, with the slash the constant does not carry",
+			tool:   "get_project",
+			args:   map[string]any{"key": "PROJ"},
+			script: jiraOK(`{"key":"PROJ"}`),
+		},
+		{
+			// `PathEscape` is `encodePathSegment`: it escapes `/ ; , ?` and
+			// leaves `$ & + : = @` alone, and multi-byte UTF-8 becomes one `%XX`
+			// per byte in uppercase hex.
+			name:   "get_project/the reserved bytes a segment keeps, the ones it escapes, and UTF-8",
+			tool:   "get_project",
+			args:   map[string]any{"key": "a$&+:=@b my key/x;y,z?q café日本語"},
+			script: jiraOK(`{"key":"X"}`),
+		},
+
+		// ─── search_issues ───────────────────────────────────────────────────
+		{
+			// JQL travels in the **body**, so nothing escapes it — unlike
+			// Confluence's CQL, which is a query parameter.
+			name: "search_issues/JQL goes in the body unescaped, and the clamp falls back to 50",
+			tool: "search_issues",
+			args: map[string]any{
+				"jql": `project = PROJ AND status = "In Progress" & x`, "max_results": 0,
+			},
+			script: jiraOK(jiraOKBody),
+		},
+		{
+			name:   "search_issues/over 100 falls back to 50 rather than clamping to 100",
+			tool:   "search_issues",
+			args:   map[string]any{"jql": "type=Bug", "max_results": 101},
+			script: jiraOK(jiraOKBody),
+		},
+		{
+			name:   "search_issues/100 is the largest value that survives",
+			tool:   "search_issues",
+			args:   map[string]any{"jql": "type=Bug", "max_results": 100},
+			script: jiraOK(jiraOKBody),
+		},
+		{
+			name:   "search_issues/a negative max_results is a zero, not an error",
+			tool:   "search_issues",
+			args:   map[string]any{"jql": "", "max_results": -5},
+			script: jiraOK(jiraOKBody),
+		},
+
+		// ─── get_issue ───────────────────────────────────────────────────────
+		{
+			name:   "get_issue/the constant already ends in a slash",
+			tool:   "get_issue",
+			args:   map[string]any{"key": "PROJ-123"},
+			script: jiraOK(`{"key":"PROJ-123"}`),
+		},
+
+		// ─── create_issue ────────────────────────────────────────────────────
+		{
+			// The project key is `PathEscape`d **inside the body**, and nothing
+			// else is. A space becomes `%20` in JSON.
+			name: "create_issue/the project key is path-escaped inside the body and nothing else is",
+			tool: "create_issue",
+			args: map[string]any{
+				"project_key": "MY PROJ/X", "issue_type": "Bug",
+				"summary": "It <broke> & burned", "description": "", "priority": "",
+			},
+			script: jiraResponseScript{Status: http.StatusCreated, Body: `{"key":"PROJ-9"}`},
+		},
+		{
+			name: "create_issue/a description becomes an ADF document, sorted at every level",
+			tool: "create_issue",
+			args: map[string]any{
+				"project_key": "PROJ", "issue_type": "Story",
+				"summary": "s", "description": "a <b> & c", "priority": "High",
+			},
+			script: jiraResponseScript{Status: http.StatusCreated, Body: `{"key":"PROJ-10"}`},
+		},
+		{
+			name: "create_issue/an empty description and priority leave no keys at all",
+			tool: "create_issue",
+			args: map[string]any{
+				"project_key": "", "issue_type": "", "summary": "",
+				"description": "", "priority": "",
+			},
+			script: jiraResponseScript{Status: 400, Body: `{"errors":{"project":"required"}}`},
+		},
+
+		// ─── update_issue ────────────────────────────────────────────────────
+		{
+			// Every field is conditional, so this sends `{"fields":{}}` — still a
+			// body, and therefore still a Content-Type.
+			name: "update_issue/an all-empty update still sends a body, and the text ignores the response",
+			tool: "update_issue",
+			args: map[string]any{
+				"key": "PROJ-1", "summary": "", "description": "", "priority": "",
+			},
+			script: jiraOK(`{"ignored":true}`),
+		},
+		{
+			name: "update_issue/every field set, description as ADF",
+			tool: "update_issue",
+			args: map[string]any{
+				"key": "PROJ-1", "summary": "new", "description": "d", "priority": "Low",
+			},
+			script: jiraResponseScript{Status: http.StatusNoContent, Body: ""},
+		},
+		{
+			name: "update_issue/a key needing escaping appears escaped in the path and raw in the text",
+			tool: "update_issue",
+			args: map[string]any{
+				"key": "a/b c", "summary": "s", "description": "", "priority": "",
+			},
+			script: jiraOK(`{}`),
+		},
+
+		// ─── add_comment ─────────────────────────────────────────────────────
+		{
+			name:   "add_comment/the comment becomes an ADF document",
+			tool:   "add_comment",
+			args:   map[string]any{"key": "PROJ-1", "comment": "looks good & <shipped>"},
+			script: jiraResponseScript{Status: http.StatusCreated, Body: `{"id":"10000"}`},
+		},
+		{
+			name:   "add_comment/an empty comment is still a document",
+			tool:   "add_comment",
+			args:   map[string]any{"key": "PROJ-1", "comment": ""},
+			script: jiraResponseScript{Status: http.StatusCreated, Body: `{"id":"10001"}`},
+		},
+
+		// ─── list_transitions / transition_issue ─────────────────────────────
+		{
+			name:   "list_transitions/a GET under the issue path",
+			tool:   "list_transitions",
+			args:   map[string]any{"key": "PROJ-1"},
+			script: jiraOK(`{"transitions":[{"id":"31"}]}`),
+		},
+		{
+			name:   "transition_issue/the text ignores the response, like update_issue's",
+			tool:   "transition_issue",
+			args:   map[string]any{"key": "PROJ-1", "transition_id": "31"},
+			script: jiraResponseScript{Status: http.StatusNoContent, Body: ""},
+		},
+		{
+			name:   "transition_issue/a failure is the API's body, not the cheerful sentence",
+			tool:   "transition_issue",
+			args:   map[string]any{"key": "PROJ-1", "transition_id": "nope"},
+			script: jiraResponseScript{Status: 400, Body: `{"errorMessages":["bad transition"]}`},
+		},
+
+		// ─── a site URL with a base path of its own ───────────────────────────
+		{
+			name:     "get_issue/a site URL with a base path prefixes the target",
+			tool:     "get_issue",
+			basePath: "/jira",
+			args:     map[string]any{"key": "PROJ-1"},
+			script:   jiraOK(`{"key":"PROJ-1"}`),
+		},
+		{
+			// Not percent-encoded, and both parsers encode it the same way.
+			name:     "add_comment/an unencoded base path is escaped by both sides, on a write",
+			tool:     "add_comment",
+			basePath: "/my jira",
+			args:     map[string]any{"key": "PROJ-1", "comment": "hi"},
+			script:   jiraResponseScript{Status: http.StatusCreated, Body: `{"id":"1"}`},
+		},
+
+		// ─── the dot-segment refusal ─────────────────────────────────────────
+		{
+			// Go sends `/rest/api/3/issue/..` verbatim; `url` would resolve it to
+			// `/rest/api/3/`, a different endpoint answering a request that
+			// carries the API token.
+			name:          "get_issue/a dot-dot segment reaches a different endpoint under url",
+			tool:          "get_issue",
+			args:          map[string]any{"key": ".."},
+			script:        jiraResponseScript{Status: 404, Body: `{"message":"Not Found"}`},
+			rustText:      "calling Jira GET /rest/api/3/issue/..: request failed",
+			rustNoRequest: true,
+		},
+		{
+			name:          "get_project/a single dot segment is sent literally too",
+			tool:          "get_project",
+			args:          map[string]any{"key": "."},
+			script:        jiraResponseScript{Status: 404, Body: `{"message":"Not Found"}`},
+			rustText:      "calling Jira GET /rest/api/3/project/.: request failed",
+			rustNoRequest: true,
+		},
+		{
+			// The write path: a PUT whose body is built and sent before the
+			// status is looked at.
+			name: "update_issue/dot segments reach the write path too",
+			tool: "update_issue",
+			args: map[string]any{
+				"key": "..", "summary": "s", "description": "", "priority": "",
+			},
+			script:        jiraResponseScript{Status: 404, Body: `{"message":"Not Found"}`},
+			rustText:      "calling Jira PUT /rest/api/3/issue/..: request failed",
+			rustNoRequest: true,
+		},
+		{
+			name:          "list_transitions/a dot segment before a suffix is refused as well",
+			tool:          "list_transitions",
+			args:          map[string]any{"key": ".."},
+			script:        jiraResponseScript{Status: 404, Body: `{"message":"Not Found"}`},
+			rustText:      "calling Jira GET /rest/api/3/issue/../transitions: request failed",
+			rustNoRequest: true,
+		},
+
+		// ─── a zero-fraction float, which models do emit ──────────────────────
+		{
+			// The Go SDK unmarshals `arguments` into a `map[string]any`,
+			// validates against the reflected schema — where JSON Schema counts
+			// `50.0` as an `integer` — and re-marshals before the typed decode,
+			// so the handler sees 50. `serde_json::from_value::<i64>` refuses.
+			name:          "search_issues/a zero-fraction float is an integer to Go and not to serde",
+			tool:          "search_issues",
+			args:          map[string]any{"jql": "type=Bug", "max_results": json.RawMessage("50.0")},
+			script:        jiraOK(jiraOKBody),
+			rustText:      "failed to deserialize parameters: invalid type: floating point `50.0`, expected i64",
+			rustNoRequest: true,
+		},
+	}
+}
+
+// ─── The generator ───────────────────────────────────────────────────────────
+
+func TestJiraVectors(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	fake := &fakeJira{}
+	srv := httptest.NewServer(fake)
+	defer srv.Close()
+
+	want := jiraVectors{
+		Comment: []string{
+			"Cross-language parity vectors for internal/integrations/jira, the Jira",
+			"integration's in-process MCP server. Generated from Go, then frozen. Read by",
+			"desktop/parity/jira_parity_test.go (Go) and by",
+			"desktop/src-tauri/src/native/integrations/jira/ (Rust). Every value is exactly",
+			"what Go produces, so a divergence fails one language against the other's real",
+			"output rather than against a belief about it.",
+			"'tools' and 'hosting' come from live tools/list calls against servers built by",
+			"jira.Start; 'calls' from live tools/call calls against a scripted fake Jira that",
+			"records the request each tool built; 'site_urls' pin that a site URL Go serves",
+			"and the Rust port cannot send a request through leaves the tool set untouched.",
+			"'email' and 'api_token' are fixtures, not secrets: they are recorded so the",
+			"base64 of the Basic header is pinned.",
+			"Regenerate with: go test ./desktop/parity/ -run TestJiraVectors -update-jira-vectors",
+		},
+		IntegrationID: jiraParityID,
+		ServerName:    fmt.Sprintf("jira-%s", jiraParityID),
+		Version:       "1.0.0",
+		Email:         jiraParityEmail,
+		APIToken:      jiraParityToken,
+	}
+
+	session := jiraSession(t, ctx, srv.URL, jiraAllServices())
+	listed, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("tools/list: %v", err)
+	}
+	for _, tool := range listed.Tools {
+		schema, err := json.Marshal(tool.InputSchema)
+		if err != nil {
+			t.Fatalf("encoding %s's input schema: %v", tool.Name, err)
+		}
+		want.Tools = append(want.Tools, jiraToolVector{
+			Name:        tool.Name,
+			Description: tool.Description,
+			InputSchema: schema,
+		})
+	}
+
+	for _, hosting := range jiraHostingCases {
+		hosting.Tools = jiraHostedTools(t, ctx, srv.URL, hosting.Services)
+		want.Hosting = append(want.Hosting, hosting)
+	}
+
+	for _, c := range jiraSiteURLCases {
+		vector := runJiraSiteURLCase(t, ctx, c.name, c.siteURL)
+		vector.RustCallText = c.rustCallText
+		want.SiteURLs = append(want.SiteURLs, vector)
+	}
+
+	// One session per distinct site URL. Most cases run against the fake's own
+	// root; the base-path ones need a server whose credentials carry that base,
+	// because a site URL is not a per-call argument.
+	sessions := map[string]*mcp.ClientSession{"": session}
+	for _, c := range jiraCallCases() {
+		if _, ok := sessions[c.basePath]; !ok {
+			sessions[c.basePath] = jiraSession(t, ctx, srv.URL+c.basePath, jiraAllServices())
+		}
+		want.Calls = append(want.Calls, runJiraCallCase(t, ctx, sessions[c.basePath], fake, c))
+	}
+
+	encoded, err := json.MarshalIndent(want, "", "  ")
+	if err != nil {
+		t.Fatalf("encoding vectors: %v", err)
+	}
+	encoded = append(encoded, '\n')
+
+	if *updateJiraVectors {
+		if err := os.WriteFile(jiraVectorsFile, encoded, 0o600); err != nil {
+			t.Fatalf("writing %s: %v", jiraVectorsFile, err)
+		}
+		t.Logf("wrote %s", jiraVectorsFile)
+		return
+	}
+
+	frozen, err := os.ReadFile(jiraVectorsFile)
+	if err != nil {
+		t.Fatalf("reading %s (regenerate with -update-jira-vectors): %v", jiraVectorsFile, err)
+	}
+	if string(frozen) != string(encoded) {
+		t.Fatalf("%s is stale: this Go toolchain produces different results.\n"+
+			"Regenerate with -update-jira-vectors and check what moved — the Rust port in "+
+			"native/integrations/jira/ reads the same file and will fail against it. A moved "+
+			"tool name, schema, request or sentence is not a cosmetic diff: the names are in "+
+			"every agent's stored allowlist and in every tool_use block already written, and "+
+			"the sentences are what the model reads.",
+			jiraVectorsFile)
+	}
+}
+
+// jiraHostedTools starts a server for services and asks it what it hosts.
+//
+// The sort makes explicit what both SDKs already do: `tools/list` answers in name
+// order. Registration order is pinned on the Rust side instead.
+func jiraHostedTools(
+	t *testing.T, ctx context.Context, siteURL string, services map[string]config.ServiceConfig,
+) []string {
+	t.Helper()
+	listed, err := jiraSession(t, ctx, siteURL, services).ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("tools/list: %v", err)
+	}
+	names := make([]string, 0, len(listed.Tools))
+	for _, tool := range listed.Tools {
+		names = append(names, tool.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// runJiraSiteURLCase hosts a server on a site URL that never resolves and records
+// what it advertises and what one call answers.
+func runJiraSiteURLCase(
+	t *testing.T, ctx context.Context, name, siteURL string,
+) jiraSiteURLVector {
+	t.Helper()
+	session := jiraSession(t, ctx, siteURL, jiraAllServices())
+
+	listed, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("%s: tools/list: %v", name, err)
+	}
+	names := make([]string, 0, len(listed.Tools))
+	for _, tool := range listed.Tools {
+		names = append(names, tool.Name)
+	}
+	sort.Strings(names)
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "list_projects", Arguments: json.RawMessage(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("%s: tools/call: %v", name, err)
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("%s: want text content, got %T", name, result.Content[0])
+	}
+	for _, secret := range []string{jiraParityToken, jiraParityEmail} {
+		if strings.Contains(text.Text, secret) {
+			t.Fatalf("%s: a credential leaked into a tool result: %s", name, text.Text)
+		}
+	}
+
+	return jiraSiteURLVector{
+		Case: name, SiteURL: siteURL, Tools: names,
+		CallText: text.Text, IsError: result.IsError,
+	}
+}
+
+// runJiraCallCase arms the fake, makes one real tools/call and records everything
+// observable: the request the tool built, and the result the model would read.
+func runJiraCallCase(
+	t *testing.T, ctx context.Context,
+	session *mcp.ClientSession, fake *fakeJira, c jiraCallCase,
+) jiraCallVector {
+	t.Helper()
+
+	fake.arm(c.script)
+	args := jsonArgs(t, c.args)
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: c.tool, Arguments: args,
+	})
+	if err != nil {
+		t.Fatalf("%s: tools/call: %v", c.name, err)
+	}
+	if len(result.Content) != 1 {
+		t.Fatalf("%s: want exactly one content block, got %d", c.name, len(result.Content))
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("%s: want text content, got %T", c.name, result.Content[0])
+	}
+
+	for _, secret := range []string{jiraParityToken, jiraParityEmail} {
+		if strings.Contains(text.Text, secret) {
+			t.Fatalf("%s: a credential leaked into a tool result: %s", c.name, text.Text)
+		}
+	}
+
+	return jiraCallVector{
+		Case:          c.name,
+		Tool:          c.tool,
+		BasePath:      c.basePath,
+		Arguments:     args,
+		Response:      c.script,
+		Request:       fake.recorded(),
+		IsError:       result.IsError,
+		Text:          text.Text,
+		RustText:      c.rustText,
+		RustNoRequest: c.rustNoRequest,
+	}
+}

--- a/desktop/parity/jira_parity_test.go
+++ b/desktop/parity/jira_parity_test.go
@@ -129,10 +129,14 @@ type jiraHostingVector struct {
 // made Jira answer per call rather than refuse to host.
 type jiraSiteURLVector struct {
 	Case string `json:"case"`
-	// Substituted for the fake's URL wholesale, so this is an absolute URL and
-	// no request can reach the fake.
-	SiteURL string   `json:"site_url"`
-	Tools   []string `json:"tools"`
+	// An absolute URL that never resolves, used as-is by both languages. Empty
+	// when FakeAuthorityPrefix is set, because the fake's port is not stable
+	// across runs and each language substitutes its own.
+	SiteURL string `json:"site_url,omitempty"`
+	// Inserted in front of the fake's authority. Set only for the case where Go
+	// reaches the fake and this port refuses.
+	FakeAuthorityPrefix string   `json:"fake_authority_prefix,omitempty"`
+	Tools               []string `json:"tools"`
 	// What a tools/call answers on the Go side.
 	CallText string `json:"call_text"`
 	IsError  bool   `json:"is_error"`
@@ -299,9 +303,15 @@ var jiraHostingCases = []jiraHostingVector{
 // Each host is one that does not resolve, so Go's own answer is its transport
 // sentence and nothing leaves the machine.
 var jiraSiteURLCases = []struct {
-	name         string
-	siteURL      string
-	rustCallText string
+	name string
+	// An absolute URL that never resolves, used as-is.
+	siteURL string
+	// …or an authority prefix inserted in front of the **fake's** host, so Go
+	// reaches it and answers a real body. That is the only way to record the
+	// refusals this port *adds* over Go: with a host that does not resolve, Go
+	// fails too and the divergence is invisible.
+	fakeAuthorityPrefix string
+	rustCallText        string
 }{
 	{
 		// `url` treats `\` as an authority separator and `net/url` rejects the
@@ -329,6 +339,21 @@ var jiraSiteURLCases = []struct {
 		// diverges; it is here because it is the difference #277 pinned.
 		name:    "plaintext, which Jira's own validator allows and Confluence's does not",
 		siteURL: "http://jira.invalid",
+	},
+	{
+		// The one case where Go **succeeds** and this port refuses, which is
+		// what makes the refusals `Base::new` adds over Go observable at all.
+		// Userinfo is outside its authority allowlist, and it is outside it
+		// because that is where a `\` hides in front of the `@` — the graft
+		// #317 found. Go dials the fake and returns its body; the port answers
+		// the transport sentence and sends nothing.
+		//
+		// An IPv6-literal base is the same class and is not recorded here only
+		// because `httptest` binds 127.0.0.1; it is named in
+		// `native/integrations/base_url.rs` with the other three.
+		name:                "userinfo, which Go dials and this build refuses",
+		fakeAuthorityPrefix: "user:pw@",
+		rustCallText:        "calling Jira GET /rest/api/3/project: request failed",
 	},
 }
 
@@ -546,6 +571,19 @@ func jiraCallCases() []jiraCallCase {
 			args:     map[string]any{"key": "PROJ-1", "comment": "hi"},
 			script:   jiraResponseScript{Status: http.StatusCreated, Body: `{"id":"1"}`},
 		},
+		{
+			// A base ending in a bare `/` contributes one: Go concatenates raw
+			// text, so the target carries an **empty first segment**. `url` renders
+			// `https://x` and `https://x/` with the same `path()`, so a port that
+			// derived its prefix from the rendered path refused every call against
+			// such a base — silently, since nothing trims it for Jira and `Update`
+			// validates nothing.
+			name:     "get_issue/a base ending in a bare slash sends a double slash",
+			tool:     "get_issue",
+			basePath: "/",
+			args:     map[string]any{"key": "PROJ-1"},
+			script:   jiraOK(`{"key":"PROJ-1"}`),
+		},
 
 		// ─── the dot-segment refusal ─────────────────────────────────────────
 		{
@@ -660,8 +698,25 @@ func TestJiraVectors(t *testing.T) {
 	}
 
 	for _, c := range jiraSiteURLCases {
-		vector := runJiraSiteURLCase(t, ctx, c.name, c.siteURL)
+		siteURL := c.siteURL
+		if c.fakeAuthorityPrefix != "" {
+			// `srv.URL` is `http://127.0.0.1:PORT`; put the prefix in front of
+			// the authority so Go actually reaches the fake.
+			siteURL = strings.Replace(srv.URL, "http://", "http://"+c.fakeAuthorityPrefix, 1)
+			fake.arm(jiraOK(`{"values":[]}`))
+		}
+		vector := runJiraSiteURLCase(t, ctx, c.name, siteURL)
 		vector.RustCallText = c.rustCallText
+		if c.fakeAuthorityPrefix != "" {
+			// The fake's port is not stable across runs, so the resolved URL
+			// cannot be frozen; each language rebuilds it from its own fake.
+			vector.SiteURL = ""
+		}
+		// The recorded site URL is what the Rust half must use, so a case built
+		// from the fake's port has to carry the resolved value — and the port is
+		// not stable across runs, which is why the Rust half substitutes its own
+		// authority rather than reading this one verbatim. See `FAKE_AUTHORITY`.
+		vector.FakeAuthorityPrefix = c.fakeAuthorityPrefix
 		want.SiteURLs = append(want.SiteURLs, vector)
 	}
 

--- a/desktop/parity/jira_vectors.json
+++ b/desktop/parity/jira_vectors.json
@@ -1,0 +1,1013 @@
+{
+  "_comment": [
+    "Cross-language parity vectors for internal/integrations/jira, the Jira",
+    "integration's in-process MCP server. Generated from Go, then frozen. Read by",
+    "desktop/parity/jira_parity_test.go (Go) and by",
+    "desktop/src-tauri/src/native/integrations/jira/ (Rust). Every value is exactly",
+    "what Go produces, so a divergence fails one language against the other's real",
+    "output rather than against a belief about it.",
+    "'tools' and 'hosting' come from live tools/list calls against servers built by",
+    "jira.Start; 'calls' from live tools/call calls against a scripted fake Jira that",
+    "records the request each tool built; 'site_urls' pin that a site URL Go serves",
+    "and the Rust port cannot send a request through leaves the tool set untouched.",
+    "'email' and 'api_token' are fixtures, not secrets: they are recorded so the",
+    "base64 of the Basic header is pinned.",
+    "Regenerate with: go test ./desktop/parity/ -run TestJiraVectors -update-jira-vectors"
+  ],
+  "integration_id": "jira-parity",
+  "server_name": "jira-jira-parity",
+  "version": "1.0.0",
+  "email": "parity@example.com",
+  "api_token": "parity-jira-api-token",
+  "tools": [
+    {
+      "name": "add_comment",
+      "description": "Adds a comment to a Jira issue.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "comment": {
+            "description": "required,The text of the comment to add",
+            "type": "string"
+          },
+          "key": {
+            "description": "required,The issue key (e.g. PROJ-123)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "comment"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "create_issue",
+      "description": "Creates a new Jira issue in a project.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "description": "Optional description of the issue",
+            "type": "string"
+          },
+          "issue_type": {
+            "description": "required,Issue type name (e.g. Bug, Story, Task)",
+            "type": "string"
+          },
+          "priority": {
+            "description": "Optional priority name (e.g. High, Medium, Low)",
+            "type": "string"
+          },
+          "project_key": {
+            "description": "required,The project key (e.g. PROJ)",
+            "type": "string"
+          },
+          "summary": {
+            "description": "required,Summary/title of the issue",
+            "type": "string"
+          }
+        },
+        "required": [
+          "project_key",
+          "issue_type",
+          "summary",
+          "description",
+          "priority"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_issue",
+      "description": "Gets details of a specific Jira issue by key (e.g. PROJ-123).",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "key": {
+            "description": "required,The issue key (e.g. PROJ-123)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_project",
+      "description": "Gets details of a specific Jira project by key.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "key": {
+            "description": "required,The project key (e.g. PROJ)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_projects",
+      "description": "Lists all accessible Jira projects.",
+      "input_schema": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_transitions",
+      "description": "Lists available status transitions for a Jira issue.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "key": {
+            "description": "required,The issue key (e.g. PROJ-123)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "search_issues",
+      "description": "Searches Jira issues using JQL (Jira Query Language).",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "jql": {
+            "description": "required,JQL query string (e.g. project = PROJ AND status = Open)",
+            "type": "string"
+          },
+          "max_results": {
+            "description": "Maximum number of issues to return (default 50, max 100)",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "jql",
+          "max_results"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "transition_issue",
+      "description": "Transitions a Jira issue to a new status.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "key": {
+            "description": "required,The issue key (e.g. PROJ-123)",
+            "type": "string"
+          },
+          "transition_id": {
+            "description": "required,The ID of the transition to perform",
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "transition_id"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "update_issue",
+      "description": "Updates fields of an existing Jira issue.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "description": "Optional new description",
+            "type": "string"
+          },
+          "key": {
+            "description": "required,The issue key (e.g. PROJ-123)",
+            "type": "string"
+          },
+          "priority": {
+            "description": "Optional new priority name (e.g. High, Medium, Low)",
+            "type": "string"
+          },
+          "summary": {
+            "description": "Optional new summary/title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "summary",
+          "description",
+          "priority"
+        ],
+        "type": "object"
+      }
+    }
+  ],
+  "hosting": [
+    {
+      "case": "the service enabled with no tool list — an empty allowed set hosts everything",
+      "services": {
+        "project_management": {
+          "enabled": true,
+          "tools": null
+        }
+      },
+      "tools": [
+        "add_comment",
+        "create_issue",
+        "get_issue",
+        "get_project",
+        "list_projects",
+        "list_transitions",
+        "search_issues",
+        "transition_issue",
+        "update_issue"
+      ]
+    },
+    {
+      "case": "no services at all",
+      "services": {},
+      "tools": []
+    },
+    {
+      "case": "the service disabled contributes neither its gate nor its tools",
+      "services": {
+        "project_management": {
+          "enabled": false,
+          "tools": [
+            "get_issue"
+          ]
+        }
+      },
+      "tools": []
+    },
+    {
+      "case": "a non-empty allowed set is a filter",
+      "services": {
+        "project_management": {
+          "enabled": true,
+          "tools": [
+            "get_issue",
+            "add_comment"
+          ]
+        }
+      },
+      "tools": [
+        "add_comment",
+        "get_issue"
+      ]
+    },
+    {
+      "case": "an enabled but unknown service still narrows the one that exists",
+      "services": {
+        "other": {
+          "enabled": true,
+          "tools": [
+            "list_projects"
+          ]
+        },
+        "project_management": {
+          "enabled": true,
+          "tools": null
+        }
+      },
+      "tools": [
+        "list_projects"
+      ]
+    },
+    {
+      "case": "a tool named by a disabled service is not allowed anywhere",
+      "services": {
+        "other": {
+          "enabled": false,
+          "tools": [
+            "create_issue"
+          ]
+        },
+        "project_management": {
+          "enabled": true,
+          "tools": [
+            "get_project"
+          ]
+        }
+      },
+      "tools": [
+        "get_project"
+      ]
+    }
+  ],
+  "site_urls": [
+    {
+      "case": "a backslash before the userinfo, which url reads as a different host",
+      "site_url": "https://evil.invalid\\@jira.invalid",
+      "tools": [
+        "add_comment",
+        "create_issue",
+        "get_issue",
+        "get_project",
+        "list_projects",
+        "list_transitions",
+        "search_issues",
+        "transition_issue",
+        "update_issue"
+      ],
+      "call_text": "creating request: parse \"https://evil.invalid\\\\@jira.invalid/rest/api/3/project\": net/url: invalid userinfo",
+      "is_error": true,
+      "rust_call_text": "calling Jira GET /rest/api/3/project: request failed"
+    },
+    {
+      "case": "a percent escape in the host, which url decodes to another domain",
+      "site_url": "https://jira.invalid%2Eevil.invalid",
+      "tools": [
+        "add_comment",
+        "create_issue",
+        "get_issue",
+        "get_project",
+        "list_projects",
+        "list_transitions",
+        "search_issues",
+        "transition_issue",
+        "update_issue"
+      ],
+      "call_text": "creating request: parse \"https://jira.invalid%2Eevil.invalid/rest/api/3/project\": invalid URL escape \"%2E\"",
+      "is_error": true,
+      "rust_call_text": "calling Jira GET /rest/api/3/project: request failed"
+    },
+    {
+      "case": "a dot segment in the base path, which url collapses",
+      "site_url": "https://jira.invalid/a/../b",
+      "tools": [
+        "add_comment",
+        "create_issue",
+        "get_issue",
+        "get_project",
+        "list_projects",
+        "list_transitions",
+        "search_issues",
+        "transition_issue",
+        "update_issue"
+      ],
+      "call_text": "calling Jira GET /rest/api/3/project: request failed",
+      "is_error": true
+    },
+    {
+      "case": "plaintext, which Jira's own validator allows and Confluence's does not",
+      "site_url": "http://jira.invalid",
+      "tools": [
+        "add_comment",
+        "create_issue",
+        "get_issue",
+        "get_project",
+        "list_projects",
+        "list_transitions",
+        "search_issues",
+        "transition_issue",
+        "update_issue"
+      ],
+      "call_text": "calling Jira GET /rest/api/3/project: request failed",
+      "is_error": true
+    }
+  ],
+  "calls": [
+    {
+      "case": "list_projects/no arguments at all, because the Go handler binds *struct{}",
+      "tool": "list_projects",
+      "arguments": {},
+      "response": {
+        "status": 200,
+        "body": "{\"issues\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"key\":\"PROJ-1\"}]}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/rest/api/3/project",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Projects: {\"issues\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"key\":\"PROJ-1\"}]}"
+    },
+    {
+      "case": "list_projects/a non-2xx status is Jira's own body, verbatim",
+      "tool": "list_projects",
+      "arguments": {},
+      "response": {
+        "status": 403,
+        "body": "{\"message\":\"Forbidden \u003cyou\u003e\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/rest/api/3/project",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": true,
+      "text": "jira API error: status 403: {\"message\":\"Forbidden \u003cyou\u003e\"}"
+    },
+    {
+      "case": "list_projects/a 204 is a success, and its empty body is the result",
+      "tool": "list_projects",
+      "arguments": {},
+      "response": {
+        "status": 204,
+        "body": ""
+      },
+      "request": {
+        "method": "GET",
+        "target": "/rest/api/3/project",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Projects: "
+    },
+    {
+      "case": "get_project/a plain key, with the slash the constant does not carry",
+      "tool": "get_project",
+      "arguments": {
+        "key": "PROJ"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"key\":\"PROJ\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/rest/api/3/project/PROJ",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Project: {\"key\":\"PROJ\"}"
+    },
+    {
+      "case": "get_project/the reserved bytes a segment keeps, the ones it escapes, and UTF-8",
+      "tool": "get_project",
+      "arguments": {
+        "key": "a$\u0026+:=@b my key/x;y,z?q café日本語"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"key\":\"X\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/rest/api/3/project/a$\u0026+:=@b%20my%20key%2Fx%3By%2Cz%3Fq%20caf%C3%A9%E6%97%A5%E6%9C%AC%E8%AA%9E",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Project: {\"key\":\"X\"}"
+    },
+    {
+      "case": "search_issues/JQL goes in the body unescaped, and the clamp falls back to 50",
+      "tool": "search_issues",
+      "arguments": {
+        "jql": "project = PROJ AND status = \"In Progress\" \u0026 x",
+        "max_results": 0
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"issues\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"key\":\"PROJ-1\"}]}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/rest/api/3/search",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "application/json",
+        "body": "{\"jql\":\"project = PROJ AND status = \\\"In Progress\\\" \\u0026 x\",\"maxResults\":50}"
+      },
+      "is_error": false,
+      "text": "Search results: {\"issues\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"key\":\"PROJ-1\"}]}"
+    },
+    {
+      "case": "search_issues/over 100 falls back to 50 rather than clamping to 100",
+      "tool": "search_issues",
+      "arguments": {
+        "jql": "type=Bug",
+        "max_results": 101
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"issues\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"key\":\"PROJ-1\"}]}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/rest/api/3/search",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "application/json",
+        "body": "{\"jql\":\"type=Bug\",\"maxResults\":50}"
+      },
+      "is_error": false,
+      "text": "Search results: {\"issues\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"key\":\"PROJ-1\"}]}"
+    },
+    {
+      "case": "search_issues/100 is the largest value that survives",
+      "tool": "search_issues",
+      "arguments": {
+        "jql": "type=Bug",
+        "max_results": 100
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"issues\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"key\":\"PROJ-1\"}]}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/rest/api/3/search",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "application/json",
+        "body": "{\"jql\":\"type=Bug\",\"maxResults\":100}"
+      },
+      "is_error": false,
+      "text": "Search results: {\"issues\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"key\":\"PROJ-1\"}]}"
+    },
+    {
+      "case": "search_issues/a negative max_results is a zero, not an error",
+      "tool": "search_issues",
+      "arguments": {
+        "jql": "",
+        "max_results": -5
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"issues\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"key\":\"PROJ-1\"}]}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/rest/api/3/search",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "application/json",
+        "body": "{\"jql\":\"\",\"maxResults\":50}"
+      },
+      "is_error": false,
+      "text": "Search results: {\"issues\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"key\":\"PROJ-1\"}]}"
+    },
+    {
+      "case": "get_issue/the constant already ends in a slash",
+      "tool": "get_issue",
+      "arguments": {
+        "key": "PROJ-123"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"key\":\"PROJ-123\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/rest/api/3/issue/PROJ-123",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Issue: {\"key\":\"PROJ-123\"}"
+    },
+    {
+      "case": "create_issue/the project key is path-escaped inside the body and nothing else is",
+      "tool": "create_issue",
+      "arguments": {
+        "description": "",
+        "issue_type": "Bug",
+        "priority": "",
+        "project_key": "MY PROJ/X",
+        "summary": "It \u003cbroke\u003e \u0026 burned"
+      },
+      "response": {
+        "status": 201,
+        "body": "{\"key\":\"PROJ-9\"}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/rest/api/3/issue",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "application/json",
+        "body": "{\"fields\":{\"issuetype\":{\"name\":\"Bug\"},\"project\":{\"key\":\"MY%20PROJ%2FX\"},\"summary\":\"It \\u003cbroke\\u003e \\u0026 burned\"}}"
+      },
+      "is_error": false,
+      "text": "Issue created: {\"key\":\"PROJ-9\"}"
+    },
+    {
+      "case": "create_issue/a description becomes an ADF document, sorted at every level",
+      "tool": "create_issue",
+      "arguments": {
+        "description": "a \u003cb\u003e \u0026 c",
+        "issue_type": "Story",
+        "priority": "High",
+        "project_key": "PROJ",
+        "summary": "s"
+      },
+      "response": {
+        "status": 201,
+        "body": "{\"key\":\"PROJ-10\"}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/rest/api/3/issue",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "application/json",
+        "body": "{\"fields\":{\"description\":{\"content\":[{\"content\":[{\"text\":\"a \\u003cb\\u003e \\u0026 c\",\"type\":\"text\"}],\"type\":\"paragraph\"}],\"type\":\"doc\",\"version\":1},\"issuetype\":{\"name\":\"Story\"},\"priority\":{\"name\":\"High\"},\"project\":{\"key\":\"PROJ\"},\"summary\":\"s\"}}"
+      },
+      "is_error": false,
+      "text": "Issue created: {\"key\":\"PROJ-10\"}"
+    },
+    {
+      "case": "create_issue/an empty description and priority leave no keys at all",
+      "tool": "create_issue",
+      "arguments": {
+        "description": "",
+        "issue_type": "",
+        "priority": "",
+        "project_key": "",
+        "summary": ""
+      },
+      "response": {
+        "status": 400,
+        "body": "{\"errors\":{\"project\":\"required\"}}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/rest/api/3/issue",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "application/json",
+        "body": "{\"fields\":{\"issuetype\":{\"name\":\"\"},\"project\":{\"key\":\"\"},\"summary\":\"\"}}"
+      },
+      "is_error": true,
+      "text": "jira API error: status 400: {\"errors\":{\"project\":\"required\"}}"
+    },
+    {
+      "case": "update_issue/an all-empty update still sends a body, and the text ignores the response",
+      "tool": "update_issue",
+      "arguments": {
+        "description": "",
+        "key": "PROJ-1",
+        "priority": "",
+        "summary": ""
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ignored\":true}"
+      },
+      "request": {
+        "method": "PUT",
+        "target": "/rest/api/3/issue/PROJ-1",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "application/json",
+        "body": "{\"fields\":{}}"
+      },
+      "is_error": false,
+      "text": "Issue PROJ-1 updated successfully."
+    },
+    {
+      "case": "update_issue/every field set, description as ADF",
+      "tool": "update_issue",
+      "arguments": {
+        "description": "d",
+        "key": "PROJ-1",
+        "priority": "Low",
+        "summary": "new"
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      },
+      "request": {
+        "method": "PUT",
+        "target": "/rest/api/3/issue/PROJ-1",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "application/json",
+        "body": "{\"fields\":{\"description\":{\"content\":[{\"content\":[{\"text\":\"d\",\"type\":\"text\"}],\"type\":\"paragraph\"}],\"type\":\"doc\",\"version\":1},\"priority\":{\"name\":\"Low\"},\"summary\":\"new\"}}"
+      },
+      "is_error": false,
+      "text": "Issue PROJ-1 updated successfully."
+    },
+    {
+      "case": "update_issue/a key needing escaping appears escaped in the path and raw in the text",
+      "tool": "update_issue",
+      "arguments": {
+        "description": "",
+        "key": "a/b c",
+        "priority": "",
+        "summary": "s"
+      },
+      "response": {
+        "status": 200,
+        "body": "{}"
+      },
+      "request": {
+        "method": "PUT",
+        "target": "/rest/api/3/issue/a%2Fb%20c",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "application/json",
+        "body": "{\"fields\":{\"summary\":\"s\"}}"
+      },
+      "is_error": false,
+      "text": "Issue a/b c updated successfully."
+    },
+    {
+      "case": "add_comment/the comment becomes an ADF document",
+      "tool": "add_comment",
+      "arguments": {
+        "comment": "looks good \u0026 \u003cshipped\u003e",
+        "key": "PROJ-1"
+      },
+      "response": {
+        "status": 201,
+        "body": "{\"id\":\"10000\"}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/rest/api/3/issue/PROJ-1/comment",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "application/json",
+        "body": "{\"body\":{\"content\":[{\"content\":[{\"text\":\"looks good \\u0026 \\u003cshipped\\u003e\",\"type\":\"text\"}],\"type\":\"paragraph\"}],\"type\":\"doc\",\"version\":1}}"
+      },
+      "is_error": false,
+      "text": "Comment added: {\"id\":\"10000\"}"
+    },
+    {
+      "case": "add_comment/an empty comment is still a document",
+      "tool": "add_comment",
+      "arguments": {
+        "comment": "",
+        "key": "PROJ-1"
+      },
+      "response": {
+        "status": 201,
+        "body": "{\"id\":\"10001\"}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/rest/api/3/issue/PROJ-1/comment",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "application/json",
+        "body": "{\"body\":{\"content\":[{\"content\":[{\"text\":\"\",\"type\":\"text\"}],\"type\":\"paragraph\"}],\"type\":\"doc\",\"version\":1}}"
+      },
+      "is_error": false,
+      "text": "Comment added: {\"id\":\"10001\"}"
+    },
+    {
+      "case": "list_transitions/a GET under the issue path",
+      "tool": "list_transitions",
+      "arguments": {
+        "key": "PROJ-1"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"transitions\":[{\"id\":\"31\"}]}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/rest/api/3/issue/PROJ-1/transitions",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Transitions: {\"transitions\":[{\"id\":\"31\"}]}"
+    },
+    {
+      "case": "transition_issue/the text ignores the response, like update_issue's",
+      "tool": "transition_issue",
+      "arguments": {
+        "key": "PROJ-1",
+        "transition_id": "31"
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      },
+      "request": {
+        "method": "POST",
+        "target": "/rest/api/3/issue/PROJ-1/transitions",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "application/json",
+        "body": "{\"transition\":{\"id\":\"31\"}}"
+      },
+      "is_error": false,
+      "text": "Issue PROJ-1 transitioned successfully."
+    },
+    {
+      "case": "transition_issue/a failure is the API's body, not the cheerful sentence",
+      "tool": "transition_issue",
+      "arguments": {
+        "key": "PROJ-1",
+        "transition_id": "nope"
+      },
+      "response": {
+        "status": 400,
+        "body": "{\"errorMessages\":[\"bad transition\"]}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/rest/api/3/issue/PROJ-1/transitions",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "application/json",
+        "body": "{\"transition\":{\"id\":\"nope\"}}"
+      },
+      "is_error": true,
+      "text": "jira API error: status 400: {\"errorMessages\":[\"bad transition\"]}"
+    },
+    {
+      "case": "get_issue/a site URL with a base path prefixes the target",
+      "tool": "get_issue",
+      "base_path": "/jira",
+      "arguments": {
+        "key": "PROJ-1"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"key\":\"PROJ-1\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/jira/rest/api/3/issue/PROJ-1",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Issue: {\"key\":\"PROJ-1\"}"
+    },
+    {
+      "case": "add_comment/an unencoded base path is escaped by both sides, on a write",
+      "tool": "add_comment",
+      "base_path": "/my jira",
+      "arguments": {
+        "comment": "hi",
+        "key": "PROJ-1"
+      },
+      "response": {
+        "status": 201,
+        "body": "{\"id\":\"1\"}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/my%20jira/rest/api/3/issue/PROJ-1/comment",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "application/json",
+        "body": "{\"body\":{\"content\":[{\"content\":[{\"text\":\"hi\",\"type\":\"text\"}],\"type\":\"paragraph\"}],\"type\":\"doc\",\"version\":1}}"
+      },
+      "is_error": false,
+      "text": "Comment added: {\"id\":\"1\"}"
+    },
+    {
+      "case": "get_issue/a dot-dot segment reaches a different endpoint under url",
+      "tool": "get_issue",
+      "arguments": {
+        "key": ".."
+      },
+      "response": {
+        "status": 404,
+        "body": "{\"message\":\"Not Found\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/rest/api/3/issue/..",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": true,
+      "text": "jira API error: status 404: {\"message\":\"Not Found\"}",
+      "rust_text": "calling Jira GET /rest/api/3/issue/..: request failed",
+      "rust_no_request": true
+    },
+    {
+      "case": "get_project/a single dot segment is sent literally too",
+      "tool": "get_project",
+      "arguments": {
+        "key": "."
+      },
+      "response": {
+        "status": 404,
+        "body": "{\"message\":\"Not Found\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/rest/api/3/project/.",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": true,
+      "text": "jira API error: status 404: {\"message\":\"Not Found\"}",
+      "rust_text": "calling Jira GET /rest/api/3/project/.: request failed",
+      "rust_no_request": true
+    },
+    {
+      "case": "update_issue/dot segments reach the write path too",
+      "tool": "update_issue",
+      "arguments": {
+        "description": "",
+        "key": "..",
+        "priority": "",
+        "summary": "s"
+      },
+      "response": {
+        "status": 404,
+        "body": "{\"message\":\"Not Found\"}"
+      },
+      "request": {
+        "method": "PUT",
+        "target": "/rest/api/3/issue/..",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "application/json",
+        "body": "{\"fields\":{\"summary\":\"s\"}}"
+      },
+      "is_error": true,
+      "text": "jira API error: status 404: {\"message\":\"Not Found\"}",
+      "rust_text": "calling Jira PUT /rest/api/3/issue/..: request failed",
+      "rust_no_request": true
+    },
+    {
+      "case": "list_transitions/a dot segment before a suffix is refused as well",
+      "tool": "list_transitions",
+      "arguments": {
+        "key": ".."
+      },
+      "response": {
+        "status": 404,
+        "body": "{\"message\":\"Not Found\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "/rest/api/3/issue/../transitions",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": true,
+      "text": "jira API error: status 404: {\"message\":\"Not Found\"}",
+      "rust_text": "calling Jira GET /rest/api/3/issue/../transitions: request failed",
+      "rust_no_request": true
+    },
+    {
+      "case": "search_issues/a zero-fraction float is an integer to Go and not to serde",
+      "tool": "search_issues",
+      "arguments": {
+        "jql": "type=Bug",
+        "max_results": 50.0
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"issues\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"key\":\"PROJ-1\"}]}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/rest/api/3/search",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "application/json",
+        "body": "{\"jql\":\"type=Bug\",\"maxResults\":50}"
+      },
+      "is_error": false,
+      "text": "Search results: {\"issues\":[{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"key\":\"PROJ-1\"}]}",
+      "rust_text": "failed to deserialize parameters: invalid type: floating point `50.0`, expected i64",
+      "rust_no_request": true
+    }
+  ]
+}

--- a/desktop/parity/jira_vectors.json
+++ b/desktop/parity/jira_vectors.json
@@ -378,6 +378,24 @@
       ],
       "call_text": "calling Jira GET /rest/api/3/project: request failed",
       "is_error": true
+    },
+    {
+      "case": "userinfo, which Go dials and this build refuses",
+      "fake_authority_prefix": "user:pw@",
+      "tools": [
+        "add_comment",
+        "create_issue",
+        "get_issue",
+        "get_project",
+        "list_projects",
+        "list_transitions",
+        "search_issues",
+        "transition_issue",
+        "update_issue"
+      ],
+      "call_text": "Projects: {\"values\":[]}",
+      "is_error": false,
+      "rust_call_text": "calling Jira GET /rest/api/3/project: request failed"
     }
   ],
   "calls": [
@@ -889,6 +907,28 @@
       },
       "is_error": false,
       "text": "Comment added: {\"id\":\"1\"}"
+    },
+    {
+      "case": "get_issue/a base ending in a bare slash sends a double slash",
+      "tool": "get_issue",
+      "base_path": "/",
+      "arguments": {
+        "key": "PROJ-1"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"key\":\"PROJ-1\"}"
+      },
+      "request": {
+        "method": "GET",
+        "target": "//rest/api/3/issue/PROJ-1",
+        "authorization": "Basic cGFyaXR5QGV4YW1wbGUuY29tOnBhcml0eS1qaXJhLWFwaS10b2tlbg==",
+        "accept": "application/json",
+        "content_type": "",
+        "body": ""
+      },
+      "is_error": false,
+      "text": "Issue: {\"key\":\"PROJ-1\"}"
     },
     {
       "case": "get_issue/a dot-dot segment reaches a different endpoint under url",

--- a/desktop/src-tauri/src/claude/schema_vectors.rs
+++ b/desktop/src-tauri/src/claude/schema_vectors.rs
@@ -30,8 +30,8 @@
 //! struct in `internal/integrations/github/` is flat, carries no `omitempty`,
 //! and uses only `string`, `int`, `int64` and `bool` — which is why the twenty
 //! schemas in `github_vectors.json` match exactly, and #317's six in
-//! `confluence_vectors.json` with them. The map exists so #313–#316 do not each
-//! rediscover the boundary.
+//! `confluence_vectors.json` and #316's nine in `jira_vectors.json` with them.
+//! The map exists so #313–#315 do not each rediscover the boundary.
 
 use std::collections::BTreeMap;
 

--- a/desktop/src-tauri/src/native/chat/mod.rs
+++ b/desktop/src-tauri/src/native/chat/mod.rs
@@ -11,12 +11,12 @@
 //! button would silently do nothing.
 //!
 //! But not every chat *can* run here: an agent whose tools come from an
-//! integration needs one MCP server per provider, and this port has four of the
-//! six still to write (#313–#316), so `runner::build_options` refuses those and
+//! integration needs one MCP server per provider, and this port has three of the
+//! six still to write (#313–#315), so `runner::build_options` refuses those and
 //! they keep running on the sidecar. Parts of that refusal have gone — the
 //! **local** in-process server (#310), then any agent whose `capabilities.mcp`
 //! names only hosted integrations (**github** since #311, **confluence** since
-//! #317) — but each only shrinks the set of chats Go still holds; it does not
+//! #317, **jira** since #316) — but each only shrinks the set of chats Go still holds; it does not
 //! empty it, and the argument here turns on the set being non-empty.
 //! So the three steering routes are answered natively **only when Rust holds a
 //! live session for that chat**, and forward otherwise. Go then answers —

--- a/desktop/src-tauri/src/native/chat/runner.rs
+++ b/desktop/src-tauri/src/native/chat/runner.rs
@@ -24,7 +24,8 @@
 //! **#311 narrowed the `mcp` half rather than removing it.** An agent is served
 //! natively when *every* name in `capabilities.mcp` is an integration this build
 //! can host — `registry::HOSTED_TYPES`, which today means `github` (#312) and
-//! `confluence` (#317), and will mean the rest as #313–#316 land. Three things
+//! `confluence` (#317) and `jira` (#316), and will mean the rest as #313–#315
+//! land. Three things
 //! still forward, and [`mcp_plan`] is where each is decided:
 //!
 //! - **A name whose type is not hosted.** A `slack` row has no Rust starter;
@@ -388,7 +389,7 @@ fn mcp_plan(
         if !crate::native::integrations::registry::can_host(db_path, id)? {
             return Err(format!(
                 "agent uses MCP server {id:?}, which is not an integration this build \
-                 can host (#313–#316)"
+                 can host (#313–#315)"
             ));
         }
         servers.push(McpServerSpec {

--- a/desktop/src-tauri/src/native/integrations.rs
+++ b/desktop/src-tauri/src/native/integrations.rs
@@ -130,8 +130,10 @@
 /// [`registry`] calls it. Hosting an integration's server is the registry's
 /// job, and this module still never reads a credential — [`registry`] does,
 /// through a projection of its own that no response type can reach.
+pub mod base_url;
 pub mod confluence;
 pub mod github;
+pub mod jira;
 
 /// The Start/Stop/Reload lifecycle, and the one place in the port that reads
 /// `integrations.credentials` (#311).
@@ -476,12 +478,12 @@ fn segment(value: &str) -> Option<&str> {
 /// on the Go side. Returns the integration id the shell owes a reload for.
 ///
 /// `Reload` has seven callers in Go. Two are ported (`Update`, and `Delete` via
-/// `Stop`). Three more — the telegram, jira and slack validators — and
+/// `Stop`). Two more — the telegram and slack validators — and
 /// `completeOAuth` are unaffected, because the switch is per type and every type
 /// they can reach is still Go's: `startProviderCallback` supports exactly
 /// `google` and `slack`, so an OAuth completion never concerns a type this
-/// process hosts. That leaves `validateGitHubPATAuth` and, since #317,
-/// `validateConfluenceAuth` — both behind
+/// process hosts. That leaves `validateGitHubPATAuth` and, since #316 and #317,
+/// `validateJiraTokenAuth` and `validateConfluenceAuth` — all behind
 /// `POST /api/integrations/{id}/auth/validate` — as the paths that write a
 /// credential for a hosted type and cannot tell anybody. Without this hook such
 /// an integration is never hosted in the session it is set up in — create, `PUT`
@@ -490,7 +492,7 @@ fn segment(value: &str) -> Option<&str> {
 ///
 /// The route predicate below is deliberately **type-blind**: it answers with the
 /// id for every integration, and `registry::reload_after_auth` reads the row's
-/// type through `can_host` before it does anything. So #313–#316 need not touch
+/// type through `can_host` before it does anything. So #313–#315 need not touch
 /// this — adding a string to `registry::HOSTED_TYPES` is what widens it.
 ///
 /// The reload runs **after** Go's answer, so the row is already written, and it
@@ -1932,7 +1934,7 @@ mod tests {
     /// reload strands a socket and a paired client that never connects.
     #[test]
     fn a_write_for_a_type_the_sidecar_hosts_forwards_without_touching_the_row() {
-        for integration_type in ["slack", "whatsapp", "telegram", "jira", "google"] {
+        for integration_type in ["slack", "whatsapp", "telegram", "google"] {
             let file = migrated();
             Connection::open(file.path())
                 .expect("open")

--- a/desktop/src-tauri/src/native/integrations/base_url.rs
+++ b/desktop/src-tauri/src/native/integrations/base_url.rs
@@ -1,0 +1,482 @@
+//! Whether a **per-row API base** is one this build can send a request through
+//! where Go would, and the prefix it contributes to every tool's path.
+//!
+//! Extracted from `native/integrations/confluence` (#317) when `jira` (#316)
+//! needed the same answer. It is not general URL handling — it is one narrow
+//! question with one right answer, arrived at over four rounds of review on
+//! #317, and getting it wrong sent the user's `Basic` credentials to an
+//! attacker's host. #313–#315 do not need it (their API bases are constants);
+//! anything after them whose base comes out of the integration row does.
+//!
+//! # The problem
+//!
+//! Go builds a request by concatenating the stored base with a path its tool
+//! escaped, handing the string to `http.NewRequestWithContext`, and letting
+//! `net/http` write `URL.RequestURI()` on the wire **verbatim**. `reqwest`
+//! builds every request through `url::Url::parse`, which normalizes. The two
+//! disagree in ways that reach a different endpoint, and for the *tool's* half
+//! of the path `github::client::absolute` already handles it: compare what
+//! `url` produced against what the tool built, and refuse rather than call
+//! somewhere else.
+//!
+//! A per-row base breaks that in two ways, and the second is the interesting
+//! one.
+//!
+//! ## The base is not necessarily encoded, so it cannot be compared raw
+//!
+//! GitHub's base is a fixed, already-escaped constant. A site URL is typed by a
+//! person: `https://intranet.example.com/my atlassian` is one Go accepts and
+//! sends as `/my%20atlassian/…` through `EscapedPath()`, and `url` encodes it
+//! identically. Comparing the parsed target against the raw concatenation
+//! therefore refuses every call against a base that works. So [`Base`] parses
+//! the base **on its own** and uses its rendered path as the expected prefix;
+//! only the tool's suffix is compared against the bytes the tool built, which is
+//! sound because that half is fully `gourl`-escaped.
+//!
+//! ## Comparing two parsers of the same string cannot see an interpretation gap
+//!
+//! Once both sides go through `url`, any place `url` and `net/url` disagree
+//! about the **base** is invisible: the comparison is the same parser on the
+//! same bytes. It catches a disagreement about where the authority *ends* and
+//! never one about what it *says* — and there are at least three of the latter,
+//! each of which grafts the site onto an attacker's label from a string that
+//! reads as the legitimate host:
+//!
+//! | base | `net/url` | `url` |
+//! |---|---|---|
+//! | `evil.com\@acme.atlassian.net` | `invalid userinfo` | host `evil.com` |
+//! | `acme.atlassian.net%2Eevil.com` | `invalid URL escape` | `acme.atlassian.net.evil.com` |
+//! | `acme.atlassian.net<U+00A0>evil.com` | that host, literally | IDNA-mapped and joined |
+//!
+//! `parseHost` is itself an **allowlist** — `integration_credentials::split_url`
+//! says so, having enumerated every ASCII byte through it — so [`Base::new`]
+//! uses one too, and a narrower one, because that module may forward what it is
+//! unsure of and a starter may not. See [`Mismatch::Authority`].
+//!
+//! # What each caller does with a [`Mismatch`], and why they differ
+//!
+//! The two callers answer differently **because Go does**, which is #277's
+//! lesson repeated:
+//!
+//! - **Confluence** validates the site URL inside `Start` (HTTPS-only), so a
+//!   base Go will not serve means Go hosts nothing. `validate_site_url` maps a
+//!   [`Mismatch`] to a refusal, the registry logs it, and the integration is
+//!   absent — which is what Go does.
+//! - **Jira**'s `Start` validates nothing at all. Go hosts the server and
+//!   advertises all nine tools whatever the base says. Refusing to host would
+//!   change the *advertised tool set*, which is the surface an agent's stored
+//!   `capabilities.mcp` allowlist depends on. So `jira::client::Client` holds
+//!   the [`Mismatch`] instead and answers Go's own transport sentence per call:
+//!   same tools, and no request built that this port cannot build faithfully.
+
+use crate::native::gourl;
+
+/// Why a base is one this build cannot send a request through.
+///
+/// A caller words its own message from this — the two callers reach a log line
+/// and a tool result respectively, and neither text is Go's (Go has no
+/// equivalent failure at all for most of these).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mismatch {
+    /// The authority is not one the two parsers are guaranteed to read alike.
+    ///
+    /// An allowlist rather than a comparison, for the reason in the module
+    /// header: ASCII letters, digits, `.`, `-` and `_`, with an optional
+    /// `:`-separated numeric port, over the **whole** authority so that `@` and
+    /// `\` are excluded — which is what makes the two agree on where the
+    /// authority ends as well as on what it says.
+    ///
+    /// **What that buys, stated exactly:** no character in the set is
+    /// *transformed* by either parser, so no admitted host can be disguised as
+    /// another — the property all three gaps above attack. It is not quite "the
+    /// two dial the same address": WHATWG runs its IPv4 parser on any host whose
+    /// last label is numeric, so `0x7f.1`, `127.1`, `010.0.0.1` and
+    /// `2130706433` are literal names to `net/url` and addresses to `url`. That
+    /// is left standing deliberately — none of them can be passed off as
+    /// `acme.atlassian.net`, and Go's own outcome is a failed lookup rather than
+    /// a working host, so nothing is redirected *away* from a host Go was
+    /// reaching. Refusing an all-numeric final label would close it, at the cost
+    /// of hostnames shaped like `1.2.3.4.5`.
+    ///
+    /// It excludes four things Go serves: userinfo, an IPv6 literal, a
+    /// non-ASCII host (which Go's own IDNA-blind resolver cannot dial either),
+    /// and a percent escape.
+    Authority,
+    /// `url::Url::parse` will not parse it — an out-of-range port, say. Go's
+    /// `url.Parse` refuses most of these too.
+    Unparseable,
+    /// It carries its own `?` or `#`, after which the concatenation is not a
+    /// prefix of the target and there is no faithful answer.
+    QueryOrFragment,
+    /// Its path holds a malformed `%` escape. `setPath` decodes first and this
+    /// is a parse error to Go as well.
+    PathDoesNotDecode,
+    /// `url` renders its path differently from Go's `EscapedPath()`.
+    ///
+    /// Go escapes `\ ^ |` in a path and `url` does not; `url` removes dot
+    /// segments and `net/url` never does. Note the comparison is against
+    /// **`EscapedPath()`** and not against `escape(Path, encodePath)`: the
+    /// second is only the first's fallback, since Go prefers the raw text
+    /// whenever it is [`gourl::valid_encoded_path`] — so `/a!b` and `/a%2Fb` are
+    /// sent verbatim by Go even though `escape` would rewrite them, and
+    /// comparing against `escape` alone refuses a base that works.
+    PathEncoding,
+}
+
+/// A base URL both parsers read alike, and the path prefix `url` renders it as.
+///
+/// Built once — per `Start` for Confluence, per `Client` for Jira — because the
+/// checks cost a percent-decode and a re-encode for a property of a value that
+/// cannot change between calls.
+#[derive(Clone)]
+pub struct Base {
+    /// The base exactly as stored. Concatenated with each tool's path, because
+    /// that is what Go concatenates; nothing here is re-rendered.
+    raw: String,
+    /// What `url` puts in front of a tool's path. Empty when the base has no
+    /// path of its own — `url` renders that as `/` and the tool's own leading
+    /// slash supplies it.
+    prefix: String,
+}
+
+impl Base {
+    /// Checks `raw` and records the prefix it contributes, or says why not.
+    ///
+    /// `raw` is the base as stored, trailing slashes already trimmed by whatever
+    /// Go trims them with (`ValidateSiteURL` for Confluence, the create-time
+    /// validator for Jira).
+    pub fn new(raw: &str) -> Result<Self, Mismatch> {
+        // The authority first, ahead of even parsing the whole thing, because it
+        // is the check that decides *which server* the credentials reach — so it
+        // should be the answer whenever it applies, rather than whichever check
+        // happens to notice first.
+        let (_, rest) = go_scheme(raw);
+        let authority = go_authority(rest);
+        let (host, port) = match authority.split_once(':') {
+            Some((host, port)) => (host, Some(port)),
+            None => (authority, None),
+        };
+        let plain_host = !host.is_empty()
+            && host
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'-' | b'_'));
+        // An empty port is Go's `Host` of `acme.atlassian.net:`, which dials the
+        // default on both sides; anything else must be digits, as
+        // `validOptionalPort` requires.
+        let plain_port = port.is_none_or(|port| port.bytes().all(|b| b.is_ascii_digit()));
+        if !plain_host || !plain_port {
+            return Err(Mismatch::Authority);
+        }
+
+        let parsed = reqwest::Url::parse(raw).map_err(|_| Mismatch::Unparseable)?;
+        if parsed.query().is_some() || parsed.fragment().is_some() {
+            return Err(Mismatch::QueryOrFragment);
+        }
+
+        let raw_path = base_path_of(raw);
+        let go_path = if raw_path.is_empty() {
+            "/".to_string()
+        } else {
+            // The `Option` alone: a well-formed escape decoding to bytes that
+            // are not UTF-8 is not an error to Go — `%FF` is a perfectly good
+            // path and `EscapedPath()` renders it back as `%FF` — which is why
+            // `unescape_path` answers `Vec<u8>` and the fallback escapes bytes
+            // rather than a `String`.
+            let decoded = gourl::unescape_path(raw_path).ok_or(Mismatch::PathDoesNotDecode)?;
+            if gourl::valid_encoded_path(raw_path) {
+                raw_path.to_string()
+            } else {
+                gourl::escape_path_bytes(&decoded)
+            }
+        };
+        if parsed.path() != go_path {
+            return Err(Mismatch::PathEncoding);
+        }
+
+        Ok(Self {
+            raw: raw.to_string(),
+            prefix: match parsed.path() {
+                "/" => String::new(),
+                path => path.to_string(),
+            },
+        })
+    }
+
+    /// What this base puts in front of every tool's path — empty when it has no
+    /// path of its own.
+    pub fn prefix(&self) -> &str {
+        &self.prefix
+    }
+
+    /// The URL a request to `path` goes to, or `None` when `url` would resolve
+    /// it somewhere other than Go sends it.
+    ///
+    /// `path` is a tool's own, already escaped by `gourl` — `path_escape` per
+    /// segment, `query_escape` per query value — which is what makes comparing
+    /// it against `url`'s rendering sound: `encodePathSegment` escapes every byte
+    /// in `url`'s path encode set and `encodeQueryComponent` every byte in its
+    /// query one, so there is nothing left for `url` to percent-encode; existing
+    /// `%XX` escapes keep their case, so Go's uppercase hex survives; and a path
+    /// with no `?` compares `""` against `query()`'s `None`.
+    ///
+    /// The comparison is **exact** rather than a `..` scan, so anything else
+    /// `url` normalizes in a tool's path — now or after an upgrade — is caught by
+    /// construction. Host, scheme and port are not compared at all, so `url`'s
+    /// default-port and case normalization cannot reach it.
+    pub fn resolve(&self, path: &str) -> Option<reqwest::Url> {
+        let url = reqwest::Url::parse(&format!("{}{path}", self.raw)).ok()?;
+        let (want_path, want_query) = path.split_once('?').unwrap_or((path, ""));
+        let want_path = format!("{}{want_path}", self.prefix);
+        (url.path() == want_path && url.query().unwrap_or("") == want_query).then_some(url)
+    }
+}
+
+/// `net/url`'s `getScheme`, lower-cased as `url.Parse` lower-cases it.
+///
+/// Answers `("", raw)` for anything without a valid scheme, which is what
+/// `getScheme` does for every case except a leading `:` — and that one is a
+/// parse error in Go, which a caller reaches by its own route.
+pub fn go_scheme(raw: &str) -> (String, &str) {
+    for (i, c) in raw.char_indices() {
+        match c {
+            'a'..='z' | 'A'..='Z' => {}
+            '0'..='9' | '+' | '-' | '.' if i > 0 => {}
+            ':' if i > 0 => return (raw[..i].to_ascii_lowercase(), &raw[i + 1..]),
+            _ => return (String::new(), raw),
+        }
+    }
+    (String::new(), raw)
+}
+
+/// The whole authority `url.Parse` would take, userinfo and port included —
+/// everything between `//` and the first `/`, `?` or `#`.
+///
+/// Empty when there is no authority at all. Separate from [`go_host`] because
+/// the two answer different questions: Go's own `u.Host == ""` wants the host,
+/// and [`Base::new`]'s allowlist wants the userinfo too, since that is where a
+/// `\` hides.
+pub fn go_authority(rest: &str) -> &str {
+    let Some(authority) = rest.strip_prefix("//") else {
+        return "";
+    };
+    match authority.find(['/', '?', '#']) {
+        Some(end) => &authority[..end],
+        None => authority,
+    }
+}
+
+/// The host `url.Parse` would set, given everything after the scheme's colon.
+///
+/// Empty unless an authority is present (`//…`), and empty for an authority that
+/// is only userinfo — both of which Go answers with `u.Host == ""`.
+pub fn go_host(rest: &str) -> &str {
+    let authority = go_authority(rest);
+    match authority.rfind('@') {
+        Some(at) => &authority[at + 1..],
+        None => authority,
+    }
+}
+
+/// The raw text of a base's path — everything from the `/` that ends the
+/// authority.
+///
+/// Raw rather than parsed, because [`Mismatch::PathEncoding`] exists precisely
+/// because parsing changes it.
+pub fn base_path_of(raw: &str) -> &str {
+    let Some(rest) = raw.split_once("://").map(|(_, rest)| rest) else {
+        return "";
+    };
+    match rest.find('/') {
+        Some(start) => &rest[start..],
+        None => "",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The refusal that matters most: a base where `url` and `net/url` read a
+    /// **different host**, which is how a `Basic` credential leaves for somebody
+    /// else's server. All three mechanisms, each verified against the real
+    /// `net/url` when it was found.
+    #[test]
+    fn a_base_the_two_parsers_read_as_different_hosts_is_refused() {
+        for raw in [
+            // `url` treats `\` as an authority separator; `net/url` rejects the
+            // userinfo that leaves, so Go hosts nothing.
+            r"https://evil.com\@acme.atlassian.net",
+            r"https://evil.com\@acme.atlassian.net/wiki",
+            // `parseHost` rejects a `%` escape that decodes to a byte it would
+            // have escaped; `url` decodes them all.
+            "https://acme.atlassian.net%2Eevil.com",
+            "https://acme.atlassian.net%41x.com",
+            // A NO-BREAK SPACE: Go keeps it literally, `url` IDNA-maps it away
+            // and joins the two labels into one name somebody else owns.
+            "https://acme.atlassian.net\u{a0}evil.com",
+            "https://exämple.net",
+            // Refused with them, and Go serves all four.
+            "https://user:pw@acme.atlassian.net",
+            "https://[::1]:8443",
+            "https://caf%C3%A9.example.com",
+            "https://acme.atlassian.net:80x",
+        ] {
+            assert_eq!(Base::new(raw).err(), Some(Mismatch::Authority), "{raw}");
+        }
+    }
+
+    /// …and the ordinary bases the allowlist must not catch, including the
+    /// shapes a self-hosted deployment actually takes.
+    #[test]
+    fn an_ordinary_base_is_admitted() {
+        for (raw, prefix) in [
+            ("https://acme.atlassian.net", ""),
+            ("https://ACME.Atlassian.NET", ""),
+            ("https://acme.atlassian.net:8443", ""),
+            ("https://confluence", ""),
+            ("https://intranet_wiki.corp", ""),
+            ("https://wiki-1.corp.example.com", ""),
+            ("https://10.0.0.5:8090/confluence", "/confluence"),
+            ("https://jira.corp.local/jira", "/jira"),
+            // Not percent-encoded, and both parsers encode it the same way.
+            (
+                "https://intranet.example.com/my atlassian",
+                "/my%20atlassian",
+            ),
+            ("https://intranet.example.com/café", "/caf%C3%A9"),
+            ("https://intranet.example.com/a%20b", "/a%20b"),
+            // `EscapedPath` sends these verbatim even though `escape` would
+            // rewrite them, and `url` agrees.
+            ("https://intranet.example.com/a!b(c)[d]", "/a!b(c)[d]"),
+            ("https://intranet.example.com/a%2Fb", "/a%2Fb"),
+            // A well-formed escape decoding to non-UTF-8 is a path Go serves.
+            ("https://acme.atlassian.net/a%FFb", "/a%FFb"),
+        ] {
+            let base =
+                Base::new(raw).unwrap_or_else(|e| panic!("{raw} is a base Go serves: {e:?}"));
+            assert_eq!(base.prefix, prefix, "{raw}");
+        }
+    }
+
+    /// The path half of the disagreement, and the two shapes with no comparison
+    /// at all.
+    #[test]
+    fn a_base_path_the_two_parsers_encode_differently_is_refused() {
+        for raw in [
+            r"https://acme.atlassian.net/a\b",
+            "https://acme.atlassian.net/a^b",
+            "https://acme.atlassian.net/a|b",
+            "https://acme.atlassian.net/a/../b",
+            "https://acme.atlassian.net/./a",
+        ] {
+            assert_eq!(Base::new(raw).err(), Some(Mismatch::PathEncoding), "{raw}");
+        }
+        assert_eq!(
+            Base::new("https://acme.atlassian.net/a%zzb").err(),
+            Some(Mismatch::PathDoesNotDecode)
+        );
+        for raw in [
+            "https://acme.atlassian.net?a=b",
+            "https://acme.atlassian.net#x",
+        ] {
+            assert_eq!(
+                Base::new(raw).err(),
+                Some(Mismatch::QueryOrFragment),
+                "{raw}"
+            );
+        }
+        // A port `url` cannot represent. Go accepts it and could never dial it.
+        assert_eq!(
+            Base::new("https://acme.atlassian.net:99999").err(),
+            Some(Mismatch::Unparseable)
+        );
+    }
+
+    /// [`Base::resolve`]: the dot-segment guard, and everything it must admit.
+    #[test]
+    fn resolve_refuses_a_dot_segment_and_nothing_legitimate() {
+        let base = Base::new("https://acme.atlassian.net").expect("plain base");
+        for path in [
+            "/rest/api/3/issue/..",
+            "/rest/api/3/issue/.",
+            "/rest/api/3/issue/%2E%2E",
+            "/rest/api/3/project/../../x",
+        ] {
+            assert!(base.resolve(path).is_none(), "{path}");
+        }
+
+        let ok = |path: &str| {
+            base.resolve(path)
+                .unwrap_or_else(|| panic!("{path} is a legitimate path"))
+        };
+        assert_eq!(ok("/rest/api/3/project").query(), None);
+        assert_eq!(
+            ok("/wiki/api/v2/spaces?limit=50").path(),
+            "/wiki/api/v2/spaces"
+        );
+        assert_eq!(
+            ok("/wiki/api/v2/search?cql=space+%3D+DEV&limit=25").query(),
+            Some("cql=space+%3D+DEV&limit=25")
+        );
+        assert_eq!(
+            ok("/rest/api/3/issue/my%20key%2Fx").path(),
+            "/rest/api/3/issue/my%20key%2Fx",
+            "uppercase hex survives, and so does an escaped slash"
+        );
+        // A dot *inside* a segment is not a dot segment, and neither is one in a
+        // query value — only the path is resolved.
+        assert_eq!(
+            ok("/rest/api/3/issue/v1.2.3").path(),
+            "/rest/api/3/issue/v1.2.3"
+        );
+        assert_eq!(
+            ok("/wiki/api/v2/search?cql=..%2F..&limit=25").query(),
+            Some("cql=..%2F..&limit=25")
+        );
+    }
+
+    /// …and the guard still fires behind a base with a path of its own, because
+    /// only the tool's suffix is compared against the bytes it built.
+    #[test]
+    fn resolve_still_fires_behind_a_base_path() {
+        for raw in [
+            "https://jira.corp.local/jira",
+            "https://intranet.example.com/my atlassian",
+        ] {
+            let base = Base::new(raw).expect("a base Go serves");
+            assert!(base.resolve("/rest/api/3/issue/..").is_none(), "{raw}");
+            let url = base
+                .resolve("/rest/api/3/project")
+                .unwrap_or_else(|| panic!("{raw}"));
+            assert!(
+                url.path().ends_with("/rest/api/3/project"),
+                "{raw}: {}",
+                url.path()
+            );
+            assert!(url.path().starts_with(base.prefix()), "{raw}");
+        }
+    }
+
+    #[test]
+    fn the_net_url_transcriptions_answer_what_net_url_answers() {
+        for (raw, scheme) in [
+            ("https://acme.atlassian.net", "https"),
+            ("HTTPS://acme.atlassian.net", "https"),
+            ("http://acme.atlassian.net", "http"),
+            ("h2.c+x-y://acme", "h2.c+x-y"),
+            ("acme.atlassian.net", ""),
+            ("1https://acme", ""),
+            ("ht tps://acme", ""),
+        ] {
+            assert_eq!(go_scheme(raw).0, scheme, "{raw}");
+        }
+        assert_eq!(go_host("//acme.atlassian.net/wiki"), "acme.atlassian.net");
+        assert_eq!(go_host("//user:pw@acme:8443?x"), "acme:8443");
+        assert_eq!(go_authority("//user:pw@acme:8443?x"), "user:pw@acme:8443");
+        for rest in ["", "//", "//user@", "opaque", "/path"] {
+            assert!(go_host(rest).is_empty(), "{rest}");
+        }
+        assert_eq!(base_path_of("https://acme.atlassian.net"), "");
+        assert_eq!(base_path_of("https://acme.atlassian.net/a/b"), "/a/b");
+    }
+}

--- a/desktop/src-tauri/src/native/integrations/base_url.rs
+++ b/desktop/src-tauri/src/native/integrations/base_url.rs
@@ -195,9 +195,21 @@ impl Base {
 
         Ok(Self {
             raw: raw.to_string(),
-            prefix: match parsed.path() {
-                "/" => String::new(),
-                path => path.to_string(),
+            // Whether the base contributed any path *text*, not what `url`
+            // rendered — because `url` renders both `https://x` and `https://x/`
+            // as `/` and Go does not treat them alike. Go concatenates, so
+            // `https://x/` + `/rest/api/3/project` is `//rest/api/3/project` on
+            // the wire, with the empty first segment intact. Deriving the prefix
+            // from `parsed.path() == "/"` made that base refuse every call.
+            //
+            // Reachable on Jira and not on Confluence: `validate_site_url` trims
+            // trailing slashes before it gets here, while `jira.Start` trims
+            // nothing and `Update` validates nothing, so a user retyping the URL
+            // in the edit form can store one.
+            prefix: if raw_path.is_empty() {
+                String::new()
+            } else {
+                parsed.path().to_string()
             },
         })
     }
@@ -356,6 +368,49 @@ mod tests {
                 Base::new(raw).unwrap_or_else(|e| panic!("{raw} is a base Go serves: {e:?}"));
             assert_eq!(base.prefix, prefix, "{raw}");
         }
+    }
+
+    /// A base ending in a bare `/` contributes one, and `url` cannot tell you so.
+    ///
+    /// `url::Url::parse` renders both `https://x` and `https://x/` with
+    /// `path() == "/"`, but Go concatenates raw text: `https://x/` +
+    /// `/rest/api/3/project` goes on the wire as `//rest/api/3/project`, empty
+    /// first segment and all. Deriving the prefix from the *rendered* path made
+    /// such a base refuse every call — silently, on Jira, where nothing trims it
+    /// and nothing validates it on `PUT`.
+    #[test]
+    fn a_base_ending_in_a_slash_contributes_one() {
+        let bare = Base::new("https://acme.atlassian.net").expect("no path");
+        assert_eq!(bare.prefix(), "");
+        assert_eq!(
+            bare.resolve("/rest/api/3/project")
+                .expect("resolves")
+                .path(),
+            "/rest/api/3/project"
+        );
+
+        let slashed = Base::new("https://acme.atlassian.net/").expect("a bare slash");
+        assert_eq!(slashed.prefix(), "/");
+        assert_eq!(
+            slashed
+                .resolve("/rest/api/3/project")
+                .expect("resolves")
+                .path(),
+            "//rest/api/3/project",
+            "Go sends the empty first segment, so this must too"
+        );
+
+        // …and the same one step down, which never had the bug because the
+        // rendered path is not `/`.
+        let nested = Base::new("https://acme.atlassian.net/jira/").expect("a trailing slash");
+        assert_eq!(nested.prefix(), "/jira/");
+        assert_eq!(
+            nested
+                .resolve("/rest/api/3/project")
+                .expect("resolves")
+                .path(),
+            "/jira//rest/api/3/project"
+        );
     }
 
     /// The path half of the disagreement, and the two shapes with no comparison

--- a/desktop/src-tauri/src/native/integrations/confluence/client.rs
+++ b/desktop/src-tauri/src/native/integrations/confluence/client.rs
@@ -44,6 +44,7 @@ use reqwest::Method;
 use tokio_stream::StreamExt;
 
 use crate::claude::CancellationToken;
+use crate::native::integrations::base_url::Base;
 
 /// `maxResponseBytes`: 2 MiB, "keeping it small avoids flooding the LLM context".
 const MAX_RESPONSE_BYTES: usize = 2 * 1024 * 1024;
@@ -82,7 +83,10 @@ const REQUEST_FAILED: &str = "calling confluence API: request failed";
 /// clone and holds nothing else.
 #[derive(Clone)]
 pub struct Client {
-    site_url: String,
+    /// `None` when the stored site URL is one this build cannot send a request
+    /// through — see [`super::super::base_url`]. Every call then answers Go's
+    /// own transport sentence.
+    base: Option<Base>,
     email: String,
     api_token: String,
 }
@@ -98,7 +102,7 @@ impl Client {
         api_token: impl Into<String>,
     ) -> Self {
         Self {
-            site_url: site_url.into(),
+            base: Base::new(&site_url.into()).ok(),
             email: email.into(),
             api_token: api_token.into(),
         }
@@ -157,96 +161,17 @@ impl Client {
     /// The URL a request to `path` goes to — or [`REQUEST_FAILED`], if this port
     /// cannot build the request Go builds.
     ///
-    /// # Why this exists, and why it refuses instead of correcting
-    ///
-    /// Go concatenates the site URL and `path`, hands the string to
-    /// `http.NewRequestWithContext`, and `net/http` writes `URL.RequestURI()` on
-    /// the wire **verbatim**. Nothing normalizes: `url.PathEscape` leaves `.` and
-    /// `..` alone (both are unreserved) and `net/url` does not remove dot
-    /// segments, so `get_page(page_id: "..")` asks Confluence for
-    /// `/wiki/api/v2/pages/..` and gets a 404.
-    ///
-    /// `reqwest` builds every request through `url::Url::parse`, which applies
-    /// WHATWG dot-segment removal for http(s). The same call would leave as
-    /// `/wiki/api/v2/` — the space *listing* rather than one page, on a request
-    /// already carrying the user's API token. `page_id`, `space_id` and
-    /// `parent_id` are model-supplied and every tool result carries
-    /// attacker-authored wiki content, so it is reachable under prompt
-    /// injection, and it applies to `update_page`'s write too. Escaping the dots
-    /// is not a fix — `%2E%2E` is collapsed as well.
-    ///
-    /// `reqwest` offers no way to send an unnormalized target, so the faithful
-    /// option is to **refuse**: the model reads the sentence a transport failure
-    /// produces rather than the answer to a question it did not ask. This is
-    /// `github::client::absolute`'s reasoning verbatim, and #313–#316 each need
-    /// it.
-    ///
-    /// # What is compared, and why it is not the raw string
-    ///
-    /// GitHub's base is a fixed, already-encoded string, so there the whole
-    /// target could be compared against the `path` argument. A site URL is
-    /// per row and **user-typed**, so it is not necessarily encoded:
-    /// `https://intranet.example.com/my atlassian` is one Go accepts, and both
-    /// `net/url`'s `EscapedPath` and `url` send it as `/my%20atlassian/…`. They
-    /// agree — but the raw text does not, so comparing against the raw
-    /// concatenation would refuse every call for a site URL that works.
-    ///
-    /// So the base is parsed **on its own** and its rendered path is the
-    /// expected prefix; only the tool's own suffix is compared against the raw
-    /// bytes it built. That is sound because the suffix *is* fully encoded, and
-    /// not by luck: `encodePathSegment` escapes every byte in `url`'s path
-    /// encode set and `encodeQueryComponent` every byte in its query one, so
-    /// there is nothing left for `url` to percent-encode; existing `%XX` escapes
-    /// are passed through with their case intact, so Go's uppercase hex
-    /// survives; and a path with no `?` compares `""` against `query()`'s
-    /// `None`. Host, scheme and port are not compared at all, so `url`'s
-    /// default-port and case normalization cannot reach this.
-    ///
-    /// The comparison stays **exact** rather than a `..` scan, so anything else
-    /// `url` normalizes in a tool's path — now or after an upgrade — is caught by
-    /// construction.
-    ///
-    /// # What this does not check, and who does
-    ///
-    /// Comparing two `url`-parsed values is blind to every place `url` and
-    /// `net/url` disagree about the **base** — most sharply the authority, where
-    /// `https://evil.com\@acme.atlassian.net` is a parse error to Go and host
-    /// `evil.com` to `url`. [`super::validate_site_url`] is the gate for those:
-    /// it runs once, at `Start`, and refuses a base whose host or path encoding
-    /// the two parsers read differently, so no `Client` should exist around one.
-    /// It is a per-call cost (a percent-decode and a re-encode) for a property
-    /// of a value that cannot change between calls, which is why it lives there
-    /// and not here.
-    ///
-    /// The three re-checks below are the cheap ones, kept so this function is
-    /// total rather than trusting its caller.
+    /// Both halves live in [`super::super::base_url`]: the base was checked once
+    /// when this client was constructed (a `None` there means every call refuses,
+    /// which cannot happen through `validate_site_url` and can through a test
+    /// that points a client anywhere), and `resolve` is the per-call dot-segment
+    /// guard `github::client::absolute` established. See that module's header for
+    /// why the base needs checking at all and why it is not a comparison.
     fn absolute(&self, path: &str) -> Result<reqwest::Url, String> {
-        let base = reqwest::Url::parse(&self.site_url).map_err(|_| REQUEST_FAILED.to_string())?;
-        if base.query().is_some() || base.fragment().is_some() {
-            return Err(REQUEST_FAILED.to_string());
-        }
-        // A dot segment in the base collapses on *both* sides of the comparison
-        // below, so it is the one shape the comparison cannot see.
-        if super::base_path_of(&self.site_url)
-            .split('/')
-            .any(|segment| segment == "." || segment == "..")
-        {
-            return Err(REQUEST_FAILED.to_string());
-        }
-        // `url` renders a base with no path of its own as `/`; the suffix
-        // supplies that slash, so the prefix is empty.
-        let prefix = match base.path() {
-            "/" => "",
-            other => other,
-        };
-
-        let url = reqwest::Url::parse(&format!("{}{path}", self.site_url))
-            .map_err(|_| REQUEST_FAILED.to_string())?;
-        let (want_path, want_query) = path.split_once('?').unwrap_or((path, ""));
-        if url.path() != format!("{prefix}{want_path}") || url.query().unwrap_or("") != want_query {
-            return Err(REQUEST_FAILED.to_string());
-        }
-        Ok(url)
+        self.base
+            .as_ref()
+            .and_then(|base| base.resolve(path))
+            .ok_or_else(|| REQUEST_FAILED.to_string())
     }
 }
 

--- a/desktop/src-tauri/src/native/integrations/confluence/mod.rs
+++ b/desktop/src-tauri/src/native/integrations/confluence/mod.rs
@@ -75,6 +75,7 @@ use rmcp::model::{CallToolResult, ContentBlock};
 
 use crate::claude::{tool_server, InProcessMcpServer, Result, ToolDef};
 
+use super::base_url::{Base, Mismatch};
 use super::ServiceConfig;
 use client::Client;
 
@@ -326,7 +327,7 @@ pub fn validate_site_url(raw: &str) -> std::result::Result<String, String> {
         return Err("invalid site URL: it holds a control character".to_string());
     }
 
-    let (scheme, rest) = go_scheme(raw);
+    let (scheme, rest) = super::base_url::go_scheme(raw);
     // A URL with no scheme is a *relative* one to `net/url`, and it refuses one
     // whose first path segment holds a colon — because re-parsing the result
     // would read that colon as a scheme. `1https://acme.atlassian.net` is the
@@ -353,140 +354,36 @@ pub fn validate_site_url(raw: &str) -> std::result::Result<String, String> {
         // has nothing either language escapes — so `{:?}` is Go's rendering.
         return Err(format!("site URL must use HTTPS (got {scheme:?})"));
     }
-    if go_host(rest).is_empty() {
+    if super::base_url::go_host(rest).is_empty() {
         return Err("site URL must include a hostname".to_string());
     }
 
     let clean = raw.trim_end_matches('/');
 
-    // The shapes `client::Client::absolute` cannot work behind. See the section
-    // above for why each is refused here rather than per call.
-    //
-    // The authority goes first, ahead of even parsing the whole thing, because
-    // it is the one that decides *which server* the credentials reach — so it
-    // should be the sentence in the log whenever it applies, rather than
-    // whichever check happens to notice first.
-    //
-    // By allowlist rather than by comparison — see above for why a comparison
-    // between the two parsers cannot see an interpretation gap, and which three
-    // gaps this closes. The **whole** authority, userinfo included, rather than
-    // [`go_host`]'s post-`@` remainder: `@` and `\` are outside the set, and
-    // refusing them is what makes the two parsers agree on where the authority
-    // *ends* as well as on what it says. `evil.com\@acme.atlassian.net` has a
-    // perfectly plain host once the userinfo is stripped, which is the trap.
-    let authority = go_authority(rest);
-    let (host, port) = match authority.split_once(':') {
-        Some((host, port)) => (host, Some(port)),
-        None => (authority, None),
-    };
-    let plain_host = !host.is_empty()
-        && host
-            .bytes()
-            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'-' | b'_'));
-    // An empty port is Go's `Host` of `acme.atlassian.net:`, which dials 443 on
-    // both sides; anything else must be digits, as `validOptionalPort` requires.
-    let plain_port = port.is_none_or(|port| port.bytes().all(|b| b.is_ascii_digit()));
-    if !plain_host || !plain_port {
-        return Err("invalid site URL: its host is not a plain ASCII hostname".to_string());
-    }
-
-    let parsed = reqwest::Url::parse(clean)
-        .map_err(|_| "invalid site URL: it is not a URL this build can send a request to")?;
-    if parsed.query().is_some() || parsed.fragment().is_some() {
-        return Err("invalid site URL: a query or fragment leaves the path open".to_string());
-    }
-
-    // …and the path, which is a wrong endpoint on the right host.
-    let raw_path = base_path_of(clean);
-    let go_path = if raw_path.is_empty() {
-        // `url` renders a base with no path of its own as `/`; Go sends the
-        // tool's own leading slash and nothing before it.
-        "/".to_string()
-    } else {
-        // `setPath` decodes first and a **malformed** escape is a parse error
-        // there, so this gate runs whichever branch wins below. It is the
-        // `Option` alone: a well-formed escape decoding to bytes that are not
-        // UTF-8 is not an error to Go — `%FF` is a perfectly good path, and
-        // `EscapedPath()` renders it back as `%FF` — which is why
-        // `unescape_path` answers `Vec<u8>` and the fallback below escapes
-        // bytes rather than a `String`.
-        let decoded = crate::native::gourl::unescape_path(raw_path)
-            .ok_or("invalid site URL: its path does not decode")?;
-        // `EscapedPath()`: the raw text when it is validly encoded, and the
-        // re-escaped decode otherwise. Both branches are needed — see
-        // `gourl::valid_encoded_path`.
-        if crate::native::gourl::valid_encoded_path(raw_path) {
-            raw_path.to_string()
-        } else {
-            crate::native::gourl::escape_path_bytes(&decoded)
+    // Everything above is Go's own `ValidateSiteURL`. The rest is not: it is
+    // whether the base is one `client::Client` can send a request through where
+    // Go sends it, which `super::base_url` owns and #316 shares. Confluence maps
+    // a mismatch to a refusal because **Go refuses too** — this check is inside
+    // `Start`, so a base Go will not serve is an integration Go does not host;
+    // Jira's `Start` validates nothing and therefore answers per call instead.
+    // See that module's header.
+    Base::new(clean).map_err(|mismatch| match mismatch {
+        Mismatch::Authority => {
+            "invalid site URL: its host is not a plain ASCII hostname".to_string()
         }
-    };
-    if parsed.path() != go_path {
-        return Err("invalid site URL: net/url and url encode its path differently".to_string());
-    }
+        Mismatch::Unparseable => {
+            "invalid site URL: it is not a URL this build can send a request to".to_string()
+        }
+        Mismatch::QueryOrFragment => {
+            "invalid site URL: a query or fragment leaves the path open".to_string()
+        }
+        Mismatch::PathDoesNotDecode => "invalid site URL: its path does not decode".to_string(),
+        Mismatch::PathEncoding => {
+            "invalid site URL: net/url and url encode its path differently".to_string()
+        }
+    })?;
 
     Ok(clean.to_string())
-}
-
-/// The raw text of a site URL's path — everything from the `/` that ends the
-/// authority.
-///
-/// Raw rather than parsed, because the dot-segment check above exists precisely
-/// because parsing removes them.
-pub(super) fn base_path_of(clean: &str) -> &str {
-    let Some(rest) = clean.split_once("://").map(|(_, rest)| rest) else {
-        return "";
-    };
-    match rest.find('/') {
-        Some(start) => &rest[start..],
-        None => "",
-    }
-}
-
-/// `net/url`'s `getScheme`, lower-cased as `url.Parse` lower-cases it.
-///
-/// Answers `("", raw)` for anything without a valid scheme, which is what
-/// `getScheme` does for every case except a leading `:` — and that one is a
-/// parse error in Go, so it reaches the same refusal by a different route.
-fn go_scheme(raw: &str) -> (String, &str) {
-    for (i, c) in raw.char_indices() {
-        match c {
-            'a'..='z' | 'A'..='Z' => {}
-            '0'..='9' | '+' | '-' | '.' if i > 0 => {}
-            ':' if i > 0 => return (raw[..i].to_ascii_lowercase(), &raw[i + 1..]),
-            _ => return (String::new(), raw),
-        }
-    }
-    (String::new(), raw)
-}
-
-/// The whole authority `url.Parse` would take, userinfo and port included —
-/// everything between `//` and the first `/`, `?` or `#`.
-///
-/// Empty when there is no authority at all. Separate from [`go_host`] because
-/// the two checks want different halves: Go's own `u.Host == ""` question wants
-/// the host, and the allowlist in [`validate_site_url`] wants the userinfo too,
-/// since that is where a `\` hides.
-fn go_authority(rest: &str) -> &str {
-    let Some(authority) = rest.strip_prefix("//") else {
-        return "";
-    };
-    match authority.find(['/', '?', '#']) {
-        Some(end) => &authority[..end],
-        None => authority,
-    }
-}
-
-/// The host `url.Parse` would set, given everything after the scheme's colon.
-///
-/// Empty unless an authority is present (`//…`), and empty for an authority that
-/// is only userinfo — both of which Go answers with `u.Host == ""`.
-fn go_host(rest: &str) -> &str {
-    let authority = go_authority(rest);
-    match authority.rfind('@') {
-        Some(at) => &authority[at + 1..],
-        None => authority,
-    }
 }
 
 /// Go's `textResult`, shared by all six tools.
@@ -574,29 +471,6 @@ mod tests {
         )]);
         assert!(build_allowed_set(&services).is_empty());
         assert_eq!(names(&services), CONFLUENCE_TOOL_NAMES);
-    }
-
-    /// The scheme split, at the shapes `getScheme` distinguishes. Every one of
-    /// these is also a `validate_site_url` vector; this is the unit view of why.
-    #[test]
-    fn the_scheme_is_read_the_way_net_url_reads_it() {
-        for (raw, scheme) in [
-            ("https://acme.atlassian.net", "https"),
-            // `url.Parse` lower-cases the scheme, so this passes the gate.
-            ("HTTPS://acme.atlassian.net", "https"),
-            ("http://acme.atlassian.net", "http"),
-            ("ftp://acme", "ftp"),
-            // A scheme may hold digits, `+`, `-` and `.` after the first byte.
-            ("h2.c+x-y://acme", "h2.c+x-y"),
-            // No colon at all, a leading digit, and an invalid byte all mean
-            // *no scheme* rather than an error.
-            ("acme.atlassian.net", ""),
-            ("1https://acme", ""),
-            ("ht tps://acme", ""),
-            ("/wiki", ""),
-        ] {
-            assert_eq!(go_scheme(raw).0, scheme, "{raw}");
-        }
     }
 
     /// The refusal that matters most: a base where `url` and `net/url` read a
@@ -731,17 +605,6 @@ mod tests {
                 Ok(site.to_string()),
                 "{site} is a site URL Go serves"
             );
-        }
-    }
-
-    /// The host, at the shapes that make it empty — which is the second refusal.
-    #[test]
-    fn a_host_needs_an_authority_and_more_than_userinfo() {
-        assert_eq!(go_host("//acme.atlassian.net/wiki"), "acme.atlassian.net");
-        assert_eq!(go_host("//user:pw@acme:8443?x"), "acme:8443");
-        assert_eq!(go_host("//acme#frag"), "acme");
-        for rest in ["", "//", "//user@", "opaque", "/path"] {
-            assert!(go_host(rest).is_empty(), "{rest}");
         }
     }
 }

--- a/desktop/src-tauri/src/native/integrations/github/client.rs
+++ b/desktop/src-tauri/src/native/integrations/github/client.rs
@@ -56,9 +56,10 @@ pub const DEFAULT_API_BASE: &str = "https://api.github.com";
 /// had to export `SetAPIBase` to be redirectable at all. Both callers here are
 /// in-crate, so `#[cfg(test)]` costs nothing and compiles the whole thing out —
 /// which is what [`api_base_lock`] below already does, for the same reason.
-/// #313–#316 each add their own seam and should follow this; #317's is a
+/// #313–#315 each add their own seam and should follow this. #317's is a
 /// constructor argument rather than a static, because a Confluence site URL is
-/// per row.
+/// per row; #316 needs none at all, because `jira.Start` does not validate the
+/// site URL and so a parity run can simply store the fake's URL.
 ///
 /// A `RwLock` rather than a `OnceLock` because a test points it at a loopback
 /// fake and then puts it back.

--- a/desktop/src-tauri/src/native/integrations/jira/client.rs
+++ b/desktop/src-tauri/src/native/integrations/jira/client.rs
@@ -95,13 +95,34 @@ pub struct Client {
 }
 
 impl Client {
+    /// Builds the client, checking the base **once**.
+    ///
+    /// A rejected base is logged here and nowhere else, which is the one place
+    /// this port is less visible than Confluence's: there a bad site URL fails
+    /// `Start`, so the registry logs it and the integration is plainly absent.
+    /// Here the server starts, all nine tools are advertised, and every call
+    /// answers a transport sentence — so without this line the only symptom
+    /// would be a Jira integration that never works and never says why. The
+    /// *reason* is logged and the site URL is not: it is a stored value from the
+    /// credentials blob and this is a shared log file.
     pub fn new(
         site_url: impl Into<String>,
         email: impl Into<String>,
         api_token: impl Into<String>,
     ) -> Self {
+        let base = match Base::new(&site_url.into()) {
+            Ok(base) => Some(base),
+            Err(mismatch) => {
+                log::warn!(
+                    "jira site URL cannot be used: {mismatch:?} — the server will host \
+                     its tools and every call will fail; see \
+                     native/integrations/base_url.rs"
+                );
+                None
+            }
+        };
         Self {
-            base: Base::new(&site_url.into()).ok(),
+            base,
             email: email.into(),
             api_token: api_token.into(),
         }

--- a/desktop/src-tauri/src/native/integrations/jira/client.rs
+++ b/desktop/src-tauri/src/native/integrations/jira/client.rs
@@ -1,0 +1,353 @@
+//! The shared HTTP client, ported from `internal/integrations/jira/tools.go`'s
+//! `client` and `validate.go`'s `jiraHTTPClient`.
+//!
+//! Everything the nine tools have in common: how a request is authenticated and
+//! shaped, how much of a response is read, and the four sentences a failure can
+//! produce. None of it shows in a tool's success text, which is why
+//! `desktop/parity/jira_vectors.json` records the *request* the fake Jira
+//! received as well as the answer.
+//!
+//! # What differs from `confluence::client`, which is otherwise its twin
+//!
+//! Both are Atlassian, both use basic auth over a per-row site URL, both cap at
+//! 2 MiB. Three things are not shared, and none is cosmetic:
+//!
+//! - **The timeout is 15 seconds**, not Confluence's 30. Set on the client,
+//!   which is what bounds a graceful shutdown — see `desktop/CLAUDE.md`.
+//! - **The failure sentence names the method and the path**: `calling Jira %s
+//!   %s: request failed`, where Confluence's names neither. The *path* and not
+//!   the URL, so the site URL never appears in text the model reads.
+//! - **A bad base is answered per call, not by refusing to host.** This is the
+//!   one that matters, and it is Go's doing: `jira.Start` validates the site URL
+//!   **not at all** — it reads `creds.SiteURL` and hands it straight to
+//!   `buildMCPServer` — where `confluence.Start` runs `ValidateSiteURL` and
+//!   fails. So Go hosts a Jira server and advertises all nine tools whatever the
+//!   base says, and a port that refused to host would differ on the *advertised
+//!   tool set*, which is the surface every agent's stored `capabilities.mcp`
+//!   allowlist depends on. [`Client`] therefore holds `Option<Base>` and answers
+//!   Go's own transport sentence when it is `None`: same tools, and no request
+//!   built that this port cannot build faithfully. #277 pinned that Jira's and
+//!   Confluence's site-URL rules are deliberately different; this is the same
+//!   difference reaching the port.
+//!
+//! # Cancellation
+//!
+//! Go threads `ctx` into `http.NewRequestWithContext`, so a cancelled turn aborts
+//! the outbound call and `client.Do` returns an error — which becomes `calling
+//! Jira %s %s: request failed`. That is what a cancelled call answers here too,
+//! so there is no divergence to invent. `crate::claude::tool` explains why the
+//! token has to be watched at all: `rmcp` spawns handlers detached, so a handler
+//! that ignores it keeps its socket open after the caller is gone.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use reqwest::Method;
+use tokio_stream::StreamExt;
+
+use crate::claude::CancellationToken;
+use crate::native::integrations::base_url::Base;
+
+/// `io.LimitReader(resp.Body, 2*1024*1024)`.
+const MAX_RESPONSE_BYTES: usize = 2 * 1024 * 1024;
+
+/// `jiraHTTPClient` — 15 seconds, redirects followed.
+///
+/// `Option`, because building one can fail here where Go's cannot:
+/// `&http.Client{Timeout: …}` is a struct literal and the trust store is not
+/// consulted until the handshake, while `reqwest` reads the platform roots inside
+/// `build()` and reports an unusable store as a builder error. That has to reach
+/// the model as Go's own `request failed` rather than as a panic inside a handler
+/// `rmcp` spawned detached.
+fn http_client() -> Option<&'static reqwest::Client> {
+    static CLIENT: OnceLock<Option<reqwest::Client>> = OnceLock::new();
+    CLIENT
+        .get_or_init(|| {
+            reqwest::Client::builder()
+                .timeout(Duration::from_secs(15))
+                .build()
+                .ok()
+        })
+        .as_ref()
+}
+
+/// `fmt.Errorf("calling Jira %s %s: request failed", method, path)`.
+///
+/// The **path**, not the URL: the site URL is a stored credential-adjacent value
+/// and this text is read by the model and persisted in a `tool_result`.
+fn request_failed(method: &Method, path: &str) -> String {
+    format!("calling Jira {method} {path}: request failed")
+}
+
+/// Go's `client` struct: the site URL and the credentials every request carries.
+///
+/// Cloned per call from the closure that captured it — the shape
+/// `crate::claude::tool`'s module docs describe — so it is deliberately cheap to
+/// clone and holds nothing else.
+#[derive(Clone)]
+pub struct Client {
+    /// `None` when the stored site URL is one this build cannot send a request
+    /// through. Every call then answers Go's transport sentence; see the module
+    /// header for why that rather than refusing to host.
+    base: Option<Base>,
+    email: String,
+    api_token: String,
+}
+
+impl Client {
+    pub fn new(
+        site_url: impl Into<String>,
+        email: impl Into<String>,
+        api_token: impl Into<String>,
+    ) -> Self {
+        Self {
+            base: Base::new(&site_url.into()).ok(),
+            email: email.into(),
+            api_token: api_token.into(),
+        }
+    }
+
+    /// `(*client).call`: an authenticated request whose body is returned as the
+    /// raw response bytes.
+    ///
+    /// `body` is already-encoded bytes rather than a value. Go passes
+    /// `map[string]any` to `json.Marshal` *inside* `call`; the callers reproduce
+    /// that with [`crate::native::gojson::to_vec_marshal`] before calling,
+    /// because the encoding has to be Go's — sorted keys at every level, and
+    /// `\u003c`/`\u003e`/`\u0026` — and doing it here would hide that. The one
+    /// visible consequence: Go's `marshaling request body` error is produced at
+    /// the tool rather than here. It is unreachable either way (every value is a
+    /// string, an integer or a map of those) and the wording is kept.
+    ///
+    /// The `Content-Type` header is set **only when there is a body** — Go's
+    /// `if body != nil` — so every GET sends `Accept` alone, and `update_issue`
+    /// with nothing set still sends `{"fields":{}}` and therefore still sends the
+    /// header.
+    pub async fn call(
+        &self,
+        ct: &CancellationToken,
+        method: Method,
+        path: &str,
+        body: Option<Vec<u8>>,
+    ) -> Result<String, String> {
+        let failed = request_failed(&method, path);
+        let has_body = body.is_some();
+
+        // The base was checked once, when this client was built. A `None` is a
+        // stored site URL `url` and `net/url` do not agree about, and `resolve`
+        // is the per-call dot-segment guard — both in
+        // `crate::native::integrations::base_url`, which explains why each is
+        // needed and why the answer is a refusal rather than a correction.
+        let url = self
+            .base
+            .as_ref()
+            .and_then(|base| base.resolve(path))
+            .ok_or_else(|| failed.clone())?;
+
+        let mut request = http_client()
+            .ok_or_else(|| failed.clone())?
+            .request(method, url)
+            // `req.SetBasicAuth(c.email, c.apiToken)`:
+            // `Basic base64(email + ":" + apiToken)`.
+            .basic_auth(&self.email, Some(&self.api_token))
+            .header("Accept", "application/json");
+        if has_body {
+            request = request.header("Content-Type", "application/json");
+        }
+        if let Some(body) = body {
+            request = request.body(body);
+        }
+
+        let response = send(ct, request, &failed).await?;
+        let status = response.status();
+        let text = read_capped(ct, response).await?;
+        // Go's `if resp.StatusCode < 200 || resp.StatusCode >= 300` — a *range*,
+        // not `!= 200`, so the `204` a transition answers is a success.
+        if !(200..300).contains(&status.as_u16()) {
+            // `fmt.Errorf("jira API error: status %d: %s", …)` — Jira's own body,
+            // **verbatim**. Decoding and re-encoding it would reorder its keys
+            // and respell its numbers, and that body is what tells the model
+            // whether it hit a permission problem or a bad issue key.
+            return Err(format!(
+                "jira API error: status {}: {text}",
+                status.as_u16()
+            ));
+        }
+        Ok(text)
+    }
+}
+
+/// Sends a request, racing the run's cancellation.
+///
+/// Cancellation and a transport failure produce the same sentence, and that is
+/// not a shortcut: in Go a cancelled `ctx` *is* how `client.Do` fails.
+async fn send(
+    ct: &CancellationToken,
+    request: reqwest::RequestBuilder,
+    failed: &str,
+) -> Result<reqwest::Response, String> {
+    tokio::select! {
+        () = ct.cancelled() => Err(failed.to_string()),
+        result = request.send() => result.map_err(|_| failed.to_string()),
+    }
+}
+
+/// `io.ReadAll(io.LimitReader(resp.Body, 2 MiB))`.
+///
+/// Streamed rather than buffered whole: the cap exists so a hostile or runaway
+/// response cannot be pulled into memory, and `bytes()` would read it all before
+/// there was anything to truncate. Lossy UTF-8 for `confluence::client`'s
+/// reason — a Go string holds arbitrary bytes and a Rust `String` cannot, and
+/// `rmcp` demands a `String` at the end of the pipe anyway.
+async fn read_capped(
+    ct: &CancellationToken,
+    response: reqwest::Response,
+) -> Result<String, String> {
+    let mut body = Vec::new();
+    let mut stream = Box::pin(response.bytes_stream());
+    loop {
+        let chunk = tokio::select! {
+            () = ct.cancelled() => return Err("reading response: context canceled".to_string()),
+            chunk = stream.next() => chunk,
+        };
+        match chunk {
+            None => break,
+            Some(Ok(chunk)) => {
+                body.extend_from_slice(&chunk);
+                if body.len() >= MAX_RESPONSE_BYTES {
+                    body.truncate(MAX_RESPONSE_BYTES);
+                    break;
+                }
+            }
+            // `fmt.Errorf("reading response: %w", err)`. The cause *is*
+            // interpolated here, unlike the send failure: this error describes a
+            // body already in flight and cannot carry the request URL.
+            Some(Err(e)) => return Err(format!("reading response: {e}")),
+        }
+    }
+    Ok(String::from_utf8_lossy(&body).into_owned())
+}
+
+/// `search_issues`'s clamp: `maxResults <= 0 || > 100` falls back to 50.
+///
+/// The only clamp in this integration, and unlike Confluence's pair it has one
+/// caller — so it lives here rather than taking a fallback parameter.
+pub fn clamp_max_results(max_results: i64) -> i64 {
+    if max_results <= 0 || max_results > 100 {
+        50
+    } else {
+        max_results
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A distinctive token, so a leak is unmistakable in any assertion.
+    const SECRET: &str = "jira-SUPER-SECRET-API-TOKEN";
+
+    fn client(site_url: &str) -> Client {
+        Client::new(site_url, "person@example.com", SECRET)
+    }
+
+    #[test]
+    fn the_clamp_is_gos() {
+        for (input, want) in [(0, 50), (-5, 50), (101, 50), (100, 100), (1, 1), (50, 50)] {
+            assert_eq!(clamp_max_results(input), want, "{input}");
+        }
+    }
+
+    /// The failure sentence carries the method and the path, and **not** the
+    /// site URL, the email or the token.
+    ///
+    /// A `reqwest::Error`'s `Display` carries the URL it was building, and a
+    /// future edit that "helpfully" interpolated the cause would put the request
+    /// — and, one refactor later, a header — into text the model reads and the
+    /// transcript stores. Go's wording has the same property.
+    #[tokio::test]
+    async fn a_failed_call_names_the_path_and_nothing_secret() {
+        // Port 1 on loopback: nothing listens, so the connect fails fast.
+        let message = client("http://127.0.0.1:1")
+            .call(
+                &CancellationToken::new(),
+                Method::GET,
+                "/rest/api/3/project",
+                None,
+            )
+            .await
+            .expect_err("nothing is listening");
+        assert_eq!(
+            message,
+            "calling Jira GET /rest/api/3/project: request failed"
+        );
+        assert!(!message.contains(SECRET));
+        assert!(!message.contains("person@example.com"));
+        assert!(!message.contains("127.0.0.1"));
+    }
+
+    /// A cancelled call answers **Go's sentence**, because in Go a cancelled
+    /// `ctx` is how `client.Do` fails.
+    #[tokio::test]
+    async fn a_cancelled_call_answers_what_a_cancelled_go_call_answers() {
+        let ct = CancellationToken::new();
+        ct.cancel();
+        assert_eq!(
+            client("http://127.0.0.1:1")
+                .call(&ct, Method::GET, "/rest/api/3/project", None)
+                .await,
+            Err("calling Jira GET /rest/api/3/project: request failed".to_string())
+        );
+    }
+
+    /// A site URL this build cannot agree with Go about makes **every** call
+    /// answer the transport sentence — and leaves the tool set alone, which is
+    /// the whole reason it is handled here rather than by refusing to host.
+    ///
+    /// `super::super::tests` asserts the other half: that all nine tools are
+    /// still advertised.
+    #[tokio::test]
+    async fn a_base_this_build_cannot_send_through_refuses_every_call() {
+        for site in [
+            r"https://evil.com\@jira.atlassian.net",
+            "https://jira.atlassian.net%2Eevil.com",
+            "https://jira.atlassian.net/a/../b",
+            "https://user:pw@jira.atlassian.net",
+        ] {
+            let answer = client(site)
+                .call(
+                    &CancellationToken::new(),
+                    Method::GET,
+                    "/rest/api/3/project",
+                    None,
+                )
+                .await;
+            assert_eq!(
+                answer,
+                Err("calling Jira GET /rest/api/3/project: request failed".to_string()),
+                "{site}"
+            );
+        }
+    }
+
+    /// `io.LimitReader` truncates rather than failing, and it stops *reading* —
+    /// which is why the port streams instead of buffering and then slicing.
+    #[tokio::test]
+    async fn a_response_is_truncated_at_the_cap_rather_than_refused() {
+        let oversized = MAX_RESPONSE_BYTES + 4096;
+        let app = axum::Router::new().fallback(move || async move { "x".repeat(oversized) });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let base = format!("http://{}", listener.local_addr().expect("addr"));
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+
+        let body = client(&base)
+            .call(&CancellationToken::new(), Method::GET, "/big", None)
+            .await
+            .expect("a 200 is a success however long the body is");
+        assert_eq!(body.len(), MAX_RESPONSE_BYTES);
+    }
+}

--- a/desktop/src-tauri/src/native/integrations/jira/mod.rs
+++ b/desktop/src-tauri/src/native/integrations/jira/mod.rs
@@ -1,0 +1,352 @@
+//! The Jira integration's in-process MCP server, ported from
+//! `internal/integrations/jira/`.
+//!
+//! Nine tools in one service group (`project_management`), over an Atlassian site
+//! URL, account email and API token read from the integration row. The third of
+//! the six (#316), after GitHub (#312) settled how to port an integration and
+//! Confluence (#317) settled what a **per-row API base** costs.
+//!
+//! ## It is Confluence's twin, and the differences are all #277's
+//!
+//! Both integrations share `config.AtlassianCredentials` — the same three fields
+//! out of the same column. #277 pinned that they deliberately do **not** share
+//! their validation, and the port has to keep every part of that:
+//!
+//! | | Confluence | Jira |
+//! |---|---|---|
+//! | create-time validator | HTTPS only, keeps the raw value | http **or** https, trims trailing `/`, **re-marshals** |
+//! | inside `Start` | `ValidateSiteURL` again | nothing at all |
+//! | client timeout | 30s | 15s |
+//! | failure sentence | names nothing | names the method and the path |
+//!
+//! The second row is what shapes this port. Because `jira.Start` validates
+//! nothing, Go hosts a server and advertises all nine tools whatever the stored
+//! site URL says — so a base this build cannot send a request through is answered
+//! **per call** rather than by refusing to host, which would change the
+//! advertised tool set. `client::Client` holds the decision; see
+//! [`super::base_url`] for why the base needs checking at all, and
+//! `client`'s header for why the two integrations answer differently.
+//!
+//! ## What has to match Go, and what checks it
+//!
+//! Four surfaces, all pinned by `desktop/parity/jira_vectors.json` — taken from
+//! the **running Go server** over its real MCP transport, against a fake Jira
+//! that records the request each tool built: which tools are hosted, each
+//! advertised schema, the request each tool builds (path escaping, the
+//! `maxResults` clamp, and the exact bytes of all six request bodies), and the
+//! result text of every success and every failure.
+//!
+//! Unlike Confluence, **no Go-side seam was needed**: `jira.Start` reads the site
+//! URL out of the credentials and does not validate it, so the generator points a
+//! real `jira.Start` at an `httptest.Server` by putting its URL in the row. There
+//! is no `internal/integrations/jira/parity.go`, and that absence is a
+//! consequence of the table above rather than an oversight.
+//!
+//! ## The gating rule, which reads backwards
+//!
+//! A service is registered when its row says `enabled`. Within it, a tool is
+//! registered when the **union of every enabled service's `tools` list** names it
+//! — *or when that union is empty*, which is the half a port gets backwards. Jira
+//! has one service, so the union half has no shape of its own here either; it is
+//! still written as `buildAllowedSet`'s loop over `cfg.Services`, and an enabled
+//! service Jira does not know still contributes its names to the set. Both halves
+//! are in the vectors.
+//!
+//! ## Where `Start` stops and [`registry`](super::registry) begins
+//!
+//! `Start` refuses an unauthenticated integration, parses
+//! `config.AtlassianCredentials`, and hands the server to
+//! `StartInProcessMCPServer`. The first two read the `auth` and `credentials`
+//! columns, which `native/integrations.rs` never selects, so they live in
+//! `native/integrations/registry.rs` — which already had
+//! `atlassian_credentials` from #317 and passes `"jira"` for the one word that
+//! differs in the wrapper (`parsing jira credentials for %q`).
+//!
+//! `validate.go`'s `ValidateCredentials` is **not ported**: it answers
+//! `POST /api/integrations/{id}/auth/validate`, which dials Atlassian and stays
+//! with Go, so a port would be dead code clippy rejects. The route is covered all
+//! the same — `native::after_forward` fires
+//! [`reload_after_auth`](super::registry::reload_after_auth) on Go's 2xx for every
+//! hosted type, and it reads the row's type through `can_host`, so adding `jira`
+//! to `HOSTED_TYPES` is all that was needed.
+
+pub mod client;
+pub mod project_management;
+
+#[cfg(test)]
+mod tests_vectors;
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use rmcp::model::{CallToolResult, ContentBlock};
+
+use crate::claude::{tool_server, InProcessMcpServer, Result, ToolDef};
+
+use super::ServiceConfig;
+use client::Client;
+
+/// The one service group.
+pub const SERVICES: &[&str] = &["project_management"];
+
+/// Every tool this integration can host, in registration order — `SERVICES`
+/// order, then each `register*Tools` batch's own.
+///
+/// **Not** the order `tools/list` answers in: both SDKs sort by name. Kept as
+/// Go's registration order so the two `buildMCPServer`s read alike, and pinned by
+/// `an_empty_allowed_set_hosts_every_tool`.
+pub const JIRA_TOOL_NAMES: &[&str] = &[
+    "list_projects",
+    "get_project",
+    "search_issues",
+    "get_issue",
+    "create_issue",
+    "update_issue",
+    "add_comment",
+    "list_transitions",
+    "transition_issue",
+];
+
+/// `fmt.Sprintf("jira-%s", cfg.ID)` — `mcp.NewServer`'s implementation name.
+///
+/// **Not** the prefix on a qualified tool name: that is the bare integration id,
+/// because `StartInProcessMCPServer(ctx, cfg.ID, …)` keys the `mcpServers` map.
+/// See `registry::allowed_tool_names`.
+pub fn server_name(integration_id: &str) -> String {
+    format!("jira-{integration_id}")
+}
+
+/// The union of every **enabled** service's `Tools`.
+pub fn build_allowed_set(services: &BTreeMap<String, ServiceConfig>) -> BTreeSet<String> {
+    let mut allowed = BTreeSet::new();
+    for service in services.values() {
+        if !service.enabled {
+            continue;
+        }
+        for tool in service.tools.iter().flat_map(|tools| tools.iter()) {
+            allowed.insert(tool.clone());
+        }
+    }
+    allowed
+}
+
+/// Present **and** enabled. An absent service is not enabled, which is how an
+/// integration configured before a service existed keeps working.
+pub fn service_enabled(services: &BTreeMap<String, ServiceConfig>, name: &str) -> bool {
+    services.get(name).is_some_and(|service| service.enabled)
+}
+
+/// Every tool `buildMCPServer` would register for `services`, over the given site
+/// and credentials.
+///
+/// Separate from [`start_jira_mcp_server`] so the tool set can be inspected
+/// without binding a port — which is what the parity assertions on the hosted set
+/// do, and what makes it cheap to assert that a bad base leaves the set alone.
+pub fn jira_tools(
+    services: &BTreeMap<String, ServiceConfig>,
+    site_url: &str,
+    email: &str,
+    api_token: &str,
+) -> Vec<ToolDef> {
+    let allowed = build_allowed_set(services);
+    let client = Client::new(site_url, email, api_token);
+    let mut tools = Vec::new();
+
+    // `len(allowed) == 0 || allowed[name]` — so an empty set admits everything.
+    let mut push = |service: &str, name: &str, tool: fn(&Client) -> ToolDef| {
+        if !service_enabled(services, service) {
+            return;
+        }
+        if !allowed.is_empty() && !allowed.contains(name) {
+            return;
+        }
+        tools.push(tool(&client));
+    };
+
+    push(
+        "project_management",
+        "list_projects",
+        project_management::list_projects,
+    );
+    push(
+        "project_management",
+        "get_project",
+        project_management::get_project,
+    );
+    push(
+        "project_management",
+        "search_issues",
+        project_management::search_issues,
+    );
+    push(
+        "project_management",
+        "get_issue",
+        project_management::get_issue,
+    );
+    push(
+        "project_management",
+        "create_issue",
+        project_management::create_issue,
+    );
+    push(
+        "project_management",
+        "update_issue",
+        project_management::update_issue,
+    );
+    push(
+        "project_management",
+        "add_comment",
+        project_management::add_comment,
+    );
+    push(
+        "project_management",
+        "list_transitions",
+        project_management::list_transitions,
+    );
+    push(
+        "project_management",
+        "transition_issue",
+        project_management::transition_issue,
+    );
+
+    tools
+}
+
+/// Starts the integration's server on a random loopback port.
+///
+/// The listener stops when the returned handle is dropped, which is what stands
+/// in for Go's `ctx`: dropping it cancels every in-flight tool call's token, and
+/// each of them watches it, so an outbound Jira request does not outlive the
+/// server.
+///
+/// Note it cannot fail on the site URL. That is `jira.Start`'s behaviour and the
+/// reason `client::Client` carries the decision instead.
+pub async fn start_jira_mcp_server(
+    integration_id: &str,
+    services: &BTreeMap<String, ServiceConfig>,
+    site_url: &str,
+    email: &str,
+    api_token: &str,
+) -> Result<InProcessMcpServer> {
+    tool_server(
+        &server_name(integration_id),
+        jira_tools(services, site_url, email, api_token),
+    )
+    .await
+}
+
+/// Go's `textResult`, shared by all nine tools.
+pub(crate) fn text_result(text: String) -> CallToolResult {
+    CallToolResult::success(vec![ContentBlock::text(text)])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::native::gojson::GoList;
+
+    fn service(enabled: bool, tools: &[&str]) -> ServiceConfig {
+        ServiceConfig {
+            enabled,
+            tools: Some(GoList(tools.iter().map(|t| t.to_string()).collect())),
+        }
+    }
+
+    fn names_for(services: &BTreeMap<String, ServiceConfig>, site: &str) -> Vec<String> {
+        jira_tools(services, site, "e", "t")
+            .iter()
+            .map(|tool| tool.name().to_string())
+            .collect()
+    }
+
+    fn names(services: &BTreeMap<String, ServiceConfig>) -> Vec<String> {
+        names_for(services, "https://jira.atlassian.net")
+    }
+
+    #[test]
+    fn the_server_name_is_gos() {
+        assert_eq!(server_name("abc123"), "jira-abc123");
+    }
+
+    /// The service enabled with no tool list hosts everything — the half of the
+    /// rule that reads backwards.
+    #[test]
+    fn an_empty_allowed_set_hosts_every_tool() {
+        let services = BTreeMap::from([("project_management".to_string(), service(true, &[]))]);
+        assert_eq!(names(&services), JIRA_TOOL_NAMES);
+        assert!(build_allowed_set(&services).is_empty());
+    }
+
+    #[test]
+    fn one_named_tool_narrows_the_service() {
+        let services = BTreeMap::from([(
+            "project_management".to_string(),
+            service(true, &["get_issue", "add_comment"]),
+        )]);
+        assert_eq!(names(&services), ["get_issue", "add_comment"]);
+    }
+
+    /// An enabled service Jira does not know still contributes its names to the
+    /// union — which is what makes the set a union rather than the known
+    /// service's own list.
+    #[test]
+    fn an_unknown_enabled_service_still_narrows_the_known_one() {
+        let services = BTreeMap::from([
+            ("project_management".to_string(), service(true, &[])),
+            ("other".to_string(), service(true, &["list_projects"])),
+        ]);
+        assert_eq!(names(&services), ["list_projects"]);
+    }
+
+    #[test]
+    fn a_disabled_service_is_invisible_in_both_directions() {
+        let services = BTreeMap::from([
+            ("project_management".to_string(), service(false, &[])),
+            ("other".to_string(), service(true, &["get_issue"])),
+        ]);
+        assert!(names(&services).is_empty());
+        assert!(!service_enabled(&services, "project_management"));
+        assert!(!service_enabled(&services, "missing"));
+    }
+
+    #[test]
+    fn no_services_at_all_hosts_nothing() {
+        assert!(names(&BTreeMap::new()).is_empty());
+    }
+
+    /// A `null` tools column is a nil Go slice, which contributes no names — and
+    /// is therefore an *empty* allowed set, not a filter.
+    #[test]
+    fn a_null_tools_column_is_not_a_filter() {
+        let services = BTreeMap::from([(
+            "project_management".to_string(),
+            ServiceConfig {
+                enabled: true,
+                tools: None,
+            },
+        )]);
+        assert!(build_allowed_set(&services).is_empty());
+        assert_eq!(names(&services), JIRA_TOOL_NAMES);
+    }
+
+    /// **A site URL this build cannot send a request through does not change the
+    /// tool set.** This is the whole reason Jira answers a bad base per call
+    /// instead of refusing to host: `jira.Start` validates nothing, so Go
+    /// advertises all nine whatever the base says, and the advertised set is what
+    /// every agent's stored `capabilities.mcp` allowlist depends on.
+    ///
+    /// `client::tests::a_base_this_build_cannot_send_through_refuses_every_call`
+    /// asserts the other half.
+    #[test]
+    fn a_base_this_build_cannot_send_through_still_hosts_every_tool() {
+        let services = BTreeMap::from([("project_management".to_string(), service(true, &[]))]);
+        for site in [
+            r"https://evil.com\@jira.atlassian.net",
+            "https://jira.atlassian.net%2Eevil.com",
+            "https://jira.atlassian.net/a/../b",
+            "http://plaintext.example.com",
+            "",
+        ] {
+            assert_eq!(names_for(&services, site), JIRA_TOOL_NAMES, "{site}");
+        }
+    }
+}

--- a/desktop/src-tauri/src/native/integrations/jira/project_management.rs
+++ b/desktop/src-tauri/src/native/integrations/jira/project_management.rs
@@ -1,0 +1,433 @@
+//! The `project_management` service's nine tools, ported from
+//! `internal/integrations/jira/tools.go`.
+//!
+//! Jira has one service group registered in four batches (`registerProjectTools`,
+//! `registerIssueReadTools`, `registerIssueMutationTools`,
+//! `registerTransitionTools`), so this file is the whole tool surface. The
+//! conventions are `native/integrations/github/repos.rs`'s — Go `json:` tags as
+//! field names, Go `jsonschema:` tags as doc comments **verbatim** (`required,`
+//! prefix included, because `jsonschema-go` reads the whole tag as the
+//! description), no `Option` anywhere since no params struct carries `omitempty`,
+//! and `deny_unknown_fields` for the `additionalProperties: false` Go's reflector
+//! emits.
+//!
+//! # Four things here that look like mistakes and are Go's behaviour
+//!
+//! Each is pinned by `desktop/parity/jira_vectors.json`, because a port that
+//! "fixed" any of them would change the wire:
+//!
+//! 1. **`list_projects` takes no arguments at all.** Its Go handler binds
+//!    `*struct{}`, so the advertised schema is an empty object — the only tool in
+//!    any of the six integrations with no fields.
+//! 2. **`create_issue` percent-escapes the project key *inside the JSON body*.**
+//!    `"project": {"key": url.PathEscape(params.ProjectKey)}` — a path escape
+//!    applied to a value that never goes in a path. A key holding a space is
+//!    therefore sent as `MY%20PROJ` in the body. Reproduced with
+//!    [`gourl::path_escape`], and note it is *only* the project key: `issuetype`,
+//!    `summary`, `priority` and every other body value are raw.
+//! 3. **`update_issue` and `transition_issue` discard the response.** Their
+//!    result text is built from the *arguments* (`Issue %s updated successfully.`)
+//!    rather than from what Jira answered, so a 200 with a surprising body still
+//!    reads as success — and `update_issue` with nothing set sends
+//!    `{"fields":{}}`, which still counts as a body and so still sends
+//!    `Content-Type`.
+//! 4. **`/rest/api/3/issue/` carries its trailing slash in the constant.** So
+//!    `get_issue` builds `/rest/api/3/issue/KEY` while `get_project` has to add
+//!    its own slash to `/rest/api/3/project`. Same shape on the wire, two
+//!    different spellings in the source.
+//!
+//! # Atlassian Document Format
+//!
+//! `docBody` wraps plain text in ADF, and it is the only nested structure any
+//! Jira body carries: a `doc` of `version` 1 whose one `paragraph` holds one
+//! `text` node. `version` is an integer, and `json.Marshal` sorts every level, so
+//! the encoded shape is not the source's field order.
+
+use schemars::JsonSchema;
+use serde_json::{json, Value};
+
+use crate::claude::{new_tool, CancellationToken, ToolDef};
+use crate::native::gourl::path_escape;
+
+use super::client::{clamp_max_results, Client};
+use super::text_result;
+
+/// `jiraAPIIssue` — note the **trailing slash**, which is why callers append a
+/// key directly.
+const API_ISSUE: &str = "/rest/api/3/issue/";
+/// `jiraAPIProject` — no trailing slash, so `get_project` adds one.
+const API_PROJECT: &str = "/rest/api/3/project";
+
+/// `json.Marshal(body)`, which `(*client).call` does inside itself in Go.
+///
+/// Go's wording is kept even though this cannot fail for any value built here —
+/// every one is a string, an integer or a map of those.
+fn marshal(payload: &Value) -> Result<Vec<u8>, String> {
+    crate::native::gojson::to_vec_marshal(payload)
+        .map_err(|e| format!("marshaling request body: {e}"))
+}
+
+/// `docBody`: plain text as an Atlassian Document Format document.
+fn doc_body(text: &str) -> Value {
+    json!({
+        "type": "doc",
+        "version": 1,
+        "content": [{
+            "type": "paragraph",
+            "content": [{"type": "text", "text": text}],
+        }],
+    })
+}
+
+/// `list_projects`.
+///
+/// The Go handler binds `*struct{}`, so this struct has no fields and the
+/// advertised schema is an empty object. It still derives `deny_unknown_fields`,
+/// which is what refuses a caller that sends anything.
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct ListProjectsInput {}
+
+pub fn list_projects(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "list_projects",
+        "Lists all accessible Jira projects.",
+        move |_input: ListProjectsInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let result = client
+                    .call(&ct, reqwest::Method::GET, API_PROJECT, None)
+                    .await?;
+                Ok(text_result(format!("Projects: {result}")))
+            }
+        },
+    )
+}
+
+/// `get_project`.
+#[allow(dead_code)] // read through serde, never constructed in Rust
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct GetProjectInput {
+    /// required,The project key (e.g. PROJ)
+    key: String,
+}
+
+pub fn get_project(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "get_project",
+        "Gets details of a specific Jira project by key.",
+        move |input: GetProjectInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                // `jiraAPIProject + "/" + url.PathEscape(key)` — the slash is the
+                // caller's here, because this constant has none.
+                let path = format!("{API_PROJECT}/{}", path_escape(&input.key));
+                let result = client.call(&ct, reqwest::Method::GET, &path, None).await?;
+                Ok(text_result(format!("Project: {result}")))
+            }
+        },
+    )
+}
+
+/// `search_issues`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct SearchIssuesInput {
+    /// required,JQL query string (e.g. project = PROJ AND status = Open)
+    jql: String,
+    /// Maximum number of issues to return (default 50, max 100)
+    max_results: i64,
+}
+
+pub fn search_issues(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "search_issues",
+        "Searches Jira issues using JQL (Jira Query Language).",
+        move |input: SearchIssuesInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                // JQL travels in the **body**, so nothing escapes it — unlike
+                // Confluence's CQL, which is a query parameter.
+                let payload = json!({
+                    "jql": input.jql,
+                    "maxResults": clamp_max_results(input.max_results),
+                });
+                let result = client
+                    .call(
+                        &ct,
+                        reqwest::Method::POST,
+                        "/rest/api/3/search",
+                        Some(marshal(&payload)?),
+                    )
+                    .await?;
+                Ok(text_result(format!("Search results: {result}")))
+            }
+        },
+    )
+}
+
+/// `get_issue`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct GetIssueInput {
+    /// required,The issue key (e.g. PROJ-123)
+    key: String,
+}
+
+pub fn get_issue(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "get_issue",
+        "Gets details of a specific Jira issue by key (e.g. PROJ-123).",
+        move |input: GetIssueInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                // The constant already ends in `/`.
+                let path = format!("{API_ISSUE}{}", path_escape(&input.key));
+                let result = client.call(&ct, reqwest::Method::GET, &path, None).await?;
+                Ok(text_result(format!("Issue: {result}")))
+            }
+        },
+    )
+}
+
+/// `create_issue`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct CreateIssueInput {
+    /// required,The project key (e.g. PROJ)
+    project_key: String,
+    /// required,Issue type name (e.g. Bug, Story, Task)
+    issue_type: String,
+    /// required,Summary/title of the issue
+    summary: String,
+    /// Optional description of the issue
+    description: String,
+    /// Optional priority name (e.g. High, Medium, Low)
+    priority: String,
+}
+
+pub fn create_issue(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "create_issue",
+        "Creates a new Jira issue in a project.",
+        move |input: CreateIssueInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let mut fields = json!({
+                    // `url.PathEscape` on a **body** value. Not a mistake to
+                    // correct: see the module header. Only the project key.
+                    "project": {"key": path_escape(&input.project_key)},
+                    "issuetype": {"name": input.issue_type},
+                    "summary": input.summary,
+                });
+                if !input.description.is_empty() {
+                    fields["description"] = doc_body(&input.description);
+                }
+                if !input.priority.is_empty() {
+                    fields["priority"] = json!({"name": input.priority});
+                }
+
+                let result = client
+                    .call(
+                        &ct,
+                        reqwest::Method::POST,
+                        "/rest/api/3/issue",
+                        Some(marshal(&json!({"fields": fields}))?),
+                    )
+                    .await?;
+                Ok(text_result(format!("Issue created: {result}")))
+            }
+        },
+    )
+}
+
+/// `update_issue`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct UpdateIssueInput {
+    /// required,The issue key (e.g. PROJ-123)
+    key: String,
+    /// Optional new summary/title
+    summary: String,
+    /// Optional new description
+    description: String,
+    /// Optional new priority name (e.g. High, Medium, Low)
+    priority: String,
+}
+
+pub fn update_issue(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "update_issue",
+        "Updates fields of an existing Jira issue.",
+        move |input: UpdateIssueInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                // Every field is conditional, so an all-empty update sends
+                // `{"fields":{}}` — still a body, and therefore still a
+                // `Content-Type`.
+                let mut fields = json!({});
+                if !input.summary.is_empty() {
+                    fields["summary"] = Value::String(input.summary.clone());
+                }
+                if !input.description.is_empty() {
+                    fields["description"] = doc_body(&input.description);
+                }
+                if !input.priority.is_empty() {
+                    fields["priority"] = json!({"name": input.priority});
+                }
+
+                let path = format!("{API_ISSUE}{}", path_escape(&input.key));
+                // The response is **discarded**: the sentence is built from the
+                // argument, so it reads the same whatever Jira answered.
+                client
+                    .call(
+                        &ct,
+                        reqwest::Method::PUT,
+                        &path,
+                        Some(marshal(&json!({"fields": fields}))?),
+                    )
+                    .await?;
+                Ok(text_result(format!(
+                    "Issue {} updated successfully.",
+                    input.key
+                )))
+            }
+        },
+    )
+}
+
+/// `add_comment`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct AddCommentInput {
+    /// required,The issue key (e.g. PROJ-123)
+    key: String,
+    /// required,The text of the comment to add
+    comment: String,
+}
+
+pub fn add_comment(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "add_comment",
+        "Adds a comment to a Jira issue.",
+        move |input: AddCommentInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let payload = json!({"body": doc_body(&input.comment)});
+                let path = format!("{API_ISSUE}{}/comment", path_escape(&input.key));
+                let result = client
+                    .call(&ct, reqwest::Method::POST, &path, Some(marshal(&payload)?))
+                    .await?;
+                Ok(text_result(format!("Comment added: {result}")))
+            }
+        },
+    )
+}
+
+/// `list_transitions`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct ListTransitionsInput {
+    /// required,The issue key (e.g. PROJ-123)
+    key: String,
+}
+
+pub fn list_transitions(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "list_transitions",
+        "Lists available status transitions for a Jira issue.",
+        move |input: ListTransitionsInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let path = format!("{API_ISSUE}{}/transitions", path_escape(&input.key));
+                let result = client.call(&ct, reqwest::Method::GET, &path, None).await?;
+                Ok(text_result(format!("Transitions: {result}")))
+            }
+        },
+    )
+}
+
+/// `transition_issue`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct TransitionIssueInput {
+    /// required,The issue key (e.g. PROJ-123)
+    key: String,
+    /// required,The ID of the transition to perform
+    transition_id: String,
+}
+
+pub fn transition_issue(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "transition_issue",
+        "Transitions a Jira issue to a new status.",
+        move |input: TransitionIssueInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let payload = json!({"transition": {"id": input.transition_id}});
+                let path = format!("{API_ISSUE}{}/transitions", path_escape(&input.key));
+                // Response discarded, like `update_issue`'s.
+                client
+                    .call(&ct, reqwest::Method::POST, &path, Some(marshal(&payload)?))
+                    .await?;
+                Ok(text_result(format!(
+                    "Issue {} transitioned successfully.",
+                    input.key
+                )))
+            }
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn encoded(payload: &Value) -> String {
+        String::from_utf8(marshal(payload).expect("encode")).expect("utf-8")
+    }
+
+    /// ADF, sorted at every level by `json.Marshal` — so the encoded shape is not
+    /// `docBody`'s source order, and `version` is an integer.
+    #[test]
+    fn a_doc_body_is_sorted_and_its_version_is_an_integer() {
+        assert_eq!(
+            encoded(&doc_body("hello")),
+            concat!(
+                r#"{"content":[{"content":[{"text":"hello","type":"text"}],"#,
+                r#""type":"paragraph"}],"type":"doc","version":1}"#
+            )
+        );
+    }
+
+    /// The HTML escaping `json.Marshal` applies and `serde_json` does not. A Jira
+    /// summary or comment is prose a person wrote, so this fires constantly.
+    #[test]
+    fn body_text_is_html_escaped_the_way_go_escapes_it() {
+        assert!(encoded(&doc_body("a <b> & c")).contains(r"a \u003cb\u003e \u0026 c"));
+    }
+
+    /// An all-empty update is still a body — which is what makes it send a
+    /// `Content-Type`.
+    #[test]
+    fn an_empty_update_sends_an_empty_fields_object() {
+        assert_eq!(encoded(&json!({"fields": json!({})})), r#"{"fields":{}}"#);
+    }
+}

--- a/desktop/src-tauri/src/native/integrations/jira/tests_vectors.rs
+++ b/desktop/src-tauri/src/native/integrations/jira/tests_vectors.rs
@@ -66,7 +66,14 @@ struct GoServiceConfig {
 #[derive(Deserialize)]
 struct SiteUrlVector {
     case: String,
+    /// An absolute URL that never resolves, used as-is.
+    #[serde(default)]
     site_url: String,
+    /// …or an authority prefix to insert in front of **this** run's fake, for
+    /// the one case where Go reaches it and this port refuses. The Go generator
+    /// could not freeze its own fake's port, so each language rebuilds the URL.
+    #[serde(default)]
+    fake_authority_prefix: String,
     tools: Vec<String>,
     call_text: String,
     is_error: bool,
@@ -241,13 +248,34 @@ fn the_hosted_tool_set_matches_the_go_vectors() {
 #[tokio::test]
 async fn a_site_url_go_serves_and_this_build_cannot_keeps_its_tools_and_refuses_its_calls() {
     let v = vectors();
-    assert!(v.site_urls.len() >= 4, "vectors look partial");
+    assert!(v.site_urls.len() >= 5, "vectors look partial");
+
+    // A fake, for the one case whose site URL points at it: Go dialled its own
+    // fake and got a body, so the divergence is only observable if this side
+    // could have reached one too. Nothing should arrive — that is the assertion.
+    let state = FakeState::default();
+    let app = axum::Router::new()
+        .fallback(serve_fake)
+        .with_state(state.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind the fake");
+    let authority = listener.local_addr().expect("addr").to_string();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
 
     for case in &v.site_urls {
+        let site_url = if case.fake_authority_prefix.is_empty() {
+            case.site_url.clone()
+        } else {
+            format!("http://{}{authority}", case.fake_authority_prefix)
+        };
+
         let server = start_jira_mcp_server(
             &v.integration_id,
             &all_services(),
-            &case.site_url,
+            &site_url,
             &v.email,
             &v.api_token,
         )
@@ -262,7 +290,7 @@ async fn a_site_url_go_serves_and_this_build_cannot_keeps_its_tools_and_refuses_
 
         let tools = ToolServer::new(&v.server_name).with_tools(jira_tools(
             &all_services(),
-            &case.site_url,
+            &site_url,
             &v.email,
             &v.api_token,
         ));
@@ -274,14 +302,31 @@ async fn a_site_url_go_serves_and_this_build_cannot_keeps_its_tools_and_refuses_
             case.case
         );
 
+        state.arm(&ResponseScript {
+            status: 200,
+            body: String::new(),
+        });
         let result = call_tool(&server, "list_projects", &serde_json::json!({})).await;
-        let want = if case.rust_call_text.is_empty() {
-            &case.call_text
+        // Every text this port substitutes is a *failure* where Go produced
+        // something else, so `rust_call_text` carries `is_error` with it — and
+        // here that is not Go's flag at all: the userinfo case records a Go
+        // **success**, which is the whole reason it is in the vectors.
+        let (want, want_error) = if case.rust_call_text.is_empty() {
+            (&case.call_text, case.is_error)
         } else {
-            &case.rust_call_text
+            (&case.rust_call_text, true)
         };
         assert_eq!(result.text, *want, "{}: call text", case.case);
-        assert_eq!(result.is_error, case.is_error, "{}: is_error", case.case);
+        assert_eq!(result.is_error, want_error, "{}: is_error", case.case);
+        if !case.rust_call_text.is_empty() {
+            // Where the two diverge, the port's answer must be a refusal that
+            // never left the process — not a request Go would not have made.
+            assert!(
+                state.0.lock().expect("fake lock").seen.is_none(),
+                "{}: the refusal still reached the network",
+                case.case
+            );
+        }
         for secret in [&v.api_token, &v.email] {
             assert!(
                 !result.text.contains(secret),

--- a/desktop/src-tauri/src/native/integrations/jira/tests_vectors.rs
+++ b/desktop/src-tauri/src/native/integrations/jira/tests_vectors.rs
@@ -1,0 +1,535 @@
+//! The Rust half of `desktop/parity/jira_vectors.json`.
+//!
+//! The Go half (`desktop/parity/jira_parity_test.go`) stands the **real**
+//! integration up through `jira.Start` — no seam, because `Start` does not look
+//! at the site URL — against an `httptest.Server` that plays a scripted Jira and
+//! records what it was asked. This half replays the same script through an axum
+//! server on loopback, the real
+//! [`start_jira_mcp_server`](super::start_jira_mcp_server), and a real
+//! `tools/call` over the MCP HTTP transport.
+//!
+//! Four surfaces, and one of them is Jira's own:
+//!
+//! 1. the advertised tool set, schemas and descriptions;
+//! 2. the gating rule in every shape the generator recorded;
+//! 3. **what a site URL this build cannot send a request through does** — Go
+//!    hosts all nine tools and fails per call, so this asserts the tool set is
+//!    untouched *and* that the call refuses. That is the property that decided
+//!    where the base check lives; see `super::client`'s header;
+//! 4. every call, request and result text.
+//!
+//! Pinned divergences, all inherited: `rust_text` + `rust_no_request` for the
+//! dot-segment refusal and the zero-fraction float, and `rust_call_text` for a
+//! site URL `url.Parse` rejects — where Go answers `creating request: parse "…"`
+//! with `net/url`'s vocabulary and the stored site URL interpolated, and this port
+//! answers the transport sentence.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::{HeaderMap, Method, StatusCode, Uri};
+use axum::response::{IntoResponse, Response};
+use rmcp::ServerHandler;
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::{jira_tools, server_name, start_jira_mcp_server, JIRA_TOOL_NAMES, SERVICES};
+use crate::claude::ToolServer;
+use crate::native::gojson::GoList;
+use crate::native::integrations::ServiceConfig;
+
+// ─── The vectors ─────────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct ToolVector {
+    name: String,
+    description: String,
+    input_schema: Value,
+}
+
+#[derive(Deserialize)]
+struct HostingVector {
+    case: String,
+    services: BTreeMap<String, GoServiceConfig>,
+    tools: Vec<String>,
+}
+
+/// `config.ServiceConfig` as the Go generator marshals it.
+#[derive(Deserialize)]
+struct GoServiceConfig {
+    enabled: bool,
+    tools: Option<Vec<String>>,
+}
+
+#[derive(Deserialize)]
+struct SiteUrlVector {
+    case: String,
+    site_url: String,
+    tools: Vec<String>,
+    call_text: String,
+    is_error: bool,
+    #[serde(default)]
+    rust_call_text: String,
+}
+
+#[derive(Deserialize)]
+struct RequestVector {
+    method: String,
+    target: String,
+    authorization: String,
+    accept: String,
+    content_type: String,
+    body: String,
+}
+
+#[derive(Deserialize)]
+struct ResponseScript {
+    status: u16,
+    body: String,
+}
+
+#[derive(Deserialize)]
+struct CallVector {
+    case: String,
+    tool: String,
+    #[serde(default)]
+    base_path: String,
+    arguments: Value,
+    response: ResponseScript,
+    request: Option<RequestVector>,
+    is_error: bool,
+    text: String,
+    #[serde(default)]
+    rust_text: String,
+    #[serde(default)]
+    rust_no_request: bool,
+}
+
+#[derive(Deserialize)]
+struct Vectors {
+    integration_id: String,
+    server_name: String,
+    email: String,
+    api_token: String,
+    tools: Vec<ToolVector>,
+    hosting: Vec<HostingVector>,
+    site_urls: Vec<SiteUrlVector>,
+    calls: Vec<CallVector>,
+}
+
+fn vectors() -> Vectors {
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../parity/jira_vectors.json");
+    let raw = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("reading {path}: {e} — regenerate it from Go"));
+    serde_json::from_str(&raw).expect("parsing the jira vectors")
+}
+
+fn services(from: &BTreeMap<String, GoServiceConfig>) -> BTreeMap<String, ServiceConfig> {
+    from.iter()
+        .map(|(name, service)| {
+            (
+                name.clone(),
+                ServiceConfig {
+                    enabled: service.enabled,
+                    tools: service.tools.clone().map(GoList),
+                },
+            )
+        })
+        .collect()
+}
+
+/// The one service enabled with no tool list — the configuration the nine schemas
+/// and every call vector were taken under.
+fn all_services() -> BTreeMap<String, ServiceConfig> {
+    SERVICES
+        .iter()
+        .map(|name| {
+            (
+                name.to_string(),
+                ServiceConfig {
+                    enabled: true,
+                    tools: None,
+                },
+            )
+        })
+        .collect()
+}
+
+// ─── The advertised surface ──────────────────────────────────────────────────
+
+/// The server name, every tool name, its description and its reflected input
+/// schema, from a live `tools/list` against the Go server.
+///
+/// `list_projects` is the interesting one: its Go handler binds `*struct{}`, so
+/// the schema is `{"type":"object","additionalProperties":false}` with no
+/// `properties` at all — the only such tool in the six integrations, and the one
+/// a fieldless Rust struct has to reproduce exactly.
+#[test]
+fn the_advertised_surface_matches_the_go_vectors() {
+    let v = vectors();
+    assert_eq!(v.server_name, server_name(&v.integration_id));
+    assert_eq!(v.tools.len(), JIRA_TOOL_NAMES.len(), "vectors look partial");
+
+    let server = ToolServer::new(&v.server_name).with_tools(jira_tools(
+        &all_services(),
+        "https://jira.atlassian.net",
+        &v.email,
+        &v.api_token,
+    ));
+    assert_eq!(
+        server.tool_names(),
+        v.tools.iter().map(|t| t.name.clone()).collect::<Vec<_>>(),
+        "the hosted tool set, as tools/list answers it"
+    );
+
+    for want in &v.tools {
+        let tool = server
+            .get_tool(&want.name)
+            .unwrap_or_else(|| panic!("{} is not registered", want.name));
+        assert_eq!(
+            tool.description.as_deref(),
+            Some(want.description.as_str()),
+            "{}'s description is what the model reads",
+            want.name
+        );
+        assert_eq!(
+            serde_json::to_value(&*tool.input_schema).expect("schema"),
+            want.input_schema,
+            "{}'s input schema is what the model is steered by",
+            want.name
+        );
+    }
+}
+
+/// The gating rule, in every shape the Go generator recorded — including the one
+/// that reads backwards, where an empty allowed set hosts everything.
+#[test]
+fn the_hosted_tool_set_matches_the_go_vectors() {
+    let v = vectors();
+    assert!(v.hosting.len() >= 5, "vectors look partial");
+    for case in &v.hosting {
+        let mut hosted: Vec<String> = jira_tools(
+            &services(&case.services),
+            "https://jira.atlassian.net",
+            &v.email,
+            &v.api_token,
+        )
+        .iter()
+        .map(|tool| tool.name().to_string())
+        .collect();
+        hosted.sort();
+        assert_eq!(hosted, case.tools, "hosting case: {}", case.case);
+    }
+}
+
+// ─── The site URLs Go serves without a glance ────────────────────────────────
+
+/// A site URL `jira.Start` accepts and this build cannot send a request through
+/// **must not change the tool set**, and must refuse per call.
+///
+/// This is the assertion that decided the design. Go validates nothing in
+/// `Start`, so it advertises all nine tools whatever the stored site URL says;
+/// refusing to host would drop tools that agents' stored `capabilities.mcp`
+/// allowlists name. So the tool set is asserted against the Go vector, and the
+/// call is asserted to refuse — with Go's own sentence where the two agree, and
+/// with `rust_call_text` where Go fails inside
+/// `http.NewRequestWithContext` and quotes the site URL back.
+///
+/// The hosts are all `.invalid`, so nothing leaves the machine on either side.
+#[tokio::test]
+async fn a_site_url_go_serves_and_this_build_cannot_keeps_its_tools_and_refuses_its_calls() {
+    let v = vectors();
+    assert!(v.site_urls.len() >= 4, "vectors look partial");
+
+    for case in &v.site_urls {
+        let server = start_jira_mcp_server(
+            &v.integration_id,
+            &all_services(),
+            &case.site_url,
+            &v.email,
+            &v.api_token,
+        )
+        .await
+        .expect("a bad site URL must not stop the server starting");
+
+        assert!(
+            !server.config().url.is_empty(),
+            "{}: the server must still be listening",
+            case.case
+        );
+
+        let tools = ToolServer::new(&v.server_name).with_tools(jira_tools(
+            &all_services(),
+            &case.site_url,
+            &v.email,
+            &v.api_token,
+        ));
+        let mut names = tools.tool_names();
+        names.sort();
+        assert_eq!(
+            names, case.tools,
+            "{}: the advertised tool set must not depend on the site URL",
+            case.case
+        );
+
+        let result = call_tool(&server, "list_projects", &serde_json::json!({})).await;
+        let want = if case.rust_call_text.is_empty() {
+            &case.call_text
+        } else {
+            &case.rust_call_text
+        };
+        assert_eq!(result.text, *want, "{}: call text", case.case);
+        assert_eq!(result.is_error, case.is_error, "{}: is_error", case.case);
+        for secret in [&v.api_token, &v.email] {
+            assert!(
+                !result.text.contains(secret),
+                "{}: a credential leaked into a tool result: {}",
+                case.case,
+                result.text
+            );
+        }
+    }
+}
+
+// ─── The fake Jira ───────────────────────────────────────────────────────────
+
+struct Recorded {
+    method: String,
+    target: String,
+    authorization: String,
+    accept: String,
+    content_type: String,
+    body: String,
+}
+
+#[derive(Default)]
+struct Fake {
+    status: u16,
+    body: String,
+    seen: Option<Recorded>,
+}
+
+#[derive(Clone, Default)]
+struct FakeState(Arc<Mutex<Fake>>);
+
+impl FakeState {
+    fn arm(&self, script: &ResponseScript) {
+        let mut fake = self.0.lock().expect("fake lock");
+        fake.status = script.status;
+        fake.body.clone_from(&script.body);
+        fake.seen = None;
+    }
+}
+
+/// One handler for every path, exactly as the Go fake does it: the point is to
+/// capture the request the tool *built*.
+async fn serve_fake(
+    State(state): State<FakeState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    let header = |name: &str| {
+        headers
+            .get(name)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default()
+            .to_string()
+    };
+
+    let (status, reply) = {
+        let mut fake = state.0.lock().expect("fake lock");
+        fake.seen = Some(Recorded {
+            method: method.to_string(),
+            target: uri
+                .path_and_query()
+                .map(|pq| pq.as_str().to_string())
+                .unwrap_or_default(),
+            authorization: header("authorization"),
+            accept: header("accept"),
+            content_type: header("content-type"),
+            body: String::from_utf8_lossy(&body).into_owned(),
+        });
+        (fake.status, fake.body.clone())
+    };
+
+    (
+        StatusCode::from_u16(status).expect("a scripted status"),
+        reply,
+    )
+        .into_response()
+}
+
+// ─── The calls ───────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn every_call_matches_the_go_vectors() {
+    let v = vectors();
+    assert!(v.calls.len() >= 20, "vectors look partial");
+
+    let state = FakeState::default();
+    let app = axum::Router::new()
+        .fallback(serve_fake)
+        .with_state(state.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind the fake");
+    let base = format!("http://{}", listener.local_addr().expect("addr"));
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    // One server per distinct site URL, as the Go generator opens one session per
+    // distinct base path: the site URL is a field on the client, not a per-call
+    // argument.
+    let mut servers: BTreeMap<String, crate::claude::InProcessMcpServer> = BTreeMap::new();
+    for case in &v.calls {
+        if servers.contains_key(&case.base_path) {
+            continue;
+        }
+        let server = start_jira_mcp_server(
+            &v.integration_id,
+            &all_services(),
+            &format!("{base}{}", case.base_path),
+            &v.email,
+            &v.api_token,
+        )
+        .await
+        .expect("start the jira server");
+        servers.insert(case.base_path.clone(), server);
+    }
+
+    for case in &v.calls {
+        let server = &servers[&case.base_path];
+        state.arm(&case.response);
+        let result = call_tool(server, &case.tool, &case.arguments).await;
+
+        for secret in [&v.api_token, &v.email] {
+            assert!(
+                !result.text.contains(secret),
+                "{}: a credential leaked into a tool result: {}",
+                case.case,
+                result.text
+            );
+        }
+
+        // Every text this port substitutes is a *failure* it produces where Go
+        // produced something else, so `rust_text` carries `is_error` with it —
+        // and that is not always Go's flag: the zero-fraction-float case scripts
+        // a 200, because what it pins is that Go went ahead while the decode here
+        // fails before any handler runs.
+        let (want_text, want_error) = if case.rust_text.is_empty() {
+            (&case.text, case.is_error)
+        } else {
+            (&case.rust_text, true)
+        };
+        assert_eq!(result.text, *want_text, "{}: result text", case.case);
+        assert_eq!(result.is_error, want_error, "{}: is_error", case.case);
+
+        let seen = state.0.lock().expect("fake lock").seen.take();
+        let want_request = if case.rust_no_request {
+            assert!(
+                seen.is_none(),
+                "{}: the refusal still reached the network: {:?}",
+                case.case,
+                seen.as_ref().map(|r| &r.target)
+            );
+            None
+        } else {
+            case.request.as_ref()
+        };
+        match (want_request, seen) {
+            (None, seen) => assert!(
+                seen.is_none(),
+                "{}: Go made no request and this one did",
+                case.case
+            ),
+            (Some(_), None) => panic!("{}: Go made a request and this one did not", case.case),
+            (Some(want), Some(got)) => {
+                assert_eq!(got.method, want.method, "{}: method", case.case);
+                assert_eq!(got.target, want.target, "{}: request target", case.case);
+                assert_eq!(
+                    got.authorization, want.authorization,
+                    "{}: the Basic prefix and the base64 of email:token",
+                    case.case
+                );
+                assert_eq!(got.accept, want.accept, "{}: Accept", case.case);
+                assert_eq!(
+                    got.content_type, want.content_type,
+                    "{}: Content-Type is sent only when there is a body",
+                    case.case
+                );
+                assert_eq!(got.body, want.body, "{}: request body", case.case);
+            }
+        }
+    }
+}
+
+struct ToolAnswer {
+    text: String,
+    is_error: bool,
+}
+
+/// One `tools/call` over the server's own HTTP transport, sent the way the CLI
+/// sends it — including the bearer token the handle's config carries.
+async fn rpc_call(
+    server: &crate::claude::InProcessMcpServer,
+    name: &str,
+    arguments: &Value,
+) -> Value {
+    let payload = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": name, "arguments": arguments},
+    });
+
+    let mut request = reqwest::Client::new()
+        .post(server.url())
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream");
+    for (header, value) in &server.config().headers {
+        request = request.header(header, value);
+    }
+    let response = request
+        .body(payload.to_string())
+        .send()
+        .await
+        .expect("send tools/call");
+    serde_json::from_str(&response.text().await.expect("text")).expect("a JSON-RPC reply")
+}
+
+/// [`rpc_call`]'s success shape: exactly one text block, and no protocol error.
+///
+/// A failing tool is never a protocol error — the convention `new_tool` ports
+/// from `mcp.AddTool`. Malformed *arguments* are the path that really guards, and
+/// the property is `new_tool`'s: it is pinned once for every ported integration by
+/// `github::tests_vectors::malformed_arguments_are_a_tool_error_rather_than_a_protocol_error`.
+async fn call_tool(
+    server: &crate::claude::InProcessMcpServer,
+    name: &str,
+    arguments: &Value,
+) -> ToolAnswer {
+    let body = rpc_call(server, name, arguments).await;
+
+    assert!(
+        body.get("error").is_none(),
+        "{name}: a tool must not raise a protocol error: {body}"
+    );
+    let content = body["result"]["content"]
+        .as_array()
+        .unwrap_or_else(|| panic!("{name}: no content array: {body}"));
+    assert_eq!(content.len(), 1, "{name}: want exactly one content block");
+    assert_eq!(content[0]["type"], "text");
+
+    ToolAnswer {
+        text: content[0]["text"]
+            .as_str()
+            .unwrap_or_else(|| panic!("{name}: content is not text: {body}"))
+            .to_string(),
+        is_error: body["result"]["isError"].as_bool().unwrap_or(false),
+    }
+}

--- a/desktop/src-tauri/src/native/integrations/registry.rs
+++ b/desktop/src-tauri/src/native/integrations/registry.rs
@@ -4,8 +4,8 @@
 //! Go keeps one long-lived in-process MCP server per enabled, authenticated
 //! integration: `Start` brings them all up at boot, `Reload` restarts one when
 //! its row changes, `Stop` tears one down when it is deleted. This module is
-//! that, for the types listed in [`HOSTED_TYPES`] — today `github` (#312) and
-//! `confluence` (#317).
+//! that, for the types listed in [`HOSTED_TYPES`] — today `github` (#312),
+//! `confluence` (#317) and `jira` (#316).
 //!
 //! ## Why the ownership had to flip before the writes could move
 //!
@@ -44,7 +44,7 @@
 //! **The list is built here, by [`hosting_env_value`], from the same
 //! [`HOSTED_TYPES`] that [`hosts_type`] and the starter dispatch read.** That is
 //! the point of carrying it in the environment rather than hardcoding it on both
-//! sides: the shell is the process that knows what it hosts, so #313–#316 each
+//! sides: the shell is the process that knows what it hosts, so #313–#315 each
 //! add one string to one list and the two halves cannot drift. The failure mode
 //! being designed against is a Rust slack starter landing while Go is never told
 //! to stop hosting slack — two processes on one integration — and its mirror is
@@ -84,17 +84,18 @@
 //!
 //! `Reload` has seven callers in Go and only two of them (`Update`, and
 //! `Delete` via `Stop`) are ported. Five run inside the sidecar. `completeOAuth`
-//! and the telegram, jira and slack validators are fine **because the gate is
+//! and the telegram and slack validators are fine **because the gate is
 //! per type**: they can only reach types Go still hosts, and
 //! `startProviderCallback` supports exactly `google` and `slack`, so an OAuth
-//! completion never concerns a hosted one. The other two — `validateGitHubPATAuth`
-//! and, since #317, `validateConfluenceAuth` — write a credential for a type
+//! completion never concerns a hosted one. The other three —
+//! `validateGitHubPATAuth`, and since #316 and #317 `validateJiraTokenAuth` and
+//! `validateConfluenceAuth` — write a credential for a type
 //! *this* process hosts, from a handler that cannot tell it. Without a hook such
 //! an integration would first be hosted at the next boot's [`start_all`], so the
 //! seam fires [`reload_after_auth`] after forwarding a 2xx for that one route
 //! (`native::after_forward`). That hook needs no per-type list of its own: it
 //! runs for every id on the route and [`reload_after_auth`] reads the row's type
-//! through [`can_host`], so #313–#316 are covered the moment they add their
+//! through [`can_host`], so #313–#315 are covered the moment they add their
 //! string to [`HOSTED_TYPES`]. The reload is idempotent and the response has
 //! already been produced, so doing it on the forward path costs nothing but a
 //! restart of a server that was about to be restarted anyway.
@@ -156,8 +157,8 @@ impl HostingRow {
 /// One list, read by three things that must agree: [`hosts_type`] (which the
 /// native `PUT`/`DELETE` consult before they touch a row), the starter dispatch
 /// in [`start_for_type`], and [`hosting_env_value`], which tells the Go sidecar
-/// which types to stop hosting. #313–#316 each add one string here.
-pub const HOSTED_TYPES: &[&str] = &["github", "confluence"];
+/// which types to stop hosting. #313–#315 each add one string here.
+pub const HOSTED_TYPES: &[&str] = &["github", "confluence", "jira"];
 
 /// Whether this process hosts an integration of the given type.
 pub fn hosts_type(integration_type: &str) -> bool {
@@ -367,6 +368,7 @@ async fn start_for_type(row: &HostingRow) -> Result<InProcessMcpServer, String> 
     match row.integration_type.as_str() {
         "github" => start_github(&row.id, &row.services(), &row.credentials).await,
         "confluence" => start_confluence(&row.id, &row.services(), &row.credentials).await,
+        "jira" => start_jira(&row.id, &row.services(), &row.credentials).await,
         other => Err(format!(
             "no starter registered for integration type {other:?}"
         )),
@@ -459,6 +461,31 @@ async fn start_confluence(
         id,
         services,
         &site_url,
+        &creds.email,
+        &creds.api_token,
+    )
+    .await
+    .map_err(|e| format!("starting in-process MCP server for {id:?}: {e}"))
+}
+
+/// `jira.Start`'s first two steps — the auth check and the credential parse —
+/// followed by the third, which `native/integrations/jira` owns.
+///
+/// **There is no third check.** `confluence.Start` normalises the site URL and
+/// fails on a bad one; `jira.Start` does not look at it, so this starter cannot
+/// fail on it either and `jira::client::Client` carries the decision per call
+/// instead. That asymmetry is #277's, and reproducing it is what keeps the
+/// advertised tool set identical to Go's — see `jira::client`'s header.
+async fn start_jira(
+    id: &str,
+    services: &BTreeMap<String, ServiceConfig>,
+    credentials: &str,
+) -> Result<InProcessMcpServer, String> {
+    let creds = atlassian_credentials("jira", id, credentials)?;
+    super::jira::start_jira_mcp_server(
+        id,
+        services,
+        &creds.site_url,
         &creds.email,
         &creds.api_token,
     )
@@ -575,6 +602,7 @@ pub async fn start_filtered_server(
     match row.integration_type.as_str() {
         "github" => start_github(&row.id, &filtered, &row.credentials).await,
         "confluence" => start_confluence(&row.id, &filtered, &row.credentials).await,
+        "jira" => start_jira(&row.id, &filtered, &row.credentials).await,
         other => Err(format!(
             "no starter registered for integration type {other:?}"
         )),
@@ -900,7 +928,7 @@ mod tests {
     /// two ways to put a credential on two open ports at once.
     #[test]
     fn the_sidecar_is_told_exactly_what_this_process_hosts() {
-        assert_eq!(hosting_env_value(), "off:github,confluence");
+        assert_eq!(hosting_env_value(), "off:github,confluence,jira");
         assert_eq!(
             hosting_env_value(),
             format!("off:{}", HOSTED_TYPES.join(",")),
@@ -908,11 +936,12 @@ mod tests {
         );
         assert!(hosts_type("github"));
         assert!(hosts_type("confluence"));
-        // The four types #313–#316 still owe. Go must keep hosting every one of
+        assert!(hosts_type("jira"));
+        // The three types #313–#315 still owe. Go must keep hosting every one of
         // them, and `whatsapp` is the reason this is a list at all: its starter
         // opens a live whatsmeow connection that its status, reconnect and QR
         // endpoints read out of a package global.
-        for unported in ["slack", "jira", "telegram", "google", "whatsapp"] {
+        for unported in ["slack", "telegram", "google", "whatsapp"] {
             assert!(!hosts_type(unported), "{unported} is not hosted here");
             assert!(
                 !hosting_env_value().contains(unported),

--- a/desktop/src-tauri/src/native/schedule/mod.rs
+++ b/desktop/src-tauri/src/native/schedule/mod.rs
@@ -11,9 +11,9 @@
 //! `cmd/web.go` starts the sidecar's scheduler on every boot. Ownership moves
 //! in one commit that stops the sidecar scheduling — the #289 model — and that
 //! commit is blocked on `chat/runner.rs::build_options`, which still refuses an
-//! agent whose tools come from an integration this build cannot host — four of
-//! the six (#313–#316), since the local in-process server (#310), github (#311)
-//! and confluence (#317) are no longer among them. A chat can forward to Go on that
+//! agent whose tools come from an integration this build cannot host — three of
+//! the six (#313–#315), since the local in-process server (#310), github (#311),
+//! confluence (#317) and jira (#316) are no longer among them. A chat can forward to Go on that
 //! refusal; a scheduled task with no Go scheduler behind it would simply never
 //! run, with nothing to say so. See "The scheduler: the computation moved, the
 //! ownership did not" in `desktop/CLAUDE.md`.

--- a/desktop/src-tauri/src/sidecar.rs
+++ b/desktop/src-tauri/src/sidecar.rs
@@ -80,7 +80,7 @@ pub async fn spawn(app: &AppHandle, port: u16) -> Result<Sidecar, String> {
         // feature: its starter opens a live whatsmeow WebSocket and registers
         // the client in a package global that the status, reconnect and QR
         // pairing endpoints read. Deriving the list from the starter table means
-        // #313–#316 each add one string in one place.
+        // #313–#315 each add one string in one place.
         //
         // It does **not** switch off `StartFilteredServer`, which is what an
         // agent run uses: that reads the integration row afresh per run and


### PR DESCRIPTION
Closes #316

## What

Ports `internal/integrations/jira/` to `desktop/src-tauri/src/native/integrations/jira/` — nine tools in one service group (`project_management`), over the **same** `config.AtlassianCredentials` Confluence uses. `jira` joins `registry::HOSTED_TYPES`, so the sidecar is started with `AGENTO_INTEGRATIONS=off:github,confluence,jira`.

## Why the shared credential type is a trap

#277 pinned that Jira and Confluence deliberately do *not* share their validation. The port has to keep every row of this:

| | Confluence | Jira |
|---|---|---|
| create-time validator | HTTPS only, keeps the raw value | http **or** https, trims trailing `/`, **re-marshals** |
| inside `Start` | `ValidateSiteURL` again | **nothing at all** |
| client timeout | 30s | 15s |
| failure sentence | names nothing | names the method and the path |
| `desktop/parity` seam | `StartAtSiteURL` needed | **none needed** |

Two of those rows change the shape of the port:

- **A base this build cannot send a request through is answered per call, not by refusing to host.** `jira.Start` validates nothing, so Go hosts the server and advertises all nine tools whatever the stored site URL says — and the advertised tool set is what every agent's stored `capabilities.mcp` allowlist depends on, so refusing to host would break agents that exist. `jira::client::Client` holds `Option<Base>` and answers Go's own transport sentence when it is `None`. Confluence refuses at `Start` because Go refuses there too: same helper, opposite answers, because the two Go packages differ.
- **No Go-side seam.** `Start` reads the site URL out of the credentials, so the generator stores the `httptest.Server`'s URL and calls the shipped `jira.Start`. There is no `internal/integrations/jira/parity.go`, and that absence is a consequence of the table rather than an oversight.

## The extraction

`native/integrations/base_url.rs` is #317's site-URL work extracted for its second caller: `Base::new` (the four base checks, including the authority allowlist that stops a credential reaching another host) and `Base::resolve` (the per-call dot-segment guard). Confluence is rewired onto it with its messages unchanged — **its vectors passing untouched is the check that the extraction preserved behaviour**. Its header is the thing to read before porting anything else whose API base comes out of the row; #313–#315 have constant bases and need only the tool-suffix guard.

## Four things in `tools.go` that read as mistakes and are Go's

All pinned, because a port that "fixed" any of them would change the wire:

- **`list_projects` binds `*struct{}`** — the only tool in the six integrations with no fields, so its schema is `{"type":"object","additionalProperties":false}` with no `properties` key.
- **`create_issue` runs `url.PathEscape` over the project key *inside the JSON body***, and over nothing else, so `MY PROJ` is sent as `MY%20PROJ`.
- **`update_issue` and `transition_issue` discard the response** and build their result text from the arguments, so a 200 with a surprising body still reads as success.
- **`/rest/api/3/issue/` carries its trailing slash in the constant** while `/rest/api/3/project` does not.

## Divergence

One, pinned in the `site_urls` block: for a site URL `url.Parse` rejects, Go fails inside `http.NewRequestWithContext` and answers `creating request: parse "…": …` with `net/url`'s vocabulary and the stored site URL interpolated. This port refuses before building anything and answers the transport sentence — which is also the narrower of the two, since Go's puts the site URL into text the model reads and a `tool_result` stores. The other two bad site URLs need no entry: Go gets as far as a DNS lookup that fails, so both languages answer the same sentence by different routes.

## Acceptance

- [x] Every tool under the same name and the same input schema, from a live `tools/list` against the Go server.
- [x] Result payloads match across 26 call vectors — every tool's success path, every distinct client failure, both base-path shapes, four dot-segment refusals and the zero-fraction float.
- [x] Credentials come from the stored row and appear in no response or log line; both languages' vector runners assert the token and email never reach a tool result.
- [x] The Jira/Confluence validation difference from #277 is preserved and pinned from both ends.

## Verification

- `cargo test` — whole suite green; 20 new Jira tests, plus `base_url`'s own, plus Confluence's existing vectors unchanged.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` — clean.
- `go test ./...` — clean; `golangci-lint` at CI's pinned v2.5.0 — 0 issues.