### PR TITLE
release: tag releases `v*`, name the binary `agento`, and cut 1.0.0

### DIFF
--- a/.github/scripts/build-update-manifest.py
+++ b/.github/scripts/build-update-manifest.py
@@ -54,14 +54,16 @@ def platform_for(name: str) -> str | None:
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--artifacts", required=True, type=Path)
-    ap.add_argument("--tag", required=True, help="e.g. desktop-v0.1.0")
+    ap.add_argument("--tag", required=True, help="e.g. v1.0.0")
     ap.add_argument("--repo", required=True, help="owner/name")
     ap.add_argument("--output", required=True, type=Path)
     args = ap.parse_args()
 
-    version = args.tag.removeprefix("desktop-v")
+    # `removeprefix` returns the string unchanged when the prefix is absent, so
+    # the equality below is what rejects a tag that is not a version tag at all.
+    version = args.tag.removeprefix("v")
     if not version or version == args.tag:
-        print(f"error: tag {args.tag!r} is not of the form desktop-vX.Y.Z", file=sys.stderr)
+        print(f"error: tag {args.tag!r} is not of the form vX.Y.Z", file=sys.stderr)
         return 1
 
     base = f"https://github.com/{args.repo}/releases/download/{args.tag}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,13 +56,18 @@ jobs:
           pkg="$(python3 -c 'import json; print(json.load(open("package.json"))["version"])')"
           lock="$(python3 -c 'import json; print(json.load(open("package-lock.json"))["version"])')"
           lock_pkg="$(python3 -c 'import json; print(json.load(open("package-lock.json"))["packages"][""]["version"])')"
+          # grep rather than a TOML parser: `tomllib` is Python 3.11 and this
+          # runner is 3.10. `[package]` opens the file, so the first `version =`
+          # is the crate's own and not a dependency's.
+          cargo_toml="$(grep -m1 '^version = ' src-tauri/Cargo.toml | cut -d'"' -f2)"
 
-          if [ "$conf" = "$pkg" ] && [ "$conf" = "$lock" ] && [ "$conf" = "$lock_pkg" ]; then
+          if [ "$conf" = "$pkg" ] && [ "$conf" = "$lock" ] && [ "$conf" = "$lock_pkg" ] \
+             && [ "$conf" = "$cargo_toml" ]; then
             echo "ok: ${conf}"
             exit 0
           fi
 
-          echo "::error::version strings disagree — tauri.conf.json=${conf} package.json=${pkg} package-lock.json=${lock} package-lock.json .packages['']=${lock_pkg}. Fix with: npm version ${conf} --no-git-tag-version (package.json + lockfile), and set src-tauri/tauri.conf.json by hand. See docs/releasing.md step 1."
+          echo "::error::version strings disagree — tauri.conf.json=${conf} package.json=${pkg} package-lock.json=${lock} package-lock.json .packages['']=${lock_pkg} src-tauri/Cargo.toml=${cargo_toml}. Fix with: npm version ${conf} --no-git-tag-version (package.json + lockfile), and set src-tauri/tauri.conf.json and src-tauri/Cargo.toml by hand (then \`cargo update -p agento --offline\` for Cargo.lock). See docs/releasing.md step 1."
           exit 1
 
       - name: Install Linux build dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,26 @@ name: Release
 # Tauri cannot cross-compile its bundles: a .dmg needs macOS, an .exe needs
 # Windows, a .deb needs Linux. So the matrix is one runner per target OS.
 #
-# Tag with `desktop-v0.1.0` on `main` to build. The `desktop-` prefix is
-# retained deliberately: every installed app polls the fixed `desktop-latest`
-# tag, and the guard job, the manifest script and `promote` all key off the
-# prefix. Renaming it is a release-infrastructure change to make on its own,
-# never as a side effect of something else.
+# Tag with `v1.0.0` on `main` to build.
+#
+# The `desktop-v*` prefix this used to require is gone: Agento is the desktop
+# app and there is no second thing to disambiguate it from. The Go server that
+# owned the plain `v*` namespace was sunset at `v0.11.2`, so `v1.0.0` and
+# everything after it is unambiguously this app — and being greater than every
+# legacy tag, it also takes over the repo's "Latest release" link.
+#
+# `desktop-latest` is a DIFFERENT thing and does NOT move. It is the fixed tag
+# the update manifest is published to, and its URL is baked into every
+# installer ever shipped (`plugins.updater.endpoints` in tauri.conf.json).
+# Renaming it would silently strand every existing install: they would go on
+# polling a URL that 404s and simply never be offered another update. The
+# release tags are free to change; this one is not.
+#
+# One consequence of the shorter prefix, since `promote` keys off it: the 15
+# legacy Go releases (`v0.1.0` … `v0.11.2`) now match it too. Re-publishing one
+# of those would run `promote` against a release that has no manifest, which is
+# why the download step names that case explicitly rather than failing on a
+# bare 404.
 #
 # The flow has a deliberate human gate in the middle:
 #
@@ -27,12 +42,12 @@ name: Release
 # draft asset URLs that 404 until someone remembers to publish the draft —
 # every installed app would see "update available" and fail the download.
 #
-# A prerelease tag (`desktop-v0.1.0-rc.1`) builds and drafts identically and
-# is auto-marked prerelease, but is never promoted: release candidates are
+# A prerelease tag (`v1.0.0-rc.1`) builds and drafts identically and is
+# auto-marked prerelease, but is never promoted: release candidates are
 # shareable from the versioned release page without being pushed to updaters.
 on:
   push:
