### PR TITLE
fix(desktop): install xdg-utils on the arm64 release runner

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -124,10 +124,12 @@ jobs:
           sudo sed -i -E 's|https?://azure\.archive\.ubuntu\.com|https://archive.ubuntu.com|g; s|https?://azure\.ports\.ubuntu\.com|http://ports.ubuntu.com|g' \
             /etc/apt/apt-mirrors.txt /etc/apt/sources.list 2>/dev/null || true
           sudo apt-get update
+          # xdg-utils: the AppImage bundler copies /usr/bin/xdg-open into the
+          # bundle; the x86_64 runner image ships it, the arm64 one does not.
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev \
             libayatana-appindicator3-dev libxdo-dev libssl-dev \
-            build-essential patchelf file
+            build-essential patchelf file xdg-utils
 
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:


### PR DESCRIPTION
Third and hopefully final release-runner gap, from re-tagged run 32302852021: `linux-aarch64` now compiles cleanly (deps fix worked, both new macOS images passed) but fails at bundling with `xdg-open binary not found /usr/bin/xdg-open` — Tauri's AppImage bundler copies it into the bundle, the x86_64 runner image ships `xdg-utils`, the arm64 image doesn't. Install it explicitly (no-op on x86_64).