### PR TITLE
feat(desktop): port the Telegram integration MCP server (#314)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -600,7 +600,7 @@ of the `Err` arms the cut-over has to turn into a real response.
 | 1 ✅ | Sidecar + proxy | — | done |
 | 2 ← | Pricing + analytics | `internal/pricing`, `internal/claudesessions` | Pure computation over JSONL + SQLite. No external deps. **In progress**: `/api/pricing/catalog`, `/api/claude-sessions`, `/api/claude-sessions/facets`, `/api/claude-analytics`, `/api/claude-sessions/insights/summary` and the agent reads are native and diff clean. |
 | 3 ← | Storage + tasks | `internal/storage`, `internal/scheduler` | **In progress (#274, #275).** `db.rs` is read-write, the 27 migrations are ported, and the writes whose every effect Rust owns are native — see below. The scheduler's *schedule computation* is ported and pinned (#275); its ownership is not, and is blocked — see below. |
-| 4 ← | Integrations | `internal/integrations`, `internal/trigger` | OAuth2 + MCP servers. Six of them: google, github, slack, jira, confluence, telegram, plus `internal/tools`. **How to host one is settled (#282)** — `claude::ToolServer`, see "Hosting a tool" below; do not invent a second way. **`internal/tools` is done (#310)** — `native/tools/`, and it is the worked example the six should be read against. **GitHub is done (#312)** — `native/integrations/github/`, the worked example for an *integration*. **The registry is done (#311)** — `native/integrations/registry.rs` plus `PUT`/`DELETE /api/integrations/{id}`, and the sidecar now runs with `AGENTO_INTEGRATIONS=off:<the types the shell hosts>`, so every type has exactly one owner. **Confluence is done (#317)** — `native/integrations/confluence/`, the smallest of the six and the one that shows what an integration adds over #312: a per-row API base, basic auth, and a `Start` check that is a decision. **Jira is done (#316)** — `native/integrations/jira/`, Confluence's twin, and the one that shows that a shared credential type does not mean shared behaviour: `jira.Start` validates nothing, so a bad base is answered per call instead of by refusing to host. **Slack is done (#315)** — `native/integrations/slack/`, the first that is not Atlassian-shaped: no model input in the URL at all, and the only integration whose token can come from the `auth` column. #313 and #314 are each "add a starter **and its name to `HOSTED_TYPES`**", which is the one list both processes are configured from. WhatsApp is **not** among them — but Go still hosts its rows, because its starter opens a live connection rather than just a port; see below. |
+| 4 ← | Integrations | `internal/integrations`, `internal/trigger` | OAuth2 + MCP servers. Six of them: google, github, slack, jira, confluence, telegram, plus `internal/tools`. **How to host one is settled (#282)** — `claude::ToolServer`, see "Hosting a tool" below; do not invent a second way. **`internal/tools` is done (#310)** — `native/tools/`, and it is the worked example the six should be read against. **GitHub is done (#312)** — `native/integrations/github/`, the worked example for an *integration*. **The registry is done (#311)** — `native/integrations/registry.rs` plus `PUT`/`DELETE /api/integrations/{id}`, and the sidecar now runs with `AGENTO_INTEGRATIONS=off:<the types the shell hosts>`, so every type has exactly one owner. **Confluence is done (#317)** — `native/integrations/confluence/`, the smallest of the six and the one that shows what an integration adds over #312: a per-row API base, basic auth, and a `Start` check that is a decision. **Jira is done (#316)** — `native/integrations/jira/`, Confluence's twin, and the one that shows that a shared credential type does not mean shared behaviour: `jira.Start` validates nothing, so a bad base is answered per call instead of by refusing to host. **Slack is done (#315)** — `native/integrations/slack/`, the first that is not Atlassian-shaped: no model input in the URL at all, and the only integration whose token can come from the `auth` column. **Telegram is done (#314)** — `native/integrations/telegram/`, the outbound half, and the one that reached two reflector divergences the map had recorded as unreachable. #313 is the last, and is "add a starter **and its name to `HOSTED_TYPES`**", which is the one list both processes are configured from. WhatsApp is **not** among them — but Go still hosts its rows, because its starter opens a live connection rather than just a port; see below. |
 | 5 ← | Agent execution | `internal/agent`, `internal/service` | **In progress (#276).** The chat SSE turn is native: `/messages`, `/input`, `/permission` and `/stop`, on top of the ported SDK. The scheduler's executor (#275) is the other caller and still Go's. |
 
 ### The session scanner (`src-tauri/src/native/scanner/`)
@@ -813,7 +813,7 @@ Consequences, each load-bearing:
   equally unbounded), and it means the only ceiling on the drain is the slowest
   handler. `github::client` sets 15s and nothing holds a long-lived stream
   (`legacy_session_mode: false` makes the stream `GET` a `405`), so today the
-  bound is real. A handler added by #313 or #314 with no client timeout would fail
+  bound is real. A handler added by #313 with no client timeout would fail
   no test while leaving a revoked credential answering `tools/call` for as long
   as its socket stays open. Set the timeout on the client, not on the drain.
 - **Go's `ServeStdioMCP` / `SelfAsStdioMCPServer` are not ported**, and
@@ -942,7 +942,7 @@ them.
 
 The first of the six, and the largest: twenty tools over five service groups,
 token auth only. It is the file to read beside `native/tools/` before porting
-#313 and #314 — that one settles *how to host a tool*, this one settles *how to port
+#313 — that one settles *how to host a tool*, this one settles *how to port
 an integration*.
 
 **Where it lives, and why there.** `native/integrations.rs` stays a file and
@@ -980,7 +980,7 @@ half is what pins the things no response reveals — `url.PathEscape` per segmen
 with
 `go test ./desktop/parity/ -run TestGitHubVectors -update-github-vectors`.
 
-Five things it brought that #313 and #314 will want:
+Five things it brought that #313 will want:
 
 - **`gourl.rs` now has all three of `net/url`'s escaping modes.**
   `url.PathEscape` is `encodePathSegment` and escapes `/ ; , ?`;
@@ -1030,7 +1030,7 @@ Five things it brought that #313 and #314 will want:
   reqwest decompresses in its service stack, so `bytes_stream()` yields
   decompressed bytes and `read_capped` caps what Go's `io.LimitReader` over a
   gunzipped `resp.Body` caps.
-- **The test seam is `#[cfg(test)]`, and should stay that way in #313 and #314.**
+- **The test seam is `#[cfg(test)]`, and should stay that way in #313.**
   `githubAPIBase` had to be *exported* on the Go side (`parity.go`) because
   `desktop/parity` is a different package; both Rust callers are in-crate, so
   `API_BASE`/`set_api_base` compile out of a shipped binary entirely. What they
@@ -1343,6 +1343,55 @@ It is **best-effort**: a user who closes the dialog before the flow completes is
 still served only at the next boot. #318 owns the OAuth flow itself and is where
 that stops being true.
 
+### The Telegram integration (`native/integrations/telegram/`, #314)
+
+Eleven tools in one service group (`messaging`), over a bot token — the largest
+tool set after GitHub's twenty, and the **outbound half only**. The inbound
+webhook (`POST /webhooks/telegram/{id}`) and `internal/trigger/`'s dispatcher are
+#319 and are untouched; they matter here only because the webhook route is
+mounted at the root and deliberately outside `guards.rs`, which nothing in this
+module is on.
+
+**It reaches two of the three reflector divergences `claude/schema_vectors.rs`
+left standing**, both of which it recorded as unreachable because "nothing in the
+six integrations" used the shape:
+
+- **`create_poll` takes a `[]string`** — the first slice parameter anywhere in
+  the six. `jsonschema-go` renders every slice as `["null","array"]`, because a
+  Go nil slice marshals as `null` and must be accepted back; `schemars` renders a
+  bare `array`. The map's guidance was "a port that needs one must add the null
+  itself", and `messaging::go_string_slice` is that, with
+  `null_is_zero_value` on the field so a `null` decodes to an empty `Vec` the way
+  it decodes to a nil slice. That second half is not cosmetic: `len(nil)` is 0, so
+  a null reaches Go's own "2-10 options" refusal rather than a decode error, and
+  the vectors pin `got 0`.
+- **`send_location` takes `float64`** — the first floats. The schema costs
+  nothing (`normalize_go_schema` drops the `format` `schemars` adds) but the
+  *encoding* would have: `encoding/json` spells a float its own way and
+  `gojson::go_float` already reproduces it. `1e+21` and `1e-7` are in the request
+  vectors because that is the only place the spelling is observable.
+
+**The bot token is in the URL path.** `apiURL` is
+`fmt.Sprintf("%s/bot%s/%s", …)`, so the credential is in the request line rather
+than a header. Two consequences: an error string must not interpolate a transport
+cause (a `reqwest::Error`'s `Display` carries the URL), which Go's wording already
+avoids by naming only the method; and `Client::endpoint` needs the same
+compare-what-`url`-produced guard the other ports have, because a token could
+contain a separator. The accepted half of that guard is the interesting one — a
+token cannot *begin* a dot segment, since `apiURL` glues it to the literal `bot`,
+so `../evil` becomes the segment `bot..` and is sent by both.
+
+**The envelope decides and the status never does** — not even a 429, which
+Slack's client does check. A 500 carrying `{"ok":true}` is a success. All three
+`encoding/json` decode rules are applied up front here rather than after review
+(`null_is_zero_value`, `GoStruct`, `Option<GoStruct<_>>`), plus a fourth that is
+Telegram's own: `result` is a `json.RawMessage`, so an **absent** one renders as
+the empty string and an explicit `null` as the four bytes `null` — and both reach
+the model in a result sentence, so `Option<Box<RawValue>>` cannot be left to
+serde, which folds a JSON null into `None`.
+
+Cap 10 MiB and timeout 60 seconds, the largest of the six on both counts.
+
 ### The integration registry, and the port's second ownership flip (#311)
 
 `native/integrations/registry.rs` is `internal/integrations/registry.go`:
@@ -1392,8 +1441,8 @@ the sidecar still serves, and the sidecar is still shipped.
 must cover it (`a_hosted_type_always_has_a_starter`), and `hosting_env_value`
 renders it into what `sidecar.rs` sets. That shape was chosen over a constant
 hardcoded on both sides because of which failure it makes impossible: the shell
-is the process that *knows* what it hosts, so #313 and #314 each add one string
-in one place. The failure being designed against is a Rust slack starter landing
+is the process that *knows* what it hosts, so #313 adds the last string in one
+place. The failure being designed against is a Rust slack starter landing
 while Go is never told to stop hosting slack — two processes on one integration —
 and its mirror is the WhatsApp bug above. A hardcoded Go list would have to be
 edited in lockstep with a Rust table, in another language, in another PR.
@@ -1411,15 +1460,15 @@ asserts both halves, the fallback and the untouched row.
 run uses: `runner.go` reads the integration row afresh per run, builds a
 throwaway server and records nothing. Gating it would have broken every
 integration-using chat, scheduled task and Telegram trigger the sidecar still
-serves — which is now the minority, since only two of the six types are #313's
-and #314's.
+serves — which is now one type, #313's.
 The Go tests assert both halves, because the switch is only safe while that
 asymmetry holds.
 
 Two consequences worth knowing before touching this:
 
-- **`github` (#312), `confluence` (#317), `jira` (#316) and `slack` (#315) have
-  starters here, and Go still hosts the rest.** A type not
+- **Five of the six have starters here** — `github` (#312), `confluence` (#317),
+  `jira` (#316), `slack` (#315) and `telegram` (#314) — **and Go still hosts
+  `google` and `whatsapp`.** A type not
   in `HOSTED_TYPES` reaches this module's own unregistered-type path — `no
   starter registered for integration type "slack"`, logged and never surfaced —
   but in practice it does not reach it at all, because the writes decline it
@@ -1770,10 +1819,11 @@ path cannot try to answer a chat turn with a `Vec<u8>`.
 **The four routes share a process-local registry, so they moved together** —
 `/messages` puts a session in, the others look one up. But not every chat *can*
 run natively: an agent whose tools come from an integration this build cannot
-host still needs #313 or #314, and `runner::build_options` refuses those before
-any subprocess exists. (Parts of that refusal are gone — the **local** server
-(#310) and any agent naming only integrations in `HOSTED_TYPES`: **github** since
-#311, **confluence** since #317, **jira** since #316, **slack** since #315. `build_options`
+host still needs #313, and `runner::build_options` refuses those before any
+subprocess exists. (Most of that refusal is gone — the **local** server (#310)
+and any agent naming only integrations in `HOSTED_TYPES`: **github** since #311,
+**confluence** since #317, **jira** since #316, **slack** since #315, **telegram**
+since #314. `build_options`
 starts each of them, and is `async` for that reason, returning the listener
 handles alongside the options because dropping one stops its server.) That would strand `/stop` for a chat still running on Go, so
 the three steering routes answer natively **only when Rust holds a live session
@@ -2384,7 +2434,7 @@ precede it.
 
 **The blocker, verified.** The flip needs Rust to *run* a task, and
 `chat/runner.rs::build_options` still refuses an agent whose capabilities name
-an MCP server this build cannot host — two of the six providers (#313 and #314). For a chat that is safe — the three steering routes forward
+an MCP server this build cannot host — one of the six providers (#313). For a chat that is safe — the three steering routes forward
 and Go answers, because Go holds the session. **For a scheduled task there is no
 second implementation behind it**: with the sidecar not scheduling, a task Rust
 cannot run does not fail, it *silently never runs*, and the job history has no
@@ -2882,10 +2932,10 @@ the sidecar runs with `AGENTO_INTEGRATIONS=off:<the types the shell hosts>` so
 every type has a single owner — the second ownership flip after the scan's, and
 the one that had to be *per type*, since `whatsapp`'s starter opens a live
 connection the sidecar's own endpoints read. `chat/runner.rs` therefore refuses
-only an agent naming an integration Rust cannot host, which is the two types
-#313 and #314 cover. #312 also produced the reflector divergence map
+only an agent naming an integration Rust cannot host, which is the one type
+#313 covers. #312 also produced the reflector divergence map
 (`parity/jsonschema_reflect_vectors.json` + `claude/schema_vectors.rs`), which
-is the file to read before starting #313 and #314. **#317, #316 and #315 followed** — the
+is the file to read before starting #313. **#317, #316, #315 and #314 followed** — the
 Confluence and Jira integrations, six and nine tools, pinned by
 `parity/confluence_vectors.json` and `parity/jira_vectors.json`. Read Confluence
 first (it is the smaller worked example) and then Jira, which is where a shared

--- a/desktop/parity/slack_parity_test.go
+++ b/desktop/parity/slack_parity_test.go
@@ -314,8 +314,12 @@ var slackTokenCases = []struct {
 		name:        "oauth mode with an auth column that does not decode",
 		credentials: `{"auth_mode":"oauth"}`,
 		auth:        `["not","a","token"]`,
+		// Column 0 rather than a position inside the document: since #314 the
+		// decode goes through `GoStruct`, which refuses a non-map at the
+		// container before the derived impl sees a field. Go refuses it too
+		// (`cannot unmarshal array`), so only the wording differs.
 		rustError: "resolving slack token for \"slack-parity\": parsing oauth token: " +
-			"does not decode at line 1 column 8",
+			"does not decode at line 1 column 0",
 	},
 	{
 		// An `auth` column that decodes but carries no access token yields an

--- a/desktop/parity/slack_vectors.json
+++ b/desktop/parity/slack_vectors.json
@@ -310,7 +310,7 @@
       "credentials": "{\"auth_mode\":\"oauth\"}",
       "auth": "[\"not\",\"a\",\"token\"]",
       "error": "resolving slack token for \"slack-parity\": parsing oauth token: parsing oauth token: json: cannot unmarshal array into Go value of type oauth2.Token",
-      "rust_error": "resolving slack token for \"slack-parity\": parsing oauth token: does not decode at line 1 column 8"
+      "rust_error": "resolving slack token for \"slack-parity\": parsing oauth token: does not decode at line 1 column 0"
     },
     {
       "case": "oauth mode with no access_token sends an empty bearer",

--- a/desktop/parity/telegram_parity_test.go
+++ b/desktop/parity/telegram_parity_test.go
@@ -1,0 +1,646 @@
+// Cross-language vectors for the Telegram integration's **outbound** MCP server
+// (`internal/integrations/telegram`, ported in #314 to
+// `desktop/src-tauri/src/native/integrations/telegram/`).
+//
+// Four things have to match byte for byte, none checkable from one language
+// alone: which tools are hosted, each advertised schema, the request each tool
+// builds, and the result text of every success and every failure. The reasoning
+// is in `confluence_parity_test.go`'s header and is not repeated.
+//
+// This is the outbound half only. `POST /webhooks/telegram/{id}` and
+// `internal/trigger/` are #319 and are not exercised here.
+//
+// Telegram-specific things pinned here, several of which no earlier integration
+// could reach:
+//
+//   - **`create_poll` takes a `[]string`** — the first slice parameter in any of
+//     the six. `jsonschema-go` renders every slice as `["null","array"]` where
+//     `schemars` renders a bare `array`, which `claude/schema_vectors.rs` left
+//     documented rather than reconciled because nothing reached it. The schema
+//     block is what pins the fix.
+//   - **`send_location` takes `float64`** — the first floats, so the request
+//     bodies pin `encoding/json`'s own float spelling (`1e+21`, `1e-7`) rather
+//     than `serde_json`'s.
+//   - **The envelope decides and the status never does** — not even a 429, which
+//     Slack's client does check. A 500 carrying `{"ok":true}` is a success.
+//   - **`result` is a `json.RawMessage`**, so an *absent* one renders as the
+//     empty string and an explicit `null` as the four bytes `null`. Both land in
+//     a result sentence the model reads.
+//   - **`read_messages` sends `offset` on `!= 0`**, so a negative offset is sent;
+//     its limit falls back to its own maximum; and `timeout: 0` is always sent.
+//   - **`create_poll` refuses 0-1 or 11+ options before any request is made.**
+//
+// The Rust half lives in
+// `desktop/src-tauri/src/native/integrations/telegram/tests_vectors.rs`.
+//
+// Regenerate (only from Go, and only when adding cases):
+//
+//	go test ./desktop/parity/ -run TestTelegramVectors -update-telegram-vectors
+package parity
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	mcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/shaharia-lab/agento/internal/config"
+	"github.com/shaharia-lab/agento/internal/integrations/telegram"
+)
+
+const telegramVectorsFile = "telegram_vectors.json"
+
+var updateTelegramVectors = flag.Bool("update-telegram-vectors", false,
+	"rewrite telegram_vectors.json from this Go toolchain")
+
+// A fixture, not a secret — and this one travels in the **URL path**, which is
+// why the recorded request target is worth pinning at all.
+const telegramParityToken = "123456:AAF-parity-bot-token" //nolint:gosec // a test fixture
+
+const telegramParityID = "tg-parity"
+
+type telegramToolVector struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"input_schema"`
+}
+
+// telegramRequestVector is what the fake Telegram saw. `Target` carries the bot
+// token, because Telegram's API puts it in the path — which is exactly the part a
+// port could get wrong invisibly.
+type telegramRequestVector struct {
+	Method      string `json:"method"`
+	Target      string `json:"target"`
+	ContentType string `json:"content_type"`
+	Body        string `json:"body"`
+}
+
+type telegramResponseScript struct {
+	Status int    `json:"status"`
+	Body   string `json:"body"`
+}
+
+type telegramCallVector struct {
+	Case      string                 `json:"case"`
+	Tool      string                 `json:"tool"`
+	Arguments json.RawMessage        `json:"arguments"`
+	Response  telegramResponseScript `json:"response"`
+	// nil where the tool answered without making a request — `create_poll`'s
+	// option-count refusal is the only such path in Go.
+	Request *telegramRequestVector `json:"request"`
+	IsError bool                   `json:"is_error"`
+	Text    string                 `json:"text"`
+	// A pinned divergence. Two users: `encoding/json`'s syntax-error vocabulary,
+	// and the zero-fraction float the Go SDK re-marshals into an integer.
+	RustText string `json:"rust_text,omitempty"`
+	// Go made a request and this port deliberately makes none.
+	RustNoRequest bool `json:"rust_no_request,omitempty"`
+}
+
+type telegramHostingVector struct {
+	Case     string                          `json:"case"`
+	Services map[string]config.ServiceConfig `json:"services"`
+	Tools    []string                        `json:"tools"`
+}
+
+type telegramVectors struct {
+	Comment       []string                `json:"_comment"`
+	IntegrationID string                  `json:"integration_id"`
+	ServerName    string                  `json:"server_name"`
+	Version       string                  `json:"version"`
+	Token         string                  `json:"token"`
+	Tools         []telegramToolVector    `json:"tools"`
+	Hosting       []telegramHostingVector `json:"hosting"`
+	Calls         []telegramCallVector    `json:"calls"`
+}
+
+// ─── The fake Telegram ───────────────────────────────────────────────────────
+
+type fakeTelegram struct {
+	mu     sync.Mutex
+	script telegramResponseScript
+	seen   *telegramRequestVector
+}
+
+func (f *fakeTelegram) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		body = nil
+	}
+	f.mu.Lock()
+	script := f.script
+	f.seen = &telegramRequestVector{
+		Method:      r.Method,
+		Target:      r.URL.RequestURI(),
+		ContentType: r.Header.Get("Content-Type"),
+		Body:        string(body),
+	}
+	f.mu.Unlock()
+
+	w.WriteHeader(script.Status)
+	_, _ = w.Write([]byte(script.Body))
+}
+
+func (f *fakeTelegram) arm(script telegramResponseScript) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.script = script
+	f.seen = nil
+}
+
+func (f *fakeTelegram) recorded() *telegramRequestVector {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.seen
+}
+
+// ─── Standing the real server up ─────────────────────────────────────────────
+
+func telegramSession(
+	t *testing.T, ctx context.Context, services map[string]config.ServiceConfig,
+) *mcp.ClientSession {
+	t.Helper()
+
+	credentials, err := json.Marshal(config.TelegramCredentials{BotToken: telegramParityToken})
+	if err != nil {
+		t.Fatalf("encoding credentials: %v", err)
+	}
+
+	cfg := &config.IntegrationConfig{
+		ID:          telegramParityID,
+		Name:        "Telegram (parity)",
+		Type:        "telegram",
+		Enabled:     true,
+		Credentials: credentials,
+		Auth:        json.RawMessage(`{"username":"parity_bot"}`),
+		Services:    services,
+	}
+
+	serverCfg, err := telegram.Start(ctx, cfg)
+	if err != nil {
+		t.Fatalf("starting the telegram integration: %v", err)
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "parity", Version: "1"}, nil)
+	session, err := client.Connect(ctx,
+		&mcp.StreamableClientTransport{Endpoint: serverCfg.URL}, nil)
+	if err != nil {
+		t.Fatalf("connecting to %s: %v", serverCfg.URL, err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	return session
+}
+
+func telegramAllServices() map[string]config.ServiceConfig {
+	return map[string]config.ServiceConfig{"messaging": {Enabled: true}}
+}
+
+var telegramHostingCases = []telegramHostingVector{
+	{Case: "the service enabled with no tool list — an empty allowed set hosts everything",
+		Services: telegramAllServices()},
+	{Case: "no services at all", Services: map[string]config.ServiceConfig{}},
+	{Case: "the service disabled contributes neither its gate nor its tools",
+		Services: map[string]config.ServiceConfig{
+			"messaging": {Enabled: false, Tools: []string{"send_message"}},
+		}},
+	{Case: "a non-empty allowed set is a filter",
+		Services: map[string]config.ServiceConfig{
+			"messaging": {Enabled: true, Tools: []string{"send_message", "pin_message"}},
+		}},
+	{Case: "an enabled but unknown service still narrows the one that exists",
+		Services: map[string]config.ServiceConfig{
+			"messaging": {Enabled: true},
+			"other":     {Enabled: true, Tools: []string{"create_poll"}},
+		}},
+	{Case: "a tool named by a disabled service is not allowed anywhere",
+		Services: map[string]config.ServiceConfig{
+			"messaging": {Enabled: true, Tools: []string{"get_chat_info"}},
+			"other":     {Enabled: false, Tools: []string{"send_photo"}},
+		}},
+}
+
+// ─── The call cases ──────────────────────────────────────────────────────────
+
+// telegramOK is a success envelope whose `result` is hostile to a re-encode:
+// keys out of order, a trailing-zero decimal, an integer too large for a float64,
+// interior whitespace. Go passes `result`'s bytes through verbatim.
+const telegramOK = `{"ok":true,"result":{"zebra":1,"id":10152021304050607,"rate":1.50, "message_id":7}}`
+
+type telegramCallCase struct {
+	name          string
+	tool          string
+	args          map[string]any
+	script        telegramResponseScript
+	rustText      string
+	rustNoRequest bool
+}
+
+func telegramOKScript() telegramResponseScript {
+	return telegramResponseScript{Status: http.StatusOK, Body: telegramOK}
+}
+
+func telegramCallCases() []telegramCallCase {
+	return []telegramCallCase{
+		// ─── send_message ────────────────────────────────────────────────────
+		{
+			name:   "send_message/an empty parse_mode leaves no key at all",
+			tool:   "send_message",
+			args:   map[string]any{"chat_id": "@channel", "text": "hi <there> & bye", "parse_mode": ""},
+			script: telegramOKScript(),
+		},
+		{
+			name:   "send_message/a parse_mode is sent when set",
+			tool:   "send_message",
+			args:   map[string]any{"chat_id": "-1001234567890", "text": "*bold*", "parse_mode": "Markdown"},
+			script: telegramOKScript(),
+		},
+
+		// ─── send_photo ──────────────────────────────────────────────────────
+		{
+			name:   "send_photo/an empty caption leaves no key",
+			tool:   "send_photo",
+			args:   map[string]any{"chat_id": "@c", "photo": "https://example.com/a.png", "caption": ""},
+			script: telegramOKScript(),
+		},
+		{
+			name:   "send_photo/a caption is sent when set",
+			tool:   "send_photo",
+			args:   map[string]any{"chat_id": "@c", "photo": "https://example.com/a.png", "caption": "look"},
+			script: telegramOKScript(),
+		},
+
+		// ─── send_location, the first float parameters in the six ────────────
+		{
+			name:   "send_location/ordinary coordinates",
+			tool:   "send_location",
+			args:   map[string]any{"chat_id": "@c", "latitude": 51.5074, "longitude": -0.1278},
+			script: telegramOKScript(),
+		},
+		{
+			// `encoding/json` switches to exponent form outside [1e-6, 1e21) and
+			// spells the exponent its own way. `serde_json` does not agree, so
+			// this is what `gojson::go_float` is for.
+			name:   "send_location/the exponent forms encoding/json switches to",
+			tool:   "send_location",
+			args:   map[string]any{"chat_id": "@c", "latitude": 1e21, "longitude": 1e-7},
+			script: telegramOKScript(),
+		},
+		{
+			name:   "send_location/a whole number has no decimal point",
+			tool:   "send_location",
+			args:   map[string]any{"chat_id": "@c", "latitude": 90, "longitude": -180},
+			script: telegramOKScript(),
+		},
+
+		// ─── create_poll, the first slice parameter in the six ───────────────
+		{
+			name: "create_poll/two options is the minimum, and the slice is sent as an array",
+			tool: "create_poll",
+			args: map[string]any{
+				"chat_id": "@c", "question": "Tea or coffee?",
+				"options": []string{"Tea", "Coffee"}, "is_anonymous": false, "type": "",
+			},
+			script: telegramOKScript(),
+		},
+		{
+			name: "create_poll/an anonymous quiz sends both conditional keys",
+			tool: "create_poll",
+			args: map[string]any{
+				"chat_id": "@c", "question": "2+2?",
+				"options": []string{"3", "4", "5"}, "is_anonymous": true, "type": "quiz",
+			},
+			script: telegramOKScript(),
+		},
+		{
+			// Go refuses **before** it builds a request.
+			name: "create_poll/one option is refused before any request",
+			tool: "create_poll",
+			args: map[string]any{
+				"chat_id": "@c", "question": "?",
+				"options": []string{"only"}, "is_anonymous": false, "type": "",
+			},
+			script: telegramOKScript(),
+		},
+		{
+			name: "create_poll/eleven options is refused before any request",
+			tool: "create_poll",
+			args: map[string]any{
+				"chat_id": "@c", "question": "?",
+				"options":      []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"},
+				"is_anonymous": false, "type": "",
+			},
+			script: telegramOKScript(),
+		},
+		{
+			// The whole reason the schema carries `"type": ["null","array"]`: Go
+			// accepts a null for any slice and it decodes to a nil one, whose
+			// length is 0 — so it reaches the same refusal rather than a decode
+			// error.
+			name: "create_poll/a null options list is a nil slice, so it is a zero-length refusal",
+			tool: "create_poll",
+			args: map[string]any{
+				"chat_id": "@c", "question": "?",
+				"options": nil, "is_anonymous": false, "type": "",
+			},
+			script: telegramOKScript(),
+		},
+
+		// ─── read_messages ───────────────────────────────────────────────────
+		{
+			name:   "read_messages/a zero offset leaves no key, and the limit falls back to its own maximum",
+			tool:   "read_messages",
+			args:   map[string]any{"offset": 0, "limit": 0},
+			script: telegramOKScript(),
+		},
+		{
+			// `!= 0`, not `> 0`: a negative offset is Telegram's idiom for "the
+			// last N updates" and is deliberately sent.
+			name:   "read_messages/a negative offset is sent, because the test is not-zero",
+			tool:   "read_messages",
+			args:   map[string]any{"offset": -5, "limit": 10},
+			script: telegramOKScript(),
+		},
+		{
+			name:   "read_messages/over 100 falls back to 100",
+			tool:   "read_messages",
+			args:   map[string]any{"offset": 42, "limit": 101},
+			script: telegramOKScript(),
+		},
+
+		// ─── the reads ───────────────────────────────────────────────────────
+		{
+			name:   "get_chat_info/one key",
+			tool:   "get_chat_info",
+			args:   map[string]any{"chat_id": "@c"},
+			script: telegramOKScript(),
+		},
+		{
+			name:   "get_chat_members/the deprecated method name Go still sends",
+			tool:   "get_chat_members",
+			args:   map[string]any{"chat_id": "@c"},
+			script: telegramResponseScript{Status: http.StatusOK, Body: `{"ok":true,"result":42}`},
+		},
+
+		// ─── the management tools ────────────────────────────────────────────
+		{
+			name:   "forward_message/three keys, one an integer",
+			tool:   "forward_message",
+			args:   map[string]any{"chat_id": "@to", "from_chat_id": "@from", "message_id": 99},
+			script: telegramOKScript(),
+		},
+		{
+			name:   "edit_message/an empty parse_mode leaves no key",
+			tool:   "edit_message",
+			args:   map[string]any{"chat_id": "@c", "message_id": 5, "text": "new", "parse_mode": ""},
+			script: telegramOKScript(),
+		},
+		{
+			// The response is discarded — the sentence is fixed.
+			name:   "delete_message/the response is discarded",
+			tool:   "delete_message",
+			args:   map[string]any{"chat_id": "@c", "message_id": 5},
+			script: telegramResponseScript{Status: http.StatusOK, Body: `{"ok":true,"result":true}`},
+		},
+		{
+			name:   "pin_message/a false disable_notification leaves no key",
+			tool:   "pin_message",
+			args:   map[string]any{"chat_id": "@c", "message_id": 5, "disable_notification": false},
+			script: telegramResponseScript{Status: http.StatusOK, Body: `{"ok":true,"result":true}`},
+		},
+		{
+			name:   "pin_message/a true one sends the literal true",
+			tool:   "pin_message",
+			args:   map[string]any{"chat_id": "@c", "message_id": 5, "disable_notification": true},
+			script: telegramResponseScript{Status: http.StatusOK, Body: `{"ok":true,"result":true}`},
+		},
+
+		// ─── the envelope, which decides instead of the status ────────────────
+		{
+			name:   "send_message/ok:false is the failure, whatever the status",
+			tool:   "send_message",
+			args:   map[string]any{"chat_id": "@c", "text": "x", "parse_mode": ""},
+			script: telegramResponseScript{Status: http.StatusOK, Body: `{"ok":false,"description":"Bad Request: chat not found"}`},
+		},
+		{
+			// The one that reads backwards.
+			name:   "get_chat_info/a 500 carrying ok:true is a success",
+			tool:   "get_chat_info",
+			args:   map[string]any{"chat_id": "@c"},
+			script: telegramResponseScript{Status: http.StatusInternalServerError, Body: telegramOK},
+		},
+		{
+			// Not even a 429 is looked at, unlike Slack's client.
+			name:   "get_chat_info/a 429 is not special-cased the way Slack's is",
+			tool:   "get_chat_info",
+			args:   map[string]any{"chat_id": "@c"},
+			script: telegramResponseScript{Status: http.StatusTooManyRequests, Body: `{"ok":false,"description":"Too Many Requests: retry after 30"}`},
+		},
+		{
+			name:   "get_chat_info/a null description interpolates an empty one",
+			tool:   "get_chat_info",
+			args:   map[string]any{"chat_id": "@c"},
+			script: telegramResponseScript{Status: http.StatusOK, Body: `{"ok":false,"description":null}`},
+		},
+		{
+			// `result` is a RawMessage: absent is the empty string.
+			name:   "get_chat_info/an absent result renders as the empty string",
+			tool:   "get_chat_info",
+			args:   map[string]any{"chat_id": "@c"},
+			script: telegramResponseScript{Status: http.StatusOK, Body: `{"ok":true}`},
+		},
+		{
+			// …and an explicit null is the four bytes.
+			name:   "get_chat_info/an explicit null result renders as the four bytes",
+			tool:   "get_chat_info",
+			args:   map[string]any{"chat_id": "@c"},
+			script: telegramResponseScript{Status: http.StatusOK, Body: `{"ok":true,"result":null}`},
+		},
+		{
+			name:   "get_chat_info/a bare null body is a no-op, not a parse failure",
+			tool:   "get_chat_info",
+			args:   map[string]any{"chat_id": "@c"},
+			script: telegramResponseScript{Status: http.StatusOK, Body: `null`},
+		},
+		{
+			// serde would build the struct from a sequence positionally without
+			// `GoStruct`, turning this into a success.
+			name:     "get_chat_info/a JSON array is not a struct",
+			tool:     "get_chat_info",
+			args:     map[string]any{"chat_id": "@c"},
+			script:   telegramResponseScript{Status: http.StatusOK, Body: `[true]`},
+			rustText: "parsing response: invalid type: sequence, expected a JSON object at line 1 column 0",
+		},
+		{
+			name:     "get_chat_info/a body that is not JSON at all",
+			tool:     "get_chat_info",
+			args:     map[string]any{"chat_id": "@c"},
+			script:   telegramResponseScript{Status: http.StatusOK, Body: `<html>nope</html>`},
+			rustText: "parsing response: expected value at line 1 column 1",
+		},
+
+		// ─── a zero-fraction float for an integer field ───────────────────────
+		{
+			name:          "read_messages/a zero-fraction float is an integer to Go and not to serde",
+			tool:          "read_messages",
+			args:          map[string]any{"offset": 0, "limit": json.RawMessage("50.0")},
+			script:        telegramOKScript(),
+			rustText:      "failed to deserialize parameters: invalid type: floating point `50.0`, expected i64",
+			rustNoRequest: true,
+		},
+	}
+}
+
+// ─── The generator ───────────────────────────────────────────────────────────
+
+func TestTelegramVectors(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	fake := &fakeTelegram{}
+	srv := httptest.NewServer(fake)
+	defer srv.Close()
+	restore := telegram.SetAPIBase(srv.URL)
+	defer restore()
+
+	want := telegramVectors{
+		Comment: []string{
+			"Cross-language parity vectors for internal/integrations/telegram, the outbound",
+			"half of the Telegram integration's in-process MCP server (the inbound webhook",
+			"and trigger dispatcher are #319 and are not covered here). Generated from Go,",
+			"then frozen. Read by desktop/parity/telegram_parity_test.go (Go) and by",
+			"desktop/src-tauri/src/native/integrations/telegram/ (Rust).",
+			"'tools' and 'hosting' come from live tools/list calls against servers built by",
+			"telegram.Start; 'calls' from live tools/call calls against a scripted fake",
+			"Telegram that records the request each tool built.",
+			"'token' is a fixture, not a secret: it is recorded because Telegram puts the bot",
+			"token in the URL path, so the request target pins it.",
+			"Regenerate with: go test ./desktop/parity/ -run TestTelegramVectors -update-telegram-vectors",
+		},
+		IntegrationID: telegramParityID,
+		ServerName:    fmt.Sprintf("telegram-%s", telegramParityID),
+		Version:       "1.0.0",
+		Token:         telegramParityToken,
+	}
+
+	session := telegramSession(t, ctx, telegramAllServices())
+	listed, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("tools/list: %v", err)
+	}
+	for _, tool := range listed.Tools {
+		schema, err := json.Marshal(tool.InputSchema)
+		if err != nil {
+			t.Fatalf("encoding %s's input schema: %v", tool.Name, err)
+		}
+		want.Tools = append(want.Tools, telegramToolVector{
+			Name:        tool.Name,
+			Description: tool.Description,
+			InputSchema: schema,
+		})
+	}
+
+	for _, hosting := range telegramHostingCases {
+		hosting.Tools = telegramHostedTools(t, ctx, hosting.Services)
+		want.Hosting = append(want.Hosting, hosting)
+	}
+
+	for _, c := range telegramCallCases() {
+		want.Calls = append(want.Calls, runTelegramCallCase(t, ctx, session, fake, c))
+	}
+
+	encoded, err := json.MarshalIndent(want, "", "  ")
+	if err != nil {
+		t.Fatalf("encoding vectors: %v", err)
+	}
+	encoded = append(encoded, '\n')
+
+	if *updateTelegramVectors {
+		if err := os.WriteFile(telegramVectorsFile, encoded, 0o600); err != nil {
+			t.Fatalf("writing %s: %v", telegramVectorsFile, err)
+		}
+		t.Logf("wrote %s", telegramVectorsFile)
+		return
+	}
+
+	frozen, err := os.ReadFile(telegramVectorsFile)
+	if err != nil {
+		t.Fatalf("reading %s (regenerate with -update-telegram-vectors): %v",
+			telegramVectorsFile, err)
+	}
+	if string(frozen) != string(encoded) {
+		t.Fatalf("%s is stale: this Go toolchain produces different results.\n"+
+			"Regenerate with -update-telegram-vectors and check what moved — the Rust port "+
+			"in native/integrations/telegram/ reads the same file and will fail against it. "+
+			"A moved tool name, schema, request or sentence is not a cosmetic diff: the "+
+			"names are in every agent's stored allowlist and in every tool_use block "+
+			"already written, and the sentences are what the model reads.",
+			telegramVectorsFile)
+	}
+}
+
+func telegramHostedTools(
+	t *testing.T, ctx context.Context, services map[string]config.ServiceConfig,
+) []string {
+	t.Helper()
+	listed, err := telegramSession(t, ctx, services).ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("tools/list: %v", err)
+	}
+	names := make([]string, 0, len(listed.Tools))
+	for _, tool := range listed.Tools {
+		names = append(names, tool.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func runTelegramCallCase(
+	t *testing.T, ctx context.Context,
+	session *mcp.ClientSession, fake *fakeTelegram, c telegramCallCase,
+) telegramCallVector {
+	t.Helper()
+
+	fake.arm(c.script)
+	args := jsonArgs(t, c.args)
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: c.tool, Arguments: args,
+	})
+	if err != nil {
+		t.Fatalf("%s: tools/call: %v", c.name, err)
+	}
+	if len(result.Content) != 1 {
+		t.Fatalf("%s: want exactly one content block, got %d", c.name, len(result.Content))
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("%s: want text content, got %T", c.name, result.Content[0])
+	}
+	// The bot token travels in the URL, so a result that echoed the request
+	// would leak it. Neither language must.
+	if strings.Contains(text.Text, telegramParityToken) {
+		t.Fatalf("%s: the bot token leaked into a tool result: %s", c.name, text.Text)
+	}
+
+	return telegramCallVector{
+		Case:          c.name,
+		Tool:          c.tool,
+		Arguments:     args,
+		Response:      c.script,
+		Request:       fake.recorded(),
+		IsError:       result.IsError,
+		Text:          text.Text,
+		RustText:      c.rustText,
+		RustNoRequest: c.rustNoRequest,
+	}
+}

--- a/desktop/parity/telegram_vectors.json
+++ b/desktop/parity/telegram_vectors.json
@@ -1,0 +1,1074 @@
+{
+  "_comment": [
+    "Cross-language parity vectors for internal/integrations/telegram, the outbound",
+    "half of the Telegram integration's in-process MCP server (the inbound webhook",
+    "and trigger dispatcher are #319 and are not covered here). Generated from Go,",
+    "then frozen. Read by desktop/parity/telegram_parity_test.go (Go) and by",
+    "desktop/src-tauri/src/native/integrations/telegram/ (Rust).",
+    "'tools' and 'hosting' come from live tools/list calls against servers built by",
+    "telegram.Start; 'calls' from live tools/call calls against a scripted fake",
+    "Telegram that records the request each tool built.",
+    "'token' is a fixture, not a secret: it is recorded because Telegram puts the bot",
+    "token in the URL path, so the request target pins it.",
+    "Regenerate with: go test ./desktop/parity/ -run TestTelegramVectors -update-telegram-vectors"
+  ],
+  "integration_id": "tg-parity",
+  "server_name": "telegram-tg-parity",
+  "version": "1.0.0",
+  "token": "123456:AAF-parity-bot-token",
+  "tools": [
+    {
+      "name": "create_poll",
+      "description": "Creates a poll in a Telegram chat.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "chat_id": {
+            "description": "required,Target chat ID or username",
+            "type": "string"
+          },
+          "is_anonymous": {
+            "description": "True if poll should be anonymous",
+            "type": "boolean"
+          },
+          "options": {
+            "description": "required,Answer options (2-10 strings)",
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "null",
+              "array"
+            ]
+          },
+          "question": {
+            "description": "required,Poll question (1-300 characters)",
+            "type": "string"
+          },
+          "type": {
+            "description": "Poll type: regular or quiz (default regular)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "chat_id",
+          "question",
+          "options",
+          "is_anonymous",
+          "type"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "delete_message",
+      "description": "Deletes a message from a chat.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "chat_id": {
+            "description": "required,The chat containing the message to delete",
+            "type": "string"
+          },
+          "message_id": {
+            "description": "required,Identifier of the message to delete",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "chat_id",
+          "message_id"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "edit_message",
+      "description": "Edits the text of a previously sent message.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "chat_id": {
+            "description": "required,The chat containing the message to edit",
+            "type": "string"
+          },
+          "message_id": {
+            "description": "required,Identifier of the message to edit",
+            "type": "integer"
+          },
+          "parse_mode": {
+            "description": "Optional parse mode: Markdown or HTML",
+            "type": "string"
+          },
+          "text": {
+            "description": "required,New text of the message",
+            "type": "string"
+          }
+        },
+        "required": [
+          "chat_id",
+          "message_id",
+          "text",
+          "parse_mode"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "forward_message",
+      "description": "Forwards a message from one chat to another.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "chat_id": {
+            "description": "required,Target chat to forward the message to",
+            "type": "string"
+          },
+          "from_chat_id": {
+            "description": "required,Source chat ID",
+            "type": "string"
+          },
+          "message_id": {
+            "description": "required,Message identifier in from_chat_id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "chat_id",
+          "from_chat_id",
+          "message_id"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_chat_info",
+      "description": "Gets detailed information about a chat.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "chat_id": {
+            "description": "required,Target chat ID or username",
+            "type": "string"
+          }
+        },
+        "required": [
+          "chat_id"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "get_chat_members",
+      "description": "Gets the number of members in a chat.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "chat_id": {
+            "description": "required,Unique identifier for the target chat",
+            "type": "string"
+          }
+        },
+        "required": [
+          "chat_id"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "pin_message",
+      "description": "Pins a message in a chat.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "chat_id": {
+            "description": "required,The chat containing the message to pin",
+            "type": "string"
+          },
+          "disable_notification": {
+            "description": "Pin silently without notifying members",
+            "type": "boolean"
+          },
+          "message_id": {
+            "description": "required,Identifier of the message to pin",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "chat_id",
+          "message_id",
+          "disable_notification"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "read_messages",
+      "description": "Reads recent messages (updates) received by the bot via getUpdates.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "limit": {
+            "description": "Max number of updates to retrieve (1-100)",
+            "type": "integer"
+          },
+          "offset": {
+            "description": "Identifier of the first update to be returned",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "offset",
+          "limit"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "send_location",
+      "description": "Sends a geographic location to a chat.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "chat_id": {
+            "description": "required,Target chat ID or username",
+            "type": "string"
+          },
+          "latitude": {
+            "description": "required,Latitude of the location",
+            "type": "number"
+          },
+          "longitude": {
+            "description": "required,Longitude of the location",
+            "type": "number"
+          }
+        },
+        "required": [
+          "chat_id",
+          "latitude",
+          "longitude"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "send_message",
+      "description": "Sends a text message to a Telegram chat.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "chat_id": {
+            "description": "required,Target chat ID or username",
+            "type": "string"
+          },
+          "parse_mode": {
+            "description": "Optional parse mode: Markdown or HTML",
+            "type": "string"
+          },
+          "text": {
+            "description": "required,Text of the message to send",
+            "type": "string"
+          }
+        },
+        "required": [
+          "chat_id",
+          "text",
+          "parse_mode"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "send_photo",
+      "description": "Sends a photo to a Telegram chat by URL.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "caption": {
+            "description": "Optional caption for the photo",
+            "type": "string"
+          },
+          "chat_id": {
+            "description": "required,Target chat ID or username",
+            "type": "string"
+          },
+          "photo": {
+            "description": "required,Photo URL to send",
+            "type": "string"
+          }
+        },
+        "required": [
+          "chat_id",
+          "photo",
+          "caption"
+        ],
+        "type": "object"
+      }
+    }
+  ],
+  "hosting": [
+    {
+      "case": "the service enabled with no tool list — an empty allowed set hosts everything",
+      "services": {
+        "messaging": {
+          "enabled": true,
+          "tools": null
+        }
+      },
+      "tools": [
+        "create_poll",
+        "delete_message",
+        "edit_message",
+        "forward_message",
+        "get_chat_info",
+        "get_chat_members",
+        "pin_message",
+        "read_messages",
+        "send_location",
+        "send_message",
+        "send_photo"
+      ]
+    },
+    {
+      "case": "no services at all",
+      "services": {},
+      "tools": []
+    },
+    {
+      "case": "the service disabled contributes neither its gate nor its tools",
+      "services": {
+        "messaging": {
+          "enabled": false,
+          "tools": [
+            "send_message"
+          ]
+        }
+      },
+      "tools": []
+    },
+    {
+      "case": "a non-empty allowed set is a filter",
+      "services": {
+        "messaging": {
+          "enabled": true,
+          "tools": [
+            "send_message",
+            "pin_message"
+          ]
+        }
+      },
+      "tools": [
+        "pin_message",
+        "send_message"
+      ]
+    },
+    {
+      "case": "an enabled but unknown service still narrows the one that exists",
+      "services": {
+        "messaging": {
+          "enabled": true,
+          "tools": null
+        },
+        "other": {
+          "enabled": true,
+          "tools": [
+            "create_poll"
+          ]
+        }
+      },
+      "tools": [
+        "create_poll"
+      ]
+    },
+    {
+      "case": "a tool named by a disabled service is not allowed anywhere",
+      "services": {
+        "messaging": {
+          "enabled": true,
+          "tools": [
+            "get_chat_info"
+          ]
+        },
+        "other": {
+          "enabled": false,
+          "tools": [
+            "send_photo"
+          ]
+        }
+      },
+      "tools": [
+        "get_chat_info"
+      ]
+    }
+  ],
+  "calls": [
+    {
+      "case": "send_message/an empty parse_mode leaves no key at all",
+      "tool": "send_message",
+      "arguments": {
+        "chat_id": "@channel",
+        "parse_mode": "",
+        "text": "hi \u003cthere\u003e \u0026 bye"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"result\":{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/sendMessage",
+        "content_type": "application/json",
+        "body": "{\"chat_id\":\"@channel\",\"text\":\"hi \\u003cthere\\u003e \\u0026 bye\"}"
+      },
+      "is_error": false,
+      "text": "Message sent successfully. Response: {\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}"
+    },
+    {
+      "case": "send_message/a parse_mode is sent when set",
+      "tool": "send_message",
+      "arguments": {
+        "chat_id": "-1001234567890",
+        "parse_mode": "Markdown",
+        "text": "*bold*"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"result\":{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/sendMessage",
+        "content_type": "application/json",
+        "body": "{\"chat_id\":\"-1001234567890\",\"parse_mode\":\"Markdown\",\"text\":\"*bold*\"}"
+      },
+      "is_error": false,
+      "text": "Message sent successfully. Response: {\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}"
+    },
+    {
+      "case": "send_photo/an empty caption leaves no key",
+      "tool": "send_photo",
+      "arguments": {
+        "caption": "",
+        "chat_id": "@c",
+        "photo": "https://example.com/a.png"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"result\":{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/sendPhoto",
+        "content_type": "application/json",
+        "body": "{\"chat_id\":\"@c\",\"photo\":\"https://example.com/a.png\"}"
+      },
+      "is_error": false,
+      "text": "Photo sent successfully. Response: {\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}"
+    },
+    {
+      "case": "send_photo/a caption is sent when set",
+      "tool": "send_photo",
+      "arguments": {
+        "caption": "look",
+        "chat_id": "@c",
+        "photo": "https://example.com/a.png"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"result\":{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/sendPhoto",
+        "content_type": "application/json",
+        "body": "{\"caption\":\"look\",\"chat_id\":\"@c\",\"photo\":\"https://example.com/a.png\"}"
+      },
+      "is_error": false,
+      "text": "Photo sent successfully. Response: {\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}"
+    },
+    {
+      "case": "send_location/ordinary coordinates",
+      "tool": "send_location",
+      "arguments": {
+        "chat_id": "@c",
+        "latitude": 51.5074,
+        "longitude": -0.1278
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"result\":{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/sendLocation",
+        "content_type": "application/json",
+        "body": "{\"chat_id\":\"@c\",\"latitude\":51.5074,\"longitude\":-0.1278}"
+      },
+      "is_error": false,
+      "text": "Location sent successfully. Response: {\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}"
+    },
+    {
+      "case": "send_location/the exponent forms encoding/json switches to",
+      "tool": "send_location",
+      "arguments": {
+        "chat_id": "@c",
+        "latitude": 1e+21,
+        "longitude": 1e-7
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"result\":{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/sendLocation",
+        "content_type": "application/json",
+        "body": "{\"chat_id\":\"@c\",\"latitude\":1e+21,\"longitude\":1e-7}"
+      },
+      "is_error": false,
+      "text": "Location sent successfully. Response: {\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}"
+    },
+    {
+      "case": "send_location/a whole number has no decimal point",
+      "tool": "send_location",
+      "arguments": {
+        "chat_id": "@c",
+        "latitude": 90,
+        "longitude": -180
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"result\":{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/sendLocation",
+        "content_type": "application/json",
+        "body": "{\"chat_id\":\"@c\",\"latitude\":90,\"longitude\":-180}"
+      },
+      "is_error": false,
+      "text": "Location sent successfully. Response: {\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}"
+    },
+    {
+      "case": "create_poll/two options is the minimum, and the slice is sent as an array",
+      "tool": "create_poll",
+      "arguments": {
+        "chat_id": "@c",
+        "is_anonymous": false,
+        "options": [
+          "Tea",
+          "Coffee"
+        ],
+        "question": "Tea or coffee?",
+        "type": ""
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"result\":{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/sendPoll",
+        "content_type": "application/json",
+        "body": "{\"chat_id\":\"@c\",\"options\":[\"Tea\",\"Coffee\"],\"question\":\"Tea or coffee?\"}"
+      },
+      "is_error": false,
+      "text": "Poll created successfully. Response: {\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}"
+    },
+    {
+      "case": "create_poll/an anonymous quiz sends both conditional keys",
+      "tool": "create_poll",
+      "arguments": {
+        "chat_id": "@c",
+        "is_anonymous": true,
+        "options": [
+          "3",
+          "4",
+          "5"
+        ],
+        "question": "2+2?",
+        "type": "quiz"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"result\":{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/sendPoll",
+        "content_type": "application/json",
+        "body": "{\"chat_id\":\"@c\",\"is_anonymous\":true,\"options\":[\"3\",\"4\",\"5\"],\"question\":\"2+2?\",\"type\":\"quiz\"}"
+      },
+      "is_error": false,
+      "text": "Poll created successfully. Response: {\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}"
+    },
+    {
+      "case": "create_poll/one option is refused before any request",
+      "tool": "create_poll",
+      "arguments": {
+        "chat_id": "@c",
+        "is_anonymous": false,
+        "options": [
+          "only"
+        ],
+        "question": "?",
+        "type": ""
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"result\":{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}}"
+      },
+      "request": null,
+      "is_error": true,
+      "text": "poll requires 2-10 options, got 1"
+    },
+    {
+      "case": "create_poll/eleven options is refused before any request",
+      "tool": "create_poll",
+      "arguments": {
+        "chat_id": "@c",
+        "is_anonymous": false,
+        "options": [
+          "1",
+          "2",
+          "3",
+          "4",
+          "5",
+          "6",
+          "7",
+          "8",
+          "9",
+          "10",
+          "11"
+        ],
+        "question": "?",
+        "type": ""
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"result\":{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}}"
+      },
+      "request": null,
+      "is_error": true,
+      "text": "poll requires 2-10 options, got 11"
+    },
+    {
+      "case": "create_poll/a null options list is a nil slice, so it is a zero-length refusal",
+      "tool": "create_poll",
+      "arguments": {
+        "chat_id": "@c",
+        "is_anonymous": false,
+        "options": null,
+        "question": "?",
+        "type": ""
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"result\":{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}}"
+      },
+      "request": null,
+      "is_error": true,
+      "text": "poll requires 2-10 options, got 0"
+    },
+    {
+      "case": "read_messages/a zero offset leaves no key, and the limit falls back to its own maximum",
+      "tool": "read_messages",
+      "arguments": {
+        "limit": 0,
+        "offset": 0
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"result\":{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/getUpdates",
+        "content_type": "application/json",
+        "body": "{\"limit\":100,\"timeout\":0}"
+      },
+      "is_error": false,
+      "text": "Updates received: {\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}"
+    },
+    {
+      "case": "read_messages/a negative offset is sent, because the test is not-zero",
+      "tool": "read_messages",
+      "arguments": {
+        "limit": 10,
+        "offset": -5
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"result\":{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/getUpdates",
+        "content_type": "application/json",
+        "body": "{\"limit\":10,\"offset\":-5,\"timeout\":0}"
+      },
+      "is_error": false,
+      "text": "Updates received: {\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}"
+    },
+    {
+      "case": "read_messages/over 100 falls back to 100",
+      "tool": "read_messages",
+      "arguments": {
+        "limit": 101,
+        "offset": 42
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"result\":{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/getUpdates",
+        "content_type": "application/json",
+        "body": "{\"limit\":100,\"offset\":42,\"timeout\":0}"
+      },
+      "is_error": false,
+      "text": "Updates received: {\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}"
+    },
+    {
+      "case": "get_chat_info/one key",
+      "tool": "get_chat_info",
+      "arguments": {
+        "chat_id": "@c"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"result\":{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/getChat",
+        "content_type": "application/json",
+        "body": "{\"chat_id\":\"@c\"}"
+      },
+      "is_error": false,
+      "text": "Chat info: {\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}"
+    },
+    {
+      "case": "get_chat_members/the deprecated method name Go still sends",
+      "tool": "get_chat_members",
+      "arguments": {
+        "chat_id": "@c"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"result\":42}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/getChatMembersCount",
+        "content_type": "application/json",
+        "body": "{\"chat_id\":\"@c\"}"
+      },
+      "is_error": false,
+      "text": "Chat member count: 42"
+    },
+    {
+      "case": "forward_message/three keys, one an integer",
+      "tool": "forward_message",
+      "arguments": {
+        "chat_id": "@to",
+        "from_chat_id": "@from",
+        "message_id": 99
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"result\":{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/forwardMessage",
+        "content_type": "application/json",
+        "body": "{\"chat_id\":\"@to\",\"from_chat_id\":\"@from\",\"message_id\":99}"
+      },
+      "is_error": false,
+      "text": "Message forwarded successfully. Response: {\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}"
+    },
+    {
+      "case": "edit_message/an empty parse_mode leaves no key",
+      "tool": "edit_message",
+      "arguments": {
+        "chat_id": "@c",
+        "message_id": 5,
+        "parse_mode": "",
+        "text": "new"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"result\":{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/editMessageText",
+        "content_type": "application/json",
+        "body": "{\"chat_id\":\"@c\",\"message_id\":5,\"text\":\"new\"}"
+      },
+      "is_error": false,
+      "text": "Message edited successfully. Response: {\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}"
+    },
+    {
+      "case": "delete_message/the response is discarded",
+      "tool": "delete_message",
+      "arguments": {
+        "chat_id": "@c",
+        "message_id": 5
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"result\":true}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/deleteMessage",
+        "content_type": "application/json",
+        "body": "{\"chat_id\":\"@c\",\"message_id\":5}"
+      },
+      "is_error": false,
+      "text": "Message deleted successfully."
+    },
+    {
+      "case": "pin_message/a false disable_notification leaves no key",
+      "tool": "pin_message",
+      "arguments": {
+        "chat_id": "@c",
+        "disable_notification": false,
+        "message_id": 5
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"result\":true}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/pinChatMessage",
+        "content_type": "application/json",
+        "body": "{\"chat_id\":\"@c\",\"message_id\":5}"
+      },
+      "is_error": false,
+      "text": "Message pinned successfully."
+    },
+    {
+      "case": "pin_message/a true one sends the literal true",
+      "tool": "pin_message",
+      "arguments": {
+        "chat_id": "@c",
+        "disable_notification": true,
+        "message_id": 5
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"result\":true}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/pinChatMessage",
+        "content_type": "application/json",
+        "body": "{\"chat_id\":\"@c\",\"disable_notification\":true,\"message_id\":5}"
+      },
+      "is_error": false,
+      "text": "Message pinned successfully."
+    },
+    {
+      "case": "send_message/ok:false is the failure, whatever the status",
+      "tool": "send_message",
+      "arguments": {
+        "chat_id": "@c",
+        "parse_mode": "",
+        "text": "x"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":false,\"description\":\"Bad Request: chat not found\"}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/sendMessage",
+        "content_type": "application/json",
+        "body": "{\"chat_id\":\"@c\",\"text\":\"x\"}"
+      },
+      "is_error": true,
+      "text": "telegram API error: Bad Request: chat not found"
+    },
+    {
+      "case": "get_chat_info/a 500 carrying ok:true is a success",
+      "tool": "get_chat_info",
+      "arguments": {
+        "chat_id": "@c"
+      },
+      "response": {
+        "status": 500,
+        "body": "{\"ok\":true,\"result\":{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/getChat",
+        "content_type": "application/json",
+        "body": "{\"chat_id\":\"@c\"}"
+      },
+      "is_error": false,
+      "text": "Chat info: {\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}"
+    },
+    {
+      "case": "get_chat_info/a 429 is not special-cased the way Slack's is",
+      "tool": "get_chat_info",
+      "arguments": {
+        "chat_id": "@c"
+      },
+      "response": {
+        "status": 429,
+        "body": "{\"ok\":false,\"description\":\"Too Many Requests: retry after 30\"}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/getChat",
+        "content_type": "application/json",
+        "body": "{\"chat_id\":\"@c\"}"
+      },
+      "is_error": true,
+      "text": "telegram API error: Too Many Requests: retry after 30"
+    },
+    {
+      "case": "get_chat_info/a null description interpolates an empty one",
+      "tool": "get_chat_info",
+      "arguments": {
+        "chat_id": "@c"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":false,\"description\":null}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/getChat",
+        "content_type": "application/json",
+        "body": "{\"chat_id\":\"@c\"}"
+      },
+      "is_error": true,
+      "text": "telegram API error: "
+    },
+    {
+      "case": "get_chat_info/an absent result renders as the empty string",
+      "tool": "get_chat_info",
+      "arguments": {
+        "chat_id": "@c"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/getChat",
+        "content_type": "application/json",
+        "body": "{\"chat_id\":\"@c\"}"
+      },
+      "is_error": false,
+      "text": "Chat info: "
+    },
+    {
+      "case": "get_chat_info/an explicit null result renders as the four bytes",
+      "tool": "get_chat_info",
+      "arguments": {
+        "chat_id": "@c"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"result\":null}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/getChat",
+        "content_type": "application/json",
+        "body": "{\"chat_id\":\"@c\"}"
+      },
+      "is_error": false,
+      "text": "Chat info: null"
+    },
+    {
+      "case": "get_chat_info/a bare null body is a no-op, not a parse failure",
+      "tool": "get_chat_info",
+      "arguments": {
+        "chat_id": "@c"
+      },
+      "response": {
+        "status": 200,
+        "body": "null"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/getChat",
+        "content_type": "application/json",
+        "body": "{\"chat_id\":\"@c\"}"
+      },
+      "is_error": true,
+      "text": "telegram API error: "
+    },
+    {
+      "case": "get_chat_info/a JSON array is not a struct",
+      "tool": "get_chat_info",
+      "arguments": {
+        "chat_id": "@c"
+      },
+      "response": {
+        "status": 200,
+        "body": "[true]"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/getChat",
+        "content_type": "application/json",
+        "body": "{\"chat_id\":\"@c\"}"
+      },
+      "is_error": true,
+      "text": "parsing response: json: cannot unmarshal array into Go value of type telegram.telegramResponse",
+      "rust_text": "parsing response: invalid type: sequence, expected a JSON object at line 1 column 0"
+    },
+    {
+      "case": "get_chat_info/a body that is not JSON at all",
+      "tool": "get_chat_info",
+      "arguments": {
+        "chat_id": "@c"
+      },
+      "response": {
+        "status": 200,
+        "body": "\u003chtml\u003enope\u003c/html\u003e"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/getChat",
+        "content_type": "application/json",
+        "body": "{\"chat_id\":\"@c\"}"
+      },
+      "is_error": true,
+      "text": "parsing response: invalid character '\u003c' looking for beginning of value",
+      "rust_text": "parsing response: expected value at line 1 column 1"
+    },
+    {
+      "case": "read_messages/a zero-fraction float is an integer to Go and not to serde",
+      "tool": "read_messages",
+      "arguments": {
+        "limit": 50.0,
+        "offset": 0
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"ok\":true,\"result\":{\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}}"
+      },
+      "request": {
+        "method": "POST",
+        "target": "/bot123456:AAF-parity-bot-token/getUpdates",
+        "content_type": "application/json",
+        "body": "{\"limit\":50,\"timeout\":0}"
+      },
+      "is_error": false,
+      "text": "Updates received: {\"zebra\":1,\"id\":10152021304050607,\"rate\":1.50, \"message_id\":7}",
+      "rust_text": "failed to deserialize parameters: invalid type: floating point `50.0`, expected i64",
+      "rust_no_request": true
+    }
+  ]
+}

