### PR TITLE
fix(desktop): stamp the release build so About stops reporting "dev"

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -149,12 +149,40 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
 
+      # What `GET /api/version` reports, and so what the About screen shows.
+      # It is NOT what the updater compares — that reads the version baked
+      # into tauri.conf.json by the bundler, which the guard job already pins
+      # to the tag. These three are a separate, purely informational stamp
+      # that nothing set until now, which is why every release through
+      # desktop-v0.1.1 displayed "dev · unknown".
+      #
+      # Kept out of the `env:` block below so a dry run can name itself: a
+      # workflow_dispatch has no tag, and stamping a dispatch build with the
+      # conf version would make it indistinguishable from the real release.
+      - name: Compute the build stamp
+        id: stamp
+        shell: bash
+        run: |
+          case "${GITHUB_REF_NAME}" in
+            desktop-v*) version="${GITHUB_REF_NAME#desktop-v}" ;;
+            *) version="$(python3 -c 'import json; print(json.load(open("src-tauri/tauri.conf.json"))["version"])')-dev" ;;
+          esac
+          echo "version=${version}" >>"$GITHUB_OUTPUT"
+          # RFC 3339, which is what the About screen's dateTime() parses.
+          echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$GITHUB_OUTPUT"
+          echo "stamping ${version}"
+
       # bundle.targets in tauri.conf.json lists exactly what ships — notably
       # NSIS and not MSI on Windows, since the updater manifest expects the
       # -setup.exe and a built-but-dropped .msi only wasted CI time.
       - name: Build installers
         run: npx tauri build --target ${{ matrix.target }}
         env:
+          # Read by src-tauri/build.rs, which re-emits them as rustc-env so a
+          # restored rust-cache cannot ship the previous tag's stamp.
+          AGENTO_BUILD_VERSION: ${{ steps.stamp.outputs.version }}
+          AGENTO_BUILD_COMMIT: ${{ github.sha }}
+          AGENTO_BUILD_DATE: ${{ steps.stamp.outputs.date }}
           # Signs the updater artifacts. This is Tauri's own minisign key, not
           # an Apple or Microsoft certificate — it only proves an update came
           # from us. Without it the build still succeeds but produces no .sig,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -763,10 +763,41 @@ Makefile does that**. `scripts/parity-instance.sh` builds with no flags, so the
 server every parity test diffs against serves the package defaults —
 `dev` / `unknown` / `unknown`. `native/version.rs` declares the same defaults,
 behind `option_env!("AGENTO_BUILD_VERSION")` and friends, so stamping the
