### PR TITLE
docs(native): stop claiming a failure forwards, because nothing does

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3123,6 +3123,17 @@ because each one cost real time to find:
   by backfilling out of band.
 - **Windows `filepath` semantics are unimplemented.** `fs.rs`,
   `claude_settings/` and the config-dir probe answer 501 there.
+- **`GET /api/fs` answers 500 where it should answer 404 or 400.** The
+  directory picker reports "internal server error" for a path the user simply
+  mistyped. The three typed bodies (404 missing, 400 unreadable, 500 no home)
+  were never written, because at the time an `Err` here reached an
+  implementation that had them. Fixing it means giving `fs::list` a typed error.
+- **Several surfaces answer 500 for input they cannot decide about**, rather
+  than reproducing an answer they cannot be sure of: a non-ASCII settings-profile
+  name, a request body that is not UTF-8, duplicate JSON keys, a document past
+  serde's recursion limit, a site URL `url::Url` rejects. Each is documented at
+  its site. They were invisible while something else could answer; they are
+  user-visible 500s now, and each is a small piece of work to resolve properly.
 - Cross-view navigation: "Continue in chat" on a session can only report the
   new `chat_id`; it cannot switch to the Chats view. Needs a nav context in
   `App.tsx`.

--- a/src-tauri/src/guards.rs
+++ b/src-tauri/src/guards.rs
@@ -74,20 +74,10 @@
 //!
 //! # Why the proxy, and why this is not belt-and-braces
 //!
-//! `proxy.rs` checked `route_is_native` and, on a match, handed the request
-//! straight to `native::serve` — no `Host` check, no `Content-Type` check. Only
-//! requests that *forwarded* reached `guards.go`. So the guards' coverage shrank
-//! with every endpoint the port claimed, which inverts the seam's rule that a
-//! ported route can only be as broken as an unported one. That is what this
-//! module fixes, and it is why the check runs **before** the `route_is_native`
-//! branch rather than inside either half.
-//!
-//! For the content type the sidecar's own copy is then a second line. **For the
-//! `Host` it is not**: [`crate::proxy::forward`] rewrites the header to the
-//! upstream authority — which is what makes a proxied request indistinguishable
-//! from a direct same-origin one, and is required for the sidecar to answer at
-//! all — so `validateHost` upstream has never seen the browser's `Host`. This is
-//! the only place it can be checked.
+//! These checks run in `dispatch`, **before** routing is decided, so a request
+//! is refused identically whichever endpoint would have answered it. Putting
+//! them inside a handler would mean every new endpoint had to remember them,
+//! and the one that forgot would be the hole.
 //!
 //! # What is deliberately *not* guarded
 //!
@@ -664,9 +654,8 @@ pub(crate) mod tests {
     }
 
     /// DNS rebinding makes an attacker's domain same-origin, so CORS stops
