### PR TITLE
fix(desktop): scope the opener ACL, or every external link is silently dead

### DIFF
--- a/.claude/skills/local-verify/SKILL.md
+++ b/.claude/skills/local-verify/SKILL.md
@@ -19,10 +19,38 @@ hops, bisect them instead of guessing.
 | Browser engine | Chrome via Vite dev server | frontend logic, CSS, UI flows |
 | WebKitGTK engine | Python `gi` WebKit2 probe | engine-level behavior without the app |
 | **Real Tauri webview** | WebKit remote inspector | the only place webview-specific bugs exist |
+| **Tauri IPC / ACL** | `__TAURI_INTERNALS__.invoke` in that webview | whether a command is *permitted*, separate from whether the UI calls it |
+| **OS handoff** | PATH shim over the launcher | whether the OS was actually asked to do the thing |
 
 A bug reported from the desktop app is not verified fixed until the fix is
 observed **in the real webview** (or the root cause is proven to live in a hop
 that Chrome shares).
+
+**Bisect down the table, not up.** A dead button has at least four candidate
+hops (handler never fired → command denied by the ACL → OS never asked →
+OS asked and did nothing). Probing `invoke` directly settles the middle two in
+one call and costs seconds; clicking through the UI settles none of them,
+because every one of those failures looks identical from the UI.
+
+## Pre-flight — run this before the first launch, always
+
+`npm run app:alongside` has two failure modes that report themselves as
+something else, and both cost a full launch cycle to diagnose:
+
+- **A stale `:1420`.** A previous Vite survives `pkill -f vite` often enough
+  that the port is the only reliable test. `tauri dev` then dies with
+  `The beforeDevCommand terminated with a non-zero status code.` — the real
+  line (`Port 1420 is already in use`) is ~10 lines above the tail you read.
+- **A stale `desktop/node_modules`.** Branches add frontend deps; the tree on
+  disk is from whatever branch you last built. Vite fails *after* announcing
+  itself as ready, with `imported but could not be resolved`.
+
+```bash
+.claude/skills/local-verify/preflight.sh
+```
+
+Kills the stale processes, frees `:1420` by port, and syncs `node_modules`.
+Run it first and both failure modes disappear.
 
 ## Scratch environments — never touch the real instances
 
