### PR TITLE
feat(desktop): the shell owns the OAuth flow (#318)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -1328,21 +1328,21 @@ because neither type was hosted here — true until #315. Now that `Reload` reac
 nothing, so a Slack integration authenticated by OAuth would first be served at
 the next boot.
 
-`reload_after_auth` cannot cover it: that hook hangs off a **forwarded request**,
-and an OAuth token does not arrive on one — the browser delivers it to a callback
-server the *sidecar* opens on its own port, which this process never sees. The
-one part of the flow that does come through the proxy is the UI polling
-`GET /api/integrations/{id}/auth/status` while it waits, so `reload_after_forward`
-now recognises two routes and returns a `Trigger` saying which:
+`reload_after_auth` could not cover it **while the sidecar owned the callback
+server**: that hook hangs off a forwarded request, and an OAuth token did not
+arrive on one — the browser delivered it to a port Go opened, which this process
+never saw. The only part of the flow that came through the proxy was the UI
+polling `GET /api/integrations/{id}/auth/status` while it waited, so
+`reload_after_forward` recognised that route too and drove a
+reload-only-if-the-fingerprint-moved.
 
-- `POST …/auth/validate` is an **event** — reload unconditionally, as Go does.
-- `GET …/auth/status` is a **poll** — `registry::reload_if_secrets_changed`
-  compares the row's current `credentials`+`auth` fingerprint against the one the
-  running server was started with, and does nothing when they match. That matters
-  because `reload` is unconditional by design: firing it per poll would rebind
-  the port and drop in-flight `tools/call`s once a second while the dialog is
-  open. The registry keeps the fingerprint (a hash, not the values) beside each
-  handle for exactly this question.
+**#318 removed all of that.** The shell binds the callback server now, writes the
+token and calls `reload_after_auth` directly, so the poll is no longer evidence
+of anything: `Trigger::AuthStatusPolled`, `registry::reload_if_secrets_changed`
+and the `secrets` fingerprint map it was the only reader of are gone.
+`reload_after_forward` recognises exactly one route again —
+`POST …/auth/validate`, an **event**, reloaded unconditionally as Go does — and
+it is still needed only because that route is still forwarded.
 
 It is **best-effort**: a user who closes the dialog before the flow completes is
 still served only at the next boot. #318 owns the OAuth flow itself and is where
@@ -1522,9 +1522,10 @@ ones — so it is test-only, and the Rust equivalent is behind `#[cfg(test)]`.
 **The flip landed as its own change**, after the port. That split was worth it
 for the reason it was made: the flip is where the risk in this series has lived —
 #315's hosting of Slack silently broke `completeOAuth`'s reload, and Google is the
-*other* provider `startProviderCallback` supports. With both hosted,
-`reload_if_secrets_changed` now covers **every** OAuth integration in the product,
-and there is no longer a case it does not have to catch.
+*other* provider `startProviderCallback` supports. With both hosted, the
+poll-driven net covered every OAuth integration in the product. **#318 then made
+the net unnecessary** by moving the flow itself, so the reload is an event again
+rather than an inference.
 
 `start_google` is the only starter needing **both** secret columns for different
 things: `credentials` carries the OAuth2 client pair, `auth` carries the token.

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -2784,6 +2784,65 @@ Two more the vectors pin, both invisible in UTC:
 `time.Date`, which *normalizes* a wall clock a DST gap removed instead of
 failing, and that normalization is the answer on the spring-forward day.
 
+### The OAuth flow, and the workaround it retires (#318)
+
+`POST /api/integrations/{id}/auth/start` and `GET …/auth/status` share
+`integrationService.oauthFlows`, a map in the process that started the flow —
+split them across two processes and `status` polls a map that will never be
+populated. That is why #300 deferred them together, and it is the whole reason
+they move together now: `native/integrations/oauth/flow.rs` binds the loopback
+callback server, exchanges the code, writes the token and reloads the hosted
+server, all here.
+
+**It retires an inference.** While the sidecar owned the callback server, the
+shell could not see a token land — the browser delivers it straight to a port Go
+opened — so `reload_after_forward` watched the UI *poll* `auth/status` and
+reloaded when the row stopped matching what was running
+(`Trigger::AuthStatusPolled`). The shell writes the token itself now, so that
+trigger, `registry::reload_if_secrets_changed` and the `secrets` fingerprint map
+it was the only reader of are **gone** rather than left running beside the real
+event. `CredentialWritten` stays, because `auth/validate` is still forwarded.
+
+**`POST …/auth/validate` is deliberately not part of this**, and the reason
+recorded in `write_routes.json` until now was wrong. It was grouped with the
+other two because the credentials it writes were read by *Go's* MCP servers —
+expired when #311–#313 moved all six here — and it never touches `oauthFlows`
+at all. Its error text is also largely reproducible: every validator's transport
+failure is a fixed string, as the ported clients' are. What actually holds it
+back is that each of the five writes a **type-specific** auth payload its own MCP
+server reads (`{"validated":true,"bot_username":…}` for Telegram, not a shared
+flag), so it is five remote-call reproductions rather than one.
+
+**The URL is a vector, not a live diff.** The redirect port comes from a fresh
+`FreePort()`, so two implementations answering the same request produce
+different URLs. `desktop/parity/oauth_vectors.json` records what Go's own
+`BuildAuthURL` produced for a fixed port. Generating rather than transcribing
+was not ceremony — `oauth2.ApprovalForce` emits **`prompt=consent`**, not the
+`approval_prompt=force` its name suggests. The vectors also pin that the Google
+scope union is *ordered* (calendar → gmail → drive) rather than sorted, that
+`scope` is **absent** rather than empty when no service is enabled, and that the
+encoding is `url.Values.Encode` where a space is `+`.
+
+**The exchange has neither a vector nor a diff**, being a call to the provider,
+so its request shape is pinned against a fake token endpoint that records what
+it was sent. That is what caught the difference that matters: Google declares
+`AuthStyleInParams` and puts its credentials in the body, while Slack declares
+no style at all, so `oauth2` tries **HTTP Basic first** and only retries in the
+body. "Params first" works against a server that accepts both and fails against
+one that does not.
+
+The stored token is Go's `json.Marshal(*oauth2.Token)`, which the sidecar's MCP
+servers still read through the ungated `StartFilteredServer`. Note **`expiry` is
+always present**: `omitempty` does not omit a struct, so a token that never
+expires stores `0001-01-01T00:00:00Z` rather than dropping the key.
+
+`WriteError::Internal` was added for this route and is not a house style: it is
+**500 with a body produced here**, where `Fallback` means "the sidecar answers".
+The distinction bites exactly once — a failed OAuth flow. Forwarding it would
+have Go answer from the stored token (`authenticated: false`, a plausible lie)
+where Go itself would have answered 500, because the map the answer depends on
+is now the shell's.
+
 ### Do not port
 
 Telemetry/OTel, Prometheus metrics, and the self-updater are server concerns.

--- a/desktop/parity/oauth_parity_test.go
+++ b/desktop/parity/oauth_parity_test.go
@@ -1,0 +1,229 @@
+// Cross-language vectors for the OAuth authorization URLs (#318).
+//
+// `POST /api/integrations/{id}/auth/start` answers a URL the user's browser is
+// sent to, and it is the one response in this port that **cannot** be compared
+// by the live diff: the redirect port comes from `integrations.FreePort()`, so
+// two implementations answering the same question produce two different URLs.
+// The bytes still have to match everywhere else, and every part of them is a
+// rule rather than a value:
+//
+//   - the **scope set and its order**, which for Google is the union of the
+//     enabled services' scopes in `Scopes`'s fixed calendar/gmail/drive order,
+//     deduplicated — an agent granted the wrong scopes silently loses tools;
+//   - the **query encoding**, because `AuthCodeURL` builds through
+//     `url.Values.Encode()`, which sorts by key and percent-encodes with Go's
+//     own `url.QueryEscape` (a space is `+`, not `%20`);
+//   - the **auth-code options**, which differ per provider: Google passes
+//     `AccessTypeOffline` and `ApprovalForce` (so a refresh token is issued
+//     every time), Slack passes none at all;
+//   - the **authorization endpoint**, which for Slack is the v2 path.
+//
+// A hand-written Rust literal would pin only what its author believed. Here the
+// URLs are what Go's own `BuildAuthURL` returned, and both languages assert
+// against them: a change to Go's builder fails Go's suite, and a Rust
+// divergence fails Rust's.
+//
+// Regenerate (only from Go, and only when adding cases):
+//
+//	go test ./desktop/parity/ -run TestOAuthVectors -update-oauth-vectors
+package parity
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/shaharia-lab/agento/internal/config"
+	googleintegration "github.com/shaharia-lab/agento/internal/integrations/google"
+	slackintegration "github.com/shaharia-lab/agento/internal/integrations/slack"
+)
+
+const oauthVectorsFile = "oauth_vectors.json"
+
+var updateOAuthVectors = flag.Bool("update-oauth-vectors", false,
+	"rewrite "+oauthVectorsFile+" from what Go's BuildAuthURL produces")
+
+// oauthCase is one integration row, and the URL Go builds for it.
+type oauthCase struct {
+	Name string `json:"name"`
+	// Why this case exists, for a reader of the JSON.
+	Note string `json:"note"`
+	Type string `json:"type"`
+	// The raw `credentials` column, verbatim, so the port exercises its own
+	// decoder rather than a struct the test built.
+	Credentials json.RawMessage `json:"credentials"`
+	// The `services` column. Google reads it for scopes; Slack ignores it.
+	Services map[string]config.ServiceConfig `json:"services"`
+	Port     int                             `json:"port"`
+	AuthURL  string                          `json:"auth_url"`
+}
+
+type oauthVectors struct {
+	Cases []oauthCase `json:"cases"`
+}
+
+// enabled is a service the integration has switched on.
+func enabled() config.ServiceConfig { return config.ServiceConfig{Enabled: true} }
+
+// off is a service present in the row but switched off — the case that
+// separates "reads the map" from "reads the flag".
+func off() config.ServiceConfig { return config.ServiceConfig{Enabled: false} }
+
+func oauthCases() []oauthCase {
+	googleCreds := json.RawMessage(`{"client_id":"cid-123.apps.googleusercontent.com","client_secret":"secret-456"}`)
+	return []oauthCase{
+		{
+			Name:        "google/all-three-services",
+			Note:        "the full scope union, in Scopes's calendar-gmail-drive order",
+			Type:        "google",
+			Credentials: googleCreds,
+			Services: map[string]config.ServiceConfig{
+				"calendar": enabled(), "gmail": enabled(), "drive": enabled(),
+			},
+			Port: 43117,
+		},
+		{
+			Name:        "google/one-service",
+			Note:        "only the enabled service's scopes are requested",
+			Type:        "google",
+			Credentials: googleCreds,
+			Services:    map[string]config.ServiceConfig{"gmail": enabled()},
+			Port:        43117,
+		},
+		{
+			Name: "google/disabled-service-is-not-a-scope",
+			Note: "presence in the map is not enough; Enabled is what counts",
+			Type: "google",
+			Credentials: json.RawMessage(
+				`{"client_id":"cid-123.apps.googleusercontent.com","client_secret":"secret-456"}`),
+			Services: map[string]config.ServiceConfig{"calendar": enabled(), "gmail": off()},
+			Port:     43117,
+		},
+		{
+			Name:        "google/no-services",
+			Note:        "an empty scope set still builds a URL — with scope absent, not empty",
+			Type:        "google",
+			Credentials: googleCreds,
+			Services:    map[string]config.ServiceConfig{},
+			Port:        43117,
+		},
+		{
+			Name: "google/credentials-needing-escapes",
+			Note: "url.Values.Encode is Go's QueryEscape: a space is +, not %20",
+			Type: "google",
+			Credentials: json.RawMessage(
+				`{"client_id":"a b&c=d","client_secret":"s"}`),
+			Services: map[string]config.ServiceConfig{"drive": enabled()},
+			Port:     1,
+		},
+		{
+			Name: "slack/bot-scopes",
+			Note: "the v2 authorize endpoint, and no access-type or approval-prompt",
+			Type: "slack",
+			Credentials: json.RawMessage(
+				`{"client_id":"9876.5432","client_secret":"slack-secret"}`),
+			Services: map[string]config.ServiceConfig{"messaging": enabled()},
+			Port:     43118,
+		},
+		{
+			Name: "slack/services-are-ignored",
+			Note: "Slack's scopes are fixed, so the same URL as above with no services",
+			Type: "slack",
+			Credentials: json.RawMessage(
+				`{"client_id":"9876.5432","client_secret":"slack-secret"}`),
+			Services: map[string]config.ServiceConfig{},
+			Port:     43118,
+		},
+	}
+}
+
+// buildAuthURL is `startProviderCallback`'s dispatch, without the callback
+// server — the URL half is the only part a vector can carry.
+func buildAuthURL(t *testing.T, c oauthCase) string {
+	t.Helper()
+	cfg := &config.IntegrationConfig{
+		ID:          "vec",
+		Type:        c.Type,
+		Credentials: c.Credentials,
+		Services:    c.Services,
+	}
+	var (
+		url string
+		err error
+	)
+	switch c.Type {
+	case "google":
+		url, err = googleintegration.BuildAuthURL(cfg, c.Port)
+	case "slack":
+		url, err = slackintegration.BuildAuthURL(cfg, c.Port)
+	default:
+		t.Fatalf("case %q has type %q, which has no OAuth flow", c.Name, c.Type)
+	}
+	if err != nil {
+		t.Fatalf("case %q: building auth URL: %v", c.Name, err)
+	}
+	return url
+}
+
+func TestOAuthVectors(t *testing.T) {
+	cases := oauthCases()
+	for i := range cases {
+		cases[i].AuthURL = buildAuthURL(t, cases[i])
+	}
+
+	encoded, err := json.MarshalIndent(oauthVectors{Cases: cases}, "", "  ")
+	if err != nil {
+		t.Fatalf("encoding vectors: %v", err)
+	}
+	encoded = append(encoded, '\n')
+
+	if *updateOAuthVectors {
+		if writeErr := os.WriteFile(oauthVectorsFile, encoded, 0o600); writeErr != nil {
+			t.Fatalf("writing %s: %v", oauthVectorsFile, writeErr)
+		}
+		return
+	}
+
+	stored, err := os.ReadFile(oauthVectorsFile)
+	if err != nil {
+		t.Fatalf("reading %s: %v (regenerate with -update-oauth-vectors)", oauthVectorsFile, err)
+	}
+	if string(stored) != string(encoded) {
+		t.Fatalf("%s is stale: Go's BuildAuthURL no longer produces it.\n"+
+			"Regenerate with: go test ./desktop/parity/ -run TestOAuthVectors -update-oauth-vectors",
+			oauthVectorsFile)
+	}
+}
+
+// TestOAuthScopeUnionIsOrderedNotSetLike pins the property the vectors above
+// can only sample: `Scopes` walks calendar, then gmail, then drive, and
+// deduplicates — so the scope *string* is deterministic even though `services`
+// is a Go map with random iteration order.
+//
+// Without this, a port could pass every vector by sorting the scopes and still
+// diverge on a services map the vectors do not contain.
+func TestOAuthScopeUnionIsOrderedNotSetLike(t *testing.T) {
+	all := map[string]config.ServiceConfig{
+		"drive": enabled(), "gmail": enabled(), "calendar": enabled(),
+	}
+	want := []string{
+		"https://www.googleapis.com/auth/calendar",
+		"https://www.googleapis.com/auth/gmail.send",
+		"https://www.googleapis.com/auth/gmail.readonly",
+		"https://www.googleapis.com/auth/drive",
+	}
+	// Repeated because the divergence this guards against is a map order that
+	// happens to agree once.
+	for i := 0; i < 50; i++ {
+		got := googleintegration.Scopes(all)
+		if len(got) != len(want) {
+			t.Fatalf("scope count: got %d, want %d", len(got), len(want))
+		}
+		for j := range want {
+			if got[j] != want[j] {
+				t.Fatalf("scope %d: got %q, want %q", j, got[j], want[j])
+			}
+		}
+	}
+}