-    tags: ["desktop-v*"]
+    tags: ["v*"]
   workflow_dispatch:
     inputs:
       dry_run:
@@ -45,7 +60,7 @@ on:
 # The event name is part of the group so publishing a draft (a `release`
 # event carrying the same tag ref) can never cancel a build run in flight.
 concurrency:
-  group: desktop-release-${{ github.event_name }}-${{ github.ref }}
+  group: release-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -70,24 +85,41 @@ jobs:
         # manifest, so a mismatch there makes every "updated" install re-offer
         # itself forever. That is why it was checked first and alone.
         #
-        # The other two are checked because nothing else ever looks at them.
+        # The others are checked because nothing else ever looks at them.
         # `package-lock.json` sat on 0.1.1 for the whole of 0.1.2 for exactly
         # that reason, and a stale lockfile version is not merely untidy: npm
         # repairs that field on almost any command, so every fresh checkout goes
         # dirty on the first `npm run build` with a change nobody made — which
         # reads as local work, invites a discard, and comes back immediately.
+        # `src-tauri/Cargo.toml` was the next one nobody was looking at: it sat
+        # on 0.1.2 while the release became 1.0.0, and cargo never repairs it,
+        # so the drift is silent rather than merely annoying.
+        env:
+          # `ref_type`, not the name's prefix. A `workflow_dispatch` run carries
+          # the branch in GITHUB_REF_NAME, and now that the prefix is one letter
+          # a branch called `validate-something` would be read as the tag
+          # `alidate-something`. Asking what the ref *is* cannot be fooled that
+          # way; the `v*` case below is then belt-and-braces.
+          REF_TYPE: ${{ github.ref_type }}
         run: |
+          if [ "$REF_TYPE" != "tag" ]; then
+            echo "not a tag build; nothing to check"
+            exit 0
+          fi
+
           tag="${GITHUB_REF_NAME}"
           case "$tag" in
-            desktop-v*) ;;
-            *) echo "not a desktop-v* tag build; nothing to check"; exit 0 ;;
+            v*) ;;
+            *) echo "not a v* tag build; nothing to check"; exit 0 ;;
           esac
-          tag_version="${tag#desktop-v}"
+          tag_version="${tag#v}"
 
           conf_version="$(python3 -c 'import json; print(json.load(open("src-tauri/tauri.conf.json"))["version"])')"
           pkg_version="$(python3 -c 'import json; print(json.load(open("package.json"))["version"])')"
           lock_version="$(python3 -c 'import json; print(json.load(open("package-lock.json"))["version"])')"
           lock_pkg_version="$(python3 -c 'import json; print(json.load(open("package-lock.json"))["packages"][""]["version"])')"
+          # See ci.yml for why this is grep and not a TOML parser.
+          cargo_toml_version="$(grep -m1 '^version = ' src-tauri/Cargo.toml | cut -d'"' -f2)"
 
           fail=0
           check() {
@@ -104,12 +136,13 @@ jobs:
           check "package.json"                       "$pkg_version"
           check "package-lock.json .version"         "$lock_version"
           check "package-lock.json .packages[''] "   "$lock_pkg_version"
+          check "src-tauri/Cargo.toml"               "$cargo_toml_version"
 
           if [ "$fail" = 1 ]; then
-            echo "::error::Fix with: npm version ${tag_version} --no-git-tag-version   (package.json + lockfile), and set src-tauri/tauri.conf.json by hand. Then re-tag. See docs/releasing.md step 1."
+            echo "::error::Fix with: npm version ${tag_version} --no-git-tag-version (package.json + lockfile), set src-tauri/tauri.conf.json and src-tauri/Cargo.toml by hand, then \`cargo update -p agento --offline\` for Cargo.lock. Then re-tag. See docs/releasing.md step 1."
             exit 1
           fi
-          echo "ok: ${tag_version} in all four places"
+          echo "ok: ${tag_version} in all five places"
 
   build:
     name: ${{ matrix.label }}
@@ -198,9 +231,15 @@ jobs:
       - name: Compute the build stamp
         id: stamp
         shell: bash
+        env:
+          # Same reasoning as the guard job: ask what the ref is, rather than
+          # what its name starts with. Getting this wrong here is quieter —
+          # a dispatch build from a `v…` branch would stamp itself as a
+          # release version instead of `-dev`, and nothing would say so.
+          REF_TYPE: ${{ github.ref_type }}
         run: |
-          case "${GITHUB_REF_NAME}" in
-            desktop-v*) version="${GITHUB_REF_NAME#desktop-v}" ;;
+          case "${REF_TYPE}:${GITHUB_REF_NAME}" in
+            tag:v*) version="${GITHUB_REF_NAME#v}" ;;
             *) version="$(python3 -c 'import json; print(json.load(open("src-tauri/tauri.conf.json"))["version"])')-dev" ;;
           esac
           echo "version=${version}" >>"$GITHUB_OUTPUT"
@@ -264,7 +303,7 @@ jobs:
   release:
     name: Draft release
     needs: build
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/desktop-v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
@@ -277,10 +316,10 @@ jobs:
       - name: Release metadata
         id: meta
         run: |