--- a/desktop/src-tauri/src/claude/schema_vectors.rs
+++ b/desktop/src-tauri/src/claude/schema_vectors.rs
@@ -31,8 +31,11 @@
 //! and uses only `string`, `int`, `int64` and `bool` — which is why the twenty
 //! schemas in `github_vectors.json` match exactly, and #317's six in
 //! `confluence_vectors.json`, #316's nine in `jira_vectors.json` and #315's seven
-//! in `slack_vectors.json` with them. The map exists so #313 and #314 do not each
-//! rediscover the boundary.
+//! in `slack_vectors.json` with them. The map exists so #313 does not rediscover
+//! the boundary — and #314 is the first port to **reach** one of the standing
+//! divergences rather than only read about it: Telegram's `create_poll` takes a
+//! `[]string`, so `messaging::go_string_slice` adds the `null` the guidance below
+//! says a port that needs one must add itself.
 
 use std::collections::BTreeMap;
 

--- a/desktop/src-tauri/src/native/chat/mod.rs
+++ b/desktop/src-tauri/src/native/chat/mod.rs
@@ -11,12 +11,12 @@
 //! button would silently do nothing.
 //!
 //! But not every chat *can* run here: an agent whose tools come from an
-//! integration needs one MCP server per provider, and this port has two of the
-//! six still to write (#313 and #314), so `runner::build_options` refuses those and
+//! integration needs one MCP server per provider, and this port has one of the
+//! six still to write (#313), so `runner::build_options` refuses those and
 //! they keep running on the sidecar. Parts of that refusal have gone — the
 //! **local** in-process server (#310), then any agent whose `capabilities.mcp`
 //! names only hosted integrations (**github** since #311, **confluence** since
