### PR TITLE
feat: sunset the Go/web build and migrate users to Agento Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,29 @@
 # Agento
 
+> ## 🌇 Agento (web) is being retired — move to Agento Desktop
+>
+> **This is the final release of the Go/web build.** Support ends **1 September 2026**;
+> after that date `agento update` stops offering updates. The app itself keeps
+> working indefinitely — nothing shuts off, nothing expires, and staying on it is
+> your call.
+>
+> **[Agento Desktop](https://github.com/shaharia-lab/agento/releases)** is where
+> development continues. It reads the **same `~/.agento/agento.db`**, so there is
+> no export and no migration: install it and your history, agents and analytics
+> are already there.
+>
+> ```bash
+> brew install --cask shaharia-lab/tap/agento     # macOS
+> ```
+>
+> Or grab the `.dmg`, `.deb`, `.rpm`, `.AppImage` or `.exe` from
+> [Releases](https://github.com/shaharia-lab/agento/releases).
+>
+> **One thing to do after installing:** if you ran `agento service install`, remove
+> the old background service with `agento service uninstall`. Left in place it runs
+> a second scheduler, so every scheduled task fires twice. `agento update` offers to
+> do this for you.
+
 [![Release](https://img.shields.io/github/v/release/shaharia-lab/agento)](https://github.com/shaharia-lab/agento/releases)
 [![Stars](https://img.shields.io/github/stars/shaharia-lab/agento?style=flat)](https://github.com/shaharia-lab/agento/stargazers)
 [![License](https://img.shields.io/github/license/shaharia-lab/agento)](https://github.com/shaharia-lab/agento/blob/main/LICENSE)
@@ -16,11 +40,10 @@ Claude Code forgets everything the moment it exits. Agento reads the session fil
 ![Agento Insights dashboard showing cost cards and productivity metrics](docs/images/insights.png)
 
 ```bash
-brew install shaharia-lab/tap/agento
-agento web
+brew install --cask shaharia-lab/tap/agento
 ```
 
-That is the whole setup. Agento opens at `http://localhost:8990`, finds your Claude Code history, and starts building your dashboards.
+That is the whole setup. Agento finds your Claude Code history and starts building your dashboards.
 
 > ### ⭐ Star this repository
 >
@@ -35,28 +58,48 @@ That is the whole setup. Agento opens at `http://localhost:8990`, finds your Cla
 <table>
 <tr><td width="50%">
 
-**Homebrew**
+**Homebrew (macOS)**
 
 ```bash
-brew install shaharia-lab/tap/agento
-agento web
+brew install --cask shaharia-lab/tap/agento
 ```
 
 </td><td width="50%">
 
 **Direct download**
 
+Grab the installer for your platform from
+[Releases](https://github.com/shaharia-lab/agento/releases):
+`.dmg` (macOS), `.deb` / `.rpm` / `.AppImage` (Linux),
+`-setup.exe` (Windows).
+
+</td></tr>
+</table>
+
+Installers for Linux (x86_64, arm64), macOS (Intel, Apple Silicon) and Windows are on the [Releases page](https://github.com/shaharia-lab/agento/releases).
+
+<details>
+<summary><b>Legacy: the Go/web build (unsupported after 1 September 2026)</b></summary>
+
+The single Go binary that serves the browser UI on `localhost:8990`. It still
+installs and still runs, but it receives no further releases — see the notice at
+the top of this file.
+
 ```bash
-# grab the archive for your platform from Releases
+brew install shaharia-lab/tap/agento     # the formula, not the cask
+agento web
+```
+
+```bash
+# or grab the archive for your platform from Releases
 tar -xzf agento_Linux_x86_64.tar.gz
 sudo mv agento /usr/local/bin/
 agento web
 ```
 
-</td></tr>
-</table>
+Everything below this point describes both builds unless it says otherwise.
 
-Binaries for Linux (x86_64, arm64), macOS (Intel, Apple Silicon) and Windows are on the [Releases page](https://github.com/shaharia-lab/agento/releases).
+</details>
 
 Useful flags: `agento web --port 3000` to change the port, `--no-browser` to skip opening a tab. To keep it running in the background across reboots:
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,12 +7,14 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 
 	"github.com/shaharia-lab/agento/internal/build"
 	"github.com/shaharia-lab/agento/internal/config"
+	"github.com/shaharia-lab/agento/internal/sunset"
 	"github.com/shaharia-lab/agento/internal/updater"
 )
 
@@ -46,6 +48,7 @@ func NewRootCmd(cfg *config.AppConfig) *cobra.Command {
 		Long:    "A platform for running Claude agents defined in YAML configuration files.",
 		Version: build.String(),
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			maybePrintSunsetNotice(cmd, cfg)
 			runAutoUpdateCheck(cmd, cfg)
 			return nil
 		},
@@ -73,6 +76,78 @@ func Execute() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+}
+
+// sunsetSkipCommands lists subcommands that must never print the one-line
+// sunset notice, and why each one is on the list.
+//
+// The list is deliberately far shorter than updateCheckSkipCommands, and it
+// skips for two different reasons:
+//
+//   - `completion` and `__complete`: cobra's shell integration parses their
+//     stdout, and although the notice goes to stderr, a shell that merges the
+//     two streams would ingest it as a completion candidate.
+//   - `web` and `update`: both print the FULL notice themselves, so the
+//     one-liner would be an immediate duplicate of a longer message the user is
+//     about to read anyway. This skips a redundant line, not a user.
+//
+// Everything else — `service`, `help`, a piped `ask`, a cron-driven run — still
+// prints, because none of those has a notice of its own and they are exactly
+// the installs a TTY-gated notice would miss.
+var sunsetSkipCommands = map[string]struct{}{ //nolint:gochecknoglobals
+	"completion": {},
+	"__complete": {},
+	"web":        {},
+	"update":     {},
+}
+
+// sunsetNow is a seam over time.Now so tests can drive the rate limit.
+var sunsetNow = time.Now //nolint:gochecknoglobals
+
+// maybePrintSunsetNotice prints the retirement notice ahead of the user's
+// command, at most once a day.
+//
+// It deliberately does NOT reuse shouldRunAutoCheck's gating. That helper
+// requires an interactive TTY on both stdin and stdout and skips `update` and
+// `service` — reasonable for a prompt that expects an answer, but wrong for a
+// one-way notice, because it would exclude exactly the people who most need to
+// see it: anyone running agento from a script, from a cron job, or under
+// `agento service`.
+//
+// The notice is static and offline. It makes no network call, so it cannot slow
+// a command down, cannot time out, and cannot break when the desktop releases
+// stop carrying their tag prefix.
+func maybePrintSunsetNotice(cmd *cobra.Command, cfg *config.AppConfig) {
+	if !shouldPrintSunsetNotice(cmd) {
+		return
+	}
+	now := sunsetNow()
+	if !sunset.ShouldPrint(cfg.DataDir, now) {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "\n%s\n\n", sunset.Notice())
+	// Best-effort: a failed stamp only means the notice shows again sooner.
+	_ = sunset.Stamp(cfg.DataDir, now) //nolint:errcheck
+}
+
+// shouldPrintSunsetNotice applies the notice's own skip rules.
+func shouldPrintSunsetNotice(cmd *cobra.Command) bool {
+	// A dev build is not an install anyone needs to migrate.
+	if build.IsDevBuild(build.Version) {
+		return false
+	}
+	// Honor the existing opt-out. It already means "do not talk to me about
+	// versions", which is the same wish.
+	if v := os.Getenv(skipUpdateCheckEnv); v == "1" || strings.EqualFold(v, "true") {
+		return false
+	}
+	if cmd == nil || !cmd.Runnable() {
+		return false
+	}
+	if _, skip := sunsetSkipCommands[cmd.Name()]; skip {
+		return false
+	}
+	return true
 }
 
 // runAutoUpdateCheck is the PersistentPreRunE body. It performs a cached

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"bufio"
-	"context"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -151,7 +148,7 @@ func shouldPrintSunsetNotice(cmd *cobra.Command) bool {
 }
 
 // runAutoUpdateCheck is the PersistentPreRunE body. It performs a cached
-// update check and, on a fresh hit, prompts the user to update.
+// update check and, on a fresh hit, announces the newer release.
 //
 // The function is split out so it can be unit-tested without spinning up cobra.
 // All paths return without raising errors — auto-check must never fail the user's command.
@@ -171,7 +168,7 @@ func runAutoUpdateCheck(cmd *cobra.Command, cfg *config.AppConfig) {
 		return
 	}
 
-	promptAndMaybeUpdate(cmd.Context(), result)
+	announceUpdate(result)
 }
 
 // shouldRunAutoCheck applies all skip rules and returns true only when the
@@ -188,7 +185,10 @@ func shouldRunAutoCheck(cmd *cobra.Command) bool {
 		return false
 	}
 
-	// Non-interactive (CI, pipes, redirected stdin/stdout) — no point prompting.
+	// Non-interactive (CI, pipes, redirected stdin/stdout). The announcement no
+	// longer prompts, but a scripted run has already had the sunset notice —
+	// which is the message that matters now — so this stays a skip rather than
+	// becoming a second unsolicited line in every pipeline.
 	if !isInteractive() {
 		return false
 	}
@@ -215,53 +215,25 @@ func shouldRunAutoCheck(cmd *cobra.Command) bool {
 }
 
 // isInteractive reports whether both stdin and stdout are connected to a TTY.
-// We require both because a yes/no prompt is meaningless if either side is piped.
 func isInteractive() bool {
 	return isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stdout.Fd())
 }
 
-// promptAndMaybeUpdate handles the interactive flow when an update is available.
-// It writes prompts to stderr so it doesn't pollute the stdout of subcommands
-// that emit machine-readable output.
+// announceUpdate tells the user a newer release exists and points them at
+// `agento update`. It writes to stderr so it doesn't pollute the stdout of
+// subcommands that emit machine-readable output.
 //
-// On confirmed update, it installs the new binary and exits the process — the
-// user will rerun their command against the new binary. On decline or error,
-// it returns and the original command proceeds.
-func promptAndMaybeUpdate(ctx context.Context, result *updater.CheckResult) {
-	// Homebrew install: print instructions and continue with the user's command.
-	if updater.DetectInstallMethod() == updater.InstallMethodHomebrew {
-		fmt.Fprintf(os.Stderr, "\nA new version (v%s) is available.\n", result.LatestVersion)
-		fmt.Fprintln(os.Stderr, updater.HomebrewUpgradeMessage)
-		fmt.Fprintln(os.Stderr)
-		return
-	}
-
-	fmt.Fprintf(os.Stderr, "\nA new version (v%s) is available. Update now? [y/N] ", result.LatestVersion)
-	// bufio.Reader is used (rather than fmt.Scanln) so the whole line — including
-	// the trailing newline — is consumed. Otherwise leftover bytes leak into the
-	// stdin of the user's subcommand (e.g. `agento ask` reading from a pipe).
-	reader := bufio.NewReader(os.Stdin)
-	line, err := reader.ReadString('\n')
-	if err != nil {
-		// EOF or read error → treat as decline. Continue with the user's command.
-		return
-	}
-	answer := strings.TrimSpace(strings.ToLower(line))
-	if answer != "y" && answer != "yes" {
-		return
-	}
-
-	fmt.Fprintf(os.Stderr, "Updating to %s...\n", result.LatestVersion)
-	if err := updater.Install(ctx, result.LatestVersion); err != nil {
-		if errors.Is(err, updater.ErrHomebrewManaged) {
-			fmt.Fprintln(os.Stderr, updater.HomebrewUpgradeMessage)
-			return
-		}
-		fmt.Fprintf(os.Stderr, "Update failed: %v\n", err)
-		return
-	}
-	fmt.Fprintf(os.Stderr, "Updated to %s. Re-run your command to use the new version.\n", result.LatestVersion)
-	// Exit cleanly so the user re-runs against the new binary. We use 0 because
-	// the update succeeded — the original subcommand simply hasn't been invoked.
-	os.Exit(0)
+// It deliberately does NOT install anything. This hook used to prompt and then
+// replace the running binary in place, which cannot survive the retirement of
+// this build: `agento update` no longer self-updates, and a binary that refuses
+// to update itself on request while quietly doing it behind an unrelated command
+// is incoherent. Removing the install path here is what makes "this build no
+// longer self-updates" true of the binary rather than only of one subcommand.
+//
+// The check itself is kept because the version it reports is still useful
+// information, and because it is the surface through which a user on an older
+// build sees this release's title at all.
+func announceUpdate(result *updater.CheckResult) {
+	fmt.Fprintf(os.Stderr, "\nA newer release (v%s) is available: %s\n", result.LatestVersion, result.ReleaseURL)
+	fmt.Fprintf(os.Stderr, "Run 'agento update' to see how to move to Agento Desktop.\n\n")
 }

--- a/cmd/service_test.go
+++ b/cmd/service_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -148,11 +149,15 @@ func captureStdout(t *testing.T, fn func()) string {
 	os.Stdout = w
 	defer func() { os.Stdout = orig }()
 
+	// Drain to EOF rather than issuing a single Read. A single Read returns as
+	// soon as ANY bytes are available, so a function that makes several separate
+	// writes — a multi-line banner, say — is captured as only its first chunk,
+	// and whether that happens at all depends on goroutine scheduling. That made
+	// it a test that passed locally and failed in CI.
 	done := make(chan string, 1)
 	go func() {
-		buf := make([]byte, 64*1024)
-		n, _ := r.Read(buf)
-		done <- string(buf[:n])
+		out, _ := io.ReadAll(r) //nolint:errcheck
+		done <- string(out)
 	}()
 
 	fn()

--- a/cmd/sunset_notice_test.go
+++ b/cmd/sunset_notice_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -135,11 +136,15 @@ func captureStderr(t *testing.T, fn func()) string {
 	os.Stderr = w
 	defer func() { os.Stderr = orig }()
 
+	// Drain to EOF rather than issuing a single Read. A single Read returns as
+	// soon as ANY bytes are available, so a function that makes several separate
+	// writes — a multi-line banner, say — is captured as only its first chunk,
+	// and whether that happens at all depends on goroutine scheduling. That made
+	// it a test that passed locally and failed in CI.
 	done := make(chan string, 1)
 	go func() {
-		buf := make([]byte, 64*1024)
-		n, _ := r.Read(buf) //nolint:errcheck
-		done <- string(buf[:n])
+		out, _ := io.ReadAll(r) //nolint:errcheck
+		done <- string(out)
 	}()
 
 	fn()

--- a/cmd/sunset_notice_test.go
+++ b/cmd/sunset_notice_test.go
@@ -1,0 +1,218 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/shaharia-lab/agento/internal/build"
+	"github.com/shaharia-lab/agento/internal/config"
+	"github.com/shaharia-lab/agento/internal/sunset"
+)
+
+// withSunsetClock swaps the sunsetNow seam for the duration of a test.
+func withSunsetClock(t *testing.T, now time.Time) {
+	t.Helper()
+	prev := sunsetNow
+	sunsetNow = func() time.Time { return now }
+	t.Cleanup(func() { sunsetNow = prev })
+}
+
+// withReleaseVersion pins build.Version to a real release for the duration of a
+// test, since a dev build never prints the notice.
+func withReleaseVersion(t *testing.T) {
+	t.Helper()
+	prev := build.Version
+	build.Version = "v0.11.2"
+	t.Cleanup(func() { build.Version = prev })
+}
+
+// TestShouldPrintSunsetNotice_ReachesWhereTheUpdateCheckDoesNot is the point of
+// having separate gating. The auto-update check skips `update` and `service`
+// and requires an interactive TTY; the notice must reach all of them, because
+// a scripted or service-only install is exactly the user who would otherwise
+// never learn this build is being retired.
+func TestShouldPrintSunsetNotice_ReachesWhereTheUpdateCheckDoesNot(t *testing.T) {
+	withReleaseVersion(t)
+
+	// `service` and `help` are skipped by the update check but must still get
+	// the notice: a service-only install has no other channel to learn from.
+	for _, name := range []string{"ask", "service", "help"} {
+		cmd := newTestCmd(name)
+		if !shouldPrintSunsetNotice(cmd) {
+			t.Errorf("the sunset notice must print for %q", name)
+		}
+		// Sanity: these really are commands the update check skips.
+		if _, skipped := updateCheckSkipCommands[name]; skipped && shouldRunAutoCheck(cmd) {
+			t.Errorf("precondition changed: %q is no longer skipped by the update check", name)
+		}
+	}
+}
+
+// TestShouldPrintSunsetNotice_SkipsCompletion guards shell completion. Its
+// stdout is parsed by the shell, and a merged stderr would turn the notice into
+// a completion candidate.
+func TestShouldPrintSunsetNotice_SkipsCompletion(t *testing.T) {
+	withReleaseVersion(t)
+
+	for _, name := range []string{"completion", "__complete"} {
+		if shouldPrintSunsetNotice(newTestCmd(name)) {
+			t.Errorf("the sunset notice must never print for %q", name)
+		}
+	}
+}
+
+// TestShouldPrintSunsetNotice_SkipsCommandsThatPrintTheFullNotice avoids
+// telling the user the same thing twice: `agento web` prints the full notice in
+// its startup banner and `agento update` prints it as its whole reason for
+// existing, so prefixing either with the one-liner is pure duplication.
+func TestShouldPrintSunsetNotice_SkipsCommandsThatPrintTheFullNotice(t *testing.T) {
+	withReleaseVersion(t)
+
+	for _, name := range []string{"web", "update"} {
+		if shouldPrintSunsetNotice(newTestCmd(name)) {
+			t.Errorf("%q prints the full notice itself; the one-liner would duplicate it", name)
+		}
+	}
+}
+
+// TestShouldPrintSunsetNotice_SkipsDevBuilds keeps the notice off local builds,
+// which are not installs anyone needs to migrate.
+func TestShouldPrintSunsetNotice_SkipsDevBuilds(t *testing.T) {
+	prev := build.Version
+	t.Cleanup(func() { build.Version = prev })
+
+	for _, v := range []string{"dev", "unknown", "v0.8.0-21-gc325de6-dirty"} {
+		build.Version = v
+		if shouldPrintSunsetNotice(newTestCmd("ask")) {
+			t.Errorf("the sunset notice must not print for version %q", v)
+		}
+	}
+}
+
+// TestShouldPrintSunsetNotice_HonoursOptOut reuses the existing opt-out, which
+// already means "do not talk to me about versions".
+func TestShouldPrintSunsetNotice_HonoursOptOut(t *testing.T) {
+	withReleaseVersion(t)
+
+	for _, v := range []string{"1", "true", "TRUE"} {
+		t.Setenv(skipUpdateCheckEnv, v)
+		if shouldPrintSunsetNotice(newTestCmd("ask")) {
+			t.Errorf("%s=%s must suppress the sunset notice", skipUpdateCheckEnv, v)
+		}
+	}
+}
+
+// TestShouldPrintSunsetNotice_SkipsNonRunnable mirrors the update check: a bare
+// `agento` printing help is not a command anyone is running.
+func TestShouldPrintSunsetNotice_SkipsNonRunnable(t *testing.T) {
+	withReleaseVersion(t)
+
+	if shouldPrintSunsetNotice(nil) {
+		t.Error("a nil command must not print")
+	}
+	if shouldPrintSunsetNotice(newNonRunnableTestCmd()) {
+		t.Error("a non-runnable command must not print")
+	}
+}
+
+func newNonRunnableTestCmd() *cobra.Command {
+	return &cobra.Command{Use: "agento"}
+}
+
+// captureStderr redirects os.Stderr for the duration of fn and returns what was
+// written. It mirrors captureStdout in service_test.go.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	done := make(chan string, 1)
+	go func() {
+		buf := make([]byte, 64*1024)
+		n, _ := r.Read(buf) //nolint:errcheck
+		done <- string(buf[:n])
+	}()
+
+	fn()
+	_ = w.Close() //nolint:errcheck
+	os.Stderr = orig
+
+	select {
+	case out := <-done:
+		return out
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out capturing stderr")
+		return ""
+	}
+}
+
+// TestMaybePrintSunsetNotice_RateLimits drives the whole hook against a real
+// data dir: it prints once, stays quiet for the rest of the day, and returns
+// the next day.
+func TestMaybePrintSunsetNotice_RateLimits(t *testing.T) {
+	withReleaseVersion(t)
+	t.Setenv(skipUpdateCheckEnv, "")
+
+	dir := t.TempDir()
+	cfg := &config.AppConfig{DataDir: dir}
+	start := time.Date(2026, time.August, 23, 9, 0, 0, 0, time.UTC)
+
+	withSunsetClock(t, start)
+	first := captureStderr(t, func() { maybePrintSunsetNotice(newTestCmd("ask"), cfg) })
+	if !strings.Contains(first, sunset.CutoffDate) {
+		t.Fatalf("the first run must print the notice, got %q", first)
+	}
+
+	withSunsetClock(t, start.Add(6*time.Hour))
+	if second := captureStderr(t, func() { maybePrintSunsetNotice(newTestCmd("ask"), cfg) }); second != "" {
+		t.Errorf("a second run the same day must be silent, got %q", second)
+	}
+
+	withSunsetClock(t, start.Add(25*time.Hour))
+	if third := captureStderr(t, func() { maybePrintSunsetNotice(newTestCmd("ask"), cfg) }); !strings.Contains(third, sunset.CutoffDate) {
+		t.Errorf("the next day must print again, got %q", third)
+	}
+}
+
+// TestMaybePrintSunsetNotice_GoesToStderr keeps stdout clean for subcommands
+// that emit machine-readable output.
+func TestMaybePrintSunsetNotice_GoesToStderr(t *testing.T) {
+	withReleaseVersion(t)
+	t.Setenv(skipUpdateCheckEnv, "")
+	withSunsetClock(t, time.Date(2026, time.August, 23, 9, 0, 0, 0, time.UTC))
+
+	cfg := &config.AppConfig{DataDir: t.TempDir()}
+	stdout := captureStdout(t, func() {
+		_ = captureStderr(t, func() { maybePrintSunsetNotice(newTestCmd("ask"), cfg) })
+	})
+	if stdout != "" {
+		t.Errorf("the notice must not reach stdout, got %q", stdout)
+	}
+}
+
+// TestMaybePrintSunsetNotice_CarriesTheFacts asserts the printed line says
+// where to go and that the database is shared — without those it is a warning
+// with no action attached.
+func TestMaybePrintSunsetNotice_CarriesTheFacts(t *testing.T) {
+	withReleaseVersion(t)
+	t.Setenv(skipUpdateCheckEnv, "")
+	withSunsetClock(t, time.Date(2026, time.August, 23, 9, 0, 0, 0, time.UTC))
+
+	cfg := &config.AppConfig{DataDir: t.TempDir()}
+	out := captureStderr(t, func() { maybePrintSunsetNotice(newTestCmd("ask"), cfg) })
+
+	for _, want := range []string{sunset.CutoffDate, sunset.DesktopReleasesURL, "~/.agento/agento.db"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the notice must mention %q, got %q", want, out)
+		}
+	}
+}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,154 +1,173 @@
 package cmd
 
 import (
+	"bufio"
 	"context"
-	"errors"
 	"fmt"
+	"io"
 	"os"
+	"runtime"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/shaharia-lab/agento/internal/build"
 	"github.com/shaharia-lab/agento/internal/config"
 	"github.com/shaharia-lab/agento/internal/daemon"
+	"github.com/shaharia-lab/agento/internal/sunset"
 	"github.com/shaharia-lab/agento/internal/updater"
 )
 
-// NewUpdateCmd returns the "update" subcommand that self-updates the binary.
+// NewUpdateCmd returns the "update" subcommand.
 //
-// Unlike the auto-check hook, this command always performs a live network
-// check (no 24-hour cache) and writes the freshly observed result back to the
-// cache so the next auto-check can rely on it.
+// It no longer self-updates the Go binary. The Go/web build is being retired in
+// favor of Agento Desktop, so this command resolves the current desktop
+// release and hands the user the direct installer link for their platform.
+//
+// Retiring the command rather than deleting it is deliberate: `agento update`
+// is the one place a user of the old build already goes when they want to be
+// current, so it is the most reliable channel we have for telling them where
+// "current" now lives.
 func NewUpdateCmd(cfg *config.AppConfig) *cobra.Command {
 	var yes bool
 	var noRestart bool
 
 	cmd := &cobra.Command{
 		Use:   "update",
-		Short: "Update agento to the latest release",
-		Long:  "Check GitHub releases for a newer version of agento and update the binary in place.",
+		Short: "Show how to move to Agento Desktop (this build is no longer self-updating)",
+		Long: "The Go/web build of Agento is being retired. This command resolves the current " +
+			"Agento Desktop release and prints the download for your platform. It also offers to " +
+			"remove a leftover background service, which would otherwise run a second scheduler " +
+			"alongside the desktop app.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runUpdate(cmd.Context(), cfg, yes, noRestart)
+			return runUpdate(cmd.Context(), cfg, yes)
 		},
 	}
 
-	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompt")
-	cmd.Flags().BoolVar(&noRestart, "no-restart", false, "Do not restart a managed agento service after updating")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Accept the service-removal prompt without asking")
+	cmd.Flags().BoolVar(&noRestart, "no-restart", false, "No longer used; kept so existing scripts do not break")
+	// The flag is retained rather than removed so a script or a service unit
+	// passing it keeps working instead of failing on an unknown flag.
+	_ = cmd.Flags().MarkDeprecated("no-restart", "this build no longer self-updates") //nolint:errcheck
+
 	return cmd
+}
+
+// outf and outln write terminal output to w. The write error is deliberately
+// discarded: this is the user's console, and there is no recovery available if
+// writing to it fails — nor any way to report the failure.
+func outf(w io.Writer, format string, args ...any) {
+	_, _ = fmt.Fprintf(w, format, args...) //nolint:errcheck
+}
+
+func outln(w io.Writer, args ...any) {
+	_, _ = fmt.Fprintln(w, args...) //nolint:errcheck
 }
 
 // newServiceManager is a seam over daemon.New so tests can substitute a stub
 // Manager without touching a real init system.
 var newServiceManager = daemon.New
 
-func runUpdate(ctx context.Context, cfg *config.AppConfig, skipConfirm, noRestart bool) error {
-	current := strings.TrimPrefix(build.Version, "v")
-	if current == "dev" || current == "unknown" {
-		return fmt.Errorf("cannot update a dev build; install a tagged release first")
+// updateNow is a seam over time.Now so tests can drive the cutoff branch.
+var updateNow = time.Now
+
+func runUpdate(ctx context.Context, cfg *config.AppConfig, skipConfirm bool) error {
+	return runUpdateTo(ctx, os.Stdout, os.Stdin, cfg, skipConfirm)
+}
+
+// runUpdateTo is runUpdate with its streams injected, so the whole flow is
+// testable without touching the process's stdio.
+func runUpdateTo(ctx context.Context, out io.Writer, in io.Reader, cfg *config.AppConfig, skipConfirm bool) error {
+	outf(out, "Current version: %s\n\n", build.Version)
+
+	// Past the cutoff there is nothing to offer, so say so and stop. Note what
+	// this does NOT do: the binary keeps working, every other command is
+	// untouched, and nothing here refuses to run. Only updating stops.
+	if sunset.Passed(updateNow()) {
+		outln(out, sunset.MigrationMessage())
+	} else {
+		printDesktopMigration(ctx, out)
 	}
 
-	fmt.Printf("Current version: %s\n", build.Version)
-	fmt.Print("Checking for updates... ")
-
-	checker := &updater.Checker{CacheDir: cfg.DataDir}
-	result, err := checker.Check(ctx, build.Version, true) // forceFresh: explicit command bypasses cache
-	if err != nil {
-		if errors.Is(err, updater.ErrNotReleaseBuild) {
-			fmt.Println()
-			return fmt.Errorf("cannot update a non-release build (%s)", build.Version)
-		}
-		return fmt.Errorf("checking for updates: %w", err)
-	}
-
-	if !result.UpdateAvailable {
-		fmt.Println("already up to date.")
-		return nil
-	}
-
-	fmt.Printf("found %s\n", result.LatestVersion)
-
-	// Homebrew installs cannot be self-updated; print instructions and return.
-	if updater.DetectInstallMethod() == updater.InstallMethodHomebrew {
-		fmt.Printf("\nA new version (v%s) is available.\n", result.LatestVersion)
-		fmt.Println(updater.HomebrewUpgradeMessage)
-		return nil
-	}
-
-	if !skipConfirm {
-		fmt.Printf("Update to %s? [y/N] ", result.LatestVersion)
-		var input string
-		fmt.Scanln(&input) //nolint:errcheck,gosec
-		if input != "y" && input != "Y" {
-			fmt.Println("Update canceled.")
-			return nil
-		}
-	}
-
-	fmt.Printf("Updating to %s...\n", result.LatestVersion)
-	if err := updater.Install(ctx, result.LatestVersion); err != nil {
-		if errors.Is(err, updater.ErrHomebrewManaged) {
-			// Defensive: the earlier branch already handled this, but keep the
-			// guard so a future refactor cannot accidentally call Install on a
-			// Homebrew binary.
-			fmt.Println(updater.HomebrewUpgradeMessage)
-			return nil
-		}
-		return fmt.Errorf("updating: %w", err)
-	}
-
-	fmt.Printf("Updated to %s.\n", result.LatestVersion)
-	maybeRestartService(ctx, cfg, noRestart)
-
-	// Belt-and-suspenders: ensure stdout is flushed before the process exits in
-	// any embedded environment that may not auto-flush.
-	_ = os.Stdout.Sync() //nolint:errcheck
+	offerServiceRemoval(ctx, out, in, cfg, skipConfirm)
 	return nil
 }
 
-// maybeRestartService restarts a managed agento service after a successful
-// update so the new binary takes effect without manual intervention. It never
-// influences the command's exit code — the update itself already succeeded, so
-// every outcome here is informational: restarted, installed-but-stopped, no
-// managed service (manual hint), or a non-fatal warning.
-func maybeRestartService(ctx context.Context, cfg *config.AppConfig, noRestart bool) {
-	if noRestart {
-		fmt.Println("Restart agento to use the new version.")
-		return
-	}
-	mgr, err := newServiceManager(cfg)
+// printDesktopMigration resolves the current desktop release and prints the
+// platform-specific download. Resolution failures degrade to the releases page
+// rather than failing the command — the user asked how to get current, and
+// "here is the page" always answers that.
+func printDesktopMigration(ctx context.Context, out io.Writer) {
+	outln(out, sunset.FullNotice())
+	outln(out)
+
+	rel, err := updater.ResolveDesktopRelease(ctx)
 	if err != nil {
-		// Unsupported OS (e.g. Windows) or any daemon-layer error: there is no
-		// managed service we can restart — fall back to the manual hint.
-		fmt.Println("Restart agento to use the new version.")
+		outf(out, "Download Agento Desktop: %s\n", updater.ReleasesPageURL())
 		return
 	}
-	restarted, status, err := restartManagedService(ctx, mgr)
-	switch {
-	case err != nil:
-		fmt.Printf("warning: restarting the agento service failed (%v). Run 'agento service restart' manually\n", err)
-	case restarted:
-		fmt.Println("Restarted the agento service. The new version is live.")
-	case status.Installed:
-		fmt.Println("The agento service is installed but not running; start it with 'agento service start'.")
-	default:
-		fmt.Println("Restart agento to use the new version.")
+
+	outf(out, "Latest Agento Desktop: %s\n", rel.Version)
+	if rel.DownloadURL != "" {
+		outf(out, "  Download   %s\n", rel.DownloadURL)
+	} else {
+		outf(out, "  Download   no installer is published for %s/%s — see the release page\n",
+			runtime.GOOS, runtime.GOARCH)
 	}
+	outf(out, "  Release    %s\n", rel.ReleasePage)
 }
 
-// restartManagedService restarts the managed service when it is both installed
-// and running. It reports the observed Status so the caller can word the
-// outcome; a Status error is returned as-is (treated as non-fatal upstream).
-func restartManagedService(ctx context.Context, mgr daemon.Manager) (restarted bool, status daemon.Status, err error) {
-	status, err = mgr.Status(ctx)
+// offerServiceRemoval checks for a leftover `agento service` unit and offers to
+// remove it.
+//
+// This matters more than it looks. A leftover launchd/systemd unit holds :8990,
+// runs its OWN scheduler — so every scheduled task fires twice once the desktop
+// app is installed — and re-registers the Telegram webhook under whichever
+// instance started last. None of that is visible to the user.
+//
+// It is an offer, never an action. Removing someone's service unit unprompted
+// is destructive, so a declined prompt, an unreadable answer, and an
+// unsupported platform all leave the unit exactly where it is.
+func offerServiceRemoval(ctx context.Context, out io.Writer, in io.Reader, cfg *config.AppConfig, skipConfirm bool) {
+	mgr, err := newServiceManager(cfg)
 	if err != nil {
-		return false, status, err
+		// Unsupported OS or a daemon-layer error: there is no managed service
+		// we can see, so there is nothing to offer.
+		return
 	}
-	if !status.Installed || !status.Running {
-		return false, status, nil
+	status, err := mgr.Status(ctx)
+	if err != nil || !status.Installed {
+		return
 	}
-	if err := mgr.Restart(ctx); err != nil {
-		return false, status, err
+
+	outln(out)
+	outln(out, "A background agento service is still installed on this machine.")
+	outln(out, "Leaving it in place alongside Agento Desktop means two schedulers:")
+	outln(out, "every scheduled task fires twice, and the Telegram webhook is claimed")
+	outln(out, "by whichever instance started last.")
+
+	if !skipConfirm && !confirm(out, in, "Remove the agento background service now? [y/N] ") {
+		outln(out, "Left in place. Remove it later with 'agento service uninstall'.")
+		return
 	}
-	return true, status, nil
+
+	if err := mgr.Uninstall(ctx); err != nil {
+		outf(out, "warning: removing the service failed (%v). Run 'agento service uninstall' manually\n", err)
+		return
+	}
+	outln(out, "Removed the agento background service.")
+}
+
+// confirm reads a yes/no answer. A read error or EOF is a decline, so a piped
+// or closed stdin can never be mistaken for consent to remove a service unit.
+func confirm(out io.Writer, in io.Reader, prompt string) bool {
+	outf(out, "%s", prompt)
+	line, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil && line == "" {
+		outln(out)
+		return false
+	}
+	answer := strings.TrimSpace(strings.ToLower(line))
+	return answer == "y" || answer == "yes"
 }

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -1,213 +1,261 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/shaharia-lab/agento/internal/config"
 	"github.com/shaharia-lab/agento/internal/daemon"
+	"github.com/shaharia-lab/agento/internal/sunset"
 )
 
-// stubManager implements daemon.Manager for update-restart tests, recording
-// whether Restart was invoked and returning canned Status/Restart results.
+// stubManager implements daemon.Manager for update tests, recording whether
+// Uninstall was invoked and returning canned Status/Uninstall results.
 type stubManager struct {
-	status      daemon.Status
-	statusErr   error
-	restartErr  error
-	restartHits int
+	status        daemon.Status
+	statusErr     error
+	uninstallErr  error
+	uninstallHits int
 }
 
 func (m *stubManager) Install(context.Context, daemon.Options) error { return nil }
-func (m *stubManager) Uninstall(context.Context) error               { return nil }
 func (m *stubManager) Start(context.Context) error                   { return nil }
 func (m *stubManager) Stop(context.Context) error                    { return nil }
+func (m *stubManager) Restart(context.Context) error                 { return nil }
 
-func (m *stubManager) Restart(context.Context) error {
-	m.restartHits++
-	return m.restartErr
+func (m *stubManager) Uninstall(context.Context) error {
+	m.uninstallHits++
+	return m.uninstallErr
 }
 
 func (m *stubManager) Status(context.Context) (daemon.Status, error) {
 	return m.status, m.statusErr
 }
 
-// TestRestartManagedServiceMatrix drives restartManagedService across the
-// status matrix: only an installed AND running service is restarted, and a
-// Restart error propagates (so the caller can warn) while a Status error is
-// returned for the caller to treat as non-fatal.
-func TestRestartManagedServiceMatrix(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name         string
-		status       daemon.Status
-		statusErr    error
-		restartErr   error
-		wantRestart  bool
-		wantRestarts int
-		wantErr      bool
-	}{
-		{
-			name:         "installed and running restarts",
-			status:       daemon.Status{Installed: true, Running: true, PID: 1234},
-			wantRestart:  true,
-			wantRestarts: 1,
-		},
-		{
-			name:         "installed but stopped is left alone",
-			status:       daemon.Status{Installed: true, Running: false},
-			wantRestart:  false,
-			wantRestarts: 0,
-		},
-		{
-			name:         "not installed is left alone",
-			status:       daemon.Status{Installed: false, Running: false},
-			wantRestart:  false,
-			wantRestarts: 0,
-		},
-		{
-			name:         "restart error propagates",
-			status:       daemon.Status{Installed: true, Running: true, PID: 1234},
-			restartErr:   errors.New("systemctl failed"),
-			wantRestart:  false,
-			wantRestarts: 1,
-			wantErr:      true,
-		},
-		{
-			name:         "status error propagates without restart",
-			status:       daemon.Status{},
-			statusErr:    errors.New("status unavailable"),
-			wantRestart:  false,
-			wantRestarts: 0,
-			wantErr:      true,
-		},
+// withManager swaps the newServiceManager seam for the duration of a test.
+func withManager(t *testing.T, mgr daemon.Manager, err error) {
+	t.Helper()
+	prev := newServiceManager
+	newServiceManager = func(*config.AppConfig) (daemon.Manager, error) { return mgr, err }
+	t.Cleanup(func() { newServiceManager = prev })
+}
+
+// withClock swaps the updateNow seam so the cutoff branch is reachable without
+// waiting for September.
+func withClock(t *testing.T, now time.Time) {
+	t.Helper()
+	prev := updateNow
+	updateNow = func() time.Time { return now }
+	t.Cleanup(func() { updateNow = prev })
+}
+
+// runUpdateCapturing drives the whole command with injected streams.
+func runUpdateCapturing(t *testing.T, stdin string, skipConfirm bool) string {
+	t.Helper()
+	var out bytes.Buffer
+	if err := runUpdateTo(context.Background(), &out, strings.NewReader(stdin), &config.AppConfig{}, skipConfirm); err != nil {
+		t.Fatalf("runUpdateTo: %v", err)
 	}
-	for _, tc := range cases {
+	return out.String()
+}
+
+// TestUpdateNeverSelfUpdates is the headline behavior of this release: the
+// command no longer replaces the binary, it points at Agento Desktop. Both
+// sides of the cutoff must offer a way to get the desktop app and neither may
+// talk about updating this binary.
+func TestUpdateNeverSelfUpdates(t *testing.T) {
+	withManager(t, &stubManager{status: daemon.Status{Installed: false}}, nil)
+
+	for _, tc := range []struct {
+		name string
+		now  time.Time
+	}{
+		{"before the cutoff", sunset.Cutoff.Add(-24 * time.Hour)},
+		{"after the cutoff", sunset.Cutoff.Add(24 * time.Hour)},
+	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			mgr := &stubManager{status: tc.status, statusErr: tc.statusErr, restartErr: tc.restartErr}
-			restarted, _, err := restartManagedService(context.Background(), mgr)
-			if (err != nil) != tc.wantErr {
-				t.Fatalf("err = %v, wantErr %v", err, tc.wantErr)
+			withClock(t, tc.now)
+			out := runUpdateCapturing(t, "", false)
+
+			if !strings.Contains(out, sunset.DesktopReleasesURL) {
+				t.Errorf("output must point at the desktop releases:\n%s", out)
 			}
-			if restarted != tc.wantRestart {
-				t.Errorf("restarted = %v, want %v", restarted, tc.wantRestart)
-			}
-			if mgr.restartHits != tc.wantRestarts {
-				t.Errorf("Restart called %d times, want %d", mgr.restartHits, tc.wantRestarts)
+			for _, forbidden := range []string{"Updating to", "already up to date", "Update to"} {
+				if strings.Contains(out, forbidden) {
+					t.Errorf("output must not talk about self-updating, found %q:\n%s", forbidden, out)
+				}
 			}
 		})
 	}
 }
 
-// TestMaybeRestartServiceUnsupportedOSFallsBackToHint asserts the
-// ErrUnsupportedOS path (e.g. Windows) prints the manual-restart hint and
-// never fails or attempts a restart.
-func TestMaybeRestartServiceUnsupportedOSFallsBackToHint(t *testing.T) {
-	prev := newServiceManager
-	newServiceManager = func(*config.AppConfig) (daemon.Manager, error) {
-		return nil, fmt.Errorf("wrap: %w", daemon.ErrUnsupportedOS)
-	}
-	t.Cleanup(func() { newServiceManager = prev })
+// TestUpdateAfterCutoffOffersNoDownload asserts the post-cutoff branch prints
+// only the migration message — and, just as importantly, that it says the rest
+// of the app is unaffected. Disabling updates is not a kill switch.
+func TestUpdateAfterCutoffOffersNoDownload(t *testing.T) {
+	withManager(t, &stubManager{status: daemon.Status{Installed: false}}, nil)
+	withClock(t, sunset.Cutoff.Add(time.Hour))
 
-	out := captureStdout(t, func() {
-		maybeRestartService(context.Background(), &config.AppConfig{}, false)
-	})
-	if got := out; got != "Restart agento to use the new version.\n" {
-		t.Errorf("got %q, want the manual-restart hint", got)
+	out := runUpdateCapturing(t, "", false)
+
+	if !strings.Contains(out, "no longer updated") {
+		t.Errorf("output must state that updates have stopped:\n%s", out)
+	}
+	if !strings.Contains(out, "Every other agento command is\nunaffected") {
+		t.Errorf("output must state the rest of the app still works:\n%s", out)
+	}
+	if strings.Contains(out, "Latest Agento Desktop:") {
+		t.Errorf("the post-cutoff branch must not resolve a release:\n%s", out)
 	}
 }
 
-// TestMaybeRestartServiceManagerErrorFallsBackToHint covers any non-OS daemon
-// construction failure — same manual hint, no panic, exit code untouched.
-func TestMaybeRestartServiceManagerErrorFallsBackToHint(t *testing.T) {
-	prev := newServiceManager
-	newServiceManager = func(*config.AppConfig) (daemon.Manager, error) {
-		return nil, errors.New("boom")
-	}
-	t.Cleanup(func() { newServiceManager = prev })
-
-	out := captureStdout(t, func() {
-		maybeRestartService(context.Background(), &config.AppConfig{}, false)
-	})
-	if got := out; got != "Restart agento to use the new version.\n" {
-		t.Errorf("got %q, want the manual-restart hint", got)
-	}
-}
-
-// TestMaybeRestartServiceNoRestartSkipsManager asserts --no-restart short-circuits
-// before any manager is even built (no systemctl/launchctl is possible) and
-// prints the manual hint.
-func TestMaybeRestartServiceNoRestartSkipsManager(t *testing.T) {
-	prev := newServiceManager
-	built := false
-	newServiceManager = func(*config.AppConfig) (daemon.Manager, error) {
-		built = true
-		return &stubManager{}, nil
-	}
-	t.Cleanup(func() { newServiceManager = prev })
-
-	out := captureStdout(t, func() {
-		maybeRestartService(context.Background(), &config.AppConfig{}, true)
-	})
-	if built {
-		t.Error("manager must not be built when --no-restart is set")
-	}
-	if got := out; got != "Restart agento to use the new version.\n" {
-		t.Errorf("got %q, want the manual-restart hint", got)
-	}
-}
-
-// TestMaybeRestartServiceMessages checks the user-facing wording for each
-// outcome via a stubbed manager.
-func TestMaybeRestartServiceMessages(t *testing.T) {
+// TestServiceRemovalPrompt covers the decision matrix around the leftover unit.
+// The destructive direction requires an explicit yes; everything else — a
+// declined prompt, EOF on a piped stdin, a stray answer — leaves the unit alone.
+func TestServiceRemovalPrompt(t *testing.T) {
 	cases := []struct {
-		name       string
-		mgr        *stubManager
-		wantSubstr string
+		name          string
+		status        daemon.Status
+		statusErr     error
+		stdin         string
+		skipConfirm   bool
+		wantUninstall int
+		wantSubstr    string
 	}{
 		{
-			name:       "restarted",
-			mgr:        &stubManager{status: daemon.Status{Installed: true, Running: true, PID: 42}},
-			wantSubstr: "Restarted the agento service. The new version is live.",
+			name:          "installed and accepted",
+			status:        daemon.Status{Installed: true},
+			stdin:         "y\n",
+			wantUninstall: 1,
+			wantSubstr:    "Removed the agento background service.",
 		},
 		{
-			name:       "installed but stopped",
-			mgr:        &stubManager{status: daemon.Status{Installed: true, Running: false}},
-			wantSubstr: "installed but not running",
+			name:          "installed and accepted with yes spelled out",
+			status:        daemon.Status{Installed: true},
+			stdin:         "YES\n",
+			wantUninstall: 1,
+			wantSubstr:    "Removed the agento background service.",
 		},
 		{
-			name:       "no managed service",
-			mgr:        &stubManager{status: daemon.Status{Installed: false, Running: false}},
-			wantSubstr: "Restart agento to use the new version.",
+			name:          "installed and declined",
+			status:        daemon.Status{Installed: true},
+			stdin:         "n\n",
+			wantUninstall: 0,
+			wantSubstr:    "Left in place.",
 		},
 		{
-			name: "restart failure warns",
-			mgr: &stubManager{
-				status:     daemon.Status{Installed: true, Running: true, PID: 42},
-				restartErr: errors.New("kickstart failed"),
-			},
-			wantSubstr: "warning: restarting the agento service failed",
+			name:          "installed with empty answer",
+			status:        daemon.Status{Installed: true},
+			stdin:         "\n",
+			wantUninstall: 0,
+			wantSubstr:    "Left in place.",
+		},
+		{
+			name:          "installed with EOF on stdin",
+			status:        daemon.Status{Installed: true},
+			stdin:         "",
+			wantUninstall: 0,
+			wantSubstr:    "Left in place.",
+		},
+		{
+			name:          "installed with -y skips the prompt",
+			status:        daemon.Status{Installed: true},
+			stdin:         "",
+			skipConfirm:   true,
+			wantUninstall: 1,
+			wantSubstr:    "Removed the agento background service.",
+		},
+		{
+			name:          "not installed asks nothing",
+			status:        daemon.Status{Installed: false},
+			stdin:         "y\n",
+			skipConfirm:   true,
+			wantUninstall: 0,
+			wantSubstr:    "",
+		},
+		{
+			name:          "status error asks nothing",
+			status:        daemon.Status{Installed: true},
+			statusErr:     errors.New("systemctl unavailable"),
+			stdin:         "y\n",
+			skipConfirm:   true,
+			wantUninstall: 0,
+			wantSubstr:    "",
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			prev := newServiceManager
-			newServiceManager = func(*config.AppConfig) (daemon.Manager, error) { return tc.mgr, nil }
-			t.Cleanup(func() { newServiceManager = prev })
+			mgr := &stubManager{status: tc.status, statusErr: tc.statusErr}
+			withManager(t, mgr, nil)
+			withClock(t, sunset.Cutoff.Add(time.Hour)) // avoid the network in the pre-cutoff branch
 
-			out := captureStdout(t, func() {
-				maybeRestartService(context.Background(), &config.AppConfig{}, false)
-			})
-			if !strings.Contains(out, tc.wantSubstr) {
+			out := runUpdateCapturing(t, tc.stdin, tc.skipConfirm)
+
+			if mgr.uninstallHits != tc.wantUninstall {
+				t.Errorf("Uninstall called %d times, want %d\n%s", mgr.uninstallHits, tc.wantUninstall, out)
+			}
+			if tc.wantSubstr != "" && !strings.Contains(out, tc.wantSubstr) {
 				t.Errorf("output %q missing %q", out, tc.wantSubstr)
 			}
-			// The restart-failure warning must name the actionable command.
-			if tc.mgr.restartErr != nil && !strings.Contains(out, "agento service restart") {
-				t.Errorf("warning %q must point at 'agento service restart'", out)
+			if tc.wantUninstall == 0 && tc.status.Installed && tc.statusErr == nil {
+				if !strings.Contains(out, "two schedulers") {
+					t.Errorf("a declined prompt must still have explained the hazard:\n%s", out)
+				}
 			}
 		})
+	}
+}
+
+// TestServiceRemovalExplainsTheHazard pins the wording that justifies the
+// prompt. A user asked to remove a service deserves to know why: the leftover
+// unit runs its own scheduler and claims the Telegram webhook.
+func TestServiceRemovalExplainsTheHazard(t *testing.T) {
+	withManager(t, &stubManager{status: daemon.Status{Installed: true}}, nil)
+	withClock(t, sunset.Cutoff.Add(time.Hour))
+
+	out := runUpdateCapturing(t, "n\n", false)
+
+	for _, want := range []string{"two schedulers", "fires twice", "Telegram webhook", "agento service uninstall"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("prompt must mention %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestServiceRemovalFailureWarnsAndPointsAtTheCommand keeps a failed uninstall
+// non-fatal and actionable.
+func TestServiceRemovalFailureWarnsAndPointsAtTheCommand(t *testing.T) {
+	withManager(t, &stubManager{
+		status:       daemon.Status{Installed: true},
+		uninstallErr: errors.New("systemctl failed"),
+	}, nil)
+	withClock(t, sunset.Cutoff.Add(time.Hour))
+
+	out := runUpdateCapturing(t, "", true)
+
+	if !strings.Contains(out, "warning: removing the service failed") {
+		t.Errorf("a failed uninstall must warn:\n%s", out)
+	}
+	if !strings.Contains(out, "agento service uninstall") {
+		t.Errorf("the warning must name the manual command:\n%s", out)
+	}
+}
+
+// TestServiceRemovalUnsupportedOSIsSilent asserts an unsupported platform
+// (daemon.New returns ErrUnsupportedOS, e.g. Windows) offers nothing rather
+// than warning about a service that cannot exist there.
+func TestServiceRemovalUnsupportedOSIsSilent(t *testing.T) {
+	withManager(t, nil, fmt.Errorf("wrap: %w", daemon.ErrUnsupportedOS))
+	withClock(t, sunset.Cutoff.Add(time.Hour))
+
+	out := runUpdateCapturing(t, "", true)
+
+	if strings.Contains(out, "background agento service") {
+		t.Errorf("no service offer is possible on an unsupported OS:\n%s", out)
 	}
 }

--- a/cmd/web.go
+++ b/cmd/web.go
@@ -38,6 +38,7 @@ import (
 	"github.com/shaharia-lab/agento/internal/server"
 	"github.com/shaharia-lab/agento/internal/service"
 	"github.com/shaharia-lab/agento/internal/storage"
+	"github.com/shaharia-lab/agento/internal/sunset"
 	"github.com/shaharia-lab/agento/internal/telemetry"
 	"github.com/shaharia-lab/agento/internal/tools"
 	"github.com/shaharia-lab/agento/internal/trigger"
@@ -544,9 +545,16 @@ const (
 func printBanner(version, serverURL, logFile string) {
 	if termenv.ColorProfile() == termenv.Ascii {
 		printPlainBanner(version, serverURL, logFile)
-		return
+	} else {
+		printFancyBanner(version, serverURL, logFile)
 	}
-	printFancyBanner(version, serverURL, logFile)
+	// The retirement notice follows the banner on every start, in both
+	// renderings. It is unconditional here rather than rate-limited: starting
+	// the server is a deliberate act, not something that happens on every shell
+	// command, and this is the surface where the notice has room to say what is
+	// happening and what to do about it.
+	fmt.Println(sunset.FullNotice())
+	fmt.Println()
 }
 
 func printFancyBanner(version, serverURL, logFile string) {

--- a/cmd/web_banner_test.go
+++ b/cmd/web_banner_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/shaharia-lab/agento/internal/sunset"
+)
+
+// TestPrintBannerCarriesTheSunsetNotice pins issue #389's requirement that
+// `agento web` states the retirement on startup.
+//
+// The notice lives in printBanner rather than in either rendering, so it cannot
+// be lost by a change to only one of them — but nothing else asserts it, and
+// the startup banner is the surface a long-running install is most likely to be
+// read from. Both renderings are exercised because the color-profile branch
+// picks between them at runtime.
+func TestPrintBannerCarriesTheSunsetNotice(t *testing.T) {
+	out := captureStdout(t, func() {
+		printBanner("v0.11.2", "http://localhost:8990", "/tmp/agento.log")
+	})
+
+	for _, want := range []string{
+		sunset.CutoffDate,
+		sunset.DesktopReleasesURL,
+		"~/.agento/agento.db",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the startup banner must mention %q:\n%s", want, out)
+		}
+	}
+
+	// The app is not being switched off, and the banner has room to say so.
+	if !strings.Contains(out, "keeps working") {
+		t.Errorf("the banner must say the app keeps working past the cutoff:\n%s", out)
+	}
+}
+
+// TestPrintPlainBannerStillCarriesTheVitals guards the non-color rendering,
+// which is what a piped or dumb terminal actually gets.
+func TestPrintPlainBannerStillCarriesTheVitals(t *testing.T) {
+	out := captureStdout(t, func() {
+		printPlainBanner("v0.11.2", "http://localhost:8990", "/tmp/agento.log")
+	})
+
+	for _, want := range []string{"v0.11.2", "http://localhost:8990", "/tmp/agento.log"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the plain banner must still show %q:\n%s", want, out)
+		}
+	}
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,10 +1,45 @@
 # Getting Started
 
+> **🌇 Start with Agento Desktop.** The Go/web build described below is being
+> retired: it receives no releases after **1 September 2026**, when
+> `agento update` stops offering updates. The app keeps working past that date —
+> only updating stops — but new work happens in the desktop app.
+>
+> Agento Desktop reads the **same `~/.agento/agento.db`**, so moving over needs
+> no export and no migration. Install it and your history is already there.
+
 **Requirements:** the [Claude Code CLI](https://claude.ai/code), installed and
 authenticated. If `claude` runs in your terminal, Agento works — it uses the
 authentication Claude Code already has, so no Anthropic API key is needed.
 
-## Install
+## Install Agento Desktop (recommended)
+
+**Homebrew (macOS)**
+
+```bash
+brew install --cask shaharia-lab/tap/agento
+```
+
+**Download an installer**
+
+Go to [Releases](https://github.com/shaharia-lab/agento/releases) and take the
+one for your platform: `.dmg` (macOS), `.deb` / `.rpm` / `.AppImage` (Linux),
+`-setup.exe` (Windows).
+
+Already running the web build? Install the desktop app, then remove the old
+background service if you had one:
+
+```bash
+agento service uninstall
+```
+
+Leaving it installed runs a second scheduler alongside the desktop app, so every
+scheduled task fires twice and the Telegram webhook is claimed by whichever
+instance started last. `agento update` offers to do this for you.
+
+## Install the legacy web build
+
+Unsupported after 1 September 2026. Still installable, still runs.
 
 **Homebrew (macOS and Linux)**
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { Outlet } from 'react-router-dom'
 import { Menu } from 'lucide-react'
 import Sidebar from './Sidebar'
+import SunsetBanner from './SunsetBanner'
 import UpdateBanner from './UpdateBanner'
 
 function AgentoLogo() {
@@ -31,6 +32,7 @@ export default function Layout() {
       <Sidebar mobileOpen={mobileOpen} onMobileClose={() => setMobileOpen(false)} />
 
       <div className="flex flex-1 flex-col overflow-hidden">
+        <SunsetBanner />
         <UpdateBanner />
 
         {/* Mobile top bar */}

--- a/frontend/src/components/SunsetBanner.test.tsx
+++ b/frontend/src/components/SunsetBanner.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import SunsetBanner from './SunsetBanner'
+import {
+  SUNSET_CUTOFF,
+  DESKTOP_RELEASES_URL,
+  SHARED_DB_PATH,
+  SUNSET_DISMISS_STORAGE_KEY,
+} from '@/lib/sunset'
+
+describe('SunsetBanner', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('states the cutoff, the download link and that the database is shared', () => {
+    render(<SunsetBanner />)
+
+    expect(screen.getByText(SUNSET_CUTOFF)).toBeInTheDocument()
+    expect(screen.getByText(SHARED_DB_PATH)).toBeInTheDocument()
+
+    const link = screen.getByRole('link', { name: /get agento desktop/i })
+    expect(link).toHaveAttribute('href', DESKTOP_RELEASES_URL)
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'))
+  })
+
+  it('says the app keeps working past the cutoff', () => {
+    render(<SunsetBanner />)
+    // The "no notice wall" decision: nothing about this release stops the app,
+    // and the banner has to say so or it reads as a shutdown warning.
+    expect(screen.getByText(/only updating stops/i)).toBeInTheDocument()
+  })
+
+  it('is never modal or blocking', () => {
+    render(<SunsetBanner />)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+  })
+
+  it('dismisses and persists the dismissal', async () => {
+    const user = userEvent.setup()
+    render(<SunsetBanner />)
+
+    await user.click(screen.getByRole('button', { name: /dismiss/i }))
+
+    expect(screen.queryByText(SUNSET_CUTOFF)).not.toBeInTheDocument()
+    expect(localStorage.getItem(SUNSET_DISMISS_STORAGE_KEY)).toBe('1')
+  })
+
+  it('stays dismissed on remount', async () => {
+    const user = userEvent.setup()
+    const first = render(<SunsetBanner />)
+    await user.click(screen.getByRole('button', { name: /dismiss/i }))
+    first.unmount()
+
+    render(<SunsetBanner />)
+    expect(screen.queryByText(SUNSET_CUTOFF)).not.toBeInTheDocument()
+  })
+
+  it('does not re-arm on a timer', async () => {
+    vi.useFakeTimers()
+    try {
+      localStorage.setItem(SUNSET_DISMISS_STORAGE_KEY, '1')
+      render(<SunsetBanner />)
+      expect(screen.queryByText(SUNSET_CUTOFF)).not.toBeInTheDocument()
+
+      // UpdateBanner re-checks hourly; this banner must have no such loop.
+      await vi.advanceTimersByTimeAsync(25 * 60 * 60 * 1000)
+      expect(screen.queryByText(SUNSET_CUTOFF)).not.toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('shows the banner when localStorage is unavailable', () => {
+    const getItem = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('denied')
+    })
+    try {
+      render(<SunsetBanner />)
+      // Failing closed here would mean a user in a restricted browsing context
+      // never learns their install is being retired.
+      expect(screen.getByText(SUNSET_CUTOFF)).toBeInTheDocument()
+    } finally {
+      getItem.mockRestore()
+    }
+  })
+
+  it('still closes when the dismissal cannot be stored', async () => {
+    const user = userEvent.setup()
+    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('denied')
+    })
+    try {
+      render(<SunsetBanner />)
+      await user.click(screen.getByRole('button', { name: /dismiss/i }))
+      expect(screen.queryByText(SUNSET_CUTOFF)).not.toBeInTheDocument()
+    } finally {
+      setItem.mockRestore()
+    }
+  })
+})

--- a/frontend/src/components/SunsetBanner.tsx
+++ b/frontend/src/components/SunsetBanner.tsx
@@ -1,0 +1,74 @@
+import { useState } from 'react'
+import { X, Sunset, ExternalLink } from 'lucide-react'
+import {
+  SUNSET_CUTOFF,
+  DESKTOP_RELEASES_URL,
+  SHARED_DB_PATH,
+  SUNSET_DISMISS_STORAGE_KEY,
+} from '@/lib/sunset'
+
+/**
+ * Announces that the Go/web build of Agento is being retired.
+ *
+ * Deliberately unlike UpdateBanner in three ways, each of them a constraint on
+ * this release rather than a style choice:
+ *
+ *  - It is **static**. No fetch, no polling interval — the facts are compiled
+ *    in, so the notice cannot fail to appear because a request failed.
+ *  - Dismissal is **permanent**. UpdateBanner keys its dismissal on the version
+ *    so a new release re-shows it; there is no such key here and nothing
+ *    re-arms the banner.
+ *  - It is **never modal and never blocking**. The web build keeps working
+ *    indefinitely past the cutoff; staying on it is the user's call.
+ */
+export default function SunsetBanner() {
+  const [dismissed, setDismissed] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(SUNSET_DISMISS_STORAGE_KEY) === '1'
+    } catch {
+      // Private browsing and similar restricted contexts: show the banner
+      // rather than swallow it.
+      return false
+    }
+  })
+
+  const handleDismiss = () => {
+    try {
+      localStorage.setItem(SUNSET_DISMISS_STORAGE_KEY, '1')
+    } catch {
+      // Ignore storage errors — the banner still closes for this session.
+    }
+    setDismissed(true)
+  }
+
+  if (dismissed) return null
+
+  return (
+    <div className="flex items-start gap-3 px-4 py-2.5 bg-sky-50 dark:bg-sky-950/40 border-b border-sky-200 dark:border-sky-800 text-sm text-sky-900 dark:text-sky-200 shrink-0">
+      <Sunset className="h-4 w-4 mt-0.5 text-sky-500 dark:text-sky-400 shrink-0" />
+      <span className="flex-1">
+        <strong>Agento (web) is being retired.</strong> This is the final release of the Go/web
+        build — updates stop after <strong>{SUNSET_CUTOFF}</strong>. The app keeps working after
+        that date; only updating stops. Agento Desktop reads the same{' '}
+        <span className="font-mono text-xs">{SHARED_DB_PATH}</span>, so there is no export and no
+        migration.{' '}
+        <a
+          href={DESKTOP_RELEASES_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 underline hover:no-underline font-medium"
+        >
+          Get Agento Desktop
+          <ExternalLink className="h-3 w-3" />
+        </a>
+      </span>
+      <button
+        onClick={handleDismiss}
+        aria-label="Dismiss the Agento web retirement notice"
+        className="shrink-0 h-6 w-6 flex items-center justify-center rounded hover:bg-sky-100 dark:hover:bg-sky-900/50 transition-colors cursor-pointer"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/lib/sunset.ts
+++ b/frontend/src/lib/sunset.ts
@@ -1,0 +1,32 @@
+/**
+ * The retirement of the Go/web build of Agento.
+ *
+ * This mirrors `internal/sunset/sunset.go` — change both together. The values
+ * are fixed literals that do not move after this release ships, which is why a
+ * mirrored constant is preferred over an API round-trip: the banner must render
+ * instantly and offline, with no dependency on a backend call that could fail
+ * and leave the user unaware.
+ */
+
+/** The end of support, matching sunset.CutoffDate on the Go side. */
+export const SUNSET_CUTOFF = '1 September 2026'
+
+/** Where the replacement lives, matching sunset.DesktopReleasesURL. */
+export const DESKTOP_RELEASES_URL = 'https://github.com/shaharia-lab/agento/releases'
+
+/**
+ * The database Agento Desktop reads. It is the same file this build already
+ * uses, which is the single most reassuring fact about the migration and so
+ * appears in every notice.
+ */
+export const SHARED_DB_PATH = '~/.agento/agento.db'
+
+/**
+ * localStorage key recording that the user dismissed the sunset banner.
+ *
+ * Unlike the update banner's key this stores no version: dismissal is
+ * permanent. Nothing re-arms this banner — not a timer, not a new release, not
+ * a page navigation. The notice is informational, and a user who has read it
+ * has read it.
+ */
+export const SUNSET_DISMISS_STORAGE_KEY = 'agento-sunset-dismissed'

--- a/internal/sunset/mirror_test.go
+++ b/internal/sunset/mirror_test.go
@@ -1,0 +1,93 @@
+package sunset
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// frontendMirror is the TypeScript half of this package's constants. The banner
+// has to render offline and instantly, so the cutoff and the download URL are
+// compiled into the frontend rather than fetched — which means they exist twice.
+const frontendMirror = "../../frontend/src/lib/sunset.ts"
+
+// TestFrontendMirrorAgrees fails when the Go and TypeScript copies of a shared
+// constant drift apart.
+//
+// A comment saying "change both together" is not a guarantee: each language's
+// own suite asserts its own copy, so editing one and not the other leaves both
+// green while the CLI and the web UI state different cutoff dates. This repo
+// already rejected that arrangement once — session_metric_vectors.json is read
+// by both internal/claudesessions/session_page_test.go and
+// frontend/src/lib/sessionMetrics.test.ts precisely so a one-sided change fails
+// the other language. Same rule here, at a fraction of the machinery, because
+// there are three literals rather than a metric suite.
+func TestFrontendMirrorAgrees(t *testing.T) {
+	t.Parallel()
+
+	raw, err := os.ReadFile(filepath.Clean(frontendMirror))
+	if err != nil {
+		// Not skipped: the `desktop` branch has no frontend/ tree, but this
+		// package only exists on main, where the file must be present.
+		t.Fatalf("reading the frontend mirror at %s: %v", frontendMirror, err)
+	}
+	src := string(raw)
+
+	cases := []struct {
+		tsConst string
+		goValue string
+		goName  string
+	}{
+		{"SUNSET_CUTOFF", CutoffDate, "sunset.CutoffDate"},
+		{"DESKTOP_RELEASES_URL", DesktopReleasesURL, "sunset.DesktopReleasesURL"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.tsConst, func(t *testing.T) {
+			t.Parallel()
+			got, ok := tsStringConst(src, tc.tsConst)
+			if !ok {
+				t.Fatalf("%s declares no exported const %s", frontendMirror, tc.tsConst)
+			}
+			if got != tc.goValue {
+				t.Errorf("%s = %q but %s = %q — change both together",
+					tc.tsConst, got, tc.goName, tc.goValue)
+			}
+		})
+	}
+
+	// The shared database path is the one fact that makes the migration a
+	// non-event for the user, so both notices must name the same file.
+	shared, ok := tsStringConst(src, "SHARED_DB_PATH")
+	if !ok {
+		t.Fatal("the frontend mirror declares no SHARED_DB_PATH")
+	}
+	if !strings.Contains(FullNotice(), shared) {
+		t.Errorf("SHARED_DB_PATH = %q but FullNotice() does not mention it", shared)
+	}
+}
+
+// tsStringConst pulls the value out of `export const NAME = '...'`, accepting
+// either quote style. It is deliberately a small string scan rather than a
+// parser: the mirror file is a handful of literals by design, and a parser
+// dependency would be far more machinery than the thing it guards.
+func tsStringConst(src, name string) (string, bool) {
+	marker := "export const " + name + " = "
+	i := strings.Index(src, marker)
+	if i < 0 {
+		return "", false
+	}
+	rest := src[i+len(marker):]
+	if rest == "" {
+		return "", false
+	}
+	quote := rest[0]
+	if quote != '\'' && quote != '"' {
+		return "", false
+	}
+	end := strings.IndexByte(rest[1:], quote)
+	if end < 0 {
+		return "", false
+	}
+	return rest[1 : 1+end], true
+}

--- a/internal/sunset/sunset.go
+++ b/internal/sunset/sunset.go
@@ -1,0 +1,165 @@
+// Package sunset owns everything about the retirement of the Go/web build of
+// Agento: the cutoff date, the user-facing notice text, and the once-per-day
+// stamp that keeps the pre-run notice from becoming a nag.
+//
+// It is deliberately the single definition every Go caller reads — the pre-run
+// hook in cmd/root.go, the `agento web` startup banner, and `agento update` all
+// resolve the same date and the same words from here, the way internal/config
+// owns values the layers above it must agree on.
+//
+// Everything in this package is static and offline. The notice makes no network
+// call at all: a notice that had to reach GitHub could time out, could degrade,
+// and would break outright once the desktop releases stop carrying the
+// `desktop-v` tag prefix — which is precisely the event this notice exists to
+// warn users about ahead of time.
+package sunset
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// CutoffDate is the end of support for the Go/web build, as a plain calendar
+// date for display. Its counterpart on the frontend is SUNSET_CUTOFF in
+// frontend/src/lib/sunset.ts — change both together.
+const CutoffDate = "1 September 2026"
+
+// Cutoff is CutoffDate as an instant. It is the moment `agento update` stops
+// offering a download; nothing else in the binary consults it, because the web
+// build keeps working indefinitely after this date. Staying on it is the user's
+// call — there is no kill switch, no license check and no date-gated refusal to
+// start anywhere in this package or its callers.
+var Cutoff = time.Date(2026, time.September, 1, 0, 0, 0, 0, time.UTC) //nolint:gochecknoglobals
+
+// DesktopReleasesURL is where users get the replacement.
+const DesktopReleasesURL = "https://github.com/shaharia-lab/agento/releases"
+
+// Passed reports whether now is at or after the cutoff. The comparison is
+// deliberately inclusive of the boundary instant: 1 September 2026 00:00:00 UTC
+// is already "on or after 1 September".
+func Passed(now time.Time) bool {
+	return !now.UTC().Before(Cutoff)
+}
+
+// Notice is the one-line form printed before every command. It is written to
+// stderr by the caller so it never pollutes the stdout of a subcommand that
+// emits machine-readable output.
+func Notice() string {
+	return fmt.Sprintf(
+		"Agento (web) is being retired: no updates after %s. "+
+			"Agento Desktop reads the same ~/.agento/agento.db — install and go: %s",
+		CutoffDate, DesktopReleasesURL,
+	)
+}
+
+// FullNotice is the multi-line form printed by `agento web` on startup, where
+// there is room to say why and what happens next.
+func FullNotice() string {
+	return fmt.Sprintf(`Agento (web) is being retired.
+
+  What        This is the final release of the Go/web build.
+  When        Support ends %s. After that date `+"`agento update`"+` stops
+              offering updates — the app itself keeps working, indefinitely.
+  Move to     Agento Desktop: %s
+  Your data   Agento Desktop reads the same ~/.agento/agento.db.
+              No export, no migration. Install it and your history is there.`,
+		CutoffDate, DesktopReleasesURL,
+	)
+}
+
+// MigrationMessage is what `agento update` prints once the cutoff has passed,
+// in place of offering a download.
+func MigrationMessage() string {
+	return fmt.Sprintf(`The Go/web build of Agento is no longer updated (support ended %s).
+
+Agento Desktop is the supported app, and it reads the same ~/.agento/agento.db —
+no export and no migration are needed.
+
+  %s
+
+This command no longer updates the binary. Every other agento command is
+unaffected and keeps working.`, CutoffDate, DesktopReleasesURL)
+}
+
+// StampFileName is the file recording when the pre-run notice was last shown.
+//
+// It is deliberately NOT updater.CacheFileName. That cache holds an
+// updater.CheckResult keyed on both the running version and the GOOS/GOARCH,
+// and it invalidates whenever either changes — sound for an update check, but
+// it would re-fire the sunset notice on conditions that have nothing to do with
+// whether the user has already read it. Same directory, separate file.
+const StampFileName = "sunset-notice.json"
+
+// noticeInterval is how long a shown notice suppresses the next one.
+const noticeInterval = 24 * time.Hour
+
+// stamp is the on-disk shape of the stamp file.
+type stamp struct {
+	LastShown time.Time `json:"last_shown"`
+}
+
+// stampPath returns the absolute path to the stamp file, or "" when there is no
+// data dir to write into.
+func stampPath(dataDir string) string {
+	if dataDir == "" {
+		return ""
+	}
+	return filepath.Join(dataDir, StampFileName)
+}
+
+// ShouldPrint reports whether the pre-run notice is due.
+//
+// Every failure path degrades to true — an unreadable directory, a corrupt
+// stamp, a clock that moved backwards. Printing one extra line is a far better
+// outcome than a user never learning their install is being retired, so the
+// only thing that suppresses the notice is a stamp we could read and that is
+// genuinely recent.
+func ShouldPrint(dataDir string, now time.Time) bool {
+	path := stampPath(dataDir)
+	if path == "" {
+		return true
+	}
+	data, err := os.ReadFile(path) //nolint:gosec // path is under our own data dir
+	if err != nil {
+		return true
+	}
+	var s stamp
+	if err := json.Unmarshal(data, &s); err != nil {
+		return true
+	}
+	if s.LastShown.IsZero() {
+		return true
+	}
+	elapsed := now.Sub(s.LastShown)
+	// A negative elapsed means the stamp is in the future — a clock change or a
+	// synced data dir. Treat it as due rather than suppressing until the clock
+	// catches up.
+	if elapsed < 0 {
+		return true
+	}
+	return elapsed >= noticeInterval
+}
+
+// Stamp records that the notice was shown at now. It is best-effort: a failure
+// here means the notice shows again sooner than intended, which is harmless,
+// so callers may ignore the error.
+func Stamp(dataDir string, now time.Time) error {
+	path := stampPath(dataDir)
+	if path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(dataDir, 0o700); err != nil {
+		return fmt.Errorf("creating data dir: %w", err)
+	}
+	data, err := json.Marshal(stamp{LastShown: now})
+	if err != nil {
+		return fmt.Errorf("marshaling sunset stamp: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("writing sunset stamp: %w", err)
+	}
+	return nil
+}

--- a/internal/sunset/sunset_test.go
+++ b/internal/sunset/sunset_test.go
@@ -1,0 +1,155 @@
+package sunset
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestPassedBoundary pins the inclusive boundary: the cutoff instant itself is
+// already past, one nanosecond before it is not. A test that only probed days
+// either side would not catch an accidental flip to a strict After.
+func TestPassedBoundary(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		now  time.Time
+		want bool
+	}{
+		{"a week before", Cutoff.Add(-7 * 24 * time.Hour), false},
+		{"one nanosecond before", Cutoff.Add(-time.Nanosecond), false},
+		{"the cutoff instant", Cutoff, true},
+		{"one nanosecond after", Cutoff.Add(time.Nanosecond), true},
+		{"a week after", Cutoff.Add(7 * 24 * time.Hour), true},
+		{"non-UTC zone before", Cutoff.Add(-2 * time.Hour).In(time.FixedZone("UTC+5", 5*3600)), false},
+		{"non-UTC zone after", Cutoff.Add(2 * time.Hour).In(time.FixedZone("UTC-5", -5*3600)), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := Passed(tc.now); got != tc.want {
+				t.Fatalf("Passed(%s) = %v, want %v", tc.now, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNoticesCarryTheRequiredFacts asserts every notice states the cutoff, the
+// download location, and that the database is shared. These three are the whole
+// point of the release; a reworded notice that drops one is a regression.
+func TestNoticesCarryTheRequiredFacts(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"Notice":           Notice(),
+		"FullNotice":       FullNotice(),
+		"MigrationMessage": MigrationMessage(),
+	}
+	for name, text := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			for _, want := range []string{CutoffDate, DesktopReleasesURL, "~/.agento/agento.db"} {
+				if !strings.Contains(text, want) {
+					t.Errorf("%s() does not mention %q:\n%s", name, want, text)
+				}
+			}
+		})
+	}
+}
+
+// TestShouldPrintRoundTrip covers the ordinary lifecycle: due on a cold data
+// dir, suppressed right after a stamp, due again a day later.
+func TestShouldPrintRoundTrip(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	now := time.Date(2026, time.August, 23, 12, 0, 0, 0, time.UTC)
+
+	if !ShouldPrint(dir, now) {
+		t.Fatal("a data dir with no stamp should print")
+	}
+	if err := Stamp(dir, now); err != nil {
+		t.Fatalf("Stamp: %v", err)
+	}
+	if ShouldPrint(dir, now.Add(time.Hour)) {
+		t.Error("an hour after the stamp should not print")
+	}
+	if ShouldPrint(dir, now.Add(23*time.Hour+59*time.Minute)) {
+		t.Error("just under 24h after the stamp should not print")
+	}
+	if !ShouldPrint(dir, now.Add(24*time.Hour)) {
+		t.Error("exactly 24h after the stamp should print")
+	}
+}
+
+// TestShouldPrintDegradesToPrinting is the load-bearing behavior: every way of
+// failing to read a stamp must show the notice rather than swallow it. Silence
+// is the failure mode this whole release exists to prevent.
+func TestShouldPrintDegradesToPrinting(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.August, 23, 12, 0, 0, 0, time.UTC)
+
+	t.Run("no data dir configured", func(t *testing.T) {
+		t.Parallel()
+		if !ShouldPrint("", now) {
+			t.Error("an empty data dir should print")
+		}
+	})
+
+	t.Run("corrupt stamp", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, StampFileName), []byte("{not json"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if !ShouldPrint(dir, now) {
+			t.Error("a corrupt stamp should print")
+		}
+	})
+
+	t.Run("zero timestamp", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, StampFileName), []byte(`{"last_shown":"0001-01-01T00:00:00Z"}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if !ShouldPrint(dir, now) {
+			t.Error("a zero timestamp should print")
+		}
+	})
+
+	t.Run("stamp in the future", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		if err := Stamp(dir, now.Add(72*time.Hour)); err != nil {
+			t.Fatal(err)
+		}
+		if !ShouldPrint(dir, now) {
+			t.Error("a stamp dated in the future should print, not suppress until the clock catches up")
+		}
+	})
+
+	t.Run("unreadable directory", func(t *testing.T) {
+		t.Parallel()
+		// A path whose parent is a regular file cannot be read or created.
+		dir := t.TempDir()
+		file := filepath.Join(dir, "not-a-dir")
+		if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if !ShouldPrint(filepath.Join(file, "nested"), now) {
+			t.Error("an unreadable data dir should print")
+		}
+	})
+}
+
+// TestStampFileIsNotTheUpdateCache guards the deliberate separation from
+// updater.CacheFileName — sharing that file would tie the notice's cadence to
+// version and platform changes that say nothing about whether the user has read
+// it.
+func TestStampFileIsNotTheUpdateCache(t *testing.T) {
+	t.Parallel()
+	if StampFileName == "update-check.json" {
+		t.Fatal("the sunset stamp must not share updater.CacheFileName")
+	}
+}

--- a/internal/updater/desktop.go
+++ b/internal/updater/desktop.go
@@ -1,0 +1,217 @@
+package updater
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+)
+
+// The Go/web build is being retired in favor of Agento Desktop, so `agento
+// update` no longer self-updates — it points the user at the desktop installer
+// for their platform. Resolving that installer cannot go through
+// go-selfupdate: its asset matcher builds every candidate as
+// "<os><sep><arch><ext>" and requires the OS token, which no Tauri asset
+// carries. A desktop-tagged release is therefore skipped entirely and the
+// picker silently falls back to the newest release that does have
+// agento_Darwin_arm64.tar.gz and friends. That is why this file exists.
+
+// desktopManifestURL is the Tauri updater manifest, published at a FIXED tag
+// that every release re-points at the newest build.
+//
+// Anchoring on this tag rather than on a release listing is deliberate, because
+// three separate things make "the newest release" the wrong answer:
+//
+//   - GET /releases/latest returns the Go build (v0.11.1), by design: desktop
+//     releases are published with `--latest=false` precisely so the CLI's
+//     go-selfupdate keeps resolving the Go release.
+//   - `desktop-latest` is itself marked as a prerelease.
+//   - the newest desktop tag is often still a draft, whose assets are not
+//     publicly downloadable.
+//
+// The fixed tag sidesteps all three, and it survives the eventual rename of
+// `desktop-v*` to plain `v*` — nothing here may key on the tag prefix.
+const desktopManifestURL = "https://github.com/shaharia-lab/agento/releases/download/desktop-latest/latest.json"
+
+// releasesPageURL is the fallback we print when a platform-specific asset
+// cannot be named. It is always correct, just less convenient.
+const releasesPageURL = "https://github.com/shaharia-lab/agento/releases"
+
+// desktopFetchTimeout bounds the manifest fetch. `agento update` is
+// interactive, so a slow network must not hang it.
+const desktopFetchTimeout = 10 * time.Second
+
+// ErrDesktopReleaseUnavailable is returned when the desktop release could not
+// be resolved at all. Callers should fall back to printing releasesPageURL
+// rather than failing the command.
+var ErrDesktopReleaseUnavailable = errors.New("could not resolve the latest Agento Desktop release")
+
+// DesktopRelease is the resolved answer: which version is current, where its
+// release page is, and the direct installer download for the running platform.
+type DesktopRelease struct {
+	// Version is the desktop version, without a leading "v" (e.g. "0.1.1").
+	Version string
+	// ReleasePage is the human-readable release page for that version.
+	ReleasePage string
+	// DownloadURL is the direct installer link for the running GOOS/GOARCH,
+	// or "" when the platform has no published installer.
+	DownloadURL string
+	// AssetName is the file name behind DownloadURL, or "" alongside an empty
+	// DownloadURL.
+	AssetName string
+}
+
+// desktopManifest is the subset of Tauri's latest.json we read. The manifest
+// lists the *auto-updater* artifacts (.app.tar.gz, .AppImage, the NSIS .exe),
+// which are not the artifacts a person installing for the first time wants — so
+// we take the version and the release tag from it and name the installer
+// ourselves.
+type desktopManifest struct {
+	Version   string `json:"version"`
+	Platforms map[string]struct {
+		URL string `json:"url"`
+	} `json:"platforms"`
+}
+
+// desktopInstallers maps "GOOS/GOARCH" to the format string naming its
+// preferred installer asset, taking the version exactly once.
+//
+// The arch token is NOT uniform across package formats: the .deb uses Debian's
+// arch names (amd64/arm64), the .rpm uses RPM's (x86_64/aarch64) plus a release
+// number, and the macOS bundles use Tauri's (x64/aarch64). Each row is
+// transcribed from the assets actually published on a desktop release; do not
+// collapse them into one pattern.
+//
+// Linux publishes three formats per arch (.deb, .rpm, .AppImage); we name the
+// .deb because it is the one most Linux desktops install with a double-click,
+// and the release page carries the rest.
+var desktopInstallers = map[string]string{ //nolint:gochecknoglobals
+	"darwin/amd64":  "Agento_%s_x64.dmg",
+	"darwin/arm64":  "Agento_%s_aarch64.dmg",
+	"linux/amd64":   "Agento_%s_amd64.deb",
+	"linux/arm64":   "Agento_%s_arm64.deb",
+	"windows/amd64": "Agento_%s_x64-setup.exe",
+}
+
+// InstallerAssetName returns the installer file name for the given platform and
+// version, or "" when that platform has no published installer. It is exported
+// for tests and kept free of any network dependency.
+func InstallerAssetName(goos, goarch, version string) string {
+	pattern, ok := desktopInstallers[goos+"/"+goarch]
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf(pattern, version)
+}
+
+// ResolveDesktopRelease fetches the desktop manifest and returns the release
+// plus the direct installer link for the running platform.
+//
+// An unknown GOOS/GOARCH yields a DesktopRelease with an empty DownloadURL
+// rather than a guessed URL: sending a user to a 404 is worse than sending them
+// to the release page.
+func ResolveDesktopRelease(ctx context.Context) (*DesktopRelease, error) {
+	return resolveDesktopRelease(ctx, desktopManifestURL, runtime.GOOS, runtime.GOARCH)
+}
+
+// resolveDesktopRelease is ResolveDesktopRelease with its inputs injected, so
+// tests can drive it against a local server and an arbitrary platform.
+func resolveDesktopRelease(ctx context.Context, manifestURL, goos, goarch string) (*DesktopRelease, error) {
+	ctx, cancel := context.WithTimeout(ctx, desktopFetchTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, manifestURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("%w: building request: %w", ErrDesktopReleaseUnavailable, err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrDesktopReleaseUnavailable, err)
+	}
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%w: manifest returned %s", ErrDesktopReleaseUnavailable, resp.Status)
+	}
+
+	var manifest desktopManifest
+	if err := json.NewDecoder(resp.Body).Decode(&manifest); err != nil {
+		return nil, fmt.Errorf("%w: decoding manifest: %w", ErrDesktopReleaseUnavailable, err)
+	}
+	version := strings.TrimPrefix(strings.TrimSpace(manifest.Version), "v")
+	if version == "" {
+		return nil, fmt.Errorf("%w: manifest carries no version", ErrDesktopReleaseUnavailable)
+	}
+
+	rel := &DesktopRelease{
+		Version:     version,
+		ReleasePage: releasePageFrom(manifest),
+	}
+	if asset := InstallerAssetName(goos, goarch, version); asset != "" {
+		rel.AssetName = asset
+		rel.DownloadURL = downloadBase(manifest) + "/" + asset
+	}
+	return rel, nil
+}
+
+// releasePageFrom derives the release page for the manifest's version.
+//
+// The tag is read back out of a platform URL rather than reconstructed from the
+// version, because the tag prefix is exactly the thing that is going to change:
+// `desktop-v0.1.1` today, plain `v0.1.1` after the flip. Whatever tag the
+// manifest points at is the right one by construction.
+func releasePageFrom(m desktopManifest) string {
+	if tag := tagFromManifest(m); tag != "" {
+		return releasesPageURL + "/tag/" + tag
+	}
+	// No usable URL in the manifest — the plain releases page still gets the
+	// user there.
+	return releasesPageURL
+}
+
+// downloadBase returns the ".../download/<tag>" prefix the installer asset
+// hangs off, falling back to the releases page's download root.
+func downloadBase(m desktopManifest) string {
+	if tag := tagFromManifest(m); tag != "" {
+		return releasesPageURL + "/download/" + tag
+	}
+	return releasesPageURL + "/latest/download"
+}
+
+// tagFromManifest extracts the release tag from a platform download URL, which
+// has the shape ".../releases/download/<tag>/<asset>".
+//
+// Platform keys are visited in sorted order rather than map order: every
+// platform in a manifest points at the same tag, but relying on that while
+// iterating a map non-deterministically would make any future violation show up
+// as a flake instead of a failure.
+func tagFromManifest(m desktopManifest) string {
+	keys := make([]string, 0, len(m.Platforms))
+	for k := range m.Platforms {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	const marker = "/releases/download/"
+	for _, k := range keys {
+		url := m.Platforms[k].URL
+		i := strings.Index(url, marker)
+		if i < 0 {
+			continue
+		}
+		rest := url[i+len(marker):]
+		if j := strings.Index(rest, "/"); j > 0 {
+			return rest[:j]
+		}
+	}
+	return ""
+}
+
+// ReleasesPageURL exposes the releases page for callers that need a fallback
+// when resolution fails.
+func ReleasesPageURL() string { return releasesPageURL }

--- a/internal/updater/desktop_test.go
+++ b/internal/updater/desktop_test.go
@@ -1,0 +1,203 @@
+package updater
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// realManifest mirrors the shape and values of the manifest published at the
+// fixed `desktop-latest` tag, including the `desktop-v` tag prefix in the URLs.
+const realManifest = `{
+  "version": "0.1.1",
+  "notes": "See https://github.com/shaharia-lab/agento/releases/tag/desktop-v0.1.1",
+  "pub_date": "2026-08-20T11:45:05Z",
+  "platforms": {
+    "darwin-aarch64": {"signature": "x", "url": "https://github.com/shaharia-lab/agento/releases/download/desktop-v0.1.1/Agento_aarch64.app.tar.gz"},
+    "darwin-x86_64": {"signature": "x", "url": "https://github.com/shaharia-lab/agento/releases/download/desktop-v0.1.1/Agento_x64.app.tar.gz"},
+    "linux-aarch64": {"signature": "x", "url": "https://github.com/shaharia-lab/agento/releases/download/desktop-v0.1.1/Agento_0.1.1_aarch64.AppImage"},
+    "linux-x86_64": {"signature": "x", "url": "https://github.com/shaharia-lab/agento/releases/download/desktop-v0.1.1/Agento_0.1.1_amd64.AppImage"},
+    "windows-x86_64": {"signature": "x", "url": "https://github.com/shaharia-lab/agento/releases/download/desktop-v0.1.1/Agento_0.1.1_x64-setup.exe"}
+  }
+}`
+
+// TestInstallerAssetNameMatrix pins every supported platform to the asset name
+// actually published on a desktop release.
+//
+// These names are transcribed from a real release listing, and the arch token
+// differs per package format — Debian's amd64/arm64 for the .deb, Tauri's
+// x64/aarch64 for the macOS bundles. A "tidy-up" that unified them would
+// produce five plausible 404s, which is exactly what this table prevents.
+func TestInstallerAssetNameMatrix(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		goos, goarch string
+		want         string
+	}{
+		{"darwin", "amd64", "Agento_0.1.1_x64.dmg"},
+		{"darwin", "arm64", "Agento_0.1.1_aarch64.dmg"},
+		{"linux", "amd64", "Agento_0.1.1_amd64.deb"},
+		{"linux", "arm64", "Agento_0.1.1_arm64.deb"},
+		{"windows", "amd64", "Agento_0.1.1_x64-setup.exe"},
+		// Unsupported platforms name nothing rather than guessing.
+		{"linux", "386", ""},
+		{"windows", "arm64", ""},
+		{"freebsd", "amd64", ""},
+		{"darwin", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.goos+"/"+tc.goarch, func(t *testing.T) {
+			t.Parallel()
+			if got := InstallerAssetName(tc.goos, tc.goarch, "0.1.1"); got != tc.want {
+				t.Fatalf("InstallerAssetName(%q, %q) = %q, want %q", tc.goos, tc.goarch, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveDesktopReleaseFromManifest drives the happy path per platform
+// against a served copy of the real manifest.
+func TestResolveDesktopReleaseFromManifest(t *testing.T) {
+	t.Parallel()
+	srv := manifestServer(t, http.StatusOK, realManifest)
+
+	cases := []struct {
+		goos, goarch string
+		wantURL      string
+	}{
+		{"darwin", "arm64", "https://github.com/shaharia-lab/agento/releases/download/desktop-v0.1.1/Agento_0.1.1_aarch64.dmg"},
+		{"darwin", "amd64", "https://github.com/shaharia-lab/agento/releases/download/desktop-v0.1.1/Agento_0.1.1_x64.dmg"},
+		{"linux", "amd64", "https://github.com/shaharia-lab/agento/releases/download/desktop-v0.1.1/Agento_0.1.1_amd64.deb"},
+		{"linux", "arm64", "https://github.com/shaharia-lab/agento/releases/download/desktop-v0.1.1/Agento_0.1.1_arm64.deb"},
+		{"windows", "amd64", "https://github.com/shaharia-lab/agento/releases/download/desktop-v0.1.1/Agento_0.1.1_x64-setup.exe"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.goos+"/"+tc.goarch, func(t *testing.T) {
+			t.Parallel()
+			rel, err := resolveDesktopRelease(context.Background(), srv.URL, tc.goos, tc.goarch)
+			if err != nil {
+				t.Fatalf("resolveDesktopRelease: %v", err)
+			}
+			if rel.Version != "0.1.1" {
+				t.Errorf("Version = %q, want 0.1.1", rel.Version)
+			}
+			if rel.DownloadURL != tc.wantURL {
+				t.Errorf("DownloadURL = %q, want %q", rel.DownloadURL, tc.wantURL)
+			}
+			want := "https://github.com/shaharia-lab/agento/releases/tag/desktop-v0.1.1"
+			if rel.ReleasePage != want {
+				t.Errorf("ReleasePage = %q, want %q", rel.ReleasePage, want)
+			}
+		})
+	}
+}
+
+// TestResolveDesktopReleaseSurvivesTagRename is the whole reason the tag is read
+// back out of the manifest instead of being reconstructed: the desktop tags
+// lose their `desktop-` prefix eventually, and resolution must not notice.
+func TestResolveDesktopReleaseSurvivesTagRename(t *testing.T) {
+	t.Parallel()
+	renamed := `{"version":"0.2.0","platforms":{"darwin-aarch64":{"url":"https://github.com/shaharia-lab/agento/releases/download/v0.2.0/Agento_aarch64.app.tar.gz"}}}`
+	srv := manifestServer(t, http.StatusOK, renamed)
+
+	rel, err := resolveDesktopRelease(context.Background(), srv.URL, "darwin", "arm64")
+	if err != nil {
+		t.Fatalf("resolveDesktopRelease: %v", err)
+	}
+	wantURL := "https://github.com/shaharia-lab/agento/releases/download/v0.2.0/Agento_0.2.0_aarch64.dmg"
+	if rel.DownloadURL != wantURL {
+		t.Errorf("DownloadURL = %q, want %q", rel.DownloadURL, wantURL)
+	}
+	if want := "https://github.com/shaharia-lab/agento/releases/tag/v0.2.0"; rel.ReleasePage != want {
+		t.Errorf("ReleasePage = %q, want %q", rel.ReleasePage, want)
+	}
+}
+
+// TestResolveDesktopReleaseUnknownPlatform asserts an unsupported platform
+// still resolves the version and the release page, but names no download —
+// sending someone to a fabricated URL is worse than sending them to the page.
+func TestResolveDesktopReleaseUnknownPlatform(t *testing.T) {
+	t.Parallel()
+	srv := manifestServer(t, http.StatusOK, realManifest)
+
+	rel, err := resolveDesktopRelease(context.Background(), srv.URL, "freebsd", "amd64")
+	if err != nil {
+		t.Fatalf("resolveDesktopRelease: %v", err)
+	}
+	if rel.DownloadURL != "" || rel.AssetName != "" {
+		t.Errorf("an unsupported platform must name no asset, got %q / %q", rel.AssetName, rel.DownloadURL)
+	}
+	if rel.ReleasePage == "" {
+		t.Error("the release page must still be resolved")
+	}
+}
+
+// TestResolveDesktopReleaseFailures covers every way the manifest can fail to
+// answer. All of them must wrap ErrDesktopReleaseUnavailable so the caller can
+// fall back to the releases page instead of failing the command.
+func TestResolveDesktopReleaseFailures(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{"not found", http.StatusNotFound, "nope"},
+		{"server error", http.StatusInternalServerError, "boom"},
+		{"malformed json", http.StatusOK, "{not json"},
+		{"no version", http.StatusOK, `{"platforms":{}}`},
+		{"blank version", http.StatusOK, `{"version":"   ","platforms":{}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := manifestServer(t, tc.status, tc.body)
+			_, err := resolveDesktopRelease(context.Background(), srv.URL, "linux", "amd64")
+			if !errors.Is(err, ErrDesktopReleaseUnavailable) {
+				t.Fatalf("err = %v, want it to wrap ErrDesktopReleaseUnavailable", err)
+			}
+		})
+	}
+}
+
+// TestResolveDesktopReleaseWithoutUsableTag falls back to the generic
+// latest/download path when no platform URL reveals a tag, rather than
+// producing a URL with an empty tag segment.
+func TestResolveDesktopReleaseWithoutUsableTag(t *testing.T) {
+	t.Parallel()
+	srv := manifestServer(t, http.StatusOK, `{"version":"9.9.9","platforms":{"linux-x86_64":{"url":"https://example.invalid/elsewhere"}}}`)
+
+	rel, err := resolveDesktopRelease(context.Background(), srv.URL, "linux", "amd64")
+	if err != nil {
+		t.Fatalf("resolveDesktopRelease: %v", err)
+	}
+	want := "https://github.com/shaharia-lab/agento/releases/latest/download/Agento_9.9.9_amd64.deb"
+	if rel.DownloadURL != want {
+		t.Errorf("DownloadURL = %q, want %q", rel.DownloadURL, want)
+	}
+	if rel.ReleasePage != ReleasesPageURL() {
+		t.Errorf("ReleasePage = %q, want the plain releases page", rel.ReleasePage)
+	}
+}
+
+// TestDesktopManifestURLIsTheFixedTag guards the anchor itself. Keying on
+// anything else — /releases/latest, the newest tag, a `desktop-` prefix — is
+// wrong for reasons documented on the constant, and all three are wrong today.
+func TestDesktopManifestURLIsTheFixedTag(t *testing.T) {
+	t.Parallel()
+	if want := "https://github.com/shaharia-lab/agento/releases/download/desktop-latest/latest.json"; desktopManifestURL != want {
+		t.Fatalf("desktopManifestURL = %q, want the fixed manifest tag %q", desktopManifestURL, want)
+	}
+}
+
+func manifestServer(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body)) //nolint:errcheck
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}

--- a/internal/updater/installer.go
+++ b/internal/updater/installer.go
@@ -91,7 +91,13 @@ func isHomebrewPath(path string) bool {
 // HomebrewUpgradeMessage is the user-facing instruction printed when an update
 // is available for a Homebrew-managed install. It is exported so callers can
 // log or format it however they need.
-const HomebrewUpgradeMessage = "You installed agento via Homebrew. Run: brew upgrade agento"
+//
+// It points at the desktop cask rather than at `brew upgrade agento`, because
+// the formula is the retiring Go build: upgrading it now only moves someone
+// between two unsupported versions. The cask lives in the same tap, so a user
+// who installed with `brew install shaharia-lab/tap/agento` needs no new tap.
+const HomebrewUpgradeMessage = "You installed agento via Homebrew. The Go build is being retired — " +
+	"install Agento Desktop instead: brew install --cask shaharia-lab/tap/agento"
 
 // ErrHomebrewManaged is returned by Install when the binary is Homebrew-managed
 // and self-update was attempted. Callers should print HomebrewUpgradeMessage instead.


### PR DESCRIPTION
Closes #389

## WHAT

The final release of the Go/web build: a static, dismissible sunset notice across CLI/web/UI, an `agento update` that hands users the desktop installer instead of self-updating, and an offer to remove the leftover `agento service` unit.

- **Sunset notice** — offline/static, once-per-day rate limited, carrying the **1 September 2026** cutoff, the desktop releases URL, and the fact that the desktop app reads the **same `~/.agento/agento.db`**.
- **`agento update`** — resolves the current desktop release and prints the direct installer link for the running GOOS/GOARCH. Never self-updates again. Past the cutoff it prints only the migration message.
- **Leftover service unit** — `agento update` checks `daemon.Status().Installed` and *offers* `Manager.Uninstall`; `-y` accepts.
- **Docs** — README + `docs/getting-started.md` lead with the desktop app; the Go build moves under a "legacy, unsupported after 1 Sept 2026" heading.

## WHY

`go-selfupdate` v1.6.0 builds every candidate asset as `<os><sep><arch><ext>`, and **no Tauri asset carries the OS token**. So once the desktop tags lose their `desktop-` prefix, a legacy binary does not mis-install a `.dmg` — it reports **"already up to date" forever**. The failure mode is silence, and a silent updater is indistinguishable from a maintained project.

A leftover `agento service` unit meanwhile holds `:8990`, runs **its own scheduler** — every scheduled task fires twice once the desktop app is installed — and re-registers the Telegram webhook under whichever instance started last. All invisible.

## HOW — three decisions worth reviewing

**1. Release resolution anchors on the fixed `desktop-latest` manifest tag.** All three obvious alternatives are wrong *today*:

| Approach | What it resolves to now |
|---|---|
| `GET /releases/latest` | `v0.11.1`, the Go build — **by design**: desktop publishes with `--latest=false` precisely so the CLI's go-selfupdate keeps resolving it |
| newest release | `desktop-latest`, which is a **prerelease** |
| newest `desktop-v*` tag | `desktop-v0.1.2`, a **draft** whose assets aren't publicly downloadable |

The release tag is read back **out of** the manifest rather than reconstructed from the version, so the eventual `desktop-v*` → `v*` rename changes nothing. `TestResolveDesktopReleaseSurvivesTagRename` pins that.

**2. The pre-run notice uses its own gating, not `shouldRunAutoCheck`'s.** That helper requires an interactive TTY on both stdin and stdout and skips `update` and `service` — right for a prompt expecting an answer, wrong for a one-way notice, because it would exclude exactly the installs this release must reach: scripted, cron-driven, and service-only. The notice skips only `completion`/`__complete` (cobra parses that stdout) and `web`/`update`, which print the **full** notice themselves — skipping a duplicate line, not a user.

**3. The rate-limit stamp is its own file, not `update-check.json`.** That cache holds an `updater.CheckResult` keyed on both the running version *and* the GOOS/GOARCH and invalidates when either changes — sound for an update check, but it would re-fire the notice on conditions that say nothing about whether the user has read it. Same directory, separate file. Every failure path (unreadable dir, corrupt stamp, clock moved backwards) degrades to **printing**.

## Deliberate non-goals

Per the issue's *Decided: no notice wall*: no paywall, licence check, kill switch, or date-gated refusal to start; no blocking/modal/non-dismissible notice; no feature degradation, no throttling, nothing that re-arms a dismissed notice. **Only updating stops on 1 Sept** — the app keeps working indefinitely, and the notices say so.

## Acceptance criteria

- [x] `agento service status` prints the notice once, then not again within 24h; `AGENTO_SKIP_UPDATE_CHECK=1` suppresses it; `__complete` output is untouched
- [x] `agento update` prints a resolvable download URL for the running platform, never calls `updater.Install`, exits 0 — verified live against the real manifest (resolved `desktop-v0.1.1` → `Agento_0.1.1_amd64.deb`)
- [x] With the clock faked past the cutoff, `agento update` offers no download; every other command is unaffected
- [x] Stubbed `Manager` with `Installed: true` prompts before uninstalling and does nothing on decline/EOF; `-y` calls `Uninstall` exactly once; `Installed: false` prompts nothing
- [x] The web banner is dismissible, stays dismissed across reload and navigation, is never modal, is never re-armed by a timer
- [ ] Release title + first three lines of notes carry the migration message — **manual, at tag time**

## Out of scope

- **The desktop app's own first-run check for a leftover service unit.** `main` has no `desktop/` tree; it needs its own issue on the `desktop` branch.
- **The Homebrew cask** ships as a companion PR against `shaharia-lab/homebrew-tap` — see the cross-link below. `HomebrewUpgradeMessage` in this PR already points at `brew install --cask shaharia-lab/tap/agento`, so **the cask PR must merge first**.
- The pinned repo announcement (GitHub UI, no code).

## Testing

New: `internal/sunset/sunset_test.go`, `internal/updater/desktop_test.go`, `cmd/sunset_notice_test.go`, `frontend/src/components/SunsetBanner.test.tsx`. Rewritten: `cmd/update_test.go` (the old suite covered the restart path, which no longer exists).

Local gates, all green: `go build` · `go vet` · `gofmt` · `golangci-lint v2.5.0` (the version CI pins — **0 issues**) · full `go test ./...` · frontend `typecheck` · `lint` · `format:check` · 207 tests · `build`.

> Note for maintainers: `golangci-lint` 2.12.2 (a local drift from CI's pinned v2.5.0) reports 13 pre-existing issues across `internal/pricing`, `internal/api` and `internal/claudesessions` that are unrelated to this PR. Verified against the pinned version instead.