### PR TITLE
feat: require a per-launch bearer token on /api (#400)

### DIFF
--- a/.claude/skills/local-verify/SKILL.md
+++ b/.claude/skills/local-verify/SKILL.md
@@ -71,15 +71,42 @@ Run it first and both failure modes disappear.
   `claude` subprocess holding the session id — the next send fails
   `Session ID … is already in use`; use a fresh chat.
 
-## Capturing the chat SSE stream
+## Reaching `/api` at all: the bearer token
 
-Every state-changing request needs `Content-Type: application/json`.
+Since #400 **every `/api` request needs `Authorization: Bearer <token>`** — reads
+included, unlike the `Content-Type` rule, which only covers the state-changing
+methods. The token is minted fresh on every app launch and held in memory, so
+there is nothing to configure and nothing to look up between runs.
+
+A debug build also writes it to `~/.agento-desktop-dev/api-token` (0600) purely
+so this playbook still works. Read it per command — it changes every launch:
 
 ```bash
-curl -s -X POST http://127.0.0.1:8991/api/chats -H "Content-Type: application/json" \
+TOKEN=$(cat ~/.agento-desktop-dev/api-token)
+curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8991/api/agents | jq
+```
+
+**Chrome on `:1420` needs nothing extra.** A plain browser tab has no Tauri IPC
+and so can never hold the token; `vite.config.ts`'s proxy reads the same file and
+adds the header server-side. That hop is unchanged.
+
+A **401** means one of: the app is not running (the file is last launch's token),
+the header is missing, or you are hitting a release build, which writes no file
+at all — use the app window.
+
+## Capturing the chat SSE stream
+
+Every state-changing request needs `Content-Type: application/json`, and every
+request needs the token above.
+
+```bash
+TOKEN=$(cat ~/.agento-desktop-dev/api-token)
+curl -s -X POST http://127.0.0.1:8991/api/chats \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
   -d '{"agent_slug":"","working_directory":"/tmp/x","model":"","settings_profile_id":""}'
 curl -sN -X POST http://127.0.0.1:8991/api/chats/<id>/messages \
-  -H "Content-Type: application/json" -d '{"content":"..."}' -o /tmp/sse.txt
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"content":"..."}' -o /tmp/sse.txt
 ```
 
 Read `/tmp/sse.txt` for the exact frames. Facts that save a loop (verified

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,6 +311,25 @@ Every state-changing `/api` request needs `Content-Type: application/json` —
 including on the payload-free endpoints. `GET`/`HEAD`/`OPTIONS` are untouched.
 `api.ts` does this for you.
 
+**And every `/api` request — reads included — needs
+`Authorization: Bearer <token>`** (#400). The token is minted per launch, held in
+memory, and delivered to the webview by `host_info` over Tauri IPC; `api.ts`
+attaches it at its two header sites, so nothing in a view changes. Note the
+scope difference from the rule above: the content-type guard is an allowlist over
+the state-changing four, while the token covers **every method**, because a `GET`
+is what returns chat transcripts and agent system prompts.
+
+Two consequences worth knowing before debugging anything:
+
+- **`curl` against `:8991` needs the header.** A debug build writes the token to
+  `<data dir>/api-token` (0600) precisely so it can:
+  `curl -H "Authorization: Bearer $(cat ~/.agento-desktop-dev/api-token)" …`.
+  A release build writes it nowhere.
+- **Opening the release URL in an ordinary browser no longer works.** There is no
+  IPC there, so no token; `api.ts` turns the resulting 401 into one honest
+  message rather than a wall of per-view errors. Chrome on `:1420` is unaffected
+  — Vite's proxy adds the header server-side.
+
 **Desktop, not web.** The UI deliberately diverges from the Agento web app:
 three resizable panes per section, 14px type, 28px rows, hairline borders,
 status bar, focus-aware selection (accent when the window is focused, grey
@@ -517,7 +536,21 @@ its `hooks` key and `POST /api/fs/mkdir`.
 
 `src-tauri/src/guards.rs` is `guards.go` at the proxy, applied in `dispatch`
 **before** the seam decides who answers, so a claimed route and a forwarded one
-are refused identically. Four things about it are load-bearing:
+are refused identically.
+
+**Since #400 it is no longer only `guards.go`.** A third check — this build's
+per-launch bearer token — sits between the two Go ones, and it is the answer to
+something they were never shaped for: both are *browser* defences, and neither
+inconveniences a local process at all. `curl` sends a loopback `Host` and sets
+its own `Content-Type`, so before the token, the whole API — which can create a
+`bypass`-permission agent and run it — was open to anything on the machine. That
+also settled a standing asymmetry: every in-process MCP server has required a
+token since #282, while the far more powerful API server did not. **Do not read
+"Agento ships without authentication on purpose" anywhere as current**; #246
+recorded that and #400 revised it, for the desktop app specifically. A **401 is a
+status Go never answers**, so it is a deliberate divergence, not a reproduction.
+
+Four things about it are load-bearing:
 
 - **It is scoped to `/api`, exactly as Go's is.** `POST /webhooks/telegram/{id}`
   is mounted at the root, arrives from Telegram's servers with a foreign `Host`
@@ -1995,7 +2028,9 @@ timeout included) are fine; the parity suites use those.
   message. Keep locally-produced turns in memory until a fresh server
   transcript for that chat loads.
 - **Secrets are stored in plaintext** in `integrations.credentials` / `.auth`.
-  Protection is perimeter-only (loopback bind + directory perms). Do not
+  Protection is perimeter-only (loopback bind + directory perms, plus the
+  `/api` bearer token since #400 — which stops another *process* reading them
+  back out through the API, but does nothing for the bytes at rest). Do not
   introduce a UI that echoes them back; the API scrubs them and the UI must not
   reintroduce them.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,6 +72,7 @@ Startup order in `lib.rs`:
 | `/api` reaches Rust via | Vite proxy to `:8991` | same origin |
 | Server port | fixed `8991` | assigned by the OS |
 | Data directory | `~/.agento-desktop-dev` | `~/.agento` |
+| `/api` bearer token | minted per launch, **also** written to `<data dir>/api-token` (0600) so `curl` and Vite's proxy can reach the API | minted per launch, memory only |
 
 Dev uses its own data directory on purpose. Two Agento processes sharing
 `~/.agento` share one SQLite file and one scheduler, so scheduled tasks fire
@@ -93,11 +94,19 @@ HTTP on loopback because:
 Do not remove it to "simplify".
 
 Because the server is reachable by anything on the machine, `guards.rs` applies
-the same two protections the Go server does, before routing:
+three protections before routing — the first two are the Go server's, the third
+is this build's:
 
 - **`validateHost`** rejects a `Host` header the server is not served under. DNS
   rebinding otherwise makes an attacker's page same-origin, at which point CORS
   stops applying.
+- **A bearer token** rejects a request that does not carry this launch's
+  `Authorization: Bearer <token>`. The two guards either side of it are
+  *browser*-shaped and neither stops a local process: `curl` sends a loopback
+  `Host` and sets its own content type, and this API can create a
+  `bypass`-permission agent and run it. The token is minted per launch, held in
+  memory, and delivered to the webview over Tauri IPC — the one channel another
+  local process cannot reach.
 - **`requireJSONContentType`** rejects a state-changing request that does not
   declare `application/json`. Without it a cross-origin `POST` carrying
   `text/plain` is a CORS simple request, sent with no preflight, and the side
@@ -105,6 +114,16 @@ the same two protections the Go server does, before routing:
 
 A body-less request is not exempt: several state-changing endpoints take no body,
 and a `POST` with neither is itself a simple request.
+
+The order is load-bearing. A request failing both the `Host` check and the token
+reads **403**, not 401; an unauthenticated one is refused **401** before it is
+told the content-type rule.
+
+All three are scoped to `/api`, so the SPA document, `/health` and the Telegram
+webhook — which arrives with a foreign `Host` and authenticates with its own
+secret — are untouched. The token is defence in depth, not a new boundary: a
+process running as this user can read `agento.db` directly. Where it is a real
+boundary is a multi-user machine, since loopback is not user-scoped.
 
 ---
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -343,14 +343,25 @@ Element, or the usual devtools shortcut.
 
 In `npm run app` the same lines go to the terminal.
 
-**Curling the API** works in dev, since the server is on a fixed port:
+**Curling the API** works in dev, since the server is on a fixed port — but
+`/api` requires a bearer token, so the header comes first:
 
 ```bash
-curl -s http://127.0.0.1:8991/api/agents | jq
+curl -s -H "Authorization: Bearer $(cat ~/.agento-desktop-dev/api-token)" \
+  http://127.0.0.1:8991/api/agents | jq
 ```
 
+The token is minted on every app launch and normally lives only in memory; a
+**debug build also writes it** to `~/.agento-desktop-dev/api-token` (0600) so
+`curl` can reach the API. A release build writes it nowhere — its API is
+reachable from the app window and nothing else. Without the header the guard
+answers **401** before the handler runs.
+
 Add `-H "Content-Type: application/json"` for anything that is not a `GET`, or
-the guard answers 415 before the handler runs.
+the guard answers 415 instead.
+
+Chrome on `:1420` needs no token of its own: Vite's proxy reads the same file and
+adds the header when it forwards.
 
 There is also a project skill, `local-verify`, describing how to reproduce a bug
 before fixing it and how to verify each hop separately: backend wire, browser

--- a/src-tauri/src/claude/mcp.rs
+++ b/src-tauri/src/claude/mcp.rs
@@ -123,7 +123,14 @@ fn server_config() -> StreamableHttpServerConfig {
 
 /// Compares two credentials without an early exit, so a wrong token leaks
 /// nothing about the right one through response timing.
-fn credentials_match(a: &str, b: &str) -> bool {
+///
+/// `pub(crate)` since #400: [`crate::guards`] authenticates the app's own API
+/// server with the same scheme and must not carry a second copy of this — one
+/// constant-time comparison in the tree is one to get right. The dependency runs
+/// that way round (app → SDK) and not the reverse, because this module is a port
+/// of an external SDK and deliberately imports nothing from the rest of the
+/// crate.
+pub(crate) fn credentials_match(a: &str, b: &str) -> bool {
     let (a, b) = (a.as_bytes(), b.as_bytes());
     a.len() == b.len() && a.iter().zip(b).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
 }

--- a/src-tauri/src/guards.rs
+++ b/src-tauri/src/guards.rs
@@ -1,8 +1,8 @@
-//! `internal/server/guards.go`, applied at the proxy (#329).
+//! `internal/server/guards.go`, applied at the proxy (#329), **plus this
+//! build's own bearer token** (#400).
 //!
-//! Agento ships without authentication on purpose — it is a single-user desktop
-//! app — and that only holds if the browser cannot be used as a way in. Two
-//! middlewares are what makes it hold, and Go scopes both to `r.Route("/api")`:
+//! Three checks now, and only the first two are Go's. Go scopes both of those to
+//! `r.Route("/api")`, and the third is scoped identically:
 //!
 //! - **`requireJSONContentType`.** A cross-origin `POST` carrying `text/plain`
 //!   is a CORS *simple request*: the browser sends it with **no preflight**, and
@@ -14,6 +14,32 @@
 //!   as far as the browser is concerned, at which point CORS stops applying at
 //!   all. A loopback bind does not help, for the same reason: the browser is
 //!   already inside.
+//! - **The bearer token** (#400). Both of the above are *browser*-shaped, and
+//!   neither is an obstacle to a caller that simply speaks HTTP:
+//!   `curl -H 'Content-Type: application/json' http://127.0.0.1:<port>/api/agents`
+//!   passes both trivially, and this API can create an agent with
+//!   `permission_mode: bypass` and run it — arbitrary command execution. The
+//!   ephemeral port is obscurity only; `/proc/net/tcp` says which one.
+//!
+//! # This build **does** authenticate, and that is a change
+//!
+//! This module used to open "Agento ships without authentication on purpose —
+//! it is a single-user desktop app". #246 recorded the same decision and called
+//! it sound. It was, **for the Go server as a web app**, where the threat model
+//! was the browser and the LAN. It is not the whole story here: loopback
+//! separates *hosts*, not *processes* or *users*, so on a multi-user machine any
+//! other account reaches this port, as does any sandboxed or lower-privilege
+//! process that can open a socket but cannot read `~/.agento`.
+//!
+//! It is defence in depth rather than a new boundary — a process already running
+//! as this user can read `agento.db` and `~/.claude` directly — and its real
+//! value is that the two halves of this binary now agree: every in-process MCP
+//! server has required a token since #282 ([`crate::claude::mcp`]), for
+//! precisely this reason and in precisely these words, while the far more
+//! powerful API server did not.
+//!
+//! **A 401 is a status Go never answers**, so it is a deliberate divergence from
+//! the ported surface rather than a reproduction of anything.
 //!
 //! # Why the proxy, and why this is not belt-and-braces
 //!
@@ -39,8 +65,14 @@
 //! secret token; a global guard would break inbound triggers. `/health` and
 //! `/metrics` are likewise untouched, and the SPA is not an API path at all.
 //! Same scoping as Go's.
+//!
+//! The SPA document and its embedded assets are the reason the token needs no
+//! special case: a page cannot put a header on its own navigation request, and
+//! those bytes hold no secrets. Everything the *page then does* is `/api`, which
+//! its own `fetch` calls can and do authenticate.
 
 use std::net::IpAddr;
+use std::sync::OnceLock;
 
 use axum::body::Body;
 use axum::http::{header, HeaderMap, Method, Request, StatusCode, Uri};
@@ -75,11 +107,55 @@ const CONTENT_TYPE_WRONG: Rejection = (
     "Content-Type must be application/json",
 );
 
+/// The 401 (#400). Go has no counterpart, so this wording is this build's own.
+///
+/// It names the scheme deliberately: the only clients are the app's own webview
+/// and a developer holding the dev token file, and both benefit from the answer
+/// saying what was missing.
+const UNAUTHORIZED: Rejection = (
+    StatusCode::UNAUTHORIZED,
+    "a valid Authorization: Bearer token is required",
+);
+
+/// The one credential scheme accepted, spelled exactly as
+/// [`crate::claude::mcp`] spells it.
+const BEARER_PREFIX: &str = "Bearer ";
+
+/// The token minted for this launch, set once during `lib.rs`'s `setup`.
+///
+/// A `OnceLock` rather than Tauri state because of who needs to read it:
+/// [`reject`] is called from `proxy::dispatch`, a plain router function with no
+/// state extractor, so there is no `tauri::State` to take. This is the shape
+/// `native::scan::state`, `native::chat::live` and `native::integrations::registry`
+/// already use for process-wide values.
+static API_TOKEN: OnceLock<String> = OnceLock::new();
+
+/// Install this launch's token, returning it.
+///
+/// Idempotent by construction: a second call returns the first token rather than
+/// replacing it, which is what lets the tests seed one without racing each other
+/// (a `cargo test` binary runs them in parallel against this one static).
+pub fn set_api_token(token: String) -> &'static str {
+    API_TOKEN.get_or_init(|| token).as_str()
+}
+
+/// This launch's token, or `None` before `setup` has installed one.
+pub fn api_token() -> Option<&'static str> {
+    API_TOKEN.get().map(String::as_str)
+}
+
 /// Why a request must be refused, or `None` to let it through.
 ///
 /// Order mirrors `server.go`'s `r.Use(s.validateHost)` then
 /// `r.Use(requireJSONContentType)`: chi runs them outermost-first, so a request
 /// that fails both is answered 403.
+///
+/// The token sits **between** them, and both halves of that placement are
+/// deliberate. After `Host`, so a request failing both still reads 403 — the
+/// rebinding answer outranks the credential one, and a browser that has been
+/// pointed here by DNS should learn nothing further. Before `Content-Type`, so
+/// an unauthenticated caller is not told the content-type rule; authentication
+/// precedes request-shape validation.
 pub fn reject(req: &Request<Body>) -> Option<Rejection> {
     // The **raw** request target, as `proxy::handle` uses for `is_api_path` and
     // for the same reason: reaching a divergence would need a percent-escape
@@ -95,7 +171,49 @@ pub fn reject(req: &Request<Body>) -> Option<Rejection> {
     if !host_allowed(&request_host(req.headers(), req.uri())) {
         return Some(HOST_REJECTION);
     }
+    if let Some(rejection) = token_rejection(req.headers(), api_token()) {
+        return Some(rejection);
+    }
     content_type_rejection(req.method(), path, req.headers())
+}
+
+/// The bearer check (#400).
+///
+/// **It applies to every method**, unlike `requireJSONContentType`, which is an
+/// allowlist over the state-changing four. A `GET` is what reads chat
+/// transcripts, agent system prompts and the integration list, so exempting
+/// reads would leave most of what is worth stealing reachable.
+///
+/// `expected` is a parameter rather than a read of [`API_TOKEN`] so the
+/// fail-closed branch is testable: a `OnceLock` cannot be un-set, so a test that
+/// wanted to observe "no token installed" could not arrange it otherwise.
+///
+/// **No token installed refuses everything.** That is the safe direction: the
+/// only way to reach it is a `setup` that failed before minting, and answering
+/// an unauthenticated request in that state would be a listener with no
+/// credential at all. The scheme match is exact, as `mcp.rs`'s is — the only
+/// clients are this app's own webview and the Vite dev proxy, and both spell it
+/// `Bearer `.
+fn token_rejection(headers: &HeaderMap, expected: Option<&str>) -> Option<Rejection> {
+    let Some(expected) = expected else {
+        return Some(UNAUTHORIZED);
+    };
+    let presented = headers
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .strip_prefix(BEARER_PREFIX)
+        .unwrap_or_default();
+
+    // Shared with the MCP servers rather than reimplemented — one constant-time
+    // comparison in the tree is one to get right. The dependency runs app → SDK,
+    // which is the only direction available: `claude/` is a port of an external
+    // SDK and imports nothing from the rest of this crate.
+    if crate::claude::mcp::credentials_match(presented, expected) {
+        None
+    } else {
+        Some(UNAUTHORIZED)
+    }
 }
 
 /// Whether the guards apply to this path.
@@ -309,16 +427,39 @@ fn is_token(s: &str) -> bool {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
 
+    /// The token every test in this binary authenticates with.
+    ///
+    /// [`set_api_token`] is `get_or_init`, so the first caller wins and every
+    /// later one — in this module or in `proxy`'s tests, which share the
+    /// process — sees the same value. That is what makes a seeded token safe
+    /// under `cargo test`'s parallelism.
+    pub(crate) fn seeded_token() -> &'static str {
+        set_api_token("test-token".to_string())
+    }
+
     fn request(method: Method, path: &str, host: &str, content_type: &str) -> Request<Body> {
+        authed_request(method, path, host, content_type, Some(seeded_token()))
+    }
+
+    fn authed_request(
+        method: Method,
+        path: &str,
+        host: &str,
+        content_type: &str,
+        token: Option<&str>,
+    ) -> Request<Body> {
         let mut builder = Request::builder().method(method).uri(path);
         if !host.is_empty() {
             builder = builder.header(header::HOST, host);
         }
         if !content_type.is_empty() {
             builder = builder.header(header::CONTENT_TYPE, content_type);
+        }
+        if let Some(token) = token {
+            builder = builder.header(header::AUTHORIZATION, format!("Bearer {token}"));
         }
         builder.body(Body::empty()).expect("request")
     }
@@ -515,10 +656,15 @@ mod tests {
         );
     }
 
-    /// Both guards are scoped to `/api` deliberately. The Telegram webhook is
-    /// mounted at the root, arrives with a foreign `Host` and is authenticated
-    /// by its own secret token; a global guard would break inbound triggers in
-    /// production.
+    /// All three guards are scoped to `/api` deliberately. The Telegram webhook
+    /// is mounted at the root, arrives with a foreign `Host` and is
+    /// authenticated by its own secret token; a global guard would break inbound
+    /// triggers in production.
+    ///
+    /// Deliberately sends **no** token, which is what makes this the token's
+    /// exemption test as well as the other two guards': the SPA document,
+    /// `/health` and the webhook all reach the server without one, and a token
+    /// check that had leaked outside `/api` would fail here.
     #[test]
     fn nothing_outside_api_is_guarded() {
         for path in [
@@ -530,11 +676,12 @@ mod tests {
             "/apiary",
         ] {
             assert_eq!(
-                reject(&request(
+                reject(&authed_request(
                     Method::POST,
                     path,
                     "api.telegram.org",
-                    "application/x-www-form-urlencoded"
+                    "application/x-www-form-urlencoded",
+                    None
                 )),
                 None,
                 "{path} should not be guarded"
@@ -545,5 +692,180 @@ mod tests {
             reject(&request(Method::POST, "/api", "attacker.example", "")),
             Some(HOST_REJECTION)
         );
+    }
+
+    /// The case #400 exists for, and the one every other guard passes: `curl`
+    /// sends a loopback `Host` and sets its own `Content-Type`, so before the
+    /// token the two Go guards admitted it — onto an API that can create a
+    /// `bypass`-permission agent and run it.
+    #[test]
+    fn an_api_request_without_a_token_is_refused() {
+        assert_eq!(
+            reject(&authed_request(
+                Method::POST,
+                "/api/agents",
+                "127.0.0.1:8991",
+                "application/json",
+                None
+            )),
+            Some(UNAUTHORIZED)
+        );
+    }
+
+    #[test]
+    fn a_wrong_token_is_refused_and_the_right_one_is_served() {
+        let token = seeded_token();
+        for wrong in [
+            "",
+            "not-the-token",
+            // A prefix and an extension of the real token: the comparison is
+            // length-checked before the byte fold, so neither is admitted.
+            &token[..token.len() - 1],
+            &format!("{token}x"),
+        ] {
+            assert_eq!(
+                reject(&authed_request(
+                    Method::GET,
+                    "/api/agents",
+                    "localhost",
+                    "",
+                    Some(wrong)
+                )),
+                Some(UNAUTHORIZED),
+                "{wrong:?} should be refused"
+            );
+        }
+        assert_eq!(
+            reject(&authed_request(
+                Method::GET,
+                "/api/agents",
+                "localhost",
+                "",
+                Some(token)
+            )),
+            None
+        );
+    }
+
+    /// **Reads are guarded too**, unlike `requireJSONContentType`, which is an
+    /// allowlist over the state-changing four. A `GET` is what returns chat
+    /// transcripts, agent system prompts and the integration list.
+    #[test]
+    fn every_method_needs_the_token_not_only_the_state_changing_ones() {
+        for method in [
+            Method::GET,
+            Method::HEAD,
+            Method::OPTIONS,
+            Method::POST,
+            Method::PUT,
+            Method::PATCH,
+            Method::DELETE,
+        ] {
+            assert_eq!(
+                reject(&authed_request(
+                    method.clone(),
+                    "/api/agents",
+                    "localhost",
+                    "application/json",
+                    None
+                )),
+                Some(UNAUTHORIZED),
+                "{method} should require the token"
+            );
+        }
+    }
+
+    /// A request failing the `Host` check **and** carrying no token reads 403,
+    /// not 401: the rebinding answer outranks the credential one.
+    #[test]
+    fn the_host_check_still_runs_before_the_token_check() {
+        assert_eq!(
+            reject(&authed_request(
+                Method::POST,
+                "/api/agents",
+                "attacker.example.com",
+                "application/json",
+                None
+            )),
+            Some(HOST_REJECTION)
+        );
+    }
+
+    /// ...and the token check runs before the content-type one, so an
+    /// unauthenticated caller is not told the content-type rule.
+    #[test]
+    fn the_token_check_runs_before_the_content_type_check() {
+        assert_eq!(
+            reject(&authed_request(
+                Method::POST,
+                "/api/agents",
+                "localhost",
+                "text/plain",
+                None
+            )),
+            Some(UNAUTHORIZED)
+        );
+        // With a token, the same request is the 415 it was before #400.
+        assert_eq!(
+            reject(&request(
+                Method::POST,
+                "/api/agents",
+                "localhost",
+                "text/plain"
+            )),
+            Some(CONTENT_TYPE_WRONG)
+        );
+    }
+
+    /// No token installed refuses everything.
+    ///
+    /// Only reachable through a `setup` that failed before minting, and the safe
+    /// direction: the alternative is a listener with no credential at all.
+    /// Tested through the parameter because a `OnceLock` cannot be un-set.
+    #[test]
+    fn no_installed_token_fails_closed() {
+        let headers = HeaderMap::new();
+        assert_eq!(token_rejection(&headers, None), Some(UNAUTHORIZED));
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::AUTHORIZATION,
+            "Bearer anything".parse().expect("hv"),
+        );
+        assert_eq!(token_rejection(&headers, None), Some(UNAUTHORIZED));
+    }
+
+    /// The scheme is matched exactly, as `mcp.rs` matches it. The only clients
+    /// are this app's webview and the Vite dev proxy, and both send `Bearer `.
+    #[test]
+    fn the_credential_must_carry_the_bearer_scheme() {
+        let token = seeded_token();
+        for value in [
+            token.to_string(),
+            format!("bearer {token}"),
+            format!("Basic {token}"),
+            format!("Bearer  {token}"),
+        ] {
+            let mut headers = HeaderMap::new();
+            headers.insert(header::AUTHORIZATION, value.parse().expect("hv"));
+            assert_eq!(
+                token_rejection(&headers, Some(token)),
+                Some(UNAUTHORIZED),
+                "{value:?} should be refused"
+            );
+        }
+    }
+
+    /// Two launches must not share a token — the `mcp.rs` property, applied to
+    /// the API server. `set_api_token` is `get_or_init` within one process, so
+    /// what is asserted is the generation: the value handed to it is fresh per
+    /// call, which is what makes each launch's token independent.
+    #[test]
+    fn a_freshly_minted_token_is_never_the_previous_one() {
+        let mint = || uuid::Uuid::new_v4().simple().to_string();
+        let first = mint();
+        let second = mint();
+        assert_ne!(first, second);
+        assert_eq!(first.len(), 32, "128 bits of hex, 122 of them random");
     }
 }

--- a/src-tauri/src/guards.rs
+++ b/src-tauri/src/guards.rs
@@ -140,8 +140,20 @@ pub fn set_api_token(token: String) -> &'static str {
 }
 
 /// This launch's token, or `None` before `setup` has installed one.
+///
+/// **An empty token reads as "none installed", and that is a safety property
+/// rather than tidiness.** `token_rejection` strips the scheme and compares what
+/// is left, so a request carrying *no* `Authorization` header at all presents
+/// `""` — which against an empty expected token is an exact match, and every
+/// unauthenticated request would be served. Nothing can reach that today (a v4
+/// UUID is 32 hex characters), but the guard must not be one careless
+/// `set_api_token(String::new())` away from being open, and the failure would be
+/// silent in exactly the way this module exists to prevent.
 pub fn api_token() -> Option<&'static str> {
-    API_TOKEN.get().map(String::as_str)
+    API_TOKEN
+        .get()
+        .map(String::as_str)
+        .filter(|token| !token.is_empty())
 }
 
 /// Why a request must be refused, or `None` to let it through.
@@ -833,6 +845,47 @@ pub(crate) mod tests {
             "Bearer anything".parse().expect("hv"),
         );
         assert_eq!(token_rejection(&headers, None), Some(UNAUTHORIZED));
+    }
+
+    /// An **empty** installed token must not authenticate the request that sends
+    /// no credential at all.
+    ///
+    /// Both sides reduce to `""` — a header-less request presents `""` after the
+    /// scheme strip — so a constant-time compare of the two is a match, and the
+    /// guard would be wide open while looking installed. [`api_token`] maps
+    /// empty to `None` for this reason; without that filter this test fails,
+    /// which is the whole point of having it.
+    #[test]
+    fn an_empty_token_is_not_a_credential() {
+        assert_eq!(
+            token_rejection(&HeaderMap::new(), Some("")),
+            None,
+            "the raw comparison matches, which is exactly why api_token() must never return it"
+        );
+
+        // Seed **first**, and deliberately so. `set_api_token` is `get_or_init`
+        // over a process-wide static, so calling it with an empty string before
+        // anything else had installed a token would install one — poisoning
+        // every other test in this binary, whichever order they happen to run
+        // in. Seeding here makes the assertion about the accessor rather than
+        // about which test won the race.
+        let token = seeded_token();
+        assert_eq!(
+            set_api_token(String::new()),
+            token,
+            "a later set must not replace the installed token"
+        );
+        assert!(!api_token().unwrap_or_default().is_empty());
+        assert_eq!(
+            reject(&authed_request(
+                Method::GET,
+                "/api/agents",
+                "localhost",
+                "",
+                None
+            )),
+            Some(UNAUTHORIZED)
+        );
     }
 
     /// The scheme is matched exactly, as `mcp.rs` matches it. The only clients

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -54,6 +54,13 @@ pub struct HostInfo {
     /// Origin the frontend should send API requests to. Empty means "same
     /// origin as this page", which is the case once the proxy serves the UI.
     pub api_base: String,
+    /// This launch's bearer token for `/api` (#400).
+    ///
+    /// Tauri IPC is the whole delivery mechanism: it is the one channel a local
+    /// process cannot reach, which is what makes the token worth having. It is
+    /// minted per launch and held in memory, so there is nothing for a user to
+    /// configure and nothing on disk for a release build to leak.
+    pub api_token: String,
     /// Resolved path to the Claude Code CLI, or null when it is not installed.
     pub claude_cli: Option<String>,
     /// Whether this install can replace itself, which decides between offering
@@ -72,6 +79,9 @@ fn host_info(state: tauri::State<'_, AppPorts>) -> HostInfo {
         version: env!("CARGO_PKG_VERSION").to_string(),
         controls_on_left: cfg!(target_os = "macos"),
         api_base: format!("http://127.0.0.1:{}", state.proxy),
+        // Read from `guards`, which owns it, rather than carried on `AppPorts`:
+        // one source of truth for the value the guard compares against.
+        api_token: guards::api_token().unwrap_or_default().to_string(),
         claude_cli: find_claude_cli(),
         can_self_update: install_kind() != "package",
         install_kind: install_kind().to_string(),
@@ -154,6 +164,56 @@ pub(crate) fn find_claude_cli() -> Option<String> {
 /// Ports resolved at startup, exposed to the frontend and to diagnostics.
 pub struct AppPorts {
     pub proxy: u16,
+}
+
+/// Where a debug build leaves this launch's `/api` token (#400).
+///
+/// **Debug only, and the whole function compiles out of a shipped binary.** The
+/// token is otherwise memory-only, and in release it must stay that way.
+///
+/// It exists because two developer workflows are load-bearing and neither can
+/// reach a token held only in this process's memory:
+///
+/// - `curl -H "Authorization: Bearer $(cat ~/.agento-desktop-dev/api-token)" …`,
+///   which is how a backend hop is bisected (`.claude/skills/local-verify/`).
+/// - Chrome on `localhost:1420`, where `vite.config.ts`'s proxy reads this file
+///   and adds the header server-side. A plain browser tab has no Tauri IPC, so
+///   the page itself can never hold a token.
+///
+/// The alternative was exempting debug builds from the guard entirely, which was
+/// rejected: the dev port is *fixed and well-known* (8991), which makes dev the
+/// easier target, and a guard never exercised where we develop is a guard whose
+/// regressions ship.
+///
+/// Rewritten on every launch because the token changes on every launch. A stale
+/// file after a crash is a 401 for whoever reads it next, which is the correct
+/// failure — it is a cache of a live value, never the source of one.
+#[cfg(debug_assertions)]
+fn write_dev_token_file(token: &str) {
+    let Some(dir) = paths::data_dir() else {
+        log::warn!("dev api token: no data dir to write it to");
+        return;
+    };
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        log::warn!("dev api token: creating {}: {e}", dir.display());
+        return;
+    }
+    let path = dir.join("api-token");
+    if let Err(e) = std::fs::write(&path, token) {
+        log::warn!("dev api token: writing {}: {e}", path.display());
+        return;
+    }
+    // 0600 before anyone can read it. On a multi-user machine the default umask
+    // would leave it world-readable, which would hand the token to exactly the
+    // account this guard exists to keep out.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Err(e) = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)) {
+            log::warn!("dev api token: chmod {}: {e}", path.display());
+        }
+    }
+    log::info!("dev api token written to {}", path.display());
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -261,6 +321,24 @@ pub fn run() {
                         }
                     }
                 }
+
+                // The `/api` bearer token (#400), minted **before** the listener
+                // is spawned so no request can arrive while `API_TOKEN` is still
+                // empty — which the guard would fail closed on, but only by
+                // luck of ordering rather than by design.
+                //
+                // 122 bits from the OS CSPRNG, which is what `Uuid::new_v4` is,
+                // and the same generation `claude::mcp` uses for its listeners
+                // so there is one way to do this in the tree. It lives and dies
+                // with the process; nothing rotates it, because a window reload
+                // re-invokes `host_info` and gets the same value.
+                let api_token =
+                    guards::set_api_token(uuid::Uuid::new_v4().simple().to_string()).to_string();
+
+                #[cfg(debug_assertions)]
+                write_dev_token_file(&api_token);
+                #[cfg(not(debug_assertions))]
+                let _ = &api_token;
 
                 #[cfg(debug_assertions)]
                 let proxy_port = DEV_PROXY_PORT;
@@ -377,4 +455,68 @@ pub fn run() {
     builder
         .run(tauri::generate_context!())
         .expect("error while running Agento");
+}
+
+#[cfg(all(test, debug_assertions))]
+mod tests {
+    use super::*;
+
+    /// The dev hatch is only worth having if it is actually written, actually
+    /// holds the live token, and is actually unreadable by other accounts.
+    ///
+    /// This is a unit test rather than a manual `npm run app` check on purpose:
+    /// the mode is the part that fails silently. A default umask would leave the
+    /// file world-readable, handing this launch's token to precisely the other
+    /// local account #400 exists to keep out — and nothing about the app's
+    /// behaviour would look different.
+    #[test]
+    fn the_dev_token_file_is_written_private_to_this_user() {
+        let _lock = crate::paths::tests::env_lock();
+        let home = tempfile::tempdir().expect("tempdir");
+        let _home = crate::paths::tests::EnvVar::set("HOME", home.path());
+
+        write_dev_token_file("a-token");
+
+        let path = crate::paths::data_dir()
+            .expect("data dir")
+            .join("api-token");
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("token file"),
+            "a-token"
+        );
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&path)
+                .expect("metadata")
+                .permissions()
+                .mode();
+            assert_eq!(
+                mode & 0o777,
+                0o600,
+                "the token must not be group/world readable"
+            );
+        }
+    }
+
+    /// Every launch mints a new token, so the file is a cache of a live value
+    /// and must be replaced rather than appended to or left stale.
+    #[test]
+    fn a_second_launch_overwrites_the_previous_launchs_token() {
+        let _lock = crate::paths::tests::env_lock();
+        let home = tempfile::tempdir().expect("tempdir");
+        let _home = crate::paths::tests::EnvVar::set("HOME", home.path());
+
+        write_dev_token_file("first-launch");
+        write_dev_token_file("second-launch");
+
+        let path = crate::paths::data_dir()
+            .expect("data dir")
+            .join("api-token");
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("token file"),
+            "second-launch"
+        );
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -332,13 +332,10 @@ pub fn run() {
                 // so there is one way to do this in the tree. It lives and dies
                 // with the process; nothing rotates it, because a window reload
                 // re-invokes `host_info` and gets the same value.
-                let api_token =
-                    guards::set_api_token(uuid::Uuid::new_v4().simple().to_string()).to_string();
+                let api_token = guards::set_api_token(uuid::Uuid::new_v4().simple().to_string());
 
                 #[cfg(debug_assertions)]
-                write_dev_token_file(&api_token);
-                #[cfg(not(debug_assertions))]
-                let _ = &api_token;
+                write_dev_token_file(api_token);
 
                 #[cfg(debug_assertions)]
                 let proxy_port = DEV_PROXY_PORT;

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -488,18 +488,26 @@ mod tests {
         assert_eq!(Served::Rejected.label(), "rejected");
     }
 
+    /// Every `/api` request needs the bearer token since #400, so a test that
+    /// means to exercise anything *past* the guards has to carry one.
+    fn bearer() -> String {
+        format!("Bearer {}", crate::guards::tests::seeded_token())
+    }
+
     /// The guards run before routing is decided, so a claimed route and an
     /// unclaimed one are refused identically (#329).
     #[tokio::test]
     async fn a_guard_rejection_precedes_routing() {
         // A claimed write route, and the shape that made #329 exploitable: a
         // cross-origin `POST` carrying `text/plain` is a CORS simple request, so
-        // the browser sends it with no preflight.
+        // the browser sends it with no preflight. Authenticated, so what is
+        // under test is the content-type refusal rather than #400's 401.
         let path = "/api/agents".to_string();
         let req = Request::builder()
             .method(Method::POST)
             .uri(&path)
             .header(header::HOST, "localhost")
+            .header(header::AUTHORIZATION, bearer())
             .header(header::CONTENT_TYPE, "text/plain")
             .body(Body::from(r#"{"name":"pwned","slug":"pwned"}"#))
             .expect("request");
@@ -524,6 +532,32 @@ mod tests {
         assert_eq!(served, Served::Rejected);
     }
 
+    /// The whole of #400 at the seam: an unauthenticated `/api` write is
+    /// answered 401 *before routing is decided*, so no handler runs and nothing
+    /// is written.
+    ///
+    /// The "nothing is written" half needs no database to assert — it is a
+    /// consequence of `reject` running ahead of the `route_is_native` branch,
+    /// which `a_guard_rejection_precedes_routing` pins. `Served::Rejected` is
+    /// the observable proof that this request never reached a handler.
+    #[tokio::test]
+    async fn an_unauthenticated_api_request_is_refused_before_any_handler_runs() {
+        let path = "/api/agents".to_string();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri(&path)
+            // Everything a local `curl` sends, and everything the pre-#400
+            // guards asked for: a loopback Host and the right content type.
+            .header(header::HOST, "127.0.0.1:8991")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(r#"{"name":"pwned","slug":"pwned"}"#))
+            .expect("request");
+
+        let (response, served) = dispatch(req, path).await;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(served, Served::Rejected);
+    }
+
     /// A route nothing claims answers chi's own 404 — status, content type,
     /// nosniff and the exact body Go's router wrote.
     #[tokio::test]
@@ -533,6 +567,7 @@ mod tests {
             .method(Method::GET)
             .uri(&path)
             .header(header::HOST, "localhost")
+            .header(header::AUTHORIZATION, bearer())
             .body(Body::empty())
             .expect("request");
 
@@ -568,6 +603,7 @@ mod tests {
             .method(Method::GET)
             .uri("/api/agents/a%252") // uri parsing needs a valid target; dispatch takes the raw path separately
             .header(header::HOST, "localhost")
+            .header(header::AUTHORIZATION, bearer())
             .body(Body::empty())
             .expect("request");
 
@@ -609,6 +645,13 @@ mod tests {
             access_level(&Method::POST, StatusCode::CONFLICT),
             log::Level::Warn
         );
+        // #400's 401 needs no special case to be visible: an unauthenticated
+        // local hit is exactly the event worth having in a bug report, and the
+        // client-error arm already promotes it out of the read volume.
+        assert_eq!(
+            access_level(&Method::GET, StatusCode::UNAUTHORIZED),
+            log::Level::Warn
+        );
     }
 
     /// A claimed route whose body is over [`max_body_for`] is answered 400 by
@@ -619,10 +662,11 @@ mod tests {
         let req = Request::builder()
             .method(Method::POST)
             .uri(&path)
-            // Both headers are required since #329: the guards run ahead of
-            // routing, so a request without them never reaches the arm under
-            // test.
+            // All three headers are required — the two guards since #329 and
+            // the bearer token since #400. The guards run ahead of routing, so
+            // a request missing any of them never reaches the arm under test.
             .header(header::HOST, "localhost")
+            .header(header::AUTHORIZATION, bearer())
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(vec![0u8; MAX_NATIVE_BODY + 1]))
             .expect("request");
@@ -634,7 +678,13 @@ mod tests {
     }
 
     /// A logged path must never carry the query string: it holds search terms,
-    /// project paths and date ranges.
+    /// project paths and date ranges — and, since #400, it is the one place a
+    /// bearer token could plausibly end up in a plaintext file on disk.
+    ///
+    /// The access line carries no headers at all, so the *header* the token
+    /// really travels in cannot leak. What this pins is the other way in: a
+    /// `?token=` appended for debugging, which is precisely the shape somebody
+    /// adds without thinking about the log.
     #[test]
     fn logged_path_drops_the_query_string() {
         let uri: Uri = "/api/claude-sessions?search=my+secret+project&project=%2Fhome%2Fme%2Fwork"
@@ -644,6 +694,12 @@ mod tests {
 
         let uri: Uri = "/api/agents".parse().expect("uri");
         assert_eq!(log_path(&uri), "/api/agents");
+
+        let token = crate::guards::tests::seeded_token();
+        let uri: Uri = format!("/api/agents?token={token}").parse().expect("uri");
+        let logged = log_path(&uri);
+        assert_eq!(logged, "/api/agents");
+        assert!(!logged.contains(token), "the log line must never carry it");
     }
 
     /// `handle` returns before the access line for anything that is not an API

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -5,7 +5,13 @@
    the server: in development Vite proxies /api to the Rust proxy, and in
    release the Rust proxy serves this page itself. That is what keeps the
    browser out of CORS and leaves SSE working.
+
+   Every request also carries this launch's bearer token (#400) — see
+   `authHeaders`. There are exactly two places headers are built, and both are
+   below; a third would be a request that 401s.
    ========================================================================== */
+
+import { hostInfo } from "./tauri";
 
 export class ApiError extends Error {
   constructor(
@@ -20,18 +26,63 @@ export class ApiError extends Error {
 
 const BASE = "/api";
 
+/**
+ * What a 401 means when this page never had a token to send (#400).
+ *
+ * The server cannot tell our own SPA loaded in Chrome from an attacker's page,
+ * and must not try — so the explanation is produced here, where "did we have a
+ * token" is actually known.
+ */
+const NO_TOKEN_HINT =
+  "Agento's API is only reachable from the desktop app window. " +
+  "Opening this address in a browser will not work.";
+
+/**
+ * The headers every request carries.
+ *
+ * The bearer token (#400) is minted per launch by the Rust side and delivered
+ * over Tauri IPC, so this awaits `hostInfo()` — memoized, so it is one IPC round
+ * trip per page, not one per request. **Awaiting it inside the request is the
+ * point**: a token resolved into a module-level variable at import time would
+ * race every view that fetches from its first effect, and the symptom would be
+ * an occasional 401 on cold start that looks like a server bug.
+ *
+ * A missing token is **not** an error here. Outside Tauri there is none to have,
+ * and in `npm run dev` Chrome talks to the app through Vite's proxy, which adds
+ * the header server-side from the dev token file — so refusing to send the
+ * request would break the one workflow the dev token file exists for. Let the
+ * server decide; a genuine 401 is then explained below.
+ */
+async function authHeaders(accept: string): Promise<Record<string, string>> {
+  const headers: Record<string, string> = {
+    Accept: accept,
+    // The server requires this on every request, not just those with a body —
+    // its requireJSONContentType guard runs before the handler.
+    "Content-Type": "application/json",
+  };
+  const info = await hostInfo();
+  if (info?.api_token) headers.Authorization = `Bearer ${info.api_token}`;
+  return headers;
+}
+
+/** A 401 we can explain, or the server's own message. */
+async function rejection(
+  res: Response,
+  headers: Record<string, string>
+): Promise<ApiError> {
+  if (res.status === 401 && !headers.Authorization) {
+    return new ApiError(res.status, NO_TOKEN_HINT);
+  }
+  return new ApiError(res.status, await errorMessage(res), await safeJson(res));
+}
+
 async function request<T>(
   method: string,
   path: string,
   body?: unknown,
   signal?: AbortSignal
 ): Promise<T> {
-  const headers: Record<string, string> = {
-    Accept: "application/json",
-    // The server requires this on every request, not just those with a body —
-    // its requireJSONContentType guard runs before the handler.
-    "Content-Type": "application/json",
-  };
+  const headers = await authHeaders("application/json");
 
   const res = await fetch(BASE + path, {
     method,
@@ -41,7 +92,7 @@ async function request<T>(
   });
 
   if (!res.ok) {
-    throw new ApiError(res.status, await errorMessage(res), await safeJson(res));
+    throw await rejection(res, headers);
   }
 
   if (res.status === 204) return undefined as T;
@@ -127,18 +178,21 @@ export function streamChatMessage(
 
   (async () => {
     try {
+      // The stream is a POST response, so this is `fetch` rather than
+      // `EventSource` — which is GET-only and cannot set headers. That is also
+      // what lets the turn carry the bearer token like any other request (#400);
+      // an EventSource-based stream would have needed a different scheme.
+      const headers = await authHeaders("text/event-stream");
+
       const res = await fetch(`${BASE}/chats/${chatId}/messages`, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Accept: "text/event-stream",
-        },
+        headers,
         body: JSON.stringify({ content }),
         signal: controller.signal,
       });
 
       if (!res.ok) {
-        throw new ApiError(res.status, await errorMessage(res));
+        throw await rejection(res, headers);
       }
       if (!res.body) throw new Error("response has no body");
 

--- a/src/lib/host.ts
+++ b/src/lib/host.ts
@@ -3,43 +3,29 @@
    ========================================================================== */
 
 import { useEffect, useState } from "react";
-import { IS_TAURI } from "./tauri";
+import { hostInfo, type HostInfo } from "./tauri";
 
-export interface HostInfo {
-  os: string;
-  arch: string;
-  version: string;
-  controls_on_left: boolean;
-  api_base: string;
-  /** Path to the Claude Code CLI, or null when it is not installed. */
-  claude_cli: string | null;
-  /** Whether this install can replace itself, or only announce updates. */
-  can_self_update: boolean;
-  /** "appimage" | "package" | "dmg" | "installer" */
-  install_kind: string;
-}
+export type { HostInfo };
 
 /**
  * Everything the installer ships is self-contained except the Claude Code CLI:
  * the backend runs agents by spawning it. Outside Tauri we cannot look at the
  * filesystem, so assume it is present rather than showing a false warning in a
  * browser tab.
+ *
+ * The fetch itself lives in `tauri.ts` and is memoized there, because `api.ts`
+ * needs the same answer for the `/api` bearer token (#400) and cannot import a
+ * React hook. This is the view-facing wrapper over that one call.
  */
 export function useHostInfo(): HostInfo | undefined {
   const [info, setInfo] = useState<HostInfo>();
 
   useEffect(() => {
-    if (!IS_TAURI) return;
     let cancelled = false;
 
-    import("@tauri-apps/api/core")
-      .then(({ invoke }) => invoke<HostInfo>("host_info"))
-      .then((result) => {
-        if (!cancelled) setInfo(result);
-      })
-      .catch(() => {
-        /* host_info is advisory; the app works without it */
-      });
+    hostInfo().then((result) => {
+      if (!cancelled && result) setInfo(result);
+    });
 
     return () => {
       cancelled = true;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -6,6 +6,50 @@
 export const IS_TAURI =
   typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 
+/** Platform facts the Rust side resolves at startup. */
+export interface HostInfo {
+  os: string;
+  arch: string;
+  version: string;
+  controls_on_left: boolean;
+  api_base: string;
+  /** Path to the Claude Code CLI, or null when it is not installed. */
+  claude_cli: string | null;
+  /** Whether this install can replace itself, or only announce updates. */
+  can_self_update: boolean;
+  /** "appimage" | "package" | "dmg" | "installer" */
+  install_kind: string;
+  /** This launch's bearer token for /api. Empty outside Tauri. */
+  api_token: string;
+}
+
+let hostInfoPromise: Promise<HostInfo | null> | undefined;
+
+/**
+ * The `host_info` command, fetched at most once per page.
+ *
+ * Memoized here rather than in `host.ts` because `api.ts` needs it too and must
+ * not depend on React — and because two independent callers invoking the same
+ * command is two round trips for one immutable answer.
+ *
+ * **This is how the /api bearer token reaches the page (#400).** IPC is the one
+ * channel a local process cannot reach, which is the entire point: a token
+ * delivered over `/api` itself would be a token anything could ask for. That
+ * makes this call load-bearing where it used to be advisory, so a failure
+ * resolves to `null` rather than rejecting — every caller already has to handle
+ * "outside Tauri", and collapsing the two cases means one path to get right.
+ */
+export function hostInfo(): Promise<HostInfo | null> {
+  if (!hostInfoPromise) {
+    hostInfoPromise = !IS_TAURI
+      ? Promise.resolve(null)
+      : import("@tauri-apps/api/core")
+          .then(({ invoke }) => invoke<HostInfo>("host_info"))
+          .catch(() => null);
+  }
+  return hostInfoPromise;
+}
+
 type AppWindow = {
   setTheme(theme: "light" | "dark" | null): Promise<void>;
   onFocusChanged(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,54 @@
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import type { ProxyOptions } from "vite";
+
+/**
+ * Where a debug build leaves its `/api` bearer token (#400).
+ *
+ * `paths::data_dir()` in a debug build is `~/.agento-desktop-dev`, deliberately
+ * not `~/.agento`. This mirrors that one constant; a release build writes no
+ * such file.
+ */
+const DEV_TOKEN_FILE = join(homedir(), ".agento-desktop-dev", "api-token");
+
+/**
+ * Read the token **per request**, never once at startup.
+ *
+ * `npm run app` starts Vite before the Tauri app, so at Vite's startup the file
+ * either does not exist yet or still holds the *previous* launch's token — and
+ * the token changes on every launch. Reading it per request costs a stat of a
+ * ~32-byte file on the dev machine only, and is the difference between the
+ * proxy working after an app restart and 401ing until Vite is restarted too.
+ */
+function devToken(): string {
+  try {
+    return readFileSync(DEV_TOKEN_FILE, "utf8").trim();
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Add the bearer token to a proxied request.
+ *
+ * This is what keeps the two workflows in `.claude/skills/local-verify/`
+ * alive now that `/api` authenticates: Chrome on `localhost:1420` has no Tauri
+ * IPC, so the page itself can never hold a token, and without this every request
+ * it makes would 401. Inside the Tauri dev webview the page *does* send its own
+ * header — this overwrites it with the identical value.
+ */
+function authenticate(): ProxyOptions["configure"] {
+  return (proxy) => {
+    proxy.on("proxyReq", (proxyReq) => {
+      const token = devToken();
+      if (token) proxyReq.setHeader("Authorization", `Bearer ${token}`);
+    });
+  };
+}
 
 // Tauri expects a fixed port and never obscures Rust errors on the terminal.
 export default defineConfig({
@@ -18,8 +67,15 @@ export default defineConfig({
         target: "http://127.0.0.1:8991",
         changeOrigin: false,
         ws: false,
+        configure: authenticate(),
       },
-      "/health": { target: "http://127.0.0.1:8991", changeOrigin: false },
+      // /health is not guarded, so it needs no token — but it costs nothing to
+      // send one and keeps the two entries from diverging on the next edit.
+      "/health": {
+        target: "http://127.0.0.1:8991",
+        changeOrigin: false,
+        configure: authenticate(),
+      },
     },
   },
   build: {


### PR DESCRIPTION
Closes #400

## What

`/api` now requires `Authorization: Bearer <token>` — **reads included**, unlike the `Content-Type` guard, which is an allowlist over the state-changing four. A `GET` is what returns chat transcripts, agent system prompts and the integration list.

The token is minted per launch, held in memory, and delivered to the webview by `host_info` over Tauri IPC. Nothing for a user to configure; nothing on disk in a release build.

## Why

The two guards from #246/#329 are browser-shaped by construction — they close CORS-simple-request abuse and DNS rebinding, and neither is an obstacle to a caller that simply speaks HTTP:

```bash
curl -H 'Content-Type: application/json' -d '{…}' http://127.0.0.1:<port>/api/agents
```

Both pass trivially: curl sends a loopback `Host` and sets its own content type. The API is not read-only — it can create an agent with `permission_mode: bypass` and run it, i.e. **arbitrary command execution**. The ephemeral port is obscurity only.

Loopback separates *hosts*, not processes or users. It is defence in depth on a single-user laptop (a process running as you can read `agento.db` directly); it is a real boundary on a **multi-user machine**, and for sandboxed processes that can open a socket but cannot read `~/.agento`. It also settles a standing asymmetry: every in-process MCP server has required a token since #282, while the far more powerful API server did not.

**This reverses a recorded decision, deliberately.** #246's "Not in scope" said authentication was intentionally absent and sound. That was right *for the Go server as a web app*, where the threat model was the browser and the LAN. `guards.rs`'s module doc has been rewritten rather than appended to, and `main` is unaffected.

## How

- **Mint** — `lib.rs` setup, `uuid::Uuid::new_v4()` as `claude::mcp` does, into a `OnceLock` in `guards.rs` (`dispatch` is a plain router fn with no `tauri::State` to take).
- **Enforce** — third check in `guards.rs::reject`, `/api`-scoped, reusing `mcp.rs`'s constant-time `credentials_match`. The dependency runs app → SDK, the only direction available: `claude/` imports nothing from the rest of the crate.
- **Deliver** — one new `HostInfo` field. No `capabilities/default.json` change: `invoke_handler` commands bypass the ACL.
- **Send** — `api.ts`'s two header sites, behind a memoized `hostInfo()` promise in `tauri.ts` (non-React, so `api.ts` need not import React). Awaited *inside* the request, so no view can race the bootstrap.
- **Dev hatch** — debug builds also write the token to `<data dir>/api-token` (0600, rewritten per launch); `vite.config.ts`'s proxy reads it **per request** and injects the header, so `curl` and the Chrome-at-`:1420` hop both survive. Release writes it nowhere.

Order is load-bearing: **Host (403) → token (401) → Content-Type (415)**. The rebinding answer outranks the credential one; an unauthenticated caller is not told the content-type rule.

A **401 is a status Go never answers** — a deliberate divergence, recorded at the site.

## Acceptance criteria

- [x] Unauthenticated `/api` write → 401, `Served::Rejected`, no handler runs
- [x] Wrong / prefix / extended token → 401; correct token → served
- [x] Constant-time compare (shared with `mcp.rs`, not a second copy)
- [x] Host+token failure reads **403**, not 401; token beats Content-Type
- [x] `/health`, the SPA and `POST /webhooks/telegram/{id}` unaffected (asserted with **no** token)
- [x] Every method needs the token, not only the state-changing four
- [x] Fresh token per launch; empty token is not a credential
- [x] Token never reaches the log (`log_path` drops the query string — asserted)
- [x] Dev token file written 0600 and overwritten each launch
- [x] Chat SSE unaffected — it is a `fetch` POST, not `EventSource`, so it carries the header like any other request

## Notes / limits

- **Two review findings were fixed in this PR**, both in my own new code: an empty installed token would have matched a request sending *no* header (`""` vs `""`), and the test for it was racy enough to poison the whole test binary under `cargo test`'s parallelism. See `1a66ca6`.
- **No frontend test runner exists** in this project, so the bootstrap-ordering and the browser-open message are enforced by construction and `tsc`, not by a unit test. Flagged rather than silently skipped.
- **The GUI could not be launched to do a live `curl` round trip** — this dev box is headless and the debug binary exits under Xvfb (WebKitGTK). The part that fails *silently* — the token file's 0600 mode — is covered by a unit test instead.
- Rebased onto `desktop` after it was force-pushed mid-flight; the trees were identical, so the rebase was content-free.

## Out of scope

- **User-generated API keys / stateless JWTs for external systems.** Separate design note: it means binding non-loopback (reopening `host_allowed`), scopes (an API that executes agents cannot hand out unscoped keys), revocation and an audit trail. The only concession made here is *shape* — the check is "does this request carry an accepted credential", not a hardcoded compare.
- The `agento://` custom-protocol move (removing the TCP listener); recorded in the design note.
