### PR TITLE
feat(desktop): port the Google MCP server, measured rather than read (#313)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -600,7 +600,7 @@ of the `Err` arms the cut-over has to turn into a real response.
 | 1 ✅ | Sidecar + proxy | — | done |
 | 2 ← | Pricing + analytics | `internal/pricing`, `internal/claudesessions` | Pure computation over JSONL + SQLite. No external deps. **In progress**: `/api/pricing/catalog`, `/api/claude-sessions`, `/api/claude-sessions/facets`, `/api/claude-analytics`, `/api/claude-sessions/insights/summary` and the agent reads are native and diff clean. |
 | 3 ← | Storage + tasks | `internal/storage`, `internal/scheduler` | **In progress (#274, #275).** `db.rs` is read-write, the 27 migrations are ported, and the writes whose every effect Rust owns are native — see below. The scheduler's *schedule computation* is ported and pinned (#275); its ownership is not, and is blocked — see below. |
-| 4 ← | Integrations | `internal/integrations`, `internal/trigger` | OAuth2 + MCP servers. Six of them: google, github, slack, jira, confluence, telegram, plus `internal/tools`. **How to host one is settled (#282)** — `claude::ToolServer`, see "Hosting a tool" below; do not invent a second way. **`internal/tools` is done (#310)** — `native/tools/`, and it is the worked example the six should be read against. **GitHub is done (#312)** — `native/integrations/github/`, the worked example for an *integration*. **The registry is done (#311)** — `native/integrations/registry.rs` plus `PUT`/`DELETE /api/integrations/{id}`, and the sidecar now runs with `AGENTO_INTEGRATIONS=off:<the types the shell hosts>`, so every type has exactly one owner. **Confluence is done (#317)** — `native/integrations/confluence/`, the smallest of the six and the one that shows what an integration adds over #312: a per-row API base, basic auth, and a `Start` check that is a decision. **Jira is done (#316)** — `native/integrations/jira/`, Confluence's twin, and the one that shows that a shared credential type does not mean shared behaviour: `jira.Start` validates nothing, so a bad base is answered per call instead of by refusing to host. **Slack is done (#315)** — `native/integrations/slack/`, the first that is not Atlassian-shaped: no model input in the URL at all, and the only integration whose token can come from the `auth` column. **Telegram is done (#314)** — `native/integrations/telegram/`, the outbound half, and the one that reached two reflector divergences the map had recorded as unreachable. #313 is the last, and is "add a starter **and its name to `HOSTED_TYPES`**", which is the one list both processes are configured from. WhatsApp is **not** among them — but Go still hosts its rows, because its starter opens a live connection rather than just a port; see below. |
+| 4 ← | Integrations | `internal/integrations`, `internal/trigger` | OAuth2 + MCP servers. Six of them: google, github, slack, jira, confluence, telegram, plus `internal/tools`. **How to host one is settled (#282)** — `claude::ToolServer`, see "Hosting a tool" below; do not invent a second way. **`internal/tools` is done (#310)** — `native/tools/`, and it is the worked example the six should be read against. **GitHub is done (#312)** — `native/integrations/github/`, the worked example for an *integration*. **The registry is done (#311)** — `native/integrations/registry.rs` plus `PUT`/`DELETE /api/integrations/{id}`, and the sidecar now runs with `AGENTO_INTEGRATIONS=off:<the types the shell hosts>`, so every type has exactly one owner. **Confluence is done (#317)** — `native/integrations/confluence/`, the smallest of the six and the one that shows what an integration adds over #312: a per-row API base, basic auth, and a `Start` check that is a decision. **Jira is done (#316)** — `native/integrations/jira/`, Confluence's twin, and the one that shows that a shared credential type does not mean shared behaviour: `jira.Start` validates nothing, so a bad base is answered per call instead of by refusing to host. **Slack is done (#315)** — `native/integrations/slack/`, the first that is not Atlassian-shaped: no model input in the URL at all, and the only integration whose token can come from the `auth` column. **Telegram is done (#314)** — `native/integrations/telegram/`, the outbound half, and the one that reached two reflector divergences the map had recorded as unreachable. **Google is ported (#313)** — `native/integrations/google/`, the last and the only one whose requests are built by a generated client rather than by the handlers, so its vectors are a specification rather than a confirmation; it is deliberately **not** in `HOSTED_TYPES` yet, and that flip is its own change. WhatsApp is **not** among them — but Go still hosts its rows, because its starter opens a live connection rather than just a port; see below. |
 | 5 ← | Agent execution | `internal/agent`, `internal/service` | **In progress (#276).** The chat SSE turn is native: `/messages`, `/input`, `/permission` and `/stop`, on top of the ported SDK. The scheduler's executor (#275) is the other caller and still Go's. |
 
 ### The session scanner (`src-tauri/src/native/scanner/`)
@@ -1392,6 +1392,102 @@ serde, which folds a JSON null into `None`.
 
 Cap 10 MiB and timeout 60 seconds, the largest of the six on both counts.
 
+### The Google integration (`native/integrations/google/`, #313)
+
+`internal/integrations/google/` — eight tools across **three** service groups
+(`calendar`, `gmail`, `drive`) over an OAuth2 token that refreshes itself. Last
+of the six, and the only one that is not a port of hand-rolled HTTP.
+
+**Read this before changing anything here.** The other five build their requests
+with `http.NewRequest` and `json.Marshal`, so the port reproduces bytes visible in
+`tools.go`. Google calls the **generated** client libraries (`calendar/v3`,
+`gmail/v1`, `drive/v3`) over an `oauth2` transport, and what those put on the wire
+is in neither this repository nor the port. Every URL, query parameter, body field
+and sentence was therefore *recorded* off the real libraries against a fake
+endpoint — `desktop/parity/google_vectors.json` is not a confirmation of the port,
+it is the **only written specification** of what the third party's code generator
+emits. Three things the port had wrong were found by running those vectors for the
+first time, and none was visible from either side's source:
+
+1. **Path parameters use `googleapi.Expand`, not `url.PathEscape`.** The generated
+   clients expand RFC 6570 templates, which percent-encode everything outside the
+   unreserved set. `PathEscape` leaves the sub-delims alone, so a Gmail message id
+   containing `&` came out as `…%3Fd&e` — an `&` that starts a query parameter.
+   `client::expand_path_segment`; this is `googleapi`'s rule, not `net/url`'s,
+   which is why it is not in `gourl`.
+2. **Every JSON body carries a trailing newline**, because `googleapi` writes it
+   with `json.NewEncoder(…).Encode`. Both the plain `application/json` POSTs and
+   the metadata part of the `multipart/related` upload. One byte, on the wire,
+   applied once in `google::marshal`.
+3. **`oauth2.RetrieveError` has two forms** and picks between them on whether the
+   body named an error code, *not* on the status. A Google refresh refusal takes
+   the one the port did not have:
+   `oauth2: "invalid_grant" "Token has been expired or revoked."`.
+
+A fourth was found by trying to *vector* it: **a response body of exactly `null`
+panics every one of the eight Go tools.** The generated clients decode into a
+`**T`, `json.Unmarshal` of `null` into a pointer-to-pointer nils the pointer, and
+the handler then reads a field off it. That is a 200 with a two-word body, which a
+proxy or a misconfigured gateway produces. It joins the two nil-dereferences the
+handlers own — `msg.Payload.Headers` in `read_email`/`search_email`,
+`ev.Start.DateTime` in `view_events`. The port returns the zero value in all
+three; a panic cannot be recorded in a vector and is not a behavior worth
+reproducing, so the `null` case is deliberately **absent** from the vectors.
+
+Google-specific behaviour the other five never reached:
+
+- **`gourl::Values` stopped being single-valued for this.** Gmail's
+  `MetadataHeaders("Subject","From","Date")` encodes as three `metadataHeaders=`
+  pairs in insertion order under one sorted key, so `Values` is now a multimap
+  with `set` and `add`.
+- **`search_email` makes N+1 requests from one tool call**, and a failed fetch is
+  **skipped** rather than surfaced — while the count in the sentence is
+  `len(list.Messages)`, the *listed* total. A partial failure therefore produces a
+  sentence whose number does not match its body. Go's, and pinned.
+- **`create_file`'s media type is sniffed from the content**, not taken from the
+  tool's `mime_type` argument, which reaches the metadata JSON alone.
+  `drive::detect_content_type` implements the subset of
+  `net/http.DetectContentType` a JSON **string** can reach — a PNG's `0x89` cannot
+  arrive as one byte, so the binary signature table is deliberately not written.
+- **Drive's upload path is an absolute reference**, so it replaces the base's
+  whole path: `/upload/drive/v3/files`, not something under `/drive/v3/`.
+- **Every clamp differs.** `view_events` and `list_files` cap at 100, `search_email`
+  at 50, and all three fall back to 10 rather than to the cap.
+- **`q` is conditional for Drive and unconditional for Gmail** — an empty Drive
+  query sends no key, an empty Gmail search still sends `q=`.
+- **`download_file` is the only call that is not `alt=json`**, and the only result
+  that is the response body verbatim rather than a formatted summary.
+- **The three bases are not one host.** Gmail moved to `gmail.googleapis.com` and
+  carries `gmail/v1/` in its *relative* paths, where Calendar and Drive carry the
+  version in the base.
+
+**The token source is #318's, built here first.** #318 says of it: "Token refresh
+is shared with the Google MCP server. One implementation, not two."
+`client::TokenSource` is that implementation — 10-second `expiryDelta`, a zero
+expiry that never expires, credentials in the **body** (`AuthStyleInParams`, not a
+`Basic` header), an absent `refresh_token` keeping the old one, and nothing
+persisted. Adopt it in #318; do not write a second.
+
+Three things are pinned as **divergence** rather than matched, all recorded in the
+vectors so they cannot drift silently: `X-Goog-Api-Client` and `User-Agent` (they
+embed the Go toolchain and library versions — no Rust build can emit `gl-go/…`),
+the random `multipart/related` boundary (the *parts* are compared instead), and
+Go's `*url.Error` wrapper around a transport or refresh failure (it embeds the
+resolver's own message).
+
+`internal/integrations/google/parity.go` exports `SetEndpoints`, a **wider** seam
+than the other integrations' `SetAPIBase` because both the API base and the OAuth2
+token endpoint have to be redirectable. It hands credentials to whatever host it
+names — the token URL receives the `client_secret` and refresh token, the durable
+ones — so it is test-only, and the Rust equivalent is behind `#[cfg(test)]`.
+
+**`google` is deliberately absent from `HOSTED_TYPES`.** Nothing here runs in a
+shipped build yet: the sidecar still hosts Google and this is dormant code with
+its parity pinned. The flip is its own change, because the flip is where the risk
+in this series has actually lived — #315's hosting of Slack silently broke
+`completeOAuth`'s reload, and Google is the *other* provider
+`startProviderCallback` supports, so it lands on the same hook.
+
 ### The integration registry, and the port's second ownership flip (#311)
 
 `native/integrations/registry.rs` is `internal/integrations/registry.go`:
@@ -1819,7 +1915,8 @@ path cannot try to answer a chat turn with a `Vec<u8>`.
 **The four routes share a process-local registry, so they moved together** —
 `/messages` puts a session in, the others look one up. But not every chat *can*
 run natively: an agent whose tools come from an integration this build cannot
-host still needs #313, and `runner::build_options` refuses those before any
+host still needs #313's **flip** — the port itself has landed, but `google` is not
+in `HOSTED_TYPES` yet — and `runner::build_options` refuses those before any
 subprocess exists. (Most of that refusal is gone — the **local** server (#310)
 and any agent naming only integrations in `HOSTED_TYPES`: **github** since #311,
 **confluence** since #317, **jira** since #316, **slack** since #315, **telegram**

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -1424,6 +1424,32 @@ first time, and none was visible from either side's source:
    the one the port did not have:
    `oauth2: "invalid_grant" "Token has been expired or revoked."`.
 
+Review then found more of the same shape, each confirmed by adding a vector and
+reading what real Go answered — which is the workflow to repeat here:
+
+4. **`googleapi.Error.Error()` is not a four-case table.** The one-error form is
+   conditional on the sub-error's message *equalling* the top-level one (the
+   normal validation-error shape has them differ, and takes `More details`);
+   `error.details` — the modern `google.rpc.ErrorInfo` envelope a real quota error
+   carries — was dropped entirely; the raw-form test is "no errors **and** no
+   message", not "no code and no message"; and a body beginning `[` is unwrapped
+   by `errorReplyFromBody`. It is now a transcription of the Go function rather
+   than a table of its outputs, because the table *was* the bug: every case it did
+   not list, it got wrong silently.
+5. **`omitempty` reaches past `description`.** `calendar.Event.Summary`,
+   `EventDateTime.DateTime` and `drive.File.Name` all carry it, so an empty
+   `start` sends an object holding nothing but its time zone.
+6. **`tokenRefresher` refuses before opening a socket** when the stored token has
+   no refresh token — the state a re-consent without `prompt=consent` leaves a row
+   in. Reproducing it is not only about the sentence: without it the port POSTs
+   the user's `client_secret` on a request Go never sends.
+7. **Gmail's `parts` is the one array where a `null` element is graceful** —
+   `extractBody` nil-checks it — so it is `Vec<Option<GoStruct<_>>>` where its
+   siblings are not, and `googleapi.Error.Errors` needs the same because it is a
+   Go **value** slice.
+8. **An empty 2xx body is a zero value, not a decode failure**
+   (`DecodeResponse` returns untouched on a 204).
+
 A fourth was found by trying to *vector* it: **a response body of exactly `null`
 panics every one of the eight Go tools.** The generated clients decode into a
 `**T`, `json.Unmarshal` of `null` into a pointer-to-pointer nils the pointer, and
@@ -1446,9 +1472,16 @@ Google-specific behaviour the other five never reached:
   sentence whose number does not match its body. Go's, and pinned.
 - **`create_file`'s media type is sniffed from the content**, not taken from the
   tool's `mime_type` argument, which reaches the metadata JSON alone.
-  `drive::detect_content_type` implements the subset of
-  `net/http.DetectContentType` a JSON **string** can reach — a PNG's `0x89` cannot
-  arrive as one byte, so the binary signature table is deliberately not written.
+  `drive::detect_content_type` is `net/http.DetectContentType` ported **whole**,
+  including the 512-byte bound. It was first written as "the subset a JSON string
+  can reach", on the reasoning that a PNG's `0x89` would be UTF-8 encoded before
+  it arrived — sound for `0x89`, wrong for most of the table, since `BM`, `%PDF-`,
+  `%!PS-Adobe-`, `GIF87a`/`GIF89a`, `ID3`, `OTTO`, `ttcf`, `wOFF`, `wOF2`,
+  `RIFF…WAVE` and `FORM…AIFF` are pure ASCII. `BM` is the one that bites: content
+  beginning "BMI calculator results…" uploads as `image/bmp`. **The lesson
+  generalizes past this function** — an argument that some subset of a third
+  party's table is unreachable has to be right about every entry, and the cheaper
+  move is to transcribe the table.
 - **Drive's upload path is an absolute reference**, so it replaces the base's
   whole path: `/upload/drive/v3/files`, not something under `/drive/v3/`.
 - **Every clamp differs.** `view_events` and `list_files` cap at 100, `search_email`

--- a/desktop/parity/google_parity_test.go
+++ b/desktop/parity/google_parity_test.go
@@ -1,0 +1,1180 @@
+// Cross-language vectors for the Google integration's MCP server
+// (`internal/integrations/google`, ported in #313 to
+// `desktop/src-tauri/src/native/integrations/google/`).
+//
+// Four things have to match byte for byte, none checkable from one language
+// alone: which tools are hosted, each advertised schema, the request each tool
+// builds, and the result text of every success and every failure. The reasoning
+// is in `confluence_parity_test.go`'s header and is not repeated.
+//
+// # Why this one exists more urgently than the other five
+//
+// The other five build their requests with `http.NewRequest` and `json.Marshal`,
+// so a reviewer can read the bytes off `tools.go` and check the port by eye.
+// Google calls the **generated** client libraries (`calendar/v3`, `gmail/v1`,
+// `drive/v3`) over an `oauth2` transport, and what those put on the wire is in
+// neither this repository nor the port. Without this file the Rust half would be
+// a guess about a third party's code generator, and nothing would notice when
+// that generator changed. So the recordings here are the specification: the
+// resolved URL, the **whole** sorted query (`alt=json&prettyPrint=false` on every
+// call, the field masks, `uploadType=multipart`), the `omitempty` bodies, the
+// `Authorization` header, the `multipart/related` parts, and every sentence.
+//
+// # What is pinned as divergence rather than matched
+//
+//   - `X-Goog-Api-Client` and `User-Agent` embed the *Go toolchain* and *client
+//     library* versions. No Rust build can emit `gl-go/…`, and freezing the value
+//     would break on a `go.mod` bump. Neither header is recorded.
+//   - The `multipart/related` **boundary** is random per request in both
+//     languages, so the parts are recorded and the byte stream is not.
+//   - A transport failure and a refresh failure carry Go's `*url.Error` text,
+//     which embeds the fake's ephemeral port and the resolver's own message. Those
+//     cases carry `rust_text`.
+//   - **Three nil-dereference panics**, none of which can be recorded in a
+//     vector and none of which is a behavior worth reproducing. Two are the
+//     handlers': `read_email`/`search_email` do `msg.Payload.Headers` and
+//     `view_events` does `ev.Start.DateTime`, both without a nil check. The third
+//     is not the handlers' at all and was found by trying to vector it: **a
+//     response body of exactly `null` panics every one of the eight tools**,
+//     because the generated clients decode into a `**T` — `json.Unmarshal` of
+//     `null` into a pointer-to-pointer *nils the pointer*, and the handler then
+//     reads a field off it. That is a 200 with a two-word body, which is to say a
+//     shape a proxy or a misconfigured gateway produces. The port returns the zero
+//     value in all three cases. The `null` case is deliberately **absent** from the
+//     vectors below: recording it would mean recording a crash.
+//
+// # Google-specific things pinned here that no earlier integration could reach
+//
+//   - **Repeated query parameters.** `MetadataHeaders("Subject","From","Date")`
+//     encodes as three `metadataHeaders=` pairs in insertion order under one
+//     sorted key. That is why `gourl::Values` stopped being single-valued.
+//   - **N+1 requests from one tool call.** `search_email` lists, then fetches each
+//     message, **skips** a failed fetch, and reports `len(list.Messages)` — the
+//     listed count, not the rendered one. A partial failure therefore produces a
+//     sentence whose number does not match its body.
+//   - **A sniffed upload content type.** `create_file`'s media part takes its type
+//     from `http.DetectContentType` over the content, not from the tool's
+//     `mime_type` argument, which reaches the metadata JSON alone.
+//   - **An absolute relative-reference.** Drive's upload resolves to
+//     `/upload/drive/v3/files`, replacing the base's whole path.
+//   - **OAuth2 refresh**, which #318 will share: when it fires, what it sends, and
+//     that the refreshed token reaches the very next request.
+//
+// One value is not deterministic: `view_events`' `time_min` defaults to
+// `time.Now()`. That case records the query with the value replaced by
+// `«now»`; both languages substitute before comparing, and both assert the
+// original parses as a seconds-precision RFC3339 instant in UTC.
+//
+// The Rust half lives in
+// `desktop/src-tauri/src/native/integrations/google/tests_vectors.rs`.
+//
+// Regenerate (only from Go, and only when adding cases):
+//
+//	go test ./desktop/parity/ -run TestGoogleVectors -update-google-vectors
+package parity
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	mcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"golang.org/x/oauth2"
+
+	"github.com/shaharia-lab/agento/internal/config"
+	"github.com/shaharia-lab/agento/internal/integrations/google"
+)
+
+const googleVectorsFile = "google_vectors.json"
+
+var updateGoogleVectors = flag.Bool("update-google-vectors", false,
+	"rewrite google_vectors.json from this Go toolchain")
+
+const googleParityID = "goog-parity"
+
+// Fixtures, not secrets. The client secret and refresh token are recorded in the
+// refresh request body, because that body is a parity surface — and because a
+// port that sent them as a `Basic` header instead would otherwise pass.
+const (
+	googleClientID     = "parity-client-id.apps.googleusercontent.com"
+	googleClientSecret = "GOCSPX-parity-client-secret" //nolint:gosec // a test fixture
+	googleRefreshToken = "1//parity-refresh-token"     //nolint:gosec // a test fixture
+	googleAccessToken  = "ya29.parity-access-token"    //nolint:gosec // a test fixture
+)
+
+// The placeholder `time_min` collapses to. Both languages substitute it.
+const googleNowPlaceholder = "«now»"
+
+// The placeholder the fake's own base URL collapses to, so a Go sentence that
+// embeds it stays stable across runs.
+const googleFakeBase = "«api»"
+
+// ─── Vector shapes ───────────────────────────────────────────────────────────
+
+type googleToolVector struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"input_schema"`
+}
+
+// googlePartVector is one part of a `multipart/related` upload. Recorded instead
+// of the raw body because the boundary is random in both languages.
+type googlePartVector struct {
+	ContentType string `json:"content_type"`
+	Body        string `json:"body"`
+}
+
+// googleRequestVector is what the fake Google saw.
+//
+// `Authorization` is recorded in full: it is how a refresh is observed reaching
+// the next request, and the token is a fixture.
+type googleRequestVector struct {
+	Method        string `json:"method"`
+	Target        string `json:"target"`
+	Authorization string `json:"authorization"`
+	ContentType   string `json:"content_type"`
+	Body          string `json:"body,omitempty"`
+	// Set instead of Body for a `multipart/related` upload.
+	Parts []googlePartVector `json:"parts,omitempty"`
+}
+
+type googleResponseScript struct {
+	Status int    `json:"status"`
+	Body   string `json:"body"`
+}
+
+type googleCallVector struct {
+	Case      string          `json:"case"`
+	Tool      string          `json:"tool"`
+	Arguments json.RawMessage `json:"arguments"`
+	// Consumed in order; the last entry is reused once exhausted, which is what
+	// lets one `search_email` case script the list and every fetch behind it.
+	Responses []googleResponseScript `json:"responses"`
+	Requests  []googleRequestVector  `json:"requests"`
+	IsError   bool                   `json:"is_error"`
+	Text      string                 `json:"text"`
+	// A pinned divergence — see the file header.
+	RustText string `json:"rust_text,omitempty"`
+	// Go made requests and this port deliberately makes none.
+	RustNoRequest bool `json:"rust_no_request,omitempty"`
+}
+
+// googleRefreshVector is a call made through a token source in a stated state,
+// so the *whole* refresh decision is recorded rather than asserted: whether a
+// refresh happened at all, what it sent, and which access token the API call
+// that followed carried.
+type googleRefreshVector struct {
+	Case string `json:"case"`
+	// Seconds from now; nil is Go's zero `time.Time`, which never expires.
+	ExpiresIn *int64 `json:"expires_in"`
+	// The scripted answer from the token endpoint. Absent when no refresh is
+	// expected.
+	TokenResponse *googleResponseScript `json:"token_response"`
+	APIResponse   googleResponseScript  `json:"api_response"`
+	// nil when no refresh was made — which is itself the assertion.
+	RefreshRequest *googleRequestVector `json:"refresh_request"`
+	APIRequest     *googleRequestVector `json:"api_request"`
+	IsError        bool                 `json:"is_error"`
+	Text           string               `json:"text"`
+	RustText       string               `json:"rust_text,omitempty"`
+}
+
+type googleHostingVector struct {
+	Case     string                          `json:"case"`
+	Services map[string]config.ServiceConfig `json:"services"`
+	Tools    []string                        `json:"tools"`
+}
+
+type googleVectors struct {
+	Comment        []string              `json:"_comment"`
+	IntegrationID  string                `json:"integration_id"`
+	ServerName     string                `json:"server_name"`
+	Version        string                `json:"version"`
+	ClientID       string                `json:"client_id"`
+	ClientSecret   string                `json:"client_secret"`
+	RefreshToken   string                `json:"refresh_token"`
+	AccessToken    string                `json:"access_token"`
+	NowPlaceholder string                `json:"now_placeholder"`
+	Tools          []googleToolVector    `json:"tools"`
+	Hosting        []googleHostingVector `json:"hosting"`
+	Calls          []googleCallVector    `json:"calls"`
+	Refreshes      []googleRefreshVector `json:"refreshes"`
+}
+
+// ─── The fake Google ─────────────────────────────────────────────────────────
+
+// fakeGoogle answers both the API bases and the token endpoint, recording each
+// separately: a refresh is the one request whose *absence* is the assertion.
+type fakeGoogle struct {
+	mu sync.Mutex
+
+	api       []googleResponseScript
+	apiSeen   []googleRequestVector
+	token     *googleResponseScript
+	tokenSeen *googleRequestVector
+
+	// Replaces the fake's own base URL in a recorded sentence.
+	baseURL string
+}
+
+func (f *fakeGoogle) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	recorded := recordGoogleRequest(r)
+
+	f.mu.Lock()
+	var script googleResponseScript
+	if r.URL.Path == "/token" {
+		f.tokenSeen = &recorded
+		if f.token != nil {
+			script = *f.token
+		} else {
+			// No refresh was scripted, so one arriving is a failure the vector
+			// should show rather than hide.
+			script = googleResponseScript{Status: http.StatusInternalServerError,
+				Body: `{"error":"unexpected refresh"}`}
+		}
+	} else {
+		f.apiSeen = append(f.apiSeen, recorded)
+		switch {
+		case len(f.api) == 0:
+			script = googleResponseScript{Status: http.StatusInternalServerError,
+				Body: `{"error":"no response scripted"}`}
+		case len(f.api) == 1:
+			script = f.api[0] // the last entry is reused
+		default:
+			script, f.api = f.api[0], f.api[1:]
+		}
+	}
+	f.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(script.Status)
+	_, _ = w.Write([]byte(script.Body))
+}
+
+// recordGoogleRequest captures exactly the fields the port must reproduce —
+// deliberately not the version-stamped headers, which it cannot.
+func recordGoogleRequest(r *http.Request) googleRequestVector {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		body = nil
+	}
+	contentType := r.Header.Get("Content-Type")
+	recorded := googleRequestVector{
+		Method:        r.Method,
+		Target:        r.URL.RequestURI(),
+		Authorization: r.Header.Get("Authorization"),
+		ContentType:   contentType,
+	}
+
+	mediaType, params, mimeErr := mime.ParseMediaType(contentType)
+	if mimeErr == nil && strings.HasPrefix(mediaType, "multipart/") {
+		// The boundary is random, so record the media type without it and the
+		// parts instead of the byte stream.
+		recorded.ContentType = mediaType
+		reader := multipart.NewReader(strings.NewReader(string(body)), params["boundary"])
+		for {
+			part, partErr := reader.NextPart()
+			if partErr != nil {
+				break
+			}
+			partBody, _ := io.ReadAll(part)
+			recorded.Parts = append(recorded.Parts, googlePartVector{
+				ContentType: part.Header.Get("Content-Type"),
+				Body:        string(partBody),
+			})
+			_ = part.Close()
+		}
+		return recorded
+	}
+
+	recorded.Body = string(body)
+	return recorded
+}
+
+func (f *fakeGoogle) armAPI(scripts []googleResponseScript) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.api = append([]googleResponseScript(nil), scripts...)
+	f.apiSeen = nil
+}
+
+func (f *fakeGoogle) armToken(script *googleResponseScript) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.token = script
+	f.tokenSeen = nil
+}
+
+func (f *fakeGoogle) recordedAPI() []googleRequestVector {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.apiSeen
+}
+
+func (f *fakeGoogle) recordedToken() *googleRequestVector {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.tokenSeen
+}
+
+// ─── Standing the real server up ─────────────────────────────────────────────
+
+// googleSession starts the real integration against the fake and returns a
+// client session. expiresIn is the stored token's lifetime; nil is Go's zero
+// `time.Time`, which never expires.
+func googleSession(
+	t *testing.T, ctx context.Context,
+	services map[string]config.ServiceConfig, expiresIn *int64,
+) *mcp.ClientSession {
+	t.Helper()
+
+	credentials, err := json.Marshal(config.GoogleCredentials{
+		ClientID:     googleClientID,
+		ClientSecret: googleClientSecret,
+	})
+	if err != nil {
+		t.Fatalf("encoding credentials: %v", err)
+	}
+
+	// An `oauth2.Token` rather than a hand-built map, because `ParseOAuthToken`
+	// decodes into one: a zero `Expiry` is what "no expiry" *is*, and it
+	// round-trips through this type and no other.
+	token := oauth2.Token{
+		AccessToken:  googleAccessToken,
+		RefreshToken: googleRefreshToken,
+		TokenType:    "Bearer",
+	}
+	if expiresIn != nil {
+		token.Expiry = time.Now().Add(time.Duration(*expiresIn) * time.Second)
+	}
+	encodedAuth, err := json.Marshal(&token)
+	if err != nil {
+		t.Fatalf("encoding auth: %v", err)
+	}
+
+	cfg := &config.IntegrationConfig{
+		ID:          googleParityID,
+		Name:        "Google (parity)",
+		Type:        "google",
+		Enabled:     true,
+		Credentials: credentials,
+		Auth:        encodedAuth,
+		Services:    services,
+	}
+
+	serverCfg, err := google.Start(ctx, cfg)
+	if err != nil {
+		t.Fatalf("starting the google integration: %v", err)
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "parity", Version: "1"}, nil)
+	session, err := client.Connect(ctx,
+		&mcp.StreamableClientTransport{Endpoint: serverCfg.URL}, nil)
+	if err != nil {
+		t.Fatalf("connecting to %s: %v", serverCfg.URL, err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	return session
+}
+
+func googleAllServices() map[string]config.ServiceConfig {
+	return map[string]config.ServiceConfig{
+		"calendar": {Enabled: true},
+		"gmail":    {Enabled: true},
+		"drive":    {Enabled: true},
+	}
+}
+
+// googleHour is the ordinary case: a token that will not expire during the run.
+func googleHour() *int64 {
+	hour := int64(3600)
+	return &hour
+}
+
+var googleHostingCases = []googleHostingVector{
+	{Case: "every service enabled with no tool list — an empty allowed set hosts everything",
+		Services: googleAllServices()},
+	{Case: "no services at all", Services: map[string]config.ServiceConfig{}},
+	{Case: "one service enabled hosts only its tools",
+		Services: map[string]config.ServiceConfig{"calendar": {Enabled: true}}},
+	{Case: "a disabled service contributes neither its gate nor its names",
+		Services: map[string]config.ServiceConfig{
+			"calendar": {Enabled: true},
+			"gmail":    {Enabled: true},
+			"drive":    {Enabled: false, Tools: []string{"create_event"}},
+		}},
+	{
+		// The union half, which only Google can exercise: naming one Gmail tool
+		// silences Calendar and Drive too.
+		Case: "one tool named under one service narrows every enabled service",
+		Services: map[string]config.ServiceConfig{
+			"calendar": {Enabled: true},
+			"gmail":    {Enabled: true, Tools: []string{"send_email"}},
+			"drive":    {Enabled: true},
+		},
+	},
+	{
+		// …and a name contributed by one service admits the tool wherever it is
+		// registered, across service boundaries.
+		Case: "a name contributed by one service admits a tool belonging to another",
+		Services: map[string]config.ServiceConfig{
+			"calendar": {Enabled: true},
+			"gmail":    {Enabled: true, Tools: []string{"send_email", "list_files"}},
+			"drive":    {Enabled: true},
+		},
+	},
+	{Case: "an enabled but unknown service still narrows the ones that exist",
+		Services: map[string]config.ServiceConfig{
+			"calendar": {Enabled: true},
+			"other":    {Enabled: true, Tools: []string{"view_events"}},
+		}},
+	{Case: "a tool named by a disabled service is not allowed anywhere",
+		Services: map[string]config.ServiceConfig{
+			"drive":    {Enabled: true, Tools: []string{"list_files"}},
+			"calendar": {Enabled: false, Tools: []string{"create_event"}},
+		}},
+}
+
+// ─── The call cases ──────────────────────────────────────────────────────────
+
+type googleCallCase struct {
+	name      string
+	tool      string
+	args      map[string]any
+	scripts   []googleResponseScript
+	rustText  string
+	rustNoReq bool
+}
+
+func googleOK(body string) []googleResponseScript {
+	return []googleResponseScript{{Status: http.StatusOK, Body: body}}
+}
+
+//nolint:funlen // one flat table; splitting it would hide what is covered
+func googleCallCases() []googleCallCase {
+	const createdEvent = `{"id":"ev1","summary":"Standup","htmlLink":"https://cal/ev1"}`
+
+	return []googleCallCase{
+		// ─── create_event ────────────────────────────────────────────────────
+		{
+			// Every key present, and `json.Marshal`'s HTML escaping in the
+			// summary — `<`, which `serde_json` does not do.
+			name: "create_event/a full event, with encoding/json's HTML escaping",
+			tool: "create_event",
+			args: map[string]any{
+				"summary": "Standup <daily> & sync", "start": "2026-03-01T10:00:00-07:00",
+				"end": "2026-03-01T10:30:00-07:00", "description": "notes & more",
+			},
+			scripts: googleOK(createdEvent),
+		},
+		{
+			// `calendar.Event`'s fields carry `omitempty`, so this sends no
+			// `description` key at all.
+			name: "create_event/an empty description sends no key",
+			tool: "create_event",
+			args: map[string]any{
+				"summary": "Standup", "start": "2026-03-01T10:00:00Z",
+				"end": "2026-03-01T10:30:00Z", "description": "",
+			},
+			scripts: googleOK(createdEvent),
+		},
+		{
+			// The result reads the **response**, so a server that renamed the
+			// event is what the model is told.
+			name: "create_event/the result reads the response and not the request",
+			tool: "create_event",
+			args: map[string]any{
+				"summary": "sent", "start": "2026-03-01T10:00:00Z",
+				"end": "2026-03-01T10:30:00Z", "description": "",
+			},
+			scripts: googleOK(`{"id":"ev2","summary":"renamed by the server","htmlLink":"https://cal/ev2"}`),
+		},
+		{
+			name: "create_event/null fields decode as zero values",
+			tool: "create_event",
+			args: map[string]any{
+				"summary": "s", "start": "2026-03-01T10:00:00Z",
+				"end": "2026-03-01T10:30:00Z", "description": "",
+			},
+			scripts: googleOK(`{"id":null,"summary":null,"htmlLink":null}`),
+		},
+		{
+			// serde would build the struct from a sequence positionally without
+			// `GoStruct`, turning this into a success.
+			name: "create_event/a JSON array is not a struct",
+			tool: "create_event",
+			args: map[string]any{
+				"summary": "s", "start": "2026-03-01T10:00:00Z",
+				"end": "2026-03-01T10:30:00Z", "description": "",
+			},
+			scripts:  googleOK(`[true]`),
+			rustText: "creating calendar event: decoding response: invalid type: sequence, expected a JSON object at line 1 column 0",
+		},
+
+		// ─── googleapi.Error, all four shapes ────────────────────────────────
+		{
+			name: "create_event/an error with one reason",
+			tool: "create_event",
+			args: map[string]any{
+				"summary": "s", "start": "2026-03-01T10:00:00Z",
+				"end": "2026-03-01T10:30:00Z", "description": "",
+			},
+			scripts: []googleResponseScript{{Status: http.StatusForbidden,
+				Body: `{"error":{"code":403,"message":"Insufficient Permission","errors":[{"message":"Insufficient Permission","domain":"global","reason":"insufficientPermissions"}]}}`}},
+		},
+		{
+			name: "create_event/an error with no errors array",
+			tool: "create_event",
+			args: map[string]any{
+				"summary": "s", "start": "2026-03-01T10:00:00Z",
+				"end": "2026-03-01T10:30:00Z", "description": "",
+			},
+			scripts: []googleResponseScript{{Status: http.StatusNotFound,
+				Body: `{"error":{"code":404,"message":"Not Found"}}`}},
+		},
+		{
+			name: "create_event/an error with several reasons",
+			tool: "create_event",
+			args: map[string]any{
+				"summary": "s", "start": "2026-03-01T10:00:00Z",
+				"end": "2026-03-01T10:30:00Z", "description": "",
+			},
+			scripts: []googleResponseScript{{Status: http.StatusBadRequest,
+				Body: `{"error":{"code":400,"message":"Bad Request","errors":[{"message":"m1","reason":"r1"},{"message":"m2","reason":"r2"}]}}`}},
+		},
+		{
+			// An `error` that is a **string** is not a Google error document, so
+			// it falls through to the raw form.
+			name: "create_event/a body that is not a Google error document",
+			tool: "create_event",
+			args: map[string]any{
+				"summary": "s", "start": "2026-03-01T10:00:00Z",
+				"end": "2026-03-01T10:30:00Z", "description": "",
+			},
+			scripts: []googleResponseScript{{Status: http.StatusForbidden,
+				Body: `{"error":"invalid_grant","error_description":"Token has been expired or revoked."}`}},
+		},
+		{
+			name: "create_event/an error body that is not JSON at all",
+			tool: "create_event",
+			args: map[string]any{
+				"summary": "s", "start": "2026-03-01T10:00:00Z",
+				"end": "2026-03-01T10:30:00Z", "description": "",
+			},
+			scripts: []googleResponseScript{{Status: http.StatusBadGateway,
+				Body: `<html>nope</html>`}},
+		},
+
+		// ─── view_events ─────────────────────────────────────────────────────
+		{
+			name: "view_events/an explicit range, with both bounds",
+			tool: "view_events",
+			args: map[string]any{
+				"time_min": "2026-03-01T00:00:00Z", "time_max": "2026-03-08T00:00:00Z",
+				"max_results": 25,
+			},
+			scripts: googleOK(`{"items":[{"id":"e1","summary":"One","htmlLink":"https://cal/e1","start":{"dateTime":"2026-03-02T09:00:00Z"}}]}`),
+		},
+		{
+			// The non-deterministic one: `time_min` defaults to `time.Now()`,
+			// recorded as «now».
+			name:    "view_events/an empty time_min defaults to now and no time_max key is sent",
+			tool:    "view_events",
+			args:    map[string]any{"time_min": "", "time_max": "", "max_results": 0},
+			scripts: googleOK(`{"items":[]}`),
+		},
+		{
+			name: "view_events/max_results above the maximum falls back to the default",
+			tool: "view_events",
+			args: map[string]any{
+				"time_min": "2026-03-01T00:00:00Z", "time_max": "", "max_results": 101,
+			},
+			scripts: googleOK(`{"items":[]}`),
+		},
+		{
+			name: "view_events/the maximum itself is sent",
+			tool: "view_events",
+			args: map[string]any{
+				"time_min": "2026-03-01T00:00:00Z", "time_max": "", "max_results": 100,
+			},
+			scripts: googleOK(`{"items":[]}`),
+		},
+		{
+			// An all-day event has `date` and no `dateTime`.
+			name: "view_events/an all-day event falls back to date",
+			tool: "view_events",
+			args: map[string]any{
+				"time_min": "2026-03-01T00:00:00Z", "time_max": "", "max_results": 10,
+			},
+			scripts: googleOK(`{"items":[{"id":"e2","summary":"Holiday","htmlLink":"https://cal/e2","start":{"date":"2026-03-03"}},{"id":"e3","summary":"Timed","htmlLink":"https://cal/e3","start":{"dateTime":"2026-03-04T09:00:00Z","date":"ignored"}}]}`),
+		},
+		{
+			name: "view_events/no items at all",
+			tool: "view_events",
+			args: map[string]any{
+				"time_min": "2026-03-01T00:00:00Z", "time_max": "", "max_results": 10,
+			},
+			scripts: googleOK(`{"items":null}`),
+		},
+
+		// ─── send_email ──────────────────────────────────────────────────────
+		{
+			// The RFC822 message is built by the handler and base64url-encoded
+			// **with padding**.
+			name: "send_email/the RFC822 message is padded base64url in the body",
+			tool: "send_email",
+			args: map[string]any{
+				"to": "alice@example.com, bob@example.com", "subject": "Hello & <hi>",
+				"body": "Line one\nLine two",
+			},
+			scripts: googleOK(`{"id":"m1"}`),
+		},
+		{
+			name:    "send_email/an empty body still produces a message",
+			tool:    "send_email",
+			args:    map[string]any{"to": "a@b", "subject": "", "body": ""},
+			scripts: googleOK(`{"id":"m2"}`),
+		},
+		{
+			name:    "send_email/non-ASCII is encoded as UTF-8 bytes before base64",
+			tool:    "send_email",
+			args:    map[string]any{"to": "a@b", "subject": "naïve — ☕", "body": "héllo"},
+			scripts: googleOK(`{"id":"m3"}`),
+		},
+
+		// ─── read_email ──────────────────────────────────────────────────────
+		{
+			name: "read_email/headers and a text/plain body",
+			tool: "read_email",
+			args: map[string]any{"message_id": "18c0f0a1b2c3d4e5"},
+			// `aGVsbG8gdGhlcmU=` is "hello there", padded.
+			scripts: googleOK(`{"id":"18c0f0a1b2c3d4e5","payload":{"mimeType":"text/plain","body":{"data":"aGVsbG8gdGhlcmU="},"headers":[{"name":"Subject","value":"Re: lunch"},{"name":"From","value":"alice@example.com"},{"name":"Date","value":"Mon, 2 Mar 2026 09:00:00 +0000"},{"name":"X-Other","value":"ignored"}]}}`),
+		},
+		{
+			// A later header of the same name wins, because Go's switch assigns
+			// on every iteration.
+			name:    "read_email/a later header of the same name wins",
+			tool:    "read_email",
+			args:    map[string]any{"message_id": "m"},
+			scripts: googleOK(`{"payload":{"headers":[{"name":"Subject","value":"first"},{"name":"Subject","value":"second"}]}}`),
+		},
+		{
+			// Unpadded base64url **fails** `URLEncoding` and falls through to
+			// the next part rather than erroring.
+			name:    "read_email/an unpadded part is skipped and the next one is used",
+			tool:    "read_email",
+			args:    map[string]any{"message_id": "m"},
+			scripts: googleOK(`{"payload":{"mimeType":"multipart/mixed","headers":[],"parts":[{"mimeType":"text/plain","body":{"data":"aGk"}},{"mimeType":"text/plain","body":{"data":"Ynll"}}]}}`),
+		},
+		{
+			name:    "read_email/only text/plain is decoded, depth first",
+			tool:    "read_email",
+			args:    map[string]any{"message_id": "m"},
+			scripts: googleOK(`{"payload":{"mimeType":"multipart/alternative","headers":[],"parts":[{"mimeType":"text/html","body":{"data":"PGI-PC9iPg=="}},{"mimeType":"text/plain","body":{"data":"aGk="}}]}}`),
+		},
+		{
+			// The id is a **path** parameter, escaped per segment.
+			name:    "read_email/a message id needing escaping",
+			tool:    "read_email",
+			args:    map[string]any{"message_id": "a/b c?d&e"},
+			scripts: googleOK(`{"payload":{"headers":[]}}`),
+		},
+		{
+			name: "read_email/a 404 quotes the id with %q",
+			tool: "read_email",
+			args: map[string]any{"message_id": "missing\"quoted"},
+			scripts: []googleResponseScript{{Status: http.StatusNotFound,
+				Body: `{"error":{"code":404,"message":"Requested entity was not found."}}`}},
+		},
+
+		// ─── search_email ────────────────────────────────────────────────────
+		{
+			// The N+1: one list, then one fetch per message, each carrying three
+			// `metadataHeaders` values under one sorted key.
+			name: "search_email/one list and one fetch per message, with repeated query keys",
+			tool: "search_email",
+			args: map[string]any{"query": "from:alice@example.com is:unread", "max_results": 2},
+			scripts: []googleResponseScript{
+				{Status: http.StatusOK, Body: `{"messages":[{"id":"m1"},{"id":"m2"}]}`},
+				{Status: http.StatusOK, Body: `{"payload":{"headers":[{"name":"Subject","value":"One"},{"name":"From","value":"a@b"},{"name":"Date","value":"D1"}]}}`},
+				{Status: http.StatusOK, Body: `{"payload":{"headers":[{"name":"Subject","value":"Two"},{"name":"From","value":"c@d"},{"name":"Date","value":"D2"}]}}`},
+			},
+		},
+		{
+			// The count is `len(list.Messages)` — the **listed** total. A skipped
+			// fetch leaves the sentence's number disagreeing with its body.
+			name: "search_email/a failed fetch is skipped and the count still counts it",
+			tool: "search_email",
+			args: map[string]any{"query": "x", "max_results": 3},
+			scripts: []googleResponseScript{
+				{Status: http.StatusOK, Body: `{"messages":[{"id":"m1"},{"id":"m2"},{"id":"m3"}]}`},
+				{Status: http.StatusOK, Body: `{"payload":{"headers":[{"name":"Subject","value":"One"}]}}`},
+				{Status: http.StatusForbidden, Body: `{"error":{"code":403,"message":"nope"}}`},
+				{Status: http.StatusOK, Body: `{"payload":{"headers":[{"name":"Subject","value":"Three"}]}}`},
+			},
+		},
+		{
+			// Unlike Drive's, Gmail's `q` is unconditional: an empty search still
+			// sends `q=`.
+			name:    "search_email/an empty query still sends the q key",
+			tool:    "search_email",
+			args:    map[string]any{"query": "", "max_results": 0},
+			scripts: googleOK(`{"messages":[]}`),
+		},
+		{
+			// 50 here, not 100 — every clamp in this integration differs.
+			name:    "search_email/max_results above 50 falls back to the default",
+			tool:    "search_email",
+			args:    map[string]any{"query": "x", "max_results": 51},
+			scripts: googleOK(`{"messages":null}`),
+		},
+		{
+			name:    "search_email/50 itself is sent",
+			tool:    "search_email",
+			args:    map[string]any{"query": "x", "max_results": 50},
+			scripts: googleOK(`{"messages":[]}`),
+		},
+
+		// ─── list_files ──────────────────────────────────────────────────────
+		{
+			name:    "list_files/a query is sent when set",
+			tool:    "list_files",
+			args:    map[string]any{"query": "name contains 'report' and trashed = false", "max_results": 3},
+			scripts: googleOK(`{"files":[{"id":"f1","name":"Report.pdf","mimeType":"application/pdf","modifiedTime":"2026-03-01T09:00:00Z","webViewLink":"https://drive/f1"}]}`),
+		},
+		{
+			// Conditional, unlike Gmail's: an empty Drive query sends no key.
+			name:    "list_files/an empty query sends no q key at all",
+			tool:    "list_files",
+			args:    map[string]any{"query": "", "max_results": 0},
+			scripts: googleOK(`{"files":[]}`),
+		},
+		{
+			name:    "list_files/max_results above the maximum falls back to the default",
+			tool:    "list_files",
+			args:    map[string]any{"query": "", "max_results": 101},
+			scripts: googleOK(`{"files":null}`),
+		},
+		{
+			name:    "list_files/several files are joined by a rule",
+			tool:    "list_files",
+			args:    map[string]any{"query": "", "max_results": 2},
+			scripts: googleOK(`{"files":[{"id":"f1","name":"A","mimeType":"text/plain","modifiedTime":"t1","webViewLink":"l1"},{"id":"f2","name":"B","mimeType":null,"modifiedTime":null,"webViewLink":null}]}`),
+		},
+
+		// ─── create_file ─────────────────────────────────────────────────────
+		{
+			// The upload path is **absolute**, so it replaces the base's whole
+			// path; and the media part's type is sniffed rather than taken from
+			// `mime_type`, which reaches only the metadata JSON.
+			name: "create_file/the media type is sniffed and the mime_type argument is metadata only",
+			tool: "create_file",
+			args: map[string]any{
+				"name": "notes.md", "content": "# Notes\n\nplain text",
+				"mime_type": "text/markdown",
+			},
+			scripts: googleOK(`{"id":"f9","name":"notes.md","webViewLink":"https://drive/f9"}`),
+		},
+		{
+			name:    "create_file/an empty mime_type defaults to text/plain in the metadata",
+			tool:    "create_file",
+			args:    map[string]any{"name": "a.txt", "content": "hello", "mime_type": ""},
+			scripts: googleOK(`{"id":"f10","name":"a.txt","webViewLink":"https://drive/f10"}`),
+		},
+		{
+			// HTML content sniffs as `text/html`, whatever `mime_type` said.
+			name: "create_file/HTML content sniffs as text/html regardless of mime_type",
+			tool: "create_file",
+			args: map[string]any{
+				"name": "page.html", "content": "<html><body>hi</body></html>",
+				"mime_type": "application/json",
+			},
+			scripts: googleOK(`{"id":"f11","name":"page.html","webViewLink":"https://drive/f11"}`),
+		},
+		{
+			name:    "create_file/an empty content still uploads a media part",
+			tool:    "create_file",
+			args:    map[string]any{"name": "empty", "content": "", "mime_type": ""},
+			scripts: googleOK(`{"id":"f12","name":"empty","webViewLink":"https://drive/f12"}`),
+		},
+
+		// ─── download_file ───────────────────────────────────────────────────
+		{
+			// The only call in the integration that is not `alt=json`, and the
+			// only result that is the response body verbatim.
+			name:    "download_file/the body is returned verbatim",
+			tool:    "download_file",
+			args:    map[string]any{"file_id": "f1"},
+			scripts: googleOK("line one\nline two\n"),
+		},
+		{
+			name:    "download_file/a file id needing escaping",
+			tool:    "download_file",
+			args:    map[string]any{"file_id": "a/b c?d"},
+			scripts: googleOK("x"),
+		},
+		{
+			name:    "download_file/an empty file is an empty result",
+			tool:    "download_file",
+			args:    map[string]any{"file_id": "f2"},
+			scripts: googleOK(""),
+		},
+		{
+			name: "download_file/a 403 quotes the id with %q",
+			tool: "download_file",
+			args: map[string]any{"file_id": "f3"},
+			scripts: []googleResponseScript{{Status: http.StatusForbidden,
+				Body: `{"error":{"code":403,"message":"Insufficient Permission","errors":[{"reason":"insufficientPermissions","message":"Insufficient Permission"}]}}`}},
+		},
+
+		// ─── a zero-fraction float for an integer field ───────────────────────
+		{
+			name:      "view_events/a zero-fraction float is an integer to Go and not to serde",
+			tool:      "view_events",
+			args:      map[string]any{"time_min": "2026-03-01T00:00:00Z", "time_max": "", "max_results": json.RawMessage("10.0")},
+			scripts:   googleOK(`{"items":[]}`),
+			rustText:  "failed to deserialize parameters: invalid type: floating point `10.0`, expected i64",
+			rustNoReq: true,
+		},
+	}
+}
+
+// ─── The refresh cases ───────────────────────────────────────────────────────
+
+type googleRefreshCase struct {
+	name          string
+	expiresIn     *int64
+	tokenResponse *googleResponseScript
+	apiResponse   googleResponseScript
+	rustText      string
+}
+
+func googleSeconds(n int64) *int64 { return &n }
+
+func googleRefreshCases() []googleRefreshCase {
+	const listed = `{"files":[]}`
+	ok := googleResponseScript{Status: http.StatusOK, Body: listed}
+
+	return []googleRefreshCase{
+		{
+			// An hour out: no refresh, and the stored access token is what the
+			// API sees.
+			name:        "a token an hour from expiry is reused without a refresh",
+			expiresIn:   googleSeconds(3600),
+			apiResponse: ok,
+		},
+		{
+			// Go's zero `time.Time` never expires — which is what an integration
+			// authenticated before the expiry was stored looks like.
+			name:        "a token with no expiry never refreshes",
+			expiresIn:   nil,
+			apiResponse: ok,
+		},
+		{
+			// Inside the 10-second `expiryDelta`, so it refreshes even though it
+			// has not expired.
+			name:      "a token five seconds from expiry refreshes inside the delta",
+			expiresIn: googleSeconds(5),
+			tokenResponse: &googleResponseScript{Status: http.StatusOK,
+				Body: `{"access_token":"ya29.refreshed","token_type":"Bearer","expires_in":3599}`},
+			apiResponse: ok,
+		},
+		{
+			// A response with no `refresh_token` keeps the old one — not
+			// observable in one request, but the next refresh would send it.
+			name:      "an expired token refreshes and the new access token reaches the request",
+			expiresIn: googleSeconds(-60),
+			tokenResponse: &googleResponseScript{Status: http.StatusOK,
+				Body: `{"access_token":"ya29.refreshed-2","token_type":"Bearer","expires_in":3599}`},
+			apiResponse: ok,
+		},
+		{
+			// The failure surfaces as the **tool's** failure, because `oauth2`'s
+			// transport returns it from `RoundTrip`. Go's text is an
+			// `*url.Error` around `oauth2`'s own; the port's is `oauth2`'s alone.
+			name:      "a refused refresh surfaces as the tool's own failure",
+			expiresIn: googleSeconds(-60),
+			tokenResponse: &googleResponseScript{Status: http.StatusBadRequest,
+				Body: `{"error":"invalid_grant","error_description":"Token has been expired or revoked."}`},
+			apiResponse: ok,
+			// Only the `*url.Error` wrapper diverges. `RetrieveError.Error()`
+			// has two forms and this is the *other* one — an `error` code in
+			// the body wins over the status line — which the port now
+			// reproduces because this recording is what revealed it.
+			rustText: `listing drive files: oauth2: "invalid_grant" "Token has been expired or revoked."`,
+		},
+	}
+}
+
+// ─── The generator ───────────────────────────────────────────────────────────
+
+func TestGoogleVectors(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	fake := &fakeGoogle{}
+	srv := httptest.NewServer(fake)
+	defer srv.Close()
+	fake.baseURL = srv.URL
+	restore := google.SetEndpoints(srv.URL, srv.URL+"/token")
+	defer restore()
+
+	want := googleVectors{
+		Comment: []string{
+			"Cross-language parity vectors for internal/integrations/google, the Google",
+			"integration's in-process MCP server. Generated from Go, then frozen. Read by",
+			"desktop/parity/google_parity_test.go (Go) and by",
+			"desktop/src-tauri/src/native/integrations/google/ (Rust).",
+			"Unlike the other five integrations, Google's requests are built by generated",
+			"client libraries rather than by the handlers, so these recordings are the only",
+			"written specification of what goes on the wire — see the test file's header.",
+			"'tools' and 'hosting' come from live tools/list calls against servers built by",
+			"google.Start; 'calls' and 'refreshes' from live tools/call calls against a",
+			"scripted fake Google that records every request each tool built.",
+			"The client secret, refresh token and access token are fixtures, not secrets:",
+			"they are recorded because the refresh request body is a parity surface.",
+			"X-Goog-Api-Client and User-Agent are deliberately not recorded (they embed the",
+			"Go toolchain version) and neither is the random multipart boundary.",
+			"Regenerate with: go test ./desktop/parity/ -run TestGoogleVectors -update-google-vectors",
+		},
+		IntegrationID:  googleParityID,
+		ServerName:     fmt.Sprintf("google-%s", googleParityID),
+		Version:        "1.0.0",
+		ClientID:       googleClientID,
+		ClientSecret:   googleClientSecret,
+		RefreshToken:   googleRefreshToken,
+		AccessToken:    googleAccessToken,
+		NowPlaceholder: googleNowPlaceholder,
+	}
+
+	session := googleSession(t, ctx, googleAllServices(), googleHour())
+	listed, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("tools/list: %v", err)
+	}
+	for _, tool := range listed.Tools {
+		schema, err := json.Marshal(tool.InputSchema)
+		if err != nil {
+			t.Fatalf("encoding %s's input schema: %v", tool.Name, err)
+		}
+		want.Tools = append(want.Tools, googleToolVector{
+			Name:        tool.Name,
+			Description: tool.Description,
+			InputSchema: schema,
+		})
+	}
+
+	for _, hosting := range googleHostingCases {
+		hosting.Tools = googleHostedTools(t, ctx, hosting.Services)
+		want.Hosting = append(want.Hosting, hosting)
+	}
+
+	for _, c := range googleCallCases() {
+		want.Calls = append(want.Calls, runGoogleCallCase(t, ctx, session, fake, c))
+	}
+
+	for _, c := range googleRefreshCases() {
+		want.Refreshes = append(want.Refreshes, runGoogleRefreshCase(t, ctx, fake, c))
+	}
+
+	encoded, err := json.MarshalIndent(want, "", "  ")
+	if err != nil {
+		t.Fatalf("encoding vectors: %v", err)
+	}
+	encoded = append(encoded, '\n')
+
+	if *updateGoogleVectors {
+		if err := os.WriteFile(googleVectorsFile, encoded, 0o600); err != nil {
+			t.Fatalf("writing %s: %v", googleVectorsFile, err)
+		}
+		t.Logf("wrote %s", googleVectorsFile)
+		return
+	}
+
+	frozen, err := os.ReadFile(googleVectorsFile)
+	if err != nil {
+		t.Fatalf("reading %s (regenerate with -update-google-vectors): %v",
+			googleVectorsFile, err)
+	}
+	if string(frozen) != string(encoded) {
+		t.Fatalf("%s is stale: this Go toolchain produces different results.\n"+
+			"Regenerate with -update-google-vectors and check what moved — the Rust port "+
+			"in native/integrations/google/ reads the same file and will fail against it. "+
+			"A moved tool name, schema, request or sentence is not a cosmetic diff: the "+
+			"names are in every agent's stored allowlist and in every tool_use block "+
+			"already written, and the sentences are what the model reads. Note that a "+
+			"generated-client or google.golang.org/api bump can move a query or a header "+
+			"without anything in this repository changing.",
+			googleVectorsFile)
+	}
+}
+
+func googleHostedTools(
+	t *testing.T, ctx context.Context, services map[string]config.ServiceConfig,
+) []string {
+	t.Helper()
+	listed, err := googleSession(t, ctx, services, googleHour()).ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("tools/list: %v", err)
+	}
+	names := make([]string, 0, len(listed.Tools))
+	for _, tool := range listed.Tools {
+		names = append(names, tool.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func runGoogleCallCase(
+	t *testing.T, ctx context.Context,
+	session *mcp.ClientSession, fake *fakeGoogle, c googleCallCase,
+) googleCallVector {
+	t.Helper()
+
+	fake.armAPI(c.scripts)
+	// No refresh is expected for these: the shared session's token is an hour
+	// out, so one arriving would be a defect the vector shows.
+	fake.armToken(nil)
+
+	args := jsonArgs(t, c.args)
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{Name: c.tool, Arguments: args})
+	if err != nil {
+		t.Fatalf("%s: tools/call: %v", c.name, err)
+	}
+	if len(result.Content) != 1 {
+		t.Fatalf("%s: want exactly one content block, got %d", c.name, len(result.Content))
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("%s: want text content, got %T", c.name, result.Content[0])
+	}
+	if refresh := fake.recordedToken(); refresh != nil {
+		t.Fatalf("%s: an hour-valid token refreshed, which it must not", c.name)
+	}
+
+	requests := fake.recordedAPI()
+	for i := range requests {
+		requests[i].Target = redactGoogleNow(t, c.name, requests[i].Target)
+	}
+
+	// A result must never carry the client secret or the refresh token, in
+	// either language.
+	if strings.Contains(text.Text, googleClientSecret) ||
+		strings.Contains(text.Text, googleRefreshToken) {
+		t.Fatalf("%s: a credential leaked into a tool result: %s", c.name, text.Text)
+	}
+
+	return googleCallVector{
+		Case:          c.name,
+		Tool:          c.tool,
+		Arguments:     args,
+		Responses:     c.scripts,
+		Requests:      requests,
+		IsError:       result.IsError,
+		Text:          redactGoogleBase(fake, text.Text),
+		RustText:      c.rustText,
+		RustNoRequest: c.rustNoReq,
+	}
+}
+
+func runGoogleRefreshCase(
+	t *testing.T, ctx context.Context, fake *fakeGoogle, c googleRefreshCase,
+) googleRefreshVector {
+	t.Helper()
+
+	fake.armAPI([]googleResponseScript{c.apiResponse})
+	fake.armToken(c.tokenResponse)
+
+	// `list_files` with no arguments: the shortest call that reaches the
+	// transport, so the vector is about the token and nothing else.
+	session := googleSession(t, ctx,
+		map[string]config.ServiceConfig{"drive": {Enabled: true, Tools: []string{"list_files"}}},
+		c.expiresIn)
+	args := jsonArgs(t, map[string]any{"query": "", "max_results": 1})
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{Name: "list_files", Arguments: args})
+	if err != nil {
+		t.Fatalf("%s: tools/call: %v", c.name, err)
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("%s: want text content, got %T", c.name, result.Content[0])
+	}
+
+	var apiRequest *googleRequestVector
+	if seen := fake.recordedAPI(); len(seen) > 0 {
+		apiRequest = &seen[0]
+	}
+
+	return googleRefreshVector{
+		Case:           c.name,
+		ExpiresIn:      c.expiresIn,
+		TokenResponse:  c.tokenResponse,
+		APIResponse:    c.apiResponse,
+		RefreshRequest: fake.recordedToken(),
+		APIRequest:     apiRequest,
+		IsError:        result.IsError,
+		Text:           redactGoogleBase(fake, text.Text),
+		RustText:       c.rustText,
+	}
+}
+
+// googleNowPattern is `time.RFC3339` at seconds precision in UTC — the one shape
+// `view_events`' default `time_min` can take.
+var googleNowPattern = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`)
+
+// googleTimeMinPattern finds the **raw** `timeMin` pair in a recorded target.
+var googleTimeMinPattern = regexp.MustCompile(`timeMin=([^&]*)`)
+
+// redactGoogleNow replaces a `timeMin` that came from `time.Now()` with the
+// placeholder, after checking it is the shape the port must produce. Anything
+// else — including an explicit `time_min` the caller passed — is left alone.
+//
+// The substitution is over the **raw** target rather than a decoded-and-
+// re-encoded one, so every other byte of the query is what the wire carried:
+// re-encoding would make this function, not the generated client, the thing the
+// vectors record.
+func redactGoogleNow(t *testing.T, caseName, target string) string {
+	t.Helper()
+	match := googleTimeMinPattern.FindStringSubmatchIndex(target)
+	if match == nil {
+		return target
+	}
+	raw := target[match[2]:match[3]]
+	decoded, err := url.QueryUnescape(raw)
+	if err != nil {
+		t.Fatalf("%s: undecodable timeMin %q in %q", caseName, raw, target)
+	}
+	if !googleNowPattern.MatchString(decoded) {
+		return target
+	}
+	// An explicit RFC3339 argument matches the pattern too, so only replace one
+	// that is actually close to now.
+	instant, err := time.Parse(time.RFC3339, decoded)
+	if err != nil || time.Since(instant).Abs() > time.Hour {
+		return target
+	}
+	return target[:match[2]] + url.QueryEscape(googleNowPlaceholder) + target[match[3]:]
+}
+
+// redactGoogleBase collapses the fake's ephemeral base URL, which appears in
+// Go's `*url.Error` text and would otherwise change on every run.
+func redactGoogleBase(fake *fakeGoogle, text string) string {
+	if fake.baseURL == "" {
+		return text
+	}
+	return strings.ReplaceAll(text, fake.baseURL, googleFakeBase)
+}

--- a/desktop/parity/google_parity_test.go
+++ b/desktop/parity/google_parity_test.go
@@ -181,6 +181,8 @@ type googleRefreshVector struct {
 	Case string `json:"case"`
 	// Seconds from now; nil is Go's zero `time.Time`, which never expires.
 	ExpiresIn *int64 `json:"expires_in"`
+	// The stored token carries no refresh token at all.
+	NoRefreshToken bool `json:"no_refresh_token"`
 	// The scripted answer from the token endpoint. Absent when no refresh is
 	// expected.
 	TokenResponse *googleResponseScript `json:"token_response"`
@@ -338,7 +340,7 @@ func (f *fakeGoogle) recordedToken() *googleRequestVector {
 // `time.Time`, which never expires.
 func googleSession(
 	t *testing.T, ctx context.Context,
-	services map[string]config.ServiceConfig, expiresIn *int64,
+	services map[string]config.ServiceConfig, expiresIn *int64, noRefreshToken bool,
 ) *mcp.ClientSession {
 	t.Helper()
 
@@ -357,6 +359,9 @@ func googleSession(
 		AccessToken:  googleAccessToken,
 		RefreshToken: googleRefreshToken,
 		TokenType:    "Bearer",
+	}
+	if noRefreshToken {
+		token.RefreshToken = ""
 	}
 	if expiresIn != nil {
 		token.Expiry = time.Now().Add(time.Duration(*expiresIn) * time.Second)
@@ -841,6 +846,174 @@ func googleCallCases() []googleCallCase {
 				Body: `{"error":{"code":403,"message":"Insufficient Permission","errors":[{"reason":"insufficientPermissions","message":"Insufficient Permission"}]}}`}},
 		},
 
+		// ─── googleapi.Error's remaining shapes, all found by review ─────────
+		{
+			// `Error()`'s one-error form is **conditional** on the sub-error's
+			// message equalling the top-level one. When they differ — the normal
+			// shape for a validation error, where the top level is generic and
+			// the item is specific — it takes the "More details" branch instead.
+			// The first fixture above passes only because its two messages
+			// happen to match.
+			name: "create_event/one error whose message differs takes the More details branch",
+			tool: "create_event",
+			args: map[string]any{
+				"summary": "s", "start": "2026-03-01T10:00:00Z",
+				"end": "2026-03-01T10:30:00Z", "description": "",
+			},
+			scripts: []googleResponseScript{{Status: http.StatusForbidden,
+				Body: `{"error":{"code":403,"message":"Insufficient Permission","errors":[{"message":"a different message","reason":"insufficientPermissions"}]}}`}},
+		},
+		{
+			// `error.details` is the modern envelope — `google.rpc.ErrorInfo`,
+			// `QuotaFailure` — and it is what a real quota error carries. Go
+			// renders it as an indented JSON block before the errors section.
+			name: "create_event/an error carrying details renders them as an indented block",
+			tool: "create_event",
+			args: map[string]any{
+				"summary": "s", "start": "2026-03-01T10:00:00Z",
+				"end": "2026-03-01T10:30:00Z", "description": "",
+			},
+			scripts: []googleResponseScript{{Status: http.StatusTooManyRequests,
+				Body: `{"error":{"code":429,"message":"Quota exceeded","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"RATE_LIMIT_EXCEEDED","domain":"googleapis.com"}]}}`}},
+		},
+		{
+			name: "create_event/details and errors together",
+			tool: "create_event",
+			args: map[string]any{
+				"summary": "s", "start": "2026-03-01T10:00:00Z",
+				"end": "2026-03-01T10:30:00Z", "description": "",
+			},
+			scripts: []googleResponseScript{{Status: http.StatusBadRequest,
+				Body: `{"error":{"code":400,"message":"Bad","details":[{"a":1}],"errors":[{"reason":"r1","message":"m1"}]}}`}},
+		},
+		{
+			// An `errors` array alone is enough to take the structured branch:
+			// the raw-form test is `len(Errors) == 0 && Message == ""`, and the
+			// code defaults to the HTTP status.
+			name: "create_event/an error with neither code nor message but an errors array",
+			tool: "create_event",
+			args: map[string]any{
+				"summary": "s", "start": "2026-03-01T10:00:00Z",
+				"end": "2026-03-01T10:30:00Z", "description": "",
+			},
+			scripts: []googleResponseScript{{Status: http.StatusForbidden,
+				Body: `{"error":{"errors":[{"reason":"r","message":"m"}]}}`}},
+		},
+		{
+			// `errorReplyFromBody` explicitly handles a body beginning with `[`.
+			name: "create_event/a top-level array error body is unwrapped",
+			tool: "create_event",
+			args: map[string]any{
+				"summary": "s", "start": "2026-03-01T10:00:00Z",
+				"end": "2026-03-01T10:30:00Z", "description": "",
+			},
+			scripts: []googleResponseScript{{Status: http.StatusForbidden,
+				Body: `[{"error":{"code":403,"message":"from an array"}}]`}},
+		},
+		{
+			// `Errors` is a **value** slice, so a null element is the zero
+			// `ErrorItem` rather than a decode failure.
+			name: "create_event/a null element in the errors array is a zero value",
+			tool: "create_event",
+			args: map[string]any{
+				"summary": "s", "start": "2026-03-01T10:00:00Z",
+				"end": "2026-03-01T10:30:00Z", "description": "",
+			},
+			scripts: []googleResponseScript{{Status: http.StatusForbidden,
+				Body: `{"error":{"code":403,"message":"Denied","errors":[null]}}`}},
+		},
+
+		// ─── omitempty reaches more than description ─────────────────────────
+		{
+			// `calendar.Event.Summary` and `EventDateTime.DateTime` carry
+			// `omitempty` too, so an empty `start` sends a `start` object holding
+			// nothing but its time zone — and an empty summary sends no key.
+			name: "create_event/omitempty applies to summary and dateTime, not only description",
+			tool: "create_event",
+			args: map[string]any{
+				"summary": "", "start": "", "end": "2026-01-01T00:00:00Z", "description": "",
+			},
+			scripts: googleOK(createdEvent),
+		},
+		{
+			name:    "create_file/an empty name sends no name key in the metadata",
+			tool:    "create_file",
+			args:    map[string]any{"name": "", "content": "x", "mime_type": ""},
+			scripts: googleOK(`{"id":"f13","name":"","webViewLink":"l"}`),
+		},
+
+		// ─── DetectContentType is a table, not a text/binary test ────────────
+		{
+			// `BM` is a two-byte signature, so *any* content starting with those
+			// letters uploads as a bitmap. The port's claim that a binary
+			// signature "cannot arrive as one byte" is false for every ASCII
+			// one.
+			name:    "create_file/content beginning BM sniffs as image/bmp",
+			tool:    "create_file",
+			args:    map[string]any{"name": "bmi.txt", "content": "BMI calculator results", "mime_type": ""},
+			scripts: googleOK(`{"id":"f14","name":"bmi.txt","webViewLink":"l"}`),
+		},
+		{
+			name:    "create_file/content beginning %PDF- sniffs as application/pdf",
+			tool:    "create_file",
+			args:    map[string]any{"name": "a", "content": "%PDF-1.4 not really", "mime_type": ""},
+			scripts: googleOK(`{"id":"f15","name":"a","webViewLink":"l"}`),
+		},
+		{
+			name:    "create_file/content beginning GIF89a sniffs as image/gif",
+			tool:    "create_file",
+			args:    map[string]any{"name": "a", "content": "GIF89a still text", "mime_type": ""},
+			scripts: googleOK(`{"id":"f16","name":"a","webViewLink":"l"}`),
+		},
+		{
+			name:    "create_file/content beginning ID3 sniffs as audio/mpeg",
+			tool:    "create_file",
+			args:    map[string]any{"name": "a", "content": "ID3 v2 notes", "mime_type": ""},
+			scripts: googleOK(`{"id":"f17","name":"a","webViewLink":"l"}`),
+		},
+		{
+			// The sniff reads at most 512 bytes, so a control byte past that
+			// offset does not make the upload binary.
+			name: "create_file/a control byte past 512 bytes does not reach the sniff",
+			tool: "create_file",
+			args: map[string]any{
+				"name": "a", "content": strings.Repeat("a", 600) + "\u0000", "mime_type": "",
+			},
+			scripts: googleOK(`{"id":"f18","name":"a","webViewLink":"l"}`),
+		},
+		{
+			name: "create_file/a control byte inside 512 bytes does",
+			tool: "create_file",
+			args: map[string]any{
+				"name": "a", "content": strings.Repeat("a", 10) + "\u0000", "mime_type": "",
+			},
+			scripts: googleOK(`{"id":"f19","name":"a","webViewLink":"l"}`),
+		},
+
+		// ─── a null element in a Gmail parts array ───────────────────────────
+		{
+			// `extractBody` has an explicit nil check, so a null part is skipped
+			// — the one place in this integration where Go handles a null
+			// element gracefully rather than panicking.
+			name:    "read_email/a null element in parts is skipped, not a decode failure",
+			tool:    "read_email",
+			args:    map[string]any{"message_id": "m"},
+			scripts: googleOK(`{"payload":{"mimeType":"multipart/mixed","headers":[],"parts":[null,{"mimeType":"text/plain","body":{"data":"aGk="}}]}}`),
+		},
+
+		// ─── an empty 2xx body ───────────────────────────────────────────────
+		{
+			// `DecodeResponse` returns without touching the target on a 204, so
+			// the handler renders zero values rather than erroring.
+			name: "create_event/a 204 renders zero values rather than failing to decode",
+			tool: "create_event",
+			args: map[string]any{
+				"summary": "s", "start": "2026-03-01T10:00:00Z",
+				"end": "2026-03-01T10:30:00Z", "description": "",
+			},
+			scripts: []googleResponseScript{{Status: http.StatusNoContent, Body: ""}},
+		},
+
 		// ─── a zero-fraction float for an integer field ───────────────────────
 		{
 			name:      "view_events/a zero-fraction float is an integer to Go and not to serde",
@@ -861,6 +1034,9 @@ type googleRefreshCase struct {
 	tokenResponse *googleResponseScript
 	apiResponse   googleResponseScript
 	rustText      string
+	// Stores a token with no refresh token at all, which `tokenRefresher` short
+	// circuits on before opening a socket.
+	noRefreshToken bool
 }
 
 func googleSeconds(n int64) *int64 { return &n }
@@ -901,6 +1077,20 @@ func googleRefreshCases() []googleRefreshCase {
 			tokenResponse: &googleResponseScript{Status: http.StatusOK,
 				Body: `{"access_token":"ya29.refreshed-2","token_type":"Bearer","expires_in":3599}`},
 			apiResponse: ok,
+		},
+		{
+			// `tokenRefresher.Token` refuses **before** any request when there is
+			// no refresh token — which is the state a re-consent without
+			// `prompt=consent` leaves a row in. Reproducing the refusal is what
+			// keeps the port from transmitting the client secret on a request Go
+			// never sends.
+			name:           "an expired token with no refresh token is refused before any request",
+			expiresIn:      googleSeconds(-60),
+			noRefreshToken: true,
+			apiResponse:    ok,
+			// Only the `*url.Error` wrapper diverges; the sentence itself is
+			// reproduced, and so is the fact that no socket is opened.
+			rustText: "listing drive files: oauth2: token expired and refresh token is not set",
 		},
 		{
 			// The failure surfaces as the **tool's** failure, because `oauth2`'s
@@ -961,7 +1151,7 @@ func TestGoogleVectors(t *testing.T) {
 		NowPlaceholder: googleNowPlaceholder,
 	}
 
-	session := googleSession(t, ctx, googleAllServices(), googleHour())
+	session := googleSession(t, ctx, googleAllServices(), googleHour(), false)
 	listed, err := session.ListTools(ctx, nil)
 	if err != nil {
 		t.Fatalf("tools/list: %v", err)
@@ -1027,7 +1217,7 @@ func googleHostedTools(
 	t *testing.T, ctx context.Context, services map[string]config.ServiceConfig,
 ) []string {
 	t.Helper()
-	listed, err := googleSession(t, ctx, services, googleHour()).ListTools(ctx, nil)
+	listed, err := googleSession(t, ctx, services, googleHour(), false).ListTools(ctx, nil)
 	if err != nil {
 		t.Fatalf("tools/list: %v", err)
 	}
@@ -1103,7 +1293,7 @@ func runGoogleRefreshCase(
 	// transport, so the vector is about the token and nothing else.
 	session := googleSession(t, ctx,
 		map[string]config.ServiceConfig{"drive": {Enabled: true, Tools: []string{"list_files"}}},
-		c.expiresIn)
+		c.expiresIn, c.noRefreshToken)
 	args := jsonArgs(t, map[string]any{"query": "", "max_results": 1})
 	result, err := session.CallTool(ctx, &mcp.CallToolParams{Name: "list_files", Arguments: args})
 	if err != nil {
@@ -1122,6 +1312,7 @@ func runGoogleRefreshCase(
 	return googleRefreshVector{
 		Case:           c.name,
 		ExpiresIn:      c.expiresIn,
+		NoRefreshToken: c.noRefreshToken,
 		TokenResponse:  c.tokenResponse,
 		APIResponse:    c.apiResponse,
 		RefreshRequest: fake.recordedToken(),

--- a/desktop/parity/google_vectors.json
+++ b/desktop/parity/google_vectors.json
@@ -1511,6 +1511,490 @@
       "text": "downloading drive file \"f3\": googleapi: Error 403: Insufficient Permission, insufficientPermissions"
     },
     {
+      "case": "create_event/one error whose message differs takes the More details branch",
+      "tool": "create_event",
+      "arguments": {
+        "description": "",
+        "end": "2026-03-01T10:30:00Z",
+        "start": "2026-03-01T10:00:00Z",
+        "summary": "s"
+      },
+      "responses": [
+        {
+          "status": 403,
+          "body": "{\"error\":{\"code\":403,\"message\":\"Insufficient Permission\",\"errors\":[{\"message\":\"a different message\",\"reason\":\"insufficientPermissions\"}]}}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/calendars/primary/events?alt=json\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "application/json",
+          "body": "{\"end\":{\"dateTime\":\"2026-03-01T10:30:00Z\",\"timeZone\":\"UTC\"},\"start\":{\"dateTime\":\"2026-03-01T10:00:00Z\",\"timeZone\":\"UTC\"},\"summary\":\"s\"}\n"
+        }
+      ],
+      "is_error": true,
+      "text": "creating calendar event: googleapi: Error 403: Insufficient Permission\nMore details:\nReason: insufficientPermissions, Message: a different message\n"
+    },
+    {
+      "case": "create_event/an error carrying details renders them as an indented block",
+      "tool": "create_event",
+      "arguments": {
+        "description": "",
+        "end": "2026-03-01T10:30:00Z",
+        "start": "2026-03-01T10:00:00Z",
+        "summary": "s"
+      },
+      "responses": [
+        {
+          "status": 429,
+          "body": "{\"error\":{\"code\":429,\"message\":\"Quota exceeded\",\"details\":[{\"@type\":\"type.googleapis.com/google.rpc.ErrorInfo\",\"reason\":\"RATE_LIMIT_EXCEEDED\",\"domain\":\"googleapis.com\"}]}}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/calendars/primary/events?alt=json\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "application/json",
+          "body": "{\"end\":{\"dateTime\":\"2026-03-01T10:30:00Z\",\"timeZone\":\"UTC\"},\"start\":{\"dateTime\":\"2026-03-01T10:00:00Z\",\"timeZone\":\"UTC\"},\"summary\":\"s\"}\n"
+        }
+      ],
+      "is_error": true,
+      "text": "creating calendar event: googleapi: Error 429: Quota exceeded\nDetails:\n[\n  {\n    \"@type\": \"type.googleapis.com/google.rpc.ErrorInfo\",\n    \"domain\": \"googleapis.com\",\n    \"reason\": \"RATE_LIMIT_EXCEEDED\"\n  }\n]"
+    },
+    {
+      "case": "create_event/details and errors together",
+      "tool": "create_event",
+      "arguments": {
+        "description": "",
+        "end": "2026-03-01T10:30:00Z",
+        "start": "2026-03-01T10:00:00Z",
+        "summary": "s"
+      },
+      "responses": [
+        {
+          "status": 400,
+          "body": "{\"error\":{\"code\":400,\"message\":\"Bad\",\"details\":[{\"a\":1}],\"errors\":[{\"reason\":\"r1\",\"message\":\"m1\"}]}}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/calendars/primary/events?alt=json\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "application/json",
+          "body": "{\"end\":{\"dateTime\":\"2026-03-01T10:30:00Z\",\"timeZone\":\"UTC\"},\"start\":{\"dateTime\":\"2026-03-01T10:00:00Z\",\"timeZone\":\"UTC\"},\"summary\":\"s\"}\n"
+        }
+      ],
+      "is_error": true,
+      "text": "creating calendar event: googleapi: Error 400: Bad\nDetails:\n[\n  {\n    \"a\": 1\n  }\n]\n\nMore details:\nReason: r1, Message: m1\n"
+    },
+    {
+      "case": "create_event/an error with neither code nor message but an errors array",
+      "tool": "create_event",
+      "arguments": {
+        "description": "",
+        "end": "2026-03-01T10:30:00Z",
+        "start": "2026-03-01T10:00:00Z",
+        "summary": "s"
+      },
+      "responses": [
+        {
+          "status": 403,
+          "body": "{\"error\":{\"errors\":[{\"reason\":\"r\",\"message\":\"m\"}]}}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/calendars/primary/events?alt=json\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "application/json",
+          "body": "{\"end\":{\"dateTime\":\"2026-03-01T10:30:00Z\",\"timeZone\":\"UTC\"},\"start\":{\"dateTime\":\"2026-03-01T10:00:00Z\",\"timeZone\":\"UTC\"},\"summary\":\"s\"}\n"
+        }
+      ],
+      "is_error": true,
+      "text": "creating calendar event: googleapi: Error 403: \nMore details:\nReason: r, Message: m\n"
+    },
+    {
+      "case": "create_event/a top-level array error body is unwrapped",
+      "tool": "create_event",
+      "arguments": {
+        "description": "",
+        "end": "2026-03-01T10:30:00Z",
+        "start": "2026-03-01T10:00:00Z",
+        "summary": "s"
+      },
+      "responses": [
+        {
+          "status": 403,
+          "body": "[{\"error\":{\"code\":403,\"message\":\"from an array\"}}]"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/calendars/primary/events?alt=json\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "application/json",
+          "body": "{\"end\":{\"dateTime\":\"2026-03-01T10:30:00Z\",\"timeZone\":\"UTC\"},\"start\":{\"dateTime\":\"2026-03-01T10:00:00Z\",\"timeZone\":\"UTC\"},\"summary\":\"s\"}\n"
+        }
+      ],
+      "is_error": true,
+      "text": "creating calendar event: googleapi: Error 403: from an array"
+    },
+    {
+      "case": "create_event/a null element in the errors array is a zero value",
+      "tool": "create_event",
+      "arguments": {
+        "description": "",
+        "end": "2026-03-01T10:30:00Z",
+        "start": "2026-03-01T10:00:00Z",
+        "summary": "s"
+      },
+      "responses": [
+        {
+          "status": 403,
+          "body": "{\"error\":{\"code\":403,\"message\":\"Denied\",\"errors\":[null]}}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/calendars/primary/events?alt=json\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "application/json",
+          "body": "{\"end\":{\"dateTime\":\"2026-03-01T10:30:00Z\",\"timeZone\":\"UTC\"},\"start\":{\"dateTime\":\"2026-03-01T10:00:00Z\",\"timeZone\":\"UTC\"},\"summary\":\"s\"}\n"
+        }
+      ],
+      "is_error": true,
+      "text": "creating calendar event: googleapi: Error 403: Denied\nMore details:\nReason: , Message: \n"
+    },
+    {
+      "case": "create_event/omitempty applies to summary and dateTime, not only description",
+      "tool": "create_event",
+      "arguments": {
+        "description": "",
+        "end": "2026-01-01T00:00:00Z",
+        "start": "",
+        "summary": ""
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"id\":\"ev1\",\"summary\":\"Standup\",\"htmlLink\":\"https://cal/ev1\"}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/calendars/primary/events?alt=json\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "application/json",
+          "body": "{\"end\":{\"dateTime\":\"2026-01-01T00:00:00Z\",\"timeZone\":\"UTC\"},\"start\":{\"timeZone\":\"UTC\"}}\n"
+        }
+      ],
+      "is_error": false,
+      "text": "Event created: Standup\nID: ev1\nLink: https://cal/ev1"
+    },
+    {
+      "case": "create_file/an empty name sends no name key in the metadata",
+      "tool": "create_file",
+      "arguments": {
+        "content": "x",
+        "mime_type": "",
+        "name": ""
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"id\":\"f13\",\"name\":\"\",\"webViewLink\":\"l\"}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/upload/drive/v3/files?alt=json\u0026fields=id%2Cname%2CwebViewLink\u0026prettyPrint=false\u0026uploadType=multipart",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "multipart/related",
+          "parts": [
+            {
+              "content_type": "application/json",
+              "body": "{\"mimeType\":\"text/plain\"}\n"
+            },
+            {
+              "content_type": "text/plain; charset=utf-8",
+              "body": "x"
+            }
+          ]
+        }
+      ],
+      "is_error": false,
+      "text": "File created: \nID: f13\nLink: l"
+    },
+    {
+      "case": "create_file/content beginning BM sniffs as image/bmp",
+      "tool": "create_file",
+      "arguments": {
+        "content": "BMI calculator results",
+        "mime_type": "",
+        "name": "bmi.txt"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"id\":\"f14\",\"name\":\"bmi.txt\",\"webViewLink\":\"l\"}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/upload/drive/v3/files?alt=json\u0026fields=id%2Cname%2CwebViewLink\u0026prettyPrint=false\u0026uploadType=multipart",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "multipart/related",
+          "parts": [
+            {
+              "content_type": "application/json",
+              "body": "{\"mimeType\":\"text/plain\",\"name\":\"bmi.txt\"}\n"
+            },
+            {
+              "content_type": "image/bmp",
+              "body": "BMI calculator results"
+            }
+          ]
+        }
+      ],
+      "is_error": false,
+      "text": "File created: bmi.txt\nID: f14\nLink: l"
+    },
+    {
+      "case": "create_file/content beginning %PDF- sniffs as application/pdf",
+      "tool": "create_file",
+      "arguments": {
+        "content": "%PDF-1.4 not really",
+        "mime_type": "",
+        "name": "a"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"id\":\"f15\",\"name\":\"a\",\"webViewLink\":\"l\"}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/upload/drive/v3/files?alt=json\u0026fields=id%2Cname%2CwebViewLink\u0026prettyPrint=false\u0026uploadType=multipart",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "multipart/related",
+          "parts": [
+            {
+              "content_type": "application/json",
+              "body": "{\"mimeType\":\"text/plain\",\"name\":\"a\"}\n"
+            },
+            {
+              "content_type": "application/pdf",
+              "body": "%PDF-1.4 not really"
+            }
+          ]
+        }
+      ],
+      "is_error": false,
+      "text": "File created: a\nID: f15\nLink: l"
+    },
+    {
+      "case": "create_file/content beginning GIF89a sniffs as image/gif",
+      "tool": "create_file",
+      "arguments": {
+        "content": "GIF89a still text",
+        "mime_type": "",
+        "name": "a"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"id\":\"f16\",\"name\":\"a\",\"webViewLink\":\"l\"}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/upload/drive/v3/files?alt=json\u0026fields=id%2Cname%2CwebViewLink\u0026prettyPrint=false\u0026uploadType=multipart",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "multipart/related",
+          "parts": [
+            {
+              "content_type": "application/json",
+              "body": "{\"mimeType\":\"text/plain\",\"name\":\"a\"}\n"
+            },
+            {
+              "content_type": "image/gif",
+              "body": "GIF89a still text"
+            }
+          ]
+        }
+      ],
+      "is_error": false,
+      "text": "File created: a\nID: f16\nLink: l"
+    },
+    {
+      "case": "create_file/content beginning ID3 sniffs as audio/mpeg",
+      "tool": "create_file",
+      "arguments": {
+        "content": "ID3 v2 notes",
+        "mime_type": "",
+        "name": "a"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"id\":\"f17\",\"name\":\"a\",\"webViewLink\":\"l\"}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/upload/drive/v3/files?alt=json\u0026fields=id%2Cname%2CwebViewLink\u0026prettyPrint=false\u0026uploadType=multipart",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "multipart/related",
+          "parts": [
+            {
+              "content_type": "application/json",
+              "body": "{\"mimeType\":\"text/plain\",\"name\":\"a\"}\n"
+            },
+            {
+              "content_type": "audio/mpeg",
+              "body": "ID3 v2 notes"
+            }
+          ]
+        }
+      ],
+      "is_error": false,
+      "text": "File created: a\nID: f17\nLink: l"
+    },
+    {
+      "case": "create_file/a control byte past 512 bytes does not reach the sniff",
+      "tool": "create_file",
+      "arguments": {
+        "content": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\u0000",
+        "mime_type": "",
+        "name": "a"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"id\":\"f18\",\"name\":\"a\",\"webViewLink\":\"l\"}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/upload/drive/v3/files?alt=json\u0026fields=id%2Cname%2CwebViewLink\u0026prettyPrint=false\u0026uploadType=multipart",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "multipart/related",
+          "parts": [
+            {
+              "content_type": "application/json",
+              "body": "{\"mimeType\":\"text/plain\",\"name\":\"a\"}\n"
+            },
+            {
+              "content_type": "text/plain; charset=utf-8",
+              "body": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\u0000"
+            }
+          ]
+        }
+      ],
+      "is_error": false,
+      "text": "File created: a\nID: f18\nLink: l"
+    },
+    {
+      "case": "create_file/a control byte inside 512 bytes does",
+      "tool": "create_file",
+      "arguments": {
+        "content": "aaaaaaaaaa\u0000",
+        "mime_type": "",
+        "name": "a"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"id\":\"f19\",\"name\":\"a\",\"webViewLink\":\"l\"}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/upload/drive/v3/files?alt=json\u0026fields=id%2Cname%2CwebViewLink\u0026prettyPrint=false\u0026uploadType=multipart",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "multipart/related",
+          "parts": [
+            {
+              "content_type": "application/json",
+              "body": "{\"mimeType\":\"text/plain\",\"name\":\"a\"}\n"
+            },
+            {
+              "content_type": "application/octet-stream",
+              "body": "aaaaaaaaaa\u0000"
+            }
+          ]
+        }
+      ],
+      "is_error": false,
+      "text": "File created: a\nID: f19\nLink: l"
+    },
+    {
+      "case": "read_email/a null element in parts is skipped, not a decode failure",
+      "tool": "read_email",
+      "arguments": {
+        "message_id": "m"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"payload\":{\"mimeType\":\"multipart/mixed\",\"headers\":[],\"parts\":[null,{\"mimeType\":\"text/plain\",\"body\":{\"data\":\"aGk=\"}}]}}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "GET",
+          "target": "/gmail/v1/users/me/messages/m?alt=json\u0026format=full\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        }
+      ],
+      "is_error": false,
+      "text": "Subject: \nFrom: \nDate: \n\nhi"
+    },
+    {
+      "case": "create_event/a 204 renders zero values rather than failing to decode",
+      "tool": "create_event",
+      "arguments": {
+        "description": "",
+        "end": "2026-03-01T10:30:00Z",
+        "start": "2026-03-01T10:00:00Z",
+        "summary": "s"
+      },
+      "responses": [
+        {
+          "status": 204,
+          "body": ""
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/calendars/primary/events?alt=json\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "application/json",
+          "body": "{\"end\":{\"dateTime\":\"2026-03-01T10:30:00Z\",\"timeZone\":\"UTC\"},\"start\":{\"dateTime\":\"2026-03-01T10:00:00Z\",\"timeZone\":\"UTC\"},\"summary\":\"s\"}\n"
+        }
+      ],
+      "is_error": false,
+      "text": "Event created: \nID: \nLink: "
+    },
+    {
       "case": "view_events/a zero-fraction float is an integer to Go and not to serde",
       "tool": "view_events",
       "arguments": {
@@ -1542,6 +2026,7 @@
     {
       "case": "a token an hour from expiry is reused without a refresh",
       "expires_in": 3600,
+      "no_refresh_token": false,
       "token_response": null,
       "api_response": {
         "status": 200,
@@ -1560,6 +2045,7 @@
     {
       "case": "a token with no expiry never refreshes",
       "expires_in": null,
+      "no_refresh_token": false,
       "token_response": null,
       "api_response": {
         "status": 200,
@@ -1578,6 +2064,7 @@
     {
       "case": "a token five seconds from expiry refreshes inside the delta",
       "expires_in": 5,
+      "no_refresh_token": false,
       "token_response": {
         "status": 200,
         "body": "{\"access_token\":\"ya29.refreshed\",\"token_type\":\"Bearer\",\"expires_in\":3599}"
@@ -1605,6 +2092,7 @@
     {
       "case": "an expired token refreshes and the new access token reaches the request",
       "expires_in": -60,
+      "no_refresh_token": false,
       "token_response": {
         "status": 200,
         "body": "{\"access_token\":\"ya29.refreshed-2\",\"token_type\":\"Bearer\",\"expires_in\":3599}"
@@ -1630,8 +2118,24 @@
       "text": "No files found."
     },
     {
+      "case": "an expired token with no refresh token is refused before any request",
+      "expires_in": -60,
+      "no_refresh_token": true,
+      "token_response": null,
+      "api_response": {
+        "status": 200,
+        "body": "{\"files\":[]}"
+      },
+      "refresh_request": null,
+      "api_request": null,
+      "is_error": true,
+      "text": "listing drive files: Get \"«api»/files?alt=json\u0026fields=files%28id%2Cname%2CmimeType%2Csize%2CmodifiedTime%2CwebViewLink%29\u0026pageSize=1\u0026prettyPrint=false\": oauth2: token expired and refresh token is not set",
+      "rust_text": "listing drive files: oauth2: token expired and refresh token is not set"
+    },
+    {
       "case": "a refused refresh surfaces as the tool's own failure",
       "expires_in": -60,
+      "no_refresh_token": false,
       "token_response": {
         "status": 400,
         "body": "{\"error\":\"invalid_grant\",\"error_description\":\"Token has been expired or revoked.\"}"

--- a/desktop/parity/google_vectors.json
+++ b/desktop/parity/google_vectors.json
@@ -1,0 +1,1656 @@
+{
+  "_comment": [
+    "Cross-language parity vectors for internal/integrations/google, the Google",
+    "integration's in-process MCP server. Generated from Go, then frozen. Read by",
+    "desktop/parity/google_parity_test.go (Go) and by",
+    "desktop/src-tauri/src/native/integrations/google/ (Rust).",
+    "Unlike the other five integrations, Google's requests are built by generated",
+    "client libraries rather than by the handlers, so these recordings are the only",
+    "written specification of what goes on the wire — see the test file's header.",
+    "'tools' and 'hosting' come from live tools/list calls against servers built by",
+    "google.Start; 'calls' and 'refreshes' from live tools/call calls against a",
+    "scripted fake Google that records every request each tool built.",
+    "The client secret, refresh token and access token are fixtures, not secrets:",
+    "they are recorded because the refresh request body is a parity surface.",
+    "X-Goog-Api-Client and User-Agent are deliberately not recorded (they embed the",
+    "Go toolchain version) and neither is the random multipart boundary.",
+    "Regenerate with: go test ./desktop/parity/ -run TestGoogleVectors -update-google-vectors"
+  ],
+  "integration_id": "goog-parity",
+  "server_name": "google-goog-parity",
+  "version": "1.0.0",
+  "client_id": "parity-client-id.apps.googleusercontent.com",
+  "client_secret": "GOCSPX-parity-client-secret",
+  "refresh_token": "1//parity-refresh-token",
+  "access_token": "ya29.parity-access-token",
+  "now_placeholder": "«now»",
+  "tools": [
+    {
+      "name": "create_event",
+      "description": "Creates a new event on the user's primary Google Calendar.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "description": "Optional description of the event",
+            "type": "string"
+          },
+          "end": {
+            "description": "required,End time in RFC3339 format",
+            "type": "string"
+          },
+          "start": {
+            "description": "required,Start time in RFC3339 format (e.g. 2026-03-01T10:00:00-07:00)",
+            "type": "string"
+          },
+          "summary": {
+            "description": "required,The title of the event",
+            "type": "string"
+          }
+        },
+        "required": [
+          "summary",
+          "start",
+          "end",
+          "description"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "create_file",
+      "description": "Creates a new file in Google Drive with the provided content.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "description": "required,Text content of the file",
+            "type": "string"
+          },
+          "mime_type": {
+            "description": "MIME type (default: text/plain)",
+            "type": "string"
+          },
+          "name": {
+            "description": "required,Name of the file to create",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "content",
+          "mime_type"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "download_file",
+      "description": "Downloads and returns the text content of a Google Drive file by its ID.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "file_id": {
+            "description": "required,The Google Drive file ID to download",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_id"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_files",
+      "description": "Lists files and folders in Google Drive.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "max_results": {
+            "description": "Maximum number of files to return (default 10, max 100)",
+            "type": "integer"
+          },
+          "query": {
+            "description": "Optional Drive query string (e.g. \"name contains 'report'\")",
+            "type": "string"
+          }
+        },
+        "required": [
+          "query",
+          "max_results"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "read_email",
+      "description": "Reads the full content of a Gmail message by its ID.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "message_id": {
+            "description": "required,The Gmail message ID to read",
+            "type": "string"
+          }
+        },
+        "required": [
+          "message_id"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "search_email",
+      "description": "Searches Gmail messages using Gmail query syntax (e.g. 'from:alice@example.com is:unread').",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "max_results": {
+            "description": "Maximum number of messages to return (default 10, max 50)",
+            "type": "integer"
+          },
+          "query": {
+            "description": "required,Gmail search query (e.g. 'from:alice@example.com is:unread')",
+            "type": "string"
+          }
+        },
+        "required": [
+          "query",
+          "max_results"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "send_email",
+      "description": "Sends an email via Gmail.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "description": "required,Plain text body of the email",
+            "type": "string"
+          },
+          "subject": {
+            "description": "required,Email subject line",
+            "type": "string"
+          },
+          "to": {
+            "description": "required,Recipient email address(es), comma-separated",
+            "type": "string"
+          }
+        },
+        "required": [
+          "to",
+          "subject",
+          "body"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "name": "view_events",
+      "description": "Lists events from the user's primary Google Calendar within an optional time range.",
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "max_results": {
+            "description": "Maximum number of events to return (default 10, max 100)",
+            "type": "integer"
+          },
+          "time_max": {
+            "description": "Upper bound for event start time in RFC3339 format.",
+            "type": "string"
+          },
+          "time_min": {
+            "description": "Lower bound for event end time in RFC3339 format. Defaults to now.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "time_min",
+          "time_max",
+          "max_results"
+        ],
+        "type": "object"
+      }
+    }
+  ],
+  "hosting": [
+    {
+      "case": "every service enabled with no tool list — an empty allowed set hosts everything",
+      "services": {
+        "calendar": {
+          "enabled": true,
+          "tools": null
+        },
+        "drive": {
+          "enabled": true,
+          "tools": null
+        },
+        "gmail": {
+          "enabled": true,
+          "tools": null
+        }
+      },
+      "tools": [
+        "create_event",
+        "create_file",
+        "download_file",
+        "list_files",
+        "read_email",
+        "search_email",
+        "send_email",
+        "view_events"
+      ]
+    },
+    {
+      "case": "no services at all",
+      "services": {},
+      "tools": []
+    },
+    {
+      "case": "one service enabled hosts only its tools",
+      "services": {
+        "calendar": {
+          "enabled": true,
+          "tools": null
+        }
+      },
+      "tools": [
+        "create_event",
+        "view_events"
+      ]
+    },
+    {
+      "case": "a disabled service contributes neither its gate nor its names",
+      "services": {
+        "calendar": {
+          "enabled": true,
+          "tools": null
+        },
+        "drive": {
+          "enabled": false,
+          "tools": [
+            "create_event"
+          ]
+        },
+        "gmail": {
+          "enabled": true,
+          "tools": null
+        }
+      },
+      "tools": [
+        "create_event",
+        "read_email",
+        "search_email",
+        "send_email",
+        "view_events"
+      ]
+    },
+    {
+      "case": "one tool named under one service narrows every enabled service",
+      "services": {
+        "calendar": {
+          "enabled": true,
+          "tools": null
+        },
+        "drive": {
+          "enabled": true,
+          "tools": null
+        },
+        "gmail": {
+          "enabled": true,
+          "tools": [
+            "send_email"
+          ]
+        }
+      },
+      "tools": [
+        "send_email"
+      ]
+    },
+    {
+      "case": "a name contributed by one service admits a tool belonging to another",
+      "services": {
+        "calendar": {
+          "enabled": true,
+          "tools": null
+        },
+        "drive": {
+          "enabled": true,
+          "tools": null
+        },
+        "gmail": {
+          "enabled": true,
+          "tools": [
+            "send_email",
+            "list_files"
+          ]
+        }
+      },
+      "tools": [
+        "list_files",
+        "send_email"
+      ]
+    },
+    {
+      "case": "an enabled but unknown service still narrows the ones that exist",
+      "services": {
+        "calendar": {
+          "enabled": true,
+          "tools": null
+        },
+        "other": {
+          "enabled": true,
+          "tools": [
+            "view_events"
+          ]
+        }
+      },
+      "tools": [
+        "view_events"
+      ]
+    },
+    {
+      "case": "a tool named by a disabled service is not allowed anywhere",
+      "services": {
+        "calendar": {
+          "enabled": false,
+          "tools": [
+            "create_event"
+          ]
+        },
+        "drive": {
+          "enabled": true,
+          "tools": [
+            "list_files"
+          ]
+        }
+      },
+      "tools": [
+        "list_files"
+      ]
+    }
+  ],
+  "calls": [
+    {
+      "case": "create_event/a full event, with encoding/json's HTML escaping",
+      "tool": "create_event",
+      "arguments": {
+        "description": "notes \u0026 more",
+        "end": "2026-03-01T10:30:00-07:00",
+        "start": "2026-03-01T10:00:00-07:00",
+        "summary": "Standup \u003cdaily\u003e \u0026 sync"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"id\":\"ev1\",\"summary\":\"Standup\",\"htmlLink\":\"https://cal/ev1\"}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/calendars/primary/events?alt=json\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "application/json",
+          "body": "{\"description\":\"notes \\u0026 more\",\"end\":{\"dateTime\":\"2026-03-01T10:30:00-07:00\",\"timeZone\":\"UTC\"},\"start\":{\"dateTime\":\"2026-03-01T10:00:00-07:00\",\"timeZone\":\"UTC\"},\"summary\":\"Standup \\u003cdaily\\u003e \\u0026 sync\"}\n"
+        }
+      ],
+      "is_error": false,
+      "text": "Event created: Standup\nID: ev1\nLink: https://cal/ev1"
+    },
+    {
+      "case": "create_event/an empty description sends no key",
+      "tool": "create_event",
+      "arguments": {
+        "description": "",
+        "end": "2026-03-01T10:30:00Z",
+        "start": "2026-03-01T10:00:00Z",
+        "summary": "Standup"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"id\":\"ev1\",\"summary\":\"Standup\",\"htmlLink\":\"https://cal/ev1\"}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/calendars/primary/events?alt=json\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "application/json",
+          "body": "{\"end\":{\"dateTime\":\"2026-03-01T10:30:00Z\",\"timeZone\":\"UTC\"},\"start\":{\"dateTime\":\"2026-03-01T10:00:00Z\",\"timeZone\":\"UTC\"},\"summary\":\"Standup\"}\n"
+        }
+      ],
+      "is_error": false,
+      "text": "Event created: Standup\nID: ev1\nLink: https://cal/ev1"
+    },
+    {
+      "case": "create_event/the result reads the response and not the request",
+      "tool": "create_event",
+      "arguments": {
+        "description": "",
+        "end": "2026-03-01T10:30:00Z",
+        "start": "2026-03-01T10:00:00Z",
+        "summary": "sent"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"id\":\"ev2\",\"summary\":\"renamed by the server\",\"htmlLink\":\"https://cal/ev2\"}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/calendars/primary/events?alt=json\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "application/json",
+          "body": "{\"end\":{\"dateTime\":\"2026-03-01T10:30:00Z\",\"timeZone\":\"UTC\"},\"start\":{\"dateTime\":\"2026-03-01T10:00:00Z\",\"timeZone\":\"UTC\"},\"summary\":\"sent\"}\n"
+        }
+      ],
+      "is_error": false,
+      "text": "Event created: renamed by the server\nID: ev2\nLink: https://cal/ev2"
+    },
+    {
+      "case": "create_event/null fields decode as zero values",
+      "tool": "create_event",
+      "arguments": {
+        "description": "",
+        "end": "2026-03-01T10:30:00Z",
+        "start": "2026-03-01T10:00:00Z",
+        "summary": "s"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"id\":null,\"summary\":null,\"htmlLink\":null}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/calendars/primary/events?alt=json\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "application/json",
+          "body": "{\"end\":{\"dateTime\":\"2026-03-01T10:30:00Z\",\"timeZone\":\"UTC\"},\"start\":{\"dateTime\":\"2026-03-01T10:00:00Z\",\"timeZone\":\"UTC\"},\"summary\":\"s\"}\n"
+        }
+      ],
+      "is_error": false,
+      "text": "Event created: \nID: \nLink: "
+    },
+    {
+      "case": "create_event/a JSON array is not a struct",
+      "tool": "create_event",
+      "arguments": {
+        "description": "",
+        "end": "2026-03-01T10:30:00Z",
+        "start": "2026-03-01T10:00:00Z",
+        "summary": "s"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "[true]"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/calendars/primary/events?alt=json\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "application/json",
+          "body": "{\"end\":{\"dateTime\":\"2026-03-01T10:30:00Z\",\"timeZone\":\"UTC\"},\"start\":{\"dateTime\":\"2026-03-01T10:00:00Z\",\"timeZone\":\"UTC\"},\"summary\":\"s\"}\n"
+        }
+      ],
+      "is_error": true,
+      "text": "creating calendar event: json: cannot unmarshal array into Go value of type calendar.Event",
+      "rust_text": "creating calendar event: decoding response: invalid type: sequence, expected a JSON object at line 1 column 0"
+    },
+    {
+      "case": "create_event/an error with one reason",
+      "tool": "create_event",
+      "arguments": {
+        "description": "",
+        "end": "2026-03-01T10:30:00Z",
+        "start": "2026-03-01T10:00:00Z",
+        "summary": "s"
+      },
+      "responses": [
+        {
+          "status": 403,
+          "body": "{\"error\":{\"code\":403,\"message\":\"Insufficient Permission\",\"errors\":[{\"message\":\"Insufficient Permission\",\"domain\":\"global\",\"reason\":\"insufficientPermissions\"}]}}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/calendars/primary/events?alt=json\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "application/json",
+          "body": "{\"end\":{\"dateTime\":\"2026-03-01T10:30:00Z\",\"timeZone\":\"UTC\"},\"start\":{\"dateTime\":\"2026-03-01T10:00:00Z\",\"timeZone\":\"UTC\"},\"summary\":\"s\"}\n"
+        }
+      ],
+      "is_error": true,
+      "text": "creating calendar event: googleapi: Error 403: Insufficient Permission, insufficientPermissions"
+    },
+    {
+      "case": "create_event/an error with no errors array",
+      "tool": "create_event",
+      "arguments": {
+        "description": "",
+        "end": "2026-03-01T10:30:00Z",
+        "start": "2026-03-01T10:00:00Z",
+        "summary": "s"
+      },
+      "responses": [
+        {
+          "status": 404,
+          "body": "{\"error\":{\"code\":404,\"message\":\"Not Found\"}}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/calendars/primary/events?alt=json\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "application/json",
+          "body": "{\"end\":{\"dateTime\":\"2026-03-01T10:30:00Z\",\"timeZone\":\"UTC\"},\"start\":{\"dateTime\":\"2026-03-01T10:00:00Z\",\"timeZone\":\"UTC\"},\"summary\":\"s\"}\n"
+        }
+      ],
+      "is_error": true,
+      "text": "creating calendar event: googleapi: Error 404: Not Found"
+    },
+    {
+      "case": "create_event/an error with several reasons",
+      "tool": "create_event",
+      "arguments": {
+        "description": "",
+        "end": "2026-03-01T10:30:00Z",
+        "start": "2026-03-01T10:00:00Z",
+        "summary": "s"
+      },
+      "responses": [
+        {
+          "status": 400,
+          "body": "{\"error\":{\"code\":400,\"message\":\"Bad Request\",\"errors\":[{\"message\":\"m1\",\"reason\":\"r1\"},{\"message\":\"m2\",\"reason\":\"r2\"}]}}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/calendars/primary/events?alt=json\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "application/json",
+          "body": "{\"end\":{\"dateTime\":\"2026-03-01T10:30:00Z\",\"timeZone\":\"UTC\"},\"start\":{\"dateTime\":\"2026-03-01T10:00:00Z\",\"timeZone\":\"UTC\"},\"summary\":\"s\"}\n"
+        }
+      ],
+      "is_error": true,
+      "text": "creating calendar event: googleapi: Error 400: Bad Request\nMore details:\nReason: r1, Message: m1\nReason: r2, Message: m2\n"
+    },
+    {
+      "case": "create_event/a body that is not a Google error document",
+      "tool": "create_event",
+      "arguments": {
+        "description": "",
+        "end": "2026-03-01T10:30:00Z",
+        "start": "2026-03-01T10:00:00Z",
+        "summary": "s"
+      },
+      "responses": [
+        {
+          "status": 403,
+          "body": "{\"error\":\"invalid_grant\",\"error_description\":\"Token has been expired or revoked.\"}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/calendars/primary/events?alt=json\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "application/json",
+          "body": "{\"end\":{\"dateTime\":\"2026-03-01T10:30:00Z\",\"timeZone\":\"UTC\"},\"start\":{\"dateTime\":\"2026-03-01T10:00:00Z\",\"timeZone\":\"UTC\"},\"summary\":\"s\"}\n"
+        }
+      ],
+      "is_error": true,
+      "text": "creating calendar event: googleapi: got HTTP response code 403 with body: {\"error\":\"invalid_grant\",\"error_description\":\"Token has been expired or revoked.\"}"
+    },
+    {
+      "case": "create_event/an error body that is not JSON at all",
+      "tool": "create_event",
+      "arguments": {
+        "description": "",
+        "end": "2026-03-01T10:30:00Z",
+        "start": "2026-03-01T10:00:00Z",
+        "summary": "s"
+      },
+      "responses": [
+        {
+          "status": 502,
+          "body": "\u003chtml\u003enope\u003c/html\u003e"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/calendars/primary/events?alt=json\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "application/json",
+          "body": "{\"end\":{\"dateTime\":\"2026-03-01T10:30:00Z\",\"timeZone\":\"UTC\"},\"start\":{\"dateTime\":\"2026-03-01T10:00:00Z\",\"timeZone\":\"UTC\"},\"summary\":\"s\"}\n"
+        }
+      ],
+      "is_error": true,
+      "text": "creating calendar event: googleapi: got HTTP response code 502 with body: \u003chtml\u003enope\u003c/html\u003e"
+    },
+    {
+      "case": "view_events/an explicit range, with both bounds",
+      "tool": "view_events",
+      "arguments": {
+        "max_results": 25,
+        "time_max": "2026-03-08T00:00:00Z",
+        "time_min": "2026-03-01T00:00:00Z"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"items\":[{\"id\":\"e1\",\"summary\":\"One\",\"htmlLink\":\"https://cal/e1\",\"start\":{\"dateTime\":\"2026-03-02T09:00:00Z\"}}]}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "GET",
+          "target": "/calendars/primary/events?alt=json\u0026maxResults=25\u0026orderBy=startTime\u0026prettyPrint=false\u0026singleEvents=true\u0026timeMax=2026-03-08T00%3A00%3A00Z\u0026timeMin=2026-03-01T00%3A00%3A00Z",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        }
+      ],
+      "is_error": false,
+      "text": "Found 1 event(s):\n\n- One\n  Start: 2026-03-02T09:00:00Z\n  ID: e1\n  Link: https://cal/e1\n"
+    },
+    {
+      "case": "view_events/an empty time_min defaults to now and no time_max key is sent",
+      "tool": "view_events",
+      "arguments": {
+        "max_results": 0,
+        "time_max": "",
+        "time_min": ""
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"items\":[]}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "GET",
+          "target": "/calendars/primary/events?alt=json\u0026maxResults=10\u0026orderBy=startTime\u0026prettyPrint=false\u0026singleEvents=true\u0026timeMin=%C2%ABnow%C2%BB",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        }
+      ],
+      "is_error": false,
+      "text": "No events found in the specified range."
+    },
+    {
+      "case": "view_events/max_results above the maximum falls back to the default",
+      "tool": "view_events",
+      "arguments": {
+        "max_results": 101,
+        "time_max": "",
+        "time_min": "2026-03-01T00:00:00Z"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"items\":[]}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "GET",
+          "target": "/calendars/primary/events?alt=json\u0026maxResults=10\u0026orderBy=startTime\u0026prettyPrint=false\u0026singleEvents=true\u0026timeMin=2026-03-01T00%3A00%3A00Z",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        }
+      ],
+      "is_error": false,
+      "text": "No events found in the specified range."
+    },
+    {
+      "case": "view_events/the maximum itself is sent",
+      "tool": "view_events",
+      "arguments": {
+        "max_results": 100,
+        "time_max": "",
+        "time_min": "2026-03-01T00:00:00Z"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"items\":[]}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "GET",
+          "target": "/calendars/primary/events?alt=json\u0026maxResults=100\u0026orderBy=startTime\u0026prettyPrint=false\u0026singleEvents=true\u0026timeMin=2026-03-01T00%3A00%3A00Z",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        }
+      ],
+      "is_error": false,
+      "text": "No events found in the specified range."
+    },
+    {
+      "case": "view_events/an all-day event falls back to date",
+      "tool": "view_events",
+      "arguments": {
+        "max_results": 10,
+        "time_max": "",
+        "time_min": "2026-03-01T00:00:00Z"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"items\":[{\"id\":\"e2\",\"summary\":\"Holiday\",\"htmlLink\":\"https://cal/e2\",\"start\":{\"date\":\"2026-03-03\"}},{\"id\":\"e3\",\"summary\":\"Timed\",\"htmlLink\":\"https://cal/e3\",\"start\":{\"dateTime\":\"2026-03-04T09:00:00Z\",\"date\":\"ignored\"}}]}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "GET",
+          "target": "/calendars/primary/events?alt=json\u0026maxResults=10\u0026orderBy=startTime\u0026prettyPrint=false\u0026singleEvents=true\u0026timeMin=2026-03-01T00%3A00%3A00Z",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        }
+      ],
+      "is_error": false,
+      "text": "Found 2 event(s):\n\n- Holiday\n  Start: 2026-03-03\n  ID: e2\n  Link: https://cal/e2\n\n- Timed\n  Start: 2026-03-04T09:00:00Z\n  ID: e3\n  Link: https://cal/e3\n"
+    },
+    {
+      "case": "view_events/no items at all",
+      "tool": "view_events",
+      "arguments": {
+        "max_results": 10,
+        "time_max": "",
+        "time_min": "2026-03-01T00:00:00Z"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"items\":null}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "GET",
+          "target": "/calendars/primary/events?alt=json\u0026maxResults=10\u0026orderBy=startTime\u0026prettyPrint=false\u0026singleEvents=true\u0026timeMin=2026-03-01T00%3A00%3A00Z",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        }
+      ],
+      "is_error": false,
+      "text": "No events found in the specified range."
+    },
+    {
+      "case": "send_email/the RFC822 message is padded base64url in the body",
+      "tool": "send_email",
+      "arguments": {
+        "body": "Line one\nLine two",
+        "subject": "Hello \u0026 \u003chi\u003e",
+        "to": "alice@example.com, bob@example.com"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"id\":\"m1\"}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/gmail/v1/users/me/messages/send?alt=json\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "application/json",
+          "body": "{\"raw\":\"VG86IGFsaWNlQGV4YW1wbGUuY29tLCBib2JAZXhhbXBsZS5jb20NClN1YmplY3Q6IEhlbGxvICYgPGhpPg0KQ29udGVudC1UeXBlOiB0ZXh0L3BsYWluOyBjaGFyc2V0PVVURi04DQoNCkxpbmUgb25lCkxpbmUgdHdv\"}\n"
+        }
+      ],
+      "is_error": false,
+      "text": "Email sent successfully. Message ID: m1"
+    },
+    {
+      "case": "send_email/an empty body still produces a message",
+      "tool": "send_email",
+      "arguments": {
+        "body": "",
+        "subject": "",
+        "to": "a@b"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"id\":\"m2\"}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/gmail/v1/users/me/messages/send?alt=json\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "application/json",
+          "body": "{\"raw\":\"VG86IGFAYg0KU3ViamVjdDogDQpDb250ZW50LVR5cGU6IHRleHQvcGxhaW47IGNoYXJzZXQ9VVRGLTgNCg0K\"}\n"
+        }
+      ],
+      "is_error": false,
+      "text": "Email sent successfully. Message ID: m2"
+    },
+    {
+      "case": "send_email/non-ASCII is encoded as UTF-8 bytes before base64",
+      "tool": "send_email",
+      "arguments": {
+        "body": "héllo",
+        "subject": "naïve — ☕",
+        "to": "a@b"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"id\":\"m3\"}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/gmail/v1/users/me/messages/send?alt=json\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "application/json",
+          "body": "{\"raw\":\"VG86IGFAYg0KU3ViamVjdDogbmHDr3ZlIOKAlCDimJUNCkNvbnRlbnQtVHlwZTogdGV4dC9wbGFpbjsgY2hhcnNldD1VVEYtOA0KDQpow6lsbG8=\"}\n"
+        }
+      ],
+      "is_error": false,
+      "text": "Email sent successfully. Message ID: m3"
+    },
+    {
+      "case": "read_email/headers and a text/plain body",
+      "tool": "read_email",
+      "arguments": {
+        "message_id": "18c0f0a1b2c3d4e5"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"id\":\"18c0f0a1b2c3d4e5\",\"payload\":{\"mimeType\":\"text/plain\",\"body\":{\"data\":\"aGVsbG8gdGhlcmU=\"},\"headers\":[{\"name\":\"Subject\",\"value\":\"Re: lunch\"},{\"name\":\"From\",\"value\":\"alice@example.com\"},{\"name\":\"Date\",\"value\":\"Mon, 2 Mar 2026 09:00:00 +0000\"},{\"name\":\"X-Other\",\"value\":\"ignored\"}]}}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "GET",
+          "target": "/gmail/v1/users/me/messages/18c0f0a1b2c3d4e5?alt=json\u0026format=full\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        }
+      ],
+      "is_error": false,
+      "text": "Subject: Re: lunch\nFrom: alice@example.com\nDate: Mon, 2 Mar 2026 09:00:00 +0000\n\nhello there"
+    },
+    {
+      "case": "read_email/a later header of the same name wins",
+      "tool": "read_email",
+      "arguments": {
+        "message_id": "m"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"payload\":{\"headers\":[{\"name\":\"Subject\",\"value\":\"first\"},{\"name\":\"Subject\",\"value\":\"second\"}]}}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "GET",
+          "target": "/gmail/v1/users/me/messages/m?alt=json\u0026format=full\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        }
+      ],
+      "is_error": false,
+      "text": "Subject: second\nFrom: \nDate: \n\n"
+    },
+    {
+      "case": "read_email/an unpadded part is skipped and the next one is used",
+      "tool": "read_email",
+      "arguments": {
+        "message_id": "m"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"payload\":{\"mimeType\":\"multipart/mixed\",\"headers\":[],\"parts\":[{\"mimeType\":\"text/plain\",\"body\":{\"data\":\"aGk\"}},{\"mimeType\":\"text/plain\",\"body\":{\"data\":\"Ynll\"}}]}}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "GET",
+          "target": "/gmail/v1/users/me/messages/m?alt=json\u0026format=full\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        }
+      ],
+      "is_error": false,
+      "text": "Subject: \nFrom: \nDate: \n\nbye"
+    },
+    {
+      "case": "read_email/only text/plain is decoded, depth first",
+      "tool": "read_email",
+      "arguments": {
+        "message_id": "m"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"payload\":{\"mimeType\":\"multipart/alternative\",\"headers\":[],\"parts\":[{\"mimeType\":\"text/html\",\"body\":{\"data\":\"PGI-PC9iPg==\"}},{\"mimeType\":\"text/plain\",\"body\":{\"data\":\"aGk=\"}}]}}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "GET",
+          "target": "/gmail/v1/users/me/messages/m?alt=json\u0026format=full\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        }
+      ],
+      "is_error": false,
+      "text": "Subject: \nFrom: \nDate: \n\nhi"
+    },
+    {
+      "case": "read_email/a message id needing escaping",
+      "tool": "read_email",
+      "arguments": {
+        "message_id": "a/b c?d\u0026e"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"payload\":{\"headers\":[]}}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "GET",
+          "target": "/gmail/v1/users/me/messages/a%2Fb%20c%3Fd%26e?alt=json\u0026format=full\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        }
+      ],
+      "is_error": false,
+      "text": "Subject: \nFrom: \nDate: \n\n"
+    },
+    {
+      "case": "read_email/a 404 quotes the id with %q",
+      "tool": "read_email",
+      "arguments": {
+        "message_id": "missing\"quoted"
+      },
+      "responses": [
+        {
+          "status": 404,
+          "body": "{\"error\":{\"code\":404,\"message\":\"Requested entity was not found.\"}}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "GET",
+          "target": "/gmail/v1/users/me/messages/missing%22quoted?alt=json\u0026format=full\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        }
+      ],
+      "is_error": true,
+      "text": "reading email \"missing\\\"quoted\": googleapi: Error 404: Requested entity was not found."
+    },
+    {
+      "case": "search_email/one list and one fetch per message, with repeated query keys",
+      "tool": "search_email",
+      "arguments": {
+        "max_results": 2,
+        "query": "from:alice@example.com is:unread"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"messages\":[{\"id\":\"m1\"},{\"id\":\"m2\"}]}"
+        },
+        {
+          "status": 200,
+          "body": "{\"payload\":{\"headers\":[{\"name\":\"Subject\",\"value\":\"One\"},{\"name\":\"From\",\"value\":\"a@b\"},{\"name\":\"Date\",\"value\":\"D1\"}]}}"
+        },
+        {
+          "status": 200,
+          "body": "{\"payload\":{\"headers\":[{\"name\":\"Subject\",\"value\":\"Two\"},{\"name\":\"From\",\"value\":\"c@d\"},{\"name\":\"Date\",\"value\":\"D2\"}]}}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "GET",
+          "target": "/gmail/v1/users/me/messages?alt=json\u0026maxResults=2\u0026prettyPrint=false\u0026q=from%3Aalice%40example.com+is%3Aunread",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        },
+        {
+          "method": "GET",
+          "target": "/gmail/v1/users/me/messages/m1?alt=json\u0026format=metadata\u0026metadataHeaders=Subject\u0026metadataHeaders=From\u0026metadataHeaders=Date\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        },
+        {
+          "method": "GET",
+          "target": "/gmail/v1/users/me/messages/m2?alt=json\u0026format=metadata\u0026metadataHeaders=Subject\u0026metadataHeaders=From\u0026metadataHeaders=Date\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        }
+      ],
+      "is_error": false,
+      "text": "Found 2 message(s):\n\nID: m1\nSubject: One\nFrom: a@b\nDate: D1\n\n---\n\nID: m2\nSubject: Two\nFrom: c@d\nDate: D2"
+    },
+    {
+      "case": "search_email/a failed fetch is skipped and the count still counts it",
+      "tool": "search_email",
+      "arguments": {
+        "max_results": 3,
+        "query": "x"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"messages\":[{\"id\":\"m1\"},{\"id\":\"m2\"},{\"id\":\"m3\"}]}"
+        },
+        {
+          "status": 200,
+          "body": "{\"payload\":{\"headers\":[{\"name\":\"Subject\",\"value\":\"One\"}]}}"
+        },
+        {
+          "status": 403,
+          "body": "{\"error\":{\"code\":403,\"message\":\"nope\"}}"
+        },
+        {
+          "status": 200,
+          "body": "{\"payload\":{\"headers\":[{\"name\":\"Subject\",\"value\":\"Three\"}]}}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "GET",
+          "target": "/gmail/v1/users/me/messages?alt=json\u0026maxResults=3\u0026prettyPrint=false\u0026q=x",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        },
+        {
+          "method": "GET",
+          "target": "/gmail/v1/users/me/messages/m1?alt=json\u0026format=metadata\u0026metadataHeaders=Subject\u0026metadataHeaders=From\u0026metadataHeaders=Date\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        },
+        {
+          "method": "GET",
+          "target": "/gmail/v1/users/me/messages/m2?alt=json\u0026format=metadata\u0026metadataHeaders=Subject\u0026metadataHeaders=From\u0026metadataHeaders=Date\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        },
+        {
+          "method": "GET",
+          "target": "/gmail/v1/users/me/messages/m3?alt=json\u0026format=metadata\u0026metadataHeaders=Subject\u0026metadataHeaders=From\u0026metadataHeaders=Date\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        }
+      ],
+      "is_error": false,
+      "text": "Found 3 message(s):\n\nID: m1\nSubject: One\nFrom: \nDate: \n\n---\n\nID: m3\nSubject: Three\nFrom: \nDate: "
+    },
+    {
+      "case": "search_email/an empty query still sends the q key",
+      "tool": "search_email",
+      "arguments": {
+        "max_results": 0,
+        "query": ""
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"messages\":[]}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "GET",
+          "target": "/gmail/v1/users/me/messages?alt=json\u0026maxResults=10\u0026prettyPrint=false\u0026q=",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        }
+      ],
+      "is_error": false,
+      "text": "No messages found matching the query."
+    },
+    {
+      "case": "search_email/max_results above 50 falls back to the default",
+      "tool": "search_email",
+      "arguments": {
+        "max_results": 51,
+        "query": "x"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"messages\":null}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "GET",
+          "target": "/gmail/v1/users/me/messages?alt=json\u0026maxResults=10\u0026prettyPrint=false\u0026q=x",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        }
+      ],
+      "is_error": false,
+      "text": "No messages found matching the query."
+    },
+    {
+      "case": "search_email/50 itself is sent",
+      "tool": "search_email",
+      "arguments": {
+        "max_results": 50,
+        "query": "x"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"messages\":[]}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "GET",
+          "target": "/gmail/v1/users/me/messages?alt=json\u0026maxResults=50\u0026prettyPrint=false\u0026q=x",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        }
+      ],
+      "is_error": false,
+      "text": "No messages found matching the query."
+    },
+    {
+      "case": "list_files/a query is sent when set",
+      "tool": "list_files",
+      "arguments": {
+        "max_results": 3,
+        "query": "name contains 'report' and trashed = false"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"files\":[{\"id\":\"f1\",\"name\":\"Report.pdf\",\"mimeType\":\"application/pdf\",\"modifiedTime\":\"2026-03-01T09:00:00Z\",\"webViewLink\":\"https://drive/f1\"}]}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "GET",
+          "target": "/files?alt=json\u0026fields=files%28id%2Cname%2CmimeType%2Csize%2CmodifiedTime%2CwebViewLink%29\u0026pageSize=3\u0026prettyPrint=false\u0026q=name+contains+%27report%27+and+trashed+%3D+false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        }
+      ],
+      "is_error": false,
+      "text": "Found 1 file(s):\n\nName: Report.pdf\nID: f1\nType: application/pdf\nModified: 2026-03-01T09:00:00Z\nLink: https://drive/f1"
+    },
+    {
+      "case": "list_files/an empty query sends no q key at all",
+      "tool": "list_files",
+      "arguments": {
+        "max_results": 0,
+        "query": ""
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"files\":[]}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "GET",
+          "target": "/files?alt=json\u0026fields=files%28id%2Cname%2CmimeType%2Csize%2CmodifiedTime%2CwebViewLink%29\u0026pageSize=10\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        }
+      ],
+      "is_error": false,
+      "text": "No files found."
+    },
+    {
+      "case": "list_files/max_results above the maximum falls back to the default",
+      "tool": "list_files",
+      "arguments": {
+        "max_results": 101,
+        "query": ""
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"files\":null}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "GET",
+          "target": "/files?alt=json\u0026fields=files%28id%2Cname%2CmimeType%2Csize%2CmodifiedTime%2CwebViewLink%29\u0026pageSize=10\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        }
+      ],
+      "is_error": false,
+      "text": "No files found."
+    },
+    {
+      "case": "list_files/several files are joined by a rule",
+      "tool": "list_files",
+      "arguments": {
+        "max_results": 2,
+        "query": ""
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"files\":[{\"id\":\"f1\",\"name\":\"A\",\"mimeType\":\"text/plain\",\"modifiedTime\":\"t1\",\"webViewLink\":\"l1\"},{\"id\":\"f2\",\"name\":\"B\",\"mimeType\":null,\"modifiedTime\":null,\"webViewLink\":null}]}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "GET",
+          "target": "/files?alt=json\u0026fields=files%28id%2Cname%2CmimeType%2Csize%2CmodifiedTime%2CwebViewLink%29\u0026pageSize=2\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        }
+      ],
+      "is_error": false,
+      "text": "Found 2 file(s):\n\nName: A\nID: f1\nType: text/plain\nModified: t1\nLink: l1\n\n---\n\nName: B\nID: f2\nType: \nModified: \nLink: "
+    },
+    {
+      "case": "create_file/the media type is sniffed and the mime_type argument is metadata only",
+      "tool": "create_file",
+      "arguments": {
+        "content": "# Notes\n\nplain text",
+        "mime_type": "text/markdown",
+        "name": "notes.md"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"id\":\"f9\",\"name\":\"notes.md\",\"webViewLink\":\"https://drive/f9\"}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/upload/drive/v3/files?alt=json\u0026fields=id%2Cname%2CwebViewLink\u0026prettyPrint=false\u0026uploadType=multipart",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "multipart/related",
+          "parts": [
+            {
+              "content_type": "application/json",
+              "body": "{\"mimeType\":\"text/markdown\",\"name\":\"notes.md\"}\n"
+            },
+            {
+              "content_type": "text/plain; charset=utf-8",
+              "body": "# Notes\n\nplain text"
+            }
+          ]
+        }
+      ],
+      "is_error": false,
+      "text": "File created: notes.md\nID: f9\nLink: https://drive/f9"
+    },
+    {
+      "case": "create_file/an empty mime_type defaults to text/plain in the metadata",
+      "tool": "create_file",
+      "arguments": {
+        "content": "hello",
+        "mime_type": "",
+        "name": "a.txt"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"id\":\"f10\",\"name\":\"a.txt\",\"webViewLink\":\"https://drive/f10\"}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/upload/drive/v3/files?alt=json\u0026fields=id%2Cname%2CwebViewLink\u0026prettyPrint=false\u0026uploadType=multipart",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "multipart/related",
+          "parts": [
+            {
+              "content_type": "application/json",
+              "body": "{\"mimeType\":\"text/plain\",\"name\":\"a.txt\"}\n"
+            },
+            {
+              "content_type": "text/plain; charset=utf-8",
+              "body": "hello"
+            }
+          ]
+        }
+      ],
+      "is_error": false,
+      "text": "File created: a.txt\nID: f10\nLink: https://drive/f10"
+    },
+    {
+      "case": "create_file/HTML content sniffs as text/html regardless of mime_type",
+      "tool": "create_file",
+      "arguments": {
+        "content": "\u003chtml\u003e\u003cbody\u003ehi\u003c/body\u003e\u003c/html\u003e",
+        "mime_type": "application/json",
+        "name": "page.html"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"id\":\"f11\",\"name\":\"page.html\",\"webViewLink\":\"https://drive/f11\"}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/upload/drive/v3/files?alt=json\u0026fields=id%2Cname%2CwebViewLink\u0026prettyPrint=false\u0026uploadType=multipart",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "multipart/related",
+          "parts": [
+            {
+              "content_type": "application/json",
+              "body": "{\"mimeType\":\"application/json\",\"name\":\"page.html\"}\n"
+            },
+            {
+              "content_type": "text/html; charset=utf-8",
+              "body": "\u003chtml\u003e\u003cbody\u003ehi\u003c/body\u003e\u003c/html\u003e"
+            }
+          ]
+        }
+      ],
+      "is_error": false,
+      "text": "File created: page.html\nID: f11\nLink: https://drive/f11"
+    },
+    {
+      "case": "create_file/an empty content still uploads a media part",
+      "tool": "create_file",
+      "arguments": {
+        "content": "",
+        "mime_type": "",
+        "name": "empty"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"id\":\"f12\",\"name\":\"empty\",\"webViewLink\":\"https://drive/f12\"}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "POST",
+          "target": "/upload/drive/v3/files?alt=json\u0026fields=id%2Cname%2CwebViewLink\u0026prettyPrint=false\u0026uploadType=multipart",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": "multipart/related",
+          "parts": [
+            {
+              "content_type": "application/json",
+              "body": "{\"mimeType\":\"text/plain\",\"name\":\"empty\"}\n"
+            },
+            {
+              "content_type": "text/plain; charset=utf-8",
+              "body": ""
+            }
+          ]
+        }
+      ],
+      "is_error": false,
+      "text": "File created: empty\nID: f12\nLink: https://drive/f12"
+    },
+    {
+      "case": "download_file/the body is returned verbatim",
+      "tool": "download_file",
+      "arguments": {
+        "file_id": "f1"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "line one\nline two\n"
+        }
+      ],
+      "requests": [
+        {
+          "method": "GET",
+          "target": "/files/f1?alt=media\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        }
+      ],
+      "is_error": false,
+      "text": "line one\nline two\n"
+    },
+    {
+      "case": "download_file/a file id needing escaping",
+      "tool": "download_file",
+      "arguments": {
+        "file_id": "a/b c?d"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "x"
+        }
+      ],
+      "requests": [
+        {
+          "method": "GET",
+          "target": "/files/a%2Fb%20c%3Fd?alt=media\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        }
+      ],
+      "is_error": false,
+      "text": "x"
+    },
+    {
+      "case": "download_file/an empty file is an empty result",
+      "tool": "download_file",
+      "arguments": {
+        "file_id": "f2"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": ""
+        }
+      ],
+      "requests": [
+        {
+          "method": "GET",
+          "target": "/files/f2?alt=media\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        }
+      ],
+      "is_error": false,
+      "text": ""
+    },
+    {
+      "case": "download_file/a 403 quotes the id with %q",
+      "tool": "download_file",
+      "arguments": {
+        "file_id": "f3"
+      },
+      "responses": [
+        {
+          "status": 403,
+          "body": "{\"error\":{\"code\":403,\"message\":\"Insufficient Permission\",\"errors\":[{\"reason\":\"insufficientPermissions\",\"message\":\"Insufficient Permission\"}]}}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "GET",
+          "target": "/files/f3?alt=media\u0026prettyPrint=false",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        }
+      ],
+      "is_error": true,
+      "text": "downloading drive file \"f3\": googleapi: Error 403: Insufficient Permission, insufficientPermissions"
+    },
+    {
+      "case": "view_events/a zero-fraction float is an integer to Go and not to serde",
+      "tool": "view_events",
+      "arguments": {
+        "max_results": 10.0,
+        "time_max": "",
+        "time_min": "2026-03-01T00:00:00Z"
+      },
+      "responses": [
+        {
+          "status": 200,
+          "body": "{\"items\":[]}"
+        }
+      ],
+      "requests": [
+        {
+          "method": "GET",
+          "target": "/calendars/primary/events?alt=json\u0026maxResults=10\u0026orderBy=startTime\u0026prettyPrint=false\u0026singleEvents=true\u0026timeMin=2026-03-01T00%3A00%3A00Z",
+          "authorization": "Bearer ya29.parity-access-token",
+          "content_type": ""
+        }
+      ],
+      "is_error": false,
+      "text": "No events found in the specified range.",
+      "rust_text": "failed to deserialize parameters: invalid type: floating point `10.0`, expected i64",
+      "rust_no_request": true
+    }
+  ],
+  "refreshes": [
+    {
+      "case": "a token an hour from expiry is reused without a refresh",
+      "expires_in": 3600,
+      "token_response": null,
+      "api_response": {
+        "status": 200,
+        "body": "{\"files\":[]}"
+      },
+      "refresh_request": null,
+      "api_request": {
+        "method": "GET",
+        "target": "/files?alt=json\u0026fields=files%28id%2Cname%2CmimeType%2Csize%2CmodifiedTime%2CwebViewLink%29\u0026pageSize=1\u0026prettyPrint=false",
+        "authorization": "Bearer ya29.parity-access-token",
+        "content_type": ""
+      },
+      "is_error": false,
+      "text": "No files found."
+    },
+    {
+      "case": "a token with no expiry never refreshes",
+      "expires_in": null,
+      "token_response": null,
+      "api_response": {
+        "status": 200,
+        "body": "{\"files\":[]}"
+      },
+      "refresh_request": null,
+      "api_request": {
+        "method": "GET",
+        "target": "/files?alt=json\u0026fields=files%28id%2Cname%2CmimeType%2Csize%2CmodifiedTime%2CwebViewLink%29\u0026pageSize=1\u0026prettyPrint=false",
+        "authorization": "Bearer ya29.parity-access-token",
+        "content_type": ""
+      },
+      "is_error": false,
+      "text": "No files found."
+    },
+    {
+      "case": "a token five seconds from expiry refreshes inside the delta",
+      "expires_in": 5,
+      "token_response": {
+        "status": 200,
+        "body": "{\"access_token\":\"ya29.refreshed\",\"token_type\":\"Bearer\",\"expires_in\":3599}"
+      },
+      "api_response": {
+        "status": 200,
+        "body": "{\"files\":[]}"
+      },
+      "refresh_request": {
+        "method": "POST",
+        "target": "/token",
+        "authorization": "",
+        "content_type": "application/x-www-form-urlencoded",
+        "body": "client_id=parity-client-id.apps.googleusercontent.com\u0026client_secret=GOCSPX-parity-client-secret\u0026grant_type=refresh_token\u0026refresh_token=1%2F%2Fparity-refresh-token"
+      },
+      "api_request": {
+        "method": "GET",
+        "target": "/files?alt=json\u0026fields=files%28id%2Cname%2CmimeType%2Csize%2CmodifiedTime%2CwebViewLink%29\u0026pageSize=1\u0026prettyPrint=false",
+        "authorization": "Bearer ya29.refreshed",
+        "content_type": ""
+      },
+      "is_error": false,
+      "text": "No files found."
+    },
+    {
+      "case": "an expired token refreshes and the new access token reaches the request",
+      "expires_in": -60,
+      "token_response": {
+        "status": 200,
+        "body": "{\"access_token\":\"ya29.refreshed-2\",\"token_type\":\"Bearer\",\"expires_in\":3599}"
+      },
+      "api_response": {
+        "status": 200,
+        "body": "{\"files\":[]}"
+      },
+      "refresh_request": {
+        "method": "POST",
+        "target": "/token",
+        "authorization": "",
+        "content_type": "application/x-www-form-urlencoded",
+        "body": "client_id=parity-client-id.apps.googleusercontent.com\u0026client_secret=GOCSPX-parity-client-secret\u0026grant_type=refresh_token\u0026refresh_token=1%2F%2Fparity-refresh-token"
+      },
+      "api_request": {
+        "method": "GET",
+        "target": "/files?alt=json\u0026fields=files%28id%2Cname%2CmimeType%2Csize%2CmodifiedTime%2CwebViewLink%29\u0026pageSize=1\u0026prettyPrint=false",
+        "authorization": "Bearer ya29.refreshed-2",
+        "content_type": ""
+      },
+      "is_error": false,
+      "text": "No files found."
+    },
+    {
+      "case": "a refused refresh surfaces as the tool's own failure",
+      "expires_in": -60,
+      "token_response": {
+        "status": 400,
+        "body": "{\"error\":\"invalid_grant\",\"error_description\":\"Token has been expired or revoked.\"}"
+      },
+      "api_response": {
+        "status": 200,
+        "body": "{\"files\":[]}"
+      },
+      "refresh_request": {
+        "method": "POST",
+        "target": "/token",
+        "authorization": "",
+        "content_type": "application/x-www-form-urlencoded",
+        "body": "client_id=parity-client-id.apps.googleusercontent.com\u0026client_secret=GOCSPX-parity-client-secret\u0026grant_type=refresh_token\u0026refresh_token=1%2F%2Fparity-refresh-token"
+      },
+      "api_request": null,
+      "is_error": true,
+      "text": "listing drive files: Get \"«api»/files?alt=json\u0026fields=files%28id%2Cname%2CmimeType%2Csize%2CmodifiedTime%2CwebViewLink%29\u0026pageSize=1\u0026prettyPrint=false\": oauth2: \"invalid_grant\" \"Token has been expired or revoked.\"",
+      "rust_text": "listing drive files: oauth2: \"invalid_grant\" \"Token has been expired or revoked.\""
+    }
+  ]
+}

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -13,6 +13,7 @@ name = "agento"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "base64 0.22.1",
  "chrono",
  "chrono-tz",
  "form_urlencoded",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -132,6 +132,11 @@ rusqlite = { version = "0.40.2", features = ["bundled"] }
 # Effective-dated rates are timestamps, and their wire format has to match Go's
 # byte for byte. `clock` is only for "which rate is in force now".
 chrono = { version = "0.4.45", default-features = false, features = ["std", "clock", "serde"] }