-          version="${GITHUB_REF_NAME#desktop-v}"
-          # A prerelease suffix (desktop-v0.1.0-rc.1) marks the draft as a
-          # prerelease, which is one of the two things keeping `promote` from
-          # ever pushing it to updaters.
+          version="${GITHUB_REF_NAME#v}"
+          # A prerelease suffix (v1.0.0-rc.1) marks the draft as a prerelease,
+          # which is one of the two things keeping `promote` from ever pushing
+          # it to updaters.
           case "$version" in
             *-*) echo "prerelease=true" >>"$GITHUB_OUTPUT" ;;
             *)   echo "prerelease=false" >>"$GITHUB_OUTPUT" ;;
@@ -338,15 +377,15 @@ jobs:
   # manifest was built and signed beside the artifacts it points at, and this
   # job only copies it to the fixed URL the updater polls. The `if` filters
   # out everything else that flows through `release: published` —
-  # desktop-latest's own publication, and any release marked prerelease; the
-  # version check below catches an rc tag even if someone unticked the
-  # prerelease box before publishing.
+  # desktop-latest's own publication (which does not start with `v`), and any
+  # release marked prerelease; the version check below catches an rc tag even
+  # if someone unticked the prerelease box before publishing.
   promote:
     name: Promote update manifest
     if: >-
       github.event_name == 'release' &&
       !github.event.release.prerelease &&
-      startsWith(github.event.release.tag_name, 'desktop-v')
+      startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
@@ -354,13 +393,25 @@ jobs:
     steps:
       - name: Download the staged manifest
         run: |
-          version="${TAG#desktop-v}"
+          version="${TAG#v}"
           case "$version" in
             *-*)
               echo "::error::${TAG} is a prerelease tag published without the prerelease flag; refusing to promote it to desktop-latest."
               exit 1
               ;;
           esac
+
+          # The `v*` prefix also matches the 15 releases the sunset Go server
+          # left behind (v0.1.0 … v0.11.2). Re-publishing one of those reaches
+          # this job, and it has no manifest to promote — say so, rather than
+          # letting `gh release download` fail on a bare "asset not found" that
+          # reads like the build broke.
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
+                 --json assets --jq '.assets[].name' | grep -qx latest.json; then
+            echo "::error::${TAG} carries no latest.json, so there is nothing to promote. Every release built by this workflow stages one; a tag without it is either a legacy Go-server release (v0.1.0 through v0.11.2) or a release whose assets were edited by hand."
+            exit 1
+          fi
+
           gh release download "$TAG" --repo "$GITHUB_REPOSITORY" \
             --pattern latest.json --output latest.json
           python3 - "$version" <<'EOF'
@@ -375,12 +426,17 @@ jobs:
       # A fixed tag so the updater has a stable manifest URL. Marked as a
       # prerelease so it never displaces the real "Latest release" on the repo
       # page — asset download URLs work for prereleases just the same.
+      #
+      # The name is `desktop-latest` and must stay that way even though the
+      # release tags dropped the prefix: this exact URL is compiled into every
+      # installer that has ever shipped, and an app polling a 404 is never
+      # offered an update and never reports a problem.
       - name: Publish to desktop-latest
         run: |
           if ! gh release view desktop-latest --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             gh release create desktop-latest --repo "$GITHUB_REPOSITORY" \
               --prerelease --title "Desktop update manifest" \
               --notes "Machine-readable manifest the Agento desktop updater polls.
