### PR TITLE
fix(desktop): stop bylining every message with the session's name

### DIFF
--- a/src/lib/sessionAgent.ts
+++ b/src/lib/sessionAgent.ts
@@ -1,0 +1,54 @@
+import type { ClaudeSessionSummary } from "./types";
+
+/**
+ * What Claude Code's `agent-name` event actually carries — and why nothing may
+ * treat it as the identity of whoever produced a message.
+ *
+ * `/rename` is what writes it. Measured across 2,231 transcripts on one
+ * developer machine: **every** `agentName` value was a session title, and in 35
+ * of the 37 sessions carrying one it was byte-identical to the `custom-title`
+ * event written beside it. The two that differed came from Claude Code 2.1.211
+ * and 2.1.224, which wrote `agent-name` *alone* for a rename; 2.1.234 writes
+ * both, back to back, and re-appends the pair on every resume. So the event's
+ * spelling has already moved once across versions, and in none of them did it
+ * name an agent.
+ *
+ * `native/scanner/summary_file.rs` stores it verbatim into
+ * `claude_session_cache.agent_name`, and must keep doing so — the column and
+ * the wire field are pinned against the Go server, so the fix for a
+ * *presentation* mistake cannot live there. The judgement about what the value
+ * means belongs here, in the one layer free to change.
+ *
+ * Two rules follow from that, and they are deliberately not the same rule:
+ *
+ * - **It is never a message byline.** A byline says who spoke, and this field
+ *   has never said that in any version. `SessionDetail` therefore labels
+ *   assistant messages with a constant, so no future spelling of `agent-name`
+ *   can leak into a per-message label again. That is the defence that does not
+ *   depend on guessing what a value looks like — the symptom this fixes was
+ *   every message in a renamed session bylined with a 100-character sentence.
+ * - **It is shown as session metadata only when it is not already on screen**,
+ *   which is what `sessionAgentName` below decides. Suppressing a duplicate is
+ *   already the house rule next to it: the inspector shows `AI title` only when
+ *   it differs from the resolved `display_title`.
+ *
+ * The surviving case is the one worth surfacing rather than hiding: a value
+ * matching none of the session's titles is a rename Agento's own title
+ * resolution cannot see, because those older Claude Code versions never wrote
+ * the `custom-title` event that `native_title` is read from. Showing it is how
+ * such a session admits it was renamed.
+ */
+export function sessionAgentName(session: ClaudeSessionSummary): string {
+  const name = session.agent_name?.trim() ?? "";
+  if (!name) return "";
+  // `preview` is in the list because `display_title` falls back to it, so a
+  // session with no title event of any kind can still be showing this string.
+  const titles = [
+    session.custom_title,
+    session.native_title,
+    session.ai_title,
+    session.display_title,
+    session.preview,
+  ];
+  return titles.some((t) => t?.trim() === name) ? "" : name;
+}

--- a/src/views/SessionsView.tsx
+++ b/src/views/SessionsView.tsx
@@ -28,6 +28,7 @@ import {
   usd,
 } from "../lib/format";
 import { Icon } from "../lib/icons";