-//! #317, **jira** since #316, **slack** since #315) — but each only shrinks the set of chats Go still holds; it does not
+//! #317, **jira** since #316, **slack** since #315, **telegram** since #314) — but each only shrinks the set of chats Go still holds; it does not
 //! empty it, and the argument here turns on the set being non-empty.
 //! So the three steering routes are answered natively **only when Rust holds a
 //! live session for that chat**, and forward otherwise. Go then answers —

--- a/desktop/src-tauri/src/native/chat/runner.rs
+++ b/desktop/src-tauri/src/native/chat/runner.rs
@@ -24,8 +24,8 @@
 //! **#311 narrowed the `mcp` half rather than removing it.** An agent is served
 //! natively when *every* name in `capabilities.mcp` is an integration this build
 //! can host — `registry::HOSTED_TYPES`, which today means `github` (#312) and
-//! `confluence` (#317), `jira` (#316) and `slack` (#315), and will mean the rest
-//! as #313 and #314 land. Three things
+//! `confluence` (#317), `jira` (#316), `slack` (#315) and `telegram` (#314), and
+//! will mean all six once #313 lands. Three things
 //! still forward, and [`mcp_plan`] is where each is decided:
 //!
 //! - **A name whose type is not hosted.** A `slack` row has no Rust starter;