-          Not a download — see the \`desktop-v*\` releases for installers."
+          Not a download — see the \`v*\` releases for installers."
           fi
           gh release upload desktop-latest latest.json --clobber --repo "$GITHUB_REPOSITORY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,30 +47,42 @@ process, one SQLite file, and the Claude Code CLI spawned per agent run.
 ## Branch and release model
 
 - PRs target **`main`**.
-- Releases are tagged **`desktop-v*`** from `main`
-  (`.github/workflows/release.yml`). The `desktop-` prefix is historical and
-  deliberately retained: installed apps poll the fixed `desktop-latest` tag, and
-  the guard job, the manifest script and `promote` all key off the prefix.
-  Renaming it is its own change, never a side effect of another.
-- The tag must equal `desktop-v` + the `version` in
-  `src-tauri/tauri.conf.json`; a guard job fails the build otherwise.
-  The updater compares the version baked into the app against the manifest's
-  (taken from the tag), so a mismatch makes every "updated" install re-offer
-  itself forever. Bump the conf in the release commit, then tag it.
-- **The release commit bumps three files, not one**: `tauri.conf.json`,
-  `package.json` and `package-lock.json` (`npm version X.Y.Z
-  --no-git-tag-version` does the last two together). Only the conf is enforced,
-  by the guard job — which is why `package-lock.json` sat on `0.1.1` for the
-  whole of `0.1.2`. A stale lockfile version is not merely untidy: npm repairs
-  that field on almost any command, so every checkout goes dirty on the first
-  `npm run build` with a change nobody made, which reads as local work and
-  comes back as soon as it is discarded. See `docs/releasing.md` step 1.
+- Releases are tagged **`v*`** from `main` (`.github/workflows/release.yml`).
+  The `desktop-v*` prefix was dropped at `v1.0.0`: Agento is the desktop app,
+  and the Go server that owned the plain `v*` namespace was sunset at `v0.11.2`,
+  so `v1.0.0` and everything after it is unambiguously this app.
+- **`desktop-latest` is a different tag and it did *not* move.** It is the fixed
+  tag the update manifest is published to, and its URL is compiled into every
+  installer ever shipped (`plugins.updater.endpoints`). Renaming it strands every
+  existing install silently — they poll a URL that 404s, are never offered an
+  update, and report nothing, because "up to date" and "cannot reach the
+  manifest" are indistinguishable from outside. Release tags are free; this one
+  is not.
+- One consequence of the shorter prefix: the 15 legacy `v0.*` server releases
+  now match `promote`'s filter too, so it checks that a release actually carries
+  a `latest.json` before promoting and says so by name when one does not.
+- The tag must equal `v` + the `version` in `src-tauri/tauri.conf.json`; a guard
+  job fails the build otherwise. The updater compares the version baked into the
+  app against the manifest's (taken from the tag), so a mismatch makes every
+  "updated" install re-offer itself forever. Bump the conf in the release commit,
+  then tag it.
+- **The release commit bumps five places, not one**: `tauri.conf.json`,
+  `package.json`, `package-lock.json` (which carries it twice, and `npm version
+  X.Y.Z --no-git-tag-version` does both), `src-tauri/Cargo.toml` and
+  `src-tauri/Cargo.lock` (`cargo update -p agento --offline`). **All five are
+  enforced** — by the release guard and by CI on every PR. They were not always:
+  only the conf was checked, which is why `package-lock.json` sat on `0.1.1` for
+  the whole of `0.1.2` and `Cargo.toml` sat on `0.1.2` until `1.0.0`. The
+  lockfile is the one with teeth — npm repairs that field on almost any command,
+  so every checkout goes dirty on the first `npm run build` with a change nobody
+  made, which reads as local work and comes back as soon as it is discarded. See
+  `docs/releasing.md` step 1.
 - Tagging builds a **draft** release with `latest.json` staged as an asset.
   Nothing has shipped at that point — draft assets are not publicly
   downloadable. **Publishing the draft is the release act**: the
   `release: published` event runs the `promote` job, which copies the staged
   manifest to the fixed `desktop-latest` tag every installed app polls.
-- A prerelease tag (`desktop-v0.1.0-rc.1`) builds and drafts identically, is
+- A prerelease tag (`v1.0.0-rc.1`) builds and drafts identically, is
   auto-marked prerelease, and is **never promoted** — a shareable release
   candidate no installed app is offered. For private smoke-test builds, run
   the workflow manually with `dry_run` instead: installers land as CI
@@ -777,9 +789,13 @@ The hook was there and nothing set the variables. Two halves fix it, and
 **neither works alone**:
 
 - `release.yml`'s **"Compute the build stamp"** step derives the version from
-  the tag (`desktop-v0.1.2` → `0.1.2`), or from `tauri.conf.json` with a `-dev`
-  suffix for a `workflow_dispatch` dry run, which has no tag to read. Together
-  with `github.sha` and an RFC 3339 date it goes into "Build installers"' `env:`.
+  the tag (`v1.0.0` → `1.0.0`), or from `tauri.conf.json` with a `-dev` suffix
+  for a `workflow_dispatch` dry run, which has no tag to read. Together with
+  `github.sha` and an RFC 3339 date it goes into "Build installers"' `env:`.
+  It branches on `github.ref_type == 'tag'`, **not** on the ref name's prefix:
+  since `v1.0.0` that prefix is one letter, and a dispatch run from a branch
+  called `validate-…` would otherwise be read as a tag and stamped as a release
+  rather than `-dev`. The guard job branches the same way for the same reason.
 - `src-tauri/build.rs`'s **`stamp_build_info`** re-emits each set variable as
   `cargo:rustc-env` and declares `cargo:rerun-if-env-changed` for it. The
   release job restores a `Swatinem/rust-cache` target dir from an earlier tag's
@@ -3104,10 +3120,14 @@ the updater swapped in.
 - Public key: `plugins.updater.pubkey` in `tauri.conf.json`.
 - Manifest: `.github/scripts/build-update-manifest.py` assembles `latest.json`
   and publishes it to the fixed `desktop-latest` tag, so the updater has a
-  stable URL. `releases/latest` could not be used — it would point at the Go
-  server's `v*` releases. The script *fails the release* if any platform is
-  missing a signature, because a manifest that silently omits a platform
-  strands exactly the users already running it, and they would never be told.
+  stable URL. `releases/latest` was originally unusable because it pointed at
+  the Go server's `v*` releases; that is no longer true — `v1.0.0` outranks
+  every `v0.*` — but the tag **still must not be renamed**, because its URL is
+  compiled into every installer already in the field. A stable manifest URL was
+  always the point; which release is "latest" never was. The script *fails the
+  release* if any platform is missing a signature, because a manifest that
+  silently omits a platform strands exactly the users already running it, and
+  they would never be told.
 
 `.deb`/`.rpm` installs are **notify-only**: dpkg and rpm own their files, so
 `install_kind()` in `lib.rs` detects them at runtime (the AppImage runtime is
@@ -3128,31 +3148,40 @@ dependencies — apt/dnf resolve them, which is the correct native behaviour;
 statically bundling them is not a thing Debian packaging does. The `.AppImage`
 bundles them for distro-independent use.
 
-### Binary naming, and renaming it back later
+### Binary naming
 
-The Debian/RPM package is named **`agento`** (from `productName`), but the GUI
-binary inside it is **`agento-desktop`** (`mainBinaryName`). That split exists
-only because the Go CLI currently installs an `agento` onto `PATH`; a package
-dropping `/usr/bin/agento` would shadow it depending on PATH order.
+The Debian/RPM package and the GUI binary inside it are both **`agento`** — the
+package name from `productName`, the binary from `mainBinaryName`.
 
-When the CLI is retired and the desktop app becomes *the* Agento, renaming is
-one line: set `mainBinaryName` back to `agento` (or delete the field). Nothing
-else has to change, and specifically:
+They were not always the same. Until `v1.0.0` the binary was `agento-desktop`,
+because the Go CLI installed an `agento` onto `PATH` and a package dropping
+`/usr/bin/agento` would have shadowed it depending on PATH order. That CLI is
+retired, so the split had nothing left to protect and the name came back. It was
+one line, and this is why nothing else had to move with it:
 
-- **dpkg/rpm handle it themselves.** The package name is unchanged, so an
+- **dpkg/rpm handle it themselves.** The package name never changed, so the
   upgrade is an ordinary file change within the same package — the old
   `/usr/bin/agento-desktop` is removed and `/usr/bin/agento` added. No
   `Conflicts:`/`Replaces:` needed, because no *package* ever owned that path
-  (the CLI is installed by hand into `~/.local/bin`).
+  (the CLI was installed by hand into `~/.local/bin`).
 - **The `.desktop` launcher is regenerated** by Tauri with the new `Exec=`.
 - **The updater is unaffected.** Every format replaces the whole artifact — the
   AppImage file, the `.app` bundle, the NSIS install — so a binary rename
   crosses an update boundary cleanly.
 - **macOS and Windows never cared**: the binary name is internal to the bundle
   and the installer.
+- **No bundle filename moved.** Artifact names come from `productName`, not
+  `mainBinaryName` — `desktop-v0.1.1` shipped `Agento_0.1.1_amd64.AppImage`
+  while the binary was `agento-desktop`. That is what keeps
+  `build-update-manifest.py`'s suffix table and the `Agento.app.tar.gz` rename
+  in `release.yml` valid across the change; verify it against a real release's
+  asset list before assuming otherwise.
 
-The one leftover is users who still have `~/.local/bin/agento` from the CLI;
-that is the CLI's uninstall to handle, not the package's.
+Two leftovers. Users who still have `~/.local/bin/agento` from the CLI — that is
+the CLI's uninstall to handle, not the package's. And `~/.agento-desktop-dev`,
+the **debug data directory** (`paths.rs`), which is unrelated to the binary name
+and deliberately unchanged: renaming it would orphan every developer's local
+database for no gain.
 
 ### The one external dependency
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ cost analytics, productivity insights and a searchable, replayable history of ev
 It also lets you build agents, chat with them, schedule them, and connect them to the tools you use.
 **No API key, no account, no telemetry. Everything stays on your machine.**
 
-[![Release](https://img.shields.io/github/v/release/shaharia-lab/agento?filter=desktop-v*&style=flat-square&color=3fa045&label=release)](https://github.com/shaharia-lab/agento/releases?q=desktop-v&expanded=true)
+[![Release](https://img.shields.io/github/v/release/shaharia-lab/agento?filter=!v0.*&style=flat-square&color=3fa045&label=release)](https://github.com/shaharia-lab/agento/releases/latest)
 [![CI](https://img.shields.io/github/actions/workflow/status/shaharia-lab/agento/ci.yml?branch=main&style=flat-square&label=CI&logo=github)](https://github.com/shaharia-lab/agento/actions/workflows/ci.yml)
 [![Downloads](https://img.shields.io/github/downloads/shaharia-lab/agento/total?style=flat-square&color=blue)](https://github.com/shaharia-lab/agento/releases)
 [![Stars](https://img.shields.io/github/stars/shaharia-lab/agento?style=flat-square&color=f5c518)](https://github.com/shaharia-lab/agento/stargazers)
@@ -48,7 +48,7 @@ Anthropic API key to enter; the app tells you on launch if the CLI is missing.
 </details>
 
 <details open>
-<summary><b>2. Download</b> — pick your platform from the <a href="https://github.com/shaharia-lab/agento/releases?q=desktop-v&expanded=true">latest release</a></summary>
+<summary><b>2. Download</b> — pick your platform from the <a href="https://github.com/shaharia-lab/agento/releases/latest">latest release</a></summary>
 
 <br>
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -94,9 +94,13 @@ from the identifier. On Linux you can watch both claims coexist:
 
 ```
 $ busctl --user list | grep shaharialab
