### PR TITLE
ci: stop the backend job depending on golangci-lint.run being reachable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,19 @@ jobs:
         with:
           version: v2.5.0
           args: --config=.golangci.yml
+          # The action's default is to run `golangci-lint config verify` first,
+          # which validates .golangci.yml against a JSON schema it downloads
+          # from golangci-lint.run. That makes every backend CI run depend on a
+          # third-party site being reachable from the runner, and when it is not
+          # the job fails *before linting anything* — a red build carrying no
+          # information about the code. Observed twice in a row on #385 with the
+          # host answering fine from elsewhere.
+          #
+          # What it checks is the config file, which changes rarely and whose
+          # breakage is immediate and local (the lint run itself rejects an
+          # unparseable config). Trading that for a CI run that cannot be
+          # blocked by someone else's CDN is the right way round.
+          verify: false
 
   # ── Frontend ───────────────────────────────────────────────────────────────
   frontend:


### PR DESCRIPTION
## The failure

`golangci-lint-action` defaults to running `golangci-lint config verify` before it lints anything, which validates `.golangci.yml` against a JSON schema it **downloads from `golangci-lint.run`**. When the runner cannot reach that host the job dies there:

```
[.golangci.yml] validate: compile schema: failing loading
"https://golangci-lint.run/jsonschema/golangci.v2.5.jsonschema.json":
context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

No linting happened. The build is red for a reason that has nothing to do with the code and cannot be fixed by changing the code.

It blocked #385 **twice in a row, forty minutes apart**, while the same URL answered in 240ms from outside Actions and `desktop` had been green earlier the same morning. The site is behind a CDN that rate-limits; this will recur, and it will recur on whichever PR is unlucky.

## The trade

`verify` checks a config file that changes rarely, and whose breakage is already immediate and local — an unparseable `.golangci.yml` fails the lint run itself, with a better message. Giving that up in exchange for a CI job that cannot be blocked by a third party's availability is the right way round.

The linter, its pinned `v2.5.0`, and `--config=.golangci.yml` are all unchanged. Only the pre-flight schema fetch is skipped.