### PR TITLE
feat(desktop): read the app log back in Settings, or nobody ever sends it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,14 +164,17 @@ src/
     tauri.ts     window + menu bridge; degrades to a plain browser tab
     clipboard.ts copyText, with the execCommand fallback WebKitGTK needs
     newChatPrefs.ts  what the New Chat bar was last set to (localStorage)
+    logs.ts      the log commands, and the line parser (target before level)
   components/    TitleBar, Sidebar, StatusBar, CommandPalette, ui.tsx,
                  DirField (native picker + the /api/fs fallback), CopyButton
   views/         one file per section
+    settings/LogsPane.tsx  Settings → Logs: tail, follow, filter, save a copy
   styles/        tokens → base → shell → controls → views (+ per-view files)
 
 src-tauri/src/
   lib.rs         setup: database (create/migrate/seed), api server, window, menu
   paths.rs       data dir + database path
+  logs.rs        the app log read back for Settings → Logs — commands, not /api
   proxy.rs       axum server; routes every request into native/'s registry
   menu.rs        native menu → menu://action events
   claude/        the Claude Agent SDK, ported from Go (phase 5's foundation)
@@ -3305,6 +3308,40 @@ The elapsed figure is time-to-headers whenever the body is still arriving —
 report a duration the request actually took. (The `forwarded`,
 `native-failed-forwarded` and `diff` labels died with the sidecar in #278; the
 remaining set is `native`, `native-stream`, `unrouted` and `rejected`.)
+
+**Settings → Logs is where that file is read back**, and it is what makes the
+retention above worth anything: a log a user cannot find is a log nobody sends.
+`src-tauri/src/logs.rs` lists the directory, tails a file, follows it and
+concatenates the lot into one file at a path the native save dialog returned;
+`src/views/settings/LogsPane.tsx` renders it with the level coloured and
+filterable. Four things about it are decisions rather than details:
+
+- **They are Tauri commands, not `/api` routes.** The log belongs to the plugin
+  in this process and has no Go counterpart, so a route would be a permanent
+  divergence in `parity/read_routes.json` — the one place the read surface is
+  kept honest. Commands also bypass the ACL, so nothing in `capabilities/` had
+  to move (the save dialog is already covered: `dialog:default` is
+  `allow-message`, `allow-save`, `allow-open`).
+- **The file name from the webview is a key into the listing, never a path
+  fragment.** `dir.join(name)` would serve `../../.ssh/id_rsa` to the page, and
+  this command hands whatever it reads straight back —
+  `a_name_outside_the_directory_is_refused` is the whole property.
+- **The pane renders outside the settings form's loading and error gates.** A
+  failed `GET /api/settings` is exactly when someone comes looking for the log;
+  rendering inside would replace it with "Settings unavailable" at the one
+  moment it is worth reading.
+- **The line format is `[date][time][target][LEVEL]` — target *before* level**,
+  which is the default `tauri_plugin_log` writes and is not what its own
+  `.timezone_strategy()` format writes (that one swaps the two). Measured
+  against a running build rather than read off the source, and the parser tells
+  the fields apart by which one *is* a level name, so neither ordering can
+  break it.
+
+The export is deliberately unfiltered and unredacted: nothing in the file is a
+secret by construction — `proxy.rs` logs no bodies, headers or query strings —
+and a redacted log is worth less than no log. What it does carry is the two
+user-authored path segments the access line already accepts (an agent slug, a
+settings-profile id), which is the same trade recorded above.
 
 None of this is a property of the *data*. An `agento web` pointed at the same
 `~/.agento` exports OTel exactly as it always did; it is this build that

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agento-desktop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agento-desktop",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@tauri-apps/api": "^2.1.1",
         "@tauri-apps/plugin-dialog": "^2.7.2",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,9 @@
 // outside the crate.
 pub mod claude;
 mod guards;
+// Reading back the log file the plugin below writes, for Settings → Logs.
+// Commands rather than `/api` routes: see the module header.
+mod logs;
 // The menubar is macOS-only: the app menu (About/Hide/Quit ⌘Q) is what macOS
 // users expect, while an in-window GTK/win32 menubar is not the convention
 // for this class of app — the titlebar and the ⌘K palette carry the same
@@ -212,7 +215,12 @@ pub fn run() {
                 .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepSome(3))
                 .build(),
         )
