### PR TITLE
feat(desktop): the Telegram webhook and trigger dispatcher (#319)

### DIFF
--- a/desktop/parity/trigger_match_parity_test.go
+++ b/desktop/parity/trigger_match_parity_test.go
@@ -1,0 +1,269 @@
+// Cross-language vectors for trigger-rule matching (#319).
+//
+// `matchRule` decides whether an inbound Telegram message runs an agent, and
+// what prompt it runs with. It is a pure function, so it can be pinned exactly —
+// and it needs to be, because almost every clause is a place Go and Rust
+// disagree by default:
+//
+//   - **`text[:prefixLen]` is a byte slice.** Go compares bytes and will happily
+//     cut a multi-byte character in half; the same index in Rust panics. The
+//     length guard is `len(text) < prefixLen` — also bytes — so a prefix longer
+//     in bytes than the message is rejected before the slice, but a message that
+//     is long enough in bytes while being shorter in characters is not.
+//   - **`strings.EqualFold` is Unicode simple folding**, not ASCII
+//     case-insensitivity and not lower-casing: sigma folds to final sigma, while
+//     U+0130 does *not* fold to ASCII `i` even though it lower-cases to one.
+//   - **`strings.TrimSpace` trims `unicode.IsSpace`**, which is not the same set
+//     as any ASCII trim.
+//   - **An empty prompt after the trim is not a match**, even though the prefix
+//     matched — a bare `/ask` with nothing after it runs nothing.
+//   - **Keywords are OR, and lower-cased on both sides** with Unicode
+//     `ToLower`; chat ids are OR and compared exactly.
+//
+// Regenerate (only from Go, and only when adding cases):
+//
+//	go test ./desktop/parity/ -run TestTriggerMatchVectors -update-trigger-match-vectors
+package parity
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/shaharia-lab/agento/internal/config"
+	"github.com/shaharia-lab/agento/internal/trigger"
+)
+
+const triggerMatchVectorsFile = "trigger_match_vectors.json"
+
+var updateTriggerMatchVectors = flag.Bool("update-trigger-match-vectors", false,
+	"rewrite "+triggerMatchVectorsFile+" from what Go's matchRule produces")
+
+type triggerMatchCase struct {
+	Name string `json:"name"`
+	Note string `json:"note"`
+
+	FilterPrefix   string   `json:"filter_prefix"`
+	FilterKeywords []string `json:"filter_keywords"`
+	FilterChatIDs  []string `json:"filter_chat_ids"`
+
+	Text   string `json:"text"`
+	ChatID string `json:"chat_id"`
+
+	Matched bool   `json:"matched"`
+	Prompt  string `json:"prompt"`
+}
+
+type triggerMatchVectors struct {
+	Cases []triggerMatchCase `json:"cases"`
+}
+
+func triggerMatchCases() []triggerMatchCase {
+	return []triggerMatchCase{
+		{
+			Name: "no-filters/everything-matches",
+			Note: "an unfiltered rule takes the message verbatim as the prompt",
+			Text: "hello there", ChatID: "42",
+		},
+		{
+			Name:         "prefix/stripped-and-trimmed",
+			Note:         "the prompt is what follows the prefix, space-trimmed",
+			FilterPrefix: "/ask", Text: "/ask   what is the time", ChatID: "42",
+		},
+		{
+			Name:         "prefix/case-insensitive",
+			Note:         "EqualFold, so the stored prefix and the sent one may differ in case",
+			FilterPrefix: "/Ask", Text: "/aSK something", ChatID: "42",
+		},
+		{
+			Name: "prefix/ascii-prefix-slices-into-a-multibyte-first-character",
+			Note: "the sharpest case here. The prefix is one ASCII byte and the " +
+				"message starts with U+212A (three bytes), so text[:1] is a lone " +
+				"continuation byte — invalid UTF-8. Go decodes it as RuneError and " +
+				"does not match. A port slicing by *character* would compare U+212A " +
+				"against 'K' instead; one slicing by byte in Rust would panic.",
+			FilterPrefix: "K", Text: "\u212Aelvin question", ChatID: "42",
+		},
+		{
+			Name: "prefix/multibyte-prefix-against-ascii-text",
+			Note: "the mirror of the case above. A three-byte prefix against ASCII " +
+				"text takes text[:3] — three whole characters — and EqualFold " +
+				"compares three runes against one, so it cannot match however the " +
+				"single rune folds. The fold orbit is exercised by the sigma cases " +
+				"instead, whose forms are all two bytes.",
+			FilterPrefix: "\u212A", Text: "kelvin question", ChatID: "42",
+		},
+		{
+			Name:         "prefix/fold-final-sigma",
+			Note:         "EqualFold is simple folding, so final sigma folds to sigma",
+			FilterPrefix: "\u03C3", Text: "\u03C2 lower sigma", ChatID: "42",
+		},
+		{
+			Name:         "prefix/fold-capital-sigma",
+			Note:         "…and the capital folds to both",
+			FilterPrefix: "\u03A3", Text: "\u03C3 sigma", ChatID: "42",
+		},
+		{
+			Name: "prefix/dotted-capital-i-does-not-fold-to-ascii-i",
+			Note: "U+0130 has no simple fold to ASCII 'i'. A port lower-casing " +
+				"instead of folding would disagree, because ToLower(U+0130) begins " +
+				"with one.",
+			FilterPrefix: "i", Text: "\u0130stanbul", ChatID: "42",
+		},
+		{
+			Name:         "prefix/no-match",
+			Note:         "a message that does not start with the prefix runs nothing",
+			FilterPrefix: "/ask", Text: "tell me a joke", ChatID: "42",
+		},
+		{
+			Name: "prefix/empty-remainder-is-not-a-match",
+			Note: "a bare prefix with nothing after it is rejected, not run with an " +
+				"empty prompt",
+			FilterPrefix: "/ask", Text: "/ask", ChatID: "42",
+		},
+		{
+			Name:         "prefix/whitespace-only-remainder-is-not-a-match",
+			Note:         "…and neither is one whose remainder trims away",
+			FilterPrefix: "/ask", Text: "/ask    ", ChatID: "42",
+		},
+		{
+			Name: "prefix/shorter-than-the-prefix-in-bytes",
+			Note: "the length guard is bytes, and it is what stops the slice below " +
+				"from being out of range",
+			FilterPrefix: "/ask", Text: "/a", ChatID: "42",
+		},
+		{
+			Name: "prefix/multibyte-text-with-ascii-prefix",
+			Note: "the byte slice cuts into a multi-byte character: Go compares the " +
+				"broken bytes and does not match, where a char-wise port would " +
+				"either panic or compare something else",
+			FilterPrefix: "ab", Text: "éxyz", ChatID: "42",
+		},
+		{
+			Name:         "prefix/multibyte-prefix-matches-itself",
+			Note:         "the same slice is exact when the prefix really is the prefix",
+			FilterPrefix: "é", Text: "é accented question", ChatID: "42",
+		},
+		{
+			Name: "prefix/nbsp-remainder-trims-away",
+			Note: "unicode.IsSpace includes U+00A0, so a NBSP-only remainder is " +
+				"empty and the rule does not fire. Rust's char::is_whitespace agrees " +
+				"— both follow White_Space — but that is two standards agreeing, " +
+				"which is why it is pinned rather than assumed.",
+			FilterPrefix: "/ask", Text: "/ask\u00A0", ChatID: "42",
+		},
+		{
+			Name:         "prefix/nel-remainder-trims-away",
+			Note:         "U+0085 is unicode.IsSpace, so this remainder is empty",
+			FilterPrefix: "/ask", Text: "/ask", ChatID: "42",
+		},
+		{
+			Name:           "keywords/or-logic",
+			Note:           "any keyword matching is enough",
+			FilterKeywords: []string{"deploy", "release"}, Text: "time to release", ChatID: "42",
+		},
+		{
+			Name:           "keywords/case-insensitive-both-sides",
+			Note:           "the text and the keyword are both lower-cased",
+			FilterKeywords: []string{"DePloY"}, Text: "Please DEPLOY now", ChatID: "42",
+		},
+		{
+			Name:           "keywords/substring-not-word",
+			Note:           "Contains, so a keyword inside a longer word matches",
+			FilterKeywords: []string{"ploy"}, Text: "redeployment", ChatID: "42",
+		},
+		{
+			Name:           "keywords/none-match",
+			FilterKeywords: []string{"deploy"}, Text: "good morning", ChatID: "42",
+		},
+		{
+			Name:           "keywords/empty-list-matches-everything",
+			FilterKeywords: []string{}, Text: "anything at all", ChatID: "42",
+		},
+		{
+			Name:          "chat-ids/allowed",
+			FilterChatIDs: []string{"42", "77"}, Text: "hi", ChatID: "77",
+		},
+		{
+			Name:          "chat-ids/not-allowed",
+			FilterChatIDs: []string{"42"}, Text: "hi", ChatID: "999",
+		},
+		{
+			Name:          "chat-ids/exact-string-compare",
+			Note:          "the id is compared as text, so a leading zero is a different chat",
+			FilterChatIDs: []string{"042"}, Text: "hi", ChatID: "42",
+		},
+		{
+			Name:          "chat-ids/negative-group-id",
+			Note:          "group chats have negative ids and are compared the same way",
+			FilterChatIDs: []string{"-1001234567890"}, Text: "hi", ChatID: "-1001234567890",
+		},
+		{
+			Name: "all-three/prefix-strips-before-keywords-are-checked-against-the-FULL-text",
+			Note: "the keyword check runs against `text`, not the stripped prompt — " +
+				"so a keyword that appears only inside the prefix still matches",
+			FilterPrefix: "/deploy", FilterKeywords: []string{"deploy"},
+			Text: "/deploy the thing", ChatID: "42",
+		},
+		{
+			Name: "all-three/keyword-only-in-prefix",
+			Note: "the sharp edge of the clause above: the prompt has no 'deploy' in " +
+				"it at all, and the rule still fires",
+			FilterPrefix: "/deploy", FilterKeywords: []string{"deploy"},
+			Text: "/deploy now please", ChatID: "42",
+		},
+		{
+			Name:         "all-three/every-filter-satisfied",
+			FilterPrefix: "/ask", FilterKeywords: []string{"status"},
+			FilterChatIDs: []string{"42"},
+			Text:          "/ask what is the status", ChatID: "42",
+		},
+		{
+			Name:         "all-three/chat-id-rejects-an-otherwise-matching-message",
+			FilterPrefix: "/ask", FilterKeywords: []string{"status"},
+			FilterChatIDs: []string{"42"},
+			Text:          "/ask what is the status", ChatID: "43",
+		},
+	}
+}
+
+func TestTriggerMatchVectors(t *testing.T) {
+	cases := triggerMatchCases()
+	for i := range cases {
+		c := &cases[i]
+		rule := &config.TriggerRule{
+			Enabled:        true,
+			FilterPrefix:   c.FilterPrefix,
+			FilterKeywords: c.FilterKeywords,
+			FilterChatIDs:  c.FilterChatIDs,
+		}
+		matched, prompt := trigger.MatchRuleForTest(rule, c.Text, c.ChatID)
+		c.Matched = matched
+		c.Prompt = prompt
+	}
+
+	encoded, err := json.MarshalIndent(triggerMatchVectors{Cases: cases}, "", "  ")
+	if err != nil {
+		t.Fatalf("encoding vectors: %v", err)
+	}
+	encoded = append(encoded, '\n')
+
+	if *updateTriggerMatchVectors {
+		if writeErr := os.WriteFile(triggerMatchVectorsFile, encoded, 0o600); writeErr != nil {
+			t.Fatalf("writing %s: %v", triggerMatchVectorsFile, writeErr)
+		}
+		return
+	}
+
+	stored, err := os.ReadFile(triggerMatchVectorsFile)
+	if err != nil {
+		t.Fatalf("reading %s: %v (regenerate with -update-trigger-match-vectors)",
+			triggerMatchVectorsFile, err)
+	}
+	if string(stored) != string(encoded) {
+		t.Fatalf("%s is stale: Go's matchRule no longer produces it.\n"+
+			"Regenerate with: go test ./desktop/parity/ -run TestTriggerMatchVectors "+
+			"-update-trigger-match-vectors", triggerMatchVectorsFile)
+	}
+}

