### PR TITLE
docs(desktop): bring the guides up to 0.1.1

### DIFF
--- a/desktop/docs/development.md
+++ b/desktop/docs/development.md
@@ -64,6 +64,7 @@ All commands run from `desktop/`.
 | Command | What it does |
 | --- | --- |
 | `npm run app` | The real desktop window, with hot reload |
+| `npm run app:alongside` | The same, but without taking over an installed Agento's window |
 | `npm run dev` | Vite only, in a browser tab. Fastest loop for pure layout work |
 | `npm run build` | Typecheck and build the frontend alone |
 | `npm run app:build` | Native installers for the current platform |
@@ -75,6 +76,37 @@ so every scheduled task would fire twice. Release builds use the real directory.
 
 To seed the dev instance with data, copy your real database into it, or create
 rows through the UI.
+
+### Running beside an installed Agento
+
+`npm run app` **cannot** run while an installed Agento is open. It will exit
+immediately with no output and focus the installed window instead — which looks
+like the command silently failing.
+
+Nothing is wrong and nothing is shared: `tauri-plugin-single-instance` derives
+its identity from the app identifier, and dev and release have the same one, so
+the dev launch finds the installed app's claim and hands off to it.
+
+```bash
+npm run app:alongside
+```
+
+merges a one-key config override (`src-tauri/tauri.alongside.conf.json`) that
+changes the identifier to `com.shaharialab.agento.dev`. That is the only lever
+that works on every platform: the plugin accepts an explicit `dbus_id` on Linux
+alone, while Windows uses a named mutex and macOS a socket path, both derived
+from the identifier. On Linux you can watch both claims coexist:
+
+```
+$ busctl --user list | grep shaharialab
+com.shaharialab.agento.SingleInstance       …  agento-desktop
+com.shaharialab.agento.dev.SingleInstance   …  agento
+```
+
+**It does not help you test anything origin-dependent.** A dev build loads the
+configured `devUrl`, which Tauri's ACL treats as a *local* origin, so the whole
+class of permission bug that only affects release builds is invisible in dev by
+construction. That needs `npm run app:build`.
 
 ### Pointing at a different Claude CLI
 

--- a/desktop/docs/installation.md
+++ b/desktop/docs/installation.md
@@ -189,6 +189,23 @@ the matching public key. A download that does not verify is rejected. This is
 independent of Apple and Microsoft code signing, which is why in-app updates work
 smoothly even though the first launch needs a Gatekeeper or SmartScreen bypass.
 
+### Updates are one-way
+
+An update can add to the database, and Agento refuses to write to a database
+newer than itself rather than risk corrupting it. So going *back* to an older
+version stops working at the first release that changed the schema — the older
+build launches and then fails on every action.
+
+That is the only reason to take a copy of `~/.agento` before a major upgrade. It
+is a single directory, so a copy is the whole backup:
+
+```bash
+cp -r ~/.agento ~/.agento.backup
+```
+
+`agento web` is not affected either way: it ignores schema it does not
+recognise.
+
 ---
 
 ## Where your data lives

--- a/desktop/docs/troubleshooting.md
+++ b/desktop/docs/troubleshooting.md
@@ -136,12 +136,21 @@ started in.
 
 ### The agent keeps asking permission
 
-That is by design in a chat. You are there to answer, so Agento prompts before a
-tool runs, whatever the agent's permission mode says. Unattended runs, meaning
-scheduled tasks, do not prompt, because nothing could answer.
+Asking is the default in a chat, because you are there to answer. Each chat
+carries its own permission mode, so to stop the prompts for a conversation you
+trust, start it with **Permissions → Never ask**.
+
+The setting is chosen when the chat is created and the inspector shows what a
+chat is running under. Existing chats keep whatever they were created with;
+chats created before this setting existed fall back to the agent's mode, and to
+asking if the agent has no preference.
+
+Unattended runs, meaning scheduled tasks, never prompt, because nothing could
+answer.
 
 If a tool is denied without any prompt at all, it is not on the agent's tool
-list. Add it there.
+list. Add it there — the allowlist is enforced whatever the permission mode
+says.
 
 ---
 
@@ -249,6 +258,16 @@ its data is safe, but it cannot be edited or used here.
 You installed from a `.deb` or `.rpm`. Those are notify only, because your package
 manager owns the installed files. Download the new package and install it the way
 you installed the first one, or switch to the AppImage for in-app updates.