-com.shaharialab.agento.SingleInstance       …  agento-desktop
+com.shaharialab.agento.SingleInstance       …  agento
 com.shaharialab.agento.dev.SingleInstance   …  agento
 ```
+
+The two process names are identical — both binaries are `agento` since `v1.0.0`
+— so it is the bus name that tells them apart, which is the whole point of the
+override.
 
 **It does not help you test anything origin-dependent.** A dev build loads the
 configured `devUrl`, which Tauri's ACL treats as a *local* origin, so the whole
@@ -360,9 +364,8 @@ Chrome but not in the app".
 ## Branches and pull requests
 
 - Work happens on a feature branch. PRs target **`main`**.
-- Releases are tagged `desktop-v*` from `main`. The prefix is retained because
-  every installed app polls the fixed `desktop-latest` tag — see
-  [Releasing](releasing.md).
+- Releases are tagged `v*` from `main`. The update manifest keeps its own fixed
+  tag, `desktop-latest`, which does **not** move — see [Releasing](releasing.md).
 
 Before opening a PR, from the repository root:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -39,9 +39,13 @@ Operating systems:
 ## Which file do I download
 
 Downloads are on the
-[releases page](https://github.com/shaharia-lab/agento/releases?q=desktop&expanded=true).
-Desktop releases are tagged `desktop-v<version>`. The Agento server has its own
-`v<version>` tags, so make sure you are looking at a `desktop-` one.
+[releases page](https://github.com/shaharia-lab/agento/releases/latest). Releases
+are tagged `v<version>`.
+
+Two older tag shapes are still visible in the repository's release list and
+neither is something to download today: `desktop-v0.1.x` was Agento Desktop
+before it took over the plain `v*` tags, and `v0.1.0` through `v0.11.2` were the
+Agento server, which is retired. Anything from `v1.0.0` onward is this app.
 
 | Platform | File | Auto-update |
 | --- | --- | --- |
@@ -115,8 +119,8 @@ during setup.
 Works on any distribution and updates itself.
 
 ```bash