-        .invoke_handler(tauri::generate_handler![host_info])
+        .invoke_handler(tauri::generate_handler![
+            host_info,
+            logs::log_files,
+            logs::read_log,
+            logs::export_logs
+        ])
         .setup(|app| {
             let handle = app.handle().clone();
 

--- a/src-tauri/src/logs.rs
+++ b/src-tauri/src/logs.rs
@@ -1,0 +1,519 @@
+//! The app log, read back for Settings → Logs.
+//!
+//! `lib.rs` configures `tauri_plugin_log` to write one file per install into
+//! Tauri's app-log directory, 5 MiB with `KeepSome(3)` archives beside it
+//! (#301). That file is the record a user is asked to send when they hit a bug
+//! — every `/api` request is in it, failures at warn and writes at info — and
+//! until now nothing in the app could show it to them. Asking someone to find
+//! `~/.local/share/com.shaharialab.agento/logs/Agento.log` by hand is asking
+//! most people for nothing.
+//!
+//! **These are Tauri commands rather than `/api` routes, and that is
+//! deliberate.** `/api` is the surface this port mirrors from the Go server,
+//! recorded route by route in `parity/read_routes.json`; the log file belongs
+//! to the plugin in *this* process and has no Go counterpart, so serving it
+//! there would be a permanent divergence in the one place the port keeps
+//! honest. Commands registered through `invoke_handler` also bypass the ACL
+//! entirely, so this needs no capability edit — see the `remote.urls` note in
+//! `CLAUDE.md` for why that matters in release builds. The cost is that the
+//! pane is blank in a plain browser tab (`npm run dev`), where there is no
+//! log file to read either way.
+//!
+//! Everything below the command wrappers takes a directory and a file stem
+//! rather than an `AppHandle`, so the tail arithmetic and the archive ordering
+//! are testable without a window.
+
+use std::fs::File;
+use std::io::{BufWriter, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use tauri::Manager;
+
+/// Most a single read may return, whatever the caller asks for. The live file
+/// is capped at 5 MiB by the plugin, so this covers a whole one; the clamp is
+/// there to stop a webview asking for a gigabyte of a file somebody replaced.
+const MAX_READ: u64 = 8 * 1024 * 1024;
+
+/// Least a single read may return. A tail smaller than this is not a window
+/// onto anything.
+const MIN_READ: u64 = 4 * 1024;
+
+/// One file in the log directory: the live one the plugin is appending to, or
+/// one of the dated archives it rotated.
+#[derive(Serialize)]
+pub struct LogFile {
+    /// File name, which is also the handle `read_log` takes back. Never a
+    /// path — see `resolve`.
+    pub name: String,
+    pub bytes: u64,
+    /// Unix milliseconds, or null when the platform cannot say.
+    pub modified_ms: Option<u64>,
+    /// True for the file currently being written.
+    pub live: bool,
+}
+
+#[derive(Serialize)]
+pub struct LogIndex {
+    /// Absolute path of the log directory, shown so a user can find the files
+    /// themselves. There is no reveal-in-file-manager button: that needs an
+    /// `opener:allow-open-path` capability this app does not grant.
+    pub dir: String,
+    /// Live file first, then archives newest to oldest.
+    pub files: Vec<LogFile>,
+}
+
+/// A window onto one file. The caller keeps `next` and passes it back as
+/// `from` to follow the file; `reset` says whether what came back replaces
+/// what it already had or is appended to it.
+#[derive(Serialize)]
+pub struct LogChunk {
+    pub text: String,
+    /// Byte offset `text` starts at.
+    pub start: u64,
+    /// Byte offset to resume from. Always a line boundary, so a message the
+    /// writer was midway through does not arrive as two lines.
+    pub next: u64,
+    /// The file's length when it was read.
+    pub size: u64,
+    /// True when the read did not start at the file's beginning, i.e. older
+    /// lines exist above what came back.
+    pub truncated: bool,
+    /// True when this chunk replaces the caller's buffer rather than extending
+    /// it — a first read, or a file that shrank underneath a follow because
+    /// the plugin rotated it.
+    pub reset: bool,
+}
+
+// --- Commands ------------------------------------------------------------
+
+#[tauri::command]
+pub fn log_files(app: tauri::AppHandle) -> Result<LogIndex, String> {
+    let (dir, stem) = location(&app)?;
+    Ok(LogIndex {
+        dir: dir.to_string_lossy().into_owned(),
+        files: index(&dir, &stem),
+    })
+}
+
+#[tauri::command]
+pub fn read_log(
+    app: tauri::AppHandle,
+    name: Option<String>,
+    max_bytes: Option<u64>,
+    from: Option<u64>,
+) -> Result<LogChunk, String> {
+    let (dir, stem) = location(&app)?;
+    let path = resolve(&dir, &stem, name.as_deref())?;
+    read_chunk(&path, max_bytes.unwrap_or(MIN_READ), from)
+}
+
+/// Write every log file this install still has into one file at `dest`,
+/// oldest first, under a header naming the build.
+///
+/// One file rather than a zip or a folder because of what it is for: something
+/// to drag into a GitHub issue. The destination comes from the native save
+/// dialog, so the user has already chosen it.
+#[tauri::command]
+pub fn export_logs(app: tauri::AppHandle, dest: String) -> Result<u64, String> {
+    let (dir, stem) = location(&app)?;
+    let info = app.package_info();
+    let header = format!(
+        "# {} {} — {} {}\n# exported {}\n# source {}\n",
+        info.name,
+        info.version,
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+        chrono::Utc::now().to_rfc3339(),
+        dir.to_string_lossy(),
+    );
+    export(&dir, &stem, Path::new(&dest), &header)
+}
+
+/// The directory the plugin writes to, and the stem it names its files with.
+///
+/// Both are read from the same places `tauri_plugin_log` reads them —
+/// `app_log_dir()` and `package_info().name` — rather than being spelled out
+/// again here, so a change to either cannot leave this module looking in the
+/// wrong place.
+fn location(app: &tauri::AppHandle) -> Result<(PathBuf, String), String> {
+    let dir = app
+        .path()
+        .app_log_dir()
+        .map_err(|e| format!("resolving the log directory: {e}"))?;
+    Ok((dir, app.package_info().name.clone()))
+}
+
+// --- The filesystem half, which knows nothing about Tauri ----------------
+
+/// Every log file in `dir`, live one first and archives newest to oldest.
+///
+/// A directory that cannot be listed is an empty index rather than an error:
+/// before the first line is written there is no directory at all, and a first
+/// run should show "nothing logged yet" instead of a failure.
+pub fn index(dir: &Path, stem: &str) -> Vec<LogFile> {
+    let live_name = format!("{stem}.log");
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+
+    let mut files: Vec<LogFile> = entries
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if !is_log_file(&name, stem) {
+                return None;
+            }
+            let meta = entry.metadata().ok()?;
+            if !meta.is_file() {
+                return None;
+            }
+            Some(LogFile {
+                live: name == live_name,
+                name,
+                bytes: meta.len(),
+                modified_ms: meta
+                    .modified()
+                    .ok()
+                    .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                    .map(|d| d.as_millis() as u64),
+            })
+        })
+        .collect();
+
+    // The archive names are `<stem>_<YYYY-MM-DD_HH-MM-SS>.log`, zero-padded
+    // throughout, so lexical order is chronological order and no timestamp has
+    // to be parsed. The live file has no date at all and is pinned to the
+    // front, because it is what a user opening this pane wants to see.
+    files.sort_by(|a, b| b.live.cmp(&a.live).then(b.name.cmp(&a.name)));
+    files
+}
+
+/// Whether `name` is one of the plugin's own files.
+///
+/// `.log.bak` is included: the rotator renames an archive out of the way with
+/// that suffix when two rotations land in the same second, and a file it will
+/// never write to again is exactly the kind that holds the line somebody is
+/// looking for.
+fn is_log_file(name: &str, stem: &str) -> bool {
+    let Some(rest) = name.strip_prefix(stem) else {
+        return false;
+    };
+    let Some(rest) = rest
+        .strip_suffix(".log")
+        .or_else(|| rest.strip_suffix(".log.bak"))
+    else {
+        return false;
+    };
+    // Either the live file (nothing between stem and extension) or a dated
+    // archive (`_` then the timestamp). Anything else in this directory —
+    // another target's file, a copy somebody made — is not ours to serve.
+    rest.is_empty() || rest.starts_with('_')
+}
+
+/// Turn a name the webview sent into a path inside the log directory.
+///
+/// **The name is matched against the directory listing rather than joined onto
+/// it.** `dir.join(name)` accepts `../../.ssh/id_rsa` and every other
+/// traversal, and this command reads any file it is given back to the page;
+/// there is no supported name it refuses, because the only names the frontend
+/// ever sends came from `index`.
+fn resolve(dir: &Path, stem: &str, name: Option<&str>) -> Result<PathBuf, String> {
+    let files = index(dir, stem);
+    let wanted = match name {
+        Some(name) => files.iter().find(|f| f.name == name),
+        // No name means the live file, falling back to the newest archive so
+        // the pane still shows something in the window between a rotation and
+        // the next line being written.
+        None => files.iter().find(|f| f.live).or_else(|| files.first()),
+    };
+    match wanted {
+        Some(file) => Ok(dir.join(&file.name)),
+        None => Err("no log file yet".to_string()),
+    }
+}
+
+/// Read at most `max_bytes` of `path`, either the tail or the span starting at
+/// `from`, cut to whole lines at both ends.
+fn read_chunk(path: &Path, max_bytes: u64, from: Option<u64>) -> Result<LogChunk, String> {
+    let span = max_bytes.clamp(MIN_READ, MAX_READ);
+
+    let mut file = File::open(path).map_err(|e| format!("opening {}: {e}", path.display()))?;
+    let size = file
+        .metadata()
+        .map_err(|e| format!("reading {}: {e}", path.display()))?
+        .len();
+
+    // A `from` past the end means the file shrank underneath us, which on this
+    // directory means the plugin rotated it: the caller's buffer describes a
+    // file that no longer exists, so start over from the tail and say so.
+    let (mut start, reset) = match from {
+        Some(offset) if offset <= size => (offset, false),
+        _ => (size.saturating_sub(span), true),
+    };
+
+    let end = size.min(start + span);
+    file.seek(SeekFrom::Start(start))
+        .map_err(|e| format!("seeking {}: {e}", path.display()))?;
+    let mut buf = Vec::with_capacity((end - start) as usize);
+    file.take(end - start)
+        .read_to_end(&mut buf)
+        .map_err(|e| format!("reading {}: {e}", path.display()))?;
+
+    // A tail almost never lands on a line boundary, so drop the partial line
+    // it starts with. Only when the read actually began mid-file: at offset 0
+    // the first line is whole.
+    let truncated = start > 0;
+    if truncated && reset {
+        if let Some(nl) = buf.iter().position(|b| *b == b'\n') {
+            buf.drain(..=nl);
+            start += nl as u64 + 1;
+        }
+    }
+
+    // Stop at the last newline, so a line the writer is midway through is left
+    // for the next read rather than arriving in two pieces. The exception is a
+    // chunk with no newline at all *and* nothing more to wait for — a whole
+    // span of one line — which would otherwise never advance.
+    let mut next = start + buf.len() as u64;
+    match buf.iter().rposition(|b| *b == b'\n') {
+        Some(nl) => {
+            buf.truncate(nl + 1);
+            next = start + buf.len() as u64;
+        }
+        None if buf.len() as u64 == span => {}
+        None => {
+            buf.clear();
+            next = start;
+        }
+    }
+
+    Ok(LogChunk {
+        // Lossy rather than strict: a log file is bytes a crash can land in the
+        // middle of, and refusing to show any of it because one line is not
+        // UTF-8 would be the wrong answer for the one file a user opens *after*
+        // something went wrong.
+        text: String::from_utf8_lossy(&buf).into_owned(),
+        start,
+        next,
+        size,
+        truncated,
+        reset,
+    })
+}
+
+/// Concatenate every log file into `dest`, oldest first.
+fn export(dir: &Path, stem: &str, dest: &Path, header: &str) -> Result<u64, String> {
+    let mut files = index(dir, stem);
+    // `index` is newest-first for the pane; an export reads top to bottom.
+    files.reverse();
+
+    let out = File::create(dest).map_err(|e| format!("writing {}: {e}", dest.display()))?;
+    let mut out = BufWriter::new(out);
+    let mut written = header.len() as u64;
+    out.write_all(header.as_bytes())
+        .map_err(|e| format!("writing {}: {e}", dest.display()))?;
+
+    for file in &files {
+        let banner = format!("\n===== {} ({} bytes) =====\n", file.name, file.bytes);
+        out.write_all(banner.as_bytes())
+            .map_err(|e| format!("writing {}: {e}", dest.display()))?;
+        written += banner.len() as u64;
+
+        // Copied rather than read into memory: three archives plus the live
+        // file is 20 MiB, and this runs on the UI's thread pool.
+        let mut src =
+            File::open(dir.join(&file.name)).map_err(|e| format!("reading {}: {e}", file.name))?;
+        written +=
+            std::io::copy(&mut src, &mut out).map_err(|e| format!("reading {}: {e}", file.name))?;
+    }
+
+    out.flush()
+        .map_err(|e| format!("writing {}: {e}", dest.display()))?;
+    Ok(written)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(dir: &Path, name: &str, body: &str) {
+        std::fs::write(dir.join(name), body).unwrap();
+    }
+
+    #[test]
+    fn the_index_is_the_live_file_then_archives_newest_first() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "Agento.log", "live\n");
+        write(dir.path(), "Agento_2026-08-20_09-00-00.log", "old\n");
+        write(dir.path(), "Agento_2026-08-21_09-00-00.log", "newer\n");
+        // Not ours, and not the app's: neither may appear.
+        write(dir.path(), "Other.log", "no\n");
+        write(dir.path(), "Agento.txt", "no\n");
+
+        let names: Vec<String> = index(dir.path(), "Agento")
+            .into_iter()
+            .map(|f| f.name)
+            .collect();
+        assert_eq!(
+            names,
+            vec![
+                "Agento.log",
+                "Agento_2026-08-21_09-00-00.log",
+                "Agento_2026-08-20_09-00-00.log",
+            ]
+        );
+    }
+
+    #[test]
+    fn a_rotated_bak_file_is_still_a_log_file() {
+        assert!(is_log_file("Agento.log", "Agento"));
+        assert!(is_log_file("Agento_2026-08-21_09-00-00.log", "Agento"));
+        assert!(is_log_file("Agento_2026-08-21_09-00-00.log.bak", "Agento"));
+        // A prefix match alone would take these, and the second is what a
+        // second app in the same directory would be called.
+        assert!(!is_log_file("Agento-old.log", "Agento"));
+        assert!(!is_log_file("AgentoOther.log", "Agento"));
+        assert!(!is_log_file("Agento.log.gz", "Agento"));
+    }
+
+    /// The whole security property of `read_log`: the name is a key into the
+    /// listing, never a path fragment. `dir.join(name)` would serve any file
+    /// on the machine to the webview.
+    #[test]
+    fn a_name_outside_the_directory_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "Agento.log", "live\n");
+
+        for name in [
+            "../../../etc/passwd",
+            "..",
+            "/etc/passwd",
+            "Agento.log/../../secret",
+        ] {
+            assert!(
+                resolve(dir.path(), "Agento", Some(name)).is_err(),
+                "{name} resolved"
+            );
+        }
+        assert_eq!(
+            resolve(dir.path(), "Agento", Some("Agento.log")).unwrap(),
+            dir.path().join("Agento.log")
+        );
+    }
+
+    #[test]
+    fn no_name_means_the_live_file_and_an_empty_directory_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(resolve(dir.path(), "Agento", None).is_err());
+
+        // Between a rotation and the next line, only the archive exists.
+        write(dir.path(), "Agento_2026-08-21_09-00-00.log", "old\n");
+        assert_eq!(
+            resolve(dir.path(), "Agento", None).unwrap(),
+            dir.path().join("Agento_2026-08-21_09-00-00.log")
+        );
+
+        write(dir.path(), "Agento.log", "live\n");
+        assert_eq!(
+            resolve(dir.path(), "Agento", None).unwrap(),
+            dir.path().join("Agento.log")
+        );
+    }
+
+    #[test]
+    fn a_tail_starts_at_a_line_boundary() {
+        let dir = tempfile::tempdir().unwrap();
+        // Comfortably past the 4 KiB floor, so the read is a real tail.
+        let body: String = (0..800).map(|i| format!("line {i:03}\n")).collect();
+        write(dir.path(), "Agento.log", &body);
+
+        let chunk = read_chunk(&dir.path().join("Agento.log"), MIN_READ, None).unwrap();
+        assert!(chunk.reset);
+        assert!(chunk.truncated);
+        assert!(
+            chunk.text.starts_with("line "),
+            "partial first line: {:?}",
+            &chunk.text[..20.min(chunk.text.len())]
+        );
+        assert!(chunk.text.ends_with("line 799\n"));
+        assert_eq!(chunk.next, chunk.size);
+    }
+
+    #[test]
+    fn a_whole_file_under_the_window_is_not_truncated() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "Agento.log", "one\ntwo\n");
+
+        let chunk = read_chunk(&dir.path().join("Agento.log"), MIN_READ, None).unwrap();
+        assert_eq!(chunk.text, "one\ntwo\n");
+        assert_eq!(chunk.start, 0);
+        assert!(!chunk.truncated);
+    }
+
+    /// What following the file does: the second read returns only what was
+    /// appended, and a line the writer has not finished is held back rather
+    /// than delivered in halves.
+    #[test]
+    fn a_follow_read_returns_only_whole_new_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("Agento.log");
+        write(dir.path(), "Agento.log", "one\n");
+
+        let first = read_chunk(&path, MIN_READ, None).unwrap();
+        assert_eq!(first.text, "one\n");
+
+        std::fs::write(&path, "one\ntwo\nthr").unwrap();
+        let second = read_chunk(&path, MIN_READ, Some(first.next)).unwrap();
+        assert!(!second.reset, "an appended file must not reset the view");
+        assert_eq!(second.text, "two\n");
+        assert_eq!(second.next, 8, "the partial line is left for the next read");
+
+        std::fs::write(&path, "one\ntwo\nthree\n").unwrap();
+        let third = read_chunk(&path, MIN_READ, Some(second.next)).unwrap();
+        assert_eq!(third.text, "three\n");
+    }
+
+    /// A rotation replaces the file with a shorter one, so the caller's offset
+    /// now points past the end. Reading from it would return nothing forever.
+    #[test]
+    fn a_file_that_shrank_resets_the_view() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("Agento.log");
+        write(dir.path(), "Agento.log", "one\ntwo\nthree\n");
+        let first = read_chunk(&path, MIN_READ, None).unwrap();
+
+        std::fs::write(&path, "fresh\n").unwrap();
+        let after = read_chunk(&path, MIN_READ, Some(first.next)).unwrap();
+        assert!(after.reset);
+        assert_eq!(after.text, "fresh\n");
+    }
+
+    #[test]
+    fn the_export_runs_oldest_to_newest_under_a_header() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "Agento.log", "live line\n");
+        write(
+            dir.path(),
+            "Agento_2026-08-20_09-00-00.log",
+            "oldest line\n",
+        );
+        write(
+            dir.path(),
+            "Agento_2026-08-21_09-00-00.log",
+            "middle line\n",
+        );
+
+        let dest = dir.path().join("out.log");
+        let written = export(dir.path(), "Agento", &dest, "# header\n").unwrap();
+
+        let out = std::fs::read_to_string(&dest).unwrap();
+        assert_eq!(written, out.len() as u64);
+        assert!(out.starts_with("# header\n"));
+        let oldest = out.find("oldest line").unwrap();
+        let middle = out.find("middle line").unwrap();
+        let live = out.find("live line").unwrap();
+        assert!(oldest < middle && middle < live, "{out}");
+        assert!(out.contains("===== Agento.log ("));
+    }
+}