+# Gmail's `send_email`/`read_email` are `base64.URLEncoding` — the **padded**
+# URL-safe alphabet — and reproducing the padding requirement is what keeps
+# `extractBody`'s part selection identical (#313). Already in the lock through
+# `rmcp`, so this is a direct name for a crate that was compiling anyway.
+base64 = "0.22"
 # Analytics buckets days, hours and weekdays in the *request's* timezone, so an
 # IANA name has to resolve to real offsets and real DST transitions. Go reaches
 # its own embedded tzdata through `time.LoadLocation`; this is the equivalent.

--- a/desktop/src-tauri/src/native/gourl.rs
+++ b/desktop/src-tauri/src/native/gourl.rs
@@ -202,18 +202,21 @@ fn escape_bytes(bytes: &[u8], mode: Encoding) -> String {
     out
 }
 
-/// Go's `url.Values`, restricted to the one shape every caller here uses.
+/// Go's `url.Values` — a `map[string][]string`, sorted by key on encode.
 ///
-/// `url.Values` is a `map[string][]string`, but every construction in
-/// `internal/integrations/` is a sequence of `q.Set(k, v)` — which *replaces* —
-/// so one value per key models it exactly, and a `BTreeMap` gives
-/// [`Values::encode`] the sorted-key iteration `Encode` performs explicitly.
+/// It was a single value per key until #313, because every construction in
+/// `internal/integrations/` was a sequence of `q.Set(k, v)` and that models
+/// `Set`'s replace exactly. Google's generated clients broke the assumption:
+/// `search_email` sends `metadataHeaders` three times, and measured against the
+/// real library the result is `…&metadataHeaders=Subject&metadataHeaders=From&
+/// metadataHeaders=Date&…` — keys sorted, **values in insertion order**, which is
+/// what `Encode` does and what a single-valued map cannot express.
 ///
 /// The sorting is not cosmetic. It is what makes a request reproducible, which
 /// is what lets `desktop/parity/github_vectors.json` pin the encoded target of
 /// every paged tool.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct Values(std::collections::BTreeMap<String, String>);