@@ -77,26 +105,49 @@ Read `/tmp/sse.txt` for the exact frames. Facts that save a loop (verified
 
 ## Driving the real Tauri webview
 
-Launch with the inspector and attach from outside — no clicking needed:
+Launch with the inspector and attach from outside — no clicking needed. The
+env var works on **either** launcher; prefer `app:alongside`, because it
+hot-rebuilds (below):
 
 ```bash
+cd desktop && WEBKIT_INSPECTOR_HTTP_SERVER=127.0.0.1:9224 \
+  setsid nohup npm run app:alongside > /tmp/app.log 2>&1 < /dev/null &
+# or, against an already-built binary:
 WEBKIT_INSPECTOR_HTTP_SERVER=127.0.0.1:9224 desktop/src-tauri/target/debug/agento
 ```
 
-`http://127.0.0.1:9224/` lists targets, but its inspector UI only works in a
-WebKit browser. Drive the protocol directly instead: WebSocket to
-`ws://127.0.0.1:9224/socket/1/1/WebPage`, wait for `Target.targetCreated`,
-then wrap every command in
-`Target.sendMessageToTarget {targetId, message: JSON.stringify({id, method, params})}`
-and unwrap `Target.dispatchMessageFromTarget`. `Runtime.evaluate` (with
-`returnByValue: true`) runs JS in the page; `Console.enable` streams console
-messages. A `ws` client is available without installing anything:
+**Do not hand-roll the protocol client — use the one in this directory:**
 
-```js
-import { createRequire } from "module";
-const require = createRequire("<repo>/e2e/node_modules/playwright-core/package.json");
-const { ws } = require("playwright-core/lib/utilsBundle");
+```bash
+node .claude/skills/local-verify/drive.mjs '<js expression>'      # evaluate
+node .claude/skills/local-verify/drive.mjs --await '<js promise>' # settle a promise
+node .claude/skills/local-verify/drive.mjs --console              # stream console
 ```
+
+It needs no dependencies (Node ≥ 22 has a global `WebSocket`) and encodes both
+traps below. The protocol, if you must extend it: WebSocket to
+`ws://127.0.0.1:9224/socket/1/1/WebPage`, wait for `Target.targetCreated`, wrap
+every command in
+`Target.sendMessageToTarget {targetId, message: JSON.stringify({id, method, params})}`
+and unwrap `Target.dispatchMessageFromTarget`. `http://127.0.0.1:9224/` lists
+targets but its inspector UI only works in a WebKit browser.
+
+Two traps that both read as success:
+
+- **`awaitPromise: true` does not work.** WebKit returns
+  `{type:"object", value:{}}` with `wasThrown:false` — indistinguishable from
+  a call that returned nothing. Park the promise on a `window.__x` slot and
+  poll it with a second evaluate. `--await` does this.
+- **Do not use `e2e/node_modules/playwright-core` for a `ws` client.** That
+  tree is usually not installed, and the failure (`Cannot find module`) sends
+  you looking for a WebSocket library you do not need.
+
+**`tauri dev` hot-rebuilds on any `src-tauri` change — including
+`capabilities/*.json` and `tauri.conf.json`.** The log says
+`File src-tauri/… changed. Rebuilding application...`, the window is replaced,
+and the inspector comes back on the same port. So the edit→verify loop for
+Rust *and* ACL changes is: edit, wait for `api server listening` in the log,
+re-run the same `drive.mjs` probe. No relaunch, no rebuild command.
 
 Driving the React UI from injected JS: set inputs through the **native value
 setter** then dispatch an `input` event (React ignores plain `.value =`):
@@ -109,6 +160,33 @@ el.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", ctrlKey: true, bub
 
 For async observations, write timeline entries into a `window.__log` array and
 poll it with a second `Runtime.evaluate` — a long-running evaluate blocks.
+
+## Verifying an OS handoff (opener, reveal-in-dir, any external launch)
+
+"A browser opened" is not observable from inside the app, and letting the real
+launcher run sprays tabs across the user's desktop on every probe. Shim the
+launcher on `PATH` and assert on its log instead — `open`'s Linux backend
+probes `xdg-open`, `gio`, `gnome-open`, `kde-open` in order, so shim all four:
+
+```bash
+mkdir -p /tmp/shim && cat > /tmp/shim/xdg-open <<'EOF'
+#!/bin/sh
+printf '%s OPENED %s\n' "$(date -Is)" "$*" >> /tmp/opened.log
+EOF
+chmod +x /tmp/shim/xdg-open
+for c in gio gnome-open kde-open; do cp /tmp/shim/xdg-open /tmp/shim/$c; done
+PATH=/tmp/shim:$PATH ... npm run app:alongside   # launch under the shim
+```
+
+`/tmp/opened.log` now holds the exact URL, which is stronger evidence than a
+tab appearing — it shows *what* was requested, not just that something opened.
+
+**Then do one final un-shimmed run.** Under the shim the user sees nothing
+happen, which is indistinguishable from the bug they reported; say so
+explicitly before they ask, and finish by relaunching without the shim so the
+handoff is confirmed on the real desktop. A capability fix is not proven by an
+error disappearing — `openExternal` swallows failures into a `console.warn`
+and returns normally, so "no error" is the *symptom*, not the fix.
 
 ## Engine-only probe (no app)
 

--- a/.claude/skills/local-verify/drive.mjs
+++ b/.claude/skills/local-verify/drive.mjs
@@ -1,0 +1,115 @@
+/**
+ * Drive the real Tauri webview through WebKit's remote inspector.
+ *
+ *   node drive.mjs '<js expression>'        # evaluate, print the value
+ *   node drive.mjs --await '<js promise>'   # park the promise, poll, print settled value
+ *   node drive.mjs --console                # stream console messages until Ctrl-C
+ *
+ * Requires the app launched with WEBKIT_INSPECTOR_HTTP_SERVER=127.0.0.1:9224.
+ * No dependencies: Node >= 22 has a global WebSocket. (Do NOT reach for `ws`
+ * via playwright-core — e2e/node_modules is usually not installed.)
+ */
+
+const PORT = process.env.INSPECTOR_PORT || "9224";
+const args = process.argv.slice(2);
+const mode = args[0] === "--await" || args[0] === "--console" ? args[0] : "--eval";
+const EXPR = mode === "--eval" ? args[0] : args[1];
+
+const sock = new WebSocket(`ws://127.0.0.1:${PORT}/socket/1/1/WebPage`);
+let targetId = null;
+let nextId = 1;
+const pending = new Map();
+
+function send(method, params) {
+  const id = nextId++;
+  const inner = JSON.stringify({ id, method, params });
+  sock.send(
+    JSON.stringify({
+      id: nextId++,
+      method: "Target.sendMessageToTarget",
+      params: { targetId, message: inner },
+    })
+  );
+  return new Promise((resolve) => pending.set(id, resolve));
+}
+
+async function evaluate(expression) {
+  // returnByValue only serializes plain values. `awaitPromise: true` does NOT
+  // work here — WebKit returns {type:"object", value:{}} with wasThrown:false,
+  // which reads exactly like success. Park promises and poll instead.
+  const r = await send("Runtime.evaluate", { expression, returnByValue: true });
+  if (r?.wasThrown) throw new Error("threw: " + JSON.stringify(r.result));
+  return r?.result?.value;
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function run() {
+  if (mode === "--console") {
+    await send("Console.enable");
+    return; // messages stream via the handler below
+  }
+
+  if (mode === "--await") {
+    const slot = "__probe_" + Date.now();
+    await evaluate(`
+      window.${slot} = { state: "pending" };
+      Promise.resolve().then(() => (${EXPR}))
+        .then((v) => { window.${slot} = { state: "resolved", value: String(v) }; })
+        .catch((e) => { window.${slot} = { state: "rejected", error: String(e) }; });
+      "fired"
+    `);
+    for (let i = 0; i < 40; i++) {
+      await sleep(250);
+      const out = await evaluate(`JSON.stringify(window.${slot})`);
+      const parsed = JSON.parse(out);
+      if (parsed.state !== "pending") {
+        await evaluate(`delete window.${slot}`);
+        console.log(JSON.stringify(parsed, null, 1));
+        process.exit(parsed.state === "rejected" ? 3 : 0);
+      }
+    }
+    console.error("TIMEOUT: promise never settled");
+    process.exit(2);
+  }
+
+  console.log(JSON.stringify(await evaluate(EXPR), null, 1));
+  process.exit(0);
+}
+
+sock.addEventListener("message", async (ev) => {
+  const raw = typeof ev.data === "string" ? ev.data : ev.data.toString();
+  const msg = JSON.parse(raw);
+
+  if (msg.method === "Target.targetCreated" && !targetId) {
+    targetId = msg.params.targetInfo.targetId;
+    run().catch((e) => {
+      console.error(String(e));
+      process.exit(1);
+    });
+    return;
+  }
+
+  if (msg.method === "Target.dispatchMessageFromTarget") {
+    const inner = JSON.parse(msg.params.message);
+    if (inner.id && pending.has(inner.id)) {
+      pending.get(inner.id)(inner.result ?? inner);
+      pending.delete(inner.id);
+    } else if (inner.method === "Console.messageAdded") {
+      const m = inner.params.message;
+      console.log(`[${m.level}] ${m.text}`);
+    }
+  }
+});
+
+sock.addEventListener("error", () => {
+  console.error(`WS ERROR — is the app running with WEBKIT_INSPECTOR_HTTP_SERVER=127.0.0.1:${PORT}?`);
+  process.exit(1);
+});
+
+if (mode !== "--console") {
+  setTimeout(() => {
+    console.error("TIMEOUT waiting for the inspector target");
+    process.exit(2);
+  }, 30000);
+}

--- a/.claude/skills/local-verify/preflight.sh
+++ b/.claude/skills/local-verify/preflight.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Clear the three things that make `npm run app:alongside` fail with an error
+# that does not name its own cause. Run from the repo root. Idempotent.
+set -u
+
+DESKTOP="$(cd "$(dirname "$0")/../../.." && pwd)/desktop"
+
+echo "==> killing stale dev processes"
+pkill -9 -f "tauri dev"            2>/dev/null
+pkill -9 -f "node_modules/.bin/vite" 2>/dev/null
+pkill -9 -f "target/debug/agento"  2>/dev/null
+sleep 2
+
+# `pkill -f vite` misses the node process that actually holds :1420 often
+# enough that checking the port is the only reliable test.
+if ss -lntp 2>/dev/null | grep -q ':1420'; then
+  echo "==> :1420 still held, killing by port"
+  fuser -k 1420/tcp 2>/dev/null
+  sleep 2
+fi
+ss -lntp 2>/dev/null | grep -q ':1420' \
+  && { echo "FAIL: :1420 still in use — tauri dev will die with"; \
+       echo '      "The beforeDevCommand terminated with a non-zero status code."'; exit 1; } \
+  || echo "    :1420 free"
+
+echo "==> syncing desktop/node_modules (branches add deps; a stale tree dies"
+echo "    mid-launch with 'imported but could not be resolved')"
+( cd "$DESKTOP" && npm install --silent ) || exit 1
+
+echo "==> preflight OK. Launch with:"
+echo "    cd desktop && WEBKIT_INSPECTOR_HTTP_SERVER=127.0.0.1:9224 \\"
+echo "      setsid nohup npm run app:alongside > /tmp/app.log 2>&1 < /dev/null &"

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -29,6 +29,7 @@
     "log:default",
     "dialog:default",
     "opener:allow-open-url",
+    "opener:allow-default-urls",
     "updater:default",
     "process:allow-restart"
   ]

--- a/desktop/src-tauri/tests/capabilities.rs
+++ b/desktop/src-tauri/tests/capabilities.rs
@@ -1,0 +1,103 @@
+//! Guards on `capabilities/default.json`.
+//!
+//! Every bug this file has produced fails the same way: the ACL denies an IPC
+//! command, the frontend's wrapper swallows the rejection, and the feature is
+//! dead with no error anywhere. Nothing here can be caught by `cargo build` —
+//! the capability is valid JSON and a valid ACL in every broken state below —
+//! so these assertions are the only thing standing between a one-word edit and
+//! a silently dead feature in a shipped build.
+
+use serde_json::Value;
+
+const CAPABILITY: &str = include_str!("../capabilities/default.json");
+
+fn capability() -> Value {
+    serde_json::from_str(CAPABILITY).expect("capabilities/default.json parses")
+}
+
+/// Permission identifiers granted as bare strings.
+fn granted(cap: &Value) -> Vec<String> {
+    cap["permissions"]
+        .as_array()
+        .expect("permissions is an array")
+        .iter()
+        .filter_map(|p| p.as_str().map(str::to_string))
+        .collect()
+}
+
+/// True when the capability carries an inline scope object for `identifier`
+/// — the `{"identifier": "…", "allow": [{"url": "…"}]}` form, which grants a
+/// scope without naming a scope permission.
+fn has_inline_scope(cap: &Value, identifier: &str) -> bool {
+    cap["permissions"]
+        .as_array()
+        .expect("permissions is an array")
+        .iter()
+        .any(|p| {
+            p.get("identifier").and_then(Value::as_str) == Some(identifier)
+                && p.get("allow")
+                    .and_then(Value::as_array)
+                    .is_some_and(|a| !a.is_empty())
+        })
+}
+
+/// The bug this test exists for: `opener:allow-open-url` enables the command
+/// but — in the plugin's own words — "without any pre-configured scope". The
+/// scope entries live in the *separate* `opener:allow-default-urls` permission
+/// that `opener:default` bundles, and `open_url` checks the scope before doing
+/// anything (`is_url_allowed` ends in `.any()`, so an empty allow list refuses
+/// every URL). Granting the command alone therefore makes every external link
+/// in the app fail with `Not allowed to open url …` — OAuth "Authorize", PR
+/// links, release links and every link in chat markdown alike. It failed that
+/// way from the first desktop commit until this test was added, because
+/// `openExternal` catches the rejection, logs a `console.warn` and returns
+/// normally, so the UI advances as if a browser had opened.
+#[test]
+fn granting_open_url_also_grants_a_url_scope() {
+    let cap = capability();
+    let perms = granted(&cap);
+
+    if !perms.iter().any(|p| p == "opener:allow-open-url") {
+        return; // command not granted at all: nothing to scope
+    }
+
+    let scoped = perms
+        .iter()
+        .any(|p| p == "opener:allow-default-urls" || p == "opener:default")
+        || has_inline_scope(&cap, "opener:allow-open-url");
+
+    assert!(
+        scoped,
+        "capabilities/default.json grants `opener:allow-open-url` with no URL \
+         scope, so every open_url call is refused with `Not allowed to open \
+         url …` and every external link in the app is silently dead. Add \
+         `opener:allow-default-urls` (mailto/tel/http/https), or an inline \
+         `allow` scope, beside it."
+    );
+}
+
+/// The #385 class, in the same file and with the same silence: a release
+/// window is navigated to `http://127.0.0.1:<port>` so the UI is same-origin
+/// with the API, and Tauri classifies that origin as *remote*. A capability
+/// with no `remote.urls` covering it is local-only, which denies every IPC
+/// command in shipped builds while dev keeps working — invisible to
+/// `npm run app` and `app:alongside` by construction.
+#[test]
+fn the_loopback_release_origin_is_in_the_remote_scope() {
+    let cap = capability();
+    let urls: Vec<&str> = cap["remote"]["urls"]
+        .as_array()
+        .expect("capabilities/default.json has a remote.urls block")
+        .iter()
+        .filter_map(Value::as_str)
+        .collect();
+
+    for host in ["127.0.0.1", "localhost"] {
+        assert!(
+            urls.iter().any(|u| u.contains(host)),
+            "remote.urls does not cover http://{host}:<port>, the origin a \
+             release window is navigated to — every IPC command would be \
+             denied in shipped builds while dev keeps working. urls: {urls:?}"
+        );
+    }
+}

--- a/desktop/src-tauri/tests/parity_session_detail.rs
+++ b/desktop/src-tauri/tests/parity_session_detail.rs
@@ -124,7 +124,7 @@ async fn the_session_detail_matches_the_live_go_response() {
     );
     pick_first(&|s| s.get("prs").is_some(), &mut picks);
     pick_first(&|s| nonzero(s, "compaction_count"), &mut picks);
-    pick_first(&|s| !s.get("is_favorite").is_none(), &mut picks);
+    pick_first(&|s| s.get("is_favorite").is_some(), &mut picks);
     // The most recent, and the busiest, whatever else they are.
     if let Some(s) = sessions.first() {
         picks.insert(id_of(s));


### PR DESCRIPTION
## The bug

Creating a Google integration and clicking **Authorise** shows "Waiting for you to finish in the browser…" — but no browser opens, and **Reopen link** does nothing either.

## Root cause

`capabilities/default.json` granted `opener:allow-open-url`. The plugin's own manifest describes that permission as:

> Enables the open_url command **without any pre-configured scope**.

The scope entries live in a *separate* permission, `opener:allow-default-urls` (`mailto:*`, `tel:*`, `http://*`, `https://*`), which `opener:default` bundles and this capability never included. Nothing supplied a global scope either — `tauri.conf.json` has only an `updater` block.

`open_url` checks that scope before doing anything:

```rust
// tauri-plugin-opener-2.5.4/src/commands.rs:36
if scope.is_url_allowed(&url, with.as_deref()) { app.opener().open_url(url, with) }
else { Err(Error::ForbiddenUrl { url, with }) }
```

and `is_url_allowed` ends in `self.allowed.iter().any(...)` — an **empty allow list returns false for every URL**.

## Why nobody noticed for the app's whole history

`git log -p --follow` shows `opener:allow-open-url` has been the entry since the first desktop commit (`c23e816`) — never scoped. It stayed invisible because `openExternal` (`desktop/src/lib/tauri.ts:53`) catches the rejection, logs a `console.warn`, and falls back to `window.open`, which is inert in WebKitGTK (no new-window handler is registered). The wrapper then **returns normally**, so the OAuth panel advances as if a browser had opened.

So this was never Google- or OAuth-specific. Every external link was dead:

| Call site | Link |
|---|---|
| `IntegrationsView.tsx:854`, `:934` | OAuth Authorise / Reopen link |
| `SessionsView.tsx:1008` | PR links |
| `chat/Markdown.tsx:47` | every link in chat output |
| `SettingsView.tsx:1690` | release URL |
| `App.tsx:274,277`, `AboutView.tsx:72` | repo / readme |

## The fix

One line: grant `opener:allow-default-urls` beside the command.

Chosen over `opener:default` because it is the same four schemes without also granting `reveal-item-in-dir`, which nothing calls. Keeping it to those schemes matters here specifically because `Markdown.tsx` routes *model-generated* links through `openExternal`.

## Verification

Reproduced and verified in the **real Tauri webview** (`npm run app:alongside` + WebKit remote inspector), not in Chrome:

| | before | after |
|---|---|---|
| `invoke("plugin:opener\|open_url")` | `REJECTED: Not allowed to open url …` | `RESOLVED` |
| `openExternal(...)` | returned normally, `console.warn` only, nothing opened | returned normally, no warn, opened |
| OS launcher (`xdg-open` PATH shim) | never invoked | `OPENED https://accounts.google.com/o/oauth2/auth?...` |

The real **Authorise** button was then clicked in the running window and handed the OS the actual Google consent URL; **Reopen link** likewise. Finally confirmed unshimmed (a real browser tab opened) and by a **real end-to-end Google authorization**, which succeeded.

## Tests

`desktop/src-tauri/tests/capabilities.rs` asserts that granting `opener:allow-open-url` also grants a URL scope, and — same file, same silent-failure class — that `remote.urls` still covers the loopback release origin (the #385 case). Both are states in which the capability is valid JSON *and* a valid ACL, so nothing but an assertion catches them. Confirmed the first test fails when the fix is reverted.

## Unrelated drive-by

`tests/parity_session_detail.rs` had a `nonminimal_bool` clippy failure (`!…is_none()`) that breaks `cargo clippy --all-targets -- -D warnings` on current stable — already failing CI on this branch. Fixed so CI can go green.

## Skill update

`.claude/skills/local-verify` gained the gaps this hunt exposed: a pre-flight script (stale `:1420` and stale `node_modules` both fail with errors that don't name their cause), a reusable zero-dependency inspector driver (`drive.mjs` — the documented `ws`-via-playwright-core recipe pointed at an uninstalled tree, and `Runtime.evaluate`'s `awaitPromise` silently returns `{}` in WebKit), plus new hops for Tauri IPC/ACL probing and OS-handoff verification.