--- a/src/lib/icons.tsx
+++ b/src/lib/icons.tsx
@@ -50,6 +50,7 @@ const PATHS = {
   chevronUD: "m6.5 8 3.5-3.5L13.5 8m-7 4 3.5 3.5L13.5 12",
   arrowUp: "M10 15.5v-11m0 0-4 4m4-4 4 4",
   arrowDown: "M10 4.5v11m0 0 4-4m-4 4-4-4",
+  download: "M10 3.5v8m0 0 3.5-3.5M10 11.5 6.5 8M4 13.5v1.5a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1v-1.5",
 
   // Domain
   terminal: "M4.5 4.5h11v11h-11v-11Zm2.5 3.5 2 2-2 2m4 .5h3",

--- a/src/lib/logs.ts
+++ b/src/lib/logs.ts
@@ -1,0 +1,176 @@
+/* ============================================================================
+   The app log, read through the shell rather than through /api.
+
+   `src-tauri/src/logs.rs` owns the files; its header says why they are Tauri
+   commands and not API routes. The one consequence here is that everything
+   below has no answer in a plain browser tab (`npm run dev`) — `available()`
+   is what the pane checks before it renders anything, rather than each call
+   inventing an empty result that would read as "nothing has been logged".
+   ========================================================================== */
+
+import { IS_TAURI } from "./tauri";
+
+export interface LogFile {
+  name: string;
+  bytes: number;
+  modified_ms: number | null;
+  live: boolean;
+}
+
+export interface LogIndex {
+  dir: string;
+  /** Live file first, then archives newest to oldest. */
+  files: LogFile[];
+}
+
+export interface LogChunk {
+  text: string;
+  start: number;
+  /** Pass back as `from` to follow the file; always a line boundary. */
+  next: number;
+  size: number;
+  /** Older lines exist above what came back. */
+  truncated: boolean;
+  /** Replaces the caller's buffer rather than extending it. */
+  reset: boolean;
+}
+
+/** Whether this build can read the log at all. False in a browser tab. */
+export const LOGS_AVAILABLE = IS_TAURI;
+
+async function invoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke<T>(cmd, args);
+}
+
+export function logFiles(): Promise<LogIndex> {
+  return invoke<LogIndex>("log_files");
+}
+
+/**
+ * Read one file. With no `from` this is the tail; with one it is whatever has
+ * been appended since — which is how following works, and why the caller keeps
+ * `next` rather than re-reading the whole file every two seconds.
+ */
+export function readLog(opts: {
+  name?: string;
+  maxBytes?: number;
+  from?: number;
+}): Promise<LogChunk> {
+  return invoke<LogChunk>("read_log", {
+    name: opts.name ?? null,
+    maxBytes: opts.maxBytes ?? null,
+    from: opts.from ?? null,
+  });
+}
+
+/** Write every log file into one at `dest`, oldest first. Returns bytes written. */
+export function exportLogs(dest: string): Promise<number> {
+  return invoke<number>("export_logs", { dest });
+}
+
+/**
+ * Native save dialog. Returns the chosen path, or null when cancelled or when
+ * running outside Tauri. `dialog:default` already covers `save`, so this needs
+ * no capability change — unlike anything reached through the fs plugin, which
+ * is not installed.
+ */
+export async function pickSavePath(defaultName: string): Promise<string | null> {
+  if (!IS_TAURI) return null;
+  const { save } = await import("@tauri-apps/plugin-dialog");
+  const picked = await save({
+    title: "Save a copy of the logs",
+    defaultPath: defaultName,
+    filters: [{ name: "Log", extensions: ["log"] }],
+  });
+  return typeof picked === "string" ? picked : null;
+}
+
+/* ============================================================================
+   Parsing
+
+   `tauri_plugin_log`'s default file format is what `lib.rs` writes:
+
+       [2026-08-22][14:03:11][agento_lib::proxy][INFO] GET /api/agents 200 4ms
+
+   **Target before level, and that is worth knowing**: the plugin has a second
+   format with the two the other way round, installed by `.timezone_strategy()`
+   — which `lib.rs` does not call, and which would silently swap the columns
+   here if it ever did. So the two bracketed fields are told apart by whether
+   one of them *is* a level name rather than by position, and neither ordering
+   can break this. Measured against a running dev build, not read off the
+   source.
+
+   Anything that does not match at all is a continuation of the line before it
+   — a panic backtrace, a multi-line error — and is kept with its parent rather
+   than dropped, because the continuation is usually the interesting half.
+   ========================================================================== */
+
+export type LogLevel = "ERROR" | "WARN" | "INFO" | "DEBUG" | "TRACE";
+
+export const LEVELS: LogLevel[] = ["ERROR", "WARN", "INFO", "DEBUG", "TRACE"];
+
+export interface LogEntry {
+  /** Index in the parsed list; stable enough to key rows off. */
+  id: number;
+  level: LogLevel;
+  /** `YYYY-MM-DD HH:MM:SS`, or "" for a line that carried no timestamp. */
+  time: string;
+  target: string;
+  text: string;
+}
+
+const LINE =
+  /^\[(\d{4}-\d{2}-\d{2})\]\[(\d{2}:\d{2}:\d{2})\]\[([^\]]*)\]\[([^\]]*)\]\s?([\s\S]*)$/;
+
+function isLevel(raw: string): raw is LogLevel {
+  return (LEVELS as string[]).includes(raw);
+}
+
+/**
+ * Split raw log text into entries.
+ *
+ * `into` lets a follow append onto the list it already has without re-parsing
+ * megabytes every two seconds; a continuation line arriving in a later chunk
+ * then still lands on the entry it belongs to.
+ */
+export function parseLog(text: string, into: LogEntry[] = []): LogEntry[] {
+  const out = into;
+  let next = out.length ? out[out.length - 1].id + 1 : 0;
+
+  for (const line of text.split("\n")) {
+    if (line === "") continue;
+    const m = LINE.exec(line);
+    if (m) {
+      // Whichever of the two fields names a level is the level; the other is
+      // the target. A line carrying neither is treated as INFO from the field
+      // that is not a level, which is what an unknown future format degrades
+      // to rather than losing the message.
+      const [a, b] = [m[3], m[4]];
+      out.push({
+        id: next++,
+        time: `${m[1]} ${m[2]}`,
+        level: isLevel(b) ? b : isLevel(a) ? a : "INFO",
+        target: isLevel(b) ? a : b,
+        text: m[5],
+      });
+    } else if (out.length) {
+      // A continuation belongs to the entry above it, at that entry's level:
+      // the second line of a panic is not an INFO line.
+      const prev = out[out.length - 1];
+      prev.text = `${prev.text}\n${line}`;
+    } else {
+      // The first line of a tail is routinely a fragment of one the read cut,
+      // and there is nothing above it to attach to.
+      out.push({ id: next++, time: "", level: "INFO", target: "", text: line });
+    }
+  }
+  return out;
+}
+
+/** Human-readable byte count, matching the app's compact number style. */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/src/styles/logs.css
+++ b/src/styles/logs.css
@@ -1,0 +1,235 @@
+/* ============================================================================
+   Settings → Logs.
+
+   A log viewer is a table of very many small rows, so everything here is about
+   density and about the level being legible at a glance — the pane exists so a
+   user can find the red line and send it to us.
+
+   Colours come from the semantic tokens (`--red`, `--amber`, …), which are
+   declared on bare `:root` and re-declared in both dark blocks, so nothing
+   here needs a media query of its own.
+   ========================================================================== */
+
+/* The Logs tab replaces the settings form's centred, scrolling column: the
+   lines want the pane's whole width, and their scroller is their own. */
+.logs__host {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  padding: var(--sp-7) var(--sp-9) var(--sp-9);
+}
+
+.logspane {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-4);
+  /* The pane's own scrolling lives in .logs__body; without this the parent's
+     scroller takes it and the toolbar leaves with the lines. */
+  min-height: 0;
+  flex: 1;
+}
+
+/* --- Toolbars ------------------------------------------------------------ */
+
+.logs__bar {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  flex-wrap: wrap;
+}
+
+.logs__bar--levels {
+  gap: var(--sp-2);
+}
+
+.logs__spacer {
+  flex: 1;
+}
+
+.logs__meta {
+  font-size: var(--text-sm);
+  color: var(--fg-tertiary);
+  white-space: nowrap;
+}
+
+/* The follow toggle reads as pressed rather than as a second primary action:
+   it is a mode, and the page already has one primary button (Save a copy). */
+.logspane .btn--on {
+  background: var(--accent-soft);
+  color: var(--accent);
+  box-shadow: 0 0 0 var(--hairline) var(--accent);
+}
+
+.logspane .btn--sm {
+  height: 22px;
+  padding: 0 var(--sp-4);
+  font-size: var(--text-sm);
+}
+
+/* --- Level chips --------------------------------------------------------- */
+
+.logchip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  height: 22px;
+  padding: 0 var(--sp-4);
+  border-radius: 999px;
+  font-size: var(--text-sm);
+  color: var(--fg-secondary);
+  background: var(--bg-inset);
+  box-shadow: 0 0 0 var(--hairline) var(--line-soft);
+  transition: opacity var(--dur-fast), background var(--dur-fast);
+}
+.logchip:hover {
+  background: var(--bg-hover);
+}
+
+/* An excluded level stays readable — it is a toggle, not a disabled control,
+   and its count is still information. */
+.logchip--off {
+  opacity: 0.45;
+}
+.logchip--off .logchip__dot {
+  background: var(--fg-quaternary);
+}
+
+.logchip__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--fg-tertiary);
+}
+.logchip--error .logchip__dot {
+  background: var(--red);
+}
+.logchip--warn .logchip__dot {
+  background: var(--amber);
+}
+.logchip--info .logchip__dot {
+  background: var(--accent);
+}
+.logchip--debug .logchip__dot {
+  background: var(--fg-tertiary);
+}
+.logchip--trace .logchip__dot {
+  background: var(--fg-quaternary);
+}
+
+.logchip__count {
+  color: var(--fg-tertiary);
+  font-size: var(--text-xs);
+}
+
+/* --- Notices ------------------------------------------------------------- */
+
+.logs__notice {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+  padding: var(--sp-3) var(--sp-5);
+  border-radius: var(--r-md);
+  background: var(--bg-inset);
+  color: var(--fg-secondary);
+  font-size: var(--text-sm);
+}
+
+/* --- The lines ----------------------------------------------------------- */
+
+.logs__body {
+  flex: 1;
+  min-height: 240px;
+  overflow: auto;
+  padding: var(--sp-3) 0;
+  border-radius: var(--r-md);
+  background: var(--bg-inset);
+  box-shadow: inset 0 0 0 var(--hairline) var(--line);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: 1.55;
+}
+
+.logs__idle {
+  padding: var(--sp-7);
+  text-align: center;
+  color: var(--fg-tertiary);
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+}
+
+.logline {
+  display: grid;
+  grid-template-columns: 62px 46px 116px 1fr;
+  gap: var(--sp-4);
+  padding: 1px var(--sp-5);
+  align-items: baseline;
+}
+.logline:hover {
+  background: var(--bg-hover);
+}
+
+.logline__time {
+  color: var(--fg-quaternary);
+}
+
+.logline__level {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  letter-spacing: 0.02em;
+  color: var(--fg-tertiary);
+}
+
+.logline__target {
+  color: var(--fg-tertiary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* A message may be a whole panic backtrace, so it wraps and keeps its own
+   newlines rather than being cut to one line. */
+.logline__text {
+  color: var(--fg-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.logline--error {
+  background: var(--red-soft);
+}
+.logline--error .logline__level,
+.logline--error .logline__text {
+  color: var(--red);
+}
+.logline--warn {
+  background: var(--amber-soft);
+}
+.logline--warn .logline__level,
+.logline--warn .logline__text {
+  color: var(--amber);
+}
+.logline--info .logline__text {
+  color: var(--fg);
+}
+.logline--debug .logline__text,
+.logline--trace .logline__text {
+  color: var(--fg-tertiary);
+}
+
+/* --- Footer -------------------------------------------------------------- */
+
+.logs__foot {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  font-size: var(--text-sm);
+  color: var(--fg-tertiary);
+}
+
+.logs__path {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 60%;
+}

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -14,6 +14,7 @@ import { Checkbox, Dropdown, Empty, FormRow, Switch } from "../components/ui";
 import { openExternal } from "../lib/tauri";
 import { DirField, useDirPicker } from "../components/DirField";
 import { useHostInfo } from "../lib/host";
+import { LogsPane } from "./settings/LogsPane";
 import {
   UPDATE_PREF_OPTIONS,
   loadUpdatePref,
@@ -113,6 +114,7 @@ type Pane =
   | "notifications"
   | "data"
   | "pricing"
+  | "logs"
   | "advanced";
 
 const PANES: { id: Pane; label: string; icon: IconName }[] = [
@@ -122,6 +124,7 @@ const PANES: { id: Pane; label: string; icon: IconName }[] = [
   { id: "notifications", label: "Notifications", icon: "bell" },
   { id: "data", label: "Data", icon: "database" },
   { id: "pricing", label: "Pricing", icon: "dollar" },
+  { id: "logs", label: "Logs", icon: "terminal" },
   { id: "advanced", label: "Advanced", icon: "cpu" },
 ];
 
@@ -303,6 +306,17 @@ export function SettingsView({
           ))}
         </div>
 
+        {/* Logs sit outside the settings form, and outside its loading and
+            error gates. Both are deliberate: the lines want the pane's whole
+            width and their own scroller, and — more importantly — a settings
+            request that failed is exactly when someone comes looking for the
+            log. Rendering it inside would replace the log with "Settings
+            unavailable" at the one moment it is worth reading. */}
+        {pane === "logs" ? (
+          <div className="logs__host">
+            <LogsPane />
+          </div>
+        ) : (
         <div className="scroll" style={{ flex: 1, padding: "var(--sp-9)" }}>
           {loading ? (
             <Empty icon="gear" title="Loading" text="Reading settings from the server." />
@@ -401,6 +415,7 @@ export function SettingsView({
             </div>
           )}
         </div>
+        )}
       </div>
     </div>
   );

--- a/src/views/settings/LogsPane.tsx
+++ b/src/views/settings/LogsPane.tsx
@@ -1,0 +1,445 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Dropdown, Empty, Search } from "../../components/ui";
+import { CopyButton } from "../../components/CopyButton";
+import { Icon } from "../../lib/icons";
+import { describeError } from "../../lib/hooks";
+import { relativeTime } from "../../lib/format";
+import {
+  LEVELS,
+  LOGS_AVAILABLE,
+  exportLogs,
+  formatBytes,
+  logFiles,
+  parseLog,
+  pickSavePath,
+  readLog,
+  type LogEntry,
+  type LogFile,
+  type LogLevel,
+} from "../../lib/logs";
+import "../../styles/logs.css";
+
+/** How much of a file the first read pulls back. */
+const FIRST_READ = 512 * 1024;
+
+/** What "Load more" multiplies that by, up to the whole file. */
+const READ_STEP = 4;
+
+/**
+ * Most rows rendered at once.
+ *
+ * The session table is not virtualised and neither is this; the difference is
+ * that a log has no natural size, so a cap is the thing standing between a
+ * 5 MiB file and ~50k DOM nodes. The newest rows are the ones kept, and the
+ * banner says so rather than letting the list quietly lie about what it holds.
+ */
+const RENDER_CAP = 4000;
+
+/** How often a followed file is re-read. */
+const FOLLOW_MS = 2000;
+
+const LEVEL_LABEL: Record<LogLevel, string> = {
+  ERROR: "Errors",
+  WARN: "Warnings",
+  INFO: "Info",
+  DEBUG: "Debug",
+  TRACE: "Trace",
+};
+
+/**
+ * Settings → Logs.
+ *
+ * The file this reads is the one a user is asked to attach to a bug report:
+ * `proxy.rs` writes an access line per `/api` request into it, failures at
+ * warn and writes at info (#301). The pane exists so that "send me your logs"
+ * is a button rather than a paragraph of platform-specific paths.
+ *
+ * Three things it is deliberately not: it does not stream (the log plugin has
+ * no tail event, so following is a 2 s re-read of what was appended), it does
+ * not virtualise (see `RENDER_CAP`), and it does not filter anything out of
+ * the *export* — a redacted log is worth less than no log, and nothing in the
+ * file is a secret by construction (`proxy.rs` logs no bodies, headers or
+ * query strings).
+ */
+export function LogsPane() {
+  const [files, setFiles] = useState<LogFile[]>([]);
+  const [dir, setDir] = useState("");
+  const [selected, setSelected] = useState<string>();
+  const [entries, setEntries] = useState<LogEntry[]>([]);
+  const [window_, setWindow] = useState(FIRST_READ);
+  const [truncated, setTruncated] = useState(false);
+  const [size, setSize] = useState(0);
+  const [error, setError] = useState<string>();
+  const [loading, setLoading] = useState(true);
+  const [follow, setFollow] = useState(true);
+  const [query, setQuery] = useState("");
+  const [hidden, setHidden] = useState<Set<LogLevel>>(new Set());
+  const [saved, setSaved] = useState<string>();
+  // Bumped by every full read, so the jump to the newest line also happens on
+  // a reload or a file switch — where the row count may not have changed and
+  // the scroll effect would otherwise not fire.
+  const [reads, setReads] = useState(0);
+
+  // The offset a follow resumes from. A ref rather than state because the poll
+  // reads it on every tick and must not re-arm the interval when it moves.
+  const cursor = useRef(0);
+  const body = useRef<HTMLDivElement>(null);
+  // Whether the view is parked at the bottom. Following scrolls only when it
+  // is, so reading back through history is not yanked away every two seconds.
+  const atBottom = useRef(true);
+
+  /* --- Loading ----------------------------------------------------------- */
+
+  const load = useCallback(
+    async (name: string | undefined, bytes: number) => {
+      setLoading(true);
+      try {
+        const chunk = await readLog({ name, maxBytes: bytes });
+        setEntries(parseLog(chunk.text));
+        setTruncated(chunk.truncated);
+        setSize(chunk.size);
+        cursor.current = chunk.next;
+        atBottom.current = true;
+        setReads((n) => n + 1);
+        setError(undefined);
+      } catch (err) {
+        setEntries([]);
+        setError(describeError(err));
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
+
+  // The file list, once. It is also what decides whether the pane has anything
+  // to show at all: no files means nothing has been logged yet.
+  useEffect(() => {
+    if (!LOGS_AVAILABLE) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    logFiles()
+      .then((index) => {
+        if (cancelled) return;
+        setDir(index.dir);
+        setFiles(index.files);
+        if (index.files.length === 0) setLoading(false);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(describeError(err));
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Re-read whenever the chosen file or the window changes. `selected` being
+  // undefined means the live file, which is what the shell picks by default.
+  useEffect(() => {
+    if (!LOGS_AVAILABLE || files.length === 0) return;
+    void load(selected, window_);
+  }, [selected, window_, files.length, load]);
+
+  const isLive = useMemo(
+    () => files.find((f) => f.name === selected)?.live ?? selected === undefined,
+    [files, selected]
+  );
+
+  // Following an archive would poll a file nothing writes to, so it is only
+  // ever armed on the live one.
+  useEffect(() => {
+    if (!LOGS_AVAILABLE || !follow || !isLive || error) return;
+    const timer = window.setInterval(async () => {
+      try {
+        const chunk = await readLog({
+          name: selected,
+          maxBytes: window_,
+          from: cursor.current,
+        });
+        cursor.current = chunk.next;
+        setSize(chunk.size);
+        if (chunk.reset) {
+          // The file rotated underneath us: what we hold describes a file that
+          // no longer exists.
+          setEntries(parseLog(chunk.text));
+          setTruncated(chunk.truncated);
+        } else if (chunk.text) {
+          // Parsed onto a copy of the existing list so a continuation line
+          // still lands on the entry it belongs to.
+          setEntries((prev) => parseLog(chunk.text, prev.slice()));
+        }
+      } catch {
+        /* a transient read failure is not worth tearing the view down over */
+      }
+    }, FOLLOW_MS);
+    return () => window.clearInterval(timer);
+  }, [follow, isLive, selected, window_, error]);
+
+  /* --- Filtering --------------------------------------------------------- */
+
+  const counts = useMemo(() => {
+    const out = { ERROR: 0, WARN: 0, INFO: 0, DEBUG: 0, TRACE: 0 };
+    for (const e of entries) out[e.level]++;
+    return out;
+  }, [entries]);
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    return entries.filter((e) => {
+      if (hidden.has(e.level)) return false;
+      if (!needle) return true;
+      return (
+        e.text.toLowerCase().includes(needle) ||
+        e.target.toLowerCase().includes(needle) ||
+        e.time.includes(needle)
+      );
+    });
+  }, [entries, hidden, query]);
+
+  const shown = filtered.length > RENDER_CAP ? filtered.slice(-RENDER_CAP) : filtered;
+
+  // Stick to the bottom, but only from the bottom: reading back through
+  // history must not be yanked away by the next poll.
+  useEffect(() => {
+    if (!atBottom.current) return;
+    const el = body.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [shown.length, reads]);
+
+  /* --- Actions ----------------------------------------------------------- */
+
+  async function save() {
+    setSaved(undefined);
+    try {
+      const stamp = new Date().toISOString().slice(0, 10);
+      const dest = await pickSavePath(`agento-logs-${stamp}.log`);
+      if (!dest) return;
+      const bytes = await exportLogs(dest);
+      setSaved(`Saved ${formatBytes(bytes)} to ${dest}`);
+    } catch (err) {
+      setError(describeError(err));
+    }
+  }
+
+  function toggleLevel(level: LogLevel) {
+    setHidden((prev) => {
+      const next = new Set(prev);
+      if (next.has(level)) next.delete(level);
+      else next.add(level);
+      return next;
+    });
+  }
+
+  /* --- Render ------------------------------------------------------------ */
+
+  if (!LOGS_AVAILABLE) {
+    return (
+      <Empty
+        icon="terminal"
+        title="Logs are a desktop feature"
+        text="The log file belongs to the app itself, so it can only be read from the desktop window — not from a browser tab."
+      />
+    );
+  }
+
+  if (!loading && files.length === 0 && !error) {
+    return (
+      <Empty
+        icon="terminal"
+        title="Nothing logged yet"
+        text={
+          dir
+            ? `This install has written no log file. It will appear in ${dir}.`
+            : "This install has written no log file yet."
+        }
+      />
+    );
+  }
+
+  const fileOptions = files.map((f) => ({
+    value: f.name,
+    label: `${f.live ? "Current" : archiveLabel(f.name)} — ${formatBytes(f.bytes)}`,
+  }));
+
+  return (
+    <div className="logspane">
+      <div className="logs__bar">
+        <Dropdown
+          small
+          value={selected ?? files.find((f) => f.live)?.name ?? files[0]?.name ?? ""}
+          options={fileOptions}
+          onChange={(v) => {
+            setWindow(FIRST_READ);
+            setSelected(v);
+          }}
+          ariaLabel="Log file"
+          style={{ minWidth: 190 }}
+        />
+        <Search value={query} onChange={setQuery} placeholder="Filter log" />
+        <button
+          className={`btn ${follow && isLive ? "btn--on" : ""}`}
+          onClick={() => setFollow((f) => !f)}
+          disabled={!isLive}
+          title={
+            isLive
+              ? "Re-read the file every two seconds and stay at the newest line"
+              : "Only the current file is still being written to"
+          }
+        >
+          <Icon name={follow && isLive ? "pause" : "play"} size={13} />
+          {follow && isLive ? "Following" : "Follow"}
+        </button>
+        <button className="btn" onClick={() => void load(selected, window_)}>
+          <Icon name="refresh" size={13} />
+          Reload
+        </button>
+        <button className="btn btn--primary" onClick={() => void save()}>
+          <Icon name="download" size={13} />
+          Save a copy…
+        </button>
+      </div>
+
+      <div className="logs__bar logs__bar--levels">
+        {LEVELS.map((level) => (
+          <button
+            key={level}
+            className={`logchip logchip--${level.toLowerCase()} ${
+              hidden.has(level) ? "logchip--off" : ""
+            }`}
+            onClick={() => toggleLevel(level)}
+            title={
+              hidden.has(level) ? `Show ${LEVEL_LABEL[level]}` : `Hide ${LEVEL_LABEL[level]}`
+            }
+          >
+            <span className="logchip__dot" />
+            {LEVEL_LABEL[level]}
+            <span className="logchip__count tnum">{counts[level]}</span>
+          </button>
+        ))}
+        <span className="logs__spacer" />
+        <span className="logs__meta">
+          {formatBytes(size)}
+          {truncated && " · tail"}
+        </span>
+        <CopyButton
+          text={() => shown.map(lineOf).join("\n")}
+          title="Copy the visible lines"
+          className="btn"
+          size={13}
+          label="Copy"
+        />
+      </div>
+
+      {error && (
+        <div className="msgline msgline--error">
+          <span className="msgline__icon">
+            <Icon name="alert" size={13} />
+          </span>
+          <span>{error}</span>
+        </div>
+      )}
+      {saved && (
+        <div className="msgline msgline--ok">
+          <span className="msgline__icon">
+            <Icon name="check" size={13} />
+          </span>
+          <span className="selectable">{saved}</span>
+        </div>
+      )}
+
+      {truncated && (
+        <div className="logs__notice">
+          <span>
+            Showing the last {formatBytes(window_)} of this file.
+          </span>
+          <button className="btn btn--sm" onClick={() => setWindow((w) => w * READ_STEP)}>
+            Load more
+          </button>
+        </div>
+      )}
+      {filtered.length > shown.length && (
+        <div className="logs__notice">
+          Showing the newest {RENDER_CAP.toLocaleString()} of{" "}
+          {filtered.length.toLocaleString()} matching lines. Filter to narrow it, or
+          save a copy for the rest.
+        </div>
+      )}
+
+      <div
+        className="logs__body"
+        ref={body}
+        onScroll={(e) => {
+          const el = e.currentTarget;
+          atBottom.current = el.scrollHeight - el.scrollTop - el.clientHeight < 24;
+        }}
+      >
+        {loading && entries.length === 0 ? (
+          <div className="logs__idle">Reading the log…</div>
+        ) : shown.length === 0 ? (
+          <div className="logs__idle">
+            {entries.length === 0 ? "This file is empty." : "No lines match."}
+          </div>
+        ) : (
+          shown.map((e) => (
+            <div key={e.id} className={`logline logline--${e.level.toLowerCase()}`}>
+              <span className="logline__time tnum">{e.time.slice(11) || "—"}</span>
+              <span className="logline__level">{e.level}</span>
+              <span className="logline__target" title={e.target}>
+                {shortTarget(e.target)}
+              </span>
+              <span className="logline__text selectable">{e.text}</span>
+            </div>
+          ))
+        )}
+      </div>
+
+      <div className="logs__foot">
+        <span className="logs__path selectable mono">{dir}</span>
+        <CopyButton text={dir} title="Copy the log directory path" />
+        <span className="logs__spacer" />
+        <span className="logs__meta">
+          {files.length} file{files.length === 1 ? "" : "s"}
+          {files[0]?.modified_ms
+            ? ` · updated ${relativeTime(new Date(files[0].modified_ms).toISOString())}`
+            : ""}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * `Agento_2026-08-21_09-00-00.log` → `2026-08-21 09:00:00`.
+ *
+ * The rotator's own name format, read back: date and time joined by `_`, with
+ * the clock's colons written as hyphens because a filename cannot hold them.
+ * A name that does not match is shown as it is rather than mangled.
+ */
+function archiveLabel(name: string): string {
+  const m = /_(\d{4}-\d{2}-\d{2})_(\d{2})-(\d{2})-(\d{2})\.log(\.bak)?$/.exec(name);
+  if (!m) return name;
+  return `${m[1]} ${m[2]}:${m[3]}:${m[4]}${m[5] ? " (bak)" : ""}`;
+}
+
+/**
+ * The whole line, for the clipboard — what someone pastes into an issue, so it
+ * is spelled the way the file spells it (target then level) rather than the
+ * way the table renders it.
+ */
+function lineOf(e: LogEntry): string {
+  return `[${e.time}][${e.target}][${e.level}] ${e.text}`;
+}
+
+/**
+ * `agento_lib::native::chat::turn` is most of the row's width and none of its
+ * information; the leaf is what identifies the code that wrote the line. The
+ * full path stays in the title attribute.
+ */
+function shortTarget(target: string): string {
+  const leaf = target.split("::").pop() ?? target;
+  return leaf === "agento_lib" ? target : leaf;
+}


### PR DESCRIPTION
## What

A **Logs** tab in Settings, between Pricing and Advanced.

- Picks between the live log file and each dated archive.
- Tails the last 512 KB, with **Load more** for older content.
- **Follow** (on by default): re-reads every 2 s, appends only whole new lines, sticks to the bottom unless you have scrolled up. A rotation mid-follow resets the view rather than polling past the end of a file that no longer exists.
- Level chips with live counts (Errors / Warnings / Info / Debug / Trace), toggleable, plus a text filter over message, target and time.
- Errors red-tinted, warnings amber, debug/trace dimmed — from the semantic tokens, so both themes work.
- **Save a copy…** writes every file concatenated oldest → newest into one `agento-logs-YYYY-MM-DD.log` under a header naming version, OS and arch. Plus **Copy** for the visible lines, and the log directory path.

## Why

`proxy.rs` has written an access line per `/api` request since #301 — failures at warn, writes at info, 5 MiB with three dated archives — and nothing in the app could show it. "Send me your logs" meant asking a user to find `~/.local/share/com.shaharialab.agento/logs/Agento.log` by hand, which for most people means no log arrives. The retention #301 chose is only worth something if the file is reachable.

## Four decisions rather than details

- **Tauri commands, not `/api` routes.** The log belongs to the plugin in this process and has no Go counterpart, so a route would be a permanent divergence in `parity/read_routes.json` — the one place the read surface is kept honest. Commands also bypass the ACL, so `capabilities/` did not move (`dialog:default` already grants `allow-save`). Cost: the tab reports "desktop only" in a plain browser tab.
- **The file name from the webview is a key into the directory listing, never a path fragment.** `dir.join(name)` would serve `../../.ssh/id_rsa` to the page, and `read_log` hands whatever it reads straight back. `a_name_outside_the_directory_is_refused` is the whole property.
- **The pane renders outside the settings form's loading and error gates.** A failed `GET /api/settings` is exactly when someone comes looking for the log; rendering inside would replace it with "Settings unavailable" at the one moment it is worth reading.
- **The line format is `[date][time][target][LEVEL]` — target *before* level.** That is what `tauri_plugin_log`'s default writes, and it is not what its own `.timezone_strategy()` format writes, which swaps the two. Measured against a running build rather than read off the source; the parser tells the fields apart by which one *is* a level name, so neither ordering can break it.

The export is deliberately unredacted. Nothing in the file is a secret by construction — `proxy.rs` logs no bodies, headers or query strings — and a redacted log is worth less than no log. What it does carry is the two user-authored path segments the access line already accepts (an agent slug, a settings-profile id), which is the trade `CLAUDE.md` already records.

## Verification

In the **real Tauri webview** through `.claude/skills/local-verify`, not only by typecheck:

- `log_files` and `read_log` answer through the ACL from the page.
- Two generated warnings (`POST /api/agents 415 rejected`, `GET /api/nope 404 unrouted`) arrived through follow within the poll interval, rendered amber, and moved the chip count.
- The Warnings chip hides its rows; the text filter narrows 18 lines to 2.
- `export_logs` wrote a headed file; colours resolve correctly with `data-theme="dark"`.

Nine unit tests cover the tail and follow boundaries, a rotation mid-follow, archive ordering, export ordering, and the traversal refusal.

**Not exercised:** the native save dialog itself — a modal blocks the inspector probe. The command behind it and the permission that grants it are both verified.

`package-lock.json` carries an unrelated `0.1.0 → 0.1.1` sync `npm install` made; the lock had been stale since the release commit.