### PR TITLE
fix(desktop): install Linux build deps on the arm64 release runner

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -46,6 +46,11 @@ jobs:
         # which turn a dead mirror into a fast, retryable failure.
         timeout-minutes: 10
         run: |
+          # When the Azure mirror is fully down, per-request timeouts alone
+          # still blow the step deadline: 30s x 3 retries x dozens of index
+          # files. Drop it from the mirror list so apt never contacts it.
+          sudo sed -i -E 's|https?://azure\.archive\.ubuntu\.com|https://archive.ubuntu.com|g; s|https?://azure\.ports\.ubuntu\.com|http://ports.ubuntu.com|g' \
+            /etc/apt/apt-mirrors.txt /etc/apt/sources.list 2>/dev/null || true
           APT_OPTS='-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30'
           sudo apt-get $APT_OPTS update
           sudo apt-get $APT_OPTS install -y \

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -92,13 +92,15 @@ jobs:
           - label: linux-aarch64
             os: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
-          # macos-14 is Apple Silicon, macos-13 is Intel. Both ship: a
+          # macos-15 is Apple Silicon, macos-15-intel is Intel. Both ship: a
           # universal binary would be simpler but doubles every download.
+          # A job naming a retired image (macos-13 was one) queues forever
+          # rather than erroring — check actions/runner-images before bumping.
           - label: macos-aarch64
-            os: macos-14
+            os: macos-15
             target: aarch64-apple-darwin
           - label: macos-x86_64
-            os: macos-13
+            os: macos-15-intel
             target: x86_64-apple-darwin
           - label: windows-x86_64
             os: windows-latest

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -118,6 +118,11 @@ jobs:
       - name: Install Linux build dependencies
         if: runner.os == 'Linux'
         run: |
+          # The Azure apt mirror has outages long enough to eat a whole step
+          # timeout in retries; drop it so apt goes straight to the canonical
+          # archive (or ports, on arm64).
+          sudo sed -i -E 's|https?://azure\.archive\.ubuntu\.com|https://archive.ubuntu.com|g; s|https?://azure\.ports\.ubuntu\.com|http://ports.ubuntu.com|g' \
+            /etc/apt/apt-mirrors.txt /etc/apt/sources.list 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev \

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -110,8 +110,11 @@ jobs:
       # Ubuntu 22.04 carries webkit2gtk-4.1, which Tauri 2 requires. The .deb
       # links against whatever the build host has, so building on the oldest
       # supported LTS is what keeps the package installable on newer ones.
+      # runner.os, not a matrix.os comparison: the arm64 runner is
+      # `ubuntu-22.04-arm`, which a string equality on `ubuntu-22.04` silently
+      # skipped — gdk-sys then failed against a runner with no GTK headers.
       - name: Install Linux build dependencies
-        if: matrix.os == 'ubuntu-22.04'
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y \


### PR DESCRIPTION
Three release-infrastructure fixes surfaced by the first real run of the release workflow (desktop-v0.1.0, run 32295589454). All failed **before** anything could ship — the #380 gating held: no draft release was created and the updater manifest was never touched.

**linux-aarch64 — GTK deps never installed.** The dependency-install step is gated on `matrix.os == 'ubuntu-22.04'`, but the arm64 runner is `ubuntu-22.04-arm`, so `gdk-sys`'s build script failed (`pkg-config` found no `gdk-3.0`). Gate on `runner.os == 'Linux'` instead.

**macos-x86_64 — retired runner image.** `macos-13` no longer exists in GitHub's hosted images, and a job naming a nonexistent label queues forever rather than erroring — the Intel build sat pending while every other leg finished. `macos-14` is deprecated and next in line, so both macOS legs move to currently-supported images: `macos-15` (Apple Silicon) and `macos-15-intel` (Intel).

**Azure apt mirror outage eats step timeouts.** Two consecutive desktop-ci runs timed out in the dependency install with `azure.archive.ubuntu.com` down — per-request timeouts (30s × 3 retries) across dozens of index files exceed the 10-minute budget on their own. Both workflows now rewrite the runner's apt mirror list to the canonical archive (ports on arm64) before `apt-get update`, so a dead Azure mirror is never contacted.

After merge: delete and re-push the `desktop-v0.1.0` tag on the fixed commit.