-desktop bundle is a build-script change rather than a code change — possible
-since #278 removed the Go binary that would have had to agree. (The parity
-test for `/api/version` still assumes an unstamped build; stamp CI, not the
-test environment.)
+desktop bundle was left as a build-script change rather than a code change —
+possible since #278 removed the Go binary that would have had to agree. (The
+parity test for `/api/version` still assumes an unstamped build; stamp CI, not
+the test environment.)
+
+**That change was never made, and every release through `desktop-v0.1.1`
+shipped an About screen reading `Version dev` over `unknown · Invalid Date`.**
+The hook was there and nothing anywhere set the variables, so a release build
+and a `cargo build` in a checkout were byte-identical on this route. Two halves
+fix it, and **neither works alone**:
+
+- `desktop-release.yml`'s **"Compute the build stamp"** step derives the version
+  from the tag (`desktop-v0.1.2` → `0.1.2`), or from `tauri.conf.json` with a
+  `-dev` suffix for a `workflow_dispatch` dry run, which has no tag to read.
+  Together with `github.sha` and an RFC 3339 date it goes into "Build
+  installers"' `env:`.
+- `src-tauri/build.rs`'s **`stamp_build_info`** re-emits each set variable as
+  `cargo:rustc-env` and declares `cargo:rerun-if-env-changed` for it. The
+  release job restores a `Swatinem/rust-cache` target dir from an earlier tag's
+  run, so exporting the variables to `cargo build` alone would let the
+  *previous* release's stamp ship — a build script that only declared the
+  dependency would rerun and change nothing, and only a changed `rustc-env`
+  forces the crate to recompile.
+
+An unset variable emits nothing, so `option_env!` still answers `None` and a
+local `npm run app:build` still reports `dev`. That is the point: an unstamped
+build is a development build. Do not "fix" it by falling back to
+`tauri.conf.json`'s version, which would make the two indistinguishable.
+
+**This was never an updater bug**, and the distinction is worth keeping
+straight because the symptom invites the wrong fix. The updater compares the
+version the bundler bakes in from `tauri.conf.json` — which the guard job
+already pins to the tag — against `desktop-latest/latest.json`. That was
+correct throughout; a `0.1.1` install reporting `dev` here was still offered
+`0.1.2`. `/api/version` is cosmetic, and the guard has no visibility into it.
 
 `/api/version/update-check` answers the short-circuit —
 `update_available: false` — for **every** build since #278. Go's other branch

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,46 @@
+/// The three build-stamp variables `native::version` reads through
+/// `option_env!`, in the order they appear on the About screen.
+const STAMP_VARS: [&str; 3] = [
+    "AGENTO_BUILD_VERSION",
+    "AGENTO_BUILD_COMMIT",
+    "AGENTO_BUILD_DATE",
+];
+
 fn main() {
+    stamp_build_info();
     tauri_build::build()
+}
+
+/// Forward the release workflow's build stamp into the crate, and make cargo
+/// notice when it moves.
+///
+/// `native::version` reads these with `option_env!`, which is resolved at
+/// compile time — so an unstamped build answers `GET /api/version` with
+/// `dev`/`unknown`/`unknown`, which is what every shipped release did until
+/// this existed (the port kept the Go server's `-ldflags` hook and nothing ever
+/// took over the stamping job).
+///
+/// **Passing the variables to `cargo build` is not enough on its own**, and
+/// that is the whole reason this indirection exists rather than the workflow
+/// simply exporting them. The release job restores a `Swatinem/rust-cache`
+/// target directory from an earlier tag's run, so a rebuild has to be
+/// *invalidated* by the new value or the previous release's stamp is what
+/// ships. `rerun-if-env-changed` re-runs this script when a value moves, and
+/// re-emitting the value as `rustc-env` is what then forces the crate itself to
+/// recompile — a build script that only declared the dependency would rerun and
+/// change nothing.
+///
+/// An unset variable emits nothing, so `option_env!` still answers `None` and a
+/// local `npm run app:build` still reports itself as `dev`. That is deliberate:
+/// an unstamped build is a development build, and claiming the version in
+/// `tauri.conf.json` would make one indistinguishable from the release.
+fn stamp_build_info() {
+    for var in STAMP_VARS {
+        println!("cargo:rerun-if-env-changed={var}");
+        if let Ok(value) = std::env::var(var) {
+            if !value.is_empty() {
+                println!("cargo:rustc-env={var}={value}");
+            }
+        }
+    }
 }

--- a/src-tauri/src/native/version.rs
+++ b/src-tauri/src/native/version.rs
@@ -4,15 +4,27 @@
 //!
 //! Two things here are not obvious.
 //!
-//! **The build stamp defaults to Go's unstamped values.** Go's `internal/build`
-//! variables were set by `-ldflags`, and only the Makefile did that —
-//! `scripts/parity-instance.sh` built with no flags, so the server the parity
-//! tests diffed against served the package defaults, and these were pinned to
-//! them. [`VERSION`] and friends still read those defaults, with an
-//! `option_env!` hook (`AGENTO_BUILD_VERSION` and friends) for the day the
-//! desktop bundle starts stamping itself. Nothing constrains them any more —
-//! #278 removed the Go binary that would have had to agree and #388 removed the
-//! Go tree — so stamping is now a build-script change and nothing else.
+//! **The build stamp is the release workflow's, and an unstamped build is
+//! honestly `dev`.** Go's `internal/build` variables were set by `-ldflags`,
+//! and only the Makefile did that — `scripts/parity-instance.sh` built with no
+//! flags, so the server the parity tests diffed against served the package
+//! defaults, and [`VERSION`] and friends were pinned to them behind an
+//! `option_env!` hook for the day the desktop bundle started stamping itself.
+//! That day did not arrive with the hook: every release through
+//! `desktop-v0.1.1` shipped `dev`/`unknown`/`unknown` on the About screen,
+//! because nothing anywhere set the variables. `desktop-release.yml`'s "Build
+//! installers" step sets all three now, via `src-tauri/build.rs` — read its
+//! `stamp_build_info` before changing either half, because passing the
+//! variables to `cargo build` alone does *not* survive a restored build cache.
+//!
+//! The defaults stay, and they are not a fallback to paper over a missing
+//! stamp: a build nobody stamped is a development build, so it says so.
+//!
+//! **This is not the version the updater compares.** That one is baked into the
+//! bundle from `tauri.conf.json` and is pinned to the tag by the release
+//! workflow's guard job; it was correct throughout, which is why an install
+//! reporting `dev` here was still offered the right updates. Two independent
+//! version sources, and only this one is cosmetic — see [`update_check`].
 //!
 //! **The update check is not the updater.** Go's release-lookup branch asked
 //! GitHub and compared, which is the self-updater — the one subsystem the