+pub struct Values(std::collections::BTreeMap<String, Vec<String>>);
 
 impl Values {
     /// An empty set of parameters — `url.Values{}`.
@@ -221,26 +224,38 @@ impl Values {
         Self::default()
     }
 
-    /// `Values.Set`: replaces whatever was under `key`.
+    /// `Values.Set`: replaces whatever was under `key`, however many values it
+    /// held.
     pub fn set(&mut self, key: impl Into<String>, value: impl Into<String>) {
-        self.0.insert(key.into(), value.into());
+        self.0.insert(key.into(), vec![value.into()]);
     }
 
-    /// `Values.Encode`: `k=v` pairs joined by `&`, keys sorted, both halves
-    /// through [`query_escape`].
+    /// `Values.Add`: appends, keeping insertion order within the key.
+    ///
+    /// One caller — Google's `search_email` — and it is the reason this type
+    /// stopped being single-valued. See the type's own docs.
+    pub fn add(&mut self, key: impl Into<String>, value: impl Into<String>) {
+        self.0.entry(key.into()).or_default().push(value.into());
+    }
+
+    /// `Values.Encode`: `k=v` pairs joined by `&`, keys sorted, values in the
+    /// order they were added, both halves through [`query_escape`].
     ///
     /// An empty set encodes to `""` — which the callers rely on, since they all
     /// append it after a literal `?` and Go produces a bare trailing `?` in
     /// exactly the same case.
     pub fn encode(&self) -> String {
         let mut out = String::new();
-        for (key, value) in &self.0 {
-            if !out.is_empty() {
-                out.push('&');
+        for (key, values) in &self.0 {
+            let key = query_escape(key);
+            for value in values {
+                if !out.is_empty() {
+                    out.push('&');
+                }
+                out.push_str(&key);
+                out.push('=');
+                out.push_str(&query_escape(value));
             }
-            out.push_str(&query_escape(key));
-            out.push('=');
-            out.push_str(&query_escape(value));
         }
         out
     }
@@ -317,6 +332,33 @@ pub fn route_path(raw: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    /// `Encode` sorts keys and keeps each key's values in insertion order —
+    /// measured against the real `url.Values` through Google's generated client,
+    /// which sends `metadataHeaders` three times.
+    #[test]
+    fn repeated_values_keep_their_order_under_a_sorted_key() {
+        let mut values = Values::new();
+        values.set("format", "metadata");
+        values.add("metadataHeaders", "Subject");
+        values.add("metadataHeaders", "From");
+        values.add("metadataHeaders", "Date");
+        values.set("alt", "json");
+        values.set("prettyPrint", "false");
+        assert_eq!(
+            values.encode(),
+            "alt=json&format=metadata&metadataHeaders=Subject&metadataHeaders=From\
+             &metadataHeaders=Date&prettyPrint=false"
+                .replace(char::is_whitespace, "")
+        );
+
+        // `set` still replaces, however many values were there.
+        let mut values = Values::new();
+        values.add("k", "a");
+        values.add("k", "b");
+        values.set("k", "c");
+        assert_eq!(values.encode(), "k=c");
+    }
+
     /// `validEncoded`'s allowlist is wider than `should_escape`'s, and the gap
     /// is the whole reason this function exists rather than a caller comparing
     /// against [`escape_path`]. Every byte here is one Go sends **verbatim**

--- a/desktop/src-tauri/src/native/integrations.rs
+++ b/desktop/src-tauri/src/native/integrations.rs
@@ -135,6 +135,7 @@
 pub mod base_url;
 pub mod confluence;
 pub mod github;
+pub mod google;
 pub mod jira;
 pub mod slack;
 pub mod telegram;

--- a/desktop/src-tauri/src/native/integrations/google/calendar.rs
+++ b/desktop/src-tauri/src/native/integrations/google/calendar.rs
@@ -1,0 +1,224 @@
+//! The `calendar` service's two tools, ported from
+//! `internal/integrations/google/calendar.go`.
+//!
+//! Conventions are `native/integrations/github/repos.rs`'s. What is different is
+//! that the request is built by a **generated client** rather than by the handler
+//! — so every URL, query key and body field below was measured off
+//! `google.golang.org/api/calendar/v3` rather than read from `calendar.go`. See
+//! `super::client` for what that does and does not let the port reproduce.
+//!
+//! Two things the generated client contributes that the handler never mentions:
+//!
+//! - **`alt=json&prettyPrint=false` on every call**, sorted in with everything
+//!   else by `url.Values.Encode`.
+//! - **`omitempty` on the request body.** `calendar.Event`'s fields carry it, so
+//!   an empty `description` sends *no key* — measured both ways.
+//!
+//! And one the handler does: **`time_min` defaults to "now"**, so the request is
+//! not deterministic. The vectors record that case with the value redacted and
+//! assert the shape instead; see `tests_vectors`.
+
+use schemars::JsonSchema;
+use serde_json::{json, Value};
+
+use crate::claude::{new_tool, CancellationToken, ToolDef};
+use crate::native::gourl::Values;
+
+use super::client::{Api, Client};
+use super::text_result;
+
+/// The two parameters every generated call carries.
+pub(super) fn base_query() -> Values {
+    let mut query = Values::new();
+    query.set("alt", "json");
+    query.set("prettyPrint", "false");
+    query
+}
+
+/// `create_event`.
+#[allow(dead_code)] // read through serde, never constructed in Rust
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct CreateEventInput {
+    /// required,The title of the event
+    summary: String,
+    /// required,Start time in RFC3339 format (e.g. 2026-03-01T10:00:00-07:00)
+    start: String,
+    /// required,End time in RFC3339 format
+    end: String,
+    /// Optional description of the event
+    description: String,
+}
+
+pub fn create_event(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "create_event",
+        "Creates a new event on the user's primary Google Calendar.",
+        move |input: CreateEventInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                // `calendar.Event` with `omitempty` everywhere: an empty
+                // description sends no key at all, and `TimeZone` is the
+                // handler's literal `"UTC"` on both ends.
+                let mut event = json!({
+                    "end": {"dateTime": input.end, "timeZone": "UTC"},
+                    "start": {"dateTime": input.start, "timeZone": "UTC"},
+                    "summary": input.summary,
+                });
+                if !input.description.is_empty() {
+                    event["description"] = Value::String(input.description.clone());
+                }
+
+                let body = super::marshal(&event)?;
+                // The decode is inside the *same* `map_err` as the request,
+                // because in Go both are `Do()` — a response the client cannot
+                // decode surfaces under the handler's own sentence, not a bare
+                // one. That holds at every decode site in this module.
+                let created: Event = client
+                    .post_json(
+                        &ct,
+                        Api::Calendar,
+                        "calendars/primary/events",
+                        &base_query(),
+                        body,
+                    )
+                    .await
+                    .and_then(|raw| super::decode(&raw))
+                    // The result reads fields off the **response**, not the
+                    // request, so a server that renamed the event is what the
+                    // model is told.
+                    .map_err(|e| format!("creating calendar event: {e}"))?;
+                Ok(text_result(format!(
+                    "Event created: {}\nID: {}\nLink: {}",
+                    created.summary, created.id, created.html_link
+                )))
+            }
+        },
+    )
+}
+
+/// `view_events`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct ViewEventsInput {
+    /// Lower bound for event end time in RFC3339 format. Defaults to now.
+    time_min: String,
+    /// Upper bound for event start time in RFC3339 format.
+    time_max: String,
+    /// Maximum number of events to return (default 10, max 100)
+    max_results: i64,
+}
+
+pub fn view_events(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "view_events",
+        "Lists events from the user's primary Google Calendar within an optional time range.",
+        move |input: ViewEventsInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let max_results = if input.max_results <= 0 || input.max_results > 100 {
+                    10
+                } else {
+                    input.max_results
+                };
+
+                let mut query = base_query();
+                query.set("maxResults", max_results.to_string());
+                query.set("orderBy", "startTime");
+                query.set("singleEvents", "true");
+                // `time.Now().UTC().Format(time.RFC3339)` — seconds precision, a
+                // literal `Z`, and the reason one vector redacts this value.
+                query.set(
+                    "timeMin",
+                    if input.time_min.is_empty() {
+                        super::now_rfc3339()
+                    } else {
+                        input.time_min.clone()
+                    },
+                );
+                if !input.time_max.is_empty() {
+                    query.set("timeMax", &input.time_max);
+                }
+
+                let listed: EventList = client
+                    .get(&ct, Api::Calendar, "calendars/primary/events", &query)
+                    .await
+                    .and_then(|raw| super::decode(&raw))
+                    .map_err(|e| format!("listing calendar events: {e}"))?;
+                if listed.items.is_empty() {
+                    return Ok(text_result(
+                        "No events found in the specified range.".to_string(),
+                    ));
+                }
+
+                let mut out = format!("Found {} event(s):\n", listed.items.len());
+                for event in listed.items() {
+                    // `ev.Start.DateTime` falls back to `.Date` for an all-day
+                    // event — and a missing `start` object is an empty string
+                    // rather than a panic, which is the one place this is
+                    // gentler than Go. See the module docs on `read_email`.
+                    let start = event
+                        .start
+                        .as_ref()
+                        .map(|when| {
+                            if when.date_time.is_empty() {
+                                when.date.clone()
+                            } else {
+                                when.date_time.clone()
+                            }
+                        })
+                        .unwrap_or_default();
+                    out.push_str(&format!(
+                        "\n- {}\n  Start: {}\n  ID: {}\n  Link: {}\n",
+                        event.summary, start, event.id, event.html_link
+                    ));
+                }
+                Ok(text_result(out))
+            }
+        },
+    )
+}
+
+/// The fields of `calendar.Event` the two handlers read.
+///
+/// Every one carries the three decode rules `desktop/CLAUDE.md` sets out — a
+/// JSON `null` is a zero value, an array is not a struct, and a bare `null` is a
+/// no-op — because this is Google's response and nothing constrains its shape.
+#[derive(Default, serde::Deserialize)]
+#[serde(default)]
+struct Event {
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    id: String,
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    summary: String,
+    #[serde(rename = "htmlLink")]
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    html_link: String,
+    start: Option<crate::native::gojson::GoStruct<EventDateTime>>,
+}
+
+#[derive(Default, serde::Deserialize)]
+#[serde(default)]
+struct EventDateTime {
+    #[serde(rename = "dateTime")]
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    date_time: String,
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    date: String,
+}
+
+#[derive(Default, serde::Deserialize)]
+#[serde(default)]
+struct EventList {
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    items: Vec<crate::native::gojson::GoStruct<Event>>,
+}
+
+impl EventList {
+    fn items(&self) -> impl Iterator<Item = &Event> {
+        self.items.iter().map(|wrapped| &wrapped.0)
+    }
+}

