### PR TITLE
feat(desktop): port the Slack integration MCP server (#315)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -600,7 +600,7 @@ of the `Err` arms the cut-over has to turn into a real response.
 | 1 ✅ | Sidecar + proxy | — | done |
 | 2 ← | Pricing + analytics | `internal/pricing`, `internal/claudesessions` | Pure computation over JSONL + SQLite. No external deps. **In progress**: `/api/pricing/catalog`, `/api/claude-sessions`, `/api/claude-sessions/facets`, `/api/claude-analytics`, `/api/claude-sessions/insights/summary` and the agent reads are native and diff clean. |
 | 3 ← | Storage + tasks | `internal/storage`, `internal/scheduler` | **In progress (#274, #275).** `db.rs` is read-write, the 27 migrations are ported, and the writes whose every effect Rust owns are native — see below. The scheduler's *schedule computation* is ported and pinned (#275); its ownership is not, and is blocked — see below. |
-| 4 ← | Integrations | `internal/integrations`, `internal/trigger` | OAuth2 + MCP servers. Six of them: google, github, slack, jira, confluence, telegram, plus `internal/tools`. **How to host one is settled (#282)** — `claude::ToolServer`, see "Hosting a tool" below; do not invent a second way. **`internal/tools` is done (#310)** — `native/tools/`, and it is the worked example the six should be read against. **GitHub is done (#312)** — `native/integrations/github/`, the worked example for an *integration*. **The registry is done (#311)** — `native/integrations/registry.rs` plus `PUT`/`DELETE /api/integrations/{id}`, and the sidecar now runs with `AGENTO_INTEGRATIONS=off:<the types the shell hosts>`, so every type has exactly one owner. **Confluence is done (#317)** — `native/integrations/confluence/`, the smallest of the six and the one that shows what an integration adds over #312: a per-row API base, basic auth, and a `Start` check that is a decision. **Jira is done (#316)** — `native/integrations/jira/`, Confluence's twin, and the one that shows that a shared credential type does not mean shared behaviour: `jira.Start` validates nothing, so a bad base is answered per call instead of by refusing to host. #313–#315 are each "add a starter **and its name to `HOSTED_TYPES`**", which is the one list both processes are configured from. WhatsApp is **not** among them — but Go still hosts its rows, because its starter opens a live connection rather than just a port; see below. |
+| 4 ← | Integrations | `internal/integrations`, `internal/trigger` | OAuth2 + MCP servers. Six of them: google, github, slack, jira, confluence, telegram, plus `internal/tools`. **How to host one is settled (#282)** — `claude::ToolServer`, see "Hosting a tool" below; do not invent a second way. **`internal/tools` is done (#310)** — `native/tools/`, and it is the worked example the six should be read against. **GitHub is done (#312)** — `native/integrations/github/`, the worked example for an *integration*. **The registry is done (#311)** — `native/integrations/registry.rs` plus `PUT`/`DELETE /api/integrations/{id}`, and the sidecar now runs with `AGENTO_INTEGRATIONS=off:<the types the shell hosts>`, so every type has exactly one owner. **Confluence is done (#317)** — `native/integrations/confluence/`, the smallest of the six and the one that shows what an integration adds over #312: a per-row API base, basic auth, and a `Start` check that is a decision. **Jira is done (#316)** — `native/integrations/jira/`, Confluence's twin, and the one that shows that a shared credential type does not mean shared behaviour: `jira.Start` validates nothing, so a bad base is answered per call instead of by refusing to host. **Slack is done (#315)** — `native/integrations/slack/`, the first that is not Atlassian-shaped: no model input in the URL at all, and the only integration whose token can come from the `auth` column. #313 and #314 are each "add a starter **and its name to `HOSTED_TYPES`**", which is the one list both processes are configured from. WhatsApp is **not** among them — but Go still hosts its rows, because its starter opens a live connection rather than just a port; see below. |
 | 5 ← | Agent execution | `internal/agent`, `internal/service` | **In progress (#276).** The chat SSE turn is native: `/messages`, `/input`, `/permission` and `/stop`, on top of the ported SDK. The scheduler's executor (#275) is the other caller and still Go's. |
 
 ### The session scanner (`src-tauri/src/native/scanner/`)
@@ -813,7 +813,7 @@ Consequences, each load-bearing:
   equally unbounded), and it means the only ceiling on the drain is the slowest
   handler. `github::client` sets 15s and nothing holds a long-lived stream
   (`legacy_session_mode: false` makes the stream `GET` a `405`), so today the
-  bound is real. A handler added by #313–#315 with no client timeout would fail
+  bound is real. A handler added by #313 or #314 with no client timeout would fail
   no test while leaving a revoked credential answering `tools/call` for as long
   as its socket stays open. Set the timeout on the client, not on the drain.
 - **Go's `ServeStdioMCP` / `SelfAsStdioMCPServer` are not ported**, and
@@ -942,7 +942,7 @@ them.
 
 The first of the six, and the largest: twenty tools over five service groups,
 token auth only. It is the file to read beside `native/tools/` before porting
-#313–#315 — that one settles *how to host a tool*, this one settles *how to port
+#313 and #314 — that one settles *how to host a tool*, this one settles *how to port
 an integration*.
 
 **Where it lives, and why there.** `native/integrations.rs` stays a file and
@@ -980,7 +980,7 @@ half is what pins the things no response reveals — `url.PathEscape` per segmen
 with
 `go test ./desktop/parity/ -run TestGitHubVectors -update-github-vectors`.
 
-Five things it brought that #313–#315 will want:
+Five things it brought that #313 and #314 will want:
 
 - **`gourl.rs` now has all three of `net/url`'s escaping modes.**
   `url.PathEscape` is `encodePathSegment` and escapes `/ ; , ?`;
@@ -1030,7 +1030,7 @@ Five things it brought that #313–#315 will want:
   reqwest decompresses in its service stack, so `bytes_stream()` yields
   decompressed bytes and `read_capped` caps what Go's `io.LimitReader` over a
   gunzipped `resp.Body` caps.
-- **The test seam is `#[cfg(test)]`, and should stay that way in #313–#315.**
+- **The test seam is `#[cfg(test)]`, and should stay that way in #313 and #314.**
   `githubAPIBase` had to be *exported* on the Go side (`parity.go`) because
   `desktop/parity` is a different package; both Rust callers are in-crate, so
   `API_BASE`/`set_api_base` compile out of a shipped binary entirely. What they
@@ -1091,9 +1091,10 @@ Four divergences are pinned rather than reconciled, all in the vectors:
   `rust_text` and `rust_no_request`. The comparison is exact rather than a `..`
   scan, so anything else `url` normalizes is caught by construction; nothing
   legitimate trips it, because `gourl`'s escaping already covers every byte in
-  `url`'s path and query encode sets. **#313–#315 each build URLs the same way
-  and need the same guard**; #316 and #317 share `native/integrations/base_url.rs`,
-  which adds what a *per-row* base costs on top of it.
+  `url`'s path and query encode sets. **A port needs this guard wherever model
+  input reaches the path** — #316 and #317 do, and share
+  `native/integrations/base_url.rs` for what a *per-row* base costs on top of it;
+  #315 does not, because Slack's methods are literals.
 
 ### The Confluence integration (`native/integrations/confluence/`, #317)
 
@@ -1262,6 +1263,86 @@ stored site URL interpolated. This port refuses before building anything and
 answers the transport sentence — which is also the narrower of the two, since
 Go's puts the site URL into text the model reads and a `tool_result` stores.
 
+### The Slack integration (`native/integrations/slack/`, #315)
+
+Seven tools in one service group (`messaging`), over a workspace token. The
+fourth of the six, and the first that is not shaped like the three before it —
+two of its differences are things no earlier port had to deal with at all.
+
+**The token can come from the `auth` column, and that widened a projection that
+deliberately never selected it.** `resolveToken` (`slack/server.go`) switches on
+`credentials.auth_mode`: `bot_token` reads the credentials blob, and `oauth`
+reads `cfg.ParseOAuthToken()` — the **`auth` column**, decoded as an
+`oauth2.Token`. Until #315, `registry.rs`'s `HOSTING_COLUMNS` collapsed `auth` to
+a boolean in SQL precisely so a stored token could not exist in this process to
+be echoed, and `native/integrations.rs` still never selects it at all. `HostingRow`
+now carries it. What did **not** change is where it may go: that struct still
+derives neither `Serialize` nor `Debug`, it is private to the module, and only a
+`&str` leaves it. There is a third arm too, and it is the one a port drops: an
+**unrecognized** `auth_mode` falls back to `bot_token` when that is non-empty, so
+a row whose mode was never set still works. The `tokens` block in
+`slack_vectors.json` pins all three arms, plus the empty-`access_token` case that
+sends a bare `Bearer` header — and both languages observe the resolved token the
+same way, by reading the `Authorization` header the fake received rather than
+recording the token, which would put the thing under test into the fixture.
+
+**Nothing model-supplied reaches the URL.** The base is a constant and every
+method is a literal (`conversations.list`, `chat.postMessage`), so there is no
+dot-segment guard and no `base_url::Base` here — the class of problem #312 and
+#317 spent their reviews on does not arise. Model input goes in a form body or a
+JSON body instead. The seam is back to GitHub's shape, though: `slackAPIBase` is
+a package variable, so `slack/parity.go` exports `SetAPIBase` and the Rust side
+gates a `RwLock` behind `#[cfg(test)]`. Confluence and Jira needed neither,
+because an Atlassian site URL is per row.
+
+Four more Slack-shaped surprises, all pinned:
+
+- **`ok` decides, not the HTTP status.** `readSlackResponse` checks 429 and then
+  ignores the status, so a **500 carrying `{"ok":true}` is a success** and a 200
+  carrying `{"ok":false}` is a failure. Every sibling gates on the 2xx range, so
+  this is the one a port gets backwards.
+- **Two encodings.** Five tools send `url.Values.Encode()` as
+  `application/x-www-form-urlencoded`; two send `json.Marshal` as
+  `application/json; charset=utf-8` — with the charset, which nothing else in the
+  tree sends.
+- **Every clamp differs**: 1000/100 for the two listers, 100/20 for
+  `read_messages` and for `search_messages`' count, and a floor of 1 with **no
+  ceiling** for `page`. Read one by one rather than generalised from the first.
+- **Rate limiting is its own sentence**, interpolating `Retry-After` verbatim —
+  including when the header is absent, which lands mid-sentence as an empty
+  string (`retry after  seconds`).
+
+Five of the seven tools return Slack's body **unlabelled**; only the two senders
+prefix it. Timeout 60s and cap 5 MiB, the largest of the six.
+
+**Hosting Slack opened a hole in #311's reload hook, and closing it needed a
+second trigger.** Go's `handleOAuthToken` writes the token to the `auth` column
+and then calls `registry.Reload`, and `startProviderCallback` supports exactly
+`google` and `slack`. `registry.rs`'s header used to say that was harmless
+because neither type was hosted here — true until #315. Now that `Reload` reaches
+nothing, so a Slack integration authenticated by OAuth would first be served at
+the next boot.
+
+`reload_after_auth` cannot cover it: that hook hangs off a **forwarded request**,
+and an OAuth token does not arrive on one — the browser delivers it to a callback
+server the *sidecar* opens on its own port, which this process never sees. The
+one part of the flow that does come through the proxy is the UI polling
+`GET /api/integrations/{id}/auth/status` while it waits, so `reload_after_forward`
+now recognises two routes and returns a `Trigger` saying which:
+
+- `POST …/auth/validate` is an **event** — reload unconditionally, as Go does.
+- `GET …/auth/status` is a **poll** — `registry::reload_if_secrets_changed`
+  compares the row's current `credentials`+`auth` fingerprint against the one the
+  running server was started with, and does nothing when they match. That matters
+  because `reload` is unconditional by design: firing it per poll would rebind
+  the port and drop in-flight `tools/call`s once a second while the dialog is
+  open. The registry keeps the fingerprint (a hash, not the values) beside each
+  handle for exactly this question.
+
+It is **best-effort**: a user who closes the dialog before the flow completes is
+still served only at the next boot. #318 owns the OAuth flow itself and is where
+that stops being true.
+
 ### The integration registry, and the port's second ownership flip (#311)
 
 `native/integrations/registry.rs` is `internal/integrations/registry.go`:
@@ -1311,8 +1392,8 @@ the sidecar still serves, and the sidecar is still shipped.
 must cover it (`a_hosted_type_always_has_a_starter`), and `hosting_env_value`
 renders it into what `sidecar.rs` sets. That shape was chosen over a constant
 hardcoded on both sides because of which failure it makes impossible: the shell
-is the process that *knows* what it hosts, so #313–#315 each add one string in
-one place. The failure being designed against is a Rust slack starter landing
+is the process that *knows* what it hosts, so #313 and #314 each add one string
+in one place. The failure being designed against is a Rust slack starter landing
 while Go is never told to stop hosting slack — two processes on one integration —
 and its mirror is the WhatsApp bug above. A hardcoded Go list would have to be
 edited in lockstep with a Rust table, in another language, in another PR.
@@ -1330,14 +1411,15 @@ asserts both halves, the fallback and the untouched row.
 run uses: `runner.go` reads the integration row afresh per run, builds a
 throwaway server and records nothing. Gating it would have broken every
 integration-using chat, scheduled task and Telegram trigger the sidecar still
-serves — which is most of them, since three of the six types are #313–#315's.
+serves — which is now the minority, since only two of the six types are #313's
+and #314's.
 The Go tests assert both halves, because the switch is only safe while that
 asymmetry holds.
 
 Two consequences worth knowing before touching this:
 
-- **Only `github` (#312), `confluence` (#317) and `jira` (#316) have starters
-  here, and Go still hosts the rest.** A type not
+- **`github` (#312), `confluence` (#317), `jira` (#316) and `slack` (#315) have
+  starters here, and Go still hosts the rest.** A type not
   in `HOSTED_TYPES` reaches this module's own unregistered-type path — `no
   starter registered for integration type "slack"`, logged and never surfaced —
   but in practice it does not reach it at all, because the writes decline it
@@ -1688,10 +1770,10 @@ path cannot try to answer a chat turn with a `Vec<u8>`.
 **The four routes share a process-local registry, so they moved together** —
 `/messages` puts a session in, the others look one up. But not every chat *can*
 run natively: an agent whose tools come from an integration this build cannot
-host still needs #313–#315, and `runner::build_options` refuses those before any
-subprocess exists. (Parts of that refusal are gone — the **local** server (#310)
-and any agent naming only integrations in `HOSTED_TYPES`: **github** since #311,
-**confluence** since #317, **jira** since #316. `build_options`
+host still needs #313 or #314, and `runner::build_options` refuses those before
+any subprocess exists. (Parts of that refusal are gone — the **local** server
+(#310) and any agent naming only integrations in `HOSTED_TYPES`: **github** since
+#311, **confluence** since #317, **jira** since #316, **slack** since #315. `build_options`
 starts each of them, and is `async` for that reason, returning the listener
 handles alongside the options because dropping one stops its server.) That would strand `/stop` for a chat still running on Go, so
 the three steering routes answer natively **only when Rust holds a live session
@@ -2302,7 +2384,7 @@ precede it.
 
 **The blocker, verified.** The flip needs Rust to *run* a task, and
 `chat/runner.rs::build_options` still refuses an agent whose capabilities name
-an MCP server this build cannot host — three of the six providers (#313–#315). For a chat that is safe — the three steering routes forward
+an MCP server this build cannot host — two of the six providers (#313 and #314). For a chat that is safe — the three steering routes forward
 and Go answers, because Go holds the session. **For a scheduled task there is no
 second implementation behind it**: with the sidecar not scheduling, a task Rust
 cannot run does not fail, it *silently never runs*, and the job history has no
@@ -2800,10 +2882,10 @@ the sidecar runs with `AGENTO_INTEGRATIONS=off:<the types the shell hosts>` so
 every type has a single owner — the second ownership flip after the scan's, and
 the one that had to be *per type*, since `whatsapp`'s starter opens a live
 connection the sidecar's own endpoints read. `chat/runner.rs` therefore refuses
-only an agent naming an integration Rust cannot host, which is the three types
-#313–#315 cover. #312 also produced the reflector divergence map
+only an agent naming an integration Rust cannot host, which is the two types
+#313 and #314 cover. #312 also produced the reflector divergence map
 (`parity/jsonschema_reflect_vectors.json` + `claude/schema_vectors.rs`), which
-is the file to read before starting #313–#315. **#317 and #316 followed** — the
+is the file to read before starting #313 and #314. **#317, #316 and #315 followed** — the
 Confluence and Jira integrations, six and nine tools, pinned by
 `parity/confluence_vectors.json` and `parity/jira_vectors.json`. Read Confluence
 first (it is the smaller worked example) and then Jira, which is where a shared

--- a/desktop/parity/slack_parity_test.go
+++ b/desktop/parity/slack_parity_test.go
@@ -472,6 +472,33 @@ func slackCallCases() []slackCallCase {
 			script:   slackResponseScript{Status: http.StatusOK, Body: `<html>nope</html>`},
 			rustText: "parsing response: expected value at line 1 column 1",
 		},
+		{
+			// Slack sends `"error": null` on a success. `encoding/json` reads a
+			// null as the zero value, so this is an ordinary success — where a
+			// plain serde derive calls it a type error and turns a Go success into
+			// a tool error.
+			name:   "get_channel_info/a null error field is a zero value, not a type error",
+			tool:   "get_channel_info",
+			args:   map[string]any{"channel": "C1"},
+			script: slackResponseScript{Status: http.StatusOK, Body: `{"ok":true,"error":null}`},
+		},
+		{
+			name:   "get_channel_info/a null ok field is a false one",
+			tool:   "get_channel_info",
+			args:   map[string]any{"channel": "C1"},
+			script: slackResponseScript{Status: http.StatusOK, Body: `{"ok":null}`},
+		},
+		{
+			// The other direction: serde builds a struct from a sequence
+			// positionally when every field has a default, so without `GoStruct`
+			// this would decode to `ok: true` and return the array as a success.
+			// Go refuses it, and the two refusals word it differently.
+			name:     "get_channel_info/a JSON array is not a struct",
+			tool:     "get_channel_info",
+			args:     map[string]any{"channel": "C1"},
+			script:   slackResponseScript{Status: http.StatusOK, Body: `[true]`},
+			rustText: "parsing response: invalid type: sequence, expected a JSON object at line 1 column 0",
+		},
 
 		// ─── rate limiting ───────────────────────────────────────────────────
 		{

--- a/desktop/parity/slack_parity_test.go
+++ b/desktop/parity/slack_parity_test.go
@@ -489,6 +489,15 @@ func slackCallCases() []slackCallCase {
 			script: slackResponseScript{Status: http.StatusOK, Body: `{"ok":null}`},
 		},
 		{
+			// The same rule one level further out: `json.Unmarshal` of a bare
+			// `null` into a struct is a no-op returning nil, so Go falls through
+			// to the `!ok` branch rather than failing to parse.
+			name:   "get_channel_info/a bare null body is a no-op, not a parse failure",
+			tool:   "get_channel_info",
+			args:   map[string]any{"channel": "C1"},
+			script: slackResponseScript{Status: http.StatusOK, Body: `null`},
+		},
+		{
 			// The other direction: serde builds a struct from a sequence
 			// positionally when every field has a default, so without `GoStruct`
 			// this would decode to `ok: true` and return the array as a success.

--- a/desktop/parity/slack_parity_test.go
+++ b/desktop/parity/slack_parity_test.go
@@ -1,0 +1,688 @@
+// Cross-language vectors for the Slack integration MCP server
+// (`internal/integrations/slack`, ported in #315 to
+// `desktop/src-tauri/src/native/integrations/slack/`).
+//
+// Four things have to match byte for byte, none checkable from one language
+// alone: which tools are hosted, each advertised schema, the request each tool
+// builds, and the result text of every success and every failure. The reasoning
+// for each is in `confluence_parity_test.go`'s header and is not repeated.
+//
+// Slack-specific things pinned here that a port would otherwise get wrong:
+//
+//   - **`ok` decides, not the HTTP status.** `readSlackResponse` checks 429 and
+//     then ignores the status, so a 500 carrying `{"ok":true}` is a **success**
+//     and a 200 carrying `{"ok":false}` is a failure. Every other integration in
+//     this tree gates on the 2xx range, so this is the one a port gets backwards.
+//   - **Two encodings.** Five tools send `url.Values.Encode()` as
+//     `application/x-www-form-urlencoded`; two send `json.Marshal` as
+//     `application/json; charset=utf-8` — with the charset, which nothing else
+//     sends.
+//   - **Every clamp differs**: 1000/100 for the two listers, 100/20 for
+//     `read_messages` and `search_messages`' count, and a floor of 1 with **no
+//     ceiling** for `page`.
+//   - **Five tools return Slack's body unlabelled**; the two senders prefix it.
+//   - **Rate limiting is its own sentence**, interpolating `Retry-After`
+//     verbatim — including when the header is absent, which lands as an empty
+//     string mid-sentence.
+//   - **`resolveToken` has three arms**, and the third is the one a port drops:
+//     an unrecognized `auth_mode` falls back to a non-empty bot token. The
+//     `tokens` block pins all of them, including that `oauth` reads the **`auth`
+//     column** rather than the credentials blob.
+//
+// The Rust half lives in
+// `desktop/src-tauri/src/native/integrations/slack/tests_vectors.rs` and reads
+// this same file.
+//
+// Regenerate (only from Go, and only when adding cases):
+//
+//	go test ./desktop/parity/ -run TestSlackVectors -update-slack-vectors
+package parity
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	mcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/shaharia-lab/agento/internal/config"
+	"github.com/shaharia-lab/agento/internal/integrations/slack"
+)
+
+const slackVectorsFile = "slack_vectors.json"
+
+var updateSlackVectors = flag.Bool("update-slack-vectors", false,
+	"rewrite slack_vectors.json from this Go toolchain")
+
+// A fixture, not a secret. Recorded so the `Bearer ` prefix is pinned — Slack's
+// own docs use `Bearer` and the older `token=` form still exists, so which one a
+// port sends is exactly what no response reveals.
+const slackParityToken = "xoxb-parity-slack-token" //nolint:gosec // a test fixture, not a credential
+
+// slackParityID is the integration id, and half of the server name.
+const slackParityID = "slack-parity"
+
+type slackToolVector struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"input_schema"`
+}
+
+// slackRequestVector is what the fake Slack saw. Slack takes everything in the
+// body, so `Target` is only ever `/<method>` — the interesting fields are
+// `ContentType` and `Body`.
+type slackRequestVector struct {
+	Method        string `json:"method"`
+	Target        string `json:"target"`
+	Authorization string `json:"authorization"`
+	ContentType   string `json:"content_type"`
+	Body          string `json:"body"`
+}
+
+// slackResponseScript is what the fake answered with. `RetryAfter` is sent only
+// when non-empty, which is how the absent-header case is scripted.
+type slackResponseScript struct {
+	Status     int    `json:"status"`
+	RetryAfter string `json:"retry_after,omitempty"`
+	Body       string `json:"body"`
+}
+
+type slackCallVector struct {
+	Case      string              `json:"case"`
+	Tool      string              `json:"tool"`
+	Arguments json.RawMessage     `json:"arguments"`
+	Response  slackResponseScript `json:"response"`
+	Request   *slackRequestVector `json:"request"`
+	IsError   bool                `json:"is_error"`
+	Text      string              `json:"text"`
+	// A pinned divergence rather than a match. Two users: `encoding/json`'s
+	// syntax-error vocabulary when Slack's body will not parse, and the
+	// zero-fraction float the Go SDK re-marshals into an integer.
+	RustText string `json:"rust_text,omitempty"`
+	// Go made a request and this port deliberately makes none — one user, the
+	// zero-fraction float, whose decode fails before any handler runs.
+	RustNoRequest bool `json:"rust_no_request,omitempty"`
+}
+
+type slackHostingVector struct {
+	Case     string                          `json:"case"`
+	Services map[string]config.ServiceConfig `json:"services"`
+	Tools    []string                        `json:"tools"`
+}
+
+// slackTokenVector pins `resolveToken`: which column the token comes from, and
+// what each failure says.
+//
+// This is the only integration whose token can come from the **`auth`** column,
+// so the port had to widen a projection that deliberately never selected it.
+type slackTokenVector struct {
+	Case string `json:"case"`
+	// The `credentials` column, verbatim.
+	Credentials string `json:"credentials"`
+	// The `auth` column, verbatim. Also what `IsAuthenticated` is computed from,
+	// so it is never empty in a case that reaches `resolveToken`.
+	Auth string `json:"auth"`
+	// The `Authorization` header the resulting server sends, which is how the
+	// resolved token is observed without recording it directly. Empty when
+	// starting failed.
+	Authorization string `json:"authorization,omitempty"`
+	// `Start`'s error, when there is one.
+	Error string `json:"error,omitempty"`
+	// Set where the port words the same refusal differently — one cause, an
+	// `encoding/json` decode failure, whose Go text is not reproducible and
+	// whose serde text would quote the token being decoded.
+	RustError string `json:"rust_error,omitempty"`
+}
+
+type slackVectors struct {
+	Comment       []string             `json:"_comment"`
+	IntegrationID string               `json:"integration_id"`
+	ServerName    string               `json:"server_name"`
+	Version       string               `json:"version"`
+	Token         string               `json:"token"`
+	Tools         []slackToolVector    `json:"tools"`
+	Hosting       []slackHostingVector `json:"hosting"`
+	Tokens        []slackTokenVector   `json:"tokens"`
+	Calls         []slackCallVector    `json:"calls"`
+}
+
+// ─── The fake Slack ──────────────────────────────────────────────────────────
+
+type fakeSlack struct {
+	mu     sync.Mutex
+	script slackResponseScript
+	seen   *slackRequestVector
+}
+
+func (f *fakeSlack) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		body = nil
+	}
+	f.mu.Lock()
+	script := f.script
+	f.seen = &slackRequestVector{
+		Method:        r.Method,
+		Target:        r.URL.RequestURI(),
+		Authorization: r.Header.Get("Authorization"),
+		ContentType:   r.Header.Get("Content-Type"),
+		Body:          string(body),
+	}
+	f.mu.Unlock()
+
+	if script.RetryAfter != "" {
+		w.Header().Set("Retry-After", script.RetryAfter)
+	}
+	w.WriteHeader(script.Status)
+	_, _ = w.Write([]byte(script.Body))
+}
+
+func (f *fakeSlack) arm(script slackResponseScript) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.script = script
+	f.seen = nil
+}
+
+func (f *fakeSlack) recorded() *slackRequestVector {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.seen
+}
+
+// ─── Standing the real server up ─────────────────────────────────────────────
+
+// slackConfig is a row in the shape `Start` reads.
+func slackConfig(
+	t *testing.T, services map[string]config.ServiceConfig, credentials, auth string,
+) *config.IntegrationConfig {
+	t.Helper()
+	return &config.IntegrationConfig{
+		ID:          slackParityID,
+		Name:        "Slack (parity)",
+		Type:        "slack",
+		Enabled:     true,
+		Credentials: json.RawMessage(credentials),
+		Auth:        json.RawMessage(auth),
+		Services:    services,
+	}
+}
+
+// botTokenCredentials is the ordinary row: `bot_token` mode with the fixture.
+func botTokenCredentials() string {
+	return fmt.Sprintf(`{"auth_mode":"bot_token","bot_token":%q}`, slackParityToken)
+}
+
+func slackSession(
+	t *testing.T, ctx context.Context, services map[string]config.ServiceConfig,
+) *mcp.ClientSession {
+	t.Helper()
+
+	serverCfg, err := slack.Start(ctx, slackConfig(t, services, botTokenCredentials(), `{"team":"parity"}`))
+	if err != nil {
+		t.Fatalf("starting the slack integration: %v", err)
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "parity", Version: "1"}, nil)
+	session, err := client.Connect(ctx,
+		&mcp.StreamableClientTransport{Endpoint: serverCfg.URL}, nil)
+	if err != nil {
+		t.Fatalf("connecting to %s: %v", serverCfg.URL, err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	return session
+}
+
+func slackAllServices() map[string]config.ServiceConfig {
+	return map[string]config.ServiceConfig{"messaging": {Enabled: true}}
+}
+
+var slackHostingCases = []slackHostingVector{
+	{Case: "the service enabled with no tool list — an empty allowed set hosts everything",
+		Services: slackAllServices()},
+	{Case: "no services at all", Services: map[string]config.ServiceConfig{}},
+	{Case: "the service disabled contributes neither its gate nor its tools",
+		Services: map[string]config.ServiceConfig{
+			"messaging": {Enabled: false, Tools: []string{"send_message"}},
+		}},
+	{Case: "a non-empty allowed set is a filter",
+		Services: map[string]config.ServiceConfig{
+			"messaging": {Enabled: true, Tools: []string{"send_message", "list_users"}},
+		}},
+	{Case: "an enabled but unknown service still narrows the one that exists",
+		Services: map[string]config.ServiceConfig{
+			"messaging": {Enabled: true},
+			"other":     {Enabled: true, Tools: []string{"read_messages"}},
+		}},
+	{Case: "a tool named by a disabled service is not allowed anywhere",
+		Services: map[string]config.ServiceConfig{
+			"messaging": {Enabled: true, Tools: []string{"get_channel_info"}},
+			"other":     {Enabled: false, Tools: []string{"send_reply"}},
+		}},
+}
+
+// slackTokenCases exercise `resolveToken` — every arm, and both columns.
+var slackTokenCases = []struct {
+	name        string
+	credentials string
+	auth        string
+	rustError   string
+}{
+	{
+		name:        "bot_token mode reads the credentials blob",
+		credentials: botTokenCredentials(),
+		auth:        `{"team":"parity"}`,
+	},
+	{
+		// The arm no other integration has: the token is the **`auth` column**,
+		// decoded as an `oauth2.Token`.
+		name:        "oauth mode reads the auth column, not the credentials",
+		credentials: `{"auth_mode":"oauth","bot_token":"xoxb-ignored-in-oauth-mode"}`,
+		auth:        `{"access_token":"xoxp-parity-oauth-token","token_type":"Bearer"}`,
+	},
+	{
+		// The fallback a port drops: an unrecognized mode still works if a bot
+		// token is there.
+		name:        "an unrecognized auth_mode falls back to a non-empty bot token",
+		credentials: fmt.Sprintf(`{"auth_mode":"","bot_token":%q}`, slackParityToken),
+		auth:        `{"team":"parity"}`,
+	},
+	{
+		name:        "an unrecognized auth_mode with no bot token is refused",
+		credentials: `{"auth_mode":"magic","bot_token":""}`,
+		auth:        `{"team":"parity"}`,
+	},
+	{
+		name:        "bot_token mode with an empty token is refused",
+		credentials: `{"auth_mode":"bot_token","bot_token":""}`,
+		auth:        `{"team":"parity"}`,
+	},
+	{
+		// `oauth` with an `auth` column that is not a token: Go's
+		// `encoding/json` wording is not reproducible, and serde's would quote
+		// the value being decoded — which in this arm is the access token.
+		name:        "oauth mode with an auth column that does not decode",
+		credentials: `{"auth_mode":"oauth"}`,
+		auth:        `["not","a","token"]`,
+		rustError: "resolving slack token for \"slack-parity\": parsing oauth token: " +
+			"does not decode at line 1 column 8",
+	},
+	{
+		// An `auth` column that decodes but carries no access token yields an
+		// **empty** bearer, which Go sends as `Bearer ` — a header a port might
+		// "helpfully" omit.
+		name:        "oauth mode with no access_token sends an empty bearer",
+		credentials: `{"auth_mode":"oauth"}`,
+		auth:        `{"token_type":"Bearer"}`,
+	},
+}
+
+// ─── The call cases ──────────────────────────────────────────────────────────
+
+// slackOK is a success envelope hostile to a re-encode: keys out of order, a
+// trailing-zero decimal, an integer too large for a float64, interior
+// whitespace. Go passes the bytes through verbatim.
+const slackOK = `{"ok":true,"zebra":1,"id":10152021304050607,"rate":1.50, "channels":[]}`
+
+type slackCallCase struct {
+	name          string
+	tool          string
+	args          map[string]any
+	script        slackResponseScript
+	rustText      string
+	rustNoRequest bool
+}
+
+func slackOKScript() slackResponseScript {
+	return slackResponseScript{Status: http.StatusOK, Body: slackOK}
+}
+
+func slackCallCases() []slackCallCase {
+	return []slackCallCase{
+		// ─── list_channels ───────────────────────────────────────────────────
+		{
+			name:   "list_channels/zero limit takes the 100 fallback and sends no cursor",
+			tool:   "list_channels",
+			args:   map[string]any{"limit": 0, "cursor": ""},
+			script: slackOKScript(),
+		},
+		{
+			name:   "list_channels/over 1000 falls back to 100, and a cursor is url-encoded",
+			tool:   "list_channels",
+			args:   map[string]any{"limit": 1001, "cursor": "dXNlcjpVMDYx a+b"},
+			script: slackOKScript(),
+		},
+		{
+			name:   "list_channels/1000 is the largest value that survives",
+			tool:   "list_channels",
+			args:   map[string]any{"limit": 1000, "cursor": ""},
+			script: slackOKScript(),
+		},
+
+		// ─── get_channel_info ────────────────────────────────────────────────
+		{
+			name:   "get_channel_info/one form field",
+			tool:   "get_channel_info",
+			args:   map[string]any{"channel": "C0123"},
+			script: slackOKScript(),
+		},
+		{
+			name:   "get_channel_info/a channel needing form escaping",
+			tool:   "get_channel_info",
+			args:   map[string]any{"channel": "a b&c=d/e日本語"},
+			script: slackOKScript(),
+		},
+
+		// ─── read_messages ───────────────────────────────────────────────────
+		{
+			// 100/20 here, a tenth of the listers' ceiling.
+			name:   "read_messages/the clamp is 100 and the fallback 20, not the listers' 1000 and 100",
+			tool:   "read_messages",
+			args:   map[string]any{"channel": "C1", "limit": 101, "cursor": ""},
+			script: slackOKScript(),
+		},
+		{
+			name:   "read_messages/100 survives, and a cursor is sent",
+			tool:   "read_messages",
+			args:   map[string]any{"channel": "C1", "limit": 100, "cursor": "next"},
+			script: slackOKScript(),
+		},
+
+		// ─── send_message / send_reply ───────────────────────────────────────
+		{
+			// JSON, with the charset nothing else sends, and sorted keys.
+			name:   "send_message/a JSON body with the charset content type",
+			tool:   "send_message",
+			args:   map[string]any{"channel": "C1", "text": "hello <there> & welcome"},
+			script: slackOKScript(),
+		},
+		{
+			name:   "send_reply/the same Slack method with one more key, and a different sentence",
+			tool:   "send_reply",
+			args:   map[string]any{"channel": "C1", "thread_ts": "1727700000.000100", "text": "ack"},
+			script: slackOKScript(),
+		},
+
+		// ─── list_users ──────────────────────────────────────────────────────
+		{
+			name:   "list_users/no channel field at all, unlike read_messages",
+			tool:   "list_users",
+			args:   map[string]any{"limit": 0, "cursor": ""},
+			script: slackOKScript(),
+		},
+
+		// ─── search_messages ─────────────────────────────────────────────────
+		{
+			name:   "search_messages/count clamps at 100 and page has a floor of 1",
+			tool:   "search_messages",
+			args:   map[string]any{"query": "from:me in:#general", "count": 0, "page": 0},
+			script: slackOKScript(),
+		},
+		{
+			// `page` has **no ceiling**, unlike every other numeric input.
+			name:   "search_messages/page has no ceiling",
+			tool:   "search_messages",
+			args:   map[string]any{"query": "x", "count": 101, "page": 999999},
+			script: slackOKScript(),
+		},
+		{
+			name:   "search_messages/an empty query still sends the key",
+			tool:   "search_messages",
+			args:   map[string]any{"query": "", "count": 50, "page": 2},
+			script: slackOKScript(),
+		},
+
+		// ─── the envelope, which decides instead of the status ────────────────
+		{
+			name:   "list_users/a 200 carrying ok:false is a failure",
+			tool:   "list_users",
+			args:   map[string]any{"limit": 0, "cursor": ""},
+			script: slackResponseScript{Status: http.StatusOK, Body: `{"ok":false,"error":"not_authed"}`},
+		},
+		{
+			// The one that reads backwards: a 500 with `ok:true` is a success,
+			// and the body is returned verbatim.
+			name:   "list_users/a 500 carrying ok:true is a success",
+			tool:   "list_users",
+			args:   map[string]any{"limit": 0, "cursor": ""},
+			script: slackResponseScript{Status: http.StatusInternalServerError, Body: slackOK},
+		},
+		{
+			name:   "get_channel_info/ok:false with no error field interpolates an empty one",
+			tool:   "get_channel_info",
+			args:   map[string]any{"channel": "C1"},
+			script: slackResponseScript{Status: http.StatusOK, Body: `{"ok":false}`},
+		},
+		{
+			// A body that is not JSON at all. Go's scanner vocabulary has no
+			// serde equivalent, so the sentence is pinned as a divergence.
+			name:     "get_channel_info/a body that is not JSON",
+			tool:     "get_channel_info",
+			args:     map[string]any{"channel": "C1"},
+			script:   slackResponseScript{Status: http.StatusOK, Body: `<html>nope</html>`},
+			rustText: "parsing response: expected value at line 1 column 1",
+		},
+
+		// ─── rate limiting ───────────────────────────────────────────────────
+		{
+			name:   "send_message/429 is its own sentence, carrying Retry-After",
+			tool:   "send_message",
+			args:   map[string]any{"channel": "C1", "text": "hi"},
+			script: slackResponseScript{Status: http.StatusTooManyRequests, RetryAfter: "30", Body: ""},
+		},
+		{
+			// An absent header is `""` to Go, which lands mid-sentence as two
+			// spaces. A port that omitted it would read differently.
+			name:   "read_messages/429 with no Retry-After leaves an empty gap in the sentence",
+			tool:   "read_messages",
+			args:   map[string]any{"channel": "C1", "limit": 0, "cursor": ""},
+			script: slackResponseScript{Status: http.StatusTooManyRequests, Body: ""},
+		},
+
+		// ─── a zero-fraction float, which models do emit ──────────────────────
+		{
+			name:          "list_channels/a zero-fraction float is an integer to Go and not to serde",
+			tool:          "list_channels",
+			args:          map[string]any{"limit": json.RawMessage("100.0"), "cursor": ""},
+			script:        slackOKScript(),
+			rustText:      "failed to deserialize parameters: invalid type: floating point `100.0`, expected i64",
+			rustNoRequest: true,
+		},
+	}
+}
+
+// ─── The generator ───────────────────────────────────────────────────────────
+
+func TestSlackVectors(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	fake := &fakeSlack{}
+	srv := httptest.NewServer(fake)
+	defer srv.Close()
+	restore := slack.SetAPIBase(srv.URL)
+	defer restore()
+
+	want := slackVectors{
+		Comment: []string{
+			"Cross-language parity vectors for internal/integrations/slack, the Slack",
+			"integration's in-process MCP server. Generated from Go, then frozen. Read by",
+			"desktop/parity/slack_parity_test.go (Go) and by",
+			"desktop/src-tauri/src/native/integrations/slack/ (Rust). Every value is exactly",
+			"what Go produces, so a divergence fails one language against the other's real",
+			"output rather than against a belief about it.",
+			"'tools' and 'hosting' come from live tools/list calls against servers built by",
+			"slack.Start; 'calls' from live tools/call calls against a scripted fake Slack",
+			"that records the request each tool built; 'tokens' pin resolveToken, including",
+			"that oauth mode reads the auth column rather than the credentials blob.",
+			"'token' is a fixture, not a secret: it is recorded so the Bearer prefix is pinned.",
+			"Regenerate with: go test ./desktop/parity/ -run TestSlackVectors -update-slack-vectors",
+		},
+		IntegrationID: slackParityID,
+		ServerName:    fmt.Sprintf("slack-%s", slackParityID),
+		Version:       "1.0.0",
+		Token:         slackParityToken,
+	}
+
+	session := slackSession(t, ctx, slackAllServices())
+	listed, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("tools/list: %v", err)
+	}
+	for _, tool := range listed.Tools {
+		schema, err := json.Marshal(tool.InputSchema)
+		if err != nil {
+			t.Fatalf("encoding %s's input schema: %v", tool.Name, err)
+		}
+		want.Tools = append(want.Tools, slackToolVector{
+			Name:        tool.Name,
+			Description: tool.Description,
+			InputSchema: schema,
+		})
+	}
+
+	for _, hosting := range slackHostingCases {
+		hosting.Tools = slackHostedTools(t, ctx, hosting.Services)
+		want.Hosting = append(want.Hosting, hosting)
+	}
+
+	for _, c := range slackTokenCases {
+		vector := runSlackTokenCase(t, ctx, fake, c.name, c.credentials, c.auth)
+		vector.RustError = c.rustError
+		want.Tokens = append(want.Tokens, vector)
+	}
+
+	for _, c := range slackCallCases() {
+		want.Calls = append(want.Calls, runSlackCallCase(t, ctx, session, fake, c))
+	}
+
+	encoded, err := json.MarshalIndent(want, "", "  ")
+	if err != nil {
+		t.Fatalf("encoding vectors: %v", err)
+	}
+	encoded = append(encoded, '\n')
+
+	if *updateSlackVectors {
+		if err := os.WriteFile(slackVectorsFile, encoded, 0o600); err != nil {
+			t.Fatalf("writing %s: %v", slackVectorsFile, err)
+		}
+		t.Logf("wrote %s", slackVectorsFile)
+		return
+	}
+
+	frozen, err := os.ReadFile(slackVectorsFile)
+	if err != nil {
+		t.Fatalf("reading %s (regenerate with -update-slack-vectors): %v", slackVectorsFile, err)
+	}
+	if string(frozen) != string(encoded) {
+		t.Fatalf("%s is stale: this Go toolchain produces different results.\n"+
+			"Regenerate with -update-slack-vectors and check what moved — the Rust port in "+
+			"native/integrations/slack/ reads the same file and will fail against it. A moved "+
+			"tool name, schema, request or sentence is not a cosmetic diff: the names are in "+
+			"every agent's stored allowlist and in every tool_use block already written, and "+
+			"the sentences are what the model reads.",
+			slackVectorsFile)
+	}
+}
+
+func slackHostedTools(
+	t *testing.T, ctx context.Context, services map[string]config.ServiceConfig,
+) []string {
+	t.Helper()
+	listed, err := slackSession(t, ctx, services).ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("tools/list: %v", err)
+	}
+	names := make([]string, 0, len(listed.Tools))
+	for _, tool := range listed.Tools {
+		names = append(names, tool.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// runSlackTokenCase starts a server for the given columns and observes which
+// token it resolved by making one call and reading the fake's `Authorization`
+// header — rather than recording the token directly, which would put the
+// resolution under test into the fixture that verifies it.
+func runSlackTokenCase(
+	t *testing.T, ctx context.Context, fake *fakeSlack, name, credentials, auth string,
+) slackTokenVector {
+	t.Helper()
+	vector := slackTokenVector{Case: name, Credentials: credentials, Auth: auth}
+
+	serverCfg, err := slack.Start(ctx, slackConfig(t, slackAllServices(), credentials, auth))
+	if err != nil {
+		vector.Error = err.Error()
+		return vector
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "parity", Version: "1"}, nil)
+	session, err := client.Connect(ctx,
+		&mcp.StreamableClientTransport{Endpoint: serverCfg.URL}, nil)
+	if err != nil {
+		t.Fatalf("%s: connecting: %v", name, err)
+	}
+	defer func() { _ = session.Close() }()
+
+	fake.arm(slackOKScript())
+	if _, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "list_users", Arguments: jsonArgs(t, map[string]any{"limit": 0, "cursor": ""}),
+	}); err != nil {
+		t.Fatalf("%s: tools/call: %v", name, err)
+	}
+	recorded := fake.recorded()
+	if recorded == nil {
+		t.Fatalf("%s: no request reached the fake", name)
+	}
+	vector.Authorization = recorded.Authorization
+	return vector
+}
+
+func runSlackCallCase(
+	t *testing.T, ctx context.Context,
+	session *mcp.ClientSession, fake *fakeSlack, c slackCallCase,
+) slackCallVector {
+	t.Helper()
+
+	fake.arm(c.script)
+	args := jsonArgs(t, c.args)
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: c.tool, Arguments: args,
+	})
+	if err != nil {
+		t.Fatalf("%s: tools/call: %v", c.name, err)
+	}
+	if len(result.Content) != 1 {
+		t.Fatalf("%s: want exactly one content block, got %d", c.name, len(result.Content))
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("%s: want text content, got %T", c.name, result.Content[0])
+	}
+	if strings.Contains(text.Text, slackParityToken) {
+		t.Fatalf("%s: the token leaked into a tool result: %s", c.name, text.Text)
+	}
+
+	return slackCallVector{
+		Case:          c.name,
+		Tool:          c.tool,
+		Arguments:     args,
+		Response:      c.script,
+		Request:       fake.recorded(),
+		IsError:       result.IsError,
+		Text:          text.Text,
+		RustText:      c.rustText,
+		RustNoRequest: c.rustNoRequest,
+	}
+}

