### PR TITLE
fix(desktop): keep the scheduler's SQLite off the runtime workers (#366)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -2651,13 +2651,16 @@ starving the proxy and every in-flight SSE stream.
 **Nor may the rusqlite, and that needs saying separately** (#366). A database
 call reads as arithmetic and is not: `db::open_read_write` sets a five-second
 `busy_timeout`, so a call meeting a lock held by the Go sidecar or by the session
-scanner's batch writer parks its thread for up to that long. `proxy.rs` already
-puts every native *handler* on the blocking pool for this reason, which covers
-everything reached from a request — and covers nothing reached from a timer or a
-webhook. The two that are, the scheduler's executor and the trigger dispatcher,
-both run to their own concurrency limit (three and ten) against a tokio default
-of one worker per core. `db::blocking(what, f)` is the single hand-off both use,
-and it is greppable on purpose. The executor's shape follows from it: `prepare`
+scanner's batch writer parks its thread for up to that long. `proxy.rs` puts its
+native handlers on the blocking pool for this reason — but **only the buffered
+ones**: `serve_stream` awaits on the worker, and `STREAM_ENDPOINTS` is the chat
+turn, so `persist::commit` was a per-turn `open_read_write` plus three writes on
+a worker. Beyond that, nothing reached from a *timer* or a *webhook* is covered
+at all: the scheduler's executor runs three at once and the trigger dispatcher
+ten, against a tokio default of one worker per core — three of four leaves the
+SPA and every SSE stream one. `db::blocking(what, f)` is the single hand-off all
+three use, and it is greppable on purpose; the label is per call site so the log
+says which section panicked. The executor's shape follows from it: `prepare`
 and `finish` are whole synchronous sections either side of the one long `await`,
 rather than eight individually wrapped calls, because a run's database work is
 contiguous. `tests/scheduled_run.rs`'s
@@ -2667,8 +2670,14 @@ longest gap goes from ~11 ms to the full 1,500 ms hold if the hand-off is
 removed. Its `last` is seeded **before** the spawn deliberately: a starved task
 is never polled, so seeding on the first poll starts the clock after the stall
 and the test passes against the defect. What is still on the worker is
-`run_headless`'s own option-building, shared verbatim with chat and the
-scheduler — worth knowing, not fixed here.
+option-building — `runner::load`, `TurnSettings::stored`, `registry::can_host` —
+which chat, the scheduler and the dispatcher share verbatim; those are reads, so
+WAL keeps them off the write lock, and the regression test measures the leftover
+exposure at ~11 ms. Worth knowing, not fixed here. A panic *inside* a handed-off
+section is the one thing `db::blocking` cannot make safe: the executor's `finish`
+may have written the session results and not the job row, leaving a `running`
+row nothing will finish, which is why the rule is "every path ends in a job
+history row" rather than "every path ends correctly".
 
 **A scheduled run uses `claude::client::query`, not `Session`.** That is Go's
 own choice — `RunAgent` calls `claude.Query` — and it is not interchangeable

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -2663,17 +2663,18 @@ three use, and it is greppable on purpose; the label is per call site so the log
 says which section panicked. The executor's shape follows from it: `prepare`
 and `finish` are whole synchronous sections either side of the one long `await`,
 rather than eight individually wrapped calls, because a run's database work is
-contiguous. `tests/scheduled_run.rs`'s
-`a_contended_write_lock_does_not_stall_the_runtime` is the regression — a
+contiguous. `a_contended_write_lock_does_not_stall_the_runtime` — one in
+`tests/scheduled_run.rs`, one in `tests/chat_turn.rs` — is the regression — a
 one-worker runtime, an outside thread holding the write lock, and a ticker whose
 longest gap goes from ~11 ms to the full 1,500 ms hold if the hand-off is
 removed. Its `last` is seeded **before** the spawn deliberately: a starved task
 is never polled, so seeding on the first poll starts the clock after the stall
 and the test passes against the defect. What is still on the worker is
-option-building — `runner::load`, `TurnSettings::stored`, `registry::can_host` —
-which chat, the scheduler and the dispatcher share verbatim; those are reads, so
-WAL keeps them off the write lock, and the regression test measures the leftover
-exposure at ~11 ms. Worth knowing, not fixed here. A panic *inside* a handed-off
+option-building — `TurnSettings::stored` and `registry::can_host`, shared by all
+three callers, plus `runner::load`, which is the chat turn's alone. Every one is
+`open_read_only`, and a WAL reader does not wait on a writer, which is why they
+are left: the test's contention is a write lock, so it says nothing about them
+either way. A *write* added there would be a different matter. A panic *inside* a handed-off
 section is the one thing `db::blocking` cannot make safe: the executor's `finish`
 may have written the session results and not the job row, leaving a `running`
 row nothing will finish, which is why the rule is "every path ends in a job

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -2648,6 +2648,28 @@ caller is still holding a scheduler semaphore permit, and an unreachable mail
 host would otherwise throttle the scheduler to three runs per SMTP timeout while
 starving the proxy and every in-flight SSE stream.
 
+**Nor may the rusqlite, and that needs saying separately** (#366). A database
+call reads as arithmetic and is not: `db::open_read_write` sets a five-second
+`busy_timeout`, so a call meeting a lock held by the Go sidecar or by the session
+scanner's batch writer parks its thread for up to that long. `proxy.rs` already
+puts every native *handler* on the blocking pool for this reason, which covers
+everything reached from a request — and covers nothing reached from a timer or a
+webhook. The two that are, the scheduler's executor and the trigger dispatcher,
+both run to their own concurrency limit (three and ten) against a tokio default
+of one worker per core. `db::blocking(what, f)` is the single hand-off both use,
+and it is greppable on purpose. The executor's shape follows from it: `prepare`
+and `finish` are whole synchronous sections either side of the one long `await`,
+rather than eight individually wrapped calls, because a run's database work is
+contiguous. `tests/scheduled_run.rs`'s
+`a_contended_write_lock_does_not_stall_the_runtime` is the regression — a
+one-worker runtime, an outside thread holding the write lock, and a ticker whose
+longest gap goes from ~11 ms to the full 1,500 ms hold if the hand-off is
+removed. Its `last` is seeded **before** the spawn deliberately: a starved task
+is never polled, so seeding on the first poll starts the clock after the stall
+and the test passes against the defect. What is still on the worker is
+`run_headless`'s own option-building, shared verbatim with chat and the
+scheduler — worth knowing, not fixed here.
+
 **A scheduled run uses `claude::client::query`, not `Session`.** That is Go's
 own choice — `RunAgent` calls `claude.Query` — and it is not interchangeable
 here: a `Session` sets `session_mode`, and `process.rs`'s reader then

--- a/desktop/src-tauri/src/native/chat/turn.rs
+++ b/desktop/src-tauri/src/native/chat/turn.rs
@@ -233,14 +233,29 @@ pub async fn run(
         // The commit is detached from the request on purpose, so a client that
         // disconnected mid-stream still has its turn persisted. Errors are
         // logged and never surfaced — the stream has already ended.
-        match super::persist::commit(&db_path, &row, &content, &state, is_first_message) {
+        // On the blocking pool, not this task's worker. This is the one
+        // *request*-driven write that `proxy.rs` does not already cover:
+        // `STREAM_ENDPOINTS` sends the chat turn down `serve_stream`, which
+        // awaits on an axum worker, and `commit` is `open_read_write` plus three
+        // writes — up to a five-second `busy_timeout` each, once per turn, while
+        // the scan's batch writer or the Go sidecar holds the lock. See
+        // [`crate::native::db::blocking`].
+        //
+        // The id for the log line is taken first, because `state` moves into the
+        // closure.
+        let sdk_session_id = state.sdk_session_id.clone();
+        let committed = crate::native::db::blocking("chat commit", move || {
+            super::persist::commit(&db_path, &row, &content, &state, is_first_message)
+        })
+        .await;
+        match committed.unwrap_or_else(|| Err("the commit task failed".to_string())) {
             // `chatService.CommitMessage`'s line, after the session update as
             // Go's is. The id is the turn's own rather than the resolved
             // fallback, which is what Go's caller passes.
             Ok(()) => log::info!(
                 "message committed session_id={:?} sdk_session_id={:?}",
                 chat_id,
-                state.sdk_session_id
+                sdk_session_id
             ),
             Err(e) => log::error!("commit message failed for chat {chat_id}: {e}"),
         }

--- a/desktop/src-tauri/src/native/chat/turn.rs
+++ b/desktop/src-tauri/src/native/chat/turn.rs
@@ -233,6 +233,14 @@ pub async fn run(
         // The commit is detached from the request on purpose, so a client that
         // disconnected mid-stream still has its turn persisted. Errors are
         // logged and never surfaced — the stream has already ended.
+        //
+        // What a `None` from the hand-off would leave behind, which
+        // [`crate::native::db::blocking`] asks each caller to state: `commit` is
+        // up to two inserts and an update with **no surrounding transaction**,
+        // so a panic between them can store the reply while `sdk_session_id` and
+        // the token counters stay stale — and the next turn would then resume
+        // the wrong CLI session. Nothing here can repair that; it is recorded
+        // because the shape is worth knowing before anyone adds a fourth write.
         // On the blocking pool, not this task's worker. This is the one
         // *request*-driven write that `proxy.rs` does not already cover:
         // `STREAM_ENDPOINTS` sends the chat turn down `serve_stream`, which

--- a/desktop/src-tauri/src/native/db.rs
+++ b/desktop/src-tauri/src/native/db.rs
@@ -112,7 +112,7 @@ pub fn open_read_write(path: &Path) -> Result<Connection, String> {
 /// worker per core, so a four-core machine has four to lose.
 ///
 /// **The proxy's cover is narrower than it looks**, which is why this exists.
-/// `serve` — the buffered path, thirteen areas' worth of handlers — is on the
+/// `serve` — the buffered path, every entry in `native::ENDPOINTS` — is on the
 /// pool. `serve_stream` is not: it awaits on the worker, and `STREAM_ENDPOINTS`
 /// is the chat turn. So the callers here are the streaming turn's own commit
 /// plus everything reached from a timer or a webhook rather than a request: the

--- a/desktop/src-tauri/src/native/db.rs
+++ b/desktop/src-tauri/src/native/db.rs
@@ -106,21 +106,25 @@ pub fn open_read_write(path: &Path) -> Result<Connection, String> {
 /// **Everything in this module blocks a thread, and `BUSY_TIMEOUT` says for how
 /// long.** A lock held by the Go sidecar or by the session scanner's batch
 /// writer parks the caller for up to five seconds. On an async worker that is
-/// not a slow call, it is a *stalled runtime*: `proxy.rs` puts every native
-/// handler on the blocking pool for exactly this reason — "one slow read cannot
+/// not a slow call, it is a *stalled runtime*: `proxy.rs` puts its native
+/// handlers on the blocking pool for exactly this reason — "one slow read cannot
 /// stall an SSE stream sharing the runtime" — and the tokio default is one
 /// worker per core, so a four-core machine has four to lose.
 ///
-/// The callers this exists for are the ones the proxy does **not** cover: work
-/// spawned from a timer or a webhook rather than from a request. The scheduler's
-/// executor (#366) and the trigger dispatcher (#319) both run up to
-/// their own concurrency limit — three and ten — which is more than the workers
-/// a laptop has.
+/// **The proxy's cover is narrower than it looks**, which is why this exists.
+/// `serve` — the buffered path, thirteen areas' worth of handlers — is on the
+/// pool. `serve_stream` is not: it awaits on the worker, and `STREAM_ENDPOINTS`
+/// is the chat turn. So the callers here are the streaming turn's own commit
+/// plus everything reached from a timer or a webhook rather than a request: the
+/// scheduler's executor (#366), which runs three at once, and the trigger
+/// dispatcher (#319), which runs ten — against a tokio default of one worker per
+/// core.
 ///
 /// `None` means the pool task itself failed, which is a panic inside `f` and
-/// nothing else. Callers fold it into whatever they already do when the database
-/// call fails, because at that point nothing was written and there is no result;
-/// it is logged here so the panic is never silent.
+/// nothing else. It is logged here so a panic is never silent, but **what it
+/// leaves behind is the caller's problem, not this function's**: a closure
+/// holding several writes can panic between them, and only the caller knows what
+/// a half-finished section left in the database.
 pub async fn blocking<T, F>(what: &'static str, f: F) -> Option<T>
 where
     F: FnOnce() -> T + Send + 'static,

--- a/desktop/src-tauri/src/native/db.rs
+++ b/desktop/src-tauri/src/native/db.rs
@@ -101,6 +101,40 @@ pub fn open_read_write(path: &Path) -> Result<Connection, String> {
     Ok(conn)
 }
 
+/// Run a synchronous database section on the blocking pool.
+///
+/// **Everything in this module blocks a thread, and `BUSY_TIMEOUT` says for how
+/// long.** A lock held by the Go sidecar or by the session scanner's batch
+/// writer parks the caller for up to five seconds. On an async worker that is
+/// not a slow call, it is a *stalled runtime*: `proxy.rs` puts every native
+/// handler on the blocking pool for exactly this reason — "one slow read cannot
+/// stall an SSE stream sharing the runtime" — and the tokio default is one
+/// worker per core, so a four-core machine has four to lose.
+///
+/// The callers this exists for are the ones the proxy does **not** cover: work
+/// spawned from a timer or a webhook rather than from a request. The scheduler's
+/// executor (#366) and the trigger dispatcher (#319) both run up to
+/// their own concurrency limit — three and ten — which is more than the workers
+/// a laptop has.
+///
+/// `None` means the pool task itself failed, which is a panic inside `f` and
+/// nothing else. Callers fold it into whatever they already do when the database
+/// call fails, because at that point nothing was written and there is no result;
+/// it is logged here so the panic is never silent.
+pub async fn blocking<T, F>(what: &'static str, f: F) -> Option<T>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    match tokio::task::spawn_blocking(f).await {
+        Ok(value) => Some(value),
+        Err(e) => {
+            log::error!("{what}: a blocking database task failed: {e}");
+            None
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/desktop/src-tauri/src/native/schedule/executor.rs
+++ b/desktop/src-tauri/src/native/schedule/executor.rs
@@ -45,6 +45,11 @@ pub async fn execute_task(scheduler: &Arc<Scheduler>, task_id: &str) {
         let (scheduler, task_id) = (Arc::clone(scheduler), task_id.to_string());
         db::blocking("scheduled run", move || due_task(&scheduler, &task_id)).await
     };
+    // Two shapes of `None` collapse here, and they mean different things: not
+    // due (or unreadable, which `due_task` has already logged), and a panic in
+    // the section itself, which `db::blocking` logs. Neither has written
+    // anything, so neither owes a job row — this is the one place in the file
+    // where returning without one is right.
     let Some(Some(task)) = due else {
         return;
     };
@@ -117,8 +122,9 @@ fn auto_pause(scheduler: &Arc<Scheduler>, mut task: ScheduledTask, reason: &str)
 /// after it is synchronous rusqlite, and the run itself is the only part that
 /// awaits — often for hours. Written inline the two ends would park an axum
 /// worker on `busy_timeout` (see [`db::blocking`]), three at a time because that
-/// is what the scheduler's semaphore permits, which is enough to stall the SPA
-/// and every SSE stream on a four-core machine. So [`prepare`] and [`finish`]
+/// is what the scheduler's semaphore permits. Tokio runs one worker per core, so
+/// on a four-core machine that is three of the four — the SPA and every SSE
+/// stream sharing the runtime are left with one. So [`prepare`] and [`finish`]
 /// are whole synchronous sections handed to the pool, rather than eight
 /// individually wrapped calls: the database work in one run is contiguous, and
 /// splitting it any finer would only add hand-offs.
@@ -165,6 +171,13 @@ async fn run_task(scheduler: &Arc<Scheduler>, task: ScheduledTask) {
         })
         .await
     };
+    // A panic in `finish` is the one case that can leave evidence behind: it may
+    // have written the session results and not the job row, so `job_history`
+    // keeps a `running` row that nothing will ever finish. There is nothing
+    // useful to do about it from here — the state is unknown, and a second
+    // write attempt from a path that just panicked is not an improvement — but
+    // it is the reason the module header's rule is "every path ends in a job
+    // history row" rather than "every path ends correctly".
     let Some(recorded) = recorded else {
         return;
     };
@@ -197,9 +210,11 @@ struct Ready {
 /// publish it. The task travels back because `update_task_after_run` re-reads
 /// the row and writes the fresh counters onto it.
 ///
-/// Boxed at the `Result` — a `ScheduledTask` is ~500 bytes, and the success side
-/// carries one too, so the unboxed `Result` would pay for the larger of them on
-/// every call. Failure is also the rarer half.
+/// Boxed to satisfy `clippy::result_large_err`, whose threshold is 128 bytes and
+/// which a bare `ScheduledTask` (~450) clears on its own. It does **not** shrink
+/// the `Result`: `Ready` carries a task, a job and an agent, so the enum is that
+/// size either way. The lint is about the cost of moving an error along a `?`
+/// chain, which is why boxing the rarer half is the answer it wants.
 struct Failed {
     task: ScheduledTask,
     message: String,

--- a/desktop/src-tauri/src/native/schedule/executor.rs
+++ b/desktop/src-tauri/src/native/schedule/executor.rs
@@ -45,11 +45,15 @@ pub async fn execute_task(scheduler: &Arc<Scheduler>, task_id: &str) {
         let (scheduler, task_id) = (Arc::clone(scheduler), task_id.to_string());
         db::blocking("scheduled run", move || due_task(&scheduler, &task_id)).await
     };
-    // Two shapes of `None` collapse here, and they mean different things: not
-    // due (or unreadable, which `due_task` has already logged), and a panic in
-    // the section itself, which `db::blocking` logs. Neither has written
-    // anything, so neither owes a job row — this is the one place in the file
-    // where returning without one is right.
+    // Two shapes of `None` collapse here: not due, and a panic in the section
+    // itself, which `db::blocking` logs. Neither owes a job row — no run was
+    // started, and this is the one place in the file where returning without one
+    // is right.
+    //
+    // "Not due" is not the same as "wrote nothing", though: the auto-pause
+    // branch parks the row and drops the timer. A panic between those two leaves
+    // a `paused` row with a live gocron entry — which `reconcile` corrects
+    // within the minute, since it reads the row.
     let Some(Some(task)) = due else {
         return;
     };
@@ -211,7 +215,7 @@ struct Ready {
 /// the row and writes the fresh counters onto it.
 ///
 /// Boxed to satisfy `clippy::result_large_err`, whose threshold is 128 bytes and
-/// which a bare `ScheduledTask` (~450) clears on its own. It does **not** shrink
+/// which a bare `ScheduledTask` (472 bytes, measured) clears on its own. It does **not** shrink
 /// the `Result`: `Ready` carries a task, a job and an agent, so the enum is that
 /// size either way. The lint is about the cost of moving an error along a `?`
 /// chain, which is why boxing the rarer half is the answer it wants.

--- a/desktop/src-tauri/src/native/schedule/executor.rs
+++ b/desktop/src-tauri/src/native/schedule/executor.rs
@@ -34,26 +34,45 @@ use super::runtime::Scheduler;
 use crate::native::agent_run::RunResult;
 use crate::native::agents::{self, Agent};
 use crate::native::chat::runner::TurnSettings;
+use crate::native::db;
 use crate::native::notifications;
 use crate::native::tasks::{self, JobHistory, ScheduledTask};
 use crate::native::template;
 
 /// `executeTask`. The semaphore is the caller's; this is everything inside it.
 pub async fn execute_task(scheduler: &Arc<Scheduler>, task_id: &str) {
-    let db_path = scheduler.db_path().to_path_buf();
+    let due = {
+        let (scheduler, task_id) = (Arc::clone(scheduler), task_id.to_string());
+        db::blocking("scheduled run", move || due_task(&scheduler, &task_id)).await
+    };
+    let Some(Some(task)) = due else {
+        return;
+    };
 
-    let task = match tasks::get_task(&db_path, task_id) {
+    log::info!(
+        "executing task task_id={:?} task_name={:?} run_count={}",
+        task.id,
+        task.name,
+        task.run_count + 1
+    );
+    run_task(scheduler, task).await;
+}
+
+/// The load-and-check half of `executeTask`: the row, its status, and the
+/// auto-pause rules. Synchronous, and called through [`db::blocking`].
+fn due_task(scheduler: &Arc<Scheduler>, task_id: &str) -> Option<ScheduledTask> {
+    let task = match tasks::get_task(scheduler.db_path(), task_id) {
         Ok(Some(task)) => task,
         // A task that vanished between the fire and the read. Go returns
         // silently; so does this — there is no row to attach a failure to.
-        Ok(None) => return,
+        Ok(None) => return None,
         Err(e) => {
             log::error!("failed to load task for execution task_id={task_id:?} error={e}");
-            return;
+            return None;
         }
     };
     if task.status != "active" {
-        return;
+        return None;
     }
 
     if should_auto_pause(&task) {
@@ -63,16 +82,9 @@ pub async fn execute_task(scheduler: &Arc<Scheduler>, task_id: &str) {
             "stop_after_time reached"
         };
         auto_pause(scheduler, task, reason);
-        return;
+        return None;
     }
-
-    log::info!(
-        "executing task task_id={:?} task_name={:?} run_count={}",
-        task.id,
-        task.name,
-        task.run_count + 1
-    );
-    run_task(scheduler, task).await;
+    Some(task)
 }
 
 /// `shouldAutoPause`. Both conditions are checked before the run, so a task that
@@ -98,9 +110,114 @@ fn auto_pause(scheduler: &Arc<Scheduler>, mut task: ScheduledTask, reason: &str)
 }
 
 /// `runTask`: interpolate, create the session and the job row, run, record.
-async fn run_task(scheduler: &Arc<Scheduler>, mut task: ScheduledTask) {
+///
+/// # Three sections, and the two on the ends are blocking
+///
+/// The shape is not arbitrary. Everything before the agent run and everything
+/// after it is synchronous rusqlite, and the run itself is the only part that
+/// awaits — often for hours. Written inline the two ends would park an axum
+/// worker on `busy_timeout` (see [`db::blocking`]), three at a time because that
+/// is what the scheduler's semaphore permits, which is enough to stall the SPA
+/// and every SSE stream on a four-core machine. So [`prepare`] and [`finish`]
+/// are whole synchronous sections handed to the pool, rather than eight
+/// individually wrapped calls: the database work in one run is contiguous, and
+/// splitting it any finer would only add hand-offs.
+///
+/// The notifications stay out here because [`publish`] already spawns and
+/// deliberately does not wait — see its own note.
+async fn run_task(scheduler: &Arc<Scheduler>, task: ScheduledTask) {
     let db_path = scheduler.db_path().to_path_buf();
     let started_at = Utc::now();
+
+    let prepared = {
+        let scheduler = Arc::clone(scheduler);
+        db::blocking("scheduled run preparation", move || {
+            prepare(&scheduler, task, started_at)
+        })
+        .await
+    };
+    // `None` is a panic in the section above. Every *handled* failure inside it
+    // has already recorded its job row, which is what the module header's "never
+    // silence" rule is about; a panic is a bug rather than an outcome, and it is
+    // logged by `db::blocking`.
+    let ready = match prepared {
+        Some(Ok(ready)) => ready,
+        Some(Err(failed)) => {
+            publish_task_failed(&db_path, &failed.task, &failed.message);
+            return;
+        }
+        None => return,
+    };
+    let Ready {
+        task,
+        job,
+        chat_session_id,
+        prompt,
+        agent,
+    } = ready;
+
+    let result = run_agent(&db_path, &task, agent, &prompt).await;
+
+    let recorded = {
+        let (scheduler, session) = (Arc::clone(scheduler), chat_session_id.clone());
+        db::blocking("scheduled run results", move || {
+            finish(&scheduler, task, job, &session, &prompt, started_at, result)
+        })
+        .await
+    };
+    let Some(recorded) = recorded else {
+        return;
+    };
+
+    if let Some(message) = &recorded.failure {
+        publish_task_failed(&db_path, &recorded.task, message);
+        return;
+    }
+    publish_task_finished(&db_path, &recorded.task, &recorded.job, &chat_session_id);
+
+    log::info!(
+        "task execution completed task_id={:?} task_name={:?} session_id={:?} run_count={}",
+        recorded.task.id,
+        recorded.task.name,
+        chat_session_id,
+        recorded.task.run_count
+    );
+}
+
+/// What a run needs once everything that can fail before it has not.
+struct Ready {
+    task: ScheduledTask,
+    job: JobHistory,
+    chat_session_id: String,
+    prompt: String,
+    agent: Agent,
+}
+
+/// A failure that has already been recorded, carrying what the caller needs to
+/// publish it. The task travels back because `update_task_after_run` re-reads
+/// the row and writes the fresh counters onto it.
+///
+/// Boxed at the `Result` — a `ScheduledTask` is ~500 bytes, and the success side
+/// carries one too, so the unboxed `Result` would pay for the larger of them on
+/// every call. Failure is also the rarer half.
+struct Failed {
+    task: ScheduledTask,
+    message: String,
+}
+
+/// `prepareTaskRun` plus `resolveAgentConfig`: everything `runTask` does before
+/// the agent run, as one synchronous section.
+///
+/// Every `Err` here is *already recorded* — the two early failures write a
+/// complete failed job row and the third finishes the running one — so the
+/// caller's only remaining job is the notification, which must not happen on
+/// this thread.
+fn prepare(
+    scheduler: &Arc<Scheduler>,
+    mut task: ScheduledTask,
+    started_at: chrono::DateTime<Utc>,
+) -> Result<Ready, Box<Failed>> {
+    let db_path = scheduler.db_path().to_path_buf();
 
     // `prepareTaskRun`. Both failures record a *complete* failed job row and
     // return — the run never reaches `createInitialJobHistory`, so there is no
@@ -108,28 +225,26 @@ async fn run_task(scheduler: &Arc<Scheduler>, mut task: ScheduledTask) {
     let prompt = match template::interpolate(&task.prompt) {
         Ok(prompt) => prompt,
         Err(e) => {
-            let msg = format!("prompt interpolation: {e}");
+            let message = format!("prompt interpolation: {e}");
             log::error!(
                 "failed to interpolate prompt task_id={:?} error={e}",
                 task.id
             );
-            record_failed_run(scheduler, &mut task, started_at, "", &msg);
-            publish_task_failed(&db_path, &task, &msg);
-            return;
+            record_failed_run(scheduler, &mut task, started_at, "", &message);
+            return Err(Box::new(Failed { task, message }));
         }
     };
 
     let chat_session_id = match create_task_session(&db_path, &task) {
         Ok(id) => id,
         Err(e) => {
-            let msg = format!("create session: {e}");
+            let message = format!("create session: {e}");
             log::error!(
                 "failed to create chat session task_id={:?} error={e}",
                 task.id
             );
-            record_failed_run(scheduler, &mut task, started_at, "", &msg);
-            publish_task_failed(&db_path, &task, &msg);
-            return;
+            record_failed_run(scheduler, &mut task, started_at, "", &message);
+            return Err(Box::new(Failed { task, message }));
         }
     };
 
@@ -141,31 +256,62 @@ async fn run_task(scheduler: &Arc<Scheduler>, mut task: ScheduledTask) {
     let agent = match resolve_agent(&db_path, &task) {
         Ok(agent) => agent,
         Err(e) => {
-            let msg = format!("resolve agent: {e}");
+            let message = format!("resolve agent: {e}");
             log::error!(
                 "failed to resolve agent config task_id={:?} error={e}",
                 task.id
             );
-            finish_job_history(&db_path, &mut job, started_at, "failed", &msg, None, "");
+            finish_job_history(&db_path, &mut job, started_at, "failed", &message, None, "");
             update_task_after_run(scheduler, &mut task, started_at, "failed");
-            publish_task_failed(&db_path, &task, &msg);
-            return;
+            return Err(Box::new(Failed { task, message }));
         }
     };
 
-    let result = run_agent(&db_path, &task, agent, &prompt).await;
+    Ok(Ready {
+        task,
+        job,
+        chat_session_id,
+        prompt,
+        agent,
+    })
+}
+
+/// What [`finish`] wrote, for the caller to publish. `failure` carries the
+/// message when the run itself failed.
+struct Recorded {
+    task: ScheduledTask,
+    job: JobHistory,
+    failure: Option<String>,
+}
+
+/// Everything `runTask` does after the agent run, as one synchronous section:
+/// the session results, the job row, and the task's own counters.
+fn finish(
+    scheduler: &Arc<Scheduler>,
+    mut task: ScheduledTask,
+    mut job: JobHistory,
+    chat_session_id: &str,
+    prompt: &str,
+    started_at: chrono::DateTime<Utc>,
+    result: Result<RunResult, String>,
+) -> Recorded {
+    let db_path = scheduler.db_path().to_path_buf();
+
     let result = match result {
         Ok(result) => result,
         Err(e) => {
             log::error!("task execution failed task_id={:?} error={e}", task.id);
             finish_job_history(&db_path, &mut job, started_at, "failed", &e, None, "");
             update_task_after_run(scheduler, &mut task, started_at, "failed");
-            publish_task_failed(&db_path, &task, &e);
-            return;
+            return Recorded {
+                task,
+                job,
+                failure: Some(e),
+            };
         }
     };
 
-    save_session_results(&db_path, &chat_session_id, &result, &prompt, started_at);
+    save_session_results(&db_path, chat_session_id, &result, prompt, started_at);
     // `task.SaveOutput` decides whether the answer is *stored*, not whether it
     // was produced — an unsaved run still has its tokens and duration recorded.
     let response_text = if task.save_output {
@@ -183,15 +329,12 @@ async fn run_task(scheduler: &Arc<Scheduler>, mut task: ScheduledTask) {
         response_text,
     );
     update_task_after_run(scheduler, &mut task, started_at, "success");
-    publish_task_finished(&db_path, &task, &job, &chat_session_id);
 
-    log::info!(
-        "task execution completed task_id={:?} task_name={:?} session_id={:?} run_count={}",
-        task.id,
-        task.name,
-        chat_session_id,
-        task.run_count
-    );
+    Recorded {
+        task,
+        job,
+        failure: None,
+    }
 }
 
 /// `createTaskSession`: the chat row a run's messages land in, titled after the

--- a/desktop/src-tauri/src/native/trigger/dispatcher.rs
+++ b/desktop/src-tauri/src/native/trigger/dispatcher.rs
@@ -32,6 +32,7 @@ use super::match_rule::{match_rule, RuleFilters};
 use super::receiver::{TelegramMsg, TelegramUpdate};
 use crate::native::agent_run;
 use crate::native::agents::Agent;
+use crate::native::db;
 
 /// `maxConcurrentExecutions`, the buffer on `Dispatcher.sem`.
 ///
@@ -76,27 +77,6 @@ pub fn handle_update(
     });
 }
 
-/// Run a blocking database call off the runtime's workers.
-///
-/// `None` when the pool task itself failed — a panic inside the closure. Each
-/// caller folds that into the answer a failed *read* already gives it, which is
-/// not the same answer everywhere: `process` stops, `execute_and_reply` sends
-/// the error reply, and the two message writes are best-effort in Go too and so
-/// ignore it.
-async fn blocking<T, F>(f: F) -> Option<T>
-where
-    F: FnOnce() -> T + Send + 'static,
-    T: Send + 'static,
-{
-    match tokio::task::spawn_blocking(f).await {
-        Ok(value) => Some(value),
-        Err(e) => {
-            log::error!("telegram dispatch: a database task failed: {e}");
-            None
-        }
-    }
-}
-
 /// `processTelegramUpdate`.
 async fn process(db_path: &Path, integration_id: &str, bot_token: &str, update: TelegramUpdate) {
     // A non-message update, or one with no text, is not a trigger.
@@ -108,7 +88,7 @@ async fn process(db_path: &Path, integration_id: &str, bot_token: &str, update: 
     // Claimed before the rules are read, so a Telegram retry cannot run the
     // agent twice — see `receiver::claim_update` for why the claim is atomic
     // here where Go's is two statements.
-    // **Every database call this module makes goes to the blocking pool.**
+    // **Every database call this module makes goes through [`db::blocking`].**
     // (Not every call the *dispatch* makes: `run_headless` opens SQLite on the
     // worker while building its options, which chat and the scheduler share
     // verbatim.) `process` runs on an axum worker, and each of these opens a connection and may sit on
@@ -122,7 +102,10 @@ async fn process(db_path: &Path, integration_id: &str, bot_token: &str, update: 
             integration_id.to_string(),
             update.update_id,
         );
-        blocking(move || super::receiver::claim_update(&db, &id, update_id)).await
+        db::blocking("telegram dispatch", move || {
+            super::receiver::claim_update(&db, &id, update_id)
+        })
+        .await
     };
     if !claimed.unwrap_or(false) {
         return;
@@ -134,7 +117,10 @@ async fn process(db_path: &Path, integration_id: &str, bot_token: &str, update: 
             integration_id.to_string(),
             msg.clone(),
         );
-        blocking(move || find_matching_rule(&db, &id, &msg)).await
+        db::blocking("telegram dispatch", move || {
+            find_matching_rule(&db, &id, &msg)
+        })
+        .await
     };
     let Some(Some((rule, prompt))) = matched else {
         return;
@@ -242,7 +228,7 @@ async fn execute_and_reply(
 
     let resolved = {
         let (db, slug) = (db_path.to_path_buf(), rule.agent_slug.clone());
-        blocking(move || resolve_agent(&db, &slug))
+        db::blocking("telegram dispatch", move || resolve_agent(&db, &slug))
             .await
             .unwrap_or_else(|| Err("the agent lookup task failed".to_string()))
     };
@@ -262,9 +248,11 @@ async fn execute_and_reply(
     // profile — a trigger run is not configurable the way a task is.
     let created = {
         let (db, rule) = (db_path.to_path_buf(), rule.clone());
-        blocking(move || create_trigger_session(&db, &rule))
-            .await
-            .unwrap_or_else(|| Err("the session task failed".to_string()))
+        db::blocking("telegram dispatch", move || {
+            create_trigger_session(&db, &rule)
+        })
+        .await
+        .unwrap_or_else(|| Err("the session task failed".to_string()))
     };
     let chat_session_id = match created {
         Ok(id) => id,
@@ -293,7 +281,10 @@ async fn execute_and_reply(
                 chat_session_id.clone(),
                 prompt.to_string(),
             );
-            blocking(move || save_messages(&db, &session, &prompt, "")).await;
+            db::blocking("telegram dispatch", move || {
+                save_messages(&db, &session, &prompt, "")
+            })
+            .await;
             return;
         }
     };
@@ -305,7 +296,7 @@ async fn execute_and_reply(
             prompt.to_string(),
         );
         let usage = result.clone();
-        blocking(move || {
+        db::blocking("telegram dispatch", move || {
             save_messages(&db, &session, &prompt, &usage.answer);
             update_session_usage(&db, &session, &usage);
         })

--- a/desktop/src-tauri/src/native/trigger/dispatcher.rs
+++ b/desktop/src-tauri/src/native/trigger/dispatcher.rs
@@ -77,6 +77,12 @@ pub fn handle_update(
     });
 }
 
+/// What `db::blocking` answering `None` costs at each call site below, since it
+/// is not the same everywhere: `claim_update` and `find_matching_rule` stop the
+/// dispatch, exactly as a failed read already does; `resolve_agent` and
+/// `create_trigger_session` become the error reply; and the two `save_messages`
+/// calls are best-effort in Go too, so they are ignored.
+///
 /// `processTelegramUpdate`.
 async fn process(db_path: &Path, integration_id: &str, bot_token: &str, update: TelegramUpdate) {
     // A non-message update, or one with no text, is not a trigger.
@@ -88,10 +94,10 @@ async fn process(db_path: &Path, integration_id: &str, bot_token: &str, update: 
     // Claimed before the rules are read, so a Telegram retry cannot run the
     // agent twice — see `receiver::claim_update` for why the claim is atomic
     // here where Go's is two statements.
-    // **Every database call this module makes goes through [`db::blocking`].**
-    // (Not every call the *dispatch* makes: `run_headless` opens SQLite on the
-    // worker while building its options, which chat and the scheduler share
-    // verbatim.) `process` runs on an axum worker, and each of these opens a connection and may sit on
+    // **Every database call this module makes goes through [`db::blocking`],**
+    // each under its own label so the log says which one panicked. (Not every
+    // call the *dispatch* makes: `run_headless` opens SQLite on the worker while
+    // building its options, which chat and the scheduler share verbatim.) `process` runs on an axum worker, and each of these opens a connection and may sit on
     // `db.rs`'s five-second `busy_timeout` while the session scan batch-writes —
     // ten of them at `MAX_CONCURRENT` is every worker on a four-core machine,
     // stalling the SPA and any SSE stream. `proxy.rs` puts native handlers on the
@@ -102,7 +108,7 @@ async fn process(db_path: &Path, integration_id: &str, bot_token: &str, update: 
             integration_id.to_string(),
             update.update_id,
         );
-        db::blocking("telegram dispatch", move || {
+        db::blocking("telegram claim", move || {
             super::receiver::claim_update(&db, &id, update_id)
         })
         .await
@@ -117,7 +123,7 @@ async fn process(db_path: &Path, integration_id: &str, bot_token: &str, update: 
             integration_id.to_string(),
             msg.clone(),
         );
-        db::blocking("telegram dispatch", move || {
+        db::blocking("telegram rule match", move || {
             find_matching_rule(&db, &id, &msg)
         })
         .await
@@ -228,7 +234,7 @@ async fn execute_and_reply(
 
     let resolved = {
         let (db, slug) = (db_path.to_path_buf(), rule.agent_slug.clone());
-        db::blocking("telegram dispatch", move || resolve_agent(&db, &slug))
+        db::blocking("telegram agent lookup", move || resolve_agent(&db, &slug))
             .await
             .unwrap_or_else(|| Err("the agent lookup task failed".to_string()))
     };
@@ -248,7 +254,7 @@ async fn execute_and_reply(
     // profile — a trigger run is not configurable the way a task is.
     let created = {
         let (db, rule) = (db_path.to_path_buf(), rule.clone());
-        db::blocking("telegram dispatch", move || {
+        db::blocking("telegram session", move || {
             create_trigger_session(&db, &rule)
         })
         .await
@@ -281,7 +287,7 @@ async fn execute_and_reply(
                 chat_session_id.clone(),
                 prompt.to_string(),
             );
-            db::blocking("telegram dispatch", move || {
+            db::blocking("telegram failed turn", move || {
                 save_messages(&db, &session, &prompt, "")
             })
             .await;
@@ -296,7 +302,7 @@ async fn execute_and_reply(
             prompt.to_string(),
         );
         let usage = result.clone();
-        db::blocking("telegram dispatch", move || {
+        db::blocking("telegram turn", move || {
             save_messages(&db, &session, &prompt, &usage.answer);
             update_session_usage(&db, &session, &usage);
         })

--- a/desktop/src-tauri/src/native/trigger/dispatcher.rs
+++ b/desktop/src-tauri/src/native/trigger/dispatcher.rs
@@ -97,7 +97,9 @@ async fn process(db_path: &Path, integration_id: &str, bot_token: &str, update: 
     // **Every database call this module makes goes through [`db::blocking`],**
     // each under its own label so the log says which one panicked. (Not every
     // call the *dispatch* makes: `run_headless` opens SQLite on the worker while
-    // building its options, which chat and the scheduler share verbatim.) `process` runs on an axum worker, and each of these opens a connection and may sit on
+    // building its options, which chat and the scheduler share verbatim.)
+    // `process` runs on an axum worker, and each of these opens a connection and
+    // may sit on
     // `db.rs`'s five-second `busy_timeout` while the session scan batch-writes —
     // ten of them at `MAX_CONCURRENT` is every worker on a four-core machine,
     // stalling the SPA and any SSE stream. `proxy.rs` puts native handlers on the

--- a/desktop/src-tauri/tests/chat_turn.rs
+++ b/desktop/src-tauri/tests/chat_turn.rs
@@ -1351,3 +1351,135 @@ async fn one_turn_emits_the_service_layer_lines_go_emits() {
     );
     assert!(committed.starts_with("INFO "), "{committed}");
 }
+
+/// The turn's commit must not stall the runtime while the write lock is held
+/// (#366).
+///
+/// The scheduler half of that issue got its own version of this test; this is
+/// the chat half, and it exists because the defect is otherwise invisible — the
+/// turn streams correctly and stores the right rows either way. What changes is
+/// *who waits*: `serve_stream` awaits on an axum worker rather than on the
+/// blocking pool `proxy.rs` uses for the buffered handlers, so an inline
+/// `persist::commit` — `open_read_write` plus up to three writes — parks a
+/// worker for the full five-second `busy_timeout` whenever the Go sidecar or the
+/// session scanner's batch writer holds the lock. Once per turn.
+///
+/// Every part of the shape is load-bearing, and two of them were false greens in
+/// the scheduler version before they were fixed there:
+///
+/// - **one worker thread**, so a single parked worker is the whole runtime;
+/// - the ticker's `last` is seeded **before** the spawn, because a starved task
+///   is never polled and seeding it on the first poll starts the clock after the
+///   stall;
+/// - the fixture is converted to **WAL** first, since `open_read_write`'s
+///   `PRAGMA journal_mode=WAL` against a rollback-journal file is a mode change
+///   that fails outright in a millisecond instead of waiting on `busy_timeout`.
+///   In production the file is always already WAL.
+///
+/// Verified in both directions rather than assumed: calling `persist::commit`
+/// inline in `turn.rs` takes the longest gap from ~11 ms to 1,540 ms — the whole
+/// hold.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn a_contended_write_lock_does_not_stall_the_runtime() {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+
+    let Some(_) = python3() else {
+        eprintln!("skipping: no python3");
+        return;
+    };
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cli = fake_cli(
+        dir.path(),
+        r#"
+    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack(req.get("request_id") or msg.get("request_id"))
+    elif msg.get("type") == "user":
+        raw('{"type":"assistant","message":{"content":[{"type":"text","text":"the reply"}]}}')
+        raw('{"type":"result","subtype":"success","is_error":false,"result":"the reply","session_id":"sdk-lock","usage":{"input_tokens":1,"output_tokens":1}}')
+"#,
+    );
+
+    let id = unique_id("contended");
+    let file = migrated_with_chat(&id);
+    agento_lib::native::db::open_read_write(file.path()).expect("convert the fixture to WAL");
+
+    /// Long enough that a parked worker is unmistakable, short enough to stay
+    /// inside the 5 s `busy_timeout` so the commit still succeeds.
+    const HOLD: Duration = Duration::from_millis(1_500);
+
+    // A writer outside the runtime, holding the lock the commit needs.
+    let (holding_tx, holding_rx) = std::sync::mpsc::channel();
+    let lock_path = file.path().to_path_buf();
+    let holder = std::thread::spawn(move || {
+        let mut conn = rusqlite::Connection::open(&lock_path).expect("open");
+        let tx = conn
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+            .expect("begin immediate");
+        holding_tx.send(()).expect("signal");
+        std::thread::sleep(HOLD);
+        tx.rollback().expect("rollback");
+    });
+    holding_rx.recv().expect("the writer took the lock");
+
+    let worst_gap_ms = Arc::new(AtomicU64::new(0));
+    let ticks = Arc::new(AtomicU64::new(0));
+    let ticker = {
+        let (worst_gap_ms, ticks, mut last) = (
+            Arc::clone(&worst_gap_ms),
+            Arc::clone(&ticks),
+            Instant::now(),
+        );
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                let now = Instant::now();
+                let gap = u64::try_from(now.duration_since(last).as_millis()).unwrap_or(u64::MAX);
+                worst_gap_ms.fetch_max(gap, Ordering::Relaxed);
+                ticks.fetch_add(1, Ordering::Relaxed);
+                last = now;
+            }
+        })
+    };
+
+    let _env = env_lock().lock().await;
+    std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", &cli);
+    let response = agento_lib::native::chat::turn::run(
+        file.path().to_path_buf(),
+        id.clone(),
+        "hello".to_string(),
+    )
+    .await
+    .expect("the turn should stream");
+    collect_with_timeout(response).await;
+
+    // The commit is detached from the request, so the body ending does not mean
+    // it has landed. Wait for the row rather than for a duration.
+    let mut committed = false;
+    for _ in 0..400 {
+        if messages(&file, &id).len() == 2 {
+            committed = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    ticker.abort();
+    holder.join().expect("the writer finished");
+
+    assert!(committed, "the turn's messages were never committed");
+
+    let worst = worst_gap_ms.load(Ordering::Relaxed);
+    assert!(
+        worst < 500,
+        "the runtime stalled for {worst} ms while the write lock was held \
+         (the hold is {} ms; anything near it means the commit blocked a worker)",
+        HOLD.as_millis()
+    );
+    let ticks = ticks.load(Ordering::Relaxed);
+    assert!(
+        ticks > 50,
+        "the ticker only advanced {ticks} times across a {} ms hold",
+        HOLD.as_millis()
+    );
+}

--- a/desktop/src-tauri/tests/scheduled_run.rs
+++ b/desktop/src-tauri/tests/scheduled_run.rs
@@ -386,3 +386,136 @@ async fn a_run_that_outlives_its_timeout_is_recorded_as_a_deadline() {
         "Go's `context.DeadlineExceeded` reaches the caller as this"
     );
 }
+
+/// A run whose database work is blocked must not stall the runtime (#366).
+///
+/// This is the only test here that measures *latency of something else* rather
+/// than what a run wrote, because that is what the defect was: `execute_task`
+/// did its rusqlite work inline on an axum worker, and `db::open_read_write`
+/// sets a five-second `busy_timeout`, so a run that met a contended write lock
+/// parked a worker for up to five seconds. Three at once — the scheduler's
+/// semaphore permits exactly that — is every worker on a four-core machine, and
+/// the SPA and every SSE stream sharing the runtime stop with them.
+///
+/// The shape is deliberate and each part is load-bearing:
+///
+/// - **one worker thread**, so a single parked worker is the whole runtime;
+/// - **`tokio::spawn`** rather than awaiting the run here, because
+///   `block_on` runs the test body on the calling thread, not on a worker —
+///   awaiting inline would block a thread the ticker never wanted;
+/// - **a plain OS thread** holds the lock, so the contention comes from outside
+///   the runtime exactly as the Go sidecar's writes and the session scanner's
+///   batch writer do.
+///
+/// Verified against the defect rather than assumed: with `prepare` called inline
+/// in place of the `db::blocking` hand-off, the longest gap goes from ~11 ms to
+/// 1,547 ms — the whole hold — and the ticker advances 5 times instead of ~150.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn a_contended_write_lock_does_not_stall_the_runtime() {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+
+    if python3().is_none() {
+        eprintln!("skipping: no python3 to script the fake CLI");
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = dir.path().join("agento.db");
+    let task_id = migrated_with_task(&db, "cron", true);
+
+    let cli = fake_cli(
+        dir.path(),
+        r#"        raw('{"type":"result","subtype":"success","is_error":false,"result":"done","session_id":"s","usage":{"input_tokens":1,"output_tokens":1}}')"#,
+    );
+
+    let _env = env_lock().lock().await;
+    std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", &cli);
+
+    /// How long the lock is held. Long enough that a parked worker is
+    /// unmistakable, short enough to stay well inside the 5s `busy_timeout` so
+    /// the run itself still succeeds.
+    const HOLD: Duration = Duration::from_millis(1_500);
+
+    // The file must already be WAL, which in production it always is — the Go
+    // server sets it, persistently, before anything else opens it. Left in the
+    // default rollback journal, `open_read_write`'s own `PRAGMA journal_mode=WAL`
+    // is a *mode change* needing an exclusive lock, and it fails outright
+    // ("database is locked") in about a millisecond instead of waiting on
+    // `busy_timeout` — which would make this test measure the wrong thing
+    // entirely.
+    agento_lib::native::db::open_read_write(&db).expect("convert the fixture to WAL");
+
+    // A writer outside the runtime, holding the lock the run needs.
+    let (holding_tx, holding_rx) = std::sync::mpsc::channel();
+    let lock_db = db.clone();
+    let holder = std::thread::spawn(move || {
+        let mut conn = rusqlite::Connection::open(&lock_db).expect("open");
+        let tx = conn
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+            .expect("begin immediate");
+        holding_tx.send(()).expect("signal");
+        std::thread::sleep(HOLD);
+        tx.rollback().expect("rollback");
+    });
+    holding_rx.recv().expect("the writer took the lock");
+
+    // The thing that must keep running. It records the **longest** gap between
+    // its own ticks, which is what a parked worker shows up as.
+    //
+    // `last` is seeded out here, before the spawn, and that is not a detail: a
+    // starved ticker is never *polled*, so seeding it on the first poll would
+    // start the clock after the stall and measure nothing. The first version of
+    // this test did exactly that and passed against the unfixed executor.
+    let worst_gap_ms = Arc::new(AtomicU64::new(0));
+    let ticks = Arc::new(AtomicU64::new(0));
+    let ticker = {
+        let (worst_gap_ms, ticks, mut last) = (
+            Arc::clone(&worst_gap_ms),
+            Arc::clone(&ticks),
+            Instant::now(),
+        );
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                let now = Instant::now();
+                let gap = u64::try_from(now.duration_since(last).as_millis()).unwrap_or(u64::MAX);
+                worst_gap_ms.fetch_max(gap, Ordering::Relaxed);
+                ticks.fetch_add(1, Ordering::Relaxed);
+                last = now;
+            }
+        })
+    };
+
+    let scheduler = agento_lib::native::schedule::runtime::detached(&db);
+    let run = tokio::spawn(async move {
+        agento_lib::native::schedule::executor::execute_task(&scheduler, &task_id).await;
+    });
+
+    run.await.expect("the run finished");
+    ticker.abort();
+    holder.join().expect("the writer finished");
+
+    let worst = worst_gap_ms.load(Ordering::Relaxed);
+    assert!(
+        worst < 500,
+        "the runtime stalled for {worst} ms while the write lock was held \
+         (the hold is {} ms; anything near it means the run blocked a worker)",
+        HOLD.as_millis()
+    );
+    // The gap alone would also read as healthy if the ticker had simply been
+    // cancelled early, so assert it really ran throughout: the hold is 1.5 s of
+    // 10 ms ticks, and a third of them is a wide margin for a loaded CI box.
+    let ticks = ticks.load(Ordering::Relaxed);
+    assert!(
+        ticks > 50,
+        "the ticker only advanced {ticks} times across a {} ms hold",
+        HOLD.as_millis()
+    );
+
+    // …and the run itself still completed, so this is not passing because
+    // nothing happened.
+    let jobs = job_rows(&db);
+    assert_eq!(jobs.len(), 1, "the run still recorded a job: {jobs:?}");
+    assert_eq!(jobs[0].0, "success", "error was {:?}", jobs[0].1);
+}

--- a/desktop/src-tauri/tests/scheduled_run.rs
+++ b/desktop/src-tauri/tests/scheduled_run.rs
@@ -393,9 +393,10 @@ async fn a_run_that_outlives_its_timeout_is_recorded_as_a_deadline() {
 /// than what a run wrote, because that is what the defect was: `execute_task`
 /// did its rusqlite work inline on an axum worker, and `db::open_read_write`
 /// sets a five-second `busy_timeout`, so a run that met a contended write lock
-/// parked a worker for up to five seconds. Three at once — the scheduler's
-/// semaphore permits exactly that — is every worker on a four-core machine, and
-/// the SPA and every SSE stream sharing the runtime stop with them.
+/// parked a worker for up to five seconds. Tokio runs one worker per core and
+/// the scheduler's semaphore permits three runs at once, so on a four-core
+/// machine that is three of the four — the SPA and every SSE stream sharing the
+/// runtime are left with one.
 ///
 /// The shape is deliberate and each part is load-bearing:
 ///


### PR DESCRIPTION
Closes #366.

## What was wrong

`execute_task` is spawned with a plain `tokio::spawn` and then does synchronous rusqlite throughout: the task read, the session transaction, both job-history writes, the session results, the counters. `db::open_read_write` sets a five-second `busy_timeout`, so any of those can park an axum worker for that long while the Go sidecar or the session scanner's batch writer holds the write lock. The scheduler's semaphore permits three runs at once — every worker on a four-core machine, with the SPA and every in-flight SSE stream sharing the runtime.

`proxy.rs` already puts every native *handler* on the blocking pool, with the reason written down. That covers everything reached from a request and nothing reached from a timer or a webhook.

## The change

- **`db::blocking(what, f)`** in `db.rs`, beside the two `open` functions it exists for, so the convention is greppable. The trigger dispatcher's private copy from #319 is replaced by it.
- **The executor is three sections rather than eight wrapped calls.** `prepare` is everything before the agent run, `finish` everything after, and each is one synchronous unit handed to the pool — a run's database work is contiguous, and splitting it finer would only add hand-offs. `execute_task`'s load-and-check half became `due_task` for the same reason.
- The notifications stay on the async side: `publish` already spawns and deliberately does not await.
- Every existing helper is untouched, so the unit tests over them still pin the same behaviour.

## The regression test

`a_contended_write_lock_does_not_stall_the_runtime` measures latency rather than rows, because that is what the defect was: a one-worker runtime, a plain OS thread holding the write lock for 1.5 s, a ticker recording its longest gap.

| | longest gap | ticks |
|---|---|---|
| with the hand-off | ~11 ms | ~150 |
| `prepare` called inline | **1,547 ms** | **5** |

Verified in both directions rather than assumed. Two things it took a false green to get right, both now in the test's own comments:

- the ticker's `last` must be seeded **before** the spawn — a starved task is never polled, so seeding it on the first poll starts the clock after the stall and the test passes against the defect;
- the fixture must be converted to WAL first, because `open_read_write`'s `PRAGMA journal_mode=WAL` against a rollback-journal file is a *mode change* that fails outright in about a millisecond instead of waiting on `busy_timeout`. In production the file is always already WAL.

## Not fixed here

`run_headless` opens SQLite on the worker while building its options (`TurnSettings::stored`, `registry::can_host`, `start_filtered_server`). That is shared verbatim with chat and the scheduler rather than specific to this path, and the test measures the remaining exposure at ~11 ms. Noted in `desktop/CLAUDE.md`.

## Gates

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --no-fail-fast` (all green), `go build ./...`, `go test ./desktop/parity/`.