### PR TITLE
feat(desktop): host google, closing the integration phase (#313)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -600,7 +600,7 @@ of the `Err` arms the cut-over has to turn into a real response.
 | 1 ✅ | Sidecar + proxy | — | done |
 | 2 ← | Pricing + analytics | `internal/pricing`, `internal/claudesessions` | Pure computation over JSONL + SQLite. No external deps. **In progress**: `/api/pricing/catalog`, `/api/claude-sessions`, `/api/claude-sessions/facets`, `/api/claude-analytics`, `/api/claude-sessions/insights/summary` and the agent reads are native and diff clean. |
 | 3 ← | Storage + tasks | `internal/storage`, `internal/scheduler` | **In progress (#274, #275).** `db.rs` is read-write, the 27 migrations are ported, and the writes whose every effect Rust owns are native — see below. The scheduler's *schedule computation* is ported and pinned (#275); its ownership is not, and is blocked — see below. |
-| 4 ← | Integrations | `internal/integrations`, `internal/trigger` | OAuth2 + MCP servers. Six of them: google, github, slack, jira, confluence, telegram, plus `internal/tools`. **How to host one is settled (#282)** — `claude::ToolServer`, see "Hosting a tool" below; do not invent a second way. **`internal/tools` is done (#310)** — `native/tools/`, and it is the worked example the six should be read against. **GitHub is done (#312)** — `native/integrations/github/`, the worked example for an *integration*. **The registry is done (#311)** — `native/integrations/registry.rs` plus `PUT`/`DELETE /api/integrations/{id}`, and the sidecar now runs with `AGENTO_INTEGRATIONS=off:<the types the shell hosts>`, so every type has exactly one owner. **Confluence is done (#317)** — `native/integrations/confluence/`, the smallest of the six and the one that shows what an integration adds over #312: a per-row API base, basic auth, and a `Start` check that is a decision. **Jira is done (#316)** — `native/integrations/jira/`, Confluence's twin, and the one that shows that a shared credential type does not mean shared behaviour: `jira.Start` validates nothing, so a bad base is answered per call instead of by refusing to host. **Slack is done (#315)** — `native/integrations/slack/`, the first that is not Atlassian-shaped: no model input in the URL at all, and the only integration whose token can come from the `auth` column. **Telegram is done (#314)** — `native/integrations/telegram/`, the outbound half, and the one that reached two reflector divergences the map had recorded as unreachable. **Google is ported (#313)** — `native/integrations/google/`, the last and the only one whose requests are built by a generated client rather than by the handlers, so its vectors are a specification rather than a confirmation; it is deliberately **not** in `HOSTED_TYPES` yet, and that flip is its own change. WhatsApp is **not** among them — but Go still hosts its rows, because its starter opens a live connection rather than just a port; see below. |
+| 4 ← | Integrations | `internal/integrations`, `internal/trigger` | OAuth2 + MCP servers. Six of them: google, github, slack, jira, confluence, telegram, plus `internal/tools`. **How to host one is settled (#282)** — `claude::ToolServer`, see "Hosting a tool" below; do not invent a second way. **`internal/tools` is done (#310)** — `native/tools/`, and it is the worked example the six should be read against. **GitHub is done (#312)** — `native/integrations/github/`, the worked example for an *integration*. **The registry is done (#311)** — `native/integrations/registry.rs` plus `PUT`/`DELETE /api/integrations/{id}`, and the sidecar now runs with `AGENTO_INTEGRATIONS=off:<the types the shell hosts>`, so every type has exactly one owner. **Confluence is done (#317)** — `native/integrations/confluence/`, the smallest of the six and the one that shows what an integration adds over #312: a per-row API base, basic auth, and a `Start` check that is a decision. **Jira is done (#316)** — `native/integrations/jira/`, Confluence's twin, and the one that shows that a shared credential type does not mean shared behaviour: `jira.Start` validates nothing, so a bad base is answered per call instead of by refusing to host. **Slack is done (#315)** — `native/integrations/slack/`, the first that is not Atlassian-shaped: no model input in the URL at all, and the only integration whose token can come from the `auth` column. **Telegram is done (#314)** — `native/integrations/telegram/`, the outbound half, and the one that reached two reflector divergences the map had recorded as unreachable. **Google is done (#313)** — `native/integrations/google/`, the last of the six and the only one whose requests are built by a generated client rather than by the handlers, so its vectors are a specification rather than a confirmation. **With its flip, `HOSTED_TYPES` covers every type the port will ever cover**, and the phase is closed. WhatsApp is **not** among them — but Go still hosts its rows, because its starter opens a live connection rather than just a port; see below. |
 | 5 ← | Agent execution | `internal/agent`, `internal/service` | **In progress (#276).** The chat SSE turn is native: `/messages`, `/input`, `/permission` and `/stop`, on top of the ported SDK. The scheduler's executor (#275) is the other caller and still Go's. |
 
 ### The session scanner (`src-tauri/src/native/scanner/`)
@@ -1514,12 +1514,30 @@ token endpoint have to be redirectable. It hands credentials to whatever host it
 names — the token URL receives the `client_secret` and refresh token, the durable
 ones — so it is test-only, and the Rust equivalent is behind `#[cfg(test)]`.
 
-**`google` is deliberately absent from `HOSTED_TYPES`.** Nothing here runs in a
-shipped build yet: the sidecar still hosts Google and this is dormant code with
-its parity pinned. The flip is its own change, because the flip is where the risk
-in this series has actually lived — #315's hosting of Slack silently broke
-`completeOAuth`'s reload, and Google is the *other* provider
-`startProviderCallback` supports, so it lands on the same hook.
+**The flip landed as its own change**, after the port. That split was worth it
+for the reason it was made: the flip is where the risk in this series has lived —
+#315's hosting of Slack silently broke `completeOAuth`'s reload, and Google is the
+*other* provider `startProviderCallback` supports. With both hosted,
+`reload_if_secrets_changed` now covers **every** OAuth integration in the product,
+and there is no longer a case it does not have to catch.
+
+`start_google` is the only starter needing **both** secret columns for different
+things: `credentials` carries the OAuth2 client pair, `auth` carries the token.
+Slack reads `auth` too but only for an access token; here the whole `oauth2.Token`
+matters, because `expiry` decides whether the first tool call refreshes. That is
+also why `google_oauth_token` **refuses a row whose `expiry` does not parse**
+rather than skipping the field as Slack's does — a corrupt expiry means not
+hosted, not hosted-with-a-token-that-never-refreshes.
+
+The accept/reject boundary is measured, not read: the `starting` section of
+`google_vectors.json` records what `google.Start` does with twenty-three
+credential and auth shapes, and `parse_go_rfc3339` exists because **`chrono` is
+more permissive than Go in two ways a stored token can reach** — a lowercase
+`t`/`z` separator and a leap second, both of which chrono accepts and
+`time.Parse` refuses.
+
+`whatsapp` is now the stand-in in all three "unported type" tests, and it stays
+there: it is dropped rather than deferred.
 
 ### The integration registry, and the port's second ownership flip (#311)
 
@@ -1948,12 +1966,11 @@ path cannot try to answer a chat turn with a `Vec<u8>`.
 **The four routes share a process-local registry, so they moved together** —
 `/messages` puts a session in, the others look one up. But not every chat *can*
 run natively: an agent whose tools come from an integration this build cannot
-host still needs #313's **flip** — the port itself has landed, but `google` is not
-in `HOSTED_TYPES` yet — and `runner::build_options` refuses those before any
-subprocess exists. (Most of that refusal is gone — the **local** server (#310)
+host still needs to fall back, and `runner::build_options` refuses those before
+any subprocess exists — but since #313 that is `whatsapp` alone. (Most of that refusal is gone — the **local** server (#310)
 and any agent naming only integrations in `HOSTED_TYPES`: **github** since #311,
 **confluence** since #317, **jira** since #316, **slack** since #315, **telegram**
-since #314. `build_options`
+since #314, **google** since #313 — which is all six. `build_options`
 starts each of them, and is `async` for that reason, returning the listener
 handles alongside the options because dropping one stops its server.) That would strand `/stop` for a chat still running on Go, so
 the three steering routes answer natively **only when Rust holds a live session

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -1530,11 +1530,32 @@ rather than skipping the field as Slack's does — a corrupt expiry means not
 hosted, not hosted-with-a-token-that-never-refreshes.
 
 The accept/reject boundary is measured, not read: the `starting` section of
-`google_vectors.json` records what `google.Start` does with twenty-three
-credential and auth shapes, and `parse_go_rfc3339` exists because **`chrono` is
-more permissive than Go in two ways a stored token can reach** — a lowercase
-`t`/`z` separator and a leap second, both of which chrono accepts and
-`time.Parse` refuses.
+`google_vectors.json` records what `google.Start` does with thirty-one
+credential and auth shapes, and the Rust replay calls `google_start_inputs` —
+the function the starter itself calls — so the **order** of the three checks is
+pinned too, not just their sentences.
+
+**Two findings there are worth carrying forward.** The first is a trap Go's own
+writer sets: `omitempty` does not suppress a struct, so `SetOAuthToken` emits
+`"expiry":"0001-01-01T00:00:00Z"` for a token with no expiry rather than omitting
+the key — and `Token.Valid()` treats that zero `time.Time` as **never expiring**.
+Read as an ordinary instant it is permanently expired, the exact inverse, so
+`google_oauth_token` maps it to `None`. The vector that was meant to cover this
+originally tested the *absent* key, a spelling Go's writer can never produce.
+
+The second is that **`gotime::parse_rfc3339` is now the one Go-RFC3339 parser**,
+shared with `native/schedule`'s `run_at` (#275). `chrono::parse_from_rfc3339`
+disagrees with `time.Parse` in **five** ways, in both directions: it accepts a
+lowercase `t`/`z` and a leap second that Go refuses, and refuses a comma decimal
+separator, a one-digit hour and an offset hour past 23 that Go accepts. The last
+three are Go being *laxer*, which a stricter port turns into refusing input Go
+takes — a schedule that will not build, or an integration that will not host.
+#275 found three of the five and wrote `parse_from_rfc3339` plus three guards;
+#313 was about to add a second copy with two. Guarding a convenient library has
+been wrong twice for one reason — **the guard list has to be right about every
+disagreement** — so the shared version parses the grammar and delegates nothing
+but the calendar arithmetic. `GoTime::parse` is deliberately left on chrono: it
+reads `effective_from`, which only this application writes, normalized.
 
 `whatsapp` is now the stand-in in all three "unported type" tests, and it stays
 there: it is dropped rather than deferred.
@@ -1607,19 +1628,19 @@ asserts both halves, the fallback and the untouched row.
 run uses: `runner.go` reads the integration row afresh per run, builds a
 throwaway server and records nothing. Gating it would have broken every
 integration-using chat, scheduled task and Telegram trigger the sidecar still
-serves — which is now one type, #313's.
+serves — which since #313 is one type, `whatsapp`'s, and permanently so.
 The Go tests assert both halves, because the switch is only safe while that
 asymmetry holds.
 
 Two consequences worth knowing before touching this:
 
-- **Five of the six have starters here** — `github` (#312), `confluence` (#317),
-  `jira` (#316), `slack` (#315) and `telegram` (#314) — **and Go still hosts
-  `google` and `whatsapp`.** A type not
-  in `HOSTED_TYPES` reaches this module's own unregistered-type path — `no
-  starter registered for integration type "slack"`, logged and never surfaced —
-  but in practice it does not reach it at all, because the writes decline it
-  first. Nothing about a Slack or WhatsApp integration changed with this issue.
+- **All six have starters here** — `github` (#312), `confluence` (#317), `jira`
+  (#316), `slack` (#315), `telegram` (#314) and `google` (#313) — **and Go hosts
+  only `whatsapp`.** A type not in `HOSTED_TYPES` reaches this module's own
+  unregistered-type path — `no starter registered for integration type
+  "whatsapp"`, logged and never surfaced — but in practice it does not reach it
+  at all, because the writes decline it first. Nothing about a WhatsApp
+  integration changed with any of these issues, and nothing will.
 - **`reload` is unconditional.** Stop then start, no diff: there is a window
   with no server and the port changes on every save. Reproduced rather than
   improved on, because "nothing changed, skip it" is a different set of live

--- a/desktop/parity/google_parity_test.go
+++ b/desktop/parity/google_parity_test.go
@@ -195,6 +195,25 @@ type googleRefreshVector struct {
 	RustText       string               `json:"rust_text,omitempty"`
 }
 
+// googleStartVector records what `google.Start` does with a given credentials
+// and auth pair — hosted, or refused with which sentence.
+//
+// The registry's other five have hand-written credential parses with
+// hand-asserted sentences. Google gets vectors instead, for one reason: its
+// `auth` column decodes as an `oauth2.Token` whose `expiry` is a Go `time.Time`,
+// so the accept/reject boundary is `time.Time.UnmarshalJSON`'s and not something
+// worth guessing at. #313's first half was a lesson in what reading rather than
+// measuring costs.
+type googleStartVector struct {
+	Case        string `json:"case"`
+	Credentials string `json:"credentials"`
+	Auth        string `json:"auth"`
+	// Empty when Start succeeded.
+	Error string `json:"error"`
+	// A pinned divergence: Go's `encoding/json` wording for a malformed blob.
+	RustError string `json:"rust_error,omitempty"`
+}
+
 type googleHostingVector struct {
 	Case     string                          `json:"case"`
 	Services map[string]config.ServiceConfig `json:"services"`
@@ -213,6 +232,7 @@ type googleVectors struct {
 	NowPlaceholder string                `json:"now_placeholder"`
 	Tools          []googleToolVector    `json:"tools"`
 	Hosting        []googleHostingVector `json:"hosting"`
+	Starting       []googleStartVector   `json:"starting"`
 	Calls          []googleCallVector    `json:"calls"`
 	Refreshes      []googleRefreshVector `json:"refreshes"`
 }
@@ -452,6 +472,81 @@ var googleHostingCases = []googleHostingVector{
 			"drive":    {Enabled: true, Tools: []string{"list_files"}},
 			"calendar": {Enabled: false, Tools: []string{"create_event"}},
 		}},
+}
+
+// ─── The Start cases ─────────────────────────────────────────────────────────
+
+// googleValidCredentials is the shape the UI writes.
+const googleValidCredentials = `{"client_id":"` + googleClientID +
+	`","client_secret":"` + googleClientSecret + `"}`
+
+func googleStartCases() []googleStartVector {
+	// What `SetOAuthToken` writes: RFC3339Nano, because that is `time.Time`'s
+	// own marshaling.
+	const validAuth = `{"access_token":"ya29.x","token_type":"Bearer",` +
+		`"refresh_token":"1//y","expiry":"2030-01-01T00:00:00.123456789Z"}`
+
+	return []googleStartVector{
+		{Case: "the ordinary shape", Credentials: googleValidCredentials, Auth: validAuth},
+		{
+			// `IsAuthenticated` is `len(Auth) > 0 && Auth != "null"`, so both of
+			// these refuse before any parse.
+			Case: "an empty auth column is unauthenticated", Credentials: googleValidCredentials, Auth: "",
+		},
+		{Case: "a literal null auth column is unauthenticated", Credentials: googleValidCredentials, Auth: "null"},
+		{
+			// …but an empty *object* is authenticated, and parses, and hosts a
+			// server whose every call carries an empty bearer token. Go's.
+			Case: "an empty auth object is authenticated and hosts", Credentials: googleValidCredentials, Auth: "{}",
+		},
+		{Case: "no expiry at all is Go's zero time, which never expires",
+			Credentials: googleValidCredentials, Auth: `{"access_token":"ya29.x","refresh_token":"1//y"}`},
+		{
+			// The boundary this section exists for: `expiry` is a `time.Time`,
+			// so a non-RFC3339 value fails the whole decode.
+			Case: "a malformed expiry fails the auth parse", Credentials: googleValidCredentials,
+			Auth: `{"access_token":"ya29.x","expiry":"not a time"}`,
+		},
+		{Case: "an expiry without a zone fails too", Credentials: googleValidCredentials,
+			Auth: `{"access_token":"ya29.x","expiry":"2030-01-01T00:00:00"}`},
+		{Case: "a date-only expiry fails too", Credentials: googleValidCredentials,
+			Auth: `{"access_token":"ya29.x","expiry":"2030-01-01"}`},
+		{Case: "an offset expiry is accepted", Credentials: googleValidCredentials,
+			Auth: `{"access_token":"ya29.x","expiry":"2030-01-01T00:00:00+05:30"}`},
+		{Case: "a numeric expiry is a type error", Credentials: googleValidCredentials,
+			Auth: `{"access_token":"ya29.x","expiry":1893456000}`},
+		{Case: "a null expiry is the zero time", Credentials: googleValidCredentials,
+			Auth: `{"access_token":"ya29.x","expiry":null}`},
+		{Case: "an empty string expiry fails", Credentials: googleValidCredentials,
+			Auth: `{"access_token":"ya29.x","expiry":""}`},
+		{
+			// Go's RFC3339 parse has been strict since 1.20, so the case of the
+			// separators is worth pinning rather than assuming either way.
+			Case: "a lowercase t and z separator", Credentials: googleValidCredentials,
+			Auth: `{"access_token":"ya29.x","expiry":"2030-01-01t00:00:00z"}`,
+		},
+		{Case: "a one-digit fractional second", Credentials: googleValidCredentials,
+			Auth: `{"access_token":"ya29.x","expiry":"2030-01-01T00:00:00.5Z"}`},
+		{Case: "a trailing space after the zone fails", Credentials: googleValidCredentials,
+			Auth: `{"access_token":"ya29.x","expiry":"2030-01-01T00:00:00Z "}`},
+		{Case: "a leap second", Credentials: googleValidCredentials,
+			Auth: `{"access_token":"ya29.x","expiry":"2030-06-30T23:59:60Z"}`},
+		{Case: "an out-of-range month", Credentials: googleValidCredentials,
+			Auth: `{"access_token":"ya29.x","expiry":"2030-13-01T00:00:00Z"}`},
+		{Case: "an auth array is not a struct", Credentials: googleValidCredentials, Auth: `["ya29.x"]`},
+		{Case: "empty credentials fail the credentials parse",
+			Credentials: "", Auth: validAuth},
+		{Case: "a null credentials blob is a no-op, so the client id is empty",
+			Credentials: "null", Auth: validAuth},
+		{Case: "a credentials array is not a struct", Credentials: `["cid","secret"]`, Auth: validAuth},
+		{Case: "credentials that are not JSON at all", Credentials: `nope`, Auth: validAuth},
+		{
+			// Neither field is checked for emptiness — Go hosts it and every
+			// refresh then fails at Google.
+			Case: "empty credentials fields still host", Credentials: `{"client_id":"","client_secret":""}`,
+			Auth: validAuth,
+		},
+	}
 }
 
 // ─── The call cases ──────────────────────────────────────────────────────────
@@ -1173,6 +1268,10 @@ func TestGoogleVectors(t *testing.T) {
 		want.Hosting = append(want.Hosting, hosting)
 	}
 
+	for _, c := range googleStartCases() {
+		want.Starting = append(want.Starting, runGoogleStartCase(t, ctx, c))
+	}
+
 	for _, c := range googleCallCases() {
 		want.Calls = append(want.Calls, runGoogleCallCase(t, ctx, session, fake, c))
 	}
@@ -1211,6 +1310,32 @@ func TestGoogleVectors(t *testing.T) {
 			"without anything in this repository changing.",
 			googleVectorsFile)
 	}
+}
+
+// runGoogleStartCase calls the real `google.Start` and records whether it hosted
+// and, if not, exactly what it said.
+func runGoogleStartCase(
+	t *testing.T, ctx context.Context, c googleStartVector,
+) googleStartVector {
+	t.Helper()
+
+	cfg := &config.IntegrationConfig{
+		ID:          googleParityID,
+		Name:        "Google (parity)",
+		Type:        "google",
+		Enabled:     true,
+		Credentials: json.RawMessage(c.Credentials),
+		Auth:        json.RawMessage(c.Auth),
+		Services:    googleAllServices(),
+	}
+
+	if _, err := google.Start(ctx, cfg); err != nil {
+		c.Error = err.Error()
+		if strings.Contains(c.Error, googleClientSecret) {
+			t.Fatalf("%s: the client secret leaked into a Start error: %s", c.Case, c.Error)
+		}
+	}
+	return c
 }
 
 func googleHostedTools(

--- a/desktop/parity/google_parity_test.go
+++ b/desktop/parity/google_parity_test.go
@@ -533,7 +533,58 @@ func googleStartCases() []googleStartVector {
 			Auth: `{"access_token":"ya29.x","expiry":"2030-06-30T23:59:60Z"}`},
 		{Case: "an out-of-range month", Credentials: googleValidCredentials,
 			Auth: `{"access_token":"ya29.x","expiry":"2030-13-01T00:00:00Z"}`},
+		{
+			// **The shape `SetOAuthToken` actually writes for a zero expiry.**
+			// `omitempty` does not suppress a struct, so Go emits the sentinel
+			// rather than omitting the key — and `Expiry.IsZero()` then makes the
+			// token never expire. The "no expiry at all" case above tests a
+			// spelling Go's own writer can never produce; this is the reachable
+			// one, and the port read it as *already expired*.
+			Case:        "Go's zero time is the sentinel its writer emits, and never expires",
+			Credentials: googleValidCredentials,
+			Auth:        `{"access_token":"ya29.x","refresh_token":"1//y","expiry":"0001-01-01T00:00:00Z"}`,
+		},
+		{
+			// Three forms `time.Parse` accepts that `chrono` refuses. Go's strict
+			// RFC3339 checks are compiled out (`case true:` in
+			// `format_rfc3339.go`), so the general parser's laxity is what a
+			// stored value actually meets.
+			Case: "a comma decimal separator", Credentials: googleValidCredentials,
+			Auth: `{"access_token":"ya29.x","expiry":"2030-01-01T00:00:00,5Z"}`,
+		},
+		{Case: "a one-digit hour", Credentials: googleValidCredentials,
+			Auth: `{"access_token":"ya29.x","expiry":"2030-01-01T5:04:05Z"}`},
+		{Case: "an offset hour of 24", Credentials: googleValidCredentials,
+			Auth: `{"access_token":"ya29.x","expiry":"2030-01-01T00:00:00+24:00"}`},
+		{
+			// `oauth2.Token` types these, so a mistyped one fails the document —
+			// which the port's three-field struct did not notice.
+			Case: "a numeric token_type is a type error", Credentials: googleValidCredentials,
+			Auth: `{"access_token":"ya29.x","token_type":5}`,
+		},
+		{Case: "a string expires_in is a type error", Credentials: googleValidCredentials,
+			Auth: `{"access_token":"ya29.x","expires_in":"soon"}`},
 		{Case: "an auth array is not a struct", Credentials: googleValidCredentials, Auth: `["ya29.x"]`},
+		// ─── ordering: which check speaks when more than one could ───────────
+		{
+			// `Start` checks `IsAuthenticated` before it parses anything, so an
+			// empty auth wins over a broken credentials blob.
+			Case:        "an empty auth beats a broken credentials blob",
+			Credentials: `nope`, Auth: "",
+		},
+		{
+			// …and `buildHTTPClient` parses credentials before the token, so a
+			// broken credentials blob wins over a broken auth blob.
+			Case:        "a broken credentials blob beats a broken auth blob",
+			Credentials: `nope`, Auth: `{"access_token":"ya29.x","expiry":"not a time"}`,
+		},
+		{
+			// A malformed blob that *carries* the secret: the failure sentence
+			// must not echo it, which is the assertion the leak check exists for
+			// and previously never had a message derived from a secret at all.
+			Case:        "a truncated credentials blob carrying the secret",
+			Credentials: `{"client_secret":"` + googleClientSecret + `",`, Auth: validAuth,
+		},
 		{Case: "empty credentials fail the credentials parse",
 			Credentials: "", Auth: validAuth},
 		{Case: "a null credentials blob is a no-op, so the client id is empty",
@@ -547,6 +598,60 @@ func googleStartCases() []googleStartVector {
 			Auth: validAuth,
 		},
 	}
+}
+
+// googleRustStartErrors is the port's sentence for each Go sentence it does not
+// reproduce — a data table, deliberately, so that "which sentences diverge" is
+// something a reader counts rather than something a classifier decides.
+//
+// Exactly two classes appear here, and every other refusal in `starting` is
+// reproduced byte for byte and asserted as such:
+//
+//   - `time.Parse` diffs the value against the layout and names the token that
+//     failed. Transcribing that buys nothing; the port names the value it could
+//     not parse, which is not a secret.
+//   - `encoding/json` names the offending value, which for a credentials or auth
+//     blob *is* the credential. The port emits line and column instead, as the
+//     five sibling parses already do.
+//
+// A case missing from this map is asserted against Go's own text, so adding a
+// vector whose sentence cannot be reproduced fails loudly rather than silently
+// going unchecked.
+var googleRustStartErrors = map[string]string{
+	"a malformed expiry fails the auth parse":            expiryRefusal(`"not a time"`),
+	"an expiry without a zone fails too":                 expiryRefusal(`"2030-01-01T00:00:00"`),
+	"a date-only expiry fails too":                       expiryRefusal(`"2030-01-01"`),
+	"an empty string expiry fails":                       expiryRefusal(`""`),
+	"a lowercase t and z separator":                      expiryRefusal(`"2030-01-01t00:00:00z"`),
+	"a trailing space after the zone fails":              expiryRefusal(`"2030-01-01T00:00:00Z "`),
+	"a leap second":                                      expiryRefusal(`"2030-06-30T23:59:60Z"`),
+	"an out-of-range month":                              expiryRefusal(`"2030-13-01T00:00:00Z"`),
+	"a numeric token_type is a type error":               authDecodeRefusal(39),
+	"a string expires_in is a type error":                authDecodeRefusal(44),
+	"an auth array is not a struct":                      authDecodeRefusal(0),
+	"a broken credentials blob beats a broken auth blob": credentialsDecodeRefusal(2),
+	"a truncated credentials blob carrying the secret":   credentialsDecodeRefusal(47),
+	"a credentials array is not a struct":                credentialsDecodeRefusal(0),
+	"credentials that are not JSON at all":               credentialsDecodeRefusal(2),
+}
+
+func expiryRefusal(quoted string) string {
+	return fmt.Sprintf("parsing auth token for %q: parsing oauth token: parsing time %s",
+		googleParityID, quoted)
+}
+
+// The line is always 1: every blob in this table is a single line, which is what
+// a stored credentials or auth column is.
+func authDecodeRefusal(column int) string {
+	return fmt.Sprintf(
+		"parsing auth token for %q: parsing oauth token: does not decode at line 1 column %d",
+		googleParityID, column)
+}
+
+func credentialsDecodeRefusal(column int) string {
+	return fmt.Sprintf(
+		"parsing google credentials for %q: does not decode at line 1 column %d",
+		googleParityID, column)
 }
 
 // ─── The call cases ──────────────────────────────────────────────────────────
@@ -1334,6 +1439,7 @@ func runGoogleStartCase(
 		if strings.Contains(c.Error, googleClientSecret) {
 			t.Fatalf("%s: the client secret leaked into a Start error: %s", c.Case, c.Error)
 		}
+		c.RustError = googleRustStartErrors[c.Case]
 	}
 	return c
 }

--- a/desktop/parity/google_vectors.json
+++ b/desktop/parity/google_vectors.json
@@ -374,6 +374,146 @@
       ]
     }
   ],
+  "starting": [
+    {
+      "case": "the ordinary shape",
+      "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
+      "auth": "{\"access_token\":\"ya29.x\",\"token_type\":\"Bearer\",\"refresh_token\":\"1//y\",\"expiry\":\"2030-01-01T00:00:00.123456789Z\"}",
+      "error": ""
+    },
+    {
+      "case": "an empty auth column is unauthenticated",
+      "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
+      "auth": "",
+      "error": "integration \"goog-parity\" has no auth token"
+    },
+    {
+      "case": "a literal null auth column is unauthenticated",
+      "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
+      "auth": "null",
+      "error": "integration \"goog-parity\" has no auth token"
+    },
+    {
+      "case": "an empty auth object is authenticated and hosts",
+      "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
+      "auth": "{}",
+      "error": ""
+    },
+    {
+      "case": "no expiry at all is Go's zero time, which never expires",
+      "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
+      "auth": "{\"access_token\":\"ya29.x\",\"refresh_token\":\"1//y\"}",
+      "error": ""
+    },
+    {
+      "case": "a malformed expiry fails the auth parse",
+      "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
+      "auth": "{\"access_token\":\"ya29.x\",\"expiry\":\"not a time\"}",
+      "error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"not a time\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"not a time\" as \"2006\""
+    },
+    {
+      "case": "an expiry without a zone fails too",
+      "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
+      "auth": "{\"access_token\":\"ya29.x\",\"expiry\":\"2030-01-01T00:00:00\"}",
+      "error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"2030-01-01T00:00:00\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"\" as \"Z07:00\""
+    },
+    {
+      "case": "a date-only expiry fails too",
+      "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
+      "auth": "{\"access_token\":\"ya29.x\",\"expiry\":\"2030-01-01\"}",
+      "error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"2030-01-01\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"\" as \"T\""
+    },
+    {
+      "case": "an offset expiry is accepted",
+      "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
+      "auth": "{\"access_token\":\"ya29.x\",\"expiry\":\"2030-01-01T00:00:00+05:30\"}",
+      "error": ""
+    },
+    {
+      "case": "a numeric expiry is a type error",
+      "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
+      "auth": "{\"access_token\":\"ya29.x\",\"expiry\":1893456000}",
+      "error": "parsing auth token for \"goog-parity\": parsing oauth token: Time.UnmarshalJSON: input is not a JSON string"
+    },
+    {
+      "case": "a null expiry is the zero time",
+      "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
+      "auth": "{\"access_token\":\"ya29.x\",\"expiry\":null}",
+      "error": ""
+    },
+    {
+      "case": "an empty string expiry fails",
+      "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
+      "auth": "{\"access_token\":\"ya29.x\",\"expiry\":\"\"}",
+      "error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"\" as \"2006\""
+    },
+    {
+      "case": "a lowercase t and z separator",
+      "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
+      "auth": "{\"access_token\":\"ya29.x\",\"expiry\":\"2030-01-01t00:00:00z\"}",
+      "error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"2030-01-01t00:00:00z\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"t00:00:00z\" as \"T\""
+    },
+    {
+      "case": "a one-digit fractional second",
+      "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
+      "auth": "{\"access_token\":\"ya29.x\",\"expiry\":\"2030-01-01T00:00:00.5Z\"}",
+      "error": ""
+    },
+    {
+      "case": "a trailing space after the zone fails",
+      "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
+      "auth": "{\"access_token\":\"ya29.x\",\"expiry\":\"2030-01-01T00:00:00Z \"}",
+      "error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"2030-01-01T00:00:00Z \": extra text: \" \""
+    },
+    {
+      "case": "a leap second",
+      "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
+      "auth": "{\"access_token\":\"ya29.x\",\"expiry\":\"2030-06-30T23:59:60Z\"}",
+      "error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"2030-06-30T23:59:60Z\": second out of range"
+    },
+    {
+      "case": "an out-of-range month",
+      "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
+      "auth": "{\"access_token\":\"ya29.x\",\"expiry\":\"2030-13-01T00:00:00Z\"}",
+      "error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"2030-13-01T00:00:00Z\": month out of range"
+    },
+    {
+      "case": "an auth array is not a struct",
+      "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
+      "auth": "[\"ya29.x\"]",
+      "error": "parsing auth token for \"goog-parity\": parsing oauth token: json: cannot unmarshal array into Go value of type oauth2.Token"
+    },
+    {
+      "case": "empty credentials fail the credentials parse",
+      "credentials": "",
+      "auth": "{\"access_token\":\"ya29.x\",\"token_type\":\"Bearer\",\"refresh_token\":\"1//y\",\"expiry\":\"2030-01-01T00:00:00.123456789Z\"}",
+      "error": "parsing google credentials for \"goog-parity\": credentials are empty"
+    },
+    {
+      "case": "a null credentials blob is a no-op, so the client id is empty",
+      "credentials": "null",
+      "auth": "{\"access_token\":\"ya29.x\",\"token_type\":\"Bearer\",\"refresh_token\":\"1//y\",\"expiry\":\"2030-01-01T00:00:00.123456789Z\"}",
+      "error": ""
+    },
+    {
+      "case": "a credentials array is not a struct",
+      "credentials": "[\"cid\",\"secret\"]",
+      "auth": "{\"access_token\":\"ya29.x\",\"token_type\":\"Bearer\",\"refresh_token\":\"1//y\",\"expiry\":\"2030-01-01T00:00:00.123456789Z\"}",
+      "error": "parsing google credentials for \"goog-parity\": json: cannot unmarshal array into Go value of type config.GoogleCredentials"
+    },
+    {
+      "case": "credentials that are not JSON at all",
+      "credentials": "nope",
+      "auth": "{\"access_token\":\"ya29.x\",\"token_type\":\"Bearer\",\"refresh_token\":\"1//y\",\"expiry\":\"2030-01-01T00:00:00.123456789Z\"}",
+      "error": "parsing google credentials for \"goog-parity\": invalid character 'o' in literal null (expecting 'u')"
+    },
+    {
+      "case": "empty credentials fields still host",
+      "credentials": "{\"client_id\":\"\",\"client_secret\":\"\"}",
+      "auth": "{\"access_token\":\"ya29.x\",\"token_type\":\"Bearer\",\"refresh_token\":\"1//y\",\"expiry\":\"2030-01-01T00:00:00.123456789Z\"}",
+      "error": ""
+    }
+  ],
   "calls": [
     {
       "case": "create_event/a full event, with encoding/json's HTML escaping",

--- a/desktop/parity/google_vectors.json
+++ b/desktop/parity/google_vectors.json
@@ -409,19 +409,22 @@
       "case": "a malformed expiry fails the auth parse",
       "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
       "auth": "{\"access_token\":\"ya29.x\",\"expiry\":\"not a time\"}",
-      "error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"not a time\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"not a time\" as \"2006\""
+      "error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"not a time\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"not a time\" as \"2006\"",
+      "rust_error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"not a time\""
     },
     {
       "case": "an expiry without a zone fails too",
       "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
       "auth": "{\"access_token\":\"ya29.x\",\"expiry\":\"2030-01-01T00:00:00\"}",
-      "error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"2030-01-01T00:00:00\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"\" as \"Z07:00\""
+      "error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"2030-01-01T00:00:00\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"\" as \"Z07:00\"",
+      "rust_error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"2030-01-01T00:00:00\""
     },
     {
       "case": "a date-only expiry fails too",
       "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
       "auth": "{\"access_token\":\"ya29.x\",\"expiry\":\"2030-01-01\"}",
-      "error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"2030-01-01\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"\" as \"T\""
+      "error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"2030-01-01\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"\" as \"T\"",
+      "rust_error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"2030-01-01\""
     },
     {
       "case": "an offset expiry is accepted",
@@ -445,13 +448,15 @@
       "case": "an empty string expiry fails",
       "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
       "auth": "{\"access_token\":\"ya29.x\",\"expiry\":\"\"}",
-      "error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"\" as \"2006\""
+      "error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"\" as \"2006\"",
+      "rust_error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"\""
     },
     {
       "case": "a lowercase t and z separator",
       "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
       "auth": "{\"access_token\":\"ya29.x\",\"expiry\":\"2030-01-01t00:00:00z\"}",
-      "error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"2030-01-01t00:00:00z\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"t00:00:00z\" as \"T\""
+      "error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"2030-01-01t00:00:00z\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"t00:00:00z\" as \"T\"",
+      "rust_error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"2030-01-01t00:00:00z\""
     },
     {
       "case": "a one-digit fractional second",
@@ -463,25 +468,87 @@
       "case": "a trailing space after the zone fails",
       "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
       "auth": "{\"access_token\":\"ya29.x\",\"expiry\":\"2030-01-01T00:00:00Z \"}",
-      "error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"2030-01-01T00:00:00Z \": extra text: \" \""
+      "error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"2030-01-01T00:00:00Z \": extra text: \" \"",
+      "rust_error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"2030-01-01T00:00:00Z \""
     },
     {
       "case": "a leap second",
       "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
       "auth": "{\"access_token\":\"ya29.x\",\"expiry\":\"2030-06-30T23:59:60Z\"}",
-      "error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"2030-06-30T23:59:60Z\": second out of range"
+      "error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"2030-06-30T23:59:60Z\": second out of range",
+      "rust_error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"2030-06-30T23:59:60Z\""
     },
     {
       "case": "an out-of-range month",
       "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
       "auth": "{\"access_token\":\"ya29.x\",\"expiry\":\"2030-13-01T00:00:00Z\"}",
-      "error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"2030-13-01T00:00:00Z\": month out of range"
+      "error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"2030-13-01T00:00:00Z\": month out of range",
+      "rust_error": "parsing auth token for \"goog-parity\": parsing oauth token: parsing time \"2030-13-01T00:00:00Z\""
+    },
+    {
+      "case": "Go's zero time is the sentinel its writer emits, and never expires",
+      "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
+      "auth": "{\"access_token\":\"ya29.x\",\"refresh_token\":\"1//y\",\"expiry\":\"0001-01-01T00:00:00Z\"}",
+      "error": ""
+    },
+    {
+      "case": "a comma decimal separator",
+      "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
+      "auth": "{\"access_token\":\"ya29.x\",\"expiry\":\"2030-01-01T00:00:00,5Z\"}",
+      "error": ""
+    },
+    {
+      "case": "a one-digit hour",
+      "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
+      "auth": "{\"access_token\":\"ya29.x\",\"expiry\":\"2030-01-01T5:04:05Z\"}",
+      "error": ""
+    },
+    {
+      "case": "an offset hour of 24",
+      "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
+      "auth": "{\"access_token\":\"ya29.x\",\"expiry\":\"2030-01-01T00:00:00+24:00\"}",
+      "error": ""
+    },
+    {
+      "case": "a numeric token_type is a type error",
+      "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
+      "auth": "{\"access_token\":\"ya29.x\",\"token_type\":5}",
+      "error": "parsing auth token for \"goog-parity\": parsing oauth token: json: cannot unmarshal number into Go struct field Token.token_type of type string",
+      "rust_error": "parsing auth token for \"goog-parity\": parsing oauth token: does not decode at line 1 column 39"
+    },
+    {
+      "case": "a string expires_in is a type error",
+      "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
+      "auth": "{\"access_token\":\"ya29.x\",\"expires_in\":\"soon\"}",
+      "error": "parsing auth token for \"goog-parity\": parsing oauth token: json: cannot unmarshal string into Go struct field Token.expires_in of type int64",
+      "rust_error": "parsing auth token for \"goog-parity\": parsing oauth token: does not decode at line 1 column 44"
     },
     {
       "case": "an auth array is not a struct",
       "credentials": "{\"client_id\":\"parity-client-id.apps.googleusercontent.com\",\"client_secret\":\"GOCSPX-parity-client-secret\"}",
       "auth": "[\"ya29.x\"]",
-      "error": "parsing auth token for \"goog-parity\": parsing oauth token: json: cannot unmarshal array into Go value of type oauth2.Token"
+      "error": "parsing auth token for \"goog-parity\": parsing oauth token: json: cannot unmarshal array into Go value of type oauth2.Token",
+      "rust_error": "parsing auth token for \"goog-parity\": parsing oauth token: does not decode at line 1 column 0"
+    },
+    {
+      "case": "an empty auth beats a broken credentials blob",
+      "credentials": "nope",
+      "auth": "",
+      "error": "integration \"goog-parity\" has no auth token"
+    },
+    {
+      "case": "a broken credentials blob beats a broken auth blob",
+      "credentials": "nope",
+      "auth": "{\"access_token\":\"ya29.x\",\"expiry\":\"not a time\"}",
+      "error": "parsing google credentials for \"goog-parity\": invalid character 'o' in literal null (expecting 'u')",
+      "rust_error": "parsing google credentials for \"goog-parity\": does not decode at line 1 column 2"
+    },
+    {
+      "case": "a truncated credentials blob carrying the secret",
+      "credentials": "{\"client_secret\":\"GOCSPX-parity-client-secret\",",
+      "auth": "{\"access_token\":\"ya29.x\",\"token_type\":\"Bearer\",\"refresh_token\":\"1//y\",\"expiry\":\"2030-01-01T00:00:00.123456789Z\"}",
+      "error": "parsing google credentials for \"goog-parity\": unexpected end of JSON input",
+      "rust_error": "parsing google credentials for \"goog-parity\": does not decode at line 1 column 47"
     },
     {
       "case": "empty credentials fail the credentials parse",
@@ -499,13 +566,15 @@
       "case": "a credentials array is not a struct",
       "credentials": "[\"cid\",\"secret\"]",
       "auth": "{\"access_token\":\"ya29.x\",\"token_type\":\"Bearer\",\"refresh_token\":\"1//y\",\"expiry\":\"2030-01-01T00:00:00.123456789Z\"}",
-      "error": "parsing google credentials for \"goog-parity\": json: cannot unmarshal array into Go value of type config.GoogleCredentials"
+      "error": "parsing google credentials for \"goog-parity\": json: cannot unmarshal array into Go value of type config.GoogleCredentials",
+      "rust_error": "parsing google credentials for \"goog-parity\": does not decode at line 1 column 0"
     },
     {
       "case": "credentials that are not JSON at all",
       "credentials": "nope",
       "auth": "{\"access_token\":\"ya29.x\",\"token_type\":\"Bearer\",\"refresh_token\":\"1//y\",\"expiry\":\"2030-01-01T00:00:00.123456789Z\"}",
-      "error": "parsing google credentials for \"goog-parity\": invalid character 'o' in literal null (expecting 'u')"
+      "error": "parsing google credentials for \"goog-parity\": invalid character 'o' in literal null (expecting 'u')",
+      "rust_error": "parsing google credentials for \"goog-parity\": does not decode at line 1 column 2"
     },
     {
       "case": "empty credentials fields still host",

--- a/desktop/src-tauri/src/native/chat/mod.rs
+++ b/desktop/src-tauri/src/native/chat/mod.rs
@@ -11,9 +11,9 @@
 //! button would silently do nothing.
 //!
 //! But not every chat *can* run here: an agent whose tools come from an
-//! integration needs one MCP server per provider, and this port has one of the
-//! six still to write (#313), so `runner::build_options` refuses those and
-//! they keep running on the sidecar. Parts of that refusal have gone — the
+//! integration needs one MCP server per provider, and `whatsapp` has no Rust
+//! starter (it is dropped, not deferred), so `runner::build_options` refuses
+//! those and they keep running on the sidecar. Parts of that refusal have gone — the
 //! **local** in-process server (#310), then any agent whose `capabilities.mcp`
 //! names only hosted integrations (**github** since #311, **confluence** since
 //! #317, **jira** since #316, **slack** since #315, **telegram** since #314) — but each only shrinks the set of chats Go still holds; it does not

--- a/desktop/src-tauri/src/native/chat/runner.rs
+++ b/desktop/src-tauri/src/native/chat/runner.rs
@@ -23,13 +23,13 @@
 //!
 //! **#311 narrowed the `mcp` half rather than removing it.** An agent is served
 //! natively when *every* name in `capabilities.mcp` is an integration this build
-//! can host — `registry::HOSTED_TYPES`, which today means `github` (#312) and
-//! `confluence` (#317), `jira` (#316), `slack` (#315) and `telegram` (#314), and
-//! will mean all six once #313 lands. Three things
+//! can host — `registry::HOSTED_TYPES`, which since #313 means **all six**:
+//! `github` (#312), `confluence` (#317), `jira` (#316), `slack` (#315),
+//! `telegram` (#314) and `google` (#313). Three things
 //! still forward, and [`mcp_plan`] is where each is decided:
 //!
-//! - **A name whose type is not hosted.** A `slack` row has no Rust starter;
-//!   running the turn here would drop its tools.
+//! - **A name whose type is not hosted.** A `whatsapp` row has no Rust starter
+//!   and will not get one; running the turn here would drop its tools.
 //! - **A name with no integration row at all.** Go would still resolve it if
 //!   `mcps.yaml` names it, and this build reads no `mcps.yaml`.
 //! - **Any `mcp` capability at all when `<data dir>/mcps.yaml` exists.** That

--- a/desktop/src-tauri/src/native/chat/runner.rs
+++ b/desktop/src-tauri/src/native/chat/runner.rs
@@ -1078,13 +1078,19 @@ mod tests {
     fn an_mcp_name_this_build_cannot_host_forwards() {
         let file = db_with_integration("gh-1", "github");
 
-        // A type with no Rust starter. `google` while #313 is unwritten — the
-        // stand-in has to be a type that is genuinely unported, so it has moved
-        // with each landing and this is the last move available.
-        let google = db_with_integration("gg-1", "google");
-        let err = mcp_plan(Some(&caps_naming("gg-1", None)), Some(google.path()), false)
-            .expect_err("google cannot be hosted");
-        assert!(err.contains(r#"MCP server "gg-1""#), "{err}");
+        // A type with no Rust starter. The stand-in has to be a type that is
+        // genuinely unported, so it moved with each landing — and with #313 it
+        // has arrived at `whatsapp`, which is where it stays: whatsapp is not
+        // deferred but dropped, because its starter opens a live whatsmeow
+        // connection registered in a package global rather than merely a port.
+        let whatsapp = db_with_integration("wa-1", "whatsapp");
+        let err = mcp_plan(
+            Some(&caps_naming("wa-1", None)),
+            Some(whatsapp.path()),
+            false,
+        )
+        .expect_err("whatsapp cannot be hosted");
+        assert!(err.contains(r#"MCP server "wa-1""#), "{err}");
 
         // A name with no integration row: `mcps.yaml` could still name it.
         assert!(mcp_plan(

--- a/desktop/src-tauri/src/native/gotime.rs
+++ b/desktop/src-tauri/src/native/gotime.rs
@@ -23,8 +23,14 @@ use serde::{Serialize, Serializer};
 pub struct GoTime(pub DateTime<FixedOffset>);
 
 impl GoTime {
-    /// Parse the RFC 3339 text SQLite holds, as `time.Parse(time.RFC3339, …)`
-    /// does on the Go side.
+    /// Parse the RFC 3339 text SQLite holds.
+    ///
+    /// This is `chrono`'s RFC 3339, which is **not** `time.Parse(time.RFC3339,
+    /// …)` — see [`parse_rfc3339`] for the five ways they disagree. The
+    /// difference is unreachable here: the only writer of `effective_from` is
+    /// this application, which normalizes to second precision on every write
+    /// path, so none of the five shapes can be stored. A reader of text some
+    /// *other* program wrote wants [`parse_rfc3339`].
     pub fn parse(text: &str) -> Result<Self, String> {
         DateTime::parse_from_rfc3339(text)
             .map(GoTime)
@@ -178,6 +184,172 @@ fn format_go_rfc3339(t: &DateTime<FixedOffset>) -> String {
     out
 }
 
+/// Go's zero `time.Time`, the instant `IsZero()` tests for.
+///
+/// It matters because `omitempty` does **not** suppress a struct: `json.Marshal`
+/// of an `oauth2.Token` with no expiry emits `"expiry":"0001-01-01T00:00:00Z"`
+/// rather than omitting the key, and `Token.Valid()` then treats that token as
+/// **never expiring**. Read as an ordinary instant it is permanently in the
+/// past, which inverts the meaning.
+pub const ZERO: chrono::NaiveDateTime = chrono::NaiveDateTime::new(
+    match chrono::NaiveDate::from_ymd_opt(1, 1, 1) {
+        Some(date) => date,
+        None => unreachable!(),
+    },
+    match chrono::NaiveTime::from_hms_opt(0, 0, 0) {
+        Some(time) => time,
+        None => unreachable!(),
+    },
+);
+
+/// `time.Parse(time.RFC3339, s)`, transcribed — for text Go wrote or that Go
+/// will judge.
+///
+/// [`GoTime::parse`] is `chrono`'s RFC 3339 and is fine for values this
+/// application wrote. This is for the two places that read somebody else's:
+/// `native/schedule`'s `one_off` `run_at`, which is free-form client input
+/// (#275), and `native/integrations/registry`'s Google `auth` expiry, which Go's
+/// `oauth2` wrote (#313).
+///
+/// It exists because **`chrono::DateTime::parse_from_rfc3339` disagrees with Go
+/// in five ways**, in both directions. The first three were found by a
+/// differential run of 636 shapes against a real `gocron.Scheduler` for #275;
+/// the last two by review of #313, from a Go program run against the pinned
+/// toolchain:
+///
+/// | value | Go | `parse_from_rfc3339` |
+/// |---|---|---|
+/// | `2026-06-01t12:00:00z` | error | accepted |
+/// | `2026-06-01T12:00:00,5Z` | accepted (12:00:00.5) | error |
+/// | `2026-06-30T23:59:60Z` | `second out of range` | accepted |
+/// | `2026-06-01T5:04:05Z` | accepted | error |
+/// | `2026-06-01T12:00:00+24:00` | accepted | error |
+///
+/// The last two are Go being *laxer*, which a stricter port turns into refusing
+/// input Go accepts — a schedule that will not build, or an integration that
+/// will not host. They exist because `parseStrictRFC3339`
+/// (`time/format_rfc3339.go`) has its extra checks compiled out behind
+/// `case true:`, so what a stored value actually meets is the **general**
+/// parser's laxity: `stdHour` takes one or two digits, `parseNanoseconds`
+/// accepts a comma, and the zone offset's hour is range-unchecked. If Go
+/// re-enables those checks — the source carries a TODO to do it behind a
+/// GODEBUG — this becomes stricter than it needs to be, which is the safe
+/// direction.
+///
+/// #275's version was `parse_from_rfc3339` plus three guards, and #313 was about
+/// to add a second copy with two. Guarding a convenient library has now been
+/// wrong twice for one reason: the guard list has to be right about *every*
+/// disagreement, and enumerating a third party's edge cases is the thing that
+/// keeps turning out incomplete. So this parses the grammar and delegates
+/// nothing but the calendar arithmetic.
+///
+/// What the general parser does not allow, and neither does this: a year that is
+/// not exactly four digits, a one-digit minute or second, a missing zone, and
+/// anything trailing.
+pub fn parse_rfc3339(s: &str) -> Option<DateTime<FixedOffset>> {
+    let bytes = s.as_bytes();
+    let digits = |from: usize, len: usize| -> Option<u32> {
+        let slice = s.get(from..from + len)?;
+        slice.bytes().all(|b| b.is_ascii_digit()).then_some(())?;
+        slice.parse::<u32>().ok()
+    };
+    let literal =
+        |at: usize, want: u8| -> Option<()> { (bytes.get(at) == Some(&want)).then_some(()) };
+
+    // `2006` — exactly four digits, the first of which must be one, so no sign.
+    let year = digits(0, 4)?;
+    literal(4, b'-')?;
+    let month = digits(5, 2)?;
+    literal(7, b'-')?;
+    let day = digits(8, 2)?;
+    // `T` is a literal in the layout, so its case is fixed — not `t`, not a
+    // space.
+    literal(10, b'T')?;
+
+    // `stdHour` is `getnum(value, false)`: one **or** two digits, unlike the
+    // minute and second, which are fixed-width.
+    let (hour, mut at) = match digits(11, 2) {
+        Some(two) if bytes.get(13) == Some(&b':') => (two, 13),
+        _ => (digits(11, 1)?, 12),
+    };
+    literal(at, b':')?;
+    let minute = digits(at + 1, 2)?;
+    literal(at + 3, b':')?;
+    let second = digits(at + 4, 2)?;
+    at += 6;
+
+    // `if len(value) >= 2 && commaOrPeriod(value[0]) && isDigit(value, 1)` — a
+    // comma is as good as a period, which is the form chrono refuses.
+    let mut nanos = 0u32;
+    if matches!(bytes.get(at), Some(b'.' | b',')) {
+        let fraction_at = at + 1;
+        let mut end = fraction_at;
+        while bytes.get(end).is_some_and(u8::is_ascii_digit) {
+            end += 1;
+        }
+        if end == fraction_at {
+            return None;
+        }
+        // Scaled to nanoseconds, dropping anything past the ninth digit as
+        // `parseNanoseconds` drops it.
+        for index in 0..9 {
+            nanos *= 10;
+            if let Some(digit) = bytes
+                .get(fraction_at + index)
+                .filter(|b| b.is_ascii_digit())
+            {
+                nanos += u32::from(digit - b'0');
+            }
+        }
+        at = end;
+    }
+
+    // `Z07:00` — a literal `Z`, or a signed `hh:mm`.
+    let offset_seconds: i32 = match bytes.get(at) {
+        Some(b'Z') => {
+            at += 1;
+            0
+        }
+        Some(sign @ (b'+' | b'-')) => {
+            let negative = *sign == b'-';
+            let zone_hour = i32::try_from(digits(at + 1, 2)?).ok()?;
+            literal(at + 3, b':')?;
+            let zone_minute = i32::try_from(digits(at + 4, 2)?).ok()?;
+            at += 6;
+            // **No range check on the hour**: the general parser has none, so
+            // `+24:00` is a legal offset to Go.
+            let magnitude = (zone_hour * 60 + zone_minute) * 60;
+            if negative {
+                -magnitude
+            } else {
+                magnitude
+            }
+        }
+        _ => return None,
+    };
+    // "extra text" — anything left over fails.
+    if at != bytes.len() {
+        return None;
+    }
+
+    // The range checks `Parse` applies once it has the fields. `from_ymd_opt` is
+    // the day-in-month check; `and_hms_nano_opt` rejects hour 24, minute 60 and
+    // **second 60**, which is Go's `second out of range` for a leap second.
+    let naive = chrono::NaiveDate::from_ymd_opt(i32::try_from(year).ok()?, month, day)?
+        .and_hms_nano_opt(hour, minute, second, nanos)?;
+    // chrono's offset type is bounded at ±24h exclusive, so an offset Go accepts
+    // but chrono cannot represent is applied by hand and carried as UTC. The
+    // instant is identical; only the printed zone differs, and no caller prints
+    // one.
+    match FixedOffset::east_opt(offset_seconds) {
+        Some(offset) => naive.and_local_timezone(offset).single(),
+        None => naive
+            .checked_sub_signed(chrono::TimeDelta::seconds(offset_seconds.into()))?
+            .and_local_timezone(FixedOffset::east_opt(0)?)
+            .single(),
+    }
+}
+
 /// Read a DATETIME column as the `time.Time` the Go driver round-trips.
 ///
 /// One definition rather than one per module: it decides that an unparseable
@@ -192,6 +364,103 @@ pub fn from_sql_text(text: &str, index: usize) -> rusqlite::Result<GoTime> {
             Box::new(std::io::Error::other(e)),
         )
     })
+}
+
+#[cfg(test)]
+mod rfc3339_tests {
+    use super::*;
+    use chrono::Timelike;
+
+    /// The five disagreements [`parse_rfc3339`] exists for, each measured
+    /// against the pinned Go toolchain rather than reasoned about.
+    #[test]
+    fn the_five_places_chrono_disagrees_with_go() {
+        // Go rejects, chrono accepts.
+        assert!(parse_rfc3339("2026-06-01t12:00:00z").is_none());
+        assert!(parse_rfc3339("2026-06-01T12:00:00z").is_none());
+        assert!(parse_rfc3339("2026-06-01t12:00:00Z").is_none());
+        assert!(
+            parse_rfc3339("2026-06-30T23:59:60Z").is_none(),
+            "a leap second is `second out of range` to Go"
+        );
+
+        // Go accepts, chrono rejects. These are the direction that turns into
+        // refusing input Go takes.
+        let comma = parse_rfc3339("2026-06-01T12:00:00,5Z").expect("Go accepts a comma");
+        assert_eq!(comma.nanosecond(), 500_000_000);
+        assert_eq!(
+            comma,
+            parse_rfc3339("2026-06-01T12:00:00.5Z").expect("and a period")
+        );
+
+        let short_hour = parse_rfc3339("2026-06-01T5:04:05Z").expect("a one-digit hour");
+        assert_eq!(short_hour.hour(), 5);
+
+        let far_offset =
+            parse_rfc3339("2026-06-01T12:00:00+24:00").expect("the offset hour is unbounded");
+        assert_eq!(
+            far_offset.to_utc(),
+            parse_rfc3339("2026-05-31T12:00:00Z")
+                .expect("the same instant")
+                .to_utc(),
+            "an offset chrono cannot represent is still the right instant"
+        );
+    }
+
+    /// Everything both agree on, including the shapes that must be refused.
+    #[test]
+    fn the_ordinary_grammar_is_unchanged() {
+        assert!(parse_rfc3339("2026-06-01T12:00:00Z").is_some());
+        assert!(parse_rfc3339("2026-06-01T12:00:00+02:00").is_some());
+        assert!(parse_rfc3339("2026-06-01T12:00:00-05:30").is_some());
+        assert!(parse_rfc3339("2026-06-01T12:00:00.123456789Z").is_some());
+        // Digits past the ninth are dropped, not refused.
+        assert_eq!(
+            parse_rfc3339("2026-06-01T12:00:00.1234567891Z")
+                .expect("ten digits")
+                .nanosecond(),
+            123_456_789
+        );
+
+        for refused in [
+            "",
+            "2026-06-01",
+            "2026-06-01 12:00:00Z",
+            "2026-06-01T12:00:00",
+            "2026-06-01T12:00:00Z ",
+            "2026-13-01T12:00:00Z",
+            "2026-06-31T12:00:00Z",
+            "2026-06-01T24:00:00Z",
+            "2026-06-01T12:60:00Z",
+            "2026-06-01T12:00:00.Z",
+            // A one-digit minute or second is fixed-width in the layout.
+            "2026-06-01T12:0:00Z",
+            "2026-06-01T12:00:0Z",
+            // The year is exactly four digits and unsigned.
+            "226-06-01T12:00:00Z",
+            "+2026-06-01T12:00:00Z",
+            "12026-06-01T12:00:00Z",
+        ] {
+            assert!(
+                parse_rfc3339(refused).is_none(),
+                "{refused:?} must be refused"
+            );
+        }
+    }
+
+    /// The sentinel Go's own writer emits for a zero `time.Time`.
+    #[test]
+    fn the_zero_time_is_recognisable() {
+        let zero = parse_rfc3339("0001-01-01T00:00:00Z").expect("a valid instant");
+        assert_eq!(zero.naive_utc(), ZERO);
+        assert_ne!(
+            parse_rfc3339("0001-01-01T00:00:00+05:30")
+                .expect("valid")
+                .naive_utc(),
+            ZERO,
+            "an offset makes it a different instant, and not Go's zero"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/desktop/src-tauri/src/native/integrations.rs
+++ b/desktop/src-tauri/src/native/integrations.rs
@@ -1979,7 +1979,10 @@ mod tests {
     /// reload strands a socket and a paired client that never connects.
     #[test]
     fn a_write_for_a_type_the_sidecar_hosts_forwards_without_touching_the_row() {
-        for integration_type in ["whatsapp", "google"] {
+        // `whatsapp` alone since #313 landed google — and it is the case that
+        // makes this more than tidiness, per the doc comment above.
+        {
+            let integration_type = "whatsapp";
             let file = migrated();
             Connection::open(file.path())
                 .expect("open")

--- a/desktop/src-tauri/src/native/integrations.rs
+++ b/desktop/src-tauri/src/native/integrations.rs
@@ -468,11 +468,11 @@ fn segment(value: &str) -> Option<&str> {
 /// port, holding a token the user had just revoked. The sidecar now runs with
 /// `AGENTO_INTEGRATIONS=off:<the types the shell hosts>` and [`registry`] is the
 /// only implementation **for those types**, so both effects are reproduced
-/// rather than lost. Note the switch is per type, not per process: a `telegram`
+/// rather than lost. Note the switch is per type, not per process: a `whatsapp`
 /// row is still Go's, and a write for one is declined here and forwarded whole
-/// (see [`claims`]'s caller and `writes.rs`). Four of the six are the shell's as
-/// of #315 — `github`, `confluence`, `jira`, `slack` — and the list to read is
-/// `registry::HOSTED_TYPES`, never this comment.
+/// (see [`claims`]'s caller and `writes.rs`). All six are the shell's as of #313
+/// — `github`, `confluence`, `jira`, `slack`, `telegram`, `google` — and the
+/// list to read is `registry::HOSTED_TYPES`, never this comment.
 ///
 /// `POST /api/integrations` needed none of that, because `Create` is a pure row
 /// write: it never touches the registry, which was verified against the whole

--- a/desktop/src-tauri/src/native/integrations/registry.rs
+++ b/desktop/src-tauri/src/native/integrations/registry.rs
@@ -4,9 +4,10 @@
 //! Go keeps one long-lived in-process MCP server per enabled, authenticated
 //! integration: `Start` brings them all up at boot, `Reload` restarts one when
 //! its row changes, `Stop` tears one down when it is deleted. This module is
-//! that, for the types listed in [`HOSTED_TYPES`] — today five of the six:
-//! `github` (#312), `confluence` (#317), `jira` (#316), `slack` (#315) and
-//! `telegram` (#314).
+//! that, for the types listed in [`HOSTED_TYPES`] — since #313, **all six**:
+//! `github` (#312), `confluence` (#317), `jira` (#316), `slack` (#315),
+//! `telegram` (#314) and `google` (#313). `whatsapp` is not among them and is
+//! not waiting to be: see below.
 //!
 //! ## Why the ownership had to flip before the writes could move
 //!
@@ -27,7 +28,7 @@
 //!
 //! It is tempting to read a starter as a pure MCP-server constructor, in which
 //! case switching Go's hosting off costs a bound port and nothing else. That is
-//! true of five of the six. It is **not** true of `whatsapp`:
+//! true of all six of the ported types. It is **not** true of `whatsapp`:
 //! `internal/integrations/whatsapp/server.go` opens a real whatsmeow WebSocket,
 //! registers the live client in a package global and only then returns a server
 //! config, and `whatsapp/status.go`'s `ConnectionStatus` reads that global. So
@@ -85,8 +86,10 @@
 //!
 //! `Reload` has seven callers in Go and only two of them (`Update`, and
 //! `Delete` via `Stop`) are ported. Five run inside the sidecar, and as of #314
-//! **none of them is safe by the per-type gate any more** — five of the six types
-//! are hosted here, so a `Reload` for one reaches nothing in the sidecar.
+//! **none of them is safe by the per-type gate any more** — and as of #313 every
+//! one of the six is hosted here, so a `Reload` for any of them reaches nothing
+//! in the sidecar. There is no longer a type for which those callers happen to
+//! be harmless.
 //!
 //! Four are the token validators — `validateGitHubPATAuth` and, since #314–#317,
 //! `validateTelegramTokenAuth`, `validateSlackTokenAuth`, `validateJiraTokenAuth`
@@ -196,7 +199,14 @@ impl HostingRow {
 /// native `PUT`/`DELETE` consult before they touch a row), the starter dispatch
 /// in [`start_for_type`], and [`hosting_env_value`], which tells the Go sidecar
 /// which types to stop hosting. #313 adds the last string here.
-pub const HOSTED_TYPES: &[&str] = &["github", "confluence", "jira", "slack", "telegram"];
+pub const HOSTED_TYPES: &[&str] = &[
+    "github",
+    "confluence",
+    "jira",
+    "slack",
+    "telegram",
+    "google",
+];
 
 /// Whether this process hosts an integration of the given type.
 pub fn hosts_type(integration_type: &str) -> bool {
@@ -445,6 +455,7 @@ async fn start_for_type(row: &HostingRow) -> Result<InProcessMcpServer, String> 
         "jira" => start_jira(&row.id, &row.services(), &row.credentials).await,
         "slack" => start_slack(&row.id, &row.services(), &row.credentials, &row.auth).await,
         "telegram" => start_telegram(&row.id, &row.services(), &row.credentials).await,
+        "google" => start_google(&row.id, &row.services(), &row.credentials, &row.auth).await,
         other => Err(format!(
             "no starter registered for integration type {other:?}"
         )),
@@ -851,10 +862,175 @@ pub async fn start_filtered_server(
         "jira" => start_jira(&row.id, &filtered, &row.credentials).await,
         "slack" => start_slack(&row.id, &filtered, &row.credentials, &row.auth).await,
         "telegram" => start_telegram(&row.id, &filtered, &row.credentials).await,
+        "google" => start_google(&row.id, &filtered, &row.credentials, &row.auth).await,
         other => Err(format!(
             "no starter registered for integration type {other:?}"
         )),
     }
+}
+
+/// `google.Start`'s first two steps — the auth check and the two parses — then
+/// the third, which `native/integrations/google` owns.
+///
+/// Google is the only one of the six whose starter needs **both** secret
+/// columns and needs them for different things: `credentials` carries the OAuth2
+/// client pair, and `auth` carries the token itself. Slack reads `auth` too, but
+/// only for an access token; here the whole `oauth2.Token` matters, because
+/// `expiry` is what decides whether the first tool call refreshes.
+///
+/// Every sentence is Go's and is pinned by the `starting` section of
+/// `desktop/parity/google_vectors.json`.
+async fn start_google(
+    id: &str,
+    services: &BTreeMap<String, ServiceConfig>,
+    credentials: &str,
+    auth: &str,
+) -> Result<InProcessMcpServer, String> {
+    // `Start`'s own `if !cfg.IsAuthenticated()`, kept for the reason the others
+    // keep theirs: `StartFilteredServer` reaches a starter by a different path.
+    if auth.is_empty() || auth == "null" {
+        return Err(format!("integration {id:?} has no auth token"));
+    }
+
+    let (client_id, client_secret) = google_credentials(id, credentials)?;
+    let token = google_oauth_token(id, auth)?;
+
+    super::google::start_google_mcp_server(
+        id,
+        services,
+        std::sync::Arc::new(super::google::client::TokenSource::new(
+            client_id,
+            client_secret,
+            token,
+        )),
+    )
+    .await
+    .map_err(|e| format!("starting in-process MCP server for {id:?}: {e}"))
+}
+
+/// `cfg.ParseCredentials(&creds)` for `config.GoogleCredentials`, wrapped as
+/// `buildHTTPClient` wraps it.
+///
+/// Note what is **not** checked: an empty client id or secret. Go hosts a row
+/// with both empty and every refresh then fails at Google — measured, and not
+/// something to improve on here.
+pub(super) fn google_credentials(id: &str, credentials: &str) -> Result<(String, String), String> {
+    #[derive(Default, serde::Deserialize)]
+    #[serde(default)]
+    struct GoogleCredentials {
+        #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+        client_id: String,
+        #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+        client_secret: String,
+    }
+
+    if credentials.is_empty() {
+        return Err(format!(
+            "parsing google credentials for {id:?}: credentials are empty"
+        ));
+    }
+    // The three rules: a `null` is a no-op, an array is not a struct, and every
+    // field takes a JSON null as its zero value.
+    serde_json::from_str::<Option<crate::native::gojson::GoStruct<GoogleCredentials>>>(credentials)
+        .map(|wrapped| wrapped.map_or_else(GoogleCredentials::default, |wrapped| wrapped.0))
+        .map(|creds| (creds.client_id, creds.client_secret))
+        .map_err(|e| {
+            // The serde message is dropped for `github_token`'s reason: it
+            // quotes the offending value, which here is the client secret.
+            format!(
+                "parsing google credentials for {id:?}: does not decode at line {} column {}",
+                e.line(),
+                e.column()
+            )
+        })
+}
+
+/// `cfg.ParseOAuthToken()` for Google, wrapped as `buildHTTPClient` wraps it.
+///
+/// The interesting field is `expiry`, a Go `time.Time`, so **the whole token is
+/// refused when it does not parse** — an integration with a corrupt expiry is not
+/// hosted at all rather than hosted with a token that never refreshes. Slack's
+/// equivalent deliberately skips this check because it reads only
+/// `access_token`; here the value decides the refresh.
+pub(super) fn google_oauth_token(
+    id: &str,
+    auth: &str,
+) -> Result<super::google::client::Token, String> {
+    #[derive(Default, serde::Deserialize)]
+    #[serde(default)]
+    struct OAuthToken {
+        #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+        access_token: String,
+        #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+        refresh_token: String,
+        /// Absent, `null` and a valid RFC3339 string are all legal; anything
+        /// else fails the document. `Option<String>` rather than a time type
+        /// because the *shape* check and the *value* check produce different Go
+        /// sentences, and only a raw string can tell them apart.
+        expiry: Option<serde_json::Value>,
+    }
+
+    let wrap = |message: String| format!("parsing auth token for {id:?}: {message}");
+
+    let parsed = serde_json::from_str::<Option<crate::native::gojson::GoStruct<OAuthToken>>>(auth)
+        .map(|wrapped| wrapped.map_or_else(OAuthToken::default, |wrapped| wrapped.0))
+        .map_err(|e| {
+            // Go's carries `encoding/json`'s wording; this drops it because the
+            // serde message quotes the offending value, which here is the
+            // access token.
+            wrap(format!(
+                "parsing oauth token: does not decode at line {} column {}",
+                e.line(),
+                e.column()
+            ))
+        })?;
+
+    let expiry = match parsed.expiry {
+        None | Some(serde_json::Value::Null) => None,
+        Some(serde_json::Value::String(raw)) => Some(
+            parse_go_rfc3339(&raw)
+                .ok_or_else(|| wrap(format!("parsing oauth token: parsing time {raw:?}")))?,
+        ),
+        // `Time.UnmarshalJSON` checks the JSON shape before the layout.
+        Some(_) => {
+            return Err(wrap(
+                "parsing oauth token: Time.UnmarshalJSON: input is not a JSON string".to_string(),
+            ))
+        }
+    };
+
+    Ok(super::google::client::Token {
+        access_token: parsed.access_token,
+        refresh_token: parsed.refresh_token,
+        expiry,
+    })
+}
+
+/// Go's `time.RFC3339` layout, `2006-01-02T15:04:05Z07:00`, as `time.Parse`
+/// applies it — which is **stricter than `chrono`'s** `parse_from_rfc3339` in two
+/// ways that a stored token can actually reach, both measured against real Go:
+///
+/// - **The separators are case-sensitive.** `2030-01-01t00:00:00z` is a parse
+///   error to Go and accepted by chrono. Go's RFC3339 handling has been strict
+///   since 1.20.
+/// - **A leap second is out of range.** `2030-06-30T23:59:60Z` is
+///   `second out of range` to Go, where chrono represents it.
+///
+/// Everything else agrees: a numeric offset, fractional seconds of any length, a
+/// rejected trailing space, and rejected out-of-range components.
+fn parse_go_rfc3339(raw: &str) -> Option<std::time::SystemTime> {
+    // `T` and the `Z` form of the zone are literals in the layout, so their case
+    // is fixed. A numeric offset carries no letter to check.
+    if !raw.contains('T') || raw.contains('t') || raw.contains('z') {
+        return None;
+    }
+    let parsed = chrono::DateTime::parse_from_rfc3339(raw).ok()?;
+    // chrono encodes a leap second as nanosecond >= 1_000_000_000 rather than as
+    // a 60th second, which is how it survives its own parse.
+    if chrono::Timelike::nanosecond(&parsed) >= 1_000_000_000 {
+        return None;
+    }
+    Some(std::time::SystemTime::from(parsed.to_utc()))
 }
 
 /// The row's `type`, and **nothing else** — no `credentials`, no `auth`.
@@ -1065,7 +1241,19 @@ pub async fn reload_after_auth(db_path: &Path, id: &str) {
 /// `slack`. While neither was hosted here that was harmless, and
 /// `registry.rs`'s own header said so. **#315 made `slack` a hosted type**, so
 /// that `Reload` now reaches nothing and a Slack integration authenticated by
-/// OAuth would first be served at the next boot's [`start_all`].
+/// OAuth would first be served at the next boot's [`start_all`]. **#313 made
+/// `google` one too**, which means this hook now covers *both* providers
+/// `startProviderCallback` supports — every OAuth integration in the product
+/// depends on it, and there is no longer a case it does not have to catch.
+///
+/// Google is also the one where being served late costs the most, and for a
+/// reason peculiar to it: a Google token *expires*. Slack's does not, so a Slack
+/// row served at the next boot is merely served late; a Google row carries an
+/// `expiry` that [`super::google::client::TokenSource`] reads, so a token first
+/// picked up hours later may already need the refresh this process would then
+/// have to make on the first tool call. That still works — it is what the refresh
+/// is for — but it turns a silent staleness into a visible one, which is worth
+/// knowing when reading a bug report about a slow first Google call.
 ///
 /// [`reload_after_auth`] cannot cover it: that hook hangs off a *forwarded
 /// request*, and an OAuth token does not arrive on one. It is delivered by the
@@ -1356,7 +1544,7 @@ mod tests {
     fn the_sidecar_is_told_exactly_what_this_process_hosts() {
         assert_eq!(
             hosting_env_value(),
-            "off:github,confluence,jira,slack,telegram"
+            "off:github,confluence,jira,slack,telegram,google"
         );
         assert_eq!(
             hosting_env_value(),
@@ -1368,17 +1556,17 @@ mod tests {
         assert!(hosts_type("jira"));
         assert!(hosts_type("slack"));
         assert!(hosts_type("telegram"));
-        // The one type #313 still owes. Go must keep hosting every one of
-        // them, and `whatsapp` is the reason this is a list at all: its starter
-        // opens a live whatsmeow connection that its status, reconnect and QR
-        // endpoints read out of a package global.
-        for unported in ["google", "whatsapp"] {
-            assert!(!hosts_type(unported), "{unported} is not hosted here");
-            assert!(
-                !hosting_env_value().contains(unported),
-                "{unported} must not be switched off in the sidecar — nobody would host it"
-            );
-        }
+        assert!(hosts_type("google"));
+        // Go must keep hosting every type not on the list — and with #313 landed,
+        // `whatsapp` is the only one left, which is also the reason this is a
+        // list rather than a flag: its starter opens a live whatsmeow connection
+        // that its status, reconnect and QR endpoints read out of a package
+        // global, so switching it off costs the feature rather than a spare port.
+        assert!(!hosts_type("whatsapp"), "whatsapp is not hosted here");
+        assert!(
+            !hosting_env_value().contains("whatsapp"),
+            "whatsapp must not be switched off in the sidecar — nobody would host it"
+        );
     }
 
     /// A type claimed by `HOSTED_TYPES` but missing from the starter dispatch
@@ -1448,25 +1636,28 @@ mod tests {
     #[tokio::test]
     async fn an_unported_type_fails_the_way_gos_unregistered_type_does() {
         let file = db();
+        // `whatsapp` is the stand-in now that #313 has landed google. It is not
+        // a placeholder waiting for a port: its starter opens a live whatsmeow
+        // connection registered in a package global, so it stays Go's.
         insert(
             &file,
-            "gg-1",
-            "google",
+            "wa-1",
+            "whatsapp",
             true,
             Some(r#"{"validated":true}"#),
-            r#"{"client_id":"gg-secret"}"#,
-            r#"{"gmail":{"enabled":true,"tools":["send"]}}"#,
+            r#"{"session":"wa-secret"}"#,
+            r#"{"messaging":{"enabled":true,"tools":["send"]}}"#,
         );
 
         // `start_all` swallows it: one bad integration must not stop the others.
         start_all(file.path()).await.expect("start_all swallows it");
-        assert!(!registry().is_hosted("gg-1"));
+        assert!(!registry().is_hosted("wa-1"));
 
         // `reload` returns it, and its callers are the ones that swallow.
-        let err = reload(file.path(), "gg-1").await.expect_err("no starter");
+        let err = reload(file.path(), "wa-1").await.expect_err("no starter");
         assert_eq!(
             err,
-            r#"no starter registered for integration type "google""#
+            r#"no starter registered for integration type "whatsapp""#
         );
     }
 
@@ -1512,6 +1703,94 @@ mod tests {
             "the integration after the failing one must still be hosted"
         );
         registry().stop("zzz-github");
+    }
+
+    /// `google.Start`'s accept/reject boundary, replayed from the `starting`
+    /// section of `desktop/parity/google_vectors.json`.
+    ///
+    /// The other five integrations' credential parses are asserted by hand.
+    /// Google's is measured, for one reason: its `auth` column decodes as an
+    /// `oauth2.Token` whose `expiry` is a Go `time.Time`, so whether a stored
+    /// value is accepted is `time.Parse`'s decision and not something to guess
+    /// at. Two of the cases below are exactly where `chrono` and Go disagree —
+    /// a lowercase `t`/`z` separator and a leap second, both of which chrono
+    /// accepts and Go refuses.
+    ///
+    /// Only the accept/reject decision is compared. Go's sentences for a bad
+    /// `expiry` embed `time.Parse`'s own layout-diffing wording, and for a
+    /// malformed blob `encoding/json`'s — the second of which is dropped on
+    /// purpose, since serde's quotes the value, which here is the access token.
+    #[test]
+    fn google_start_accepts_exactly_what_go_accepts() {
+        #[derive(serde::Deserialize)]
+        struct StartVector {
+            case: String,
+            credentials: String,
+            auth: String,
+            error: String,
+        }
+        #[derive(serde::Deserialize)]
+        struct Vectors {
+            starting: Vec<StartVector>,
+        }
+
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../parity/google_vectors.json");
+        let raw = std::fs::read_to_string(path)
+            .unwrap_or_else(|e| panic!("reading {path}: {e} — regenerate it from Go"));
+        let vectors: Vectors = serde_json::from_str(&raw).expect("parsing the google vectors");
+        assert!(vectors.starting.len() >= 20, "vectors look partial");
+
+        for case in &vectors.starting {
+            // `Start`'s own auth check, then the two parses, in Go's order.
+            let got = if case.auth.is_empty() || case.auth == "null" {
+                Err(r#"integration "goog-parity" has no auth token"#.to_string())
+            } else {
+                google_credentials("goog-parity", &case.credentials)
+                    .and_then(|_| google_oauth_token("goog-parity", &case.auth).map(|_| ()))
+            };
+
+            assert_eq!(
+                got.is_err(),
+                !case.error.is_empty(),
+                "{}: Go said {:?}, this said {:?}",
+                case.case,
+                case.error,
+                got.err().unwrap_or_default()
+            );
+
+            // Whatever it says, it must never name the secret it was handed.
+            if let Err(message) = google_credentials("goog-parity", &case.credentials) {
+                assert!(
+                    !message.contains("GOCSPX"),
+                    "{}: the client secret leaked: {message}",
+                    case.case
+                );
+            }
+        }
+    }
+
+    /// The two places `chrono` is more permissive than Go, called out on their
+    /// own because the vector loop above only proves the pair agree — this says
+    /// which rule is doing the work.
+    #[test]
+    fn the_expiry_parse_is_gos_layout_and_not_chronos() {
+        assert!(parse_go_rfc3339("2030-01-01T00:00:00Z").is_some());
+        assert!(parse_go_rfc3339("2030-01-01T00:00:00+05:30").is_some());
+        assert!(parse_go_rfc3339("2030-01-01T00:00:00.5Z").is_some());
+        // chrono accepts both of these; Go does not.
+        assert!(
+            parse_go_rfc3339("2030-01-01t00:00:00z").is_none(),
+            "Go's RFC3339 separators are case-sensitive"
+        );
+        assert!(
+            parse_go_rfc3339("2030-06-30T23:59:60Z").is_none(),
+            "a leap second is `second out of range` to Go"
+        );
+        // …and both agree on these.
+        assert!(parse_go_rfc3339("2030-01-01T00:00:00Z ").is_none());
+        assert!(parse_go_rfc3339("2030-13-01T00:00:00Z").is_none());
+        assert!(parse_go_rfc3339("2030-01-01").is_none());
+        assert!(parse_go_rfc3339("").is_none());
     }
 
     /// The credential parse: Go's two failure shapes, and neither may echo the
@@ -1670,7 +1949,7 @@ mod tests {
     async fn a_filtered_server_refuses_the_way_go_refuses() {
         let file = db();
         insert(&file, "gh-off", "github", false, Some("{}"), "{}", "{}");
-        insert(&file, "gg-1", "google", true, Some("{}"), "{}", "{}");
+        insert(&file, "wa-1", "whatsapp", true, Some("{}"), "{}", "{}");
 
         // `.err()` rather than `unwrap_err()`: the `Ok` side is an
         // `InProcessMcpServer`, which deliberately has no `Debug` — printing
@@ -1691,9 +1970,9 @@ mod tests {
             r#"integration "gh-off" is not enabled or not authenticated"#
         );
         assert_eq!(
-            refusal("gg-1").await,
-            r#"no starter registered for integration type "google""#
+            refusal("wa-1").await,
+            r#"no starter registered for integration type "whatsapp""#
         );
-        assert!(!can_host(file.path(), "gg-1").expect("can_host"));
+        assert!(!can_host(file.path(), "wa-1").expect("can_host"));
     }
 }

--- a/desktop/src-tauri/src/native/integrations/registry.rs
+++ b/desktop/src-tauri/src/native/integrations/registry.rs
@@ -886,14 +886,7 @@ async fn start_google(
     credentials: &str,
     auth: &str,
 ) -> Result<InProcessMcpServer, String> {
-    // `Start`'s own `if !cfg.IsAuthenticated()`, kept for the reason the others
-    // keep theirs: `StartFilteredServer` reaches a starter by a different path.
-    if auth.is_empty() || auth == "null" {
-        return Err(format!("integration {id:?} has no auth token"));
-    }
-
-    let (client_id, client_secret) = google_credentials(id, credentials)?;
-    let token = google_oauth_token(id, auth)?;
+    let (client_id, client_secret, token) = google_start_inputs(id, credentials, auth)?;
 
     super::google::start_google_mcp_server(
         id,
@@ -906,6 +899,31 @@ async fn start_google(
     )
     .await
     .map_err(|e| format!("starting in-process MCP server for {id:?}: {e}"))
+}
+
+/// Everything `google.Start` decides **before** it builds a server: the auth
+/// check, then the credentials parse, then the token parse — in that order,
+/// which is `Start` calling `IsAuthenticated` and then `buildHTTPClient` calling
+/// its two parses.
+///
+/// Split out of [`start_google`] so the order is testable without binding a
+/// port. The order is half of what the vectors pin — two of them have more than
+/// one thing wrong — and a test that rebuilt this chain itself would agree with
+/// whatever it had written rather than with the starter.
+pub(super) fn google_start_inputs(
+    id: &str,
+    credentials: &str,
+    auth: &str,
+) -> Result<(String, String, super::google::client::Token), String> {
+    // `Start`'s own `if !cfg.IsAuthenticated()`, kept for the reason the others
+    // keep theirs: `StartFilteredServer` reaches a starter by a different path.
+    // It runs first, so an empty auth beats a broken credentials blob.
+    if auth.is_empty() || auth == "null" {
+        return Err(format!("integration {id:?} has no auth token"));
+    }
+    let (client_id, client_secret) = google_credentials(id, credentials)?;
+    let token = google_oauth_token(id, auth)?;
+    Ok((client_id, client_secret, token))
 }
 
 /// `cfg.ParseCredentials(&creds)` for `config.GoogleCredentials`, wrapped as
@@ -968,6 +986,19 @@ pub(super) fn google_oauth_token(
         /// because the *shape* check and the *value* check produce different Go
         /// sentences, and only a raw string can tell them apart.
         expiry: Option<serde_json::Value>,
+        /// Declared but unread, and that is the point: Go decodes into the whole
+        /// `oauth2.Token`, so `{"token_type": 5}` fails the **document**. A
+        /// three-field struct here silently hosted a row Go refuses.
+        ///
+        /// Its value is deliberately not used for the `Authorization` scheme —
+        /// see `google::client`'s header on the hardcoded `Bearer`.
+        #[allow(dead_code)]
+        #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+        token_type: String,
+        /// Same: declared for the type check. The transport reads `expiry`.
+        #[allow(dead_code)]
+        #[serde(deserialize_with = "crate::native::gojson::null_is_zero_value")]
+        expires_in: i64,
     }
 
     let wrap = |message: String| format!("parsing auth token for {id:?}: {message}");
@@ -987,10 +1018,18 @@ pub(super) fn google_oauth_token(
 
     let expiry = match parsed.expiry {
         None | Some(serde_json::Value::Null) => None,
-        Some(serde_json::Value::String(raw)) => Some(
-            parse_go_rfc3339(&raw)
-                .ok_or_else(|| wrap(format!("parsing oauth token: parsing time {raw:?}")))?,
-        ),
+        Some(serde_json::Value::String(raw)) => {
+            let parsed = crate::native::gotime::parse_rfc3339(&raw)
+                .ok_or_else(|| wrap(format!("parsing oauth token: parsing time {raw:?}")))?;
+            // **Go's zero `time.Time` is a valid parse of a token that never
+            // expires**, not a failure and not an instant in year 1.
+            // `omitempty` does not suppress a struct, so `SetOAuthToken` emits
+            // `"expiry":"0001-01-01T00:00:00Z"` rather than omitting the key,
+            // and `Token.Valid()` then reuses that token forever. Read as an
+            // ordinary instant it is permanently expired — the inverse.
+            (parsed.naive_utc() != crate::native::gotime::ZERO)
+                .then(|| std::time::SystemTime::from(parsed.to_utc()))
+        }
         // `Time.UnmarshalJSON` checks the JSON shape before the layout.
         Some(_) => {
             return Err(wrap(
@@ -1004,33 +1043,6 @@ pub(super) fn google_oauth_token(
         refresh_token: parsed.refresh_token,
         expiry,
     })
-}
-
-/// Go's `time.RFC3339` layout, `2006-01-02T15:04:05Z07:00`, as `time.Parse`
-/// applies it — which is **stricter than `chrono`'s** `parse_from_rfc3339` in two
-/// ways that a stored token can actually reach, both measured against real Go:
-///
-/// - **The separators are case-sensitive.** `2030-01-01t00:00:00z` is a parse
-///   error to Go and accepted by chrono. Go's RFC3339 handling has been strict
-///   since 1.20.
-/// - **A leap second is out of range.** `2030-06-30T23:59:60Z` is
-///   `second out of range` to Go, where chrono represents it.
-///
-/// Everything else agrees: a numeric offset, fractional seconds of any length, a
-/// rejected trailing space, and rejected out-of-range components.
-fn parse_go_rfc3339(raw: &str) -> Option<std::time::SystemTime> {
-    // `T` and the `Z` form of the zone are literals in the layout, so their case
-    // is fixed. A numeric offset carries no letter to check.
-    if !raw.contains('T') || raw.contains('t') || raw.contains('z') {
-        return None;
-    }
-    let parsed = chrono::DateTime::parse_from_rfc3339(raw).ok()?;
-    // chrono encodes a leap second as nanosecond >= 1_000_000_000 rather than as
-    // a 60th second, which is how it survives its own parse.
-    if chrono::Timelike::nanosecond(&parsed) >= 1_000_000_000 {
-        return None;
-    }
-    Some(std::time::SystemTime::from(parsed.to_utc()))
 }
 
 /// The row's `type`, and **nothing else** — no `credentials`, no `auth`.
@@ -1491,6 +1503,73 @@ mod tests {
         registry().stop("never-existed");
     }
 
+    /// The Google starter end to end, which nothing else covers.
+    ///
+    /// `a_hosted_type_always_has_a_starter` inserts empty credentials, so for
+    /// google it only ever reaches the `credentials are empty` arm — it proves
+    /// the dispatch arm exists and nothing more. `tests_vectors` covers
+    /// `start_google_mcp_server` with a hand-built `TokenSource`. What neither
+    /// touches is the glue this PR added: the precheck, the two parses being
+    /// wired to the columns they belong to, and the order of
+    /// `TokenSource::new`'s arguments — a swap there would send the client id as
+    /// the secret and fail only at refresh time, months later, on somebody's
+    /// laptop.
+    #[tokio::test]
+    async fn a_google_integration_starts_reloads_and_stops() {
+        let file = db();
+        insert(
+            &file,
+            "gg-1",
+            "google",
+            true,
+            // An hour out, so nothing tries to refresh while the test runs.
+            Some(
+                r#"{"access_token":"ya29.test","refresh_token":"1//test","expiry":"2099-01-01T00:00:00Z"}"#,
+            ),
+            r#"{"client_id":"cid.apps.googleusercontent.com","client_secret":"GOCSPX-test"}"#,
+            r#"{"gmail":{"enabled":true,"tools":["send_email"]}}"#,
+        );
+
+        start_all(file.path()).await.expect("start_all");
+        assert!(registry().is_hosted("gg-1"), "a valid google row must host");
+
+        reload(file.path(), "gg-1").await.expect("reload");
+        assert!(registry().is_hosted("gg-1"));
+
+        registry().stop("gg-1");
+        assert!(!registry().is_hosted("gg-1"));
+    }
+
+    /// The columns land in the right parameters — the failure that would
+    /// otherwise surface only at refresh time.
+    #[test]
+    fn the_credential_columns_are_not_swapped() {
+        let (client_id, client_secret, token) = google_start_inputs(
+            "gg-1",
+            r#"{"client_id":"CID","client_secret":"SECRET"}"#,
+            r#"{"access_token":"ACCESS","refresh_token":"REFRESH","expiry":"2099-01-01T00:00:00Z"}"#,
+        )
+        .expect("a valid row");
+        assert_eq!(client_id, "CID");
+        assert_eq!(client_secret, "SECRET");
+        assert_eq!(token.access_token, "ACCESS");
+        assert_eq!(token.refresh_token, "REFRESH");
+        assert!(token.expiry.is_some());
+
+        // Go's zero time is the sentinel its own writer emits, and it means
+        // "never expires" — not "expired in the year 1".
+        let (_, _, zero) = google_start_inputs(
+            "gg-1",
+            r#"{"client_id":"CID","client_secret":"SECRET"}"#,
+            r#"{"access_token":"ACCESS","expiry":"0001-01-01T00:00:00Z"}"#,
+        )
+        .expect("a zero expiry is a valid token");
+        assert!(
+            zero.expiry.is_none(),
+            "Go's zero time must reach the token source as `never expires`"
+        );
+    }
+
     /// Both flags gate hosting, exactly as they gate `available-tools`.
     #[tokio::test]
     async fn a_disabled_or_unauthenticated_integration_is_not_hosted() {
@@ -1712,14 +1791,19 @@ mod tests {
     /// Google's is measured, for one reason: its `auth` column decodes as an
     /// `oauth2.Token` whose `expiry` is a Go `time.Time`, so whether a stored
     /// value is accepted is `time.Parse`'s decision and not something to guess
-    /// at. Two of the cases below are exactly where `chrono` and Go disagree —
-    /// a lowercase `t`/`z` separator and a leap second, both of which chrono
-    /// accepts and Go refuses.
+    /// at. Five vectors are exactly where `chrono` and Go disagree, in both
+    /// directions.
     ///
-    /// Only the accept/reject decision is compared. Go's sentences for a bad
-    /// `expiry` embed `time.Parse`'s own layout-diffing wording, and for a
-    /// malformed blob `encoding/json`'s — the second of which is dropped on
-    /// purpose, since serde's quotes the value, which here is the access token.
+    /// It calls [`google_start_inputs`] — the function [`start_google`] itself
+    /// calls — rather than re-chaining the three checks, because the **order** is
+    /// half of what this pins: two vectors have more than one thing wrong, and a
+    /// test that rebuilt the chain would agree with itself whatever the starter
+    /// did.
+    ///
+    /// Sentences are compared exactly wherever Go's is reproducible. The two
+    /// classes that are not carry `rust_error` in the vector: `time.Parse`'s
+    /// layout-diffing wording, and `encoding/json`'s — the second dropped on
+    /// purpose, since serde's quotes the value, which here is a credential.
     #[test]
     fn google_start_accepts_exactly_what_go_accepts() {
         #[derive(serde::Deserialize)]
@@ -1728,6 +1812,8 @@ mod tests {
             credentials: String,
             auth: String,
             error: String,
+            #[serde(default)]
+            rust_error: String,
         }
         #[derive(serde::Deserialize)]
         struct Vectors {
@@ -1738,16 +1824,14 @@ mod tests {
         let raw = std::fs::read_to_string(path)
             .unwrap_or_else(|e| panic!("reading {path}: {e} — regenerate it from Go"));
         let vectors: Vectors = serde_json::from_str(&raw).expect("parsing the google vectors");
-        assert!(vectors.starting.len() >= 20, "vectors look partial");
+        assert!(vectors.starting.len() >= 30, "vectors look partial");
 
+        // Collected rather than asserted one at a time: a change to a shared
+        // sentence moves many cases at once, and seeing only the first is how a
+        // regeneration turns into several rounds.
+        let mut mismatches: Vec<String> = Vec::new();
         for case in &vectors.starting {
-            // `Start`'s own auth check, then the two parses, in Go's order.
-            let got = if case.auth.is_empty() || case.auth == "null" {
-                Err(r#"integration "goog-parity" has no auth token"#.to_string())
-            } else {
-                google_credentials("goog-parity", &case.credentials)
-                    .and_then(|_| google_oauth_token("goog-parity", &case.auth).map(|_| ()))
-            };
+            let got = google_start_inputs("goog-parity", &case.credentials, &case.auth);
 
             assert_eq!(
                 got.is_err(),
@@ -1755,42 +1839,51 @@ mod tests {
                 "{}: Go said {:?}, this said {:?}",
                 case.case,
                 case.error,
-                got.err().unwrap_or_default()
+                got.as_ref().err()
             );
 
-            // Whatever it says, it must never name the secret it was handed.
-            if let Err(message) = google_credentials("goog-parity", &case.credentials) {
-                assert!(
-                    !message.contains("GOCSPX"),
-                    "{}: the client secret leaked: {message}",
-                    case.case
-                );
+            match got {
+                Ok((client_id, client_secret, _)) => {
+                    // A swapped pair would only surface at refresh time, so the
+                    // happy path asserts which column landed where.
+                    assert!(
+                        client_secret.is_empty() || client_secret.starts_with("GOCSPX"),
+                        "{}: the client secret is not the secret column",
+                        case.case
+                    );
+                    assert!(
+                        !client_id.starts_with("GOCSPX"),
+                        "{}: the client id carries the secret",
+                        case.case
+                    );
+                }
+                Err(message) => {
+                    // Whatever it says, it must never name a credential.
+                    assert!(
+                        !message.contains("GOCSPX") && !message.contains("1//"),
+                        "{}: a credential leaked into a refusal: {message}",
+                        case.case
+                    );
+                    let want = if case.rust_error.is_empty() {
+                        &case.error
+                    } else {
+                        &case.rust_error
+                    };
+                    if &message != want {
+                        mismatches.push(format!(
+                            "  {}\n    go/expected: {want:?}\n    rust:        {message:?}",
+                            case.case
+                        ));
+                    }
+                }
             }
         }
-    }
-
-    /// The two places `chrono` is more permissive than Go, called out on their
-    /// own because the vector loop above only proves the pair agree — this says
-    /// which rule is doing the work.
-    #[test]
-    fn the_expiry_parse_is_gos_layout_and_not_chronos() {
-        assert!(parse_go_rfc3339("2030-01-01T00:00:00Z").is_some());
-        assert!(parse_go_rfc3339("2030-01-01T00:00:00+05:30").is_some());
-        assert!(parse_go_rfc3339("2030-01-01T00:00:00.5Z").is_some());
-        // chrono accepts both of these; Go does not.
         assert!(
-            parse_go_rfc3339("2030-01-01t00:00:00z").is_none(),
-            "Go's RFC3339 separators are case-sensitive"
+            mismatches.is_empty(),
+            "{} refusal sentence(s) differ from the vectors:\n{}",
+            mismatches.len(),
+            mismatches.join("\n")
         );
-        assert!(
-            parse_go_rfc3339("2030-06-30T23:59:60Z").is_none(),
-            "a leap second is `second out of range` to Go"
-        );
-        // …and both agree on these.
-        assert!(parse_go_rfc3339("2030-01-01T00:00:00Z ").is_none());
-        assert!(parse_go_rfc3339("2030-13-01T00:00:00Z").is_none());
-        assert!(parse_go_rfc3339("2030-01-01").is_none());
-        assert!(parse_go_rfc3339("").is_none());
     }
 
     /// The credential parse: Go's two failure shapes, and neither may echo the

--- a/desktop/src-tauri/src/native/schedule/mod.rs
+++ b/desktop/src-tauri/src/native/schedule/mod.rs
@@ -11,10 +11,11 @@
 //! `cmd/web.go` starts the sidecar's scheduler on every boot. Ownership moves
 //! in one commit that stops the sidecar scheduling — the #289 model — and that
 //! commit is blocked on `chat/runner.rs::build_options`, which still refuses an
-//! agent whose tools come from an integration this build cannot host — one of
-//! the six (#313), since the local in-process server (#310), github (#311),
-//! confluence (#317), jira (#316), slack (#315) and telegram (#314) are no longer
-//! among them. A chat can forward to Go on that
+//! agent whose tools come from an integration this build cannot host. Since #313
+//! that is `whatsapp` alone — the local in-process server (#310), github (#311),
+//! confluence (#317), jira (#316), slack (#315), telegram (#314) and google
+//! (#313) are all hosted here — so the remaining blockers are that one type and
+//! the two non-integration forwards. A chat can forward to Go on that
 //! refusal; a scheduled task with no Go scheduler behind it would simply never
 //! run, with nothing to say so. See "The scheduler: the computation moved, the
 //! ownership did not" in `desktop/CLAUDE.md`.
@@ -191,51 +192,16 @@ pub fn build_job_definition(
 
 /// `time.Parse(time.RFC3339, s)`, which is not `chrono`'s RFC 3339.
 ///
-/// They disagree in both directions, and `run_at` is free-form client input, so
-/// the disagreement is reachable from `POST /api/tasks`:
-///
-/// - **Lowercase designators.** RFC 3339 §5.6 permits `t` and `z`; Go does not.
-///   Its fast path tests `s[10] == 'T'` and its fallback matches the layout's
-///   literal `T` and `Z` exactly, so `2026-06-01t12:00:00z` is a parse error.
-///   `chrono` accepts it and would schedule a one-off Go refuses.
-/// - **A comma decimal separator.** Go's fast path wants `.`, fails, and falls
-///   back to the general parser — which treats `,` and `.` alike — so
-///   `2026-06-01T12:00:00,5Z` is 12:00:00.5. `chrono` rejects it.
-/// - **A leap second.** `chrono` accepts `:60` and encodes it as a nanosecond
-///   past one billion; Go bounds the field at 59 and errors. Left in `chrono`'s
-///   representation it is not even a fire time — the schedule builds and then
-///   produces nothing.
-///
-/// Everything else is left to `chrono`: a differential run of 636 shapes
-/// through a real `gocron.Scheduler` found no other disagreement, including on
-/// component widths, the `+hh:mm` offset form and trailing text.
+/// They disagree in **five** ways, in both directions, and `run_at` is free-form
+/// client input, so every one of them is reachable from `POST /api/tasks`. The
+/// table and the transcription live in [`crate::native::gotime`], which is the
+/// single implementation: #275 found three of the five by a differential run of
+/// 636 shapes through a real `gocron.Scheduler`, and #313 needed the same parse
+/// for a Google token's `expiry` and found two more — a one-digit hour and an
+/// offset hour past 23, both of which Go accepts and this used to refuse to
+/// schedule.
 fn parse_go_rfc3339(s: &str) -> Option<DateTime<FixedOffset>> {
-    let bytes = s.as_bytes();
-    // Go's date/time separator is the layout's literal 'T'. Nothing else — not
-    // 't', not a space — matches it.
-    if bytes.get(10) != Some(&b'T') {
-        return None;
-    }
-    // ...and the zone is 'Z' or a numeric offset; a trailing 'z' is neither.
-    if bytes.last() == Some(&b'z') {
-        return None;
-    }
-    // `,` is a fractional-second separator for Go and not for chrono. It can
-    // only appear in that one position, since every other byte of an RFC 3339
-    // timestamp is fixed, so replacing all of them is replacing at most one.
-    let normalized;
-    let s = if s.contains(',') {
-        normalized = s.replace(',', ".");
-        normalized.as_str()
-    } else {
-        s
-    };
-    let parsed = DateTime::parse_from_rfc3339(s).ok()?;
-    // chrono's leap-second encoding: the extra second lives in `nanosecond`.
-    if parsed.nanosecond() >= 1_000_000_000 {
-        return None;
-    }
-    Some(parsed)
+    crate::native::gotime::parse_rfc3339(s)
 }
 
 /// Go's `time.Duration` arithmetic: `int64` nanoseconds that **wrap** rather


### PR DESCRIPTION
Closes #313.

The second half. The port landed in #360 as dormant code with its parity pinned; this adds `google` to `HOSTED_TYPES` and gives it a starter.

**With this, all six integration types are hosted by the Rust shell** and `hosting_env_value()` tells the sidecar to drop every one of them. Only `whatsapp` stays Go's — dropped rather than deferred, because its starter opens a live whatsmeow connection registered in a package global that the status, reconnect and QR endpoints read.

## Why the flip was worth splitting out

The flip is where the risk in this series has actually lived. #315's hosting of Slack silently broke `completeOAuth`'s reload, and Google is the *other* provider `startProviderCallback` supports — so it lands on the same hook.

With both hosted, `reload_if_secrets_changed` now covers **every** OAuth integration in the product. There is no longer a case it does not have to catch, which is a better place to be than the one #315 left us in.

Google is also the one where being served late costs the most, for a reason peculiar to it: **a Google token expires**. A Slack row served at the next boot is merely served late; a Google row carries an `expiry` that `TokenSource` reads, so a token first picked up hours later may already need a refresh on the first tool call. That still works — it is what the refresh is for — but it is worth knowing when reading a bug report about a slow first Google call.

## `start_google` is the only starter needing both secret columns

`credentials` carries the OAuth2 client pair; `auth` carries the token. Slack reads `auth` too, but only for an access token. Here the whole `oauth2.Token` matters, because `expiry` decides whether the first tool call refreshes.

That is also why **`google_oauth_token` refuses a row whose `expiry` does not parse**, where Slack's equivalent deliberately skips the field. A corrupt expiry means *not hosted* — not hosted with a token that never refreshes.

## The boundary is measured, not read

This is the lesson the first half taught, applied up front. A new `starting` section in `google_vectors.json` records what the **real** `google.Start` does with twenty-three credential and auth shapes, and a Rust test replays it.

That is how `parse_go_rfc3339` came to exist. **`chrono` is more permissive than Go in two ways a stored token can actually reach:**

| value | Go | chrono |
|---|---|---|
| `2030-01-01t00:00:00z` | parse error (strict since 1.20) | accepted |
| `2030-06-30T23:59:60Z` | `second out of range` | accepted |

Neither was guessable from either side's source. The rest agree: a numeric offset is accepted, fractional seconds of any length are accepted, and a trailing space, an out-of-range month, a date-only value, an empty string and a numeric expiry are all refused. A `null` or absent expiry is Go's zero `time.Time`, which never expires.

Some other things the vectors settled, all Go's behaviour and none of it obvious:

- An **empty** `auth` column and a literal `null` are both "no auth token", refused before any parse — but an empty **object** `{}` is authenticated, parses, and hosts a server whose every call carries an empty bearer token.
- A `null` credentials blob is a no-op, so the client id ends up empty and the row still hosts.
- Neither client id nor secret is checked for emptiness: Go hosts a row with both empty and every refresh then fails at Google.

## Stand-ins

Three "unported type" tests move from `google` to `whatsapp`, where they stay. One of them said in a comment that google was *"the last move available"* — it was right.

Clippy caught two of these as `for loop over a single element`, which is a fair description of what a stand-in list becomes when only one type is left; both are now direct assertions.

## Gates

`cargo test` (898 lib + the rest, all green), `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `go test ./...`, `golangci-lint run ./...` at the pinned v2.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