@@ -389,7 +389,7 @@ fn mcp_plan(
         if !crate::native::integrations::registry::can_host(db_path, id)? {
             return Err(format!(
                 "agent uses MCP server {id:?}, which is not an integration this build \
-                 can host (#313, #314)"
+                 can host (#313)"
             ));
         }
         servers.push(McpServerSpec {
@@ -1078,17 +1078,13 @@ mod tests {
     fn an_mcp_name_this_build_cannot_host_forwards() {
         let file = db_with_integration("gh-1", "github");
 
-        // A type with no Rust starter. `telegram` while #314 is unwritten — the
-        // stand-in has to be a type that is genuinely unported, so it moves each
-        // time one lands.
-        let telegram = db_with_integration("tg-1", "telegram");
-        let err = mcp_plan(
-            Some(&caps_naming("tg-1", None)),
-            Some(telegram.path()),
-            false,
-        )
-        .expect_err("telegram cannot be hosted");
-        assert!(err.contains(r#"MCP server "tg-1""#), "{err}");
+        // A type with no Rust starter. `google` while #313 is unwritten — the
+        // stand-in has to be a type that is genuinely unported, so it has moved
+        // with each landing and this is the last move available.
+        let google = db_with_integration("gg-1", "google");
+        let err = mcp_plan(Some(&caps_naming("gg-1", None)), Some(google.path()), false)
+            .expect_err("google cannot be hosted");
+        assert!(err.contains(r#"MCP server "gg-1""#), "{err}");
 
         // A name with no integration row: `mcps.yaml` could still name it.
         assert!(mcp_plan(
@@ -1107,7 +1103,7 @@ mod tests {
         let mut mixed = caps_naming("gh-1", None);
         if let Some(mcp) = mixed.mcp.as_mut() {
             mcp.0.insert(
-                "tg-1".to_string(),
+                "gg-1".to_string(),
                 crate::native::agents::McpCapability { tools: None }.into(),
             );
         }

--- a/desktop/src-tauri/src/native/integration_credentials.rs
+++ b/desktop/src-tauri/src/native/integration_credentials.rs
@@ -104,12 +104,22 @@ where
             format!("invalid {kind} credentials: credentials are empty"),
         ));
     };
-    // Through `Option<T>` rather than straight to `T`: a literal `null` is a
-    // *type error* to serde but leaves the zero value in Go, so a direct
-    // deserialize would forward `"credentials": null` instead of reporting the
-    // first missing field the way Go does.
-    serde_json::from_str::<Option<T>>(raw.get())
-        .map(Option::unwrap_or_default)
+    // Two wrappers, one Go rule each, and the request struct beside this one
+    // carries both on `services` for the same reasons (#295, #337):
+    //
+    // - `Option<T>` rather than straight to `T`, because a literal `null` is a
+    //   *type error* to serde and the zero value to Go — a direct deserialize
+    //   would forward `"credentials": null` instead of reporting the first
+    //   missing field the way Go does.
+    // - `GoStruct<T>`, because serde fills a struct from a JSON **array**
+    //   positionally when every field has a default, so `"credentials":["tok"]`
+    //   decoded to a populated struct, passed the non-empty check and **created
+    //   the row 201** where `validateTelegramCredentials` answers 422
+    //   `cannot unmarshal array`. This is the decode behind all seven per-type
+    //   validators, so it is the one place the rule decides whether a row is
+    //   written at all rather than only whether a server is hosted.
+    serde_json::from_str::<Option<super::gojson::GoStruct<T>>>(raw.get())
+        .map(|wrapped| wrapped.map_or_else(T::default, |wrapped| wrapped.0))
         .map_err(|e| {
             // **The error is deliberately not included.** serde_json quotes the
             // offending value, so a caller who sends
@@ -490,6 +500,31 @@ fn json_string(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    /// A JSON **array** where a credentials object belongs.
+    ///
+    /// serde fills a struct from a sequence positionally when every field has a
+    /// default, so this decoded to a populated struct, passed the non-empty check
+    /// and created the row — where Go answers 422 `cannot unmarshal array`. It
+    /// forwards now, which is how Go's own message reaches the caller verbatim.
+    ///
+    /// The same rule `services` has carried since #337, one field along in the
+    /// same request struct.
+    #[test]
+    fn a_json_array_is_not_a_credentials_object() {
+        for (kind, blob) in [
+            ("telegram", r#"["123456:AAF-token"]"#),
+            ("github", r#"["pat","ghp_x"]"#),
+            ("confluence", "[]"),
+        ] {
+            let raw = serde_json::value::RawValue::from_string(blob.to_string()).expect("raw");
+            let err = validate(kind, Some(&raw)).expect_err("an array must not be accepted");
+            assert!(
+                matches!(err, WriteError::Fallback(_)),
+                "{kind} {blob}: {err:?}"
+            );
+        }
+    }
+
     use super::*;
 
     fn raw(s: &str) -> Box<RawValue> {

--- a/desktop/src-tauri/src/native/integrations.rs
+++ b/desktop/src-tauri/src/native/integrations.rs
@@ -485,18 +485,24 @@ fn segment(value: &str) -> Option<&str> {
 /// on the Go side. Returns the integration id the shell owes a reload for.
 ///
 /// `Reload` has seven callers in Go. Two are ported (`Update`, and `Delete` via
-/// `Stop`). None of the rest is left unaccounted for:
-/// `completeOAuth` are unaffected, because the switch is per type and every type
-/// they can reach is still Go's: `startProviderCallback` supports exactly
-/// `google` and `slack`, so an OAuth completion never concerns a type this
-/// process hosts. That leaves `validateGitHubPATAuth` and, since #314–#317,
-/// `validateTelegramTokenAuth`, `validateSlackTokenAuth`,
-/// `validateJiraTokenAuth` and `validateConfluenceAuth` — all behind
-/// `POST /api/integrations/{id}/auth/validate` — as the paths that write a
-/// credential for a hosted type and cannot tell anybody. Without this hook such
-/// an integration is never hosted in the session it is set up in — create, `PUT`
-/// and `auth/validate` all leave it unauthenticated or unheard, and it appears
-/// only at the next boot's `start_all`.
+/// `Stop`). Of the five that run inside the sidecar, **none is covered by the
+/// per-type gate any more**: as of #314 five of the six types are hosted here, so
+/// a `Reload` for one reaches nothing in that process.
+///
+/// Four are the token validators — `validateGitHubPATAuth` and, since #314–#317,
+/// `validateTelegramTokenAuth`, `validateSlackTokenAuth`, `validateJiraTokenAuth`
+/// and `validateConfluenceAuth` — all behind
+/// `POST /api/integrations/{id}/auth/validate`, which is the route this hook
+/// answers. Without it such an integration is never hosted in the session it is
+/// set up in: create, `PUT` and `auth/validate` all leave it unauthenticated or
+/// unheard, and it appears only at the next boot's `start_all`.
+///
+/// The fifth is `completeOAuth`, which this hook does **not** cover and which is
+/// not safe by the gate either — `startProviderCallback` supports `google` and
+/// `slack`, and `slack` has been hosted here since #315. Its token never crosses
+/// this proxy at all (the browser delivers it to a callback server the sidecar
+/// opens), so it is picked up from the *other* route below instead. See
+/// `registry::reload_if_secrets_changed`.
 ///
 /// The route predicate below is deliberately **type-blind**: it answers with the
 /// id for every integration, and `registry::reload_after_auth` reads the row's

--- a/desktop/src-tauri/src/native/integrations.rs
+++ b/desktop/src-tauri/src/native/integrations.rs
@@ -137,6 +137,7 @@ pub mod confluence;
 pub mod github;
 pub mod jira;
 pub mod slack;
+pub mod telegram;
 
 /// The Start/Stop/Reload lifecycle, and the one place in the port that reads
 /// `integrations.credentials` (#311).
@@ -484,13 +485,13 @@ fn segment(value: &str) -> Option<&str> {
 /// on the Go side. Returns the integration id the shell owes a reload for.
 ///
 /// `Reload` has seven callers in Go. Two are ported (`Update`, and `Delete` via
-/// `Stop`). One more — the telegram validator — and
+/// `Stop`). None of the rest is left unaccounted for:
 /// `completeOAuth` are unaffected, because the switch is per type and every type
 /// they can reach is still Go's: `startProviderCallback` supports exactly
 /// `google` and `slack`, so an OAuth completion never concerns a type this
-/// process hosts. That leaves `validateGitHubPATAuth` and, since #315–#317,
-/// `validateSlackTokenAuth`, `validateJiraTokenAuth` and
-/// `validateConfluenceAuth` — all behind
+/// process hosts. That leaves `validateGitHubPATAuth` and, since #314–#317,
+/// `validateTelegramTokenAuth`, `validateSlackTokenAuth`,
+/// `validateJiraTokenAuth` and `validateConfluenceAuth` — all behind
 /// `POST /api/integrations/{id}/auth/validate` — as the paths that write a
 /// credential for a hosted type and cannot tell anybody. Without this hook such
 /// an integration is never hosted in the session it is set up in — create, `PUT`
@@ -499,7 +500,7 @@ fn segment(value: &str) -> Option<&str> {
 ///
 /// The route predicate below is deliberately **type-blind**: it answers with the
 /// id for every integration, and `registry::reload_after_auth` reads the row's
-/// type through `can_host` before it does anything. So #313 and #314 need not touch
+/// type through `can_host` before it does anything. So #313 need not touch
 /// this — adding a string to `registry::HOSTED_TYPES` is what widens it.
 ///
 /// The reload runs **after** Go's answer, so the row is already written, and it
@@ -1971,7 +1972,7 @@ mod tests {
     /// reload strands a socket and a paired client that never connects.
     #[test]
     fn a_write_for_a_type_the_sidecar_hosts_forwards_without_touching_the_row() {
-        for integration_type in ["whatsapp", "telegram", "google"] {
+        for integration_type in ["whatsapp", "google"] {
             let file = migrated();
             Connection::open(file.path())
                 .expect("open")

--- a/desktop/src-tauri/src/native/integrations/base_url.rs
+++ b/desktop/src-tauri/src/native/integrations/base_url.rs
@@ -6,7 +6,8 @@
 //! question with one right answer, arrived at over four rounds of review on
 //! #317, and getting it wrong sent the user's `Basic` credentials to an
 //! attacker's host. #313–#315 do not need it — their API bases are constants,
-//! which #315 confirmed — and anything whose base comes out of the row does.
+//! which #314 and #315 confirmed — and anything whose base comes out of the row
+//! does.
 //!
 //! # The problem
 //!

--- a/desktop/src-tauri/src/native/integrations/github/client.rs
+++ b/desktop/src-tauri/src/native/integrations/github/client.rs
@@ -56,8 +56,8 @@ pub const DEFAULT_API_BASE: &str = "https://api.github.com";
 /// had to export `SetAPIBase` to be redirectable at all. Both callers here are
 /// in-crate, so `#[cfg(test)]` costs nothing and compiles the whole thing out —
 /// which is what [`api_base_lock`] below already does, for the same reason.
-/// #313 and #314 each add their own seam and should follow this, as #315 did —
-/// Slack's base is a package variable too. #317's is a constructor argument
+/// #313 adds the last seam and should follow this, as #314 and #315 did —
+/// Slack's and Telegram's bases are package variables too. #317's is a constructor argument
 /// rather than a static, because a Confluence site URL is per row; #316 needs
 /// none at all, because `jira.Start` does not validate the site URL and so a
 /// parity run can simply store the fake's URL.

--- a/desktop/src-tauri/src/native/integrations/registry.rs
+++ b/desktop/src-tauri/src/native/integrations/registry.rs
@@ -4,8 +4,9 @@
 //! Go keeps one long-lived in-process MCP server per enabled, authenticated
 //! integration: `Start` brings them all up at boot, `Reload` restarts one when
 //! its row changes, `Stop` tears one down when it is deleted. This module is
-//! that, for the types listed in [`HOSTED_TYPES`] — today `github` (#312),
-//! `confluence` (#317), `jira` (#316) and `slack` (#315).
+//! that, for the types listed in [`HOSTED_TYPES`] — today five of the six:
+//! `github` (#312), `confluence` (#317), `jira` (#316), `slack` (#315) and
+//! `telegram` (#314).
 //!
 //! ## Why the ownership had to flip before the writes could move
 //!
@@ -44,7 +45,7 @@
 //! **The list is built here, by [`hosting_env_value`], from the same
 //! [`HOSTED_TYPES`] that [`hosts_type`] and the starter dispatch read.** That is
 //! the point of carrying it in the environment rather than hardcoding it on both
-//! sides: the shell is the process that knows what it hosts, so #313 and #314 each
+//! sides: the shell is the process that knows what it hosts, so #313 adds the last
 //! add one string to one list and the two halves cannot drift. The failure mode
 //! being designed against is a Rust slack starter landing while Go is never told
 //! to stop hosting slack — two processes on one integration — and its mirror is
@@ -83,21 +84,31 @@
 //! ## What still reaches Go's `Reload` and not this one
 //!
 //! `Reload` has seven callers in Go and only two of them (`Update`, and
-//! `Delete` via `Stop`) are ported. Five run inside the sidecar. `completeOAuth`
-//! and the telegram validator is fine **because the gate is per type**: they can only reach types Go still hosts, and
-//! `startProviderCallback` supports exactly `google` and `slack`, so an OAuth
-//! completion never concerns a hosted one. The other three —
-//! `validateGitHubPATAuth`, and since #316 and #317 `validateJiraTokenAuth` and
-//! `validateConfluenceAuth` — write a credential for a type
-//! *this* process hosts, from a handler that cannot tell it. Without a hook such
-//! an integration would first be hosted at the next boot's [`start_all`], so the
+//! `Delete` via `Stop`) are ported. Five run inside the sidecar, and as of #314
+//! **none of them is safe by the per-type gate any more** — five of the six types
+//! are hosted here, so a `Reload` for one reaches nothing in the sidecar.
+//!
+//! Four are the token validators — `validateGitHubPATAuth` and, since #314–#317,
+//! `validateTelegramTokenAuth`, `validateSlackTokenAuth`, `validateJiraTokenAuth`
+//! and `validateConfluenceAuth`. Each writes a credential for a type *this*
+//! process hosts, from a handler that cannot tell it. Without a hook such an
+//! integration would first be hosted at the next boot's [`start_all`], so the
 //! seam fires [`reload_after_auth`] after forwarding a 2xx for that one route
 //! (`native::after_forward`). That hook needs no per-type list of its own: it
 //! runs for every id on the route and [`reload_after_auth`] reads the row's type
-//! through [`can_host`], so #313 and #314 are covered the moment they add their
+//! through [`can_host`], so #313 is covered the moment it adds its
 //! string to [`HOSTED_TYPES`]. The reload is idempotent and the response has
 //! already been produced, so doing it on the forward path costs nothing but a
 //! restart of a server that was about to be restarted anyway.
+//!
+//! The fifth is `completeOAuth`, and it needed a **different** hook because its
+//! trigger never crosses the proxy: `startProviderCallback` supports `google`
+//! and `slack`, and since #315 the `slack` half concerns a hosted type, but the
+//! token is delivered by the browser to a callback server the *sidecar* opens on
+//! its own port. The only part of that flow this process sees is the UI polling
+//! `GET /api/integrations/{id}/auth/status`, which is a *poll* rather than an
+//! event — see [`reload_if_secrets_changed`] for why that one is conditional
+//! where [`reload_after_auth`] is not.
 //!
 //! ## Secrets
 //!
@@ -184,8 +195,8 @@ impl HostingRow {
 /// One list, read by three things that must agree: [`hosts_type`] (which the
 /// native `PUT`/`DELETE` consult before they touch a row), the starter dispatch
 /// in [`start_for_type`], and [`hosting_env_value`], which tells the Go sidecar
-/// which types to stop hosting. #313 and #314 each add one string here.
-pub const HOSTED_TYPES: &[&str] = &["github", "confluence", "jira", "slack"];
+/// which types to stop hosting. #313 adds the last string here.
+pub const HOSTED_TYPES: &[&str] = &["github", "confluence", "jira", "slack", "telegram"];
 
 /// Whether this process hosts an integration of the given type.
 pub fn hosts_type(integration_type: &str) -> bool {
@@ -433,6 +444,7 @@ async fn start_for_type(row: &HostingRow) -> Result<InProcessMcpServer, String> 
         "confluence" => start_confluence(&row.id, &row.services(), &row.credentials).await,
         "jira" => start_jira(&row.id, &row.services(), &row.credentials).await,
         "slack" => start_slack(&row.id, &row.services(), &row.credentials, &row.auth).await,
+        "telegram" => start_telegram(&row.id, &row.services(), &row.credentials).await,
         other => Err(format!(
             "no starter registered for integration type {other:?}"
         )),
@@ -664,6 +676,52 @@ pub(super) fn resolve_slack_token(
     }
 }
 
+/// `telegram.Start`'s first two steps — the auth check and the credential parse
+/// — followed by the third, which `native/integrations/telegram` owns.
+///
+/// `config.TelegramCredentials` is one field, so this needs no shared struct the
+/// way the two Atlassian ones do.
+async fn start_telegram(
+    id: &str,
+    services: &BTreeMap<String, ServiceConfig>,
+    credentials: &str,
+) -> Result<InProcessMcpServer, String> {
+    #[derive(Default, serde::Deserialize)]
+    #[serde(default)]
+    struct TelegramCredentials {
+        #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+        bot_token: String,
+    }
+
+    if credentials.is_empty() {
+        return Err(format!(
+            "parsing telegram credentials for {id:?}: credentials are empty"
+        ));
+    }
+    // Through `Option<T>`, because a literal `null` is a no-op to
+    // `json.Unmarshal` and a type error to serde.
+    let token = serde_json::from_str::<Option<TelegramCredentials>>(credentials)
+        .map(Option::unwrap_or_default)
+        .map(|creds| creds.bot_token)
+        .map_err(|e| {
+            // The serde message is dropped for [`github_token`]'s reason: it
+            // quotes the offending value, which here is the bot token.
+            format!(
+                "parsing telegram credentials for {id:?}: does not decode at line {} column {}",
+                e.line(),
+                e.column()
+            )
+        })?;
+
+    // Note what is **not** checked: an empty bot token. `telegram.Start` reads
+    // `creds.BotToken` and hosts whatever it finds, so an empty one produces a
+    // server whose every call 404s at `/bot/<method>` — Go's behaviour, and not
+    // something to improve on here.
+    super::telegram::start_telegram_mcp_server(id, services, &token)
+        .await
+        .map_err(|e| format!("starting in-process MCP server for {id:?}: {e}"))
+}
+
 /// `config.AtlassianCredentials` — the struct Confluence and Jira share.
 ///
 /// Neither derives `Debug` nor `Serialize`, for [`HostingRow`]'s reason: a
@@ -775,6 +833,7 @@ pub async fn start_filtered_server(
         "confluence" => start_confluence(&row.id, &filtered, &row.credentials).await,
         "jira" => start_jira(&row.id, &filtered, &row.credentials).await,
         "slack" => start_slack(&row.id, &filtered, &row.credentials, &row.auth).await,
+        "telegram" => start_telegram(&row.id, &filtered, &row.credentials).await,
         other => Err(format!(
             "no starter registered for integration type {other:?}"
         )),
@@ -1278,7 +1337,10 @@ mod tests {
     /// two ways to put a credential on two open ports at once.
     #[test]
     fn the_sidecar_is_told_exactly_what_this_process_hosts() {
-        assert_eq!(hosting_env_value(), "off:github,confluence,jira,slack");
+        assert_eq!(
+            hosting_env_value(),
+            "off:github,confluence,jira,slack,telegram"
+        );
         assert_eq!(
             hosting_env_value(),
             format!("off:{}", HOSTED_TYPES.join(",")),
@@ -1288,11 +1350,12 @@ mod tests {
         assert!(hosts_type("confluence"));
         assert!(hosts_type("jira"));
         assert!(hosts_type("slack"));
-        // The two types #313 and #314 still owe. Go must keep hosting every one of
+        assert!(hosts_type("telegram"));
+        // The one type #313 still owes. Go must keep hosting every one of
         // them, and `whatsapp` is the reason this is a list at all: its starter
         // opens a live whatsmeow connection that its status, reconnect and QR
         // endpoints read out of a package global.
-        for unported in ["telegram", "google", "whatsapp"] {
+        for unported in ["google", "whatsapp"] {
             assert!(!hosts_type(unported), "{unported} is not hosted here");
             assert!(
                 !hosting_env_value().contains(unported),
@@ -1370,23 +1433,23 @@ mod tests {
         let file = db();
         insert(
             &file,
-            "tg-1",
-            "telegram",
+            "gg-1",
+            "google",
             true,
             Some(r#"{"validated":true}"#),
-            r#"{"bot_token":"tg-secret"}"#,
-            r#"{"chat":{"enabled":true,"tools":["post"]}}"#,
+            r#"{"client_id":"gg-secret"}"#,
+            r#"{"gmail":{"enabled":true,"tools":["send"]}}"#,
         );
 
         // `start_all` swallows it: one bad integration must not stop the others.
         start_all(file.path()).await.expect("start_all swallows it");
-        assert!(!registry().is_hosted("tg-1"));
+        assert!(!registry().is_hosted("gg-1"));
 
         // `reload` returns it, and its callers are the ones that swallow.
-        let err = reload(file.path(), "tg-1").await.expect_err("no starter");
+        let err = reload(file.path(), "gg-1").await.expect_err("no starter");
         assert_eq!(
             err,
-            r#"no starter registered for integration type "telegram""#
+            r#"no starter registered for integration type "google""#
         );
     }
 
@@ -1541,7 +1604,7 @@ mod tests {
     async fn a_filtered_server_refuses_the_way_go_refuses() {
         let file = db();
         insert(&file, "gh-off", "github", false, Some("{}"), "{}", "{}");
-        insert(&file, "tg-1", "telegram", true, Some("{}"), "{}", "{}");
+        insert(&file, "gg-1", "google", true, Some("{}"), "{}", "{}");
 
         // `.err()` rather than `unwrap_err()`: the `Ok` side is an
         // `InProcessMcpServer`, which deliberately has no `Debug` — printing
@@ -1562,9 +1625,9 @@ mod tests {
             r#"integration "gh-off" is not enabled or not authenticated"#
         );
         assert_eq!(
-            refusal("tg-1").await,
-            r#"no starter registered for integration type "telegram""#
+            refusal("gg-1").await,
+            r#"no starter registered for integration type "google""#
         );
-        assert!(!can_host(file.path(), "tg-1").expect("can_host"));
+        assert!(!can_host(file.path(), "gg-1").expect("can_host"));
     }
 }

--- a/desktop/src-tauri/src/native/integrations/registry.rs
+++ b/desktop/src-tauri/src/native/integrations/registry.rs
@@ -45,8 +45,8 @@
 //! **The list is built here, by [`hosting_env_value`], from the same
 //! [`HOSTED_TYPES`] that [`hosts_type`] and the starter dispatch read.** That is
 //! the point of carrying it in the environment rather than hardcoding it on both
-//! sides: the shell is the process that knows what it hosts, so #313 adds the last
-//! add one string to one list and the two halves cannot drift. The failure mode
+//! sides: the shell is the process that knows what it hosts, so #313 adds the
+//! last string to one list and the two halves cannot drift. The failure mode
 //! being designed against is a Rust slack starter landing while Go is never told
 //! to stop hosting slack — two processes on one integration — and its mirror is
 //! the WhatsApp bug above.
@@ -493,8 +493,8 @@ fn github_token(id: &str, credentials: &str) -> Result<String, String> {
     // Through `Option<T>`, because a literal `null` is a no-op to
     // `json.Unmarshal` and a type error to serde — the rule
     // `native/integration_credentials.rs` carries for the same columns.
-    serde_json::from_str::<Option<GitHubCredentials>>(credentials)
-        .map(Option::unwrap_or_default)
+    serde_json::from_str::<Option<crate::native::gojson::GoStruct<GitHubCredentials>>>(credentials)
+        .map(|wrapped| wrapped.map_or_else(GitHubCredentials::default, |wrapped| wrapped.0))
         .map(|creds| creds.personal_access_token)
         .map_err(|e| {
             // **The serde message is deliberately dropped.** It quotes the
@@ -625,15 +625,17 @@ pub(super) fn resolve_slack_token(
             "parsing slack credentials: credentials are empty".to_string(),
         ));
     }
-    let creds = serde_json::from_str::<Option<SlackCredentials>>(credentials)
-        .map(Option::unwrap_or_default)
-        .map_err(|e| {
-            wrap(format!(
-                "parsing slack credentials: does not decode at line {} column {}",
-                e.line(),
-                e.column()
-            ))
-        })?;
+    let creds = serde_json::from_str::<Option<crate::native::gojson::GoStruct<SlackCredentials>>>(
+        credentials,
+    )
+    .map(|wrapped| wrapped.map_or_else(SlackCredentials::default, |wrapped| wrapped.0))
+    .map_err(|e| {
+        wrap(format!(
+            "parsing slack credentials: does not decode at line {} column {}",
+            e.line(),
+            e.column()
+        ))
+    })?;
 
     match creds.auth_mode.as_str() {
         "bot_token" => {
@@ -654,15 +656,16 @@ pub(super) fn resolve_slack_token(
                 #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
                 access_token: String,
             }
-            let token = serde_json::from_str::<Option<OAuthToken>>(auth)
-                .map(Option::unwrap_or_default)
-                .map_err(|e| {
-                    wrap(format!(
-                        "parsing oauth token: does not decode at line {} column {}",
-                        e.line(),
-                        e.column()
-                    ))
-                })?;
+            let token =
+                serde_json::from_str::<Option<crate::native::gojson::GoStruct<OAuthToken>>>(auth)
+                    .map(|wrapped| wrapped.map_or_else(OAuthToken::default, |wrapped| wrapped.0))
+                    .map_err(|e| {
+                        wrap(format!(
+                            "parsing oauth token: does not decode at line {} column {}",
+                            e.line(),
+                            e.column()
+                        ))
+                    })?;
             Ok(token.access_token)
         }
         other => {
@@ -686,6 +689,24 @@ async fn start_telegram(
     services: &BTreeMap<String, ServiceConfig>,
     credentials: &str,
 ) -> Result<InProcessMcpServer, String> {
+    let token = telegram_bot_token(id, credentials)?;
+    super::telegram::start_telegram_mcp_server(id, services, &token)
+        .await
+        .map_err(|e| format!("starting in-process MCP server for {id:?}: {e}"))
+}
+
+/// `cfg.ParseCredentials(&creds)` for `config.TelegramCredentials`, wrapped as
+/// `telegram.Start` wraps it.
+///
+/// `pub(super)` so the sentences can be asserted directly: they are hand-written
+/// rather than vector-pinned, and one of them would carry the bot token if the
+/// serde message were kept.
+///
+/// Note what is **not** checked: an empty bot token. `telegram.Start` reads
+/// `creds.BotToken` and hosts whatever it finds, so an empty one produces a
+/// server whose every call reaches `/bot/<method>` and 404s — Go's behaviour, and
+/// not something to improve on here.
+pub(super) fn telegram_bot_token(id: &str, credentials: &str) -> Result<String, String> {
     #[derive(Default, serde::Deserialize)]
     #[serde(default)]
     struct TelegramCredentials {
@@ -698,28 +719,24 @@ async fn start_telegram(
             "parsing telegram credentials for {id:?}: credentials are empty"
         ));
     }
-    // Through `Option<T>`, because a literal `null` is a no-op to
-    // `json.Unmarshal` and a type error to serde.
-    let token = serde_json::from_str::<Option<TelegramCredentials>>(credentials)
-        .map(Option::unwrap_or_default)
-        .map(|creds| creds.bot_token)
-        .map_err(|e| {
-            // The serde message is dropped for [`github_token`]'s reason: it
-            // quotes the offending value, which here is the bot token.
-            format!(
-                "parsing telegram credentials for {id:?}: does not decode at line {} column {}",
-                e.line(),
-                e.column()
-            )
-        })?;
-
-    // Note what is **not** checked: an empty bot token. `telegram.Start` reads
-    // `creds.BotToken` and hosts whatever it finds, so an empty one produces a
-    // server whose every call 404s at `/bot/<method>` — Go's behaviour, and not
-    // something to improve on here.
-    super::telegram::start_telegram_mcp_server(id, services, &token)
-        .await
-        .map_err(|e| format!("starting in-process MCP server for {id:?}: {e}"))
+    // `Option<GoStruct<T>>`: a literal `null` is a no-op to `json.Unmarshal` and
+    // a type error to serde, and a JSON **array** is a type error to Go and a
+    // positional struct to serde. Both directions matter here more than anywhere
+    // — a bogus token becomes a URL path segment.
+    serde_json::from_str::<Option<crate::native::gojson::GoStruct<TelegramCredentials>>>(
+        credentials,
+    )
+    .map(|wrapped| wrapped.map_or_else(TelegramCredentials::default, |wrapped| wrapped.0))
+    .map(|creds| creds.bot_token)
+    .map_err(|e| {
+        // The serde message is dropped for [`github_token`]'s reason: it quotes
+        // the offending value, which here is the bot token.
+        format!(
+            "parsing telegram credentials for {id:?}: does not decode at line {} column {}",
+            e.line(),
+            e.column()
+        )
+    })
 }
 
 /// `config.AtlassianCredentials` — the struct Confluence and Jira share.
@@ -762,8 +779,8 @@ fn atlassian_credentials(
     // Through `Option<T>`, because a literal `null` is a no-op to
     // `json.Unmarshal` and a type error to serde — the rule
     // `native/integration_credentials.rs` carries for the same columns.
-    serde_json::from_str::<Option<Raw>>(credentials)
-        .map(Option::unwrap_or_default)
+    serde_json::from_str::<Option<crate::native::gojson::GoStruct<Raw>>>(credentials)
+        .map(|wrapped| wrapped.map_or_else(Raw::default, |wrapped| wrapped.0))
         .map(|raw| AtlassianCredentials {
             site_url: raw.site_url,
             email: raw.email,
@@ -1519,6 +1536,55 @@ mod tests {
         assert_eq!(
             github_token("gh-1", &github_credentials()).expect("valid"),
             PAT
+        );
+
+        // …and a JSON **array** is a type error to Go, where serde would build
+        // the struct from it positionally. Measured against `json.Unmarshal`:
+        // `["tok"]` is `cannot unmarshal array into Go value of type
+        // config.GitHubCredentials`, so hosting a server for it would run one Go
+        // refuses to start.
+        assert!(github_token("gh-1", &format!(r#"[{PAT:?}]"#)).is_err());
+    }
+
+    /// The same three shapes for Telegram, which is the one integration where a
+    /// bogus token becomes a **URL path segment** rather than a header value.
+    ///
+    /// Hand-written rather than vector-pinned — `telegram.Start`'s wrapper is not
+    /// reachable from a `tools/call` — so the sentences are asserted here.
+    #[test]
+    fn a_telegram_credential_failure_never_carries_the_token() {
+        const BOT: &str = "123456:AAF-secret-bot-token";
+
+        assert_eq!(
+            telegram_bot_token("tg-1", "").unwrap_err(),
+            r#"parsing telegram credentials for "tg-1": credentials are empty"#
+        );
+
+        let err = telegram_bot_token("tg-1", &format!(r#"{{"bot_token":{BOT:?},"#))
+            .expect_err("truncated json");
+        assert!(
+            !err.contains(BOT),
+            "the bot token must not reach the log line: {err}"
+        );
+        assert!(err.contains("does not decode at line"), "{err}");
+
+        // A literal `null` is a zero value; a JSON array is a type error.
+        assert_eq!(
+            telegram_bot_token("tg-1", "null").expect("null decodes"),
+            ""
+        );
+        assert!(telegram_bot_token("tg-1", &format!(r#"[{BOT:?}]"#)).is_err());
+
+        assert_eq!(
+            telegram_bot_token("tg-1", &format!(r#"{{"bot_token":{BOT:?}}}"#)).expect("valid"),
+            BOT
+        );
+
+        // An **empty** bot token is deliberately not refused: `telegram.Start`
+        // hosts whatever it reads, so every call 404s at `/bot/<method>`.
+        assert_eq!(
+            telegram_bot_token("tg-1", r#"{"bot_token":""}"#).expect("empty is hosted"),
+            ""
         );
     }
 

--- a/desktop/src-tauri/src/native/integrations/telegram/client.rs
+++ b/desktop/src-tauri/src/native/integrations/telegram/client.rs
@@ -451,9 +451,12 @@ mod tests {
             .await
             .map(|response| response.result().to_string())
             .expect_err("the body ends early");
+        // No disjunction with the send-path sentence: if the failure ever
+        // migrates there, this must fail loudly rather than quietly stop
+        // asserting the thing it exists for.
         assert!(
-            message.starts_with("reading response: ") || message.starts_with("calling Telegram "),
-            "unexpected sentence: {message}"
+            message.starts_with("reading response: "),
+            "this must fail in the body stream, not the send: {message}"
         );
         assert!(!message.contains(SECRET), "the bot token reached the model");
         assert!(

--- a/desktop/src-tauri/src/native/integrations/telegram/client.rs
+++ b/desktop/src-tauri/src/native/integrations/telegram/client.rs
@@ -1,0 +1,481 @@
+//! The shared HTTP client, ported from `internal/integrations/telegram/tools.go`
+//! (`apiURL`, `callTelegram`) and `validate.go` (`telegramHTTPClient`,
+//! `telegramResponse`).
+//!
+//! # The bot token is in the URL path
+//!
+//! `apiURL` is `fmt.Sprintf("%s/bot%s/%s", apiBaseURL, token, method)`, so every
+//! request carries the credential in its **path** rather than in a header. That
+//! is Telegram's API design, not a choice available to the port, and it changes
+//! what the error strings have to avoid: a `reqwest::Error`'s `Display` carries
+//! the URL it was building, so interpolating a transport cause here would put the
+//! bot token into text the model reads and a `tool_result` stores. Go's wording
+//! already avoids it — `calling Telegram %s: request failed` names the *method*
+//! and nothing else — and [`a_failed_call_names_neither_the_token_nor_the_cause`]
+//! asserts that rather than trusting it.
+//!
+//! It also means the token reaches [`crate::native::gourl`]-free URL
+//! construction: `Sprintf` does not escape it, so neither does this. See
+//! [`Client::endpoint`] for the one guard that adds.
+//!
+//! # The envelope decides, and it is Slack's shape with different names
+//!
+//! `callTelegram` reads `{"ok":…,"description":…,"result":…}` and never looks at
+//! the HTTP status at all — not even a 429, which Slack's does. `ok: false` is
+//! the failure, whatever the status; a 500 carrying `ok: true` is a success. The
+//! three `encoding/json` rules that decode needs are spelled out on
+//! [`TelegramResponse`], because #315 shipped two of them wrong in the file next
+//! door before review caught it.
+//!
+//! Cap 10 MiB and timeout 60 seconds, the largest of the six on both counts.
+
+use std::sync::OnceLock;
+#[cfg(test)]
+use std::sync::RwLock;
+use std::time::Duration;
+
+use serde_json::value::RawValue;
+use tokio_stream::StreamExt;
+
+use crate::claude::CancellationToken;
+
+/// `apiBaseURL`'s default.
+pub const DEFAULT_API_BASE: &str = "https://api.telegram.org";
+
+/// Go's `apiBaseURL`, "a variable so tests can point it at a local httptest
+/// server".
+///
+/// **Test-only, where Go's is not** — `github::client::API_BASE`'s reasoning, and
+/// sharper here: the seam points every request, *token in the path*, at an
+/// arbitrary host. Go had to export `SetAPIBase` (`telegram/parity.go`) because
+/// `desktop/parity` is a different package; both callers here are in-crate.
+#[cfg(test)]
+static API_BASE: RwLock<Option<String>> = RwLock::new(None);
+
+#[cfg(test)]
+fn api_base() -> String {
+    API_BASE
+        .read()
+        .expect("the telegram API base lock is poisoned")
+        .clone()
+        .unwrap_or_else(|| DEFAULT_API_BASE.to_string())
+}
+
+#[cfg(not(test))]
+fn api_base() -> String {
+    DEFAULT_API_BASE.to_string()
+}
+
+/// Points every subsequent request at `base`; `None` restores the default.
+#[cfg(test)]
+pub(super) fn set_api_base(base: Option<String>) {
+    *API_BASE
+        .write()
+        .expect("the telegram API base lock is poisoned") = base;
+}
+
+/// Serializes the tests that redirect [`API_BASE`].
+#[cfg(test)]
+pub(super) async fn api_base_lock() -> tokio::sync::MutexGuard<'static, ()> {
+    static LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+    LOCK.lock().await
+}
+
+/// `io.LimitReader(resp.Body, 10*1024*1024)`.
+const MAX_RESPONSE_BYTES: usize = 10 * 1024 * 1024;
+
+/// `telegramHTTPClient` — 60 seconds.
+fn http_client() -> Option<&'static reqwest::Client> {
+    static CLIENT: OnceLock<Option<reqwest::Client>> = OnceLock::new();
+    CLIENT
+        .get_or_init(|| {
+            reqwest::Client::builder()
+                .timeout(Duration::from_secs(60))
+                .build()
+                .ok()
+        })
+        .as_ref()
+}
+
+/// `telegramResponse`, and the three `encoding/json` rules a derived
+/// `Deserialize` gets wrong.
+///
+/// All three are written down in `desktop/CLAUDE.md` and all three were missed
+/// in #315's equivalent struct before review caught them, so they are stated
+/// here rather than assumed:
+///
+/// 1. **A JSON `null` is a zero value, not a type error.** Telegram sends
+///    `"description": null` beside a failure and `"result": null` beside a
+///    success; a plain derive answers `invalid type: null`. Hence
+///    `null_is_zero_value` on the two scalars.
+/// 2. **A JSON array is not a struct.** serde builds a struct from a sequence
+///    positionally when every field has a default, so `[true]` would decode to
+///    `ok: true` and turn Go's `cannot unmarshal array` into a *success*. Hence
+///    [`crate::native::gojson::GoStruct`].
+/// 3. **A bare `null` body is a no-op**, not a parse failure —
+///    `json.Unmarshal([]byte("null"), &v)` leaves the struct zeroed and returns
+///    `nil`, so Go falls through to the `!ok` branch. Hence the `Option<…>`
+///    around the wrapper in [`read_response`].
+///
+/// And one that is Telegram's own: **`result` is a `json.RawMessage`**, so an
+/// *absent* field is `nil` (which `string(nil)` renders as `""`) while an
+/// explicit `null` is the four bytes `null`. `Option<Box<RawValue>>` cannot tell
+/// those apart on its own — serde maps a JSON `null` to `None` — so
+/// [`raw_or_absent`] captures the null as a `RawValue` and lets `#[serde(default)]`
+/// supply the absent case. Both spellings reach the model verbatim in a result
+/// sentence, so the difference is observable.
+#[derive(Default, serde::Deserialize)]
+#[serde(default)]
+pub struct TelegramResponse {
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    pub ok: bool,
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    pub description: String,
+    #[serde(deserialize_with = "raw_or_absent")]
+    result: Option<Box<RawValue>>,
+}
+
+impl TelegramResponse {
+    /// `string(tgResp.Result)`: the raw bytes, `""` when the field was absent and
+    /// `null` when it was an explicit null.
+    pub fn result(&self) -> &str {
+        self.result.as_ref().map_or("", |raw| raw.get())
+    }
+}
+
+/// Captures an explicit `null` as a `RawValue` rather than as `None`.
+///
+/// `Option<Box<RawValue>>`'s own impl folds a JSON `null` into `None`, which
+/// would make `{"result":null}` and an absent `result` the same value — and they
+/// are not: Go renders the first as `null` and the second as the empty string,
+/// both of which land in a result sentence the model reads.
+fn raw_or_absent<'de, D>(deserializer: D) -> Result<Option<Box<RawValue>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    serde::Deserialize::deserialize(deserializer).map(Some)
+}
+
+/// Go's implicit client: a bot token and the requests made with it.
+#[derive(Clone)]
+pub struct Client {
+    token: String,
+}
+
+impl Client {
+    pub fn new(token: impl Into<String>) -> Self {
+        Self {
+            token: token.into(),
+        }
+    }
+
+    /// `callTelegram`: a JSON POST whose envelope is checked before the caller
+    /// sees it.
+    ///
+    /// `body` is already-encoded bytes, because the encoding has to be
+    /// `json.Marshal`'s — sorted keys, HTML escaping, and Go's own float
+    /// spelling for `send_location`'s coordinates.
+    pub async fn call(
+        &self,
+        ct: &CancellationToken,
+        method: &str,
+        body: Vec<u8>,
+    ) -> Result<TelegramResponse, String> {
+        let failed = format!("calling Telegram {method}: request failed");
+
+        let request = http_client()
+            .ok_or_else(|| failed.clone())?
+            .post(self.endpoint(method).ok_or_else(|| failed.clone())?)
+            .header("Content-Type", "application/json")
+            .body(body);
+
+        let response = tokio::select! {
+            () = ct.cancelled() => return Err(failed),
+            result = request.send() => result.map_err(|_| failed)?,
+        };
+
+        read_response(ct, response).await
+    }
+
+    /// `apiURL(token, method)` — `{base}/bot{token}/{method}`, unescaped, plus
+    /// the guard that costs.
+    ///
+    /// Go hands `Sprintf`'s output to `http.NewRequestWithContext` and `net/http`
+    /// writes it verbatim; `reqwest` builds every request through
+    /// `url::Url::parse`, which normalizes. The interpolated value here is the
+    /// **bot token**, so a token holding a `.`/`..` segment or a byte `url`
+    /// re-encodes would send this request somewhere Go does not — with the token
+    /// itself as the credential. A token is not model-supplied, which makes this
+    /// far less reachable than #312's and #317's equivalents, but the failure is
+    /// the same shape and the check is three lines.
+    ///
+    /// `None` rather than a sentence, because the caller already has Go's
+    /// wording for a request it could not make.
+    fn endpoint(&self, method: &str) -> Option<reqwest::Url> {
+        let path = format!("/bot{}/{method}", self.token);
+        let url = reqwest::Url::parse(&format!("{}{path}", api_base())).ok()?;
+        (url.path() == path && url.query().is_none()).then_some(url)
+    }
+}
+
+/// The tail of `callTelegram`: read the body, decode the envelope, and turn
+/// `ok: false` into Go's sentence.
+///
+/// **The HTTP status is never looked at** — not even 429, which Slack's
+/// equivalent does check. A 500 carrying `{"ok":true}` is a success here.
+async fn read_response(
+    ct: &CancellationToken,
+    response: reqwest::Response,
+) -> Result<TelegramResponse, String> {
+    let body = read_capped(ct, response).await?;
+
+    let envelope =
+        serde_json::from_str::<Option<crate::native::gojson::GoStruct<TelegramResponse>>>(&body)
+            .map(|wrapped| wrapped.map_or_else(TelegramResponse::default, |wrapped| wrapped.0))
+            // `fmt.Errorf("parsing response: %w", err)`. `encoding/json`'s wording is not
+            // reproducible, so this carries serde's — pinned as a divergence. It cannot
+            // leak the token: what is being parsed is Telegram's response.
+            .map_err(|e| format!("parsing response: {e}"))?;
+
+    if !envelope.ok {
+        return Err(format!("telegram API error: {}", envelope.description));
+    }
+    Ok(envelope)
+}
+
+/// `io.ReadAll(io.LimitReader(resp.Body, 10 MiB))`.
+async fn read_capped(
+    ct: &CancellationToken,
+    response: reqwest::Response,
+) -> Result<String, String> {
+    let mut body = Vec::new();
+    let mut stream = Box::pin(response.bytes_stream());
+    loop {
+        let chunk = tokio::select! {
+            () = ct.cancelled() => return Err("reading response: context canceled".to_string()),
+            chunk = stream.next() => chunk,
+        };
+        match chunk {
+            None => break,
+            Some(Ok(chunk)) => {
+                body.extend_from_slice(&chunk);
+                if body.len() >= MAX_RESPONSE_BYTES {
+                    body.truncate(MAX_RESPONSE_BYTES);
+                    break;
+                }
+            }
+            Some(Err(e)) => return Err(format!("reading response: {e}")),
+        }
+    }
+    Ok(String::from_utf8_lossy(&body).into_owned())
+}
+
+/// `read_messages`' clamp — the only one in this integration, and the only one
+/// in the six whose fallback is its own **maximum**.
+///
+/// `limit <= 0 || limit > 100` becomes 100, where every sibling falls back to
+/// something smaller than its ceiling. Read from `tools.go` rather than
+/// generalised from the pattern.
+pub fn clamp_limit(limit: i64) -> i64 {
+    if limit <= 0 || limit > 100 {
+        100
+    } else {
+        limit
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode;
+
+    /// A distinctive token, so a leak is unmistakable — and this one would be in
+    /// the *URL*, which is what makes it worth asserting.
+    const SECRET: &str = "123456:AAF-SUPER-SECRET-BOT-TOKEN";
+
+    /// One scripted reply through the real client, reduced to what a tool would
+    /// actually use: `result()` on success, the sentence on failure.
+    ///
+    /// Reduced rather than returned whole because [`TelegramResponse`]
+    /// deliberately derives no `Debug` — it holds Telegram's `result`, which is
+    /// chat content, and an assertion helper is exactly the kind of place a
+    /// `{:?}` gets added later and then copied into a log line.
+    async fn reply(status: u16, body: &str) -> Result<String, String> {
+        let body = body.to_string();
+        let app = axum::Router::new().fallback(move || {
+            let body = body.clone();
+            async move { (StatusCode::from_u16(status).expect("status"), body) }
+        });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let base = format!("http://{}", listener.local_addr().expect("addr"));
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        set_api_base(Some(base));
+        Client::new(SECRET)
+            .call(&CancellationToken::new(), "getChat", b"{}".to_vec())
+            .await
+            .map(|response| response.result().to_string())
+    }
+
+    /// The three `encoding/json` rules, each at the shape that distinguishes it.
+    ///
+    /// Every expectation here was measured against a real `json.Unmarshal` into
+    /// `telegramResponse` before it was written.
+    #[tokio::test]
+    async fn the_envelope_decodes_the_way_encoding_json_decodes_it() {
+        let _guard = api_base_lock().await;
+
+        // 1. A null is a zero value, not a type error.
+        assert_eq!(
+            reply(200, r#"{"ok":false,"description":null}"#)
+                .await
+                .expect_err("ok:false"),
+            "telegram API error: "
+        );
+        assert_eq!(
+            reply(200, r#"{"ok":null}"#).await.expect_err("ok:false"),
+            "telegram API error: "
+        );
+
+        // 2. A bare null body is a no-op, so Go reaches the !ok branch.
+        assert_eq!(
+            reply(200, "null").await.expect_err("ok:false"),
+            "telegram API error: "
+        );
+
+        // 3. An array is not a struct — without `GoStruct` this decodes
+        //    positionally to `ok: true` and becomes a success.
+        assert!(reply(200, "[true]")
+            .await
+            .expect_err("an array is a parse failure")
+            .starts_with("parsing response: "));
+
+        set_api_base(None);
+    }
+
+    /// `result` distinguishes **absent** from an explicit `null`, and both reach
+    /// the model in a result sentence.
+    #[tokio::test]
+    async fn an_absent_result_and_a_null_result_are_different_strings() {
+        let _guard = api_base_lock().await;
+
+        assert_eq!(
+            reply(200, r#"{"ok":true}"#).await.expect("ok"),
+            "",
+            "an absent RawMessage is nil, and string(nil) is empty"
+        );
+        assert_eq!(
+            reply(200, r#"{"ok":true,"result":null}"#)
+                .await
+                .expect("ok"),
+            "null",
+            "an explicit null is the four bytes"
+        );
+        // …and a real result is passed through verbatim, key order and all.
+        assert_eq!(
+            reply(200, r#"{"ok":true,"result":{"z":1,"a":2}}"#)
+                .await
+                .expect("ok"),
+            r#"{"z":1,"a":2}"#
+        );
+
+        set_api_base(None);
+    }
+
+    /// The status is never looked at — not even a 429, which Slack's client does
+    /// check.
+    #[tokio::test]
+    async fn the_status_never_decides() {
+        let _guard = api_base_lock().await;
+        assert_eq!(
+            reply(500, r#"{"ok":true,"result":1}"#)
+                .await
+                .expect("a 500 with ok:true is a success"),
+            "1"
+        );
+        assert_eq!(
+            reply(429, r#"{"ok":false,"description":"Too Many Requests"}"#)
+                .await
+                .expect_err("ok:false"),
+            "telegram API error: Too Many Requests"
+        );
+        set_api_base(None);
+    }
+
+    /// The token is in the URL, so the failure sentence must name the method and
+    /// nothing else — not the URL, not the cause, not the token.
+    #[tokio::test]
+    async fn a_failed_call_names_neither_the_token_nor_the_cause() {
+        let _guard = api_base_lock().await;
+        set_api_base(Some("http://127.0.0.1:1".to_string()));
+
+        let message = Client::new(SECRET)
+            .call(&CancellationToken::new(), "sendMessage", b"{}".to_vec())
+            .await
+            .map(|response| response.result().to_string())
+            .expect_err("nothing is listening");
+        assert_eq!(message, "calling Telegram sendMessage: request failed");
+        assert!(!message.contains(SECRET), "the bot token reached the model");
+        assert!(!message.contains("127.0.0.1"));
+
+        set_api_base(None);
+    }
+
+    #[tokio::test]
+    async fn a_cancelled_call_answers_what_a_cancelled_go_call_answers() {
+        let _guard = api_base_lock().await;
+        set_api_base(Some("http://127.0.0.1:1".to_string()));
+        let ct = CancellationToken::new();
+        ct.cancel();
+        assert_eq!(
+            Client::new(SECRET)
+                .call(&ct, "getChat", b"{}".to_vec())
+                .await
+                .map(|response| response.result().to_string()),
+            Err("calling Telegram getChat: request failed".to_string())
+        );
+        set_api_base(None);
+    }
+
+    /// The endpoint guard: a token `url` would resolve differently is refused
+    /// rather than sent somewhere Go does not send it.
+    ///
+    /// The accepted half is the more interesting one. A token cannot begin a dot
+    /// segment, because `apiURL` glues it to the literal `bot` — `../evil`
+    /// becomes the segment `bot..`, which neither parser touches — so the guard
+    /// admits it, and it must, since Go sends exactly that. Only a separator
+    /// *inside* the token can produce one.
+    #[test]
+    fn a_token_url_would_resolve_differently_is_refused() {
+        for (token, path) in [
+            ("123456:AAF-token", "/bot123456:AAF-token/sendMessage"),
+            // The `bot` prefix defuses a leading `..`: the segment is `bot..`.
+            ("../evil", "/bot../evil/sendMessage"),
+            // Reserved bytes a path keeps are kept by both.
+            ("a$&+:=@b", "/bota$&+:=@b/sendMessage"),
+        ] {
+            let url = Client::new(token)
+                .endpoint("sendMessage")
+                .unwrap_or_else(|| panic!("{token} is a token Go sends"));
+            assert_eq!(url.path(), path, "{token}");
+        }
+
+        for token in [
+            // A separator *inside* the token can build a dot segment, and `url`
+            // resolves it away.
+            "a/../b", "a/./b", "a/..",
+            // …and these end the path early, so the rest becomes a query or a
+            // fragment where Go sends it as path bytes.
+            "x?y", "x#y", // A byte `url` percent-encodes and Go does not.
+            "a b", "a\\b",
+        ] {
+            assert!(
+                Client::new(token).endpoint("sendMessage").is_none(),
+                "{token} must be refused"
+            );
+        }
+    }
+}

--- a/desktop/src-tauri/src/native/integrations/telegram/client.rs
+++ b/desktop/src-tauri/src/native/integrations/telegram/client.rs
@@ -34,7 +34,6 @@ use std::sync::OnceLock;
 use std::sync::RwLock;
 use std::time::Duration;
 
-use serde_json::value::RawValue;
 use tokio_stream::StreamExt;
 
 use crate::claude::CancellationToken;
@@ -121,8 +120,8 @@ fn http_client() -> Option<&'static reqwest::Client> {
 /// *absent* field is `nil` (which `string(nil)` renders as `""`) while an
 /// explicit `null` is the four bytes `null`. `Option<Box<RawValue>>` cannot tell
 /// those apart on its own — serde maps a JSON `null` to `None` — so
-/// [`raw_or_absent`] captures the null as a `RawValue` and lets `#[serde(default)]`
-/// supply the absent case. Both spellings reach the model verbatim in a result
+/// [`crate::native::gojson::captured_raw`] captures the null as a `RawValue` and
+/// lets `#[serde(default)]` supply the absent case. Both spellings reach the model verbatim in a result
 /// sentence, so the difference is observable.
 #[derive(Default, serde::Deserialize)]
 #[serde(default)]
@@ -131,8 +130,8 @@ pub struct TelegramResponse {
     pub ok: bool,
     #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
     pub description: String,
-    #[serde(deserialize_with = "raw_or_absent")]
-    result: Option<Box<RawValue>>,
+    #[serde(deserialize_with = "crate::native::gojson::captured_raw")]
+    result: Option<Box<serde_json::value::RawValue>>,
 }
 
 impl TelegramResponse {
@@ -141,19 +140,6 @@ impl TelegramResponse {
     pub fn result(&self) -> &str {
         self.result.as_ref().map_or("", |raw| raw.get())
     }
-}
-
-/// Captures an explicit `null` as a `RawValue` rather than as `None`.
-///
-/// `Option<Box<RawValue>>`'s own impl folds a JSON `null` into `None`, which
-/// would make `{"result":null}` and an absent `result` the same value — and they
-/// are not: Go renders the first as `null` and the second as the empty string,
-/// both of which land in a result sentence the model reads.
-fn raw_or_absent<'de, D>(deserializer: D) -> Result<Option<Box<RawValue>>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    serde::Deserialize::deserialize(deserializer).map(Some)
 }
 
 /// Go's implicit client: a bot token and the requests made with it.
@@ -264,6 +250,15 @@ async fn read_capped(
                     break;
                 }
             }
+            // `fmt.Errorf("reading response: %w", err)` — the one place this
+            // module interpolates a cause, and the module header's rule says
+            // not to because the URL *is* the credential here. It is safe and
+            // the reason is narrow: a `bytes_stream` error is built without a
+            // URL attached, and reqwest's `Display` prints one only when it is
+            // (`error.rs`'s `if let Some(url) = &self.url`). That is an internal
+            // of a dependency, so
+            // `a_body_that_dies_mid_stream_still_names_nothing_secret` asserts it
+            // rather than trusting it.
             Some(Err(e)) => return Err(format!("reading response: {e}")),
         }
     }
@@ -420,6 +415,51 @@ mod tests {
         assert_eq!(message, "calling Telegram sendMessage: request failed");
         assert!(!message.contains(SECRET), "the bot token reached the model");
         assert!(!message.contains("127.0.0.1"));
+
+        set_api_base(None);
+    }
+
+    /// The body-phase failure, which is the one error in this module that
+    /// interpolates its cause.
+    ///
+    /// Go does too, so keeping it is parity — but the URL here carries the bot
+    /// token, so "reqwest does not attach a URL to a decode error" is load-bearing
+    /// and belongs in a test rather than in a comment alone.
+    #[tokio::test]
+    async fn a_body_that_dies_mid_stream_still_names_nothing_secret() {
+        let _guard = api_base_lock().await;
+
+        // A `Content-Length` larger than the body, so the connection ends before
+        // the promised bytes arrive and the *stream* fails rather than the send.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        tokio::spawn(async move {
+            if let Ok((mut socket, _)) = listener.accept().await {
+                use tokio::io::AsyncWriteExt;
+                let _ = socket
+                    .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 4096\r\n\r\n{\"ok\":true")
+                    .await;
+                let _ = socket.shutdown().await;
+            }
+        });
+        set_api_base(Some(format!("http://{addr}")));
+
+        let message = Client::new(SECRET)
+            .call(&CancellationToken::new(), "getChat", b"{}".to_vec())
+            .await
+            .map(|response| response.result().to_string())
+            .expect_err("the body ends early");
+        assert!(
+            message.starts_with("reading response: ") || message.starts_with("calling Telegram "),
+            "unexpected sentence: {message}"
+        );
+        assert!(!message.contains(SECRET), "the bot token reached the model");
+        assert!(
+            !message.contains(&addr.to_string()),
+            "the URL reached the model: {message}"
+        );
 
         set_api_base(None);
     }

--- a/desktop/src-tauri/src/native/integrations/telegram/messaging.rs
+++ b/desktop/src-tauri/src/native/integrations/telegram/messaging.rs
@@ -1,0 +1,534 @@
+//! The `messaging` service's eleven tools, ported from
+//! `internal/integrations/telegram/tools.go`.
+//!
+//! One service group registered in three batches (`registerSendingTools`,
+//! `registerReadingTools`, `registerManagementTools`). Conventions are
+//! `native/integrations/github/repos.rs`'s.
+//!
+//! # Two shapes no earlier integration had, both documented as unreached until now
+//!
+//! `claude/schema_vectors.rs` lists three reflector divergences left standing
+//! because "nothing in the six integrations" reached them. Telegram reaches two:
+//!
+//! 1. **`create_poll` takes `Options []string`** — the first slice parameter
+//!    anywhere in the six. `jsonschema-go` renders *every* slice as
+//!    `["null","array"]`, because a Go nil slice marshals as `null` and must be
+//!    accepted back; `Vec<String>` renders a bare `array`. The map's guidance is
+//!    explicit — "a port that needs one must add the null itself" — so
+//!    [`go_string_slice`] does, and `null_is_zero_value` makes the null decode to
+//!    an empty `Vec` the way it decodes to a nil slice. That matters beyond the
+//!    schema: `len(nil)` is 0, so a null reaches Go's own "2-10 options" refusal
+//!    rather than a decode error.
+//! 2. **`send_location` takes `float64`** — the first float parameters. The
+//!    schema side is free (`normalize_go_schema` drops the `format` `schemars`
+//!    adds), but the *encoding* is not: `encoding/json` spells a float its own
+//!    way, and `gojson`'s `go_float` already reproduces it — `1e+21` and `1e-7`
+//!    among the shapes it gets right and `serde_json` does not.
+//!
+//! # Other things that read as mistakes and are Go's
+//!
+//! - **`read_messages` sends `offset` only when it is non-zero, and the test is
+//!   `!= 0`** — so a *negative* offset is sent, which is a documented Telegram
+//!   idiom for "the last N updates". `> 0` would drop it.
+//! - **`read_messages`' limit falls back to its own maximum.** `<= 0 || > 100`
+//!   becomes 100, not a smaller default like every other integration's clamp.
+//! - **`timeout: 0` is always sent**, with the comment "never long-poll inside a
+//!   tool call" — a key no argument controls.
+//! - **`delete_message` and `pin_message` discard the response** and answer a
+//!   fixed sentence; `create_poll` validates before it makes any request at all.
+
+use schemars::JsonSchema;
+use serde_json::{json, Value};
+
+use crate::claude::{new_tool, CancellationToken, ToolDef};
+
+use super::client::{clamp_limit, Client};
+use super::text_result;
+
+/// `json.Marshal(payload)`, which `callTelegram` does inside itself in Go.
+fn marshal(payload: &Value) -> Result<Vec<u8>, String> {
+    crate::native::gojson::to_vec_marshal(payload).map_err(|e| format!("marshaling request: {e}"))
+}
+
+/// `jsonschema-go`'s rendering of a `[]string`, which is not `schemars`'.
+///
+/// Go admits a JSON `null` for every slice — a nil slice marshals as `null`, so
+/// the reflector accepts one back — and renders `"type": ["null","array"]`. This
+/// is the "a port that needs one must add the null itself" case from
+/// `claude/schema_vectors.rs`, and `create_poll` is the first tool in the six to
+/// need it.
+fn go_string_slice(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
+    schemars::json_schema!({
+        "type": ["null", "array"],
+        "items": {"type": "string"},
+    })
+}
+
+/// `send_message`.
+#[allow(dead_code)] // read through serde, never constructed in Rust
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct SendMessageInput {
+    /// required,Target chat ID or username
+    chat_id: String,
+    /// required,Text of the message to send
+    text: String,
+    /// Optional parse mode: Markdown or HTML
+    parse_mode: String,
+}
+
+pub fn send_message(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "send_message",
+        "Sends a text message to a Telegram chat.",
+        move |input: SendMessageInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let mut payload = json!({"chat_id": input.chat_id, "text": input.text});
+                if !input.parse_mode.is_empty() {
+                    payload["parse_mode"] = Value::String(input.parse_mode.clone());
+                }
+                let response = client.call(&ct, "sendMessage", marshal(&payload)?).await?;
+                Ok(text_result(format!(
+                    "Message sent successfully. Response: {}",
+                    response.result()
+                )))
+            }
+        },
+    )
+}
+
+/// `send_photo`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct SendPhotoInput {
+    /// required,Target chat ID or username
+    chat_id: String,
+    /// required,Photo URL to send
+    photo: String,
+    /// Optional caption for the photo
+    caption: String,
+}
+
+pub fn send_photo(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "send_photo",
+        "Sends a photo to a Telegram chat by URL.",
+        move |input: SendPhotoInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let mut payload = json!({"chat_id": input.chat_id, "photo": input.photo});
+                if !input.caption.is_empty() {
+                    payload["caption"] = Value::String(input.caption.clone());
+                }
+                let response = client.call(&ct, "sendPhoto", marshal(&payload)?).await?;
+                Ok(text_result(format!(
+                    "Photo sent successfully. Response: {}",
+                    response.result()
+                )))
+            }
+        },
+    )
+}
+
+/// `send_location`.
+///
+/// The first tool in the six with float parameters — see the module header on
+/// why the encoding matters and the schema does not.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct SendLocationInput {
+    /// required,Target chat ID or username
+    chat_id: String,
+    /// required,Latitude of the location
+    latitude: f64,
+    /// required,Longitude of the location
+    longitude: f64,
+}
+
+pub fn send_location(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "send_location",
+        "Sends a geographic location to a chat.",
+        move |input: SendLocationInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let payload = json!({
+                    "chat_id": input.chat_id,
+                    "latitude": input.latitude,
+                    "longitude": input.longitude,
+                });
+                let response = client.call(&ct, "sendLocation", marshal(&payload)?).await?;
+                Ok(text_result(format!(
+                    "Location sent successfully. Response: {}",
+                    response.result()
+                )))
+            }
+        },
+    )
+}
+
+/// `create_poll`.
+///
+/// The first tool in the six with a slice parameter — see the module header and
+/// [`go_string_slice`].
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct CreatePollInput {
+    /// required,Target chat ID or username
+    chat_id: String,
+    /// required,Poll question (1-300 characters)
+    question: String,
+    /// required,Answer options (2-10 strings)
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    #[schemars(schema_with = "go_string_slice")]
+    options: Vec<String>,
+    /// True if poll should be anonymous
+    is_anonymous: bool,
+    /// Poll type: regular or quiz (default regular)
+    #[serde(rename = "type")]
+    poll_type: String,
+}
+
+pub fn create_poll(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "create_poll",
+        "Creates a poll in a Telegram chat.",
+        move |input: CreatePollInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                // Go refuses **before** it builds a request, so a bad option
+                // count never reaches Telegram — and a `null` arrives here as an
+                // empty vec, exactly as a nil slice does, so it is a `got 0`
+                // rather than a decode failure.
+                if input.options.len() < 2 || input.options.len() > 10 {
+                    return Err(format!(
+                        "poll requires 2-10 options, got {}",
+                        input.options.len()
+                    ));
+                }
+
+                let mut payload = json!({
+                    "chat_id": input.chat_id,
+                    "question": input.question,
+                    "options": input.options,
+                });
+                if input.is_anonymous {
+                    payload["is_anonymous"] = Value::Bool(true);
+                }
+                if !input.poll_type.is_empty() {
+                    payload["type"] = Value::String(input.poll_type.clone());
+                }
+                let response = client.call(&ct, "sendPoll", marshal(&payload)?).await?;
+                Ok(text_result(format!(
+                    "Poll created successfully. Response: {}",
+                    response.result()
+                )))
+            }
+        },
+    )
+}
+
+/// `read_messages`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct ReadMessagesInput {
+    /// Identifier of the first update to be returned
+    offset: i64,
+    /// Max number of updates to retrieve (1-100)
+    limit: i64,
+}
+
+pub fn read_messages(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "read_messages",
+        "Reads recent messages (updates) received by the bot via getUpdates.",
+        move |input: ReadMessagesInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                // `timeout: 0` always — "never long-poll inside a tool call".
+                let mut payload = json!({"timeout": 0});
+                // `!= 0`, not `> 0`: a **negative** offset is Telegram's idiom
+                // for "the last N updates" and is deliberately sent.
+                if input.offset != 0 {
+                    payload["offset"] = json!(input.offset);
+                }
+                // The fallback is the *maximum*, unlike every other clamp here.
+                payload["limit"] = json!(clamp_limit(input.limit));
+                let response = client.call(&ct, "getUpdates", marshal(&payload)?).await?;
+                Ok(text_result(format!(
+                    "Updates received: {}",
+                    response.result()
+                )))
+            }
+        },
+    )
+}
+
+/// `get_chat_info`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct GetChatInfoInput {
+    /// required,Target chat ID or username
+    chat_id: String,
+}
+
+pub fn get_chat_info(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "get_chat_info",
+        "Gets detailed information about a chat.",
+        move |input: GetChatInfoInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let payload = json!({"chat_id": input.chat_id});
+                let response = client.call(&ct, "getChat", marshal(&payload)?).await?;
+                Ok(text_result(format!("Chat info: {}", response.result())))
+            }
+        },
+    )
+}
+
+/// `get_chat_members`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct GetChatMembersInput {
+    /// required,Unique identifier for the target chat
+    chat_id: String,
+}
+
+pub fn get_chat_members(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "get_chat_members",
+        "Gets the number of members in a chat.",
+        move |input: GetChatMembersInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let payload = json!({"chat_id": input.chat_id});
+                // Telegram's own spelling, deprecated on their side and kept
+                // here because changing it would change the request.
+                let response = client
+                    .call(&ct, "getChatMembersCount", marshal(&payload)?)
+                    .await?;
+                Ok(text_result(format!(
+                    "Chat member count: {}",
+                    response.result()
+                )))
+            }
+        },
+    )
+}
+
+/// `forward_message`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct ForwardMessageInput {
+    /// required,Target chat to forward the message to
+    chat_id: String,
+    /// required,Source chat ID
+    from_chat_id: String,
+    /// required,Message identifier in from_chat_id
+    message_id: i64,
+}
+
+pub fn forward_message(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "forward_message",
+        "Forwards a message from one chat to another.",
+        move |input: ForwardMessageInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let payload = json!({
+                    "chat_id": input.chat_id,
+                    "from_chat_id": input.from_chat_id,
+                    "message_id": input.message_id,
+                });
+                let response = client
+                    .call(&ct, "forwardMessage", marshal(&payload)?)
+                    .await?;
+                Ok(text_result(format!(
+                    "Message forwarded successfully. Response: {}",
+                    response.result()
+                )))
+            }
+        },
+    )
+}
+
+/// `edit_message`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct EditMessageInput {
+    /// required,The chat containing the message to edit
+    chat_id: String,
+    /// required,Identifier of the message to edit
+    message_id: i64,
+    /// required,New text of the message
+    text: String,
+    /// Optional parse mode: Markdown or HTML
+    parse_mode: String,
+}
+
+pub fn edit_message(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "edit_message",
+        "Edits the text of a previously sent message.",
+        move |input: EditMessageInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let mut payload = json!({
+                    "chat_id": input.chat_id,
+                    "message_id": input.message_id,
+                    "text": input.text,
+                });
+                if !input.parse_mode.is_empty() {
+                    payload["parse_mode"] = Value::String(input.parse_mode.clone());
+                }
+                let response = client
+                    .call(&ct, "editMessageText", marshal(&payload)?)
+                    .await?;
+                Ok(text_result(format!(
+                    "Message edited successfully. Response: {}",
+                    response.result()
+                )))
+            }
+        },
+    )
+}
+
+/// `delete_message`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct DeleteMessageInput {
+    /// required,The chat containing the message to delete
+    chat_id: String,
+    /// required,Identifier of the message to delete
+    message_id: i64,
+}
+
+pub fn delete_message(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "delete_message",
+        "Deletes a message from a chat.",
+        move |input: DeleteMessageInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let payload = json!({
+                    "chat_id": input.chat_id,
+                    "message_id": input.message_id,
+                });
+                // The response is **discarded**: a fixed sentence, whatever
+                // Telegram answered.
+                client
+                    .call(&ct, "deleteMessage", marshal(&payload)?)
+                    .await?;
+                Ok(text_result("Message deleted successfully.".to_string()))
+            }
+        },
+    )
+}
+
+/// `pin_message`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct PinMessageInput {
+    /// required,The chat containing the message to pin
+    chat_id: String,
+    /// required,Identifier of the message to pin
+    message_id: i64,
+    /// Pin silently without notifying members
+    disable_notification: bool,
+}
+
+pub fn pin_message(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "pin_message",
+        "Pins a message in a chat.",
+        move |input: PinMessageInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let mut payload = json!({
+                    "chat_id": input.chat_id,
+                    "message_id": input.message_id,
+                });
+                // `if params.DisableNotification` — the literal `true`, so a
+                // false flag leaves no key at all.
+                if input.disable_notification {
+                    payload["disable_notification"] = Value::Bool(true);
+                }
+                client
+                    .call(&ct, "pinChatMessage", marshal(&payload)?)
+                    .await?;
+                Ok(text_result("Message pinned successfully.".to_string()))
+            }
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn encoded(payload: &Value) -> String {
+        String::from_utf8(marshal(payload).expect("encode")).expect("utf-8")
+    }
+
+    /// Go's float spelling, which `serde_json` does not share. Measured against
+    /// `json.Marshal` before it was written.
+    #[test]
+    fn coordinates_are_spelled_the_way_encoding_json_spells_them() {
+        for (value, want) in [
+            (51.5074_f64, "51.5074"),
+            (-0.1278, "-0.1278"),
+            (0.0, "0"),
+            (90.0, "90"),
+            (-180.0, "-180"),
+            (1e21, "1e+21"),
+            (1e-7, "1e-7"),
+        ] {
+            assert_eq!(
+                encoded(&json!({"latitude": value})),
+                format!(r#"{{"latitude":{want}}}"#),
+                "{value}"
+            );
+        }
+    }
+
+    /// A body is sorted at every level and HTML-escaped, so `send_message`'s is
+    /// not in the handler's order.
+    #[test]
+    fn a_body_is_sorted_and_html_escaped() {
+        assert_eq!(
+            encoded(&json!({"text": "a <b> & c", "chat_id": "@x"})),
+            r#"{"chat_id":"@x","text":"a \u003cb\u003e \u0026 c"}"#
+        );
+    }
+
+    /// The clamp whose fallback is its own maximum.
+    #[test]
+    fn the_limit_falls_back_to_its_own_maximum() {
+        for (input, want) in [(0_i64, 100_i64), (-5, 100), (101, 100), (100, 100), (1, 1)] {
+            assert_eq!(clamp_limit(input), want, "{input}");
+        }
+    }
+}

--- a/desktop/src-tauri/src/native/integrations/telegram/mod.rs
+++ b/desktop/src-tauri/src/native/integrations/telegram/mod.rs
@@ -1,0 +1,242 @@
+//! The Telegram integration's **outbound** in-process MCP server, ported from
+//! `internal/integrations/telegram/`.
+//!
+//! Eleven tools in one service group (`messaging`), over a bot token. The fifth
+//! of the six (#314), and the largest tool set after GitHub's twenty.
+//!
+//! ## Outbound only — the inbound half is somebody else's issue
+//!
+//! Telegram is the one integration with two directions. This is the tool server;
+//! `POST /webhooks/telegram/{id}` and `internal/trigger/`'s dispatcher are #319
+//! and are **not** touched here. They matter to this port for one reason: the
+//! webhook route is mounted at the *root* rather than under `/api`, arrives with
+//! a foreign `Host`, and is authenticated by its own secret token, so
+//! `guards.rs` deliberately does not cover it — see the root `CLAUDE.md`.
+//! Nothing in this module is on that path.
+//!
+//! `webhook.go` is likewise unported: it answers the integration's webhook
+//! management routes, which stay with Go.
+//!
+//! ## What is new here, and both were documented as unreached
+//!
+//! `claude/schema_vectors.rs` left three reflector divergences standing because
+//! "nothing in the six integrations" reached them. This one reaches two — a
+//! `[]string` parameter and `float64` parameters — and `messaging`'s header has
+//! the detail. The slice is the one that needed new code: Go renders every slice
+//! as `["null","array"]` and `schemars` renders a bare `array`, so the port adds
+//! the null itself, exactly as the map's guidance says a port that needs one must.
+//!
+//! ## The bot token is in the URL path
+//!
+//! `apiURL` interpolates it into the path rather than a header, which is
+//! Telegram's design. It changes what an error string may carry and it puts a
+//! credential where `url::Url::parse` can normalise — see `client`'s header and
+//! `Client::endpoint`.
+//!
+//! ## What has to match Go, and what checks it
+//!
+//! Four surfaces, pinned by `desktop/parity/telegram_vectors.json` — taken from
+//! the **running Go server** over its real MCP transport against a fake Telegram
+//! that records the request each tool built: the hosted tool set, each advertised
+//! schema (including the `["null","array"]` one), the request body of all eleven,
+//! and the result text of every success and every failure.
+//!
+//! `telegram/parity.go`'s `SetAPIBase` is the seam, as GitHub's and Slack's are:
+//! the base is a package variable, so a test cannot pass one.
+//!
+//! `validate.go`'s `ValidateBotToken` is **not ported** — it answers
+//! `POST /api/integrations/{id}/auth/validate`, which dials Telegram and stays
+//! with Go. That route is covered by
+//! [`reload_after_auth`](super::registry::reload_after_auth), which is type-blind
+//! and gated on the row's type.
+
+pub mod client;
+pub mod messaging;
+
+#[cfg(test)]
+mod tests_vectors;
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use rmcp::model::{CallToolResult, ContentBlock};
+
+use crate::claude::{tool_server, InProcessMcpServer, Result, ToolDef};
+
+use super::ServiceConfig;
+use client::Client;
+
+/// The one service group.
+pub const SERVICES: &[&str] = &["messaging"];
+
+/// Every tool this integration can host, in registration order — `SERVICES`
+/// order, then each `register*Tools` batch's own.
+///
+/// **Not** the order `tools/list` answers in: both SDKs sort by name.
+pub const TELEGRAM_TOOL_NAMES: &[&str] = &[
+    "send_message",
+    "send_photo",
+    "send_location",
+    "create_poll",
+    "read_messages",
+    "get_chat_info",
+    "get_chat_members",
+    "forward_message",
+    "edit_message",
+    "delete_message",
+    "pin_message",
+];
+
+/// `fmt.Sprintf("telegram-%s", cfg.ID)` — `mcp.NewServer`'s implementation name,
+/// **not** the prefix on a qualified tool name (that is the bare integration id).
+pub fn server_name(integration_id: &str) -> String {
+    format!("telegram-{integration_id}")
+}
+
+/// The union of every **enabled** service's `Tools`.
+pub fn build_allowed_set(services: &BTreeMap<String, ServiceConfig>) -> BTreeSet<String> {
+    let mut allowed = BTreeSet::new();
+    for service in services.values() {
+        if !service.enabled {
+            continue;
+        }
+        for tool in service.tools.iter().flat_map(|tools| tools.iter()) {
+            allowed.insert(tool.clone());
+        }
+    }
+    allowed
+}
+
+/// Present **and** enabled.
+pub fn service_enabled(services: &BTreeMap<String, ServiceConfig>, name: &str) -> bool {
+    services.get(name).is_some_and(|service| service.enabled)
+}
+
+/// Every tool `buildMCPServer` would register for `services`, over `token`.
+pub fn telegram_tools(services: &BTreeMap<String, ServiceConfig>, token: &str) -> Vec<ToolDef> {
+    let allowed = build_allowed_set(services);
+    let client = Client::new(token);
+    let mut tools = Vec::new();
+
+    // `len(allowed) == 0 || allowed[name]` — so an empty set admits everything.
+    let mut push = |service: &str, name: &str, tool: fn(&Client) -> ToolDef| {
+        if !service_enabled(services, service) {
+            return;
+        }
+        if !allowed.is_empty() && !allowed.contains(name) {
+            return;
+        }
+        tools.push(tool(&client));
+    };
+
+    push("messaging", "send_message", messaging::send_message);
+    push("messaging", "send_photo", messaging::send_photo);
+    push("messaging", "send_location", messaging::send_location);
+    push("messaging", "create_poll", messaging::create_poll);
+    push("messaging", "read_messages", messaging::read_messages);
+    push("messaging", "get_chat_info", messaging::get_chat_info);
+    push("messaging", "get_chat_members", messaging::get_chat_members);
+    push("messaging", "forward_message", messaging::forward_message);
+    push("messaging", "edit_message", messaging::edit_message);
+    push("messaging", "delete_message", messaging::delete_message);
+    push("messaging", "pin_message", messaging::pin_message);
+
+    tools
+}
+
+/// Starts the integration's server on a random loopback port.
+pub async fn start_telegram_mcp_server(
+    integration_id: &str,
+    services: &BTreeMap<String, ServiceConfig>,
+    token: &str,
+) -> Result<InProcessMcpServer> {
+    tool_server(
+        &server_name(integration_id),
+        telegram_tools(services, token),
+    )
+    .await
+}
+
+/// Go's `textResult`, shared by all eleven tools.
+pub(crate) fn text_result(text: String) -> CallToolResult {
+    CallToolResult::success(vec![ContentBlock::text(text)])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::native::gojson::GoList;
+
+    fn service(enabled: bool, tools: &[&str]) -> ServiceConfig {
+        ServiceConfig {
+            enabled,
+            tools: Some(GoList(tools.iter().map(|t| t.to_string()).collect())),
+        }
+    }
+
+    fn names(services: &BTreeMap<String, ServiceConfig>) -> Vec<String> {
+        telegram_tools(services, "123456:token")
+            .iter()
+            .map(|tool| tool.name().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn the_server_name_is_gos() {
+        assert_eq!(server_name("abc123"), "telegram-abc123");
+    }
+
+    #[test]
+    fn an_empty_allowed_set_hosts_every_tool() {
+        let services = BTreeMap::from([("messaging".to_string(), service(true, &[]))]);
+        assert_eq!(names(&services), TELEGRAM_TOOL_NAMES);
+        assert!(build_allowed_set(&services).is_empty());
+    }
+
+    #[test]
+    fn one_named_tool_narrows_the_service() {
+        let services = BTreeMap::from([(
+            "messaging".to_string(),
+            service(true, &["send_message", "pin_message"]),
+        )]);
+        assert_eq!(names(&services), ["send_message", "pin_message"]);
+    }
+
+    /// An enabled service Telegram does not know still contributes its names.
+    #[test]
+    fn an_unknown_enabled_service_still_narrows_the_known_one() {
+        let services = BTreeMap::from([
+            ("messaging".to_string(), service(true, &[])),
+            ("other".to_string(), service(true, &["create_poll"])),
+        ]);
+        assert_eq!(names(&services), ["create_poll"]);
+    }
+
+    #[test]
+    fn a_disabled_service_is_invisible_in_both_directions() {
+        let services = BTreeMap::from([
+            ("messaging".to_string(), service(false, &[])),
+            ("other".to_string(), service(true, &["send_photo"])),
+        ]);
+        assert!(names(&services).is_empty());
+        assert!(!service_enabled(&services, "messaging"));
+        assert!(!service_enabled(&services, "missing"));
+    }
+
+    #[test]
+    fn no_services_at_all_hosts_nothing() {
+        assert!(names(&BTreeMap::new()).is_empty());
+    }
+
+    #[test]
+    fn a_null_tools_column_is_not_a_filter() {
+        let services = BTreeMap::from([(
+            "messaging".to_string(),
+            ServiceConfig {
+                enabled: true,
+                tools: None,
+            },
+        )]);
+        assert!(build_allowed_set(&services).is_empty());
+        assert_eq!(names(&services), TELEGRAM_TOOL_NAMES);
+    }
+}

--- a/desktop/src-tauri/src/native/integrations/telegram/tests_vectors.rs
+++ b/desktop/src-tauri/src/native/integrations/telegram/tests_vectors.rs
@@ -1,0 +1,406 @@
+//! The Rust half of `desktop/parity/telegram_vectors.json`.
+//!
+//! The Go half (`desktop/parity/telegram_parity_test.go`) stands the **real**
+//! integration up through `telegram.Start`, points `apiBaseURL` at an
+//! `httptest.Server` that plays a scripted Telegram and records what it was
+//! asked. This half replays the same script through an axum server on loopback,
+//! the real [`start_telegram_mcp_server`](super::start_telegram_mcp_server), and
+//! a real `tools/call` over the MCP HTTP transport.
+//!
+//! Three surfaces are worth calling out because no earlier integration exercised
+//! them:
+//!
+//! - **`create_poll`'s `options` schema** is `["null","array"]`, which
+//!   `schemars` does not produce and `super::messaging::go_string_slice` supplies.
+//!   `the_advertised_surface_matches_the_go_vectors` is what pins it.
+//! - **`send_location`'s coordinates** pin `encoding/json`'s float spelling in a
+//!   *request body*, which is the only place it is observable.
+//! - **`result`'s absent-versus-null distinction** reaches the model in a result
+//!   sentence, so it is pinned as text rather than as a decode.
+//!
+//! Pinned divergences: `rust_text` for `encoding/json`'s syntax-error vocabulary,
+//! and `rust_text` + `rust_no_request` for the zero-fraction float.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::{HeaderMap, Method, StatusCode, Uri};
+use axum::response::{IntoResponse, Response};
+use rmcp::ServerHandler;
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::client::{api_base_lock, set_api_base};
+use super::{
+    server_name, start_telegram_mcp_server, telegram_tools, SERVICES, TELEGRAM_TOOL_NAMES,
+};
+use crate::claude::ToolServer;
+use crate::native::gojson::GoList;
+use crate::native::integrations::ServiceConfig;
+
+// ─── The vectors ─────────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct ToolVector {
+    name: String,
+    description: String,
+    input_schema: Value,
+}
+
+#[derive(Deserialize)]
+struct HostingVector {
+    case: String,
+    services: BTreeMap<String, GoServiceConfig>,
+    tools: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct GoServiceConfig {
+    enabled: bool,
+    tools: Option<Vec<String>>,
+}
+
+#[derive(Deserialize)]
+struct RequestVector {
+    method: String,
+    target: String,
+    content_type: String,
+    body: String,
+}
+
+#[derive(Deserialize)]
+struct ResponseScript {
+    status: u16,
+    body: String,
+}
+
+#[derive(Deserialize)]
+struct CallVector {
+    case: String,
+    tool: String,
+    arguments: Value,
+    response: ResponseScript,
+    request: Option<RequestVector>,
+    is_error: bool,
+    text: String,
+    #[serde(default)]
+    rust_text: String,
+    #[serde(default)]
+    rust_no_request: bool,
+}
+
+#[derive(Deserialize)]
+struct Vectors {
+    integration_id: String,
+    server_name: String,
+    token: String,
+    tools: Vec<ToolVector>,
+    hosting: Vec<HostingVector>,
+    calls: Vec<CallVector>,
+}
+
+fn vectors() -> Vectors {
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../parity/telegram_vectors.json"
+    );
+    let raw = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("reading {path}: {e} — regenerate it from Go"));
+    serde_json::from_str(&raw).expect("parsing the telegram vectors")
+}
+
+fn services(from: &BTreeMap<String, GoServiceConfig>) -> BTreeMap<String, ServiceConfig> {
+    from.iter()
+        .map(|(name, service)| {
+            (
+                name.clone(),
+                ServiceConfig {
+                    enabled: service.enabled,
+                    tools: service.tools.clone().map(GoList),
+                },
+            )
+        })
+        .collect()
+}
+
+fn all_services() -> BTreeMap<String, ServiceConfig> {
+    SERVICES
+        .iter()
+        .map(|name| {
+            (
+                name.to_string(),
+                ServiceConfig {
+                    enabled: true,
+                    tools: None,
+                },
+            )
+        })
+        .collect()
+}
+
+// ─── The advertised surface ──────────────────────────────────────────────────
+
+/// The server name, every tool name, its description and its reflected input
+/// schema, from a live `tools/list` against the Go server.
+///
+/// `create_poll` is the interesting one: `jsonschema-go` renders its `[]string`
+/// as `{"type":["null","array"],"items":{"type":"string"}}` and `schemars`
+/// renders a bare `array`, which is the divergence
+/// `crate::claude::schema_vectors` left standing because nothing reached it.
+/// This assertion is what proves `messaging::go_string_slice` closed it.
+#[test]
+fn the_advertised_surface_matches_the_go_vectors() {
+    let v = vectors();
+    assert_eq!(v.server_name, server_name(&v.integration_id));
+    assert_eq!(
+        v.tools.len(),
+        TELEGRAM_TOOL_NAMES.len(),
+        "vectors look partial"
+    );
+
+    let server =
+        ToolServer::new(&v.server_name).with_tools(telegram_tools(&all_services(), &v.token));
+    assert_eq!(
+        server.tool_names(),
+        v.tools.iter().map(|t| t.name.clone()).collect::<Vec<_>>(),
+        "the hosted tool set, as tools/list answers it"
+    );
+
+    for want in &v.tools {
+        let tool = server
+            .get_tool(&want.name)
+            .unwrap_or_else(|| panic!("{} is not registered", want.name));
+        assert_eq!(
+            tool.description.as_deref(),
+            Some(want.description.as_str()),
+            "{}'s description is what the model reads",
+            want.name
+        );
+        assert_eq!(
+            serde_json::to_value(&*tool.input_schema).expect("schema"),
+            want.input_schema,
+            "{}'s input schema is what the model is steered by",
+            want.name
+        );
+    }
+}
+
+#[test]
+fn the_hosted_tool_set_matches_the_go_vectors() {
+    let v = vectors();
+    assert!(v.hosting.len() >= 5, "vectors look partial");
+    for case in &v.hosting {
+        let mut hosted: Vec<String> = telegram_tools(&services(&case.services), &v.token)
+            .iter()
+            .map(|tool| tool.name().to_string())
+            .collect();
+        hosted.sort();
+        assert_eq!(hosted, case.tools, "hosting case: {}", case.case);
+    }
+}
+
+// ─── The fake Telegram ───────────────────────────────────────────────────────
+
+struct Recorded {
+    method: String,
+    target: String,
+    content_type: String,
+    body: String,
+}
+
+#[derive(Default)]
+struct Fake {
+    status: u16,
+    body: String,
+    seen: Option<Recorded>,
+}
+
+#[derive(Clone, Default)]
+struct FakeState(Arc<Mutex<Fake>>);
+
+impl FakeState {
+    fn arm(&self, script: &ResponseScript) {
+        let mut fake = self.0.lock().expect("fake lock");
+        fake.status = script.status;
+        fake.body.clone_from(&script.body);
+        fake.seen = None;
+    }
+}
+
+async fn serve_fake(
+    State(state): State<FakeState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    let (status, reply) = {
+        let mut fake = state.0.lock().expect("fake lock");
+        fake.seen = Some(Recorded {
+            method: method.to_string(),
+            // Carries the bot token, because Telegram puts it in the path.
+            target: uri
+                .path_and_query()
+                .map(|pq| pq.as_str().to_string())
+                .unwrap_or_default(),
+            content_type: headers
+                .get("content-type")
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .to_string(),
+            body: String::from_utf8_lossy(&body).into_owned(),
+        });
+        (fake.status, fake.body.clone())
+    };
+
+    (
+        StatusCode::from_u16(status).expect("a scripted status"),
+        reply,
+    )
+        .into_response()
+}
+
+// ─── The calls ───────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn every_call_matches_the_go_vectors() {
+    let v = vectors();
+    assert!(v.calls.len() >= 25, "vectors look partial");
+
+    let state = FakeState::default();
+    let app = axum::Router::new()
+        .fallback(serve_fake)
+        .with_state(state.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind the fake");
+    let base = format!("http://{}", listener.local_addr().expect("addr"));
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    let _guard = api_base_lock().await;
+    set_api_base(Some(base));
+
+    let server = start_telegram_mcp_server(&v.integration_id, &all_services(), &v.token)
+        .await
+        .expect("start the telegram server");
+
+    for case in &v.calls {
+        state.arm(&case.response);
+        let result = call_tool(&server, &case.tool, &case.arguments).await;
+
+        // The bot token travels in the URL, so a result echoing the request
+        // would leak it.
+        assert!(
+            !result.text.contains(&v.token),
+            "{}: the bot token leaked into a tool result: {}",
+            case.case,
+            result.text
+        );
+
+        let (want_text, want_error) = if case.rust_text.is_empty() {
+            (&case.text, case.is_error)
+        } else {
+            (&case.rust_text, true)
+        };
+        assert_eq!(result.text, *want_text, "{}: result text", case.case);
+        assert_eq!(result.is_error, want_error, "{}: is_error", case.case);
+
+        let seen = state.0.lock().expect("fake lock").seen.take();
+        let want_request = if case.rust_no_request {
+            assert!(
+                seen.is_none(),
+                "{}: the refusal still reached the network",
+                case.case
+            );
+            None
+        } else {
+            case.request.as_ref()
+        };
+        match (want_request, seen) {
+            (None, seen) => assert!(
+                seen.is_none(),
+                "{}: Go made no request and this one did",
+                case.case
+            ),
+            (Some(_), None) => panic!("{}: Go made a request and this one did not", case.case),
+            (Some(want), Some(got)) => {
+                assert_eq!(got.method, want.method, "{}: method", case.case);
+                assert_eq!(
+                    got.target, want.target,
+                    "{}: the request target, bot token included",
+                    case.case
+                );
+                assert_eq!(
+                    got.content_type, want.content_type,
+                    "{}: Content-Type",
+                    case.case
+                );
+                assert_eq!(got.body, want.body, "{}: request body", case.case);
+            }
+        }
+    }
+
+    set_api_base(None);
+}
+
+struct ToolAnswer {
+    text: String,
+    is_error: bool,
+}
+
+async fn rpc_call(
+    server: &crate::claude::InProcessMcpServer,
+    name: &str,
+    arguments: &Value,
+) -> Value {
+    let payload = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": name, "arguments": arguments},
+    });
+
+    let mut request = reqwest::Client::new()
+        .post(server.url())
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream");
+    for (header, value) in &server.config().headers {
+        request = request.header(header, value);
+    }
+    let response = request
+        .body(payload.to_string())
+        .send()
+        .await
+        .expect("send tools/call");
+    serde_json::from_str(&response.text().await.expect("text")).expect("a JSON-RPC reply")
+}
+
+async fn call_tool(
+    server: &crate::claude::InProcessMcpServer,
+    name: &str,
+    arguments: &Value,
+) -> ToolAnswer {
+    let body = rpc_call(server, name, arguments).await;
+
+    assert!(
+        body.get("error").is_none(),
+        "{name}: a tool must not raise a protocol error: {body}"
+    );
+    let content = body["result"]["content"]
+        .as_array()
+        .unwrap_or_else(|| panic!("{name}: no content array: {body}"));
+    assert_eq!(content.len(), 1, "{name}: want exactly one content block");
+    assert_eq!(content[0]["type"], "text");
+
+    ToolAnswer {
+        text: content[0]["text"]
+            .as_str()
+            .unwrap_or_else(|| panic!("{name}: content is not text: {body}"))
+            .to_string(),
+        is_error: body["result"]["isError"].as_bool().unwrap_or(false),
+    }
+}

--- a/desktop/src-tauri/src/native/schedule/mod.rs
+++ b/desktop/src-tauri/src/native/schedule/mod.rs
@@ -11,10 +11,10 @@
 //! `cmd/web.go` starts the sidecar's scheduler on every boot. Ownership moves
 //! in one commit that stops the sidecar scheduling — the #289 model — and that
 //! commit is blocked on `chat/runner.rs::build_options`, which still refuses an
-//! agent whose tools come from an integration this build cannot host — two of
-//! the six (#313 and #314), since the local in-process server (#310), github
-//! (#311), confluence (#317), jira (#316) and slack (#315) are no longer among
-//! them. A chat can forward to Go on that
+//! agent whose tools come from an integration this build cannot host — one of
+//! the six (#313), since the local in-process server (#310), github (#311),
+//! confluence (#317), jira (#316), slack (#315) and telegram (#314) are no longer
+//! among them. A chat can forward to Go on that
 //! refusal; a scheduled task with no Go scheduler behind it would simply never
 //! run, with nothing to say so. See "The scheduler: the computation moved, the
 //! ownership did not" in `desktop/CLAUDE.md`.

--- a/desktop/src-tauri/src/sidecar.rs
+++ b/desktop/src-tauri/src/sidecar.rs
@@ -80,7 +80,7 @@ pub async fn spawn(app: &AppHandle, port: u16) -> Result<Sidecar, String> {
         // feature: its starter opens a live whatsmeow WebSocket and registers
         // the client in a package global that the status, reconnect and QR
         // pairing endpoints read. Deriving the list from the starter table means
-        // #313 and #314 each add one string in one place.
+        // #313 adds the last string in one place.
         //
         // It does **not** switch off `StartFilteredServer`, which is what an
         // agent run uses: that reads the integration row afresh per run and

--- a/internal/integrations/telegram/parity.go
+++ b/internal/integrations/telegram/parity.go
@@ -1,0 +1,38 @@
+package telegram
+
+// This file is the seam `desktop/parity/telegram_parity_test.go` builds its
+// cross-language vectors through, and it exists for exactly one reason: the
+// vectors have to come from the **real** server, not from a restatement of it.
+//
+// `desktop/parity` is a different package, so it cannot reach `apiBaseURL` to
+// stand a server up against a local fake. The alternative — a generator that
+// rebuilt the tool set from this package's source — would freeze someone's
+// reading of the code rather than the code, and the whole point of the vectors is
+// that a change here fails the Rust port in
+// `desktop/src-tauri/src/native/integrations/telegram/`.
+//
+// #312 and #315 did the same for GitHub and Slack, which have the same shape: one
+// API root in a package variable. #316 and #317 needed no seam, because an
+// Atlassian site URL is per row and a test can simply store one.
+//
+// Nothing below changes behavior or wording: `Start` remains the only way the app
+// builds this server.
+
+// SetAPIBase points every outgoing Telegram request at base and returns a
+// function that restores the previous value.
+//
+// Do not call outside tests. It is a primitive for pointing every Telegram
+// request in the process at an arbitrary host — and Telegram puts the bot token
+// in the **URL path**, so a caller anywhere in the running server would hand the
+// credential to that host as part of the request line, not merely leak a header.
+// It is exported only because `desktop/parity` is a different package; the Rust
+// port gates the same seam behind `#[cfg(test)]`, so it does not exist in a
+// shipped desktop binary at all.
+//
+// Not safe for concurrent use with a live integration — which is fine, because
+// the only callers are tests that own the process.
+func SetAPIBase(base string) (restore func()) {
+	previous := apiBaseURL
+	apiBaseURL = base
+	return func() { apiBaseURL = previous }
+}


### PR DESCRIPTION
Closes #314

## What

Ports `internal/integrations/telegram/` to `desktop/src-tauri/src/native/integrations/telegram/` — eleven tools in one service group (`messaging`), over a bot token. **Outbound only**: `POST /webhooks/telegram/{id}` and `internal/trigger/`'s dispatcher are #319 and are untouched. `telegram` joins `registry::HOSTED_TYPES`, so five of the six types are now the shell's and the sidecar runs with `AGENTO_INTEGRATIONS=off:github,confluence,jira,slack,telegram`.

## It reaches two divergences the reflector map recorded as unreachable

`claude/schema_vectors.rs` left three standing because "nothing in the six integrations" used the shape. Telegram uses two:

- **`create_poll` takes a `[]string`** — the first slice parameter anywhere in the six. `jsonschema-go` renders every slice as `["null","array"]` (a Go nil slice marshals as `null` and must be accepted back); `schemars` renders a bare `array`. The map's guidance was *"a port that needs one must add the null itself"*, and `messaging::go_string_slice` is that. `null_is_zero_value` on the field is the other half, and it is not cosmetic: `len(nil)` is 0, so a `null` reaches Go's own "2-10 options" refusal rather than a decode error. Pinned as `got 0`.
- **`send_location` takes `float64`** — the first floats. The schema costs nothing (`normalize_go_schema` drops the `format` `schemars` adds) but the encoding would have: `gojson::go_float` already reproduces `encoding/json`'s spelling, and `1e+21` / `1e-7` are in the request-body vectors because that is the only place it is observable.

## The bot token is in the URL path

`apiURL` is `fmt.Sprintf("%s/bot%s/%s", …)`, so the credential is in the request line rather than a header. Two consequences:

- An error string must not interpolate a transport cause — a `reqwest::Error`'s `Display` carries the URL it was building. Go's wording already names only the method, and a test asserts the token, the host and the cause are all absent.
- `Client::endpoint` needs the compare-what-`url`-produced guard the other ports have. Its **accepted** half is the interesting one: a token cannot *begin* a dot segment, because `apiURL` glues it to the literal `bot`, so `../evil` becomes the segment `bot..` and both parsers send it unchanged. Only a separator *inside* the token can build one.

## The JSON rules, applied up front this time

#315 shipped two of these wrong before review caught them, so all three are applied here with the reasoning stated on the struct: `null_is_zero_value` (Telegram sends `"description": null` and `"result": null`), `GoStruct` (an array would otherwise decode positionally into a *success*), and `Option<GoStruct<_>>` (a bare `null` body is a no-op to `json.Unmarshal`, so Go reaches the `!ok` branch).

Plus a fourth that is Telegram's own: **`result` is a `json.RawMessage`**, so an *absent* one renders as the empty string and an explicit `null` as the four bytes `null`. Both land in a result sentence the model reads, and `Option<Box<RawValue>>` cannot be left to serde, which folds a JSON null into `None` — `raw_or_absent` captures it instead. Every expectation was measured against a real `json.Unmarshal` before it was written.

The envelope decides and the status never does — not even a 429, which Slack's client checks. Cap 10 MiB and timeout 60s, the largest of the six on both counts.

## Acceptance

- [x] Every tool under the same name and the same input schema, from a live `tools/list` — including `create_poll`'s `["null","array"]`.
- [x] Result payloads match across 30 call vectors: every tool, both `create_poll` refusal paths and its null-slice path, all three float shapes, the envelope in both directions, absent-vs-null `result`, a bare null body, an array body, a non-JSON body, and the zero-fraction float.
- [x] Credentials come from the stored row and appear in no response or log line; both languages' runners assert the bot token never reaches a tool result, which matters more here because it is in the URL.

## Verification

- `cargo test` — whole suite green; 19 new Telegram tests.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` — clean.
- `go test ./...` — clean; `golangci-lint` at CI's pinned v2.5.0 — 0 issues.

One note: `tests/claude_sdk.rs::run_returns_the_final_result_and_surfaces_an_error_one` failed once and passed on re-run. It drives a fake CLI subprocess and is unrelated to this change; flagging it rather than hiding it.