--- a/desktop/parity/oauth_vectors.json
+++ b/desktop/parity/oauth_vectors.json
@@ -1,0 +1,125 @@
+{
+  "cases": [
+    {
+      "name": "google/all-three-services",
+      "note": "the full scope union, in Scopes's calendar-gmail-drive order",
+      "type": "google",
+      "credentials": {
+        "client_id": "cid-123.apps.googleusercontent.com",
+        "client_secret": "secret-456"
+      },
+      "services": {
+        "calendar": {
+          "enabled": true,
+          "tools": null
+        },
+        "drive": {
+          "enabled": true,
+          "tools": null
+        },
+        "gmail": {
+          "enabled": true,
+          "tools": null
+        }
+      },
+      "port": 43117,
+      "auth_url": "https://accounts.google.com/o/oauth2/auth?access_type=offline\u0026client_id=cid-123.apps.googleusercontent.com\u0026prompt=consent\u0026redirect_uri=http%3A%2F%2Flocalhost%3A43117%2Fcallback\u0026response_type=code\u0026scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcalendar+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fgmail.send+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fgmail.readonly+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdrive\u0026state=state"
+    },
+    {
+      "name": "google/one-service",
+      "note": "only the enabled service's scopes are requested",
+      "type": "google",
+      "credentials": {
+        "client_id": "cid-123.apps.googleusercontent.com",
+        "client_secret": "secret-456"
+      },
+      "services": {
+        "gmail": {
+          "enabled": true,
+          "tools": null
+        }
+      },
+      "port": 43117,
+      "auth_url": "https://accounts.google.com/o/oauth2/auth?access_type=offline\u0026client_id=cid-123.apps.googleusercontent.com\u0026prompt=consent\u0026redirect_uri=http%3A%2F%2Flocalhost%3A43117%2Fcallback\u0026response_type=code\u0026scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fgmail.send+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fgmail.readonly\u0026state=state"
+    },
+    {
+      "name": "google/disabled-service-is-not-a-scope",
+      "note": "presence in the map is not enough; Enabled is what counts",
+      "type": "google",
+      "credentials": {
+        "client_id": "cid-123.apps.googleusercontent.com",
+        "client_secret": "secret-456"
+      },
+      "services": {
+        "calendar": {
+          "enabled": true,
+          "tools": null
+        },
+        "gmail": {
+          "enabled": false,
+          "tools": null
+        }
+      },
+      "port": 43117,
+      "auth_url": "https://accounts.google.com/o/oauth2/auth?access_type=offline\u0026client_id=cid-123.apps.googleusercontent.com\u0026prompt=consent\u0026redirect_uri=http%3A%2F%2Flocalhost%3A43117%2Fcallback\u0026response_type=code\u0026scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcalendar\u0026state=state"
+    },
+    {
+      "name": "google/no-services",
+      "note": "an empty scope set still builds a URL — with scope absent, not empty",
+      "type": "google",
+      "credentials": {
+        "client_id": "cid-123.apps.googleusercontent.com",
+        "client_secret": "secret-456"
+      },
+      "services": {},
+      "port": 43117,
+      "auth_url": "https://accounts.google.com/o/oauth2/auth?access_type=offline\u0026client_id=cid-123.apps.googleusercontent.com\u0026prompt=consent\u0026redirect_uri=http%3A%2F%2Flocalhost%3A43117%2Fcallback\u0026response_type=code\u0026state=state"
+    },
+    {
+      "name": "google/credentials-needing-escapes",
+      "note": "url.Values.Encode is Go's QueryEscape: a space is +, not %20",
+      "type": "google",
+      "credentials": {
+        "client_id": "a b\u0026c=d",
+        "client_secret": "s"
+      },
+      "services": {
+        "drive": {
+          "enabled": true,
+          "tools": null
+        }
+      },
+      "port": 1,
+      "auth_url": "https://accounts.google.com/o/oauth2/auth?access_type=offline\u0026client_id=a+b%26c%3Dd\u0026prompt=consent\u0026redirect_uri=http%3A%2F%2Flocalhost%3A1%2Fcallback\u0026response_type=code\u0026scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdrive\u0026state=state"
+    },
+    {
+      "name": "slack/bot-scopes",
+      "note": "the v2 authorize endpoint, and no access-type or approval-prompt",
+      "type": "slack",
+      "credentials": {
+        "client_id": "9876.5432",
+        "client_secret": "slack-secret"
+      },
+      "services": {
+        "messaging": {
+          "enabled": true,
+          "tools": null
+        }
+      },
+      "port": 43118,
+      "auth_url": "https://slack.com/oauth/v2/authorize?client_id=9876.5432\u0026redirect_uri=http%3A%2F%2Flocalhost%3A43118%2Fcallback\u0026response_type=code\u0026scope=channels%3Aread+channels%3Ahistory+chat%3Awrite+users%3Aread+search%3Aread+groups%3Aread+groups%3Ahistory\u0026state=state"
+    },
+    {
+      "name": "slack/services-are-ignored",
+      "note": "Slack's scopes are fixed, so the same URL as above with no services",
+      "type": "slack",
+      "credentials": {
+        "client_id": "9876.5432",
+        "client_secret": "slack-secret"
+      },
+      "services": {},
+      "port": 43118,
+      "auth_url": "https://slack.com/oauth/v2/authorize?client_id=9876.5432\u0026redirect_uri=http%3A%2F%2Flocalhost%3A43118%2Fcallback\u0026response_type=code\u0026scope=channels%3Aread+channels%3Ahistory+chat%3Awrite+users%3Aread+search%3Aread+groups%3Aread+groups%3Ahistory\u0026state=state"
+    }
+  ]
+}