+import { sessionAgentName } from "../lib/sessionAgent";
 import { openExternal } from "../lib/tauri";
 import {
   Dropdown,
@@ -837,6 +838,7 @@ function Inspector({
   const subCost = costOf(session.subagent_cost);
   const prs = session.prs ?? [];
   const badge = modeBadge(session);
+  const agentName = sessionAgentName(session);
 
   return (
     <>
@@ -859,6 +861,12 @@ function Inspector({
         {session.native_title && (
           <InspRow label="Native">{session.native_title}</InspRow>
         )}
+        {/* Another name Claude Code recorded for the session, shown only when
+            it is not one of the titles above — the same suppression the AI
+            title gets, for the reasons in lib/sessionAgent.ts. It was labelled
+            "Agent" and sat beside Model and Config until it turned out never to
+            name an agent, so it belongs here with the other titles. */}
+        {agentName && <InspRow label="Named">{agentName}</InspRow>}
         <InspRow label="Project">
           <span title={session.project_path}>
             {tildePath(session.project_path)}
@@ -889,9 +897,6 @@ function Inspector({
           )}
         </InspRow>
         <InspRow label="Config">{session.config_dir ?? "Default"}</InspRow>
-        {session.agent_name && (
-          <InspRow label="Agent">{session.agent_name}</InspRow>
-        )}
       </InspGroup>
 
       <InspGroup title="Activity">

--- a/src/views/sessions/SessionDetail.tsx
+++ b/src/views/sessions/SessionDetail.tsx
@@ -113,9 +113,7 @@ export function SessionDetail({
                 This transcript holds no conversation turns.
               </div>
             ) : (
-              messages.map((m, i) => (
-                <Message key={m.uuid || i} msg={m} agent={agentLabel(detail.data)} />
-              ))
+              messages.map((m, i) => <Message key={m.uuid || i} msg={m} />)
             )}
           </div>
         </div>
@@ -138,11 +136,18 @@ const INJECTED_MARKERS = [
   "Base directory for this skill:",
 ];
 
-function agentLabel(d: ClaudeSessionDetail | null | undefined): string {
-  return d?.agent_name || "Claude";
-}
+/**
+ * The byline every assistant message carries.
+ *
+ * A constant, and deliberately not the session's `agent_name`: Claude Code's
+ * `agent-name` event is the session's own name — what `/rename` sets — in every
+ * version that has written one, so using it here bylined all 104 messages of a
+ * renamed session with its 100-character title. `lib/sessionAgent.ts` carries
+ * the evidence and the rest of the rule.
+ */
+const ASSISTANT_LABEL = "Claude";
 
-function Message({ msg, agent }: { msg: ClaudeMessage; agent: string }) {
+function Message({ msg }: { msg: ClaudeMessage }) {
   const isUser = msg.type === "user";
   const blocks = msg.blocks?.length ? msg.blocks : null;
 
@@ -156,7 +161,9 @@ function Message({ msg, agent }: { msg: ClaudeMessage; agent: string }) {
       </div>
       <div className="msg__body">
         <div className="msg__head">
-          <span className="msg__author">{isUser ? "You" : agent}</span>
+          <span className="msg__author">
+            {isUser ? "You" : ASSISTANT_LABEL}
+          </span>
           <span className="msg__time">{dateTime(msg.timestamp)}</span>
         </div>
         {blocks ? (


### PR DESCRIPTION
## The report

A macOS user renamed a Claude session with `/rename`, and the session detail
page then labelled **every one of its 104 messages** with the full title:

> PTECH-74957 problem_statement_bot asks a long 3-option clarification question instead of a simple either/or

Not a glitch — deterministic, and permanent for any renamed session.

## What was actually wrong

The repeated string is not message *content*. It is the author **byline**.

`/rename` writes an `agent-name` event; the scanner stores its `agentName` into
`claude_session_cache.agent_name` (`native/scanner/summary_file.rs:281`), and
`SessionDetail`'s `agentLabel` read that column as the identity of whoever
produced a message, defaulting to `"Claude"`:

```ts
function agentLabel(d) { return d?.agent_name || "Claude"; }
```

It never was an agent identity. In the reported transcript there are **zero**
`agent-name` and `custom-title` events before line 1217; at the rename both
appear back to back with the identical string, and the pair is re-appended on
every resume (9 pairs = 9 resumes).

Checked against every transcript on a developer machine — 2,231 files:

- **Every** `agentName` value is a session title. Not one names an agent.
- In **35 of 37** sessions carrying one it is byte-identical to the
  `custom-title` written beside it.
- The **2** that differ were written by Claude Code **2.1.211** and **2.1.224**,
  which wrote `agent-name` *alone* for a rename; **2.1.234** writes both.

So the event's spelling has already moved once across versions, which is the
reason the fix is shaped defensively rather than as a one-line swap.

## The fix, and why it is two rules

It lands in the **UI, not the scanner**: the column and the wire field are
pinned against the Go server, so a presentation mistake cannot be corrected
there. `src/lib/sessionAgent.ts` carries the rule and the evidence.

- **A byline never comes from `agent_name`.** `SessionDetail` labels assistant
  messages with a constant, so no future spelling of `agent-name` can reach a
  per-message label again. This is the half that does **not** depend on guessing
  what a value looks like — a heuristic would still have mislabelled the two
  older-version sessions above, whose names match no title at all.
- **`sessionAgentName` suppresses a value duplicating any of the session's
  titles** (`custom_title`, `native_title`, `ai_title`, `display_title`,
  `preview`). That is already the house rule beside it: the inspector shows
  `AI title` only when it differs from `display_title`. What survives is the one
  case worth surfacing rather than hiding — a name matching no title is a rename
  Agento's title resolution cannot see, because those older Claude Code versions
  never wrote the `custom-title` event `native_title` is read from.

The inspector row moves with it: out of the identity half beside Model and
Config, in with the other title sources, and labelled **"Named"** rather than
**"Agent"**.

## Not changed, deliberately

- **The repeated timestamps in the screenshot are real.** The transcript
  genuinely holds those events inside one minute (`08:28Z` = 10:28 local) and
  `dateTime` renders to the minute. Nothing to fix.
- **The toolbar title was already correct** — `resolve_display_title` prefers
  `custom_title`/`native_title`.
- **`resolve_display_title` is untouched.** Making `agent_name` a title fallback
  would fix the *titles* of sessions renamed under 2.1.211–2.1.224, but it is a
  parity-pinned wire field and a separate question. Worth filing; not this PR.

## Verification

- `tsc --noEmit` and `vite build` clean.
- `sessionAgentName` exercised against the reported session's real field values
  plus the older-version shape, an Agento-side rename, an unrenamed session,
  whitespace, and a hypothetical future Claude Code that does put a real agent
  name there — all seven behave as intended.

No frontend test runner exists in this package, so the rule is documented at its
site rather than pinned by a test.