-chmod +x Agento_0.1.0_amd64.AppImage
-./Agento_0.1.0_amd64.AppImage
+chmod +x Agento_1.0.0_amd64.AppImage
+./Agento_1.0.0_amd64.AppImage
 ```
 
 Keep the file anywhere you like, for example `~/Applications`. There is no
@@ -130,25 +134,33 @@ If your desktop does not show a launcher for it, install
 ### Debian and Ubuntu
 
 ```bash
-sudo apt install ./Agento_0.1.0_amd64.deb
+sudo apt install ./Agento_1.0.0_amd64.deb
 ```
 
 ### Fedora, RHEL, openSUSE
 
 ```bash
-sudo dnf install ./Agento-0.1.0-1.x86_64.rpm
+sudo dnf install ./Agento-1.0.0-1.x86_64.rpm
 ```
 
 Both packages declare `libwebkit2gtk-4.1` and `gtk3` as dependencies, so your
 package manager installs whatever is missing. If a dependency cannot be resolved,
 your distribution is likely older than WebKitGTK 4.1: use the AppImage instead.
 
-### The binary is called `agento-desktop`
+### The binary is called `agento`
 
-The package is named `agento`, but the executable it installs is
-`/usr/bin/agento-desktop`. That is deliberate. The Agento server CLI installs a
-binary called `agento`, and a package dropping a second `agento` onto your `PATH`
-would shadow it.
+The package and the executable it installs are both `agento`, at
+`/usr/bin/agento`.
+
+Before `v1.0.0` the executable was `/usr/bin/agento-desktop`: the Agento server
+CLI installed a binary called `agento`, and a package dropping a second one onto
+your `PATH` would have shadowed it. That CLI is retired, so the name came back.
+
+Upgrading a `.deb` or `.rpm` across that change needs nothing from you — the
+package name never changed, so it is an ordinary file replacement within the same
+package and your package manager removes `agento-desktop` as it adds `agento`.
+The application launcher is regenerated too. Only your own scripts or shortcuts
+naming `agento-desktop` need updating.
 
 ---
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -2,11 +2,25 @@
 
 How a release is cut, and the two things that break it.
 
-Releases are tagged `desktop-v*` from `main`. The `desktop-` prefix is
-historical and is kept deliberately: every installed app polls the fixed
-`desktop-latest` tag, and the guard job, the manifest script and the `promote`
-job all key off the prefix. Renaming it is a release-infrastructure change to
-make on its own, never as a side effect of something else.
+Releases are tagged `v*` from `main`.
+
+**Two tag names matter here and they are not the same thing.** Release tags are
+`v1.0.0`, `v1.1.0` and so on — the guard job, the manifest script and the
+`promote` job all key off that `v` prefix. The *update manifest* is published to
+a separate, fixed tag called **`desktop-latest`**, and that name is frozen: its
+download URL is compiled into every installer that has ever shipped
+(`plugins.updater.endpoints` in `src-tauri/tauri.conf.json`). Rename it and every
+existing install polls a URL that 404s — they are never offered another update
+and never report a problem, because "no update available" and "cannot reach the
+manifest" look identical from the outside. Change the release tags freely; leave
+`desktop-latest` alone.
+
+Two legacy tag namespaces are still in the repository and neither is ever built
+again: `desktop-v0.1.x` is what this app's releases were called before `v1.0.0`,
+and `v0.1.0` … `v0.11.2` are the retired Agento server's. The second is why
+`promote` checks that a release actually carries a `latest.json` before doing
+anything — re-publishing one of those old server releases would otherwise reach
+it with nothing to promote.
 
 - [The flow](#the-flow)
 - [Cutting a release](#cutting-a-release)
@@ -22,7 +36,7 @@ make on its own, never as a side effect of something else.
 ## The flow
 
 ```
-  bump tauri.conf.json  ──>  tag desktop-vX.Y.Z  ──>  guard + build matrix
+  bump tauri.conf.json  ──>  tag vX.Y.Z  ──────────>  guard + build matrix
                                                             │
                                                             v
                                               DRAFT release, installers
@@ -49,34 +63,38 @@ cannot download.
 
 ## Cutting a release
 