+
+### Can I go back to an older version?
+
+Not below 0.1.1. That release added a database column, and Agento refuses to
+write to a database newer than itself rather than corrupting it — so an older
+build would appear to fail on every action.
+
+Your data is not damaged by this and `agento web` is unaffected; it simply
+ignores schema it does not know. If you need an older desktop build, restore the
+`~/.agento` backup you took before upgrading.
 
 ### The update download fails
 

--- a/desktop/docs/user-guide.md
+++ b/desktop/docs/user-guide.md
@@ -66,25 +66,43 @@ On macOS use `⌘` instead of `Ctrl`, and the menu bar carries the same actions.
 
 A chat is a conversation with an agent, kept for as long as you want it.
 
-**Start one:** press `Ctrl N` or click the `+` above the chat list. Pick an agent
-(or none), choose a **working directory**, and type your first message.
+**Start one:** press `Ctrl N` or click the `+` above the chat list. Set up how the
+conversation should run, then type your first message. The chat is created when
+you send.
+
+| Setting | What it does |
+| --- | --- |
+| **Agent** | Which saved agent to talk to, or none for a direct chat. Hidden until you have created one |
+| **Model** | Sonnet, Opus or Haiku. Locked when the agent already names one, because the agent's wins |
+| **Permissions** | How much this conversation may do without asking. See below |
+| **Settings** | Which Claude settings profile to run under, if you have more than one |
+| **Working directory** | Required. The folder the agent can see and act in |
 
 The working directory matters. It is the folder the agent can see and act in, the
-same way `claude` behaves when you run it from that folder. Click the folder icon
-to pick one with your system's file picker.
+same way `claude` behaves when you run it from that folder. **Browse…** opens your
+system's file picker, falling back to a built-in one if that is unavailable.
+
+Your choices are remembered and filled in next time you start a chat. They start
+from **Settings → General** the first time.
+
+**Replies are rendered as markdown** — headings, lists, tables, links and code
+blocks. Hover a message for a **copy** button, and any code block for its own.
+Copying a message gives you the markdown source, which is what you want when it
+is going into an issue or a commit message.
 
 **While a turn is running:**
 
 - The reply streams in as it is produced.
 - Tool calls appear inline, with the input and the result.
 - If the agent needs permission for a tool, a prompt appears. Approve or deny.
+  Chats set to *Never ask* skip this.
 - If the agent asks you a question, answer it in the composer and the run
   continues.
 - **Stop** halts the run. Anything already written stays.
 
-**The inspector** shows the agent, the model, the message count and the token
-usage of the whole conversation, split into input, output, cache read and cache
-write, with the cost.
+**The inspector** shows the agent, the model, the permission mode, the message
+count and the token usage of the whole conversation, split into input, output,
+cache read and cache write, with the cost.
 
 Rename a chat from the title, or delete it from the toolbar. Deleting removes its
 messages too.
@@ -92,6 +110,22 @@ messages too.
 **One thing worth knowing:** a turn that produced no final answer, for example one
 you stopped immediately, stores nothing. That is the same rule Claude Code
 follows.
+
+### Permissions, per conversation
+
+The **Permissions** setting decides how much this chat may do on its own:
+
+| Choice | Behaviour |
+| --- | --- |
+| **Agent default** | Use whatever the agent is configured for, or ask if it has no preference |
+| **Ask before acting** | Prompt in the transcript before every tool call |
+| **Never ask** | Run tools without prompting. For work you have already decided to trust |
+| **Plan only** | Propose a plan without acting on it |
+| **Don't ask** | Claude Code's `dontAsk` mode |
+
+It applies to that conversation alone and does not change the agent. A tool the
+agent does not list is still denied without asking, whatever you pick here — the
+allowlist is enforced separately.
 
 ---
 
@@ -110,27 +144,31 @@ Fields:
 | **Thinking** | Adaptive, always on, or disabled. Controls extended reasoning |
 | **Permission mode** | How much an unattended run may do without asking. See below |
 | **System prompt** | The agent's instructions |
-| **Claude config dir** | Run this agent as a different Claude Code account |
+| **Claude config dir** | Run this agent as a different Claude Code account. **Browse…** picks one |
 | **Tools** | Exactly what this agent is allowed to use |
 
 ### Permissions
 
-Two rules, and they do not depend on the agent's settings:
+One rule holds everywhere, whatever anything is set to:
 