--- a/desktop/src-tauri/src/native/integrations/google/calendar.rs
+++ b/desktop/src-tauri/src/native/integrations/google/calendar.rs
@@ -58,16 +58,31 @@ pub fn create_event(client: &Client) -> ToolDef {
         move |input: CreateEventInput, ct: CancellationToken| {
             let client = client.clone();
             async move {
-                // `calendar.Event` with `omitempty` everywhere: an empty
-                // description sends no key at all, and `TimeZone` is the
-                // handler's literal `"UTC"` on both ends.
+                // `calendar.Event` carries `omitempty` on **every** field, not
+                // just `description` — `Summary` and `EventDateTime.DateTime`
+                // too. So an empty start sends a `start` object holding nothing
+                // but its time zone, and an empty summary sends no key. Only
+                // `TimeZone` is unconditional, because it is the handler's own
+                // literal `"UTC"` rather than an argument.
+                let when = |value: &str| {
+                    let mut object = serde_json::Map::new();
+                    if !value.is_empty() {
+                        object.insert("dateTime".to_string(), Value::String(value.to_string()));
+                    }
+                    object.insert("timeZone".to_string(), Value::String("UTC".to_string()));
+                    Value::Object(object)
+                };
                 let mut event = json!({
-                    "end": {"dateTime": input.end, "timeZone": "UTC"},
-                    "start": {"dateTime": input.start, "timeZone": "UTC"},
-                    "summary": input.summary,
+                    "end": when(&input.end),
+                    "start": when(&input.start),
                 });
-                if !input.description.is_empty() {
-                    event["description"] = Value::String(input.description.clone());
+                for (key, value) in [
+                    ("description", &input.description),
+                    ("summary", &input.summary),
+                ] {
+                    if !value.is_empty() {
+                        event[key] = Value::String(value.clone());
+                    }
                 }
 
                 let body = super::marshal(&event)?;

--- a/desktop/src-tauri/src/native/integrations/google/client.rs
+++ b/desktop/src-tauri/src/native/integrations/google/client.rs
@@ -31,6 +31,37 @@
 //!   its content type — rather than the byte stream.
 //! - `Accept-Encoding: gzip`, which both sides send but neither controls.
 //!
+//! ## Four small divergences that are known and left standing
+//!
+//! Each was found by review, checked against the Go source, and judged not worth
+//! the machinery — but "we did not notice" and "we decided not to" are different
+//! things, so they are written down rather than left implicit:
+//!
+//! - **Dot segments in a path parameter.** `.` is unreserved, so
+//!   [`expand_path_segment`] passes `..` through, and `reqwest::Url` then
+//!   normalizes it away — `download_file` with a `file_id` of `..` requests the
+//!   Drive *collection* where Go requests `/files/..`. Go never normalizes,
+//!   because it expands the template after resolving it. Fixing this means not
+//!   using `Url` at all, since both `parse` and `join` normalize; the input is
+//!   nonsense either way and both answers are errors from Google.
+//! - **`status_line` uses `canonical_reason()`** where Go reads the reason phrase
+//!   off the wire, so a non-standard status or a custom phrase renders
+//!   differently inside `oauth2: cannot fetch token: …`.
+//! - **The `Authorization` scheme is the literal `Bearer`**, where Go title-cases
+//!   `Token.TokenType`. Google always says `Bearer`.
+//! - **`expires_in` must be a JSON number here.** Go's `expirationTime` goes
+//!   through `json.Number`, which also accepts `"3600"` as a string; Google sends
+//!   a number.
+//!
+//! ## The upload shape is settled only under 16 MiB
+//!
+//! `googleapi.DefaultUploadChunkSize` is 16 MiB, above which `PrepareUpload`
+//! switches to a **resumable** upload: a different endpoint, `uploadType=resumable`,
+//! an `X-Upload-Content-Type` header and a two-phase POST/PUT. This port always
+//! sends `uploadType=multipart`. `create_file`'s content arrives as a JSON string
+//! in a `tools/call`, so reaching 16 MiB means a 16 MiB tool argument; if that
+//! ever becomes reachable, this is the thing to port.
+//!
 //! # The token source
 //!
 //! `buildHTTPClient` wraps the stored token in `oauth2.Config.TokenSource` and
@@ -249,6 +280,15 @@ impl TokenSource {
 
     /// The refresh request, measured against `golang.org/x/oauth2`.
     async fn refresh(&self, ct: &CancellationToken, current: &Token) -> Result<Token, String> {
+        // `tokenRefresher.Token` refuses **before opening a socket** when there
+        // is no refresh token (`oauth2.go:274`). Reproducing the refusal is not
+        // only about the sentence: without it this port POSTs the user's
+        // `client_secret` to Google on a request Go never sends. A re-consent
+        // without `prompt=consent` is exactly how a row ends up in this state.
+        if current.refresh_token.is_empty() {
+            return Err(NO_REFRESH_TOKEN.to_string());
+        }
+
         // `url.Values.Encode()` — sorted keys, and the client credentials in the
         // **body** because `google.Endpoint` declares `AuthStyleInParams`. A
         // `Basic` header here would be a different request.
@@ -394,6 +434,9 @@ fn status_line(status: reqwest::StatusCode) -> String {
 /// It names nothing: the request holds the `client_secret` and the refresh
 /// token, and a `reqwest::Error`'s `Display` can carry the URL.
 const REFRESH_FAILED: &str = "oauth2: cannot fetch token: request failed";
+
+/// `tokenRefresher.Token`'s refusal when the stored token has no refresh token.
+const NO_REFRESH_TOKEN: &str = "oauth2: token expired and refresh token is not set";
 
 fn http_client() -> Option<&'static reqwest::Client> {
     static CLIENT: OnceLock<Option<reqwest::Client>> = OnceLock::new();
@@ -562,86 +605,162 @@ impl Client {
 /// is a pinned divergence rather than an attempt.
 const TRANSPORT_FAILED: &str = "the request could not be sent";
 
-/// `googleapi.Error.Error()`, measured across every shape it takes.
+/// `googleapi.CheckResponse` + `Error.Error()`, ported statement by statement
+/// rather than case by case.
 ///
-/// Four forms, and the port reproduces all four:
+/// It was first written as a four-case `match` over an earlier reading, and
+/// review found three of the four branch conditions wrong. The shapes below are
+/// all pinned by `desktop/parity/google_vectors.json`, but the reason this is now
+/// a transcription of the Go function rather than a table of its outputs is that
+/// the table was the bug: every case it did not list, it got wrong silently.
 ///
-/// | body | text |
-/// |---|---|
-/// | one error with a reason | `googleapi: Error 403: Insufficient Permission, insufficientPermissions` |
-/// | no `errors` array | `googleapi: Error 404: Not Found` |
-/// | several errors | `googleapi: Error 400: Bad Request\nMore details:\nReason: r1, Message: m1\n…` |
-/// | not a Google error document | `googleapi: got HTTP response code 403 with body: …` |
+/// The three that were wrong, each a real Google response:
 ///
-/// This text reaches the model inside every tool's own wrapper, so it is a
-/// parity surface rather than a log line.
+/// - **The one-error form is conditional** on the sub-error's message equalling
+///   the top-level one. When they differ — the normal shape for a validation
+///   error, where the top level is generic and the item specific — Go takes the
+///   `More details` branch.
+/// - **`error.details` was dropped entirely.** It is the modern envelope
+///   (`google.rpc.ErrorInfo`, `QuotaFailure`) and it is what a real quota error
+///   carries, rendered as an indented JSON block.
+/// - **The raw-form test is `errors.is_empty() && message.is_empty()`**, not
+///   "no code and no message" — an `errors` array alone takes the structured
+///   branch, with the code defaulting to the HTTP status.
+///
+/// This text reaches the model inside every tool's own wrapper, so it is a parity
+/// surface rather than a log line.
 fn googleapi_error(status: reqwest::StatusCode, body: &str) -> String {
-    #[derive(Default, serde::Deserialize)]
-    #[serde(default)]
-    struct Detail {
-        #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
-        message: String,
-        #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
-        reason: String,
-    }
-    #[derive(Default, serde::Deserialize)]
-    #[serde(default)]
-    struct Inner {
-        #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
-        code: i64,
-        #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
-        message: String,
-        #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
-        errors: Vec<Detail>,
-    }
-    #[derive(Default, serde::Deserialize)]
-    #[serde(default)]
-    struct Envelope {
-        error: Option<crate::native::gojson::GoStruct<Inner>>,
-    }
-
-    let parsed = serde_json::from_str::<Option<crate::native::gojson::GoStruct<Envelope>>>(body)
-        .ok()
-        .and_then(|wrapped| wrapped.map(|wrapped| wrapped.0))
-        .and_then(|envelope| envelope.error)
-        .map(|wrapped| wrapped.0);
-
-    // `googleapi.CheckResponse` only produces an `*Error` when the document has
-    // an `error` **object**; `{"error":"invalid_grant"}` is a string and falls
-    // through to the raw form, which is why a token-endpoint style error reads
-    // differently from an API one.
-    let Some(inner) = parsed.filter(|inner| inner.code != 0 || !inner.message.is_empty()) else {
-        return format!(
+    let raw = || {
+        format!(
             "googleapi: got HTTP response code {} with body: {body}",
             status.as_u16()
-        );
+        )
     };
 
-    let code = if inner.code != 0 {
-        inner.code
+    // `errorReplyFromBody`: a body beginning with `[` is unwrapped as an array of
+    // replies and the first is taken.
+    let trimmed = body.trim_start();
+    let parsed = if trimmed.starts_with('[') {
+        serde_json::from_str::<Vec<crate::native::gojson::GoStruct<Envelope>>>(body)
+            .ok()
+            .and_then(|replies| replies.into_iter().next())
+            .and_then(|wrapped| wrapped.0.error)
     } else {
-        i64::from(status.as_u16())
+        // `CheckResponse` only produces an `*Error` when the document has an
+        // `error` **object**; `{"error":"invalid_grant"}` is a string and falls
+        // through to the raw form, which is why a token-endpoint style error
+        // reads differently from an API one.
+        serde_json::from_str::<Option<crate::native::gojson::GoStruct<Envelope>>>(body)
+            .ok()
+            .and_then(|wrapped| wrapped.map(|wrapped| wrapped.0))
+            .and_then(|envelope| envelope.error)
     };
-    match inner.errors.len() {
-        0 => format!("googleapi: Error {code}: {}", inner.message),
-        1 => format!(
-            "googleapi: Error {code}: {}, {}",
-            inner.message, inner.errors[0].reason
-        ),
-        _ => {
-            let mut out = format!(
-                "googleapi: Error {code}: {}\nMore details:\n",
-                inner.message
-            );
-            for detail in &inner.errors {
-                out.push_str(&format!(
-                    "Reason: {}, Message: {}\n",
-                    detail.reason, detail.message
-                ));
-            }
-            out
+    let Some(inner) = parsed.map(|wrapped| wrapped.0) else {
+        return raw();
+    };
+
+    // `Error()`'s own first line, and the only place the raw form is reachable
+    // from a document that *did* parse.
+    if inner.errors.is_empty() && inner.message.is_empty() {
+        return raw();
+    }
+
+    // `CheckResponse` defaults a zero code to the HTTP status.
+    let code = if inner.code == 0 {
+        i64::from(status.as_u16())
+    } else {
+        inner.code
+    };
+
+    let mut out = format!("googleapi: Error {code}: ");
+    out.push_str(&inner.message);
+
+    if !inner.details.is_empty() {
+        // `json.NewEncoder(&buf).SetIndent("", "  ").Encode(details)` — Go's
+        // sorted keys and HTML escaping, two-space indent, and the encoder's
+        // trailing newline, which the `TrimSpace` below removes when no errors
+        // section follows it.
+        if let Ok(compact) = crate::native::gojson::to_vec_marshal(&inner.details) {
+            let indented = crate::native::gojson::indent_compact(&compact);
+            out.push_str("\nDetails:\n");
+            out.push_str(&String::from_utf8_lossy(&indented));
+            out.push('\n');
         }
     }
+
+    if inner.errors.is_empty() {
+        // `strings.TrimSpace`, which is what removes the encoder's newline.
+        return out.trim().to_string();
+    }
+
+    let details = inner.details();
+    if details.len() == 1 && details[0].message == inner.message {
+        out.push_str(&format!(", {}", details[0].reason));
+        return out;
+    }
+
+    // `Fprintln` — hence the newline after the colon as well as before.
+    out.push_str("\nMore details:\n");
+    for detail in details {
+        out.push_str(&format!(
+            "Reason: {}, Message: {}\n",
+            detail.reason, detail.message
+        ));
+    }
+    out
+}
+
+/// One entry of `googleapi.Error.Errors`.
+#[derive(Default, serde::Deserialize)]
+#[serde(default)]
+struct ErrorItem {
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    message: String,
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    reason: String,
+}
+
+/// `googleapi.Error`, reduced to the fields `Error()` reads.
+#[derive(Default, serde::Deserialize)]
+#[serde(default)]
+struct GoogleError {
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    code: i64,
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    message: String,
+    /// Kept as raw values because `Error()` re-encodes them; `[]interface{}` in
+    /// Go, so any shape is legal here.
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    details: Vec<serde_json::Value>,
+    /// `Errors []ErrorItem` is a **value** slice in Go, so a `null` element
+    /// unmarshals to the zero `ErrorItem` rather than failing the document. The
+    /// `Option` is what reproduces that; `GoStruct` still refuses an array, which
+    /// is the rule the rest of this port follows.
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    errors: Vec<Option<crate::native::gojson::GoStruct<ErrorItem>>>,
+}
+
+impl GoogleError {
+    /// The `errors` array with every `null` collapsed to its zero value.
+    fn details(&self) -> Vec<ErrorItem> {
+        self.errors
+            .iter()
+            .map(|entry| {
+                entry
+                    .as_ref()
+                    .map_or_else(ErrorItem::default, |wrapped| ErrorItem {
+                        message: wrapped.0.message.clone(),
+                        reason: wrapped.0.reason.clone(),
+                    })
+            })
+            .collect()
+    }
+}
+
+#[derive(Default, serde::Deserialize)]
+#[serde(default)]
+struct Envelope {
+    error: Option<crate::native::gojson::GoStruct<GoogleError>>,
 }
 
 /// A boundary of the shape `googleapi`'s writer produces — 60 lowercase hex
@@ -740,6 +859,58 @@ mod tests {
         assert_eq!(
             googleapi_error(forbidden, "not json at all"),
             "googleapi: got HTTP response code 403 with body: not json at all"
+        );
+
+        // The branch the earlier four-case version got wrong: the one-error form
+        // requires the sub-error's message to *equal* the top-level one, so a
+        // differing message takes `More details`. Pinned in the vectors too.
+        assert_eq!(
+            googleapi_error(
+                forbidden,
+                r#"{"error":{"code":403,"message":"Insufficient Permission","errors":[{"message":"a different message","reason":"insufficientPermissions"}]}}"#
+            ),
+            "googleapi: Error 403: Insufficient Permission\nMore details:\nReason: insufficientPermissions, Message: a different message\n"
+        );
+        // `errors` alone is enough to take the structured branch, and the code
+        // defaults to the HTTP status.
+        assert_eq!(
+            googleapi_error(
+                forbidden,
+                r#"{"error":{"errors":[{"reason":"r","message":"m"}]}}"#
+            ),
+            "googleapi: Error 403: \nMore details:\nReason: r, Message: m\n"
+        );
+        // `Errors` is a value slice, so a null element is the zero item.
+        assert_eq!(
+            googleapi_error(
+                forbidden,
+                r#"{"error":{"code":403,"message":"Denied","errors":[null]}}"#
+            ),
+            "googleapi: Error 403: Denied\nMore details:\nReason: , Message: \n"
+        );
+        // …but an array is still not a struct, which is what keeps `GoStruct`
+        // meaningful here: Go fails the document and falls to the raw form.
+        let arrayed = r#"{"error":{"code":403,"message":"Denied","errors":[[]]}}"#;
+        assert_eq!(
+            googleapi_error(forbidden, arrayed),
+            format!("googleapi: got HTTP response code 403 with body: {arrayed}")
+        );
+        // A body beginning `[` is unwrapped by `errorReplyFromBody`.
+        assert_eq!(
+            googleapi_error(
+                forbidden,
+                r#"[{"error":{"code":403,"message":"from an array"}}]"#
+            ),
+            "googleapi: Error 403: from an array"
+        );
+        // `details` renders as an indented block, and the encoder's trailing
+        // newline is trimmed when nothing follows it.
+        assert_eq!(
+            googleapi_error(
+                reqwest::StatusCode::TOO_MANY_REQUESTS,
+                r#"{"error":{"code":429,"message":"Quota exceeded","details":[{"reason":"RATE_LIMIT"}]}}"#
+            ),
+            "googleapi: Error 429: Quota exceeded\nDetails:\n[\n  {\n    \"reason\": \"RATE_LIMIT\"\n  }\n]"
         );
     }
 

--- a/desktop/src-tauri/src/native/integrations/google/client.rs
+++ b/desktop/src-tauri/src/native/integrations/google/client.rs
@@ -648,18 +648,20 @@ fn googleapi_error(status: reqwest::StatusCode, body: &str) -> String {
 /// characters.
 ///
 /// Random per request there and here, which is why the vectors pin the parts
-/// rather than the bytes.
+/// rather than the byte stream.
+///
+/// **The randomness has to be unpredictable, not merely varying.** Neither Go nor
+/// this port checks whether the boundary occurs inside the content being
+/// uploaded — Go can skip that because `googleapi` draws its boundary from
+/// `crypto/rand`, so the chance is negligible. A boundary derived from the clock
+/// and the thread id would not be: `create_file`'s `content` is a tool argument,
+/// so a model could be steered into supplying one that terminates the upload
+/// early and lets the rest of the file be read as MIME headers. Two `Uuid::v4`s
+/// are 64 CSPRNG-backed hex characters, which is the repo's existing way of
+/// asking for exactly this.
 fn multipart_boundary() -> String {
-    use std::hash::{Hash, Hasher};
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    std::time::SystemTime::now().hash(&mut hasher);
-    std::thread::current().id().hash(&mut hasher);
-    let mut out = String::with_capacity(60);
-    let mut seed = hasher.finish();
-    while out.len() < 60 {
-        seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
-        out.push_str(&format!("{:016x}", seed));
-    }
+    let mut out = uuid::Uuid::new_v4().simple().to_string();
+    out.push_str(&uuid::Uuid::new_v4().simple().to_string());
     out.truncate(60);
     out
 }

--- a/desktop/src-tauri/src/native/integrations/google/client.rs
+++ b/desktop/src-tauri/src/native/integrations/google/client.rs
@@ -1,0 +1,817 @@
+//! The OAuth2-authenticated HTTP client, ported from
+//! `internal/integrations/google/server.go`'s `buildHTTPClient` plus the parts of
+//! `golang.org/x/oauth2` and `google.golang.org/api` that are observable on the
+//! wire.
+//!
+//! # Google is the only one of the six that does not hand-roll HTTP
+//!
+//! The other five build a request with `http.NewRequest` and `json.Marshal`, so
+//! the port reproduces bytes it can read in `tools.go`. Google calls the
+//! **generated** client libraries (`calendar/v3`, `gmail/v1`, `drive/v3`) over an
+//! `oauth2` transport, so what goes on the wire is decided by code that is not in
+//! this repository. Every value below was therefore *measured* — a recording
+//! server behind `option.WithEndpoint` — rather than read off a source file.
+//!
+//! ## What is reproduced, and what cannot be
+//!
+//! Reproduced, and pinned by `desktop/parity/google_vectors.json`: the method,
+//! the path, the **whole** query string (`alt=json&prettyPrint=false` on every
+//! call, sorted keys, the field masks, `uploadType=multipart`), the JSON request
+//! bodies, the `Authorization` header, and every result and error sentence.
+//!
+//! Not reproducible, and pinned as divergence rather than hidden:
+//!
+//! - **`X-Goog-Api-Client: gl-go/1.26.5 gdcl/0.291.0`** and
+//!   **`User-Agent: google-api-go-client/0.5`**. The first embeds the *Go
+//!   toolchain* version and the *client library* version; no Rust build can emit
+//!   `gl-go/…`, and freezing the value would break on any `go.mod` bump. This
+//!   port sends neither.
+//! - **The multipart boundary** `create_file` generates is random per request, so
+//!   the vectors pin the *parts* — the JSON metadata part and the media part with
+//!   its content type — rather than the byte stream.
+//! - `Accept-Encoding: gzip`, which both sides send but neither controls.
+//!
+//! # The token source
+//!
+//! `buildHTTPClient` wraps the stored token in `oauth2.Config.TokenSource` and
+//! `oauth2.NewClient`, which refreshes transparently. Measured, and reproduced
+//! exactly:
+//!
+//! - A token refreshes when `Valid()` is false — which is `AccessToken != ""` and
+//!   not expired, where **a zero expiry never expires** and the comparison
+//!   carries a **10-second** `expiryDelta`. A token due in 5s refreshes; one due
+//!   in an hour does not.
+//! - The refresh is `POST` to `https://oauth2.googleapis.com/token`,
+//!   `application/x-www-form-urlencoded`, body
+//!   `client_id=…&client_secret=…&grant_type=refresh_token&refresh_token=…` —
+//!   `url.Values.Encode`'s sorted keys, and the client credentials in the
+//!   **body**, not a `Basic` header, because `google.Endpoint` declares
+//!   `AuthStyleInParams` (measured: `AuthStyle=1`).
+//! - A response with no `refresh_token` keeps the old one.
+//! - **Nothing is persisted.** Go refreshes in memory for the life of the client
+//!   and never writes the new token back, so a restart re-reads the stored one.
+//!
+//! #318 owns the OAuth *flow* and says of this: "Token refresh is shared with the
+//! Google MCP server. One implementation, not two." [`TokenSource`] is that
+//! implementation, kept behind a narrow interface so #318 can adopt it rather
+//! than write a second.
+
+use std::sync::OnceLock;
+#[cfg(test)]
+use std::sync::RwLock;
+use std::time::{Duration, SystemTime};
+
+use tokio::sync::Mutex;
+
+use crate::claude::CancellationToken;
+use crate::native::gourl::Values;
+
+/// `google.Endpoint.TokenURL`, measured.
+pub const DEFAULT_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
+
+/// The three generated clients' `BasePath`s, measured off a real service.
+///
+/// Note they are not one host: Gmail moved to its own, and its relative paths
+/// carry `gmail/v1/` where the other two carry it in the base.
+pub const CALENDAR_BASE: &str = "https://www.googleapis.com/calendar/v3/";
+pub const DRIVE_BASE: &str = "https://www.googleapis.com/drive/v3/";
+pub const GMAIL_BASE: &str = "https://gmail.googleapis.com/";
+
+/// Where requests go, when a test has redirected them.
+///
+/// One override for all four bases: `option.WithEndpoint` replaces the base and
+/// leaves each generated method's *relative* reference alone, so a fake sees
+/// `/calendars/primary/events`, `/gmail/v1/users/me/messages/send` and `/files`
+/// — which is exactly what this reproduces. Test-only for
+/// `github::client::API_BASE`'s reason, and sharper here: the override would
+/// point a refresh carrying the user's `client_secret` at an arbitrary host.
+#[cfg(test)]
+static API_BASE: RwLock<Option<String>> = RwLock::new(None);
+
+#[cfg(test)]
+pub(super) fn set_api_base(base: Option<String>) {
+    *API_BASE
+        .write()
+        .expect("the google API base lock is poisoned") = base;
+}
+
+#[cfg(test)]
+pub(super) async fn api_base_lock() -> tokio::sync::MutexGuard<'static, ()> {
+    static LOCK: Mutex<()> = Mutex::const_new(());
+    LOCK.lock().await
+}
+
+#[cfg(test)]
+fn override_base() -> Option<String> {
+    API_BASE
+        .read()
+        .expect("the google API base lock is poisoned")
+        .clone()
+}
+
+#[cfg(not(test))]
+fn override_base() -> Option<String> {
+    None
+}
+
+/// Which generated client a request belongs to — and therefore which base it
+/// resolves against.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Api {
+    Calendar,
+    Drive,
+    Gmail,
+}
+
+impl Api {
+    fn base(self) -> String {
+        if let Some(base) = override_base() {
+            return base;
+        }
+        match self {
+            Self::Calendar => CALENDAR_BASE.to_string(),
+            Self::Drive => DRIVE_BASE.to_string(),
+            Self::Gmail => GMAIL_BASE.to_string(),
+        }
+    }
+}
+
+/// `googleapi.ResolveRelative(basePath, ref)`.
+///
+/// A reference beginning with `/` replaces the base's whole path — which is what
+/// makes Drive's upload endpoint `https://www.googleapis.com/upload/drive/v3/files`
+/// rather than something under `/drive/v3/`. Anything else is appended to the
+/// base, which always ends in `/`.
+fn resolve_relative(base: &str, reference: &str) -> Option<reqwest::Url> {
+    let base = reqwest::Url::parse(base).ok()?;
+    base.join(reference).ok()
+}
+
+/// `googleapi.Expand`'s path-parameter escaping — **not** `url.PathEscape`.
+///
+/// The generated clients build their paths from RFC 6570 URI templates
+/// (`gmail/v1/users/{userId}/messages/{id}`) and expand them with
+/// `googleapi.Expand`, whose simple-string expansion percent-encodes everything
+/// outside RFC 3986's *unreserved* set. `url.PathEscape` leaves the sub-delims
+/// alone, so the two disagree on characters a Gmail message id or a Drive file id
+/// can legitimately contain: measured, `a/b c?d&e` expands to `a%2Fb%20c%3Fd%26e`
+/// where `PathEscape` gives `a%2Fb%20c%3Fd&e` — an `&` that would start a query
+/// parameter.
+///
+/// This is `googleapi`'s rule rather than `net/url`'s, which is why it lives here
+/// and not in `gourl`.
+pub(super) fn expand_path_segment(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.as_bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~') {
+            out.push(*byte as char);
+        } else {
+            out.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    out
+}
+
+/// `oauth2.Token`, reduced to what the transport reads.
+#[derive(Clone)]
+pub struct Token {
+    pub access_token: String,
+    pub refresh_token: String,
+    /// `None` is Go's zero `time.Time`, which **never expires**.
+    pub expiry: Option<SystemTime>,
+}
+
+impl Token {
+    /// `(*Token).Valid()`: a non-empty access token that is not expired.
+    ///
+    /// `expired()` is `Expiry.Add(-expiryDelta).Before(now)` with a **10-second**
+    /// delta, and a zero expiry short-circuits to "not expired". Both halves are
+    /// measured: a token due in 5 seconds refreshes, one with no expiry never
+    /// does.
+    fn valid(&self, now: SystemTime) -> bool {
+        if self.access_token.is_empty() {
+            return false;
+        }
+        match self.expiry {
+            None => true,
+            Some(expiry) => expiry
+                .checked_sub(EXPIRY_DELTA)
+                .is_none_or(|deadline| deadline >= now),
+        }
+    }
+}
+
+/// `oauth2`'s `defaultExpiryDelta`.
+const EXPIRY_DELTA: Duration = Duration::from_secs(10);
+
+/// `oauth2.Config.TokenSource` + `oauth2.NewClient`, reduced to the one thing
+/// they do that is observable: hand out a valid access token, refreshing it when
+/// it is not.
+///
+/// A `Mutex` rather than a lock-free cache because two concurrent `tools/call`s
+/// on an expired token must not both refresh — Go's `reuseTokenSource` holds a
+/// mutex for exactly that.
+pub struct TokenSource {
+    client_id: String,
+    client_secret: String,
+    current: Mutex<Token>,
+}
+
+impl TokenSource {
+    pub fn new(
+        client_id: impl Into<String>,
+        client_secret: impl Into<String>,
+        token: Token,
+    ) -> Self {
+        Self {
+            client_id: client_id.into(),
+            client_secret: client_secret.into(),
+            current: Mutex::new(token),
+        }
+    }
+
+    /// The access token to put in `Authorization`, refreshing first if the stored
+    /// one is not `Valid()`.
+    ///
+    /// `failed` is the caller's sentence, because a refresh failure surfaces as
+    /// the *tool's* failure in Go — `oauth2`'s transport returns it from
+    /// `RoundTrip`, so the generated client wraps it exactly as it wraps any
+    /// other transport error.
+    async fn access_token(&self, ct: &CancellationToken) -> Result<String, String> {
+        let mut current = self.current.lock().await;
+        if current.valid(SystemTime::now()) {
+            return Ok(current.access_token.clone());
+        }
+        let refreshed = self.refresh(ct, &current).await?;
+        *current = refreshed;
+        Ok(current.access_token.clone())
+    }
+
+    /// The refresh request, measured against `golang.org/x/oauth2`.
+    async fn refresh(&self, ct: &CancellationToken, current: &Token) -> Result<Token, String> {
+        // `url.Values.Encode()` — sorted keys, and the client credentials in the
+        // **body** because `google.Endpoint` declares `AuthStyleInParams`. A
+        // `Basic` header here would be a different request.
+        let mut form = Values::new();
+        form.set("client_id", &self.client_id);
+        form.set("client_secret", &self.client_secret);
+        form.set("grant_type", "refresh_token");
+        form.set("refresh_token", &current.refresh_token);
+
+        let token_url = override_base().map_or_else(
+            || DEFAULT_TOKEN_URL.to_string(),
+            |base| format!("{}{}", base.trim_end_matches('/'), "/token"),
+        );
+
+        let request = http_client()
+            .ok_or(REFRESH_FAILED)?
+            .post(token_url)
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .body(form.encode());
+
+        let response = tokio::select! {
+            () = ct.cancelled() => return Err(REFRESH_FAILED.to_string()),
+            result = request.send() => result.map_err(|_| REFRESH_FAILED.to_string())?,
+        };
+
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .map_err(|_| REFRESH_FAILED.to_string())?;
+
+        // `oauth2/internal.doTokenRoundTrip`, reproduced in its own order —
+        // which is not the obvious one. The status is *not* checked first: the
+        // body is parsed first, and an `error` code in a **200** is still a
+        // failure, "because some unorthodox servers respond 200 in error case".
+        let failure = !(200..=299).contains(&status.as_u16());
+
+        // One deliberate omission. `doTokenRoundTrip` has a second branch for a
+        // `application/x-www-form-urlencoded` or `text/plain` response body,
+        // "because some endpoints return a query string". Google's does not — it
+        // is `application/json` and this port only ever talks to Google's — so
+        // reproducing `url.ParseQuery` here would be unreachable code with its own
+        // parity surface. A form-encoded body reaches the JSON branch instead and
+        // fails to decode, which lands on the same two sentences below.
+        //
+        // The three decode rules every response in this port carries; see
+        // `native/integrations/telegram/client.rs` for why each is needed.
+        let parsed = match serde_json::from_str::<
+            Option<crate::native::gojson::GoStruct<TokenResponse>>,
+        >(&body)
+        {
+            Ok(wrapped) => wrapped.map_or_else(TokenResponse::default, |wrapped| wrapped.0),
+            Err(_) if failure => {
+                return Err(retrieve_error(status, &body, &TokenResponse::default()))
+            }
+            Err(e) => return Err(format!("oauth2: cannot parse json: {e}")),
+        };
+
+        if failure || !parsed.error.is_empty() {
+            return Err(retrieve_error(status, &body, &parsed));
+        }
+        if parsed.access_token.is_empty() {
+            return Err("oauth2: server response missing access_token".to_string());
+        }
+
+        Ok(Token {
+            access_token: parsed.access_token,
+            // "Don't overwrite `RefreshToken` with an empty value if this was a
+            // token refreshing request" — `retrieveToken`, which substitutes the
+            // one the *request* carried.
+            refresh_token: if parsed.refresh_token.is_empty() {
+                current.refresh_token.clone()
+            } else {
+                parsed.refresh_token
+            },
+            // `tokenJSON.expiry()` tests `!= 0`, not `> 0` — a negative
+            // `expires_in` produces an expiry in the past rather than none.
+            expiry: (parsed.expires_in != 0).then(|| {
+                let delta = Duration::from_secs(parsed.expires_in.unsigned_abs());
+                if parsed.expires_in > 0 {
+                    SystemTime::now() + delta
+                } else {
+                    SystemTime::now() - delta
+                }
+            }),
+        })
+    }
+}
+
+/// `oauth2/internal.tokenJSON`, reduced to the fields the transport reads.
+#[derive(Default, serde::Deserialize)]
+#[serde(default)]
+struct TokenResponse {
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    access_token: String,
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    refresh_token: String,
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    expires_in: i64,
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    error: String,
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    error_description: String,
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    error_uri: String,
+}
+
+/// `oauth2.RetrieveError.Error()`, which has **two** forms and picks between them
+/// on whether the body named an error code — not on the status.
+///
+/// Measured: a Google refresh refusal reads
+/// `oauth2: "invalid_grant" "Token has been expired or revoked."`, not the
+/// `cannot fetch token: 400 Bad Request` form the port originally had. Both are
+/// reachable and both are pinned by `desktop/parity/google_vectors.json`.
+///
+/// `{:?}` stands in for `%q`, as it does at every other `%q` site in this port.
+fn retrieve_error(status: reqwest::StatusCode, body: &str, parsed: &TokenResponse) -> String {
+    if parsed.error.is_empty() {
+        return format!(
+            "oauth2: cannot fetch token: {}\nResponse: {body}",
+            status_line(status)
+        );
+    }
+    let mut out = format!("oauth2: {:?}", parsed.error);
+    for extra in [&parsed.error_description, &parsed.error_uri] {
+        if !extra.is_empty() {
+            out.push_str(&format!(" {extra:?}"));
+        }
+    }
+    out
+}
+
+/// `net/http`'s status line, which is what `%v` renders for `oauth2`'s error.
+fn status_line(status: reqwest::StatusCode) -> String {
+    match status.canonical_reason() {
+        Some(reason) => format!("{} {reason}", status.as_u16()),
+        None => format!("{}", status.as_u16()),
+    }
+}
+
+/// The sentence a refresh failure carries when it never reached a response.
+///
+/// It names nothing: the request holds the `client_secret` and the refresh
+/// token, and a `reqwest::Error`'s `Display` can carry the URL.
+const REFRESH_FAILED: &str = "oauth2: cannot fetch token: request failed";
+
+fn http_client() -> Option<&'static reqwest::Client> {
+    static CLIENT: OnceLock<Option<reqwest::Client>> = OnceLock::new();
+    CLIENT
+        .get_or_init(|| {
+            // The generated clients set no timeout of their own — Go's
+            // `oauth2.NewClient` builds a plain `http.Client`. One is set here
+            // for the reason `desktop/CLAUDE.md` gives: a handler with no client
+            // timeout is what an unbounded graceful shutdown waits on. 60s
+            // matches the longest any sibling uses.
+            reqwest::Client::builder()
+                .timeout(Duration::from_secs(60))
+                .build()
+                .ok()
+        })
+        .as_ref()
+}
+
+/// The two parts of a `multipart/related` upload, bundled so `post_multipart`
+/// takes a body rather than three loose pieces of one.
+pub struct Multipart {
+    /// Already carrying `super::marshal`'s trailing newline.
+    pub metadata: Vec<u8>,
+    /// **Sniffed from the content**, not the tool's `mime_type` argument.
+    pub media_type: String,
+    pub media: Vec<u8>,
+}
+
+/// One authenticated call to a generated Google API.
+///
+/// Cloned per tool from the closure that captured it, so the token source is
+/// shared: a refresh by one tool is seen by the next, which is what
+/// `oauth2.NewClient` gives Go.
+#[derive(Clone)]
+pub struct Client {
+    tokens: std::sync::Arc<TokenSource>,
+}
+
+impl Client {
+    pub fn new(tokens: std::sync::Arc<TokenSource>) -> Self {
+        Self { tokens }
+    }
+
+    /// A `GET` whose response is decoded as JSON.
+    pub async fn get(
+        &self,
+        ct: &CancellationToken,
+        api: Api,
+        reference: &str,
+        query: &Values,
+    ) -> Result<String, String> {
+        self.send(ct, api, reqwest::Method::GET, reference, query, None)
+            .await
+    }
+
+    /// A `POST` carrying a JSON body.
+    pub async fn post_json(
+        &self,
+        ct: &CancellationToken,
+        api: Api,
+        reference: &str,
+        query: &Values,
+        body: Vec<u8>,
+    ) -> Result<String, String> {
+        self.send(
+            ct,
+            api,
+            reqwest::Method::POST,
+            reference,
+            query,
+            Some(("application/json".to_string(), body)),
+        )
+        .await
+    }
+
+    /// A `POST` carrying a `multipart/related` upload — Drive's `create_file`.
+    ///
+    /// The boundary is random in Go and random here; the vectors pin the parts.
+    pub async fn post_multipart(
+        &self,
+        ct: &CancellationToken,
+        api: Api,
+        reference: &str,
+        query: &Values,
+        upload: Multipart,
+    ) -> Result<String, String> {
+        let Multipart {
+            metadata,
+            media_type,
+            media,
+        } = upload;
+        let boundary = multipart_boundary();
+        let mut body = Vec::new();
+        // `googleapi`'s `multipart/related` writer: the metadata part is
+        // `application/json`, the media part carries the file's own type, and
+        // each part's headers are followed by a blank line.
+        body.extend_from_slice(
+            format!("--{boundary}\r\nContent-Type: application/json\r\n\r\n").as_bytes(),
+        );
+        // `metadata` already carries `json.NewEncoder(...).Encode`'s trailing
+        // newline — see `super::marshal`, which is where both body shapes get it.
+        body.extend_from_slice(&metadata);
+        body.extend_from_slice(
+            format!("\r\n--{boundary}\r\nContent-Type: {media_type}\r\n\r\n").as_bytes(),
+        );
+        body.extend_from_slice(&media);
+        body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+
+        self.send(
+            ct,
+            api,
+            reqwest::Method::POST,
+            reference,
+            query,
+            Some((format!("multipart/related; boundary={boundary}"), body)),
+        )
+        .await
+    }
+
+    async fn send(
+        &self,
+        ct: &CancellationToken,
+        api: Api,
+        method: reqwest::Method,
+        reference: &str,
+        query: &Values,
+        body: Option<(String, Vec<u8>)>,
+    ) -> Result<String, String> {
+        let mut url = resolve_relative(&api.base(), reference).ok_or(TRANSPORT_FAILED)?;
+        url.set_query(Some(&query.encode()));
+
+        let token = self.tokens.access_token(ct).await?;
+        let mut request = http_client()
+            .ok_or(TRANSPORT_FAILED)?
+            .request(method, url)
+            // `oauth2`'s `SetAuthHeader`: the token type title-cased, and an
+            // empty type is `Bearer`.
+            .header("Authorization", format!("Bearer {token}"));
+        if let Some((content_type, body)) = body {
+            request = request.header("Content-Type", content_type).body(body);
+        }
+
+        let response = tokio::select! {
+            () = ct.cancelled() => return Err(TRANSPORT_FAILED.to_string()),
+            result = request.send() => result.map_err(|_| TRANSPORT_FAILED.to_string())?,
+        };
+
+        let status = response.status();
+        let text = response
+            .text()
+            .await
+            .map_err(|e| format!("reading response: {e}"))?;
+        if !(200..300).contains(&status.as_u16()) {
+            return Err(googleapi_error(status, &text));
+        }
+        Ok(text)
+    }
+}
+
+/// What a transport failure reads as.
+///
+/// The generated clients surface a `*url.Error` here, whose text carries the
+/// method and URL — and the URL is a Google endpoint rather than a credential,
+/// so Go's is not a leak. It is not reproducible all the same (`Get "…": dial
+/// tcp …: connect: connection refused` embeds the resolver's message), so this
+/// is a pinned divergence rather than an attempt.
+const TRANSPORT_FAILED: &str = "the request could not be sent";
+
+/// `googleapi.Error.Error()`, measured across every shape it takes.
+///
+/// Four forms, and the port reproduces all four:
+///
+/// | body | text |
+/// |---|---|
+/// | one error with a reason | `googleapi: Error 403: Insufficient Permission, insufficientPermissions` |
+/// | no `errors` array | `googleapi: Error 404: Not Found` |
+/// | several errors | `googleapi: Error 400: Bad Request\nMore details:\nReason: r1, Message: m1\n…` |
+/// | not a Google error document | `googleapi: got HTTP response code 403 with body: …` |
+///
+/// This text reaches the model inside every tool's own wrapper, so it is a
+/// parity surface rather than a log line.
+fn googleapi_error(status: reqwest::StatusCode, body: &str) -> String {
+    #[derive(Default, serde::Deserialize)]
+    #[serde(default)]
+    struct Detail {
+        #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+        message: String,
+        #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+        reason: String,
+    }
+    #[derive(Default, serde::Deserialize)]
+    #[serde(default)]
+    struct Inner {
+        #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+        code: i64,
+        #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+        message: String,
+        #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+        errors: Vec<Detail>,
+    }
+    #[derive(Default, serde::Deserialize)]
+    #[serde(default)]
+    struct Envelope {
+        error: Option<crate::native::gojson::GoStruct<Inner>>,
+    }
+
+    let parsed = serde_json::from_str::<Option<crate::native::gojson::GoStruct<Envelope>>>(body)
+        .ok()
+        .and_then(|wrapped| wrapped.map(|wrapped| wrapped.0))
+        .and_then(|envelope| envelope.error)
+        .map(|wrapped| wrapped.0);
+
+    // `googleapi.CheckResponse` only produces an `*Error` when the document has
+    // an `error` **object**; `{"error":"invalid_grant"}` is a string and falls
+    // through to the raw form, which is why a token-endpoint style error reads
+    // differently from an API one.
+    let Some(inner) = parsed.filter(|inner| inner.code != 0 || !inner.message.is_empty()) else {
+        return format!(
+            "googleapi: got HTTP response code {} with body: {body}",
+            status.as_u16()
+        );
+    };
+
+    let code = if inner.code != 0 {
+        inner.code
+    } else {
+        i64::from(status.as_u16())
+    };
+    match inner.errors.len() {
+        0 => format!("googleapi: Error {code}: {}", inner.message),
+        1 => format!(
+            "googleapi: Error {code}: {}, {}",
+            inner.message, inner.errors[0].reason
+        ),
+        _ => {
+            let mut out = format!(
+                "googleapi: Error {code}: {}\nMore details:\n",
+                inner.message
+            );
+            for detail in &inner.errors {
+                out.push_str(&format!(
+                    "Reason: {}, Message: {}\n",
+                    detail.reason, detail.message
+                ));
+            }
+            out
+        }
+    }
+}
+
+/// A boundary of the shape `googleapi`'s writer produces — 60 lowercase hex
+/// characters.
+///
+/// Random per request there and here, which is why the vectors pin the parts
+/// rather than the bytes.
+fn multipart_boundary() -> String {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    std::time::SystemTime::now().hash(&mut hasher);
+    std::thread::current().id().hash(&mut hasher);
+    let mut out = String::with_capacity(60);
+    let mut seed = hasher.finish();
+    while out.len() < 60 {
+        seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+        out.push_str(&format!("{:016x}", seed));
+    }
+    out.truncate(60);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECRET: &str = "GOCSPX-SUPER-SECRET-CLIENT-SECRET";
+    const REFRESH: &str = "1//SUPER-SECRET-REFRESH-TOKEN";
+
+    fn token(expiry: Option<SystemTime>) -> Token {
+        Token {
+            access_token: "OLD-ACCESS".to_string(),
+            refresh_token: REFRESH.to_string(),
+            expiry,
+        }
+    }
+
+    /// `Valid()`'s three rules, each measured against `oauth2` before it was
+    /// written: a zero expiry never expires, and the comparison carries a
+    /// ten-second delta.
+    #[test]
+    fn validity_matches_oauth2s_rules() {
+        let now = SystemTime::now();
+        assert!(token(None).valid(now), "a zero expiry never expires");
+        assert!(
+            token(Some(now + Duration::from_secs(3600))).valid(now),
+            "an hour out is valid"
+        );
+        assert!(
+            !token(Some(now + Duration::from_secs(5))).valid(now),
+            "inside the 10s delta is not"
+        );
+        assert!(
+            !token(Some(now - Duration::from_secs(1))).valid(now),
+            "past is not"
+        );
+        let mut empty = token(None);
+        empty.access_token.clear();
+        assert!(!empty.valid(now), "an empty access token is never valid");
+    }
+
+    /// `googleapi.Error.Error()`, all four shapes, each copied from a measured
+    /// run against the real library.
+    #[test]
+    fn the_googleapi_error_text_matches_the_library() {
+        let forbidden = reqwest::StatusCode::FORBIDDEN;
+        assert_eq!(
+            googleapi_error(
+                forbidden,
+                r#"{"error":{"code":403,"message":"Insufficient Permission","errors":[{"message":"Insufficient Permission","domain":"global","reason":"insufficientPermissions"}]}}"#
+            ),
+            "googleapi: Error 403: Insufficient Permission, insufficientPermissions"
+        );
+        assert_eq!(
+            googleapi_error(forbidden, r#"{"error":{"code":404,"message":"Not Found"}}"#),
+            "googleapi: Error 404: Not Found"
+        );
+        assert_eq!(
+            googleapi_error(
+                forbidden,
+                r#"{"error":{"code":400,"message":"Bad Request","errors":[{"message":"m1","reason":"r1"},{"message":"m2","reason":"r2"}]}}"#
+            ),
+            "googleapi: Error 400: Bad Request\nMore details:\nReason: r1, Message: m1\nReason: r2, Message: m2\n"
+        );
+        // An `error` that is a **string** is not a Google error document, so it
+        // falls through to the raw form — which is what a token-endpoint style
+        // failure looks like.
+        let raw =
+            r#"{"error":"invalid_grant","error_description":"Token has been expired or revoked."}"#;
+        assert_eq!(
+            googleapi_error(forbidden, raw),
+            format!("googleapi: got HTTP response code 403 with body: {raw}")
+        );
+        assert_eq!(
+            googleapi_error(forbidden, "not json at all"),
+            "googleapi: got HTTP response code 403 with body: not json at all"
+        );
+    }
+
+    /// `ResolveRelative`: an absolute reference replaces the base's path, which
+    /// is what puts Drive's upload on `/upload/drive/v3/files`.
+    #[test]
+    fn resolve_relative_matches_googleapis_rule() {
+        assert_eq!(
+            resolve_relative(CALENDAR_BASE, "calendars/primary/events")
+                .expect("resolves")
+                .as_str(),
+            "https://www.googleapis.com/calendar/v3/calendars/primary/events"
+        );
+        assert_eq!(
+            resolve_relative(DRIVE_BASE, "files")
+                .expect("resolves")
+                .as_str(),
+            "https://www.googleapis.com/drive/v3/files"
+        );
+        assert_eq!(
+            resolve_relative(DRIVE_BASE, "/upload/drive/v3/files")
+                .expect("resolves")
+                .as_str(),
+            "https://www.googleapis.com/upload/drive/v3/files",
+            "an absolute reference replaces the base's whole path"
+        );
+        assert_eq!(
+            resolve_relative(GMAIL_BASE, "gmail/v1/users/me/messages/send")
+                .expect("resolves")
+                .as_str(),
+            "https://gmail.googleapis.com/gmail/v1/users/me/messages/send"
+        );
+    }
+
+    /// A refresh that never reaches a response names nothing: the request body
+    /// holds both the `client_secret` and the refresh token.
+    #[tokio::test]
+    async fn a_failed_refresh_names_neither_secret() {
+        let _guard = api_base_lock().await;
+        set_api_base(Some("http://127.0.0.1:1".to_string()));
+
+        let source = TokenSource::new("CID", SECRET, token(Some(SystemTime::now())));
+        let err = source
+            .access_token(&CancellationToken::new())
+            .await
+            .expect_err("nothing is listening");
+        assert_eq!(err, REFRESH_FAILED);
+        assert!(!err.contains(SECRET));
+        assert!(!err.contains(REFRESH));
+
+        set_api_base(None);
+    }
+
+    /// A valid token is handed back without a request being made at all — which
+    /// is what stops every call refreshing.
+    #[tokio::test]
+    async fn a_valid_token_is_reused_without_a_refresh() {
+        let _guard = api_base_lock().await;
+        // Port 1: a refresh would fail, so reaching one is observable.
+        set_api_base(Some("http://127.0.0.1:1".to_string()));
+
+        let source = TokenSource::new(
+            "CID",
+            SECRET,
+            token(Some(SystemTime::now() + Duration::from_secs(3600))),
+        );
+        assert_eq!(
+            source
+                .access_token(&CancellationToken::new())
+                .await
+                .expect("valid tokens need no refresh"),
+            "OLD-ACCESS"
+        );
+
+        set_api_base(None);
+    }
+}

--- a/desktop/src-tauri/src/native/integrations/google/drive.rs
+++ b/desktop/src-tauri/src/native/integrations/google/drive.rs
@@ -1,0 +1,348 @@
+//! The `drive` service's three tools, ported from
+//! `internal/integrations/google/drive.go`.
+//!
+//! Two things here are unlike anything in the other five integrations:
+//!
+//! 1. **`create_file` is a `multipart/related` upload** to a *different* path
+//!    from every other Drive call — `/upload/drive/v3/files`, which the generated
+//!    client resolves as an **absolute** reference and so replaces the base's
+//!    whole path. Measured; see `client::resolve_relative`.
+//! 2. **The media part's `Content-Type` is sniffed from the content**, not taken
+//!    from the tool's `mime_type` argument. Measured across five inputs: an
+//!    `image/png` payload yields `image/png` and every textual one yields
+//!    `text/plain; charset=utf-8`, *regardless* of what `mime_type` said. The
+//!    argument reaches the metadata JSON alone. See [`detect_content_type`].
+//!
+//! And one shared with Gmail: `download_file` is the only call in the whole
+//! integration that is not `alt=json` — it is `alt=media`, and its result is the
+//! response body verbatim rather than a formatted summary.
+
+use schemars::JsonSchema;
+use serde_json::json;
+
+use crate::claude::{new_tool, CancellationToken, ToolDef};
+use crate::native::gourl::Values;
+
+use super::client::{Api, Client, Multipart};
+use super::text_result;
+
+/// `list_files`.
+#[allow(dead_code)] // read through serde, never constructed in Rust
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct ListFilesInput {
+    /// Optional Drive query string (e.g. "name contains 'report'")
+    query: String,
+    /// Maximum number of files to return (default 10, max 100)
+    max_results: i64,
+}
+
+pub fn list_files(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "list_files",
+        "Lists files and folders in Google Drive.",
+        move |input: ListFilesInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let max_results = if input.max_results <= 0 || input.max_results > 100 {
+                    10
+                } else {
+                    input.max_results
+                };
+
+                let mut query = super::calendar::base_query();
+                query.set(
+                    "fields",
+                    "files(id,name,mimeType,size,modifiedTime,webViewLink)",
+                );
+                query.set("pageSize", max_results.to_string());
+                // Conditional, unlike Gmail's `q` — an empty Drive query sends
+                // no key at all.
+                if !input.query.is_empty() {
+                    query.set("q", &input.query);
+                }
+
+                let listed: FileList = client
+                    .get(&ct, Api::Drive, "files", &query)
+                    .await
+                    .and_then(|raw| super::decode(&raw))
+                    .map_err(|e| format!("listing drive files: {e}"))?;
+                if listed.files.is_empty() {
+                    return Ok(text_result("No files found.".to_string()));
+                }
+
+                let rows: Vec<String> = listed
+                    .files()
+                    .map(|file| {
+                        format!(
+                            "Name: {}\nID: {}\nType: {}\nModified: {}\nLink: {}",
+                            file.name,
+                            file.id,
+                            file.mime_type,
+                            file.modified_time,
+                            file.web_view_link
+                        )
+                    })
+                    .collect();
+
+                Ok(text_result(format!(
+                    "Found {} file(s):\n\n{}",
+                    listed.files.len(),
+                    rows.join("\n\n---\n\n")
+                )))
+            }
+        },
+    )
+}
+
+/// `create_file`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct CreateFileInput {
+    /// required,Name of the file to create
+    name: String,
+    /// required,Text content of the file
+    content: String,
+    /// MIME type (default: text/plain)
+    mime_type: String,
+}
+
+pub fn create_file(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "create_file",
+        "Creates a new file in Google Drive with the provided content.",
+        move |input: CreateFileInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let mime_type = if input.mime_type.is_empty() {
+                    "text/plain"
+                } else {
+                    &input.mime_type
+                };
+
+                let mut query = super::calendar::base_query();
+                query.set("fields", "id,name,webViewLink");
+                query.set("uploadType", "multipart");
+
+                // The metadata part. `drive.File`'s fields carry `omitempty`,
+                // and both of these are always set, so both always appear —
+                // sorted, as `json.Marshal` sorts a struct's declared order into
+                // the generated field order (`mimeType` before `name`).
+                let metadata = super::marshal(&json!({
+                    "mimeType": mime_type,
+                    "name": input.name,
+                }))?;
+
+                // **Sniffed**, not `mime_type` — see the module docs.
+                let media_type = detect_content_type(input.content.as_bytes());
+
+                let created: File = client
+                    .post_multipart(
+                        &ct,
+                        Api::Drive,
+                        // Absolute, so it replaces the base's path entirely.
+                        "/upload/drive/v3/files",
+                        &query,
+                        Multipart {
+                            metadata,
+                            media_type,
+                            media: input.content.clone().into_bytes(),
+                        },
+                    )
+                    .await
+                    .and_then(|raw| super::decode(&raw))
+                    .map_err(|e| format!("creating drive file: {e}"))?;
+                Ok(text_result(format!(
+                    "File created: {}\nID: {}\nLink: {}",
+                    created.name, created.id, created.web_view_link
+                )))
+            }
+        },
+    )
+}
+
+/// `download_file`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct DownloadFileInput {
+    /// required,The Google Drive file ID to download
+    file_id: String,
+}
+
+pub fn download_file(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "download_file",
+        "Downloads and returns the text content of a Google Drive file by its ID.",
+        move |input: DownloadFileInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                // The only call in the integration that is not `alt=json`.
+                let mut query = Values::new();
+                query.set("alt", "media");
+                query.set("prettyPrint", "false");
+                let path = format!(
+                    "files/{}",
+                    super::client::expand_path_segment(&input.file_id)
+                );
+
+                let body = client
+                    .get(&ct, Api::Drive, &path, &query)
+                    .await
+                    // Go quotes the id with `%q`.
+                    .map_err(|e| format!("downloading drive file {:?}: {e}", input.file_id))?;
+
+                // The bytes, verbatim — no summary and no label.
+                Ok(text_result(body))
+            }
+        },
+    )
+}
+
+/// `drive.File`, reduced to the fields the handlers read.
+#[derive(Default, serde::Deserialize)]
+#[serde(default)]
+struct File {
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    id: String,
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    name: String,
+    #[serde(rename = "mimeType")]
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    mime_type: String,
+    #[serde(rename = "modifiedTime")]
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    modified_time: String,
+    #[serde(rename = "webViewLink")]
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    web_view_link: String,
+}
+
+#[derive(Default, serde::Deserialize)]
+#[serde(default)]
+struct FileList {
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    files: Vec<crate::native::gojson::GoStruct<File>>,
+}
+
+impl FileList {
+    fn files(&self) -> impl Iterator<Item = &File> {
+        self.files.iter().map(|wrapped| &wrapped.0)
+    }
+}
+
+/// `net/http.DetectContentType`, over the subset a **text** `content` argument
+/// can reach.
+///
+/// `googleapi`'s media writer sniffs the reader when no content type is set, so
+/// this decides the media part's header and the tool's `mime_type` does not.
+///
+/// The full algorithm is a table of thirty-odd magic numbers. Most of it is
+/// unreachable here and deliberately not written: `content` is a JSON **string**,
+/// so a PNG's leading `0x89` cannot arrive as one byte — it would be UTF-8
+/// encoded to `C2 89` — and the same holds for every binary signature. What a
+/// string *can* reach is implemented: the BOM rules, the HTML tag table, `<?xml`,
+/// and the binary-vs-text fallback.
+///
+/// Measured against the real function for each case below.
+fn detect_content_type(data: &[u8]) -> String {
+    // `DetectContentType` answers this for an empty input rather than sniffing.
+    if data.is_empty() {
+        return "text/plain; charset=utf-8".to_string();
+    }
+    // Byte-order marks win over everything.
+    for (bom, kind) in [
+        (&[0xFE, 0xFF][..], "text/plain; charset=utf-16be"),
+        (&[0xFF, 0xFE][..], "text/plain; charset=utf-16le"),
+        (&[0xEF, 0xBB, 0xBF][..], "text/plain; charset=utf-8"),
+    ] {
+        if data.starts_with(bom) {
+            return kind.to_string();
+        }
+    }
+
+    // The HTML table matches case-insensitively and requires a tag terminator,
+    // so `<html>` is HTML and `<htmlish` is not.
+    let trimmed = {
+        let mut rest = data;
+        while let Some((first, tail)) = rest.split_first() {
+            if matches!(first, b'\t' | b'\n' | 0x0C | b'\r' | b' ') {
+                rest = tail;
+            } else {
+                break;
+            }
+        }
+        rest
+    };
+    const HTML_TAGS: &[&[u8]] = &[
+        b"<!DOCTYPE HTML",
+        b"<HTML",
+        b"<HEAD",
+        b"<SCRIPT",
+        b"<IFRAME",
+        b"<H1",
+        b"<DIV",
+        b"<FONT",
+        b"<TABLE",
+        b"<A",
+        b"<STYLE",
+        b"<TITLE",
+        b"<B",
+        b"<BODY",
+        b"<BR",
+        b"<P",
+        b"<!--",
+    ];
+    for tag in HTML_TAGS {
+        if trimmed.len() > tag.len()
+            && trimmed[..tag.len()].eq_ignore_ascii_case(tag)
+            && matches!(trimmed[tag.len()], b' ' | b'>')
+        {
+            return "text/html; charset=utf-8".to_string();
+        }
+    }
+    if trimmed.starts_with(b"<?xml") {
+        return "text/xml; charset=utf-8".to_string();
+    }
+
+    // The fallback: text unless a byte is one `DetectContentType` calls binary.
+    let binary = data
+        .iter()
+        .any(|&b| matches!(b, 0x00..=0x08 | 0x0B | 0x0E..=0x1A | 0x1C..=0x1F));
+    if binary {
+        "application/octet-stream".to_string()
+    } else {
+        "text/plain; charset=utf-8".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The sniffing, at every shape a JSON string argument can produce.
+    ///
+    /// The first four were measured against the real `DetectContentType` through
+    /// the generated Drive client; the rest are the algorithm's own rules.
+    #[test]
+    fn the_media_type_is_sniffed_and_not_the_mime_type_argument() {
+        for (content, want) in [
+            ("hello", "text/plain; charset=utf-8"),
+            (r#"{"a":1}"#, "text/plain; charset=utf-8"),
+            ("a,b\n1,2", "text/plain; charset=utf-8"),
+            ("", "text/plain; charset=utf-8"),
+            ("<html><body>hi</body></html>", "text/html; charset=utf-8"),
+            ("  \n <HTML>", "text/html; charset=utf-8"),
+            ("<?xml version=\"1.0\"?>", "text/xml; charset=utf-8"),
+            // A tag needs a terminator, so this is prose.
+            ("<htmlish thing", "text/plain; charset=utf-8"),
+            ("a\u{0}b", "application/octet-stream"),
+        ] {
+            assert_eq!(detect_content_type(content.as_bytes()), want, "{content:?}");
+        }
+    }
+}

--- a/desktop/src-tauri/src/native/integrations/google/drive.rs
+++ b/desktop/src-tauri/src/native/integrations/google/drive.rs
@@ -502,7 +502,7 @@ mod tests {
             ("RIFF1234WAVEmore", "audio/wave"),
             ("RIFF1234AVI more", "video/avi"),
             ("FORM1234AIFFmore", "audio/aiff"),
-            // Reachable through a JSON   escape.
+            // Reachable through a JSON \u0000 escape.
             ("OggS\u{0}", "application/ogg"),
             ("MThd\u{0}\u{0}\u{0}\u{6}", "audio/midi"),
             ("PK\u{3}\u{4}", "application/zip"),

--- a/desktop/src-tauri/src/native/integrations/google/drive.rs
+++ b/desktop/src-tauri/src/native/integrations/google/drive.rs
@@ -8,10 +8,13 @@
 //!    client resolves as an **absolute** reference and so replaces the base's
 //!    whole path. Measured; see `client::resolve_relative`.
 //! 2. **The media part's `Content-Type` is sniffed from the content**, not taken
-//!    from the tool's `mime_type` argument. Measured across five inputs: an
-//!    `image/png` payload yields `image/png` and every textual one yields
-//!    `text/plain; charset=utf-8`, *regardless* of what `mime_type` said. The
-//!    argument reaches the metadata JSON alone. See [`detect_content_type`].
+//!    from the tool's `mime_type` argument, which reaches the metadata JSON
+//!    alone. The sniff is `net/http.DetectContentType`, ported whole — and it is
+//!    a *table*, not a text-versus-binary test, so a `content` beginning `BM`,
+//!    `%PDF-`, `GIF89a` or `ID3` uploads as a bitmap, a PDF, a GIF or an MP3
+//!    however innocent the prose that follows. See [`detect_content_type`], whose
+//!    header explains why the earlier "only the reachable subset" version of it
+//!    was wrong.
 //!
 //! And one shared with Gmail: `download_file` is the only call in the whole
 //! integration that is not `alt=json` — it is `alt=media`, and its result is the
@@ -127,14 +130,16 @@ pub fn create_file(client: &Client) -> ToolDef {
                 query.set("fields", "id,name,webViewLink");
                 query.set("uploadType", "multipart");
 
-                // The metadata part. `drive.File`'s fields carry `omitempty`,
-                // and both of these are always set, so both always appear —
-                // sorted, as `json.Marshal` sorts a struct's declared order into
-                // the generated field order (`mimeType` before `name`).
-                let metadata = super::marshal(&json!({
-                    "mimeType": mime_type,
-                    "name": input.name,
-                }))?;
+                // The metadata part. `drive.File`'s fields carry `omitempty`, so
+                // an empty `name` sends no key — `mimeType` always appears
+                // because the handler defaults it above. Sorted, as
+                // `json.Marshal` sorts a struct's declared order into the
+                // generated field order (`mimeType` before `name`).
+                let mut file = json!({"mimeType": mime_type});
+                if !input.name.is_empty() {
+                    file["name"] = serde_json::Value::String(input.name.clone());
+                }
+                let metadata = super::marshal(&file)?;
 
                 // **Sniffed**, not `mime_type` — see the module docs.
                 let media_type = detect_content_type(input.content.as_bytes());
@@ -235,114 +240,336 @@ impl FileList {
     }
 }
 
-/// `net/http.DetectContentType`, over the subset a **text** `content` argument
-/// can reach.
+/// `net/http.DetectContentType`, ported whole.
 ///
 /// `googleapi`'s media writer sniffs the reader when no content type is set, so
-/// this decides the media part's header and the tool's `mime_type` does not.
+/// this decides the media part's `Content-Type` and the tool's `mime_type`
+/// argument does not.
 ///
-/// The full algorithm is a table of thirty-odd magic numbers. Most of it is
-/// unreachable here and deliberately not written: `content` is a JSON **string**,
-/// so a PNG's leading `0x89` cannot arrive as one byte — it would be UTF-8
-/// encoded to `C2 89` — and the same holds for every binary signature. What a
-/// string *can* reach is implemented: the BOM rules, the HTML tag table, `<?xml`,
-/// and the binary-vs-text fallback.
+/// # Why the whole table, when `content` is a JSON string
 ///
-/// Measured against the real function for each case below.
+/// This was first written as "the subset a text argument can reach", on the
+/// reasoning that a PNG's leading `0x89` cannot arrive as one byte because a Rust
+/// `String` would UTF-8 encode it. That reasoning is sound for `0x89` and wrong
+/// for most of the table, which review caught: `BM`, `%PDF-`, `%!PS-Adobe-`,
+/// `GIF87a`/`GIF89a`, `ID3`, `OTTO`, `ttcf`, `wOFF`, `wOF2`, `RIFF…WAVE`,
+/// `FORM…AIFF` and `OggS` are **pure ASCII**, and `PK\x03\x04`, `MThd`, the icon
+/// signatures and the 34-NUL EOT one are all reachable through a JSON `\u0000`
+/// escape. `BM` is the one that matters in practice: it is two bytes, so any
+/// content beginning "BMI calculator results…" uploads as `image/bmp` — which is
+/// what Go does, and is now what this does.
+///
+/// The lesson is the reason this is a transcription rather than a subset: an
+/// argument about what is unreachable has to be right about *every* entry, and
+/// it was not. Every signature is pinned by `desktop/parity/google_vectors.json`
+/// or by the table test below.
+///
+/// The 512-byte truncation is part of the algorithm, not an optimisation — a
+/// control byte past that offset does not make the upload binary.
 fn detect_content_type(data: &[u8]) -> String {
-    // `DetectContentType` answers this for an empty input rather than sniffing.
-    if data.is_empty() {
-        return "text/plain; charset=utf-8".to_string();
-    }
-    // Byte-order marks win over everything.
-    for (bom, kind) in [
-        (&[0xFE, 0xFF][..], "text/plain; charset=utf-16be"),
-        (&[0xFF, 0xFE][..], "text/plain; charset=utf-16le"),
-        (&[0xEF, 0xBB, 0xBF][..], "text/plain; charset=utf-8"),
-    ] {
-        if data.starts_with(bom) {
-            return kind.to_string();
-        }
-    }
+    // `sniffLen`. `gax.DetermineContentType` also feeds the writer only the first
+    // 512 bytes, so this bound applies twice in Go and once here.
+    let data = &data[..data.len().min(512)];
 
-    // The HTML table matches case-insensitively and requires a tag terminator,
-    // so `<html>` is HTML and `<htmlish` is not.
-    let trimmed = {
-        let mut rest = data;
-        while let Some((first, tail)) = rest.split_first() {
-            if matches!(first, b'\t' | b'\n' | 0x0C | b'\r' | b' ') {
-                rest = tail;
-            } else {
-                break;
-            }
-        }
-        rest
-    };
-    const HTML_TAGS: &[&[u8]] = &[
-        b"<!DOCTYPE HTML",
-        b"<HTML",
-        b"<HEAD",
-        b"<SCRIPT",
-        b"<IFRAME",
-        b"<H1",
-        b"<DIV",
-        b"<FONT",
-        b"<TABLE",
-        b"<A",
-        b"<STYLE",
-        b"<TITLE",
-        b"<B",
-        b"<BODY",
-        b"<BR",
-        b"<P",
-        b"<!--",
-    ];
-    for tag in HTML_TAGS {
-        if trimmed.len() > tag.len()
-            && trimmed[..tag.len()].eq_ignore_ascii_case(tag)
-            && matches!(trimmed[tag.len()], b' ' | b'>')
-        {
-            return "text/html; charset=utf-8".to_string();
-        }
-    }
-    if trimmed.starts_with(b"<?xml") {
-        return "text/xml; charset=utf-8".to_string();
-    }
-
-    // The fallback: text unless a byte is one `DetectContentType` calls binary.
-    let binary = data
+    let first_non_ws = data
         .iter()
-        .any(|&b| matches!(b, 0x00..=0x08 | 0x0B | 0x0E..=0x1A | 0x1C..=0x1F));
-    if binary {
-        "application/octet-stream".to_string()
-    } else {
-        "text/plain; charset=utf-8".to_string()
+        .position(|b| !matches!(b, b'\t' | b'\n' | 0x0C | b'\r' | b' '))
+        .unwrap_or(data.len());
+
+    for sig in SNIFF_SIGNATURES {
+        if let Some(ct) = sig.matches(data, first_non_ws) {
+            return ct.to_string();
+        }
+    }
+    "application/octet-stream".to_string()
+}
+
+/// One entry of Go's `sniffSignatures`, in its four flavours.
+enum Sniff {
+    /// `htmlSig` — case-insensitive on ASCII letters, and the next byte must
+    /// terminate the tag, so `<html>` is HTML and `<htmlish` is not.
+    Html(&'static [u8]),
+    /// `exactSig` — a plain prefix.
+    Exact(&'static [u8], &'static str),
+    /// `maskedSig` — each byte compared after `&`ing with the mask.
+    Masked(&'static [u8], &'static [u8], bool, &'static str),
+    /// `mp4Sig` — a box-length walk rather than a prefix.
+    Mp4,
+    /// `textSig` — no byte in the control ranges. Always last.
+    Text,
+}
+
+impl Sniff {
+    fn matches(&self, data: &[u8], first_non_ws: usize) -> Option<&'static str> {
+        match self {
+            Self::Html(tag) => {
+                let data = &data[first_non_ws..];
+                if data.len() < tag.len() + 1 {
+                    return None;
+                }
+                for (index, byte) in tag.iter().enumerate() {
+                    let mut got = data[index];
+                    if byte.is_ascii_uppercase() {
+                        got &= 0xDF;
+                    }
+                    if *byte != got {
+                        return None;
+                    }
+                }
+                // 0xTT — a tag-terminating byte.
+                matches!(data[tag.len()], b' ' | b'>').then_some("text/html; charset=utf-8")
+            }
+            Self::Exact(sig, ct) => data.starts_with(sig).then_some(*ct),
+            Self::Masked(pat, mask, skip_ws, ct) => {
+                let data = if *skip_ws {
+                    &data[first_non_ws..]
+                } else {
+                    data
+                };
+                if pat.len() != mask.len() || data.len() < pat.len() {
+                    return None;
+                }
+                pat.iter()
+                    .zip(mask.iter())
+                    .enumerate()
+                    .all(|(index, (byte, mask))| data[index] & mask == *byte)
+                    .then_some(*ct)
+            }
+            Self::Mp4 => {
+                if data.len() < 12 {
+                    return None;
+                }
+                let box_size = u32::from_be_bytes([data[0], data[1], data[2], data[3]]) as usize;
+                if data.len() < box_size || !box_size.is_multiple_of(4) || &data[4..8] != b"ftyp" {
+                    return None;
+                }
+                let mut start = 8;
+                while start < box_size {
+                    // The four bytes of the major brand's version are skipped.
+                    if start != 12 && data.get(start..start + 3) == Some(b"mp4") {
+                        return Some("video/mp4");
+                    }
+                    start += 4;
+                }
+                None
+            }
+            Self::Text => data[first_non_ws..]
+                .iter()
+                .all(|b| !matches!(b, 0x00..=0x08 | 0x0B | 0x0E..=0x1A | 0x1C..=0x1F))
+                .then_some("text/plain; charset=utf-8"),
+        }
     }
 }
+
+/// `net/http`'s `sniffSignatures`, **in order** — the order is the algorithm, not
+/// a presentation choice, which is why the BOMs sit after the HTML tags and
+/// `%PDF-` rather than "winning over everything" as an earlier comment here
+/// claimed.
+const SNIFF_SIGNATURES: &[Sniff] = &[
+    Sniff::Html(b"<!DOCTYPE HTML"),
+    Sniff::Html(b"<HTML"),
+    Sniff::Html(b"<HEAD"),
+    Sniff::Html(b"<SCRIPT"),
+    Sniff::Html(b"<IFRAME"),
+    Sniff::Html(b"<H1"),
+    Sniff::Html(b"<DIV"),
+    Sniff::Html(b"<FONT"),
+    Sniff::Html(b"<TABLE"),
+    Sniff::Html(b"<A"),
+    Sniff::Html(b"<STYLE"),
+    Sniff::Html(b"<TITLE"),
+    Sniff::Html(b"<B"),
+    Sniff::Html(b"<BODY"),
+    Sniff::Html(b"<BR"),
+    Sniff::Html(b"<P"),
+    Sniff::Html(b"<!--"),
+    Sniff::Masked(b"<?xml", b"\xFF\xFF\xFF\xFF\xFF", true, "text/xml; charset=utf-8"),
+    Sniff::Exact(b"%PDF-", "application/pdf"),
+    Sniff::Exact(b"%!PS-Adobe-", "application/postscript"),
+    // UTF BOMs.
+    Sniff::Masked(b"\xFE\xFF\x00\x00", b"\xFF\xFF\x00\x00", false, "text/plain; charset=utf-16be"),
+    Sniff::Masked(b"\xFF\xFE\x00\x00", b"\xFF\xFF\x00\x00", false, "text/plain; charset=utf-16le"),
+    Sniff::Masked(b"\xEF\xBB\xBF\x00", b"\xFF\xFF\xFF\x00", false, "text/plain; charset=utf-8"),
+    // Images.
+    Sniff::Exact(b"\x00\x00\x01\x00", "image/x-icon"),
+    Sniff::Exact(b"\x00\x00\x02\x00", "image/x-icon"),
+    Sniff::Exact(b"BM", "image/bmp"),
+    Sniff::Exact(b"GIF87a", "image/gif"),
+    Sniff::Exact(b"GIF89a", "image/gif"),
+    Sniff::Masked(
+        b"RIFF\x00\x00\x00\x00WEBPVP",
+        b"\xFF\xFF\xFF\xFF\x00\x00\x00\x00\xFF\xFF\xFF\xFF\xFF\xFF",
+        false,
+        "image/webp",
+    ),
+    Sniff::Exact(b"\x89PNG\x0D\x0A\x1A\x0A", "image/png"),
+    Sniff::Exact(b"\xFF\xD8\xFF", "image/jpeg"),
+    // Audio and video, in the order the spec prescribes.
+    Sniff::Masked(
+        b"FORM\x00\x00\x00\x00AIFF",
+        b"\xFF\xFF\xFF\xFF\x00\x00\x00\x00\xFF\xFF\xFF\xFF",
+        false,
+        "audio/aiff",
+    ),
+    Sniff::Masked(b"ID3", b"\xFF\xFF\xFF", false, "audio/mpeg"),
+    Sniff::Masked(b"OggS\x00", b"\xFF\xFF\xFF\xFF\xFF", false, "application/ogg"),
+    Sniff::Masked(
+        b"MThd\x00\x00\x00\x06",
+        b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF",
+        false,
+        "audio/midi",
+    ),
+    Sniff::Masked(
+        b"RIFF\x00\x00\x00\x00AVI ",
+        b"\xFF\xFF\xFF\xFF\x00\x00\x00\x00\xFF\xFF\xFF\xFF",
+        false,
+        "video/avi",
+    ),
+    Sniff::Masked(
+        b"RIFF\x00\x00\x00\x00WAVE",
+        b"\xFF\xFF\xFF\xFF\x00\x00\x00\x00\xFF\xFF\xFF\xFF",
+        false,
+        "audio/wave",
+    ),
+    Sniff::Mp4,
+    Sniff::Exact(b"\x1A\x45\xDF\xA3", "video/webm"),
+    // Fonts. The first is 34 NUL bytes followed by "LP".
+    Sniff::Masked(
+        b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00LP",
+        b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xFF\xFF",
+        false,
+        "application/vnd.ms-fontobject",
+    ),
+    Sniff::Exact(b"\x00\x01\x00\x00", "font/ttf"),
+    Sniff::Exact(b"OTTO", "font/otf"),
+    Sniff::Exact(b"ttcf", "font/collection"),
+    Sniff::Exact(b"wOFF", "font/woff"),
+    Sniff::Exact(b"wOF2", "font/woff2"),
+    // Archives.
+    Sniff::Exact(b"\x1F\x8B\x08", "application/x-gzip"),
+    Sniff::Exact(b"PK\x03\x04", "application/zip"),
+    Sniff::Exact(b"Rar!\x1A\x07\x00", "application/x-rar-compressed"),
+    Sniff::Exact(b"Rar!\x1A\x07\x01\x00", "application/x-rar-compressed"),
+    Sniff::Exact(b"\x00\x61\x73\x6D", "application/wasm"),
+    Sniff::Text,
+];
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// The sniffing, at every shape a JSON string argument can produce.
+    /// The signatures a `create_file` **argument** can actually reach, which is
+    /// most of the table.
     ///
-    /// The first four were measured against the real `DetectContentType` through
-    /// the generated Drive client; the rest are the algorithm's own rules.
+    /// The ASCII ones and the 512-byte bound are pinned in
+    /// `desktop/parity/google_vectors.json` against the real
+    /// `DetectContentType`; the rest are here because a vector for each would
+    /// be a large fixture for a rule the transcription already states.
+    ///
+    /// This test replaced one that asserted only nine cases and the claim that
+    /// "a binary signature cannot arrive as one byte" — the claim was false for
+    /// every ASCII signature below, and the nine cases were exactly the ones
+    /// that claim did not cover.
     #[test]
     fn the_media_type_is_sniffed_and_not_the_mime_type_argument() {
         for (content, want) in [
+            // Ordinary prose, JSON and CSV.
             ("hello", "text/plain; charset=utf-8"),
             (r#"{"a":1}"#, "text/plain; charset=utf-8"),
             ("a,b\n1,2", "text/plain; charset=utf-8"),
             ("", "text/plain; charset=utf-8"),
+            // The HTML table, its whitespace skip and its terminator rule.
             ("<html><body>hi</body></html>", "text/html; charset=utf-8"),
             ("  \n <HTML>", "text/html; charset=utf-8"),
-            ("<?xml version=\"1.0\"?>", "text/xml; charset=utf-8"),
-            // A tag needs a terminator, so this is prose.
+            ("<!-- a comment", "text/html; charset=utf-8"),
             ("<htmlish thing", "text/plain; charset=utf-8"),
+            // `<A` needs a terminator too, so a bare `<A` at end of input is not
+            // HTML — the `len < tag.len() + 1` guard.
+            ("<A", "text/plain; charset=utf-8"),
+            ("<?xml version=\"1.0\"?>", "text/xml; charset=utf-8"),
+            // Pure-ASCII signatures — all reachable from a JSON string, which is
+            // the class the earlier version of this function missed entirely.
+            ("BMI calculator results", "image/bmp"),
+            ("%PDF-1.4 not really", "application/pdf"),
+            ("%!PS-Adobe-3.0", "application/postscript"),
+            ("GIF87a", "image/gif"),
+            ("GIF89a still text", "image/gif"),
+            ("ID3 v2 notes", "audio/mpeg"),
+            ("OTTO font", "font/otf"),
+            ("ttcf collection", "font/collection"),
+            ("wOFF web font", "font/woff"),
+            ("wOF2 web font", "font/woff2"),
+            ("RIFF1234WAVEmore", "audio/wave"),
+            ("RIFF1234AVI more", "video/avi"),
+            ("FORM1234AIFFmore", "audio/aiff"),
+            // Reachable through a JSON   escape.
+            ("OggS\u{0}", "application/ogg"),
+            ("MThd\u{0}\u{0}\u{0}\u{6}", "audio/midi"),
+            ("PK\u{3}\u{4}", "application/zip"),
+            ("\u{0}\u{0}\u{1}\u{0}", "image/x-icon"),
+            ("\u{0}\u{1}\u{0}\u{0}", "font/ttf"),
+            ("\u{0}asm", "application/wasm"),
+            ("Rar!\u{1a}\u{7}\u{0}", "application/x-rar-compressed"),
+            // The masked WEBP signature: the four length bytes are wildcards.
+            ("RIFF????WEBPVP8 ", "image/webp"),
+            // The text fallback and its control-byte set.
             ("a\u{0}b", "application/octet-stream"),
+            ("a\u{b}b", "application/octet-stream"),
+            // 0x09/0x0A/0x0C/0x0D and 0x1B are *not* binary.
+            ("a\tb\nc\u{c}d\re\u{1b}f", "text/plain; charset=utf-8"),
         ] {
             assert_eq!(detect_content_type(content.as_bytes()), want, "{content:?}");
         }
+    }
+
+    /// `sniffLen`: the algorithm reads at most 512 bytes, so a control byte past
+    /// that offset does not make the upload binary — and a signature past it is
+    /// not seen either.
+    #[test]
+    fn only_the_first_512_bytes_are_sniffed() {
+        let mut past = "a".repeat(600);
+        past.push('\u{0}');
+        assert_eq!(
+            detect_content_type(past.as_bytes()),
+            "text/plain; charset=utf-8"
+        );
+
+        let mut within = "a".repeat(10);
+        within.push('\u{0}');
+        assert_eq!(
+            detect_content_type(within.as_bytes()),
+            "application/octet-stream"
+        );
+
+        // Exactly at the boundary: index 511 is the last byte read.
+        let mut edge = "a".repeat(511);
+        edge.push('\u{0}');
+        assert_eq!(
+            detect_content_type(edge.as_bytes()),
+            "application/octet-stream"
+        );
+        let mut just_past = "a".repeat(512);
+        just_past.push('\u{0}');
+        assert_eq!(
+            detect_content_type(just_past.as_bytes()),
+            "text/plain; charset=utf-8"
+        );
+    }
+
+    /// The mp4 box walk, which is the one signature that is not a prefix test.
+    #[test]
+    fn the_mp4_signature_walks_boxes() {
+        // A 20-byte box: length, "ftyp", a major brand, its version, then a
+        // compatible brand of "mp4".
+        let mut data = Vec::from(20u32.to_be_bytes());
+        data.extend_from_slice(b"ftypisom");
+        data.extend_from_slice(b"\x00\x00\x02\x00");
+        data.extend_from_slice(b"mp41");
+        assert_eq!(detect_content_type(&data), "video/mp4");
+
+        // A box length that is not a multiple of four is rejected.
+        let mut odd = Vec::from(21u32.to_be_bytes());
+        odd.extend_from_slice(b"ftypisom....mp41");
+        assert_ne!(detect_content_type(&odd), "video/mp4");
     }
 }

--- a/desktop/src-tauri/src/native/integrations/google/gmail.rs
+++ b/desktop/src-tauri/src/native/integrations/google/gmail.rs
@@ -274,8 +274,12 @@ struct MessagePart {
     body: Option<crate::native::gojson::GoStruct<MessagePartBody>>,
     #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
     headers: Vec<crate::native::gojson::GoStruct<Header>>,
+    /// `Parts []*MessagePart` is a **pointer** slice and `extractBody` has an
+    /// explicit nil check for it (`gmail.go:117`) — the one place in this
+    /// integration where Go handles a null element gracefully instead of
+    /// panicking. So a `null` here is a skipped part, not a decode failure.
     #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
-    parts: Vec<crate::native::gojson::GoStruct<MessagePart>>,
+    parts: Vec<Option<crate::native::gojson::GoStruct<MessagePart>>>,
 }
 
 impl MessagePart {
@@ -283,7 +287,7 @@ impl MessagePart {
         self.headers.iter().map(|wrapped| &wrapped.0)
     }
     fn parts(&self) -> impl Iterator<Item = &MessagePart> {
-        self.parts.iter().map(|wrapped| &wrapped.0)
+        self.parts.iter().flatten().map(|wrapped| &wrapped.0)
     }
 }
 

--- a/desktop/src-tauri/src/native/integrations/google/gmail.rs
+++ b/desktop/src-tauri/src/native/integrations/google/gmail.rs
@@ -1,0 +1,416 @@
+//! The `gmail` service's three tools, ported from
+//! `internal/integrations/google/gmail.go`.
+//!
+//! Three things here are unlike anything in the other five integrations:
+//!
+//! 1. **`search_email` makes N+1 requests.** It lists, then fetches each message
+//!    for its headers, and a failed fetch is **skipped** (`continue`) rather than
+//!    surfaced. The count in the result sentence is `len(list.Messages)` — the
+//!    *listed* total — not the number of entries actually rendered, so a partial
+//!    failure produces a sentence whose number does not match its body. Go's, and
+//!    pinned.
+//! 2. **Repeated query parameters.** `MetadataHeaders("Subject","From","Date")`
+//!    encodes as three `metadataHeaders=` pairs in insertion order under one
+//!    sorted key. That is why `gourl::Values` stopped being single-valued.
+//! 3. **base64url with padding, both ways.** `base64.URLEncoding` is the padded
+//!    alphabet; `RawURLEncoding` is not, and Gmail's own `body.data` is usually
+//!    unpadded — which `DecodeString` then *rejects*, so `extractBody` falls
+//!    through to the next part. That is Go's behaviour and it is reproduced,
+//!    padding requirement included.
+//!
+//! # One deliberate divergence, and it is a panic
+//!
+//! `read_email` does `msg.Payload.Headers` with no nil check, and
+//! `search_email` does the same on each fetched message. A Gmail response
+//! carrying no `payload` therefore **panics** the Go handler. This port treats a
+//! missing payload as no headers and an empty body. A panic is not a behaviour
+//! worth reproducing, it cannot be recorded in a vector, and the resulting text
+//! is what Go produces for the *adjacent* case of a payload with no matching
+//! headers — so the divergence is narrow and is documented rather than hidden.
+
+use schemars::JsonSchema;
+use serde_json::json;
+
+use crate::claude::{new_tool, CancellationToken, ToolDef};
+
+use super::calendar::base_query;
+use super::client::{Api, Client};
+use super::text_result;
+
+/// `send_email`.
+#[allow(dead_code)] // read through serde, never constructed in Rust
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct SendEmailInput {
+    /// required,Recipient email address(es), comma-separated
+    to: String,
+    /// required,Email subject line
+    subject: String,
+    /// required,Plain text body of the email
+    body: String,
+}
+
+pub fn send_email(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "send_email",
+        "Sends an email via Gmail.",
+        move |input: SendEmailInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                // The RFC822 message, with `\r\n` line endings and a blank line
+                // before the body — built by the handler, not by a library.
+                let raw = format!(
+                    "To: {}\r\nSubject: {}\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n{}",
+                    input.to, input.subject, input.body
+                );
+                // `base64.URLEncoding` — the **padded** URL-safe alphabet.
+                let encoded = super::base64_url_encode(raw.as_bytes());
+
+                let body = super::marshal(&json!({"raw": encoded}))?;
+                let sent: Message = client
+                    .post_json(
+                        &ct,
+                        Api::Gmail,
+                        "gmail/v1/users/me/messages/send",
+                        &base_query(),
+                        body,
+                    )
+                    .await
+                    .and_then(|raw| super::decode(&raw))
+                    .map_err(|e| format!("sending email: {e}"))?;
+                Ok(text_result(format!(
+                    "Email sent successfully. Message ID: {}",
+                    sent.id
+                )))
+            }
+        },
+    )
+}
+
+/// `read_email`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct ReadEmailInput {
+    /// required,The Gmail message ID to read
+    message_id: String,
+}
+
+pub fn read_email(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "read_email",
+        "Reads the full content of a Gmail message by its ID.",
+        move |input: ReadEmailInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                let mut query = base_query();
+                query.set("format", "full");
+                // The message id is a **path** parameter, escaped per segment by
+                // the generated client — measured: `a/b c?d` becomes
+                // `a%2Fb%20c%3Fd`.
+                let path = format!(
+                    "gmail/v1/users/me/messages/{}",
+                    super::client::expand_path_segment(&input.message_id)
+                );
+
+                let message: Message = client
+                    .get(&ct, Api::Gmail, &path, &query)
+                    .await
+                    .and_then(|raw| super::decode(&raw))
+                    // Go quotes the id with `%q` here.
+                    .map_err(|e| format!("reading email {:?}: {e}", input.message_id))?;
+                let headers = message.headers();
+                Ok(text_result(format!(
+                    "Subject: {}\nFrom: {}\nDate: {}\n\n{}",
+                    headers.subject,
+                    headers.from,
+                    headers.date,
+                    message
+                        .payload
+                        .as_ref()
+                        .map_or_else(String::new, |payload| { extract_body(&payload.0) })
+                )))
+            }
+        },
+    )
+}
+
+/// `search_email`.
+#[allow(dead_code)]
+#[derive(serde::Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct SearchEmailInput {
+    /// required,Gmail search query (e.g. 'from:alice@example.com is:unread')
+    query: String,
+    /// Maximum number of messages to return (default 10, max 50)
+    max_results: i64,
+}
+
+pub fn search_email(client: &Client) -> ToolDef {
+    let client = client.clone();
+    new_tool(
+        "search_email",
+        "Searches Gmail messages using Gmail query syntax (e.g. 'from:alice@example.com is:unread').",
+        move |input: SearchEmailInput, ct: CancellationToken| {
+            let client = client.clone();
+            async move {
+                // 50 here, not 100 — every clamp in this integration differs.
+                let max_results = if input.max_results <= 0 || input.max_results > 50 {
+                    10
+                } else {
+                    input.max_results
+                };
+
+                let mut query = base_query();
+                query.set("maxResults", max_results.to_string());
+                // Unconditional, unlike Drive's: an empty search still sends
+                // `q=`.
+                query.set("q", &input.query);
+
+                let listed: MessageList = client
+                    .get(&ct, Api::Gmail, "gmail/v1/users/me/messages", &query)
+                    .await
+                    .and_then(|raw| super::decode(&raw))
+                    .map_err(|e| format!("searching emails: {e}"))?;
+                if listed.messages.is_empty() {
+                    return Ok(text_result(
+                        "No messages found matching the query.".to_string(),
+                    ));
+                }
+
+                let mut rendered = Vec::with_capacity(listed.messages.len());
+                for message in listed.messages() {
+                    let mut query = base_query();
+                    query.set("format", "metadata");
+                    // Three values under one key, in this order — the reason
+                    // `gourl::Values` is a multimap.
+                    query.add("metadataHeaders", "Subject");
+                    query.add("metadataHeaders", "From");
+                    query.add("metadataHeaders", "Date");
+                    let path = format!(
+                        "gmail/v1/users/me/messages/{}",
+                        super::client::expand_path_segment(&message.id)
+                    );
+
+                    // A failed fetch is **skipped**, not surfaced — so a search
+                    // can answer with fewer entries than its own count. A failed
+                    // *decode* is skipped for the same reason: both are one
+                    // `Do()` to Go.
+                    let Ok(fetched) = client
+                        .get(&ct, Api::Gmail, &path, &query)
+                        .await
+                        .and_then(|raw| super::decode::<Message>(&raw))
+                    else {
+                        continue;
+                    };
+                    let headers = fetched.headers();
+                    rendered.push(format!(
+                        "ID: {}\nSubject: {}\nFrom: {}\nDate: {}",
+                        message.id, headers.subject, headers.from, headers.date
+                    ));
+                }
+
+                // `len(list.Messages)`, the **listed** count — not
+                // `len(results)`. A partial failure leaves the two disagreeing,
+                // which is Go's and is pinned.
+                Ok(text_result(format!(
+                    "Found {} message(s):\n\n{}",
+                    listed.messages.len(),
+                    rendered.join("\n\n---\n\n")
+                )))
+            }
+        },
+    )
+}
+
+/// The three headers both readers pull out, in Go's `switch` order.
+#[derive(Default)]
+struct Headers {
+    subject: String,
+    from: String,
+    date: String,
+}
+
+/// `gmail.Message`, reduced to the fields the handlers read.
+#[derive(Default, serde::Deserialize)]
+#[serde(default)]
+struct Message {
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    id: String,
+    payload: Option<crate::native::gojson::GoStruct<MessagePart>>,
+}
+
+impl Message {
+    /// Go's `for _, h := range msg.Payload.Headers { switch h.Name … }`.
+    ///
+    /// A **later** header of the same name wins, because the switch assigns on
+    /// every iteration. A missing payload is no headers here where Go panics;
+    /// see the module docs.
+    fn headers(&self) -> Headers {
+        let mut out = Headers::default();
+        let Some(payload) = self.payload.as_ref() else {
+            return out;
+        };
+        for header in payload.0.headers() {
+            match header.name.as_str() {
+                "Subject" => out.subject = header.value.clone(),
+                "From" => out.from = header.value.clone(),
+                "Date" => out.date = header.value.clone(),
+                _ => {}
+            }
+        }
+        out
+    }
+}
+
+#[derive(Default, serde::Deserialize)]
+#[serde(default)]
+struct MessagePart {
+    #[serde(rename = "mimeType")]
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    mime_type: String,
+    body: Option<crate::native::gojson::GoStruct<MessagePartBody>>,
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    headers: Vec<crate::native::gojson::GoStruct<Header>>,
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    parts: Vec<crate::native::gojson::GoStruct<MessagePart>>,
+}
+
+impl MessagePart {
+    fn headers(&self) -> impl Iterator<Item = &Header> {
+        self.headers.iter().map(|wrapped| &wrapped.0)
+    }
+    fn parts(&self) -> impl Iterator<Item = &MessagePart> {
+        self.parts.iter().map(|wrapped| &wrapped.0)
+    }
+}
+
+#[derive(Default, serde::Deserialize)]
+#[serde(default)]
+struct MessagePartBody {
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    data: String,
+}
+
+#[derive(Default, serde::Deserialize)]
+#[serde(default)]
+struct Header {
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    name: String,
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    value: String,
+}
+
+#[derive(Default, serde::Deserialize)]
+#[serde(default)]
+struct MessageList {
+    #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+    messages: Vec<crate::native::gojson::GoStruct<Message>>,
+}
+
+impl MessageList {
+    fn messages(&self) -> impl Iterator<Item = &Message> {
+        self.messages.iter().map(|wrapped| &wrapped.0)
+    }
+}
+
+/// `extractBody`: the first `text/plain` part whose data decodes, depth-first.
+///
+/// Three details that are Go's and are easy to lose:
+///
+/// - The part must be `text/plain` **and** have non-empty data before a decode is
+///   even attempted.
+/// - A decode **failure** is not an error: it falls through to the children, so a
+///   part whose base64 is unpadded is skipped rather than surfaced.
+/// - The recursion takes the first child that yields a **non-empty** string, so a
+///   `text/plain` part decoding to `""` does not stop the search.
+fn extract_body(payload: &MessagePart) -> String {
+    if payload.mime_type == "text/plain" {
+        if let Some(body) = payload.body.as_ref().filter(|body| !body.0.data.is_empty()) {
+            if let Some(decoded) = super::base64_url_decode(&body.0.data) {
+                return String::from_utf8_lossy(&decoded).into_owned();
+            }
+        }
+    }
+    for part in payload.parts() {
+        let text = extract_body(part);
+        if !text.is_empty() {
+            return text;
+        }
+    }
+    String::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn message(json: &str) -> Message {
+        super::super::decode(json).expect("decodes")
+    }
+
+    /// The header scan: a later header of the same name wins, an unknown one is
+    /// ignored, and a missing payload is empty rather than a panic.
+    #[test]
+    fn headers_are_read_the_way_gos_switch_reads_them() {
+        let headers = message(
+            r#"{"payload":{"headers":[
+                {"name":"Subject","value":"first"},
+                {"name":"X-Other","value":"ignored"},
+                {"name":"From","value":"a@b"},
+                {"name":"Subject","value":"second"}
+            ]}}"#,
+        )
+        .headers();
+        assert_eq!(headers.subject, "second", "a later header wins");
+        assert_eq!(headers.from, "a@b");
+        assert_eq!(headers.date, "");
+
+        let empty = message(r#"{"id":"m1"}"#).headers();
+        assert_eq!(empty.subject, "");
+    }
+
+    /// `extractBody`'s three rules.
+    #[test]
+    fn the_body_is_the_first_decodable_text_plain_part() {
+        let body = |json: &str| {
+            let msg = message(json);
+            msg.payload
+                .as_ref()
+                .map_or_else(String::new, |p| extract_body(&p.0))
+        };
+
+        // `aGk=` is "hi" in padded base64url.
+        assert_eq!(
+            body(r#"{"payload":{"mimeType":"text/plain","body":{"data":"aGk="}}}"#),
+            "hi"
+        );
+        // A non-text/plain parent recurses into its parts.
+        assert_eq!(
+            body(
+                r#"{"payload":{"mimeType":"multipart/alternative","parts":[
+                    {"mimeType":"text/html","body":{"data":"PGI-"}},
+                    {"mimeType":"text/plain","body":{"data":"aGk="}}
+                ]}}"#
+            ),
+            "hi",
+            "only text/plain is decoded"
+        );
+        // **Unpadded** data fails `URLEncoding` and falls through to the next
+        // part rather than erroring — Go's behaviour.
+        assert_eq!(
+            body(
+                r#"{"payload":{"mimeType":"multipart/mixed","parts":[
+                    {"mimeType":"text/plain","body":{"data":"aGk"}},
+                    {"mimeType":"text/plain","body":{"data":"Ynll"}}
+                ]}}"#
+            ),
+            "bye",
+            "an unpadded part is skipped, not reported"
+        );
+        // No body at all.
+        assert_eq!(body(r#"{"payload":{"mimeType":"text/plain"}}"#), "");
+    }
+}