-1. **Bump the version in all three files**, and commit them together on
-   `desktop`: `src-tauri/tauri.conf.json`, `package.json` and
-   `package-lock.json`.
+1. **Bump the version in all five places**, and commit them together on `main`:
+   `src-tauri/tauri.conf.json`, `package.json`, `package-lock.json` (which
+   carries it twice), `src-tauri/Cargo.toml` and `src-tauri/Cargo.lock`.
 
    ```bash
-   npm version 0.2.0 --no-git-tag-version   # package.json + package-lock.json
+   npm version 1.1.0 --no-git-tag-version   # package.json + package-lock.json
    # then, by hand:
-   # src-tauri/tauri.conf.json → { "version": "0.2.0" }
+   # src-tauri/tauri.conf.json → { "version": "1.1.0" }
+   # src-tauri/Cargo.toml      → version = "1.1.0"
+   cd src-tauri && cargo update -p agento --offline   # Cargo.lock
    ```
 
    `npm version` is what keeps the lockfile in step; bumping `package.json`
-   alone leaves it behind.
+   alone leaves it behind. `cargo update -p agento --offline` does the same job
+   for `Cargo.lock` without touching any dependency.
 
-   **Only `tauri.conf.json` is enforced** — the guard job in step 2 compares it
-   against the tag, and the bundler bakes it into the installer. The other two
-   have nothing checking them, which is exactly why `package-lock.json` was
-   still on `0.1.1` for the whole of `0.1.2` (fixed in `1f5cc9a`). That drift is
-   not cosmetic in one specific way: npm silently repairs the lockfile's version
-   field on almost any command, so the first `npm run build` or `tauri dev`
-   after a checkout leaves the working tree dirty with a change nobody made.
-   It reads as local work, invites someone to discard it, and comes straight
-   back on the next npm command.
+   **All five are enforced now**, by the guard job in step 2 and by CI on every
+   PR. `tauri.conf.json` is the one that decides what ships — the bundler bakes
+   it into the installer and the updater compares against it — and the rest are
+   checked because nothing else ever looks at them. That is not hypothetical:
+   `package-lock.json` sat on `0.1.1` for the whole of `0.1.2` (fixed in
+   `1f5cc9a`), and `src-tauri/Cargo.toml` sat on `0.1.2` right up to `1.0.0`.
+   The lockfile drift is the one with teeth — npm silently repairs that field on
+   almost any command, so the first `npm run build` after a checkout leaves the
+   tree dirty with a change nobody made, which reads as local work, invites
+   someone to discard it, and comes straight back.
 
 2. **Tag that commit** and push the tag.
 
    ```bash
-   git tag desktop-v0.2.0
-   git push origin desktop-v0.2.0
+   git tag v1.1.0
+   git push origin v1.1.0
    ```
 
 3. **Wait for the build.** Five runners, one per target: Linux x86_64, Linux
@@ -95,13 +113,14 @@ cannot download.
 
 ## The two guards
 
-**The tag must equal `desktop-v` plus the version in `tauri.conf.json`.** A guard
-job fails the build otherwise, before anything is built.
+**The tag must equal `v` plus the version in `tauri.conf.json`** (and in the four
+other files listed in step 1). A guard job fails the build otherwise, before
+anything is built.
 
 This is not tidiness. The installed app compares the version baked into it at
 build time against the manifest's version, which comes from the tag. If the tag
-says `0.2.0` and the conf still says `0.1.0`, every "updated" install keeps
-reporting `0.1.0` and is offered the same update forever.
+says `1.1.0` and the conf still says `1.0.0`, every "updated" install keeps
+reporting `1.0.0` and is offered the same update forever.
 
 **Every platform must produce a signature.** The manifest script aborts the
 release if a payload has no `.sig`, or if a platform produced nothing at all. A
@@ -116,8 +135,8 @@ running it, and their app would keep reporting "up to date" indefinitely.
 is **never promoted**:
 
 ```bash
-git tag desktop-v0.2.0-rc.1
-git push origin desktop-v0.2.0-rc.1
+git tag v1.1.0-rc.1
+git push origin v1.1.0-rc.1
 ```
 
 Share the release page with testers. No installed app is offered it. The promote
@@ -172,6 +191,10 @@ The manifest is served from a fixed tag, `desktop-latest`, so the updater has a
 stable URL that does not move with each release. That tag is itself marked
 prerelease so it never displaces the real latest release on the repository page.
 
+Its name outlived the `desktop-v*` release tags on purpose. The URL is baked
+into every shipped installer, so the tag has to keep answering for as long as
+any of those installs exist — see the note at the top of this file.
+
 ---
 
 ## Signing keys
@@ -203,8 +226,8 @@ therefore needs a Gatekeeper or SmartScreen bypass, which the release notes and
 `tauri.conf.json`, commit, and re-tag.
 
 ```bash
-git tag -d desktop-v0.2.0
-git push origin :refs/tags/desktop-v0.2.0
+git tag -d v1.1.0
+git push origin :refs/tags/v1.1.0
 ```
 
 **One runner failed.** `fail-fast` is off, so the others still finish, but the

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -46,7 +46,7 @@ sudo apt install libfuse2      # Debian, Ubuntu
 or run without it:
 
 ```bash
-./Agento_0.1.0_amd64.AppImage --appimage-extract-and-run
+./Agento_1.0.0_amd64.AppImage --appimage-extract-and-run
 ```
 
 Also check the file is executable: `chmod +x Agento_*.AppImage`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agento-desktop",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agento-desktop",
