### PR TITLE
fix(desktop): arch-suffix the macOS updater tarballs at collection

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -177,6 +177,20 @@ jobs:
                -o -name '*.dmg' -o -name '*-setup.exe' \
                -o -name '*.app.tar.gz' -o -name '*.sig' \) \
             -exec cp {} out/ \;
+          # Tauri names the macOS updater tarball Agento.app.tar.gz with no
+          # arch — identical on both macOS legs, so the release job's merged
+          # artifact download would silently overwrite one arch's payload
+          # with the other's. Rename to the arch-suffixed form the manifest
+          # script keys platforms by.
+          case "${{ matrix.target }}" in
+            aarch64-apple-darwin) suffix=aarch64 ;;
+            x86_64-apple-darwin)  suffix=x64 ;;
+            *)                    suffix= ;;
+          esac
+          if [ -n "$suffix" ] && [ -f out/Agento.app.tar.gz ]; then
+            mv out/Agento.app.tar.gz "out/Agento_${suffix}.app.tar.gz"
+            mv out/Agento.app.tar.gz.sig "out/Agento_${suffix}.app.tar.gz.sig"
+          fi
           ls -lh out
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4


### PR DESCRIPTION
Run 32304875983: **all five platform builds succeeded** (every runner fix landed), but the draft-release job failed in the manifest script with `no updater artifact for: darwin-aarch64, darwin-x86_64`.

Cause: Tauri names the macOS updater tarball `Agento.app.tar.gz` with no arch suffix — identical on both macOS legs. Two consequences: the manifest script (which keys platforms by `aarch64.app.tar.gz` / `x64.app.tar.gz` suffixes) matched neither, and — worse — the release job's `merge-multiple: true` artifact download was silently overwriting one arch's payload with the other's, which would have shipped the wrong binary to one macOS arch had the names matched.

Fix: the collect step renames tarball + signature to `Agento_aarch64.app.tar.gz` / `Agento_x64.app.tar.gz` (signatures sign bytes, not names). Linux and Windows payloads already carry their arch and are untouched.

Once merged, re-tag `desktop-v0.1.0` — fourth build; the five platform legs are all proven now, this only touches post-build file handling.