### PR TITLE
fix(desktop): gate the update manifest behind publishing the draft release

### DIFF
--- a/.github/scripts/build-update-manifest.py
+++ b/.github/scripts/build-update-manifest.py
@@ -19,20 +19,29 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-# Filename suffix -> the platform key the updater looks itself up by.
-# macOS updates ship as .app.tar.gz; the .dmg is only for first install.
+# Filename suffix -> the platform key the updater looks itself up by. The key
+# is tauri-plugin-updater's `{os}-{arch}` where arch is Rust's target_arch
+# spelling ("aarch64", never "arm64") — a key it will not look up strands that
+# platform's users silently. macOS updates ship as .app.tar.gz; the .dmg is
+# only for first install.
 PLATFORMS: list[tuple[str, str]] = [
     ("aarch64.app.tar.gz", "darwin-aarch64"),
     ("x64.app.tar.gz", "darwin-x86_64"),
     ("amd64.AppImage", "linux-x86_64"),
-    ("aarch64.AppImage", "linux-arm64"),
+    ("aarch64.AppImage", "linux-aarch64"),
     ("x64-setup.exe", "windows-x86_64"),
     ("arm64-setup.exe", "windows-aarch64"),
 ]
 
-# Platforms a release must contain. The arm64 Linux and Windows entries above
-# are recognised if present but are not currently built.
-REQUIRED = {"darwin-aarch64", "darwin-x86_64", "linux-x86_64", "windows-x86_64"}
+# Platforms a release must contain — everything the workflow matrix builds.
+# The arm64 Windows entry above is recognised if present but not yet built.
+REQUIRED = {
+    "darwin-aarch64",
+    "darwin-x86_64",
+    "linux-x86_64",
+    "linux-aarch64",
+    "windows-x86_64",
+}
 
 
 def platform_for(name: str) -> str | None:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -3,11 +3,29 @@ name: Desktop Release
 # Builds the native installers for the Tauri desktop app and publishes the
 # update manifest the in-app updater reads.
 #
-# Tauri cannot cross-compile its bundles: a .dmg needs macOS, an .msi needs
+# Tauri cannot cross-compile its bundles: a .dmg needs macOS, an .exe needs
 # Windows, a .deb needs Linux. So the matrix is one runner per target OS.
 #
 # Releases are cut from the `desktop` branch, not `main`, until the two merge.
-# Tag with `desktop-v0.1.0` on `desktop` to publish.
+# Tag with `desktop-v0.1.0` on `desktop` to build. The flow has a deliberate
+# human gate in the middle:
+#
+#   tag push        -> guard + build matrix -> DRAFT release with installers
+#                      and `latest.json` staged as one of its assets. Draft
+#                      assets are not publicly downloadable, so nothing has
+#                      shipped yet — installed apps cannot even fetch it.
+#   publish draft   -> the `release: published` event runs `promote`, which
+#                      copies the staged `latest.json` to the fixed
+#                      `desktop-latest` tag. That URL is what every installed
+#                      app polls, so THIS is the moment a release goes live.
+#
+# Publishing the manifest immediately at build time would point updaters at
+# draft asset URLs that 404 until someone remembers to publish the draft —
+# every installed app would see "update available" and fail the download.
+#
+# A prerelease tag (`desktop-v0.1.0-rc.1`) builds and drafts identically and
+# is auto-marked prerelease, but is never promoted: release candidates are
+# shareable from the versioned release page without being pushed to updaters.
 on:
   push:
     tags: ["desktop-v*"]
@@ -17,17 +35,50 @@ on:
         description: "Build installers without creating a release"
         type: boolean
         default: true
+  release:
+    types: [published]
 
+# The event name is part of the group so publishing a draft (a `release`
+# event carrying the same tag ref) can never cancel a build run in flight.
 concurrency:
-  group: desktop-release-${{ github.ref }}
+  group: desktop-release-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: write
 
 jobs:
+  # The installed app compares the version baked into it at build time (from
+  # tauri.conf.json) against the manifest's version (taken from the tag). If
+  # the tag says 0.1.1 but the conf still says 0.1.0, every "updated" install
+  # keeps reporting 0.1.0 and is re-offered the same update forever — so a
+  # mismatched tag must never reach the build matrix.
+  guard:
+    name: Tag matches tauri.conf.json
+    if: github.event_name != 'release'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+
+      - name: Check the tag against the bundled version
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          case "$tag" in
+            desktop-v*) ;;
+            *) echo "not a desktop-v* tag build; nothing to check"; exit 0 ;;
+          esac
+          tag_version="${tag#desktop-v}"
+          conf_version="$(python3 -c 'import json; print(json.load(open("desktop/src-tauri/tauri.conf.json"))["version"])')"
+          if [ "$tag_version" != "$conf_version" ]; then
+            echo "::error::tag ${tag} says ${tag_version} but desktop/src-tauri/tauri.conf.json says ${conf_version}. Bump the conf and re-tag, or the shipped app will re-offer itself as an update forever."
+            exit 1
+          fi
+          echo "ok: ${tag_version}"
+
   build:
     name: ${{ matrix.label }}
