### PR TITLE
docs(desktop): user and developer documentation for the first release

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ agento service install     # then: status | stop | start | restart | logs | unin
 
 <br>
 
+## Prefer a desktop app?
+
+Agento also ships as a native desktop app for macOS, Windows and Linux. Same
+features, no browser tab and no server to start, with in-app updates on most
+install types.
+
+Download it from the [desktop releases](https://github.com/shaharia-lab/agento/releases?q=desktop&expanded=true),
+or read the [desktop documentation](desktop/README.md) first.
+
+<br>
+
 ## What you get
 
 ### Every token type, priced properly
@@ -296,6 +307,13 @@ Only do that on a network you trust, or put a proxy that authenticates in front 
 - [Security](docs/security.md): network exposure, the API guards, and where your data lives
 - [Monitoring](docs/monitoring.md): OpenTelemetry traces, metrics and logs
 - [Development](docs/development.md): architecture and contribution guidelines
+
+**Desktop app**
+
+- [Installation](desktop/docs/installation.md): downloads per platform, updates, and where your data lives
+- [User guide](desktop/docs/user-guide.md): every section of the app
+- [Troubleshooting](desktop/docs/troubleshooting.md): common problems and the logs
+- [Architecture](desktop/docs/architecture.md) and [development](desktop/docs/development.md): for contributors
 
 <br>
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,154 +1,144 @@
 # Agento Desktop
 
-A native desktop client for [Agento](https://github.com/shaharia-lab/agento),
-built with **Tauri 2 + Rust + React**.
+A native desktop app for [Agento](https://github.com/shaharia-lab/agento): build
+AI agents, chat with them, schedule them, and see exactly what your Claude Code
+usage costs. Everything runs on your own machine.
 
-The backend is native Rust (`src-tauri/src/native/`), a subsystem-by-subsystem
-port of the Agento Go server completed with #278 — the bundled Go sidecar is
-gone. Behaviour is pinned to the Go implementation by the byte-level parity
-corpus in `parity/`; see [CLAUDE.md](CLAUDE.md) for how that works.
+One window, no browser tab, no server to start.
 
----
-
-## Running it
-
-```bash
-npm install
-npm run app        # Tauri dev window, hot reload on save
-```
-
-Development runs against `~/.agento-desktop-dev`, not your real `~/.agento` —
-two Agento processes sharing a data directory share a scheduler, which would
-double-fire scheduled tasks. Release builds use the real one.
-
-Other scripts:
-
-| Command | What it does |
-| --- | --- |
-| `npm run dev` | Vite only, in a browser tab — fastest loop for pure layout work |
-| `npm run app` | The real desktop window with hot reload |
-| `npm run app:build` | Production bundle (`.deb`, `.AppImage`, `.rpm`) |
-| `npm run build` | Typecheck + build the frontend alone |
-
-### Linux system dependencies
-
-Already installed on this machine. On a fresh box:
-
-```bash
-sudo apt install libwebkit2gtk-4.1-dev build-essential curl wget file \
-  libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
-```
+- **Docs:** [User Guide](docs/user-guide.md) | [Installation](docs/installation.md) | [Troubleshooting](docs/troubleshooting.md)
+- **For contributors:** [Development](docs/development.md) | [Architecture](docs/architecture.md) | [Releasing](docs/releasing.md)
 
 ---
 
-## Why it doesn't look like the web app
+## Before you install
 
-The web version is a page: a nav rail, a big `<h1>`, a primary button in the top
-right, and a wide column of cards. That layout is correct for a browser and
-wrong for a window. The desktop build deliberately breaks from it:
+Agento Desktop needs the **[Claude Code CLI](https://claude.ai/code)**, installed
+and signed in. If `claude` runs in your terminal, you are ready.
 
-**Three panes, not one page.** Every section is `list → detail → inspector`,
-resizable by dragging the hairline dividers. You navigate *within* a window
-instead of replacing its contents, which is why there's no page-level heading
-anywhere — the titlebar already says where you are.
+There is no Anthropic API key to enter. Agento reuses the sign-in Claude Code
+already has. The app checks for the CLI on launch and tells you if it is missing.
 
-**Density.** 13px base type, 26px rows, 24px toolbar controls, hairline
-`0.5px` borders. The web app runs roughly 16px/48px; at desktop distances that
-reads as a website embedded in a frame.
+---
 
-**The window owns its chrome.** `decorations: false`, so the titlebar is ours:
-drag region, back/forward, sidebar toggle, and window controls that follow
-platform convention (right on Linux/Windows, reserved space for the traffic
-lights on macOS).
+## Download
 
-**A status bar.** Persistent, always truthful — running agents, active model,
-today's tokens and spend, connection state. Web apps almost never have one.
+Get the files from the
+[latest desktop release](https://github.com/shaharia-lab/agento/releases?q=desktop&expanded=true).
+Release tags start with `desktop-v`.
 
-**Selection behaves natively.** The source list and table rows fill with the
-accent colour when the window is focused and drop to neutral grey when it
-isn't — the single strongest "this is a real app" signal, and something almost
-no web port does.
+| Platform | Download | Auto-update |
+| --- | --- | --- |
+| **macOS** (Apple Silicon) | `Agento_<version>_aarch64.dmg` | Yes, in-app |
+| **macOS** (Intel) | `Agento_<version>_x64.dmg` | Yes, in-app |
+| **Windows** (x64) | `Agento_<version>_x64-setup.exe` | Yes, in-app |
+| **Linux** (any distro) | `Agento_<version>_amd64.AppImage` or `_aarch64.AppImage` | Yes, in-app |
+| **Linux** (Debian, Ubuntu) | `Agento_<version>_amd64.deb` or `_arm64.deb` | No, notify only |
+| **Linux** (Fedora, RHEL, openSUSE) | `Agento-<version>-1.x86_64.rpm` or `.aarch64.rpm` | No, notify only |
 
-**Keyboard first.** A ⌘K palette plus a real native menu (`src-tauri/src/menu.rs`)
-that emits actions the webview handles, so the menu path and the shortcut path
-run identical code.
+**Auto-update** means the app can download and install a new version itself, then
+restart. The `.deb` and `.rpm` packages are owned by your system package manager,
+so Agento never overwrites them: it tells you a new version exists and links to
+the download. Pick the AppImage if you want in-app updates on Linux.
 
-**No browser affordances.** Text isn't selectable except where you'd actually
-read or copy it, the context menu is suppressed, scrollbars are overlay-style,
-and focus rings appear for keyboard navigation only.
+Every download is also published with a `.sig` file. That signature is Agento's
+own update key, used by the in-app updater to verify a download.
+
+---
+
+## Install
+
+### macOS
+
+1. Open the `.dmg` and drag **Agento** into Applications.
+2. Launch it. macOS blocks it the first time, because the app is not signed with
+   an Apple Developer certificate.
+3. Open **System Settings → Privacy & Security**, scroll down, and click
+   **Open Anyway**. Confirm once.
+
+Only the first launch needs this. Updates installed by the app do not.
+
+### Windows
+
+1. Run `Agento_<version>_x64-setup.exe`.
+2. Windows SmartScreen warns about an unrecognized publisher. Click **More info**,
+   then **Run anyway**.
+3. The installer asks for administrator rights, because it installs for all users.
+
+The bundled WebView2 runtime installs automatically if your machine does not
+already have it.
+
+### Linux, AppImage
+
+```bash
+chmod +x Agento_*.AppImage
+./Agento_*.AppImage
+```
+
+No installation, no root. Keep the file wherever you like. The app updates itself
+in place.
+
+### Linux, Debian or Ubuntu
+
+```bash
+sudo apt install ./Agento_*_amd64.deb
+```
+
+### Linux, Fedora, RHEL or openSUSE
+
+```bash
+sudo dnf install ./Agento-*.x86_64.rpm
+```
+
+Both packages declare their GTK and WebKitGTK dependencies, so your package
+manager pulls in what is missing.
+
+---
+
+## First run
+
+The app opens on **Chats**. On launch it starts reading the Claude Code history
+already on your disk. A large history takes a few minutes to index the first
+time, and the Sessions view shows progress while it works. Everything else is
+usable meanwhile.
+
+Your data lives in `~/.agento` (`%USERPROFILE%\.agento` on Windows) as a single
+SQLite file. Nothing is uploaded anywhere.
+
+Read the [User Guide](docs/user-guide.md) next.
 
 ---
 
 ## Keyboard shortcuts
 
+`Ctrl` on Windows and Linux, `⌘` on macOS.
+
 | Shortcut | Action |
 | --- | --- |
 | `Ctrl K` | Command palette |
-| `Ctrl B` | Toggle sidebar |
-| `Ctrl I` | Toggle inspector |
 | `Ctrl N` | New chat |
 | `Ctrl ,` | Settings |
+| `Ctrl B` | Show or hide the sidebar |
+| `Ctrl I` | Show or hide the inspector |
 | `Ctrl [` / `Ctrl ]` | Back / forward |
-| `Ctrl 1`–`7` | Jump to a section |
+| `Ctrl 1` to `Ctrl 7` | Jump to a section |
 
 ---
 
-## Layout
+## Building from source
 
-```
-┌──────────────────────────────────────────────────────┐
-│ titlebar — drag, nav, window controls                │
-├─────────┬────────────────────────────────────────────┤
-│ sidebar │ toolbar                                    │
-│ (source ├──────────┬──────────────────┬──────────────┤
-│  list)  │ list     │ detail           │ inspector    │
-├─────────┴──────────┴──────────────────┴──────────────┤
-│ status bar                                           │
-└──────────────────────────────────────────────────────┘
+```bash
+cd desktop
+npm install
+npm run app          # dev window with hot reload
+npm run app:build    # installers for your platform
 ```
 
-## Project structure
-
-```
-src/
-  lib/
-    api.ts         fetch wrapper + POST-based SSE for chat streaming
-    types.ts       TypeScript mirrors of the Go JSON, field-for-field
-    hooks.ts       useResource / useDebounced / usePoll
-    format.ts      shared number, money, duration and date formatting
-    stats.ts       sidebar + status bar counters
-    icons.tsx      16px / 1.5-stroke icon set
-    nav.ts         sidebar sections and view ids
-    tauri.ts       window + menu bridge; degrades to a plain browser tab
-  styles/
-    tokens.css     type scale, spacing, control metrics, light + dark palettes
-    base.css       app-shell resets (no document scrolling, no text selection)
-    shell.css      titlebar, sidebar, panes, splitters, status bar
-    controls.css   buttons, segmented controls, fields, switches, menus
-    views.css      list rows, transcript, tables, dashboard, inspector, forms
-  components/      TitleBar, Sidebar, StatusBar, CommandPalette, ui primitives
-  views/           one file per section
-
-src-tauri/
-  src/lib.rs       app setup: database, migrations, api server, window, menu
-  src/proxy.rs     axum server: routes every request to src/native/
-  src/native/      the ported backend — one module per API area
-  src/claude/      the Claude Agent SDK, ported from Go
-  src/menu.rs      native menu; emits `menu://action` to the webview
-  tauri.conf.json  undecorated 1280×820 window, CSP, bundle targets
-  capabilities/    the window permissions the custom chrome needs
-```
-
-## Theming
-
-Three states — light, dark, and match-system — set via the status bar, the
-Appearance pane, or the palette. Tokens are defined on bare `:root` for light,
-then re-declared under both `@media (prefers-color-scheme: dark)` and
-`:root[data-theme="dark"]`, so an explicit choice wins in either direction.
+See [Development](docs/development.md) for the full setup, including Linux system
+dependencies and how the parity test suite works.
 
 ---
 
-## Not built yet
+## License
 
-Multi-window, tray icon, native context menus, drag-and-drop, virtualised lists
-for the session table, and Tauri auto-update.
+MIT, same as the rest of the Agento repository.

--- a/desktop/docs/README.md
+++ b/desktop/docs/README.md
@@ -1,0 +1,23 @@
+# Agento Desktop documentation
+
+## For users
+
+| Guide | What it covers |
+| --- | --- |
+| [Installation](installation.md) | Downloads per platform, first launch, updates, where your data lives, uninstalling |
+| [User Guide](user-guide.md) | Every section of the app: chats, agents, integrations, scheduled tasks, session history, analytics, settings |
+| [Troubleshooting](troubleshooting.md) | Common problems, and how to read the logs |
+
+Start with [Installation](installation.md).
+
+## For contributors
+
+| Guide | What it covers |
+| --- | --- |
+| [Architecture](architecture.md) | Stack, process model, the native backend, the Claude SDK, design principles, parity with the Go server |
+| [Development](development.md) | Setup, running locally, tests, parity testing, conventions, debugging |
+| [Releasing](releasing.md) | Cutting a release, the guards, the update manifest, signing keys |
+
+[`desktop/CLAUDE.md`](../CLAUDE.md) is the full working notes: every decision,
+with the reasoning and the failures behind it. These guides are the map, that file
+is the territory.

--- a/desktop/docs/architecture.md
+++ b/desktop/docs/architecture.md
@@ -1,0 +1,339 @@
+# Architecture
+
+How Agento Desktop is put together, and why.
+
+For the exhaustive working notes, including the reasoning behind individual
+decisions, read [`desktop/CLAUDE.md`](../CLAUDE.md). This document is the map;
+that one is the territory.
+
+- [The short version](#the-short-version)
+- [Process model](#process-model)
+- [Why there is a local HTTP server](#why-there-is-a-local-http-server)
+- [The native backend](#the-native-backend)
+- [The Claude Agent SDK](#the-claude-agent-sdk)
+- [Data](#data)
+- [The frontend](#the-frontend)
+- [Design principles](#design-principles)
+- [Parity with the Go server](#parity-with-the-go-server)
+- [What the desktop app deliberately does not do](#what-the-desktop-app-deliberately-does-not-do)
+
+---
+
+## The short version
+
+| Layer | Technology |
+| --- | --- |
+| Shell and windowing | Tauri 2 |
+| Backend | Rust, `axum`, `rusqlite` |
+| Frontend | React 18, TypeScript, Vite |
+| Storage | SQLite at `~/.agento/agento.db` |
+| Agent runtime | The Claude Code CLI, spawned as a subprocess |
+
+One process. No sidecar, no bundled server, nothing fetched at runtime. The only
+external dependency is the Claude Code CLI, which is not redistributed.
+
+The Rust backend is a port of Agento's Go server. The Go sources still live in
+this repository (they ship as `agento web` on `main`) and remain the port's
+specification.
+
+---
+
+## Process model
+
+```
+┌─ Agento ────────────────────────────────────────────────┐
+│ Tauri (Rust)                                            │
+│   lib.rs    create data dir, migrate, seed pricing      │
+│   proxy.rs  axum on 127.0.0.1:<port>                    │
+│      /api/*  ──> native/ endpoint registry              │
+│      /*      ──> the embedded frontend (release only)   │
+│   menu.rs   native menu (macOS), emits menu://action    │
+│                                                         │
+│   WebView ──> React UI ──> fetch("/api/...")            │
+└─────────────────────────────────────────────────────────┘
+                     │
+                     └── spawns `claude` per agent run
+```
+
+Startup order in `lib.rs`:
+
+1. Resolve the data directory (`paths.rs`).
+2. Create the SQLite database if it does not exist, apply migrations, seed the
+   pricing catalog.
+3. Bind the axum server on loopback.
+4. Start the background scan of the Claude Code corpus.
+5. Start the task scheduler.
+6. Show the window.
+
+| | dev | release |
+| --- | --- | --- |
+| UI served by | Vite on `:1420` | the Rust server, from embedded assets |
+| `/api` reaches Rust via | Vite proxy to `:8991` | same origin |
+| Server port | fixed `8991` | assigned by the OS |
+| Data directory | `~/.agento-desktop-dev` | `~/.agento` |
+
+Dev uses its own data directory on purpose. Two Agento processes sharing
+`~/.agento` share one SQLite file and one scheduler, so scheduled tasks fire
+twice.
+
+---
+
+## Why there is a local HTTP server
+
+A Tauri app could call Rust through `invoke` commands instead. This one serves
+HTTP on loopback because:
+
+- **One origin in front of both halves sidesteps CORS entirely**, and keeps
+  server-sent events intact. Chat streaming is a POST whose response is an SSE
+  stream, which an `invoke` shim cannot carry.
+- **The frontend is the same shape as the web app's**, so `fetch("/api/...")`
+  works unchanged in a browser tab during development.
+
+Do not remove it to "simplify".
+
+Because the server is reachable by anything on the machine, `guards.rs` applies
+the same two protections the Go server does, before routing:
+
+- **`validateHost`** rejects a `Host` header the server is not served under. DNS
+  rebinding otherwise makes an attacker's page same-origin, at which point CORS
+  stops applying.
+- **`requireJSONContentType`** rejects a state-changing request that does not
+  declare `application/json`. Without it a cross-origin `POST` carrying
+  `text/plain` is a CORS simple request, sent with no preflight, and the side
+  effect lands even though the response is unreadable.
+
+A body-less request is not exempt: several state-changing endpoints take no body,
+and a `POST` with neither is itself a simple request.
+
+---
+
+## The native backend
+
+`src-tauri/src/native/` is one module per API area. Each declares its own
+`claims` (which requests it answers) and `serve` (how), and `ENDPOINTS` in
+`native/mod.rs` lists them.
+
+Two properties are load-bearing:
+
+- **Claiming a route and implementing it are one edit**, in the module they
+  belong to. A route cannot end up claimed by a handler that does not exist.
+- **Adding an endpoint is one appended line** plus a file. A single `match` over
+  every route meant two ports in flight always collided in the same hunk.
+
+A test asserts no two endpoints claim the same request, because the registry's
+one failure mode is a silent first-wins overlap.
+
+### Two registries
+
+| Registry | Shape | Used by |
+| --- | --- | --- |
+| `Endpoint` | Sync `fn`, returns a buffered `Vec<u8>` | Everything that hands back a finished document |
+| `StreamEndpoint` | Async, returns a `Response<Body>` | The chat turn, which lasts as long as the model talks |
+
+### Threading
+
+`rusqlite` is blocking, and the connection sets a five second busy timeout, so a
+call that meets a lock parks its thread. `proxy.rs` runs buffered handlers on the
+blocking pool for that reason.
+
+Anything reached from a **timer** or a **webhook** rather than a request is not
+covered by that, so the scheduler, the trigger dispatcher and the chat turn's
+persistence all hand database work to `db::blocking(label, f)`. It is greppable
+on purpose. A regression test drives a one-worker runtime against a held write
+lock and fails if the hand-off is removed.
+
+### Areas
+
+Roughly, one directory or file per area:
+
+| Module | Covers |
+| --- | --- |
+| `scanner/` | Reading Claude Code transcripts into the cache |
+| `insights/` | Nine passes producing a per-session insight row |
+| `analytics/` | The dashboards, bucketed in the request's timezone |
+| `sessions/` | The paged session list, facets, detail, continue-as-chat |
+| `chat/` | The SSE turn and the three routes that steer it |
+| `schedule/` | When a task fires, and running it |
+| `integrations/` | Six in-process MCP servers, and their lifecycle |
+| `tools/` | Agento's own local in-process tools |
+| `pricing.rs` | The rate catalog and resolver |
+| `agents.rs`, `chats.rs`, `tasks.rs` | Ordinary CRUD |
+| `gojson.rs`, `gotime.rs`, `gourl.rs`, `gopath.rs` | Go's semantics, in Rust |
+
+Those last four exist because the port's bar is byte-identical JSON, and Rust's
+natural encoding is not Go's. `3` against `3.0`, `<` against `<`, sorted
+against declared key order, and `filepath` and `net/url` behaviour that no Rust
+crate reproduces by accident.
+
+---
+
+## The Claude Agent SDK
+
+`src-tauri/src/claude/` is a Rust port of
+[`claude-agent-sdk-go`](https://github.com/shaharia-lab/claude-agent-sdk-go), the
+library every agent run goes through.
+
+It is **not an API client.** It spawns the `claude` CLI and speaks stream-json
+over stdio plus a control protocol. There is no inference to reimplement and no
+API key: the CLI's own sign-in is the credential.
+
+Four protocol facts that are expensive to rediscover:
+
+- **The handshake order matters.** Reader task live, register the request id,
+  write `initialize`, block on the acknowledgement, and only then send the first
+  user message. Getting it wrong races rather than fails.
+- **`sdkMcpServers` is never sent.** The CLI accepts only strings there, and a
+  rejection fails the entire initialize, silently taking hooks, agents, the
+  system prompt and the output format with it. MCP servers travel as
+  `--mcp-config`.
+- **`control_response` routes on the nested `response.request_id`**, and the
+  caller gets the innermost payload.
+- **Every inbound `control_request` must be answered.** A missing reply hangs the
+  CLI with no error on either side. `can_use_tool` with no handler is answered
+  with an error, never an allow.
+
+### Tools and MCP
+
+Every integration is an in-process MCP server, hosted over `rmcp` (the official
+Rust MCP SDK) on a loopback listener. `claude::ToolServer` is the typed-tool
+layer: schemas are derived from the input struct, and tools are registered at
+runtime from the integration's allowlist.
+
+Two rules:
+
+- **A tool's error is text the model reads**, never a protocol error. A protocol
+  error renders as "tool result missing due to internal error", which tells the
+  model nothing to retry against.
+- **Every server requires a bearer token**, which the Go server's does not. From
+  the moment those servers answer with the user's live Slack, GitHub and Google
+  credentials, loopback is not a boundary: it separates hosts, not processes.
+
+---
+
+## Data
+
+One SQLite file, `~/.agento/agento.db`, holding agents, chats, messages,
+scheduled tasks, job history, integrations, settings, the pricing catalog, and
+the cache of the Claude Code corpus.
+
+Migrations are embedded from `parity/migrations_vectors.json`, generated from the
+Go migration slice rather than transcribed, and applied at startup. Adding a
+migration on the Go side without regenerating fails the Go test suite.
+
+Two rules that surprise people:
+
+- **Cost is stored, not derived.** Each session's cost is computed at scan time,
+  per assistant message, against the rate in effect at that message's timestamp.
+  Analytics sums stored values and never re-prices. Editing a rate therefore
+  forces a re-read of the corpus, which is what the pricing revision fingerprint
+  in `claude_cache_metadata` is for.
+- **Duration means active duration.** Sessions are resumable, so the span from
+  first to last event counts idle days. Gaps beyond a user-configurable
+  threshold are excluded, and the resulting figure is stored, so changing the
+  threshold invalidates the same rows a rate edit does.
+
+The scan is parallel-read and batched-write: a small pool decodes transcripts,
+one writer commits them in batches, because SQLite serializes writers and a
+transaction per file was thousands of fsyncs on a full re-read.
+
+---
+
+## The frontend
+
+```
+src/
+  lib/
+    api.ts       fetch wrapper, and POST-based SSE for chat streaming
+    types.ts     TypeScript mirrors of the Go JSON, field for field
+    hooks.ts     useResource / useDebounced / usePoll / describeError
+    format.ts    numbers, money, durations, relative time
+    stats.ts     the sidebar and status bar counters
+    nav.ts       sections and view ids
+    icons.tsx    16px, 1.5 stroke icon set
+    tauri.ts     window and menu bridge; degrades to a plain browser tab
+    updater.ts   the in-app update flow
+  components/    TitleBar, Sidebar, StatusBar, CommandPalette, ui.tsx
+  views/         one file per section
+  styles/        tokens, base, shell, controls, views, plus per-view files
+```
+
+**Wire types are not translated.** `types.ts` uses the Go `json:` tags as they
+are. Renaming at the boundary would only hide drift. Go marshals an empty slice
+as `null`, so every array field is `T[] | null`.
+
+**`lib/tauri.ts` degrades.** Every Tauri call is behind it, so `npm run dev` in a
+browser tab still renders the UI.
+
+---
+
+## Design principles
+
+The desktop UI deliberately diverges from the web app. The web version is a page:
+a nav rail, a large heading, a primary button top right, a wide column of cards.
+That is correct for a browser and wrong for a window.
+
+- **Three panes, not one page.** Every section is list, detail, inspector. You
+  navigate within a window instead of replacing its contents, which is why there
+  is no page-level heading anywhere.
+- **Density.** 14px base type, 28px rows, hairline borders. The web app runs
+  roughly 16px and 48px, which at desktop distances reads as a website in a
+  frame.
+- **A status bar.** Persistent and always truthful. Web apps rarely have one.
+- **Selection behaves natively.** Rows fill with the accent colour when the
+  window is focused and drop to neutral grey when it is not. It is the single
+  strongest "this is a real app" signal, and almost no web port does it.
+- **Keyboard first.** A command palette, plus a native macOS menu that emits
+  actions the webview handles, so menu and shortcut run identical code.
+- **No browser affordances.** Text is not selectable except where you would read
+  or copy it, the context menu is suppressed, scrollbars are overlay style, and
+  focus rings appear for keyboard navigation only.
+- **Window chrome belongs to the OS.** `decorations: true` everywhere. macOS gets
+  its native traffic lights over the app's own titlebar strip; Linux and Windows
+  get an ordinary decorated titlebar.
+
+Theming: tokens are defined on bare `:root` for light, then re-declared under
+both `@media (prefers-color-scheme: dark)` and `:root[data-theme="dark"]`, so an
+explicit choice wins in either direction. Never give a colour its only definition
+inside a media block.
+
+---
+
+## Parity with the Go server
+
+The Rust backend is a port, and the bar is **byte-identical JSON**. The frontend
+is shared, so any drift in field names, key order, escaping or float spelling is
+a regression, and only a byte comparison catches all four.
+
+Three mechanisms enforce it, and all three are still live:
+
+1. **Fixture goldens.** `desktop/parity/` holds files Go generates and both
+   languages assert against. Shared primitives take a vector form instead:
+   `gopath_vectors.json` records what Go's `filepath` functions answer, and both
+   languages test against it.
+2. **Live diffs.** `scripts/parity-instance.sh` builds the Go server from this
+   checkout, runs it against a copy of the real data, and the suites in
+   `src-tauri/tests/parity_*.rs` replay each request against both and compare.
+3. **Route tables.** `parity/write_routes.json` and `parity/read_routes.json` are
+   generated by walking the Go router, and Rust tests assert every route's real
+   `claims()` matches its recorded disposition. A route cannot be claimed or
+   unclaimed without the file moving.
+
+Never diff against an installed Agento. That binary is whatever the developer
+last installed, and it drifts behind the repository in both directions: a stale
+baseline fails a correct port, and a stale baseline that happens to agree hides a
+real divergence.
+
+---
+
+## What the desktop app deliberately does not do
+
+| Not here | Why |
+| --- | --- |
+| **WhatsApp** | `whatsmeow` has no Rust equivalent and will not be reimplemented. Existing rows survive and are read-only |
+| **OpenTelemetry and Prometheus** | Server concerns. The two config routes answer 501 with a message naming the alternative, rather than 404, which would read as a version mismatch |
+| **The self-updater** | Tauri's updater replaces it. `GET /api/version/update-check` short-circuits so the two cannot race |
+| **The legacy filesystem import** | It predates every desktop install |
+
+Instead of telemetry, the app writes one access line per API request to a
+rotating log file, plus a line per write saying what it did. No bodies, no
+headers, no query strings.

--- a/desktop/docs/development.md
+++ b/desktop/docs/development.md
@@ -1,0 +1,347 @@
+# Development
+
+Setting up, running and testing Agento Desktop locally.
+
+Read [Architecture](architecture.md) first if you have not. The full working
+notes, with the reasoning behind individual decisions, are in
+[`desktop/CLAUDE.md`](../CLAUDE.md).
+
+- [Prerequisites](#prerequisites)
+- [Setup](#setup)
+- [Running it](#running-it)
+- [Project layout](#project-layout)
+- [Tests](#tests)
+- [Parity testing](#parity-testing)
+- [Conventions](#conventions)
+- [Debugging](#debugging)
+- [Branches and pull requests](#branches-and-pull-requests)
+
+---
+
+## Prerequisites
+
+| Tool | Version |
+| --- | --- |
+| Rust | stable, 1.88 or newer |
+| Node.js | 22 |
+| Go | 1.25 or newer, only for the parity tests |
+| Claude Code CLI | any recent version, for running agents |
+
+**Linux system packages**, once:
+
+```bash
+sudo apt install libwebkit2gtk-4.1-dev build-essential curl wget file \
+  libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
+```
+
+Fedora and openSUSE have the same libraries under their own names. macOS needs
+Xcode command line tools; Windows needs the MSVC build tools.
+
+The crate declares Rust 1.88 as its minimum. That floor is what makes cargo
+resolve `rmcp` 3.x rather than silently falling back to a superseded major, and
+it turns on clippy's version-gated lints.
+
+---
+
+## Setup
+
+```bash
+git clone https://github.com/shaharia-lab/agento.git
+cd agento
+git checkout desktop
+cd desktop
+npm install
+```
+
+Note the branch. Desktop work happens on `desktop`, not `main`.
+
+---
+
+## Running it
+
+All commands run from `desktop/`.
+
+| Command | What it does |
+| --- | --- |
+| `npm run app` | The real desktop window, with hot reload |
+| `npm run dev` | Vite only, in a browser tab. Fastest loop for pure layout work |
+| `npm run build` | Typecheck and build the frontend alone |
+| `npm run app:build` | Native installers for the current platform |
+| `cd src-tauri && cargo build` | Backend only |
+
+`npm run app` runs against `~/.agento-desktop-dev`, **not** your real `~/.agento`.
+That is deliberate: two Agento processes on one data directory share a scheduler,
+so every scheduled task would fire twice. Release builds use the real directory.
+
+To seed the dev instance with data, copy your real database into it, or create
+rows through the UI.
+
+### Pointing at a different Claude CLI
+
+```bash
+AGENTO_CLAUDE_EXECUTABLE=/path/to/claude npm run app
+```
+
+This is also how the turn tests point the runner at a scripted fake CLI.
+
+---
+
+## Project layout
+
+```
+desktop/
+  src/                 the React frontend
+  src-tauri/
+    src/lib.rs         startup: database, migrations, pricing seed, window, menu
+    src/proxy.rs       the axum server; routes every request into native/
+    src/guards.rs      the Host and Content-Type guards, applied before routing
+    src/menu.rs        the native macOS menu
+    src/paths.rs       data directory and database path
+    src/claude/        the Claude Agent SDK, ported from Go
+    src/native/        the ported backend, one module per API area
+    tests/             integration tests, including the parity suites
+  parity/              cross-language fixtures, asserted by both Go and Rust
+  scripts/
+    parity-instance.sh a Go server built from this checkout, on a copy of the DB
+  docs/                this documentation
+  CLAUDE.md            the full working notes
+```
+
+---
+
+## Tests
+
+```bash
+cd src-tauri
+
+cargo test                    # unit tests and the non-ignored integration tests
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+```
+
+From `desktop/`:
+
+```bash
+npm run build                 # tsc --noEmit plus the Vite build
+```
+
+CI runs exactly those four. It only runs on changes under `desktop/`,
+`.github/workflows/desktop-*`, and the Go sources the parity fixtures come from.
+
+### Tests that need something
+
+Several suites are `#[ignore]`d because they need a corpus, a database or a
+running Go server that CI does not have.
+
+```bash
+# The scan, against a copy of your real corpus.
+cargo test --test scan_live -- --ignored --nocapture
+
+# The MCP server, dialled by the real Claude Code CLI.
+cargo test --test claude_mcp_live -- --ignored --nocapture
+```
+
+Verify scanner changes against real data, not a fixture. The failure that matters
+is a scan that runs, reports success and writes nothing, and a three-file fixture
+cannot tell that apart from a healthy one.
+
+### The fake CLI
+
+`tests/claude_sdk.rs`, `tests/chat_turn.rs` and `tests/scheduled_run.rs` drive a
+scripted fake `claude` CLI: a Python program that logs every line it receives on
+stdin and replies to order. It is the only way to test things that are properties
+of a **sequence** rather than of a function, such as the handshake order or a
+disconnect while a permission prompt is pending.
+
+Two traps in writing those tests:
+
+- **The fake must not exit after the result.** A real CLI in session mode stays
+  alive. A fake that exits closes stdout, ends the stream for free, and passes
+  against a drain that would never terminate on its own.
+- **Assert the revert fails.** A disconnect test that passes with and without the
+  fix is testing nothing.
+
+---
+
+## Parity testing
+
+The Rust backend is a port of the Go server, and correctness means matching it
+byte for byte. See [Architecture](architecture.md#parity-with-the-go-server) for
+why.
+
+### Fixtures
+
+`parity/` holds files generated from Go and asserted by both languages.
+Regenerate from the repository root:
+
+```bash
+go test ./desktop/parity/ -run TestGitHubVectors    -update-github-vectors
+go test ./desktop/parity/ -run TestWriteRoutes      -update-write-routes
+go test ./internal/scheduler/ -run TestScheduleVectors -update-scheduler-vectors
+go test ./internal/storage/ -update-migration-vectors
+```
+
+Each vector file names its own generator in the test beside it. Regenerate
+**after** deciding whether the change was intended: these files are the record of
+what Go does, not a snapshot to be refreshed on failure.
+
+### Live diffs
+
+```bash
+cd desktop
+eval "$(./scripts/parity-instance.sh start)"
+(cd src-tauri && cargo test --test parity_analytics -- --ignored --nocapture)
+./scripts/parity-instance.sh stop
+```
+
+To run every suite, drop `--test` and add `--no-fail-fast`. Without it, cargo
+stops at the first failing test **binary**, so one red suite hides every suite
+after it.
+
+Notes:
+
+- `parity-instance.sh` builds the Go server from this checkout and runs it
+  against a **copy** of `~/.agento`. Never diff against the Agento you have
+  installed: it drifts behind the repository, and a stale baseline that happens
+  to agree hides a real divergence.
+- It is safe to run concurrently from separate checkouts. Two agents sharing one
+  checkout need `AGENTO_PARITY_WORKER=<id>` or `AGENTO_PARITY_DIR=<path>`.
+- `parity_writes` **mutates**, unlike every other suite, so it refuses to run
+  unless `AGENTO_LIVE_URL` is set rather than defaulting to `:8990`.
+- `parity_claude_settings` refuses to run unless `CLAUDE_CONFIG_DIR` points
+  somewhere other than `~/.claude`, because it overwrites `settings.json`.
+
+### Go is not always byte-stable
+
+Several Go analytics builders collect into a map, which iterates randomly, and
+then sort unstably, so two rows tying on the sort key come out in either order.
+The Rust port sorts stably, so it matches only one of the orderings Go produces.
+
+Before assuming a diff is your bug, **ask Go the same question twice.**
+
+---
+
+## Conventions
+
+### Porting a route
+
+1. **Read `native/gojson.rs` first.** Rust's natural JSON is not Go's. Encode
+   through `gojson::to_vec`, keep struct fields in the Go struct's declaration
+   order, and use `skip_serializing_if` for `omitempty`.
+2. Mirror the Go source's ordering and grouping exactly, including anything
+   hashed. A fingerprint over rows in a different order is a different
+   fingerprint for identical data.
+3. Prove it two ways: a fixture both languages build against a Go-written golden,
+   and the live diff against real data.
+4. Only then leave it claimed.
+
+### JSON decoding
+
+Go's `json.Unmarshal` treats `null` as a no-op for every type here, and serde
+rejects it. Three helper types exist for that, and they are **types rather than
+`deserialize_with` functions** for a reason recorded in `gojson.rs`: a function
+makes the field required, which forces `#[serde(default)]` on every call site,
+which in turn widens the struct into accepting short positional arrays that Go
+refuses.
+
+| Helper | Covers |
+| --- | --- |
+| `null_is_zero_value` | A `null` scalar field |
+| `GoList<T>` / `GoMap<V>` | A `null` element or map value |
+| `GoStruct<T>` | A struct built positionally from a JSON array |
+
+The direction matters. An over-**reject** is visible. An over-**accept** writes a
+row Go would refuse, with nothing to report it.
+
+### Wire types
+
+`src/lib/types.ts` uses the Go `json:` tags verbatim. Every array field is
+`T[] | null`, because Go marshals a nil slice as `null`.
+
+Every state-changing `/api` request needs `Content-Type: application/json`,
+including the ones with no body. `api.ts` does this for you.
+
+### UI
+
+- Reuse the existing CSS classes. New CSS goes in a per-view file imported by
+  that view.
+- **No `window.confirm`, `alert` or `prompt`.** They block the WebView and can
+  wedge the app. Render inline confirmation UI.
+- External links must go through `openExternal` in `lib/tauri.ts`.
+  `window.open` and `target="_blank"` do not leave a Tauri webview.
+- Directory fields use the native picker via `pickDirectory`. The in-app browser
+  is the plain-browser fallback only.
+- Charts are inline SVG using the theme tokens. No chart libraries.
+- `.card` sets `overflow: hidden`, so as a flex child of a scrolling column its
+  min-content height collapses to zero. Dashboard containers need
+  `> * { flex: 0 0 auto; }`.
+
+### Database access off the request path
+
+Anything reached from a timer, a webhook or a stream must hand its database work
+to `db::blocking(label, f)`. The label is per call site so the log says which
+section panicked. See
+[Architecture](architecture.md#threading).
+
+### Logging
+
+`message key=value`, every string value with `{:?}`, at `info`, and **after** the
+effect. Failures at `warn`, writes at `info`, successful reads at `debug`.
+
+Never log a body, a header or a query string. Bodies here are chat prompts,
+system prompts and integration credentials; query strings carry search terms and
+project paths.
+
+Every write log line has a test asserting it is emitted. A line with no test is a
+line that quietly stops being emitted.
+
+---
+
+## Debugging
+
+**The webview inspector** is available in dev builds: right-click, Inspect
+Element, or the usual devtools shortcut.
+
+**The log file** is where backend problems land:
+
+| Platform | Path |
+| --- | --- |
+| Linux | `~/.local/share/com.shaharialab.agento/logs/Agento.log` |
+| macOS | `~/Library/Logs/com.shaharialab.agento/Agento.log` |
+| Windows | `%LOCALAPPDATA%\com.shaharialab.agento\logs\Agento.log` |
+
+In `npm run app` the same lines go to the terminal.
+
+**Curling the API** works in dev, since the server is on a fixed port:
+
+```bash
+curl -s http://127.0.0.1:8991/api/agents | jq
+```
+
+Add `-H "Content-Type: application/json"` for anything that is not a `GET`, or
+the guard answers 415 before the handler runs.
+
+There is also a project skill, `local-verify`, describing how to reproduce a bug
+before fixing it and how to verify each hop separately: backend wire, browser
+engine, real Tauri webview, then the UI flow. Use it for anything that "works in
+Chrome but not in the app".
+
+---
+
+## Branches and pull requests
+
+- Desktop work happens on the **`desktop`** branch. PRs target `desktop`, not
+  `main`.
+- `main` carries the Go server and is left alone until the two converge.
+- Desktop releases are tagged `desktop-v*` from `desktop`. The Go server keeps
+  its own `v*` tags. The two patterns do not overlap, so both ship independently
+  from one repository.
+
+Before opening a PR:
+
+```bash
+cd desktop && npm run build
+cd src-tauri && cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test
+```
+
+Releasing is documented separately in [Releasing](releasing.md).

--- a/desktop/docs/installation.md
+++ b/desktop/docs/installation.md
@@ -1,0 +1,244 @@
+# Installation
+
+Everything you need to get Agento Desktop running, keep it updated, and remove it
+again.
+
+- [Requirements](#requirements)
+- [Which file do I download](#which-file-do-i-download)
+- [macOS](#macos)
+- [Windows](#windows)
+- [Linux](#linux)
+- [Updates](#updates)
+- [Where your data lives](#where-your-data-lives)
+- [Uninstalling](#uninstalling)
+
+---
+
+## Requirements
+
+**The Claude Code CLI, installed and signed in.** Agento runs every agent by
+launching `claude` on your machine. If `claude` works in your terminal, Agento
+works.
+
+You do **not** need an Anthropic API key. Agento uses the authentication Claude
+Code already holds.
+
+If the CLI is missing, the app still opens and shows a banner explaining what to
+install. Analytics and history still work; chats and scheduled runs do not.
+
+Operating systems:
+
+| Platform | Minimum |
+| --- | --- |
+| macOS | 10.15 Catalina, Apple Silicon or Intel |
+| Windows | Windows 10 or 11, 64 bit |
+| Linux | Any distro with GTK 3 and WebKitGTK 4.1 |
+
+---
+
+## Which file do I download
+
+Downloads are on the
+[releases page](https://github.com/shaharia-lab/agento/releases?q=desktop&expanded=true).
+Desktop releases are tagged `desktop-v<version>`. The Agento server has its own
+`v<version>` tags, so make sure you are looking at a `desktop-` one.
+
+| Platform | File | Auto-update |
+| --- | --- | --- |
+| macOS, Apple Silicon (M1 and later) | `Agento_<version>_aarch64.dmg` | Yes |
+| macOS, Intel | `Agento_<version>_x64.dmg` | Yes |
+| Windows x64 | `Agento_<version>_x64-setup.exe` | Yes |
+| Linux x86_64, portable | `Agento_<version>_amd64.AppImage` | Yes |
+| Linux ARM64, portable | `Agento_<version>_aarch64.AppImage` | Yes |
+| Debian, Ubuntu x86_64 | `Agento_<version>_amd64.deb` | Notify only |
+| Debian, Ubuntu ARM64 | `Agento_<version>_arm64.deb` | Notify only |
+| Fedora, RHEL, openSUSE x86_64 | `Agento-<version>-1.x86_64.rpm` | Notify only |
+| Fedora, RHEL, openSUSE ARM64 | `Agento-<version>-1.aarch64.rpm` | Notify only |
+
+The `.sig` files beside each download are used by the in-app updater. You do not
+need to download them.
+
+Not sure which Mac you have: **Apple menu → About This Mac**. "Apple M1" or later
+means take the `aarch64` build.
+
+---
+
+## macOS
+
+1. Open the `.dmg`.
+2. Drag **Agento** to the **Applications** folder.
+3. Eject the disk image and launch Agento from Applications.
+
+### The first launch is blocked
+
+macOS refuses to open the app the first time and says it cannot be verified. This
+is expected. The app is not signed with a paid Apple Developer certificate, so
+Gatekeeper treats it as an unidentified developer.
+
+To allow it:
+
+1. Try to open Agento once, and dismiss the warning.
+2. Open **System Settings → Privacy & Security**.
+3. Scroll to the Security section. You will see a line about Agento being blocked.
+4. Click **Open Anyway** and confirm.
+
+Command line alternative, if you prefer:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/Agento.app
+```
+
+You only do this once. Updates the app installs itself are not quarantined, so
+they launch without any prompt.
+
+---
+
+## Windows
+
+1. Run `Agento_<version>_x64-setup.exe`.
+2. SmartScreen shows "Windows protected your PC" because the installer is not
+   signed with a code signing certificate. Click **More info**, then
+   **Run anyway**.
+3. Accept the administrator prompt. Agento installs for all users on the machine.
+4. Launch **Agento** from the Start menu.
+
+Agento needs the Microsoft WebView2 runtime. The installer carries a copy and
+installs it if your machine does not already have it, so nothing is downloaded
+during setup.
+
+---
+
+## Linux
+
+### AppImage, recommended
+
+Works on any distribution and updates itself.
+
+```bash
+chmod +x Agento_0.1.0_amd64.AppImage
+./Agento_0.1.0_amd64.AppImage
+```
+
+Keep the file anywhere you like, for example `~/Applications`. There is no
+installation step and no root access needed. When the app updates itself, it
+replaces that file in place, so put it somewhere you can write to.
+
+If your desktop does not show a launcher for it, install
+[AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher) or create a
+`.desktop` file by hand.
+
+### Debian and Ubuntu
+
+```bash
+sudo apt install ./Agento_0.1.0_amd64.deb
+```
+
+### Fedora, RHEL, openSUSE
+
+```bash
+sudo dnf install ./Agento-0.1.0-1.x86_64.rpm
+```
+
+Both packages declare `libwebkit2gtk-4.1` and `gtk3` as dependencies, so your
+package manager installs whatever is missing. If a dependency cannot be resolved,
+your distribution is likely older than WebKitGTK 4.1: use the AppImage instead.
+
+### The binary is called `agento-desktop`
+
+The package is named `agento`, but the executable it installs is
+`/usr/bin/agento-desktop`. That is deliberate. The Agento server CLI installs a
+binary called `agento`, and a package dropping a second `agento` onto your `PATH`
+would shadow it.
+
+---
+
+## Updates
+
+Agento checks for updates on launch and from **Settings → General → Updates**, and
+you can also check on demand from the **About** screen.
+
+You choose the behaviour:
+
+| Setting | What happens |
+| --- | --- |
+| **Download and install automatically** | Agento fetches the update, installs it and restarts itself |
+| **Notify me** | Agento checks on launch and shows a badge; you install when you want to |
+| **Never check** | No update checks at all |
+
+This preference is stored per install, not per account, because the same person
+may run an AppImage on one machine and a `.deb` on another.
+
+### What each install type can do
+
+| Install | Behaviour |
+| --- | --- |
+| macOS `.dmg` | Installs updates in place, then restarts |
+| Windows `.exe` | Installs updates in place, then restarts |
+| Linux AppImage | Replaces the AppImage file in place, then restarts |
+| Linux `.deb` and `.rpm` | Tells you a version is available and links to the download. Nothing is installed automatically |
+
+`.deb` and `.rpm` are notify only because `dpkg` and `rpm` own the files they
+installed. If Agento overwrote them, your package database would describe a
+version that is no longer on disk. Update those installs the way you update
+everything else on the system, by downloading the newer package and installing it.
+
+### Update safety
+
+Every update payload is signed with Agento's own signing key, and the app carries
+the matching public key. A download that does not verify is rejected. This is
+independent of Apple and Microsoft code signing, which is why in-app updates work
+smoothly even though the first launch needs a Gatekeeper or SmartScreen bypass.
+
+---
+
+## Where your data lives
+
+Everything is in one directory, and one SQLite database inside it.
+
+| Platform | Path |
+| --- | --- |
+| macOS and Linux | `~/.agento/agento.db` |
+| Windows | `%USERPROFILE%\.agento\agento.db` |
+
+That holds your agents, chats, scheduled tasks, job history, integration
+settings and the index of your Claude Code sessions. To back Agento up, copy that
+directory while the app is closed.
+
+Agento reads your Claude Code history from `~/.claude` (or whatever
+`CLAUDE_CONFIG_DIR` points at). It only reads: your transcripts are never
+modified.
+
+Application logs:
+
+| Platform | Path |
+| --- | --- |
+| Linux | `~/.local/share/com.shaharialab.agento/logs/Agento.log` |
+| macOS | `~/Library/Logs/com.shaharialab.agento/Agento.log` |
+| Windows | `%LOCALAPPDATA%\com.shaharialab.agento\logs\Agento.log` |
+
+### Running the desktop app and `agento web` together
+
+Do not point both at the same data directory at the same time. Two processes
+sharing one database also share one scheduler, so every scheduled task fires
+twice. Run one or the other, or give one of them its own directory with
+`AGENTO_DATA_DIR`.
+
+---
+
+## Uninstalling
+
+| Install | How |
+| --- | --- |
+| macOS | Drag `Agento.app` from Applications to the Trash |
+| Windows | Settings → Apps → Agento → Uninstall |
+| AppImage | Delete the `.AppImage` file |
+| Debian, Ubuntu | `sudo apt remove agento` |
+| Fedora, RHEL | `sudo dnf remove Agento` |
+
+None of these removes your data. To delete that too:
+
+```bash
+rm -rf ~/.agento
+```
+
+Your Claude Code history in `~/.claude` is untouched either way.

--- a/desktop/docs/releasing.md
+++ b/desktop/docs/releasing.md
@@ -1,0 +1,207 @@
+# Releasing
+
+How a desktop release is cut, and the two things that break it.
+
+Desktop releases are tagged `desktop-v*` from the `desktop` branch. The Agento
+server keeps its own `v*` tags on `main`. The patterns do not overlap, so both
+ship independently from one repository.
+
+- [The flow](#the-flow)
+- [Cutting a release](#cutting-a-release)
+- [The two guards](#the-two-guards)
+- [Release candidates and dry runs](#release-candidates-and-dry-runs)
+- [What gets built](#what-gets-built)
+- [The update manifest](#the-update-manifest)
+- [Signing keys](#signing-keys)
+- [If something goes wrong](#if-something-goes-wrong)
+
+---
+
+## The flow
+
+```
+  bump tauri.conf.json  ──>  tag desktop-vX.Y.Z  ──>  guard + build matrix
+                                                            │
+                                                            v
+                                              DRAFT release, installers
+                                              attached, latest.json staged
+                                                            │
+                                            (a human checks the installers)
+                                                            │
+                                                  publish the draft
+                                                            │
+                                                            v
+                                     promote: copy latest.json to the fixed
+                                     `desktop-latest` tag every app polls
+```
+
+**Publishing the draft is the release act.** Draft assets are not publicly
+downloadable, so nothing has shipped until then. Installed apps cannot even fetch
+the manifest.
+
+The manifest is deliberately not published at build time. A live manifest
+pointing at draft asset URLs would make every installed app report an update it
+cannot download.
+
+---
+
+## Cutting a release
+
+1. **Bump the version** in `desktop/src-tauri/tauri.conf.json`. Commit it on
+   `desktop`.
+
+   ```json
+   { "version": "0.2.0" }
+   ```
+
+2. **Tag that commit** and push the tag.
+
+   ```bash
+   git tag desktop-v0.2.0
+   git push origin desktop-v0.2.0
+   ```
+
+3. **Wait for the build.** Five runners, one per target: Linux x86_64, Linux
+   aarch64, macOS Apple Silicon, macOS Intel, Windows x86_64. Tauri cannot
+   cross-compile its bundles, which is why each needs its own runner.
+
+4. **Check the draft release.** Confirm every platform's installer is attached
+   and `latest.json` is there. Download one and launch it if the change was
+   risky.
+
+5. **Publish the draft.** That fires `promote`, which copies the staged manifest
+   to `desktop-latest`. Installed apps start seeing the update within their next
+   check.
+
+---
+
+## The two guards
+
+**The tag must equal `desktop-v` plus the version in `tauri.conf.json`.** A guard
+job fails the build otherwise, before anything is built.
+
+This is not tidiness. The installed app compares the version baked into it at
+build time against the manifest's version, which comes from the tag. If the tag
+says `0.2.0` and the conf still says `0.1.0`, every "updated" install keeps
+reporting `0.1.0` and is offered the same update forever.
+
+**Every platform must produce a signature.** The manifest script aborts the
+release if a payload has no `.sig`, or if a platform produced nothing at all. A
+manifest that silently omitted a platform would strand exactly the users already
+running it, and their app would keep reporting "up to date" indefinitely.
+
+---
+
+## Release candidates and dry runs
+
+**A prerelease tag** builds and drafts identically, is auto-marked prerelease, and
+is **never promoted**:
+
+```bash
+git tag desktop-v0.2.0-rc.1
+git push origin desktop-v0.2.0-rc.1
+```
+
+Share the release page with testers. No installed app is offered it. The promote
+job double-checks the version string too, so an rc tag published with the
+prerelease box unticked is refused rather than pushed to updaters.
+
+**A private smoke test** needs no tag at all. Run the workflow manually with
+`dry_run`. Installers land as CI artifacts and no release is created.
+
+---
+
+## What gets built
+
+| Runner | Target | Artifacts |
+| --- | --- | --- |
+| `ubuntu-22.04` | `x86_64-unknown-linux-gnu` | `.deb`, `.rpm`, `.AppImage` |
+| `ubuntu-22.04-arm` | `aarch64-unknown-linux-gnu` | `.deb`, `.rpm`, `.AppImage` |
+| `macos-15` | `aarch64-apple-darwin` | `.dmg`, `.app.tar.gz` |
+| `macos-15-intel` | `x86_64-apple-darwin` | `.dmg`, `.app.tar.gz` |
+| `windows-latest` | `x86_64-pc-windows-msvc` | `-setup.exe` |
+
+Notes worth knowing before touching the matrix:
+
+- **Linux builds on the oldest supported LTS.** The `.deb` links against whatever
+  the build host has, so building on 22.04 is what keeps the package installable
+  on newer releases.
+- **macOS ships two separate builds, not a universal binary.** A universal
+  binary would be simpler and would double every download.
+- **A job naming a retired runner image queues forever** rather than erroring.
+  Check `actions/runner-images` before bumping one.
+- **NSIS, not MSI, on Windows.** The updater manifest expects the `-setup.exe`; a
+  built-and-dropped `.msi` only wasted CI time.
+- **The macOS updater tarball is renamed at collection.** Tauri names it
+  `Agento.app.tar.gz` with no architecture, identical on both macOS legs, so the
+  merged artifact download would silently overwrite one architecture's payload
+  with the other's.
+
+---
+
+## The update manifest
+
+`.github/scripts/build-update-manifest.py` walks the collected artifacts, pairs
+each updater payload with its detached signature, and writes `latest.json`.
+
+Platform keys are `tauri-plugin-updater`'s `{os}-{arch}`, where the architecture
+uses Rust's spelling: `aarch64`, never `arm64`. A key the plugin does not look up
+strands that platform's users silently.
+
+macOS updates ship as `.app.tar.gz`. The `.dmg` is only for the first install.
+
+The manifest is served from a fixed tag, `desktop-latest`, so the updater has a
+stable URL. `releases/latest` could not be used: it would point at the Go
+server's `v*` releases. That tag is itself marked prerelease so it never
+displaces the real latest release on the repository page.
+
+---
+
+## Signing keys
+
+Updates are signed with **our own minisign key**, generated by
+`tauri signer generate`. It has nothing to do with Apple or Microsoft code
+signing. It only proves an update came from us, which is why in-app updates work
+on unsigned macOS builds: Gatekeeper gates the first launch of a downloaded app,
+not a bundle the updater swapped in.
+
+| Half | Where |
+| --- | --- |
+| Private | 1Password, then GCP Secret Manager (`github-repo-agento-tauri-updater-private-key`), then the `TAURI_SIGNING_PRIVATE_KEY` Actions secret, all via `terraform/` |
+| Public | `plugins.updater.pubkey` in `tauri.conf.json` |
+
+**Losing the private key means no existing install can ever be updated again.**
+Every installed app verifies against the public key it was built with, so a new
+key cannot reach them.
+
+Builds are **not** Apple notarised and **not** Windows code signed. First launch
+therefore needs a Gatekeeper or SmartScreen bypass, which the release notes and
+[Installation](installation.md) both explain.
+
+---
+
+## If something goes wrong
+
+**The guard failed.** The tag and the conf disagree. Delete the tag, fix
+`tauri.conf.json`, commit, and re-tag.
+
+```bash
+git tag -d desktop-v0.2.0
+git push origin :refs/tags/desktop-v0.2.0
+```
+
+**One runner failed.** `fail-fast` is off, so the others still finish, but the
+draft release job needs all of them. Re-run the failed job; if it is a mirror or
+network failure, that is usually enough.
+
+**The manifest job failed with a missing signature.** A build succeeded without
+`TAURI_SIGNING_PRIVATE_KEY` reaching it. Check the secret is still set, then
+re-run the build.
+
+**You published the draft by accident.** The manifest is already on
+`desktop-latest`. Publish a corrected version rather than trying to withdraw it:
+apps that already checked have the old manifest cached anyway, and a manifest
+pointing backwards does not undo an installed update.
+
+**The draft looks wrong.** Delete the draft release and the tag, fix, and start
+again. Nothing has shipped until a draft is published.

--- a/desktop/docs/troubleshooting.md
+++ b/desktop/docs/troubleshooting.md
@@ -1,0 +1,293 @@
+# Troubleshooting
+
+Common problems and what to do about them.
+
+- [Installing and launching](#installing-and-launching)
+- [The Claude Code CLI](#the-claude-code-cli)
+- [Chats](#chats)
+- [History and analytics](#history-and-analytics)
+- [Scheduled tasks](#scheduled-tasks)
+- [Integrations](#integrations)
+- [Updates](#updates)
+- [Reading the logs](#reading-the-logs)
+- [Still stuck](#still-stuck)
+
+---
+
+## Installing and launching
+
+### macOS says the app is damaged or cannot be verified
+
+The app is not signed with a paid Apple Developer certificate, so macOS blocks
+the first launch. Open **System Settings → Privacy & Security**, find the line
+about Agento, and click **Open Anyway**.
+
+If that line is not there:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/Agento.app
+```
+
+Only the first launch needs this.
+
+### Windows SmartScreen blocks the installer
+
+Click **More info**, then **Run anyway**. The installer is not code signed, so
+SmartScreen has no publisher to recognize.
+
+### The AppImage will not start
+
+Most often a missing FUSE library. Either install it:
+
+```bash
+sudo apt install libfuse2      # Debian, Ubuntu
+```
+
+or run without it:
+
+```bash
+./Agento_0.1.0_amd64.AppImage --appimage-extract-and-run
+```
+
+Also check the file is executable: `chmod +x Agento_*.AppImage`.
+
+### The .deb or .rpm will not install
+
+Your package manager could not find GTK 3 or WebKitGTK 4.1. That usually means
+the distribution release is older than WebKitGTK 4.1. Use the AppImage instead.
+
+### The window opens blank or white
+
+Your system's webview is too old or missing.
+
+- **Linux**: install `libwebkit2gtk-4.1-0`.
+- **Windows**: install the
+  [WebView2 runtime](https://developer.microsoft.com/microsoft-edge/webview2/).
+  The installer normally handles this.
+
+Restart the app after installing.
+
+### Launching Agento does nothing
+
+It is probably already running. Agento allows one copy at a time, and a second
+launch focuses the existing window instead of opening a new one. Check your dock,
+taskbar or window list.
+
+---
+
+## The Claude Code CLI
+
+### "Claude Code CLI not found"
+
+Agents run by launching `claude`. Agento looks for it on your `PATH` and in the
+usual per-user install locations (`~/.local/bin`, `~/.npm-global/bin`,
+`~/.bun/bin`, `~/.volta/bin`, `~/bin`, and `AppData/Roaming/npm` on Windows).
+
+First check it works in a terminal:
+
+```bash
+claude --version
+```
+
+If that works but Agento still cannot find it, the cause is almost always that a
+GUI app inherits a smaller `PATH` than your shell does. Point Agento at the
+binary directly:
+
+```bash
+AGENTO_CLAUDE_EXECUTABLE=/full/path/to/claude
+```
+
+Set that in your environment before launching the app. `which claude` gives you
+the path.
+
+### Chats fail with an authentication error
+
+Agento does not manage Claude authentication. Sign in with the CLI:
+
+```bash
+claude
+```
+
+Complete the sign-in there, then retry in Agento.
+
+---
+
+## Chats
+
+### A chat is stuck mid-stream
+
+Click **Stop**. If the composer is still blocked afterwards, reload the
+transcript from the toolbar.
+
+If it keeps happening, check the log for the run. A `claude` subprocess that
+crashed ends the stream with nothing to say why, and the log is where the reason
+lands.
+
+### An agent will not use a tool
+
+Tools are an allowlist. Open the agent and confirm the tool is ticked. For
+integration tools, also confirm that integration's service is enabled and that
+its credentials are still valid.
+
+### The agent cannot see my files
+
+Check the chat's working directory. An agent only reaches the folder the chat was
+started in.
+
+### The agent keeps asking permission
+
+That is by design in a chat. You are there to answer, so Agento prompts before a
+tool runs, whatever the agent's permission mode says. Unattended runs, meaning
+scheduled tasks, do not prompt, because nothing could answer.
+
+If a tool is denied without any prompt at all, it is not on the agent's tool
+list. Add it there.
+
+---
+
+## History and analytics
+
+### The sessions list is empty
+
+If it says "Scanning" with a count, the first index is still running. Wait for it.
+
+If it says there are no sessions, Agento found no Claude Code history where it
+looked. Check **Settings → Claude → Indexed directories** covers the directory
+your transcripts are in. The default is `~/.claude`.
+
+### Sessions from a second Claude account are missing
+
+Add that account's configuration directory in
+**Settings → Claude → Indexed directories**. Both accounts then appear in every
+total.
+
+### A project is missing from every chart
+
+Check **Settings → Data → Hidden projects**. Unhiding is immediate and costs
+nothing.
+
+### Costs look wrong
+
+Cost is computed from the price catalog in **Settings → Pricing**, at the price
+in effect when each message was sent.
+
+- A model with no entry contributes no cost, and the totals say how many tokens
+  were unpriced.
+- If a price in the catalog is wrong, use **Correct a rate**, not "add a rate".
+  Correcting rewrites history; adding only affects messages after that date.
+
+Either way, sessions re-price in the background afterwards. It can take a few
+minutes on a large history.
+
+### Durations look too short
+
+They are meant to. Duration means active time, not the span from first to last
+message. A session resumed a week later would otherwise report a week. Adjust the
+threshold in **Settings → Data → Idle gap threshold**.
+
+### A scan seems to run for no reason
+
+Some changes invalidate every stored figure and force a full re-read: a price
+edit, and a change to the idle gap threshold. That is expected, it runs in the
+background, and the app stays usable.
+
+---
+
+## Scheduled tasks
+
+### A task never runs
+
+Check, in order:
+
+1. The task is **Enabled**.
+2. The inspector shows a **Next run** in the future.
+3. **Stop after** has not been reached and **Stop at** has not passed.
+4. Agento is actually running. A desktop app that is closed fires nothing.
+
+### Every task fires twice
+
+Two Agento processes are sharing one data directory, most likely the desktop app
+and `agento web`. Close one, or give one its own directory with
+`AGENTO_DATA_DIR`.
+
+### A run failed with a timeout
+
+The run took longer than the task's **Timeout**. Raise it, or make the prompt
+narrower.
+
+---
+
+## Integrations
+
+### Credentials stopped working after an edit
+
+Re-enter them. Agento asks for credentials again when you edit an integration
+that has stored ones, because saving the form without them would wipe the working
+credential.
+
+### An OAuth window did not come back
+
+Close the browser window and try **Connect** again. If your browser blocked the
+redirect to a local address, allow it and retry.
+
+### Tools from an integration are not offered to an agent
+
+Three things have to line up: the integration is connected, the service is
+enabled inside it, and the tool is ticked on the agent.
+
+### WhatsApp is listed but unusable
+
+The desktop app does not support WhatsApp. An existing integration is listed and
+its data is safe, but it cannot be edited or used here.
+
+---
+
+## Updates
+
+### The app says an update is available but there is no install button
+
+You installed from a `.deb` or `.rpm`. Those are notify only, because your package
+manager owns the installed files. Download the new package and install it the way
+you installed the first one, or switch to the AppImage for in-app updates.
+
+### The update download fails
+
+Check your network and try again from **About → Check for updates**. Updates are
+downloaded from GitHub, so a proxy or a firewall that blocks it will stop them.
+
+If it keeps failing, download the release manually and install over the top. Your
+data is untouched by a reinstall.
+
+### I do not want update checks
+
+**Settings → General → Updates → Never check**.
+
+---
+
+## Reading the logs
+
+| Platform | Path |
+| --- | --- |
+| Linux | `~/.local/share/com.shaharialab.agento/logs/Agento.log` |
+| macOS | `~/Library/Logs/com.shaharialab.agento/Agento.log` |
+| Windows | `%LOCALAPPDATA%\com.shaharialab.agento\logs\Agento.log` |
+
+The live file plus three dated archives are kept, roughly 20 MB in total.
+
+The log records one line per API request, plus what each write did. It does
+**not** record message bodies, prompts, credentials or search terms. It does
+record agent slugs and file paths, so treat it as mildly sensitive when sharing.
+
+---
+
+## Still stuck
+
+Open an issue at
+[github.com/shaharia-lab/agento/issues](https://github.com/shaharia-lab/agento/issues)
+with:
+
+- Your platform and how you installed (dmg, exe, AppImage, deb, rpm).
+- The Agento version from **About**.
+- `claude --version`.
+- What you did and what happened.
+- The relevant lines from the log.

--- a/desktop/docs/user-guide.md
+++ b/desktop/docs/user-guide.md
@@ -1,0 +1,427 @@
+# User Guide
+
+How to use Agento Desktop, section by section.
+
+New here? Install first: [Installation](installation.md).
+
+- [The window](#the-window)
+- [Chats](#chats)
+- [Agents](#agents)
+- [Integrations](#integrations)
+- [Scheduled tasks](#scheduled-tasks)
+- [Job history](#job-history)
+- [Claude sessions](#claude-sessions)
+- [Analytics](#analytics)
+- [Settings](#settings)
+- [Privacy](#privacy)
+
+---
+
+## The window
+
+Agento is one window with four parts.
+
+```
+┌──────────────────────────────────────────────────────┐
+│ titlebar: back, forward, sidebar toggle              │
+├─────────┬────────────────────────────────────────────┤
+│ sidebar │ toolbar                                    │
+│         ├──────────┬──────────────────┬──────────────┤
+│ sections│ list     │ detail           │ inspector    │
+├─────────┴──────────┴──────────────────┴──────────────┤
+│ status bar: running agents, model, today's spend     │
+└──────────────────────────────────────────────────────┘
+```
+
+- **Sidebar**: the sections of the app. `Ctrl B` hides it.
+- **List**: what is in the current section. Search and filters sit above it.
+- **Detail**: the thing you selected.
+- **Inspector**: facts and figures about that thing. `Ctrl I` hides it.
+- **Status bar**: always live. Running agents, the active model, today's tokens
+  and spend, and connection state.
+
+Drag the thin lines between panes to resize them. The app remembers your window
+size and position between launches.
+
+### Getting around fast
+
+Press `Ctrl K` (or `⌘K`) for the command palette. Type a few letters of what you
+want and press Enter. It reaches every section and the common actions.
+
+| Shortcut | Action |
+| --- | --- |
+| `Ctrl K` | Command palette |
+| `Ctrl N` | New chat |
+| `Ctrl ,` | Settings |
+| `Ctrl B` | Sidebar |
+| `Ctrl I` | Inspector |
+| `Ctrl [` / `Ctrl ]` | Back / forward |
+| `Ctrl 1` to `Ctrl 7` | Jump to a section |
+
+On macOS use `⌘` instead of `Ctrl`, and the menu bar carries the same actions.
+
+---
+
+## Chats
+
+A chat is a conversation with an agent, kept for as long as you want it.
+
+**Start one:** press `Ctrl N` or click the `+` above the chat list. Pick an agent
+(or none), choose a **working directory**, and type your first message.
+
+The working directory matters. It is the folder the agent can see and act in, the
+same way `claude` behaves when you run it from that folder. Click the folder icon
+to pick one with your system's file picker.
+
+**While a turn is running:**
+
+- The reply streams in as it is produced.
+- Tool calls appear inline, with the input and the result.
+- If the agent needs permission for a tool, a prompt appears. Approve or deny.
+- If the agent asks you a question, answer it in the composer and the run
+  continues.
+- **Stop** halts the run. Anything already written stays.
+
+**The inspector** shows the agent, the model, the message count and the token
+usage of the whole conversation, split into input, output, cache read and cache
+write, with the cost.
+
+Rename a chat from the title, or delete it from the toolbar. Deleting removes its
+messages too.
+
+**One thing worth knowing:** a turn that produced no final answer, for example one
+you stopped immediately, stores nothing. That is the same rule Claude Code
+follows.
+
+---
+
+## Agents
+
+An agent is a saved configuration you can reuse from chats, scheduled tasks and
+the command palette.
+
+Fields:
+
+| Field | What it does |
+| --- | --- |
+| **Name** and **slug** | The slug identifies it in the API and the CLI. It is filled in for you |
+| **Description** | For you, not for the model |
+| **Model** | Sonnet, Opus or Haiku. Leave empty to use the Claude Code default |
+| **Thinking** | Adaptive, always on, or disabled. Controls extended reasoning |
+| **Permission mode** | How much an unattended run may do without asking. See below |
+| **System prompt** | The agent's instructions |
+| **Claude config dir** | Run this agent as a different Claude Code account |
+| **Tools** | Exactly what this agent is allowed to use |
+
+### Permissions
+
+Two rules, and they do not depend on the agent's settings:
+
+- **In a chat, Agento asks you before a tool runs.** You are there to answer, so
+  the prompt appears in the transcript and the run waits.
+- **A tool the agent does not list is denied without asking.** The allowlist is
+  enforced whatever the permission mode says.
+
+The **permission mode** field applies to unattended runs, meaning scheduled
+tasks, where nothing can answer a prompt. Left unset, those runs proceed without
+prompting, because the alternative is a task that hangs until it times out.
+
+**Known limitation:** the permission mode you pick in the form is not currently
+saved. The underlying API drops the field, and the desktop app reproduces the
+server's behaviour rather than diverging from it. Treat the selector as
+informational for now, and rely on the tool allowlist and the working directory
+to bound what an agent can do.
+
+### Tools
+
+Tools are an allowlist. An agent can use only what you tick.
+
+- **Built-in tools**: the Claude Code tools, such as reading and writing files,
+  running commands and searching.
+- **Local tools**: small helpers Agento serves itself.
+- **Integration tools**: individual tools from the integrations you have
+  connected, for example "send a Slack message" or "create a GitHub issue".
+
+### Template variables
+
+System prompts support `{{current_date}}` and `{{current_time}}`, filled in at the
+moment the agent runs. Useful for scheduled tasks that need to know what day it is.
+
+### Running as another Claude account
+
+Set **Claude config dir** on an agent to point at a different Claude Code
+configuration directory. That is how a work agent and a personal agent can run in
+one copy of Agento, each authenticated as its own account.
+
+---
+
+## Integrations
+
+Integrations connect an outside service and expose it to your agents as tools.
+
+Available in the desktop app:
+
+| Service | What agents can do |
+| --- | --- |
+| **Google** | Calendar events, Gmail, Drive files |
+| **Slack** | List channels, read and send messages, search |
+| **GitHub** | Repositories, issues, pull requests, actions, releases |
+| **Telegram** | Send messages, and trigger agents from incoming ones |
+| **Jira** | Search, create, update and transition issues |
+| **Confluence** | Read, search, create and update pages |
+
+**To connect one:** open Integrations and pick a service under **Add
+integration**, then fill in the form. Google and Slack use OAuth, so a browser
+window opens and you approve access there. GitHub, Telegram, Jira and Confluence
+use a token you paste in.
+
+For each integration you choose which **services** are enabled (for example Gmail
+but not Drive) and which **tools** within them. Agents then pick from what you
+enabled.
+
+**Editing credentials:** when you change an integration that has stored
+credentials, Agento asks you to re-enter them rather than saving a blank. That is
+deliberate: saving a scrubbed form would wipe the working credential.
+
+### Telegram triggers
+
+A Telegram integration can also run agents on incoming messages. Add a trigger
+rule saying which messages match and which agent handles them. The agent's reply
+goes back to the same chat.
+
+### If you paired WhatsApp in the web app
+
+The desktop app does not support WhatsApp. An existing WhatsApp integration is
+listed and its data is safe, but it cannot be edited or used here.
+
+---
+
+## Scheduled tasks
+
+A scheduled task runs an agent on its own, on a schedule, and records what
+happened.
+
+Create one with a name, an agent, and the **prompt** sent to that agent verbatim
+on every run.
+
+**Schedules:**
+
+| Type | Meaning |
+| --- | --- |
+| **Immediately** | Run once, a couple of seconds from now |
+| **Once** | Run once at a date and time you pick |
+| **Interval** | Every N minutes, hours or days, optionally at a fixed time of day |
+| **Cron** | A crontab expression, for anything more specific |
+
+Other options:
+
+- **Working directory**: the folder the run happens in.
+- **Model**: override the agent's model for this task.
+- **Timeout**: runs longer than this are cancelled and recorded as failed.
+- **Save output**: keep the agent's reply in the run history.
+- **Stop after**: end the task after N runs. `0` means never.
+- **Stop at**: an end date.
+- **Enabled**: pause without deleting.
+
+The inspector shows the next run, the last run, the total number of runs and the
+last outcome.
+
+**Times are your local time.** They are stored in UTC and converted for display.
+
+**One process only.** If you also run `agento web` against the same data
+directory, both would fire every task. Run one or the other.
+
+---
+
+## Job history
+
+Every scheduled run leaves a record: which task, when it started, how long it
+took, whether it succeeded, the tokens and cost, and the output if you asked for
+it to be saved.
+
+Failed runs carry the reason. A run that hit its timeout says so.
+
+Select one run or several and delete them.
+
+---
+
+## Claude sessions
+
+This is your Claude Code history, indexed and searchable. It covers everything
+`claude` has ever done on this machine, not only what you ran through Agento.
+
+**The list** pages as you scroll and filters in the database, so it stays fast at
+thousands of sessions. Filter by project, model, date, cost or duration, search
+titles and message content, and sort by recent, cost, tokens, duration or message
+count.
+
+Each row carries its project, model, turn count, tokens, cost, duration, and
+badges for permission mode, linked pull requests and git branch.
+
+**Actions on a session:**
+
+- **Star it** to find it again, then filter to favourites only.
+- **Continue in chat** turns that session into an Agento chat that resumes it.
+  The app tells you the new chat id; open Chats to carry on there.
+
+**The detail view** replays the run step by step: every prompt, response, tool
+call and result in order, with each sub-agent's steps nested under the delegation
+that spawned it. When a long unattended run went wrong, this is where you find
+where.
+
+Beside it are the session's own metrics: turns, steps per turn, longest
+autonomous chain, active duration, time Claude spent working, your own average
+reply time, and tool error rate.
+
+### Duration means active time
+
+Claude Code sessions are resumable, so a session you picked up a week later would
+otherwise report a week of work. Gaps longer than a threshold you control are
+excluded everywhere a duration is shown. Change the threshold in
+**Settings → Data**.
+
+### The first scan
+
+On first launch, Agento reads every transcript on your disk. On a large history
+that takes a few minutes, and the list shows progress while it works. After that
+it only re-reads files that changed.
+
+Some changes force a full re-read: editing a model price, or changing the idle
+threshold. That is expected, and it happens in the background.
+
+---
+
+## Analytics
+
+Three views over the same indexed history. All of them take a date range, and
+group by hour, day, week, month or year depending on how wide that range is.
+
+### Token usage
+
+Where the tokens and the money go.
+
+- **Token composition**: input, output, cache reads and cache writes kept apart,
+  because they bill at very different rates.
+- **Tokens over time** and **cache efficiency**.
+- **Cost by model**, credited to the model that actually spent it, including work
+  done inside sub-agents. Delegating to a cheaper model shows up as a real saving.
+- **Projects**, ranked by spend.
+
+Models with no published price are disclosed rather than counted as free, so a
+total that is missing something says so.
+
+### General usage
+
+How you work.
+
+- Sessions over time and by model.
+- Busiest days, hour of day, weekly rhythm.
+- Top sessions by cost, duration and tokens.
+
+The hour chart counts a session in **every** hour it was running, not only the
+hour it ended, so the per-hour numbers add up to more than the session count.
+That is intentional and the chart says so.
+
+### Insights
+
+Beta, and the most opinionated view.
+
+Headline numbers: sessions, average autonomy score, average turns, cache hit
+rate, and total cost. Each compared against the previous period, so you can see
+the direction.
+
+Below that, **tool call attribution**: every tool call broken down by the skill,
+plugin, MCP server, sub-agent and reasoning effort responsible. This is how you
+find the skill quietly burning a third of your calls.
+
+Then a set of cards suggesting concrete things to change. One of them prices what
+prompt caching saved you, which is an estimate from list prices and is labelled as
+one.
+
+---
+
+## Settings
+
+`Ctrl ,` opens Settings. Seven panes.
+
+### General
+
+- **Working directory**: the default folder for new chats and tasks.
+- **Default model**: used when neither the chat nor the agent picks one.
+- **Public URL**: only relevant if you also run the server.
+- **Updates**: how Agento behaves when a new version exists. See
+  [Updates](installation.md#updates).
+
+### Claude
+
+- **Run directory**: which Claude Code configuration directory runs use by
+  default.
+- **Indexed directories**: which directories analytics reads. Add a second one if
+  you use more than one Claude account, and both appear in every total.
+- **Settings profiles**: named Claude Code settings files, managed here. Runs use
+  the profile marked as default.
+
+Removing a directory from the indexed list hides its sessions rather than
+deleting them. Adding it back is instant.
+
+### Appearance
+
+Light, dark, or match the system. Also available from the status bar and the
+command palette.
+
+### Notifications
+
+Email delivery over SMTP, and which events send one. Scheduled task outcomes are
+the main use. There is a test button that sends one message so you know the
+configuration works before you rely on it.
+
+### Data
+
+- **Idle gap threshold**: how long a pause has to be before it stops counting as
+  working time. Between 1 and 240 minutes, 10 by default. Changing it re-reads
+  your history in the background, because durations are stored rather than
+  recomputed on every view.
+- **Hidden projects**: keep a project out of every chart and list. Its data is
+  kept, so unhiding is immediate.
+
+### Pricing
+
+The model price catalog every cost figure is computed from. It ships filled in
+for Anthropic, Moonshot, Z.ai and Alibaba models.
+
+Two separate actions, on purpose:
+
+- **Add a rate** when a price changes going forward. History keeps what it was
+  charged.
+- **Correct a rate** when the existing entry was wrong. This rewrites costs that
+  were already reported.
+
+Either way, your sessions are re-priced in the background afterwards.
+
+### Advanced
+
+Monitoring configuration, shown read-only. The desktop app does not export
+telemetry. If you also run `agento web` against the same data directory, that is
+where the setting takes effect.
+
+---
+
+## Privacy
+
+- Everything is stored locally, in `~/.agento`.
+- Nothing is sent to Anthropic beyond what Claude Code itself sends when an agent
+  runs.
+- Agento has no account, no telemetry and no analytics of its own.
+- The only outbound network calls are the ones you asked for: agent runs, the
+  integrations you connected, and the update check (which you can switch off).
+- Integration credentials are stored in plain text in the local database. Its
+  protection is your user account and your disk. Treat `~/.agento` as sensitive.
+- Your Claude Code transcripts in `~/.claude` are read only, never modified.
+
+---
+
+## Getting help
+
+Something not working? Start with [Troubleshooting](troubleshooting.md), then open
+an issue at
+[github.com/shaharia-lab/agento/issues](https://github.com/shaharia-lab/agento/issues).


### PR DESCRIPTION
`desktop/README.md` was written for whoever was building the app. With
`desktop-v0.1.0` published there is now an audience that has an installer and no
idea which one to take, so it becomes a user-facing front page and the rest moves
into `desktop/docs/`.

## What a download page here has to say

**Which install types can update themselves.** `.deb` and `.rpm` are notify-only,
because dpkg and rpm own the files they installed, so `install_kind()` detects
them at runtime and the UI offers a link instead of a button. Someone who picks
the `.deb` without knowing that reads the missing install button as a bug. It is
a column in the download table in both the README and the installation guide.

**That the first launch is blocked.** The builds are neither Apple notarised nor
Windows code signed, so Gatekeeper and SmartScreen both refuse them once. Written
as an install step, not left as a surprise.

## The files

| File | For |
| --- | --- |
| `docs/installation.md` | Downloads per platform, first launch, updates, data locations, uninstall |
| `docs/user-guide.md` | Every section of the app, and what it deliberately omits |
| `docs/troubleshooting.md` | The failures that have an answer, and where the log is |
| `docs/architecture.md` | Process model, the native registry, the SDK, parity |
| `docs/development.md` | Setup, tests, parity testing, conventions, debugging |
| `docs/releasing.md` | The tag-to-promote flow and the two guards around it |

The three developer documents are a **map** of `CLAUDE.md`, not a second copy of
it. That file stays the place to read before changing a mechanism; nobody
arriving at the repo reads 226k of working notes first. Each developer doc links
back to it.

## Two things corrected against the code

Both were tempting to write from what the UI implies:

- **A session cannot be renamed from the desktop app.** `custom_title` is
  displayed in the inspector, and no control sets it. Only starring and
  continue-as-chat exist, so that is what the guide says.
- **An agent's permission mode is not persisted.** `AgentRequest` carries no such
  field and `native/agents.rs` reproduces that deliberately, pinned by
  `a_permission_mode_in_the_request_is_ignored_as_go_ignores_it`. A chat prompts
  regardless (the interactive handler overrides the agent's mode), and a tool
  absent from the allowlist is denied without a prompt. The guide states the real
  rules and records the selector as a known limitation rather than advising
  people to rely on it.

The root README gains a pointer to the desktop app and links to its docs.

Docs only. No code, no behaviour change.