--- a/desktop/parity/write_routes.json
+++ b/desktop/parity/write_routes.json
@@ -187,16 +187,16 @@
     {
       "method": "POST",
       "route": "/api/integrations/{id}/auth/start",
-      "status": "deferred",
-      "owner": "-",
-      "reason": "mints an OAuth URL and holds the in-flight flow in memory"
+      "status": "native",
+      "owner": "#318",
+      "reason": "the shell owns the callback server and the in-flight flow"
     },
     {
       "method": "POST",
       "route": "/api/integrations/{id}/auth/validate",
       "status": "deferred",
       "owner": "-",
-      "reason": "dials the remote service; the error text is not reproducible"
+      "reason": "five per-type remote validations, each writing its own auth payload"
     },
     {
       "method": "POST",

--- a/desktop/parity/write_routes_parity_test.go
+++ b/desktop/parity/write_routes_parity_test.go
@@ -168,8 +168,19 @@ var dispositions = map[string]disposition{
 	"POST /api/tasks/{id}/resume": {statusNative, "#275", "re-registers the cron entry"},
 
 	// ── Deferred: it talks to somebody else's server ────────────────────────
-	"POST /api/integrations/{id}/auth/start":                {statusDeferred, "-", "mints an OAuth URL and holds the in-flight flow in memory"},
-	"POST /api/integrations/{id}/auth/validate":             {statusDeferred, "-", "dials the remote service; the error text is not reproducible"},
+	// #318 moved the flow itself: the shell binds the loopback callback
+	// server, exchanges the code and writes the token, so the in-flight map is
+	// its own. `auth/status` reads that same map, which is why the two could
+	// never be split.
+	"POST /api/integrations/{id}/auth/start": {statusNative, "#318", "the shell owns the callback server and the in-flight flow"},
+	// Still deferred, but not for the reason recorded until #318. The error
+	// text *is* largely reproducible — every validator's transport failure is a
+	// fixed string, as the ported clients' are, and the rest interpolates the
+	// provider's own response. What actually holds it back is that each of the
+	// five writes a **type-specific** auth payload its MCP server reads
+	// (`{"validated":true,"bot_username":…}` for Telegram, not a shared flag),
+	// so this is five remote-call reproductions rather than one.
+	"POST /api/integrations/{id}/auth/validate": {statusDeferred, "-", "five per-type remote validations, each writing its own auth payload"},
 	"POST /api/integrations/{id}/webhook/register":          {statusDeferred, "-", "registers the webhook with Telegram"},
 	"DELETE /api/integrations/{id}/webhook/register":        {statusDeferred, "-", "deregisters the webhook with Telegram"},
 	"POST /api/integrations/{id}/webhook/regenerate-secret": {statusDeferred, "-", "rotates the secret and re-registers with Telegram"},

--- a/desktop/parity/write_routes_parity_test.go
+++ b/desktop/parity/write_routes_parity_test.go
@@ -180,7 +180,7 @@ var dispositions = map[string]disposition{
 	// five writes a **type-specific** auth payload its MCP server reads
 	// (`{"validated":true,"bot_username":…}` for Telegram, not a shared flag),
 	// so this is five remote-call reproductions rather than one.
-	"POST /api/integrations/{id}/auth/validate": {statusDeferred, "-", "five per-type remote validations, each writing its own auth payload"},
+	"POST /api/integrations/{id}/auth/validate":             {statusDeferred, "-", "five per-type remote validations, each writing its own auth payload"},
 	"POST /api/integrations/{id}/webhook/register":          {statusDeferred, "-", "registers the webhook with Telegram"},
 	"DELETE /api/integrations/{id}/webhook/register":        {statusDeferred, "-", "deregisters the webhook with Telegram"},
 	"POST /api/integrations/{id}/webhook/regenerate-secret": {statusDeferred, "-", "rotates the secret and re-registers with Telegram"},

--- a/desktop/src-tauri/src/native/integrations.rs
+++ b/desktop/src-tauri/src/native/integrations.rs
@@ -147,6 +147,7 @@ pub mod telegram;
 /// *this* module — the column is never selected here and `auth` is a boolean
 /// before it leaves SQLite — and it stays literally true with the secrets
 /// projection living next door, where nothing that builds a response can see it.
+pub mod oauth;
 pub mod registry;
 
 use std::collections::BTreeMap;

--- a/desktop/src-tauri/src/native/integrations.rs
+++ b/desktop/src-tauri/src/native/integrations.rs
@@ -407,6 +407,28 @@ fn trigger_rule_by_id(
     .optional()
 }
 
+// ─── OAuth (#318) ─────────────────────────────────────────────────────────────
+
+/// `map[string]bool{"authenticated": …}` — one key, so nothing to sort.
+#[derive(Serialize)]
+struct AuthStatusResponse {
+    authenticated: bool,
+}
+
+/// `map[string]string{"auth_url": …}`.
+#[derive(Serialize)]
+struct AuthStartResponse {
+    auth_url: String,
+}
+
+/// `handleStartOAuth`.
+fn start_oauth(db_path: &Path, id: &str) -> Result<super::Answer, WriteError> {
+    let auth_url = oauth::flow::start(db_path, id)?;
+    let body = super::gojson::to_vec(&AuthStartResponse { auth_url })
+        .map_err(|e| WriteError::Fallback(format!("encoding auth start: {e}")))?;
+    Ok(super::Answer::json(body))
+}
+
 // ─── The seam ─────────────────────────────────────────────────────────────────
 
 /// This module's entry in `native::ENDPOINTS`.
@@ -423,6 +445,10 @@ enum Route<'a> {
     Triggers(&'a str),
     /// `{id}/triggers/{rid}` — the rule routes that take a rule id.
     Trigger(&'a str, &'a str),
+    /// `{id}/auth/start` — begins an OAuth flow and answers its URL (#318).
+    AuthStart(&'a str),
+    /// `{id}/auth/status` — polls the in-flight flow, or the stored token.
+    AuthStatus(&'a str),
 }
 
 /// Match the reads, plus the write routes that share their paths.
@@ -441,6 +467,12 @@ fn route_of(path: &str) -> Option<Route<'_>> {
     }
     if let Some(id) = rest.strip_suffix("/triggers") {
         return segment(id).map(Route::Triggers);
+    }
+    if let Some(id) = rest.strip_suffix("/auth/start") {
+        return segment(id).map(Route::AuthStart);
+    }
+    if let Some(id) = rest.strip_suffix("/auth/status") {
+        return segment(id).map(Route::AuthStatus);
     }
     if let Some((id, tail)) = rest.split_once("/triggers/") {
         return match (segment(id), segment(tail)) {
@@ -499,12 +531,14 @@ fn segment(value: &str) -> Option<&str> {
 /// set up in: create, `PUT` and `auth/validate` all leave it unauthenticated or
 /// unheard, and it appears only at the next boot's `start_all`.
 ///
-/// The fifth is `completeOAuth`, which this hook does **not** cover and which is
-/// not safe by the gate either — `startProviderCallback` supports `google` and
-/// `slack`, and `slack` has been hosted here since #315. Its token never crosses
-/// this proxy at all (the browser delivers it to a callback server the sidecar
-/// opens), so it is picked up from the *other* route below instead. See
-/// `registry::reload_if_secrets_changed`.
+/// The fifth is `completeOAuth`, whose token used to reach neither this proxy
+/// nor this process: the browser delivered it to a callback server the
+/// **sidecar** opened. #318 moved that server here, so the shell now writes the
+/// token itself and reloads directly from `oauth::flow` — which is why the
+/// `AuthStatusPolled` trigger this function used to return is **gone** rather
+/// than kept beside the real thing. Watching the UI poll `auth/status` and
+/// reloading when the row stopped matching what was running was an inference
+/// standing in for an event the shell could not see; it can see it now.
 ///
 /// The route predicate below is deliberately **type-blind**: it answers with the
 /// id for every integration, and `registry::reload_after_auth` reads the row's
@@ -516,30 +550,16 @@ fn segment(value: &str) -> Option<&str> {
 /// restarted. Go fires its own from a goroutine (`reloadIntegration`), so doing
 /// it off the response path is parity rather than a shortcut.
 ///
-/// # Two routes, two triggers
+/// # What is left
 ///
-/// `POST …/auth/validate` is an **event**: a credential was just written, so the
-/// reload is unconditional, exactly as Go's is.
-///
-/// `GET …/auth/status` is a **poll**, added by #315. Go's `handleOAuthToken`
-/// reloads after an OAuth token lands, and `startProviderCallback` supports
-/// `google` and `slack` — so the moment `slack` became a hosted type, that
-/// reload started reaching nothing. The token itself never comes through this
-/// proxy (the browser delivers it to a callback server the *sidecar* opens), so
-/// the UI's polling of this route is the only part of the flow the shell can
-/// see. Being a poll, it must not fire an unconditional reload — see
-/// `registry::reload_if_secrets_changed`, which reloads only when the row stops
-/// matching what is running.
+/// One route: `POST …/auth/validate`, an **event** — a credential was just
+/// written, so the reload is unconditional, exactly as Go's is. It stays here
+/// because that route is still forwarded; see `claims`.
 pub fn reload_after_forward<'a>(method: &Method, path: &'a str) -> Option<(&'a str, Trigger)> {
     let rest = path.strip_prefix("/api/integrations/")?;
     if method == Method::POST {
         if let Some(id) = rest.strip_suffix("/auth/validate") {
             return segment(id).map(|id| (id, Trigger::CredentialWritten));
-        }
-    }
-    if method == Method::GET {
-        if let Some(id) = rest.strip_suffix("/auth/status") {
-            return segment(id).map(|id| (id, Trigger::AuthStatusPolled));
         }
     }
     None
@@ -551,8 +571,6 @@ pub enum Trigger {
     /// A credential was written by a forwarded request. Reload unconditionally,
     /// as Go does.
     CredentialWritten,
-    /// The UI polled an in-flight OAuth flow. Reload only if something changed.
-    AuthStatusPolled,
 }
 
 fn claims(method: &Method, path: &str) -> bool {
@@ -564,6 +582,23 @@ fn claims(method: &Method, path: &str) -> bool {
         }
         Some(Route::Triggers(_)) => method == Method::GET || method == Method::POST,
         Some(Route::Trigger(..)) => method == Method::PUT || method == Method::DELETE,
+        // #318 moved the OAuth **flow**: `start` and `status` share the
+        // in-flight map, so splitting them across two processes leaves `status`
+        // polling a map that is never populated. That pair is the part #300
+        // could not split and the reason it deferred all three.
+        //
+        // `POST …/auth/validate` is **deliberately still forwarded**. It was
+        // grouped with them for a second reason that has since expired — the
+        // credentials it writes were read by *Go's* MCP servers, and #311–#313
+        // moved all six here — and it never touches `oauthFlows` at all. What
+        // it does do is dial five different services and write a
+        // **type-specific** auth payload each one's MCP server reads
+        // (`{"validated":true,"bot_username":…}` for Telegram, not a shared
+        // flag). Five remote-call reproductions belong in their own change.
+        // `reload_after_forward`'s `CredentialWritten` trigger keeps covering
+        // its reload meanwhile.
+        Some(Route::AuthStart(_)) => method == Method::POST,
+        Some(Route::AuthStatus(_)) => method == Method::GET,
         None => false,
     }
 }
@@ -580,6 +615,7 @@ fn serve(ctx: &super::Ctx, req: &super::Request) -> Result<super::Answer, String
                 finish(update_trigger_rule(db, id, rid, req.body))
             }
             Some(Route::Trigger(id, rid)) => finish(delete_trigger_rule(db, id, rid)),
+            Some(Route::AuthStart(id)) => finish(start_oauth(db, id)),
             _ => Err(format!(
                 "{} {} is not an integration write",
                 req.method, req.path
@@ -605,9 +641,26 @@ fn serve(ctx: &super::Ctx, req: &super::Request) -> Result<super::Answer, String
         Some(Route::Triggers(id)) => super::gojson::to_vec(&list_trigger_rules(db, id)?)
             .map_err(|e| format!("encoding trigger rules: {e}"))?,
 
+        Some(Route::AuthStatus(id)) => {
+            let authenticated = match oauth::flow::status(db, id) {
+                Ok(authenticated) => authenticated,
+                // A read, so the seam wants a `Result<_, String>`; `finish`
+                // is the write path's shape. `Internal` and the typed errors
+                // answer natively, and only `Fallback` forwards.
+                Err(WriteError::Fallback(reason)) => return Err(reason),
+                Err(e) => {
+                    let body = super::gojson::to_vec(&super::writes::error_body(&e.message()))
+                        .map_err(|enc| format!("encoding error body: {enc}"))?;
+                    return Ok(super::Answer::json_status(e.status(), body));
+                }
+            };
+            super::gojson::to_vec(&AuthStatusResponse { authenticated })
+                .map_err(|e| format!("encoding auth status: {e}"))?
+        }
+
         // `claims` never admits a GET here — chi has no such route, so Go 405s
         // and forwarding is what reproduces that.
-        Some(Route::Trigger(..)) | None => {
+        Some(Route::AuthStart(_)) | Some(Route::Trigger(..)) | None => {
             return Err(format!("{} is not an integration read", req.path))
         }
     };
@@ -1547,8 +1600,23 @@ mod tests {
         assert!(!claims(&Method::POST, "/api/integrations/abc/triggers/r1"));
         assert!(!claims(&Method::PUT, "/api/integrations/abc/triggers/r1/x"));
 
+        // #318: the OAuth flow is the shell's, so its two routes are claimed.
+        assert!(claims(&Method::GET, "/api/integrations/abc/auth/status"));
+        assert!(claims(&Method::POST, "/api/integrations/abc/auth/start"));
+        // …and only for their own methods.
+        assert!(!claims(&Method::POST, "/api/integrations/abc/auth/status"));
+        assert!(!claims(&Method::GET, "/api/integrations/abc/auth/start"));
+        // An id is one segment on both.
+        assert!(!claims(&Method::GET, "/api/integrations//auth/status"));
+        assert!(!claims(&Method::POST, "/api/integrations/a/b/auth/start"));
+        // `validate` is still forwarded — five remote-call reproductions, and
+        // it never touched the flow map. See `claims`.
+        assert!(!claims(
+            &Method::POST,
+            "/api/integrations/abc/auth/validate"
+        ));
+
         // Reads that stay with Go, each for its own reason — see the header.
-        assert!(!claims(&Method::GET, "/api/integrations/abc/auth/status"));
         assert!(!claims(
             &Method::GET,
             "/api/integrations/abc/webhook/status"
@@ -2082,17 +2150,22 @@ mod tests {
         );
     }
 
-    /// The two routes the seam owes something after Go has answered them — one
-    /// an event (#311) and one a poll (#315).
+    /// The one route the seam still owes something after Go has answered it.
+    ///
+    /// It was two until #318: `GET …/auth/status` used to trigger a
+    /// reload-if-changed, because the shell could not see an OAuth token land
+    /// in a callback server the sidecar owned. It owns that server now, so the
+    /// poll is no longer evidence of anything and the trigger is gone.
     #[test]
-    fn only_the_two_auth_routes_ask_the_shell_to_look_again() {
+    fn only_the_validate_route_asks_the_shell_to_look_again() {
         assert_eq!(
             reload_after_forward(&Method::POST, "/api/integrations/int-1/auth/validate"),
             Some(("int-1", Trigger::CredentialWritten))
         );
         assert_eq!(
             reload_after_forward(&Method::GET, "/api/integrations/int-1/auth/status"),
-            Some(("int-1", Trigger::AuthStatusPolled))
+            None,
+            "the shell answers this route itself now"
         );
         // The method matters on both, and neither admits an empty or
         // multi-segment id.

--- a/desktop/src-tauri/src/native/integrations/oauth/exchange.rs
+++ b/desktop/src-tauri/src/native/integrations/oauth/exchange.rs
@@ -1,0 +1,531 @@
+//! Trading an authorization code for a token, and storing it the way Go stores
+//! it. Mirrors `oauth2.Config.Exchange` and `IntegrationConfig.SetOAuthToken`.
+//!
+//! # This is the half with no live diff and no vector
+//!
+//! The authorization URL can be pinned against Go (`super`'s vectors) because it
+//! is a pure function. The exchange is a **network call to the provider**, so
+//! neither a golden file nor the live parity suite can reach it — and a mistake
+//! here is not a wrong byte in a response, it is an integration that silently
+//! never authenticates. So the request shape is pinned instead, against a fake
+//! token endpoint that records what it was sent: the same technique
+//! `tests/chat_turn.rs` uses for the CLI.
+//!
+//! # The two provider differences that are invisible until they fail
+//!
+//! `oauth2` decides where the client credentials go from the endpoint's
+//! `AuthStyle`, and the two providers here disagree:
+//!
+//! - **Google** declares `AuthStyleInParams`, so `client_id` and
+//!   `client_secret` are form fields in the body and there is no
+//!   `Authorization` header.
+//! - **Slack** declares no style at all, which is `AuthStyleAutoDetect`: the
+//!   library tries **`AuthStyleInHeader` first** — HTTP Basic, with the id and
+//!   secret URL-encoded per RFC 6749 §2.3.1 — and only retries in the body if
+//!   that attempt fails. Reproducing "params first" would work against a server
+//!   that accepts both and fail against one that does not, which is exactly the
+//!   kind of difference that shows up as "OAuth works in the web app but not the
+//!   desktop one".
+//!
+//! # The stored shape is Go's `json.Marshal(*oauth2.Token)`
+//!
+//! `integrations.auth` is read by the integration MCP servers — including the
+//! sidecar's, since `StartFilteredServer` is ungated and serves agent runs Go
+//! answers. So the column has to hold what Go would have written:
+//!
+//! - `access_token` always;
+//! - `token_type`, `refresh_token`, `expires_in` with `omitempty`;
+//! - **`expiry` always**, because `omitempty` does not omit a struct — a zero
+//!   `time.Time` marshals as `"0001-01-01T00:00:00Z"` rather than disappearing.
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+/// Where a provider's token endpoint wants the client credentials.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthStyle {
+    /// `oauth2.AuthStyleInParams` — form fields in the body.
+    InParams,
+    /// `oauth2.AuthStyleInHeader` — HTTP Basic.
+    InHeader,
+    /// `oauth2.AuthStyleAutoDetect`: header first, then params on failure.
+    AutoDetect,
+}
+
+/// One provider's token endpoint.
+#[derive(Debug, Clone)]
+pub struct TokenEndpoint {
+    pub url: String,
+    pub style: AuthStyle,
+}
+
+impl TokenEndpoint {
+    /// `googleoauth.Endpoint`.
+    pub fn google() -> Self {
+        Self {
+            url: "https://oauth2.googleapis.com/token".to_string(),
+            style: AuthStyle::InParams,
+        }
+    }
+
+    /// Slack's v2 access endpoint, which declares no `AuthStyle`.
+    pub fn slack() -> Self {
+        Self {
+            url: "https://slack.com/api/oauth.v2.access".to_string(),
+            style: AuthStyle::AutoDetect,
+        }
+    }
+}
+
+/// `oauth2.Token`, in the field order Go declares — which is the order
+/// `encoding/json` writes them and therefore the order stored in the column.
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+pub struct StoredToken {
+    pub access_token: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub token_type: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub refresh_token: String,
+    /// Always serialized: `omitempty` does not omit a `time.Time`, so Go writes
+    /// `"0001-01-01T00:00:00Z"` for a token with no expiry rather than dropping
+    /// the key.
+    pub expiry: String,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub expires_in: i64,
+}
+
+fn is_zero(v: &i64) -> bool {
+    *v == 0
+}
+
+/// Go's zero `time.Time` as `encoding/json` renders it.
+pub const ZERO_TIME: &str = "0001-01-01T00:00:00Z";
+
+/// What a token endpoint answered, before it becomes a [`StoredToken`].
+#[derive(Debug, Default, serde::Deserialize)]
+struct TokenResponse {
+    #[serde(default)]
+    access_token: String,
+    #[serde(default)]
+    token_type: String,
+    #[serde(default)]
+    refresh_token: String,
+    /// Seconds. `0` means the provider sent none, which is a token that never
+    /// expires — Go leaves `Expiry` at its zero value in that case.
+    #[serde(default)]
+    expires_in: i64,
+}
+
+/// `oauth2.Config.Exchange`.
+///
+/// `now` is a parameter because `Expiry` is `now + expires_in` and a test that
+/// could not fix the clock could only assert that a timestamp was *some* value.
+pub async fn exchange(
+    client: &reqwest::Client,
+    endpoint: &TokenEndpoint,
+    client_id: &str,
+    client_secret: &str,
+    code: &str,
+    redirect_uri: &str,
+    now: std::time::SystemTime,
+) -> Result<StoredToken, String> {
+    let attempts: &[AuthStyle] = match endpoint.style {
+        AuthStyle::InParams => &[AuthStyle::InParams],
+        AuthStyle::InHeader => &[AuthStyle::InHeader],
+        // "the first way we'll try", then "the second way we'll try".
+        AuthStyle::AutoDetect => &[AuthStyle::InHeader, AuthStyle::InParams],
+    };
+
+    let mut last: Option<String> = None;
+    for style in attempts {
+        match post_token(
+            client,
+            endpoint,
+            *style,
+            client_id,
+            client_secret,
+            code,
+            redirect_uri,
+        )
+        .await
+        {
+            Ok(response) => return Ok(store(response, now)),
+            Err(e) => last = Some(e),
+        }
+    }
+    Err(last.unwrap_or_else(|| "exchanging code: no attempt was made".to_string()))
+}
+
+async fn post_token(
+    client: &reqwest::Client,
+    endpoint: &TokenEndpoint,
+    style: AuthStyle,
+    client_id: &str,
+    client_secret: &str,
+    code: &str,
+    redirect_uri: &str,
+) -> Result<TokenResponse, String> {
+    // `BTreeMap` so the body is deterministic; `url.Values.Encode` sorts too,
+    // which is what the fake endpoint's assertions rely on.
+    let mut form: BTreeMap<&str, &str> = BTreeMap::new();
+    form.insert("grant_type", "authorization_code");
+    form.insert("code", code);
+    form.insert("redirect_uri", redirect_uri);
+
+    let mut request = client.post(&endpoint.url);
+    match style {
+        AuthStyle::InParams | AuthStyle::AutoDetect => {
+            form.insert("client_id", client_id);
+            form.insert("client_secret", client_secret);
+        }
+        AuthStyle::InHeader => {
+            // RFC 6749 §2.3.1: both halves are URL-encoded *before* base64, and
+            // `oauth2` does exactly that rather than passing them raw.
+            request = request.basic_auth(
+                crate::native::gourl::query_escape(client_id),
+                Some(crate::native::gourl::query_escape(client_secret)),
+            );
+        }
+    }
+
+    let response = request
+        .form(&form)
+        .send()
+        .await
+        // The cause is deliberately not interpolated, matching every other
+        // ported client: the message describes the request.
+        .map_err(|_| "exchanging code: request failed".to_string())?;
+
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .map_err(|_| "exchanging code: reading response failed".to_string())?;
+    if !status.is_success() {
+        return Err(format!(
+            "exchanging code: server response: {} {}",
+            status.as_u16(),
+            body.trim()
+        ));
+    }
+
+    let decoded: TokenResponse = serde_json::from_str(&body)
+        .map_err(|e| format!("exchanging code: parsing token response: {e}"))?;
+    if decoded.access_token.is_empty() {
+        // `oauth2` raises this rather than returning an empty token, and the
+        // difference matters: an empty token stored would read as authenticated.
+        return Err("exchanging code: server response missing access_token".to_string());
+    }
+    Ok(decoded)
+}
+
+/// `tokenFromInternal` plus `Token.Expiry = now + expires_in`.
+fn store(response: TokenResponse, now: std::time::SystemTime) -> StoredToken {
+    let expiry = if response.expires_in > 0 {
+        let at = now + std::time::Duration::from_secs(response.expires_in as u64);
+        let at: chrono::DateTime<chrono::Utc> = at.into();
+        // `time.Time` marshals as RFC 3339 with a variable-length fraction; the
+        // exchange sets a whole-second expiry, so there is never one here.
+        crate::native::gotime::GoTime::from_utc(at).to_rfc3339_nano()
+    } else {
+        ZERO_TIME.to_string()
+    };
+    StoredToken {
+        access_token: response.access_token,
+        token_type: response.token_type,
+        refresh_token: response.refresh_token,
+        expiry,
+        expires_in: response.expires_in,
+    }
+}
+
+/// The `auth` column's bytes, as `SetOAuthToken` writes them.
+pub fn encode(token: &StoredToken) -> Result<String, String> {
+    let bytes = crate::native::gojson::to_vec_marshal(token)
+        .map_err(|e| format!("marshaling oauth token: {e}"))?;
+    String::from_utf8(bytes).map_err(|e| format!("marshaling oauth token: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_stored_shape_is_gos_marshalled_token() {
+        let full = StoredToken {
+            access_token: "at".into(),
+            token_type: "Bearer".into(),
+            refresh_token: "rt".into(),
+            expiry: "2026-08-18T10:00:00Z".into(),
+            expires_in: 3599,
+        };
+        assert_eq!(
+            encode(&full).expect("encode"),
+            r#"{"access_token":"at","token_type":"Bearer","refresh_token":"rt","expiry":"2026-08-18T10:00:00Z","expires_in":3599}"#,
+            "field order is the Go struct's declaration order"
+        );
+
+        // A Slack token: no refresh, no expiry. `expiry` survives as the zero
+        // time because `omitempty` does not omit a struct — getting this wrong
+        // drops a key Go always writes.
+        let bare = StoredToken {
+            access_token: "xoxb-1".into(),
+            token_type: "bot".into(),
+            expiry: ZERO_TIME.into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            encode(&bare).expect("encode"),
+            r#"{"access_token":"xoxb-1","token_type":"bot","expiry":"0001-01-01T00:00:00Z"}"#
+        );
+    }
+
+    #[test]
+    fn an_expiry_is_now_plus_expires_in_and_absent_when_the_provider_sends_none() {
+        // 1_800_000_000 is 2027-01-15T08:00:00Z.
+        let now = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_800_000_000);
+        let with = store(
+            TokenResponse {
+                access_token: "at".into(),
+                expires_in: 3600,
+                ..Default::default()
+            },
+            now,
+        );
+        assert_eq!(with.expiry, "2027-01-15T09:00:00Z", "now + expires_in");
+        assert_eq!(with.expires_in, 3600);
+
+        let without = store(
+            TokenResponse {
+                access_token: "at".into(),
+                ..Default::default()
+            },
+            now,
+        );
+        assert_eq!(
+            without.expiry, ZERO_TIME,
+            "no expires_in is a token that never expires, not one expiring now"
+        );
+        assert_eq!(without.expires_in, 0, "…and the field is then omitted");
+    }
+}
+
+#[cfg(test)]
+mod tests_wire {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    /// What the fake token endpoint was sent.
+    #[derive(Debug, Clone, Default)]
+    struct Seen {
+        authorization: Option<String>,
+        content_type: Option<String>,
+        body: String,
+    }
+
+    /// The fake's state: what it has been sent, and what it has left to answer.
+    type FakeState = (Arc<Mutex<Vec<Seen>>>, Arc<Mutex<Vec<(u16, String)>>>);
+
+    /// A token endpoint that records each request and answers what it is told
+    /// to. Returns its base URL and the log.
+    ///
+    /// This is the only way to verify the exchange: it is a call to a provider,
+    /// so there is neither a golden file nor a live diff, and the failure mode
+    /// is not a wrong byte but an integration that never authenticates.
+    async fn fake_endpoint(replies: Vec<(u16, String)>) -> (String, Arc<Mutex<Vec<Seen>>>) {
+        use axum::extract::State;
+        use axum::routing::post;
+
+        let seen: Arc<Mutex<Vec<Seen>>> = Arc::new(Mutex::new(Vec::new()));
+        let replies = Arc::new(Mutex::new(replies.into_iter().collect::<Vec<_>>()));
+
+        let state = (Arc::clone(&seen), Arc::clone(&replies));
+        let app = axum::Router::new()
+            .route(
+                "/token",
+                post(
+                    |State((seen, replies)): State<FakeState>,
+                     headers: axum::http::HeaderMap,
+                     body: String| async move {
+                        let header = |name: &str| {
+                            headers
+                                .get(name)
+                                .and_then(|v| v.to_str().ok())
+                                .map(|s| s.to_string())
+                        };
+                        seen.lock().expect("lock").push(Seen {
+                            authorization: header("authorization"),
+                            content_type: header("content-type"),
+                            body,
+                        });
+                        let mut replies = replies.lock().expect("lock");
+                        let (status, payload) = if replies.is_empty() {
+                            (200, "{}".to_string())
+                        } else {
+                            replies.remove(0)
+                        };
+                        (
+                            axum::http::StatusCode::from_u16(status).expect("status"),
+                            payload,
+                        )
+                    },
+                ),
+            )
+            .with_state(state);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        (format!("http://{addr}/token"), seen)
+    }
+
+    fn form_pairs(body: &str) -> BTreeMap<String, String> {
+        form_urlencoded::parse(body.as_bytes())
+            .map(|(k, v)| (k.into_owned(), v.into_owned()))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn google_sends_its_credentials_in_the_body_and_no_authorization_header() {
+        let (url, seen) = fake_endpoint(vec![(
+            200,
+            r#"{"access_token":"ya29.a0","token_type":"Bearer","refresh_token":"1//rt","expires_in":3599}"#
+                .to_string(),
+        )])
+        .await;
+
+        let token = exchange(
+            &reqwest::Client::new(),
+            &TokenEndpoint {
+                url,
+                style: AuthStyle::InParams,
+            },
+            "cid",
+            "secret",
+            "the-code",
+            "http://localhost:4321/callback",
+            std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_800_000_000),
+        )
+        .await
+        .expect("exchange");
+
+        assert_eq!(token.access_token, "ya29.a0");
+        assert_eq!(token.refresh_token, "1//rt");
+        assert_eq!(token.expiry, "2027-01-15T08:59:59Z");
+
+        let seen = seen.lock().expect("lock");
+        assert_eq!(seen.len(), 1, "AuthStyleInParams makes exactly one attempt");
+        assert!(
+            seen[0].authorization.is_none(),
+            "credentials belong in the body for Google, not in a header"
+        );
+        assert_eq!(
+            seen[0].content_type.as_deref(),
+            Some("application/x-www-form-urlencoded")
+        );
+        let form = form_pairs(&seen[0].body);
+        assert_eq!(
+            form.get("grant_type").map(String::as_str),
+            Some("authorization_code")
+        );
+        assert_eq!(form.get("code").map(String::as_str), Some("the-code"));
+        assert_eq!(
+            form.get("redirect_uri").map(String::as_str),
+            Some("http://localhost:4321/callback"),
+            "the provider checks this against what the auth URL declared"
+        );
+        assert_eq!(form.get("client_id").map(String::as_str), Some("cid"));
+        assert_eq!(
+            form.get("client_secret").map(String::as_str),
+            Some("secret")
+        );
+    }
+
+    #[tokio::test]
+    async fn slack_tries_basic_auth_first_and_falls_back_to_the_body() {
+        // The first attempt is refused, exactly as a server that only accepts
+        // params would refuse it.
+        let (url, seen) = fake_endpoint(vec![
+            (401, r#"{"error":"invalid_client"}"#.to_string()),
+            (
+                200,
+                r#"{"access_token":"xoxb-1","token_type":"bot"}"#.to_string(),
+            ),
+        ])
+        .await;
+
+        let token = exchange(
+            &reqwest::Client::new(),
+            &TokenEndpoint {
+                url,
+                style: AuthStyle::AutoDetect,
+            },
+            "9876.5432",
+            "slack-secret",
+            "code",
+            "http://localhost:4321/callback",
+            std::time::UNIX_EPOCH,
+        )
+        .await
+        .expect("the retry succeeds");
+
+        assert_eq!(token.access_token, "xoxb-1");
+        assert_eq!(
+            token.expiry, ZERO_TIME,
+            "a Slack v2 token does not expire, so Go stores the zero time"
+        );
+
+        let seen = seen.lock().expect("lock");
+        assert_eq!(seen.len(), 2, "auto-detect makes two attempts");
+        assert!(
+            seen[0]
+                .authorization
+                .as_deref()
+                .is_some_and(|v| v.starts_with("Basic ")),
+            "the *first* attempt is Basic, which is oauth2's order: {:?}",
+            seen[0].authorization
+        );
+        assert!(
+            !form_pairs(&seen[0].body).contains_key("client_secret"),
+            "…and it does not also put the secret in the body"
+        );
+        assert!(
+            seen[1].authorization.is_none(),
+            "the retry moves the credentials into the body"
+        );
+        assert_eq!(
+            form_pairs(&seen[1].body)
+                .get("client_secret")
+                .map(String::as_str),
+            Some("slack-secret")
+        );
+    }
+
+    #[tokio::test]
+    async fn a_response_with_no_access_token_is_an_error_rather_than_an_empty_token() {
+        // An empty token stored would read as authenticated by
+        // `IsAuthenticated`, which only checks that `auth` is non-empty.
+        let (url, _seen) =
+            fake_endpoint(vec![(200, r#"{"token_type":"Bearer"}"#.to_string())]).await;
+        let err = exchange(
+            &reqwest::Client::new(),
+            &TokenEndpoint {
+                url,
+                style: AuthStyle::InParams,
+            },
+            "cid",
+            "secret",
+            "code",
+            "http://localhost:4321/callback",
+            std::time::UNIX_EPOCH,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("missing access_token"), "{err}");
+    }
+}

--- a/desktop/src-tauri/src/native/integrations/oauth/flow.rs
+++ b/desktop/src-tauri/src/native/integrations/oauth/flow.rs
@@ -1,0 +1,568 @@
+//! The in-flight OAuth flow: the loopback callback server, the state the UI
+//! polls, and the token write. Mirrors `startOAuthFlow`, `startProviderCallback`,
+//! `handleOAuthToken` and `GetAuthStatus` in
+//! `internal/service/integration_service.go`.
+//!
+//! # Why this is the piece that forced the other two
+//!
+//! `POST …/auth/start` and `GET …/auth/status` share
+//! `integrationService.oauthFlows`, a map in the process that started the flow.
+//! Split them across two processes and `status` polls a map that will never be
+//! populated — which is why #300 deferred them together and why they move
+//! together now.
+//!
+//! **It also retires a workaround.** While the sidecar owned the callback
+//! server, the shell could not see a token land: the browser delivers it
+//! straight to a port Go opened, so `native/integrations.rs` inferred the event
+//! by watching the UI *poll* `auth/status` and reloading when the row stopped
+//! matching what was running (`Trigger::AuthStatusPolled`). With the flow here,
+//! the shell writes the token itself and reloads directly, exactly as
+//! `handleOAuthToken` does — so the inference is redundant and is removed rather
+//! than left running beside the real thing.
+//!
+//! # Three behaviours that are easy to lose
+//!
+//! - **The callback server outlives the request.** `StartOAuth` returns the URL
+//!   immediately; the user has not opened it yet. Go is explicit about this —
+//!   its context is `WithoutCancel` plus a 10-minute deadline, with a comment
+//!   warning not to `defer cancel()`. Tying the server to the HTTP request would
+//!   kill it before the redirect arrives.
+//! - **A failed flow is remembered.** `handleOAuthToken` stores the error on the
+//!   state, and `GetAuthStatus` returns it — so the UI's poll surfaces a 500
+//!   rather than reporting "not authenticated" forever.
+//! - **The token is written against a re-read row.** Go loads the integration
+//!   again inside `handleOAuthToken` rather than closing over the one `start`
+//!   read, because ten minutes have passed and the row may have been edited.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use crate::native::integrations::registry;
+use crate::native::writes::WriteError;
+
+use super::exchange::{self, TokenEndpoint};
+
+/// `oauthState`. Absent from the map means no flow has been started in this
+/// process for that integration.
+#[derive(Debug, Clone, Default)]
+struct FlowState {
+    /// Set once the callback has been answered, either way. Go tracks it and
+    /// never reads it; kept for the same reason the field exists there.
+    #[allow(dead_code)]
+    done: bool,
+    authenticated: bool,
+    /// Why the flow failed. `GetAuthStatus` turns this into a 500.
+    err: Option<String>,
+}
+
+/// `integrationService.oauthFlows`.
+fn flows() -> &'static Mutex<HashMap<String, FlowState>> {
+    static FLOWS: OnceLock<Mutex<HashMap<String, FlowState>>> = OnceLock::new();
+    FLOWS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn lock_flows() -> std::sync::MutexGuard<'static, HashMap<String, FlowState>> {
+    flows().lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// How long a flow may stay open. `context.WithTimeout(…, 10*time.Minute)`.
+const FLOW_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10 * 60);
+
+/// `loadOAuthConfig`'s type check, with Go's exact wording.
+fn oauth_provider(integration_type: &str) -> Option<TokenEndpoint> {
+    match integration_type {
+        "google" => Some(TokenEndpoint::google()),
+        "slack" => Some(TokenEndpoint::slack()),
+        _ => None,
+    }
+}
+
+/// The client id and secret both providers store under the same two keys.
+#[derive(Debug, Default, serde::Deserialize)]
+struct ClientCredentials {
+    #[serde(
+        default,
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
+    client_id: String,
+    #[serde(
+        default,
+        deserialize_with = "crate::native::gojson::null_is_zero_value"
+    )]
+    client_secret: String,
+}
+
+/// `StartOAuth`: the auth URL the user's browser is sent to.
+///
+/// Synchronous, because the seam's handler is — the listener is bound with
+/// `std::net::TcpListener` (which does not need a runtime) and only the serving
+/// half is spawned. Binding here rather than in the spawned task is what lets
+/// the port appear in the URL this returns.
+pub fn start(db_path: &std::path::Path, id: &str) -> Result<String, WriteError> {
+    let Some(row) = registry::get_for_hosting(db_path, id).map_err(WriteError::Fallback)? else {
+        return Err(WriteError::NotFound {
+            resource: "integration".to_string(),
+            id: id.to_string(),
+        });
+    };
+    let Some(endpoint) = oauth_provider(&row.integration_type) else {
+        // `loadOAuthConfig`'s `ValidationError`, wording included.
+        return Err(WriteError::validation(
+            "type",
+            format!(
+                "OAuth flow is not supported for integration type {:?}",
+                row.integration_type
+            ),
+        ));
+    };
+
+    let creds: ClientCredentials = serde_json::from_str(&row.credentials).map_err(|e| {
+        // Go's `BuildAuthURL` wraps this as "parsing <type> credentials"; the
+        // handler turns any non-typed error into a 500, which the seam forwards.
+        WriteError::Fallback(format!("parsing {} credentials: {e}", row.integration_type))
+    })?;
+
+    // `integrations.FreePort()`. Bound now and handed to the server, rather than
+    // probed and re-bound: the gap between the two is a race a second flow can
+    // land in, and the port is already in the URL by then.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0")
+        .map_err(|e| WriteError::Fallback(format!("finding free port: {e}")))?;
+    let port = listener
+        .local_addr()
+        .map_err(|e| WriteError::Fallback(format!("finding free port: {e}")))?
+        .port();
+
+    let auth_url = match row.integration_type.as_str() {
+        "google" => {
+            let services = super::services_of(db_path, id).map_err(WriteError::Fallback)?;
+            super::google_auth_url(&creds.client_id, port, &services)
+        }
+        _ => super::slack_auth_url(&creds.client_id, port),
+    };
+
+    // Registered before the server starts, so a callback that arrives
+    // impossibly fast still finds a state to write to.
+    lock_flows().insert(id.to_string(), FlowState::default());
+
+    let spawned = spawn_callback_server(
+        listener,
+        CallbackContext {
+            db_path: db_path.to_path_buf(),
+            id: id.to_string(),
+            endpoint,
+            client_id: creds.client_id,
+            client_secret: creds.client_secret,
+            redirect_uri: super::redirect_uri(port),
+        },
+    );
+    if let Err(e) = spawned {
+        // Go's `startProviderCallback` cancels and returns the error, leaving no
+        // flow behind; the map entry has to go with it or `status` would poll a
+        // flow that is not running.
+        lock_flows().remove(id);
+        return Err(WriteError::Fallback(format!(
+            "starting callback server: {e}"
+        )));
+    }
+
+    log::info!(
+        "oauth flow started id={id:?} type={:?}",
+        row.integration_type
+    );
+    Ok(auth_url)
+}
+
+/// Everything the callback needs once the browser arrives.
+struct CallbackContext {
+    db_path: std::path::PathBuf,
+    id: String,
+    endpoint: TokenEndpoint,
+    client_id: String,
+    client_secret: String,
+    redirect_uri: String,
+}
+
+/// `oauthSuccessHTML`, byte for byte — it is what the user sees.
+const SUCCESS_HTML: &str = "<!DOCTYPE html><html><body>\n\
+<h2>Authentication successful!</h2>\n\
+<p>You can close this tab and return to Agento.</p>\n\
+<script>window.close();</script>\n\
+</body></html>";
+
+fn spawn_callback_server(
+    listener: std::net::TcpListener,
+    ctx: CallbackContext,
+) -> Result<(), String> {
+    use axum::extract::{Query, State};
+    use axum::routing::get;
+
+    let handle = tokio::runtime::Handle::try_current()
+        .map_err(|_| "no tokio runtime on this thread".to_string())?;
+    listener
+        .set_nonblocking(true)
+        .map_err(|e| format!("setting the callback listener non-blocking: {e}"))?;
+
+    let ctx = Arc::new(ctx);
+    let app = axum::Router::new()
+        .route(
+            "/callback",
+            get(
+                |State(ctx): State<Arc<CallbackContext>>,
+                 Query(params): Query<HashMap<String, String>>| async move {
+                    handle_callback(ctx, params).await
+                },
+            ),
+        )
+        .with_state(Arc::clone(&ctx));
+
+    handle.spawn(async move {
+        let listener = match tokio::net::TcpListener::from_std(listener) {
+            Ok(listener) => listener,
+            Err(e) => {
+                fail_flow(&ctx.id, format!("callback listener: {e}"));
+                return;
+            }
+        };
+        // The deadline is the whole point: without it a flow the user abandons
+        // leaves a listener bound for the life of the process.
+        let served = tokio::time::timeout(FLOW_TIMEOUT, axum::serve(listener, app)).await;
+        if served.is_err() {
+            fail_flow(&ctx.id, "oauth flow timed out".to_string());
+        }
+    });
+    Ok(())
+}
+
+/// The `/callback` handler: `callbackHandler` plus `handleOAuthToken`.
+async fn handle_callback(
+    ctx: Arc<CallbackContext>,
+    params: HashMap<String, String>,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+
+    let code = params.get("code").map(String::as_str).unwrap_or_default();
+    if code.is_empty() {
+        // Go prefers the provider's own `error` and falls back to a fixed
+        // string, then answers 400 with it.
+        let reason = params
+            .get("error")
+            .filter(|e| !e.is_empty())
+            .map(String::as_str)
+            .unwrap_or("no code in callback");
+        let message = format!("oauth callback error: {reason}");
+        fail_flow(&ctx.id, message);
+        return (
+            axum::http::StatusCode::BAD_REQUEST,
+            format!("Authentication failed: {reason}\n"),
+        )
+            .into_response();
+    }
+
+    let token = match exchange::exchange(
+        &reqwest::Client::new(),
+        &ctx.endpoint,
+        &ctx.client_id,
+        &ctx.client_secret,
+        code,
+        &ctx.redirect_uri,
+        std::time::SystemTime::now(),
+    )
+    .await
+    {
+        Ok(token) => token,
+        Err(e) => {
+            fail_flow(&ctx.id, e);
+            return (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to exchange token\n",
+            )
+                .into_response();
+        }
+    };
+
+    if let Err(e) = store_token(&ctx.db_path, &ctx.id, &token) {
+        fail_flow(&ctx.id, e);
+        return (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to exchange token\n",
+        )
+            .into_response();
+    }
+
+    {
+        let mut flows = lock_flows();
+        let state = flows.entry(ctx.id.clone()).or_default();
+        state.done = true;
+        state.authenticated = true;
+        state.err = None;
+    }
+    log::info!(
+        "OAuth completed, starting integration server id={:?}",
+        ctx.id
+    );
+
+    // `go s.registry.Reload(...)` — detached, so a slow start does not hold the
+    // browser's redirect open. This is the direct reload that makes
+    // `Trigger::AuthStatusPolled` unnecessary.
+    let db_path = ctx.db_path.clone();
+    let id = ctx.id.clone();
+    tokio::spawn(async move {
+        registry::reload_after_auth(&db_path, &id).await;
+    });
+
+    (
+        axum::http::StatusCode::OK,
+        [(axum::http::header::CONTENT_TYPE, "text/html")],
+        SUCCESS_HTML,
+    )
+        .into_response()
+}
+
+/// `handleOAuthToken`'s error arm: remember why, so the poll can report it.
+fn fail_flow(id: &str, message: String) {
+    log::warn!("OAuth flow failed id={id:?} error={message}");
+    let mut flows = lock_flows();
+    let state = flows.entry(id.to_string()).or_default();
+    state.done = true;
+    state.authenticated = false;
+    state.err = Some(message);
+}
+
+/// `SetOAuthToken` + `store.Save`, against a **re-read** row.
+///
+/// Go re-loads the integration inside `handleOAuthToken` rather than using the
+/// one `StartOAuth` read: ten minutes may have passed and the row may have been
+/// edited or deleted in between.
+fn store_token(
+    db_path: &std::path::Path,
+    id: &str,
+    token: &exchange::StoredToken,
+) -> Result<(), String> {
+    let encoded = exchange::encode(token)?;
+    let mut conn = crate::native::db::open_read_write(db_path)?;
+    let tx = conn
+        .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+        .map_err(|e| format!("begin oauth token write: {e}"))?;
+
+    let exists: bool = tx
+        .query_row("SELECT 1 FROM integrations WHERE id = ?1", [id], |_| {
+            Ok(true)
+        })
+        .ok()
+        .unwrap_or(false);
+    if !exists {
+        // Go's `loading integration after OAuth` arm.
+        return Err(format!("loading integration after OAuth: {id:?} not found"));
+    }
+
+    tx.execute(
+        "UPDATE integrations SET auth = ?1, updated_at = ?2 WHERE id = ?3",
+        rusqlite::params![encoded, crate::native::gotime::now_go_text(), id],
+    )
+    .map_err(|e| format!("saving token: {e}"))?;
+    tx.commit().map_err(|e| format!("saving token: {e}"))
+}
+
+/// `GetAuthStatus`.
+///
+/// An in-flight flow answers from the map; anything else falls through to the
+/// stored token. The error arm is what makes a failed flow visible instead of
+/// looking like "still not authenticated".
+pub fn status(db_path: &std::path::Path, id: &str) -> Result<bool, WriteError> {
+    let state = lock_flows().get(id).cloned();
+    if let Some(state) = state {
+        if let Some(err) = state.err {
+            // `httpErr`'s default arm: logged, and answered as a flat 500.
+            log::error!("internal server error error={err}");
+            return Err(WriteError::Internal("internal server error".to_string()));
+        }
+        return Ok(state.authenticated);
+    }
+
+    match crate::native::integrations::get(db_path, id).map_err(WriteError::Fallback)? {
+        Some(integration) => Ok(integration.authenticated),
+        None => Err(WriteError::NotFound {
+            resource: "integration".to_string(),
+            id: id.to_string(),
+        }),
+    }
+}
+
+#[cfg(test)]
+pub(super) fn reset_flows_for_test() {
+    lock_flows().clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A fresh database with one integration, under an id **unique to the
+    /// caller**.
+    ///
+    /// The flow map is process-global — it mirrors `integrationService.oauthFlows`,
+    /// which is one map per server — so two tests sharing an id share a flow,
+    /// and `cargo test` runs them in parallel. Distinct ids rather than a mutex,
+    /// because the global is the thing under test.
+    fn migrated(
+        dir: &std::path::Path,
+        id: &str,
+        integration_type: &str,
+        credentials: &str,
+    ) -> std::path::PathBuf {
+        let db = dir.join("agento.db");
+        let mut conn = rusqlite::Connection::open(&db).expect("open");
+        crate::native::migrate::apply(&mut conn).expect("migrate");
+        conn.execute(
+            "INSERT INTO integrations (id, name, type, enabled, credentials, auth, services,
+                                       created_at, updated_at)
+             VALUES (?1, 'I', ?2, 1, ?3, '', '{}',
+                     '2026-01-01 00:00:00 +0000 UTC', '2026-01-01 00:00:00 +0000 UTC')",
+            rusqlite::params![id, integration_type, credentials],
+        )
+        .expect("seed");
+        db
+    }
+
+    #[test]
+    fn a_type_with_no_oauth_flow_is_gos_422() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path(), "no-oauth", "telegram", r#"{"bot_token":"t"}"#);
+        let err = start(&db, "no-oauth").unwrap_err();
+        assert_eq!(err.status(), axum::http::StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(
+            err.message(),
+            r#"validation error for "type": OAuth flow is not supported for integration type "telegram""#
+        );
+    }
+
+    #[test]
+    fn an_unknown_integration_is_404() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(
+            dir.path(),
+            "unknown-probe",
+            "google",
+            r#"{"client_id":"c"}"#,
+        );
+        let err = start(&db, "nope").unwrap_err();
+        assert_eq!(err.status(), axum::http::StatusCode::NOT_FOUND);
+        assert_eq!(err.message(), r#"integration "nope" not found"#);
+    }
+
+    #[tokio::test]
+    async fn starting_a_flow_answers_a_url_carrying_the_port_it_bound() {
+        reset_flows_for_test();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(
+            dir.path(),
+            "bound-port",
+            "google",
+            r#"{"client_id":"cid","client_secret":"sec"}"#,
+        );
+
+        let url = start(&db, "bound-port").expect("start");
+        // The port is the one just bound, so it cannot be asserted literally —
+        // what matters is that the URL and the listener agree, which is the
+        // whole reason the bind happens before the URL is built.
+        let redirect = url
+            .split("redirect_uri=")
+            .nth(1)
+            .and_then(|rest| rest.split('&').next())
+            .expect("a redirect_uri");
+        let decoded = redirect.replace("%3A", ":").replace("%2F", "/");
+        let port: u16 = decoded
+            .trim_start_matches("http://localhost:")
+            .trim_end_matches("/callback")
+            .parse()
+            .expect("a port");
+        assert!(port > 0);
+        // The listener is live: a second bind of the same port must fail.
+        assert!(
+            std::net::TcpListener::bind(("127.0.0.1", port)).is_err(),
+            "the callback server holds the port the URL advertises"
+        );
+
+        // …and a flow is now in flight, so `status` answers from the map rather
+        // than from the stored token.
+        assert!(!status(&db, "bound-port").expect("status"));
+    }
+
+    #[tokio::test]
+    async fn a_failed_flow_is_remembered_as_a_500_rather_than_reported_as_unauthenticated() {
+        reset_flows_for_test();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(
+            dir.path(),
+            "denied",
+            "google",
+            r#"{"client_id":"cid","client_secret":"sec"}"#,
+        );
+        start(&db, "denied").expect("start");
+
+        fail_flow("denied", "oauth callback error: access_denied".to_string());
+
+        let err = status(&db, "denied").unwrap_err();
+        assert_eq!(
+            err.status(),
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            "a user who denied consent must not see 'still waiting' forever"
+        );
+    }
+
+    #[test]
+    fn with_no_flow_the_status_is_the_stored_token() {
+        reset_flows_for_test();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path(), "stored", "google", r#"{"client_id":"c"}"#);
+        assert!(!status(&db, "stored").expect("status"), "auth is empty");
+
+        let conn = rusqlite::Connection::open(&db).expect("open");
+        conn.execute(
+            "UPDATE integrations SET auth = ?1 WHERE id = 'stored'",
+            [r#"{"access_token":"at","expiry":"0001-01-01T00:00:00Z"}"#],
+        )
+        .expect("store token");
+        drop(conn);
+        assert!(status(&db, "stored").expect("status"));
+    }
+
+    #[test]
+    fn the_stored_token_lands_in_the_auth_column_and_touches_updated_at() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path(), "tok", "google", r#"{"client_id":"c"}"#);
+        let token = exchange::StoredToken {
+            access_token: "at".into(),
+            token_type: "Bearer".into(),
+            refresh_token: "rt".into(),
+            expiry: "2027-01-15T09:00:00Z".into(),
+            expires_in: 3600,
+        };
+        store_token(&db, "tok", &token).expect("store");
+
+        let conn = rusqlite::Connection::open(&db).expect("open");
+        let (auth, updated): (String, String) = conn
+            .query_row(
+                "SELECT auth, updated_at FROM integrations WHERE id = 'tok'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .expect("row");
+        assert_eq!(
+            auth,
+            r#"{"access_token":"at","token_type":"Bearer","refresh_token":"rt","expiry":"2027-01-15T09:00:00Z","expires_in":3600}"#
+        );
+        assert_ne!(
+            updated, "2026-01-01 00:00:00 +0000 UTC",
+            "handleOAuthToken stamps UpdatedAt"
+        );
+    }
+
+    #[test]
+    fn a_token_for_a_deleted_integration_is_an_error_rather_than_a_silent_no_op() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path(), "present", "google", r#"{"client_id":"c"}"#);
+        let err = store_token(&db, "gone", &exchange::StoredToken::default()).unwrap_err();
+        assert!(err.contains("loading integration after OAuth"), "{err}");
+    }
+}

--- a/desktop/src-tauri/src/native/integrations/oauth/flow.rs
+++ b/desktop/src-tauri/src/native/integrations/oauth/flow.rs
@@ -47,8 +47,8 @@ use super::exchange::{self, TokenEndpoint};
 #[derive(Debug, Clone, Default)]
 struct FlowState {
     /// Set once the callback has been answered, either way. Go tracks it and
-    /// never reads it; kept for the same reason the field exists there.
-    #[allow(dead_code)]
+    /// never reads it; here it is what [`fail_flow_if_in_flight`] checks, so the
+    /// deadline cannot overwrite a finished flow.
     done: bool,
     authenticated: bool,
     /// Why the flow failed. `GetAuthStatus` turns this into a 500.
@@ -67,6 +67,21 @@ fn lock_flows() -> std::sync::MutexGuard<'static, HashMap<String, FlowState>> {
 
 /// How long a flow may stay open. `context.WithTimeout(…, 10*time.Minute)`.
 const FLOW_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10 * 60);
+
+/// `httpErr`'s default body. Go logs the real error and answers exactly this.
+const GO_INTERNAL_ERROR: &str = "internal server error";
+
+/// Log the real reason and answer what Go answers.
+///
+/// The detail reaches the log, never the wire — `httpErr`'s default arm does the
+/// same, and reproducing it here rather than forwarding is what stops the
+/// sidecar starting a second flow. See [`start`].
+fn internal<E: std::fmt::Display>(what: &'static str) -> impl Fn(E) -> WriteError {
+    move |e| {
+        log::error!("internal server error error={what}: {e}");
+        WriteError::Internal(GO_INTERNAL_ERROR.to_string())
+    }
+}
 
 /// `loadOAuthConfig`'s type check, with Go's exact wording.
 fn oauth_provider(integration_type: &str) -> Option<TokenEndpoint> {
@@ -98,8 +113,25 @@ struct ClientCredentials {
 /// `std::net::TcpListener` (which does not need a runtime) and only the serving
 /// half is spawned. Binding here rather than in the spawned task is what lets
 /// the port appear in the URL this returns.
+///
+/// # Nothing here may `Fallback`
+///
+/// Every other native write forwards on doubt and lets Go answer. This one must
+/// not: forwarding `auth/start` makes the **sidecar** run a real flow, with its
+/// own callback server on its own port. The shell would never see that token
+/// land — the inference that used to cover it (`Trigger::AuthStatusPolled`) is
+/// gone precisely because this route moved — and Go's own `registry.Reload` is
+/// switched off for the six hosted types by `AGENTO_INTEGRATIONS`. The result is
+/// an integration that authenticates and is hosted by nobody until the next app
+/// start.
+///
+/// So the failures Go answers with a flat 500 are answered here as
+/// [`WriteError::Internal`], with Go's own body: the same bytes on the wire, and
+/// one flow instead of two.
 pub fn start(db_path: &std::path::Path, id: &str) -> Result<String, WriteError> {
-    let Some(row) = registry::get_for_hosting(db_path, id).map_err(WriteError::Fallback)? else {
+    let Some(row) =
+        registry::get_for_hosting(db_path, id).map_err(internal("loading integration"))?
+    else {
         return Err(WriteError::NotFound {
             resource: "integration".to_string(),
             id: id.to_string(),
@@ -116,25 +148,24 @@ pub fn start(db_path: &std::path::Path, id: &str) -> Result<String, WriteError> 
         ));
     };
 
-    let creds: ClientCredentials = serde_json::from_str(&row.credentials).map_err(|e| {
-        // Go's `BuildAuthURL` wraps this as "parsing <type> credentials"; the
-        // handler turns any non-typed error into a 500, which the seam forwards.
-        WriteError::Fallback(format!("parsing {} credentials: {e}", row.integration_type))
-    })?;
+    // Go's `BuildAuthURL` wraps this as "parsing <type> credentials", and the
+    // handler turns any non-typed error into a flat 500.
+    let creds: ClientCredentials =
+        serde_json::from_str(&row.credentials).map_err(internal("parsing credentials"))?;
 
     // `integrations.FreePort()`. Bound now and handed to the server, rather than
     // probed and re-bound: the gap between the two is a race a second flow can
     // land in, and the port is already in the URL by then.
-    let listener = std::net::TcpListener::bind("127.0.0.1:0")
-        .map_err(|e| WriteError::Fallback(format!("finding free port: {e}")))?;
+    let listener =
+        std::net::TcpListener::bind("127.0.0.1:0").map_err(internal("finding free port"))?;
     let port = listener
         .local_addr()
-        .map_err(|e| WriteError::Fallback(format!("finding free port: {e}")))?
+        .map_err(internal("finding free port"))?
         .port();
 
     let auth_url = match row.integration_type.as_str() {
         "google" => {
-            let services = super::services_of(db_path, id).map_err(WriteError::Fallback)?;
+            let services = super::services_of(db_path, id).map_err(internal("reading services"))?;
             super::google_auth_url(&creds.client_id, port, &services)
         }
         _ => super::slack_auth_url(&creds.client_id, port),
@@ -153,6 +184,8 @@ pub fn start(db_path: &std::path::Path, id: &str) -> Result<String, WriteError> 
             client_id: creds.client_id,
             client_secret: creds.client_secret,
             redirect_uri: super::redirect_uri(port),
+            // Replaced inside `spawn_callback_server`, which owns the channel.
+            done: Mutex::new(None),
         },
     );
     if let Err(e) = spawned {
@@ -160,9 +193,8 @@ pub fn start(db_path: &std::path::Path, id: &str) -> Result<String, WriteError> 
         // flow behind; the map entry has to go with it or `status` would poll a
         // flow that is not running.
         lock_flows().remove(id);
-        return Err(WriteError::Fallback(format!(
-            "starting callback server: {e}"
-        )));
+        log::error!("internal server error error=starting callback server: {e}");
+        return Err(WriteError::Internal(GO_INTERNAL_ERROR.to_string()));
     }
 
     log::info!(
@@ -180,6 +212,28 @@ struct CallbackContext {
     client_id: String,
     client_secret: String,
     redirect_uri: String,
+    /// Fired once, when the callback has been answered either way, to shut the
+    /// server down.
+    ///
+    /// Go closes its server the moment it consumes the result
+    /// (`defer srv.Close()` in the goroutine reading `resultCh`), and both
+    /// halves of that matter. A server left running keeps an
+    /// **unauthenticated loopback listener** bound for the rest of the
+    /// ten-minute window, and it will answer a *second* `/callback` — which the
+    /// success page invites, since it only calls `window.close()` and browsers
+    /// often refuse. The second request re-exchanges a spent code, the provider
+    /// answers `invalid_grant`, and a flow that had just succeeded becomes an
+    /// error.
+    done: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+}
+
+impl CallbackContext {
+    /// Stop the server. Idempotent: the second call finds the sender gone.
+    fn finish(&self) {
+        if let Some(tx) = self.done.lock().unwrap_or_else(|e| e.into_inner()).take() {
+            let _ = tx.send(());
+        }
+    }
 }
 
 /// `oauthSuccessHTML`, byte for byte — it is what the user sees.
@@ -202,7 +256,11 @@ fn spawn_callback_server(
         .set_nonblocking(true)
         .map_err(|e| format!("setting the callback listener non-blocking: {e}"))?;
 
-    let ctx = Arc::new(ctx);
+    let (done_tx, done_rx) = tokio::sync::oneshot::channel::<()>();
+    let ctx = Arc::new(CallbackContext {
+        done: Mutex::new(Some(done_tx)),
+        ..ctx
+    });
     let app = axum::Router::new()
         .route(
             "/callback",
@@ -223,11 +281,24 @@ fn spawn_callback_server(
                 return;
             }
         };
-        // The deadline is the whole point: without it a flow the user abandons
-        // leaves a listener bound for the life of the process.
-        let served = tokio::time::timeout(FLOW_TIMEOUT, axum::serve(listener, app)).await;
-        if served.is_err() {
-            fail_flow(&ctx.id, "oauth flow timed out".to_string());
+
+        // **The shutdown signal is what makes the deadline mean "abandoned".**
+        // `axum::serve` never resolves on its own, so timing it out
+        // unconditionally would fire ten minutes after *every* flow, successful
+        // ones included — overwriting a stored-and-hosted integration's state
+        // with `oauth flow timed out` and leaving `auth/status` answering 500
+        // for the life of the process. Go cannot reach that: its `select` takes
+        // the result arm and the goroutine exits, so the deadline arm is
+        // unreachable once a callback has been answered.
+        let served = axum::serve(listener, app).with_graceful_shutdown(async move {
+            let _ = done_rx.await;
+        });
+
+        if tokio::time::timeout(FLOW_TIMEOUT, served).await.is_err() {
+            // Only reachable while the flow is still in flight — the callback
+            // signals the shutdown above — but checked anyway, because the one
+            // thing this must never do is turn a success into a failure.
+            fail_flow_if_in_flight(&ctx.id);
         }
     });
     Ok(())
@@ -251,6 +322,7 @@ async fn handle_callback(
             .unwrap_or("no code in callback");
         let message = format!("oauth callback error: {reason}");
         fail_flow(&ctx.id, message);
+        ctx.finish();
         return (
             axum::http::StatusCode::BAD_REQUEST,
             format!("Authentication failed: {reason}\n"),
@@ -272,6 +344,7 @@ async fn handle_callback(
         Ok(token) => token,
         Err(e) => {
             fail_flow(&ctx.id, e);
+            ctx.finish();
             return (
                 axum::http::StatusCode::INTERNAL_SERVER_ERROR,
                 "Failed to exchange token\n",
@@ -282,6 +355,7 @@ async fn handle_callback(
 
     if let Err(e) = store_token(&ctx.db_path, &ctx.id, &token) {
         fail_flow(&ctx.id, e);
+        ctx.finish();
         return (
             axum::http::StatusCode::INTERNAL_SERVER_ERROR,
             "Failed to exchange token\n",
@@ -316,6 +390,28 @@ async fn handle_callback(
         SUCCESS_HTML,
     )
         .into_response()
+}
+
+/// Fail the flow **only if it has not already finished**.
+///
+/// The deadline arm's guard: a flow that succeeded and was overwritten with a
+/// timeout would report 500 forever, having stored a working token.
+fn fail_flow_if_in_flight(id: &str) {
+    let mut flows = lock_flows();
+    match flows.get(id) {
+        Some(state) if state.done => {}
+        _ => {
+            log::warn!("OAuth flow timed out id={id:?}");
+            flows.insert(
+                id.to_string(),
+                FlowState {
+                    done: true,
+                    authenticated: false,
+                    err: Some("oauth flow timed out".to_string()),
+                },
+            );
+        }
+    }
 }
 
 /// `handleOAuthToken`'s error arm: remember why, so the poll can report it.
@@ -379,6 +475,9 @@ pub fn status(db_path: &std::path::Path, id: &str) -> Result<bool, WriteError> {
         return Ok(state.authenticated);
     }
 
+    // `Fallback` is safe *here*, unlike anywhere in `start`: a status read
+    // starts nothing, and Go answering it re-reads the same row to the same
+    // effect. Only reached when this process holds no flow for the id.
     match crate::native::integrations::get(db_path, id).map_err(WriteError::Fallback)? {
         Some(integration) => Ok(integration.authenticated),
         None => Err(WriteError::NotFound {
@@ -507,6 +606,70 @@ mod tests {
             err.status(),
             axum::http::StatusCode::INTERNAL_SERVER_ERROR,
             "a user who denied consent must not see 'still waiting' forever"
+        );
+    }
+
+    /// The high finding on PR #367: the deadline must not overwrite a flow that
+    /// already finished.
+    ///
+    /// `axum::serve` never resolves, so timing it out unconditionally fires ten
+    /// minutes after *every* flow — successful ones included. A user who
+    /// abandons one attempt, retries and succeeds would have the first attempt's
+    /// timer turn the second's success into a permanent 500, with the token
+    /// stored and the MCP server running.
+    #[test]
+    fn the_deadline_cannot_overwrite_a_flow_that_already_succeeded() {
+        reset_flows_for_test();
+        lock_flows().insert(
+            "settled".to_string(),
+            FlowState {
+                done: true,
+                authenticated: true,
+                err: None,
+            },
+        );
+
+        fail_flow_if_in_flight("settled");
+
+        let state = lock_flows().get("settled").cloned().expect("state");
+        assert!(state.authenticated, "the success survives its own deadline");
+        assert!(state.err.is_none());
+    }
+
+    #[test]
+    fn the_deadline_does_fail_a_flow_still_in_flight() {
+        reset_flows_for_test();
+        lock_flows().insert("waiting".to_string(), FlowState::default());
+
+        fail_flow_if_in_flight("waiting");
+
+        let state = lock_flows().get("waiting").cloned().expect("state");
+        assert!(state.done);
+        assert_eq!(state.err.as_deref(), Some("oauth flow timed out"));
+    }
+
+    #[test]
+    fn a_failed_flow_is_not_re_failed_by_the_deadline() {
+        // Also finished — the first reason is the useful one to keep.
+        reset_flows_for_test();
+        lock_flows().insert(
+            "denied-then-timed-out".to_string(),
+            FlowState {
+                done: true,
+                authenticated: false,
+                err: Some("oauth callback error: access_denied".to_string()),
+            },
+        );
+
+        fail_flow_if_in_flight("denied-then-timed-out");
+
+        assert_eq!(
+            lock_flows()
+                .get("denied-then-timed-out")
+                .and_then(|s| s.err.clone())
+                .as_deref(),
+            Some("oauth callback error: access_denied"),
+            "the original reason is what the user needs"
         );
     }
 

--- a/desktop/src-tauri/src/native/integrations/oauth/mod.rs
+++ b/desktop/src-tauri/src/native/integrations/oauth/mod.rs
@@ -1,0 +1,283 @@
+//! The authorization URL half of the OAuth flow (#318).
+//!
+//! Mirrors `BuildAuthURL` in `internal/integrations/{google,slack}/oauth.go`,
+//! and through it `oauth2.Config.AuthCodeURL`.
+//!
+//! # Why this is a vector rather than a live diff
+//!
+//! Every other ported route is verified by asking both implementations the same
+//! question and comparing bytes. `POST …/auth/start` cannot be: the redirect
+//! port comes from a fresh `FreePort()`, so two implementations answering the
+//! same request produce two legitimately different URLs. Everything *else* about
+//! the bytes still has to match, and all of it is rule rather than value — the
+//! scope set and its order, the query encoding, the per-provider auth-code
+//! options, the endpoint. `desktop/parity/oauth_vectors.json` records what Go's
+//! own builder produced for a fixed port, and both languages assert against it.
+//!
+//! Generating rather than hand-writing was not ceremony: `oauth2.ApprovalForce`
+//! emits **`prompt=consent`**, not the `approval_prompt=force` its name suggests
+//! and that a transcription would have produced.
+//!
+//! # The three things that are easy to get wrong
+//!
+//! - **The scope union is ordered, not set-like.** `Scopes` walks calendar, then
+//!   gmail, then drive, and deduplicates — so the string is deterministic even
+//!   though `services` is a Go map with random iteration order. Sorting instead
+//!   would pass most vectors and diverge on the rest.
+//! - **`scope` is absent, not empty, when nothing is enabled.** `AuthCodeURL`
+//!   guards with `if len(c.Scopes) > 0`, so a Google integration with no enabled
+//!   service produces a URL with no `scope` key at all.
+//! - **The encoding is `url.Values.Encode`**: keys sorted, values through
+//!   [`crate::native::gourl::query_escape`], where a space is `+` rather than
+//!   `%20`. The scope separator is a space, so this is on every URL with more
+//!   than one scope.
+
+pub mod exchange;
+
+use std::collections::BTreeMap;
+
+use crate::native::gourl::query_escape;
+use crate::native::integrations::ServiceConfig;
+
+/// `googleoauth.Endpoint.AuthURL`.
+const GOOGLE_AUTH_ENDPOINT: &str = "https://accounts.google.com/o/oauth2/auth";
+
+/// Slack's **v2** authorize endpoint. The v1 path is a different grant.
+const SLACK_AUTH_ENDPOINT: &str = "https://slack.com/oauth/v2/authorize";
+
+/// `calendarScopes`, `gmailScopes`, `driveScopes` — in the order `Scopes` adds
+/// them, which is the order they appear in the URL.
+const CALENDAR_SCOPES: &[&str] = &["https://www.googleapis.com/auth/calendar"];
+const GMAIL_SCOPES: &[&str] = &[
+    "https://www.googleapis.com/auth/gmail.send",
+    "https://www.googleapis.com/auth/gmail.readonly",
+];
+const DRIVE_SCOPES: &[&str] = &["https://www.googleapis.com/auth/drive"];
+
+/// `slack/oauth.go`'s `oauthScopes`, in its declared order.
+const SLACK_SCOPES: &[&str] = &[
+    "channels:read",
+    "channels:history",
+    "chat:write",
+    "users:read",
+    "search:read",
+    "groups:read",
+    "groups:history",
+];
+
+/// `google.Scopes`: the union of the enabled services' scopes, deduplicated,
+/// in calendar → gmail → drive order.
+///
+/// The three service names are checked individually rather than by iterating
+/// the map, which is what makes the result independent of map order — Go reads
+/// `services["calendar"]`, `services["gmail"]`, `services["drive"]` in that
+/// sequence, and a service present but `enabled: false` contributes nothing.
+pub fn google_scopes(services: &BTreeMap<String, ServiceConfig>) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let add = |scopes: &[&str], out: &mut Vec<String>| {
+        for scope in scopes {
+            if !out.iter().any(|seen| seen == scope) {
+                out.push((*scope).to_string());
+            }
+        }
+    };
+    for (name, scopes) in [
+        ("calendar", CALENDAR_SCOPES),
+        ("gmail", GMAIL_SCOPES),
+        ("drive", DRIVE_SCOPES),
+    ] {
+        if services.get(name).is_some_and(|svc| svc.enabled) {
+            add(scopes, &mut out);
+        }
+    }
+    out
+}
+
+/// `fmt.Sprintf("http://localhost:%d/callback", redirectPort)`.
+///
+/// `localhost`, not `127.0.0.1`: it is what the provider has registered as the
+/// redirect URI, so the spelling is part of the contract rather than a choice.
+pub fn redirect_uri(port: u16) -> String {
+    format!("http://localhost:{port}/callback")
+}
+
+/// `oauth2.Config.AuthCodeURL(state, opts…)`.
+///
+/// `url.Values.Encode()` sorts by key, so the parameters are collected into a
+/// `BTreeMap` and rendered in that order rather than in the order they were
+/// added.
+fn auth_code_url(
+    endpoint: &str,
+    client_id: &str,
+    port: u16,
+    scopes: &[String],
+    extra: &[(&str, &str)],
+) -> String {
+    let mut params: BTreeMap<&str, String> = BTreeMap::new();
+    params.insert("response_type", "code".to_string());
+    params.insert("client_id", client_id.to_string());
+    params.insert("redirect_uri", redirect_uri(port));
+    // `if len(c.Scopes) > 0` — absent, not empty, when there are none.
+    if !scopes.is_empty() {
+        params.insert("scope", scopes.join(" "));
+    }
+    // `AuthCodeURL` always sets state, and both callers pass the literal
+    // "state" — neither verifies it on the way back, which is Go's behaviour
+    // and not something a port may quietly improve.
+    params.insert("state", "state".to_string());
+    for (key, value) in extra {
+        params.insert(key, (*value).to_string());
+    }
+
+    let query = params
+        .iter()
+        .map(|(k, v)| format!("{}={}", query_escape(k), query_escape(v)))
+        .collect::<Vec<_>>()
+        .join("&");
+    // Both endpoints have no query of their own, so `AuthCodeURL`'s `?` vs `&`
+    // branch always takes the `?` arm.
+    format!("{endpoint}?{query}")
+}
+
+/// `google.BuildAuthURL`.
+///
+/// `AccessTypeOffline` and `ApprovalForce` are what make Google re-issue a
+/// refresh token on every consent — without them a second authorization returns
+/// only an access token and the stored credential silently stops refreshing.
+pub fn google_auth_url(
+    client_id: &str,
+    port: u16,
+    services: &BTreeMap<String, ServiceConfig>,
+) -> String {
+    auth_code_url(
+        GOOGLE_AUTH_ENDPOINT,
+        client_id,
+        port,
+        &google_scopes(services),
+        // `oauth2.ApprovalForce` is `prompt=consent`, despite the name.
+        &[("access_type", "offline"), ("prompt", "consent")],
+    )
+}
+
+/// `slack.BuildAuthURL`.
+///
+/// No auth-code options at all, and the scopes are fixed — `services` is not
+/// read. Slack v2 tokens do not expire and carry no refresh token unless the
+/// app enables rotation, which Go's own comment says this flow does not handle.
+pub fn slack_auth_url(client_id: &str, port: u16) -> String {
+    let scopes: Vec<String> = SLACK_SCOPES.iter().map(|s| (*s).to_string()).collect();
+    auth_code_url(SLACK_AUTH_ENDPOINT, client_id, port, &scopes, &[])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn enabled() -> ServiceConfig {
+        ServiceConfig {
+            enabled: true,
+            ..Default::default()
+        }
+    }
+
+    fn disabled() -> ServiceConfig {
+        ServiceConfig::default()
+    }
+
+    fn services(pairs: &[(&str, ServiceConfig)]) -> BTreeMap<String, ServiceConfig> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), v.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn the_scope_union_is_ordered_and_deduplicated() {
+        let all = services(&[
+            ("drive", enabled()),
+            ("gmail", enabled()),
+            ("calendar", enabled()),
+        ]);
+        assert_eq!(
+            google_scopes(&all),
+            vec![
+                "https://www.googleapis.com/auth/calendar",
+                "https://www.googleapis.com/auth/gmail.send",
+                "https://www.googleapis.com/auth/gmail.readonly",
+                "https://www.googleapis.com/auth/drive",
+            ],
+            "calendar, then gmail, then drive — not the map's order and not sorted"
+        );
+    }
+
+    #[test]
+    fn a_disabled_or_absent_service_contributes_no_scope() {
+        assert!(google_scopes(&services(&[])).is_empty());
+        assert!(google_scopes(&services(&[("gmail", disabled())])).is_empty());
+        assert_eq!(
+            google_scopes(&services(&[("gmail", enabled()), ("drive", disabled())])).len(),
+            2,
+            "gmail's two scopes and nothing from drive"
+        );
+    }
+
+    #[test]
+    fn an_unknown_service_is_not_a_scope() {
+        // `Scopes` reads three fixed keys; anything else in the column is
+        // ignored rather than mapped.
+        assert!(google_scopes(&services(&[("mail", enabled())])).is_empty());
+    }
+}
+
+#[cfg(test)]
+mod tests_vectors {
+    use super::*;
+
+    /// `desktop/parity/oauth_vectors.json`, byte for byte.
+    ///
+    /// The URLs are what Go's own `BuildAuthURL` produced; a divergence here is
+    /// a user sent to a consent screen asking for the wrong scopes, or a
+    /// provider rejecting the request outright.
+    #[derive(serde::Deserialize)]
+    struct Vectors {
+        cases: Vec<Case>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct Case {
+        name: String,
+        #[allow(dead_code)]
+        note: String,
+        #[serde(rename = "type")]
+        integration_type: String,
+        /// The raw `credentials` column, so this exercises the real decoder
+        /// rather than a struct the test built.
+        credentials: serde_json::Value,
+        services: Option<std::collections::BTreeMap<String, ServiceConfig>>,
+        port: u16,
+        auth_url: String,
+    }
+
+    #[test]
+    fn every_auth_url_matches_what_go_built() {
+        let raw = include_str!("../../../../../parity/oauth_vectors.json");
+        let vectors: Vectors = serde_json::from_str(raw).expect("vectors decode");
+        assert!(!vectors.cases.is_empty(), "the vector file is empty");
+
+        for case in &vectors.cases {
+            let client_id = case
+                .credentials
+                .get("client_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            let services = case.services.clone().unwrap_or_default();
+
+            let got = match case.integration_type.as_str() {
+                "google" => google_auth_url(client_id, case.port, &services),
+                "slack" => slack_auth_url(client_id, case.port),
+                other => panic!("case {:?} has no OAuth flow: {other}", case.name),
+            };
+            assert_eq!(got, case.auth_url, "case {:?}", case.name);
+        }
+    }
+}

--- a/desktop/src-tauri/src/native/integrations/oauth/mod.rs
+++ b/desktop/src-tauri/src/native/integrations/oauth/mod.rs
@@ -33,6 +33,7 @@
 //!   than one scope.
 
 pub mod exchange;
+pub mod flow;
 
 use std::collections::BTreeMap;
 
@@ -91,6 +92,17 @@ pub fn google_scopes(services: &BTreeMap<String, ServiceConfig>) -> Vec<String> 
         }
     }
     out
+}
+
+/// The `services` column, for the scope union. Read separately from the hosting
+/// row because that projection carries secrets and this does not.
+pub fn services_of(
+    db_path: &std::path::Path,
+    id: &str,
+) -> Result<BTreeMap<String, ServiceConfig>, String> {
+    Ok(crate::native::integrations::get(db_path, id)?
+        .and_then(|i| i.services)
+        .unwrap_or_default())
 }
 
 /// `fmt.Sprintf("http://localhost:%d/callback", redirectPort)`.

--- a/desktop/src-tauri/src/native/integrations/registry.rs
+++ b/desktop/src-tauri/src/native/integrations/registry.rs
@@ -104,13 +104,17 @@
 //! already been produced, so doing it on the forward path costs nothing but a
 //! restart of a server that was about to be restarted anyway.
 //!
-//! The fifth is `completeOAuth`, and it needed a **different** hook because its
-//! trigger never crosses the proxy: `startProviderCallback` supports `google`
-//! and `slack`, and since #315 the `slack` half concerns a hosted type, but the
-//! token is delivered by the browser to a callback server the *sidecar* opens on
-//! its own port. The only part of that flow this process sees is the UI polling
-//! `GET /api/integrations/{id}/auth/status`, which is a *poll* rather than an
-//! where [`reload_after_auth`] is not.
+//! The fifth is `completeOAuth`, and until #318 it needed a **different** hook
+//! because its trigger never crossed the proxy: the token was delivered by the
+//! browser to a callback server the *sidecar* opened on its own port, so the
+//! only part of the flow this process could see was the UI polling
+//! `GET /api/integrations/{id}/auth/status`. That poll drove a
+//! reload-only-if-changed, which was an inference standing in for an event.
+//!
+//! #318 moved the flow here: `oauth::flow` binds the callback server, writes the
+//! token and calls [`reload_after_auth`] directly, exactly as `handleOAuthToken`
+//! does. So the inference and the fingerprint it compared against are gone, and
+//! `completeOAuth` now uses the same hook as everything else.
 //!
 //! ## Secrets
 //!

--- a/desktop/src-tauri/src/native/integrations/registry.rs
+++ b/desktop/src-tauri/src/native/integrations/registry.rs
@@ -110,7 +110,6 @@
 //! token is delivered by the browser to a callback server the *sidecar* opens on
 //! its own port. The only part of that flow this process sees is the UI polling
 //! `GET /api/integrations/{id}/auth/status`, which is a *poll* rather than an
-//! event — see [`reload_if_secrets_changed`] for why that one is conditional
 //! where [`reload_after_auth`] is not.
 //!
 //! ## Secrets
@@ -140,15 +139,15 @@ use super::{decode_services, ServiceConfig};
 /// on it is a mistake: `Serialize` would put a token on the wire and `Debug`
 /// would put one in a log line, which is the same leak with a longer fuse. See
 /// the module header.
-struct HostingRow {
-    id: String,
-    integration_type: String,
+pub(super) struct HostingRow {
+    pub(super) id: String,
+    pub(super) integration_type: String,
     enabled: bool,
     /// `IsAuthenticated()`, computed in SQL so the predicate does not depend on
     /// parsing [`Self::auth`].
     authenticated: bool,
     /// The raw `credentials` column. A secret.
-    credentials: String,
+    pub(super) credentials: String,
     /// The raw `auth` column. **Also a secret**, and the newer of the two.
     ///
     /// Until #315 this projection selected `auth` only as the boolean above, and
@@ -169,21 +168,6 @@ impl HostingRow {
     /// `Reload` apply before they reach a starter.
     fn is_startable(&self) -> bool {
         self.enabled && self.authenticated
-    }
-
-    /// A fingerprint of the two secret columns, for [`reload_if_secrets_changed`].
-    ///
-    /// A hash, so the registry's record of "what is this server running on" is
-    /// not a second place the token itself lives. `DefaultHasher` because the
-    /// question is only ever "did this change", within one process, against a
-    /// value this process wrote — there is nothing here for a collision to buy
-    /// an attacker that reading the database would not.
-    fn secrets_fingerprint(&self) -> u64 {
-        use std::hash::{Hash, Hasher};
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        self.credentials.hash(&mut hasher);
-        self.auth.hash(&mut hasher);
-        hasher.finish()
     }
 
     /// The services map a starter sees. A stored `null` is a nil Go map, which
@@ -242,13 +226,6 @@ struct State {
     /// since. A `DELETE` in that window therefore drops the new server instead
     /// of leaving a bound port holding a credential for a deleted row.
     generations: HashMap<String, u64>,
-    /// A fingerprint of the secrets each hosted server was **started with**.
-    ///
-    /// Only [`reload_if_secrets_changed`] reads it, and only to answer "is what
-    /// is running still what the row says". It is a hash rather than the values,
-    /// so this map is not a second place a token lives — see that function for
-    /// why the question needs asking at all.
-    secrets: HashMap<String, u64>,
 }
 
 /// The process-wide registry.
@@ -284,7 +261,6 @@ impl Registry {
     pub fn stop(&self, id: &str) {
         let mut state = self.lock();
         *state.generations.entry(id.to_string()).or_default() += 1;
-        state.secrets.remove(id);
         let removed = state.servers.remove(id);
         drop(state);
         if removed.is_some() {
@@ -312,47 +288,19 @@ impl Registry {
     /// Returns whether the handle was kept. A refused handle is dropped here,
     /// which fires its shutdown oneshot — so the listener the caller started
     /// goes away rather than outliving the row it was built from.
-    fn put_if_current(
-        &self,
-        id: &str,
-        generation: u64,
-        server: InProcessMcpServer,
-        secrets: u64,
-    ) -> bool {
+    fn put_if_current(&self, id: &str, generation: u64, server: InProcessMcpServer) -> bool {
         let mut state = self.lock();
         if state.generations.get(id).copied().unwrap_or_default() != generation {
             return false;
         }
         state.servers.insert(id.to_string(), server);
-        state.secrets.insert(id.to_string(), secrets);
         true
-    }
-
-    /// The fingerprint the server hosted under `id` was started with, or `None`
-    /// when nothing is hosted for it.
-    fn secrets(&self, id: &str) -> Option<u64> {
-        self.lock().secrets.get(id).copied()
     }
 
     /// Whether an integration is hosted right now. Nothing on the wire reads
     /// this; it exists so the lifecycle can be asserted.
     pub fn is_hosted(&self, id: &str) -> bool {
         self.lock().servers.contains_key(id)
-    }
-
-    /// The loopback URL a hosted server is listening on.
-    ///
-    /// Test-only, and it is how "did this reload actually restart anything"
-    /// is observed: `reload` binds a fresh port every time, so an unchanged URL
-    /// is proof that nothing was torn down. Not exposed outside tests because
-    /// nothing else needs it — `InProcessMcpServer` deliberately has no `Debug`,
-    /// and the URL is the one part of it that is safe to look at.
-    #[cfg(test)]
-    fn url(&self, id: &str) -> Option<String> {
-        self.lock()
-            .servers
-            .get(id)
-            .map(|server| server.url().to_string())
     }
 }
 
@@ -419,7 +367,7 @@ pub async fn reload(db_path: &Path, id: &str) -> Result<(), String> {
 async fn start_one(row: &HostingRow, generation: u64) -> Result<(), String> {
     let server = start_for_type(row).await?;
     let url = server.url().to_string();
-    if !registry().put_if_current(&row.id, generation, server, row.secrets_fingerprint()) {
+    if !registry().put_if_current(&row.id, generation, server) {
         log::info!(
             "integration MCP server discarded before it was recorded, \
              the integration was stopped while it started: id={:?} type={:?}",
@@ -1051,7 +999,7 @@ pub(super) fn google_oauth_token(
 /// projection in the port that reads the secret columns, and its charter is to
 /// read them *to build a tool server*. Two callers only want to know whether the
 /// type is one this process hosts, and both are on hot paths for rows it does
-/// not: [`can_host`] runs per chat turn, and [`reload_if_secrets_changed`] runs
+/// not: [`can_host`] runs per chat turn, and the reload paths run
 /// per poll of an OAuth dialog — which the Google, WhatsApp and detail pages all
 /// poll. Answering that question through the secret-carrying projection would
 /// pull an unrelated integration's token into memory to decide it belongs to
@@ -1167,7 +1115,7 @@ fn list_for_hosting(db_path: &Path) -> Result<Vec<HostingRow>, String> {
     Ok(out)
 }
 
-fn get_for_hosting(db_path: &Path, id: &str) -> Result<Option<HostingRow>, String> {
+pub(super) fn get_for_hosting(db_path: &Path, id: &str) -> Result<Option<HostingRow>, String> {
     let conn = crate::native::db::open_read_only(db_path)?;
     let sql = format!("{HOSTING_COLUMNS}\n     WHERE id = ?1");
     conn.query_row(&sql, [id], scan_hosting_row)
@@ -1244,84 +1192,6 @@ pub async fn reload_after_auth(db_path: &Path, id: &str) {
     }
 }
 
-/// Reload only if what the row says no longer matches what is hosted.
-///
-/// # The hole this fills, which #315 opened
-///
-/// Go's `handleOAuthToken` writes the token to the `auth` column and then calls
-/// `registry.Reload` — and `startProviderCallback` supports exactly `google` and
-/// `slack`. While neither was hosted here that was harmless, and
-/// `registry.rs`'s own header said so. **#315 made `slack` a hosted type**, so
-/// that `Reload` now reaches nothing and a Slack integration authenticated by
-/// OAuth would first be served at the next boot's [`start_all`]. **#313 made
-/// `google` one too**, which means this hook now covers *both* providers
-/// `startProviderCallback` supports — every OAuth integration in the product
-/// depends on it, and there is no longer a case it does not have to catch.
-///
-/// Google is also the one where being served late costs the most, and for a
-/// reason peculiar to it: a Google token *expires*. Slack's does not, so a Slack
-/// row served at the next boot is merely served late; a Google row carries an
-/// `expiry` that [`super::google::client::TokenSource`] reads, so a token first
-/// picked up hours later may already need the refresh this process would then
-/// have to make on the first tool call. That still works — it is what the refresh
-/// is for — but it turns a silent staleness into a visible one, which is worth
-/// knowing when reading a bug report about a slow first Google call.
-///
-/// [`reload_after_auth`] cannot cover it: that hook hangs off a *forwarded
-/// request*, and an OAuth token does not arrive on one. It is delivered by the
-/// browser to a callback server the **sidecar** opens on its own port, which
-/// this process never sees. The one part of the flow that does come through the
-/// proxy is the UI polling `GET /api/integrations/{id}/auth/status` while it
-/// waits, so that is where this hangs — which makes it **best-effort**: a user
-/// who closes the dialog before it completes is served at the next boot, as they
-/// were before. #318 owns the flow itself and is where that stops being true.
-///
-/// # Why conditional, where [`reload_after_auth`] is not
-///
-/// A poll is not an event. `reload` is unconditional by design — stop, then
-/// start, with a new port each time — so firing it per poll would restart the
-/// server every second the dialog is open and drop any in-flight `tools/call`
-/// with it. So this compares the row's current secrets against the ones the
-/// running server was started with and does nothing when they match. That covers
-/// every transition without churn: unauthenticated → authenticated (nothing
-/// hosted, now startable), a re-authentication that replaces the token
-/// (fingerprint moved), and a de-authentication (startable → not, which stops
-/// it).
-pub async fn reload_if_secrets_changed(db_path: &Path, id: &str) {
-    // The type first, through a projection that reads no secret: every page with
-    // an auth dialog polls this route, and most of those rows are types this
-    // process does not host.
-    match type_of(db_path, id) {
-        Ok(Some(integration_type)) if hosts_type(&integration_type) => {}
-        // Not ours, or deleted between the poll and this read. `stop` is the
-        // `DELETE` path's job and has already run; nothing to do here.
-        Ok(_) => return,
-        Err(e) => {
-            log::warn!("reloading integration {id:?} after an auth-status poll: {e}");
-            return;
-        }
-    }
-
-    let row = match get_for_hosting(db_path, id) {
-        Ok(Some(row)) => row,
-        Ok(None) => return,
-        Err(e) => {
-            log::warn!("reloading integration {id:?} after an auth-status poll: {e}");
-            return;
-        }
-    };
-
-    let want = row.is_startable().then(|| row.secrets_fingerprint());
-    if want == registry().secrets(id) {
-        return;
-    }
-
-    log::info!("integration {id:?} changed while its auth status was polled; reloading");
-    if let Err(e) = reload(db_path, id).await {
-        log::warn!("failed to reload integration server after auth: id={id:?} error={e}");
-    }
-}
-
 pub fn reload_blocking(db_path: &Path, id: &str) {
     let db_path = db_path.to_path_buf();
     let owned_id = id.to_string();
@@ -1382,96 +1252,6 @@ mod tests {
 
     fn github_credentials() -> String {
         format!(r#"{{"auth_mode":"pat","personal_access_token":"{PAT}"}}"#)
-    }
-
-    /// The poll-driven reload: it fires on a change and, crucially, **not**
-    /// otherwise.
-    ///
-    /// #315 opened the hole this fills — Go reloads after an OAuth token lands
-    /// and `slack` is now hosted here, but the token arrives on the sidecar's own
-    /// callback port, so the UI's polling of `auth/status` is the only part of
-    /// the flow this process sees. A poll is not an event, so the anti-churn half
-    /// is as load-bearing as the firing half: `reload` rebinds the port and drops
-    /// in-flight calls, and the dialog polls every second.
-    #[tokio::test]
-    async fn a_polled_auth_status_reloads_on_a_change_and_not_on_a_poll() {
-        let file = db();
-        // Unauthenticated, so not startable. Slack would be the true subject, but
-        // its starter needs a live token to be interesting; the condition under
-        // test is type-blind and github is the type these tests already seed.
-        insert(
-            &file,
-            "gh-oauth",
-            "github",
-            true,
-            None,
-            &github_credentials(),
-            "{}",
-        );
-
-        // Nothing hosted and nothing startable: the poll must be a no-op rather
-        // than an attempt.
-        reload_if_secrets_changed(file.path(), "gh-oauth").await;
-        assert!(!registry().is_hosted("gh-oauth"));
-
-        // The token lands — which is what Go's `handleOAuthToken` does, and what
-        // it then tells nobody about.
-        Connection::open(file.path())
-            .expect("open")
-            .execute(
-                "UPDATE integrations SET auth = ?1 WHERE id = 'gh-oauth'",
-                rusqlite::params![r#"{"login":"octocat"}"#],
-            )
-            .expect("authenticate");
-
-        reload_if_secrets_changed(file.path(), "gh-oauth").await;
-        assert!(
-            registry().is_hosted("gh-oauth"),
-            "the poll after the token landed must host it"
-        );
-        let first = registry()
-            .url("gh-oauth")
-            .expect("a hosted server has a url");
-
-        // …and every later poll must leave it exactly where it is. A changed
-        // port here would mean the dialog restarts the server once a second.
-        for _ in 0..3 {
-            reload_if_secrets_changed(file.path(), "gh-oauth").await;
-            assert_eq!(
-                registry().url("gh-oauth").as_deref(),
-                Some(first.as_str()),
-                "a poll that changed nothing must not rebind the port"
-            );
-        }
-
-        // A token *replaced* is a change, and must be picked up.
-        Connection::open(file.path())
-            .expect("open")
-            .execute(
-                "UPDATE integrations SET credentials = ?1 WHERE id = 'gh-oauth'",
-                rusqlite::params![r#"{"auth_mode":"pat","personal_access_token":"ghp-second"}"#],
-            )
-            .expect("re-authenticate");
-        reload_if_secrets_changed(file.path(), "gh-oauth").await;
-        assert!(registry().is_hosted("gh-oauth"));
-        assert_ne!(
-            registry().url("gh-oauth").as_deref(),
-            Some(first.as_str()),
-            "a replaced credential must restart the server"
-        );
-
-        // …and a de-authentication stops it.
-        Connection::open(file.path())
-            .expect("open")
-            .execute(
-                "UPDATE integrations SET auth = NULL WHERE id = 'gh-oauth'",
-                [],
-            )
-            .expect("de-authenticate");
-        reload_if_secrets_changed(file.path(), "gh-oauth").await;
-        assert!(!registry().is_hosted("gh-oauth"));
-
-        registry().stop("gh-oauth");
     }
 
     /// The whole lifecycle over the one type Rust hosts.
@@ -1695,7 +1475,7 @@ mod tests {
             .await
             .expect("a server to race with");
         assert!(
-            !registry().put_if_current("gh-race", generation, server, 0),
+            !registry().put_if_current("gh-race", generation, server),
             "a handle whose generation has moved must be refused"
         );
         assert!(!registry().is_hosted("gh-race"));
@@ -1705,7 +1485,7 @@ mod tests {
         let server = start_filtered_server(file.path(), "gh-race", &[])
             .await
             .expect("server");
-        assert!(registry().put_if_current("gh-race", generation, server, 0));
+        assert!(registry().put_if_current("gh-race", generation, server));
         assert!(registry().is_hosted("gh-race"));
         registry().stop("gh-race");
     }

--- a/desktop/src-tauri/src/native/mod.rs
+++ b/desktop/src-tauri/src/native/mod.rs
@@ -345,13 +345,14 @@ pub fn after_forward(method: &Method, path: &str, status: StatusCode) {
     tokio::spawn(async move {
         match trigger {
             // A credential was just written: reload, as Go does.
+            //
+            // The only trigger since #318. `AuthStatusPolled` used to sit
+            // beside it, reloading when a polled row stopped matching what was
+            // running — an inference standing in for an OAuth token the shell
+            // could not see land, because the sidecar owned the callback
+            // server. The shell owns it now and reloads directly.
             integrations::Trigger::CredentialWritten => {
                 integrations::registry::reload_after_auth(&db_path, &id).await;
-            }
-            // A poll, not an event — so only if the row stopped matching what is
-            // running. See `registry::reload_if_secrets_changed`.
-            integrations::Trigger::AuthStatusPolled => {
-                integrations::registry::reload_if_secrets_changed(&db_path, &id).await;
             }
         }
     });
@@ -604,7 +605,9 @@ mod tests {
         assert!(claims(&Method::PUT, "/api/integrations/abc"));
         assert!(claims(&Method::DELETE, "/api/integrations/abc"));
         assert!(!claims(&Method::PATCH, "/api/integrations/abc"));
-        assert!(!claims(&Method::GET, "/api/integrations/abc/auth/status"));
+        // #318: the OAuth flow moved, so its two routes are the shell's.
+        assert!(claims(&Method::GET, "/api/integrations/abc/auth/status"));
+        assert!(claims(&Method::POST, "/api/integrations/abc/auth/start"));
         assert!(!claims(
             &Method::GET,
             "/api/integrations/abc/webhook/status"

--- a/desktop/src-tauri/src/native/writes.rs
+++ b/desktop/src-tauri/src/native/writes.rs
@@ -70,6 +70,19 @@ pub enum WriteError {
     /// users (#309): the desktop build exports no telemetry, so a save that
     /// appeared to succeed would be the worst answer available.
     NotImplemented(String),
+    /// Go answers **500 with this exact body**, and forwarding would answer
+    /// something else.
+    ///
+    /// The distinction from [`Self::Fallback`] is the whole reason this exists.
+    /// `Fallback` means "the sidecar can answer this better than I can", which
+    /// holds for every 500 whose body comes from a Go error string. It stops
+    /// holding the moment the state the answer depends on lives **here**:
+    /// `GET /api/integrations/{id}/auth/status` reads the in-flight OAuth map,
+    /// and since #318 that map is the shell's. Forwarding a failed flow would
+    /// have Go answer from the stored token — `authenticated: false`, a
+    /// plausible-looking lie — where Go itself would have answered 500. So the
+    /// 500 is produced here, with `httpErr`'s default body verbatim.
+    Internal(String),
     /// Not reproducible here: let the sidecar answer.
     Fallback(String),
 }
@@ -92,7 +105,7 @@ impl WriteError {
             Self::NotFound { .. } | Self::NotFoundMessage(_) => StatusCode::NOT_FOUND,
             Self::Forbidden(_) => StatusCode::FORBIDDEN,
             Self::NotImplemented(_) => StatusCode::NOT_IMPLEMENTED,
-            Self::Fallback(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::Internal(_) | Self::Fallback(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 
@@ -121,15 +134,15 @@ impl WriteError {
             Self::NotFoundMessage(m) => m.clone(),
             Self::Forbidden(m) => m.clone(),
             Self::NotImplemented(m) => m.clone(),
-            Self::Fallback(m) => m.clone(),
+            Self::Internal(m) | Self::Fallback(m) => m.clone(),
         }
     }
 }
 
 /// Go's `writeError` body: a one-key map, so the encoder sorts nothing.
 #[derive(Serialize)]
-struct ErrorBody<'a> {
-    error: &'a str,
+pub struct ErrorBody<'a> {
+    pub error: &'a str,
 }
 
 /// Turn a handler result into what the seam expects.
@@ -139,6 +152,13 @@ struct ErrorBody<'a> {
 /// user which field is wrong is an *answer*, not a failure to answer, and
 /// forwarding it would make the sidecar redo the work to reach the same
 /// conclusion.
+/// `writeError`'s body, for a handler that answers a typed error outside the
+/// write path — `GET …/auth/status`, whose 404 and 500 are the *read* seam's
+/// shape but Go's own `httpErr` mapping.
+pub fn error_body(message: &str) -> ErrorBody<'_> {
+    ErrorBody { error: message }
+}
+
 pub fn finish(result: Result<super::Answer, WriteError>) -> Result<super::Answer, String> {
     match result {
         Ok(answer) => Ok(answer),


### PR DESCRIPTION
Addresses #318 — the flow half. `POST …/auth/validate` stays forwarded; see below.

## What

`POST /api/integrations/{id}/auth/start` and `GET …/auth/status` share `integrationService.oauthFlows`, a map in the process that started the flow. Split them across two processes and `status` polls a map that will never be populated — that is the pair #300 could not split, and it moves here whole. `native/integrations/oauth/` binds the loopback callback server, exchanges the code, writes the token in Go's shape, and reloads the hosted MCP server.

## It retires a workaround rather than adding beside one

While the sidecar owned the callback server, the shell **could not see a token land** — the browser delivers it straight to a port Go opened. So `reload_after_forward` inferred the event by watching the UI *poll* `auth/status`, reloading when the row stopped matching what was running (`Trigger::AuthStatusPolled`).

The shell writes the token itself now and reloads directly, exactly as `handleOAuthToken` does. So that trigger, `registry::reload_if_secrets_changed`, and the `secrets` fingerprint map it was the only reader of are **removed**. Leaving them would be a second, redundant reload path watching a route the shell now answers itself.

## Scope: `auth/validate` stays forwarded, and its recorded reason was wrong

The issue says all three move together. Half that reasoning has expired, and I checked rather than inherited it:

- **`start` + `status`** are genuinely coupled — verified that `oauthFlows` is touched at exactly two places, both of them these.
- **`validate` never touches it.** It was grouped because the credentials it writes were consumed by *Go's* MCP servers — which stopped being true when #311–#313 moved all six here.
- Its `write_routes.json` reason, *"the error text is not reproducible"*, is also no longer accurate: every validator's transport failure is a **fixed** string (the cause deliberately not interpolated), exactly as the ported clients do it.

What actually holds it back is different, so I've recorded that instead: each of the five writes a **type-specific** auth payload its own MCP server reads — `{"validated":true,"bot_username":…}` for Telegram, not a shared flag — so it is five remote-call reproductions, not one. `CredentialWritten` keeps covering its reload meanwhile.

## Verification, for two halves that cannot be live-diffed

**The URL is a vector.** The redirect port comes from a fresh `FreePort()`, so two implementations legitimately answer different URLs; everything else about the bytes is a rule. `desktop/parity/oauth_vectors.json` is generated from Go's own `BuildAuthURL`, and generating rather than transcribing immediately earned it — `oauth2.ApprovalForce` emits **`prompt=consent`**, not the `approval_prompt=force` its name implies. The seven cases also pin that the Google scope union is *ordered* (calendar → gmail → drive) rather than sorted, that `scope` is **absent** rather than empty when nothing is enabled, and that the encoding is `url.Values.Encode` where a space is `+`.

**The exchange has no vector either**, being a call to the provider — and a mistake there is not a wrong byte but an integration that silently never authenticates. So its request shape is pinned against a fake token endpoint that records what it was sent. That caught the difference that matters: **Google declares `AuthStyleInParams`** and puts its credentials in the body, while **Slack declares no style at all**, so `oauth2` tries **HTTP Basic first** and only retries in the body. Reproducing "params first" works against a server that accepts both and fails against one that does not.

**The stored token is Go's `json.Marshal(*oauth2.Token)`**, which the sidecar's MCP servers still read through the ungated `StartFilteredServer`. Note `expiry` is *always* present: `omitempty` does not omit a struct, so a token that never expires stores `0001-01-01T00:00:00Z` rather than dropping the key.

## One new `WriteError` variant, deliberately

`Internal` is **500 with a body produced here**, where `Fallback` means "the sidecar answers". The distinction bites exactly once: a failed OAuth flow. Forwarding it would have Go answer from the stored token — `authenticated: false`, a plausible-looking lie — where Go itself answers 500, because the map the answer depends on is now the shell's.

## Checks

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --no-fail-fast`, `go build ./...`, `go test ./internal/... ./cmd/... ./desktop/parity/` — all green. 16 new tests across the URL, the exchange wire shape, and the flow.