--- a/desktop/src-tauri/src/native/integrations/google/mod.rs
+++ b/desktop/src-tauri/src/native/integrations/google/mod.rs
@@ -1,0 +1,337 @@
+//! The Google integration's in-process MCP server, ported from
+//! `internal/integrations/google/`.
+//!
+//! Eight tools across **three** service groups — `calendar`, `gmail`, `drive` —
+//! over an OAuth2 token that refreshes itself. The last of the six (#313), and
+//! the only one that is not a port of hand-rolled HTTP.
+//!
+//! ## Why this one is measured rather than read
+//!
+//! The other five build their requests with `http.NewRequest` and
+//! `json.Marshal`, so the port reproduces bytes that are visible in `tools.go`.
+//! Google calls the **generated** client libraries (`calendar/v3`, `gmail/v1`,
+//! `drive/v3`) over an `oauth2` transport, and what those put on the wire is not
+//! in this repository. Every URL, query parameter, body field and error sentence
+//! here was therefore recorded off the real libraries against a fake endpoint
+//! before it was written. `client`'s header lists what that does and does not let
+//! the port reproduce — in short: everything except two version-stamped headers
+//! and a random multipart boundary, all three pinned as divergence.
+//!
+//! ## This module is not hosted yet
+//!
+//! `google` is deliberately **absent** from `registry::HOSTED_TYPES`, so nothing
+//! here runs in a shipped build: the sidecar still hosts Google and this is
+//! dormant code with its parity pinned. The flip is its own change, because the
+//! flip is where the risk in this series has actually lived — #315's hosting of
+//! Slack silently broke `completeOAuth`'s reload, and Google is the *other*
+//! provider `startProviderCallback` supports, so it lands on the same hook.
+//! Splitting lets that be reviewed on its own and reverted without reverting the
+//! port.
+//!
+//! ## The refresh path is #318's, built here first
+//!
+//! #318 says of it: "Token refresh is shared with the Google MCP server. One
+//! implementation, not two." [`client::TokenSource`] is that implementation, and
+//! it is deliberately the only thing in this module that knows about
+//! `client_secret` — so #318 can adopt the type rather than write a second one.
+//!
+//! ## The gating rule, which reads backwards
+//!
+//! A service registers when its row says `enabled`; within it a tool registers
+//! when the **union of every enabled service's `tools` list** names it, *or when
+//! that union is empty*. Google is the only integration of the six with more than
+//! two service groups, so it is the one where the union half is fully exercised:
+//! naming a single Gmail tool narrows Calendar and Drive too.
+//!
+//! There is a second gate no sibling has. Go builds each service's client with
+//! `calendar.NewService(...)` and **returns early without registering anything**
+//! if that fails — silently. Reproduced by [`google_tools`] skipping a group
+//! whose client cannot be built; in practice it cannot fail here, because the
+//! Rust client is infallible once the token source exists.
+
+pub mod calendar;
+pub mod client;
+pub mod drive;
+pub mod gmail;
+
+#[cfg(test)]
+mod tests_vectors;
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use rmcp::model::{CallToolResult, ContentBlock};
+use serde_json::Value;
+
+use crate::claude::{tool_server, InProcessMcpServer, Result, ToolDef};
+
+use super::ServiceConfig;
+use client::{Client, TokenSource};
+
+/// The three service groups, in the order `buildMCPServer` gates them.
+pub const SERVICES: &[&str] = &["calendar", "gmail", "drive"];
+
+/// Every tool this integration can host, in registration order — `SERVICES`
+/// order, then each `register*Tools` function's own.
+pub const GOOGLE_TOOL_NAMES: &[&str] = &[
+    "create_event",
+    "view_events",
+    "send_email",
+    "read_email",
+    "search_email",
+    "list_files",
+    "create_file",
+    "download_file",
+];
+
+/// `fmt.Sprintf("google-%s", cfg.ID)` — `mcp.NewServer`'s implementation name,
+/// **not** the prefix on a qualified tool name (that is the bare integration id).
+pub fn server_name(integration_id: &str) -> String {
+    format!("google-{integration_id}")
+}
+
+/// The union of every **enabled** service's `Tools`.
+pub fn build_allowed_set(services: &BTreeMap<String, ServiceConfig>) -> BTreeSet<String> {
+    let mut allowed = BTreeSet::new();
+    for service in services.values() {
+        if !service.enabled {
+            continue;
+        }
+        for tool in service.tools.iter().flat_map(|tools| tools.iter()) {
+            allowed.insert(tool.clone());
+        }
+    }
+    allowed
+}
+
+/// Present **and** enabled.
+pub fn service_enabled(services: &BTreeMap<String, ServiceConfig>, name: &str) -> bool {
+    services.get(name).is_some_and(|service| service.enabled)
+}
+
+/// Every tool `buildMCPServer` would register for `services`, over `tokens`.
+pub fn google_tools(
+    services: &BTreeMap<String, ServiceConfig>,
+    tokens: Arc<TokenSource>,
+) -> Vec<ToolDef> {
+    let allowed = build_allowed_set(services);
+    let client = Client::new(tokens);
+    let mut tools = Vec::new();
+
+    // `len(allowed) == 0 || allowed[name]` — so an empty set admits everything.
+    let mut push = |service: &str, name: &str, tool: fn(&Client) -> ToolDef| {
+        if !service_enabled(services, service) {
+            return;
+        }
+        if !allowed.is_empty() && !allowed.contains(name) {
+            return;
+        }
+        tools.push(tool(&client));
+    };
+
+    push("calendar", "create_event", calendar::create_event);
+    push("calendar", "view_events", calendar::view_events);
+
+    push("gmail", "send_email", gmail::send_email);
+    push("gmail", "read_email", gmail::read_email);
+    push("gmail", "search_email", gmail::search_email);
+
+    push("drive", "list_files", drive::list_files);
+    push("drive", "create_file", drive::create_file);
+    push("drive", "download_file", drive::download_file);
+
+    tools
+}
+
+/// Starts the integration's server on a random loopback port.
+///
+/// Not reachable from the registry yet — see the module header on why the flip is
+/// a separate change.
+pub async fn start_google_mcp_server(
+    integration_id: &str,
+    services: &BTreeMap<String, ServiceConfig>,
+    tokens: Arc<TokenSource>,
+) -> Result<InProcessMcpServer> {
+    tool_server(&server_name(integration_id), google_tools(services, tokens)).await
+}
+
+/// Go's `textResult`, shared by all eight tools.
+pub(crate) fn text_result(text: String) -> CallToolResult {
+    CallToolResult::success(vec![ContentBlock::text(text)])
+}
+
+/// A request body as `googleapi` writes one: `json.Marshal`'s sorting and HTML
+/// escaping, **plus a trailing newline**.
+///
+/// The newline is `json.NewEncoder(buf).Encode(v)`'s, which is what every one of
+/// the generated clients uses to build a body — both the plain `application/json`
+/// POSTs and the metadata part of a `multipart/related` upload. It is one byte
+/// and it is on the wire, so `desktop/parity/google_vectors.json` records it;
+/// this port did not have it until the vectors were first replayed.
+pub(crate) fn marshal(payload: &Value) -> std::result::Result<Vec<u8>, String> {
+    let mut body = crate::native::gojson::to_vec_marshal(payload)
+        .map_err(|e| format!("marshaling request: {e}"))?;
+    body.push(b'\n');
+    Ok(body)
+}
+
+/// Decode a Google response into the fields a handler reads.
+///
+/// The three rules every decode in this port carries — see
+/// `native/integrations/telegram/client.rs` — plus one specific to here: a
+/// decode failure is **not** a shape Go can produce, because the generated client
+/// decodes into its own struct and surfaces a `json` error the handler wraps. The
+/// sentence is therefore a pinned divergence rather than a match.
+pub(crate) fn decode<T>(raw: &str) -> std::result::Result<T, String>
+where
+    T: Default + serde::de::DeserializeOwned,
+{
+    serde_json::from_str::<Option<crate::native::gojson::GoStruct<T>>>(raw)
+        .map(|wrapped| wrapped.map_or_else(T::default, |wrapped| wrapped.0))
+        .map_err(|e| format!("decoding response: {e}"))
+}
+
+/// `time.Now().UTC().Format(time.RFC3339)` — seconds precision and a literal `Z`.
+///
+/// One caller: `view_events`' default `time_min`, which is why one vector has to
+/// redact a query value.
+pub(crate) fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+/// `base64.URLEncoding.EncodeToString` — URL-safe alphabet, **padded**.
+pub(crate) fn base64_url_encode(data: &[u8]) -> String {
+    use base64::Engine;
+    base64::engine::general_purpose::URL_SAFE.encode(data)
+}
+
+/// `base64.URLEncoding.DecodeString` — URL-safe alphabet, and padding is
+/// **required**.
+///
+/// `None` where Go returns an error, which `extractBody` treats as "skip this
+/// part". Gmail commonly sends unpadded data, so this rejecting it is not an edge
+/// case; it is the ordinary path, and reproducing the rejection is what keeps the
+/// body selection identical.
+pub(crate) fn base64_url_decode(data: &str) -> Option<Vec<u8>> {
+    use base64::Engine;
+    base64::engine::general_purpose::URL_SAFE.decode(data).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::native::gojson::GoList;
+    use std::time::SystemTime;
+
+    fn tokens() -> Arc<TokenSource> {
+        Arc::new(TokenSource::new(
+            "CID",
+            "CSECRET",
+            client::Token {
+                access_token: "ACCESS".to_string(),
+                refresh_token: "REFRESH".to_string(),
+                expiry: Some(SystemTime::now() + std::time::Duration::from_secs(3600)),
+            },
+        ))
+    }
+
+    fn service(enabled: bool, tools: &[&str]) -> ServiceConfig {
+        ServiceConfig {
+            enabled,
+            tools: Some(GoList(tools.iter().map(|t| t.to_string()).collect())),
+        }
+    }
+
+    fn names(services: &BTreeMap<String, ServiceConfig>) -> Vec<String> {
+        google_tools(services, tokens())
+            .iter()
+            .map(|tool| tool.name().to_string())
+            .collect()
+    }
+
+    fn all() -> BTreeMap<String, ServiceConfig> {
+        SERVICES
+            .iter()
+            .map(|name| (name.to_string(), service(true, &[])))
+            .collect()
+    }
+
+    #[test]
+    fn the_server_name_is_gos() {
+        assert_eq!(server_name("abc123"), "google-abc123");
+    }
+
+    #[test]
+    fn an_empty_allowed_set_hosts_every_tool() {
+        assert_eq!(names(&all()), GOOGLE_TOOL_NAMES);
+        assert!(build_allowed_set(&all()).is_empty());
+    }
+
+    /// The union half, which only Google fully exercises: a tool named under one
+    /// service narrows **all three**.
+    #[test]
+    fn one_named_tool_narrows_every_enabled_service() {
+        let mut services = all();
+        services.insert("gmail".to_string(), service(true, &["send_email"]));
+        assert_eq!(
+            names(&services),
+            ["send_email"],
+            "naming one Gmail tool silences Calendar and Drive too"
+        );
+
+        // …and a name contributed by one service admits the tool wherever it is
+        // registered.
+        services.insert(
+            "gmail".to_string(),
+            service(true, &["send_email", "list_files"]),
+        );
+        assert_eq!(names(&services), ["send_email", "list_files"]);
+    }
+
+    #[test]
+    fn a_disabled_service_is_invisible_in_both_directions() {
+        let mut services = all();
+        services.insert("drive".to_string(), service(false, &["create_event"]));
+        assert_eq!(
+            names(&services),
+            [
+                "create_event",
+                "view_events",
+                "send_email",
+                "read_email",
+                "search_email"
+            ],
+            "a disabled service contributes neither its gate nor its names"
+        );
+        assert!(!service_enabled(&services, "drive"));
+    }
+
+    #[test]
+    fn one_service_enabled_hosts_only_its_tools() {
+        let services = BTreeMap::from([("calendar".to_string(), service(true, &[]))]);
+        assert_eq!(names(&services), ["create_event", "view_events"]);
+    }
+
+    #[test]
+    fn no_services_at_all_hosts_nothing() {
+        assert!(names(&BTreeMap::new()).is_empty());
+    }
+
+    #[test]
+    fn a_null_tools_column_is_not_a_filter() {
+        let services: BTreeMap<String, ServiceConfig> = SERVICES
+            .iter()
+            .map(|name| {
+                (
+                    name.to_string(),
+                    ServiceConfig {
+                        enabled: true,
+                        tools: None,
+                    },
+                )
+            })
+            .collect();
+        assert!(build_allowed_set(&services).is_empty());
+        assert_eq!(names(&services), GOOGLE_TOOL_NAMES);
+    }
+}