@@ -134,14 +146,29 @@ mod tests {
         );
     }
 
-    /// The unstamped defaults are what both the bundled sidecar and the parity
-    /// server serve, so parity depends on them matching `internal/build`.
+    /// The unstamped defaults are `internal/build`'s, which is what the parity
+    /// server served — and an unstamped build must keep saying `dev` rather
+    /// than borrowing `tauri.conf.json`'s version, or a local build becomes
+    /// indistinguishable from a release.
+    ///
+    /// The other arm is the regression: every release through `desktop-v0.1.1`
+    /// took it and reported `dev`, because nothing set the variables. It is
+    /// `desktop-release.yml`'s "Build installers" step and
+    /// `src-tauri/build.rs` that make a release take the first arm; a test here
+    /// can only pin that a stamp, when present, is what the route answers.
     #[test]
-    fn the_unstamped_defaults_match_the_go_package() {
-        if option_env!("AGENTO_BUILD_VERSION").is_none() {
-            assert_eq!(VERSION, "dev");
-            assert_eq!(COMMIT_SHA, "unknown");
-            assert_eq!(BUILD_DATE, "unknown");
+    fn a_stamped_build_reports_its_stamp_and_an_unstamped_one_says_dev() {
+        match option_env!("AGENTO_BUILD_VERSION") {
+            Some(stamped) => {
+                assert_eq!(VERSION, stamped);
+                assert_ne!(VERSION, "dev", "an empty stamp must not be emitted");
+                assert_eq!(version().version, stamped);
+            }
+            None => {
+                assert_eq!(VERSION, "dev");
+                assert_eq!(COMMIT_SHA, "unknown");
+                assert_eq!(BUILD_DATE, "unknown");
+            }
         }
     }
 


### PR DESCRIPTION
Every desktop release through `desktop-v0.1.1` answered `GET /api/version` with `dev`/`unknown`/`unknown`, so the About screen on a shipped 0.1.1 install reads **Version dev** over `unknown · Invalid Date`.

`native/version.rs` reads the three build variables through `option_env!` — carried over from the Go server’s `-ldflags` stamp and left as *“a build-script change for the day the desktop bundle starts stamping itself.”* That day never came: at the `desktop-v0.1.1` tag the only occurrences of `AGENTO_BUILD_VERSION` in the tree are `version.rs`’s own, and the release workflow’s build step sets nothing but the signing key. A release build and a plain `cargo build` were identical on this route.

**This was never an updater bug.** The updater compares the version the bundler bakes in from `tauri.conf.json`, which the guard job already pins to the tag — so a 0.1.1 install reporting `dev` was still offered the right updates. `/api/version` is cosmetic and the guard has no visibility into it.

## The fix — two halves, neither works alone

- **`desktop-release.yml`** gains a *Compute the build stamp* step: version from the tag (`desktop-v0.1.2` → `0.1.2`), or from `tauri.conf.json` with a `-dev` suffix for a `workflow_dispatch` dry run, which has no tag to read. That plus `github.sha` and an RFC 3339 date goes into *Build installers*’ `env:`.
- **`src-tauri/build.rs`** re-emits each set variable as `cargo:rustc-env` and declares `cargo:rerun-if-env-changed` for it. The release job restores a `Swatinem/rust-cache` target dir from an earlier tag’s run, so exporting the variables to `cargo build` alone would let the **previous** release’s stamp ship — a build script that only declared the dependency would rerun and change nothing, and only a changed `rustc-env` forces the crate to recompile.

An unset variable emits nothing, so `option_env!` still answers `None` and a local `npm run app:build` still says `dev`. Deliberate: an unstamped build *is* a development build, and falling back to `tauri.conf.json`’s version would make the two indistinguishable.

## Verification

- `cargo test --lib native::version` passes unstamped and stamped.
- Invalidation checked in both directions against a warm target dir — cargo recompiles the crate when the stamp appears and again when it is removed.
- Empirically confirmed the value reaches the artifact: `strings` on the compiled lib finds `9.9.9` and the test commit SHA after a stamped build.
- `cargo fmt --check` and `cargo clippy --all-targets` clean; workflow YAML parses.

The unstamped-defaults test becomes `a_stamped_build_reports_its_stamp_and_an_unstamped_one_says_dev`, covering both arms. `CLAUDE.md`’s “The build stamp” section is updated to record why the two halves are both required.