--- a/desktop/parity/slack_vectors.json
+++ b/desktop/parity/slack_vectors.json
@@ -681,6 +681,67 @@
       "rust_text": "parsing response: expected value at line 1 column 1"
     },
     {
+      "case": "get_channel_info/a null error field is a zero value, not a type error",
+      "tool": "get_channel_info",
+      "arguments": {
+        "channel": "C1"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"error\":null}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/conversations.info",
+        "authorization": "Bearer xoxb-parity-slack-token",
+        "content_type": "application/x-www-form-urlencoded",
+        "body": "channel=C1"
+      },
+      "is_error": false,
+      "text": "{\"ok\":true,\"error\":null}"
+    },
+    {
+      "case": "get_channel_info/a null ok field is a false one",
+      "tool": "get_channel_info",
+      "arguments": {
+        "channel": "C1"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":null}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/conversations.info",
+        "authorization": "Bearer xoxb-parity-slack-token",
+        "content_type": "application/x-www-form-urlencoded",
+        "body": "channel=C1"
+      },
+      "is_error": true,
+      "text": "slack API error (conversations.info): "
+    },
+    {
+      "case": "get_channel_info/a JSON array is not a struct",
+      "tool": "get_channel_info",
+      "arguments": {
+        "channel": "C1"
+      },
+      "response": {
+        "status": 200,
+        "body": "[true]"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/conversations.info",
+        "authorization": "Bearer xoxb-parity-slack-token",
+        "content_type": "application/x-www-form-urlencoded",
+        "body": "channel=C1"
+      },
+      "is_error": true,
+      "text": "parsing response: json: cannot unmarshal array into Go value of type struct { OK bool \"json:\\\"ok\\\"\"; Error string \"json:\\\"error,omitempty\\\"\" }",
+      "rust_text": "parsing response: invalid type: sequence, expected a JSON object at line 1 column 0"
+    },
+    {
       "case": "send_message/429 is its own sentence, carrying Retry-After",
       "tool": "send_message",
       "arguments": {

--- a/desktop/parity/slack_vectors.json
+++ b/desktop/parity/slack_vectors.json
@@ -721,6 +721,26 @@
       "text": "slack API error (conversations.info): "
     },
     {
+      "case": "get_channel_info/a bare null body is a no-op, not a parse failure",
+      "tool": "get_channel_info",
+      "arguments": {
+        "channel": "C1"
+      },
+      "response": {
+        "status": 200,
+        "body": "null"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/conversations.info",
+        "authorization": "Bearer xoxb-parity-slack-token",
+        "content_type": "application/x-www-form-urlencoded",
+        "body": "channel=C1"
+      },
+      "is_error": true,
+      "text": "slack API error (conversations.info): "
+    },
+    {
       "case": "get_channel_info/a JSON array is not a struct",
       "tool": "get_channel_info",
       "arguments": {

--- a/desktop/parity/slack_vectors.json
+++ b/desktop/parity/slack_vectors.json
@@ -1,0 +1,751 @@
+{
+  "_comment": [
+    "Cross-language parity vectors for internal/integrations/slack, the Slack",
+    "integration's in-process MCP server. Generated from Go, then frozen. Read by",
+    "desktop/parity/slack_parity_test.go (Go) and by",
+    "desktop/src-tauri/src/native/integrations/slack/ (Rust). Every value is exactly",
+    "what Go produces, so a divergence fails one language against the other's real",
+    "output rather than against a belief about it.",
+    "'tools' and 'hosting' come from live tools/list calls against servers built by",
+    "slack.Start; 'calls' from live tools/call calls against a scripted fake Slack",
+    "that records the request each tool built; 'tokens' pin resolveToken, including",
+    "that oauth mode reads the auth column rather than the credentials blob.",
+    "'token' is a fixture, not a secret: it is recorded so the Bearer prefix is pinned.",
+    "Regenerate with: go test ./desktop/parity/ -run TestSlackVectors -update-slack-vectors"
+  ],
+  "integration_id": "slack-parity",
+  "server_name": "slack-slack-parity",
+  "version": "1.0.0",
+  "token": "xoxb-parity-slack-token",
+  "tools": [
+    {
+      "name": "get_channel_info",
+      "description": "Gets detailed information about a Slack channel.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "channel": {
+            "description": "required,Channel ID to get info for",
+            "type": "string"
+          }
+        },
+        "required": [
+          "channel"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_channels",
+      "description": "Lists Slack channels (public and private) the bot has access to.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "cursor": {
+            "description": "Pagination cursor for next page of results",
+            "type": "string"
+          },
+          "limit": {
+            "description": "Maximum number of channels to return (default 100, max 1000)",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "limit",
+          "cursor"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_users",
+      "description": "Lists users in the Slack workspace.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "cursor": {
+            "description": "Pagination cursor for next page of results",
+            "type": "string"
+          },
+          "limit": {
+            "description": "Maximum number of users to return (default 100, max 1000)",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "limit",
+          "cursor"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "read_messages",
+      "description": "Reads recent messages from a Slack channel.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "channel": {
+            "description": "required,Channel ID to read messages from",
+            "type": "string"
+          },
+          "cursor": {
+            "description": "Pagination cursor for next page of results",
+            "type": "string"
+          },
+          "limit": {
+            "description": "Maximum number of messages to return (default 20, max 100)",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "channel",
+          "limit",
+          "cursor"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "search_messages",
+      "description": "Searches messages across the Slack workspace. Note: requires OAuth authentication (user token). This tool will return an error when used with a bot token.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "count": {
+            "description": "Number of results to return per page (default 20, max 100)",
+            "type": "integer"
+          },
+          "page": {
+            "description": "Page number of results to return (default 1)",
+            "type": "integer"
+          },
+          "query": {
+            "description": "required,Search query string",
+            "type": "string"
+          }
+        },
+        "required": [
+          "query",
+          "count",
+          "page"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "send_message",
+      "description": "Sends a message to a Slack channel.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "channel": {
+            "description": "required,Channel ID to send the message to",
+            "type": "string"
+          },
+          "text": {
+            "description": "required,Text of the message to send",
+            "type": "string"
+          }
+        },
+        "required": [
+          "channel",
+          "text"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "send_reply",
+      "description": "Sends a threaded reply to a message in a Slack channel.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "channel": {
+            "description": "required,Channel ID containing the thread",
+            "type": "string"
+          },
+          "text": {
+            "description": "required,Text of the reply",
+            "type": "string"
+          },
+          "thread_ts": {
+            "description": "required,Timestamp of the parent message to reply to",
+            "type": "string"
+          }
+        },
+        "required": [
+          "channel",
+          "thread_ts",
+          "text"
+        ],
+        "type": "object"
+      }
+    }
+  ],
+  "hosting": [
+    {
+      "case": "the service enabled with no tool list — an empty allowed set hosts everything",
+      "services": {
+        "messaging": {
+          "enabled": true,
+          "tools": null
+        }
+      },
+      "tools": [
+        "get_channel_info",
+        "list_channels",
+        "list_users",
+        "read_messages",
+        "search_messages",
+        "send_message",
+        "send_reply"
+      ]
+    },
+    {
+      "case": "no services at all",
+      "services": {},
+      "tools": []
+    },
+    {
+      "case": "the service disabled contributes neither its gate nor its tools",
+      "services": {
+        "messaging": {
+          "enabled": false,
+          "tools": [
+            "send_message"
+          ]
+        }
+      },
+      "tools": []
+    },
+    {
+      "case": "a non-empty allowed set is a filter",
+      "services": {
+        "messaging": {
+          "enabled": true,
+          "tools": [
+            "send_message",
+            "list_users"
+          ]
+        }
+      },
+      "tools": [
+        "list_users",
+        "send_message"
+      ]
+    },
+    {
+      "case": "an enabled but unknown service still narrows the one that exists",
+      "services": {
+        "messaging": {
+          "enabled": true,
+          "tools": null
+        },
+        "other": {
+          "enabled": true,
+          "tools": [
+            "read_messages"
+          ]
+        }
+      },
+      "tools": [
+        "read_messages"
+      ]
+    },
+    {
+      "case": "a tool named by a disabled service is not allowed anywhere",
+      "services": {
+        "messaging": {
+          "enabled": true,
+          "tools": [
+            "get_channel_info"
+          ]
+        },
+        "other": {
+          "enabled": false,
+          "tools": [
+            "send_reply"
+          ]
+        }
+      },
+      "tools": [
+        "get_channel_info"
+      ]
+    }
+  ],
+  "tokens": [
+    {
+      "case": "bot_token mode reads the credentials blob",
+      "credentials": "{\"auth_mode\":\"bot_token\",\"bot_token\":\"xoxb-parity-slack-token\"}",
+      "auth": "{\"team\":\"parity\"}",
+      "authorization": "Bearer xoxb-parity-slack-token"
+    },
+    {
+      "case": "oauth mode reads the auth column, not the credentials",
+      "credentials": "{\"auth_mode\":\"oauth\",\"bot_token\":\"xoxb-ignored-in-oauth-mode\"}",
+      "auth": "{\"access_token\":\"xoxp-parity-oauth-token\",\"token_type\":\"Bearer\"}",
+      "authorization": "Bearer xoxp-parity-oauth-token"
+    },
+    {
+      "case": "an unrecognized auth_mode falls back to a non-empty bot token",
+      "credentials": "{\"auth_mode\":\"\",\"bot_token\":\"xoxb-parity-slack-token\"}",
+      "auth": "{\"team\":\"parity\"}",
+      "authorization": "Bearer xoxb-parity-slack-token"
+    },
+    {
+      "case": "an unrecognized auth_mode with no bot token is refused",
+      "credentials": "{\"auth_mode\":\"magic\",\"bot_token\":\"\"}",
+      "auth": "{\"team\":\"parity\"}",
+      "error": "resolving slack token for \"slack-parity\": unsupported auth_mode \"magic\" and no bot_token available"
+    },
+    {
+      "case": "bot_token mode with an empty token is refused",
+      "credentials": "{\"auth_mode\":\"bot_token\",\"bot_token\":\"\"}",
+      "auth": "{\"team\":\"parity\"}",
+      "error": "resolving slack token for \"slack-parity\": bot_token is empty"
+    },
+    {
+      "case": "oauth mode with an auth column that does not decode",
+      "credentials": "{\"auth_mode\":\"oauth\"}",
+      "auth": "[\"not\",\"a\",\"token\"]",
+      "error": "resolving slack token for \"slack-parity\": parsing oauth token: parsing oauth token: json: cannot unmarshal array into Go value of type oauth2.Token",
+      "rust_error": "resolving slack token for \"slack-parity\": parsing oauth token: does not decode at line 1 column 8"
+    },
+    {
+      "case": "oauth mode with no access_token sends an empty bearer",
+      "credentials": "{\"auth_mode\":\"oauth\"}",
+      "auth": "{\"token_type\":\"Bearer\"}",
+      "authorization": "Bearer"
+    }
+  ],
+  "calls": [
+    {
+      "case": "list_channels/zero limit takes the 100 fallback and sends no cursor",
+      "tool": "list_channels",
+      "arguments": {
+        "cursor": "",
+        "limit": 0
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/conversations.list",
+        "authorization": "Bearer xoxb-parity-slack-token",
+        "content_type": "application/x-www-form-urlencoded",
+        "body": "limit=100\u0026types=public_channel%2Cprivate_channel"
+      },
+      "is_error": false,
+      "text": "{\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+    },
+    {
+      "case": "list_channels/over 1000 falls back to 100, and a cursor is url-encoded",
+      "tool": "list_channels",
+      "arguments": {
+        "cursor": "dXNlcjpVMDYx a+b",
+        "limit": 1001
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/conversations.list",
+        "authorization": "Bearer xoxb-parity-slack-token",
+        "content_type": "application/x-www-form-urlencoded",
+        "body": "cursor=dXNlcjpVMDYx+a%2Bb\u0026limit=100\u0026types=public_channel%2Cprivate_channel"
+      },
+      "is_error": false,
+      "text": "{\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+    },
+    {
+      "case": "list_channels/1000 is the largest value that survives",
+      "tool": "list_channels",
+      "arguments": {
+        "cursor": "",
+        "limit": 1000
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/conversations.list",
+        "authorization": "Bearer xoxb-parity-slack-token",
+        "content_type": "application/x-www-form-urlencoded",
+        "body": "limit=1000\u0026types=public_channel%2Cprivate_channel"
+      },
+      "is_error": false,
+      "text": "{\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+    },
+    {
+      "case": "get_channel_info/one form field",
+      "tool": "get_channel_info",
+      "arguments": {
+        "channel": "C0123"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/conversations.info",
+        "authorization": "Bearer xoxb-parity-slack-token",
+        "content_type": "application/x-www-form-urlencoded",
+        "body": "channel=C0123"
+      },
+      "is_error": false,
+      "text": "{\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+    },
+    {
+      "case": "get_channel_info/a channel needing form escaping",
+      "tool": "get_channel_info",
+      "arguments": {
+        "channel": "a b\u0026c=d/e日本語"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/conversations.info",
+        "authorization": "Bearer xoxb-parity-slack-token",
+        "content_type": "application/x-www-form-urlencoded",
+        "body": "channel=a+b%26c%3Dd%2Fe%E6%97%A5%E6%9C%AC%E8%AA%9E"
+      },
+      "is_error": false,
+      "text": "{\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+    },
+    {
+      "case": "read_messages/the clamp is 100 and the fallback 20, not the listers' 1000 and 100",
+      "tool": "read_messages",
+      "arguments": {
+        "channel": "C1",
+        "cursor": "",
+        "limit": 101
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/conversations.history",
+        "authorization": "Bearer xoxb-parity-slack-token",
+        "content_type": "application/x-www-form-urlencoded",
+        "body": "channel=C1\u0026limit=20"
+      },
+      "is_error": false,
+      "text": "{\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+    },
+    {
+      "case": "read_messages/100 survives, and a cursor is sent",
+      "tool": "read_messages",
+      "arguments": {
+        "channel": "C1",
+        "cursor": "next",
+        "limit": 100
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/conversations.history",
+        "authorization": "Bearer xoxb-parity-slack-token",
+        "content_type": "application/x-www-form-urlencoded",
+        "body": "channel=C1\u0026cursor=next\u0026limit=100"
+      },
+      "is_error": false,
+      "text": "{\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+    },
+    {
+      "case": "send_message/a JSON body with the charset content type",
+      "tool": "send_message",
+      "arguments": {
+        "channel": "C1",
+        "text": "hello \u003cthere\u003e \u0026 welcome"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/chat.postMessage",
+        "authorization": "Bearer xoxb-parity-slack-token",
+        "content_type": "application/json; charset=utf-8",
+        "body": "{\"channel\":\"C1\",\"text\":\"hello \\u003cthere\\u003e \\u0026 welcome\"}"
+      },
+      "is_error": false,
+      "text": "Message sent successfully. Response: {\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+    },
+    {
+      "case": "send_reply/the same Slack method with one more key, and a different sentence",
+      "tool": "send_reply",
+      "arguments": {
+        "channel": "C1",
+        "text": "ack",
+        "thread_ts": "1727700000.000100"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/chat.postMessage",
+        "authorization": "Bearer xoxb-parity-slack-token",
+        "content_type": "application/json; charset=utf-8",
+        "body": "{\"channel\":\"C1\",\"text\":\"ack\",\"thread_ts\":\"1727700000.000100\"}"
+      },
+      "is_error": false,
+      "text": "Reply sent successfully. Response: {\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+    },
+    {
+      "case": "list_users/no channel field at all, unlike read_messages",
+      "tool": "list_users",
+      "arguments": {
+        "cursor": "",
+        "limit": 0
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/users.list",
+        "authorization": "Bearer xoxb-parity-slack-token",
+        "content_type": "application/x-www-form-urlencoded",
+        "body": "limit=100"
+      },
+      "is_error": false,
+      "text": "{\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+    },
+    {
+      "case": "search_messages/count clamps at 100 and page has a floor of 1",
+      "tool": "search_messages",
+      "arguments": {
+        "count": 0,
+        "page": 0,
+        "query": "from:me in:#general"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/search.messages",
+        "authorization": "Bearer xoxb-parity-slack-token",
+        "content_type": "application/x-www-form-urlencoded",
+        "body": "count=20\u0026page=1\u0026query=from%3Ame+in%3A%23general"
+      },
+      "is_error": false,
+      "text": "{\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+    },
+    {
+      "case": "search_messages/page has no ceiling",
+      "tool": "search_messages",
+      "arguments": {
+        "count": 101,
+        "page": 999999,
+        "query": "x"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/search.messages",
+        "authorization": "Bearer xoxb-parity-slack-token",
+        "content_type": "application/x-www-form-urlencoded",
+        "body": "count=20\u0026page=999999\u0026query=x"
+      },
+      "is_error": false,
+      "text": "{\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+    },
+    {
+      "case": "search_messages/an empty query still sends the key",
+      "tool": "search_messages",
+      "arguments": {
+        "count": 50,
+        "page": 2,
+        "query": ""
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/search.messages",
+        "authorization": "Bearer xoxb-parity-slack-token",
+        "content_type": "application/x-www-form-urlencoded",
+        "body": "count=50\u0026page=2\u0026query="
+      },
+      "is_error": false,
+      "text": "{\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+    },
+    {
+      "case": "list_users/a 200 carrying ok:false is a failure",
+      "tool": "list_users",
+      "arguments": {
+        "cursor": "",
+        "limit": 0
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":false,\"error\":\"not_authed\"}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/users.list",
+        "authorization": "Bearer xoxb-parity-slack-token",
+        "content_type": "application/x-www-form-urlencoded",
+        "body": "limit=100"
+      },
+      "is_error": true,
+      "text": "slack API error (users.list): not_authed"
+    },
+    {
+      "case": "list_users/a 500 carrying ok:true is a success",
+      "tool": "list_users",
+      "arguments": {
+        "cursor": "",
+        "limit": 0
+      },
+      "response": {
+        "status": 500,
+        "body": "{\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/users.list",
+        "authorization": "Bearer xoxb-parity-slack-token",
+        "content_type": "application/x-www-form-urlencoded",
+        "body": "limit=100"
+      },
+      "is_error": false,
+      "text": "{\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+    },
+    {
+      "case": "get_channel_info/ok:false with no error field interpolates an empty one",
+      "tool": "get_channel_info",
+      "arguments": {
+        "channel": "C1"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":false}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/conversations.info",
+        "authorization": "Bearer xoxb-parity-slack-token",
+        "content_type": "application/x-www-form-urlencoded",
+        "body": "channel=C1"
+      },
+      "is_error": true,
+      "text": "slack API error (conversations.info): "
+    },
+    {
+      "case": "get_channel_info/a body that is not JSON",
+      "tool": "get_channel_info",
+      "arguments": {
+        "channel": "C1"
+      },
+      "response": {
+        "status": 200,
+        "body": "\u003chtml\u003enope\u003c/html\u003e"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/conversations.info",
+        "authorization": "Bearer xoxb-parity-slack-token",
+        "content_type": "application/x-www-form-urlencoded",
+        "body": "channel=C1"
+      },
+      "is_error": true,
+      "text": "parsing response: invalid character '\u003c' looking for beginning of value",
+      "rust_text": "parsing response: expected value at line 1 column 1"
+    },
+    {
+      "case": "send_message/429 is its own sentence, carrying Retry-After",
+      "tool": "send_message",
+      "arguments": {
+        "channel": "C1",
+        "text": "hi"
+      },
+      "response": {
+        "status": 429,
+        "retry_after": "30",
+        "body": ""
+      },
+      "request": {
+        "method": "POST",
+        "target": "/chat.postMessage",
+        "authorization": "Bearer xoxb-parity-slack-token",
+        "content_type": "application/json; charset=utf-8",
+        "body": "{\"channel\":\"C1\",\"text\":\"hi\"}"
+      },
+      "is_error": true,
+      "text": "slack rate limited (chat.postMessage), retry after 30 seconds"
+    },
+    {
+      "case": "read_messages/429 with no Retry-After leaves an empty gap in the sentence",
+      "tool": "read_messages",
+      "arguments": {
+        "channel": "C1",
+        "cursor": "",
+        "limit": 0
+      },
+      "response": {
+        "status": 429,
+        "body": ""
+      },
+      "request": {
+        "method": "POST",
+        "target": "/conversations.history",
+        "authorization": "Bearer xoxb-parity-slack-token",
+        "content_type": "application/x-www-form-urlencoded",
+        "body": "channel=C1\u0026limit=20"
+      },
+      "is_error": true,
+      "text": "slack rate limited (conversations.history), retry after  seconds"
+    },
+    {
+      "case": "list_channels/a zero-fraction float is an integer to Go and not to serde",
+      "tool": "list_channels",
+      "arguments": {
+        "cursor": "",
+        "limit": 100.0
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/conversations.list",
+        "authorization": "Bearer xoxb-parity-slack-token",
+        "content_type": "application/x-www-form-urlencoded",
+        "body": "limit=100\u0026types=public_channel%2Cprivate_channel"
+      },
+      "is_error": false,
+      "text": "{\"ok\":true,\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"channels\":[]}",
+      "rust_text": "failed to deserialize parameters: invalid type: floating point `100.0`, expected i64",
+      "rust_no_request": true
+    }
+  ]
+}

--- a/desktop/src-tauri/src/claude/schema_vectors.rs
+++ b/desktop/src-tauri/src/claude/schema_vectors.rs
@@ -30,8 +30,9 @@
 //! struct in `internal/integrations/github/` is flat, carries no `omitempty`,
 //! and uses only `string`, `int`, `int64` and `bool` — which is why the twenty
 //! schemas in `github_vectors.json` match exactly, and #317's six in
-//! `confluence_vectors.json` and #316's nine in `jira_vectors.json` with them.
-//! The map exists so #313–#315 do not each rediscover the boundary.
+//! `confluence_vectors.json`, #316's nine in `jira_vectors.json` and #315's seven
+//! in `slack_vectors.json` with them. The map exists so #313 and #314 do not each
+//! rediscover the boundary.
 
 use std::collections::BTreeMap;
 

--- a/desktop/src-tauri/src/native/chat/mod.rs
+++ b/desktop/src-tauri/src/native/chat/mod.rs
@@ -11,12 +11,12 @@
 //! button would silently do nothing.
 //!
 //! But not every chat *can* run here: an agent whose tools come from an
-//! integration needs one MCP server per provider, and this port has three of the
-//! six still to write (#313–#315), so `runner::build_options` refuses those and
+//! integration needs one MCP server per provider, and this port has two of the
+//! six still to write (#313 and #314), so `runner::build_options` refuses those and
 //! they keep running on the sidecar. Parts of that refusal have gone — the
 //! **local** in-process server (#310), then any agent whose `capabilities.mcp`
 //! names only hosted integrations (**github** since #311, **confluence** since
-//! #317, **jira** since #316) — but each only shrinks the set of chats Go still holds; it does not
+//! #317, **jira** since #316, **slack** since #315) — but each only shrinks the set of chats Go still holds; it does not
 //! empty it, and the argument here turns on the set being non-empty.
 //! So the three steering routes are answered natively **only when Rust holds a
 //! live session for that chat**, and forward otherwise. Go then answers —

--- a/desktop/src-tauri/src/native/chat/runner.rs
+++ b/desktop/src-tauri/src/native/chat/runner.rs
@@ -24,8 +24,8 @@
 //! **#311 narrowed the `mcp` half rather than removing it.** An agent is served
 //! natively when *every* name in `capabilities.mcp` is an integration this build
 //! can host — `registry::HOSTED_TYPES`, which today means `github` (#312) and
-//! `confluence` (#317) and `jira` (#316), and will mean the rest as #313–#315
-//! land. Three things
+//! `confluence` (#317), `jira` (#316) and `slack` (#315), and will mean the rest
+//! as #313 and #314 land. Three things
 //! still forward, and [`mcp_plan`] is where each is decided:
 //!
 //! - **A name whose type is not hosted.** A `slack` row has no Rust starter;
@@ -389,7 +389,7 @@ fn mcp_plan(
         if !crate::native::integrations::registry::can_host(db_path, id)? {
             return Err(format!(
                 "agent uses MCP server {id:?}, which is not an integration this build \
-                 can host (#313–#315)"
+                 can host (#313, #314)"
             ));
         }
         servers.push(McpServerSpec {
@@ -1078,11 +1078,17 @@ mod tests {
     fn an_mcp_name_this_build_cannot_host_forwards() {
         let file = db_with_integration("gh-1", "github");
 
-        // A type with no Rust starter.
-        let slack = db_with_integration("sl-1", "slack");
-        let err = mcp_plan(Some(&caps_naming("sl-1", None)), Some(slack.path()), false)
-            .expect_err("slack cannot be hosted");
-        assert!(err.contains(r#"MCP server "sl-1""#), "{err}");
+        // A type with no Rust starter. `telegram` while #314 is unwritten — the
+        // stand-in has to be a type that is genuinely unported, so it moves each
+        // time one lands.
+        let telegram = db_with_integration("tg-1", "telegram");
+        let err = mcp_plan(
+            Some(&caps_naming("tg-1", None)),
+            Some(telegram.path()),
+            false,
+        )
+        .expect_err("telegram cannot be hosted");
+        assert!(err.contains(r#"MCP server "tg-1""#), "{err}");
 
         // A name with no integration row: `mcps.yaml` could still name it.
         assert!(mcp_plan(
@@ -1101,7 +1107,7 @@ mod tests {
         let mut mixed = caps_naming("gh-1", None);
         if let Some(mcp) = mixed.mcp.as_mut() {
             mcp.0.insert(
-                "sl-1".to_string(),
+                "tg-1".to_string(),
                 crate::native::agents::McpCapability { tools: None }.into(),
             );
         }

--- a/desktop/src-tauri/src/native/integrations.rs
+++ b/desktop/src-tauri/src/native/integrations.rs
@@ -134,6 +134,7 @@ pub mod base_url;
 pub mod confluence;
 pub mod github;
 pub mod jira;
+pub mod slack;
 
 /// The Start/Stop/Reload lifecycle, and the one place in the port that reads
 /// `integrations.credentials` (#311).
@@ -478,12 +479,13 @@ fn segment(value: &str) -> Option<&str> {
 /// on the Go side. Returns the integration id the shell owes a reload for.
 ///
 /// `Reload` has seven callers in Go. Two are ported (`Update`, and `Delete` via
-/// `Stop`). Two more — the telegram and slack validators — and
+/// `Stop`). One more — the telegram validator — and
 /// `completeOAuth` are unaffected, because the switch is per type and every type
 /// they can reach is still Go's: `startProviderCallback` supports exactly
 /// `google` and `slack`, so an OAuth completion never concerns a type this
-/// process hosts. That leaves `validateGitHubPATAuth` and, since #316 and #317,
-/// `validateJiraTokenAuth` and `validateConfluenceAuth` — all behind
+/// process hosts. That leaves `validateGitHubPATAuth` and, since #315–#317,
+/// `validateSlackTokenAuth`, `validateJiraTokenAuth` and
+/// `validateConfluenceAuth` — all behind
 /// `POST /api/integrations/{id}/auth/validate` — as the paths that write a
 /// credential for a hosted type and cannot tell anybody. Without this hook such
 /// an integration is never hosted in the session it is set up in — create, `PUT`
@@ -492,21 +494,51 @@ fn segment(value: &str) -> Option<&str> {
 ///
 /// The route predicate below is deliberately **type-blind**: it answers with the
 /// id for every integration, and `registry::reload_after_auth` reads the row's
-/// type through `can_host` before it does anything. So #313–#315 need not touch
+/// type through `can_host` before it does anything. So #313 and #314 need not touch
 /// this — adding a string to `registry::HOSTED_TYPES` is what widens it.
 ///
 /// The reload runs **after** Go's answer, so the row is already written, and it
 /// is idempotent — the worst case is restarting a server that was about to be
 /// restarted. Go fires its own from a goroutine (`reloadIntegration`), so doing
 /// it off the response path is parity rather than a shortcut.
-pub fn reload_after_forward<'a>(method: &Method, path: &'a str) -> Option<&'a str> {
-    if method != Method::POST {
-        return None;
+///
+/// # Two routes, two triggers
+///
+/// `POST …/auth/validate` is an **event**: a credential was just written, so the
+/// reload is unconditional, exactly as Go's is.
+///
+/// `GET …/auth/status` is a **poll**, added by #315. Go's `handleOAuthToken`
+/// reloads after an OAuth token lands, and `startProviderCallback` supports
+/// `google` and `slack` — so the moment `slack` became a hosted type, that
+/// reload started reaching nothing. The token itself never comes through this
+/// proxy (the browser delivers it to a callback server the *sidecar* opens), so
+/// the UI's polling of this route is the only part of the flow the shell can
+/// see. Being a poll, it must not fire an unconditional reload — see
+/// `registry::reload_if_secrets_changed`, which reloads only when the row stops
+/// matching what is running.
+pub fn reload_after_forward<'a>(method: &Method, path: &'a str) -> Option<(&'a str, Trigger)> {
+    let rest = path.strip_prefix("/api/integrations/")?;
+    if method == Method::POST {
+        if let Some(id) = rest.strip_suffix("/auth/validate") {
+            return segment(id).map(|id| (id, Trigger::CredentialWritten));
+        }
     }
-    segment(
-        path.strip_prefix("/api/integrations/")?
-            .strip_suffix("/auth/validate")?,
-    )
+    if method == Method::GET {
+        if let Some(id) = rest.strip_suffix("/auth/status") {
+            return segment(id).map(|id| (id, Trigger::AuthStatusPolled));
+        }
+    }
+    None
+}
+
+/// Why the shell is being asked to look at an integration again.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Trigger {
+    /// A credential was written by a forwarded request. Reload unconditionally,
+    /// as Go does.
+    CredentialWritten,
+    /// The UI polled an in-flight OAuth flow. Reload only if something changed.
+    AuthStatusPolled,
 }
 
 fn claims(method: &Method, path: &str) -> bool {
@@ -1934,7 +1966,7 @@ mod tests {
     /// reload strands a socket and a paired client that never connects.
     #[test]
     fn a_write_for_a_type_the_sidecar_hosts_forwards_without_touching_the_row() {
-        for integration_type in ["slack", "whatsapp", "telegram", "google"] {
+        for integration_type in ["whatsapp", "telegram", "google"] {
             let file = migrated();
             Connection::open(file.path())
                 .expect("open")
@@ -2033,20 +2065,29 @@ mod tests {
         );
     }
 
-    /// The one route the seam owes a reload after Go has answered it (#311).
+    /// The two routes the seam owes something after Go has answered them — one
+    /// an event (#311) and one a poll (#315).
     #[test]
-    fn only_a_successful_auth_validate_asks_the_shell_to_reload() {
+    fn only_the_two_auth_routes_ask_the_shell_to_look_again() {
         assert_eq!(
             reload_after_forward(&Method::POST, "/api/integrations/int-1/auth/validate"),
-            Some("int-1")
+            Some(("int-1", Trigger::CredentialWritten))
         );
-        // Not a POST, not that route, and no empty or multi-segment id.
+        assert_eq!(
+            reload_after_forward(&Method::GET, "/api/integrations/int-1/auth/status"),
+            Some(("int-1", Trigger::AuthStatusPolled))
+        );
+        // The method matters on both, and neither admits an empty or
+        // multi-segment id.
         for (method, path) in [
             (Method::GET, "/api/integrations/int-1/auth/validate"),
+            (Method::POST, "/api/integrations/int-1/auth/status"),
             (Method::POST, "/api/integrations/int-1/auth/start"),
             (Method::POST, "/api/integrations/int-1"),
             (Method::POST, "/api/integrations//auth/validate"),
+            (Method::GET, "/api/integrations//auth/status"),
             (Method::POST, "/api/integrations/a/b/auth/validate"),
+            (Method::GET, "/api/integrations/a/b/auth/status"),
             (Method::POST, "/api/agents"),
         ] {
             assert_eq!(reload_after_forward(&method, path), None, "{method} {path}");

--- a/desktop/src-tauri/src/native/integrations.rs
+++ b/desktop/src-tauri/src/native/integrations.rs
@@ -25,8 +25,10 @@
 //!   the old config: an integration still using a token the user just revoked,
 //!   with a 200 saying it worked. #311 did not solve that by adding a second
 //!   registry — it moved the *ownership*. The sidecar now runs with
-//!   `AGENTO_INTEGRATIONS=off` and [`registry`] is the only implementation,
-//!   which is #289's flip applied a second time.
+//!   `AGENTO_INTEGRATIONS=off:<types>` and [`registry`] is the only
+//!   implementation for the types named there, which is #289's flip applied a
+//!   second time — per type rather than per process, because a starter is not
+//!   always a pure MCP-server constructor. See `registry::HOSTED_TYPES`.
 //! - `POST /api/integrations` needed none of that: `Create` touches no registry
 //!   at all. That was verified against the whole of `integrationService.Create`
 //!   rather than inferred from its siblings, which is the point — `Create` and
@@ -462,10 +464,13 @@ fn segment(value: &str) -> Option<&str> {
 /// switched off, a native write there would have persisted the row and left the
 /// sidecar's server running on stale config — on an unauthenticated loopback
 /// port, holding a token the user had just revoked. The sidecar now runs with
-/// `AGENTO_INTEGRATIONS=off` and [`registry`] is the only implementation, so
-/// both effects are reproduced rather than lost. Note this is a property of the
-/// *process*, not of the six types: a Slack row is not hosted by anyone, which
-/// is a Slack integration that does nothing rather than one running twice.
+/// `AGENTO_INTEGRATIONS=off:<the types the shell hosts>` and [`registry`] is the
+/// only implementation **for those types**, so both effects are reproduced
+/// rather than lost. Note the switch is per type, not per process: a `telegram`
+/// row is still Go's, and a write for one is declined here and forwarded whole
+/// (see [`claims`]'s caller and `writes.rs`). Four of the six are the shell's as
+/// of #315 — `github`, `confluence`, `jira`, `slack` — and the list to read is
+/// `registry::HOSTED_TYPES`, never this comment.
 ///
 /// `POST /api/integrations` needed none of that, because `Create` is a pure row
 /// write: it never touches the registry, which was verified against the whole

--- a/desktop/src-tauri/src/native/integrations/base_url.rs
+++ b/desktop/src-tauri/src/native/integrations/base_url.rs
@@ -5,8 +5,8 @@
 //! needed the same answer. It is not general URL handling — it is one narrow
 //! question with one right answer, arrived at over four rounds of review on
 //! #317, and getting it wrong sent the user's `Basic` credentials to an
-//! attacker's host. #313–#315 do not need it (their API bases are constants);
-//! anything after them whose base comes out of the integration row does.
+//! attacker's host. #313–#315 do not need it — their API bases are constants,
+//! which #315 confirmed — and anything whose base comes out of the row does.
 //!
 //! # The problem
 //!

--- a/desktop/src-tauri/src/native/integrations/github/client.rs
+++ b/desktop/src-tauri/src/native/integrations/github/client.rs
@@ -56,10 +56,11 @@ pub const DEFAULT_API_BASE: &str = "https://api.github.com";
 /// had to export `SetAPIBase` to be redirectable at all. Both callers here are
 /// in-crate, so `#[cfg(test)]` costs nothing and compiles the whole thing out —
 /// which is what [`api_base_lock`] below already does, for the same reason.
-/// #313–#315 each add their own seam and should follow this. #317's is a
-/// constructor argument rather than a static, because a Confluence site URL is
-/// per row; #316 needs none at all, because `jira.Start` does not validate the
-/// site URL and so a parity run can simply store the fake's URL.
+/// #313 and #314 each add their own seam and should follow this, as #315 did —
+/// Slack's base is a package variable too. #317's is a constructor argument
+/// rather than a static, because a Confluence site URL is per row; #316 needs
+/// none at all, because `jira.Start` does not validate the site URL and so a
+/// parity run can simply store the fake's URL.
 ///
 /// A `RwLock` rather than a `OnceLock` because a test points it at a loopback
 /// fake and then puts it back.

--- a/desktop/src-tauri/src/native/integrations/registry.rs
+++ b/desktop/src-tauri/src/native/integrations/registry.rs
@@ -791,8 +791,30 @@ pub async fn start_filtered_server(
 /// in `native/integrations.rs` have already read the row and so call
 /// [`hosts_type`] directly rather than reading it a second time through the
 /// credential-carrying projection.
+/// The row's `type`, and **nothing else** — no `credentials`, no `auth`.
+///
+/// The point is what it does not select. [`HOSTING_COLUMNS`] is the one
+/// projection in the port that reads the secret columns, and its charter is to
+/// read them *to build a tool server*. Two callers only want to know whether the
+/// type is one this process hosts, and both are on hot paths for rows it does
+/// not: [`can_host`] runs per chat turn, and [`reload_if_secrets_changed`] runs
+/// per poll of an OAuth dialog — which the Google, WhatsApp and detail pages all
+/// poll. Answering that question through the secret-carrying projection would
+/// pull an unrelated integration's token into memory to decide it belongs to
+/// somebody else.
+fn type_of(db_path: &Path, id: &str) -> Result<Option<String>, String> {
+    let conn = crate::native::db::open_read_only(db_path)?;
+    conn.query_row("SELECT type FROM integrations WHERE id = ?1", [id], |row| {
+        row.get::<_, String>(0)
+    })
+    .optional()
+    .map_err(|e| format!("looking up integration {id:?}: {e}"))
+}
+
 pub fn can_host(db_path: &Path, id: &str) -> Result<bool, String> {
-    Ok(get_for_hosting(db_path, id)?.is_some_and(|row| hosts_type(&row.integration_type)))
+    // [`type_of`] rather than the hosting projection: this answers a question
+    // about the `type` column and has no business reading the other two.
+    Ok(type_of(db_path, id)?.is_some_and(|integration_type| hosts_type(&integration_type)))
 }
 
 /// `filterConfigTools`: keep only the requested tools, of only the enabled
@@ -991,19 +1013,28 @@ pub async fn reload_after_auth(db_path: &Path, id: &str) {
 /// (fingerprint moved), and a de-authentication (startable → not, which stops
 /// it).
 pub async fn reload_if_secrets_changed(db_path: &Path, id: &str) {
+    // The type first, through a projection that reads no secret: every page with
+    // an auth dialog polls this route, and most of those rows are types this
+    // process does not host.
+    match type_of(db_path, id) {
+        Ok(Some(integration_type)) if hosts_type(&integration_type) => {}
+        // Not ours, or deleted between the poll and this read. `stop` is the
+        // `DELETE` path's job and has already run; nothing to do here.
+        Ok(_) => return,
+        Err(e) => {
+            log::warn!("reloading integration {id:?} after an auth-status poll: {e}");
+            return;
+        }
+    }
+
     let row = match get_for_hosting(db_path, id) {
         Ok(Some(row)) => row,
-        // Deleted between the poll and this read, or unreadable. `stop` is the
-        // `DELETE` path's job and it has already run; nothing to do here.
         Ok(None) => return,
         Err(e) => {
             log::warn!("reloading integration {id:?} after an auth-status poll: {e}");
             return;
         }
     };
-    if !hosts_type(&row.integration_type) {
-        return;
-    }
 
     let want = row.is_startable().then(|| row.secrets_fingerprint());
     if want == registry().secrets(id) {

--- a/desktop/src-tauri/src/native/integrations/registry.rs
+++ b/desktop/src-tauri/src/native/integrations/registry.rs
@@ -5,7 +5,7 @@
 //! integration: `Start` brings them all up at boot, `Reload` restarts one when
 //! its row changes, `Stop` tears one down when it is deleted. This module is
 //! that, for the types listed in [`HOSTED_TYPES`] — today `github` (#312),
-//! `confluence` (#317) and `jira` (#316).
+//! `confluence` (#317), `jira` (#316) and `slack` (#315).
 //!
 //! ## Why the ownership had to flip before the writes could move
 //!
@@ -44,7 +44,7 @@
 //! **The list is built here, by [`hosting_env_value`], from the same
 //! [`HOSTED_TYPES`] that [`hosts_type`] and the starter dispatch read.** That is
 //! the point of carrying it in the environment rather than hardcoding it on both
-//! sides: the shell is the process that knows what it hosts, so #313–#315 each
+//! sides: the shell is the process that knows what it hosts, so #313 and #314 each
 //! add one string to one list and the two halves cannot drift. The failure mode
 //! being designed against is a Rust slack starter landing while Go is never told
 //! to stop hosting slack — two processes on one integration — and its mirror is
@@ -84,8 +84,7 @@
 //!
 //! `Reload` has seven callers in Go and only two of them (`Update`, and
 //! `Delete` via `Stop`) are ported. Five run inside the sidecar. `completeOAuth`
-//! and the telegram and slack validators are fine **because the gate is
-//! per type**: they can only reach types Go still hosts, and
+//! and the telegram validator is fine **because the gate is per type**: they can only reach types Go still hosts, and
 //! `startProviderCallback` supports exactly `google` and `slack`, so an OAuth
 //! completion never concerns a hosted one. The other three —
 //! `validateGitHubPATAuth`, and since #316 and #317 `validateJiraTokenAuth` and
@@ -95,7 +94,7 @@
 //! seam fires [`reload_after_auth`] after forwarding a 2xx for that one route
 //! (`native::after_forward`). That hook needs no per-type list of its own: it
 //! runs for every id on the route and [`reload_after_auth`] reads the row's type
-//! through [`can_host`], so #313–#315 are covered the moment they add their
+//! through [`can_host`], so #313 and #314 are covered the moment they add their
 //! string to [`HOSTED_TYPES`]. The reload is idempotent and the response has
 //! already been produced, so doing it on the forward path costs nothing but a
 //! restart of a server that was about to be restarted anyway.
@@ -131,10 +130,23 @@ struct HostingRow {
     id: String,
     integration_type: String,
     enabled: bool,
-    /// `IsAuthenticated()`, computed in SQL so the token itself is never read.
+    /// `IsAuthenticated()`, computed in SQL so the predicate does not depend on
+    /// parsing [`Self::auth`].
     authenticated: bool,
     /// The raw `credentials` column. A secret.
     credentials: String,
+    /// The raw `auth` column. **Also a secret**, and the newer of the two.
+    ///
+    /// Until #315 this projection selected `auth` only as the boolean above, and
+    /// `native/integrations.rs` still never selects it at all — the rule that a
+    /// stored token cannot exist in this process to be echoed. Slack is the
+    /// exception that forced it: `resolveToken` reads
+    /// `cfg.ParseOAuthToken()` — the `auth` column parsed as an `oauth2.Token` —
+    /// whenever `credentials.auth_mode` is `oauth`, so the value is genuinely
+    /// needed to build the server. What has *not* changed is where it may go:
+    /// this struct still derives neither `Serialize` nor `Debug`, it is private
+    /// to this module, and only a `&str` ever leaves it.
+    auth: String,
     services: Option<BTreeMap<String, ServiceConfig>>,
 }
 
@@ -143,6 +155,21 @@ impl HostingRow {
     /// `Reload` apply before they reach a starter.
     fn is_startable(&self) -> bool {
         self.enabled && self.authenticated
+    }
+
+    /// A fingerprint of the two secret columns, for [`reload_if_secrets_changed`].
+    ///
+    /// A hash, so the registry's record of "what is this server running on" is
+    /// not a second place the token itself lives. `DefaultHasher` because the
+    /// question is only ever "did this change", within one process, against a
+    /// value this process wrote — there is nothing here for a collision to buy
+    /// an attacker that reading the database would not.
+    fn secrets_fingerprint(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        self.credentials.hash(&mut hasher);
+        self.auth.hash(&mut hasher);
+        hasher.finish()
     }
 
     /// The services map a starter sees. A stored `null` is a nil Go map, which
@@ -157,8 +184,8 @@ impl HostingRow {
 /// One list, read by three things that must agree: [`hosts_type`] (which the
 /// native `PUT`/`DELETE` consult before they touch a row), the starter dispatch
 /// in [`start_for_type`], and [`hosting_env_value`], which tells the Go sidecar
-/// which types to stop hosting. #313–#315 each add one string here.
-pub const HOSTED_TYPES: &[&str] = &["github", "confluence", "jira"];
+/// which types to stop hosting. #313 and #314 each add one string here.
+pub const HOSTED_TYPES: &[&str] = &["github", "confluence", "jira", "slack"];
 
 /// Whether this process hosts an integration of the given type.
 pub fn hosts_type(integration_type: &str) -> bool {
@@ -194,6 +221,13 @@ struct State {
     /// since. A `DELETE` in that window therefore drops the new server instead
     /// of leaving a bound port holding a credential for a deleted row.
     generations: HashMap<String, u64>,
+    /// A fingerprint of the secrets each hosted server was **started with**.
+    ///
+    /// Only [`reload_if_secrets_changed`] reads it, and only to answer "is what
+    /// is running still what the row says". It is a hash rather than the values,
+    /// so this map is not a second place a token lives — see that function for
+    /// why the question needs asking at all.
+    secrets: HashMap<String, u64>,
 }
 
 /// The process-wide registry.
@@ -229,6 +263,7 @@ impl Registry {
     pub fn stop(&self, id: &str) {
         let mut state = self.lock();
         *state.generations.entry(id.to_string()).or_default() += 1;
+        state.secrets.remove(id);
         let removed = state.servers.remove(id);
         drop(state);
         if removed.is_some() {
@@ -256,19 +291,47 @@ impl Registry {
     /// Returns whether the handle was kept. A refused handle is dropped here,
     /// which fires its shutdown oneshot — so the listener the caller started
     /// goes away rather than outliving the row it was built from.
-    fn put_if_current(&self, id: &str, generation: u64, server: InProcessMcpServer) -> bool {
+    fn put_if_current(
+        &self,
+        id: &str,
+        generation: u64,
+        server: InProcessMcpServer,
+        secrets: u64,
+    ) -> bool {
         let mut state = self.lock();
         if state.generations.get(id).copied().unwrap_or_default() != generation {
             return false;
         }
         state.servers.insert(id.to_string(), server);
+        state.secrets.insert(id.to_string(), secrets);
         true
+    }
+
+    /// The fingerprint the server hosted under `id` was started with, or `None`
+    /// when nothing is hosted for it.
+    fn secrets(&self, id: &str) -> Option<u64> {
+        self.lock().secrets.get(id).copied()
     }
 
     /// Whether an integration is hosted right now. Nothing on the wire reads
     /// this; it exists so the lifecycle can be asserted.
     pub fn is_hosted(&self, id: &str) -> bool {
         self.lock().servers.contains_key(id)
+    }
+
+    /// The loopback URL a hosted server is listening on.
+    ///
+    /// Test-only, and it is how "did this reload actually restart anything"
+    /// is observed: `reload` binds a fresh port every time, so an unchanged URL
+    /// is proof that nothing was torn down. Not exposed outside tests because
+    /// nothing else needs it — `InProcessMcpServer` deliberately has no `Debug`,
+    /// and the URL is the one part of it that is safe to look at.
+    #[cfg(test)]
+    fn url(&self, id: &str) -> Option<String> {
+        self.lock()
+            .servers
+            .get(id)
+            .map(|server| server.url().to_string())
     }
 }
 
@@ -335,7 +398,7 @@ pub async fn reload(db_path: &Path, id: &str) -> Result<(), String> {
 async fn start_one(row: &HostingRow, generation: u64) -> Result<(), String> {
     let server = start_for_type(row).await?;
     let url = server.url().to_string();
-    if !registry().put_if_current(&row.id, generation, server) {
+    if !registry().put_if_current(&row.id, generation, server, row.secrets_fingerprint()) {
         log::info!(
             "integration MCP server discarded before it was recorded, \
              the integration was stopped while it started: id={:?} type={:?}",
@@ -369,6 +432,7 @@ async fn start_for_type(row: &HostingRow) -> Result<InProcessMcpServer, String> 
         "github" => start_github(&row.id, &row.services(), &row.credentials).await,
         "confluence" => start_confluence(&row.id, &row.services(), &row.credentials).await,
         "jira" => start_jira(&row.id, &row.services(), &row.credentials).await,
+        "slack" => start_slack(&row.id, &row.services(), &row.credentials, &row.auth).await,
         other => Err(format!(
             "no starter registered for integration type {other:?}"
         )),
@@ -493,6 +557,113 @@ async fn start_jira(
     .map_err(|e| format!("starting in-process MCP server for {id:?}: {e}"))
 }
 
+/// `slack.Start`'s first two steps — the auth check and `resolveToken` —
+/// followed by the third, which `native/integrations/slack` owns.
+///
+/// The token is the reason this starter takes `auth` where the others take only
+/// `credentials`: see [`resolve_slack_token`].
+async fn start_slack(
+    id: &str,
+    services: &BTreeMap<String, ServiceConfig>,
+    credentials: &str,
+    auth: &str,
+) -> Result<InProcessMcpServer, String> {
+    let token = resolve_slack_token(id, credentials, auth)?;
+    super::slack::start_slack_mcp_server(id, services, &token)
+        .await
+        .map_err(|e| format!("starting in-process MCP server for {id:?}: {e}"))
+}
+
+/// `resolveToken` (`slack/server.go`), wrapped as `Start` wraps it.
+///
+/// Three arms, and the third is the one a port drops:
+///
+/// - `bot_token` — the credentials blob, refusing an empty one.
+/// - `oauth` — `cfg.ParseOAuthToken()`, which is the **`auth` column** decoded
+///   as an `oauth2.Token`. This is the only place in the port that reads that
+///   column as a value; see [`HostingRow::auth`].
+/// - anything else, **including the empty string** — falls back to the bot token
+///   if it is non-empty, and only then fails. So a row whose `auth_mode` was
+///   never set still works, which is what makes this a fallback rather than a
+///   default.
+///
+/// Every message is Go's, and none of them interpolates a token. The one
+/// deliberate divergence is the `oauth` arm's decode failure: Go's carries
+/// `encoding/json`'s wording, and this carries line and column for
+/// [`github_token`]'s reason — the serde message quotes the offending value,
+/// which here *is* the access token.
+pub(super) fn resolve_slack_token(
+    id: &str,
+    credentials: &str,
+    auth: &str,
+) -> Result<String, String> {
+    #[derive(Default, serde::Deserialize)]
+    #[serde(default)]
+    struct SlackCredentials {
+        #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+        auth_mode: String,
+        #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+        bot_token: String,
+    }
+
+    let wrap = |message: String| format!("resolving slack token for {id:?}: {message}");
+
+    if credentials.is_empty() {
+        return Err(wrap(
+            "parsing slack credentials: credentials are empty".to_string(),
+        ));
+    }
+    let creds = serde_json::from_str::<Option<SlackCredentials>>(credentials)
+        .map(Option::unwrap_or_default)
+        .map_err(|e| {
+            wrap(format!(
+                "parsing slack credentials: does not decode at line {} column {}",
+                e.line(),
+                e.column()
+            ))
+        })?;
+
+    match creds.auth_mode.as_str() {
+        "bot_token" => {
+            if creds.bot_token.is_empty() {
+                return Err(wrap("bot_token is empty".to_string()));
+            }
+            Ok(creds.bot_token)
+        }
+        "oauth" => {
+            // `oauth2.Token`, of which only `access_token` is read. A Go
+            // `json.Unmarshal` into that struct would also reject a malformed
+            // `expiry` (it is a `time.Time`), which this does not — an
+            // unreachable difference, since the column is written by
+            // `SetOAuthToken`, and a log line either way.
+            #[derive(Default, serde::Deserialize)]
+            #[serde(default)]
+            struct OAuthToken {
+                #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+                access_token: String,
+            }
+            let token = serde_json::from_str::<Option<OAuthToken>>(auth)
+                .map(Option::unwrap_or_default)
+                .map_err(|e| {
+                    wrap(format!(
+                        "parsing oauth token: does not decode at line {} column {}",
+                        e.line(),
+                        e.column()
+                    ))
+                })?;
+            Ok(token.access_token)
+        }
+        other => {
+            if !creds.bot_token.is_empty() {
+                return Ok(creds.bot_token);
+            }
+            Err(wrap(format!(
+                "unsupported auth_mode {other:?} and no bot_token available"
+            )))
+        }
+    }
+}
+
 /// `config.AtlassianCredentials` — the struct Confluence and Jira share.
 ///
 /// Neither derives `Debug` nor `Serialize`, for [`HostingRow`]'s reason: a
@@ -603,6 +774,7 @@ pub async fn start_filtered_server(
         "github" => start_github(&row.id, &filtered, &row.credentials).await,
         "confluence" => start_confluence(&row.id, &filtered, &row.credentials).await,
         "jira" => start_jira(&row.id, &filtered, &row.credentials).await,
+        "slack" => start_slack(&row.id, &filtered, &row.credentials, &row.auth).await,
         other => Err(format!(
             "no starter registered for integration type {other:?}"
         )),
@@ -675,7 +847,7 @@ fn filter_config_tools(
 /// point of that constant is that the column is not in it.
 const HOSTING_COLUMNS: &str = "SELECT id, type, enabled,
             (auth IS NOT NULL AND auth != '' AND auth != 'null') AS authenticated,
-            credentials, services
+            credentials, services, COALESCE(auth, '')
      FROM integrations";
 
 fn scan_hosting_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<HostingRow> {
@@ -689,6 +861,7 @@ fn scan_hosting_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<HostingRow> {
         authenticated: authenticated != 0,
         credentials: row.get(4)?,
         services: decode_services(&services),
+        auth: row.get(6)?,
     })
 }
 
@@ -786,6 +959,63 @@ pub async fn reload_after_auth(db_path: &Path, id: &str) {
     }
 }
 
+/// Reload only if what the row says no longer matches what is hosted.
+///
+/// # The hole this fills, which #315 opened
+///
+/// Go's `handleOAuthToken` writes the token to the `auth` column and then calls
+/// `registry.Reload` — and `startProviderCallback` supports exactly `google` and
+/// `slack`. While neither was hosted here that was harmless, and
+/// `registry.rs`'s own header said so. **#315 made `slack` a hosted type**, so
+/// that `Reload` now reaches nothing and a Slack integration authenticated by
+/// OAuth would first be served at the next boot's [`start_all`].
+///
+/// [`reload_after_auth`] cannot cover it: that hook hangs off a *forwarded
+/// request*, and an OAuth token does not arrive on one. It is delivered by the
+/// browser to a callback server the **sidecar** opens on its own port, which
+/// this process never sees. The one part of the flow that does come through the
+/// proxy is the UI polling `GET /api/integrations/{id}/auth/status` while it
+/// waits, so that is where this hangs — which makes it **best-effort**: a user
+/// who closes the dialog before it completes is served at the next boot, as they
+/// were before. #318 owns the flow itself and is where that stops being true.
+///
+/// # Why conditional, where [`reload_after_auth`] is not
+///
+/// A poll is not an event. `reload` is unconditional by design — stop, then
+/// start, with a new port each time — so firing it per poll would restart the
+/// server every second the dialog is open and drop any in-flight `tools/call`
+/// with it. So this compares the row's current secrets against the ones the
+/// running server was started with and does nothing when they match. That covers
+/// every transition without churn: unauthenticated → authenticated (nothing
+/// hosted, now startable), a re-authentication that replaces the token
+/// (fingerprint moved), and a de-authentication (startable → not, which stops
+/// it).
+pub async fn reload_if_secrets_changed(db_path: &Path, id: &str) {
+    let row = match get_for_hosting(db_path, id) {
+        Ok(Some(row)) => row,
+        // Deleted between the poll and this read, or unreadable. `stop` is the
+        // `DELETE` path's job and it has already run; nothing to do here.
+        Ok(None) => return,
+        Err(e) => {
+            log::warn!("reloading integration {id:?} after an auth-status poll: {e}");
+            return;
+        }
+    };
+    if !hosts_type(&row.integration_type) {
+        return;
+    }
+
+    let want = row.is_startable().then(|| row.secrets_fingerprint());
+    if want == registry().secrets(id) {
+        return;
+    }
+
+    log::info!("integration {id:?} changed while its auth status was polled; reloading");
+    if let Err(e) = reload(db_path, id).await {
+        log::warn!("failed to reload integration server after auth: id={id:?} error={e}");
+    }
+}
+
 pub fn reload_blocking(db_path: &Path, id: &str) {
     let db_path = db_path.to_path_buf();
     let owned_id = id.to_string();
@@ -846,6 +1076,96 @@ mod tests {
 
     fn github_credentials() -> String {
         format!(r#"{{"auth_mode":"pat","personal_access_token":"{PAT}"}}"#)
+    }
+
+    /// The poll-driven reload: it fires on a change and, crucially, **not**
+    /// otherwise.
+    ///
+    /// #315 opened the hole this fills — Go reloads after an OAuth token lands
+    /// and `slack` is now hosted here, but the token arrives on the sidecar's own
+    /// callback port, so the UI's polling of `auth/status` is the only part of
+    /// the flow this process sees. A poll is not an event, so the anti-churn half
+    /// is as load-bearing as the firing half: `reload` rebinds the port and drops
+    /// in-flight calls, and the dialog polls every second.
+    #[tokio::test]
+    async fn a_polled_auth_status_reloads_on_a_change_and_not_on_a_poll() {
+        let file = db();
+        // Unauthenticated, so not startable. Slack would be the true subject, but
+        // its starter needs a live token to be interesting; the condition under
+        // test is type-blind and github is the type these tests already seed.
+        insert(
+            &file,
+            "gh-oauth",
+            "github",
+            true,
+            None,
+            &github_credentials(),
+            "{}",
+        );
+
+        // Nothing hosted and nothing startable: the poll must be a no-op rather
+        // than an attempt.
+        reload_if_secrets_changed(file.path(), "gh-oauth").await;
+        assert!(!registry().is_hosted("gh-oauth"));
+
+        // The token lands — which is what Go's `handleOAuthToken` does, and what
+        // it then tells nobody about.
+        Connection::open(file.path())
+            .expect("open")
+            .execute(
+                "UPDATE integrations SET auth = ?1 WHERE id = 'gh-oauth'",
+                rusqlite::params![r#"{"login":"octocat"}"#],
+            )
+            .expect("authenticate");
+
+        reload_if_secrets_changed(file.path(), "gh-oauth").await;
+        assert!(
+            registry().is_hosted("gh-oauth"),
+            "the poll after the token landed must host it"
+        );
+        let first = registry()
+            .url("gh-oauth")
+            .expect("a hosted server has a url");
+
+        // …and every later poll must leave it exactly where it is. A changed
+        // port here would mean the dialog restarts the server once a second.
+        for _ in 0..3 {
+            reload_if_secrets_changed(file.path(), "gh-oauth").await;
+            assert_eq!(
+                registry().url("gh-oauth").as_deref(),
+                Some(first.as_str()),
+                "a poll that changed nothing must not rebind the port"
+            );
+        }
+
+        // A token *replaced* is a change, and must be picked up.
+        Connection::open(file.path())
+            .expect("open")
+            .execute(
+                "UPDATE integrations SET credentials = ?1 WHERE id = 'gh-oauth'",
+                rusqlite::params![r#"{"auth_mode":"pat","personal_access_token":"ghp-second"}"#],
+            )
+            .expect("re-authenticate");
+        reload_if_secrets_changed(file.path(), "gh-oauth").await;
+        assert!(registry().is_hosted("gh-oauth"));
+        assert_ne!(
+            registry().url("gh-oauth").as_deref(),
+            Some(first.as_str()),
+            "a replaced credential must restart the server"
+        );
+
+        // …and a de-authentication stops it.
+        Connection::open(file.path())
+            .expect("open")
+            .execute(
+                "UPDATE integrations SET auth = NULL WHERE id = 'gh-oauth'",
+                [],
+            )
+            .expect("de-authenticate");
+        reload_if_secrets_changed(file.path(), "gh-oauth").await;
+        assert!(!registry().is_hosted("gh-oauth"));
+
+        registry().stop("gh-oauth");
     }
 
     /// The whole lifecycle over the one type Rust hosts.
@@ -928,7 +1248,7 @@ mod tests {
     /// two ways to put a credential on two open ports at once.
     #[test]
     fn the_sidecar_is_told_exactly_what_this_process_hosts() {
-        assert_eq!(hosting_env_value(), "off:github,confluence,jira");
+        assert_eq!(hosting_env_value(), "off:github,confluence,jira,slack");
         assert_eq!(
             hosting_env_value(),
             format!("off:{}", HOSTED_TYPES.join(",")),
@@ -937,11 +1257,12 @@ mod tests {
         assert!(hosts_type("github"));
         assert!(hosts_type("confluence"));
         assert!(hosts_type("jira"));
-        // The three types #313–#315 still owe. Go must keep hosting every one of
+        assert!(hosts_type("slack"));
+        // The two types #313 and #314 still owe. Go must keep hosting every one of
         // them, and `whatsapp` is the reason this is a list at all: its starter
         // opens a live whatsmeow connection that its status, reconnect and QR
         // endpoints read out of a package global.
-        for unported in ["slack", "telegram", "google", "whatsapp"] {
+        for unported in ["telegram", "google", "whatsapp"] {
             assert!(!hosts_type(unported), "{unported} is not hosted here");
             assert!(
                 !hosting_env_value().contains(unported),
@@ -997,7 +1318,7 @@ mod tests {
             .await
             .expect("a server to race with");
         assert!(
-            !registry().put_if_current("gh-race", generation, server),
+            !registry().put_if_current("gh-race", generation, server, 0),
             "a handle whose generation has moved must be refused"
         );
         assert!(!registry().is_hosted("gh-race"));
@@ -1007,7 +1328,7 @@ mod tests {
         let server = start_filtered_server(file.path(), "gh-race", &[])
             .await
             .expect("server");
-        assert!(registry().put_if_current("gh-race", generation, server));
+        assert!(registry().put_if_current("gh-race", generation, server, 0));
         assert!(registry().is_hosted("gh-race"));
         registry().stop("gh-race");
     }
@@ -1019,21 +1340,24 @@ mod tests {
         let file = db();
         insert(
             &file,
-            "sl-1",
-            "slack",
+            "tg-1",
+            "telegram",
             true,
             Some(r#"{"validated":true}"#),
-            r#"{"bot_token":"xoxb-secret"}"#,
+            r#"{"bot_token":"tg-secret"}"#,
             r#"{"chat":{"enabled":true,"tools":["post"]}}"#,
         );
 
         // `start_all` swallows it: one bad integration must not stop the others.
         start_all(file.path()).await.expect("start_all swallows it");
-        assert!(!registry().is_hosted("sl-1"));
+        assert!(!registry().is_hosted("tg-1"));
 
         // `reload` returns it, and its callers are the ones that swallow.
-        let err = reload(file.path(), "sl-1").await.expect_err("no starter");
-        assert_eq!(err, r#"no starter registered for integration type "slack""#);
+        let err = reload(file.path(), "tg-1").await.expect_err("no starter");
+        assert_eq!(
+            err,
+            r#"no starter registered for integration type "telegram""#
+        );
     }
 
     /// A row that has been deleted is `Ok(())`, not a failure — `DELETE` stops
@@ -1187,7 +1511,7 @@ mod tests {
     async fn a_filtered_server_refuses_the_way_go_refuses() {
         let file = db();
         insert(&file, "gh-off", "github", false, Some("{}"), "{}", "{}");
-        insert(&file, "sl-1", "slack", true, Some("{}"), "{}", "{}");
+        insert(&file, "tg-1", "telegram", true, Some("{}"), "{}", "{}");
 
         // `.err()` rather than `unwrap_err()`: the `Ok` side is an
         // `InProcessMcpServer`, which deliberately has no `Debug` — printing
@@ -1208,9 +1532,9 @@ mod tests {
             r#"integration "gh-off" is not enabled or not authenticated"#
         );
         assert_eq!(
-            refusal("sl-1").await,
-            r#"no starter registered for integration type "slack""#
+            refusal("tg-1").await,
+            r#"no starter registered for integration type "telegram""#
         );
-        assert!(!can_host(file.path(), "sl-1").expect("can_host"));
+        assert!(!can_host(file.path(), "tg-1").expect("can_host"));
     }
 }

--- a/desktop/src-tauri/src/native/integrations/registry.rs
+++ b/desktop/src-tauri/src/native/integrations/registry.rs
@@ -781,16 +781,6 @@ pub async fn start_filtered_server(
     }
 }
 
-/// Whether a run naming this integration can be served natively at all.
-///
-/// Separate from [`start_filtered_server`] because the caller has to decide
-/// *before* it starts anything: an agent that names a type Rust cannot host must
-/// forward the whole turn to Go rather than run with some of its tools missing.
-///
-/// [`hosts_type`] is the predicate; this only adds the row read. The two writes
-/// in `native/integrations.rs` have already read the row and so call
-/// [`hosts_type`] directly rather than reading it a second time through the
-/// credential-carrying projection.
 /// The row's `type`, and **nothing else** — no `credentials`, no `auth`.
 ///
 /// The point is what it does not select. [`HOSTING_COLUMNS`] is the one
@@ -811,9 +801,18 @@ fn type_of(db_path: &Path, id: &str) -> Result<Option<String>, String> {
     .map_err(|e| format!("looking up integration {id:?}: {e}"))
 }
 
+/// Whether a run naming this integration can be served natively at all.
+///
+/// Separate from [`start_filtered_server`] because the caller has to decide
+/// *before* it starts anything: an agent that names a type Rust cannot host must
+/// forward the whole turn to Go rather than run with some of its tools missing.
+///
+/// [`hosts_type`] is the predicate and [`type_of`] is the whole of the read —
+/// one column, chosen because this question has no business touching the other
+/// two. The two writes in `native/integrations.rs` reach [`hosts_type`] by yet
+/// another route: they have already read the row for their own purposes, so they
+/// call it directly rather than reading anything a second time.
 pub fn can_host(db_path: &Path, id: &str) -> Result<bool, String> {
-    // [`type_of`] rather than the hosting projection: this answers a question
-    // about the `type` column and has no business reading the other two.
     Ok(type_of(db_path, id)?.is_some_and(|integration_type| hosts_type(&integration_type)))
 }
 

--- a/desktop/src-tauri/src/native/integrations/slack/client.rs
+++ b/desktop/src-tauri/src/native/integrations/slack/client.rs
@@ -222,20 +222,37 @@ async fn read_slack_response(
     // Only `ok` and `error` are decoded, and everything else in the envelope is
     // ignored — so the body is returned to the caller **verbatim**, never
     // re-encoded from this value.
-    #[derive(serde::Deserialize)]
+    //
+    // Two `encoding/json` rules this has to carry, both of which a plain
+    // `#[derive(Deserialize)]` gets wrong in *opposite* directions:
+    //
+    // - **A JSON `null` is a zero value, not a type error.** Slack sends
+    //   `"error": null` on a success, so `{"ok":true,"error":null}` is an
+    //   ordinary success to Go and would be `invalid type: null, expected a
+    //   string` here. `null_is_zero_value` is `desktop/CLAUDE.md`'s rule for it.
+    // - **A JSON array is not a struct.** serde builds a struct from a sequence
+    //   positionally when every field has a default, so `[true]` would decode to
+    //   `ok: true` and turn Go's `cannot unmarshal array` into a *success* whose
+    //   text is the raw body. `GoStruct` refuses a non-map, which is #337's
+    //   over-accept and the direction this port must never move in.
+    #[derive(Default, serde::Deserialize)]
+    #[serde(default)]
     struct Envelope {
-        #[serde(default)]
+        #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
         ok: bool,
-        #[serde(default)]
+        #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
         error: String,
     }
-    let envelope: Envelope = serde_json::from_str(&body).map_err(|e| {
-        // `fmt.Errorf("parsing response: %w", err)`. `encoding/json`'s wording is
-        // not reproducible (see `github::body::parse_string_map`), so this
-        // carries serde's — a divergence the vectors pin. It cannot leak the
-        // token: the text being parsed is Slack's response, not the request.
-        format!("parsing response: {e}")
-    })?;
+    let envelope = serde_json::from_str::<crate::native::gojson::GoStruct<Envelope>>(&body)
+        .map(|wrapped| wrapped.0)
+        .map_err(|e| {
+            // `fmt.Errorf("parsing response: %w", err)`. `encoding/json`'s
+            // wording is not reproducible (see `github::body::parse_string_map`),
+            // so this carries serde's — a divergence the vectors pin. It cannot
+            // leak the token: the text being parsed is Slack's response, not the
+            // request.
+            format!("parsing response: {e}")
+        })?;
     if !envelope.ok {
         return Err(format!("slack API error ({method}): {}", envelope.error));
     }
@@ -350,6 +367,73 @@ mod tests {
             Err("calling Slack chat.postMessage: request failed".to_string())
         );
         set_api_base(None);
+    }
+
+    /// The two `encoding/json` rules the envelope decode has to carry, each of
+    /// which a plain derive gets wrong in the opposite direction.
+    ///
+    /// Both were verified against a real `json.Unmarshal` into the same two-field
+    /// struct before being fixed.
+    #[tokio::test]
+    async fn a_null_field_is_a_zero_value_and_an_array_is_not_a_struct() {
+        let _guard = api_base_lock().await;
+        let cases: &[(&str, Result<&str, &str>)] = &[
+            // Slack sends `"error": null` on a success. To Go that is the zero
+            // value and the call succeeds; a plain derive calls it a type error.
+            (
+                r#"{"ok":true,"error":null}"#,
+                Ok(r#"{"ok":true,"error":null}"#),
+            ),
+            (
+                r#"{"ok":false,"error":null}"#,
+                Err("slack API error (conversations.info): "),
+            ),
+            (
+                r#"{"ok":null}"#,
+                Err("slack API error (conversations.info): "),
+            ),
+        ];
+        for (body, want) in cases {
+            let got = reply(body).await;
+            assert_eq!(got.as_deref().map_err(String::as_str), *want, "{body}");
+        }
+
+        // …and the other direction: serde would build the struct positionally
+        // from a sequence, turning Go's parse error into a success.
+        for body in [r"[true]", r"[]", r#"[false,"boom"]"#] {
+            let got = reply(body).await;
+            assert!(
+                got.as_ref()
+                    .err()
+                    .is_some_and(|e| e.starts_with("parsing response: ")),
+                "{body} must not decode as a struct: {got:?}"
+            );
+        }
+        set_api_base(None);
+    }
+
+    /// One scripted 200 through the real client, for the two tests above.
+    async fn reply(body: &str) -> Result<String, String> {
+        let body = body.to_string();
+        let app = axum::Router::new().fallback(move || {
+            let body = body.clone();
+            async move { (StatusCode::OK, body) }
+        });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let base = format!("http://{}", listener.local_addr().expect("addr"));
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        set_api_base(Some(base));
+        Client::new(SECRET)
+            .call_form(
+                &CancellationToken::new(),
+                "conversations.info",
+                String::new(),
+            )
+            .await
     }
 
     /// The envelope decides, not the status — which is Slack's own convention and

--- a/desktop/src-tauri/src/native/integrations/slack/client.rs
+++ b/desktop/src-tauri/src/native/integrations/slack/client.rs
@@ -235,6 +235,22 @@ async fn read_slack_response(
     //   `ok: true` and turn Go's `cannot unmarshal array` into a *success* whose
     //   text is the raw body. `GoStruct` refuses a non-map, which is #337's
     //   over-accept and the direction this port must never move in.
+    //
+    // A bare `null` body needs the same rule **one level further out**:
+    // `json.Unmarshal([]byte("null"), &envelope)` is a no-op returning `nil`, so
+    // Go falls through to the `!ok` branch. Hence `Option<GoStruct<_>>` — the
+    // idiom `resolve_slack_token` uses twice on the same rule.
+    //
+    // Two shapes are **accepted divergences**, both unreachable from
+    // `api.slack.com` and neither reproducible without hand-writing
+    // `Deserialize`, which is not worth it for a wording difference on a body
+    // Slack does not send:
+    //
+    // - `{"ok":false,"ok":true}` — `encoding/json` takes the last key and
+    //   succeeds; serde's derive refuses a duplicate field.
+    // - `{"OK":true}` — `encoding/json` falls back to case-insensitive field
+    //   matching and succeeds; serde matches names exactly, so this reads as
+    //   `ok: false`.
     #[derive(Default, serde::Deserialize)]
     #[serde(default)]
     struct Envelope {
@@ -243,8 +259,8 @@ async fn read_slack_response(
         #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
         error: String,
     }
-    let envelope = serde_json::from_str::<crate::native::gojson::GoStruct<Envelope>>(&body)
-        .map(|wrapped| wrapped.0)
+    let envelope = serde_json::from_str::<Option<crate::native::gojson::GoStruct<Envelope>>>(&body)
+        .map(|wrapped| wrapped.map_or_else(Envelope::default, |wrapped| wrapped.0))
         .map_err(|e| {
             // `fmt.Errorf("parsing response: %w", err)`. `encoding/json`'s
             // wording is not reproducible (see `github::body::parse_string_map`),
@@ -397,6 +413,13 @@ mod tests {
             let got = reply(body).await;
             assert_eq!(got.as_deref().map_err(String::as_str), *want, "{body}");
         }
+
+        // A bare `null` is a no-op to `json.Unmarshal`, so Go falls through to
+        // the `!ok` branch rather than failing to parse.
+        assert_eq!(
+            reply("null").await,
+            Err("slack API error (conversations.info): ".to_string())
+        );
 
         // …and the other direction: serde would build the struct positionally
         // from a sequence, turning Go's parse error into a success.

--- a/desktop/src-tauri/src/native/integrations/slack/client.rs
+++ b/desktop/src-tauri/src/native/integrations/slack/client.rs
@@ -1,0 +1,413 @@
+//! The shared HTTP client, ported from `internal/integrations/slack/tools.go`
+//! (`callSlack`, `callSlackJSON`, `readSlackResponse`) and `validate.go`
+//! (`slackHTTPClient`, `slackAPIBase`).
+//!
+//! # Slack is not shaped like the other four
+//!
+//! Every integration ported so far builds a URL out of model input. Slack does
+//! not: the base is a constant and the method is a literal (`conversations.list`,
+//! `chat.postMessage`), so **nothing model-supplied reaches the path**. That
+//! removes the whole class of problem #312 and #317 spent their reviews on —
+//! there is no dot-segment guard here and no [`base_url::Base`], because there is
+//! nothing to guard. Model input goes in a form body or a JSON body instead.
+//!
+//! Four other things differ from every sibling:
+//!
+//! - **Two call shapes, not one.** `callSlack` sends
+//!   `application/x-www-form-urlencoded` built by `url.Values.Encode()`;
+//!   `callSlackJSON` sends `application/json; charset=utf-8` — note the charset,
+//!   which no other integration sends. Five tools use the first and two the
+//!   second.
+//! - **Failure is in the envelope, not the status.** `readSlackResponse` checks
+//!   HTTP 429 and then stops looking at the status: it decodes `{"ok":…}` and
+//!   treats `ok: false` as the error. So a **500 carrying `{"ok":true}` is a
+//!   success** and a 200 carrying `{"ok":false,"error":"…"}` is a failure. That
+//!   is the opposite of the 2xx-range gate every other integration uses, and it
+//!   is reproduced exactly.
+//! - **Rate limiting is a distinct sentence** carrying the `Retry-After` header
+//!   verbatim — absent header included, which renders as an empty string in the
+//!   middle of the sentence.
+//! - **The cap is 5 MiB and the timeout 60 seconds**, both larger than any
+//!   sibling's. Set on the client, which is what bounds a graceful shutdown.
+//!
+//! # Cancellation
+//!
+//! Go threads `ctx` into `http.NewRequestWithContext`, so a cancelled turn aborts
+//! the call and `client.Do` fails — which becomes `calling Slack %s: request
+//! failed`. That is what a cancelled call answers here too.
+
+use std::sync::OnceLock;
+#[cfg(test)]
+use std::sync::RwLock;
+use std::time::Duration;
+
+use tokio_stream::StreamExt;
+
+use crate::claude::CancellationToken;
+
+/// `slackAPIBase`'s default.
+pub const DEFAULT_API_BASE: &str = "https://slack.com/api";
+
+/// Go's `slackAPIBase`, "a variable so tests can point it at a local httptest
+/// server".
+///
+/// **Test-only, where Go's is not**, exactly as `github::client::API_BASE` is:
+/// the seam points every Slack request — each bearing the workspace token — at
+/// an arbitrary host, so it should not exist in a shipped binary. Go had to
+/// export `SetAPIBase` (`slack/parity.go`) because `desktop/parity` is a
+/// different package; both callers here are in-crate.
+///
+/// Confluence and Jira needed no such thing, because their base is per row and a
+/// test can simply pass one. Slack's is a package-level constant, so the seam is
+/// back.
+#[cfg(test)]
+static API_BASE: RwLock<Option<String>> = RwLock::new(None);
+
+#[cfg(test)]
+fn api_base() -> String {
+    API_BASE
+        .read()
+        .expect("the slack API base lock is poisoned")
+        .clone()
+        .unwrap_or_else(|| DEFAULT_API_BASE.to_string())
+}
+
+#[cfg(not(test))]
+fn api_base() -> String {
+    DEFAULT_API_BASE.to_string()
+}
+
+/// Points every subsequent request at `base`; `None` restores the default.
+#[cfg(test)]
+pub(super) fn set_api_base(base: Option<String>) {
+    *API_BASE
+        .write()
+        .expect("the slack API base lock is poisoned") = base;
+}
+
+/// Serializes the tests that redirect [`API_BASE`].
+///
+/// The base is process-wide, as Go's package variable is, so two tests pointing
+/// it at different fakes would race — and `cargo test` runs tests in parallel
+/// where `go test` runs a package's in sequence.
+#[cfg(test)]
+pub(super) async fn api_base_lock() -> tokio::sync::MutexGuard<'static, ()> {
+    static LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+    LOCK.lock().await
+}
+
+/// `io.LimitReader(resp.Body, 5*1024*1024)`.
+const MAX_RESPONSE_BYTES: usize = 5 * 1024 * 1024;
+
+/// `slackHTTPClient` — 60 seconds, the longest of the six.
+fn http_client() -> Option<&'static reqwest::Client> {
+    static CLIENT: OnceLock<Option<reqwest::Client>> = OnceLock::new();
+    CLIENT
+        .get_or_init(|| {
+            reqwest::Client::builder()
+                .timeout(Duration::from_secs(60))
+                .build()
+                .ok()
+        })
+        .as_ref()
+}
+
+/// Go's implicit client: a token and the requests made with it.
+#[derive(Clone)]
+pub struct Client {
+    token: String,
+}
+
+impl Client {
+    pub fn new(token: impl Into<String>) -> Self {
+        Self {
+            token: token.into(),
+        }
+    }
+
+    /// `callSlack`: a form-encoded POST.
+    ///
+    /// `body` is `url.Values.Encode()`'s output — sorted keys, `+` for space —
+    /// which [`crate::native::gourl::Values`] reproduces. Passed already encoded
+    /// rather than as a map, so the encoding is visible at the call site the way
+    /// it is in Go.
+    pub async fn call_form(
+        &self,
+        ct: &CancellationToken,
+        method: &str,
+        body: String,
+    ) -> Result<String, String> {
+        self.send(
+            ct,
+            method,
+            "application/x-www-form-urlencoded",
+            body.into_bytes(),
+        )
+        .await
+    }
+
+    /// `callSlackJSON`: a JSON POST.
+    ///
+    /// Note the content type carries `; charset=utf-8`, which no other
+    /// integration sends and which the vectors pin.
+    pub async fn call_json(
+        &self,
+        ct: &CancellationToken,
+        method: &str,
+        body: Vec<u8>,
+    ) -> Result<String, String> {
+        self.send(ct, method, "application/json; charset=utf-8", body)
+            .await
+    }
+
+    async fn send(
+        &self,
+        ct: &CancellationToken,
+        method: &str,
+        content_type: &str,
+        body: Vec<u8>,
+    ) -> Result<String, String> {
+        // `slackAPIBase + "/" + method`. Nothing escapes the method because
+        // every one is a literal in the source — there is no model input in this
+        // URL at all, which is why this module has no dot-segment guard.
+        let failed = format!("calling Slack {method}: request failed");
+        let url = format!("{}/{method}", api_base());
+
+        let request = http_client()
+            .ok_or_else(|| failed.clone())?
+            .post(url)
+            .header("Authorization", format!("Bearer {}", self.token))
+            .header("Content-Type", content_type)
+            .body(body);
+
+        let response = tokio::select! {
+            () = ct.cancelled() => return Err(failed),
+            result = request.send() => result.map_err(|_| failed)?,
+        };
+
+        read_slack_response(ct, method, response).await
+    }
+}
+
+/// `readSlackResponse`: the 429 check, the cap, and the envelope.
+///
+/// **The HTTP status is otherwise never looked at.** Go checks 429 and then
+/// decodes the body; `ok: false` is the failure and `ok: true` is the success,
+/// whatever the status was. A port that added a 2xx gate — as every other
+/// integration here has — would turn a `500` carrying `{"ok":true}` into an
+/// error and change what the model reads.
+async fn read_slack_response(
+    ct: &CancellationToken,
+    method: &str,
+    response: reqwest::Response,
+) -> Result<String, String> {
+    if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        // `Header.Get` on an absent header is `""` to Go, which lands in the
+        // middle of the sentence — `retry after  seconds`, two spaces. Kept.
+        //
+        // `from_utf8_lossy` over the raw bytes rather than `to_str()`, which
+        // refuses non-ASCII: Go hands back whatever bytes arrived.
+        let retry_after = response
+            .headers()
+            .get(reqwest::header::RETRY_AFTER)
+            .map(|value| String::from_utf8_lossy(value.as_bytes()).into_owned())
+            .unwrap_or_default();
+        return Err(format!(
+            "slack rate limited ({method}), retry after {retry_after} seconds"
+        ));
+    }
+
+    let body = read_capped(ct, response).await?;
+
+    // Only `ok` and `error` are decoded, and everything else in the envelope is
+    // ignored — so the body is returned to the caller **verbatim**, never
+    // re-encoded from this value.
+    #[derive(serde::Deserialize)]
+    struct Envelope {
+        #[serde(default)]
+        ok: bool,
+        #[serde(default)]
+        error: String,
+    }
+    let envelope: Envelope = serde_json::from_str(&body).map_err(|e| {
+        // `fmt.Errorf("parsing response: %w", err)`. `encoding/json`'s wording is
+        // not reproducible (see `github::body::parse_string_map`), so this
+        // carries serde's — a divergence the vectors pin. It cannot leak the
+        // token: the text being parsed is Slack's response, not the request.
+        format!("parsing response: {e}")
+    })?;
+    if !envelope.ok {
+        return Err(format!("slack API error ({method}): {}", envelope.error));
+    }
+
+    Ok(body)
+}
+
+/// `io.ReadAll(io.LimitReader(resp.Body, 5 MiB))`.
+async fn read_capped(
+    ct: &CancellationToken,
+    response: reqwest::Response,
+) -> Result<String, String> {
+    let mut body = Vec::new();
+    let mut stream = Box::pin(response.bytes_stream());
+    loop {
+        let chunk = tokio::select! {
+            () = ct.cancelled() => return Err("reading response: context canceled".to_string()),
+            chunk = stream.next() => chunk,
+        };
+        match chunk {
+            None => break,
+            Some(Ok(chunk)) => {
+                body.extend_from_slice(&chunk);
+                if body.len() >= MAX_RESPONSE_BYTES {
+                    body.truncate(MAX_RESPONSE_BYTES);
+                    break;
+                }
+            }
+            Some(Err(e)) => return Err(format!("reading response: {e}")),
+        }
+    }
+    Ok(String::from_utf8_lossy(&body).into_owned())
+}
+
+/// The `<= 0 || > max` clamp all five paging tools apply, with a per-tool
+/// fallback and a per-tool ceiling — both of which differ between them, which is
+/// why neither is a constant here.
+///
+/// `list_channels` and `list_users` are `(1000, 100)`, `read_messages` is
+/// `(100, 20)`, `search_messages`' count is `(100, 20)`. Verified one by one
+/// rather than assumed from the first.
+pub fn clamp(value: i64, max: i64, fallback: i64) -> i64 {
+    if value <= 0 || value > max {
+        fallback
+    } else {
+        value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECRET: &str = "xoxb-SUPER-SECRET-SLACK-TOKEN";
+
+    #[test]
+    fn the_clamps_are_gos() {
+        // list_channels / list_users
+        assert_eq!(clamp(0, 1000, 100), 100);
+        assert_eq!(clamp(1001, 1000, 100), 100);
+        assert_eq!(clamp(1000, 1000, 100), 1000);
+        assert_eq!(clamp(-5, 1000, 100), 100);
+        // read_messages / search_messages count
+        assert_eq!(clamp(0, 100, 20), 20);
+        assert_eq!(clamp(101, 100, 20), 20);
+        assert_eq!(clamp(100, 100, 20), 100);
+        assert_eq!(clamp(1, 100, 20), 1);
+    }
+
+    #[tokio::test]
+    async fn the_api_base_is_redirectable_and_restorable() {
+        let _guard = api_base_lock().await;
+        assert_eq!(api_base(), DEFAULT_API_BASE);
+        set_api_base(Some("http://127.0.0.1:1".to_string()));
+        assert_eq!(api_base(), "http://127.0.0.1:1");
+        set_api_base(None);
+        assert_eq!(api_base(), DEFAULT_API_BASE);
+    }
+
+    /// The failure sentence names the **method** and nothing else — not the URL,
+    /// not the cause, not the token.
+    #[tokio::test]
+    async fn a_failed_call_names_the_method_and_nothing_secret() {
+        let _guard = api_base_lock().await;
+        set_api_base(Some("http://127.0.0.1:1".to_string()));
+
+        let message = Client::new(SECRET)
+            .call_form(
+                &CancellationToken::new(),
+                "conversations.list",
+                String::new(),
+            )
+            .await
+            .expect_err("nothing is listening");
+        assert_eq!(message, "calling Slack conversations.list: request failed");
+        assert!(!message.contains(SECRET));
+        assert!(!message.contains("127.0.0.1"));
+
+        set_api_base(None);
+    }
+
+    #[tokio::test]
+    async fn a_cancelled_call_answers_what_a_cancelled_go_call_answers() {
+        let _guard = api_base_lock().await;
+        set_api_base(Some("http://127.0.0.1:1".to_string()));
+        let ct = CancellationToken::new();
+        ct.cancel();
+        assert_eq!(
+            Client::new(SECRET)
+                .call_json(&ct, "chat.postMessage", b"{}".to_vec())
+                .await,
+            Err("calling Slack chat.postMessage: request failed".to_string())
+        );
+        set_api_base(None);
+    }
+
+    /// The envelope decides, not the status — which is Slack's own convention and
+    /// the opposite of every other integration in this tree.
+    #[tokio::test]
+    async fn the_envelope_decides_and_the_status_does_not() {
+        let _guard = api_base_lock().await;
+        let cases: &[(u16, &str, Result<&str, &str>)] = &[
+            // A 500 carrying `ok: true` is a **success**.
+            (
+                500,
+                r#"{"ok":true,"note":"served"}"#,
+                Ok(r#"{"ok":true,"note":"served"}"#),
+            ),
+            // …and a 200 carrying `ok: false` is a failure.
+            (
+                200,
+                r#"{"ok":false,"error":"channel_not_found"}"#,
+                Err("slack API error (conversations.info): channel_not_found"),
+            ),
+            // An absent `error` is an empty one, which Go interpolates as such.
+            (
+                200,
+                r#"{"ok":false}"#,
+                Err("slack API error (conversations.info): "),
+            ),
+        ];
+
+        for (status, body, want) in cases {
+            let (status, body) = (*status, body.to_string());
+            let app = axum::Router::new().fallback(move || {
+                let body = body.clone();
+                async move { (StatusCode::from_u16(status).expect("status"), body) }
+            });
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind");
+            let base = format!("http://{}", listener.local_addr().expect("addr"));
+            tokio::spawn(async move {
+                let _ = axum::serve(listener, app).await;
+            });
+            set_api_base(Some(base));
+
+            let got = Client::new(SECRET)
+                .call_form(
+                    &CancellationToken::new(),
+                    "conversations.info",
+                    String::new(),
+                )
+                .await;
+            assert_eq!(
+                got.as_deref().map_err(String::as_str),
+                *want,
+                "status {status}"
+            );
+        }
+        set_api_base(None);
+    }
+
+    use axum::http::StatusCode;
+}

--- a/desktop/src-tauri/src/native/integrations/slack/messaging.rs
+++ b/desktop/src-tauri/src/native/integrations/slack/messaging.rs
@@ -1,0 +1,327 @@
+//! The `messaging` service's seven tools, ported from
+//! `internal/integrations/slack/tools.go`.
+//!
+//! One service group registered in three batches (`registerChannelTools`,
+//! `registerMessageTools`, `registerWorkspaceTools`). Conventions are
+//! `native/integrations/github/repos.rs`'s: Go `json:` tags as field names, Go
+//! `jsonschema:` tags as doc comments verbatim, no `Option`, and
+//! `deny_unknown_fields`.
+//!
+//! # What is different here
+//!
+//! - **Five tools return Slack's body untouched** and two prefix it (`Message
+//!   sent successfully. Response: …`). The five that pass it through do not even
+//!   wrap it in a label, unlike every other integration.
+//! - **Two encodings.** `list_channels`, `get_channel_info`, `read_messages`,
+//!   `list_users` and `search_messages` send `url.Values.Encode()`; `send_message`
+//!   and `send_reply` send `json.Marshal` of a `map[string]any`. Both sort their
+//!   keys, and both are pinned as request bodies in the vectors.
+//! - **Every clamp is different.** `<= 0 || > max` with a per-tool `max` and a
+//!   per-tool fallback: 1000/100 for the two listers, 100/20 for `read_messages`
+//!   and for `search_messages`' count, and `page <= 0 → 1` with no ceiling at
+//!   all. Read one by one from `tools.go` rather than generalised from the first.
+//! - **`search_messages`' description says it needs a user token** and will error
+//!   on a bot token. That is advertised text, so it is copied verbatim; nothing
+//!   in the code enforces it, because Slack does.
+
+use schemars::JsonSchema;
+use serde_json::{json, Value};
+
+use crate::claude::{new_tool, CancellationToken, ToolDef};
+use crate::native::gourl::Values;
+
+use super::client::{clamp, Client};
+use super::text_result;
+
+/// `json.Marshal(payload)` for the two JSON-body tools.
+fn marshal(payload: &Value) -> Result<Vec<u8>, String> {
+    crate::native::gojson::to_vec_marshal(payload).map_err(|e| format!("marshaling request: {e}"))
+}
+
+/// `list_channels`.
+#[allow(dead_code)] // read through serde, never constructed in Rust
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct ListChannelsInput {
+    /// Maximum number of channels to return (default 100, max 1000)
+    limit: i64,
+    /// Pagination cursor for next page of results
+    cursor: String,
+}
+
+pub fn list_channels(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "list_channels",
+        "Lists Slack channels (public and private) the bot has access to.",
+        move |input: ListChannelsInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let mut values = Values::new();
+                values.set("types", "public_channel,private_channel");
+                values.set("limit", clamp(input.limit, 1000, 100).to_string());
+                // A cursor is written only when non-empty, so the first page
+                // carries no `cursor` key at all.
+                if !input.cursor.is_empty() {
+                    values.set("cursor", &input.cursor);
+                }
+                let body = client
+                    .call_form(&ct, "conversations.list", values.encode())
+                    .await?;
+                // The body, verbatim and unlabelled.
+                Ok(text_result(body))
+            }
+        },
+    )
+}
+
+/// `get_channel_info`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct GetChannelInfoInput {
+    /// required,Channel ID to get info for
+    channel: String,
+}
+
+pub fn get_channel_info(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "get_channel_info",
+        "Gets detailed information about a Slack channel.",
+        move |input: GetChannelInfoInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let mut values = Values::new();
+                values.set("channel", &input.channel);
+                let body = client
+                    .call_form(&ct, "conversations.info", values.encode())
+                    .await?;
+                Ok(text_result(body))
+            }
+        },
+    )
+}
+
+/// `read_messages`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct ReadMessagesInput {
+    /// required,Channel ID to read messages from
+    channel: String,
+    /// Maximum number of messages to return (default 20, max 100)
+    limit: i64,
+    /// Pagination cursor for next page of results
+    cursor: String,
+}
+
+pub fn read_messages(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "read_messages",
+        "Reads recent messages from a Slack channel.",
+        move |input: ReadMessagesInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let mut values = Values::new();
+                values.set("channel", &input.channel);
+                // 100/20 here, not 1000/100 — the two listers' ceiling is ten
+                // times this one's.
+                values.set("limit", clamp(input.limit, 100, 20).to_string());
+                if !input.cursor.is_empty() {
+                    values.set("cursor", &input.cursor);
+                }
+                let body = client
+                    .call_form(&ct, "conversations.history", values.encode())
+                    .await?;
+                Ok(text_result(body))
+            }
+        },
+    )
+}
+
+/// `send_message`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct SendMessageInput {
+    /// required,Channel ID to send the message to
+    channel: String,
+    /// required,Text of the message to send
+    text: String,
+}
+
+pub fn send_message(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "send_message",
+        "Sends a message to a Slack channel.",
+        move |input: SendMessageInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let payload = json!({"channel": input.channel, "text": input.text});
+                let body = client
+                    .call_json(&ct, "chat.postMessage", marshal(&payload)?)
+                    .await?;
+                Ok(text_result(format!(
+                    "Message sent successfully. Response: {body}"
+                )))
+            }
+        },
+    )
+}
+
+/// `send_reply`.
+///
+/// The same Slack method as [`send_message`] with one more key — so the
+/// *request* is nearly identical and the result sentence is not.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct SendReplyInput {
+    /// required,Channel ID containing the thread
+    channel: String,
+    /// required,Timestamp of the parent message to reply to
+    thread_ts: String,
+    /// required,Text of the reply
+    text: String,
+}
+
+pub fn send_reply(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "send_reply",
+        "Sends a threaded reply to a message in a Slack channel.",
+        move |input: SendReplyInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let payload = json!({
+                    "channel": input.channel,
+                    "thread_ts": input.thread_ts,
+                    "text": input.text,
+                });
+                let body = client
+                    .call_json(&ct, "chat.postMessage", marshal(&payload)?)
+                    .await?;
+                Ok(text_result(format!(
+                    "Reply sent successfully. Response: {body}"
+                )))
+            }
+        },
+    )
+}
+
+/// `list_users`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct ListUsersInput {
+    /// Maximum number of users to return (default 100, max 1000)
+    limit: i64,
+    /// Pagination cursor for next page of results
+    cursor: String,
+}
+
+pub fn list_users(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "list_users",
+        "Lists users in the Slack workspace.",
+        move |input: ListUsersInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let mut values = Values::new();
+                values.set("limit", clamp(input.limit, 1000, 100).to_string());
+                if !input.cursor.is_empty() {
+                    values.set("cursor", &input.cursor);
+                }
+                let body = client.call_form(&ct, "users.list", values.encode()).await?;
+                Ok(text_result(body))
+            }
+        },
+    )
+}
+
+/// `search_messages`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct SearchMessagesInput {
+    /// required,Search query string
+    query: String,
+    /// Number of results to return per page (default 20, max 100)
+    count: i64,
+    /// Page number of results to return (default 1)
+    page: i64,
+}
+
+pub fn search_messages(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "search_messages",
+        "Searches messages across the Slack workspace. \
+         Note: requires OAuth authentication (user token). \
+         This tool will return an error when used with a bot token.",
+        move |input: SearchMessagesInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let mut values = Values::new();
+                // Unconditional, unlike every cursor above: an empty search
+                // still sends `query=`.
+                values.set("query", &input.query);
+                values.set("count", clamp(input.count, 100, 20).to_string());
+                // `page` has **no ceiling** — only a floor — so it is not a
+                // `clamp` call.
+                let page = if input.page <= 0 { 1 } else { input.page };
+                values.set("page", page.to_string());
+                let body = client
+                    .call_form(&ct, "search.messages", values.encode())
+                    .await?;
+                Ok(text_result(body))
+            }
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn encoded(payload: &Value) -> String {
+        String::from_utf8(marshal(payload).expect("encode")).expect("utf-8")
+    }
+
+    /// `url.Values.Encode()` sorts its keys and writes a space as `+`, so the
+    /// form body is not the order the handler set them in.
+    #[test]
+    fn a_form_body_is_sorted_and_plus_encoded() {
+        let mut values = Values::new();
+        values.set("types", "public_channel,private_channel");
+        values.set("limit", "100");
+        values.set("cursor", "a b&c");
+        assert_eq!(
+            values.encode(),
+            "cursor=a+b%26c&limit=100&types=public_channel%2Cprivate_channel"
+        );
+    }
+
+    /// …and `json.Marshal` over a map sorts too, so `send_reply`'s body is
+    /// channel, text, thread_ts — not the source's order.
+    #[test]
+    fn a_json_body_is_sorted_and_html_escaped() {
+        assert_eq!(
+            encoded(&json!({"channel": "C1", "thread_ts": "1.2", "text": "a <b> & c"})),
+            r#"{"channel":"C1","text":"a \u003cb\u003e \u0026 c","thread_ts":"1.2"}"#
+        );
+    }
+
+    /// `page` has a floor and no ceiling, unlike every other numeric input here.
+    #[test]
+    fn the_page_floor_has_no_ceiling() {
+        for (input, want) in [(0_i64, 1_i64), (-3, 1), (1, 1), (5, 5), (100_000, 100_000)] {
+            let page = if input <= 0 { 1 } else { input };
+            assert_eq!(page, want, "{input}");
+        }
+    }
+}

--- a/desktop/src-tauri/src/native/integrations/slack/mod.rs
+++ b/desktop/src-tauri/src/native/integrations/slack/mod.rs
@@ -1,0 +1,237 @@
+//! The Slack integration's in-process MCP server, ported from
+//! `internal/integrations/slack/`.
+//!
+//! Seven tools in one service group (`messaging`), over a workspace token. The
+//! fourth of the six (#315), and the first that is not shaped like the three
+//! before it.
+//!
+//! ## Two things here that no earlier port had
+//!
+//! 1. **The token can come from the `auth` column.** `resolveToken`
+//!    (`slack/server.go`) switches on `credentials.auth_mode`: `bot_token` reads
+//!    the credentials blob, `oauth` reads `cfg.ParseOAuthToken()` — which is the
+//!    **`auth` column**, parsed as an `oauth2.Token`. Every integration before
+//!    this one used `auth` only as a boolean ("is it authenticated"), and
+//!    `native/integrations/registry.rs` collapsed it to one in SQL precisely so
+//!    the value could not exist in this process to be echoed. Slack is why
+//!    `HostingRow` now carries it; see that module on what changed and what did
+//!    not.
+//!
+//!    There is a third arm, and it is the one a port would drop: an
+//!    **unrecognized** `auth_mode` falls back to `bot_token` if it is non-empty,
+//!    and only then fails. So a row with `auth_mode: ""` and a bot token works.
+//!
+//! 2. **Nothing model-supplied reaches the URL.** The base is a constant and
+//!    every method is a literal (`conversations.list`, `chat.postMessage`), so
+//!    there is no dot-segment guard and no [`base_url`](super::base_url) here —
+//!    the whole class of problem #312 and #317 spent their reviews on does not
+//!    arise. Model input goes in a form body or a JSON body instead.
+//!
+//! ## The other Slack-shaped surprises
+//!
+//! - **`ok` decides, not the HTTP status.** `readSlackResponse` checks 429 and
+//!   then ignores the status entirely, so a `500` carrying `{"ok":true}` is a
+//!   success. Reproduced in `client`; it is the opposite of the 2xx-range gate
+//!   every sibling uses.
+//! - **Five of the seven tools return Slack's body unlabelled**; the two senders
+//!   prefix it.
+//! - Timeout 60s and cap 5 MiB, the largest of the six.
+//!
+//! ## What has to match Go, and what checks it
+//!
+//! Four surfaces, pinned by `desktop/parity/slack_vectors.json` — taken from the
+//! **running Go server** over its real MCP transport against a fake Slack that
+//! records the request each tool built: the hosted tool set, each advertised
+//! schema, the request (both encodings, and the sorted keys of each), and the
+//! result text of every success and every failure.
+//!
+//! `slack/parity.go`'s `SetAPIBase` is the seam, exactly as GitHub's is and for
+//! the same reason: the base is a package variable, so a test cannot pass one.
+//! Confluence and Jira needed no such thing because theirs is per row.
+//!
+//! `validate.go`'s `ValidateToken` and `oauth.go` are **not ported**: they answer
+//! `POST /api/integrations/{id}/auth/validate` and the OAuth flow (#318), which
+//! dial Slack and stay with Go. The validate route is covered all the same —
+//! `native::after_forward` fires
+//! [`reload_after_auth`](super::registry::reload_after_auth) on Go's 2xx for
+//! every hosted type.
+
+pub mod client;
+pub mod messaging;
+
+#[cfg(test)]
+mod tests_vectors;
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use rmcp::model::{CallToolResult, ContentBlock};
+
+use crate::claude::{tool_server, InProcessMcpServer, Result, ToolDef};
+
+use super::ServiceConfig;
+use client::Client;
+
+/// The one service group.
+pub const SERVICES: &[&str] = &["messaging"];
+
+/// Every tool this integration can host, in registration order — `SERVICES`
+/// order, then each `register*Tools` batch's own.
+///
+/// **Not** the order `tools/list` answers in: both SDKs sort by name.
+pub const SLACK_TOOL_NAMES: &[&str] = &[
+    "list_channels",
+    "get_channel_info",
+    "read_messages",
+    "send_message",
+    "send_reply",
+    "list_users",
+    "search_messages",
+];
+
+/// `fmt.Sprintf("slack-%s", cfg.ID)` — `mcp.NewServer`'s implementation name,
+/// **not** the prefix on a qualified tool name (that is the bare integration id).
+pub fn server_name(integration_id: &str) -> String {
+    format!("slack-{integration_id}")
+}
+
+/// The union of every **enabled** service's `Tools`.
+pub fn build_allowed_set(services: &BTreeMap<String, ServiceConfig>) -> BTreeSet<String> {
+    let mut allowed = BTreeSet::new();
+    for service in services.values() {
+        if !service.enabled {
+            continue;
+        }
+        for tool in service.tools.iter().flat_map(|tools| tools.iter()) {
+            allowed.insert(tool.clone());
+        }
+    }
+    allowed
+}
+
+/// Present **and** enabled.
+pub fn service_enabled(services: &BTreeMap<String, ServiceConfig>, name: &str) -> bool {
+    services.get(name).is_some_and(|service| service.enabled)
+}
+
+/// Every tool `buildMCPServer` would register for `services`, over `token`.
+pub fn slack_tools(services: &BTreeMap<String, ServiceConfig>, token: &str) -> Vec<ToolDef> {
+    let allowed = build_allowed_set(services);
+    let client = Client::new(token);
+    let mut tools = Vec::new();
+
+    // `len(allowed) == 0 || allowed[name]` — so an empty set admits everything.
+    let mut push = |service: &str, name: &str, tool: fn(&Client) -> ToolDef| {
+        if !service_enabled(services, service) {
+            return;
+        }
+        if !allowed.is_empty() && !allowed.contains(name) {
+            return;
+        }
+        tools.push(tool(&client));
+    };
+
+    push("messaging", "list_channels", messaging::list_channels);
+    push("messaging", "get_channel_info", messaging::get_channel_info);
+    push("messaging", "read_messages", messaging::read_messages);
+    push("messaging", "send_message", messaging::send_message);
+    push("messaging", "send_reply", messaging::send_reply);
+    push("messaging", "list_users", messaging::list_users);
+    push("messaging", "search_messages", messaging::search_messages);
+
+    tools
+}
+
+/// Starts the integration's server on a random loopback port.
+pub async fn start_slack_mcp_server(
+    integration_id: &str,
+    services: &BTreeMap<String, ServiceConfig>,
+    token: &str,
+) -> Result<InProcessMcpServer> {
+    tool_server(&server_name(integration_id), slack_tools(services, token)).await
+}
+
+/// Go's `textResult`, shared by all seven tools.
+pub(crate) fn text_result(text: String) -> CallToolResult {
+    CallToolResult::success(vec![ContentBlock::text(text)])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::native::gojson::GoList;
+
+    fn service(enabled: bool, tools: &[&str]) -> ServiceConfig {
+        ServiceConfig {
+            enabled,
+            tools: Some(GoList(tools.iter().map(|t| t.to_string()).collect())),
+        }
+    }
+
+    fn names(services: &BTreeMap<String, ServiceConfig>) -> Vec<String> {
+        slack_tools(services, "xoxb-token")
+            .iter()
+            .map(|tool| tool.name().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn the_server_name_is_gos() {
+        assert_eq!(server_name("abc123"), "slack-abc123");
+    }
+
+    #[test]
+    fn an_empty_allowed_set_hosts_every_tool() {
+        let services = BTreeMap::from([("messaging".to_string(), service(true, &[]))]);
+        assert_eq!(names(&services), SLACK_TOOL_NAMES);
+        assert!(build_allowed_set(&services).is_empty());
+    }
+
+    #[test]
+    fn one_named_tool_narrows_the_service() {
+        let services = BTreeMap::from([(
+            "messaging".to_string(),
+            service(true, &["send_message", "list_users"]),
+        )]);
+        assert_eq!(names(&services), ["send_message", "list_users"]);
+    }
+
+    /// An enabled service Slack does not know still contributes its names to the
+    /// union.
+    #[test]
+    fn an_unknown_enabled_service_still_narrows_the_known_one() {
+        let services = BTreeMap::from([
+            ("messaging".to_string(), service(true, &[])),
+            ("other".to_string(), service(true, &["read_messages"])),
+        ]);
+        assert_eq!(names(&services), ["read_messages"]);
+    }
+
+    #[test]
+    fn a_disabled_service_is_invisible_in_both_directions() {
+        let services = BTreeMap::from([
+            ("messaging".to_string(), service(false, &[])),
+            ("other".to_string(), service(true, &["send_reply"])),
+        ]);
+        assert!(names(&services).is_empty());
+        assert!(!service_enabled(&services, "messaging"));
+        assert!(!service_enabled(&services, "missing"));
+    }
+
+    #[test]
+    fn no_services_at_all_hosts_nothing() {
+        assert!(names(&BTreeMap::new()).is_empty());
+    }
+
+    #[test]
+    fn a_null_tools_column_is_not_a_filter() {
+        let services = BTreeMap::from([(
+            "messaging".to_string(),
+            ServiceConfig {
+                enabled: true,
+                tools: None,
+            },
+        )]);
+        assert!(build_allowed_set(&services).is_empty());
+        assert_eq!(names(&services), SLACK_TOOL_NAMES);
+    }
+}

--- a/desktop/src-tauri/src/native/integrations/slack/tests_vectors.rs
+++ b/desktop/src-tauri/src/native/integrations/slack/tests_vectors.rs
@@ -1,0 +1,496 @@
+//! The Rust half of `desktop/parity/slack_vectors.json`.
+//!
+//! The Go half (`desktop/parity/slack_parity_test.go`) stands the **real**
+//! integration up through `slack.Start`, points `slackAPIBase` at an
+//! `httptest.Server` that plays a scripted Slack and records what it was asked,
+//! and writes down four things. This half replays the same script through an axum
+//! server on loopback, the real
+//! [`start_slack_mcp_server`](super::start_slack_mcp_server), and a real
+//! `tools/call` over the MCP HTTP transport.
+//!
+//! The fourth block is Slack's own: `tokens` pins `resolveToken`, which is the
+//! only place in the port that reads the **`auth` column** as a value. Both
+//! languages observe the resolved token the same way — by making one call and
+//! reading the `Authorization` header the fake received — rather than recording
+//! it directly, which would put the thing under test into the fixture that
+//! verifies it.
+//!
+//! Pinned divergences: `rust_text` + `rust_no_request` for the zero-fraction
+//! float, `rust_text` alone for `encoding/json`'s syntax-error vocabulary when
+//! Slack's body will not parse, and `rust_error` for a credential blob that will
+//! not decode — where Go carries `encoding/json`'s wording and this carries line
+//! and column, because serde's message quotes the value, which in the `oauth` arm
+//! *is* the access token.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::{HeaderMap, Method, StatusCode, Uri};
+use axum::response::{IntoResponse, Response};
+use rmcp::ServerHandler;
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::client::{api_base_lock, set_api_base};
+use super::{server_name, slack_tools, start_slack_mcp_server, SERVICES, SLACK_TOOL_NAMES};
+use crate::claude::ToolServer;
+use crate::native::gojson::GoList;
+use crate::native::integrations::registry::resolve_slack_token;
+use crate::native::integrations::ServiceConfig;
+
+// ─── The vectors ─────────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct ToolVector {
+    name: String,
+    description: String,
+    input_schema: Value,
+}
+
+#[derive(Deserialize)]
+struct HostingVector {
+    case: String,
+    services: BTreeMap<String, GoServiceConfig>,
+    tools: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct GoServiceConfig {
+    enabled: bool,
+    tools: Option<Vec<String>>,
+}
+
+#[derive(Deserialize)]
+struct TokenVector {
+    case: String,
+    credentials: String,
+    auth: String,
+    #[serde(default)]
+    authorization: String,
+    #[serde(default)]
+    error: String,
+    #[serde(default)]
+    rust_error: String,
+}
+
+#[derive(Deserialize)]
+struct RequestVector {
+    method: String,
+    target: String,
+    authorization: String,
+    content_type: String,
+    body: String,
+}
+
+#[derive(Deserialize)]
+struct ResponseScript {
+    status: u16,
+    #[serde(default)]
+    retry_after: String,
+    body: String,
+}
+
+#[derive(Deserialize)]
+struct CallVector {
+    case: String,
+    tool: String,
+    arguments: Value,
+    response: ResponseScript,
+    request: Option<RequestVector>,
+    is_error: bool,
+    text: String,
+    #[serde(default)]
+    rust_text: String,
+    #[serde(default)]
+    rust_no_request: bool,
+}
+
+#[derive(Deserialize)]
+struct Vectors {
+    integration_id: String,
+    server_name: String,
+    token: String,
+    tools: Vec<ToolVector>,
+    hosting: Vec<HostingVector>,
+    tokens: Vec<TokenVector>,
+    calls: Vec<CallVector>,
+}
+
+fn vectors() -> Vectors {
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../parity/slack_vectors.json");
+    let raw = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("reading {path}: {e} — regenerate it from Go"));
+    serde_json::from_str(&raw).expect("parsing the slack vectors")
+}
+
+fn services(from: &BTreeMap<String, GoServiceConfig>) -> BTreeMap<String, ServiceConfig> {
+    from.iter()
+        .map(|(name, service)| {
+            (
+                name.clone(),
+                ServiceConfig {
+                    enabled: service.enabled,
+                    tools: service.tools.clone().map(GoList),
+                },
+            )
+        })
+        .collect()
+}
+
+fn all_services() -> BTreeMap<String, ServiceConfig> {
+    SERVICES
+        .iter()
+        .map(|name| {
+            (
+                name.to_string(),
+                ServiceConfig {
+                    enabled: true,
+                    tools: None,
+                },
+            )
+        })
+        .collect()
+}
+
+// ─── The advertised surface ──────────────────────────────────────────────────
+
+#[test]
+fn the_advertised_surface_matches_the_go_vectors() {
+    let v = vectors();
+    assert_eq!(v.server_name, server_name(&v.integration_id));
+    assert_eq!(
+        v.tools.len(),
+        SLACK_TOOL_NAMES.len(),
+        "vectors look partial"
+    );
+
+    let server = ToolServer::new(&v.server_name).with_tools(slack_tools(&all_services(), &v.token));
+    assert_eq!(
+        server.tool_names(),
+        v.tools.iter().map(|t| t.name.clone()).collect::<Vec<_>>(),
+        "the hosted tool set, as tools/list answers it"
+    );
+
+    for want in &v.tools {
+        let tool = server
+            .get_tool(&want.name)
+            .unwrap_or_else(|| panic!("{} is not registered", want.name));
+        assert_eq!(
+            tool.description.as_deref(),
+            Some(want.description.as_str()),
+            "{}'s description is what the model reads",
+            want.name
+        );
+        assert_eq!(
+            serde_json::to_value(&*tool.input_schema).expect("schema"),
+            want.input_schema,
+            "{}'s input schema is what the model is steered by",
+            want.name
+        );
+    }
+}
+
+#[test]
+fn the_hosted_tool_set_matches_the_go_vectors() {
+    let v = vectors();
+    assert!(v.hosting.len() >= 5, "vectors look partial");
+    for case in &v.hosting {
+        let mut hosted: Vec<String> = slack_tools(&services(&case.services), &v.token)
+            .iter()
+            .map(|tool| tool.name().to_string())
+            .collect();
+        hosted.sort();
+        assert_eq!(hosted, case.tools, "hosting case: {}", case.case);
+    }
+}
+
+// ─── `resolveToken`, and the auth column ─────────────────────────────────────
+
+/// Every arm of `resolveToken`, observed the way Go observed it: by making a call
+/// and reading the `Authorization` header the fake received.
+///
+/// The two rows that matter most are the ones no other integration has — `oauth`
+/// mode reading the **`auth` column** rather than the credentials blob, and the
+/// fallback arm where an unrecognized `auth_mode` still works if a bot token is
+/// present.
+#[tokio::test]
+async fn resolve_token_matches_the_go_vectors() {
+    let v = vectors();
+    assert!(v.tokens.len() >= 6, "vectors look partial");
+
+    let state = FakeState::default();
+    let app = axum::Router::new()
+        .fallback(serve_fake)
+        .with_state(state.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind the fake");
+    let base = format!("http://{}", listener.local_addr().expect("addr"));
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    let _guard = api_base_lock().await;
+    set_api_base(Some(base));
+
+    for case in &v.tokens {
+        let resolved = resolve_slack_token(&v.integration_id, &case.credentials, &case.auth);
+
+        if !case.error.is_empty() {
+            let want = if case.rust_error.is_empty() {
+                &case.error
+            } else {
+                &case.rust_error
+            };
+            assert_eq!(resolved, Err(want.clone()), "{}: refusal", case.case);
+            continue;
+        }
+
+        let token = resolved
+            .unwrap_or_else(|e| panic!("{}: Go resolved a token and this did not: {e}", case.case));
+        let server = start_slack_mcp_server(&v.integration_id, &all_services(), &token)
+            .await
+            .expect("start the slack server");
+
+        state.arm(&ResponseScript {
+            status: 200,
+            retry_after: String::new(),
+            body: r#"{"ok":true}"#.to_string(),
+        });
+        let _ = call_tool(
+            &server,
+            "list_users",
+            &serde_json::json!({"limit": 0, "cursor": ""}),
+        )
+        .await;
+
+        let seen = state.0.lock().expect("fake lock").seen.take();
+        let seen = seen.unwrap_or_else(|| panic!("{}: no request reached the fake", case.case));
+        assert_eq!(
+            seen.authorization, case.authorization,
+            "{}: the header Go sent",
+            case.case
+        );
+    }
+
+    set_api_base(None);
+}
+
+// ─── The fake Slack ──────────────────────────────────────────────────────────
+
+struct Recorded {
+    method: String,
+    target: String,
+    authorization: String,
+    content_type: String,
+    body: String,
+}
+
+#[derive(Default)]
+struct Fake {
+    status: u16,
+    retry_after: String,
+    body: String,
+    seen: Option<Recorded>,
+}
+
+#[derive(Clone, Default)]
+struct FakeState(Arc<Mutex<Fake>>);
+
+impl FakeState {
+    fn arm(&self, script: &ResponseScript) {
+        let mut fake = self.0.lock().expect("fake lock");
+        fake.status = script.status;
+        fake.retry_after.clone_from(&script.retry_after);
+        fake.body.clone_from(&script.body);
+        fake.seen = None;
+    }
+}
+
+async fn serve_fake(
+    State(state): State<FakeState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    let header = |name: &str| {
+        headers
+            .get(name)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default()
+            .to_string()
+    };
+
+    let (status, retry_after, reply) = {
+        let mut fake = state.0.lock().expect("fake lock");
+        fake.seen = Some(Recorded {
+            method: method.to_string(),
+            target: uri
+                .path_and_query()
+                .map(|pq| pq.as_str().to_string())
+                .unwrap_or_default(),
+            authorization: header("authorization"),
+            content_type: header("content-type"),
+            body: String::from_utf8_lossy(&body).into_owned(),
+        });
+        (fake.status, fake.retry_after.clone(), fake.body.clone())
+    };
+
+    let mut response = (
+        StatusCode::from_u16(status).expect("a scripted status"),
+        reply,
+    )
+        .into_response();
+    if !retry_after.is_empty() {
+        response.headers_mut().insert(
+            axum::http::header::RETRY_AFTER,
+            retry_after.parse().expect("a scripted Retry-After"),
+        );
+    }
+    response
+}
+
+// ─── The calls ───────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn every_call_matches_the_go_vectors() {
+    let v = vectors();
+    assert!(v.calls.len() >= 18, "vectors look partial");
+
+    let state = FakeState::default();
+    let app = axum::Router::new()
+        .fallback(serve_fake)
+        .with_state(state.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind the fake");
+    let base = format!("http://{}", listener.local_addr().expect("addr"));
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    let _guard = api_base_lock().await;
+    set_api_base(Some(base));
+
+    let server = start_slack_mcp_server(&v.integration_id, &all_services(), &v.token)
+        .await
+        .expect("start the slack server");
+
+    for case in &v.calls {
+        state.arm(&case.response);
+        let result = call_tool(&server, &case.tool, &case.arguments).await;
+
+        assert!(
+            !result.text.contains(&v.token),
+            "{}: the token leaked into a tool result: {}",
+            case.case,
+            result.text
+        );
+
+        let (want_text, want_error) = if case.rust_text.is_empty() {
+            (&case.text, case.is_error)
+        } else {
+            (&case.rust_text, true)
+        };
+        assert_eq!(result.text, *want_text, "{}: result text", case.case);
+        assert_eq!(result.is_error, want_error, "{}: is_error", case.case);
+
+        let seen = state.0.lock().expect("fake lock").seen.take();
+        let want_request = if case.rust_no_request {
+            assert!(
+                seen.is_none(),
+                "{}: the refusal still reached the network",
+                case.case
+            );
+            None
+        } else {
+            case.request.as_ref()
+        };
+        match (want_request, seen) {
+            (None, seen) => assert!(
+                seen.is_none(),
+                "{}: Go made no request and this one did",
+                case.case
+            ),
+            (Some(_), None) => panic!("{}: Go made a request and this one did not", case.case),
+            (Some(want), Some(got)) => {
+                assert_eq!(got.method, want.method, "{}: method", case.case);
+                assert_eq!(got.target, want.target, "{}: request target", case.case);
+                assert_eq!(
+                    got.authorization, want.authorization,
+                    "{}: the Bearer prefix and the token",
+                    case.case
+                );
+                assert_eq!(
+                    got.content_type, want.content_type,
+                    "{}: form or JSON, and the charset",
+                    case.case
+                );
+                assert_eq!(got.body, want.body, "{}: request body", case.case);
+            }
+        }
+    }
+
+    set_api_base(None);
+}
+
+struct ToolAnswer {
+    text: String,
+    is_error: bool,
+}
+
+async fn rpc_call(
+    server: &crate::claude::InProcessMcpServer,
+    name: &str,
+    arguments: &Value,
+) -> Value {
+    let payload = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": name, "arguments": arguments},
+    });
+
+    let mut request = reqwest::Client::new()
+        .post(server.url())
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream");
+    for (header, value) in &server.config().headers {
+        request = request.header(header, value);
+    }
+    let response = request
+        .body(payload.to_string())
+        .send()
+        .await
+        .expect("send tools/call");
+    serde_json::from_str(&response.text().await.expect("text")).expect("a JSON-RPC reply")
+}
+
+async fn call_tool(
+    server: &crate::claude::InProcessMcpServer,
+    name: &str,
+    arguments: &Value,
+) -> ToolAnswer {
+    let body = rpc_call(server, name, arguments).await;
+
+    assert!(
+        body.get("error").is_none(),
+        "{name}: a tool must not raise a protocol error: {body}"
+    );
+    let content = body["result"]["content"]
+        .as_array()
+        .unwrap_or_else(|| panic!("{name}: no content array: {body}"));
+    assert_eq!(content.len(), 1, "{name}: want exactly one content block");
+    assert_eq!(content[0]["type"], "text");
+
+    ToolAnswer {
+        text: content[0]["text"]
+            .as_str()
+            .unwrap_or_else(|| panic!("{name}: content is not text: {body}"))
+            .to_string(),
+        is_error: body["result"]["isError"].as_bool().unwrap_or(false),
+    }
+}

--- a/desktop/src-tauri/src/native/mod.rs
+++ b/desktop/src-tauri/src/native/mod.rs
@@ -333,15 +333,26 @@ pub fn after_forward(method: &Method, path: &str, status: StatusCode) {
     if !status.is_success() {
         return;
     }
-    let Some(id) = integrations::reload_after_forward(method, path).map(str::to_string) else {
+    let Some((id, trigger)) = integrations::reload_after_forward(method, path) else {
         return;
     };
+    let id = id.to_string();
     let Some(db_path) = paths::database_path() else {
         log::warn!("no data dir; not reloading integration {id:?} after {path}");
         return;
     };
     tokio::spawn(async move {
-        integrations::registry::reload_after_auth(&db_path, &id).await;
+        match trigger {
+            // A credential was just written: reload, as Go does.
+            integrations::Trigger::CredentialWritten => {
+                integrations::registry::reload_after_auth(&db_path, &id).await;
+            }
+            // A poll, not an event — so only if the row stopped matching what is
+            // running. See `registry::reload_if_secrets_changed`.
+            integrations::Trigger::AuthStatusPolled => {
+                integrations::registry::reload_if_secrets_changed(&db_path, &id).await;
+            }
+        }
     });
 }
 

--- a/desktop/src-tauri/src/native/schedule/mod.rs
+++ b/desktop/src-tauri/src/native/schedule/mod.rs
@@ -11,9 +11,10 @@
 //! `cmd/web.go` starts the sidecar's scheduler on every boot. Ownership moves
 //! in one commit that stops the sidecar scheduling — the #289 model — and that
 //! commit is blocked on `chat/runner.rs::build_options`, which still refuses an
-//! agent whose tools come from an integration this build cannot host — three of
-//! the six (#313–#315), since the local in-process server (#310), github (#311),
-//! confluence (#317) and jira (#316) are no longer among them. A chat can forward to Go on that
+//! agent whose tools come from an integration this build cannot host — two of
+//! the six (#313 and #314), since the local in-process server (#310), github
+//! (#311), confluence (#317), jira (#316) and slack (#315) are no longer among
+//! them. A chat can forward to Go on that
 //! refusal; a scheduled task with no Go scheduler behind it would simply never
 //! run, with nothing to say so. See "The scheduler: the computation moved, the
 //! ownership did not" in `desktop/CLAUDE.md`.

--- a/desktop/src-tauri/src/sidecar.rs
+++ b/desktop/src-tauri/src/sidecar.rs
@@ -80,7 +80,7 @@ pub async fn spawn(app: &AppHandle, port: u16) -> Result<Sidecar, String> {
         // feature: its starter opens a live whatsmeow WebSocket and registers
         // the client in a package global that the status, reconnect and QR
         // pairing endpoints read. Deriving the list from the starter table means
-        // #313–#315 each add one string in one place.
+        // #313 and #314 each add one string in one place.
         //
         // It does **not** switch off `StartFilteredServer`, which is what an
         // agent run uses: that reads the integration row afresh per run and

--- a/internal/integrations/slack/parity.go
+++ b/internal/integrations/slack/parity.go
@@ -1,0 +1,40 @@
+package slack
+
+// This file is the seam `desktop/parity/slack_parity_test.go` builds its
+// cross-language vectors through, and it exists for exactly one reason: the
+// vectors have to come from the **real** server, not from a restatement of it.
+//
+// `desktop/parity` is a different package, so it cannot reach `slackAPIBase` to
+// stand a server up against a local fake. The alternative — a generator that
+// rebuilt the tool set from this package's source — would freeze someone's
+// reading of the code rather than the code, and the whole point of the vectors
+// is that a change here fails the Rust port in
+// `desktop/src-tauri/src/native/integrations/slack/`.
+//
+// #312 did the same for GitHub, which has the same shape: one API root in a
+// package variable. #316 and #317 needed no seam of their own, because an
+// Atlassian site URL is per row and a test can simply store one — the difference
+// is where the base lives, not how careful the test is being.
+//
+// Nothing below changes behavior or wording: `Start` remains the only way the
+// app builds this server.
+
+// SetAPIBase points every outgoing Slack request at base and returns a function
+// that restores the previous value.
+//
+// Do not call outside tests. What it is is a primitive for pointing every Slack
+// request in the process — each one bearing the workspace's bot or user token —
+// at an arbitrary host, so a caller anywhere in the running server would be a
+// credential-exfiltration seam rather than a misconfiguration. It is exported
+// only because `desktop/parity` is a different package; the Rust port gates the
+// same seam behind `#[cfg(test)]`, so it does not exist in a shipped desktop
+// binary at all.
+//
+// The variable it writes is the same one this package's own tests redirect. Not
+// safe for concurrent use with a live integration — which is fine, because the
+// only callers are tests that own the process.
+func SetAPIBase(base string) (restore func()) {
+	previous := slackAPIBase
+	slackAPIBase = base
+	return func() { slackAPIBase = previous }
+}


### PR DESCRIPTION
Closes #315

## What

Ports `internal/integrations/slack/` to `desktop/src-tauri/src/native/integrations/slack/` — seven tools in one service group (`messaging`), over a workspace token. `slack` joins `registry::HOSTED_TYPES`, so the sidecar is started with `AGENTO_INTEGRATIONS=off:github,confluence,jira,slack`.

## Why this one is not like the last three

Confluence, Jira and GitHub all build URLs out of model input and all read their credential from one column. Slack does neither.

### The token can come from the `auth` column

`resolveToken` switches on `credentials.auth_mode`: `bot_token` reads the credentials blob, and `oauth` reads `cfg.ParseOAuthToken()` — the **`auth` column**, decoded as an `oauth2.Token`. Every port before this used `auth` only as a boolean, and `registry.rs` collapsed it to one *in SQL* precisely so a stored token could not exist in this process to be echoed. `HostingRow` now carries it. What did **not** change is where it may go: no `Serialize`, no `Debug`, private to the module, only a `&str` leaving.

There is a third arm too, and it is the one a port drops: an **unrecognized** `auth_mode` falls back to `bot_token` when that is non-empty, so a row whose mode was never set still works. All three arms are pinned, plus the empty-`access_token` case that sends a bare `Bearer` header — and both languages observe the resolved token by reading the `Authorization` header the fake received, rather than recording it, which would put the thing under test into the fixture that verifies it.

### Nothing model-supplied reaches the URL

The base is a constant and every method is a literal, so there is no dot-segment guard and no `base_url::Base` — the class of problem #312 and #317 spent their reviews on does not arise here. The seam is back to GitHub's shape instead: `slackAPIBase` is a package variable, so `slack/parity.go` exports `SetAPIBase` and the Rust side gates a `RwLock` behind `#[cfg(test)]`.

## Four Slack-shaped surprises, all pinned

- **`ok` decides, not the HTTP status.** `readSlackResponse` checks 429 and then ignores the status, so a **500 carrying `{"ok":true}` is a success** and a 200 carrying `{"ok":false}` is a failure. Every sibling gates on the 2xx range, so this is the one a port gets backwards.
- **Two encodings.** Five tools send `url.Values.Encode()` as form data; two send `json.Marshal` as `application/json; charset=utf-8` — with the charset, which nothing else in the tree sends.
- **Four different clamps**: 1000/100 for the two listers, 100/20 for `read_messages` and `search_messages`' count, and a floor of 1 with **no ceiling** for `page`.
- **Rate limiting is its own sentence**, interpolating `Retry-After` verbatim — including when absent, which lands mid-sentence as an empty string.

## Hosting Slack opened a hole in #311's reload hook

Go's `handleOAuthToken` writes the token and calls `registry.Reload`, and `startProviderCallback` supports exactly `google` and `slack`. `registry.rs`'s header said in as many words that this was harmless *because neither type was hosted here* — true until this PR. Now that `Reload` reaches nothing, and a Slack integration authenticated by OAuth would first be served at the next boot.

`reload_after_auth` cannot cover it: that hook hangs off a **forwarded request**, and an OAuth token does not arrive on one — the browser delivers it to a callback server the *sidecar* opens on its own port. The one part of the flow that crosses this proxy is the UI polling `GET /api/integrations/{id}/auth/status`, so `reload_after_forward` now returns a `Trigger`:

- `POST …/auth/validate` is an **event** — reload unconditionally, as Go does.
- `GET …/auth/status` is a **poll** — `reload_if_secrets_changed` compares the row's `credentials`+`auth` fingerprint against the one the running server was started with, and does nothing when they match. That is load-bearing: `reload` rebinds the port and drops in-flight `tools/call`s, and the dialog polls every second.

Covered by `a_polled_auth_status_reloads_on_a_change_and_not_on_a_poll`, which asserts the firing half *and* that three consecutive no-op polls leave the port untouched. **Best-effort by construction** — a user who closes the dialog early is still served at the next boot; #318 owns the flow itself.

## Acceptance

- [x] Every tool under the same name and the same input schema, from a live `tools/list` against the Go server.
- [x] Result payloads match across 19 call vectors — every tool, both encodings, the envelope-over-status rule in both directions, both rate-limit shapes, and a non-JSON body.
- [x] Credentials come from the stored row and appear in no response or log line; the vector runners assert the token never reaches a tool result.
- [x] `resolveToken`'s three arms pinned, including that `oauth` reads the `auth` column.

## Verification

- `cargo test` — whole suite green; 19 new Slack tests plus the registry's new one.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` — clean.
- `go test ./...` — clean; `golangci-lint` at CI's pinned v2.5.0 — 0 issues.

Note three existing tests moved their "an unported type" stand-in from `slack` to `telegram`, which is now the honest one.