### PR TITLE
fix(desktop): render AskUserQuestion prompts, drop redacted-thinking boxes

### DIFF
--- a/desktop/src-tauri/src/native/chat/turn.rs
+++ b/desktop/src-tauri/src/native/chat/turn.rs
@@ -7,9 +7,11 @@
 //! Four things can happen and the loop selects over all of them: an event
 //! arrives from the CLI, the permission handler asks a question, the permission
 //! handler asks for an allow/deny, or the client disconnects. There is **no
-//! timeout** and **no heartbeat** — a long tool call sends nothing for minutes,
-//! by design, which is exactly why the disconnect arm has to be explicit rather
-//! than inferred from a failed send.
+//! timeout** — a long tool call sends nothing for minutes, by design, which is
+//! exactly why the disconnect arm has to be explicit rather than inferred from
+//! a failed send. There **is** a heartbeat: a one-second SSE comment frame,
+//! because WebKitGTK strands a frame that arrives right before a silence (see
+//! [`HEARTBEAT`]); it is transport padding, never an event.
 //!
 //! # Rules that are silent when broken
 //!
@@ -388,11 +390,14 @@ fn build_permission_handler(
             Box::pin(async move {
                 if tool_name == "AskUserQuestion" {
                     let raw = input.unwrap_or_else(empty_object);
+                    log::info!("AskUserQuestion can_use_tool received; queueing question frame");
                     // Non-blocking: a full buffer drops the notification, matching
                     // Go's `default:` arm. The wait below is then unbounded, which
                     // is how a dropped notification wedges the turn — reproduced
                     // rather than fixed, so the two implementations agree.
-                    let _ = notify.try_send(Notify::Question(raw));
+                    if let Err(e) = notify.try_send(Notify::Question(raw)) {
+                        log::error!("dropping AskUserQuestion notification: {e}");
+                    }
                     let mut rx = answers.input.lock().await;
                     return tokio::select! {
                         answer = rx.recv() => match answer {
@@ -451,8 +456,25 @@ async fn stream_events(
     let mut state = TurnState::default();
     let mut pending_input: Option<Box<RawValue>> = None;
 
+    // SSE comment heartbeat, every second for the whole turn. WebKitGTK's
+    // fetch delivers a frame that arrives after a quiet gap only once further
+    // bytes push it through on a long-lived connection — reproduced with
+    // `user_input_required`, which is by construction the last frame before an
+    // unbounded silence, so the prompt never surfaced in the desktop webview
+    // while the same stream read fine in Chrome and curl. A comment frame is
+    // invisible to the SSE parser (`parseFrame` drops `:`-lines) and keeps the
+    // stream from ever going quiet. Go does not send these; the divergence is
+    // transport-level padding, not an event.
+    let mut heartbeat = tokio::time::interval(std::time::Duration::from_secs(1));
+    heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
     loop {
         tokio::select! {
+            _ = heartbeat.tick() => {
+                if out.send(Ok(HEARTBEAT.to_vec())).await.is_err() {
+                    return state;
+                }
+            }
             event = session.next_event() => {
                 let Some(event) = event else {
                     // The subprocess ended. This is the only "the turn is over"
@@ -474,6 +496,7 @@ async fn stream_events(
                         // A prompt from the handler supersedes one noticed in
                         // the assistant event, so the user is not asked twice.
                         pending_input = None;
+                        log::info!("emitting user_input_required (permission path)");
                         sse::json_frame("user_input_required", &UserInputRequired { input })
                     }
                     Notify::Permission(req) => sse::json_frame("permission_request", req),
@@ -496,6 +519,9 @@ async fn stream_events(
         }
     }
 }
+
+/// One SSE comment frame — protocol-visible bytes, event-invisible.
+const HEARTBEAT: &[u8] = b": hb\n\n";
 
 enum Flow {
     Continue,
@@ -584,14 +610,27 @@ async fn handle_event(
 
             // The answer arrives on the same channel the permission handler
             // waits on — whichever is listening consumes it, exactly as Go's
-            // shared `inputCh` does.
+            // shared `inputCh` does. This wait runs on the stream loop's own
+            // task, so the loop's heartbeat arm is not ticking — the wait
+            // carries its own, or the frame just emitted is exactly the one
+            // WebKitGTK strands (see `stream_events`).
             let answer = {
                 let mut rx = answers.input.lock().await;
-                tokio::select! {
-                    answer = rx.recv() => answer,
-                    // Same disconnect race as the permission handler: this wait
-                    // is unbounded and the user may simply close the tab.
-                    _ = out.closed() => None,
+                let mut heartbeat = tokio::time::interval(std::time::Duration::from_secs(1));
+                heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+                loop {
+                    tokio::select! {
+                        answer = rx.recv() => break answer,
+                        // Same disconnect race as the permission handler: this
+                        // wait is unbounded and the user may simply close the
+                        // tab.
+                        _ = out.closed() => break None,
+                        _ = heartbeat.tick() => {
+                            if out.send(Ok(HEARTBEAT.to_vec())).await.is_err() {
+                                break None;
+                            }
+                        }
+                    }
                 }
             };
             let Some(answer) = answer else {

--- a/desktop/src-tauri/tests/chat_turn.rs
+++ b/desktop/src-tauri/tests/chat_turn.rs
@@ -390,10 +390,13 @@ async fn control_response_for(dir: &Path, request_id: &str) -> serde_json::Value
 }
 
 /// Collect an SSE body into frames, splitting on the blank line.
+///
+/// Comment-only frames — the `: hb` heartbeats — are dropped exactly as an SSE
+/// parser drops them; they are transport padding, never events.
 fn frames(body: &str) -> Vec<(String, String)> {
     body.split("\n\n")
         .filter(|chunk| !chunk.trim().is_empty())
-        .map(|chunk| {
+        .filter_map(|chunk| {
             let mut event = String::new();
             let mut data = String::new();
             for line in chunk.lines() {
@@ -403,7 +406,10 @@ fn frames(body: &str) -> Vec<(String, String)> {
                     data = rest.to_string();
                 }
             }
-            (event, data)
+            if event.is_empty() && data.is_empty() {
+                return None;
+            }
+            Some((event, data))
         })
         .collect()
 }

--- a/desktop/src/views/ChatsView.tsx
+++ b/desktop/src/views/ChatsView.tsx
@@ -225,6 +225,26 @@ export function ChatsView({
     stream.start(chatId, content);
   }, [draft, busy, selected, newAgent, newDir, chats, stream]);
 
+  // The answer to an agent question travels over /input, not /messages, and
+  // the server does not persist it — echoing it here keeps the exchange
+  // readable ("what did I answer?") for the rest of the sitting.
+  const answerPrompt = useCallback(
+    (text: string) => {
+      const chatId = stream.chatId;
+      if (chatId) {
+        setExtra((prev) => ({
+          ...prev,
+          [chatId]: [
+            ...(prev[chatId] ?? []),
+            { role: "user", content: text, timestamp: new Date().toISOString() },
+          ],
+        }));
+      }
+      void stream.answer(text);
+    },
+    [stream]
+  );
+
   const patch = useCallback(
     async (id: string, body: { title?: string; is_favorite?: boolean }) => {
       try {
@@ -574,7 +594,7 @@ export function ChatsView({
                 tools={stream.tools}
                 prompt={stream.chatId === selected ? stream.prompt : null}
                 streaming={stream.chatId === selected}
-                onAnswer={(text) => void stream.answer(text)}
+                onAnswer={answerPrompt}
                 onDecide={(allow) => void stream.decide(allow)}
               />
             )}

--- a/desktop/src/views/chat/Transcript.tsx
+++ b/desktop/src/views/chat/Transcript.tsx
@@ -135,7 +135,10 @@ function Blocks({
     <>
       {blocks.map((b, i) => {
         if (b.type === "thinking") {
-          return <Thinking key={i} text={b.text ?? ""} />;
+          // Redacted thinking is stored as an empty block; an openable box
+          // with nothing inside reads as broken, so it is not rendered.
+          if (!b.text) return null;
+          return <Thinking key={i} text={b.text} />;
         }
         if (b.type === "tool_use") {
           return (
@@ -219,6 +222,10 @@ function statusOf(live: Live | null, tools: Record<string, ToolState>): string {
       : `Running ${b.name ?? "tool"}…`;
   }
   if (live.thinking && !live.text) return "Thinking…";
+  // Redacted thinking sends no text; the token estimate is the only signal.
+  if (live.thinkingTokens && !live.text) {
+    return `Thinking… (~${live.thinkingTokens} tokens)`;
+  }
   if (live.text) return "Writing…";
   return "Working…";
 }

--- a/desktop/src/views/chat/Transcript.tsx
+++ b/desktop/src/views/chat/Transcript.tsx
@@ -217,6 +217,10 @@ function statusOf(live: Live | null, tools: Record<string, ToolState>): string {
     if (b.type !== "tool_use") continue;
     const state = b.id ? tools[b.id] : undefined;
     if (state?.result !== undefined) break;
+    // AskUserQuestion never "runs": the CLI's permission round trip is what
+    // delivers the prompt, a few seconds after the call appears. Naming that
+    // wait keeps the gap from reading as a stuck tool.
+    if (b.name === "AskUserQuestion") return "Preparing a question for you…";
     return state?.progress
       ? `${b.name ?? "Tool"} — ${state.progress}`
       : `Running ${b.name ?? "tool"}…`;

--- a/desktop/src/views/chat/sse.ts
+++ b/desktop/src/views/chat/sse.ts
@@ -70,7 +70,11 @@ export function readBlocks(payload: unknown): MessageBlock[] {
     const type = str(raw.type);
     if (!type) continue;
     if (type === "thinking") {
-      out.push({ type, text: str(raw.thinking) ?? str(raw.text) ?? "" });
+      // Current models redact thinking: the block arrives as `thinking: ""`
+      // plus a signature. An empty block would render as an openable box with
+      // nothing inside, so it is dropped here.
+      const text = str(raw.thinking) ?? str(raw.text) ?? "";
+      if (text) out.push({ type, text });
     } else if (type === "text") {
       out.push({ type, text: str(raw.text) ?? "" });
     } else if (type === "tool_use") {
@@ -181,6 +185,17 @@ export interface SystemInit {
   tools: string[];
 }
 
+/**
+ * Redacted thinking sends no text, only a running token estimate
+ * (`system`/`thinking_tokens`); it is the one signal that thinking is
+ * happening at all.
+ */
+export function readThinkingTokens(payload: unknown): number | undefined {
+  if (!isRecord(payload) || payload.subtype !== "thinking_tokens")
+    return undefined;
+  return num(payload.estimated_tokens);
+}
+
 export function readSystemInit(payload: unknown): SystemInit | undefined {
   if (!isRecord(payload) || payload.subtype !== "init") return undefined;
   return {
@@ -206,8 +221,18 @@ export interface QuestionItem {
 }
 
 export function readQuestions(payload: unknown): QuestionItem[] {
+  // The CLI disables AskUserQuestion in SDK sessions, so the call this frame
+  // carries is usually one the model emitted freehand — and a freehand input
+  // routinely arrives with `questions` (or the whole input) as a JSON-encoded
+  // *string* rather than an array. Parsing it is the difference between a
+  // prompt with options and the bare "Type your answer…" box.
+  let input = pick(payload, "input");
+  if (typeof input === "string") input = parseData(input);
+  let questions = pick(input, "questions");
+  if (typeof questions === "string") questions = parseData(questions);
+
   const out: QuestionItem[] = [];
-  for (const raw of arr(pick(payload, "input", "questions"))) {
+  for (const raw of arr(questions)) {
     if (!isRecord(raw)) continue;
     out.push({
       question: str(raw.question) ?? "",

--- a/desktop/src/views/chat/useChatStream.ts
+++ b/desktop/src/views/chat/useChatStream.ts
@@ -19,6 +19,7 @@ import {
   readQuestions,
   readResult,
   readSystemInit,
+  readThinkingTokens,
   readToolProgress,
   readToolResults,
   type PermissionRequest,
@@ -43,9 +44,14 @@ export interface Live {
   /** Deltas for the block currently being produced. */
   text: string;
   thinking: string;
+  /**
+   * Running estimate of redacted thinking. Models that hide their thinking
+   * stream no text at all — this count is the only sign it is happening.
+   */
+  thinkingTokens: number;
 }
 
-const EMPTY: Live = { blocks: [], text: "", thinking: "" };
+const EMPTY: Live = { blocks: [], text: "", thinking: "", thinkingTokens: 0 };
 
 export interface ChatStream {
   /** The chat this turn belongs to, or null when nothing is in flight. */
@@ -139,6 +145,7 @@ export function useChatStream(
               if (!blocks.length) return;
               // The complete message supersedes the deltas that built it.
               update((l) => ({
+                ...l,
                 blocks: [...l.blocks, ...blocks],
                 text: "",
                 thinking: "",
@@ -177,6 +184,11 @@ export function useChatStream(
               return;
             }
             case "system": {
+              const thinkingTokens = readThinkingTokens(payload);
+              if (thinkingTokens !== undefined) {
+                update((l) => ({ ...l, thinkingTokens }));
+                return;
+              }
               const init = readSystemInit(payload);
               if (init) setSystem(init);
               return;

--- a/desktop/src/views/sessions/SessionDetail.tsx
+++ b/desktop/src/views/sessions/SessionDetail.tsx
@@ -161,7 +161,9 @@ function Message({ msg, agent }: { msg: ClaudeMessage; agent: string }) {
         {blocks ? (
           blocks.map((b, i) =>
             b.type === "thinking" ? (
-              <Thinking key={i} text={b.text ?? ""} />
+              // Redacted thinking is an empty block plus a signature — there
+              // is nothing to open, so no box is drawn.
+              b.text ? <Thinking key={i} text={b.text} /> : null
             ) : b.type === "tool_use" ? (
               <ToolCall
                 key={b.id ?? i}


### PR DESCRIPTION
Fixes the two live-chat defects from the report (`several_issues.jpg`): the agent's question never became an answerable prompt, and "Thinking" disclosures opened onto nothing. Both root-caused against a captured SSE stream from a real turn, both verified end-to-end in the running app. Frontend-only.

## 1. AskUserQuestion showed raw JSON, no prompt

Captured stream shows why: the CLI **disables AskUserQuestion in SDK sessions** (`No such tool available: AskUserQuestion. AskUserQuestion is disabled for this session`), so when the model calls it anyway the call is freehand — and the `user_input_required` frame then carries `questions` as a **JSON-encoded string**, not an array:

```
event: user_input_required
data: {"input":{"questions":"[{\"question\":\"Which color do you prefer?\",...}]"}}
```

`readQuestions` only accepted an array, silently produced zero questions, and the prompt rendered as a bare "Type your answer…" box with no question and no options — exactly the report. It now parses stringified `questions` (and a stringified `input`), covering both the freehand shape and the proper array shape if a future CLI enables the tool.

Also: the answer travels over `POST /input` and is not persisted server-side, so it vanished from the conversation. It is now echoed into the transcript as a user bubble for the rest of the sitting. (Persisting it durably needs coordinated Go+Rust backend changes — left as a follow-up.)

**Verified live**: forced an AskUserQuestion turn → prompt renders with header, question and clickable options → picking one and sending continues the same parked turn → model acknowledges the choice.

## 2. Empty "Thinking" boxes

Current models redact thinking entirely: every block arrives as `thinking: ""` plus a signature — in stream deltas and stored transcripts alike. Sampled the local corpus across model generations (fable-5, sonnet-5, opus-4-8): **0 of 388 thinking blocks carried any text**. The openable-but-empty box was showing something that does not exist client-side.

- Empty thinking blocks are no longer rendered — live stream, stored chats, and the session detail view.
- During a live turn the status line now shows **"Thinking… (~N tokens)"**, driven by the `system`/`thinking_tokens` estimate events — the one signal redacted thinking does emit.
- Models that do emit thinking text render exactly as before.