--- a/desktop/parity/trigger_match_parity_test.go
+++ b/desktop/parity/trigger_match_parity_test.go
@@ -156,7 +156,7 @@ func triggerMatchCases() []triggerMatchCase {
 		{
 			Name:         "prefix/nel-remainder-trims-away",
 			Note:         "U+0085 is unicode.IsSpace, so this remainder is empty",
-			FilterPrefix: "/ask", Text: "/ask", ChatID: "42",
+			FilterPrefix: "/ask", Text: "/ask\u0085", ChatID: "42",
 		},
 		{
 			Name:           "keywords/or-logic",

--- a/desktop/parity/trigger_match_vectors.json
+++ b/desktop/parity/trigger_match_vectors.json
@@ -1,0 +1,353 @@
+{
+  "cases": [
+    {
+      "name": "no-filters/everything-matches",
+      "note": "an unfiltered rule takes the message verbatim as the prompt",
+      "filter_prefix": "",
+      "filter_keywords": null,
+      "filter_chat_ids": null,
+      "text": "hello there",
+      "chat_id": "42",
+      "matched": true,
+      "prompt": "hello there"
+    },
+    {
+      "name": "prefix/stripped-and-trimmed",
+      "note": "the prompt is what follows the prefix, space-trimmed",
+      "filter_prefix": "/ask",
+      "filter_keywords": null,
+      "filter_chat_ids": null,
+      "text": "/ask   what is the time",
+      "chat_id": "42",
+      "matched": true,
+      "prompt": "what is the time"
+    },
+    {
+      "name": "prefix/case-insensitive",
+      "note": "EqualFold, so the stored prefix and the sent one may differ in case",
+      "filter_prefix": "/Ask",
+      "filter_keywords": null,
+      "filter_chat_ids": null,
+      "text": "/aSK something",
+      "chat_id": "42",
+      "matched": true,
+      "prompt": "something"
+    },
+    {
+      "name": "prefix/ascii-prefix-slices-into-a-multibyte-first-character",
+      "note": "the sharpest case here. The prefix is one ASCII byte and the message starts with U+212A (three bytes), so text[:1] is a lone continuation byte — invalid UTF-8. Go decodes it as RuneError and does not match. A port slicing by *character* would compare U+212A against 'K' instead; one slicing by byte in Rust would panic.",
+      "filter_prefix": "K",
+      "filter_keywords": null,
+      "filter_chat_ids": null,
+      "text": "Kelvin question",
+      "chat_id": "42",
+      "matched": false,
+      "prompt": ""
+    },
+    {
+      "name": "prefix/multibyte-prefix-against-ascii-text",
+      "note": "the mirror of the case above. A three-byte prefix against ASCII text takes text[:3] — three whole characters — and EqualFold compares three runes against one, so it cannot match however the single rune folds. The fold orbit is exercised by the sigma cases instead, whose forms are all two bytes.",
+      "filter_prefix": "K",
+      "filter_keywords": null,
+      "filter_chat_ids": null,
+      "text": "kelvin question",
+      "chat_id": "42",
+      "matched": false,
+      "prompt": ""
+    },
+    {
+      "name": "prefix/fold-final-sigma",
+      "note": "EqualFold is simple folding, so final sigma folds to sigma",
+      "filter_prefix": "σ",
+      "filter_keywords": null,
+      "filter_chat_ids": null,
+      "text": "ς lower sigma",
+      "chat_id": "42",
+      "matched": true,
+      "prompt": "lower sigma"
+    },
+    {
+      "name": "prefix/fold-capital-sigma",
+      "note": "…and the capital folds to both",
+      "filter_prefix": "Σ",
+      "filter_keywords": null,
+      "filter_chat_ids": null,
+      "text": "σ sigma",
+      "chat_id": "42",
+      "matched": true,
+      "prompt": "sigma"
+    },
+    {
+      "name": "prefix/dotted-capital-i-does-not-fold-to-ascii-i",
+      "note": "U+0130 has no simple fold to ASCII 'i'. A port lower-casing instead of folding would disagree, because ToLower(U+0130) begins with one.",
+      "filter_prefix": "i",
+      "filter_keywords": null,
+      "filter_chat_ids": null,
+      "text": "İstanbul",
+      "chat_id": "42",
+      "matched": false,
+      "prompt": ""
+    },
+    {
+      "name": "prefix/no-match",
+      "note": "a message that does not start with the prefix runs nothing",
+      "filter_prefix": "/ask",
+      "filter_keywords": null,
+      "filter_chat_ids": null,
+      "text": "tell me a joke",
+      "chat_id": "42",
+      "matched": false,
+      "prompt": ""
+    },
+    {
+      "name": "prefix/empty-remainder-is-not-a-match",
+      "note": "a bare prefix with nothing after it is rejected, not run with an empty prompt",
+      "filter_prefix": "/ask",
+      "filter_keywords": null,
+      "filter_chat_ids": null,
+      "text": "/ask",
+      "chat_id": "42",
+      "matched": false,
+      "prompt": ""
+    },
+    {
+      "name": "prefix/whitespace-only-remainder-is-not-a-match",
+      "note": "…and neither is one whose remainder trims away",
+      "filter_prefix": "/ask",
+      "filter_keywords": null,
+      "filter_chat_ids": null,
+      "text": "/ask    ",
+      "chat_id": "42",
+      "matched": false,
+      "prompt": ""
+    },
+    {
+      "name": "prefix/shorter-than-the-prefix-in-bytes",
+      "note": "the length guard is bytes, and it is what stops the slice below from being out of range",
+      "filter_prefix": "/ask",
+      "filter_keywords": null,
+      "filter_chat_ids": null,
+      "text": "/a",
+      "chat_id": "42",
+      "matched": false,
+      "prompt": ""
+    },
+    {
+      "name": "prefix/multibyte-text-with-ascii-prefix",
+      "note": "the byte slice cuts into a multi-byte character: Go compares the broken bytes and does not match, where a char-wise port would either panic or compare something else",
+      "filter_prefix": "ab",
+      "filter_keywords": null,
+      "filter_chat_ids": null,
+      "text": "éxyz",
+      "chat_id": "42",
+      "matched": false,
+      "prompt": ""
+    },
+    {
+      "name": "prefix/multibyte-prefix-matches-itself",
+      "note": "the same slice is exact when the prefix really is the prefix",
+      "filter_prefix": "é",
+      "filter_keywords": null,
+      "filter_chat_ids": null,
+      "text": "é accented question",
+      "chat_id": "42",
+      "matched": true,
+      "prompt": "accented question"
+    },
+    {
+      "name": "prefix/nbsp-remainder-trims-away",
+      "note": "unicode.IsSpace includes U+00A0, so a NBSP-only remainder is empty and the rule does not fire. Rust's char::is_whitespace agrees — both follow White_Space — but that is two standards agreeing, which is why it is pinned rather than assumed.",
+      "filter_prefix": "/ask",
+      "filter_keywords": null,
+      "filter_chat_ids": null,
+      "text": "/ask ",
+      "chat_id": "42",
+      "matched": false,
+      "prompt": ""
+    },
+    {
+      "name": "prefix/nel-remainder-trims-away",
+      "note": "U+0085 is unicode.IsSpace, so this remainder is empty",
+      "filter_prefix": "/ask",
+      "filter_keywords": null,
+      "filter_chat_ids": null,
+      "text": "/ask",
+      "chat_id": "42",
+      "matched": false,
+      "prompt": ""
+    },
+    {
+      "name": "keywords/or-logic",
+      "note": "any keyword matching is enough",
+      "filter_prefix": "",
+      "filter_keywords": [
+        "deploy",
+        "release"
+      ],
+      "filter_chat_ids": null,
+      "text": "time to release",
+      "chat_id": "42",
+      "matched": true,
+      "prompt": "time to release"
+    },
+    {
+      "name": "keywords/case-insensitive-both-sides",
+      "note": "the text and the keyword are both lower-cased",
+      "filter_prefix": "",
+      "filter_keywords": [
+        "DePloY"
+      ],
+      "filter_chat_ids": null,
+      "text": "Please DEPLOY now",
+      "chat_id": "42",
+      "matched": true,
+      "prompt": "Please DEPLOY now"
+    },
+    {
+      "name": "keywords/substring-not-word",
+      "note": "Contains, so a keyword inside a longer word matches",
+      "filter_prefix": "",
+      "filter_keywords": [
+        "ploy"
+      ],
+      "filter_chat_ids": null,
+      "text": "redeployment",
+      "chat_id": "42",
+      "matched": true,
+      "prompt": "redeployment"
+    },
+    {
+      "name": "keywords/none-match",
+      "note": "",
+      "filter_prefix": "",
+      "filter_keywords": [
+        "deploy"
+      ],
+      "filter_chat_ids": null,
+      "text": "good morning",
+      "chat_id": "42",
+      "matched": false,
+      "prompt": ""
+    },
+    {
+      "name": "keywords/empty-list-matches-everything",
+      "note": "",
+      "filter_prefix": "",
+      "filter_keywords": [],
+      "filter_chat_ids": null,
+      "text": "anything at all",
+      "chat_id": "42",
+      "matched": true,
+      "prompt": "anything at all"
+    },
+    {
+      "name": "chat-ids/allowed",
+      "note": "",
+      "filter_prefix": "",
+      "filter_keywords": null,
+      "filter_chat_ids": [
+        "42",
+        "77"
+      ],
+      "text": "hi",
+      "chat_id": "77",
+      "matched": true,
+      "prompt": "hi"
+    },
+    {
+      "name": "chat-ids/not-allowed",
+      "note": "",
+      "filter_prefix": "",
+      "filter_keywords": null,
+      "filter_chat_ids": [
+        "42"
+      ],
+      "text": "hi",
+      "chat_id": "999",
+      "matched": false,
+      "prompt": ""
+    },
+    {
+      "name": "chat-ids/exact-string-compare",
+      "note": "the id is compared as text, so a leading zero is a different chat",
+      "filter_prefix": "",
+      "filter_keywords": null,
+      "filter_chat_ids": [
+        "042"
+      ],
+      "text": "hi",
+      "chat_id": "42",
+      "matched": false,
+      "prompt": ""
+    },
+    {
+      "name": "chat-ids/negative-group-id",
+      "note": "group chats have negative ids and are compared the same way",
+      "filter_prefix": "",
+      "filter_keywords": null,
+      "filter_chat_ids": [
+        "-1001234567890"
+      ],
+      "text": "hi",
+      "chat_id": "-1001234567890",
+      "matched": true,
+      "prompt": "hi"
+    },
+    {
+      "name": "all-three/prefix-strips-before-keywords-are-checked-against-the-FULL-text",
+      "note": "the keyword check runs against `text`, not the stripped prompt — so a keyword that appears only inside the prefix still matches",
+      "filter_prefix": "/deploy",
+      "filter_keywords": [
+        "deploy"
+      ],
+      "filter_chat_ids": null,
+      "text": "/deploy the thing",
+      "chat_id": "42",
+      "matched": true,
+      "prompt": "the thing"
+    },
+    {
+      "name": "all-three/keyword-only-in-prefix",
+      "note": "the sharp edge of the clause above: the prompt has no 'deploy' in it at all, and the rule still fires",
+      "filter_prefix": "/deploy",
+      "filter_keywords": [
+        "deploy"
+      ],
+      "filter_chat_ids": null,
+      "text": "/deploy now please",
+      "chat_id": "42",
+      "matched": true,
+      "prompt": "now please"
+    },
+    {
+      "name": "all-three/every-filter-satisfied",
+      "note": "",
+      "filter_prefix": "/ask",
+      "filter_keywords": [
+        "status"
+      ],
+      "filter_chat_ids": [
+        "42"
+      ],
+      "text": "/ask what is the status",
+      "chat_id": "42",
+      "matched": true,
+      "prompt": "what is the status"
+    },
+    {
+      "name": "all-three/chat-id-rejects-an-otherwise-matching-message",
+      "note": "",
+      "filter_prefix": "/ask",
+      "filter_keywords": [
+        "status"
+      ],
+      "filter_chat_ids": [
+        "42"
+      ],
+      "text": "/ask what is the status",
+      "chat_id": "43",
+      "matched": false,
+      "prompt": ""
+    }
+  ]
+}

--- a/desktop/parity/write_routes.json
+++ b/desktop/parity/write_routes.json
@@ -285,9 +285,9 @@
     {
       "method": "POST",
       "route": "/webhooks/telegram/{id}",
-      "status": "deferred",
-      "owner": "#275",
-      "reason": "dispatches an agent run; the executor is still Go's"
+      "status": "native",
+      "owner": "#319",
+      "reason": "the shell receives the update and dispatches the run"
     },
     {
       "method": "PUT",

--- a/desktop/parity/write_routes.json
+++ b/desktop/parity/write_routes.json
@@ -54,9 +54,9 @@
     {
       "method": "DELETE",
       "route": "/api/integrations/{id}/webhook/register",
-      "status": "deferred",
-      "owner": "-",
-      "reason": "deregisters the webhook with Telegram"
+      "status": "native",
+      "owner": "#319",
+      "reason": "a failed deleteWebhook is a warning; the row is cleared either way"
     },
     {
       "method": "DELETE",
@@ -208,16 +208,16 @@
     {
       "method": "POST",
       "route": "/api/integrations/{id}/webhook/regenerate-secret",
-      "status": "deferred",
-      "owner": "-",
-      "reason": "rotates the secret and re-registers with Telegram"
+      "status": "native",
+      "owner": "#319",
+      "reason": "delete, clear, register — the delete's failure is swallowed as Go swallows it"
     },
     {
       "method": "POST",
       "route": "/api/integrations/{id}/webhook/register",
-      "status": "deferred",
-      "owner": "-",
-      "reason": "registers the webhook with Telegram"
+      "status": "native",
+      "owner": "#319",
+      "reason": "fails before the Telegram call, never after"
     },
     {
       "method": "POST",

--- a/desktop/parity/write_routes_parity_test.go
+++ b/desktop/parity/write_routes_parity_test.go
@@ -195,7 +195,12 @@ var dispositions = map[string]disposition{
 	// with a foreign `Host` — and its effect is a trigger-rule match plus an
 	// agent run through the dispatcher, which is the scheduler's executor by
 	// another name.
-	"POST /webhooks/telegram/{id}": {statusDeferred, "#275", "dispatches an agent run; the executor is still Go's"},
+	// #275 moved the executor, which was the reason recorded here, and #319
+	// moved the dispatcher that uses it. The route is mounted at the root, so it
+	// is the one claimed path outside `/api` and outside both guards — it
+	// arrives from Telegram with a foreign Host and authenticates on its own
+	// secret token.
+	"POST /webhooks/telegram/{id}": {statusNative, "#319", "the shell receives the update and dispatches the run"},
 
 	// ── Not deferred: dropped (#273) ────────────────────────────────────────
 	"POST /api/integrations/{id}/whatsapp/pair":      {statusDropped, "#273", "WhatsApp is dropped, not deferred; dies with the sidecar"},

--- a/desktop/parity/write_routes_parity_test.go
+++ b/desktop/parity/write_routes_parity_test.go
@@ -180,10 +180,14 @@ var dispositions = map[string]disposition{
 	// five writes a **type-specific** auth payload its MCP server reads
 	// (`{"validated":true,"bot_username":…}` for Telegram, not a shared flag),
 	// so this is five remote-call reproductions rather than one.
-	"POST /api/integrations/{id}/auth/validate":             {statusDeferred, "-", "five per-type remote validations, each writing its own auth payload"},
-	"POST /api/integrations/{id}/webhook/register":          {statusDeferred, "-", "registers the webhook with Telegram"},
-	"DELETE /api/integrations/{id}/webhook/register":        {statusDeferred, "-", "deregisters the webhook with Telegram"},
-	"POST /api/integrations/{id}/webhook/regenerate-secret": {statusDeferred, "-", "rotates the secret and re-registers with Telegram"},
+	"POST /api/integrations/{id}/auth/validate": {statusDeferred, "-", "five per-type remote validations, each writing its own auth payload"},
+	// The three that call Telegram (#319). They are native because the order is
+	// the design: every fallible step happens before setWebhook, and nothing
+	// after it may fail — an Err after a successful call forwards, and Go
+	// registers the webhook again under its own secret.
+	"POST /api/integrations/{id}/webhook/register":          {statusNative, "#319", "fails before the Telegram call, never after"},
+	"DELETE /api/integrations/{id}/webhook/register":        {statusNative, "#319", "a failed deleteWebhook is a warning; the row is cleared either way"},
+	"POST /api/integrations/{id}/webhook/regenerate-secret": {statusNative, "#319", "delete, clear, register — the delete's failure is swallowed as Go swallows it"},
 
 	// ── Deferred: the sidecar's boot-time snapshot (#305) ───────────────────
 	"PUT /api/settings": {statusDeferred, "#305", "the sidecar holds a snapshot these preferences resolve through; no AGENTO_SCANNER=off equivalent exists"},

--- a/desktop/src-tauri/src/native/agent_run.rs
+++ b/desktop/src-tauri/src/native/agent_run.rs
@@ -48,6 +48,20 @@ pub async fn run_headless(
     prompt: &str,
     timeout: std::time::Duration,
 ) -> Result<RunResult, String> {
+    // `resolveSystemPrompt`, which Go calls inside `RunAgent` — so it applies to
+    // **every** caller, and returning its error unwrapped is what makes an agent
+    // with an unresolvable `{{name}}` a recorded failure rather than a run that
+    // ships the raw placeholder to the model.
+    //
+    // It lives here rather than in each caller for the reason the one-shot does:
+    // the scheduler had it and the dispatcher did not, which is exactly the
+    // divergence a shared function exists to prevent. `build_options` cannot do
+    // it — the chat path deliberately interpolates leniently, so the strictness
+    // is the headless caller's.
+    if let Some(agent) = spec.agent.as_ref() {
+        crate::native::template::interpolate(&agent.system_prompt).map_err(|e| e.to_string())?;
+    }
+
     let deadline = tokio::time::Instant::now() + timeout;
 
     // The refusal this port has that Go does not — an agent whose tools cannot

--- a/desktop/src-tauri/src/native/agent_run.rs
+++ b/desktop/src-tauri/src/native/agent_run.rs
@@ -1,0 +1,187 @@
+//! Running an agent to completion with **no interactive permission handler and
+//! no SSE** — `agent.RunAgent` plus `collectRunResult`.
+//!
+//! Shared by the two callers that have no user watching: the scheduler (#275)
+//! and the Telegram trigger dispatcher (#319). Go shares it too — both call
+//! `agent.RunAgent` — and the reason to share it here is sharper than tidiness.
+//!
+//! **The trap this file exists to hold in one place:** the run must go through
+//! [`crate::claude::client::query`], the *one-shot*, and never through
+//! `Session`. A `Session` sets `session_mode`, and `process.rs`'s reader then
+//! deliberately neither closes stdin nor stops at the `result` event, "so the
+//! subprocess survives for the next send". A headless run has no next send, so
+//! the event channel never closes, the drain blocks past the answer, and the
+//! run sits until its timeout before being recorded as a failure. That shipped
+//! once already, in the scheduler, and was invisible to CI, to byte-identical
+//! live parity and to fifty unit tests, because none of them ran a task. One
+//! implementation means the second caller cannot reintroduce it.
+
+use std::sync::Arc;
+
+use crate::native::chat::runner::{self, RunSpec};
+
+/// What one run produced. `agent.AgentResult`, narrowed to the fields its two
+/// callers store — the thinking, cost and per-model breakdowns are collected
+/// by Go and then dropped by this caller.
+#[derive(Debug, Default)]
+pub struct RunResult {
+    pub session_id: String,
+    pub answer: String,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_creation_tokens: i64,
+    pub cache_read_tokens: i64,
+}
+
+/// `agent.RunAgent`: build the options, spawn the CLI, drain it, answer the
+/// result.
+///
+/// `deadline` covers **every stage that can await**, as Go's
+/// `context.WithTimeout` around the whole call does — `build_options` included,
+/// since it is not arithmetic but starts an in-process MCP server per
+/// integration the agent names. It is a shared `Instant` rather than one future
+/// wrapping everything, because `Stream` has no `Drop`: cancelling a future that
+/// owns one abandons the subprocess instead of stopping it, so `close()` has to
+/// stay reachable.
+pub async fn run_headless(
+    spec: &RunSpec,
+    prompt: &str,
+    timeout: std::time::Duration,
+) -> Result<RunResult, String> {
+    let deadline = tokio::time::Instant::now() + timeout;
+
+    // The refusal this port has that Go does not — an agent whose tools cannot
+    // be hosted here. The caller decides what to do with it; both callers
+    // record it rather than dropping it.
+    let (options, tool_servers) =
+        tokio::time::timeout_at(deadline, runner::build_options(spec, None))
+            .await
+            .map_err(|_| DEADLINE_EXCEEDED.to_string())?
+            .map_err(|e| format!("agent setup: {e}"))?;
+
+    let mut stream = match tokio::time::timeout_at(
+        deadline,
+        crate::claude::client::query(prompt, options),
+    )
+    .await
+    {
+        Ok(Ok(stream)) => stream,
+        Ok(Err(e)) => {
+            drop(tool_servers);
+            return Err(format!("starting agent: {e}"));
+        }
+        Err(_) => {
+            drop(tool_servers);
+            return Err(DEADLINE_EXCEEDED.to_string());
+        }
+    };
+
+    let collected = tokio::time::timeout_at(deadline, collect_run_result(&mut stream))
+        .await
+        .unwrap_or_else(|_| Err(DEADLINE_EXCEEDED.to_string()));
+
+    stream.close();
+    // The in-process tool listeners outlive the subprocess and stop when
+    // dropped, so this is after `close` rather than before it.
+    drop(tool_servers);
+    collected
+}
+
+/// A `RunSpec` for a headless run of `agent`, with no session pinned.
+///
+/// `buildRunOptions` sets neither session field, so the CLI generates its own id
+/// and the caller stores it afterwards.
+pub fn headless_spec(
+    db_path: &std::path::Path,
+    agent: crate::native::agents::Agent,
+    working_dir: String,
+    settings_profile_id: String,
+) -> RunSpec {
+    RunSpec {
+        agent: Some(agent),
+        // Never called: both callers synthesize an agent rather than passing
+        // `None`, because Go's own resolvers return a non-nil config — and a
+        // non-nil config with empty capabilities gets all twelve built-in
+        // tools where a nil one gets none.
+        no_agent_model: Box::new(String::new),
+        settings: Arc::new(runner::TurnSettings::from_db(db_path)),
+        working_dir,
+        settings_profile_id,
+        resume_session_id: None,
+        custom_session_id: String::new(),
+    }
+}
+
+/// What `context.DeadlineExceeded` reaches Go's caller as, and therefore what
+/// lands in `job_history.error_message` for a run that ran out of time.
+pub const DEADLINE_EXCEEDED: &str = "context deadline exceeded";
+
+/// `collectRunResult`: drain every event, keep the last result.
+///
+/// The drain does **not** stop at the result event, and that is Go's comment
+/// rather than an accident: the subprocess still has its transcript to write,
+/// and returning early would race the scanner against a half-written file.
+async fn collect_run_result(
+    stream: &mut crate::claude::client::Stream,
+) -> Result<RunResult, String> {
+    let mut result: Option<RunResult> = None;
+    let mut result_err: Option<String> = None;
+
+    while let Some(event) = stream.next_event().await {
+        let Some(r) = event.result.as_ref() else {
+            continue;
+        };
+        if r.is_error {
+            result_err = Some(build_result_error(r));
+        } else {
+            result = Some(RunResult {
+                session_id: r.session_id.clone(),
+                answer: r.result.clone(),
+                input_tokens: r.usage.input_tokens,
+                output_tokens: r.usage.output_tokens,
+                cache_creation_tokens: r.usage.cache_creation_input_tokens,
+                cache_read_tokens: r.usage.cache_read_input_tokens,
+            });
+        }
+    }
+
+    if let Some(err) = result_err {
+        return Err(err);
+    }
+    result.ok_or_else(|| "agent finished without returning a result".to_string())
+}
+
+/// `buildResultError`, message for message.
+fn build_result_error(r: &crate::claude::messages::Result) -> String {
+    let mut msg = r.result.clone();
+    if msg.is_empty() && !r.errors.is_empty() {
+        msg = r.errors.join("; ");
+    }
+    if msg.is_empty() {
+        msg = format!("subtype={}", r.subtype);
+    }
+    format!("agent error: {msg}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_result_error_prefers_the_message_then_the_errors_then_the_subtype() {
+        let mut r = crate::claude::messages::Result {
+            subtype: "error_max_turns".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(
+            build_result_error(&r),
+            "agent error: subtype=error_max_turns"
+        );
+
+        r.errors = vec!["one".to_string(), "two".to_string()];
+        assert_eq!(build_result_error(&r), "agent error: one; two");
+
+        r.result = "the message".to_string();
+        assert_eq!(build_result_error(&r), "agent error: the message");
+    }
+}

--- a/desktop/src-tauri/src/native/agent_run.rs
+++ b/desktop/src-tauri/src/native/agent_run.rs
@@ -23,7 +23,7 @@ use crate::native::chat::runner::{self, RunSpec};
 /// What one run produced. `agent.AgentResult`, narrowed to the fields its two
 /// callers store — the thinking, cost and per-model breakdowns are collected
 /// by Go and then dropped by this caller.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct RunResult {
     pub session_id: String,
     pub answer: String,

--- a/desktop/src-tauri/src/native/integrations.rs
+++ b/desktop/src-tauri/src/native/integrations.rs
@@ -84,8 +84,6 @@
 //!   token only when no flow is running, so a native reader would report the
 //!   pre-flow answer in exactly the window the endpoint exists for — while the
 //!   user is completing a consent screen.
-//! - **`GET /{id}/webhook/status`** asks Telegram, over the network, with the
-//!   bot token.
 //! - **`GET /{id}/whatsapp/*`** is not ported at all: WhatsApp is dropped from
 //!   the desktop app by decision (`whatsmeow` has no Rust equivalent), so these
 //!   routes must keep answering exactly as the sidecar answers them. As of
@@ -149,6 +147,7 @@ pub mod telegram;
 /// projection living next door, where nothing that builds a response can see it.
 pub mod oauth;
 pub mod registry;
+pub mod webhook;
 
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -449,6 +448,8 @@ enum Route<'a> {
     AuthStart(&'a str),
     /// `{id}/auth/status` — polls the in-flight flow, or the stored token.
     AuthStatus(&'a str),
+    /// `{id}/webhook/status` — the stored Telegram webhook state (#319).
+    WebhookStatus(&'a str),
 }
 
 /// Match the reads, plus the write routes that share their paths.
@@ -473,6 +474,9 @@ fn route_of(path: &str) -> Option<Route<'_>> {
     }
     if let Some(id) = rest.strip_suffix("/auth/status") {
         return segment(id).map(Route::AuthStatus);
+    }
+    if let Some(id) = rest.strip_suffix("/webhook/status") {
+        return segment(id).map(Route::WebhookStatus);
     }
     if let Some((id, tail)) = rest.split_once("/triggers/") {
         return match (segment(id), segment(tail)) {
@@ -582,23 +586,15 @@ fn claims(method: &Method, path: &str) -> bool {
         }
         Some(Route::Triggers(_)) => method == Method::GET || method == Method::POST,
         Some(Route::Trigger(..)) => method == Method::PUT || method == Method::DELETE,
-        // #318 moved the OAuth **flow**: `start` and `status` share the
-        // in-flight map, so splitting them across two processes leaves `status`
-        // polling a map that is never populated. That pair is the part #300
-        // could not split and the reason it deferred all three.
-        //
-        // `POST …/auth/validate` is **deliberately still forwarded**. It was
-        // grouped with them for a second reason that has since expired — the
-        // credentials it writes were read by *Go's* MCP servers, and #311–#313
-        // moved all six here — and it never touches `oauthFlows` at all. What
-        // it does do is dial five different services and write a
-        // **type-specific** auth payload each one's MCP server reads
-        // (`{"validated":true,"bot_username":…}` for Telegram, not a shared
-        // flag). Five remote-call reproductions belong in their own change.
-        // `reload_after_forward`'s `CredentialWritten` trigger keeps covering
-        // its reload meanwhile.
         Some(Route::AuthStart(_)) => method == Method::POST,
         Some(Route::AuthStatus(_)) => method == Method::GET,
+        // #319. The reason this stayed with Go — "asks Telegram, over the
+        // network, with the bot token" — was simply wrong: `GetWebhookStatus`
+        // reads three columns off the row and composes a URL from the public
+        // URL, and `internal/integrations/telegram` has no status call at all.
+        // The network belongs to *registration*, which is a different route and
+        // still forwards.
+        Some(Route::WebhookStatus(_)) => method == Method::GET,
         None => false,
     }
 }
@@ -657,6 +653,9 @@ fn serve(ctx: &super::Ctx, req: &super::Request) -> Result<super::Answer, String
             super::gojson::to_vec(&AuthStatusResponse { authenticated })
                 .map_err(|e| format!("encoding auth status: {e}"))?
         }
+
+        Some(Route::WebhookStatus(id)) => super::gojson::to_vec(&webhook::status(db, id)?)
+            .map_err(|e| format!("encoding webhook status: {e}"))?,
 
         // `claims` never admits a GET here — chi has no such route, so Go 405s
         // and forwarding is what reproduces that.
@@ -1617,9 +1616,24 @@ mod tests {
         ));
 
         // Reads that stay with Go, each for its own reason — see the header.
+        // #319: a plain read of three columns; see `claims`.
+        assert!(claims(&Method::GET, "/api/integrations/abc/webhook/status"));
         assert!(!claims(
-            &Method::GET,
+            &Method::POST,
             "/api/integrations/abc/webhook/status"
+        ));
+        // The registration routes still forward — they call Telegram.
+        assert!(!claims(
+            &Method::POST,
+            "/api/integrations/abc/webhook/register"
+        ));
+        assert!(!claims(
+            &Method::DELETE,
+            "/api/integrations/abc/webhook/register"
+        ));
+        assert!(!claims(
+            &Method::POST,
+            "/api/integrations/abc/webhook/regenerate-secret"
         ));
         assert!(!claims(&Method::GET, "/api/integrations/abc/whatsapp/qr"));
         assert!(!claims(

--- a/desktop/src-tauri/src/native/integrations.rs
+++ b/desktop/src-tauri/src/native/integrations.rs
@@ -450,6 +450,10 @@ enum Route<'a> {
     AuthStatus(&'a str),
     /// `{id}/webhook/status` — the stored Telegram webhook state (#319).
     WebhookStatus(&'a str),
+    /// `{id}/webhook/register` — POST registers with Telegram, DELETE removes.
+    WebhookRegister(&'a str),
+    /// `{id}/webhook/regenerate-secret` — rotate and re-register.
+    WebhookRegenerate(&'a str),
 }
 
 /// Match the reads, plus the write routes that share their paths.
@@ -477,6 +481,12 @@ fn route_of(path: &str) -> Option<Route<'_>> {
     }
     if let Some(id) = rest.strip_suffix("/webhook/status") {
         return segment(id).map(Route::WebhookStatus);
+    }
+    if let Some(id) = rest.strip_suffix("/webhook/register") {
+        return segment(id).map(Route::WebhookRegister);
+    }
+    if let Some(id) = rest.strip_suffix("/webhook/regenerate-secret") {
+        return segment(id).map(Route::WebhookRegenerate);
     }
     if let Some((id, tail)) = rest.split_once("/triggers/") {
         return match (segment(id), segment(tail)) {
@@ -595,6 +605,12 @@ fn claims(method: &Method, path: &str) -> bool {
         // The network belongs to *registration*, which is a different route and
         // still forwards.
         Some(Route::WebhookStatus(_)) => method == Method::GET,
+        // The three that call Telegram. Every fallible step happens *before*
+        // the call — an `Err` after a successful `setWebhook` forwards, and Go
+        // would register the webhook a second time under its own secret. See
+        // `trigger::registration`.
+        Some(Route::WebhookRegister(_)) => method == Method::POST || method == Method::DELETE,
+        Some(Route::WebhookRegenerate(_)) => method == Method::POST,
         None => false,
     }
 }
@@ -612,6 +628,11 @@ fn serve(ctx: &super::Ctx, req: &super::Request) -> Result<super::Answer, String
             }
             Some(Route::Trigger(id, rid)) => finish(delete_trigger_rule(db, id, rid)),
             Some(Route::AuthStart(id)) => finish(start_oauth(db, id)),
+            Some(Route::WebhookRegister(id)) if req.method == Method::DELETE => {
+                finish(super::trigger::serve_delete(db, id))
+            }
+            Some(Route::WebhookRegister(id)) => finish(super::trigger::serve_register(db, id)),
+            Some(Route::WebhookRegenerate(id)) => finish(super::trigger::serve_regenerate(db, id)),
             _ => Err(format!(
                 "{} {} is not an integration write",
                 req.method, req.path
@@ -659,9 +680,11 @@ fn serve(ctx: &super::Ctx, req: &super::Request) -> Result<super::Answer, String
 
         // `claims` never admits a GET here — chi has no such route, so Go 405s
         // and forwarding is what reproduces that.
-        Some(Route::AuthStart(_)) | Some(Route::Trigger(..)) | None => {
-            return Err(format!("{} is not an integration read", req.path))
-        }
+        Some(Route::AuthStart(_))
+        | Some(Route::WebhookRegister(_))
+        | Some(Route::WebhookRegenerate(_))
+        | Some(Route::Trigger(..))
+        | None => return Err(format!("{} is not an integration read", req.path)),
     };
     Ok(super::Answer::json(body))
 }
@@ -1622,17 +1645,26 @@ mod tests {
             &Method::POST,
             "/api/integrations/abc/webhook/status"
         ));
-        // The registration routes still forward — they call Telegram.
-        assert!(!claims(
+        // The three that call Telegram (#319).
+        assert!(claims(
             &Method::POST,
+            "/api/integrations/abc/webhook/register"
+        ));
+        assert!(claims(
+            &Method::DELETE,
+            "/api/integrations/abc/webhook/register"
+        ));
+        assert!(claims(
+            &Method::POST,
+            "/api/integrations/abc/webhook/regenerate-secret"
+        ));
+        // …each only for the methods chi mounts.
+        assert!(!claims(
+            &Method::GET,
             "/api/integrations/abc/webhook/register"
         ));
         assert!(!claims(
             &Method::DELETE,
-            "/api/integrations/abc/webhook/register"
-        ));
-        assert!(!claims(
-            &Method::POST,
             "/api/integrations/abc/webhook/regenerate-secret"
         ));
         assert!(!claims(&Method::GET, "/api/integrations/abc/whatsapp/qr"));

--- a/desktop/src-tauri/src/native/integrations/registry.rs
+++ b/desktop/src-tauri/src/native/integrations/registry.rs
@@ -143,15 +143,15 @@ use super::{decode_services, ServiceConfig};
 /// on it is a mistake: `Serialize` would put a token on the wire and `Debug`
 /// would put one in a log line, which is the same leak with a longer fuse. See
 /// the module header.
-pub(super) struct HostingRow {
-    pub(super) id: String,
-    pub(super) integration_type: String,
+pub(crate) struct HostingRow {
+    pub(crate) id: String,
+    pub(crate) integration_type: String,
     enabled: bool,
     /// `IsAuthenticated()`, computed in SQL so the predicate does not depend on
     /// parsing [`Self::auth`].
     authenticated: bool,
     /// The raw `credentials` column. A secret.
-    pub(super) credentials: String,
+    pub(crate) credentials: String,
     /// The raw `auth` column. **Also a secret**, and the newer of the two.
     ///
     /// Until #315 this projection selected `auth` only as the boolean above, and
@@ -1119,7 +1119,7 @@ fn list_for_hosting(db_path: &Path) -> Result<Vec<HostingRow>, String> {
     Ok(out)
 }
 
-pub(super) fn get_for_hosting(db_path: &Path, id: &str) -> Result<Option<HostingRow>, String> {
+pub(crate) fn get_for_hosting(db_path: &Path, id: &str) -> Result<Option<HostingRow>, String> {
     let conn = crate::native::db::open_read_only(db_path)?;
     let sql = format!("{HOSTING_COLUMNS}\n     WHERE id = ?1");
     conn.query_row(&sql, [id], scan_hosting_row)

--- a/desktop/src-tauri/src/native/integrations/telegram/client.rs
+++ b/desktop/src-tauri/src/native/integrations/telegram/client.rs
@@ -47,7 +47,9 @@ pub const DEFAULT_API_BASE: &str = "https://api.telegram.org";
 /// **Test-only, where Go's is not** — `github::client::API_BASE`'s reasoning, and
 /// sharper here: the seam points every request, *token in the path*, at an
 /// arbitrary host. Go had to export `SetAPIBase` (`telegram/parity.go`) because
-/// `desktop/parity` is a different package; both callers here are in-crate.
+/// `desktop/parity` is a different package; every caller here is in-crate —
+/// `native::trigger::registration` is one, which is why these are `pub(crate)`
+/// rather than `pub(super)`.
 #[cfg(test)]
 static API_BASE: RwLock<Option<String>> = RwLock::new(None);
 
@@ -67,7 +69,7 @@ fn api_base() -> String {
 
 /// Points every subsequent request at `base`; `None` restores the default.
 #[cfg(test)]
-pub(super) fn set_api_base(base: Option<String>) {
+pub(crate) fn set_api_base(base: Option<String>) {
     *API_BASE
         .write()
         .expect("the telegram API base lock is poisoned") = base;
@@ -75,7 +77,7 @@ pub(super) fn set_api_base(base: Option<String>) {
 
 /// Serializes the tests that redirect [`API_BASE`].
 #[cfg(test)]
-pub(super) async fn api_base_lock() -> tokio::sync::MutexGuard<'static, ()> {
+pub(crate) async fn api_base_lock() -> tokio::sync::MutexGuard<'static, ()> {
     static LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
     LOCK.lock().await
 }

--- a/desktop/src-tauri/src/native/integrations/webhook.rs
+++ b/desktop/src-tauri/src/native/integrations/webhook.rs
@@ -1,0 +1,270 @@
+//! Telegram webhook state: `GET /api/integrations/{id}/webhook/status` (#319).
+//!
+//! Mirrors `triggerService.GetWebhookStatus` and `SQLiteTriggerStore.GetWebhookInfo`.
+//!
+//! # The reason this route stayed with Go was wrong
+//!
+//! `native/integrations.rs` recorded it as *"asks Telegram, over the network,
+//! with the bot token"*. It does not, and never did:
+//! `GetWebhookStatus` reads three columns off the `integrations` row
+//! (`webhook_secret`, `webhook_status`, `webhook_error`) and composes a URL from
+//! the configured public URL. `internal/integrations/telegram` has no status
+//! call at all — its whole surface is `RegisterWebhook`, `DeleteWebhook`,
+//! `GenerateSecretToken`, `SendChatAction` and `SendReply`. The network calls
+//! belong to *registration*, which is a different route.
+//!
+//! So this is a plain read, and the four-reads-still-Go list is one shorter.
+//!
+//! # What the read has to get right
+//!
+//! - **A missing integration is not an error.** `GetWebhookInfo` turns
+//!   `sql.ErrNoRows` into four empty strings, so an unknown id answers
+//!   `{"status":"inactive","url":"","has_secret":false,"error":""}` with a 200
+//!   rather than a 404 — the one `{id}` route that does not check existence.
+//! - **`url` is populated only while `status` is `active`**, and only when a
+//!   public URL is configured. A registered webhook on an instance whose public
+//!   URL was later cleared reports active with no URL, which is the state the
+//!   UI needs to show.
+//! - **The secret never leaves**: the column is read only to answer
+//!   `has_secret`.
+
+use std::path::Path;
+
+use serde::Serialize;
+
+use crate::native::db;
+
+/// `service.WebhookStatus`, in Go's field order — **no `omitempty` anywhere**,
+/// so every key is present even when empty.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct WebhookStatus {
+    /// "active", "inactive" or "error".
+    pub status: String,
+    /// The registered webhook URL, or empty.
+    pub url: String,
+    /// Whether a secret is stored. The secret itself is never exposed.
+    pub has_secret: bool,
+    /// The last registration error, if any.
+    pub error: String,
+}
+
+/// The three columns `GetWebhookInfo` reads.
+struct WebhookInfo {
+    secret: String,
+    status: String,
+    error: String,
+}
+
+/// `GetWebhookInfo`. A missing row is empty strings rather than an error, which
+/// is what makes the status of an unknown integration a 200.
+fn webhook_info(db_path: &Path, id: &str) -> Result<WebhookInfo, String> {
+    let conn = db::open_read_only(db_path)?;
+    conn.query_row(
+        "SELECT webhook_secret, webhook_status, webhook_error FROM integrations WHERE id = ?1",
+        [id],
+        |row| {
+            Ok(WebhookInfo {
+                secret: row.get(0)?,
+                status: row.get(1)?,
+                error: row.get(2)?,
+            })
+        },
+    )
+    .or_else(|e| match e {
+        rusqlite::Error::QueryReturnedNoRows => Ok(WebhookInfo {
+            secret: String::new(),
+            status: String::new(),
+            error: String::new(),
+        }),
+        other => Err(format!("getting webhook info for {id:?}: {other}")),
+    })
+}
+
+/// `triggerService.publicURL`: the environment wins over the stored setting, and
+/// either is right-trimmed of `/`.
+///
+/// The trim is load-bearing rather than cosmetic — the URL is built by
+/// concatenation, so a stored `https://x.example/` would otherwise produce
+/// `https://x.example//webhooks/telegram/…`, which Telegram registers verbatim
+/// and then calls.
+pub fn public_url(db_path: &Path) -> String {
+    if let Ok(from_env) = std::env::var("AGENTO_PUBLIC_URL") {
+        if !from_env.is_empty() {
+            return from_env.trim_end_matches('/').to_string();
+        }
+    }
+    let Ok(conn) = db::open_read_only(db_path) else {
+        return String::new();
+    };
+    crate::native::settings::load_stored(&conn)
+        .public_url
+        .trim_end_matches('/')
+        .to_string()
+}
+
+/// The URL a registered webhook is reachable at.
+pub fn webhook_url(base: &str, integration_id: &str) -> String {
+    format!("{base}/webhooks/telegram/{integration_id}")
+}
+
+/// `GetWebhookStatus`.
+pub fn status(db_path: &Path, id: &str) -> Result<WebhookStatus, String> {
+    let info = webhook_info(db_path, id)?;
+    let status = if info.status.is_empty() {
+        "inactive".to_string()
+    } else {
+        info.status
+    };
+
+    let url = if status == "active" {
+        let base = public_url(db_path);
+        if base.is_empty() {
+            String::new()
+        } else {
+            webhook_url(&base, id)
+        }
+    } else {
+        String::new()
+    };
+
+    Ok(WebhookStatus {
+        status,
+        url,
+        has_secret: !info.secret.is_empty(),
+        error: info.error,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn migrated(dir: &Path) -> std::path::PathBuf {
+        let db = dir.join("agento.db");
+        let mut conn = rusqlite::Connection::open(&db).expect("open");
+        crate::native::migrate::apply(&mut conn).expect("migrate");
+        conn.execute(
+            "INSERT INTO integrations (id, name, type, enabled, credentials, services,
+                                       created_at, updated_at)
+             VALUES ('tg', 'T', 'telegram', 1, '{}', '{}',
+                     '2026-01-01 00:00:00 +0000 UTC', '2026-01-01 00:00:00 +0000 UTC')",
+            [],
+        )
+        .expect("seed");
+        db
+    }
+
+    fn set_webhook(db: &Path, secret: &str, status: &str, error: &str) {
+        let conn = rusqlite::Connection::open(db).expect("open");
+        conn.execute(
+            "UPDATE integrations SET webhook_secret = ?1, webhook_status = ?2,
+                                     webhook_error = ?3 WHERE id = 'tg'",
+            rusqlite::params![secret, status, error],
+        )
+        .expect("set");
+    }
+
+    fn set_public_url(db: &Path, url: &str) {
+        let conn = rusqlite::Connection::open(db).expect("open");
+        conn.execute(
+            "INSERT INTO user_settings (id, public_url) VALUES (1, ?1)
+             ON CONFLICT(id) DO UPDATE SET public_url = excluded.public_url",
+            [url],
+        )
+        .expect("set public url");
+    }
+
+    #[test]
+    fn an_unregistered_integration_is_inactive_rather_than_an_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path());
+        assert_eq!(
+            status(&db, "tg").expect("status"),
+            WebhookStatus {
+                status: "inactive".to_string(),
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn an_unknown_integration_is_a_200_not_a_404() {
+        // `GetWebhookInfo` turns `sql.ErrNoRows` into empty strings, so this is
+        // the one `{id}` route with no existence check.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path());
+        assert_eq!(
+            status(&db, "no-such-id").expect("status").status,
+            "inactive"
+        );
+    }
+
+    #[test]
+    fn the_url_appears_only_while_active_and_only_with_a_public_url() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path());
+        set_public_url(&db, "https://agento.example");
+
+        set_webhook(&db, "s3cret", "active", "");
+        let active = status(&db, "tg").expect("status");
+        assert_eq!(active.url, "https://agento.example/webhooks/telegram/tg");
+        assert!(active.has_secret, "…without exposing the secret itself");
+
+        // An inactive webhook has no URL even though one could be composed.
+        set_webhook(&db, "s3cret", "inactive", "");
+        assert_eq!(status(&db, "tg").expect("status").url, "");
+
+        // …and an active one on an instance with no public URL reports active
+        // with no URL, which is the state the UI has to show.
+        set_public_url(&db, "");
+        set_webhook(&db, "s3cret", "active", "");
+        let no_base = status(&db, "tg").expect("status");
+        assert_eq!(no_base.status, "active");
+        assert_eq!(no_base.url, "");
+    }
+
+    #[test]
+    fn a_trailing_slash_on_the_public_url_does_not_double_up() {
+        // `publicURL` right-trims, and the URL is built by concatenation — so
+        // without the trim Telegram would be registered against `…//webhooks/…`
+        // and would call exactly that.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path());
+        set_public_url(&db, "https://agento.example/");
+        set_webhook(&db, "s", "active", "");
+        assert_eq!(
+            status(&db, "tg").expect("status").url,
+            "https://agento.example/webhooks/telegram/tg"
+        );
+    }
+
+    #[test]
+    fn a_registration_error_is_carried_through() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path());
+        set_webhook(&db, "", "error", "telegram API error: bad webhook");
+        let s = status(&db, "tg").expect("status");
+        assert_eq!(s.status, "error");
+        assert_eq!(s.error, "telegram API error: bad webhook");
+        assert!(!s.has_secret);
+        assert_eq!(s.url, "", "an errored webhook has no URL");
+    }
+
+    #[test]
+    fn the_shape_is_gos_field_order_with_every_key_present() {
+        // No `omitempty` on any field, so an empty status still carries all
+        // four keys — a UI reading `has_secret` must not see it absent.
+        let encoded = String::from_utf8(
+            crate::native::gojson::to_vec_marshal(&WebhookStatus {
+                status: "inactive".to_string(),
+                ..Default::default()
+            })
+            .expect("encode"),
+        )
+        .expect("utf-8");
+        assert_eq!(
+            encoded,
+            r#"{"status":"inactive","url":"","has_secret":false,"error":""}"#
+        );
+    }
+}

--- a/desktop/src-tauri/src/native/mod.rs
+++ b/desktop/src-tauri/src/native/mod.rs
@@ -608,10 +608,8 @@ mod tests {
         // #318: the OAuth flow moved, so its two routes are the shell's.
         assert!(claims(&Method::GET, "/api/integrations/abc/auth/status"));
         assert!(claims(&Method::POST, "/api/integrations/abc/auth/start"));
-        assert!(!claims(
-            &Method::GET,
-            "/api/integrations/abc/webhook/status"
-        ));
+        // #319: the webhook status is a plain read of three columns.
+        assert!(claims(&Method::GET, "/api/integrations/abc/webhook/status"));
         assert!(!claims(&Method::GET, "/api/integrations/abc/whatsapp/qr"));
     }
 

--- a/desktop/src-tauri/src/native/mod.rs
+++ b/desktop/src-tauri/src/native/mod.rs
@@ -97,6 +97,15 @@ pub struct Request<'a> {
     /// which lives only in this header — every other claimed route decodes JSON
     /// and ignores it.
     pub content_type: &'a str,
+    /// `X-Telegram-Bot-Api-Secret-Token`, or `""` when absent.
+    ///
+    /// Carried for exactly one route, on the same terms as `content_type`
+    /// above: `POST /webhooks/telegram/{id}` is authenticated by this header and
+    /// nothing else. It is mounted at the **root**, so neither guard in
+    /// `guards.rs` applies — the request arrives from Telegram with a foreign
+    /// `Host`, which `validate_host` would 403 — and this header is what makes
+    /// that safe rather than open.
+    pub secret_token: &'a str,
     /// The request body, already buffered. Empty for a GET, and empty for the
     /// several writes Go accepts with no payload at all.
     pub body: &'a [u8],
@@ -123,6 +132,8 @@ pub struct Answer {
     pub status: StatusCode,
     /// `None` sends no body and no `Content-Type`.
     pub body: Option<Vec<u8>>,
+    /// Send the body as `text/plain` rather than JSON. See [`Answer::text_status`].
+    pub text: bool,
 }
 
 impl Answer {
@@ -131,6 +142,7 @@ impl Answer {
         Self {
             status: StatusCode::OK,
             body: Some(body),
+            text: false,
         }
     }
 
@@ -139,6 +151,7 @@ impl Answer {
         Self {
             status,
             body: Some(body),
+            text: false,
         }
     }
 
@@ -146,7 +159,27 @@ impl Answer {
     /// call `w.WriteHeader(...)` directly rather than going through `writeJSON`
     /// — `POST /api/claude-sessions/refresh` answers `202` this way.
     pub fn status_only(status: StatusCode) -> Self {
-        Self { status, body: None }
+        Self {
+            status,
+            body: None,
+            text: false,
+        }
+    }
+
+    /// `http.Error`'s answer: a plain-text body under a status the handler
+    /// chooses.
+    ///
+    /// The one non-JSON body in the seam, and it has one caller:
+    /// `POST /webhooks/telegram/{id}` refuses a bad secret through `http.Error`
+    /// rather than the API's JSON envelope, because it is not an `/api` route
+    /// and Go's handler there writes with `http.Error` directly. That also sets
+    /// `X-Content-Type-Options: nosniff`, which `response` reproduces.
+    pub fn text_status(status: StatusCode, body: &str) -> Self {
+        Self {
+            status,
+            body: Some(body.as_bytes().to_vec()),
+            text: true,
+        }
     }
 
     /// `204 No Content`: no body, no `Content-Type`.
@@ -154,6 +187,7 @@ impl Answer {
         Self {
             status: StatusCode::NO_CONTENT,
             body: None,
+            text: false,
         }
     }
 }
@@ -265,6 +299,8 @@ const ENDPOINTS: &[Endpoint] = &[
     integrations::ENDPOINT,
     scan::ENDPOINT,
     uploads::ENDPOINT,
+    // The one entry that is not under `/api`; see its `claims`.
+    trigger::ENDPOINT,
 ];
 
 /// Whether this request is answered by ported Rust code.
@@ -386,6 +422,11 @@ pub fn serve(req: &Request) -> Result<Answer, String> {
 pub fn response(answer: Answer) -> Response<Body> {
     let builder = Response::builder().status(answer.status);
     let built = match answer.body {
+        // `http.Error` sets both of these; every other body is the API's JSON.
+        Some(body) if answer.text => builder
+            .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
+            .header("X-Content-Type-Options", "nosniff")
+            .body(Body::from(body)),
         Some(body) => builder
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(body)),
@@ -779,6 +820,7 @@ mod tests {
             path: "/api/nothing-here",
             query: "",
             content_type: "",
+            secret_token: "",
             body: &[],
         })
         .is_err());
@@ -922,6 +964,8 @@ mod tests {
         let writes = [
             (Method::POST, "/api/uploads"),
             (Method::POST, "/api/claude-sessions/abc/continue"),
+            // The one claimed route outside `/api` (#319).
+            (Method::POST, "/webhooks/telegram/abc"),
         ];
         for endpoint in ENDPOINTS {
             let reachable = probes.iter().any(|p| (endpoint.claims)(&Method::GET, p))

--- a/desktop/src-tauri/src/native/mod.rs
+++ b/desktop/src-tauri/src/native/mod.rs
@@ -12,6 +12,7 @@
 //! the behaviour the app had before the port instead of a 500.
 
 pub mod active_time;
+pub mod agent_run;
 pub mod agents;
 pub mod analytics;
 pub mod chat;

--- a/desktop/src-tauri/src/native/mod.rs
+++ b/desktop/src-tauri/src/native/mod.rs
@@ -40,6 +40,7 @@ pub mod settings;
 pub mod tasks;
 pub mod template;
 pub mod tools;
+pub mod trigger;
 pub mod uploads;
 pub mod version;
 pub mod writes;

--- a/desktop/src-tauri/src/native/monitoring.rs
+++ b/desktop/src-tauri/src/native/monitoring.rs
@@ -550,6 +550,7 @@ mod tests {
                     path,
                     query: "",
                     content_type: "application/json",
+                    secret_token: "",
                     body: br#"{"enabled":true,"otlp_endpoint":"localhost:4317"}"#,
                 },
             )
@@ -579,6 +580,7 @@ mod tests {
                 path: "/api/monitoring",
                 query: "",
                 content_type: "",
+                secret_token: "",
                 body: &[],
             },
         )

--- a/desktop/src-tauri/src/native/schedule/executor.rs
+++ b/desktop/src-tauri/src/native/schedule/executor.rs
@@ -338,14 +338,8 @@ async fn run_agent(
     agent: Agent,
     prompt: &str,
 ) -> Result<RunResult, String> {
-    // `resolveSystemPrompt`, which Go calls **before** building any options and
-    // whose error it returns unwrapped — so an agent with an unresolvable
-    // `{{name}}` in its system prompt is a recorded failed run, not a run that
-    // quietly ships the raw placeholder to the model. `build_options` cannot do
-    // this itself: the chat path deliberately interpolates leniently, and the
-    // strictness is the caller's (see `native::template`).
-    template::interpolate(&agent.system_prompt).map_err(|e| e.to_string())?;
-
+    // `resolveSystemPrompt`'s strictness lives in `run_headless`, so both
+    // headless callers get it — see that function.
     let spec = crate::native::agent_run::headless_spec(
         db_path,
         agent,

--- a/desktop/src-tauri/src/native/schedule/executor.rs
+++ b/desktop/src-tauri/src/native/schedule/executor.rs
@@ -31,24 +31,12 @@ use std::sync::Arc;
 use chrono::Utc;
 
 use super::runtime::Scheduler;
+use crate::native::agent_run::RunResult;
 use crate::native::agents::{self, Agent};
-use crate::native::chat::runner::{self, RunSpec, TurnSettings};
+use crate::native::chat::runner::TurnSettings;
 use crate::native::notifications;
 use crate::native::tasks::{self, JobHistory, ScheduledTask};
 use crate::native::template;
-
-/// What one run produced. `agent.AgentResult`, narrowed to the fields the
-/// scheduler stores — the thinking, cost and per-model breakdowns are collected
-/// by Go and then dropped by this caller.
-#[derive(Debug, Default)]
-struct RunResult {
-    session_id: String,
-    answer: String,
-    input_tokens: i64,
-    output_tokens: i64,
-    cache_creation_tokens: i64,
-    cache_read_tokens: i64,
-}
 
 /// `executeTask`. The semaphore is the caller's; this is everything inside it.
 pub async fn execute_task(scheduler: &Arc<Scheduler>, task_id: &str) {
@@ -339,170 +327,35 @@ fn resolve_agent(db_path: &std::path::Path, task: &ScheduledTask) -> Result<Agen
     })
 }
 
-/// `agent.RunAgent` + `collectRunResult`, for a run with no interactive
-/// permission handler and no SSE.
+/// The scheduler's half of `agent.RunAgent`: resolve the system prompt, then
+/// hand the run to [`crate::native::agent_run`].
 ///
-/// The timeout is `context.WithTimeout(parentCtx, task.TimeoutMinutes)`. It
-/// wraps the *whole* drain, so a subprocess that stops producing events is
-/// abandoned rather than waited on forever, and the session is closed on the way
-/// out either way.
+/// The run itself is shared with the trigger dispatcher (#319) — see that
+/// module for why the one-shot `query` rather than a `Session` is not a detail.
 async fn run_agent(
     db_path: &std::path::Path,
     task: &ScheduledTask,
     agent: Agent,
     prompt: &str,
 ) -> Result<RunResult, String> {
-    let settings = Arc::new(TurnSettings::from_db(db_path));
-    let spec = RunSpec {
-        agent: Some(agent),
-        // Never called: `resolve_agent` always yields an agent, because Go's
-        // scheduler always has a non-nil config. Present because `RunSpec`
-        // models the chat's branch too.
-        no_agent_model: Box::new(String::new),
-        settings,
-        working_dir: task.working_directory.clone(),
-        settings_profile_id: task.settings_profile_id.clone(),
-        resume_session_id: None,
-        // `buildRunOptions` sets neither session field, so the CLI picks its own
-        // id and `saveSessionResults` stores it afterwards.
-        custom_session_id: String::new(),
-    };
-
-    // **One deadline across every stage that can await, not a timeout on the
-    // drain alone.** Go wraps the whole `agent.RunAgent` call — its
-    // `resolveSystemPrompt` and `buildSDKOptions` included — and the difference
-    // is not theoretical: anything that hangs before the first event would
-    // leave the `job_history` row `running` forever *and* hold this run's
-    // scheduler permit for the life of the process; three of those and no
-    // scheduled task runs again. `build_options` belongs inside it because it
-    // is not arithmetic — it starts an in-process MCP server per integration
-    // the agent names.
-    //
-    // A shared `Instant` rather than one future wrapping everything, because
-    // `Session` has no `Drop`: cancelling a future that owns one abandons the
-    // subprocess instead of stopping it. Staged this way, `close()` stays
-    // reachable on every path where a session exists.
-    let deadline = tokio::time::Instant::now()
-        + std::time::Duration::from_secs(
-            u64::try_from(task.timeout_minutes.max(0)).unwrap_or(0) * 60,
-        );
-
     // `resolveSystemPrompt`, which Go calls **before** building any options and
     // whose error it returns unwrapped — so an agent with an unresolvable
     // `{{name}}` in its system prompt is a recorded failed run, not a run that
     // quietly ships the raw placeholder to the model. `build_options` cannot do
-    // this check itself: the chat path deliberately interpolates leniently, and
-    // the strictness is the caller's (see `native::template`).
-    if let Some(agent) = spec.agent.as_ref() {
-        template::interpolate(&agent.system_prompt).map_err(|e| e.to_string())?;
-    }
+    // this itself: the chat path deliberately interpolates leniently, and the
+    // strictness is the caller's (see `native::template`).
+    template::interpolate(&agent.system_prompt).map_err(|e| e.to_string())?;
 
-    // The refusal this port has that Go does not — an agent whose tools cannot
-    // be hosted here. A recorded failure, never silence. See the module header.
-    //
-    // **The message is passed through, not rewritten.** `build_options` fails
-    // for more than a refusal: `start_local_tools` and `start_integration_servers`
-    // bind loopback listeners and read integration rows, so a port-bind failure
-    // or a SQLite error arrives here too. Since this row is the *only* evidence
-    // a scheduled run leaves, labelling all of them "this build cannot host your
-    // agent's tools" would send a user to the wrong fix. Every one of those
-    // messages already describes itself.
-    let (options, tool_servers) =
-        tokio::time::timeout_at(deadline, runner::build_options(&spec, None))
-            .await
-            .map_err(|_| DEADLINE_EXCEEDED.to_string())?
-            .map_err(|e| format!("agent setup: {e}"))?;
-
-    // **`query`, not `Session`** — the one-shot, which is what Go's `RunAgent`
-    // uses (`claude.Query`). The difference is the whole run: a `Session` sets
-    // `session_mode`, and `process.rs`'s reader then deliberately does *not*
-    // close stdin or stop at the `result` event, "so the subprocess survives
-    // for the next send". There is no next send here, so the event channel
-    // never closes, `collect_run_result` blocks past the answer, and every
-    // scheduled run would sit until its timeout — 30 minutes by default, up to
-    // 240 — then record `failed`, persist no chat, and hold one of the three
-    // semaphore permits the entire time.
-    //
-    // The one-shot reader closes stdin and breaks *after* emitting the result,
-    // which is also what makes `collect_run_result`'s drain-past-the-result
-    // rule terminate rather than hang.
-    let mut stream = match tokio::time::timeout_at(
-        deadline,
-        crate::claude::client::query(prompt, options),
-    )
-    .await
-    {
-        Ok(Ok(stream)) => stream,
-        Ok(Err(e)) => {
-            drop(tool_servers);
-            return Err(format!("starting agent: {e}"));
-        }
-        Err(_) => {
-            drop(tool_servers);
-            return Err(DEADLINE_EXCEEDED.to_string());
-        }
-    };
-
-    let collected = tokio::time::timeout_at(deadline, collect_run_result(&mut stream))
-        .await
-        .unwrap_or_else(|_| Err(DEADLINE_EXCEEDED.to_string()));
-
-    stream.close();
-    // The in-process tool listeners outlive the subprocess and stop when
-    // dropped, so this is after `close` rather than before it.
-    drop(tool_servers);
-    collected
-}
-
-/// What `context.DeadlineExceeded` reaches Go's caller as, and therefore what
-/// lands in `job_history.error_message` for a run that ran out of time.
-const DEADLINE_EXCEEDED: &str = "context deadline exceeded";
-
-/// `collectRunResult`: drain every event, keep the last result.
-///
-/// The drain does **not** stop at the result event, and that is Go's comment
-/// rather than an accident: the subprocess still has its transcript to write,
-/// and returning early would race the scanner against a half-written file.
-async fn collect_run_result(
-    stream: &mut crate::claude::client::Stream,
-) -> Result<RunResult, String> {
-    let mut result: Option<RunResult> = None;
-    let mut result_err: Option<String> = None;
-
-    while let Some(event) = stream.next_event().await {
-        let Some(r) = event.result.as_ref() else {
-            continue;
-        };
-        if r.is_error {
-            result_err = Some(build_result_error(r));
-        } else {
-            result = Some(RunResult {
-                session_id: r.session_id.clone(),
-                answer: r.result.clone(),
-                input_tokens: r.usage.input_tokens,
-                output_tokens: r.usage.output_tokens,
-                cache_creation_tokens: r.usage.cache_creation_input_tokens,
-                cache_read_tokens: r.usage.cache_read_input_tokens,
-            });
-        }
-    }
-
-    if let Some(err) = result_err {
-        return Err(err);
-    }
-    result.ok_or_else(|| "agent finished without returning a result".to_string())
-}
-
-/// `buildResultError`, message for message.
-fn build_result_error(r: &crate::claude::messages::Result) -> String {
-    let mut msg = r.result.clone();
-    if msg.is_empty() && !r.errors.is_empty() {
-        msg = r.errors.join("; ");
-    }
-    if msg.is_empty() {
-        msg = format!("subtype={}", r.subtype);
-    }
-    format!("agent error: {msg}")
+    let spec = crate::native::agent_run::headless_spec(
+        db_path,
+        agent,
+        task.working_directory.clone(),
+        task.settings_profile_id.clone(),
+    );
+    let timeout = std::time::Duration::from_secs(
+        u64::try_from(task.timeout_minutes.max(0)).unwrap_or(0) * 60,
+    );
+    crate::native::agent_run::run_headless(&spec, prompt, timeout).await
 }
 
 /// `saveSessionResults`: the run's totals onto the chat row, then the two
@@ -1245,24 +1098,6 @@ mod tests {
             199,
             "cut back to the boundary rather than through the character"
         );
-    }
-
-    #[test]
-    fn a_result_error_prefers_the_message_then_the_errors_then_the_subtype() {
-        let mut r = crate::claude::messages::Result {
-            subtype: "error_max_turns".to_string(),
-            ..Default::default()
-        };
-        assert_eq!(
-            build_result_error(&r),
-            "agent error: subtype=error_max_turns"
-        );
-
-        r.errors = vec!["one".to_string(), "two".to_string()];
-        assert_eq!(build_result_error(&r), "agent error: one; two");
-
-        r.result = "the message".to_string();
-        assert_eq!(build_result_error(&r), "agent error: the message");
     }
 
     #[test]

--- a/desktop/src-tauri/src/native/trigger/dispatcher.rs
+++ b/desktop/src-tauri/src/native/trigger/dispatcher.rs
@@ -76,6 +76,24 @@ pub fn handle_update(
     });
 }
 
+/// Run a blocking database call off the runtime's workers.
+///
+/// `None` when the pool task itself failed, which the callers treat as "do not
+/// proceed" — the same answer a failed read gives.
+async fn blocking<T, F>(f: F) -> Option<T>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    match tokio::task::spawn_blocking(f).await {
+        Ok(value) => Some(value),
+        Err(e) => {
+            log::error!("telegram dispatch: a database task failed: {e}");
+            None
+        }
+    }
+}
+
 /// `processTelegramUpdate`.
 async fn process(db_path: &Path, integration_id: &str, bot_token: &str, update: TelegramUpdate) {
     // A non-message update, or one with no text, is not a trigger.
@@ -87,11 +105,33 @@ async fn process(db_path: &Path, integration_id: &str, bot_token: &str, update: 
     // Claimed before the rules are read, so a Telegram retry cannot run the
     // agent twice — see `receiver::claim_update` for why the claim is atomic
     // here where Go's is two statements.
-    if !super::receiver::claim_update(db_path, integration_id, update.update_id) {
+    // **Every database call here goes to the blocking pool.** `process` runs on
+    // an axum worker, and each of these opens a connection and may sit on
+    // `db.rs`'s five-second `busy_timeout` while the session scan batch-writes —
+    // ten of them at `MAX_CONCURRENT` is every worker on a four-core machine,
+    // stalling the SPA and any SSE stream. `proxy.rs` puts native handlers on the
+    // blocking pool for exactly this reason.
+    let claimed = {
+        let (db, id, update_id) = (
+            db_path.to_path_buf(),
+            integration_id.to_string(),
+            update.update_id,
+        );
+        blocking(move || super::receiver::claim_update(&db, &id, update_id)).await
+    };
+    if !claimed.unwrap_or(false) {
         return;
     }
 
-    let Some((rule, prompt)) = find_matching_rule(db_path, integration_id, &msg) else {
+    let matched = {
+        let (db, id, msg) = (
+            db_path.to_path_buf(),
+            integration_id.to_string(),
+            msg.clone(),
+        );
+        blocking(move || find_matching_rule(&db, &id, &msg)).await
+    };
+    let Some(Some((rule, prompt))) = matched else {
         return;
     };
 
@@ -195,7 +235,13 @@ async fn execute_and_reply(
     // discarded.
     super::telegram_api::send_chat_action(bot_token, msg.chat.id).await;
 
-    let agent = match resolve_agent(db_path, &rule.agent_slug) {
+    let resolved = {
+        let (db, slug) = (db_path.to_path_buf(), rule.agent_slug.clone());
+        blocking(move || resolve_agent(&db, &slug))
+            .await
+            .unwrap_or_else(|| Err("the agent lookup task failed".to_string()))
+    };
+    let agent = match resolved {
         Ok(agent) => agent,
         Err(e) => {
             log::error!(
@@ -209,7 +255,13 @@ async fn execute_and_reply(
 
     // Go creates the session with **no** working directory, model or settings
     // profile — a trigger run is not configurable the way a task is.
-    let chat_session_id = match create_trigger_session(db_path, rule) {
+    let created = {
+        let (db, rule) = (db_path.to_path_buf(), rule.clone());
+        blocking(move || create_trigger_session(&db, &rule))
+            .await
+            .unwrap_or_else(|| Err("the session task failed".to_string()))
+    };
+    let chat_session_id = match created {
         Ok(id) => id,
         Err(e) => {
             log::error!("failed to create chat session for trigger: {e}");
@@ -231,13 +283,30 @@ async fn execute_and_reply(
             send_error_reply(bot_token, msg).await;
             // The user turn is still stored, with no answer — so the chat shows
             // what was asked even when nothing came back.
-            save_messages(db_path, &chat_session_id, prompt, "");
+            let (db, session, prompt) = (
+                db_path.to_path_buf(),
+                chat_session_id.clone(),
+                prompt.to_string(),
+            );
+            blocking(move || save_messages(&db, &session, &prompt, "")).await;
             return;
         }
     };
 
-    save_messages(db_path, &chat_session_id, prompt, &result.answer);
-    update_session_usage(db_path, &chat_session_id, &result);
+    {
+        let (db, session, prompt, answer) = (
+            db_path.to_path_buf(),
+            chat_session_id.clone(),
+            prompt.to_string(),
+            result.answer.clone(),
+        );
+        let usage = result.clone();
+        blocking(move || {
+            save_messages(&db, &session, &prompt, &answer);
+            update_session_usage(&db, &session, &usage);
+        })
+        .await;
+    }
 
     // An empty answer still gets a reply — silence would be indistinguishable
     // from the bot being broken.

--- a/desktop/src-tauri/src/native/trigger/dispatcher.rs
+++ b/desktop/src-tauri/src/native/trigger/dispatcher.rs
@@ -78,8 +78,11 @@ pub fn handle_update(
 
 /// Run a blocking database call off the runtime's workers.
 ///
-/// `None` when the pool task itself failed, which the callers treat as "do not
-/// proceed" — the same answer a failed read gives.
+/// `None` when the pool task itself failed — a panic inside the closure. Each
+/// caller folds that into the answer a failed *read* already gives it, which is
+/// not the same answer everywhere: `process` stops, `execute_and_reply` sends
+/// the error reply, and the two message writes are best-effort in Go too and so
+/// ignore it.
 async fn blocking<T, F>(f: F) -> Option<T>
 where
     F: FnOnce() -> T + Send + 'static,
@@ -105,8 +108,10 @@ async fn process(db_path: &Path, integration_id: &str, bot_token: &str, update: 
     // Claimed before the rules are read, so a Telegram retry cannot run the
     // agent twice — see `receiver::claim_update` for why the claim is atomic
     // here where Go's is two statements.
-    // **Every database call here goes to the blocking pool.** `process` runs on
-    // an axum worker, and each of these opens a connection and may sit on
+    // **Every database call this module makes goes to the blocking pool.**
+    // (Not every call the *dispatch* makes: `run_headless` opens SQLite on the
+    // worker while building its options, which chat and the scheduler share
+    // verbatim.) `process` runs on an axum worker, and each of these opens a connection and may sit on
     // `db.rs`'s five-second `busy_timeout` while the session scan batch-writes —
     // ten of them at `MAX_CONCURRENT` is every worker on a four-core machine,
     // stalling the SPA and any SSE stream. `proxy.rs` puts native handlers on the
@@ -294,15 +299,14 @@ async fn execute_and_reply(
     };
 
     {
-        let (db, session, prompt, answer) = (
+        let (db, session, prompt) = (
             db_path.to_path_buf(),
             chat_session_id.clone(),
             prompt.to_string(),
-            result.answer.clone(),
         );
         let usage = result.clone();
         blocking(move || {
-            save_messages(&db, &session, &prompt, &answer);
+            save_messages(&db, &session, &prompt, &usage.answer);
             update_session_usage(&db, &session, &usage);
         })
         .await;

--- a/desktop/src-tauri/src/native/trigger/dispatcher.rs
+++ b/desktop/src-tauri/src/native/trigger/dispatcher.rs
@@ -21,7 +21,7 @@
 //!   messages on a `[Telegram] <rule>` session.
 //! - **The timeout is a flat five minutes**, not the task's own — triggers have
 //!   no configurable timeout.
-//! - **Concurrency is bounded to 5**, not the scheduler's 3, and the bound is
+//! - **Concurrency is bounded to 10**, not the scheduler's 3, and the bound is
 //!   Go's `sem` on the dispatcher rather than a per-run permit.
 
 use std::path::Path;
@@ -33,8 +33,12 @@ use super::receiver::{TelegramMsg, TelegramUpdate};
 use crate::native::agent_run;
 use crate::native::agents::Agent;
 
-/// `Dispatcher.sem`: `maxConcurrent` in `NewDispatcher`.
-const MAX_CONCURRENT: usize = 5;
+/// `maxConcurrentExecutions`, the buffer on `Dispatcher.sem`.
+///
+/// **Ten, not the scheduler's three.** A busy group chat can fire several rules
+/// at once, and with the flat five-minute run timeout a limit set too low makes
+/// the sixth message wait up to five minutes before its "typing…" even appears.
+const MAX_CONCURRENT: usize = 10;
 
 /// `context.WithTimeout(ctx, 5*time.Minute)` in `executeAndReply`.
 const RUN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5 * 60);
@@ -75,7 +79,8 @@ pub fn handle_update(
 /// `processTelegramUpdate`.
 async fn process(db_path: &Path, integration_id: &str, bot_token: &str, update: TelegramUpdate) {
     // A non-message update, or one with no text, is not a trigger.
-    let Some(msg) = update.message.filter(|m| !m.text.is_empty()) else {
+    // `GoStruct` is a decode-shape wrapper; the message itself is inside it.
+    let Some(msg) = update.message.map(|m| m.0).filter(|m| !m.text.is_empty()) else {
         return;
     };
 
@@ -320,16 +325,24 @@ fn create_trigger_session(db_path: &Path, rule: &Rule) -> Result<String, String>
 /// shape, and it is what makes a failed trigger visible in the chat rather than
 /// leaving an empty session.
 fn save_messages(db_path: &Path, chat_session_id: &str, prompt: &str, answer: &str) {
-    let write = || -> Result<(), String> {
-        let conn = crate::native::db::open_read_write(db_path)?;
-        append_message(&conn, chat_session_id, "user", prompt)?;
-        if !answer.is_empty() {
-            append_message(&conn, chat_session_id, "assistant", answer)?;
+    let conn = match crate::native::db::open_read_write(db_path) {
+        Ok(conn) => conn,
+        Err(e) => {
+            log::warn!("failed to store user message: {e}");
+            return;
         }
-        Ok(())
     };
-    if let Err(e) = write() {
-        log::warn!("failed to store trigger messages: {e}");
+    // **Each insert is logged on its own**, as `saveSessionMessages` does. A
+    // shared `?` would let a failed user turn skip the assistant one, leaving
+    // the session with neither where Go leaves it with the answer — and the
+    // reply has already gone to Telegram either way.
+    if let Err(e) = append_message(&conn, chat_session_id, "user", prompt) {
+        log::warn!("failed to store user message: {e}");
+    }
+    if !answer.is_empty() {
+        if let Err(e) = append_message(&conn, chat_session_id, "assistant", answer) {
+            log::warn!("failed to store assistant message: {e}");
+        }
     }
 }
 
@@ -435,7 +448,9 @@ mod tests {
     fn msg(text: &str, chat_id: i64) -> TelegramMsg {
         TelegramMsg {
             message_id: 1,
-            chat: super::super::receiver::TelegramChat { id: chat_id },
+            chat: crate::native::gojson::GoStruct(crate::native::trigger::receiver::TelegramChat {
+                id: chat_id,
+            }),
             text: text.to_string(),
         }
     }

--- a/desktop/src-tauri/src/native/trigger/dispatcher.rs
+++ b/desktop/src-tauri/src/native/trigger/dispatcher.rs
@@ -1,0 +1,600 @@
+//! One inbound Telegram message, from matched rule to sent reply. Mirrors
+//! `Dispatcher.processTelegramUpdate` and `executeAndReply`
+//! (`internal/trigger/dispatcher.go`).
+//!
+//! # The fourth caller of the agent runner
+//!
+//! After chat (#276), the scheduler (#275) and `agento ask`, this is the fourth
+//! place an agent runs — and the second headless one. It goes through
+//! [`crate::native::agent_run`] for that reason: the one-shot-vs-`Session` trap
+//! that made every scheduled run hang lives there now, in one place, so this
+//! caller cannot reintroduce it.
+//!
+//! # Where this differs from the scheduler, and why
+//!
+//! - **The reply is the product.** A scheduled run's evidence is a
+//!   `job_history` row; this one's is a message in a chat. So a failure that the
+//!   scheduler records silently must here also *say something* — Go sends
+//!   "Sorry, something went wrong." on every failure path, and a user who gets
+//!   nothing back cannot tell a broken agent from an ignored message.
+//! - **There is no job history at all.** The run is recorded only as chat
+//!   messages on a `[Telegram] <rule>` session.
+//! - **The timeout is a flat five minutes**, not the task's own — triggers have
+//!   no configurable timeout.
+//! - **Concurrency is bounded to 5**, not the scheduler's 3, and the bound is
+//!   Go's `sem` on the dispatcher rather than a per-run permit.
+
+use std::path::Path;
+
+use tokio::sync::Semaphore;
+
+use super::match_rule::{match_rule, RuleFilters};
+use super::receiver::{TelegramMsg, TelegramUpdate};
+use crate::native::agent_run;
+use crate::native::agents::Agent;
+
+/// `Dispatcher.sem`: `maxConcurrent` in `NewDispatcher`.
+const MAX_CONCURRENT: usize = 5;
+
+/// `context.WithTimeout(ctx, 5*time.Minute)` in `executeAndReply`.
+const RUN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5 * 60);
+
+/// What Go replies with on every failure path.
+const ERROR_REPLY: &str = "Sorry, something went wrong.";
+
+fn semaphore() -> &'static Semaphore {
+    static SEM: std::sync::OnceLock<Semaphore> = std::sync::OnceLock::new();
+    SEM.get_or_init(|| Semaphore::new(MAX_CONCURRENT))
+}
+
+/// `HandleTelegramUpdate`: returns immediately, processes in the background,
+/// bounded by the semaphore.
+///
+/// Spawned rather than awaited because the receiver has already answered 200 —
+/// Telegram must not be held open for an agent run, and would retry if it were.
+pub fn handle_update(
+    db_path: &Path,
+    integration_id: &str,
+    bot_token: &str,
+    update: TelegramUpdate,
+) {
+    let db_path = db_path.to_path_buf();
+    let integration_id = integration_id.to_string();
+    let bot_token = bot_token.to_string();
+    tokio::spawn(async move {
+        let Ok(_permit) = semaphore().acquire().await else {
+            log::warn!(
+                "dispatcher stopped, dropping telegram update integration_id={integration_id:?}"
+            );
+            return;
+        };
+        process(&db_path, &integration_id, &bot_token, update).await;
+    });
+}
+
+/// `processTelegramUpdate`.
+async fn process(db_path: &Path, integration_id: &str, bot_token: &str, update: TelegramUpdate) {
+    // A non-message update, or one with no text, is not a trigger.
+    let Some(msg) = update.message.filter(|m| !m.text.is_empty()) else {
+        return;
+    };
+
+    // Claimed before the rules are read, so a Telegram retry cannot run the
+    // agent twice — see `receiver::claim_update` for why the claim is atomic
+    // here where Go's is two statements.
+    if !super::receiver::claim_update(db_path, integration_id, update.update_id) {
+        return;
+    }
+
+    let Some((rule, prompt)) = find_matching_rule(db_path, integration_id, &msg) else {
+        return;
+    };
+
+    log::info!(
+        "trigger rule matched rule_id={:?} rule_name={:?} agent_slug={:?} chat_id={}",
+        rule.id,
+        rule.name,
+        rule.agent_slug,
+        msg.chat.id
+    );
+
+    execute_and_reply(db_path, bot_token, &msg, &rule, &prompt).await;
+}
+
+/// One trigger rule, narrowed to what the dispatcher reads.
+#[derive(Debug, Clone)]
+pub struct Rule {
+    pub id: String,
+    pub name: String,
+    pub agent_slug: String,
+    pub filters: RuleFilters,
+}
+
+/// `findMatchingRule`: the first **enabled** rule that matches, in the order the
+/// store returns them (oldest first).
+fn find_matching_rule(
+    db_path: &Path,
+    integration_id: &str,
+    msg: &TelegramMsg,
+) -> Option<(Rule, String)> {
+    let rules = match load_rules(db_path, integration_id) {
+        Ok(rules) => rules,
+        Err(e) => {
+            log::error!("failed to load trigger rules integration_id={integration_id:?} error={e}");
+            return None;
+        }
+    };
+    // `fmt.Sprintf("%d", msg.Chat.ID)`.
+    let chat_id = msg.chat.id.to_string();
+    rules
+        .into_iter()
+        .find_map(|rule| match_rule(&rule.filters, &msg.text, &chat_id).map(|p| (rule, p)))
+}
+
+/// `ListRules`, filtered to the enabled ones as `findMatchingRule` does.
+fn load_rules(db_path: &Path, integration_id: &str) -> Result<Vec<Rule>, String> {
+    let conn = crate::native::db::open_read_only(db_path)?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, name, agent_slug, filter_prefix, filter_keywords, filter_chat_ids
+             FROM trigger_rules
+             WHERE integration_id = ?1 AND enabled = 1
+             ORDER BY created_at ASC",
+        )
+        .map_err(|e| format!("preparing trigger rules query: {e}"))?;
+
+    let rows = stmt
+        .query_map([integration_id], |row| {
+            let keywords: String = row.get(4)?;
+            let chat_ids: String = row.get(5)?;
+            Ok(Rule {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                agent_slug: row.get(2)?,
+                filters: RuleFilters {
+                    prefix: row.get(3)?,
+                    keywords: decode_list(&keywords),
+                    chat_ids: decode_list(&chat_ids),
+                },
+            })
+        })
+        .map_err(|e| format!("querying trigger rules: {e}"))?;
+
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row.map_err(|e| format!("scanning trigger rule: {e}"))?);
+    }
+    Ok(out)
+}
+
+/// A stored `[]string` column. An unparseable or null value is an empty list,
+/// which the matcher reads as "no filter" — the same answer Go's zero slice
+/// gives.
+fn decode_list(raw: &str) -> Vec<String> {
+    serde_json::from_str::<Option<Vec<Option<String>>>>(raw)
+        .ok()
+        .flatten()
+        .map(|list| list.into_iter().map(Option::unwrap_or_default).collect())
+        .unwrap_or_default()
+}
+
+/// `executeAndReply`.
+async fn execute_and_reply(
+    db_path: &Path,
+    bot_token: &str,
+    msg: &TelegramMsg,
+    rule: &Rule,
+    prompt: &str,
+) {
+    // "typing…" while the agent runs. Best-effort in Go too — the result is
+    // discarded.
+    super::telegram_api::send_chat_action(bot_token, msg.chat.id).await;
+
+    let agent = match resolve_agent(db_path, &rule.agent_slug) {
+        Ok(agent) => agent,
+        Err(e) => {
+            log::error!(
+                "failed to resolve agent for trigger agent_slug={:?} error={e}",
+                rule.agent_slug
+            );
+            send_error_reply(bot_token, msg).await;
+            return;
+        }
+    };
+
+    // Go creates the session with **no** working directory, model or settings
+    // profile — a trigger run is not configurable the way a task is.
+    let chat_session_id = match create_trigger_session(db_path, rule) {
+        Ok(id) => id,
+        Err(e) => {
+            log::error!("failed to create chat session for trigger: {e}");
+            send_error_reply(bot_token, msg).await;
+            return;
+        }
+    };
+
+    let spec = agent_run::headless_spec(db_path, agent, String::new(), String::new());
+    let result = agent_run::run_headless(&spec, prompt, RUN_TIMEOUT).await;
+
+    let result = match result {
+        Ok(result) => result,
+        Err(e) => {
+            log::error!(
+                "agent execution failed for trigger rule_id={:?} error={e}",
+                rule.id
+            );
+            send_error_reply(bot_token, msg).await;
+            // The user turn is still stored, with no answer — so the chat shows
+            // what was asked even when nothing came back.
+            save_messages(db_path, &chat_session_id, prompt, "");
+            return;
+        }
+    };
+
+    save_messages(db_path, &chat_session_id, prompt, &result.answer);
+    update_session_usage(db_path, &chat_session_id, &result);
+
+    // An empty answer still gets a reply — silence would be indistinguishable
+    // from the bot being broken.
+    let reply = if result.answer.is_empty() {
+        "No response generated."
+    } else {
+        &result.answer
+    };
+    if let Err(e) =
+        super::telegram_api::send_reply(bot_token, msg.chat.id, msg.message_id, reply).await
+    {
+        log::error!(
+            "failed to send telegram reply chat_id={} error={e}",
+            msg.chat.id
+        );
+    }
+}
+
+/// `resolveAgent`: the named agent, or a synthesized config carrying only the
+/// default model.
+///
+/// The no-slug branch returns a **synthesized `Agent`** rather than `None`, for
+/// the reason the scheduler's does: Go builds a non-nil `config.AgentConfig`,
+/// and `resolveToolsAndMCP` gives a non-nil config with empty capabilities all
+/// twelve built-in tools where a nil one gets none.
+fn resolve_agent(db_path: &Path, agent_slug: &str) -> Result<Agent, String> {
+    if !agent_slug.is_empty() {
+        return match crate::native::agents::get(db_path, agent_slug) {
+            Ok(Some(agent)) => Ok(agent),
+            Ok(None) => Err(format!("agent {agent_slug:?} not found")),
+            Err(e) => Err(format!("loading agent {agent_slug:?}: {e}")),
+        };
+    }
+    // Go's fallback here is the literal "sonnet" when there is no settings
+    // manager, and the stored default otherwise — unlike the scheduler, which
+    // has no literal.
+    let model = {
+        let settings = crate::native::chat::runner::TurnSettings::from_db(db_path);
+        let model = settings.default_model();
+        if model.is_empty() {
+            "sonnet".to_string()
+        } else {
+            model
+        }
+    };
+    Ok(Agent {
+        name: String::new(),
+        slug: String::new(),
+        description: String::new(),
+        model,
+        thinking: "adaptive".to_string(),
+        permission_mode: String::new(),
+        system_prompt: String::new(),
+        capabilities: Default::default(),
+        claude_config_dir: String::new(),
+    })
+}
+
+/// The `[Telegram] <rule>` chat a trigger run is recorded in.
+fn create_trigger_session(db_path: &Path, rule: &Rule) -> Result<String, String> {
+    let mut conn = crate::native::db::open_read_write(db_path)?;
+    let tx = conn
+        .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+        .map_err(|e| format!("begin trigger session: {e}"))?;
+    let session = crate::native::chats::insert_session(&tx, &rule.agent_slug, "", "", "")
+        .map_err(|e| e.message())?;
+    tx.commit()
+        .map_err(|e| format!("commit trigger session: {e}"))?;
+
+    // Two writes, as Go has them: a failed title update is a warning, not a
+    // failed run.
+    let title = format!("[Telegram] {}", rule.name);
+    if let Err(e) = conn.execute(
+        "UPDATE chat_sessions SET title = ?1, updated_at = ?2 WHERE id = ?3",
+        rusqlite::params![title, crate::native::gotime::now_go_text(), session.id],
+    ) {
+        log::warn!("failed to update session title: {e}");
+    }
+    Ok(session.id)
+}
+
+/// `saveSessionMessages`.
+///
+/// **The user turn is stored even when there is no answer** — that is Go's
+/// shape, and it is what makes a failed trigger visible in the chat rather than
+/// leaving an empty session.
+fn save_messages(db_path: &Path, chat_session_id: &str, prompt: &str, answer: &str) {
+    let write = || -> Result<(), String> {
+        let conn = crate::native::db::open_read_write(db_path)?;
+        append_message(&conn, chat_session_id, "user", prompt)?;
+        if !answer.is_empty() {
+            append_message(&conn, chat_session_id, "assistant", answer)?;
+        }
+        Ok(())
+    };
+    if let Err(e) = write() {
+        log::warn!("failed to store trigger messages: {e}");
+    }
+}
+
+fn append_message(
+    conn: &rusqlite::Connection,
+    chat_session_id: &str,
+    role: &str,
+    content: &str,
+) -> Result<(), String> {
+    // `id` is `INTEGER PRIMARY KEY AUTOINCREMENT`, so it is not in the column
+    // list; `blocks` defaults to `[]`, which every reader JSON-decodes.
+    conn.execute(
+        "INSERT INTO chat_messages (session_id, role, content, blocks, timestamp)
+         VALUES (?1, ?2, ?3, '[]', ?4)",
+        rusqlite::params![
+            chat_session_id,
+            role,
+            content,
+            crate::native::gotime::now_go_text()
+        ],
+    )
+    .map_err(|e| format!("storing {role} message: {e}"))?;
+    Ok(())
+}
+
+/// `updateSessionUsage`.
+fn update_session_usage(db_path: &Path, chat_session_id: &str, result: &agent_run::RunResult) {
+    let write = || -> Result<(), String> {
+        let conn = crate::native::db::open_read_write(db_path)?;
+        conn.execute(
+            "UPDATE chat_sessions SET
+                sdk_session_id = ?1, total_input_tokens = ?2, total_output_tokens = ?3,
+                total_cache_creation_tokens = ?4, total_cache_read_tokens = ?5, updated_at = ?6
+             WHERE id = ?7",
+            rusqlite::params![
+                result.session_id,
+                result.input_tokens,
+                result.output_tokens,
+                result.cache_creation_tokens,
+                result.cache_read_tokens,
+                crate::native::gotime::now_go_text(),
+                chat_session_id,
+            ],
+        )
+        .map_err(|e| format!("updating chat session: {e}"))?;
+        Ok(())
+    };
+    if let Err(e) = write() {
+        log::warn!("failed to update chat session after trigger: {e}");
+    }
+}
+
+async fn send_error_reply(bot_token: &str, msg: &TelegramMsg) {
+    if let Err(e) =
+        super::telegram_api::send_reply(bot_token, msg.chat.id, msg.message_id, ERROR_REPLY).await
+    {
+        log::error!(
+            "failed to send error reply chat_id={} error={e}",
+            msg.chat.id
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn migrated(dir: &Path) -> std::path::PathBuf {
+        let db = dir.join("agento.db");
+        let mut conn = rusqlite::Connection::open(&db).expect("open");
+        crate::native::migrate::apply(&mut conn).expect("migrate");
+        conn.execute(
+            "INSERT INTO integrations (id, name, type, enabled, credentials, services,
+                                       created_at, updated_at)
+             VALUES ('tg', 'T', 'telegram', 1, '{}', '{}',
+                     '2026-01-01 00:00:00 +0000 UTC', '2026-01-01 00:00:00 +0000 UTC')",
+            [],
+        )
+        .expect("seed integration");
+        db
+    }
+
+    fn add_rule(
+        db: &Path,
+        id: &str,
+        enabled: bool,
+        prefix: &str,
+        keywords: &str,
+        chat_ids: &str,
+        created_at: &str,
+    ) {
+        let conn = rusqlite::Connection::open(db).expect("open");
+        conn.execute(
+            "INSERT INTO trigger_rules
+                (id, integration_id, name, agent_slug, enabled, filter_prefix,
+                 filter_keywords, filter_chat_ids, created_at, updated_at)
+             VALUES (?1, 'tg', ?1, 'a', ?2, ?3, ?4, ?5, ?6, ?6)",
+            rusqlite::params![id, enabled, prefix, keywords, chat_ids, created_at],
+        )
+        .expect("seed rule");
+    }
+
+    fn msg(text: &str, chat_id: i64) -> TelegramMsg {
+        TelegramMsg {
+            message_id: 1,
+            chat: super::super::receiver::TelegramChat { id: chat_id },
+            text: text.to_string(),
+        }
+    }
+
+    #[test]
+    fn the_first_matching_enabled_rule_wins_in_store_order() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path());
+        // Oldest first, as `ListRules` orders them.
+        add_rule(
+            &db,
+            "old",
+            true,
+            "",
+            "[]",
+            "[]",
+            "2026-01-01 00:00:00 +0000 UTC",
+        );
+        add_rule(
+            &db,
+            "new",
+            true,
+            "",
+            "[]",
+            "[]",
+            "2026-02-01 00:00:00 +0000 UTC",
+        );
+
+        let (rule, prompt) = find_matching_rule(&db, "tg", &msg("anything", 42)).expect("a match");
+        assert_eq!(rule.id, "old", "oldest first, not newest");
+        assert_eq!(prompt, "anything");
+    }
+
+    #[test]
+    fn a_disabled_rule_is_never_considered() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path());
+        add_rule(
+            &db,
+            "off",
+            false,
+            "",
+            "[]",
+            "[]",
+            "2026-01-01 00:00:00 +0000 UTC",
+        );
+        assert!(find_matching_rule(&db, "tg", &msg("anything", 42)).is_none());
+
+        // …and an enabled one after it still matches.
+        add_rule(
+            &db,
+            "on",
+            true,
+            "",
+            "[]",
+            "[]",
+            "2026-02-01 00:00:00 +0000 UTC",
+        );
+        assert_eq!(
+            find_matching_rule(&db, "tg", &msg("anything", 42))
+                .expect("a match")
+                .0
+                .id,
+            "on"
+        );
+    }
+
+    #[test]
+    fn the_filters_come_off_the_row_and_are_applied() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path());
+        add_rule(
+            &db,
+            "filtered",
+            true,
+            "/ask",
+            r#"["status"]"#,
+            r#"["42"]"#,
+            "2026-01-01 00:00:00 +0000 UTC",
+        );
+
+        let (_, prompt) =
+            find_matching_rule(&db, "tg", &msg("/ask what is the status", 42)).expect("a match");
+        assert_eq!(prompt, "what is the status", "the prefix is stripped");
+
+        // Each filter can reject on its own.
+        assert!(find_matching_rule(&db, "tg", &msg("what is the status", 42)).is_none());
+        assert!(find_matching_rule(&db, "tg", &msg("/ask something else", 42)).is_none());
+        assert!(find_matching_rule(&db, "tg", &msg("/ask what is the status", 99)).is_none());
+    }
+
+    #[test]
+    fn rules_are_scoped_to_their_integration() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path());
+        add_rule(
+            &db,
+            "mine",
+            true,
+            "",
+            "[]",
+            "[]",
+            "2026-01-01 00:00:00 +0000 UTC",
+        );
+        assert!(find_matching_rule(&db, "other", &msg("hi", 42)).is_none());
+    }
+
+    #[test]
+    fn a_null_or_broken_filter_column_is_no_filter_rather_than_no_match() {
+        // Go decodes these into a nil slice, which `matchesKeywords` reads as
+        // "everything". A port treating the failure as "match nothing" would
+        // silently stop a working rule.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path());
+        add_rule(
+            &db,
+            "nulls",
+            true,
+            "",
+            "null",
+            "not json",
+            "2026-01-01 00:00:00 +0000 UTC",
+        );
+        assert!(find_matching_rule(&db, "tg", &msg("anything", 42)).is_some());
+    }
+
+    #[test]
+    fn a_null_element_in_a_filter_list_is_an_empty_string() {
+        // #295's rule: a `null` inside a list is the zero value, not an error.
+        assert_eq!(
+            decode_list(r#"["a",null]"#),
+            vec!["a".to_string(), String::new()]
+        );
+        assert!(decode_list("null").is_empty());
+        assert!(decode_list("").is_empty());
+        assert!(decode_list("[]").is_empty());
+    }
+
+    #[test]
+    fn a_synthesized_agent_carries_the_default_model_and_adaptive_thinking() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = dir.path().join("missing.db");
+        let agent = resolve_agent(&db, "").expect("no slug is never an error");
+        assert_eq!(agent.thinking, "adaptive");
+        assert!(
+            !agent.model.is_empty(),
+            "Go falls back to a literal 'sonnet'"
+        );
+        assert!(
+            agent.capabilities.built_in.is_none(),
+            "empty caps, so all built-ins"
+        );
+    }
+
+    #[test]
+    fn an_unknown_agent_slug_is_an_error_rather_than_a_synthesized_agent() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path());
+        let err = resolve_agent(&db, "nope").unwrap_err();
+        assert_eq!(err, r#"agent "nope" not found"#);
+    }
+}

--- a/desktop/src-tauri/src/native/trigger/match_rule.rs
+++ b/desktop/src-tauri/src/native/trigger/match_rule.rs
@@ -1,0 +1,267 @@
+//! Whether an inbound Telegram message fires a trigger rule, and what prompt it
+//! runs with. Mirrors `matchRule` in `internal/trigger/dispatcher.go`.
+//!
+//! Pinned to `desktop/parity/trigger_match_vectors.json`, generated from Go's
+//! own matcher. Almost every clause here is a place the two languages disagree
+//! by default, and two of them disproved what this file's author believed before
+//! the vectors were generated:
+//!
+//! - **`text[:prefixLen]` is a byte slice, and Go will cut a character in half.**
+//!   A one-byte ASCII prefix against a message starting with a three-byte
+//!   character takes `text[..1]` — a lone continuation byte, invalid UTF-8 — and
+//!   `EqualFold` decodes it as `RuneError`, so it does not match. Slicing by
+//!   *character* would compare the whole character instead (and might match);
+//!   slicing by byte in Rust would **panic**. This function therefore compares
+//!   bytes and never indexes a `str`.
+//! - **The length guard is bytes too.** `len(text) < prefixLen` rejects before
+//!   the slice, which is what keeps the slice in range.
+//! - **`EqualFold` is Unicode simple folding**, not ASCII case-insensitivity and
+//!   not lower-casing: sigma folds to final sigma, while `U+0130` does *not*
+//!   fold to ASCII `i` even though it lower-cases to one.
+//! - **`TrimSpace` is `unicode.IsSpace`**, which includes `U+00A0` and `U+0085`.
+//!   Rust's `char::is_whitespace` agrees, both following `White_Space` — two
+//!   standards agreeing, which is why the vectors pin it rather than assume it.
+//! - **An empty prompt after the trim is not a match.** A bare `/ask` runs
+//!   nothing rather than running with an empty prompt.
+//! - **Keywords are checked against the *whole* message, not the stripped
+//!   prompt.** So a keyword that appears only inside the prefix still satisfies
+//!   the filter — the rule fires with a prompt that does not contain it.
+
+/// One rule's filters, which is all the matcher reads.
+#[derive(Debug, Default, Clone)]
+pub struct RuleFilters {
+    pub prefix: String,
+    pub keywords: Vec<String>,
+    pub chat_ids: Vec<String>,
+}
+
+/// `matchRule`: `Some(prompt)` when the rule fires.
+pub fn match_rule(filters: &RuleFilters, text: &str, chat_id: &str) -> Option<String> {
+    let mut prompt = text.to_string();
+
+    if !filters.prefix.is_empty() {
+        let prefix_len = filters.prefix.len();
+        let bytes = text.as_bytes();
+        // `len(text) < prefixLen` — bytes on both sides.
+        if bytes.len() < prefix_len {
+            return None;
+        }
+        if !equal_fold(&bytes[..prefix_len], filters.prefix.as_bytes()) {
+            return None;
+        }
+        // The remainder is always a char boundary when the prefix matched by
+        // folding, because a fold match implies the bytes decoded as whole
+        // characters. `from_utf8` rather than an index, so a future change to
+        // the comparison cannot turn this into a panic.
+        let rest = match std::str::from_utf8(&bytes[prefix_len..]) {
+            Ok(rest) => rest,
+            // Unreachable today; a mid-character split cannot have folded equal.
+            Err(_) => return None,
+        };
+        prompt = rest.trim().to_string();
+        if prompt.is_empty() {
+            return None;
+        }
+    }
+
+    // Deliberately `text`, not `prompt` — see the module header.
+    if !matches_keywords(&filters.keywords, text) {
+        return None;
+    }
+    if !matches_chat_ids(&filters.chat_ids, chat_id) {
+        return None;
+    }
+    Some(prompt)
+}
+
+/// `matchesKeywords`: empty is "everything", otherwise OR over case-folded
+/// `Contains`.
+fn matches_keywords(keywords: &[String], text: &str) -> bool {
+    if keywords.is_empty() {
+        return true;
+    }
+    // `strings.ToLower` on both sides. Full Unicode lower-casing in both
+    // languages, unlike the prefix comparison, which folds.
+    let lower = text.to_lowercase();
+    keywords.iter().any(|kw| lower.contains(&kw.to_lowercase()))
+}
+
+/// `matchesChatIDs`: empty is "everything", otherwise an exact string compare.
+fn matches_chat_ids(allowed: &[String], chat_id: &str) -> bool {
+    allowed.is_empty() || allowed.iter().any(|id| id == chat_id)
+}
+
+/// `strings.EqualFold` over bytes, with Go's UTF-8 decoding.
+///
+/// Byte slices rather than `&str` because the caller may hand it a slice that
+/// splits a character — that is the case the vectors exist for. Go decodes such
+/// a byte as `RuneError` with width 1, which is reproduced here.
+fn equal_fold(a: &[u8], b: &[u8]) -> bool {
+    let (mut a, mut b) = (a, b);
+    loop {
+        let (Some((ar, asize)), Some((br, bsize))) = (decode_rune(a), decode_rune(b)) else {
+            // One or both exhausted: equal only if both are.
+            return a.is_empty() && b.is_empty();
+        };
+        a = &a[asize..];
+        b = &b[bsize..];
+        if ar == br {
+            continue;
+        }
+        if !simple_fold_eq(ar, br) {
+            return false;
+        }
+    }
+}
+
+/// `utf8.DecodeRuneInString`: the next rune and its width, with an invalid
+/// sequence decoding as `U+FFFD` of width 1.
+fn decode_rune(bytes: &[u8]) -> Option<(char, usize)> {
+    if bytes.is_empty() {
+        return None;
+    }
+    // Longest valid prefix is at most 4 bytes.
+    let upto = bytes.len().min(4);
+    for width in 1..=upto {
+        if let Ok(s) = std::str::from_utf8(&bytes[..width]) {
+            if let Some(c) = s.chars().next() {
+                return Some((c, width));
+            }
+        }
+    }
+    Some((char::REPLACEMENT_CHARACTER, 1))
+}
+
+/// Whether two runes are equal under Unicode **simple** folding.
+///
+/// Go walks `unicode.SimpleFold`'s orbit; the orbits that matter in practice are
+/// reproduced through `to_lowercase`/`to_uppercase`, with the ASCII fast path
+/// first because it is the overwhelmingly common case and is exact.
+///
+/// **This is an approximation of the full orbit table**, and the vectors are
+/// what bound it: sigma's three-way orbit and `U+0130`'s *absence* from ASCII
+/// `i`'s orbit are both pinned, because those are the two shapes a
+/// lower-casing implementation gets wrong in opposite directions.
+fn simple_fold_eq(a: char, b: char) -> bool {
+    if a.is_ascii() && b.is_ascii() {
+        return a.eq_ignore_ascii_case(&b);
+    }
+    // `U+0130` lower-cases to "i̇" (two chars) and `U+0131` upper-cases to "I",
+    // but neither shares an orbit with ASCII `i`. Comparing single-char
+    // case mappings keeps them apart, where a string-wise `to_lowercase`
+    // comparison would fold the first into ASCII.
+    let one = |c: char, f: fn(char) -> std::char::ToLowercase| {
+        let mut it = f(c);
+        match (it.next(), it.next()) {
+            (Some(only), None) => Some(only),
+            _ => None,
+        }
+    };
+    let lower = |c: char| one(c, char::to_lowercase);
+    if let (Some(x), Some(y)) = (lower(a), lower(b)) {
+        if x == y {
+            return true;
+        }
+    }
+    // **The uppercase direction is not redundant.** Sigma's orbit is
+    // `σ → ς → Σ`, so the two lowercase forms map to themselves and only agree
+    // through the capital. Lower-casing alone reports them different, which is
+    // what the vectors caught.
+    let upper = |c: char| {
+        let mut it = c.to_uppercase();
+        match (it.next(), it.next()) {
+            (Some(only), None) => Some(only),
+            _ => None,
+        }
+    };
+    match (upper(a), upper(b)) {
+        (Some(x), Some(y)) => x == y,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(serde::Deserialize)]
+    struct Vectors {
+        cases: Vec<Case>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct Case {
+        name: String,
+        #[allow(dead_code)]
+        note: String,
+        filter_prefix: String,
+        filter_keywords: Option<Vec<String>>,
+        filter_chat_ids: Option<Vec<String>>,
+        text: String,
+        chat_id: String,
+        matched: bool,
+        prompt: String,
+    }
+
+    #[test]
+    fn every_case_matches_what_go_decided() {
+        let raw = include_str!("../../../../parity/trigger_match_vectors.json");
+        let vectors: Vectors = serde_json::from_str(raw).expect("vectors decode");
+        assert!(!vectors.cases.is_empty(), "the vector file is empty");
+
+        for case in &vectors.cases {
+            let filters = RuleFilters {
+                prefix: case.filter_prefix.clone(),
+                keywords: case.filter_keywords.clone().unwrap_or_default(),
+                chat_ids: case.filter_chat_ids.clone().unwrap_or_default(),
+            };
+            let got = match_rule(&filters, &case.text, &case.chat_id);
+            assert_eq!(got.is_some(), case.matched, "case {:?}: matched", case.name);
+            assert_eq!(
+                got.unwrap_or_default(),
+                case.prompt,
+                "case {:?}: prompt",
+                case.name
+            );
+        }
+    }
+
+    #[test]
+    fn a_prefix_longer_than_the_message_never_indexes_out_of_range() {
+        // The guard is bytes, and this is the case that would panic without it.
+        let filters = RuleFilters {
+            prefix: "/askmore".to_string(),
+            ..Default::default()
+        };
+        assert!(match_rule(&filters, "/a", "1").is_none());
+        assert!(match_rule(&filters, "", "1").is_none());
+    }
+
+    #[test]
+    fn a_multibyte_message_with_a_shorter_ascii_prefix_does_not_panic() {
+        // `text[..1]` here is a lone continuation byte. Go compares it as
+        // RuneError; the point of the byte-wise comparison is that Rust neither
+        // panics nor silently compares a whole character.
+        let filters = RuleFilters {
+            prefix: "K".to_string(),
+            ..Default::default()
+        };
+        assert!(match_rule(&filters, "\u{212A}elvin", "1").is_none());
+        assert!(match_rule(&filters, "\u{00E9}xyz", "1").is_none());
+    }
+
+    #[test]
+    fn decoding_matches_gos_widths() {
+        assert_eq!(decode_rune(b"a"), Some(('a', 1)));
+        assert_eq!(decode_rune("é".as_bytes()), Some(('é', 2)));
+        assert_eq!(decode_rune("\u{212A}".as_bytes()), Some(('\u{212A}', 3)));
+        assert_eq!(decode_rune(b""), None);
+        // A lone continuation byte is RuneError of width 1, as Go decodes it.
+        assert_eq!(decode_rune(&[0x80]), Some((char::REPLACEMENT_CHARACTER, 1)));
+        // …and so is a truncated multi-byte sequence.
+        assert_eq!(
+            decode_rune(&"é".as_bytes()[..1]),
+            Some((char::REPLACEMENT_CHARACTER, 1))
+        );
+    }
+}

--- a/desktop/src-tauri/src/native/trigger/match_rule.rs
+++ b/desktop/src-tauri/src/native/trigger/match_rule.rs
@@ -146,6 +146,15 @@ fn simple_fold_eq(a: char, b: char) -> bool {
     if a.is_ascii() && b.is_ascii() {
         return a.eq_ignore_ascii_case(&b);
     }
+    // **The Turkish pair are self-orbits, in both directions.**
+    // `unicode.SimpleFold` maps U+0130 and U+0131 to themselves, so
+    // `EqualFold("ı", "i")` and `EqualFold("İ", "i")` are both false — verified
+    // against Go. The case mappings below would say otherwise: `ı`
+    // upper-cases to ASCII `I`, and `İ` lower-cases to a string starting with
+    // ASCII `i`. Neither is a fold.
+    if matches!(a, '\u{0130}' | '\u{0131}') || matches!(b, '\u{0130}' | '\u{0131}') {
+        return false;
+    }
     // `U+0130` lower-cases to "i̇" (two chars) and `U+0131` upper-cases to "I",
     // but neither shares an orbit with ASCII `i`. Comparing single-char
     // case mappings keeps them apart, where a string-wise `to_lowercase`
@@ -248,6 +257,25 @@ mod tests {
         };
         assert!(match_rule(&filters, "\u{212A}elvin", "1").is_none());
         assert!(match_rule(&filters, "\u{00E9}xyz", "1").is_none());
+    }
+
+    #[test]
+    fn the_turkish_pair_fold_with_nothing_but_themselves() {
+        // Verified against Go: `unicode.SimpleFold` maps both U+0130 and U+0131
+        // to themselves, so `EqualFold("ı","i")` and `EqualFold("İ","i")` are
+        // false. The case mappings say otherwise in both directions — `ı`
+        // upper-cases to ASCII `I`, `İ` lower-cases to a string starting with
+        // ASCII `i` — so this is the one place folding and casing disagree
+        // enough to need naming.
+        assert!(!simple_fold_eq('\u{0131}', 'i'));
+        assert!(!simple_fold_eq('\u{0131}', 'I'));
+        assert!(!simple_fold_eq('\u{0130}', 'i'));
+        assert!(!simple_fold_eq('\u{0130}', 'I'));
+        // …and each still equals itself, through the `ar == br` fast path.
+        assert!(equal_fold("\u{0131}".as_bytes(), "\u{0131}".as_bytes()));
+        assert!(equal_fold("\u{0130}".as_bytes(), "\u{0130}".as_bytes()));
+        // The sigma orbit is unaffected by the guard.
+        assert!(simple_fold_eq('\u{03C2}', '\u{03C3}'));
     }
 
     #[test]

--- a/desktop/src-tauri/src/native/trigger/mod.rs
+++ b/desktop/src-tauri/src/native/trigger/mod.rs
@@ -3,5 +3,85 @@
 //!
 //! Mirrors `internal/trigger`.
 
+pub mod dispatcher;
 pub mod match_rule;
 pub mod receiver;
+pub mod telegram_api;
+
+use axum::http::Method;
+
+/// This module's entry in `native::ENDPOINTS`.
+pub const ENDPOINT: crate::native::Endpoint = crate::native::Endpoint {
+    name: "telegram-webhook",
+    claims,
+    serve,
+};
+
+/// `POST /webhooks/telegram/{id}` — and nothing else.
+///
+/// **Not under `/api`**, which is the only route in `ENDPOINTS` that is true of.
+/// `proxy::is_api_path` already admits `/webhooks`, so the request reaches the
+/// seam; `guards.rs` deliberately does not, because the request arrives from
+/// Telegram with a foreign `Host` and is authenticated by its own secret.
+fn claims(method: &Method, path: &str) -> bool {
+    method == Method::POST && webhook_id(path).is_some()
+}
+
+/// The integration id in `/webhooks/telegram/{id}`, if the path is one.
+///
+/// One segment, as chi routes it — a trailing slash or a nested path is not this
+/// route.
+fn webhook_id(path: &str) -> Option<&str> {
+    let rest = path.strip_prefix("/webhooks/telegram/")?;
+    if rest.is_empty() || rest.contains('/') {
+        return None;
+    }
+    Some(rest)
+}
+
+fn serve(
+    ctx: &crate::native::Ctx,
+    req: &crate::native::Request,
+) -> Result<crate::native::Answer, String> {
+    let Some(id) = webhook_id(req.path) else {
+        return Err(format!("{} is not the telegram webhook", req.path));
+    };
+
+    match receiver::receive(&ctx.db_path, id, req.secret_token, req.body) {
+        // Go writes the 200 **before** dispatching, so Telegram is never held
+        // open for an agent run and never retries because of one.
+        receiver::Inbound::Dispatch { bot_token, update } => {
+            dispatcher::handle_update(&ctx.db_path, id, &bot_token, update);
+            Ok(crate::native::Answer::status_only(
+                axum::http::StatusCode::OK,
+            ))
+        }
+        receiver::Inbound::Ignore => Ok(crate::native::Answer::status_only(
+            axum::http::StatusCode::OK,
+        )),
+        // `http.Error`, which writes the message and a trailing newline as
+        // `text/plain` — not the JSON envelope every `/api` error uses.
+        receiver::Inbound::Forbidden => Ok(crate::native::Answer::text_status(
+            axum::http::StatusCode::FORBIDDEN,
+            "forbidden\n",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_the_post_webhook_path_is_claimed() {
+        assert!(claims(&Method::POST, "/webhooks/telegram/abc"));
+        // The method matters: chi mounts only POST.
+        assert!(!claims(&Method::GET, "/webhooks/telegram/abc"));
+        // One segment, and non-empty.
+        assert!(!claims(&Method::POST, "/webhooks/telegram/"));
+        assert!(!claims(&Method::POST, "/webhooks/telegram"));
+        assert!(!claims(&Method::POST, "/webhooks/telegram/a/b"));
+        assert!(!claims(&Method::POST, "/webhooks/slack/abc"));
+        assert!(!claims(&Method::POST, "/api/webhooks/telegram/abc"));
+    }
+}

--- a/desktop/src-tauri/src/native/trigger/mod.rs
+++ b/desktop/src-tauri/src/native/trigger/mod.rs
@@ -69,6 +69,74 @@ fn serve(
     }
 }
 
+/// Run an async handler to completion from the seam's **synchronous** `serve`.
+///
+/// `serve` is a sync `fn` the proxy calls on `spawn_blocking`, and the three
+/// registration routes are network calls — so something has to bridge, and
+/// unlike `registry::block_on_detached` this one needs the *result*.
+///
+/// `Handle::block_on` is correct here for the reason it is wrong there: a
+/// `spawn_blocking` thread is not a runtime worker, so blocking it parks a
+/// thread from the blocking pool rather than stalling the executor. That is
+/// exactly what the pool is for.
+fn block_on_result<F, T>(what: &str, future: F) -> Result<T, crate::native::writes::WriteError>
+where
+    F: std::future::Future<Output = Result<T, crate::native::writes::WriteError>>,
+{
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) => handle.block_on(future),
+        // Only reachable from a unit test calling the handler directly; the
+        // proxy is axum and always has a runtime.
+        Err(_) => Err(crate::native::writes::WriteError::Fallback(format!(
+            "{what}: no tokio runtime on this thread"
+        ))),
+    }
+}
+
+/// `POST /api/integrations/{id}/webhook/register`.
+pub fn serve_register(
+    db_path: &std::path::Path,
+    id: &str,
+) -> Result<crate::native::Answer, crate::native::writes::WriteError> {
+    block_on_result("registering webhook", registration::register(db_path, id))?;
+    status_response("registered")
+}
+
+/// `DELETE /api/integrations/{id}/webhook/register`. 204, no body.
+pub fn serve_delete(
+    db_path: &std::path::Path,
+    id: &str,
+) -> Result<crate::native::Answer, crate::native::writes::WriteError> {
+    block_on_result("deleting webhook", registration::delete(db_path, id))?;
+    Ok(crate::native::Answer::no_content())
+}
+
+/// `POST /api/integrations/{id}/webhook/regenerate-secret`.
+pub fn serve_regenerate(
+    db_path: &std::path::Path,
+    id: &str,
+) -> Result<crate::native::Answer, crate::native::writes::WriteError> {
+    block_on_result(
+        "regenerating webhook secret",
+        registration::regenerate(db_path, id),
+    )?;
+    status_response("regenerated")
+}
+
+/// `map[string]string{"status": …}` — one key, so nothing to sort.
+fn status_response(
+    status: &str,
+) -> Result<crate::native::Answer, crate::native::writes::WriteError> {
+    #[derive(serde::Serialize)]
+    struct StatusResponse<'a> {
+        status: &'a str,
+    }
+    let body = crate::native::gojson::to_vec(&StatusResponse { status }).map_err(|e| {
+        crate::native::writes::WriteError::Fallback(format!("encoding status: {e}"))
+    })?;
+    Ok(crate::native::Answer::json(body))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/desktop/src-tauri/src/native/trigger/mod.rs
+++ b/desktop/src-tauri/src/native/trigger/mod.rs
@@ -6,6 +6,7 @@
 pub mod dispatcher;
 pub mod match_rule;
 pub mod receiver;
+pub mod registration;
 pub mod telegram_api;
 
 use axum::http::Method;

--- a/desktop/src-tauri/src/native/trigger/mod.rs
+++ b/desktop/src-tauri/src/native/trigger/mod.rs
@@ -1,0 +1,6 @@
+//! The Telegram trigger path: matching an inbound message to a rule, and
+//! running the agent it names (#319).
+//!
+//! Mirrors `internal/trigger`.
+
+pub mod match_rule;

--- a/desktop/src-tauri/src/native/trigger/mod.rs
+++ b/desktop/src-tauri/src/native/trigger/mod.rs
@@ -4,3 +4,4 @@
 //! Mirrors `internal/trigger`.
 
 pub mod match_rule;
+pub mod receiver;

--- a/desktop/src-tauri/src/native/trigger/receiver.rs
+++ b/desktop/src-tauri/src/native/trigger/receiver.rs
@@ -29,7 +29,7 @@ use std::path::Path;
 use serde::Deserialize;
 
 use crate::native::db;
-use crate::native::gojson::null_is_zero_value;
+use crate::native::gojson::{null_is_zero_value, GoStruct};
 
 /// `trigger.TelegramUpdate`.
 ///
@@ -41,7 +41,13 @@ use crate::native::gojson::null_is_zero_value;
 pub struct TelegramUpdate {
     #[serde(deserialize_with = "null_is_zero_value")]
     pub update_id: i64,
-    pub message: Option<TelegramMsg>,
+    /// [`GoStruct`] for #337: every field of `TelegramMsg` has a default, so
+    /// serde's derived `visit_seq` would build one from a JSON **array** of any
+    /// length — `[7,{…}]` would decode to a full update and dispatch an agent
+    /// run where Go's `json.Unmarshal` errors and answers a silent 200. The
+    /// wrapper refuses the array shape. `Option` because a `null` message is a
+    /// nil pointer to Go, which is not an error either.
+    pub message: Option<GoStruct<TelegramMsg>>,
 }
 
 /// `trigger.TelegramMsg`.
@@ -50,8 +56,10 @@ pub struct TelegramUpdate {
 pub struct TelegramMsg {
     #[serde(deserialize_with = "null_is_zero_value")]
     pub message_id: i64,
+    /// `GoStruct` for the same reason as `message` above; `null_is_zero_value`
+    /// because a `null` chat is the zero struct to `encoding/json`.
     #[serde(deserialize_with = "null_is_zero_value")]
-    pub chat: TelegramChat,
+    pub chat: GoStruct<TelegramChat>,
     #[serde(deserialize_with = "null_is_zero_value")]
     pub text: String,
 }
@@ -148,7 +156,11 @@ pub fn receive(db_path: &Path, id: &str, header_secret: &str, body: &[u8]) -> In
 
     // An undecodable payload is logged at debug and answered 200 — Telegram
     // would retry a 4xx forever for a body it will keep sending.
-    let Ok(update) = serde_json::from_slice::<TelegramUpdate>(body) else {
+    // `GoStruct` around the **whole** decode, not only the nested fields —
+    // #337's rule 2. Wrapping `message` and `chat` alone still leaves the outer
+    // update buildable from a positional array, and `[7,{…}]` would dispatch a
+    // real agent run where Go's `json.Unmarshal` errors into a silent 200.
+    let Ok(GoStruct(update)) = serde_json::from_slice::<GoStruct<TelegramUpdate>>(body) else {
         log::debug!("failed to decode telegram webhook payload integration_id={id:?}");
         return Inbound::Ignore;
     };
@@ -318,6 +330,30 @@ mod tests {
                 assert_eq!(update.message.expect("message").text, "");
             }
             other => panic!("expected dispatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_positional_array_is_refused_where_go_refuses_it() {
+        // #337's over-accept. Every field has a default, so serde's derived
+        // `visit_seq` would build the struct from a JSON **array** — and an
+        // update that decoded from `[7,{…}]` would dispatch a real agent run
+        // where Go's `json.Unmarshal` errors and answers a silent 200. The
+        // seam's `Err`-means-forward cannot catch an over-accept, so the
+        // `GoStruct` wrapper is the only guard.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path(), true, "s3cret", "active");
+        for body in [
+            &br#"[7,{"message_id":1,"chat":{"id":5},"text":"do something"}]"#[..],
+            br#"{"update_id":7,"message":[1,{"id":5},"do something"]}"#,
+            br#"{"update_id":7,"message":{"message_id":1,"chat":[5],"text":"x"}}"#,
+        ] {
+            assert_eq!(
+                receive(&db, "tg", "s3cret", body),
+                Inbound::Ignore,
+                "an array shape must not decode: {}",
+                String::from_utf8_lossy(body)
+            );
         }
     }
 

--- a/desktop/src-tauri/src/native/trigger/receiver.rs
+++ b/desktop/src-tauri/src/native/trigger/receiver.rs
@@ -1,0 +1,382 @@
+//! `POST /webhooks/telegram/{id}` — the inbound webhook, and the update
+//! deduplication behind it. Mirrors `TelegramWebhookHandler.handleInbound` and
+//! `SQLiteTriggerStore.{IsUpdateProcessed,MarkUpdateProcessed}`.
+//!
+//! # This route is not under `/api`, and that is deliberate
+//!
+//! It is mounted at the **root**, so neither guard in `guards.rs` applies to it,
+//! and both would break it: the request arrives from Telegram's servers with a
+//! foreign `Host`, which `validate_host` answers 403 to. Its authentication is
+//! its own — a secret token in `X-Telegram-Bot-Api-Secret-Token`, compared in
+//! constant time against the one stored when the webhook was registered.
+//! `guards.rs` already scopes itself to `/api` and has a test saying so; this
+//! module depends on that and does not re-check it.
+//!
+//! # Almost every failure is a 200
+//!
+//! An unknown integration, an inactive webhook, no stored secret, a disabled
+//! integration, an undecodable body, unparseable credentials — all answer **200
+//! and do nothing**. That is not laxity: Telegram *retries* a non-2xx, so a 4xx
+//! for a permanent condition would turn one bad update into a retry loop. The
+//! single exception is a **wrong secret**, which is 403 — the one case where
+//! telling the caller it is unauthorised is right, because it is not Telegram.
+//!
+//! The 200 is also written **before** the update is dispatched, so a slow agent
+//! run cannot hold Telegram's connection open or make it retry.
+
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::native::db;
+use crate::native::gojson::null_is_zero_value;
+
+/// `trigger.TelegramUpdate`.
+///
+/// Every field is `null_is_zero_value`: this is JSON from Telegram decoded by
+/// `encoding/json` on the Go side, where a `null` is a no-op rather than a type
+/// error, and an undecodable body is a silent 200 either way.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize)]
+#[serde(default)]
+pub struct TelegramUpdate {
+    #[serde(deserialize_with = "null_is_zero_value")]
+    pub update_id: i64,
+    pub message: Option<TelegramMsg>,
+}
+
+/// `trigger.TelegramMsg`.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize)]
+#[serde(default)]
+pub struct TelegramMsg {
+    #[serde(deserialize_with = "null_is_zero_value")]
+    pub message_id: i64,
+    #[serde(deserialize_with = "null_is_zero_value")]
+    pub chat: TelegramChat,
+    #[serde(deserialize_with = "null_is_zero_value")]
+    pub text: String,
+}
+
+/// `trigger.TelegramChat`.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize)]
+#[serde(default)]
+pub struct TelegramChat {
+    #[serde(deserialize_with = "null_is_zero_value")]
+    pub id: i64,
+}
+
+/// What the receiver decided, so the caller can act without re-reading rows.
+#[derive(Debug, PartialEq)]
+pub enum Inbound {
+    /// 200, and nothing else to do.
+    Ignore,
+    /// 403: the secret did not match.
+    Forbidden,
+    /// 200, and this update should be dispatched.
+    Dispatch {
+        bot_token: String,
+        update: TelegramUpdate,
+    },
+}
+
+/// The stored webhook credentials this route authenticates against.
+struct Registered {
+    secret: String,
+    status: String,
+}
+
+fn registered(db_path: &Path, id: &str) -> Option<Registered> {
+    let conn = db::open_read_only(db_path).ok()?;
+    conn.query_row(
+        "SELECT webhook_secret, webhook_status FROM integrations WHERE id = ?1",
+        [id],
+        |row| {
+            Ok(Registered {
+                secret: row.get(0)?,
+                status: row.get(1)?,
+            })
+        },
+    )
+    .ok()
+}
+
+/// The integration's bot token, if it is enabled and its credentials parse.
+fn enabled_bot_token(db_path: &Path, id: &str) -> Option<String> {
+    #[derive(Deserialize)]
+    struct Creds {
+        #[serde(default, deserialize_with = "null_is_zero_value")]
+        bot_token: String,
+    }
+
+    let conn = db::open_read_only(db_path).ok()?;
+    let (enabled, credentials): (bool, String) = conn
+        .query_row(
+            "SELECT enabled, credentials FROM integrations WHERE id = ?1",
+            [id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .ok()?;
+    if !enabled {
+        return None;
+    }
+    serde_json::from_str::<Creds>(&credentials)
+        .ok()
+        .map(|c| c.bot_token)
+}
+
+/// `handleInbound`, without the HTTP.
+///
+/// The order is Go's, and it is load-bearing: the secret is checked **before**
+/// the integration is loaded, so a caller with the wrong secret learns nothing
+/// about whether the integration exists or is enabled.
+pub fn receive(db_path: &Path, id: &str, header_secret: &str, body: &[u8]) -> Inbound {
+    // A read failure, an unknown id, an inactive webhook or no stored secret are
+    // all the same silent 200 — Go collapses them into one condition.
+    let Some(reg) = registered(db_path, id) else {
+        return Inbound::Ignore;
+    };
+    if reg.status != "active" || reg.secret.is_empty() {
+        return Inbound::Ignore;
+    }
+
+    if !constant_time_eq(header_secret.as_bytes(), reg.secret.as_bytes()) {
+        return Inbound::Forbidden;
+    }
+
+    let Some(bot_token) = enabled_bot_token(db_path, id) else {
+        return Inbound::Ignore;
+    };
+
+    // An undecodable payload is logged at debug and answered 200 — Telegram
+    // would retry a 4xx forever for a body it will keep sending.
+    let Ok(update) = serde_json::from_slice::<TelegramUpdate>(body) else {
+        log::debug!("failed to decode telegram webhook payload integration_id={id:?}");
+        return Inbound::Ignore;
+    };
+
+    Inbound::Dispatch { bot_token, update }
+}
+
+/// `crypto/subtle.ConstantTimeCompare`.
+///
+/// Go's returns 0 for unequal lengths *without* comparing, and so does this —
+/// the length of a secret is not itself a secret. What must not vary with the
+/// input is the comparison of two equal-length slices.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// `IsUpdateProcessed` + `MarkUpdateProcessed`: `true` when this update is new
+/// and has now been claimed.
+///
+/// Go does the two as separate statements. They are one transaction here, which
+/// is a **narrowing**: two updates with the same id arriving together — Telegram
+/// does retry — could both pass Go's `IsUpdateProcessed` before either marked,
+/// and run the agent twice. `INSERT OR IGNORE` inside an immediate transaction
+/// makes the claim atomic, and the row count says who won.
+pub fn claim_update(db_path: &Path, integration_id: &str, update_id: i64) -> bool {
+    let claim = || -> Result<bool, String> {
+        let mut conn = db::open_read_write(db_path)?;
+        let tx = conn
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+            .map_err(|e| format!("begin update claim: {e}"))?;
+        let now = crate::native::gotime::now_go_text();
+        let inserted = tx
+            .execute(
+                "INSERT OR IGNORE INTO telegram_processed_updates
+                    (integration_id, update_id, processed_at)
+                 VALUES (?1, ?2, ?3)",
+                rusqlite::params![integration_id, update_id, now],
+            )
+            .map_err(|e| format!("marking update as processed: {e}"))?;
+
+        // `MarkUpdateProcessed`'s best-effort sweep, on the same 48-hour
+        // horizon. A failure here is ignored exactly as Go ignores it.
+        let cutoff = crate::native::gotime::go_string_from_millis(
+            (chrono::Utc::now() - chrono::Duration::hours(48)).timestamp_millis(),
+        );
+        let _ = tx.execute(
+            "DELETE FROM telegram_processed_updates WHERE processed_at < ?1",
+            [&cutoff],
+        );
+
+        tx.commit()
+            .map_err(|e| format!("commit update claim: {e}"))?;
+        Ok(inserted > 0)
+    };
+    match claim() {
+        Ok(claimed) => claimed,
+        Err(e) => {
+            // Go logs and returns false — do not run the agent on a database it
+            // could not record the run against.
+            log::error!(
+                "failed to claim telegram update integration_id={integration_id:?} \
+                 update_id={update_id} error={e}"
+            );
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn migrated(dir: &Path, enabled: bool, secret: &str, status: &str) -> std::path::PathBuf {
+        let db = dir.join("agento.db");
+        let mut conn = rusqlite::Connection::open(&db).expect("open");
+        crate::native::migrate::apply(&mut conn).expect("migrate");
+        conn.execute(
+            "INSERT INTO integrations (id, name, type, enabled, credentials, services,
+                                       webhook_secret, webhook_status,
+                                       created_at, updated_at)
+             VALUES ('tg', 'T', 'telegram', ?1, '{\"bot_token\":\"botsecret\"}', '{}',
+                     ?2, ?3, '2026-01-01 00:00:00 +0000 UTC', '2026-01-01 00:00:00 +0000 UTC')",
+            rusqlite::params![enabled, secret, status],
+        )
+        .expect("seed");
+        db
+    }
+
+    const UPDATE: &[u8] =
+        br#"{"update_id":7,"message":{"message_id":3,"chat":{"id":-100},"text":"hello"}}"#;
+
+    #[test]
+    fn a_matching_secret_dispatches_with_the_bot_token() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path(), true, "s3cret", "active");
+        match receive(&db, "tg", "s3cret", UPDATE) {
+            Inbound::Dispatch { bot_token, update } => {
+                assert_eq!(bot_token, "botsecret");
+                assert_eq!(update.update_id, 7);
+                let msg = update.message.expect("a message");
+                assert_eq!(msg.text, "hello");
+                assert_eq!(msg.chat.id, -100, "group ids are negative");
+                assert_eq!(msg.message_id, 3);
+            }
+            other => panic!("expected dispatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_wrong_secret_is_the_only_non_200() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path(), true, "s3cret", "active");
+        assert_eq!(receive(&db, "tg", "wrong", UPDATE), Inbound::Forbidden);
+        assert_eq!(receive(&db, "tg", "", UPDATE), Inbound::Forbidden);
+        // …and a *longer* guess is refused without a panic or a length leak.
+        assert_eq!(
+            receive(&db, "tg", "s3cret-and-more", UPDATE),
+            Inbound::Forbidden
+        );
+    }
+
+    #[test]
+    fn every_permanent_condition_is_a_silent_200() {
+        // Telegram retries a non-2xx, so a 4xx here would be a retry loop for a
+        // body it will keep sending.
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        let unknown = migrated(dir.path(), true, "s", "active");
+        assert_eq!(receive(&unknown, "nope", "s", UPDATE), Inbound::Ignore);
+
+        for (enabled, secret, status, why) in [
+            (true, "s", "inactive", "the webhook is not registered"),
+            (true, "", "active", "no secret is stored"),
+            (false, "s", "active", "the integration is disabled"),
+        ] {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let db = migrated(dir.path(), enabled, secret, status);
+            assert_eq!(receive(&db, "tg", "s", UPDATE), Inbound::Ignore, "{why}");
+        }
+    }
+
+    #[test]
+    fn an_undecodable_body_is_ignored_rather_than_rejected() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path(), true, "s3cret", "active");
+        assert_eq!(receive(&db, "tg", "s3cret", b"not json"), Inbound::Ignore);
+    }
+
+    #[test]
+    fn a_null_field_is_the_zero_value_rather_than_a_decode_failure() {
+        // `encoding/json` treats these as no-ops, so the update still
+        // dispatches — with an empty text, which the dispatcher then drops.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path(), true, "s3cret", "active");
+        let body =
+            br#"{"update_id":null,"message":{"message_id":null,"chat":{"id":null},"text":null}}"#;
+        match receive(&db, "tg", "s3cret", body) {
+            Inbound::Dispatch { update, .. } => {
+                assert_eq!(update.update_id, 0);
+                assert_eq!(update.message.expect("message").text, "");
+            }
+            other => panic!("expected dispatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_update_with_no_message_still_decodes() {
+        // Telegram sends many update kinds; the dispatcher drops the ones with
+        // no message, but the receiver must not reject them.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path(), true, "s3cret", "active");
+        match receive(&db, "tg", "s3cret", br#"{"update_id":9}"#) {
+            Inbound::Dispatch { update, .. } => assert!(update.message.is_none()),
+            other => panic!("expected dispatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_update_is_claimed_exactly_once() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path(), true, "s", "active");
+        assert!(claim_update(&db, "tg", 42), "the first claim wins");
+        assert!(!claim_update(&db, "tg", 42), "a retry does not");
+        // A different update, and the same id under a different integration,
+        // are both their own claims.
+        assert!(claim_update(&db, "tg", 43));
+        assert!(claim_update(&db, "other", 42));
+    }
+
+    #[test]
+    fn the_sweep_drops_entries_older_than_the_horizon() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path(), true, "s", "active");
+        {
+            let conn = rusqlite::Connection::open(&db).expect("open");
+            conn.execute(
+                "INSERT INTO telegram_processed_updates (integration_id, update_id, processed_at)
+                 VALUES ('tg', 1, '2020-01-01 00:00:00 +0000 UTC')",
+                [],
+            )
+            .expect("seed old row");
+        }
+        claim_update(&db, "tg", 2);
+
+        let conn = rusqlite::Connection::open(&db).expect("open");
+        let remaining: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM telegram_processed_updates WHERE update_id = 1",
+                [],
+                |r| r.get(0),
+            )
+            .expect("count");
+        assert_eq!(remaining, 0, "the 48-hour sweep runs with the claim");
+    }
+
+    #[test]
+    fn the_constant_time_compare_agrees_with_equality() {
+        assert!(constant_time_eq(b"abc", b"abc"));
+        assert!(!constant_time_eq(b"abc", b"abd"));
+        assert!(!constant_time_eq(b"abc", b"ab"));
+        assert!(!constant_time_eq(b"", b"a"));
+        assert!(constant_time_eq(b"", b""));
+    }
+}

--- a/desktop/src-tauri/src/native/trigger/registration.rs
+++ b/desktop/src-tauri/src/native/trigger/registration.rs
@@ -1,0 +1,379 @@
+//! Registering, removing and rotating a Telegram webhook. Mirrors
+//! `triggerService.{RegisterWebhook,DeleteWebhook,RegenerateSecret}`.
+//!
+//! # These are the routes that call Telegram, and the order is the whole design
+//!
+//! The issue's own trap: **fail before the call, never after.** A native handler
+//! that returns `Err` forwards to Go, and Go re-runs the whole handler — so an
+//! `Err` raised *after* a successful `setWebhook` registers the webhook twice,
+//! the second time with whatever secret Go generates, silently invalidating the
+//! one this process just stored. Every fallible step therefore happens **before**
+//! the network call, and nothing after it may fail:
+//!
+//! 1. resolve the public URL, the row, the type and the credentials;
+//! 2. read or mint the secret;
+//! 3. call Telegram;
+//! 4. store the outcome — and only log if that write fails.
+//!
+//! Step 4 is where Go and this port part company in one respect worth stating:
+//! Go returns an error if `SetWebhookInfo` fails after a *successful*
+//! registration, which would forward and re-register. Here that write failure is
+//! logged and the request still answers 200, because the webhook **is**
+//! registered at that point and telling the caller otherwise is the more
+//! damaging lie.
+//!
+//! # The failure path stores its own status
+//!
+//! When `setWebhook` fails, Go writes `("error", err.Error())` to the row before
+//! returning, so `GET …/webhook/status` can show why. That write is reproduced,
+//! and it is the one write that happens on a failure.
+
+use std::path::Path;
+
+use serde::Serialize;
+
+use crate::native::integrations::telegram::client::Client as TelegramClient;
+use crate::native::integrations::webhook;
+use crate::native::writes::WriteError;
+
+/// `setWebhook`'s payload. Go builds it as `map[string]any`, so `json.Marshal`
+/// writes the keys **sorted** — `allowed_updates`, `drop_pending_updates`,
+/// `secret_token`, `url`, not the order a person would write them.
+#[derive(Serialize)]
+struct SetWebhook<'a> {
+    allowed_updates: [&'static str; 1],
+    drop_pending_updates: bool,
+    secret_token: &'a str,
+    url: &'a str,
+}
+
+/// `GenerateSecretToken`: 32 random bytes, hex-encoded to 64 characters.
+fn generate_secret() -> String {
+    // `uuid::Uuid::new_v4` is backed by `getrandom`, the same OS entropy
+    // `crypto/rand` reads; two of them give the 32 bytes Go asks for.
+    let mut bytes = [0u8; 32];
+    bytes[..16].copy_from_slice(uuid::Uuid::new_v4().as_bytes());
+    bytes[16..].copy_from_slice(uuid::Uuid::new_v4().as_bytes());
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// What `RegisterWebhook` needs, gathered before anything can fail.
+///
+/// `Debug` carries the bot token and the secret, so it is **test-only**: the
+/// rule `registry::HostingRow` follows for the same reason.
+#[cfg_attr(test, derive(Debug))]
+struct Registration {
+    bot_token: String,
+    secret: String,
+    webhook_url: String,
+}
+
+/// Everything fallible in `RegisterWebhook`, in Go's order, before the call.
+fn prepare(db_path: &Path, id: &str) -> Result<Registration, WriteError> {
+    // The public URL is checked first, and its absence is a 422 rather than a
+    // failed registration — there is nothing to register against.
+    let base = webhook::public_url(db_path);
+    if base.is_empty() {
+        return Err(WriteError::validation(
+            "public_url",
+            "public URL must be configured before registering a webhook",
+        ));
+    }
+
+    let Some(row) = crate::native::integrations::registry::get_for_hosting(db_path, id)
+        .map_err(WriteError::Fallback)?
+    else {
+        return Err(WriteError::NotFound {
+            resource: "integration".to_string(),
+            id: id.to_string(),
+        });
+    };
+    if row.integration_type != "telegram" {
+        return Err(WriteError::validation(
+            "type",
+            "webhooks are only supported for telegram integrations",
+        ));
+    }
+
+    #[derive(serde::Deserialize)]
+    struct Creds {
+        #[serde(
+            default,
+            deserialize_with = "crate::native::gojson::null_is_zero_value"
+        )]
+        bot_token: String,
+    }
+    let creds: Creds = serde_json::from_str(&row.credentials).map_err(|e| {
+        // Go wraps this and the handler turns it into a 500, which forwards —
+        // and forwarding is safe here because nothing has been called yet.
+        WriteError::Fallback(format!("parsing telegram credentials: {e}"))
+    })?;
+
+    // Reuse the stored secret if there is one, so re-registering does not
+    // invalidate a webhook that is already working.
+    let stored = read_secret(db_path, id).map_err(WriteError::Fallback)?;
+    let secret = if stored.is_empty() {
+        generate_secret()
+    } else {
+        stored
+    };
+
+    Ok(Registration {
+        webhook_url: webhook::webhook_url(&base, id),
+        bot_token: creds.bot_token,
+        secret,
+    })
+}
+
+fn read_secret(db_path: &Path, id: &str) -> Result<String, String> {
+    let conn = crate::native::db::open_read_only(db_path)?;
+    conn.query_row(
+        "SELECT webhook_secret FROM integrations WHERE id = ?1",
+        [id],
+        |row| row.get(0),
+    )
+    .or_else(|e| match e {
+        // `GetWebhookInfo` turns no rows into empty strings.
+        rusqlite::Error::QueryReturnedNoRows => Ok(String::new()),
+        other => Err(format!("getting webhook info: {other}")),
+    })
+}
+
+/// `SetWebhookInfo`. Logged rather than returned by its callers after a
+/// successful registration — see the module header.
+fn store(db_path: &Path, id: &str, secret: &str, status: &str, error: &str) -> Result<(), String> {
+    let conn = crate::native::db::open_read_write(db_path)?;
+    conn.execute(
+        "UPDATE integrations SET webhook_secret = ?1, webhook_status = ?2, webhook_error = ?3
+         WHERE id = ?4",
+        rusqlite::params![secret, status, error, id],
+    )
+    .map_err(|e| format!("setting webhook info for {id:?}: {e}"))?;
+    Ok(())
+}
+
+/// `RegisterWebhook`.
+pub async fn register(db_path: &Path, id: &str) -> Result<(), WriteError> {
+    let prepared = prepare(db_path, id)?;
+
+    // ── Nothing above this line has called Telegram; nothing below may fail. ──
+    let payload = crate::native::gojson::to_vec_marshal(&SetWebhook {
+        allowed_updates: ["message"],
+        drop_pending_updates: false,
+        secret_token: &prepared.secret,
+        url: &prepared.webhook_url,
+    })
+    .map_err(|e| WriteError::Fallback(format!("encoding setWebhook: {e}")))?;
+
+    let client = TelegramClient::new(&prepared.bot_token);
+    let ct = tokio_util::sync::CancellationToken::new();
+    match client.call(&ct, "setWebhook", payload).await {
+        Ok(_) => {
+            if let Err(e) = store(db_path, id, &prepared.secret, "active", "") {
+                // The webhook **is** registered. Answering an error would
+                // forward and register it again, under a different secret.
+                log::error!("saving webhook info after a successful registration: {e}");
+            }
+            log::info!(
+                "telegram webhook registered integration_id={id:?} url={:?}",
+                prepared.webhook_url
+            );
+            Ok(())
+        }
+        Err(e) => {
+            // Go records the failure so `webhook/status` can show it, then
+            // returns the error. Nothing was registered, so answering an error
+            // is safe.
+            let message = format!("registering webhook: {e}");
+            if let Err(store_err) = store(db_path, id, &prepared.secret, "error", &message) {
+                log::warn!("recording webhook registration failure: {store_err}");
+            }
+            Err(WriteError::Fallback(message))
+        }
+    }
+}
+
+/// `DeleteWebhook`.
+///
+/// **A failed `deleteWebhook` is a warning, not an error** — Go logs it and
+/// clears the row anyway, on the reasoning that a webhook the user asked to
+/// remove should stop being *ours* whether or not Telegram agreed.
+pub async fn delete(db_path: &Path, id: &str) -> Result<(), WriteError> {
+    let Some(row) = crate::native::integrations::registry::get_for_hosting(db_path, id)
+        .map_err(WriteError::Fallback)?
+    else {
+        return Err(WriteError::NotFound {
+            resource: "integration".to_string(),
+            id: id.to_string(),
+        });
+    };
+
+    #[derive(serde::Deserialize)]
+    struct Creds {
+        #[serde(
+            default,
+            deserialize_with = "crate::native::gojson::null_is_zero_value"
+        )]
+        bot_token: String,
+    }
+    let creds: Creds = serde_json::from_str(&row.credentials)
+        .map_err(|e| WriteError::Fallback(format!("parsing telegram credentials: {e}")))?;
+
+    let client = TelegramClient::new(&creds.bot_token);
+    let ct = tokio_util::sync::CancellationToken::new();
+    if let Err(e) = client.call(&ct, "deleteWebhook", b"{}".to_vec()).await {
+        log::warn!("failed to delete telegram webhook integration_id={id:?} error={e}");
+    }
+
+    // The clear is the one write, and its failure *is* returned — unlike the
+    // register path, nothing has been left in a state a retry would duplicate.
+    store(db_path, id, "", "inactive", "")
+        .map_err(|e| WriteError::Fallback(format!("clearing webhook info: {e}")))?;
+    log::info!("telegram webhook deleted integration_id={id:?}");
+    Ok(())
+}
+
+/// `RegenerateSecret`: delete, clear, register.
+///
+/// The delete's failure is swallowed — Go logs and carries on, because the point
+/// is to end up registered with a *new* secret and an old webhook that refused
+/// to go away does not change that.
+pub async fn regenerate(db_path: &Path, id: &str) -> Result<(), WriteError> {
+    if let Err(e) = delete(db_path, id).await {
+        log::warn!(
+            "failed to delete old webhook before regenerating: {}",
+            e.message()
+        );
+    }
+    // Clearing the secret is what makes `prepare` mint a new one rather than
+    // reuse the old.
+    store(db_path, id, "", "", "")
+        .map_err(|e| WriteError::Fallback(format!("clearing old secret: {e}")))?;
+    register(db_path, id).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn migrated(dir: &Path, integration_type: &str, public_url: &str) -> std::path::PathBuf {
+        let db = dir.join("agento.db");
+        let mut conn = rusqlite::Connection::open(&db).expect("open");
+        crate::native::migrate::apply(&mut conn).expect("migrate");
+        conn.execute(
+            "INSERT INTO integrations (id, name, type, enabled, credentials, services,
+                                       created_at, updated_at)
+             VALUES ('tg', 'T', ?1, 1, '{\"bot_token\":\"bot\"}', '{}',
+                     '2026-01-01 00:00:00 +0000 UTC', '2026-01-01 00:00:00 +0000 UTC')",
+            [integration_type],
+        )
+        .expect("seed");
+        if !public_url.is_empty() {
+            conn.execute(
+                "INSERT INTO user_settings (id, public_url) VALUES (1, ?1)",
+                [public_url],
+            )
+            .expect("seed settings");
+        }
+        db
+    }
+
+    #[test]
+    fn a_secret_is_64_hex_characters_and_not_repeated() {
+        let a = generate_secret();
+        assert_eq!(a.len(), 64, "32 bytes, hex-encoded");
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_ne!(a, generate_secret());
+    }
+
+    #[test]
+    fn no_public_url_is_a_422_before_anything_is_called() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path(), "telegram", "");
+        let err = prepare(&db, "tg").unwrap_err();
+        assert_eq!(err.status(), axum::http::StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(
+            err.message(),
+            r#"validation error for "public_url": public URL must be configured before registering a webhook"#
+        );
+    }
+
+    #[test]
+    fn a_non_telegram_integration_is_a_422() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path(), "github", "https://x.example");
+        let err = prepare(&db, "tg").unwrap_err();
+        assert_eq!(
+            err.message(),
+            r#"validation error for "type": webhooks are only supported for telegram integrations"#
+        );
+    }
+
+    #[test]
+    fn an_unknown_integration_is_a_404() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path(), "telegram", "https://x.example");
+        let err = prepare(&db, "nope").unwrap_err();
+        assert_eq!(err.status(), axum::http::StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn preparation_reuses_a_stored_secret_and_mints_one_otherwise() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path(), "telegram", "https://x.example/");
+
+        let first = prepare(&db, "tg").expect("prepare");
+        assert_eq!(first.secret.len(), 64, "minted when the column is empty");
+        // The trailing slash on the public URL does not double up.
+        assert_eq!(first.webhook_url, "https://x.example/webhooks/telegram/tg");
+        assert_eq!(first.bot_token, "bot");
+
+        store(&db, "tg", "existing-secret", "active", "").expect("store");
+        let second = prepare(&db, "tg").expect("prepare");
+        assert_eq!(
+            second.secret, "existing-secret",
+            "re-registering must not invalidate a working webhook"
+        );
+    }
+
+    #[test]
+    fn a_failed_registration_records_why_and_leaves_the_secret() {
+        // No network here: the bot token is nonsense, so the call fails, which
+        // is the path under test — the row must carry the reason for
+        // `webhook/status` to show.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path(), "telegram", "https://x.example");
+        store(&db, "tg", "s3cret", "active", "").expect("store");
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let result = rt.block_on(register(&db, "tg"));
+        assert!(result.is_err(), "a failed setWebhook is an error");
+
+        let status = webhook::status(&db, "tg").expect("status");
+        assert_eq!(status.status, "error");
+        assert!(
+            status.error.starts_with("registering webhook:"),
+            "the reason is stored: {:?}",
+            status.error
+        );
+        assert!(status.has_secret, "the secret survives a failed attempt");
+    }
+
+    #[test]
+    fn the_set_webhook_payload_is_gos_sorted_map() {
+        let body = crate::native::gojson::to_vec_marshal(&SetWebhook {
+            allowed_updates: ["message"],
+            drop_pending_updates: false,
+            secret_token: "s",
+            url: "https://x.example/webhooks/telegram/tg",
+        })
+        .expect("encode");
+        assert_eq!(
+            String::from_utf8(body).expect("utf-8"),
+            r#"{"allowed_updates":["message"],"drop_pending_updates":false,"secret_token":"s","url":"https://x.example/webhooks/telegram/tg"}"#
+        );
+    }
+}

--- a/desktop/src-tauri/src/native/trigger/registration.rs
+++ b/desktop/src-tauri/src/native/trigger/registration.rs
@@ -15,6 +15,11 @@
 //! 3. call Telegram;
 //! 4. store the outcome — and only log if that write fails.
 //!
+//! That rule is also why a **failed** `setWebhook` answers `WriteError::Internal`
+//! rather than `Fallback`: forwarding would call Telegram a second time, and a
+//! transport failure does not prove the first call did nothing — a lost response
+//! to a successful registration would be re-registered under Go's secret.
+//!
 //! Step 4 is where Go and this port part company in one respect worth stating:
 //! Go returns an error if `SetWebhookInfo` fails after a *successful*
 //! registration, which would forward and re-register. Here that write failure is
@@ -188,7 +193,15 @@ pub async fn register(db_path: &Path, id: &str) -> Result<(), WriteError> {
             if let Err(store_err) = store(db_path, id, &prepared.secret, "error", &message) {
                 log::warn!("recording webhook registration failure: {store_err}");
             }
-            Err(WriteError::Fallback(message))
+            // **Answered here, not forwarded.** `Fallback` would have Go re-run
+            // `RegisterWebhook` — a *second* `setWebhook` — and a client-side
+            // failure does not prove the first one did nothing: a lost response
+            // to a successful call would be re-registered under Go's own secret,
+            // which is the exact hazard this module's header claims to avoid.
+            // Go answers this with `httpErr`'s flat 500, so that is what goes on
+            // the wire, with the reason in the log and on the row.
+            log::error!("internal server error error=registering telegram webhook: {message}");
+            Err(WriteError::Internal("internal server error".to_string()))
         }
     }
 }
@@ -336,27 +349,54 @@ mod tests {
         );
     }
 
-    #[test]
-    fn a_failed_registration_records_why_and_leaves_the_secret() {
-        // No network here: the bot token is nonsense, so the call fails, which
-        // is the path under test — the row must carry the reason for
-        // `webhook/status` to show.
+    /// A failed `setWebhook` records why, keeps the secret, and is answered
+    /// **here** rather than forwarded.
+    ///
+    /// Pointed at a local fake rather than Telegram. The first version of this
+    /// test claimed "no network here" and was wrong: it issued a real HTTPS POST
+    /// to `api.telegram.org` from every `cargo test` run, and offline it passed
+    /// for the wrong reason — a transport failure instead of the `ok:false`
+    /// envelope it says it covers.
+    #[tokio::test]
+    async fn a_failed_registration_records_why_and_is_not_forwarded() {
+        use crate::native::integrations::telegram::client::{api_base_lock, set_api_base};
+
+        let _guard = api_base_lock().await;
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        tokio::spawn(async move {
+            let app = axum::Router::new().fallback(|| async {
+                // What Telegram answers for a bad token: 200 with ok:false.
+                (
+                    axum::http::StatusCode::OK,
+                    r#"{"ok":false,"description":"Unauthorized"}"#,
+                )
+            });
+            let _ = axum::serve(listener, app).await;
+        });
+        set_api_base(Some(format!("http://{addr}")));
+
         let dir = tempfile::tempdir().expect("tempdir");
         let db = migrated(dir.path(), "telegram", "https://x.example");
         store(&db, "tg", "s3cret", "active", "").expect("store");
 
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("runtime");
-        let result = rt.block_on(register(&db, "tg"));
-        assert!(result.is_err(), "a failed setWebhook is an error");
+        let err = register(&db, "tg").await.unwrap_err();
+        set_api_base(None);
+
+        assert_eq!(
+            err.status(),
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            "answered here — forwarding would call setWebhook a second time"
+        );
+        assert_eq!(err.message(), "internal server error", "Go's httpErr body");
 
         let status = webhook::status(&db, "tg").expect("status");
         assert_eq!(status.status, "error");
         assert!(
-            status.error.starts_with("registering webhook:"),
-            "the reason is stored: {:?}",
+            status.error.contains("Unauthorized"),
+            "the provider's own reason reaches the row: {:?}",
             status.error
         );
         assert!(status.has_secret, "the secret survives a failed attempt");

--- a/desktop/src-tauri/src/native/trigger/registration.rs
+++ b/desktop/src-tauri/src/native/trigger/registration.rs
@@ -15,10 +15,13 @@
 //! 3. call Telegram;
 //! 4. store the outcome — and only log if that write fails.
 //!
-//! That rule is also why a **failed** `setWebhook` answers `WriteError::Internal`
-//! rather than `Fallback`: forwarding would call Telegram a second time, and a
-//! transport failure does not prove the first call did nothing — a lost response
-//! to a successful registration would be re-registered under Go's secret.
+//! A **failed** `setWebhook` answers `WriteError::Internal` for a related but
+//! weaker reason. Go answers it with `httpErr`'s flat 500, so forwarding would
+//! spend a second `setWebhook` call to arrive at the same status — and if that
+//! second attempt *succeeded*, the shell would answer 200 where Go's own single
+//! attempt answered 500, overwriting the row this branch just wrote. The secret
+//! itself is not at risk on this path, unlike the one above: step 4 has already
+//! stored it, and Go only mints a new one when the column is empty.
 //!
 //! Step 4 is where Go and this port part company in one respect worth stating:
 //! Go returns an error if `SetWebhookInfo` fails after a *successful*
@@ -193,13 +196,14 @@ pub async fn register(db_path: &Path, id: &str) -> Result<(), WriteError> {
             if let Err(store_err) = store(db_path, id, &prepared.secret, "error", &message) {
                 log::warn!("recording webhook registration failure: {store_err}");
             }
-            // **Answered here, not forwarded.** `Fallback` would have Go re-run
-            // `RegisterWebhook` — a *second* `setWebhook` — and a client-side
-            // failure does not prove the first one did nothing: a lost response
-            // to a successful call would be re-registered under Go's own secret,
-            // which is the exact hazard this module's header claims to avoid.
-            // Go answers this with `httpErr`'s flat 500, so that is what goes on
-            // the wire, with the reason in the log and on the row.
+            // **Answered here, not forwarded.** Go answers a failed
+            // registration with `httpErr`'s flat 500, so `Fallback` would have
+            // the sidecar re-run all of `RegisterWebhook` — a *second*
+            // `setWebhook` — to reach the status this branch already knows. A
+            // retry that succeeded would be worse than wasteful: 200 where Go's
+            // own single attempt answered 500, over a row saying `error`. The
+            // deliberate cost is that a transient failure is no longer silently
+            // retried; the caller retries by asking again.
             log::error!("internal server error error=registering telegram webhook: {message}");
             Err(WriteError::Internal("internal server error".to_string()))
         }

--- a/desktop/src-tauri/src/native/trigger/telegram_api.rs
+++ b/desktop/src-tauri/src/native/trigger/telegram_api.rs
@@ -1,0 +1,217 @@
+//! The two Telegram calls the dispatcher makes: the typing indicator and the
+//! reply. Mirrors `SendChatAction`, `SendReply` and `splitMessage`
+//! (`internal/integrations/telegram/webhook.go`).
+//!
+//! The transport is [`crate::native::integrations::telegram::client`], already
+//! ported for the outbound tools (#314) — same `callTelegram`, same fixed
+//! `calling Telegram <method>: request failed` wording for a transport error.
+//!
+//! # `splitMessage` cuts at 4096 **bytes**
+//!
+//! Telegram's limit is on the message, and Go's splitter is byte-based: it takes
+//! `text[:4096]` and walks `end` back while the byte at that index is not a rune
+//! start. Two consequences a character-based split would get wrong — a 4096-rune
+//! message of multi-byte text is split where Go sends it whole is the harmless
+//! direction, and a message Go splits that a port sends whole is rejected by
+//! Telegram outright.
+//!
+//! Only the **first** chunk is a reply to the original message; the rest are
+//! plain sends, so a long answer does not quote the question five times.
+
+use serde::Serialize;
+
+use crate::native::integrations::telegram::client::Client as TelegramClient;
+
+/// Telegram's per-message limit, in bytes.
+const MAX_MESSAGE_LEN: usize = 4096;
+
+/// **Field order is alphabetical, not natural.** Go builds both payloads as
+/// `map[string]any`, and `encoding/json` marshals a map with its keys **sorted**
+/// — so `action` precedes `chat_id`, and `reply_to_message_id` sits between
+/// `chat_id` and `text`. Declaring them in the order a person would write them
+/// produces different bytes for the same request.
+#[derive(Serialize)]
+struct ChatAction {
+    action: &'static str,
+    chat_id: i64,
+}
+
+/// Sorted, for the reason above. `reply_to_message_id` is omitted rather than
+/// null on a continuation chunk, because Go's map simply does not have the key.
+#[derive(Serialize)]
+struct SendMessage<'a> {
+    chat_id: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reply_to_message_id: Option<i64>,
+    text: &'a str,
+}
+
+/// `SendChatAction`. Best-effort: Go discards both return values, because a
+/// failed "typing…" must not stop the run that follows.
+pub async fn send_chat_action(bot_token: &str, chat_id: i64) {
+    let Ok(body) = crate::native::gojson::to_vec_marshal(&ChatAction {
+        action: "typing",
+        chat_id,
+    }) else {
+        return;
+    };
+    let client = TelegramClient::new(bot_token);
+    let _ = client
+        .call(
+            &tokio_util::sync::CancellationToken::new(),
+            "sendChatAction",
+            body,
+        )
+        .await;
+}
+
+/// `SendReply`: the text, split to Telegram's limit, with only the first chunk
+/// quoting the original message.
+pub async fn send_reply(
+    bot_token: &str,
+    chat_id: i64,
+    reply_to_message_id: i64,
+    text: &str,
+) -> Result<(), String> {
+    let client = TelegramClient::new(bot_token);
+    let ct = tokio_util::sync::CancellationToken::new();
+
+    for (i, chunk) in split_message(text, MAX_MESSAGE_LEN).iter().enumerate() {
+        let payload = SendMessage {
+            chat_id,
+            // `if i == 0 && replyToMsgID > 0`.
+            reply_to_message_id: (i == 0 && reply_to_message_id > 0).then_some(reply_to_message_id),
+            text: chunk,
+        };
+        let body = crate::native::gojson::to_vec_marshal(&payload)
+            .map_err(|e| format!("encoding sendMessage: {e}"))?;
+        client
+            .call(&ct, "sendMessage", body)
+            .await
+            .map_err(|e| format!("sending reply chunk {}: {e}", i + 1))?;
+    }
+    Ok(())
+}
+
+/// `splitMessage`: chunks of at most `max_len` **bytes**, split on rune
+/// boundaries.
+///
+/// Go walks `end` back while `!utf8.RuneStart(text[end])`, with a fallback to
+/// the hard limit if it reaches zero — unreachable for valid UTF-8, and
+/// unreachable here for a different reason: a `&str` is always valid, so the
+/// walk always finds a boundary.
+pub fn split_message(text: &str, max_len: usize) -> Vec<&str> {
+    if text.len() <= max_len {
+        return vec![text];
+    }
+    let mut chunks = Vec::with_capacity(text.len() / max_len + 1);
+    let mut rest = text;
+    while rest.len() > max_len {
+        let mut end = max_len;
+        while end > 0 && !rest.is_char_boundary(end) {
+            end -= 1;
+        }
+        if end == 0 {
+            // Go's guard against an infinite loop. Unreachable over a `&str`,
+            // where a boundary always exists at or below `max_len`.
+            break;
+        }
+        let (chunk, tail) = rest.split_at(end);
+        chunks.push(chunk);
+        rest = tail;
+    }
+    if !rest.is_empty() {
+        chunks.push(rest);
+    }
+    chunks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_short_message_is_one_chunk() {
+        assert_eq!(split_message("hello", 4096), vec!["hello"]);
+        assert_eq!(split_message("", 4096), vec![""]);
+        // Exactly the limit is not over it.
+        let exact = "a".repeat(10);
+        assert_eq!(split_message(&exact, 10), vec![exact.as_str()]);
+    }
+
+    #[test]
+    fn a_long_message_splits_at_the_byte_limit() {
+        let text = "a".repeat(25);
+        assert_eq!(
+            split_message(&text, 10),
+            vec!["aaaaaaaaaa", "aaaaaaaaaa", "aaaaa"]
+        );
+        assert_eq!(split_message(&text, 10).concat(), text, "nothing is lost");
+    }
+
+    #[test]
+    fn a_split_never_lands_inside_a_character() {
+        // Ten 3-byte characters, split at 10 bytes: the boundary walks back to
+        // 9, so each chunk is three whole characters.
+        let text = "€".repeat(10);
+        let chunks = split_message(&text, 10);
+        for chunk in &chunks {
+            assert!(chunk.chars().all(|c| c == '€'), "{chunk:?}");
+            assert!(chunk.len() <= 10);
+        }
+        assert_eq!(chunks.concat(), text, "nothing is lost or duplicated");
+        assert_eq!(chunks[0].chars().count(), 3, "9 bytes, not 10");
+    }
+
+    #[test]
+    fn a_character_wider_than_the_limit_would_stall_and_does_not() {
+        // The `end == 0` guard: a 4-byte character with a 3-byte limit has no
+        // boundary to walk back to. Go falls back to the hard limit and would
+        // emit invalid UTF-8; this stops instead, which is the only
+        // representable answer and cannot happen at the real 4096.
+        let text = "𝄞𝄞";
+        let chunks = split_message(text, 3);
+        assert_eq!(chunks.concat(), text, "the message still arrives whole");
+    }
+
+    #[test]
+    fn the_payloads_are_gos_json() {
+        // Go builds these as `map[string]any`, so `json.Marshal` sorts the keys.
+        // Declaration order would put `text` before `reply_to_message_id` and
+        // `chat_id` before `action`, which is different bytes for the same
+        // request.
+        let with_reply = crate::native::gojson::to_vec_marshal(&SendMessage {
+            chat_id: -100,
+            reply_to_message_id: Some(7),
+            text: "hi",
+        })
+        .expect("encode");
+        assert_eq!(
+            String::from_utf8(with_reply).expect("utf-8"),
+            r#"{"chat_id":-100,"reply_to_message_id":7,"text":"hi"}"#
+        );
+
+        // A continuation chunk omits the key entirely, as Go's map does by not
+        // setting it.
+        let without = crate::native::gojson::to_vec_marshal(&SendMessage {
+            chat_id: -100,
+            reply_to_message_id: None,
+            text: "hi",
+        })
+        .expect("encode");
+        assert_eq!(
+            String::from_utf8(without).expect("utf-8"),
+            r#"{"chat_id":-100,"text":"hi"}"#
+        );
+
+        let action = crate::native::gojson::to_vec_marshal(&ChatAction {
+            action: "typing",
+            chat_id: 42,
+        })
+        .expect("encode");
+        assert_eq!(
+            String::from_utf8(action).expect("utf-8"),
+            r#"{"action":"typing","chat_id":42}"#
+        );
+    }
+}

--- a/desktop/src-tauri/src/proxy.rs
+++ b/desktop/src-tauri/src/proxy.rs
@@ -456,6 +456,15 @@ async fn dispatch(
             .and_then(|v| v.to_str().ok())
             .unwrap_or_default()
             .to_string();
+        // Likewise carried for one route: the Telegram webhook authenticates on
+        // this header alone, being mounted outside `/api` and so outside both
+        // guards. See `native::Request::secret_token`.
+        let secret_token = req
+            .headers()
+            .get("x-telegram-bot-api-secret-token")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
         let native_answer = {
             let path = path.clone();
             tokio::task::spawn_blocking(move || {
@@ -464,6 +473,7 @@ async fn dispatch(
                     path: &path,
                     query: &query,
                     content_type: &content_type,
+                    secret_token: &secret_token,
                     body: &body_bytes,
                 })
             })

--- a/internal/trigger/export_test_support.go
+++ b/internal/trigger/export_test_support.go
@@ -1,0 +1,15 @@
+package trigger
+
+import "github.com/shaharia-lab/agento/internal/config"
+
+// MatchRuleForTest exposes `matchRule` for the cross-language vectors in
+// `desktop/parity`, which are generated from this implementation and asserted
+// against the Rust port.
+//
+// Not in an `export_test.go`: that file would only be compiled for this
+// package's own tests, and the vector generator lives in another package. The
+// matcher is a pure function over a rule and a message, so exposing it costs
+// nothing — it reads no state and touches no store.
+func MatchRuleForTest(rule *config.TriggerRule, text, chatID string) (bool, string) {
+	return matchRule(rule, text, chatID)
+}


### PR DESCRIPTION
Closes #319.

## What moved

- **`GET /api/integrations/{id}/webhook/status`** — a plain read.
- **`POST /webhooks/telegram/{id}`** — the receiver, and the only claimed route outside `/api`.
- **The dispatcher** — rule matching, the agent run, and the reply.
- **`native/agent_run.rs`** — the headless run, now shared with the scheduler.

## Three recorded reasons that were wrong

Each was checked rather than inherited:

1. **`webhook/status` "asks Telegram, over the network, with the bot token."** It does not. `GetWebhookStatus` reads three columns off the row and composes a URL from the public URL; `internal/integrations/telegram` has no status call at all. The network belongs to *registration*.
2. **`POST /webhooks/telegram/{id}` was deferred to #275** as "dispatches an agent run; the executor is still Go's". #275 moved the executor, so that expired.
3. My own notes on `matchRule`, disproved by generating the vectors rather than transcribing them — see below.

## The vectors caught three things I had written down as fact

- The case I labelled *"Kelvin sign folds to k"* demonstrates nothing about folding. The prefix is one ASCII byte and the message starts with a three-byte character, so `text[:1]` is a lone continuation byte; Go decodes it as `RuneError` and does not match. A port slicing by **character** would compare the whole character; one slicing by **byte** in Rust would panic. The matcher compares bytes and never indexes a `str`.
- I wrote that `unicode.IsSpace` excludes U+00A0. It includes it.
- **Lower-casing is not folding, in both directions.** Sigma's orbit is three-way and same-case, so comparing lowercase forms calls the two lowercase sigmas different — only the uppercase direction sees it. `U+0130` goes the other way: it lower-cases to a string starting with ASCII `i` but shares no orbit with it.

31 vectors, all passing.

## The seam grew two things, both for this one route

- `Request::secret_token`, on the same terms `content_type` is carried for uploads. The route is mounted at the **root**, so neither guard applies — it arrives from Telegram with a foreign `Host` that `validate_host` would 403 — and this header is what makes that safe rather than open.
- `Answer::text_status`, because Go refuses a bad secret through `http.Error` (`text/plain`, trailing newline, `nosniff`) rather than the API's JSON envelope.

## Two shapes worth naming

- **Almost every receiver failure is a 200.** Unknown integration, inactive webhook, no secret, disabled integration, undecodable body — all 200 and do nothing, because Telegram *retries* a non-2xx and a 4xx for a permanent condition is a retry loop. A wrong secret is the one 403.
- **The reply is the product.** A scheduled run's evidence is a `job_history` row; this one's is a message. So every failure path also sends "Sorry, something went wrong." — a user who gets nothing back cannot tell a broken agent from an ignored message. The user turn is stored even when the run failed.

## Sharing the headless run was not tidiness

The dispatcher is the fourth caller of the agent runner and the second headless one. `native/agent_run.rs` holds the run once because of the trap that shipped in the scheduler: it must go through `claude::client::query`, the one-shot, and never `Session` — whose reader neither closes stdin nor stops at the `result` event, so a headless run blocks past its answer until the timeout. All five end-to-end scheduled-run tests pass unchanged after the extraction, which is the check that matters for a refactor of that shape.

Also: `sendMessage`/`sendChatAction` are built from Go's `map[string]any`, which `json.Marshal` writes **sorted**, so the payload structs are declared alphabetically rather than naturally. The first version got that wrong and its test asserted the wrong bytes.

## The three routes that call Telegram

`POST`/`DELETE /webhook/register` and `POST /webhook/regenerate-secret` are native too, and the issue's own trap is the design: **fail before the call, never after**, because an `Err` raised after a successful `setWebhook` forwards to Go, which registers the webhook again under its own secret — silently invalidating the one just stored. So every fallible step (public URL, row, type, credentials, secret) happens before the network call, and nothing after it may fail.

One deliberate departure: Go returns an error when the post-registration write fails, which would forward and re-register. Here that is logged and the request answers 200 — the webhook **is** registered at that point, and saying otherwise is the more damaging lie.

A failed `setWebhook` still records `("error", reason)` on the row, so `webhook/status` can show why; that is the one write that happens on a failure.

## Checks

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --no-fail-fast`, `go build ./...`, `go test ./desktop/parity/` — all green.