+    needs: guard
+    if: github.event_name != 'release'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -87,6 +138,9 @@ jobs:
         working-directory: desktop
         run: npm ci
 
+      # bundle.targets in tauri.conf.json lists exactly what ships — notably
+      # NSIS and not MSI on Windows, since the updater manifest expects the
+      # -setup.exe and a built-but-dropped .msi only wasted CI time.
       - name: Build installers
         working-directory: desktop
         run: npx tauri build --target ${{ matrix.target }}
@@ -120,9 +174,9 @@ jobs:
           if-no-files-found: error
 
   release:
-    name: Publish release
+    name: Draft release
     needs: build
-    if: startsWith(github.ref, 'refs/tags/desktop-v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/desktop-v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
@@ -132,8 +186,19 @@ jobs:
           path: artifacts
           merge-multiple: true
 
+      - name: Release metadata
+        id: meta
+        run: |
+          version="${GITHUB_REF_NAME#desktop-v}"
+          # A prerelease suffix (desktop-v0.1.0-rc.1) marks the draft as a
+          # prerelease, which is one of the two things keeping `promote` from
+          # ever pushing it to updaters.
+          case "$version" in
+            *-*) echo "prerelease=true" >>"$GITHUB_OUTPUT" ;;
+            *)   echo "prerelease=false" >>"$GITHUB_OUTPUT" ;;
+          esac
+
       - name: Build update manifest
-        id: manifest
         run: |
           python3 .github/scripts/build-update-manifest.py \
             --artifacts artifacts \
@@ -142,8 +207,13 @@ jobs:
             --output artifacts/latest.json
           cat artifacts/latest.json
 