--- a/desktop/src-tauri/src/native/integrations/google/mod.rs
+++ b/desktop/src-tauri/src/native/integrations/google/mod.rs
@@ -186,6 +186,13 @@ pub(crate) fn decode<T>(raw: &str) -> std::result::Result<T, String>
 where
     T: Default + serde::de::DeserializeOwned,
 {
+    // `gensupport.DecodeResponse` returns without touching the target on a 204,
+    // so an empty 2xx body renders zero values rather than erroring. The status
+    // is gone by the time this runs, but an empty body is the only way to reach
+    // it: every other 2xx carries JSON.
+    if raw.is_empty() {
+        return Ok(T::default());
+    }
     serde_json::from_str::<Option<crate::native::gojson::GoStruct<T>>>(raw)
         .map(|wrapped| wrapped.map_or_else(T::default, |wrapped| wrapped.0))
         .map_err(|e| format!("decoding response: {e}"))

--- a/desktop/src-tauri/src/native/integrations/google/tests_vectors.rs
+++ b/desktop/src-tauri/src/native/integrations/google/tests_vectors.rs
@@ -121,6 +121,8 @@ struct CallVector {
 struct RefreshVector {
     case: String,
     expires_in: Option<i64>,
+    #[serde(default)]
+    no_refresh_token: bool,
     token_response: Option<ResponseScript>,
     api_response: ResponseScript,
     refresh_request: Option<RequestVector>,
@@ -622,7 +624,13 @@ async fn every_refresh_matches_the_go_vectors() {
             &v.client_secret,
             Token {
                 access_token: v.access_token.clone(),
-                refresh_token: v.refresh_token.clone(),
+                // An empty refresh token is the state `tokenRefresher` refuses
+                // on before opening a socket.
+                refresh_token: if case.no_refresh_token {
+                    String::new()
+                } else {
+                    v.refresh_token.clone()
+                },
                 // `None` is Go's zero `time.Time`, which never expires — and a
                 // negative offset is a token already past its expiry.
                 expiry: case.expires_in.map(|seconds| {

--- a/desktop/src-tauri/src/native/integrations/google/tests_vectors.rs
+++ b/desktop/src-tauri/src/native/integrations/google/tests_vectors.rs
@@ -1,0 +1,744 @@
+//! The Rust half of `desktop/parity/google_vectors.json`.
+//!
+//! The Go half (`desktop/parity/google_parity_test.go`) stands the **real**
+//! integration up through `google.Start`, points the generated clients and the
+//! OAuth2 token endpoint at an `httptest.Server` that plays a scripted Google and
+//! records what it was asked. This half replays the same script through an axum
+//! server on loopback, the real
+//! [`start_google_mcp_server`](super::start_google_mcp_server), and a real
+//! `tools/call` over the MCP HTTP transport.
+//!
+//! # Why this file carries more weight than its five siblings
+//!
+//! For the other integrations the vectors *confirm* a port a reader could check
+//! by eye against `tools.go`. Here they are the **only** written statement of
+//! what `calendar/v3`, `gmail/v1` and `drive/v3` put on the wire, because those
+//! requests are built by a code generator that lives outside this repository.
+//! Three mismatches were found by running these vectors for the first time, and
+//! none of them was visible from either side's source:
+//!
+//! 1. **Path parameters use `googleapi.Expand`, not `url.PathEscape`** — so an
+//!    `&` in a message id is `%26`, where `PathEscape` leaves it alone and starts
+//!    a query parameter. [`super::client::expand_path_segment`].
+//! 2. **The multipart metadata part carries a trailing newline**, because
+//!    `googleapi` writes it with `json.NewEncoder(…).Encode`.
+//! 3. **`oauth2.RetrieveError` has two forms**, and a Google refresh refusal
+//!    takes the one the port did not have:
+//!    `oauth2: "invalid_grant" "Token has been expired or revoked."`.
+//!
+//! # Two things the replay has to normalize, and only two
+//!
+//! - **`«now»`** — `view_events`' `time_min` defaults to `time.Now()`. The
+//!   recorded target holds the placeholder; this half substitutes it after
+//!   asserting the value it replaced is a seconds-precision RFC3339 instant in
+//!   UTC, so the *shape* is still pinned.
+//! - **The multipart boundary** — random in both languages, so the fake parses
+//!   the body into parts and compares those.
+//!
+//! Everything else is byte-for-byte, including the `Authorization` header, which
+//! is how a refresh is observed reaching the request that follows it.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime};
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::{HeaderMap, Method, StatusCode, Uri};
+use axum::response::{IntoResponse, Response};
+use rmcp::ServerHandler;
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::client::{api_base_lock, set_api_base, Token, TokenSource};
+use super::{google_tools, server_name, start_google_mcp_server, GOOGLE_TOOL_NAMES, SERVICES};
+use crate::claude::ToolServer;
+use crate::native::gojson::GoList;
+use crate::native::integrations::ServiceConfig;
+
+// ─── The vectors ─────────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct ToolVector {
+    name: String,
+    description: String,
+    input_schema: Value,
+}
+
+#[derive(Deserialize)]
+struct HostingVector {
+    case: String,
+    services: BTreeMap<String, GoServiceConfig>,
+    tools: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct GoServiceConfig {
+    enabled: bool,
+    tools: Option<Vec<String>>,
+}
+
+#[derive(Clone, Deserialize)]
+struct PartVector {
+    content_type: String,
+    body: String,
+}
+
+#[derive(Clone, Deserialize)]
+struct RequestVector {
+    method: String,
+    target: String,
+    authorization: String,
+    content_type: String,
+    #[serde(default)]
+    body: String,
+    #[serde(default)]
+    parts: Vec<PartVector>,
+}
+
+#[derive(Clone, Deserialize)]
+struct ResponseScript {
+    status: u16,
+    body: String,
+}
+
+#[derive(Deserialize)]
+struct CallVector {
+    case: String,
+    tool: String,
+    arguments: Value,
+    responses: Vec<ResponseScript>,
+    requests: Vec<RequestVector>,
+    is_error: bool,
+    text: String,
+    #[serde(default)]
+    rust_text: String,
+    #[serde(default)]
+    rust_no_request: bool,
+}
+
+#[derive(Deserialize)]
+struct RefreshVector {
+    case: String,
+    expires_in: Option<i64>,
+    token_response: Option<ResponseScript>,
+    api_response: ResponseScript,
+    refresh_request: Option<RequestVector>,
+    api_request: Option<RequestVector>,
+    is_error: bool,
+    text: String,
+    #[serde(default)]
+    rust_text: String,
+}
+
+#[derive(Deserialize)]
+struct Vectors {
+    integration_id: String,
+    server_name: String,
+    client_id: String,
+    client_secret: String,
+    refresh_token: String,
+    access_token: String,
+    now_placeholder: String,
+    tools: Vec<ToolVector>,
+    hosting: Vec<HostingVector>,
+    calls: Vec<CallVector>,
+    refreshes: Vec<RefreshVector>,
+}
+
+fn vectors() -> Vectors {
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../parity/google_vectors.json");
+    let raw = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("reading {path}: {e} — regenerate it from Go"));
+    serde_json::from_str(&raw).expect("parsing the google vectors")
+}
+
+fn services(from: &BTreeMap<String, GoServiceConfig>) -> BTreeMap<String, ServiceConfig> {
+    from.iter()
+        .map(|(name, service)| {
+            (
+                name.clone(),
+                ServiceConfig {
+                    enabled: service.enabled,
+                    tools: service.tools.clone().map(GoList),
+                },
+            )
+        })
+        .collect()
+}
+
+fn all_services() -> BTreeMap<String, ServiceConfig> {
+    SERVICES
+        .iter()
+        .map(|name| {
+            (
+                name.to_string(),
+                ServiceConfig {
+                    enabled: true,
+                    tools: None,
+                },
+            )
+        })
+        .collect()
+}
+
+/// A token source in the ordinary state: an hour from expiry, so nothing
+/// refreshes.
+fn hour_source(v: &Vectors) -> Arc<TokenSource> {
+    Arc::new(TokenSource::new(
+        &v.client_id,
+        &v.client_secret,
+        Token {
+            access_token: v.access_token.clone(),
+            refresh_token: v.refresh_token.clone(),
+            expiry: Some(SystemTime::now() + Duration::from_secs(3600)),
+        },
+    ))
+}
+
+// ─── The advertised surface ──────────────────────────────────────────────────
+
+/// The server name, every tool name, its description and its reflected input
+/// schema, from a live `tools/list` against the Go server.
+#[test]
+fn the_advertised_surface_matches_the_go_vectors() {
+    let v = vectors();
+    assert_eq!(v.server_name, server_name(&v.integration_id));
+    assert_eq!(
+        v.tools.len(),
+        GOOGLE_TOOL_NAMES.len(),
+        "vectors look partial"
+    );
+
+    let server =
+        ToolServer::new(&v.server_name).with_tools(google_tools(&all_services(), hour_source(&v)));
+    let mut hosted = server.tool_names();
+    hosted.sort();
+    assert_eq!(
+        hosted,
+        v.tools.iter().map(|t| t.name.clone()).collect::<Vec<_>>(),
+        "the hosted tool set, as tools/list answers it"
+    );
+
+    for want in &v.tools {
+        let tool = server
+            .get_tool(&want.name)
+            .unwrap_or_else(|| panic!("{} is not registered", want.name));
+        assert_eq!(
+            tool.description.as_deref(),
+            Some(want.description.as_str()),
+            "{}'s description is what the model reads",
+            want.name
+        );
+        assert_eq!(
+            serde_json::to_value(&*tool.input_schema).expect("schema"),
+            want.input_schema,
+            "{}'s input schema is what the model is steered by",
+            want.name
+        );
+    }
+}
+
+#[test]
+fn the_hosted_tool_set_matches_the_go_vectors() {
+    let v = vectors();
+    assert!(v.hosting.len() >= 8, "vectors look partial");
+    for case in &v.hosting {
+        let mut hosted: Vec<String> = google_tools(&services(&case.services), hour_source(&v))
+            .iter()
+            .map(|tool| tool.name().to_string())
+            .collect();
+        hosted.sort();
+        assert_eq!(hosted, case.tools, "hosting case: {}", case.case);
+    }
+}
+
+// ─── The fake Google ─────────────────────────────────────────────────────────
+
+#[derive(Clone)]
+struct Recorded {
+    method: String,
+    target: String,
+    authorization: String,
+    content_type: String,
+    body: String,
+    parts: Vec<PartVector>,
+}
+
+#[derive(Default)]
+struct Fake {
+    /// Consumed in order; the last entry is reused, exactly as the Go fake does,
+    /// which is what lets one `search_email` case script a list and every fetch
+    /// behind it.
+    api: Vec<ResponseScript>,
+    api_seen: Vec<Recorded>,
+    token: Option<ResponseScript>,
+    token_seen: Option<Recorded>,
+}
+
+#[derive(Clone, Default)]
+struct FakeState(Arc<Mutex<Fake>>);
+
+impl FakeState {
+    fn arm_api(&self, scripts: &[ResponseScript]) {
+        let mut fake = self.0.lock().expect("fake lock");
+        fake.api = scripts.to_vec();
+        fake.api_seen.clear();
+    }
+
+    fn arm_token(&self, script: Option<&ResponseScript>) {
+        let mut fake = self.0.lock().expect("fake lock");
+        fake.token = script.cloned();
+        fake.token_seen = None;
+    }
+
+    fn api_seen(&self) -> Vec<Recorded> {
+        self.0.lock().expect("fake lock").api_seen.clone()
+    }
+
+    fn token_seen(&self) -> Option<Recorded> {
+        self.0.lock().expect("fake lock").token_seen.clone()
+    }
+}
+
+async fn serve_fake(
+    State(state): State<FakeState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    let path = uri.path().to_string();
+    let recorded = record(&method, &uri, &headers, &body);
+
+    let (status, reply) = {
+        let mut fake = state.0.lock().expect("fake lock");
+        if path == "/token" {
+            fake.token_seen = Some(recorded);
+            match fake.token.clone() {
+                Some(script) => (script.status, script.body),
+                // Matching the Go fake: an unscripted refresh is answered with a
+                // failure the assertion shows rather than one it hides.
+                None => (500, r#"{"error":"unexpected refresh"}"#.to_string()),
+            }
+        } else {
+            fake.api_seen.push(recorded);
+            match fake.api.len() {
+                0 => (500, r#"{"error":"no response scripted"}"#.to_string()),
+                1 => (fake.api[0].status, fake.api[0].body.clone()),
+                _ => {
+                    let script = fake.api.remove(0);
+                    (script.status, script.body)
+                }
+            }
+        }
+    };
+
+    (
+        StatusCode::from_u16(status).expect("a scripted status"),
+        reply,
+    )
+        .into_response()
+}
+
+fn record(method: &Method, uri: &Uri, headers: &HeaderMap, body: &Bytes) -> Recorded {
+    let content_type = headers
+        .get("content-type")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    let raw = String::from_utf8_lossy(body).into_owned();
+
+    // The boundary is random, so a multipart body is recorded as its parts —
+    // which is what the Go fake records too.
+    let (content_type, body, parts) = match multipart_boundary_of(&content_type) {
+        Some((media_type, boundary)) => (media_type, String::new(), split_parts(&raw, &boundary)),
+        None => (content_type, raw, Vec::new()),
+    };
+
+    Recorded {
+        method: method.to_string(),
+        target: uri
+            .path_and_query()
+            .map(|pq| pq.as_str().to_string())
+            .unwrap_or_default(),
+        authorization: headers
+            .get("authorization")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default()
+            .to_string(),
+        content_type,
+        body,
+        parts,
+    }
+}
+
+/// `mime.ParseMediaType`, over the one shape this fake sees.
+fn multipart_boundary_of(content_type: &str) -> Option<(String, String)> {
+    let mut fields = content_type.split(';');
+    let media_type = fields.next()?.trim().to_string();
+    if !media_type.starts_with("multipart/") {
+        return None;
+    }
+    for field in fields {
+        let (key, value) = field.split_once('=')?;
+        if key.trim().eq_ignore_ascii_case("boundary") {
+            return Some((media_type, value.trim().trim_matches('"').to_string()));
+        }
+    }
+    None
+}
+
+/// `multipart.Reader`, over the framing `googleapi` writes and nothing more:
+/// each part is `Content-Type: …` then a blank line then the body.
+fn split_parts(body: &str, boundary: &str) -> Vec<PartVector> {
+    let mut parts = Vec::new();
+    for chunk in body.split(&format!("--{boundary}")) {
+        let chunk = chunk.trim_start_matches("\r\n");
+        if chunk.is_empty() || chunk.starts_with("--") {
+            continue;
+        }
+        let Some((headers, content)) = chunk.split_once("\r\n\r\n") else {
+            continue;
+        };
+        let content_type = headers
+            .lines()
+            .find_map(|line| line.split_once(':'))
+            .filter(|(name, _)| name.eq_ignore_ascii_case("Content-Type"))
+            .map(|(_, value)| value.trim().to_string())
+            .unwrap_or_default();
+        parts.push(PartVector {
+            content_type,
+            // The reader strips the CRLF that precedes the next boundary.
+            body: content.strip_suffix("\r\n").unwrap_or(content).to_string(),
+        });
+    }
+    parts
+}
+
+// ─── Comparing a request ─────────────────────────────────────────────────────
+
+/// Substitutes the placeholder for a `timeMin` this run generated, after
+/// asserting it is the shape Go's `time.Now().UTC().Format(time.RFC3339)`
+/// produces — so the value is checked even though it cannot be compared.
+fn substitute_now(case: &str, target: &str, placeholder: &str) -> String {
+    let Some(start) = target.find("timeMin=") else {
+        return target.to_string();
+    };
+    let value_at = start + "timeMin=".len();
+    let end = target[value_at..]
+        .find('&')
+        .map_or(target.len(), |offset| value_at + offset);
+    let encoded = &target[value_at..end];
+
+    // Percent-decoding the one escape a `timeMin` can carry.
+    let decoded = encoded.replace("%3A", ":");
+    // `2026-08-17T12:34:56Z` — seconds precision, a literal `Z`, never an offset.
+    let shaped = decoded.len() == 20
+        && decoded.ends_with('Z')
+        && decoded.as_bytes()[10] == b'T'
+        && decoded
+            .chars()
+            .all(|c| c.is_ascii_digit() || matches!(c, '-' | ':' | 'T' | 'Z'));
+    if !shaped {
+        // Not a generated one — an explicit `time_min` the caller passed through.
+        return target.to_string();
+    }
+    let Ok(instant) = chrono::DateTime::parse_from_rfc3339(&decoded) else {
+        panic!("{case}: a time_min of this shape must be RFC3339: {decoded}");
+    };
+    // An explicit `time_min` argument has the same shape, so only a value
+    // actually close to now is the generated one — the same test the Go half
+    // applies before it writes the placeholder.
+    if (chrono::Utc::now() - instant.with_timezone(&chrono::Utc))
+        .num_seconds()
+        .abs()
+        > 3600
+    {
+        return target.to_string();
+    }
+
+    format!(
+        "{}{}{}",
+        &target[..value_at],
+        urlencoding_of(placeholder),
+        &target[end..]
+    )
+}
+
+/// `url.QueryEscape`, over the placeholder alone.
+fn urlencoding_of(value: &str) -> String {
+    crate::native::gourl::query_escape(value)
+}
+
+fn assert_request(case: &str, want: &RequestVector, got: &Recorded, placeholder: &str) {
+    assert_eq!(got.method, want.method, "{case}: method");
+    assert_eq!(
+        substitute_now(case, &got.target, placeholder),
+        want.target,
+        "{case}: the request target, query included"
+    );
+    assert_eq!(
+        got.authorization, want.authorization,
+        "{case}: Authorization — which is how a refresh is observed"
+    );
+    assert_eq!(got.content_type, want.content_type, "{case}: Content-Type");
+    assert_eq!(got.body, want.body, "{case}: request body");
+    assert_eq!(
+        got.parts.len(),
+        want.parts.len(),
+        "{case}: multipart part count"
+    );
+    for (index, (got, want)) in got.parts.iter().zip(&want.parts).enumerate() {
+        assert_eq!(
+            got.content_type, want.content_type,
+            "{case}: part {index}'s Content-Type — sniffed, not the mime_type argument"
+        );
+        assert_eq!(got.body, want.body, "{case}: part {index}'s body");
+    }
+}
+
+// ─── The calls ───────────────────────────────────────────────────────────────
+
+struct Harness {
+    state: FakeState,
+    base: String,
+}
+
+async fn harness() -> Harness {
+    let state = FakeState::default();
+    let app = axum::Router::new()
+        .fallback(serve_fake)
+        .with_state(state.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind the fake");
+    let base = format!("http://{}", listener.local_addr().expect("addr"));
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    Harness { state, base }
+}
+
+#[tokio::test]
+async fn every_call_matches_the_go_vectors() {
+    let v = vectors();
+    assert!(v.calls.len() >= 35, "vectors look partial");
+
+    let fake = harness().await;
+    let _guard = api_base_lock().await;
+    set_api_base(Some(fake.base.clone()));
+
+    let server = start_google_mcp_server(&v.integration_id, &all_services(), hour_source(&v))
+        .await
+        .expect("start the google server");
+
+    for case in &v.calls {
+        fake.state.arm_api(&case.responses);
+        // The token is an hour out, so a refresh arriving is itself a defect.
+        fake.state.arm_token(None);
+
+        let result = call_tool(&server, &case.tool, &case.arguments).await;
+
+        // A result must never carry the durable credentials, in either language.
+        assert!(
+            !result.text.contains(&v.client_secret) && !result.text.contains(&v.refresh_token),
+            "{}: a credential leaked into a tool result: {}",
+            case.case,
+            result.text
+        );
+        assert!(
+            fake.state.token_seen().is_none(),
+            "{}: an hour-valid token refreshed, which it must not",
+            case.case
+        );
+
+        let (want_text, want_error) = if case.rust_text.is_empty() {
+            (&case.text, case.is_error)
+        } else {
+            (&case.rust_text, true)
+        };
+        assert_eq!(result.text, *want_text, "{}: result text", case.case);
+        assert_eq!(result.is_error, want_error, "{}: is_error", case.case);
+
+        let seen = fake.state.api_seen();
+        if case.rust_no_request {
+            assert!(
+                seen.is_empty(),
+                "{}: the refusal still reached the network",
+                case.case
+            );
+            continue;
+        }
+        assert_eq!(
+            seen.len(),
+            case.requests.len(),
+            "{}: request count — search_email is the one that makes N+1",
+            case.case
+        );
+        for (index, (want, got)) in case.requests.iter().zip(&seen).enumerate() {
+            assert_request(
+                &format!("{} [request {index}]", case.case),
+                want,
+                got,
+                &v.now_placeholder,
+            );
+        }
+    }
+
+    set_api_base(None);
+}
+
+// ─── The refreshes ───────────────────────────────────────────────────────────
+
+/// The whole refresh decision, recorded rather than asserted: whether one
+/// happened at all, what it sent, and which access token the request that
+/// followed carried.
+#[tokio::test]
+async fn every_refresh_matches_the_go_vectors() {
+    let v = vectors();
+    assert!(v.refreshes.len() >= 5, "vectors look partial");
+
+    let fake = harness().await;
+    let _guard = api_base_lock().await;
+    set_api_base(Some(fake.base.clone()));
+
+    // The one service the Go half used: the shortest call that reaches the
+    // transport, so each case is about the token and nothing else.
+    let drive_only = BTreeMap::from([(
+        "drive".to_string(),
+        ServiceConfig {
+            enabled: true,
+            tools: Some(GoList(vec!["list_files".to_string()])),
+        },
+    )]);
+
+    for case in &v.refreshes {
+        fake.state.arm_api(std::slice::from_ref(&case.api_response));
+        fake.state.arm_token(case.token_response.as_ref());
+
+        let tokens = Arc::new(TokenSource::new(
+            &v.client_id,
+            &v.client_secret,
+            Token {
+                access_token: v.access_token.clone(),
+                refresh_token: v.refresh_token.clone(),
+                // `None` is Go's zero `time.Time`, which never expires — and a
+                // negative offset is a token already past its expiry.
+                expiry: case.expires_in.map(|seconds| {
+                    let delta = Duration::from_secs(seconds.unsigned_abs());
+                    if seconds >= 0 {
+                        SystemTime::now() + delta
+                    } else {
+                        SystemTime::now() - delta
+                    }
+                }),
+            },
+        ));
+
+        let server = start_google_mcp_server(&v.integration_id, &drive_only, tokens)
+            .await
+            .expect("start the google server");
+        let result = call_tool(
+            &server,
+            "list_files",
+            &serde_json::json!({"query": "", "max_results": 1}),
+        )
+        .await;
+
+        let (want_text, want_error) = if case.rust_text.is_empty() {
+            (&case.text, case.is_error)
+        } else {
+            (&case.rust_text, true)
+        };
+        assert_eq!(result.text, *want_text, "{}: result text", case.case);
+        assert_eq!(result.is_error, want_error, "{}: is_error", case.case);
+
+        // Whether a refresh happened at all is the assertion — a port that
+        // refreshed on every call would pass every text comparison above.
+        match (&case.refresh_request, fake.state.token_seen()) {
+            (None, seen) => assert!(
+                seen.is_none(),
+                "{}: Go made no refresh and this one did",
+                case.case
+            ),
+            (Some(_), None) => panic!("{}: Go refreshed and this one did not", case.case),
+            (Some(want), Some(got)) => assert_request(
+                &format!("{} [refresh]", case.case),
+                want,
+                &got,
+                &v.now_placeholder,
+            ),
+        }
+
+        match (&case.api_request, fake.state.api_seen().first()) {
+            (None, seen) => assert!(
+                seen.is_none(),
+                "{}: Go reached no API request and this one did",
+                case.case
+            ),
+            (Some(_), None) => panic!("{}: Go reached the API and this one did not", case.case),
+            (Some(want), Some(got)) => assert_request(
+                &format!("{} [api]", case.case),
+                want,
+                got,
+                &v.now_placeholder,
+            ),
+        }
+    }
+
+    set_api_base(None);
+}
+
+// ─── Driving a tool over the real transport ──────────────────────────────────
+
+struct ToolAnswer {
+    text: String,
+    is_error: bool,
+}
+
+async fn call_tool(
+    server: &crate::claude::InProcessMcpServer,
+    name: &str,
+    arguments: &Value,
+) -> ToolAnswer {
+    let payload = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": name, "arguments": arguments},
+    });
+
+    let mut request = reqwest::Client::new()
+        .post(server.url())
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream");
+    for (header, value) in &server.config().headers {
+        request = request.header(header, value);
+    }
+    let response = request
+        .body(payload.to_string())
+        .send()
+        .await
+        .expect("send tools/call");
+    let body: Value =
+        serde_json::from_str(&response.text().await.expect("text")).expect("a JSON-RPC reply");
+
+    assert!(
+        body.get("error").is_none(),
+        "{name}: a tool must not raise a protocol error: {body}"
+    );
+    let content = body["result"]["content"]
+        .as_array()
+        .unwrap_or_else(|| panic!("{name}: no content array: {body}"));
+    assert_eq!(content.len(), 1, "{name}: want exactly one content block");
+    assert_eq!(content[0]["type"], "text");
+
+    ToolAnswer {
+        text: content[0]["text"]
+            .as_str()
+            .unwrap_or_else(|| panic!("{name}: content is not text: {body}"))
+            .to_string(),
+        is_error: body["result"]["isError"].as_bool().unwrap_or(false),
+    }
+}

--- a/internal/integrations/google/calendar.go
+++ b/internal/integrations/google/calendar.go
@@ -8,14 +8,13 @@ import (
 
 	mcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	"google.golang.org/api/calendar/v3"
-	"google.golang.org/api/option"
 )
 
 // registerCalendarTools adds Google Calendar MCP tools to the server.
 // Only tools whose names are in the allowed set are registered.
 // If allowed is empty, all tools are registered.
 func registerCalendarTools(server *mcp.Server, httpClient *http.Client, allowed map[string]bool) {
-	calSvc, err := calendar.NewService(context.Background(), option.WithHTTPClient(httpClient))
+	calSvc, err := calendar.NewService(context.Background(), clientOptions(httpClient)...)
 	if err != nil {
 		// If we can't create the service, skip registration — server will start without calendar tools.
 		return

--- a/internal/integrations/google/drive.go
+++ b/internal/integrations/google/drive.go
@@ -9,14 +9,13 @@ import (
 
 	mcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	"google.golang.org/api/drive/v3"
-	"google.golang.org/api/option"
 )
 
 // registerDriveTools adds Google Drive MCP tools to the server.
 // Only tools whose names are in the allowed set are registered.
 // If allowed is empty, all tools are registered.
 func registerDriveTools(server *mcp.Server, httpClient *http.Client, allowed map[string]bool) {
-	driveSvc, err := drive.NewService(context.Background(), option.WithHTTPClient(httpClient))
+	driveSvc, err := drive.NewService(context.Background(), clientOptions(httpClient)...)
 	if err != nil {
 		return
 	}

--- a/internal/integrations/google/gmail.go
+++ b/internal/integrations/google/gmail.go
@@ -9,14 +9,13 @@ import (
 
 	mcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	"google.golang.org/api/gmail/v1"
-	"google.golang.org/api/option"
 )
 
 // registerGmailTools adds Gmail MCP tools to the server.
 // Only tools whose names are in the allowed set are registered.
 // If allowed is empty, all tools are registered.
 func registerGmailTools(server *mcp.Server, httpClient *http.Client, allowed map[string]bool) {
-	gmailSvc, err := gmail.NewService(context.Background(), option.WithHTTPClient(httpClient))
+	gmailSvc, err := gmail.NewService(context.Background(), clientOptions(httpClient)...)
 	if err != nil {
 		return
 	}

--- a/internal/integrations/google/parity.go
+++ b/internal/integrations/google/parity.go
@@ -1,0 +1,46 @@
+package google
+
+import "golang.org/x/oauth2"
+
+// This file is the seam `desktop/parity/google_parity_test.go` builds its
+// cross-language vectors through, for the reason `telegram/parity.go` sets out:
+// the vectors have to come from the **real** server, not from a restatement of
+// it, and `desktop/parity` is a different package.
+//
+// Google needs a wider seam than the other five, and the reason is the whole
+// difficulty of #313. The others build their requests with `http.NewRequest`, so
+// a reader can see the bytes. Google calls the generated client libraries
+// (`calendar/v3`, `gmail/v1`, `drive/v3`) over an `oauth2` transport, and what
+// those put on the wire — the resolved URL, the sorted query, the `omitempty`
+// body, the `multipart/related` framing, the `googleapi.Error` sentence — is in
+// neither this repository nor the port. It has to be *recorded*, which means both
+// the API base and the OAuth2 token endpoint must be redirectable at a local
+// fake.
+//
+// Nothing below changes behavior or wording: `Start` remains the only way the app
+// builds this server.
+
+// SetEndpoints points the three generated clients at apiBase and every token
+// refresh at tokenURL, returning a function that restores the previous values.
+//
+// Do not call outside tests. Both halves hand credentials to whatever host they
+// name: the API base receives the access token in an `Authorization` header, and
+// the token URL receives the **client secret and refresh token** — the durable
+// credential, not the hour-long one. It is exported only because `desktop/parity`
+// is a different package; the Rust port gates its equivalent behind
+// `#[cfg(test)]`, so it does not exist in a shipped desktop binary at all.
+//
+// Not safe for concurrent use with a live integration — which is fine, because
+// the only callers are tests that own the process.
+func SetEndpoints(apiBase, tokenURL string) (restore func()) {
+	previousAPI, previousOAuth := apiEndpoint, oauthEndpoint
+	apiEndpoint = apiBase
+	oauthEndpoint = oauth2.Endpoint{
+		AuthURL:   tokenURL,
+		TokenURL:  tokenURL,
+		AuthStyle: oauth2.AuthStyleInParams,
+	}
+	return func() {
+		apiEndpoint, oauthEndpoint = previousAPI, previousOAuth
+	}
+}

--- a/internal/integrations/google/server.go
+++ b/internal/integrations/google/server.go
@@ -9,9 +9,33 @@ import (
 	claude "github.com/shaharia-lab/claude-agent-sdk-go/claude"
 	"golang.org/x/oauth2"
 	googleoauth "golang.org/x/oauth2/google"
+	"google.golang.org/api/option"
 
 	"github.com/shaharia-lab/agento/internal/config"
 )
+
+// apiEndpoint overrides the base URL of the three generated Google clients, and
+// oauthEndpoint overrides the OAuth2 endpoints used to refresh the access token.
+//
+// Both are empty/zero in a running server and are variables for the reason
+// `slackAPIBase` and `apiBaseURL` are in the sibling packages: `desktop/parity`
+// has to stand the **real** server up against a local fake, and a generator that
+// rebuilt the tool set from this source would freeze someone's reading of the
+// code rather than the code. See parity.go.
+var (
+	apiEndpoint   string
+	oauthEndpoint = googleoauth.Endpoint
+)
+
+// clientOptions returns the options every generated service is built with —
+// the shared OAuth2 client, plus the endpoint override when a test has set one.
+func clientOptions(httpClient *http.Client) []option.ClientOption {
+	opts := []option.ClientOption{option.WithHTTPClient(httpClient)}
+	if apiEndpoint != "" {
+		opts = append(opts, option.WithEndpoint(apiEndpoint))
+	}
+	return opts
+}
 
 // Start creates and starts an in-process MCP server for the given Google integration config.
 // Only tools listed in each service's Tools slice are registered. If a service has an empty
@@ -52,7 +76,7 @@ func buildHTTPClient(ctx context.Context, cfg *config.IntegrationConfig) (*http.
 	oauthCfg := &oauth2.Config{
 		ClientID:     creds.ClientID,
 		ClientSecret: creds.ClientSecret,
-		Endpoint:     googleoauth.Endpoint,
+		Endpoint:     oauthEndpoint,
 	}
 
 	// Create a token source that uses the stored token. The oauth2 library handles


### PR DESCRIPTION
Closes part of #313 — **the port. The hosting flip is a follow-up PR.**

Eight tools across three service groups (`calendar`, `gmail`, `drive`) over an OAuth2 token that refreshes itself. Last of the six integrations, and the only one that is not a port of hand-rolled HTTP.

## Why this one is measured rather than read

The other five build their requests with `http.NewRequest` and `json.Marshal`, so the port reproduces bytes visible in `tools.go`. Google calls the **generated** client libraries (`calendar/v3`, `gmail/v1`, `drive/v3`) over an `oauth2` transport, and what those put on the wire is in neither this repository nor the port.

So every URL, query parameter, body field and sentence was *recorded* off the real libraries against a fake endpoint before it was written. `desktop/parity/google_vectors.json` is not a confirmation of the port — it is the **only written specification** of what that third-party code generator emits, and it is what will notice when the generator changes.

## Four things this found that no amount of reading would have

Three were port bugs, caught the first time the vectors were replayed:

1. **Path parameters use `googleapi.Expand`, not `url.PathEscape`.** The generated clients expand RFC 6570 templates, escaping everything outside the unreserved set. `PathEscape` leaves the sub-delims alone — so a Gmail message id containing `&` came out as `…%3Fd&e`, an `&` that starts a query parameter.
2. **Every JSON body carries a trailing newline**, because `googleapi` writes it with `json.NewEncoder(…).Encode`. Both the plain `application/json` POSTs and the metadata part of the `multipart/related` upload.
3. **`oauth2.RetrieveError` has two forms** and picks between them on whether the body named an error code, *not* on the status. A Google refresh refusal takes the one the port did not have: `oauth2: "invalid_grant" "Token has been expired or revoked."`.

The fourth is Go's, and was found by trying to vector it:

4. **A response body of exactly `null` panics every one of the eight Go tools.** The generated clients decode into a `**T`; `json.Unmarshal` of `null` into a pointer-to-pointer nils the pointer, and the handler reads a field off it. That is a 200 with a two-word body — what a proxy or a misconfigured gateway produces. It joins the two nil-dereferences the handlers own (`msg.Payload.Headers`, `ev.Start.DateTime`). The port returns the zero value in all three. The case is deliberately **absent** from the vectors: recording it would mean recording a crash.

## Google-specific behaviour the other five never reached

- **`gourl::Values` stopped being single-valued for this.** Gmail's `MetadataHeaders("Subject","From","Date")` is three `metadataHeaders=` pairs in insertion order under one sorted key, so `Values` is now a multimap with `set` and `add`.
- **`search_email` makes N+1 requests from one tool call**, skips a failed fetch rather than surfacing it, and reports `len(list.Messages)` — the *listed* count. A partial failure produces a sentence whose number does not match its body. Go's, and pinned.
- **`create_file`'s media type is sniffed from the content**, not taken from `mime_type`, which reaches the metadata JSON alone.
- **Drive's upload path is an absolute reference**, replacing the base's whole path: `/upload/drive/v3/files`.
- **Every clamp differs** (100 / 100 / 50, all falling back to 10), **`q` is conditional for Drive and unconditional for Gmail**, and **`download_file` is the only call that is not `alt=json`**.

## Pinned as divergence rather than matched

All recorded in the vectors so they cannot drift silently: `X-Goog-Api-Client` and `User-Agent` (they embed the Go toolchain and library versions — no Rust build can emit `gl-go/…`), the random `multipart/related` boundary (the *parts* are compared instead), and Go's `*url.Error` wrapper around a transport or refresh failure.

One value is not deterministic — `view_events`' `time_min` defaults to `time.Now()` — so that vector records `«now»`, and both languages assert the value it replaced is a seconds-precision RFC3339 instant in UTC before substituting.

## The Go side

`internal/integrations/google/parity.go` exports `SetEndpoints`: a **wider** seam than the other integrations' `SetAPIBase`, because both the API base and the OAuth2 token endpoint have to be redirectable at a fake. It is test-only — the token URL receives the `client_secret` and refresh token, the durable credentials. The three registrars now build through `clientOptions`. No behaviour or wording changes; `Start` remains the only way the app builds this server.

## Why `google` is not in `HOSTED_TYPES`

Nothing here runs in a shipped build. The sidecar still hosts Google and this is dormant code with its parity pinned. The flip is its own PR, because the flip is where the risk in this series has actually lived — #315's hosting of Slack silently broke `completeOAuth`'s reload, and Google is the *other* provider `startProviderCallback` supports, so it lands on the same hook. Splitting lets that be reviewed on its own and reverted without reverting the port.

`client::TokenSource` is also the refresh implementation #318 says must not be written twice.

## Gates

`cargo test` (896 + 19 + 15 …, all green), `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `go test ./...`, `golangci-lint run ./...` at the pinned v2.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)