-    /// applying entirely — and unlike the content type, the sidecar's own copy
-    /// of this check cannot help, because `proxy::forward` rewrites the `Host`
-    /// to the upstream authority before it gets there.
+    /// applying entirely. This check is the only thing standing between a
+    /// rebound name and the whole API.
     #[test]
     fn only_a_host_the_proxy_is_served_under_is_admitted() {
         for host in [

--- a/src-tauri/src/native/agents.rs
+++ b/src-tauri/src/native/agents.rs
@@ -26,9 +26,10 @@
 //!   `desktop/CLAUDE.md`; reproducing it is the parity bar, and "fixing" it here
 //!   would make the two implementations disagree.
 //! - **Deleting a missing agent is a 500, not a 404.** The store returns a plain
-//!   `fmt.Errorf` rather than a `NotFoundError`, so `httpErr` falls through to
-//!   its default arm. This port does not reproduce 500s: it detects the case,
-//!   writes nothing, and forwards, so Go produces its own answer.
+//!   error rather than a typed not-found, so the error mapping falls through to
+//!   its default arm. Inherited behaviour, reproduced: the case is detected,
+//!   nothing is written, and the answer is a 500. It is on the known-bugs list
+//!   in `CLAUDE.md`.
 
 use std::path::{Path, PathBuf};
 
@@ -135,9 +136,9 @@ fn scan(row: &rusqlite::Row<'_>) -> rusqlite::Result<Agent> {
         thinking: row.get(4)?,
         permission_mode: row.get(5)?,
         system_prompt: row.get(6)?,
-        // Go fails the whole request on unparsable capabilities rather than
-        // serving an agent whose tool allowlist is unknown. So does this: the
-        // error reaches the proxy, which falls back to Go.
+        // An unparsable capabilities column fails the whole request rather
+        // than serving an agent whose tool allowlist is unknown — a silently
+        // empty allowlist is the dangerous answer here, not the loud one.
         //
         // Through [`GoStruct`] (#337) so a stored *array* fails here too. Go's
         // `json.Unmarshal` refuses one and this used to accept a full-length
@@ -175,7 +176,7 @@ fn claims(method: &Method, path: &str) -> bool {
         Method::GET => path == "/api/agents" || slug_of(path).is_some(),
         Method::POST => path == "/api/agents",
         // One agent: replaced or removed. `/api/agents/{slug}/duplicate` is a
-        // different route and `slug_of` rejects it, so it still forwards.
+        // different route and `slug_of` rejects it, so it is unclaimed.
         Method::PUT | Method::DELETE => slug_of(path).is_some(),
         _ => false,
     }
@@ -218,9 +219,7 @@ fn serve_read(ctx: &super::Ctx, req: &super::Request) -> Result<super::Answer, S
             Some(agent) => {
                 super::gojson::to_vec(&agent).map_err(|e| format!("encoding agent: {e}"))?
             }
-            // `handleGetAgent`'s own 404, body verbatim. This used to forward
-            // so Go could answer it; with the sidecar gone (#278) it is
-            // answered here.
+            // `handleGetAgent`'s own 404, body verbatim.
             None => {
                 return super::Answer::error(axum::http::StatusCode::NOT_FOUND, "agent not found")
             }
@@ -334,9 +333,10 @@ fn create(db_path: &Path, body: &[u8]) -> Result<super::Answer, WriteError> {
     save(&tx, &agent)?;
 
     // Encode *before* committing. Everything after the commit must be
-    // infallible: an `Err` there forwards to Go, which would create a second
-    // agent. A failing `commit` is the one safe exception — it rolls back, so
-    // forwarding is exactly right.
+    // infallible: a failure there would answer 500 for an agent that was
+    // actually created, so the caller retries and creates a second one. A
+    // failing `commit` is the one safe exception — it rolls back, so there is
+    // nothing to be wrong about.
     let answer = encode(StatusCode::CREATED, &agent)?;
     tx.commit()
         .map_err(|e| WriteError::Fallback(format!("commit agent create: {e}")))?;
@@ -387,15 +387,15 @@ fn update(db_path: &Path, slug: &str, body: &[u8]) -> Result<super::Answer, Writ
     Ok(answer)
 }
 
-/// `agentService.Delete`. A missing agent is a 500 in Go, so it forwards.
+/// `agentService.Delete`. A missing agent is a 500 — inherited, not a 404.
 fn delete(db_path: &Path, slug: &str) -> Result<super::Answer, WriteError> {
     let conn = open_for_write(db_path)?;
     let affected = conn
         .execute("DELETE FROM agents WHERE slug = ?1", [slug])
         .map_err(|e| WriteError::Fallback(format!("deleting agent {slug:?}: {e}")))?;
     if affected == 0 {
-        // Nothing was written, so forwarding cannot double-apply. Go answers
-        // its own 500, which is the behaviour the app has today.
+        // Nothing was written, so the 500 is honest: it reports a delete that
+        // did not happen rather than hiding one that did.
         return Err(WriteError::Fallback(format!("agent {slug:?} not found")));
     }
     log::info!("agent deleted slug={slug:?}");
@@ -452,9 +452,9 @@ fn normalize_config_dir(agent: &mut Agent) -> Result<(), WriteError> {
                 format!("claude config dir {normalized:?} does not exist"),
             ))
         }
-        // Go wraps the underlying error here, and its text is the Go runtime's.
-        // Reproducing it is not possible, so this forwards instead of inventing
-        // a message the user would see.
+        // The original wrapped a runtime error whose text is not reproducible,
+        // so this answers the same status class with the reason in the log
+        // rather than inventing a message the user would see.
         Err(e) => {
             return Err(WriteError::Fallback(format!(
                 "claude config dir {normalized:?} is not readable: {e}"
@@ -492,7 +492,8 @@ fn normalize_claude_config_dir(raw: &str) -> String {
 /// `SQLiteAgentStore.Save` — one upsert, `created_at` untouched on conflict.
 fn save(tx: &rusqlite::Transaction, agent: &Agent) -> Result<(), WriteError> {
     // `validateAgentForSave` rejects an unknown thinking value with a plain
-    // error, which is a 500. Detect it before writing and forward.
+    // error, which is a 500. Detect it *before* writing, so the 500 reports a
+    // save that did not happen.
     if !matches!(
         agent.thinking.as_str(),
         "" | "adaptive" | "disabled" | "enabled"
@@ -1019,9 +1020,9 @@ mod tests {
         assert!(stored(&file, "bye").is_none());
     }
 
-    /// Go answers 500 here, and this port does not reproduce 500s — it forwards
-    /// so Go answers for itself. The important half is that nothing was written
-    /// first, or the forward would delete something else.
+    /// A missing agent is a 500, inherited. The important half is that nothing
+    /// is written first: the status has to report a delete that did not
+    /// happen.
     #[test]
     fn deleting_a_missing_agent_forwards_rather_than_inventing_a_404() {
         let file = migrated();

--- a/src-tauri/src/native/analytics/params.rs
+++ b/src-tauri/src/native/analytics/params.rs
@@ -36,11 +36,10 @@ pub struct AnalyticsParams {
 impl AnalyticsParams {
     /// Read the parameters out of a raw query string.
     ///
-    /// `Err` means "let Go answer this one". The only case is a timezone this
-    /// build's tzdata does not know: Go would fall back to UTC, but *its*
-    /// tzdata may well know the zone, and answering in UTC when Go would answer
-    /// in Asia/Kathmandu is a wrong answer rather than a missing one. Forwarding
-    /// gets whichever answer Go would have given, which is the bar.
+    /// `Err` is a 500, and the only case is a timezone this build's tzdata does
+    /// not know. Refusing beats the alternative: silently bucketing in UTC when
+    /// the user asked for Asia/Kathmandu is a *wrong* answer rather than a
+    /// missing one, and every figure on the dashboard would be quietly shifted.
     pub fn parse(query: &str) -> Result<Self, String> {
         let params = first_values(query);
         let get = |key: &str| params.get(key).cloned().unwrap_or_default();
@@ -173,8 +172,8 @@ fn parse_ymd(raw: &str) -> Option<(i32, i32, i32)> {
 }
 
 /// Resolve an IANA timezone name. Empty is UTC, matching `parseTimezone`;
-/// anything this build's tzdata cannot resolve is an error, so the request
-/// forwards to Go rather than being answered in the wrong zone.
+/// anything this build's tzdata cannot resolve is an error rather than being
+/// answered in the wrong zone.
 fn parse_timezone(name: &str) -> Result<Tz, String> {
     if name.is_empty() {
         return Ok(Tz::UTC);

--- a/src-tauri/src/native/chat/mod.rs
+++ b/src-tauri/src/native/chat/mod.rs
@@ -222,7 +222,7 @@ mod tests {
         // The CRUD routes, which `native::chats` owns.
         assert!(!claims(&Method::POST, "/api/chats"));
         assert!(!claims(&Method::POST, "/api/chats/abc"));
-        // Unknown actions and nested paths forward.
+        // Unknown actions and nested paths are unrouted.
         assert!(!claims(&Method::POST, "/api/chats/abc/unknown"));
         assert!(!claims(&Method::POST, "/api/chats//messages"));
         assert!(!claims(&Method::POST, "/api/chats/abc/messages/extra"));

--- a/src-tauri/src/native/chat/runner.rs
+++ b/src-tauri/src/native/chat/runner.rs
@@ -8,13 +8,10 @@
 //! which `resolveServerConfig` looks up first in the `mcps.yaml` registry and
 //! then among the **integrations** (`internal/integrations`). An agent that
 //! reached a subprocess with some of those silently missing would be a worse
-//! answer than the sidecar's, so [`build_options`] returns `Err` for one, the
-//! seam forwards, and Go runs that chat exactly as before. This is the "a route
-//! moves only when Rust reproduces every effect" rule #274 established, applied
-//! per *agent* rather than per route — which is why `chat::stream` also forwards
-//! `/input`, `/permission` and `/stop` for any chat it does not itself hold a
-//! live session for. Without that, a chat running on Go would have its stop
-//! button claimed by a Rust registry that never saw it.
+//! answer than none, so [`build_options`] returns `Err` and the turn is
+//! **refused** rather than run degraded. In a chat that is a 500 carrying the
+//! reason, produced before any subprocess exists; in a scheduled run it is a
+//! recorded `job_history` failure. Silence is the one outcome not allowed.
 //!
 //! The `local` half of that refusal went in #310: [`build_options`] starts the
 //! local tools server itself and hands back the handle, because the listener's
@@ -25,8 +22,8 @@
 //! natively when *every* name in `capabilities.mcp` is an integration this build
 //! can host — `registry::HOSTED_TYPES`, which since #313 means **all six**:
 //! `github` (#312), `confluence` (#317), `jira` (#316), `slack` (#315),
-//! `telegram` (#314) and `google` (#313). Three things
-//! still forward, and [`mcp_plan`] is where each is decided:
+//! `telegram` (#314) and `google` (#313). Three things are still refused, and
+//! [`mcp_plan`] is where each is decided:
 //!
 //! - **A name whose type is not hosted.** A `whatsapp` row has no Rust starter
 //!   and will not get one; running the turn here would drop its tools.
@@ -225,10 +222,11 @@ pub struct RunSpec {
 
 /// Build the SDK options for one chat turn.
 ///
-/// `Err` means "this port cannot run this chat" and forwards to Go — never a
-/// user-visible failure. Every failure here happens before a subprocess exists,
-/// including the one that binds a port: a local tools server that failed to
-/// start is dropped on the way out, so forwarding leaves nothing behind.
+/// `Err` means "this build cannot run this chat", and it is answered rather
+/// than run degraded — a 500 in a chat, a recorded failure in a scheduled run.
+/// Every failure here happens before a subprocess exists, including the one
+/// that binds a port: a local tools server that failed to start is dropped on
+/// the way out, so a refusal leaves no listener behind.
 ///
 /// The second half of the pair is the **tool listeners** this turn owns: the
 /// local tools server for an agent that named a local tool, plus one per
@@ -240,7 +238,7 @@ pub async fn build_options(
 ) -> Result<(Options, Vec<InProcessMcpServer>), String> {
     let caps = spec.agent.as_ref().map(|a| &a.capabilities);
     // Decided **before** anything binds a port. Everything below this line
-    // either cannot fail or is dropped on the way out, so a forward leaves no
+    // either cannot fail or is dropped on the way out, so a refusal leaves no
     // listener behind.
     let mcp_plan = mcp_plan(
         caps,
@@ -411,7 +409,7 @@ struct McpPlan {
 /// `resolveExternalMCP`'s inputs, checked before any of them is acted on.
 ///
 /// `Ok(None)` is an agent that names no MCP server — the overwhelmingly common
-/// case, and one that must not open the database. `Err` forwards the whole
+/// case, and one that must not open the database. `Err` refuses the whole
 /// turn; see the module header for the three shapes that take that path and why
 /// the third is broader than it strictly has to be.
 ///
@@ -478,12 +476,12 @@ fn mcps_yaml_exists() -> bool {
 ///
 /// Two departures from Go, both deliberate:
 ///
-/// - **A start failure forwards rather than being skipped.** Go's
-///   `resolveServerConfig` discards the error and returns `nil`, so the turn
-///   runs without that server's tools. Forwarding reaches the same place — Go
-///   runs the turn and skips the same server — with one fewer thing this port
-///   has to be right about, and it is the rule `start_local_tools` already
-///   follows.
+/// - **A start failure refuses the turn rather than being skipped.** The
+///   reference `resolveServerConfig` discards the error and returns `nil`, so
+///   the turn runs without that server's tools — silently, which is the
+///   behaviour worth diverging from: an agent that quietly loses a tool set
+///   gives a worse answer than one that says it cannot run. `start_local_tools`
+///   already follows this rule.
 /// - **The map is a `BTreeMap`, so the order is stable.** Go ranges a map, so
 ///   its own `--allowedTools` order for two MCP servers differs between runs.
 ///   Strictly better, and it matches one of the orders Go produces.
@@ -793,7 +791,7 @@ pub fn load(
         match crate::native::agents::get(db_path, &row.agent_slug)? {
             Some(agent) => Some(agent),
             // Go returns NotFoundError{"agent"} here, a 404 with its own
-            // wording. Forward rather than reproduce a second 404 shape.
+            // wording. Decline rather than invent a second 404 shape.
             None => return Err(format!("agent {:?} not found", row.agent_slug)),
         }
     };
@@ -1199,9 +1197,9 @@ mod tests {
             .is_none());
     }
 
-    /// The three shapes that still forward, each for its own reason.
+    /// The three shapes that are still refused, each for its own reason.
     #[test]
-    fn an_mcp_name_this_build_cannot_host_forwards() {
+    fn an_mcp_name_this_build_cannot_host_is_refused() {
         let file = db_with_integration("gh-1", "github");
 
         // A type with no Rust starter. The stand-in has to be a type that is
@@ -1227,10 +1225,10 @@ mod tests {
         .is_err());
 
         // An `mcps.yaml` on disk takes precedence over the integrations in Go,
-        // and this build reads none — so any MCP capability forwards.
+        // and this build reads none — so any MCP capability is refused.
         assert!(mcp_plan(Some(&caps_naming("gh-1", None)), Some(file.path()), true).is_err());
 
-        // One unhostable name among several forwards the whole turn: a partial
+        // One unhostable name among several refuses the whole turn: a partial
         // tool set is the failure the refusal exists to prevent.
         let mut mixed = caps_naming("gh-1", None);
         if let Some(mcp) = mixed.mcp.as_mut() {
@@ -1305,7 +1303,7 @@ mod tests {
     }
 
     /// The whole of #310: an agent naming a local tool builds options rather
-    /// than forwarding, and what it builds is Go's — the server registered
+    /// than refusing, and what it builds is the server registered
     /// under `local-tools`, the qualified name in the allowlist, and
     /// `--strict-mcp-config` alongside so the user's own `.mcp.json` cannot add
     /// to what the agent may reach.

--- a/src-tauri/src/native/chat/turn.rs
+++ b/src-tauri/src/native/chat/turn.rs
@@ -105,10 +105,9 @@ pub struct TurnState {
 /// answered as a clean JSON error — a 404 for a missing chat, Go's fixed
 /// `500 "failed to start message"` for machinery failures (reason in the log,
 /// as Go logged it), and a 500 carrying the refusal reason for the cases that
-/// have no Go counterpart (`whatsapp` tools are dropped, `mcps.yaml` is not
-/// read). There is nothing to forward to since #278. Once the stream has
-/// begun, a failure ends the stream rather than changing the status — the 200
-/// is already committed.
+/// this build refuses outright (`whatsapp` tools are dropped, `mcps.yaml` is
+/// not read). Once the stream has begun, a failure ends the stream rather than
+/// changing the status — the 200 is already committed.
 pub async fn run(
     db_path: std::path::PathBuf,
     chat_id: String,

--- a/src-tauri/src/native/chats.rs
+++ b/src-tauri/src/native/chats.rs
@@ -235,8 +235,9 @@ fn scan_message(row: &rusqlite::Row<'_>) -> rusqlite::Result<ChatMessage> {
 
 /// Read a DATETIME column as the `time.Time` the Go driver round-trips.
 ///
-/// Unparsable text is an error rather than a zero time: Go's `rows.Scan` fails
-/// the whole request there, and the proxy's fallback then lets Go answer.
+/// Unparsable text fails the whole request rather than decoding to a zero time,
+/// which is what `rows.Scan` does — a zero timestamp would be indistinguishable
+/// from a real one.
 fn timestamp(row: &rusqlite::Row<'_>, index: usize) -> rusqlite::Result<GoTime> {
     let text: String = row.get(index)?;
     GoTime::parse_any(&text).map_err(|e| {
@@ -440,10 +441,10 @@ fn create(db_path: &Path, body: &[u8]) -> Result<super::Answer, WriteError> {
         },
     )?;
 
-    // Everything fallible happens before the commit. After it, an `Err` would
-    // forward to Go, which would mint a fresh UUID and insert a *second* chat.
-    // A failing `commit` is the one safe exception: it rolls back, so
-    // forwarding is exactly right.
+    // Everything fallible happens before the commit. After it, an `Err` answers
+    // 500 for a chat that was actually created — so the caller retries and ends
+    // up with a *second* chat under a fresh UUID. A failing `commit` is the one
+    // safe exception: it rolls back, so the 500 is honest.
     let body = super::gojson::to_vec(&session)
         .map_err(|e| WriteError::Fallback(format!("encoding chat: {e}")))?;
 

--- a/src-tauri/src/native/claude_settings/mod.rs
+++ b/src-tauri/src/native/claude_settings/mod.rs
@@ -47,14 +47,12 @@
 //!
 //! ## …and the bytes are not always UTF-8
 //!
-//! `encoding/json` never rejects a document for its bytes and serde_json does,
-//! which is not a boundary disagreement but a different answer to "is this
-//! JSON". Until #278 every path that parses or re-emits bytes here guarded
-//! with [`is_utf8`] and **forwarded**, deferring to Go's answer. With the
-//! sidecar gone the split is: a *file* that is not UTF-8 is decoded lossily —
-//! the U+FFFD substitution is Go's own answer, so a hand-corrupted
-//! settings.json still renders — while a request *body* that is not UTF-8 is
-//! a 400, because the app's own requests are always UTF-8.
+//! The reference JSON reader never rejects a document for its bytes and
+//! serde_json does, which is not a boundary disagreement but a different answer
+//! to "is this JSON". The split here: a *file* that is not UTF-8 is decoded
+//! lossily — the U+FFFD substitution is the inherited answer, so a
+//! hand-corrupted settings.json still renders — while a request *body* that is
+//! not UTF-8 is a 400, because the app's own requests are always UTF-8.
 //!
 //! # The cache question
 //!
@@ -174,13 +172,13 @@ const GO_MAX_NESTING_DEPTH: usize = 10000;
 /// validate, so [`go_json_valid`] agrees, but `parse_str` does, so every parse
 /// that actually materializes the string fails.
 ///
-/// Left unguarded that produced five *wrong answers* rather than five forwards —
+/// Left unguarded that produced five *wrong answers* rather than five refusals —
 /// a 400 where Go writes the file and answers 200, a seeded default profile
 /// whose bytes are not Go's, and a `settings` key silently missing from a 200.
 /// So every path that is about to parse or re-emit bytes checks this first and
-/// forwards, which is the only answer this port can be sure of: reproducing
-/// Go's substitution would mean reproducing where `encoding/json` puts the
-/// replacement character, and that is a guess.
+/// declines, which is the only honest answer available: reproducing the lossy
+/// substitution would mean reproducing exactly where the replacement character
+/// lands, and that is a guess.
 pub fn is_utf8(src: &[u8]) -> bool {
     std::str::from_utf8(src).is_ok()
 }
@@ -253,7 +251,7 @@ fn nesting_depth_exceeds(src: &[u8], limit: usize) -> bool {
 ///
 /// Matched on the message because `Category` does not distinguish it: the
 /// alternative is `disable_recursion_limit`, which trades a wrong answer for a
-/// stack overflow. Pinned by `a_document_deeper_than_serdes_limit_forwards`.
+/// stack overflow. Pinned by `a_document_deeper_than_serdes_limit_is_declined`.
 fn is_recursion_limit(e: &serde_json::Error) -> bool {
     e.to_string().contains("recursion limit exceeded")
 }
@@ -274,7 +272,8 @@ pub enum Decoded {
     /// *different* 400 message, and on the profile path a 422 — so the two
     /// cases cannot be collapsed.
     NumberOutOfRange,
-    /// Neither parser is the authority. Forward.
+    /// Neither parser is the authority, so this is declined rather than
+    /// guessed at.
     Undecidable(String),
 }
 
@@ -337,9 +336,10 @@ pub fn decode_stream_head(body: &[u8]) -> Result<&[u8], Option<String>> {
 /// value, and anything else — an array, a scalar, nothing at all — is the type
 /// error the handler turns into its 400.
 ///
-/// Duplicate keys forward for the reason `decode_body` documents: `encoding/json`
-/// keeps the last occurrence but type-checks every one, and serde refuses them
-/// outright, so only Go can answer. Safe because this runs before any mutation.
+/// Duplicate keys are declined for the reason `decode_body` documents: the
+/// reference reader keeps the last occurrence but type-checks every one, and
+/// serde refuses them outright, so neither behaviour can be claimed with
+/// confidence. Safe because this runs before any mutation.
 ///
 /// The two guards ahead of the decode are the two places serde and
 /// `encoding/json` disagree about the *body* rather than about a value:
@@ -351,8 +351,9 @@ pub fn decode_stream_head(body: &[u8]) -> Result<&[u8], Option<String>> {
 ///   *created a profile Go refuses*, answering 201 where Go answers
 ///   `400 name is required`. A state-changing divergence, which is why the
 ///   check is on the body and not on the fields.
-/// - **UTF-8.** See [`is_utf8`]: Go substitutes U+FFFD into a `string` field
-///   and carries on, serde fails the decode. Forwarded rather than guessed.
+/// - **UTF-8.** See [`is_utf8`]: the reference reader substitutes U+FFFD into a
+///   `string` field and carries on, serde fails the decode. Declined rather
+///   than guessed.
 pub(crate) fn decode_request<T>(body: &[u8]) -> Result<T, WriteError>
 where
     T: serde::de::DeserializeOwned + Default,
@@ -363,7 +364,7 @@ where
         return Err(WriteError::InvalidBody);
     }
     if !is_utf8(body) {
-        // Go substituted U+FFFD and carried on; with nothing to forward to
+        // The reference reader substituted U+FFFD and carried on; here
         // (#278) the strict decode's refusal is the answer, and the app's own
         // requests are always UTF-8.
         return Err(WriteError::InvalidBody);
@@ -429,7 +430,7 @@ pub fn go_any(body: &[u8]) -> Decoded {
         },
         // A `Value` decode *is* recursive, unlike the `IgnoredAny` skip above,
         // so 129 levels stop it where Go carries on to 10000. That one is
-        // forwarded; an ordinary syntax error is Go's own decode failure, which
+        // declined; an ordinary syntax error is a plain decode failure, which
         // `ensureDefaultProfileExists` handles by seeding an empty object.
         Err(e) if is_recursion_limit(&e) => Decoded::Undecidable(e.to_string()),
         Err(_) => Decoded::NotJson,
@@ -478,7 +479,7 @@ fn numbers_fit_float64(src: &[u8]) -> bool {
             }
             let token = std::str::from_utf8(&src[start..i]).unwrap_or("");
             // A token this port cannot parse at all is one it will not judge —
-            // the `Value` decode below decides, and forwards if it cannot.
+            // the `Value` decode below decides, and declines if it cannot.
             if let Ok(f) = token.parse::<f64>() {
                 if !f.is_finite() {
                     return false;
@@ -534,7 +535,7 @@ pub fn marshal_indent(value: &Value) -> Result<Vec<u8>, String> {
 /// `skip_serializing_if` or a nullable field, so a `None` here would not be an
 /// error — it would be a **200 with the `settings` key quietly missing**, which
 /// is exactly what non-UTF-8 bytes used to produce. Callers now have to say what
-/// a failure means, and all of them say "forward".
+/// a failure means, and none of them can be answered with confidence.
 pub fn raw_field(bytes: &[u8]) -> Result<Box<RawValue>, String> {
     let text = std::str::from_utf8(bytes).map_err(|_| not_utf8_reason("the stored bytes"))?;
     RawValue::from_string(gojson::compact(text))
@@ -634,7 +635,7 @@ pub fn put_settings(dir: &str, body: &[u8]) -> Result<super::Answer, WriteError>
         }
         Decoded::Undecidable(reason) => return Err(WriteError::Fallback(reason)),
         // Step 1 captured a complete value and checked its bytes, so this means
-        // the two parsers disagree about what JSON is. Forward rather than pick
+        // the two parsers disagree about what JSON is. Decline rather than pick
         // a side: the arm that used to answer 400 here was reachable through
         // non-UTF-8 bytes, where Go writes the file and answers 200.
         Decoded::NotJson => {
@@ -732,7 +733,7 @@ fn serve(ctx: &super::Ctx, req: &super::Request) -> Result<super::Answer, String
         );
     }
     // Resolved once, here: every handler below works inside one directory, and
-    // a failure to resolve it forwards before anything is written.
+    // a failure to resolve it is answered before anything is written.
     let dir = &run_dir(&ctx.db_path)?;
     match (route(req.path), req.method) {
         (Some(Route::Settings), &Method::GET) => get_settings(dir),
@@ -960,19 +961,19 @@ mod tests {
     /// **Go's JSON layer is not UTF-8-strict and serde's is.** Every one of
     /// these is `true`/`Ok` in Go — `json.Valid`, `Unmarshal` into `any`,
     /// `MarshalIndent`, and the encoder's `json.RawMessage` passthrough — so
-    /// none of them may be a Rust *answer*. They forward.
+    /// none of them may be answered with a guessed status. They decline.
     #[test]
-    fn bytes_that_are_not_utf8_forward_rather_than_answering() {
+    fn bytes_that_are_not_utf8_are_declined_rather_than_answered() {
         let src = b"{\"a\":\"\xff\"}";
 
         // `json.Valid` says true, and so does this — the skip does not validate.
         assert!(go_json_valid(src));
-        // …but every parse that materializes the string forwards.
+        // …but every parse that materializes the string declines.
         assert!(matches!(go_any(src), Decoded::Undecidable(_)));
         assert!(matches!(decode_go_any(src), Decoded::Undecidable(_)));
         assert!(
             decode_stream_head(src).unwrap_err().is_some(),
-            "a forward, not Go's decode error"
+            "declined, not answered with a decode error"
         );
 
         #[derive(Debug, Default, Deserialize)]
@@ -1051,9 +1052,9 @@ mod tests {
     }
 
     /// A `Value` decode stops at 128 levels and Go's at 10000. This port
-    /// answers neither way — it forwards, so Go gives whatever answer Go gives.
+    /// answers neither way — it declines rather than guessing between them.
     #[test]
-    fn a_document_deeper_than_serdes_limit_forwards() {
+    fn a_document_deeper_than_serdes_limit_is_declined() {
         let deep = format!("{}{}", "[".repeat(200), "]".repeat(200));
         assert!(matches!(
             decode_go_any(deep.as_bytes()),
@@ -1203,7 +1204,7 @@ mod tests {
         );
 
         // An unparseable file is a 500 in Go, and this port does not invent
-        // 500s — it forwards.
+        // 500s — it declines.
         write_file(&settings_json_path(&dir), b"not json").expect("write");
         assert!(get_settings(&dir).is_err());
 

--- a/src-tauri/src/native/claude_settings/profiles.rs
+++ b/src-tauri/src/native/claude_settings/profiles.rs
@@ -33,7 +33,7 @@
 //! that the agreement is uninformative, which is a caveat rather than an
 //! exemption.
 //!
-//! # Which errors are answers, and which are forwarded
+//! # Which errors reach the wire
 //!
 //! `httpErr` maps the service's three typed errors and turns everything else
 //! into a 500. Only four failures reach the wire from this file:
@@ -46,7 +46,7 @@
 //! | 409 `profile with id "<id>" already exists` | `ConflictError` — used both for a rename collision **and** for deleting the default profile, where the wording is Go's and reads oddly. Reproduced, not improved. |
 //! | 422 `validation error for "settings": failed to parse settings JSON` | the one reachable `ValidationError`: `json.Valid` passes a number `strconv.ParseFloat` then rejects. |
 //!
-//! Everything else Go answers with a 500, so it forwards.
+//! Everything else is a 500.
 //!
 //! # Two rules with no error to announce them
 //!
@@ -60,8 +60,9 @@
 //!   is a 500 in Go unless every character happens to be dropped. Rust's
 //!   `char::is_alphabetic` is a *different* set (it includes `Nl` and
 //!   `Other_Alphabetic`), so rather than approximate the tables, any non-ASCII
-//!   name forwards. It forwards before anything is written, and Go then gives
-//!   whichever of the two answers is right.
+//!   name is **declined with a 500** before anything is written. That is a
+//!   known limitation rather than a reproduction — see the known-bugs list in
+//!   `CLAUDE.md`.
 
 use axum::http::StatusCode;
 use serde::{Deserialize, Serialize};
@@ -112,7 +113,7 @@ struct MetadataOut<'a> {
 }
 
 /// `config.LoadProfilesMetadata`. A missing file is an empty index, not an
-/// error; anything else Go answers with a 500, so it forwards.
+/// error; anything else is a 500.
 ///
 /// Public because the agent runner needs it: `LoadProfileFilePathIn` resolves a
 /// named settings profile through this same index, and there is now exactly one
@@ -195,7 +196,7 @@ fn ensure_default(dir: &str) -> Result<(), WriteError> {
             // Go's parser would have succeeded; ours cannot say — a document
             // past serde's 128-level limit, or bytes that are not UTF-8, which
             // Go decodes with a U+FFFD substitution this port will not guess.
-            // Nothing but the directory has been touched, so forwarding is
+            // Nothing but the directory has been touched, so the 500 is
             // exact.
             Decoded::Undecidable(reason) => return Err(WriteError::Fallback(reason)),
         }
@@ -249,7 +250,7 @@ fn deduplicate_id(base: &str, profiles: &[Profile]) -> String {
 }
 
 /// `slugify`, for the ASCII names it can be reproduced for — see the module
-/// header for why a non-ASCII one forwards instead.
+/// header for why a non-ASCII one is declined instead.
 fn slugify(name: &str) -> Result<String, WriteError> {
     if !name.is_ascii() {
         return Err(WriteError::Fallback(format!(
@@ -297,7 +298,7 @@ fn resolve_profile_file_path(dir: &str, id: &str) -> Result<String, WriteError> 
 
 /// `validatePathWithinDir`.
 ///
-/// A **relative** recorded path forwards rather than being resolved: Go's
+/// A **relative** recorded path is declined rather than resolved: the original's
 /// `filepath.Abs` resolves it against the *server's* working directory, which is
 /// a different process's and unknowable here. Every path this surface writes is
 /// absolute, so this only fires on a hand-edited index.
@@ -361,7 +362,7 @@ fn detail_body(profile: &Profile, dir: &str) -> Result<Vec<u8>, WriteError> {
     if let Ok(data) = std::fs::read(&profile.file_path) {
         // Go's `json.Valid` accepted bytes that are not UTF-8 and its encoder
         // shipped the document with U+FFFD substituted — serde cannot carry
-        // them, so until #278 this forwarded and Go answered. The lossy
+        // them, so this is declined rather than answered. The lossy
         // conversion *is* that substitution, the same answer `get_settings`
         // gives the unnamed file; only a hand-corrupted file ever takes this
         // branch, since the app writes UTF-8.
@@ -482,12 +483,11 @@ pub fn update(dir: &str, id: &str, body: &[u8]) -> Result<Answer, WriteError> {
     let idx = find_index(&profiles, id).ok_or_else(|| not_found(id))?;
 
     // Hoisted out of the closing `detail_body`, which is where it used to run.
-    // It forwards on a relative or out-of-dir recorded path — but by then the
+    // It refuses a relative or out-of-dir recorded path — but by then the
     // rename may have moved the file and `save` rewritten the index under the
-    // new id, so Go would look up the URL's *old* id, find nothing and answer
-    // 404 where Go alone would have answered 500. `delete`, `duplicate` and
-    // `set_default` all validate up front; this is the same rule, and it costs
-    // no parity because the check only ever decides forward-versus-answer.
+    // new id, so the request would fail having already half-applied itself.
+    // `delete`, `duplicate` and `set_default` all validate up front; this is
+    // the same rule.
     validate_path_within_dir(&profiles[idx].file_path, dir)?;
 
     // `validateSettingsJSON` runs before any filesystem mutation so a rename
@@ -496,8 +496,9 @@ pub fn update(dir: &str, id: &str, body: &[u8]) -> Result<Answer, WriteError> {
     // `any`, can, and Go reaches it only after the rename. Parsing here and
     // reporting later keeps both: Go's state and Go's answer.
     //
-    // Deciding it now is also what makes `Undecidable` safe to forward: an
-    // `Err` after the rename would send Go a request whose id no longer exists.
+    // Deciding it now is also what makes `Undecidable` safe to answer: an
+    // `Err` after the rename would report failure for a profile that has
+    // already moved.
     let settings = match req.settings.as_deref().map(RawValue::get) {
         None => None,
         Some("null") => None,
@@ -513,7 +514,7 @@ pub fn update(dir: &str, id: &str, body: &[u8]) -> Result<Answer, WriteError> {
                 Decoded::NumberOutOfRange => Some(Err(())),
                 // `go_json_valid` just passed over the same bytes, so this is
                 // the two parsers disagreeing rather than a malformed request.
-                // Forward — answering 400 here would be inventing a status Go
+                // Declined — answering 400 here would be inventing a status
                 // has no reason to send.
                 Decoded::NotJson => {
                     return Err(WriteError::Fallback(
@@ -722,7 +723,7 @@ mod tests {
     /// character happened to be dropped. Two different answers from one rule
     /// this port does not reproduce, so it hands the name over.
     #[test]
-    fn a_non_ascii_name_forwards_rather_than_guessing_a_slug() {
+    fn a_non_ascii_name_is_declined_rather_than_guessing_a_slug() {
         assert!(matches!(
             slugify("Café").unwrap_err(),
             WriteError::Fallback(_)
@@ -841,7 +842,7 @@ mod tests {
         assert!(load(&d).expect("nil list").is_empty());
 
         // An array where a struct belongs is a type error in Go: a 500, so it
-        // forwards rather than reading as empty.
+        // is declined rather than read as empty.
         std::fs::write(super::super::profiles_path(&d), "[]").expect("write");
         assert!(matches!(load(&d).unwrap_err(), WriteError::Fallback(_)));
     }
@@ -918,9 +919,9 @@ mod tests {
 
     /// A `settings.json` that is valid JSON to Go but not UTF-8: Go seeds the
     /// document with U+FFFD substituted, which this port will not guess. It
-    /// forwards, having touched only the directory.
+    /// is declined, having touched only the directory.
     #[test]
-    fn seeding_from_a_non_utf8_settings_json_forwards() {
+    fn seeding_from_a_non_utf8_settings_json_is_declined() {
         let root = dir();
         let d = path_of(&root);
         std::fs::write(settings_json_path(&d), b"{\"a\":\"\xff\"}").expect("write");
@@ -930,7 +931,7 @@ mod tests {
         ));
         assert!(
             !std::path::Path::new(&format!("{d}/settings_default.json")).exists(),
-            "the forward must leave no seeded profile behind"
+            "the refusal must leave no seeded profile behind"
         );
     }
 
@@ -1044,7 +1045,7 @@ mod tests {
 
         // A file that is valid JSON to Go but not UTF-8 is served lossily
         // since #278: the U+FFFD substitution is Go's own answer, and there is
-        // no sidecar left to forward the raw bytes to.
+        // nothing that could decode the raw bytes the other way.
         std::fs::write(&profile.file_path, b"{\"a\":\"\xff\"}").expect("write");
         let body =
             String::from_utf8(detail_body(&profile, &d).expect("lossy detail")).expect("utf8");
@@ -1261,9 +1262,9 @@ mod tests {
     /// The same cap on `update`, which is a **400** and not the 422 a
     /// hand-written depth check inside `validateSettingsJSON` produced: Go's
     /// `Decode` fails first, so the service never runs. The 128–10000 band
-    /// still forwards, which is the neighbouring case easy to lose.
+    /// is still declined, which is the neighbouring case easy to lose.
     #[test]
-    fn an_update_deeper_than_gos_scanner_is_400_and_the_band_below_forwards() {
+    fn an_update_deeper_than_gos_scanner_is_400_and_the_band_below_is_declined() {
         let root = dir();
         let d = path_of(&root);
         list(&d).expect("seed");
@@ -1278,7 +1279,7 @@ mod tests {
         assert_eq!(err.message(), "invalid JSON body");
 
         // Past serde's 128-level limit but inside Go's 10000: neither parser is
-        // the authority, so it forwards.
+        // the authority, so it declines.
         let band = format!(r#"{{"settings":{}{}}}"#, "[".repeat(200), "]".repeat(200));
         assert!(matches!(
             update(&d, "default", band.as_bytes()).unwrap_err(),
@@ -1289,9 +1290,8 @@ mod tests {
     /// **`update` validates the recorded path before it mutates anything.** It
     /// used to reach `validate_path_within_dir` only in the closing
     /// `detail_body` — after the rename had moved the file and `save` had
-    /// rewritten the index under the new id — so the forward sent Go a request
-    /// whose URL id no longer existed and Go answered 404 where Go alone would
-    /// have answered 500.
+    /// rewritten the index under the new id — so the failure was reported for a
+    /// profile that had already been renamed underneath it.
     #[test]
     fn update_validates_the_recorded_path_before_it_renames() {
         let root = dir();
@@ -1315,8 +1315,7 @@ mod tests {
             WriteError::Fallback(_)
         ));
 
-        // The forward has to be exact, which means the id in the URL still
-        // resolves on Go's side.
+        // The refusal has to be total: nothing may have moved.
         let profiles = load(&d).expect("load");
         assert_eq!(profiles[0].id, "stray", "the index must be untouched");
         assert_eq!(profiles[0].file_path, stray);

--- a/src-tauri/src/native/fs.rs
+++ b/src-tauri/src/native/fs.rs
@@ -30,10 +30,11 @@
 //! **Answered on Unix only.** The endpoint is `filepath.Clean`/`Dir`/`Join`
 //! wrapped in a response, and Windows `filepath` strips a volume name before
 //! cleaning and accepts both separators — a different algorithm, with no Windows
-//! machine in this loop to verify a port of it against. The route is still
-//! *claimed* there and [`serve`] returns `Err`, which the seam forwards: gating
+//! machine in this loop to verify an implementation of it against. The route is
+//! still *claimed* there and [`serve`] answers a 501 naming the gap: gating
 //! `claims` instead would leave a registry entry that claims nothing, and the
-//! two registry tests exist precisely to catch that shape. See [`super::gopath`].
+//! two registry tests exist precisely to catch that shape. See
+//! [`super::gopath`].
 //!
 //! `POST /api/fs/mkdir` is here too (#296). It was deferred by #293 as one of
 //! the two routes that escaped every category — ~20 lines, no database, no
@@ -76,10 +77,15 @@ pub struct FsListResponse {
 
 /// `handleFSList`.
 ///
-/// Errors mean "fall back": Go answers 404 for a missing path, 400 for anything
-/// else unreadable and 500 when the home directory cannot be resolved, each with
-/// its own body. Reproducing those here would be three more strings to keep in
-/// step for no gain while the sidecar can answer them itself.
+/// **Every error here is a 500, and two of them should not be.** The inherited
+/// behaviour answers 404 for a missing path, 400 for anything else unreadable
+/// and 500 only when the home directory cannot be resolved. Those three bodies
+/// were never written, because at the time an `Err` reached an implementation
+/// that had them. Nothing does now, so the directory picker reports "internal
+/// server error" for a path the user simply mistyped.
+///
+/// Known gap rather than a decision — it is on the list in `CLAUDE.md`. Fixing
+/// it means giving this function a typed error and three bodies.
 pub fn list(raw_path: &str) -> Result<FsListResponse, String> {
     // `""` and `"~"` — and nothing else — mean the home directory.
     let expanded = if raw_path.is_empty() || raw_path == "~" {
@@ -172,9 +178,9 @@ struct MkdirResponse {
 ///
 /// The response body is built **before** the directory is created, per the
 /// write path's rule that nothing fallible may run after the effect. Here the
-/// consequence would in fact be benign — `MkdirAll` is idempotent, so the
-/// forward would re-run it to the same result — but the rule is cheaper to
-/// keep than to reason about each time.
+/// consequence would in fact be benign — `MkdirAll` is idempotent, so a retry
+/// reaches the same result — but the rule is cheaper to keep than to reason
+/// about each time.
 pub fn mkdir(body: &[u8]) -> Result<super::Answer, WriteError> {
     let req = decode_body::<MkdirRequest>(body)?;
     if req.path.is_empty() {
@@ -244,9 +250,8 @@ fn claims(method: &Method, path: &str) -> bool {
 const PATH_MKDIR: &str = "/api/fs/mkdir";
 
 fn serve(_ctx: &super::Ctx, req: &super::Request) -> Result<super::Answer, String> {
-    // Windows `filepath` is a different algorithm and unverified here. Until
-    // #278 this forwarded and the sidecar answered; with it gone the honest
-    // answer is a 501 naming the gap, not a listing built with Unix path
+    // Windows `filepath` is a different algorithm and unverified here. The
+    // honest answer is a 501 naming the gap, not a listing built with Unix path
     // arithmetic — `gopath::dir` on `C:\Users\u` finds no `/` and answers
     // `"."`, so the picker would silently browse the wrong directory.
     if !cfg!(unix) {
@@ -429,8 +434,7 @@ mod tests {
         );
         assert!(std::path::Path::new(&target).is_dir());
 
-        // `MkdirAll` is idempotent, which is what makes the forward-on-error
-        // arm safe.
+        // `MkdirAll` is idempotent, which is what makes a retry harmless.
         assert!(mkdir(mkdir_body(&target).as_bytes()).is_ok());
     }
 
@@ -548,8 +552,8 @@ mod tests {
     fn the_listing_and_the_mkdir_are_claimed_and_nothing_else_is() {
         assert!(claims(&Method::GET, "/api/fs"));
         assert!(claims(&Method::POST, "/api/fs/mkdir"));
-        // Each route for its own method only, so the wrong pairing still
-        // forwards and gets chi's own 405.
+        // Each route for its own method only, so the wrong pairing is
+        // unrouted.
         assert!(!claims(&Method::POST, "/api/fs"));
         assert!(!claims(&Method::GET, "/api/fs/mkdir"));
         assert!(!claims(&Method::DELETE, "/api/fs/mkdir"));

--- a/src-tauri/src/native/gojson.rs
+++ b/src-tauri/src/native/gojson.rs
@@ -357,10 +357,10 @@ impl<V> From<std::collections::BTreeMap<String, V>> for GoMap<V> {
 ///
 /// **This is the direction that matters.** Every other decode divergence in the
 /// port has been an over-*reject* — a request Go applies is refused, which is
-/// visible and safe, and which `Err`-means-forward turns into Go's own answer.
+/// visible and safe: it answers an error rather than writing a bad row.
 /// This one is an over-*accept*: it writes a row Go refuses, so the two
 /// implementations' databases diverge with nothing to report it, and the
-/// fallback cannot help because nothing errors.
+/// nothing errors, so nothing reports it.
 ///
 /// # Why a type, and not a `deserialize_with`
 ///

--- a/src-tauri/src/native/gopath.rs
+++ b/src-tauri/src/native/gopath.rs
@@ -22,7 +22,7 @@
 //! **Unix only.** Windows `filepath` is a different algorithm — a volume name is
 //! stripped before cleaning and both separators are accepted — and there is no
 //! Windows machine in this loop to verify it on. [`super::fs`] therefore still
-//! claims its route there but answers `Err`, so the request forwards to the
+//! claims its route there but answers a 501 naming the gap, rather than the
 //! sidecar.
 
 /// Go's `filepath.Clean`, transcribed from `path/filepath/path.go`.

--- a/src-tauri/src/native/gourl.rs
+++ b/src-tauri/src/native/gourl.rs
@@ -31,12 +31,10 @@
 //! character that needs no escaping does not round-trip, so Go hands over the
 //! escaped text unchanged.
 //!
-//! Matching on the raw path therefore agreed with Go on the second and fifth
-//! rows and disagreed on the third and fourth. While every claimed route was a
-//! read that was invisible — a miss produced `Err` and forwarded, and Go
-//! answered correctly — but #274 and #276 claimed writes, so `agents::update`
-//! now *answers* 404 and `chats::patch` answers `chat not found` for a request
-//! Go would have applied to a real row.
+//! Matching on the raw path therefore agrees on the second and fifth rows and
+//! disagrees on the third and fourth. Getting it wrong is not cosmetic on a
+//! write: `agents::update` *answers* 404 and `chats::patch` answers `chat not
+//! found` for a request that names a real row.
 //!
 //! [`route_path`] is that whole rule in one function, applied once in
 //! `proxy.rs` where `native::Request` is built, so no module's claim function
@@ -297,18 +295,17 @@ pub fn unescape_path(s: &str) -> Option<Vec<u8>> {
 /// `RawPath != "" ? RawPath : Path`, with `RawPath` derived the way
 /// `url.setPath` derives it — see the module header for the table this produces.
 ///
-/// `None` means **forward**, for either of two reasons, and both are the seam
-/// working as designed rather than a gap:
+/// `None` means **there is no route path**, for either of two reasons.
+/// `proxy.rs` tells them apart and answers each:
 ///
 /// - the escaping is malformed (`/api/agents/a%2`). `url.ParseRequestURI` fails
-///   on it, so Go answers 400 from inside `net/http` and never reaches a
-///   handler. Forwarding is how that 400 gets produced — reproducing it here
-///   would mean reproducing the server's error page too.
+///   on it, so the reference server answers 400 before any handler runs, and
+///   `proxy.rs` answers the same 400.
 /// - the escaping is canonical **and** the decoded path is not UTF-8
-///   (`/api/agents/%FF`). Go carries it happily; Rust cannot put it in a `&str`,
-///   and every claim function and bound parameter downstream wants one. Rather
-///   than lossily converting — which would look up a *different* slug than Go
-///   looks up — the request forwards and Go answers it correctly.
+///   (`/api/agents/%FF`). Rust cannot put that byte in a `&str`, and every
+///   claim function and bound parameter downstream wants one. A lossy
+///   conversion would look up a *different* slug, so the request is unrouted
+///   and answers the router's 404. No real client produces one.
 ///
 /// **The canonical check runs on bytes, before anything demands UTF-8**, and the
 /// order is load-bearing: `/api/agents/%ff` decodes to the same unrepresentable
@@ -565,18 +562,18 @@ mod tests {
 
     #[test]
     fn a_malformed_escape_has_no_route_path() {
-        // `ParseRequestURI` fails on each of these, so Go answers 400 from
-        // inside `net/http`. `None` forwards, which is how that 400 is produced.
+        // `ParseRequestURI` fails on each of these, so the answer is a 400
+        // from before any handler — see `proxy.rs`, which produces it.
         assert_eq!(route_path("/api/agents/a%2"), None);
         assert_eq!(route_path("/api/agents/a%"), None);
         assert_eq!(route_path("/api/agents/a%zz"), None);
     }
 
     #[test]
-    fn a_non_utf8_path_forwards_only_when_that_is_what_chi_routes_on() {
-        // `%FF` is canonical, so chi routes on the *decoded* path: one byte Rust
-        // cannot carry in a `&str`, and a lossy conversion would look up a
-        // different slug. Forwarding is the only right answer.
+    fn a_non_utf8_path_is_unrouted_only_when_that_is_what_routes() {
+        // `%FF` is canonical, so the *decoded* path is what routes: one byte
+        // Rust cannot carry in a `&str`, and a lossy conversion would look up a
+        // different slug. Refusing to route it is the only right answer.
         assert_eq!(route_path("/api/agents/%FF"), None);
         assert_eq!(
             unescape_path("/api/agents/%FF"),

--- a/src-tauri/src/native/health.rs
+++ b/src-tauri/src/native/health.rs
@@ -1,11 +1,9 @@
-//! `GET /health` — the liveness probe, answered natively since #278.
+//! `GET /health` — the liveness probe.
 //!
-//! The route sat outside `/api`, so the write-routes audit (writes-only by
-//! design) never decided it, and while the sidecar existed it simply forwarded.
-//! With the sidecar gone the choice was drop or answer, and answering wins on
-//! cost: it is one constant, and anything external that ever probed the Go
-//! server's `/health` — a script, a monitor, the sidecar supervisor itself used
-//! to — keeps getting the same bytes.
+//! The route sits outside `/api`, so the write-routes audit (writes-only by
+//! design) never decided it. Answering wins on cost over dropping it: it is one
+//! constant, and anything external that ever probed `/health` — a script, a
+//! monitor — keeps getting the same bytes.
 //!
 //! The body is Go's literal `w.Write([]byte(`{"status":"ok"}`))`
 //! (`internal/server/server.go`): no trailing newline, because it never went

--- a/src-tauri/src/native/integration_credentials.rs
+++ b/src-tauri/src/native/integration_credentials.rs
@@ -92,9 +92,9 @@ fn raw_is_absent(credentials: Option<&RawValue>) -> bool {
 
 /// `cfg.ParseCredentials(&creds)`.
 ///
-/// The empty case is Go's own `fmt.Errorf("credentials are empty")`, which is a
-/// fixed string and so reproducible. A real unmarshal failure is not, and
-/// forwards.
+/// The empty case is a fixed string and so reproducible. A real unmarshal
+/// failure is not, so it is reported as a 422 with this build's own wording
+/// rather than the decoder's — which would quote the offending value.
 fn parse<T>(kind: &str, credentials: Option<&RawValue>) -> Result<T, WriteError>
 where
     T: for<'de> Deserialize<'de> + Default,
@@ -110,8 +110,8 @@ where
     //
     // - `Option<T>` rather than straight to `T`, because a literal `null` is a
     //   *type error* to serde and the zero value to Go — a direct deserialize
-    //   would forward `"credentials": null` instead of reporting the first
-    //   missing field the way Go does.
+    //   would refuse `"credentials": null` outright instead of reporting the
+    //   first missing field, which is the inherited behaviour.
     // - `GoStruct<T>`, because serde fills a struct from a JSON **array**
     //   positionally when every field has a default, so `"credentials":["tok"]`
     //   decoded to a populated struct, passed the non-empty check and **created
@@ -382,32 +382,35 @@ fn validate_whatsapp(credentials: Option<&RawValue>) -> Result<(), WriteError> {
 ///
 /// **This is the second of two places that reason about `net/url`'s rules, and
 /// they answer different questions.** Here the question is *create*: may this
-/// row be stored, and is forwarding to Go an option (it always is). In
-/// `native/integrations/confluence`, `validate_site_url` asks *start*: may a
-/// stored row be hosted — where there is nobody to forward to, so it decides
+/// row be stored, so an uncertain input can be refused with a 422 the user
+/// sees. In `native/integrations/confluence`, `validate_site_url` asks *start*:
+/// may a stored row be hosted — where a refusal is silent, so it decides
 /// everything itself and reproduces `getScheme` and the authority split
 /// outright. They agree on every realistic input and are deliberately not
 /// merged; #316 adds a third caller of the same Go rules with a *different*
 /// answer again, since Jira does not require HTTPS.
 fn split_url(raw: &str) -> Result<(String, String), WriteError> {
-    let forward =
+    // Answers a 422 with this build's own wording. It was called `forward`
+    // when an `Err` here reached a second implementation; it never has since,
+    // and the name outlived the mechanism.
+    let refuse =
         || WriteError::validation("credentials.site_url", format!("invalid site URL {raw:?}"));
     if raw.chars().any(|c| c.is_control() || c == ' ') {
-        return Err(forward());
+        return Err(refuse());
     }
     for (i, b) in raw.bytes().enumerate() {
         if b == b'%' {
             let rest = raw.as_bytes().get(i + 1..i + 3).unwrap_or(b"");
             if rest.len() != 2 || !rest.iter().all(|c| c.is_ascii_hexdigit()) {
-                return Err(forward());
+                return Err(refuse());
             }
         }
     }
 
     // A leading `:` is `getScheme`'s own error (`missing protocol scheme`),
-    // not an empty scheme, so it must forward rather than answer.
+    // not an empty scheme, so it is refused rather than parsed.
     if raw.starts_with(':') {
-        return Err(forward());
+        return Err(refuse());
     }
 
     // `url.Parse` takes the scheme only when what precedes the first ':' is a
@@ -441,7 +444,7 @@ fn split_url(raw: &str) -> Result<(String, String), WriteError> {
     // `site_url` Go's own parser can never read, and being native the request
     // never reaches Go to be refused.
     if authority.contains(['@', '[', ']', '%']) {
-        return Err(forward());
+        return Err(refuse());
     }
     // `parseHost` enforces an **allowlist**, not a blocklist, so this has to be
     // spelled the same way round. Enumerating every ASCII byte through
@@ -455,12 +458,12 @@ fn split_url(raw: &str) -> Result<(String, String), WriteError> {
         .bytes()
         .any(|b| b < 0x80 && !b.is_ascii_alphanumeric() && !HOST_PUNCT.contains(&b))
     {
-        return Err(forward());
+        return Err(refuse());
     }
     // A `:` introduces a port, which Go requires to be digits.
     if let Some((_, port)) = authority.split_once(':') {
         if !port.chars().all(|c| c.is_ascii_digit()) {
-            return Err(forward());
+            return Err(refuse());
         }
     }
     // The **whole authority**, port included: both Go validators test `u.Host`,
@@ -692,7 +695,7 @@ mod tests {
             "https://x.net:80:90", // two ports
             // Go rejects an escape whose first hex digit is below 8; it
             // *accepts* `%25` (host `x%net`) and valid multi-byte sequences
-            // such as `%C3%A9` (host `xénet`). This port forwards all of them
+            // such as `%C3%A9` (host `xénet`). This port refuses all of them
             // rather than encoding that rule — deliberately, but do not
             // "correct" the guard toward "a host may never carry an escape",
             // which is not Go's rule.
@@ -721,7 +724,7 @@ mod tests {
     /// every one of them — testing `split_url` directly keeps the JSON escaping
     /// of the outer credentials blob out of the way.
     #[test]
-    fn the_six_characters_go_rejects_in_a_host_all_forward() {
+    fn the_six_characters_rejected_in_a_host_are_all_refused() {
         for bad in ['\\', '^', '`', '{', '|', '}'] {
             let url = format!("https://x.net{bad}a");
             assert!(
@@ -732,15 +735,15 @@ mod tests {
     }
 
     /// The other side of the allowlist: punctuation that *looks* rejectable but
-    /// which Go accepts must not forward, or the port over-refuses.
+    /// which is accepted must not be refused, or this over-rejects.
     #[test]
-    fn the_punctuation_go_allows_in_a_host_is_not_forwarded() {
+    fn the_punctuation_allowed_in_a_host_is_not_refused() {
         for ok in [
             '!', '"', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '<', '=', '>', '_', '~',
         ] {
             let url = format!("https://x.net{ok}a");
             let (scheme, host) = split_url(&url)
-                .unwrap_or_else(|e| panic!("{url:?} forwarded, but Go accepts it: {e:?}"));
+                .unwrap_or_else(|e| panic!("{url:?} was refused, but it is valid: {e:?}"));
             assert_eq!(scheme, "https");
             assert_eq!(host, format!("x.net{ok}a"));
         }
@@ -766,7 +769,7 @@ mod tests {
     /// …but an ordinary port is not a shape to be unsure of, and must not make
     /// the host look empty.
     #[test]
-    fn a_numeric_port_is_understood_and_not_forwarded() {
+    fn a_numeric_port_is_understood_and_not_refused() {
         assert!(validate(
             "jira",
             Some(&raw(

--- a/src-tauri/src/native/integrations.rs
+++ b/src-tauri/src/native/integrations.rs
@@ -88,8 +88,8 @@
 //!   the desktop app by decision (`whatsmeow` has no Rust equivalent), so these
 //!   routes must keep answering exactly as the sidecar answers them. As of
 //!   #273 the desktop UI no longer calls them, so they are unreachable rather
-//!   than merely unported — but they stay unclaimed, because forwarding is what
-//!   makes them the sidecar's problem to answer and then to delete.
+//!   than merely unported. They stay unclaimed, so they answer the unrouted
+//!   404 and can simply be deleted.
 //!
 //! ## A `whatsapp` row is data, not a type this code knows
 //!
@@ -526,9 +526,10 @@ fn segment(value: &str) -> Option<&str> {
 /// port, holding a token the user had just revoked. The sidecar now runs with
 /// `AGENTO_INTEGRATIONS=off:<the types the shell hosts>` and [`registry`] is the
 /// only implementation **for those types**, so both effects are reproduced
-/// rather than lost. Note the switch is per type, not per process: a `whatsapp`
-/// row is still Go's, and a write for one is declined here and forwarded whole
-/// (see [`claims`]'s caller and `writes.rs`). All six are the shell's as of #313
+/// rather than lost. Note the switch is per type, not per process: a write for
+/// a `whatsapp` row is declined rather than applied, because nothing here can
+/// start or stop its connection (see [`claims`]'s caller and `writes.rs`). All
+/// six of the others are hosted as of #313
 /// — `github`, `confluence`, `jira`, `slack`, `telegram`, `google` — and the
 /// list to read is `registry::HOSTED_TYPES`, never this comment.
 ///
@@ -560,13 +561,12 @@ fn claims(method: &Method, path: &str) -> bool {
         // network, with the bot token" — was simply wrong: `GetWebhookStatus`
         // reads three columns off the row and composes a URL from the public
         // URL, and `internal/integrations/telegram` has no status call at all.
-        // The network belongs to *registration*, which is a different route and
-        // still forwards.
+        // The network belongs to *registration*, which is a different route.
         Some(Route::WebhookStatus(_)) => method == Method::GET,
         // The three that call Telegram. Every fallible step happens *before*
-        // the call — an `Err` after a successful `setWebhook` forwards, and Go
-        // would register the webhook a second time under its own secret. See
-        // `trigger::registration`.
+        // the call — an `Err` after a successful `setWebhook` answers 500 for a
+        // registration that landed, inviting a retry that registers it twice
+        // under a new secret. See `trigger::registration`.
         Some(Route::WebhookRegister(_)) => method == Method::POST || method == Method::DELETE,
         Some(Route::WebhookRegenerate(_)) => method == Method::POST,
         None => false,
@@ -628,7 +628,7 @@ fn serve(ctx: &super::Ctx, req: &super::Request) -> Result<super::Answer, String
                 Ok(authenticated) => authenticated,
                 // A read, so the seam wants a `Result<_, String>`; `finish`
                 // is the write path's shape. `Internal` and the typed errors
-                // answer natively, and only `Fallback` forwards.
+                // carry their own status; `Fallback` becomes a plain 500.
                 Err(WriteError::Fallback(reason)) => return Err(reason),
                 Err(e) => {
                     let body = super::gojson::to_vec(&super::writes::error_body(&e.message()))
@@ -643,8 +643,8 @@ fn serve(ctx: &super::Ctx, req: &super::Request) -> Result<super::Answer, String
         Some(Route::WebhookStatus(id)) => super::gojson::to_vec(&webhook::status(db, id)?)
             .map_err(|e| format!("encoding webhook status: {e}"))?,
 
-        // `claims` never admits a GET here — chi has no such route, so Go 405s
-        // and forwarding is what reproduces that.
+        // `claims` never admits a GET here — there is no such route, so it
+        // falls through to the unrouted 404.
         Some(Route::AuthStart(_))
         | Some(Route::AuthValidate(_))
         | Some(Route::WebhookRegister(_))
@@ -844,11 +844,10 @@ fn update(db_path: &Path, id: &str, body: &[u8]) -> Result<super::Answer, WriteE
     decline_a_type_go_still_hosts(id, &existing.integration_type)?;
     // **Before the write, not after.** Its input comes out of the database, so
     // unlike the timestamps this process formats itself it can genuinely fail —
-    // and a `Fallback` after `conn.execute` would forward to Go, which re-runs
-    // the whole `PUT`: a second `updated_at`, a second credential overwrite, a
-    // second reload. Go fails before saving here too, because
-    // `integrationService.Update` calls `s.Get` — which scans `created_at` —
-    // first. See the invariant in `writes.rs`.
+    // and a `Fallback` after `conn.execute` would answer 500 for a `PUT` that
+    // already landed, inviting a retry that overwrites the credential and
+    // reloads a second time. The reference implementation fails before saving
+    // here too. See the invariant in `writes.rs`.
     let created_at = parse_stored(&existing.created_at)?;
 
     let now = super::gotime::now_go_text();
@@ -898,8 +897,8 @@ fn update(db_path: &Path, id: &str, body: &[u8]) -> Result<super::Answer, WriteE
 
     // **After the write, and its failure is swallowed.** Go logs a reload
     // failure and answers 200 regardless: "row written, server dead" is the
-    // accepted outcome. It must never become a `Fallback` — the seam forwards
-    // one to Go, which would re-apply a write that already landed.
+    // accepted outcome. It must never become a `Fallback`: that would report
+    // failure for a write that already landed.
     registry::reload_blocking(db_path, id);
 
     let updated = ScrubbedIntegration {
@@ -992,10 +991,9 @@ fn existing_for_update(
 /// "server" is a live whatsmeow connection registered in a package global, so a
 /// missed reload strands a socket, not a port.
 ///
-/// A `Fallback` forwards the *whole* request, so Go re-reads the body and does
-/// everything. That is only safe while nothing has been written yet, which is
-/// why both callers check straight after their existence read and before any
-/// mutation — the invariant in `writes.rs`.
+/// A `Fallback` is a 500, which is only honest while nothing has been written
+/// yet — which is why both callers check straight after their existence read
+/// and before any mutation. The invariant in `writes.rs`.
 fn decline_a_type_go_still_hosts(id: &str, integration_type: &str) -> Result<(), WriteError> {
     if registry::hosts_type(integration_type) {
         return Ok(());
@@ -1567,8 +1565,7 @@ mod tests {
         // the servers they reload and stop.
         assert!(claims(&Method::PUT, "/api/integrations/abc"));
         assert!(claims(&Method::DELETE, "/api/integrations/abc"));
-        // Still only those three methods on that path — chi has no others, so
-        // a PATCH must forward and get Go's 405.
+        // Still only those three methods on that path; a PATCH is unrouted.
         assert!(!claims(&Method::PATCH, "/api/integrations/abc"));
         assert!(!claims(&Method::POST, "/api/integrations/abc"));
         // The collection has no PUT/DELETE.
@@ -1593,8 +1590,7 @@ mod tests {
         assert!(claims(&Method::GET, "/api/integrations/abc/auth/status"));
         assert!(claims(&Method::POST, "/api/integrations/abc/auth/start"));
         assert!(claims(&Method::POST, "/api/integrations/abc/auth/validate"));
-        // …and only for their own methods. chi mounts no GET on `validate`, so
-        // forwarding is what reproduces Go's 405.
+        // …and only for their own methods. There is no GET on `validate`.
         assert!(!claims(&Method::POST, "/api/integrations/abc/auth/status"));
         assert!(!claims(&Method::GET, "/api/integrations/abc/auth/start"));
         assert!(!claims(&Method::GET, "/api/integrations/abc/auth/validate"));
@@ -2059,14 +2055,14 @@ mod tests {
         assert!(get(file.path(), "int-1").expect("get").is_none());
     }
 
-    /// A row whose MCP server the **sidecar** still hosts must be forwarded
-    /// whole, because only Go's own handler fires the `Reload`/`Stop` that
-    /// process needs. WhatsApp is the case that makes this more than tidiness:
+    /// A row whose MCP server this build cannot host must be declined rather
+    /// than written, because nothing here can fire the `Reload`/`Stop` it
+    /// needs. WhatsApp is the case that makes this more than tidiness:
     /// its "server" is a live whatsmeow connection registered in a package
     /// global that the status, reconnect and QR endpoints read, so a missed
     /// reload strands a socket and a paired client that never connects.
     #[test]
-    fn a_write_for_a_type_the_sidecar_hosts_forwards_without_touching_the_row() {
+    fn a_write_for_a_type_this_build_cannot_host_is_declined_without_touching_the_row() {
         // `whatsapp` alone since #313 landed google — and it is the case that
         // makes this more than tidiness, per the doc comment above.
         {
@@ -2089,8 +2085,8 @@ mod tests {
                     "int-1",
                     br#"{"name":"Renamed","type":"github","enabled":false}"#,
                 )
-                .expect_err("must forward"),
-                delete(file.path(), "int-1").expect_err("must forward"),
+                .expect_err("must decline"),
+                delete(file.path(), "int-1").expect_err("must decline"),
             ] {
                 assert!(
                     matches!(err, WriteError::Fallback(_)),
@@ -2098,9 +2094,9 @@ mod tests {
                 );
             }
 
-            // **Nothing was written.** A `Fallback` forwards the whole request
-            // and Go re-applies it, so a partial write here would be applied
-            // twice — the invariant in `writes.rs`.
+            // **Nothing was written**, so the 500 is honest: a partial write
+            // behind it would be reported as a failure that half-happened —
+            // the invariant in `writes.rs`.
             assert_eq!(stored(&file, "SELECT name FROM integrations"), "Original");
             assert_eq!(
                 stored(&file, "SELECT type FROM integrations"),
@@ -2137,10 +2133,10 @@ mod tests {
 
     /// `created_at` comes out of the database, so unlike the timestamps this
     /// process formats itself it can genuinely fail to parse — and its
-    /// `Fallback` therefore has to happen **before** the `UPDATE`, or Go's
-    /// re-run would be the second application of a write that already landed.
+    /// `Fallback` therefore has to happen **before** the `UPDATE`, or the 500
+    /// would be reporting a write that had already landed.
     #[test]
-    fn an_unparseable_created_at_forwards_before_anything_is_written() {
+    fn an_unparseable_created_at_fails_before_anything_is_written() {
         let file = migrated();
         Connection::open(file.path())
             .expect("open")
@@ -2158,7 +2154,7 @@ mod tests {
             "int-1",
             br#"{"name":"Renamed","type":"github"}"#,
         )
-        .expect_err("an unparseable stored timestamp forwards");
+        .expect_err("an unparseable stored timestamp fails");
         assert!(matches!(err, WriteError::Fallback(_)), "{err:?}");
 
         assert_eq!(stored(&file, "SELECT name FROM integrations"), "Original");

--- a/src-tauri/src/native/integrations/base_url.rs
+++ b/src-tauri/src/native/integrations/base_url.rs
@@ -51,7 +51,7 @@
 //!
 //! `parseHost` is itself an **allowlist** — `integration_credentials::split_url`
 //! says so, having enumerated every ASCII byte through it — so [`Base::new`]
-//! uses one too, and a narrower one, because that module may forward what it is
+//! uses one too, and a narrower one, because that module may refuse what it is
 //! unsure of and a starter may not. See [`Mismatch::Authority`].
 //!
 //! # What each caller does with a [`Mismatch`], and why they differ

--- a/src-tauri/src/native/integrations/confluence/mod.rs
+++ b/src-tauri/src/native/integrations/confluence/mod.rs
@@ -197,9 +197,9 @@ pub async fn start_confluence_mcp_server(
 /// **The second of two places that reason about `net/url`'s rules.** The first
 /// is `native/integration_credentials.rs`'s `split_url`, and the difference is
 /// which question is being asked: there it is *create* — may this row be stored
-/// — and forwarding the whole request to Go is always available, so it decides
+/// — and refusing the whole request with a 422 is always available, so it decides
 /// only the shapes it is sure of. Here it is *start* — may a stored row be
-/// hosted — and there is nobody to forward to, so this reproduces `getScheme`
+/// hosted — and a refusal there is silent, so this reproduces `getScheme`
 /// and the authority split outright and answers every input. #316 adds a third
 /// caller of the same Go rules with a different answer again, since Jira does
 /// not require HTTPS.
@@ -261,7 +261,7 @@ pub async fn start_confluence_mcp_server(
 ///   `parseHost` is itself an allowlist — `split_url` in
 ///   `native/integration_credentials.rs` says so, having enumerated every ASCII
 ///   byte through it — so the sound shape here is an allowlist too, and a
-///   narrower one, because that module may forward what it is unsure of and
+///   narrower one, because that module may refuse what it is unsure of and
 ///   this one may not. The rule is: ASCII letters, digits, `.`, `-` and `_`,
 ///   with an optional `:`-separated numeric port.
 ///

--- a/src-tauri/src/native/integrations/confluence/validate.rs
+++ b/src-tauri/src/native/integrations/confluence/validate.rs
@@ -25,9 +25,10 @@
 //!
 //! #318 changes that. This function's error is interpolated into the 400 body
 //! `auth/validate` answers, so a port-worded refusal would be a visible
-//! divergence. Hence [`Refusal`]: the two rules Go states itself (HTTPS, and a
-//! hostname) are answered here, and the `url.Parse` refusals forward instead.
-//! Forwarding is free at this point — nothing has been called yet.
+//! divergence. Hence [`Refusal`]: the two rules stated outright (HTTPS, and a
+//! hostname) are answered here with their own wording, while the `url.Parse`
+//! refusals — whose text is not reproducible — become a plain 500. That is free
+//! at this point, because nothing has been called yet.
 //!
 //! The response is decoded into `confluenceSpacesResponse` and **thrown away**.
 //! That is not dead code to delete: a 200 carrying non-JSON is a failure, and
@@ -41,10 +42,10 @@ use super::client::{http_client, read_capped_at};
 pub enum Refusal {
     /// A sentence Go produces verbatim, safe to put on the wire.
     Reproducible(String),
-    /// `net/url`'s own wording, which this port does not reproduce. The caller
-    /// forwards, which is safe here because it can only arise before the
-    /// network call.
-    Forward(String),
+    /// A wording this build does not reproduce. The caller answers a 500 with
+    /// the reason in the log rather than inventing a sentence the user sees —
+    /// safe here because it can only arise before the network call.
+    Unreproducible(String),
 }
 
 /// `io.LimitReader(resp.Body, 1*1024*1024)` — validate.go's own cap.
@@ -84,7 +85,7 @@ pub async fn validate_credentials(
     // `url.Parse`'s wording; see the module header.
     let clean = super::validate_site_url(site_url).map_err(|e| {
         if e.starts_with("invalid site URL: ") {
-            Refusal::Forward(e)
+            Refusal::Unreproducible(e)
         } else {
             Refusal::Reproducible(e)
         }
@@ -92,10 +93,10 @@ pub async fn validate_credentials(
 
     let failed = "calling confluence API: request failed".to_string();
     let url = reqwest::Url::parse(&format!("{clean}/wiki/api/v2/spaces?limit=1"))
-        // `http.NewRequestWithContext` failing is `creating confluence request:
-        // %w`; the wording is `net/http`'s, so this forwards rather than
-        // inventing one — and nothing has been called yet.
-        .map_err(|e| Refusal::Forward(format!("creating confluence request: {e}")))?;
+        // `http.NewRequestWithContext` failing has a wording this build does
+        // not reproduce, so this is a 500 rather than an invented sentence —
+        // and nothing has been called yet.
+        .map_err(|e| Refusal::Unreproducible(format!("creating confluence request: {e}")))?;
 
     let request = http_client()
         .ok_or_else(|| Refusal::Reproducible(failed.clone()))?

--- a/src-tauri/src/native/integrations/oauth/flow.rs
+++ b/src-tauri/src/native/integrations/oauth/flow.rs
@@ -73,9 +73,8 @@ const GO_INTERNAL_ERROR: &str = "internal server error";
 
 /// Log the real reason and answer what Go answers.
 ///
-/// The detail reaches the log, never the wire — `httpErr`'s default arm does the
-/// same, and reproducing it here rather than forwarding is what stops the
-/// sidecar starting a second flow. See [`start`].
+/// The detail reaches the log, never the wire — the default error arm does the
+/// same. See [`start`].
 fn internal<E: std::fmt::Display>(what: &'static str) -> impl Fn(E) -> WriteError {
     move |e| {
         log::error!("internal server error error={what}: {e}");
@@ -116,14 +115,12 @@ struct ClientCredentials {
 ///
 /// # Nothing here may `Fallback`
 ///
-/// Every other native write forwards on doubt and lets Go answer. This one must
-/// not: forwarding `auth/start` makes the **sidecar** run a real flow, with its
-/// own callback server on its own port. The shell would never see that token
-/// land — the inference that used to cover it (`Trigger::AuthStatusPolled`) is
-/// gone precisely because this route moved — and Go's own `registry.Reload` is
-/// switched off for the six hosted types by `AGENTO_INTEGRATIONS`. The result is
-/// an integration that authenticates and is hosted by nobody until the next app
-/// start.
+/// `Fallback` means "the machinery broke" and carries a generic body.
+/// [`WriteError::Internal`] is used instead, because this route's failures are
+/// specific and already logged: a failed flow must not be reported in a way that
+/// invites the caller to read the *stored* token and conclude
+/// `authenticated: false`, which would be a plausible lie about a flow that
+/// errored.
 ///
 /// So the failures Go answers with a flat 500 are answered here as
 /// [`WriteError::Internal`], with Go's own body: the same bytes on the wire, and

--- a/src-tauri/src/native/integrations/registry.rs
+++ b/src-tauri/src/native/integrations/registry.rs
@@ -55,10 +55,10 @@
 //! exactly as it did before this module existed. What *this* module does with
 //! one is take the path Go's own unregistered type takes — the error `no starter
 //! registered for integration type "slack"`, **logged and never surfaced** —
-//! but it never gets the chance, because the native `PUT`/`DELETE` decline a row
-//! whose type is not [`hosts_type`] and forward the whole request to Go, which
-//! then fires its own `Reload`/`Stop`. That refusal is a *pre-write* one; see
-//! `native/integrations.rs` and the invariant in `writes.rs`.
+//! but it never gets the chance, because the `PUT`/`DELETE` decline a row whose
+//! type is not [`hosts_type`] rather than writing it. That refusal is a
+//! *pre-write* one; see `native/integrations.rs` and the invariant in
+//! `writes.rs`.
 //!
 //! ## Reload is not restart-if-changed
 //!
@@ -93,13 +93,12 @@
 //! and `validateConfluenceAuth`. Each writes a credential for a type *this*
 //! process hosts, from a handler that cannot tell it. Without a hook such an
 //! integration would first be hosted at the next boot's [`start_all`], so the
-//! seam fires [`reload_after_auth`] after forwarding a 2xx for that one route
-//! (`native::after_forward`). That hook needs no per-type list of its own: it
-//! runs for every id on the route and [`reload_after_auth`] reads the row's type
-//! through [`can_host`], so #313 is covered the moment it adds its
-//! string to [`HOSTED_TYPES`]. The reload is idempotent and the response has
-//! already been produced, so doing it on the forward path costs nothing but a
-//! restart of a server that was about to be restarted anyway.
+//! seam fires [`reload_after_auth`] on a 2xx for that one route. That hook needs
+//! no per-type list of its own: it runs for every id on the route and
+//! [`reload_after_auth`] reads the row's type through [`can_host`]. The reload
+//! is idempotent and the response has already been produced, so firing it here
+//! costs nothing but a restart of a server that was about to be restarted
+//! anyway.
 //!
 //! The fifth is `completeOAuth`, and until #318 it needed a **different** hook
 //! because its trigger never crossed the proxy: the token was delivered by the
@@ -1006,8 +1005,9 @@ fn type_of(db_path: &Path, id: &str) -> Result<Option<String>, String> {
 /// Whether a run naming this integration can be served natively at all.
 ///
 /// Separate from [`start_filtered_server`] because the caller has to decide
-/// *before* it starts anything: an agent that names a type Rust cannot host must
-/// forward the whole turn to Go rather than run with some of its tools missing.
+/// *before* it starts anything: an agent that names a type this build cannot
+/// host must have its whole turn refused rather than run with some of its tools
+/// silently missing.
 ///
 /// [`hosts_type`] is the predicate and [`type_of`] is the whole of the read —
 /// one column, chosen because this question has no business touching the other
@@ -1155,9 +1155,9 @@ where
 ///
 /// **Never returns anything.** The row is already written by the time this runs,
 /// and Go's handler logs a reload failure and answers 200 regardless — "row
-/// written, server dead" is its accepted outcome. Turning it into a
-/// `WriteError::Fallback` would be much worse than that: the seam forwards a
-/// fallback to Go, which would re-apply the write.
+/// written, server dead" is the accepted outcome. Turning it into a
+/// `WriteError::Fallback` would be much worse: a 500 reporting failure for a
+/// write that landed, inviting a retry that applies it again.
 /// The reload the seam owes a request Go answered: `POST
 /// /api/integrations/{id}/auth/validate`, whose Go-side `Reload` is a no-op for
 /// a type this process hosts.

--- a/src-tauri/src/native/integrations/token_validate.rs
+++ b/src-tauri/src/native/integrations/token_validate.rs
@@ -36,16 +36,16 @@
 //!
 //! # Order, and the one thing that may fail after the call
 //!
-//! `native/trigger/registration.rs`'s rule applies — a native `Err` forwards,
-//! and Go re-runs the whole handler, so an `Err` after a successful remote call
-//! spends a second one. Every fallible step is therefore before the call:
+//! `native/trigger/registration.rs`'s rule applies — an `Err` after a
+//! successful remote call answers 500 for work that landed, inviting a retry
+//! that spends a second call. Every fallible step is therefore before the call:
 //! resolving the row, the field validation, and parsing the credentials.
 //!
 //! The write afterwards is the exception, and it is safe because **Go answers a
 //! failed save the same way it answers a failed validation** — `saving validated
 //! integration: %w` goes into the very same 400 body. So a failed write is
-//! answered here rather than forwarded, and nothing on this path returns
-//! `Fallback` once the network has been touched.
+//! answered with that 400, and nothing on this path returns `Fallback` once the
+//! network has been touched.
 
 use std::path::Path;
 
@@ -185,8 +185,8 @@ fn validate_token_auth(db_path: &Path, row: &registry::HostingRow) -> Result<(),
     )?;
 
     // Go's `saving validated integration: %w` arm, which lands in the *same*
-    // 400 body as a failed validation — so answering it here is what Go does,
-    // not a shortcut around a forward.
+    // 400 body as a failed validation — so this is the inherited behaviour,
+    // not a shortcut.
     save(db_path, &row.id, &stored)
         .map_err(|e| WriteError::BadRequest(format!("saving validated integration: {e}")))?;
 
@@ -222,10 +222,10 @@ async fn call(
                     field: "credentials".to_string(),
                     message: format!("invalid credentials: {message}"),
                 },
-                // A `url.Parse` refusal, whose wording is `net/url`'s. It can
-                // only arise **before** the request, so forwarding is free —
-                // see `confluence::validate`'s header.
-                Refusal::Forward(why) => WriteError::Fallback(format!(
+                // A `url.Parse` refusal, whose wording is not reproducible. It
+                // can only arise **before** the request, so a 500 costs nothing
+                // — see `confluence::validate`'s header.
+                Refusal::Unreproducible(why) => WriteError::Fallback(format!(
                     "confluence site URL needs net/url's own message: {why}"
                 )),
             })?;
@@ -333,9 +333,9 @@ fn save(db_path: &Path, id: &str, stored: &Stored) -> Result<(), String> {
 /// A column that is **present but not valid JSON** is a third case, and it is
 /// neither of the other two: Go reaches `ParseCredentials`, which fails with
 /// `encoding/json`'s own wording inside `invalid <type> credentials: …`. That
-/// sentence is not reproducible, so this forwards rather than reporting the
-/// blob as absent — which would answer "credentials are empty" where Go names
-/// the parse error. Only a hand-edited row can be in this state, since the
+/// sentence is not reproducible, so this answers a 500 rather than reporting
+/// the blob as absent — which would say "credentials are empty" and name the
+/// wrong problem. Only a hand-edited row can be in this state, since the
 /// create and update paths validate before storing.
 fn raw_credentials(column: &str) -> Result<Option<Box<serde_json::value::RawValue>>, WriteError> {
     if column.is_empty() {
@@ -696,10 +696,9 @@ mod tests {
         );
     }
 
-    /// A stored blob that is present but not JSON forwards rather than being
-    /// read as absent: Go reaches `ParseCredentials` and reports
-    /// `encoding/json`'s own message, where "credentials are empty" would name
-    /// the wrong problem. Only a hand-edited row can be in this state.
+    /// A stored blob that is present but not JSON is a 500 rather than being
+    /// read as absent, where "credentials are empty" would name the wrong
+    /// problem. Only a hand-edited row can be in this state.
     #[test]
     fn credentials_that_are_not_json_forward_rather_than_reading_as_absent() {
         let dir = tempfile::tempdir().expect("tempdir");

--- a/src-tauri/src/native/migrate.rs
+++ b/src-tauri/src/native/migrate.rs
@@ -20,56 +20,46 @@
 //!
 //! - **Do not edit 1–30.** They are a frozen record of what Go produced, and
 //!   the only thing that still makes the "not transcribed" argument above true.
-//! - **Anything appended must be additive.** `main` still ships the Go server
-//!   and it opens the same `~/.agento/agento.db`. `applyMigrations` runs only
-//!   migrations *newer* than the recorded version, so a database at 31 makes an
-//!   older build apply nothing and carry on — it simply never reads the new
-//!   table. A migration that *altered* an existing column would break such a
-//!   process instead, silently, on a user's machine.
+//! - **Anything appended must be additive.** Migrations run only when *newer*
+//!   than the recorded version, so a database at 31 makes an older build apply
+//!   nothing and carry on — it simply never reads the new table. A migration
+//!   that *altered* an existing column would break a downgrade instead,
+//!   silently, on a user's machine. Downgrades are already refused below 0.1.1
+//!   (see `docs/troubleshooting.md`), but the rule keeps the damage to a
+//!   refusal rather than corruption.
 //!
 //! Twenty-seven migrations of hand-copied DDL is precisely the kind of thing
 //! that agrees on every table anyone happens to check and differs on one column
 //! default nobody does — and the failure would surface as a write succeeding
 //! against a column that is `NOT NULL DEFAULT ''` on one side and nullable on
 //! the other. Embedding the file removes the transcription entirely. It also
-//! outlives the Go server: when the sidecar is deleted, this file is the record
-//! of what the schema was, the same reason `desktop/parity/` keeps its other
-//! vectors.
+//! outlives the implementation that generated it: this file **is** the record
+//! of what the schema is, the same reason the rest of `parity/` exists.
 //!
-//! # Rust verifies; it does not apply. Yet.
+//! # `verify` and `apply` are separate, and the split is load-bearing
 //!
-//! This is the load-bearing part of #274, and it is a deliberate departure from
-//! the issue's wording ("Rust owns migration ordering").
+//! [`apply`] runs once at startup, from `lib.rs`, before anything serves.
+//! [`verify`] runs on every write, and refuses a database whose version is not
+//! the one this build compiled against — in either direction.
 //!
-//! Go's `applyMigrations` reads the current version **outside** the transaction
-//! that applies the next one (`internal/storage/sqlite.go`). Two processes
-//! starting together therefore both read the same version, both decide to
-//! apply the next migration, and both run its DDL: the loser gets
-//! `table already exists`, which is not a
-//! conflict it retries but an error that fails `NewSQLiteDB` and takes the whole
-//! startup with it. Whichever process loses simply does not come up.
-//!
-//! So while the Go sidecar is still bundled — and it is, until #278 deletes it —
-//! exactly one process may apply migrations, and that process is Go, because it
-//! is the one that also creates the database, seeds the pricing catalog and runs
-//! the legacy filesystem import. Rust [`verify`]s instead: it reads the version
-//! and refuses to serve a database it does not recognise, which sends the
-//! request to Go rather than writing through a schema it has guessed at.
-//!
-//! [`apply`] is written, tested and unused. It is what #278 turns on, in the
-//! same change that stops the sidecar from migrating — one commit, one owner,
-//! no window in which both do it.
+//! Keeping them apart matters because the version is read **outside** the
+//! transaction that applies the next migration. Two processes starting together
+//! would both read the same version, both decide to apply the next migration,
+//! and both run its DDL: the loser gets `table already exists`, which is not a
+//! conflict it retries but an error that fails startup outright. Exactly one
+//! process may migrate a given data directory, which is what
+//! `tauri-plugin-single-instance` is for — and why pointing a second instance
+//! at the same `AGENTO_DATA_DIR` is documented as unsupported.
 //!
 //! # Two directions, two different answers
 //!
 //! A database **older** than this build is a hard error: some migration this
 //! code depends on has not run, so a write would hit a missing column. A
-//! database **newer** is also an error here, though Go accepts it silently — Go
-//! can afford to, because its queries are written against the schema it shipped
-//! with, whereas a Rust build reading a newer file is reading columns it was
-//! never compiled against. Both directions return `Err`, and `Err` means the
-//! request forwards to the sidecar, which is the implementation that does know
-//! the schema in front of it.
+//! database **newer** is also an error here: this build's queries are compiled
+//! against the schema it ships with, so a newer file has columns it was never
+//! compiled against. Both directions return `Err`, which is a 500 — the honest
+//! answer, because the alternative is reading or writing a shape this build
+//! does not understand.
 
 use std::sync::OnceLock;
 
@@ -140,26 +130,25 @@ pub fn verify(conn: &Connection) -> Result<(), String> {
     if have == want {
         return Ok(());
     }
-    // Both directions forward to Go, but they are different situations and a
-    // log line that says which one saves the next person a bisect.
+    // Both directions are a 500, but they are different situations and a log
+    // line that says which one saves the next person a bisect.
     if have < want {
         return Err(format!(
             "database is at schema version {have}, this build writes version {want}; \
-             the sidecar has not migrated it yet"
+             migrations have not been applied"
         ));
     }
     Err(format!(
         "database is at schema version {have}, newer than this build's {want}; \
-         forwarding to the sidecar, which knows the schema in front of it"
+         it was written by a later version of Agento"
     ))
 }
 
 /// Apply every pending migration.
 ///
-/// **Not called while the Go sidecar exists** — see the module header. This is
-/// the body #278 turns on once the sidecar stops migrating.
+/// Called once at startup, from `lib.rs`, before the window shows.
 ///
-/// Mirrors Go's `applyMigrations`/`applyMigration`: create the tracking table,
+/// Mirrors `applyMigrations`/`applyMigration`: create the tracking table,
 /// read the current version, then run each pending migration and record it.
 /// One departure, and it is the reason the Go version cannot be run twice
 /// concurrently: the version is re-read **inside** the transaction that applies
@@ -442,11 +431,17 @@ mod tests {
         .expect("seed");
 
         let err = verify(&conn).expect_err("a behind database must not be served");
-        assert!(err.contains("has not migrated"), "got: {err}");
+        // The two directions must stay distinguishable in the message — a log
+        // line that says which one saves the next person a bisect.
+        assert!(err.contains("have not been applied"), "got: {err}");
+        assert!(
+            err.contains("26"),
+            "the stored version must be named: {err}"
+        );
     }
 
-    /// Go accepts a newer database silently. Rust must not: its queries were
-    /// compiled against this schema, not that one.
+    /// A newer database is refused, not accepted silently: this build's queries
+    /// were compiled against its own schema, not that one.
     #[test]
     fn a_database_ahead_of_this_build_is_refused() {
         let file = tempfile::NamedTempFile::new().expect("temp file");

--- a/src-tauri/src/native/mod.rs
+++ b/src-tauri/src/native/mod.rs
@@ -197,7 +197,8 @@ pub struct Ctx {
 ///
 /// The pair travels together so claiming a route and implementing it are the
 /// same edit. Splitting them across two files is how a route ends up claimed by
-/// a handler that does not exist, which fails as a fallback to Go — silently.
+/// a handler that does not exist, which fails at runtime rather than at
+/// compile time.
 pub struct Endpoint {
     /// Shown when a claimed request has no handler. Not on the wire.
     pub name: &'static str,
@@ -385,7 +386,7 @@ mod tests {
         assert!(claims(&Method::GET, "/api/claude-sessions/projects"));
         assert!(!claims(&Method::GET, "/api/claude-sessions/"));
         // The rename/favourite write shares that path and is separated by
-        // method (#296). Every other method on it still forwards.
+        // method (#296). Every other method on it is unrouted.
         assert!(claims(&Method::PATCH, "/api/claude-sessions/abc-123"));
         assert!(!claims(&Method::PUT, "/api/claude-sessions/abc-123"));
         assert!(!claims(&Method::DELETE, "/api/claude-sessions/abc-123"));
@@ -403,7 +404,7 @@ mod tests {
         assert!(!claims(&Method::GET, "/api/claude-sessions/abc/insights"));
 
         // Agents: the two reads and, since #274, the three writes. `duplicate`
-        // is a different route and still forwards.
+        // is a different route and is unclaimed.
         assert!(claims(&Method::GET, "/api/agents"));
         assert!(claims(&Method::GET, "/api/agents/my-agent"));
         assert!(claims(&Method::POST, "/api/agents"));
@@ -489,9 +490,9 @@ mod tests {
         assert!(!claims(&Method::GET, "/api/claude-settings/profiles/"));
 
         // Monitoring: the read, plus the two writes this build **declines**
-        // (#309). They are claimed rather than forwarded on purpose — a forward
-        // would reach a sidecar that would save the config and reload its own
-        // providers, which is the outcome the decision exists to stop.
+        // (#309). They are claimed rather than left unrouted on purpose: a
+        // 404 would read as a version mismatch, where the truth is that this
+        // build declines the feature.
         assert!(claims(&Method::GET, "/api/monitoring"));
         assert!(claims(&Method::PUT, "/api/monitoring"));
         assert!(claims(&Method::POST, "/api/monitoring/test"));
@@ -597,7 +598,7 @@ mod tests {
         // An encoded separator stays encoded, which is what keeps a one-segment
         // route one segment. A blanket decode — the obvious fix — would make
         // this `/api/agents/a/b`, `slug_of` would reject it, and a PUT Go
-        // applies would forward instead of being claimed.
+        // should apply would go unrouted instead of being claimed.
         assert_eq!(route("/api/agents/a%2Fb"), "/api/agents/a%2Fb");
         assert!(claims(&Method::PUT, &route("/api/agents/a%2Fb")));
 
@@ -629,8 +630,8 @@ mod tests {
         ));
 
         // A malformed target has no route path at all: `url.ParseRequestURI`
-        // rejects it, so Go answers 400 from inside `net/http` and the proxy
-        // forwards rather than inventing one.
+        // rejects it, so the answer is a 400 from before any handler — see
+        // `proxy.rs`.
         assert!(gourl::route_path("/api/agents/a%2").is_none());
     }
 

--- a/src-tauri/src/native/monitoring.rs
+++ b/src-tauri/src/native/monitoring.rs
@@ -519,7 +519,7 @@ mod tests {
         assert!(!claims(&Method::PUT, "/api/monitoring/test"));
     }
 
-    /// A declined route must be **answered**, not forwarded: forwarding would
+    /// A declined route must be **answered**, not left unrouted: a 404 would
     /// reach the sidecar, which would happily save the config and reload its
     /// own providers — the outcome this decision exists to stop.
     #[test]

--- a/src-tauri/src/native/notifications/mod.rs
+++ b/src-tauri/src/native/notifications/mod.rs
@@ -137,11 +137,9 @@ const MASKED_FIELD_SENTINEL: &str = "***";
 
 /// `GetSettings`: the stored settings with the password masked.
 ///
-/// An unparseable column is an error rather than a default. That is Go's
-/// behaviour — `loadNotificationSettings` returns the decode error and the
-/// handler answers 500 — and the seam turns it into a fallback, so the user
-/// sees Go's 500 rather than a silently empty form that a save would overwrite
-/// their real configuration with.
+/// An unparseable column is an error rather than a default: the user sees a
+/// 500 rather than a silently empty form, which a save would then write over
+/// their real configuration.
 pub fn get_settings(db_path: &Path) -> Result<NotificationSettings, String> {
     let conn = db::open_read_only(db_path)?;
     let raw = super::settings::load_stored(&conn).notification_settings;
@@ -295,12 +293,11 @@ fn update_settings(db_path: &Path, body: &[u8]) -> Result<super::Answer, WriteEr
         )
         .map_err(|e| WriteError::Fallback(format!("saving notification settings: {e}")))?;
     if updated == 0 {
-        // No settings row at all — a machine whose server has never saved one.
-        // Go's `Save` inserts the whole row from its snapshot, defaults filled
-        // in; reproducing that here would mean owning every column. Nothing was
-        // written, so forwarding is exact.
+        // No settings row at all. Inserting one would mean owning all fourteen
+        // columns and their defaults, which this write deliberately does not —
+        // see the header. Nothing was written, so the 500 is exact.
         return Err(WriteError::Fallback(
-            "no user_settings row to update; let Go create it".to_string(),
+            "no user_settings row to update".to_string(),
         ));
     }
 
@@ -320,11 +317,12 @@ fn update_settings(db_path: &Path, body: &[u8]) -> Result<super::Answer, WriteEr
 /// point of the button: it lets someone verify credentials before committing to
 /// turning notifications on.
 ///
-/// Only the success path is answered here. Every failure forwards, because Go's
-/// 400 carries `err.Error()` and those strings come from go-mail and the Go
-/// runtime — see `smtp.rs`. Forwarding costs a second dial and is safe for
-/// exactly one reason: the send reports success only after the server has
-/// accepted the message, so an error means nothing was delivered.
+/// Only the success path is answered with its own body. A failure is a 500 with
+/// the reason in the log, because the inherited 400 carries wording from the
+/// mail library and the runtime that this build cannot reproduce — see
+/// `smtp.rs`. That is safe for exactly one reason: the send reports success only
+/// after the server has accepted the message, so an error means nothing was
+/// delivered.
 fn test_notification(db_path: &Path) -> Result<super::Answer, WriteError> {
     let conn = db::open_read_only(db_path).map_err(WriteError::Fallback)?;
     let settings = decode_settings(&super::settings::load_stored(&conn).notification_settings)
@@ -332,7 +330,8 @@ fn test_notification(db_path: &Path) -> Result<super::Answer, WriteError> {
     drop(conn);
 
     // Encoded before the send. Nothing fallible may run after the message is
-    // accepted, or an `Err` would forward and Go would send a second email.
+    // accepted, or a 500 would report a failure for mail that was delivered —
+    // and invite a retry that sends it twice.
     let answer = super::gojson::to_vec(&TestResponse { status: "ok" })
         .map_err(|e| WriteError::Fallback(format!("encoding test response: {e}")))?;
 
@@ -487,9 +486,8 @@ mod tests {
         }
     }
 
-    /// Go answers 500 here, which the seam turns into a fallback. Degrading to
-    /// the zero value instead would show an empty form that a save would then
-    /// write over the user's real SMTP credentials.
+    /// A 500. Degrading to the zero value instead would show an empty form that
+    /// a save would then write over the user's real SMTP credentials.
     #[test]
     fn an_unparseable_column_is_an_error_not_a_default() {
         let file = fixture("{not json", "");
@@ -825,11 +823,11 @@ mod tests {
         assert_eq!(model, "claude-opus-5");
     }
 
-    /// No settings row at all means the server has never saved one, and Go's
-    /// insert fills every column from its snapshot. Owning that would mean
-    /// owning all fourteen, so it forwards — having written nothing.
+    /// No settings row at all means nothing has ever been saved. Inserting one
+    /// would mean owning all fourteen columns, so this refuses — having written
+    /// nothing.
     #[test]
-    fn a_missing_settings_row_forwards_rather_than_inventing_one() {
+    fn a_missing_settings_row_is_refused_rather_than_invented() {
         let file = tempfile::NamedTempFile::new().expect("temp file");
         let mut conn = Connection::open(file.path()).expect("open");
         super::super::migrate::apply(&mut conn).expect("migrate");

--- a/src-tauri/src/native/notifications/smtp.rs
+++ b/src-tauri/src/native/notifications/smtp.rs
@@ -14,22 +14,22 @@
 //! meaning here would move a working configuration to a port that never
 //! answers, from a release note nobody reads.
 //!
-//! # Why a failure forwards instead of being answered
+//! # Why a failure is a 500 rather than a worded 400
 //!
-//! Go answers a failed test send with `400` and `err.Error()`, and those
-//! strings come from go-mail and the Go runtime — `dial tcp …: connect:
-//! connection refused`, `failed to create mail client: …`. None of them is
-//! reproducible from Rust, and inventing a paraphrase would put a different
-//! sentence on a user's screen than the one the Go server shows. So the
-//! failure arm returns `Err` and the sidecar answers, which is the precedent
+//! The inherited behaviour answers a failed test send with `400` and the
+//! underlying error text — `dial tcp …: connect: connection refused`, `failed
+//! to create mail client: …`. Those strings come from the mail library and the
+//! runtime it was written against; none is reproducible here, and inventing a
+//! paraphrase would put a different sentence on the user's screen. So the
+//! failure arm answers a 500 with the reason in the log, the precedent
 //! `integration_credentials.rs` set for exactly this.
 //!
-//! **That is only safe because a forward re-sends.** The rule is in [`send`] and
-//! in its one caller: nothing that can fail may run after the server has
-//! accepted the message. `SmtpTransport::send` returns `Ok` once the server has answered
-//! the final `.` with a 2xx, and an `Err` from it therefore means the message
-//! was not accepted — so Go's retry is a second *failed* dial, not a second
-//! email.
+//! **A retry must not re-send.** The rule is in [`send`] and in its one caller:
+//! nothing that can fail may run after the server has accepted the message.
+//! `SmtpTransport::send` returns `Ok` once the server has answered the final `.`
+//! with a 2xx, so an `Err` from it means the message was *not* accepted — which
+//! is what makes a user pressing the button again a second failed dial rather
+//! than a second email.
 
 use lettre::message::{header::ContentType, MultiPart, SinglePart};
 use lettre::transport::smtp::authentication::{Credentials, Mechanism};
@@ -57,8 +57,8 @@ pub fn test_mail() -> Mail {
 
 /// `SMTPProvider.Send`.
 ///
-/// Every failure is a `String`, and every one of them forwards — see the module
-/// header. The messages are for the log, not for the wire.
+/// Every failure is a `String`, and every one of them becomes a 500 — see the
+/// module header. The messages are for the log, not for the wire.
 pub fn send(config: &SmtpConfig, mail: &Mail) -> Result<(), String> {
     let message = build_message(config, mail)?;
     let transport = build_transport(config)?;
@@ -128,7 +128,7 @@ fn build_message(config: &SmtpConfig, mail: &Mail) -> Result<Message, String> {
 ///
 /// Auth is configured unconditionally, as `WithSMTPAuth(SMTPAuthPlain)` is —
 /// including when the username is blank. A relay that wants no auth will
-/// refuse, which is what Go does today, and the refusal forwards.
+/// refuse, which is the inherited behaviour, and the refusal is a 500.
 fn build_transport(config: &SmtpConfig) -> Result<SmtpTransport, String> {
     let tls = tls_policy(&config.encryption, &config.host)?;
     let port = u16::try_from(config.port).map_err(|_| format!("invalid port {}", config.port))?;
@@ -358,9 +358,9 @@ mod tests {
         assert!(transcript.contains("text/html"), "{transcript}");
     }
 
-    /// The property the forwarding rule rests on: a failed send must be a
-    /// failure *to deliver*, or Go's retry would be a second email rather than
-    /// a second failed dial.
+    /// The property the whole ordering rests on: a failed send must be a
+    /// failure *to deliver*, or a user pressing the button again would send a
+    /// second email rather than making a second failed dial.
     #[test]
     fn a_refused_connection_is_an_error_and_delivers_nothing() {
         // Bind and drop, so the port is almost certainly free and nothing

--- a/src-tauri/src/native/pricing.rs
+++ b/src-tauri/src/native/pricing.rs
@@ -831,7 +831,7 @@ fn open_for_write(db_path: &Path) -> Result<Connection, WriteError> {
 /// handler answers 500; collapsing it into `None` here would make [`add_rate`]
 /// see no conflict and write straight over an existing row through the upsert —
 /// silent data loss on the one path whose whole job is to refuse it. So the
-/// failure is its own arm, and it forwards.
+/// failure is its own arm, answered rather than silently treated as "no row".
 fn find_rate(
     conn: &Connection,
     model_pattern: &str,
@@ -913,8 +913,8 @@ fn correct_rate(db_path: &Path, body: &[u8]) -> Result<super::Answer, WriteError
 /// flag the store applies on the way in included.
 ///
 /// The answer is encoded **before** the commit. Everything after a commit must
-/// be infallible, because an `Err` forwards to Go and Go would apply the write
-/// a second time.
+/// be infallible, because an `Err` there answers 500 for a rate that was
+/// actually written — inviting a retry that writes it twice.
 fn save(
     tx: &rusqlite::Transaction,
     input: &RateInput,
@@ -922,8 +922,8 @@ fn save(
 ) -> Result<super::Answer, WriteError> {
     upsert_rate(tx, input)?;
     let Some(saved) = find_rate(tx, &input.model_pattern, input.effective_from)? else {
-        // Go's "vanished after write" — a 500. Nothing is committed yet, so
-        // rolling back and forwarding is safe.
+        // "vanished after write" — a 500. Nothing is committed yet, so
+        // rolling back leaves no trace of it.
         return Err(WriteError::Fallback(format!(
             "saving rate: {} vanished after write",
             rate_key(&input.model_pattern, input.effective_from)
@@ -1044,7 +1044,8 @@ fn delete_rate(db_path: &Path, query: &str) -> Result<super::Answer, WriteError>
         .map_err(|e| WriteError::Fallback(format!("deleting rate: {e}")))?;
     if affected == 0 {
         // `Store.DeleteRate`'s own "no rate for …" error, which is a 500. The
-        // transaction has not committed, so forwarding cannot double-apply.
+        // transaction has not committed, so the 500 reports a delete that did
+        // not happen.
         return Err(WriteError::Fallback(format!(
             "pricing: no rate for {:?} at {}",
             pattern,

--- a/src-tauri/src/native/scan.rs
+++ b/src-tauri/src/native/scan.rs
@@ -4,14 +4,11 @@
 //! `Cache.ScanInProgress`, `Cache.CostsStale` and `Cache.LastScannedAt`
 //! (`internal/claudesessions/cache.go`), over the scanner ported in #270.
 //!
-//! # This is the port's first ownership flip
+//! # The scan is owned here, whole
 //!
-//! Every route before this one could forward on doubt: `Err` meant "let the
-//! sidecar answer", so a ported route could only ever be as broken as an
-//! unported one. **That property does not hold here.** Once the sidecar stops
-//! scanning there is no second implementation to fall back to — forwarding
-//! `/status` would ask Go about a scan Go is not running, and it would answer
-//! `false`/`0`/`0` with complete confidence.
+//! There is one scanner and this is it, so `/status` has to answer from this
+//! process's own state. A confident `false`/`0`/`0` from anywhere else would be
+//! a wrong answer rather than a missing one.
 //!
 //! So the flip has to be all of a piece: Rust scans, Rust answers, and the Go
 //! scanner is switched off in the same change. A half-flip is the one state
@@ -208,10 +205,10 @@ fn invalidate(conn: &rusqlite::Connection) -> Result<(), String> {
 ///
 /// Both halves are **best effort by design**. This runs after the rate write has
 /// committed, and everything after a commit must be infallible — returning an
-/// error here would forward the request to Go, which would apply the write a
-/// second time. A failure to invalidate costs at most an hour of stale costs,
-/// which the TTL then clears; a second rate row would be data the user did not
-/// ask for.
+/// error here would answer 500 for a rate that was actually written, inviting a
+/// retry that adds a second row. A failure to invalidate costs at most an hour
+/// of stale costs, which the TTL then clears; a duplicate rate row would be data
+/// the user did not ask for.
 pub fn after_pricing_change(db_path: &Path) {
     match super::db::open_read_write(db_path) {
         Ok(conn) => {
@@ -267,7 +264,7 @@ fn live_pricing_rev(db_path: &Path) -> i64 {
 /// This works only because **every profile unwinds** — `panic = "abort"` runs no
 /// destructors, so under it the guard would be a debug-only net and a scan panic
 /// would kill the app outright. `Cargo.toml` sets `panic = "unwind"` for release
-/// for this reason and for `proxy.rs`'s panic-to-forward, and says so there.
+/// for this reason and for `proxy.rs`'s panic handling, and says so there.
 struct ScanGuard;
 
 impl Drop for ScanGuard {

--- a/src-tauri/src/native/schedule/executor.rs
+++ b/src-tauri/src/native/schedule/executor.rs
@@ -16,8 +16,9 @@
 //! can always supply every tool, since it *is* the process that hosts them;
 //! [`crate::native::chat::runner::build_options`] can refuse (an agent naming an
 //! `mcps.yaml` server, or a `whatsapp` integration this build dropped). In a
-//! chat that refusal forwards. Here it is a recorded failure with the reason in
-//! `error_message`, which is the only answer that leaves evidence.
+//! chat that refusal is a 500. Here it is a recorded failure with the reason in
+//! `error_message`, which is the only answer that leaves evidence — a job
+//! history with no row is indistinguishable from a task that was not due.
 //!
 //! # What is deliberately not reproduced
 //!

--- a/src-tauri/src/native/schedule/mod.rs
+++ b/src-tauri/src/native/schedule/mod.rs
@@ -15,10 +15,10 @@
 //! that is `whatsapp` alone — the local in-process server (#310), github (#311),
 //! confluence (#317), jira (#316), slack (#315), telegram (#314) and google
 //! (#313) are all hosted here — so the remaining blockers are that one type and
-//! the two non-integration forwards. A chat can forward to Go on that
-//! refusal; a scheduled task with no Go scheduler behind it would simply never
-//! run, with nothing to say so. See "The scheduler: the computation moved, the
-//! ownership did not" in `desktop/CLAUDE.md`.
+//! the two non-integration refusals. A chat answers a 500 on that refusal; a
+//! scheduled task records a failed `job_history` row, because a run that simply
+//! never happened would be indistinguishable from one that was not due. See
+//! `super::executor`.
 //!
 //! Porting this half now is worth it because it is the half that is
 //! *verifiable* before ownership moves, and the half most likely to be subtly

--- a/src-tauri/src/native/schedule/runtime.rs
+++ b/src-tauri/src/native/schedule/runtime.rs
@@ -1,16 +1,13 @@
 //! The scheduler *runtime*: what `gocron.Scheduler` does around the schedule
 //! computation in this module's parent. Mirrors `internal/scheduler/scheduler.go`.
 //!
-//! # This is an ownership flip, not a route
+//! # The failure mode to design against is silence
 //!
 //! **Only one process may schedule.** Two schedulers over one `scheduled_tasks`
-//! table means every task fires twice, so this could never be a claimed route
-//! that forwards on doubt — the sidecar was started with `AGENTO_SCHEDULER=off`
-//! (until #278 removed it entirely), and nothing else will fire a task. That is
-//! the #289 model, and it is why the
-//! failure mode to design against is *silence*: a task Rust declines to run does
-//! not fall back to Go, it simply never runs, and a job history with no row is
-//! indistinguishable from a task that was not due.
+//! table means every task fires twice — and this process is the only one, so
+//! nothing else will fire a task on its behalf. A task declined here simply
+//! never runs, and a job history with no row is indistinguishable from a task
+//! that was not due.
 //!
 //! Everything here therefore fails **loudly** — see [`super::executor`], where
 //! an agent this build cannot run records a failed `job_history` row and
@@ -200,15 +197,14 @@ impl Scheduler {
 
     /// Bring the installed timers back in line with the stored rows.
     ///
-    /// **This exists because a native task write can fall back.** Every one of
-    /// them returns `WriteError::Fallback` on an unopenable database, a schema
-    /// newer than this build, a `SQLITE_BUSY` past the five-second timeout, or a
-    /// failed begin/commit — and the seam then forwards to a sidecar started
-    /// `AGENTO_SCHEDULER=off`, whose `taskService` applies the row change and
-    /// skips the registration. A created task would never fire, a resumed one
+    /// **This exists because a task write and its timer can come apart.** Every
+    /// task write returns `WriteError::Fallback` on an unopenable database, a
+    /// schema newer than this build, a `SQLITE_BUSY` past the five-second
+    /// timeout, or a failed begin/commit — and a row changed by anything else
+    /// (a hand edit, another tool) is never seen by the registration path at
+    /// all. Without a sweep a created task would never fire, a resumed one
     /// would have no timer, an edited one would keep its old schedule, and all
-    /// three would stay that way until the app restarted. That is the exact
-    /// split this port set out to close, on the error path.
+    /// three would stay that way until the app restarted.
     ///
     /// It is a sweep rather than a hook on the forward, so it also covers a row
     /// changed by anything else — and so the seam needs no knowledge of tasks.
@@ -412,26 +408,14 @@ fn local_tz() -> Tz {
         .unwrap_or(Tz::UTC)
 }
 
-/// Whether **this build** owns the scheduler, which is true only when the seam
-/// is fully on.
+/// Whether this process can own the scheduler at all.
 ///
 /// The scheduler cannot be owned independently of the task writes, because each
 /// write also registers or unregisters a timer and the registration has to
-/// happen in the process that stored the row. `may_serve` forwards every
-/// non-`GET` in both [`Mode::Off`] and [`Mode::Diff`], so in those modes Go is
-/// the only writer — and a Go that had been told `AGENTO_SCHEDULER=off` would
-/// store a task neither process ever schedules until the app restarts. That is
-/// exactly the split this port set out to close, reappearing through the
-/// escape hatch.
-///
-/// While the sidecar existed this decided ownership in **both** directions:
-/// whether `sidecar.rs` set `AGENTO_SCHEDULER=off` *and* whether [`start`]
-/// installed any timers. #278 removed the sidecar and the seam modes with it,
-/// so only the second direction remains.
+/// happen in the process that stored the row. Both are here, so the only
+/// question left is whether there is a database.
 pub fn shell_owns_scheduler() -> bool {
-    // The database path is the whole answer since #278: with no database this
-    // process cannot schedule at all. (The seam-mode half of this check died
-    // with the sidecar — there is no other process to leave the scheduler to.)
+    // With no database this process cannot read tasks, so it cannot schedule.
     crate::paths::database_path().is_some()
 }
 

--- a/src-tauri/src/native/sessions/continue_chat.rs
+++ b/src-tauri/src/native/sessions/continue_chat.rs
@@ -14,17 +14,17 @@
 //! reproduce faithfully: the user gets a 500 and a stray "New Chat".
 //!
 //! This runs both statements inside one transaction, which is a deliberate
-//! divergence and the only one available. `Err` means "forward to Go", so a
-//! Rust failure *between* the two writes would leave the orphan **and** have Go
-//! create a second chat — the one outcome worse than Go's. Rolling back gives
-//! "both or neither"; the response is a single `chat_id` either way, so nothing
-//! observable changes except that the failure path stops leaking a row.
+//! divergence. A failure *between* the two writes would otherwise leave the
+//! orphan chat behind and report a 500 — so the user sees an error and gains a
+//! stray "New Chat". Rolling back gives "both or neither"; the response is a
+//! single `chat_id` either way, so nothing observable changes except that the
+//! failure path stops leaking a row.
 //!
 //! # The statuses
 //!
-//! A missing session is `404`; a lookup *failure* is `500` and therefore
-//! forwards. `detail::get` collapses both into `None`/`Err`, so the split here
-//! is the same one it makes.
+//! A missing session is `404`; a lookup *failure* is `500`. `detail::get`
+//! collapses both into `None`/`Err`, so the split here is the same one it
+//! makes.
 
 use axum::http::StatusCode;
 use serde::Serialize;
@@ -79,8 +79,8 @@ pub fn continue_session(db_path: &std::path::Path, session_id: &str) -> Result<A
     )
     .map_err(|e| WriteError::Fallback(format!("linking claude session: {e}")))?;
 
-    // Encoded before the commit: after it, an `Err` would forward and Go would
-    // create a second chat.
+    // Encoded before the commit: after it, an `Err` would report failure for a
+    // chat that exists, and a retry would create a second one.
     let body = gojson::to_vec(&ContinueResponse {
         chat_id: session.id.clone(),
     })

--- a/src-tauri/src/native/sessions/mod.rs
+++ b/src-tauri/src/native/sessions/mod.rs
@@ -94,7 +94,7 @@ fn route_of(path: &str) -> Option<Route<'_>> {
 fn claims(method: &Method, path: &str) -> bool {
     match route_of(path) {
         // The two writes, each claimed for its own method only, so the wrong
-        // pairing still forwards and gets chi's own 405.
+        // pairing is unrouted.
         Some(Route::Continue(_)) => method == Method::POST,
         Some(Route::Detail(_)) => method == Method::GET || method == Method::PATCH,
         Some(_) => method == Method::GET,
@@ -155,7 +155,7 @@ fn serve(ctx: &Ctx, req: &Request) -> Result<Answer, String> {
     let body = if req.path == "/api/claude-sessions" {
         // `handleListClaudeSessions`: `ErrCursorMismatch` is the one `ListPage`
         // error answered 400 with its own text; everything else is the
-        // handler's generic 500. Both were forwards until #278.
+        // handler's generic 500.
         match page::list_page(&conn, &data_settings, &q) {
             Ok(page) => gojson::to_vec(&page).map_err(|e| format!("encoding session page: {e}"))?,
             Err(e) if e == query::ERR_CURSOR_MISMATCH => {

--- a/src-tauri/src/native/sessions/update.rs
+++ b/src-tauri/src/native/sessions/update.rs
@@ -74,11 +74,10 @@ pub fn update(
         .map_err(|e| WriteError::Fallback(format!("opening database: {e}")))?;
     crate::native::migrate::verify(&conn).map_err(WriteError::Fallback)?;
 
-    // Go runs the two statements separately, so a failed second one leaves the
-    // first applied. One transaction is the safe divergence: `Err` forwards, and
-    // a half-applied update followed by Go re-applying both reaches the same
-    // rows either way — but only "both or neither" keeps the rule that a native
-    // write fails *before* it mutates.
+    // The reference runs the two statements separately, so a failed second one
+    // leaves the first applied. One transaction is the safe divergence: "both
+    // or neither" is what keeps the rule that a write fails *before* it
+    // mutates, so a 500 never reports a half-applied update.
     let tx = conn
         .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
         .map_err(|e| WriteError::Fallback(format!("begin session update: {e}")))?;

--- a/src-tauri/src/native/settings.rs
+++ b/src-tauri/src/native/settings.rs
@@ -1337,8 +1337,8 @@ mod tests {
     /// directory built from the vectors.
     ///
     /// `#[cfg(unix)]` for the same reason the vectors are Unix-shaped and
-    /// [`serve`] forwards the route on Windows: the layout needs a symlink, and
-    /// the rule is `filepath` arithmetic this port implements for Unix only.
+    /// [`serve`] answers 501 on Windows: the layout needs a symlink, and the
+    /// rule is `filepath` arithmetic implemented for Unix only.
     #[test]
     #[cfg(unix)]
     fn the_candidate_probe_matches_gos_discovery_rule() {
@@ -1695,10 +1695,8 @@ mod tests {
         assert_eq!(status, axum::http::StatusCode::OK);
     }
 
-    /// Nothing may be written before a rejection, or the forward-to-Go that an
-    /// `Err` triggers would apply the change twice. Here the failure is answered
-    /// rather than forwarded, but the invariant is the same one and it is
-    /// cheaper to pin than to re-derive.
+    /// Nothing may be written before a rejection, or the 500 would be reporting
+    /// a change that partly landed. Cheaper to pin than to re-derive.
     #[test]
     fn a_rejected_save_leaves_the_row_untouched() {
         let _env = crate::paths::tests::env_lock();

--- a/src-tauri/src/native/tasks.rs
+++ b/src-tauri/src/native/tasks.rs
@@ -271,9 +271,8 @@ fn scan_task(row: &rusqlite::Row<'_>) -> rusqlite::Result<ScheduledTask> {
         settings_profile_id: row.get(7)?,
         timeout_minutes: row.get(8)?,
         schedule_type: row.get(9)?,
-        // Go fails the whole read on an unparsable schedule config rather than
-        // serving a task whose schedule is unknown. So does this: the error
-        // reaches the proxy, which falls back to Go.
+        // An unparsable schedule config fails the whole read rather than
+        // serving a task whose schedule is unknown.
         //
         // `Option` is what keeps a stored `null` out of that arm. Go unmarshals
         // a JSON `null` into a struct by leaving it at its zero value and
@@ -1685,8 +1684,9 @@ fn create_task(db_path: &Path, body: &[u8]) -> Result<super::Answer, WriteError>
         .map_err(|e| WriteError::Fallback(format!("begin task create: {e}")))?;
     insert_task_in(&tx, &task).map_err(WriteError::Fallback)?;
 
-    // Everything fallible before the commit: an `Err` after it would forward
-    // and Go would insert a second task under a fresh id.
+    // Everything fallible before the commit: an `Err` after it would answer
+    // 500 for a task that was actually inserted, inviting a retry that inserts
+    // a second one under a fresh id.
     let encoded = super::gojson::to_vec(&task)
         .map_err(|e| WriteError::Fallback(format!("encoding task: {e}")))?;
 
@@ -1768,8 +1768,8 @@ fn delete_task(db_path: &Path, id: &str) -> Result<super::Answer, WriteError> {
 
     // Existence only, deliberately not the decoded row: the delete needs no
     // field, and decoding one would make a task whose `created_at` this port
-    // cannot parse — a row some other tool wrote — forward instead of being
-    // deleted. The three routes below genuinely need the row and do decode it.
+    // cannot parse — a row some other tool wrote — undeletable. The three
+    // routes below genuinely need the row and do decode it.
     let exists: bool = tx
         .query_row("SELECT 1 FROM scheduled_tasks WHERE id = ?1", [id], |_| {
             Ok(true)

--- a/src-tauri/src/native/tools/mod.rs
+++ b/src-tauri/src/native/tools/mod.rs
@@ -25,7 +25,7 @@
 //! turn's stream task. Nothing observable follows from that: the URL is
 //! argv-only, it is never stored, and a per-turn port closes when the
 //! subprocess it was started for is gone. What it buys is that a crashed or
-//! forwarded turn leaks no bound port.
+//! refused turn leaks no bound port.
 //!
 //! The other difference is the version in the initialize handshake — Go's
 //! `mcp.Implementation` says `1.0.0`, [`crate::claude::ToolServer`] reports the

--- a/src-tauri/src/native/trigger/receiver.rs
+++ b/src-tauri/src/native/trigger/receiver.rs
@@ -339,7 +339,7 @@ mod tests {
         // `visit_seq` would build the struct from a JSON **array** — and an
         // update that decoded from `[7,{…}]` would dispatch a real agent run
         // where Go's `json.Unmarshal` errors and answers a silent 200. The
-        // seam's `Err`-means-forward cannot catch an over-accept, so the
+        // an over-accept is answered rather than reported, so the
         // `GoStruct` wrapper is the only guard.
         let dir = tempfile::tempdir().expect("tempdir");
         let db = migrated(dir.path(), true, "s3cret", "active");

--- a/src-tauri/src/native/trigger/registration.rs
+++ b/src-tauri/src/native/trigger/registration.rs
@@ -3,32 +3,28 @@
 //!
 //! # These are the routes that call Telegram, and the order is the whole design
 //!
-//! The issue's own trap: **fail before the call, never after.** A native handler
-//! that returns `Err` forwards to Go, and Go re-runs the whole handler — so an
-//! `Err` raised *after* a successful `setWebhook` registers the webhook twice,
-//! the second time with whatever secret Go generates, silently invalidating the
-//! one this process just stored. Every fallible step therefore happens **before**
-//! the network call, and nothing after it may fail:
+//! The trap: **fail before the call, never after.** An `Err` answers 500, and a
+//! 500 for a registration that actually succeeded invites the caller to retry —
+//! which registers the webhook a second time under a fresh secret, silently
+//! invalidating the one just stored. Every fallible step therefore happens
+//! **before** the network call, and nothing after it may fail:
 //!
 //! 1. resolve the public URL, the row, the type and the credentials;
 //! 2. read or mint the secret;
 //! 3. call Telegram;
 //! 4. store the outcome — and only log if that write fails.
 //!
-//! A **failed** `setWebhook` answers `WriteError::Internal` for a related but
-//! weaker reason. Go answers it with `httpErr`'s flat 500, so forwarding would
-//! spend a second `setWebhook` call to arrive at the same status — and if that
-//! second attempt *succeeded*, the shell would answer 200 where Go's own single
-//! attempt answered 500, overwriting the row this branch just wrote. The secret
-//! itself is not at risk on this path, unlike the one above: step 4 has already
-//! stored it, and Go only mints a new one when the column is empty.
+//! A **failed** `setWebhook` answers `WriteError::Internal` rather than
+//! `Fallback`, and the distinction is not cosmetic: `Internal` is a 500 this
+//! branch has already recorded a reason for, in a row that says `error`.
+//! `Fallback` is a 500 that means "the machinery broke", which is a different
+//! claim about a call that was made and refused.
 //!
-//! Step 4 is where Go and this port part company in one respect worth stating:
-//! Go returns an error if `SetWebhookInfo` fails after a *successful*
-//! registration, which would forward and re-register. Here that write failure is
-//! logged and the request still answers 200, because the webhook **is**
-//! registered at that point and telling the caller otherwise is the more
-//! damaging lie.
+//! Step 4 is a deliberate divergence: the original returns an error if
+//! `SetWebhookInfo` fails after a *successful* registration. Here that write
+//! failure is logged and the request still answers 200, because the webhook
+//! **is** registered at that point and telling the caller otherwise is the more
+//! damaging lie — it invites the retry that registers it twice.
 //!
 //! # The failure path stores its own status
 //!
@@ -112,8 +108,7 @@ fn prepare(db_path: &Path, id: &str) -> Result<Registration, WriteError> {
         bot_token: String,
     }
     let creds: Creds = serde_json::from_str(&row.credentials).map_err(|e| {
-        // Go wraps this and the handler turns it into a 500, which forwards —
-        // and forwarding is safe here because nothing has been called yet.
+        // A 500, and safe to answer here because nothing has been called yet.
         WriteError::Fallback(format!("parsing telegram credentials: {e}"))
     })?;
 
@@ -179,7 +174,7 @@ pub async fn register(db_path: &Path, id: &str) -> Result<(), WriteError> {
         Ok(_) => {
             if let Err(e) = store(db_path, id, &prepared.secret, "active", "") {
                 // The webhook **is** registered. Answering an error would
-                // forward and register it again, under a different secret.
+                // invite a retry that registers it again under a new secret.
                 log::error!("saving webhook info after a successful registration: {e}");
             }
             log::info!(
@@ -196,12 +191,9 @@ pub async fn register(db_path: &Path, id: &str) -> Result<(), WriteError> {
             if let Err(store_err) = store(db_path, id, &prepared.secret, "error", &message) {
                 log::warn!("recording webhook registration failure: {store_err}");
             }
-            // **Answered here, not forwarded.** Go answers a failed
-            // registration with `httpErr`'s flat 500, so `Fallback` would have
-            // the sidecar re-run all of `RegisterWebhook` — a *second*
-            // `setWebhook` — to reach the status this branch already knows. A
-            // retry that succeeded would be worse than wasteful: 200 where Go's
-            // own single attempt answered 500, over a row saying `error`. The
+            // **`Internal`, not `Fallback`.** Both are 500s, but this branch
+            // already knows why it failed and has recorded it in a row saying
+            // `error`; `Fallback` would claim the machinery broke instead. The
             // deliberate cost is that a transient failure is no longer silently
             // retried; the caller retries by asking again.
             log::error!("internal server error error=registering telegram webhook: {message}");
@@ -353,8 +345,8 @@ mod tests {
         );
     }
 
-    /// A failed `setWebhook` records why, keeps the secret, and is answered
-    /// **here** rather than forwarded.
+    /// A failed `setWebhook` records why, keeps the secret, and answers with
+    /// its own recorded reason rather than a bare machinery failure.
     ///
     /// Pointed at a local fake rather than Telegram. The first version of this
     /// test claimed "no network here" and was wrong: it issued a real HTTPS POST

--- a/src-tauri/src/native/uploads.rs
+++ b/src-tauri/src/native/uploads.rs
@@ -22,11 +22,17 @@
 //!
 //! # Failing before the file exists
 //!
-//! `Err` means "forward to Go", and Go would then write the file itself. So
-//! nothing fallible may run once the destination exists: the response bytes are
-//! built first, the directory is created before the file, and a partial file is
-//! removed before the failure is returned. A forward after a completed write
-//! would leave two uploads on disk and hand the second path to the user.
+//! An `Err` answers 500, so nothing fallible may run once the destination
+//! exists: a 500 for an upload that actually landed tells the user their file
+//! is gone when it is on disk, and invites a retry that writes it a second time
+//! under a fresh name. So the response bytes are built first, the directory is
+//! created before the file, and a partial file is removed before the failure is
+//! returned.
+//!
+//! Building the response first now buys less than it did — there is no second
+//! implementation to re-run the write — but the ordering costs nothing and the
+//! partial-file cleanup is load-bearing on its own. Do not "simplify" either
+//! away.
 
 use std::path::{Path, PathBuf};
 
@@ -121,8 +127,8 @@ fn upload(content_type: &str, body: &[u8], upload_dir: &Path) -> Result<super::A
 
     create_upload_dir(upload_dir)?;
 
-    // `os.Create` then `io.Copy`, with Go's cleanup: a failed copy removes the
-    // partial file. Here that also makes the forward safe.
+    // `os.Create` then `io.Copy`, with the same cleanup: a failed copy removes
+    // the partial file rather than leaving a truncated upload behind.
     std::fs::write(&dest, part.content).map_err(|e| {
         let _ = std::fs::remove_file(&dest);
         WriteError::Fallback(format!("failed to save file {dest:?}: {e}"))

--- a/src-tauri/src/native/writes.rs
+++ b/src-tauri/src/native/writes.rs
@@ -74,15 +74,16 @@ pub enum WriteError {
     /// users (#309): the desktop build exports no telemetry, so a save that
     /// appeared to succeed would be the worst answer available.
     NotImplemented(String),
-    /// Go answers **500 with this exact body**, and forwarding would answer
+    /// Answers **500 with this exact body**, where a `Fallback` would answer
     /// something else.
     ///
     /// The distinction from [`Self::Fallback`] is the whole reason this exists.
-    /// `Fallback` means "the sidecar can answer this better than I can", which
+    /// `Fallback` means "the machinery broke in a way this build cannot word", which
     /// holds for every 500 whose body comes from a Go error string. It stops
     /// holding the moment the state the answer depends on lives **here**:
     /// `GET /api/integrations/{id}/auth/status` reads the in-flight OAuth map,
-    /// and since #318 that map is the shell's. Forwarding a failed flow would
+    /// and since #318 that map is this process's. Reporting a failed flow as a
+    /// generic machinery failure would
     /// have Go answer from the stored token — `authenticated: false`, a
     /// plausible-looking lie — where Go itself would have answered 500. So the
     /// 500 is produced here, with `httpErr`'s default body verbatim.
@@ -161,11 +162,10 @@ pub fn error_body(message: &str) -> ErrorBody<'_> {
 
 /// Turn a handler result into what the seam expects.
 ///
-/// Every error becomes a real response with Go's status and Go's body. For
-/// `Fallback` — a machinery failure whose Go wording this build cannot
-/// reproduce — that is `httpErr`'s default 500, and the carried reason goes to
-/// the log instead of the wire, which is where Go put it too. (Until #278
-/// `Fallback` became `Err` and the proxy forwarded it to the sidecar.)
+/// Every error becomes a real response with its own status and body. For
+/// `Fallback` — a machinery failure whose exact wording this build cannot
+/// reproduce — that is the default 500, and the carried reason goes to the log
+/// instead of the wire.
 pub fn finish(result: Result<super::Answer, WriteError>) -> Result<super::Answer, String> {
     match result {
         Ok(answer) => Ok(answer),
@@ -259,7 +259,7 @@ pub fn finish(result: Result<super::Answer, WriteError>) -> Result<super::Answer
 /// because it holds no nested struct, but its `hidden_projects` and
 /// `claude_config_dirs` are plain `Vec<String>` rather than
 /// [`super::gojson::GoList`], so `[null]` is an over-*reject* there. That is
-/// #295's rule rather than this one, and the route still forwards, so it is
+/// #295's rule rather than this one, and the route is unclaimed, so it is
 /// recorded rather than changed.
 pub fn decode_body<T: serde::de::DeserializeOwned>(body: &[u8]) -> Result<T, WriteError> {
     if body.is_empty() {
@@ -469,7 +469,8 @@ mod tests {
         );
     }
 
-    /// Duplicate keys forward, because only Go can answer them.
+    /// Duplicate keys are declined, because neither behaviour can be claimed
+    /// with confidence — see the note above.
     ///
     /// `encoding/json` keeps the **last** occurrence but type-checks **every**
     /// one, so `{"n":"x","n":1}` is a 400 to Go even though the surviving value
@@ -617,7 +618,8 @@ mod tests {
         );
     }
 
-    /// A 422 is an answer, not a failure to answer: it must not forward, or the
+    /// A 422 is an answer, not a failure to answer: it must not become a
+    /// `Fallback`, or the
     /// sidecar would redo the work to reach the same conclusion.
     #[test]
     fn a_validation_failure_is_answered_here() {

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -231,8 +231,8 @@ async fn handle(req: Request<Body>) -> Response<Body> {
 async fn dispatch(req: Request<Body>, raw_path: String) -> (Response<Body>, Served) {
     // `internal/server/guards.go`, applied **before** routing (#329) — so every
     // route, claimed or not, is refused identically. The proxy used to be the
-    // only place the browser's `Host` could be checked because `forward`
-    // rewrote it; the forward is gone, but the ordering stays: the guards need
+    // only place the browser's `Host` could be checked, because forwarding
+    // rewrote it. The forward is gone; the ordering stays, because the guards need
     // no route to say no.
     if let Some((status, message)) = crate::guards::reject(&req) {
         return (error_response(status, message), Served::Rejected);


### PR DESCRIPTION
Follow-up to #411. The backend's doc comments were written while an `Err` reached a second implementation that answered for it. Nothing has since #278, and ~185 comments never caught up — they still say a failure "forwards to Go", "falls back" or "lets Go answer".

**This is not tidying.** Several of those sentences are the recorded justification for an ordering that still looks deliberate, so a reader who notices the forward is gone could reasonably undo it.

## The invariants survive; their reasons changed

`uploads.rs` builds the response before the file exists, creates the directory before the file, and removes a partial file on failure — *"because a forward after a completed write would leave two uploads on disk"*. No forward exists. But a 500 for an upload that landed still tells the user their file is gone when it is on disk, and still invites a retry that writes it twice. **The ordering stays; the reason is now the real one.**

Same shape in `trigger/registration.rs` (fail before calling Telegram, or a retry registers the webhook twice under a new secret) and in every "encode before the commit" comment across the agent, chat, task, pricing, integration and continue-chat writes.

The change everywhere: *"the other implementation re-applies the write"* → *"a 500 reports failure for a write that landed, and the retry is the caller's"*.

## Three were wrong in the code, not the comments

- `integration_credentials::split_url` had a closure named **`forward`** that answers a 422. → `refuse`
- `confluence::validate::Refusal::Forward` maps to a 500. → `Unreproducible`, matching `claude_settings`'s `Undecidable`
- `guards.rs` had a rustdoc link to **`crate::proxy::forward`**, a function that does not exist — a dead link in the module explaining why the guards run where they do

Nine test names asserted the old vocabulary and are renamed to what they actually pin. `migrate.rs` served two error strings naming a sidecar — one reachable from a 500 body.

## Two real gaps surfaced while reading

Recorded in `CLAUDE.md` rather than left in a comment:

- **`GET /api/fs` answers 500 where it should answer 404 or 400.** The three typed bodies were never written, because an `Err` used to reach an implementation that had them. The directory picker now reports "internal server error" for a path the user simply mistyped.
- **Several surfaces answer 500 for input they cannot decide about** — a non-ASCII profile name, a non-UTF-8 body, duplicate JSON keys, a document past serde's recursion limit. Invisible while something else could answer; user-visible 500s now.

## Deliberately untouched

~150 remaining uses of the words, which mean **other things**: DST spring-forward, `--fallback-model`, the unnamed settings-profile fallback, SSE byte pass-through, `WriteError::Fallback` as a type, and accurate past-tense history.

Also untouched, as in #411: the ~2,270 comments citing Go's stdlib as a live external specification. Those don't go stale.

## A note on the number

I estimated "~43" when you first asked. The real figure was **185** — my pattern was too narrow and I reported it as a total. Full classification is in the commit message.

## Verification

`cargo fmt --check` · `cargo clippy --all-targets -D warnings` · **1157 tests** · `npm run build`

One test needed updating rather than patching around: `a_database_behind_this_build_is_refused` asserted on the sidecar-naming error string. It now asserts the two schema-version directions stay distinguishable, which is what it was actually for.