-      # The versioned release: what people download.
-      - name: Publish release
+      # The versioned release: what people download. It is a DRAFT — a human
+      # vets the installers before anything ships, and draft assets are not
+      # publicly downloadable. That is also why latest.json is only STAGED
+      # here rather than published to desktop-latest now: a live manifest
+      # pointing at draft asset URLs would make every installed app report an
+      # update it cannot download. Publishing this draft fires `promote`.
+      - name: Publish draft release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: |
@@ -154,7 +224,9 @@ jobs:
             artifacts/*-setup.exe
             artifacts/*.app.tar.gz
             artifacts/*.sig
+            artifacts/latest.json
           draft: true
+          prerelease: ${{ steps.meta.outputs.prerelease }}
           generate_release_notes: true
           body: |
             Desktop builds of Agento.
@@ -174,17 +246,53 @@ jobs:
 
             Requires the Claude Code CLI to be installed and signed in.
 
+  # Runs when a human publishes the draft. Promotion, not regeneration: the
+  # manifest was built and signed beside the artifacts it points at, and this
+  # job only copies it to the fixed URL the updater polls. The `if` filters
+  # out everything else that flows through `release: published` — the Go
+  # server's v* releases, desktop-latest's own publication, and any release
+  # marked prerelease; the version check below catches an rc tag even if
+  # someone unticked the prerelease box before publishing.
+  promote:
+    name: Promote update manifest
+    if: >-
+      github.event_name == 'release' &&
+      !github.event.release.prerelease &&
+      startsWith(github.event.release.tag_name, 'desktop-v')
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      TAG: ${{ github.event.release.tag_name }}
+    steps:
+      - name: Download the staged manifest
+        run: |
+          version="${TAG#desktop-v}"
+          case "$version" in
+            *-*)
+              echo "::error::${TAG} is a prerelease tag published without the prerelease flag; refusing to promote it to desktop-latest."
+              exit 1
+              ;;
+          esac
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --pattern latest.json --output latest.json
+          python3 - "$version" <<'EOF'
+          import json, sys
+          version = sys.argv[1]
+          manifest = json.load(open("latest.json"))
+          if manifest["version"] != version:
+              sys.exit(f"staged manifest says {manifest['version']!r}, tag says {version!r}")
+          print(f"promoting {version}: {', '.join(sorted(manifest['platforms']))}")
+          EOF
+
       # A fixed tag so the updater has a stable manifest URL. Marked as a
       # prerelease so it never displaces the real "Latest release" on the repo
       # page — asset download URLs work for prereleases just the same.
-      - name: Publish update manifest
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
-        with:
-          files: artifacts/latest.json
-          tag_name: desktop-latest
-          name: Desktop update manifest
-          body: |
-            Machine-readable manifest the Agento desktop updater polls.
-            Not a download — see the `desktop-v*` releases for installers.
-          prerelease: true
-          draft: false
+      - name: Publish to desktop-latest
+        run: |
+          if ! gh release view desktop-latest --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release create desktop-latest --repo "$GITHUB_REPOSITORY" \
+              --prerelease --title "Desktop update manifest" \
+              --notes "Machine-readable manifest the Agento desktop updater polls.
+          Not a download — see the \`desktop-v*\` releases for installers."
+          fi
+          gh release upload desktop-latest latest.json --clobber --repo "$GITHUB_REPOSITORY"

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -22,6 +22,21 @@ server and is left alone until the two converge.
   (`.github/workflows/desktop-release.yml`).
 - The Go server keeps its own release on `v*` tags. The two tag patterns do not
   overlap, so both ship independently from the same repo.
+- The tag must equal `desktop-v` + the `version` in
+  `desktop/src-tauri/tauri.conf.json`; a guard job fails the build otherwise.
+  The updater compares the version baked into the app against the manifest's
+  (taken from the tag), so a mismatch makes every "updated" install re-offer
+  itself forever. Bump the conf in the release commit, then tag it.
+- Tagging builds a **draft** release with `latest.json` staged as an asset.
+  Nothing has shipped at that point — draft assets are not publicly
+  downloadable. **Publishing the draft is the release act**: the
+  `release: published` event runs the `promote` job, which copies the staged
+  manifest to the fixed `desktop-latest` tag every installed app polls.
+- A prerelease tag (`desktop-v0.1.0-rc.1`) builds and drafts identically, is
+  auto-marked prerelease, and is **never promoted** — a shareable release
+  candidate no installed app is offered. For private smoke-test builds, run
+  the workflow manually with `dry_run` instead: installers land as CI
+  artifacts and no release is created.
 
 ---
 

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -35,7 +35,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": ["deb", "rpm", "appimage", "app", "dmg", "nsis"],
     "publisher": "Shaharia Lab",
     "homepage": "https://github.com/shaharia-lab/agento",
     "license": "MIT",


### PR DESCRIPTION
Release-flow fixes ahead of the first `desktop-v*` tag, so a tagged build can be vetted before anything reaches installed apps.

## The gate

Previously the release job published `latest.json` to `desktop-latest` **immediately at build time**, while the versioned release it points at is created as a draft — and draft assets are not publicly downloadable. From the second release onward, every installed app would see "update available" and fail the download until someone remembered to publish the draft.

Now:

- **tag push** → guard + build matrix → **draft** release with the installers and `latest.json` staged as an asset. Nothing has shipped.
- **publishing the draft** → a `promote` job (on `release: published`) copies the staged manifest to `desktop-latest`, the fixed URL every installed app polls. Publishing the draft is the release act.
- A prerelease tag (`desktop-v0.1.0-rc.1`) builds and drafts identically, is auto-marked prerelease, and is **never promoted** — a shareable RC no updater is offered. (Private smoke builds remain `workflow_dispatch` + `dry_run`.)

The promote `if` filters out the Go server's `v*` releases, `desktop-latest`'s own publication, and prerelease-flagged releases; a version-part check catches an rc tag even if the prerelease box was unticked, and the staged manifest's `version` is verified against the tag before upload.

## Version guard

A cheap `guard` job fails a tag build whose version differs from `tauri.conf.json`'s. The installed app compares its baked-in version against the manifest's (taken from the tag): tag `desktop-v0.1.1` over a conf still saying `0.1.0` means every "updated" install keeps reporting 0.1.0 and is re-offered the same update forever.

## arm64 Linux updater key (found while reviewing arch coverage)

`build-update-manifest.py` keyed the arm64 AppImage as `linux-arm64`, but `tauri-plugin-updater` looks itself up by `{os}-{target_arch}` — i.e. `linux-aarch64` (verified against tauri-plugin-updater 2.10.1's `get_updater_arch`). Every arm64 Linux install would have been silently stranded on its installed version — exactly the failure the script's strictness exists to prevent. The key is fixed and `linux-aarch64` added to `REQUIRED`, since the matrix always builds it.

## Windows .msi

`bundle.targets` now lists exactly what ships (`deb`, `rpm`, `appimage`, `app`, `dmg`, `nsis`) instead of `"all"`: the `.msi` was built and then silently dropped by the collect step, wasting Windows CI time — the manifest expects the NSIS `-setup.exe`.

Docs: the branch-and-release-model section in `desktop/CLAUDE.md` now describes the gate, the guard, and the RC path.