### PR TITLE
fix(desktop): five GUI defects — hairlines, switch, dropdowns, New Chat, session detail

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -30,6 +30,8 @@ export default function App() {
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [inspectorOpen, setInspectorOpen] = useState(true);
   const [paletteOpen, setPaletteOpen] = useState(false);
+  // Bumped by every "New Chat" entry point; ChatsView opens a draft on change.
+  const [newChatNonce, setNewChatNonce] = useState(0);
   const [focused, setFocused] = useState(true);
   const [theme, setTheme] = useState<Theme>(
     () => (localStorage.getItem("agento.theme") as Theme) || "system"
@@ -74,6 +76,13 @@ export default function App() {
     setView(history[next]);
   }, [cursor, history]);
 
+  // "New Chat" everywhere (sidebar, menu, ⌘N, palette) means "go to Chats AND
+  // open a fresh draft" — navigating alone left the button looking dead.
+  const newChat = useCallback(() => {
+    navigate("chats");
+    setNewChatNonce((n) => n + 1);
+  }, [navigate]);
+
   const stats = useAppStats();
   const host = useHostInfo();
   const update = useBackgroundUpdate(host?.can_self_update);
@@ -99,7 +108,7 @@ export default function App() {
         group: "Actions",
         icon: "plus",
         shortcut: `${MOD} N`,
-        run: () => navigate("chats"),
+        run: newChat,
       },
       {
         id: "toggle-sidebar",
@@ -148,7 +157,7 @@ export default function App() {
       },
       ...nav,
     ];
-  }, [navigate]);
+  }, [navigate, newChat]);
 
   /* --- Global shortcuts -------------------------------------------------- */
   useEffect(() => {
@@ -171,7 +180,7 @@ export default function App() {
         navigate("settings");
       } else if (k === "n") {
         e.preventDefault();
-        navigate("chats");
+        newChat();
       } else if (k === "[") {
         e.preventDefault();
         goBack();
@@ -188,7 +197,7 @@ export default function App() {
 
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [goBack, goForward, navigate]);
+  }, [goBack, goForward, navigate, newChat]);
 
   /* --- Native menu ------------------------------------------------------- */
   useEffect(
@@ -200,7 +209,7 @@ export default function App() {
         }
         switch (id) {
           case "new_chat":
-            navigate("chats");
+            newChat();
             break;
           case "new_agent":
             navigate("agents");
@@ -237,7 +246,7 @@ export default function App() {
             break;
         }
       }),
-    [goBack, goForward, navigate]
+    [goBack, goForward, navigate, newChat]
   );
 
   const counts: Partial<Record<ViewId, number>> = {
@@ -266,7 +275,7 @@ export default function App() {
           active={view}
           onSelect={navigate}
           counts={counts}
-          onNewChat={() => navigate("chats")}
+          onNewChat={newChat}
         />
 
         <main className="main">
@@ -315,7 +324,9 @@ export default function App() {
               </button>
             </div>
           )}
-          {view === "chats" && <ChatsView inspectorOpen={inspectorOpen} />}
+          {view === "chats" && (
+            <ChatsView inspectorOpen={inspectorOpen} newChatNonce={newChatNonce} />
+          )}
           {view === "agents" && <AgentsView inspectorOpen={inspectorOpen} />}
           {view === "integrations" && (
             <IntegrationsView inspectorOpen={inspectorOpen} />

--- a/desktop/src/components/ui.tsx
+++ b/desktop/src/components/ui.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
 import { Icon, type IconName } from "../lib/icons";
 
 /* --- Segmented control --------------------------------------------------- */
@@ -96,22 +103,231 @@ export function Checkbox({
   );
 }
 
-/* --- Select (native-looking, non-functional in v1) ----------------------- */
+/* --- Dropdown ------------------------------------------------------------- */
 
-export function Select({
+export interface DropdownOption {
+  value: string;
+  label: string;
+}
+
+/**
+ * The app's one select control. A native <select> keeps the platform's own
+ * popup, which fights the app styling on every OS (worst on WebKitGTK), so the
+ * menu is rendered by the app instead: a portal to <body>, positioned off the
+ * trigger, styled like every other .menu. Replaces both the old display-only
+ * Select and the per-view native-<select> wrappers.
+ */
+export function Dropdown({
   value,
+  options,
+  onChange,
   small,
+  disabled,
+  label,
+  placeholder = "Choose…",
+  className,
+  style,
+  ariaLabel,
 }: {
   value: string;
+  options: DropdownOption[];
+  onChange(v: string): void;
   small?: boolean;
+  disabled?: boolean;
+  /** Overrides the trigger text (e.g. "Sort: Recent"). */
+  label?: string;
+  placeholder?: string;
+  className?: string;
+  style?: React.CSSProperties;
+  ariaLabel?: string;
 }) {
+  const [open, setOpen] = useState(false);
+  const [active, setActive] = useState(-1);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState<{
+    left: number;
+    top: number;
+    minWidth: number;
+    maxHeight: number;
+    up: boolean;
+  }>();
+
+  const selectedIndex = options.findIndex((o) => o.value === value);
+  const current = selectedIndex >= 0 ? options[selectedIndex] : undefined;
+
+  const openMenu = useCallback(() => {
+    const el = triggerRef.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    const below = window.innerHeight - r.bottom - 8;
+    const above = r.top - 8;
+    const up = below < 160 && above > below;
+    setPos({
+      left: Math.max(4, Math.min(r.left, window.innerWidth - r.width - 4)),
+      top: up ? r.top - 4 : r.bottom + 4,
+      minWidth: r.width,
+      maxHeight: Math.min(320, up ? above : below),
+      up,
+    });
+    setActive(options.findIndex((o) => o.value === value));
+    setOpen(true);
+  }, [options, value]);
+
+  const close = useCallback(() => setOpen(false), []);
+
+  const pick = useCallback(
+    (v: string) => {
+      setOpen(false);
+      if (v !== value) onChange(v);
+    },
+    [onChange, value]
+  );
+
+  // The menu is a portal, so "outside" means outside both the trigger and the
+  // menu. Any scroll or resize under an open menu would strand it, so close.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      const t = e.target as Node;
+      if (menuRef.current?.contains(t) || triggerRef.current?.contains(t)) return;
+      close();
+    };
+    const onScroll = (e: Event) => {
+      if (menuRef.current?.contains(e.target as Node)) return;
+      close();
+    };
+    document.addEventListener("mousedown", onDown);
+    window.addEventListener("scroll", onScroll, true);
+    window.addEventListener("resize", close);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      window.removeEventListener("scroll", onScroll, true);
+      window.removeEventListener("resize", close);
+    };
+  }, [open, close]);
+
+  // Keep the selected row in view when the menu opens.
+  useLayoutEffect(() => {
+    if (!open) return;
+    menuRef.current
+      ?.querySelector('[aria-selected="true"]')
+      ?.scrollIntoView({ block: "nearest" });
+  }, [open]);
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (!open) {
+      if (["ArrowDown", "ArrowUp", "Enter", " "].includes(e.key)) {
+        e.preventDefault();
+        openMenu();
+      }
+      return;
+    }
+    switch (e.key) {
+      case "Escape":
+        e.preventDefault();
+        close();
+        break;
+      case "ArrowDown":
+        e.preventDefault();
+        setActive((i) => Math.min(options.length - 1, i + 1));
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setActive((i) => Math.max(0, i < 0 ? 0 : i - 1));
+        break;
+      case "Home":
+        e.preventDefault();
+        setActive(0);
+        break;
+      case "End":
+        e.preventDefault();
+        setActive(options.length - 1);
+        break;
+      case "Enter":
+      case " ":
+        e.preventDefault();
+        if (active >= 0 && options[active]) pick(options[active].value);
+        else close();
+        break;
+      case "Tab":
+        close();
+        break;
+    }
+  };
+
+  // Keyboard movement must keep the active row visible in a scrolled menu.
+  useEffect(() => {
+    if (!open || active < 0) return;
+    menuRef.current
+      ?.querySelector(`[data-index="${active}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [open, active]);
+
   return (
-    <button className={`select ${small ? "select--sm" : ""}`}>
-      {value}
-      <span className="select__chevron">
-        <Icon name="chevronUD" size={12} />
-      </span>
-    </button>
+    <>
+      <button
+        type="button"
+        ref={triggerRef}
+        className={`select ${small ? "select--sm" : ""} ${
+          open ? "select--open" : ""
+        } ${className ?? ""}`}
+        style={style}
+        disabled={disabled}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+        title={label ?? current?.label}
+        onClick={() => (open ? close() : openMenu())}
+        onKeyDown={onKeyDown}
+      >
+        <span className="select__label">
+          {label ?? current?.label ?? placeholder}
+        </span>
+        <span className="select__chevron">
+          <Icon name="chevronUD" size={12} />
+        </span>
+      </button>
+
+      {open &&
+        pos &&
+        createPortal(
+          <div
+            ref={menuRef}
+            className="menu dropdown__menu scroll"
+            role="listbox"
+            style={{
+              left: pos.left,
+              ...(pos.up
+                ? { bottom: window.innerHeight - pos.top }
+                : { top: pos.top }),
+              minWidth: pos.minWidth,
+              maxHeight: pos.maxHeight,
+            }}
+          >
+            {options.map((o, i) => (
+              <button
+                key={o.value}
+                type="button"
+                role="option"
+                data-index={i}
+                aria-selected={o.value === value}
+                className={`dropdown__item ${
+                  i === active ? "dropdown__item--active" : ""
+                }`}
+                onMouseEnter={() => setActive(i)}
+                onClick={() => pick(o.value)}
+              >
+                <span className="dropdown__check">
+                  {o.value === value && <Icon name="check" size={11} />}
+                </span>
+                <span className="truncate">{o.label}</span>
+              </button>
+            ))}
+          </div>,
+          document.body
+        )}
+    </>
   );
 }
 

--- a/desktop/src/lib/types.ts
+++ b/desktop/src/lib/types.ts
@@ -291,6 +291,56 @@ export interface ClaudeSessionSummary {
   unpriced_tokens?: number;
 }
 
+/** One content block of an assistant turn, normalized by the scanner. */
+export interface NormalizedBlock {
+  type: string; // "thinking" | "text" | "tool_use"
+  text?: string;
+  id?: string;
+  name?: string;
+  input?: unknown;
+}
+
+/** One conversation turn from a session transcript. */
+export interface ClaudeMessage {
+  uuid: string;
+  parent_uuid?: string;
+  type: string; // "user" | "assistant"
+  timestamp: string;
+  role?: string;
+  content?: string;
+  blocks?: NormalizedBlock[] | null;
+  usage?: TokenUsage | null;
+  git_branch?: string;
+  is_sidechain?: boolean;
+  children?: ClaudeMessage[] | null;
+}
+
+export interface ClaudeTodo {
+  content: string;
+  status: string; // "completed" | "in_progress" | "pending"
+  active_form?: string;
+}
+
+export interface ClaudeSubagent {
+  agent_id: string;
+  agent_type?: string;
+  description?: string;
+  tool_use_id?: string;
+  start_time: string;
+  last_activity: string;
+  message_count: number;
+  event_count: number;
+  usage: TokenUsage;
+  model?: string;
+}
+
+/** GET /api/claude-sessions/{id} — the summary plus the full transcript. */
+export interface ClaudeSessionDetail extends ClaudeSessionSummary {
+  messages: ClaudeMessage[] | null;
+  todos: ClaudeTodo[] | null;
+  subagents: ClaudeSubagent[] | null;
+}
+
 export interface SessionPage {
   items: ClaudeSessionSummary[];
   next_cursor: string;

--- a/desktop/src/styles/agents.css
+++ b/desktop/src/styles/agents.css
@@ -2,23 +2,10 @@
    Agents view — only what the shared sheets do not already cover.
    ========================================================================== */
 
-/* A real <select>: .select gives the chrome, the native control fills it so
-   the popup stays the platform's own. */
+/* Sizing for the shared Dropdown inside the form column. */
 .agents-select {
-  display: flex;
   width: 100%;
   max-width: 260px;
-}
-.agents-select--wide {
-  max-width: none;
-}
-.agents-select select {
-  flex: 1;
-  min-width: 0;
-  appearance: none;
-  -webkit-appearance: none;
-  font-size: inherit;
-  cursor: default;
 }
 
 /* --- Capability pickers --------------------------------------------------- */
@@ -95,7 +82,7 @@
   align-items: center;
   gap: var(--sp-4);
   padding: var(--sp-4) var(--sp-7);
-  border-top: 0.5px solid var(--line);
+  border-top: var(--hairline) solid var(--line);
   background: var(--bg-content);
   box-shadow: 0 -1px 3px rgba(0, 0, 0, 0.04);
 }
@@ -119,7 +106,7 @@
   align-items: center;
   gap: var(--sp-4);
   padding: var(--sp-4) var(--sp-7);
-  border-bottom: 0.5px solid var(--line);
+  border-bottom: var(--hairline) solid var(--line);
   background: var(--red-soft);
   font-size: var(--text-base);
 }

--- a/desktop/src/styles/analytics.css
+++ b/desktop/src/styles/analytics.css
@@ -8,24 +8,9 @@
 
 /* --- Toolbar controls ---------------------------------------------------- */
 
-/* A real <select> wearing the .select skin. The shared <Select> is decorative,
-   and the project filter has to actually change the request. */
+/* Project filter sizing — the control itself is the shared Dropdown. */
 .a-select {
-  appearance: none;
-  border: 0;
-  outline: 0;
-  font-family: inherit;
-  cursor: default;
   max-width: 220px;
-  text-overflow: ellipsis;
-}
-.a-select:focus-visible {
-  box-shadow: 0 0 0 0.5px var(--line-strong), var(--focus-ring);
-}
-/* The native control paints its own arrow, so the .select padding for the
-   decorative chevron would leave a gap. */
-.a-select.select--sm {
-  padding-right: var(--sp-6);
 }
 
 .a-date {
@@ -34,7 +19,7 @@
   background: var(--bg-raised);
   border: 0;
   border-radius: var(--r-md);
-  box-shadow: 0 0 0 0.5px var(--line-strong), var(--shadow-sm);
+  box-shadow: 0 0 0 var(--hairline) var(--line-strong), var(--shadow-sm);
   color: var(--fg);
   font-family: inherit;
   font-size: var(--text-sm);
@@ -42,7 +27,7 @@
 }
 .a-date:focus-visible {
   outline: 0;
-  box-shadow: 0 0 0 0.5px var(--line-strong), var(--focus-ring);
+  box-shadow: 0 0 0 var(--hairline) var(--line-strong), var(--focus-ring);
 }
 
 /* --- Dashboard grids ----------------------------------------------------- */
@@ -187,7 +172,7 @@
   padding: var(--sp-2) var(--sp-6);
 }
 .a-rank__row + .a-rank__row {
-  border-top: 0.5px solid var(--line-soft);
+  border-top: var(--hairline) solid var(--line-soft);
 }
 .a-rank__name {
   font-size: var(--text-sm);
@@ -225,7 +210,7 @@
   gap: var(--sp-2);
   padding: var(--sp-5);
   background: var(--bg-list);
-  border: 0.5px solid var(--line);
+  border: var(--hairline) solid var(--line);
   border-radius: var(--r-lg);
 }
 .a-insight__head {

--- a/desktop/src/styles/base.css
+++ b/desktop/src/styles/base.css
@@ -79,6 +79,15 @@ a {
   border-radius: var(--r-sm);
 }
 
+/* A wrapper that paints its own focus-within ring speaks for its control.
+   Text inputs match :focus-visible even on mouse focus, so without this the
+   global ring draws a second ring nested inside the wrapper's. */
+.field input:focus-visible,
+.search input:focus-visible,
+.composer__inner :focus-visible {
+  box-shadow: none;
+}
+
 /* --- Scrollbars: overlay style, appear on hover, never reserve layout ----- */
 .scroll {
   overflow-y: auto;

--- a/desktop/src/styles/chats.css
+++ b/desktop/src/styles/chats.css
@@ -67,7 +67,7 @@
 .toolcall__sep {
   margin: var(--sp-4) 0 var(--sp-3);
   padding-top: var(--sp-3);
-  border-top: 0.5px solid var(--line);
+  border-top: var(--hairline) solid var(--line);
   font-family: var(--font-ui);
   font-size: var(--text-xs);
   font-weight: var(--weight-semibold);
@@ -84,12 +84,12 @@
   padding: var(--sp-6);
   background: var(--bg-content);
   border-radius: var(--r-lg);
-  box-shadow: 0 0 0 1px var(--accent-soft), 0 0 0 0.5px var(--line-strong),
+  box-shadow: 0 0 0 1px var(--accent-soft), 0 0 0 var(--hairline) var(--line-strong),
     var(--shadow-sm);
 }
 
 .prompt--permission {
-  box-shadow: 0 0 0 1px var(--amber-soft), 0 0 0 0.5px var(--line-strong),
+  box-shadow: 0 0 0 1px var(--amber-soft), 0 0 0 var(--hairline) var(--line-strong),
     var(--shadow-sm);
 }
 
@@ -141,7 +141,7 @@
   padding: 0 var(--sp-5);
   border-radius: var(--r-full);
   background: var(--bg-inset);
-  box-shadow: inset 0 0 0 0.5px var(--line);
+  box-shadow: inset 0 0 0 var(--hairline) var(--line);
   font-size: var(--text-sm);
   color: var(--fg-secondary);
   transition: background var(--dur-fast), color var(--dur-fast);
@@ -163,7 +163,7 @@
   font-size: var(--text-base);
   line-height: var(--leading-normal);
   resize: none;
-  box-shadow: inset 0 0 0 0.5px var(--line);
+  box-shadow: inset 0 0 0 var(--hairline) var(--line);
 }
 .prompt__input:focus {
   box-shadow: inset 0 0 0 1px var(--accent);
@@ -196,7 +196,7 @@
   gap: var(--sp-4);
   padding: var(--sp-4) var(--sp-6);
   background: var(--bg-content);
-  border-bottom: 0.5px solid var(--line);
+  border-bottom: var(--hairline) solid var(--line);
 }
 
 .newchat__dir {
@@ -208,17 +208,6 @@
 .newchat__note {
   font-size: var(--text-sm);
   color: var(--red);
-}
-
-.selectwrap {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-}
-
-select.chatpick {
-  appearance: none;
-  font-family: inherit;
 }
 
 /* --- Toolbar title / rename ---------------------------------------------- */

--- a/desktop/src/styles/controls.css
+++ b/desktop/src/styles/controls.css
@@ -16,7 +16,7 @@
   font-weight: var(--weight-medium);
   color: var(--fg);
   background: var(--bg-raised);
-  box-shadow: 0 0 0 0.5px var(--line-strong), var(--shadow-sm);
+  box-shadow: 0 0 0 var(--hairline) var(--line-strong), var(--shadow-sm);
   white-space: nowrap;
   transition: background var(--dur-fast), box-shadow var(--dur-fast),
     transform var(--dur-fast);
@@ -36,7 +36,7 @@
 .btn--primary {
   background: var(--accent);
   color: var(--accent-fg);
-  box-shadow: 0 0 0 0.5px rgba(0, 0, 0, 0.13), var(--shadow-sm);
+  box-shadow: 0 0 0 var(--hairline) rgba(0, 0, 0, 0.13), var(--shadow-sm);
 }
 .btn--primary:hover {
   background: var(--accent-hover);
@@ -100,7 +100,7 @@
   padding: 2px;
   background: var(--bg-inset);
   border-radius: var(--r-md);
-  box-shadow: inset 0 0 0 0.5px var(--line-soft);
+  box-shadow: inset 0 0 0 var(--hairline) var(--line-soft);
   flex: none;
 }
 
@@ -123,7 +123,7 @@
 .segmented__item--active {
   background: var(--bg-raised);
   color: var(--fg);
-  box-shadow: var(--shadow-sm), 0 0 0 0.5px var(--line);
+  box-shadow: var(--shadow-sm), 0 0 0 var(--hairline) var(--line);
 }
 
 /* --- Text fields --------------------------------------------------------- */
@@ -135,7 +135,7 @@
   padding: 0 var(--sp-5);
   background: var(--bg-content);
   border-radius: var(--r-md);
-  box-shadow: inset 0 0 0 0.5px var(--line-strong);
+  box-shadow: inset 0 0 0 var(--hairline) var(--line-strong);
   transition: box-shadow var(--dur-fast);
 }
 .field:focus-within {
@@ -167,7 +167,7 @@
   padding: 0 var(--sp-4);
   background: var(--bg-inset);
   border-radius: var(--r-md);
-  box-shadow: inset 0 0 0 0.5px var(--line-soft);
+  box-shadow: inset 0 0 0 var(--hairline) var(--line-soft);
   color: var(--fg-tertiary);
   transition: box-shadow var(--dur-fast), background var(--dur-fast);
 }
@@ -190,7 +190,7 @@ textarea.field-area {
   padding: var(--sp-5);
   background: var(--bg-content);
   border-radius: var(--r-md);
-  box-shadow: inset 0 0 0 0.5px var(--line-strong);
+  box-shadow: inset 0 0 0 var(--hairline) var(--line-strong);
   font-size: var(--text-base);
   line-height: var(--leading-normal);
   resize: none;
@@ -209,7 +209,7 @@ textarea.field-area:focus {
   padding: 0 var(--sp-8) 0 var(--sp-5);
   background: var(--bg-raised);
   border-radius: var(--r-md);
-  box-shadow: 0 0 0 0.5px var(--line-strong), var(--shadow-sm);
+  box-shadow: 0 0 0 var(--hairline) var(--line-strong), var(--shadow-sm);
   font-size: var(--text-base);
   color: var(--fg);
   transition: background var(--dur-fast);
@@ -233,9 +233,59 @@ textarea.field-area:focus {
 .select--sm .select__chevron {
   right: var(--sp-3);
 }
+.select--open {
+  background: var(--bg-hover);
+}
+.select:disabled {
+  opacity: 0.45;
+  pointer-events: none;
+}
+.select__label {
+  flex: 1;
+  min-width: 0;
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* The dropdown's menu — a portal to <body>, so no pane can clip it. It wears
+   .menu for the surface and adds fixed positioning plus its own rows. */
+.dropdown__menu {
+  position: fixed;
+  z-index: 300;
+  max-width: 440px;
+  overflow-y: auto;
+}
+.dropdown__item {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  width: 100%;
+  min-height: var(--row-h);
+  padding: 0 var(--sp-4) 0 var(--sp-2);
+  border-radius: var(--r-sm);
+  font-size: var(--text-base);
+  color: var(--fg);
+  text-align: left;
+}
+.dropdown__item--active {
+  background: var(--accent);
+  color: var(--accent-fg);
+}
+.dropdown__check {
+  width: 16px;
+  flex: none;
+  display: grid;
+  place-items: center;
+}
 
 /* --- Switch -------------------------------------------------------------- */
 .switch {
+  /* Flex, not the button default: the knob is a <span>, and an inline span
+     ignores its width/height — the switch rendered as a bare pill without it. */
+  display: inline-flex;
+  align-items: center;
   width: 34px;
   height: 20px;
   border-radius: var(--r-full);
@@ -248,6 +298,7 @@ textarea.field-area:focus {
   background: var(--green);
 }
 .switch__knob {
+  display: block;
   width: 16px;
   height: 16px;
   border-radius: var(--r-full);
@@ -330,7 +381,7 @@ textarea.field-area:focus {
   padding: 0 var(--sp-3);
   border-radius: var(--r-sm);
   background: var(--bg-inset);
-  box-shadow: inset 0 0 0 0.5px var(--line);
+  box-shadow: inset 0 0 0 var(--hairline) var(--line);
   font-family: var(--font-ui);
   font-size: var(--text-xs);
   font-weight: var(--weight-medium);
@@ -389,7 +440,7 @@ textarea.field-area:focus {
   color: var(--fg-tertiary);
 }
 .menu__sep {
-  height: 0.5px;
+  height: var(--hairline);
   background: var(--line);
   margin: var(--sp-2) var(--sp-4);
 }

--- a/desktop/src/styles/integrations.css
+++ b/desktop/src/styles/integrations.css
@@ -18,13 +18,13 @@
   padding: var(--sp-5);
   border-radius: var(--r-lg);
   background: var(--bg-list);
-  box-shadow: inset 0 0 0 0.5px var(--line);
+  box-shadow: inset 0 0 0 var(--hairline) var(--line);
   text-align: left;
   transition: background var(--dur-fast), box-shadow var(--dur-fast);
 }
 .provcard:hover {
   background: var(--bg-hover);
-  box-shadow: inset 0 0 0 0.5px var(--line-strong);
+  box-shadow: inset 0 0 0 var(--hairline) var(--line-strong);
 }
 .provcard__body {
   min-width: 0;
@@ -49,7 +49,7 @@
 .svcblock {
   border-radius: var(--r-lg);
   background: var(--bg-list);
-  box-shadow: inset 0 0 0 0.5px var(--line);
+  box-shadow: inset 0 0 0 var(--hairline) var(--line);
   overflow: hidden;
 }
 .svcblock + .svcblock {
@@ -73,7 +73,7 @@
   color: var(--fg-tertiary);
 }
 .svcblock__tools {
-  border-top: 0.5px solid var(--line);
+  border-top: var(--hairline) solid var(--line);
   padding: var(--sp-4) var(--sp-6) var(--sp-5);
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
@@ -136,7 +136,7 @@
   padding: var(--sp-5) var(--sp-6);
 }
 .rulerow + .rulerow {
-  border-top: 0.5px solid var(--line);
+  border-top: var(--hairline) solid var(--line);
 }
 .rulerow__body {
   flex: 1;
@@ -154,34 +154,6 @@
 }
 
 /* --- Shared bits --------------------------------------------------------- */
-
-.nselect {
-  height: var(--control-h-lg);
-  padding: 0 var(--sp-4);
-  background: var(--bg-raised);
-  border-radius: var(--r-md);
-  box-shadow: 0 0 0 0.5px var(--line-strong), var(--shadow-sm);
-  font-size: var(--text-base);
-  font-family: inherit;
-  color: var(--fg);
-  min-width: 0;
-  transition: background var(--dur-fast), box-shadow var(--dur-fast);
-}
-.nselect:hover {
-  background: var(--bg-hover);
-}
-.nselect:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 1px var(--accent), 0 0 0 3px var(--accent-soft);
-}
-.nselect:disabled {
-  opacity: 0.45;
-  pointer-events: none;
-}
-.nselect--sm {
-  height: var(--control-h);
-  font-size: var(--text-sm);
-}
 
 .msgline {
   display: flex;
@@ -235,7 +207,7 @@
   padding: var(--sp-4) var(--sp-6);
   border-radius: var(--r-lg);
   background: var(--bg-raised);
-  box-shadow: 0 0 0 0.5px var(--line-strong), var(--shadow-md);
+  box-shadow: 0 0 0 var(--hairline) var(--line-strong), var(--shadow-md);
 }
 .savebar__text {
   flex: 1;

--- a/desktop/src/styles/sessions.css
+++ b/desktop/src/styles/sessions.css
@@ -4,28 +4,61 @@
    shared sheets.
    ========================================================================== */
 
-/* A real <select> laid invisibly over the shared .select shell, so the menu is
-   the OS one while the control keeps the app's chrome. */
+/* Toolbar dropdown sizing — the control itself is the shared Dropdown. */
 .sess-select {
-  position: relative;
   max-width: 230px;
 }
-.sess-select__value {
-  display: block;
-  max-width: 190px;
-  overflow: hidden;
-  text-overflow: ellipsis;
+
+/* --- Session detail (read-only transcript) -------------------------------- */
+.sess-detail__meta {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-7);
+  min-width: 0;
+  padding: var(--sp-3) var(--sp-7);
+  border-bottom: var(--hairline) solid var(--line);
+  font-size: var(--text-sm);
+  color: var(--fg-secondary);
   white-space: nowrap;
 }
-.sess-select__native {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  opacity: 0;
-  appearance: none;
-  -webkit-appearance: none;
-  cursor: default;
+.sess-detail__meta > * {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+.sess-detail__meta > .mono {
+  flex: 0 1 auto;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sess-todos {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+  font-family: var(--font-ui);
+  white-space: normal;
+}
+.sess-todo {
+  display: flex;
+  align-items: baseline;
+  gap: var(--sp-4);
+}
+.sess-todo > svg {
+  flex: none;
+  align-self: center;
+}
+.sess-todo--completed {
+  color: var(--fg-tertiary);
+}
+.sess-todo--completed > svg {
+  color: var(--green);
+}
+.sess-todo--in_progress {
+  color: var(--fg);
 }
 
 /* --- Table cells --------------------------------------------------------- */
@@ -106,7 +139,7 @@
   background: var(--red-soft);
   color: var(--red);
   font-size: var(--text-sm);
-  border-top: 0.5px solid var(--line);
+  border-top: var(--hairline) solid var(--line);
 }
 .sess-err__msg {
   overflow: hidden;

--- a/desktop/src/styles/settings.css
+++ b/desktop/src/styles/settings.css
@@ -38,40 +38,10 @@
 
 /* --- Native select ------------------------------------------------------- */
 
-/* A real <select> is used wherever the value is bound; ui.tsx's Select is a
-   display-only button. The chevron is the native one, so no overlay is drawn. */
-.nselect {
-  height: var(--control-h-lg);
-  padding: 0 var(--sp-4);
-  background: var(--bg-raised);
-  border-radius: var(--r-md);
-  box-shadow: 0 0 0 0.5px var(--line-strong), var(--shadow-sm);
-  font-size: var(--text-base);
-  font-family: inherit;
-  color: var(--fg);
-  min-width: 0;
-  transition: background var(--dur-fast), box-shadow var(--dur-fast);
-}
-.nselect:hover {
-  background: var(--bg-hover);
-}
-.nselect:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 1px var(--accent), 0 0 0 3px var(--accent-soft);
-}
-.nselect:disabled {
-  opacity: 0.45;
-  pointer-events: none;
-}
-.nselect--sm {
-  height: var(--control-h);
-  font-size: var(--text-sm);
-}
-
 /* A disabled .field reads as read-only rather than broken. */
 .field--locked {
   background: var(--bg-inset);
-  box-shadow: inset 0 0 0 0.5px var(--line);
+  box-shadow: inset 0 0 0 var(--hairline) var(--line);
 }
 .field--locked input {
   color: var(--fg-tertiary);
@@ -92,7 +62,7 @@
   padding: var(--sp-4) var(--sp-6);
   border-radius: var(--r-lg);
   background: var(--bg-raised);
-  box-shadow: 0 0 0 0.5px var(--line-strong), var(--shadow-md);
+  box-shadow: 0 0 0 var(--hairline) var(--line-strong), var(--shadow-md);
 }
 .savebar__text {
   flex: 1;
@@ -145,7 +115,7 @@
   padding: 0 var(--sp-3) 0 var(--sp-4);
   border-radius: var(--r-md);
   background: var(--bg-inset);
-  box-shadow: inset 0 0 0 0.5px var(--line);
+  box-shadow: inset 0 0 0 var(--hairline) var(--line);
   font-size: var(--text-sm);
   max-width: 100%;
 }
@@ -185,7 +155,7 @@
   flex-direction: column;
   background: var(--bg-raised);
   border-radius: var(--r-xl);
-  box-shadow: var(--shadow-lg), 0 0 0 0.5px var(--line-strong);
+  box-shadow: var(--shadow-lg), 0 0 0 var(--hairline) var(--line-strong);
   overflow: hidden;
   animation: browser-in var(--dur-med) var(--ease-out);
 }
@@ -200,7 +170,7 @@
   align-items: center;
   gap: var(--sp-3);
   padding: var(--sp-4) var(--sp-5);
-  border-bottom: 0.5px solid var(--line);
+  border-bottom: var(--hairline) solid var(--line);
 }
 .browser__path {
   flex: 1;
@@ -247,7 +217,7 @@
   align-items: center;
   gap: var(--sp-3);
   padding: var(--sp-4) var(--sp-5);
-  border-top: 0.5px solid var(--line);
+  border-top: var(--hairline) solid var(--line);
 }
 
 /* --- Inline confirm ------------------------------------------------------ */
@@ -279,12 +249,12 @@
   font-weight: var(--weight-medium);
   color: var(--fg-tertiary);
   padding: var(--sp-3) var(--sp-4);
-  border-bottom: 0.5px solid var(--line);
+  border-bottom: var(--hairline) solid var(--line);
   white-space: nowrap;
 }
 .kvtable td {
   padding: var(--sp-3) var(--sp-4);
-  border-bottom: 0.5px solid var(--line-soft);
+  border-bottom: var(--hairline) solid var(--line-soft);
   vertical-align: top;
 }
 .kvtable tbody tr:hover {
@@ -308,7 +278,7 @@
   padding: var(--sp-5);
   border-radius: var(--r-lg);
   background: var(--bg-list);
-  box-shadow: inset 0 0 0 0.5px var(--line);
+  box-shadow: inset 0 0 0 var(--hairline) var(--line);
   text-align: left;
 }
 .provcard:hover {
@@ -323,7 +293,7 @@
 .svcblock {
   border-radius: var(--r-lg);
   background: var(--bg-list);
-  box-shadow: inset 0 0 0 0.5px var(--line);
+  box-shadow: inset 0 0 0 var(--hairline) var(--line);
   overflow: hidden;
 }
 .svcblock__head {
@@ -333,7 +303,7 @@
   padding: var(--sp-5) var(--sp-6);
 }
 .svcblock__tools {
-  border-top: 0.5px solid var(--line);
+  border-top: var(--hairline) solid var(--line);
   padding: var(--sp-4) var(--sp-6) var(--sp-5);
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));

--- a/desktop/src/styles/shell.css
+++ b/desktop/src/styles/shell.css
@@ -197,8 +197,8 @@
   flex-direction: column;
   background: var(--bg-content);
   border-top-left-radius: var(--r-lg);
-  border-left: 0.5px solid var(--line);
-  border-top: 0.5px solid var(--line);
+  border-left: var(--hairline) solid var(--line);
+  border-top: var(--hairline) solid var(--line);
   overflow: hidden;
   box-shadow: -1px -1px 3px rgba(0, 0, 0, 0.03);
 }
@@ -211,7 +211,7 @@
   align-items: center;
   gap: var(--sp-3);
   padding: 0 var(--sp-5);
-  border-bottom: 0.5px solid var(--line);
+  border-bottom: var(--hairline) solid var(--line);
   background: var(--bg-content);
 }
 
@@ -229,7 +229,7 @@
 }
 
 .toolbar__sep {
-  width: 0.5px;
+  width: var(--hairline);
   height: 16px;
   background: var(--line-strong);
   margin: 0 var(--sp-2);
@@ -248,7 +248,7 @@
   display: flex;
   flex-direction: column;
   background: var(--bg-list);
-  border-right: 0.5px solid var(--line);
+  border-right: var(--hairline) solid var(--line);
   min-height: 0;
 }
 
@@ -267,7 +267,7 @@
   display: flex;
   flex-direction: column;
   background: var(--bg-list);
-  border-left: 0.5px solid var(--line);
+  border-left: var(--hairline) solid var(--line);
   min-height: 0;
   overflow: hidden;
 }
@@ -300,7 +300,7 @@
   gap: var(--sp-5);
   padding: 0 var(--sp-5);
   background: var(--bg-window);
-  border-top: 0.5px solid var(--line);
+  border-top: var(--hairline) solid var(--line);
   font-size: var(--text-sm);
   color: var(--fg-tertiary);
   user-select: none;

--- a/desktop/src/styles/tasks.css
+++ b/desktop/src/styles/tasks.css
@@ -4,44 +4,6 @@
    affordances. Everything else reuses the existing classes.
    ========================================================================== */
 
-/* --- Native select, dressed as the app's .select -------------------------- */
-.selectwrap {
-  position: relative;
-  display: flex;
-  align-items: center;
-  min-width: 0;
-}
-
-.selectfield {
-  appearance: none;
-  -webkit-appearance: none;
-  width: 100%;
-  height: var(--control-h-lg);
-  padding: 0 var(--sp-8) 0 var(--sp-5);
-  border-radius: var(--r-md);
-  background: var(--bg-raised);
-  box-shadow: 0 0 0 0.5px var(--line-strong), var(--shadow-sm);
-  font-size: var(--text-base);
-  color: var(--fg);
-  cursor: default;
-  transition: background var(--dur-fast), box-shadow var(--dur-fast);
-}
-.selectfield:hover {
-  background: var(--bg-hover);
-}
-.selectfield:focus-visible {
-  box-shadow: var(--focus-ring);
-}
-
-.selectwrap--sm .selectfield {
-  height: var(--control-h);
-  padding-left: var(--sp-4);
-  font-size: var(--text-sm);
-}
-.selectwrap--sm .select__chevron {
-  right: var(--sp-3);
-}
-
 /* --- Field sizing for the schedule editor -------------------------------- */
 .inline {
   display: flex;

--- a/desktop/src/styles/tokens.css
+++ b/desktop/src/styles/tokens.css
@@ -67,6 +67,19 @@
   --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
   --dur-fast: 90ms;
   --dur-med: 160ms;
+
+  /* --- Hairline width ----------------------------------------------------- */
+  /* A 0.5px line only rasterizes on displays that have a physical half pixel.
+     On 1x screens (most Linux and Windows monitors) WebKit and WebView2 round
+     it away edge by edge, which is why every field looked borderless there —
+     so the hairline is 1 CSS px at 1x and a true half pixel on 2x+ displays. */
+  --hairline: 1px;
+}
+
+@media (min-resolution: 1.5dppx) {
+  :root {
+    --hairline: 0.5px;
+  }
 }
 
 /* ============================================================================
@@ -121,9 +134,9 @@
 
   /* Elevation — desktop shadows are tight and low-opacity */
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.07);
-  --shadow-md: 0 2px 6px rgba(0, 0, 0, 0.09), 0 0 0 0.5px rgba(0, 0, 0, 0.06);
-  --shadow-lg: 0 10px 32px rgba(0, 0, 0, 0.16), 0 0 0 0.5px rgba(0, 0, 0, 0.08);
-  --shadow-pane: 0 0 0 0.5px rgba(0, 0, 0, 0.09), 0 1px 3px rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 2px 6px rgba(0, 0, 0, 0.09), 0 0 0 var(--hairline) rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 10px 32px rgba(0, 0, 0, 0.16), 0 0 0 var(--hairline) rgba(0, 0, 0, 0.08);
+  --shadow-pane: 0 0 0 var(--hairline) rgba(0, 0, 0, 0.09), 0 1px 3px rgba(0, 0, 0, 0.05);
 
   --focus-ring: 0 0 0 3px var(--accent-soft), 0 0 0 1px var(--accent);
   color-scheme: light;
@@ -175,9 +188,9 @@
     --teal-soft: rgba(62, 192, 212, 0.16);
 
     --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 2px 8px rgba(0, 0, 0, 0.45), 0 0 0 0.5px rgba(255, 255, 255, 0.07);
-    --shadow-lg: 0 12px 36px rgba(0, 0, 0, 0.6), 0 0 0 0.5px rgba(255, 255, 255, 0.09);
-    --shadow-pane: 0 0 0 0.5px rgba(255, 255, 255, 0.07), 0 1px 3px rgba(0, 0, 0, 0.3);
+    --shadow-md: 0 2px 8px rgba(0, 0, 0, 0.45), 0 0 0 var(--hairline) rgba(255, 255, 255, 0.07);
+    --shadow-lg: 0 12px 36px rgba(0, 0, 0, 0.6), 0 0 0 var(--hairline) rgba(255, 255, 255, 0.09);
+    --shadow-pane: 0 0 0 var(--hairline) rgba(255, 255, 255, 0.07), 0 1px 3px rgba(0, 0, 0, 0.3);
 
     color-scheme: dark;
   }
@@ -225,9 +238,9 @@
   --teal-soft: rgba(62, 192, 212, 0.16);
 
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-  --shadow-md: 0 2px 8px rgba(0, 0, 0, 0.45), 0 0 0 0.5px rgba(255, 255, 255, 0.07);
-  --shadow-lg: 0 12px 36px rgba(0, 0, 0, 0.6), 0 0 0 0.5px rgba(255, 255, 255, 0.09);
-  --shadow-pane: 0 0 0 0.5px rgba(255, 255, 255, 0.07), 0 1px 3px rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 2px 8px rgba(0, 0, 0, 0.45), 0 0 0 var(--hairline) rgba(255, 255, 255, 0.07);
+  --shadow-lg: 0 12px 36px rgba(0, 0, 0, 0.6), 0 0 0 var(--hairline) rgba(255, 255, 255, 0.09);
+  --shadow-pane: 0 0 0 var(--hairline) rgba(255, 255, 255, 0.07), 0 1px 3px rgba(0, 0, 0, 0.3);
 
   color-scheme: dark;
 }

--- a/desktop/src/styles/views.css
+++ b/desktop/src/styles/views.css
@@ -9,7 +9,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--sp-4);
-  border-bottom: 0.5px solid var(--line);
+  border-bottom: var(--hairline) solid var(--line);
 }
 
 .listhead__row {
@@ -255,7 +255,7 @@
 
 /* Tool call — a disclosure strip, the way a dev tool shows work. */
 .toolcall {
-  border: 0.5px solid var(--line);
+  border: var(--hairline) solid var(--line);
   border-radius: var(--r-md);
   background: var(--bg-inset);
   overflow: hidden;
@@ -285,7 +285,7 @@
 
 .toolcall__body {
   padding: var(--sp-5);
-  border-top: 0.5px solid var(--line);
+  border-top: var(--hairline) solid var(--line);
   font-family: var(--font-mono);
   font-size: var(--text-sm);
   line-height: var(--leading-normal);
@@ -310,7 +310,7 @@
   flex: none;
   padding: var(--sp-5) var(--sp-9) var(--sp-6);
   background: var(--bg-content);
-  border-top: 0.5px solid var(--line);
+  border-top: var(--hairline) solid var(--line);
 }
 
 .composer__inner {
@@ -318,7 +318,7 @@
   margin: 0 auto;
   background: var(--bg-content);
   border-radius: var(--r-xl);
-  box-shadow: 0 0 0 0.5px var(--line-strong), var(--shadow-sm);
+  box-shadow: 0 0 0 var(--hairline) var(--line-strong), var(--shadow-sm);
   transition: box-shadow var(--dur-fast);
 }
 .composer__inner:focus-within {
@@ -394,7 +394,7 @@
   color: var(--fg-tertiary);
   padding: var(--sp-3) var(--sp-5);
   height: 26px;
-  border-bottom: 0.5px solid var(--line);
+  border-bottom: var(--hairline) solid var(--line);
   white-space: nowrap;
   user-select: none;
 }
@@ -438,7 +438,7 @@
 
 .table tbody td {
   padding: var(--sp-2) var(--sp-5);
-  border-bottom: 0.5px solid var(--line-soft);
+  border-bottom: var(--hairline) solid var(--line-soft);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -503,7 +503,7 @@
 .tile {
   padding: var(--sp-6);
   background: var(--bg-list);
-  border: 0.5px solid var(--line);
+  border: var(--hairline) solid var(--line);
   border-radius: var(--r-lg);
   display: flex;
   flex-direction: column;
@@ -541,7 +541,7 @@
 
 .card {
   background: var(--bg-list);
-  border: 0.5px solid var(--line);
+  border: var(--hairline) solid var(--line);
   border-radius: var(--r-lg);
   overflow: hidden;
   display: flex;
@@ -553,7 +553,7 @@
   align-items: center;
   gap: var(--sp-4);
   padding: var(--sp-5) var(--sp-6);
-  border-bottom: 0.5px solid var(--line);
+  border-bottom: var(--hairline) solid var(--line);
 }
 
 .card__title {
@@ -618,7 +618,7 @@
   display: flex;
   align-items: center;
   padding: 0 var(--sp-5);
-  border-bottom: 0.5px solid var(--line);
+  border-bottom: var(--hairline) solid var(--line);
   font-size: var(--text-xs);
   font-weight: var(--weight-semibold);
   letter-spacing: 0.07em;
@@ -722,14 +722,14 @@
 }
 
 .divider {
-  height: 0.5px;
+  height: var(--hairline);
   background: var(--line);
 }
 
 /* Grouped inset list — the modern settings idiom. */
 .grouplist {
   background: var(--bg-list);
-  border: 0.5px solid var(--line);
+  border: var(--hairline) solid var(--line);
   border-radius: var(--r-lg);
   overflow: hidden;
 }
@@ -742,7 +742,7 @@
   text-align: left;
 }
 .grouplist__row + .grouplist__row {
-  border-top: 0.5px solid var(--line);
+  border-top: var(--hairline) solid var(--line);
 }
 .grouplist__row--button:hover {
   background: var(--bg-hover);
@@ -826,7 +826,7 @@
   align-items: center;
   gap: var(--sp-5);
   padding: 0 var(--sp-6);
-  border-bottom: 0.5px solid var(--line);
+  border-bottom: var(--hairline) solid var(--line);
 }
 .palette__input input {
   flex: 1;
@@ -877,7 +877,7 @@
   gap: var(--sp-4);
   padding: var(--sp-3) var(--sp-5);
   background: var(--amber-soft);
-  border-bottom: 0.5px solid var(--line);
+  border-bottom: var(--hairline) solid var(--line);
   font-size: var(--text-base);
   color: var(--fg);
   flex: none;

--- a/desktop/src/views/AgentsView.tsx
+++ b/desktop/src/views/AgentsView.tsx
@@ -11,6 +11,7 @@ import type {
 } from "../lib/types";
 import {
   Checkbox,
+  Dropdown,
   Empty,
   FormRow,
   InspGroup,
@@ -795,18 +796,12 @@ function Picker({
   onChange(v: string): void;
 }) {
   return (
-    <div className="select agents-select">
-      <select value={value} onChange={(e) => onChange(e.target.value)}>
-        {options.map((o) => (
-          <option key={o.value} value={o.value}>
-            {o.label}
-          </option>
-        ))}
-      </select>
-      <span className="select__chevron">
-        <Icon name="chevronUD" size={12} />
-      </span>
-    </div>
+    <Dropdown
+      value={value}
+      options={options}
+      onChange={onChange}
+      className="agents-select"
+    />
   );
 }
 

--- a/desktop/src/views/AnalyticsView.tsx
+++ b/desktop/src/views/AnalyticsView.tsx
@@ -8,7 +8,14 @@ import type {
   ClaudeProject,
   InsightsSummary,
 } from "../lib/types";
-import { Empty, InspGroup, InspRow, Segmented, Splitter } from "../components/ui";
+import {
+  Dropdown,
+  Empty,
+  InspGroup,
+  InspRow,
+  Segmented,
+  Splitter,
+} from "../components/ui";
 import {
   RANGE_OPTIONS,
   TZ,
@@ -266,20 +273,21 @@ function ProjectFilter({
   );
 
   return (
-    <select
-      className="select select--sm a-select"
+    <Dropdown
+      small
+      className="a-select"
       value={value}
-      onChange={(e) => onChange(e.target.value)}
-      aria-label="Project filter"
-      title={value ? projectLabel(value) : "All projects"}
-    >
-      <option value="">All projects</option>
-      {visible.map((p) => (
-        <option key={p.encoded_name} value={p.decoded_path}>
-          {projectLabel(p.decoded_path)} ({p.session_count})
-        </option>
-      ))}
-    </select>
+      onChange={onChange}
+      ariaLabel="Project filter"
+      label={value ? projectLabel(value) : "All projects"}
+      options={[
+        { value: "", label: "All projects" },
+        ...visible.map((p) => ({
+          value: p.decoded_path,
+          label: `${projectLabel(p.decoded_path)} (${p.session_count})`,
+        })),
+      ]}
+    />
   );
 }
 

--- a/desktop/src/views/ChatsView.tsx
+++ b/desktop/src/views/ChatsView.tsx
@@ -14,6 +14,7 @@ import {
 import { Icon } from "../lib/icons";
 import type { Agent, ChatDetail, ChatMessage, ChatSession } from "../lib/types";
 import {
+  Dropdown,
   Empty,
   InspGroup,
   InspRow,
@@ -42,7 +43,13 @@ async function fetchDetail(id: string, signal: AbortSignal): Promise<ChatDetail>
   return { ...session, messages: raw.messages ?? [] };
 }
 
-export function ChatsView({ inspectorOpen }: { inspectorOpen: boolean }) {
+export function ChatsView({
+  inspectorOpen,
+  newChatNonce = 0,
+}: {
+  inspectorOpen: boolean;
+  newChatNonce?: number;
+}) {
   const chats = useResource<ChatSession[]>(
     (signal) => api.get<ChatSession[]>("/chats", signal),
     []
@@ -167,12 +174,27 @@ export function ChatsView({ inspectorOpen }: { inspectorOpen: boolean }) {
     autoSelected.current = true;
   }, []);
 
+  // The sidebar button, the native menu and ⌘N all land here: App bumps the
+  // nonce, and the view answers by opening a draft. 0 is "never asked".
+  const seenNonce = useRef(0);
+  useEffect(() => {
+    if (newChatNonce === seenNonce.current) return;
+    seenNonce.current = newChatNonce;
+    startNew();
+  }, [newChatNonce, startNew]);
+
   const send = useCallback(async () => {
     const content = draft.trim();
     if (!content || busy) return;
 
     let id = selected;
     if (!id) {
+      // An agent run without a working directory lands in whatever directory
+      // the server happened to start in — refuse to create the chat instead.
+      if (!newDir.trim()) {
+        setActionError("Set a working directory before starting the chat.");
+        return;
+      }
       try {
         const created = await api.post<ChatSession>("/chats", {
           agent_slug: newAgent,
@@ -363,23 +385,19 @@ export function ChatsView({ inspectorOpen }: { inspectorOpen: boolean }) {
             </div>
 
             <div className="newchat">
-              <span className="selectwrap">
-                <select
-                  className="select select--sm chatpick"
-                  value={newAgent}
-                  onChange={(e) => setNewAgent(e.target.value)}
-                >
-                  <option value="">No agent — direct chat</option>
-                  {(agents.data ?? []).map((a) => (
-                    <option key={a.slug} value={a.slug}>
-                      {a.name || a.slug}
-                    </option>
-                  ))}
-                </select>
-                <span className="select__chevron">
-                  <Icon name="chevronUD" size={12} />
-                </span>
-              </span>
+              <Dropdown
+                small
+                value={newAgent}
+                onChange={setNewAgent}
+                ariaLabel="Agent"
+                options={[
+                  { value: "", label: "No agent — direct chat" },
+                  ...(agents.data ?? []).map((a) => ({
+                    value: a.slug,
+                    label: a.name || a.slug,
+                  })),
+                ]}
+              />
 
               <label className="field field--sm newchat__dir">
                 <span className="field__icon">
@@ -388,7 +406,7 @@ export function ChatsView({ inspectorOpen }: { inspectorOpen: boolean }) {
                 <input
                   value={newDir}
                   onChange={(e) => setNewDir(e.target.value)}
-                  placeholder="Working directory (optional)"
+                  placeholder="Working directory (required)"
                   spellCheck={false}
                 />
               </label>
@@ -403,7 +421,7 @@ export function ChatsView({ inspectorOpen }: { inspectorOpen: boolean }) {
               <Empty
                 icon="sparkle"
                 title="Start the conversation"
-                text="Pick an agent and working directory, then send the first message. The chat is created when you send."
+                text="Pick an agent and a working directory, then send the first message. The chat is created when you send — a working directory is required."
               />
             </div>
 

--- a/desktop/src/views/IntegrationsView.tsx
+++ b/desktop/src/views/IntegrationsView.tsx
@@ -6,6 +6,7 @@ import { Icon } from "../lib/icons";
 import { IS_TAURI } from "../lib/tauri";
 import {
   Checkbox,
+  Dropdown,
   Empty,
   InspGroup,
   InspRow,
@@ -1220,18 +1221,16 @@ function RuleForm({
           />
         </label>
         {agents.length > 0 ? (
-          <select
-            className="nselect nselect--sm"
+          <Dropdown
+            small
             value={draft.agent_slug}
-            onChange={(e) => onChange({ ...draft, agent_slug: e.target.value })}
-          >
-            <option value="">Choose an agent…</option>
-            {agents.map((a) => (
-              <option key={a.slug} value={a.slug}>
-                {a.name}
-              </option>
-            ))}
-          </select>
+            onChange={(v) => onChange({ ...draft, agent_slug: v })}
+            placeholder="Choose an agent…"
+            options={[
+              { value: "", label: "Choose an agent…" },
+              ...agents.map((a) => ({ value: a.slug, label: a.name })),
+            ]}
+          />
         ) : (
           <label className="field field--sm" style={{ flex: 1 }}>
             <input

--- a/desktop/src/views/SessionsView.tsx
+++ b/desktop/src/views/SessionsView.tsx
@@ -345,6 +345,25 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
     );
   }, [openId, items, lastSelected]);
 
+  // Single click selects, and the transcript opens on an explicit action:
+  // double-click, the inspector's "View session", or Enter. Rows never take
+  // focus, so Enter is only claimed while nothing focusable holds it — a
+  // focused button or the search field keeps its own Enter.
+  useEffect(() => {
+    if (openId) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Enter" || e.metaKey || e.ctrlKey || e.altKey || e.shiftKey)
+        return;
+      const active = document.activeElement;
+      if (active && active !== document.body) return;
+      if (!selectedId) return;
+      e.preventDefault();
+      setOpenId(selectedId);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [openId, selectedId]);
+
   // A native list always has a selection: take the first row whenever the
   // current one is not among the loaded rows.
   useEffect(() => {
@@ -645,7 +664,8 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
                           className={
                             s.session_id === selectedId ? "is-selected" : ""
                           }
-                          onClick={() => {
+                          onClick={() => select(s)}
+                          onDoubleClick={() => {
                             select(s);
                             setOpenId(s.session_id);
                           }}
@@ -776,6 +796,7 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
                   busy={busy}
                   error={actionError}
                   continuedChat={continuedChat}
+                  onOpen={(s) => setOpenId(s.session_id)}
                   onToggleFavorite={toggleFavorite}
                   onContinue={continueInChat}
                 />
@@ -797,6 +818,7 @@ function Inspector({
   busy,
   error,
   continuedChat,
+  onOpen,
   onToggleFavorite,
   onContinue,
 }: {
@@ -804,6 +826,7 @@ function Inspector({
   busy: "favorite" | "continue" | undefined;
   error: string | undefined;
   continuedChat: string | undefined;
+  onOpen(s: ClaudeSessionSummary): void;
   onToggleFavorite(s: ClaudeSessionSummary): void;
   onContinue(s: ClaudeSessionSummary): void;
 }) {
@@ -989,6 +1012,10 @@ function Inspector({
 
       <InspGroup title="Actions">
         <div className="sess-actions">
+          <button className="btn btn--primary" onClick={() => onOpen(session)}>
+            <Icon name="chat" size={13} />
+            View session
+          </button>
           <button
             className="btn"
             disabled={busy !== undefined}

--- a/desktop/src/views/SessionsView.tsx
+++ b/desktop/src/views/SessionsView.tsx
@@ -28,7 +28,15 @@ import {
   usd,
 } from "../lib/format";
 import { Icon } from "../lib/icons";
-import { Empty, InspGroup, InspRow, Search, Splitter } from "../components/ui";
+import {
+  Dropdown,
+  Empty,
+  InspGroup,
+  InspRow,
+  Search,
+  Splitter,
+} from "../components/ui";
+import { SessionDetail } from "./sessions/SessionDetail";
 import "../styles/sessions.css";
 
 /**
@@ -314,6 +322,8 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
 
   const [selectedId, setSelectedId] = useState<string>();
   const [lastSelected, setLastSelected] = useState<ClaudeSessionSummary>();
+  /** Session whose transcript fills the pane; unset shows the table. */
+  const [openId, setOpenId] = useState<string>();
 
   // Prefer the row in the current page set so favourite toggles show through;
   // fall back to the last selection while a reload has emptied the table.
@@ -326,6 +336,14 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
     setSelectedId(s.session_id);
     setLastSelected(s);
   }, []);
+
+  const openSession = useMemo(() => {
+    if (!openId) return undefined;
+    return (
+      items.find((s) => s.session_id === openId) ??
+      (lastSelected?.session_id === openId ? lastSelected : undefined)
+    );
+  }, [openId, items, lastSelected]);
 
   // A native list always has a selection: take the first row whenever the
   // current one is not among the loaded rows.
@@ -440,6 +458,13 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
   return (
     <div className="panes">
       <div className="pane-detail">
+        {openSession ? (
+          <SessionDetail
+            session={openSession}
+            onBack={() => setOpenId(undefined)}
+          />
+        ) : (
+          <>
         <div className="toolbar">
           <div style={{ width: 260, display: "flex" }}>
             <Search
@@ -450,6 +475,8 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
           </div>
 
           <Dropdown
+            small
+            className="sess-select"
             label={
               filters.project
                 ? projectLabel(projectOptions, filters.project)
@@ -459,14 +486,18 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
             onChange={(v) => patchFilters({ project: v })}
             options={[
               { value: "", label: "All projects" },
+              // The server filters on project_path — the decoded path, exactly.
+              // encoded_name silently matches nothing.
               ...projectOptions.map((p) => ({
-                value: p.encoded_name,
+                value: p.decoded_path,
                 label: `${p.decoded_path} (${p.session_count})`,
               })),
             ]}
           />
 
           <Dropdown
+            small
+            className="sess-select"
             label={`Sort: ${
               SORTS.find((s) => s.value === filters.sort)?.label ?? "Recent"
             }`}
@@ -614,7 +645,10 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
                           className={
                             s.session_id === selectedId ? "is-selected" : ""
                           }
-                          onClick={() => select(s)}
+                          onClick={() => {
+                            select(s);
+                            setOpenId(s.session_id);
+                          }}
                         >
                           <td title={s.display_title}>
                             <span className="sess-title">
@@ -726,6 +760,8 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
             </button>
           </div>
         ) : null}
+          </>
+        )}
       </div>
 
       {inspectorOpen && (
@@ -996,44 +1032,6 @@ function Inspector({
 /* --- Toolbar dropdown ----------------------------------------------------- */
 
 function projectLabel(options: ClaudeProject[], value: string): string {
-  const hit = options.find((p) => p.encoded_name === value);
+  const hit = options.find((p) => p.decoded_path === value);
   return hit ? hit.decoded_path : value;
-}
-
-/**
- * The shared <Select> is display-only, so the toolbar wears its chrome over a
- * real <select> — the menu is then the platform's own.
- */
-function Dropdown({
-  label,
-  value,
-  onChange,
-  options,
-}: {
-  label: string;
-  value: string;
-  onChange(v: string): void;
-  options: { value: string; label: string }[];
-}) {
-  return (
-    <span className="select select--sm sess-select">
-      <span className="sess-select__value" title={label}>
-        {label}
-      </span>
-      <select
-        className="sess-select__native"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-      >
-        {options.map((o) => (
-          <option key={o.value} value={o.value}>
-            {o.label}
-          </option>
-        ))}
-      </select>
-      <span className="select__chevron">
-        <Icon name="chevronUD" size={12} />
-      </span>
-    </span>
-  );
 }

--- a/desktop/src/views/SettingsView.tsx
+++ b/desktop/src/views/SettingsView.tsx
@@ -10,7 +10,7 @@ import { api, ApiError, qs } from "../lib/api";
 import { describeError, useResource, type Resource } from "../lib/hooks";
 import { dateTime, relativeTime, tildePath, usd } from "../lib/format";
 import { Icon, type IconName } from "../lib/icons";
-import { Checkbox, Empty, FormRow, Switch } from "../components/ui";
+import { Checkbox, Dropdown, Empty, FormRow, Switch } from "../components/ui";
 import { useHostInfo } from "../lib/host";
 import {
   UPDATE_PREF_OPTIONS,
@@ -476,22 +476,18 @@ function GeneralPane({
                 : undefined
           }
         >
-          <select
-            className="nselect"
+          <Dropdown
             style={{ maxWidth: 200 }}
             value={user.default_model}
-            onChange={(e) => onPatch({ default_model: e.target.value })}
+            onChange={(v) => onPatch({ default_model: v })}
             disabled={!!modelLock}
-          >
-            {MODELS.some((m) => m.value === user.default_model) ? null : (
-              <option value={user.default_model}>{user.default_model}</option>
-            )}
-            {MODELS.map((m) => (
-              <option key={m.value} value={m.value}>
-                {m.label}
-              </option>
-            ))}
-          </select>
+            options={[
+              ...(MODELS.some((m) => m.value === user.default_model)
+                ? []
+                : [{ value: user.default_model, label: user.default_model }]),
+              ...MODELS,
+            ]}
+          />
         </FormRow>
 
         <FormRow
@@ -1133,21 +1129,18 @@ function AppearancePane({
       </FormRow>
 
       <FormRow label="Font size" help="Stored with your account. 0 keeps the system size.">
-        <select
-          className="nselect"
+        <Dropdown
           style={{ maxWidth: 160 }}
           value={String(user.appearance_font_size)}
-          onChange={(e) =>
-            onPatch({ appearance_font_size: Number(e.target.value) })
-          }
-        >
-          <option value="0">System default</option>
-          {[12, 13, 14, 15, 16, 17, 18].map((n) => (
-            <option key={n} value={String(n)}>
-              {n} px
-            </option>
-          ))}
-        </select>
+          onChange={(v) => onPatch({ appearance_font_size: Number(v) })}
+          options={[
+            { value: "0", label: "System default" },
+            ...[12, 13, 14, 15, 16, 17, 18].map((n) => ({
+              value: String(n),
+              label: `${n} px`,
+            })),
+          ]}
+        />
       </FormRow>
 
       <FormRow label="Font family" help="Blank uses the system UI font.">
@@ -1283,16 +1276,16 @@ function NotificationsPane({
         </FormRow>
 
         <FormRow label="Encryption">
-          <select
-            className="nselect"
+          <Dropdown
             style={{ maxWidth: 180 }}
             value={provider.encryption || "none"}
-            onChange={(e) => patchProvider({ encryption: e.target.value })}
-          >
-            <option value="none">None</option>
-            <option value="starttls">STARTTLS</option>
-            <option value="ssl_tls">SSL / TLS</option>
-          </select>
+            onChange={(v) => patchProvider({ encryption: v })}
+            options={[
+              { value: "none", label: "None" },
+              { value: "starttls", label: "STARTTLS" },
+              { value: "ssl_tls", label: "SSL / TLS" },
+            ]}
+          />
         </FormRow>
 
         <FormRow label="Username">

--- a/desktop/src/views/TasksView.tsx
+++ b/desktop/src/views/TasksView.tsx
@@ -11,6 +11,7 @@ import { describeError, usePoll, useResource } from "../lib/hooks";
 import { dateTime, duration, relativeTime, toneFor } from "../lib/format";
 import { Icon } from "../lib/icons";
 import {
+  Dropdown,
   Empty,
   FormRow,
   InspGroup,
@@ -821,22 +822,7 @@ function Picker({
   small?: boolean;
 }) {
   return (
-    <div className={`selectwrap ${small ? "selectwrap--sm" : ""}`}>
-      <select
-        className="selectfield"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-      >
-        {options.map((o) => (
-          <option key={o.value} value={o.value}>
-            {o.label}
-          </option>
-        ))}
-      </select>
-      <span className="select__chevron">
-        <Icon name="chevronUD" size={12} />
-      </span>
-    </div>
+    <Dropdown value={value} options={options} onChange={onChange} small={small} />
   );
 }
 

--- a/desktop/src/views/chat/Transcript.tsx
+++ b/desktop/src/views/chat/Transcript.tsx
@@ -225,7 +225,7 @@ function statusOf(live: Live | null, tools: Record<string, ToolState>): string {
 
 /* --- Blocks -------------------------------------------------------------- */
 
-function Thinking({ text, defaultOpen }: { text: string; defaultOpen?: boolean }) {
+export function Thinking({ text, defaultOpen }: { text: string; defaultOpen?: boolean }) {
   const [open, setOpen] = useState(defaultOpen ?? false);
   return (
     <div className="toolcall">
@@ -244,7 +244,7 @@ function Thinking({ text, defaultOpen }: { text: string; defaultOpen?: boolean }
   );
 }
 
-function ToolCall({
+export function ToolCall({
   name,
   input,
   state,
@@ -441,7 +441,7 @@ function PermissionPrompt({
 /* --- Text ---------------------------------------------------------------- */
 
 /** Paragraphs, plus fenced code lifted out so long output stays scannable. */
-function RichText({ text, caret }: { text: string; caret?: boolean }) {
+export function RichText({ text, caret }: { text: string; caret?: boolean }) {
   if (!text) return null;
   const parts = text.split(/```/);
   return (

--- a/desktop/src/views/sessions/SessionDetail.tsx
+++ b/desktop/src/views/sessions/SessionDetail.tsx
@@ -1,0 +1,209 @@
+import { useMemo } from "react";
+import { api } from "../../lib/api";
+import { useResource } from "../../lib/hooks";
+import { dateTime, integer, tildePath, usd } from "../../lib/format";
+import { Icon } from "../../lib/icons";
+import type {
+  ClaudeMessage,
+  ClaudeSessionDetail,
+  ClaudeSessionSummary,
+  ClaudeTodo,
+} from "../../lib/types";
+import { Empty } from "../../components/ui";
+import { RichText, Thinking, ToolCall } from "../chat/Transcript";
+
+/**
+ * Read-only transcript of one indexed Claude Code session, rendered with the
+ * same primitives the live chat transcript uses. The row the list handed over
+ * paints the header immediately; the full transcript loads behind it.
+ */
+export function SessionDetail({
+  session,
+  onBack,
+}: {
+  session: ClaudeSessionSummary;
+  onBack(): void;
+}) {
+  const detail = useResource<ClaudeSessionDetail>(
+    (signal) =>
+      api.get<ClaudeSessionDetail>(
+        `/claude-sessions/${session.session_id}`,
+        signal
+      ),
+    [session.session_id]
+  );
+
+  // Sidechain events are a sub-agent's own transcript leaking into the
+  // parent's, a user event with nothing to show is a tool_result carrier, and
+  // content opening with one of Claude Code's own injection wrappers is the
+  // harness talking, not the user — the scanner's turn count excludes all
+  // three, so showing them here would render turns the header does not count.
+  const messages = useMemo(
+    () =>
+      (detail.data?.messages ?? []).filter((m) => {
+        if (m.is_sidechain) return false;
+        if (m.type !== "user") return true;
+        const text = m.content?.trim() ?? "";
+        if (!text && !m.blocks?.length) return false;
+        return !INJECTED_MARKERS.some((w) => text.startsWith(w));
+      }),
+    [detail.data]
+  );
+  const todos = detail.data?.todos ?? [];
+  const title = detail.data?.display_title || session.display_title;
+
+  return (
+    <>
+      <div className="toolbar">
+        <button className="btn btn--ghost" onClick={onBack}>
+          <Icon name="chevronR" size={13} style={{ transform: "rotate(180deg)" }} />
+          Sessions
+        </button>
+        <div className="toolbar__sep" />
+        <div className="toolbar__title truncate" title={title}>
+          {title || "Untitled session"}
+        </div>
+        <div className="spacer" />
+        <span className="toolbar__sub tnum">
+          {integer(session.message_count)} msgs ·{" "}
+          {usd(
+            (session.cost?.total_usd ?? 0) +
+              (session.subagent_cost?.total_usd ?? 0)
+          )}
+        </span>
+      </div>
+
+      <div className="sess-detail__meta">
+        <span className="mono" title={session.project_path}>
+          {tildePath(session.project_path)}
+        </span>
+        {session.git_branch && (
+          <span>
+            <Icon name="branch" size={11} /> {session.git_branch}
+          </span>
+        )}
+        {session.model && <span>{session.model}</span>}
+        <span>{dateTime(session.start_time)}</span>
+      </div>
+
+      {detail.error && !detail.data ? (
+        <Empty
+          icon="alert"
+          title="Couldn't load this session"
+          text={detail.error}
+          action={
+            <button className="btn" onClick={() => detail.reload()}>
+              <Icon name="refresh" size={13} />
+              Try again
+            </button>
+          }
+        />
+      ) : !detail.data ? (
+        <div className="sess-loading">
+          <span className="sess-spinner" />
+          Reading transcript…
+        </div>
+      ) : (
+        <div className="transcript scroll">
+          <div className="transcript__inner">
+            {todos.length > 0 && <TodoList todos={todos} />}
+            {messages.length === 0 ? (
+              <div className="sess-note">
+                This transcript holds no conversation turns.
+              </div>
+            ) : (
+              messages.map((m, i) => (
+                <Message key={m.uuid || i} msg={m} agent={agentLabel(detail.data)} />
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+/**
+ * The harness's injection wrappers — internal/claudesessions'
+ * injectedTurnMarkers, plus the skill-invocation preamble.
+ */
+const INJECTED_MARKERS = [
+  "<task-notification>",
+  "<command-message>",
+  "<command-name>",
+  "<local-command-caveat>",
+  "<local-command-stdout>",
+  "<system-reminder>",
+  "Base directory for this skill:",
+];
+
+function agentLabel(d: ClaudeSessionDetail | null | undefined): string {
+  return d?.agent_name || "Claude";
+}
+
+function Message({ msg, agent }: { msg: ClaudeMessage; agent: string }) {
+  const isUser = msg.type === "user";
+  const blocks = msg.blocks?.length ? msg.blocks : null;
+
+  return (
+    <div className={`msg ${isUser ? "msg--user" : ""}`}>
+      <div
+        className={`avatar ${isUser ? "" : "avatar--purple"}`}
+        style={{ width: 28, height: 28 }}
+      >
+        {isUser ? <Icon name="users" size={13} /> : <Icon name="sparkle" size={13} />}
+      </div>
+      <div className="msg__body">
+        <div className="msg__head">
+          <span className="msg__author">{isUser ? "You" : agent}</span>
+          <span className="msg__time">{dateTime(msg.timestamp)}</span>
+        </div>
+        {blocks ? (
+          blocks.map((b, i) =>
+            b.type === "thinking" ? (
+              <Thinking key={i} text={b.text ?? ""} />
+            ) : b.type === "tool_use" ? (
+              <ToolCall
+                key={b.id ?? i}
+                name={b.name ?? "tool"}
+                input={b.input}
+                state={undefined}
+                live={false}
+              />
+            ) : (
+              <RichText key={i} text={b.text ?? ""} />
+            )
+          )
+        ) : (
+          <RichText text={msg.content ?? ""} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TodoList({ todos }: { todos: ClaudeTodo[] }) {
+  const done = todos.filter((t) => t.status === "completed").length;
+  return (
+    <div className="toolcall">
+      <div className="toolcall__head" style={{ pointerEvents: "none" }}>
+        <Icon name="task" size={13} />
+        <span className="toolcall__name">Todos</span>
+        <span className="truncate">
+          {done}/{todos.length} completed
+        </span>
+      </div>
+      <div className="toolcall__body sess-todos">
+        {todos.map((t, i) => (
+          <div key={i} className={`sess-todo sess-todo--${t.status}`}>
+            <Icon
+              name={t.status === "completed" ? "check" : "clock"}
+              size={11}
+            />
+            <span>{t.content}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Fixes the five GUI defects reported against the desktop app, verified end-to-end in a running dev instance (Vite + scratch backend, both themes). Frontend-only — no Rust or Go changes, so no parity surface moves.

## 1. Form borders barely visible (`agento_border.png`)
Every control's border was a `0.5px` box-shadow/border. A half-pixel hairline only rasterizes on displays with a physical half pixel — on 1x screens (most Linux/Windows monitors) WebKitGTK and WebView2 round it away edge by edge, which is why fields showed only a faint bottom line. New `--hairline` token in `tokens.css`: **1px at 1x, 0.5px at 2x+** (`min-resolution: 1.5dppx`), substituted at every former `0.5px` site. Resolution-based, not OS-based, so retina Macs keep true hairlines.

## 2. Session rows only fed the right sidebar
The desktop UI had no session detail view at all. Clicking a row now opens a **read-only transcript** of the session (`GET /api/claude-sessions/{id}`, already served natively), with a back button that restores the table exactly as left. Built from the chat transcript's own primitives (`Thinking` / `ToolCall` / `RichText`, now exported) plus a todos panel. Tool-result carrier events and Claude Code's injected wrappers (`<task-notification>`, `<system-reminder>`, skill preambles, …) are filtered the same way the scanner's turn predicate does, so the view shows the turns the header counts.

**Bonus bug found while verifying:** the sessions project filter sent `encoded_name` where the server matches `project_path` (the decoded path) exactly — selecting any project always returned zero sessions. It sends `decoded_path` now.

## 3. Switch rendered as a flat green pill (`checkmark_mouse_in_input.png`)
`.switch__knob` is a `<span>`, and width/height do not apply to inline elements, so the 16px knob collapsed to nothing. `.switch` is `inline-flex` now and the knob `display: block` — knob and slide animation render on every engine.

## 4. Sidebar "New Chat" did nothing + chats started without a working directory
All four New-Chat entry points (sidebar button, ⌘/Ctrl+N, command palette, native menu) only called `navigate("chats")`. They now also open a fresh draft (App bumps a nonce ChatsView reacts to). Creating a chat **requires a working directory**: sending without one is refused with an inline error, and the field/placeholder say "required" instead of "optional".

## 5. Dropdowns looked terrible when opened
Seven views each dressed a native `<select>`; the opened popup is the OS/GTK menu, which clashes with the app on every platform. The display-only `Select` stub in `ui.tsx` is replaced by one reusable, functional **`Dropdown`** — app-styled menu in a portal (never clipped by panes), selected-item checkmark, keyboard navigation (arrows/Home/End/Enter/Esc), flip-up when short on space, theme-aware. All native selects (Agents, Tasks, Sessions, Analytics, Integrations, Settings, Chats) now use it, and their per-view native-select CSS is deleted.

## Verification
Driven in Chrome against the Vite dev server + a scratch-data backend on the real `~/.claude` corpus (1,056 sessions), light and dark themes: sidebar New Chat opens a draft; empty working dir is refused; switch toggles with knob in both states; all dropdowns open app-styled menus and apply their value (project filter actually filters now — 70/1,056); session row → transcript → back preserves list state; `npm run build` (tsc + vite) clean.