-- **In a chat, Agento asks you before a tool runs.** You are there to answer, so
-  the prompt appears in the transcript and the run waits.
 - **A tool the agent does not list is denied without asking.** The allowlist is
-  enforced whatever the permission mode says.
+  enforced independently of every permission mode.
 
-The **permission mode** field applies to unattended runs, meaning scheduled
-tasks, where nothing can answer a prompt. Left unset, those runs proceed without
-prompting, because the alternative is a task that hangs until it times out.
+Beyond that, who decides depends on whether anyone is watching:
 
-**Known limitation:** the permission mode you pick in the form is not currently
+- **In a chat**, the conversation decides. Each chat carries its own permission
+  mode, chosen when you start it — see [Permissions, per
+  conversation](#permissions-per-conversation). Left at *Agent default* it falls
+  back to the agent's, and to asking you if the agent has no preference.
+- **In an unattended run**, meaning a scheduled task, the agent's **permission
+  mode** field decides. Left unset those runs proceed without prompting, because
+  the alternative is a task that hangs until it times out.
+
+**Known limitation:** the permission mode you pick on an *agent* is not currently
 saved. The underlying API drops the field, and the desktop app reproduces the
-server's behaviour rather than diverging from it. Treat the selector as
-informational for now, and rely on the tool allowlist and the working directory
-to bound what an agent can do.
+server's behaviour rather than diverging from it. This does not affect chats,
+which store their own mode. For agents, rely on the tool allowlist and the
+working directory to bound what a run can do.
 
 ### Tools
 
@@ -201,8 +239,9 @@ listed and its data is safe, but it cannot be edited or used here.
 A scheduled task runs an agent on its own, on a schedule, and records what
 happened.
 
-Create one with a name, an agent, and the **prompt** sent to that agent verbatim
-on every run.
+Create one with a name, an agent and the **prompt** sent to that agent verbatim
+on every run. The agent is chosen from a list; if you have not created one yet
+the form says so, and the Agents section is where to start.
 
 **Schedules:**
 
@@ -215,7 +254,7 @@ on every run.
 
 Other options:
 
-- **Working directory**: the folder the run happens in.
+- **Working directory**: the folder the run happens in. **Browse…** picks one.
 - **Model**: override the agent's model for this task.
 - **Timeout**: runs longer than this are cancelled and recorded as failed.
 - **Save output**: keep the agent's reply in the run history.


### PR DESCRIPTION
The guides describe 0.1.0. Two passages are now actively wrong rather than merely incomplete, which is the reason this is a PR rather than a backlog item.

## The permissions model changed shape

The user guide stated, as a rule that does not depend on settings:

> **In a chat, Agento asks you before a tool runs.** You are there to answer, so the prompt appears in the transcript and the run waits.

That was true when written — and it is exactly the behaviour 0.1.1 changed. A chat now carries its own permission mode, so a reader following the old text would conclude the new picker does nothing.

Rewritten around what is actually unconditional (the tool allowlist), with the decision split by whether anyone is watching: the conversation decides in a chat, the agent's field decides for unattended runs.

The "known limitation" note is **kept but narrowed** rather than deleted. The agent form still cannot persist a permission mode — `AgentRequest` drops the field — and a reader who carried the old note over to chats would now be misinformed in the opposite direction.

## Everything else in 0.1.1

- The New Chat settings table (agent / model / permissions / settings profile / working directory), that the choices are remembered, and that the model locks when the agent names one
- Markdown replies and the copy buttons, including that copying a message gives you the markdown source
- The browse fallback on directory fields
- The task agent picker and its "no agents configured" state
- The inspector reporting the mode a chat is running under

## `npm run app:alongside`

In `development.md`, with why plain `npm run app` exits silently beside an installed Agento — it hands off to the installed app's single-instance claim — and what the identifier override does on each platform.

It also says what the script does **not** buy: a dev build loads the configured `devUrl`, which the ACL treats as local, so origin-dependent bugs are invisible there. Someone reaching for this script after reading about the ACL fix will otherwise assume the opposite.

## Upgrades are one-way

0.1.1 adds a column, and the app refuses to write to a database newer than itself. A downgrade therefore presents as every action failing, not as an error anyone would connect to the version.

Documented in `installation.md` (with the `cp -r ~/.agento ~/.agento.backup` command, since this is the only reason to take that copy) and as a troubleshooting entry, both noting `agento web` is unaffected.

---

Docs only — no code, no behaviour change.