-      "version": "0.1.2",
+      "version": "1.0.0",
       "dependencies": {
         "@tauri-apps/api": "^2.1.1",
         "@tauri-apps/plugin-dialog": "^2.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agento-desktop",
   "private": true,
-  "version": "0.1.2",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agento"
-version = "0.1.2"
+version = "1.0.0"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agento"
-version = "0.1.2"
+version = "1.0.0"
 description = "Personal AI agent platform for Claude Code"
 authors = ["Shaharia Lab"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Agento",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "identifier": "com.shaharialab.agento",
-  "mainBinaryName": "agento-desktop",
+  "mainBinaryName": "agento",
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -28,9 +28,15 @@ export type UpdateState =
   | { kind: "installed" }
   | { kind: "error"; message: string };
 
-/** Where to send someone whose install cannot update itself. */
+/**
+ * Where to send someone whose install cannot update itself.
+ *
+ * `/releases/latest`, not a filtered search: releases are tagged `v*` since
+ * v1.0.0 and that tag is the newest in the repository, so the plain link is
+ * both correct and the one a user would guess.
+ */
 export const RELEASES_URL =
-  "https://github.com/shaharia-lab/agento/releases?q=desktop&expanded=true";
+  "https://github.com/shaharia-lab/agento/releases/latest";
 
 /**
  * Ask the update server whether a newer version exists.


### PR DESCRIPTION
Prepares the first release after the desktop flip. Three changes that belong together, plus the version bump.

## 1. Release tags drop the `desktop-` prefix

Agento is the desktop app, and the Go server that owned the plain `v*` namespace was sunset at `v0.11.2`. The prefix has nothing left to disambiguate against, so releases are tagged `v*` from `v1.0.0` on. Being greater than every legacy tag, `v1.0.0` also makes the repo's **Latest release** point at this app for the first time.

Switched: the `push` trigger, the guard job, the build stamp, the draft-release job, `promote`, and `build-update-manifest.py`.

## 2. `desktop-latest` does **not** move — deliberately

This is the part that could have gone badly. `desktop-latest` is the fixed tag the update manifest is published to, and its URL is compiled into **every installer ever shipped** (`plugins.updater.endpoints`). Renaming it would strand every existing install *in silence*: they would poll a URL that 404s, never be offered an update, and report nothing — "up to date" and "cannot reach the manifest" are indistinguishable from outside the app.

`src-tauri/tauri.conf.json` is unchanged apart from `version` and `mainBinaryName`. The reasoning is now written at each site so nobody tidies it away later.

## 3. The binary is `agento` again

The `agento-desktop` split existed only because the Go CLI put an `agento` on `PATH`. That CLI is retired.

- dpkg/rpm handle the rename themselves — same package name, so `/usr/bin/agento-desktop` is removed as `/usr/bin/agento` is added. No `Conflicts:`/`Replaces:` needed.
- **No bundle filename moves.** Artifact names come from `productName`, not `mainBinaryName` — verified against `desktop-v0.1.1`'s real asset list, which is `Agento_0.1.1_amd64.AppImage` while its binary was `agento-desktop`. So the manifest script's suffix table and the `Agento.app.tar.gz` rename in `release.yml` stay valid.
- `~/.agento-desktop-dev` is the debug **data directory** and is untouched.

## Two robustness fixes found while auditing

- **`promote` now matches the legacy server releases too.** `v0.1.0` … `v0.11.2` start with `v`. Re-publishing one would reach the job with no manifest, so it checks for `latest.json` first and names the case, instead of failing on a bare "asset not found" that reads like the build broke.
- **Two sites keyed off the ref *name's* prefix; they now key off `github.ref_type`.** A `workflow_dispatch` carries the branch in `GITHUB_REF_NAME`, and with a single-letter prefix a branch called `validate-something` would be read as a tag — the guard comparing nonsense, and the build stamp labelling a dispatch build as a release instead of `-dev`, with nothing to say so.

## Version → 1.0.0, and a fifth guarded file

`src-tauri/Cargo.toml` was on `0.1.2` with nothing looking at it — the same drift that left `package-lock.json` on `0.1.1` for all of `0.1.2`. It is bumped and added to **both** version guards, which now check five places. `grep` rather than a TOML parser because `tomllib` is Python 3.11 and the runner is 3.10.

## Docs

`README.md`, `docs/installation.md`, `docs/releasing.md`, `docs/development.md`, `docs/troubleshooting.md`, `CLAUDE.md`, and `src/lib/updater.ts`'s `RELEASES_URL` (shipped app code — the link `.deb`/`.rpm` users are sent to).

`docs/releasing.md` step 1 still said to commit on `desktop`, which no longer exists.

The README release badge keeps a filter, now `!v0.*`. Dropping it would advertise the Go server's `v0.11.2` until `v1.0.0` publishes; the negation is correct both before and after. `filter=!v0.*,!desktop-*` was tried against shields and silently falls back to unfiltered, so single negation it is.

## Verification

- `npm run build` passes; manifest script exercised end-to-end against fixture artifacts (5 platforms, correct URLs) and confirmed to reject both `desktop-latest` and `desktop-v1.0.0`
- Guard simulated locally against tag `v1.0.0` — all five version strings agree
- Updater endpoint asserted still `desktop-latest`
- Badge filter behaviour verified against shields.io, not assumed

## After merging

1. Tag `v1.0.0` on `main` and push it — **promptly**, since `README`/`docs` now link to `/releases/latest`, which points at the Go server's `v0.11.2` until this ships.
2. Vet the draft, then publish it — publishing is the release act.
3. The stale **`desktop-v0.1.2` draft** (built, never published — the live manifest is still `0.1.1`) is worth deleting so it cannot be published by accident.