### PR TITLE
fix(desktop): a session id under two project paths keeps both rows' side tables (#344)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -414,8 +414,13 @@ only a byte comparison catches all four.
      ./scripts/parity-instance.sh stop
      ```
      One suite per area (`tests/parity_<area>.rs`, sharing `tests/parity_common/`),
-     so a port runs its own diff and two ports do not edit one file. Drop the
-     `--test` flag to run them all — but note that `parity_writes` **mutates**,
+     so a port runs its own diff and two ports do not edit one file. **There is
+     no `tests/live_parity.rs`** — several issue templates say
+     `cargo test --test live_parity`, and that names nothing. Drop the
+     `--test` flag to run them all, and add **`--no-fail-fast`** when you do:
+     `cargo test` stops at the first failing test *binary*, so one red suite
+     hides every suite listed after it and a sweep reports one failure where
+     there are three. Note also that `parity_writes` **mutates**,
      unlike every other suite. It creates, renames and deletes rows, so it
      refuses to run unless `AGENTO_LIVE_URL` is set rather than falling back to
      the `:8990` default the read suites use. Start the scratch instance first.

--- a/desktop/src-tauri/src/native/sessions/corpus.rs
+++ b/desktop/src-tauri/src/native/sessions/corpus.rs
@@ -119,10 +119,16 @@ fn attach_subagent_usage_by_model(conn: &Connection, sessions: &mut [SessionSumm
         return;
     }
 
+    // `get`, never `remove`. `claude_session_cache` is keyed on
+    // `(session_id, project_path)` and `claude_subagent_cache` on the parent
+    // session id alone, so one id can appear under two project paths and
+    // draining the entry would leave the second row's breakdown empty — which
+    // falls back to the parent's model rather than failing. Go re-reads the map
+    // per row.
     for s in sessions.iter_mut() {
-        if let Some((usage, cost)) = by_session.remove(&s.session_id) {
-            s.subagent_usage_by_model = usage;
-            s.subagent_cost_by_model = cost;
+        if let Some((usage, cost)) = by_session.get(&s.session_id) {
+            s.subagent_usage_by_model = usage.clone();
+            s.subagent_cost_by_model = cost.clone();
         }
     }
 }

--- a/desktop/src-tauri/src/native/sessions/page.rs
+++ b/desktop/src-tauri/src/native/sessions/page.rs
@@ -324,9 +324,15 @@ fn attach_prs(conn: &Connection, sessions: &mut [SessionSummary]) {
         return;
     }
 
+    // `get`, never `remove`: `claude_session_cache` is keyed on
+    // `(session_id, project_path)` while `claude_session_pr` is keyed on the
+    // session id alone, so one id legitimately yields two rows on a page and
+    // draining the entry would leave every row after the first with `prs: []`.
+    // Go re-reads the map per row, and an empty list renders as "no linked
+    // PRs" rather than as an error, so the divergence would be silent.
     for s in sessions.iter_mut() {
-        if let Some(prs) = by_session.remove(&s.session_id) {
-            s.prs = prs;
+        if let Some(prs) = by_session.get(&s.session_id) {
+            s.prs = prs.clone();
         }
     }
 }
@@ -393,10 +399,14 @@ fn attach_subagent_usage_by_model(conn: &Connection, sessions: &mut [SessionSumm
         return;
     }
 
+    // `get`, never `remove` — same reason as `attach_prs` above:
+    // `claude_subagent_cache` is keyed on the parent session id alone, so a
+    // session id appearing under two project paths must not have its
+    // breakdown consumed by whichever of the two rows the page listed first.
     for s in sessions.iter_mut() {
-        if let Some((usage, cost)) = by_session.remove(&s.session_id) {
-            s.subagent_usage_by_model = usage;
-            s.subagent_cost_by_model = cost;
+        if let Some((usage, cost)) = by_session.get(&s.session_id) {
+            s.subagent_usage_by_model = usage.clone();
+            s.subagent_cost_by_model = cost.clone();
         }
     }
 }

--- a/desktop/src-tauri/src/native/sessions/tests_db.rs
+++ b/desktop/src-tauri/src/native/sessions/tests_db.rs
@@ -24,7 +24,7 @@ use crate::native::settings::DataSettings;
 /// list reads. Kept in the shape `internal/storage/sqlite.go` produces.
 const SCHEMA: &str = "
     CREATE TABLE claude_session_cache (
-        session_id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
         project_path TEXT NOT NULL DEFAULT '',
         preview TEXT NOT NULL DEFAULT '',
         custom_title TEXT NOT NULL DEFAULT '',
@@ -62,7 +62,12 @@ const SCHEMA: &str = "
         unpriced_tokens INTEGER NOT NULL DEFAULT 0,
         cost_by_model TEXT NOT NULL DEFAULT '',
         active_duration_ms INTEGER NOT NULL DEFAULT 0,
-        config_dir TEXT NOT NULL DEFAULT ''
+        config_dir TEXT NOT NULL DEFAULT '',
+        -- The real key, as `internal/storage/sqlite.go` declares it. It was
+        -- `session_id TEXT PRIMARY KEY` here, which made the one shape these
+        -- tests could not express — a session id under two project paths —
+        -- also the one that reached production broken (#344).
+        PRIMARY KEY (session_id, project_path)
     );
     CREATE TABLE claude_subagent_cache (
         parent_session_id TEXT NOT NULL,
@@ -462,4 +467,69 @@ fn a_drilldown_window_replaces_the_range_rather_than_narrowing_it() {
     );
 
     let _ = conn;
+}
+
+#[test]
+fn a_session_id_under_two_project_paths_keeps_both_rows_side_tables() {
+    // `claude_session_cache` is keyed on `(session_id, project_path)`, so
+    // copying one Claude account's history onto a machine that already has it
+    // — or simply resuming the same session id from two checkouts — puts one
+    // id on a page twice. `claude_session_pr` and `claude_subagent_cache` are
+    // keyed on the session id alone, so both rows must be handed the *same*
+    // entry. Draining the map instead gave the first row everything and every
+    // later row an empty list, which renders as "no linked PRs" rather than as
+    // an error (#344).
+    let conn = fixture(&[
+        TestSession {
+            id: "dup",
+            project: "/home/u/projects/alpha",
+            cost_usd: 2.0,
+            ..Default::default()
+        },
+        TestSession {
+            id: "dup",
+            project: "/home/u/projects/beta",
+            cost_usd: 1.0,
+            ..Default::default()
+        },
+    ]);
+    conn.execute(
+        "INSERT INTO claude_session_pr
+            (session_id, pr_number, pr_url, pr_repository, first_seen_at)
+         VALUES ('dup', 7, 'https://github.com/o/r/pull/7', 'o/r',
+                 '2026-08-01 11:00:00 +0000 UTC')",
+        [],
+    )
+    .expect("insert pr");
+    conn.execute(
+        "INSERT INTO claude_subagent_cache
+            (parent_session_id, agent_id, model, input_tokens, output_tokens,
+             total_cost_usd)
+         VALUES ('dup', 'agent-9', 'claude-haiku-4-5-20251001', 11, 22, 0.5)",
+        [],
+    )
+    .expect("insert sub-agent");
+
+    let page = list_page(&conn, &no_settings(), &SessionQuery::default()).expect("page");
+    assert_eq!(page.items.len(), 2, "both rows are on the page");
+    for s in &page.items {
+        assert_eq!(s.prs.len(), 1, "row {} lost its linked PRs", s.project_path);
+        assert_eq!(s.prs[0].pr_number, 7);
+        assert_eq!(
+            s.subagent_usage_by_model
+                .get("claude-haiku-4-5-20251001")
+                .map(|u| u.input_tokens),
+            Some(11),
+            "row {} lost its per-model delegated usage",
+            s.project_path
+        );
+        assert_eq!(
+            s.subagent_cost_by_model
+                .get("claude-haiku-4-5-20251001")
+                .map(|c| c.total_usd),
+            Some(0.5),
+            "row {} lost its per-model delegated cost",
+            s.project_path
+        );
+    }
 }

--- a/desktop/src-tauri/src/native/sessions/tests_db.rs
+++ b/desktop/src-tauri/src/native/sessions/tests_db.rs
@@ -126,7 +126,7 @@ struct TestSession {
 fn fixture(sessions: &[TestSession]) -> Connection {
     let conn = Connection::open_in_memory().expect("in-memory database");
     conn.execute_batch(SCHEMA).expect("schema");
-    for s in sessions {
+    for (i, s) in sessions.iter().enumerate() {
         let last = if s.last_activity.is_empty() {
             "2026-08-01 12:00:00 +0000 UTC"
         } else {
@@ -157,13 +157,18 @@ fn fixture(sessions: &[TestSession]) -> Connection {
             || s.sub_cost_usd != 0.0
             || s.sub_active_ms != 0
         {
+            // The agent id is per row, not a constant: `claude_subagent_cache`
+            // is keyed on `(parent_session_id, agent_id)`, so two rows sharing
+            // a session id — which the composite session key now admits —
+            // would otherwise collide here instead of expressing the shape.
             conn.execute(
                 "INSERT INTO claude_subagent_cache
                     (parent_session_id, agent_id, input_tokens, output_tokens,
                      total_cost_usd, active_duration_ms)
-                 VALUES (?, 'agent-1', ?, ?, ?, ?)",
+                 VALUES (?, ?, ?, ?, ?, ?)",
                 rusqlite::params![
                     s.id,
+                    format!("agent-{i}"),
                     s.sub_input_tokens,
                     s.sub_output_tokens,
                     s.sub_cost_usd,


### PR DESCRIPTION
Closes #344

## What

`desktop/src-tauri/src/native/sessions/page.rs` attached the two side tables to a page's rows by **draining** a map — `BTreeMap::remove`. But `claude_session_cache` is keyed on `(session_id, project_path)` while `claude_session_pr` and `claude_subagent_cache` are keyed on the session id alone, so one id legitimately yields two rows on a page. The first row took the entry; every later row with the same id shipped `prs: []` and an empty `subagent_usage_by_model` / `subagent_cost_by_model`.

Fixed with `get().cloned()` at both sites, plus **a third the sweep found**: `corpus.rs::attach_subagent_usage_by_model`, the corpus-wide variant behind `List` that feeds analytics, had the identical shape. The issue asked for the rest of `page.rs` to be checked; `corpus.rs` is the same one-line defect in the sibling function, so it is fixed here rather than left for a second PR to rediscover.

## Why

Go re-reads the map per row (`sessions[i].PRs = bySession[sessions[i].SessionID]`), so this was a straight divergence — and a silent one, since an empty list renders as "no linked PRs" rather than as an error.

## How

- `page.rs` — `attach_prs` and `attach_subagent_usage_by_model`: `remove` → `get`, with the reason recorded at both sites so the next edit does not undo it.
- `corpus.rs` — same change in `attach_subagent_usage_by_model`.
- `tests_db.rs` — the fixture declared `session_id TEXT PRIMARY KEY`, which is precisely why nothing in the suite could express the broken shape. It now carries the real composite key from `internal/storage/sqlite.go`, and a new test pins both rows keeping their PRs and their per-model delegated usage and cost. Verified it fails against the old `remove` and passes against the fix.
- `desktop/CLAUDE.md` — records the two things the issue's "note for whoever picks this up" flagged: there is **no `tests/live_parity.rs`** target despite several issue templates naming it, and a full parity sweep needs **`--no-fail-fast`** or one red suite hides every suite after it.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --no-fail-fast` — all green (905 unit + every integration suite).
- Live parity against a Go server built from this checkout: **`parity_sessions::session_list_and_facets_match_the_live_go_responses` now passes** — it was one of the two suites the issue reported failing. Every list and facets variant byte-identical.

## Deferred

**#364 — the keyset order is not total either.** Review of this PR found that the cursor tiebreaks on `session_id` alone, so two rows sharing an id *and* tying on the sort column leave the second unreachable by any page while `facets` still counts it. Same root cause as this fix, worse symptom — but the predicate is identical in `internal/claudesessions/session_page.go`, so fixing it on the Rust side alone would break `parity_sessions`. It needs both languages in one commit and is deferred to #364.

The issue's second suspected failure was confirmed to be a different root cause and is **not** fixed here: `session_insights` is keyed on `session_id` alone, so the stored row and the recomputed one for `1de427b5-3f0b-4847-9bef-a5c8aa85da90` are drawn from two different transcripts. Both languages inherit that from the schema, so it is not a port bug. Deferred to #362, where the confirmation is recorded — `parity_insights` still reports `1 of 1034 sessions diverged` on exactly that id.