### PR TITLE
feat(security): add the llm token scope for the gateway data plane (#423)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -368,7 +368,24 @@ Four consequences worth knowing before debugging anything:
   malformed, expired, revoked, signed by a superseded key. 403 with `this
   token's scope does not permit this request` means it did, and the token is
   `read`-scoped against a state-changing method (or against `/api/security/*`,
-  which needs `write` whatever the method). Retrying will not help.
+  which needs `write` whatever the method), **or it is `llm`-scoped and on
+  `/api` at all**. Retrying will not help.
+- **There are three scopes, and the third is not on the ladder** (#423).
+  `read` < `write` is a hierarchy; **`llm` is disjoint from both**. It is the LLM
+  gateway's data-plane credential: `write` does **not** cover it, `llm` covers
+  nothing on `/api`, and `required_scope` never returns it — those two halves
+  together are what make it disjoint, so neither can be relaxed alone. The
+  reasoning is that a gateway token is pasted into tool configs in plaintext
+  (`OPENAI_API_KEY`, `ANTHROPIC_AUTH_TOKEN`), where `write` would be arbitrary
+  command execution and `read` would be every chat transcript; and conversely a
+  credential for spending provider credits has no business reading chat history.
+  `Scope::covers` is deliberately **enumerated rather than wildcarded** — it was
+  `(Write, _) | (Read, Read)`, and adding a variant under that wildcard would
+  have made `write` a gateway credential silently, with every test still green.
+  Do not reintroduce a wildcard there.
+  One dev consequence: the debug build's `api-token` file holds a **`write`**
+  token, so it will *not* work against the gateway — mint an `llm` one via
+  `POST /api/security/tokens` first.
 - **`api.ts` retries a 401 exactly once**, re-invoking `host_info` for a fresh
   token first. That is what makes a keypair regenerate recoverable without a
   restart, and the bound is structural rather than a counter — see `withAuth`,

--- a/docs/development.md
+++ b/docs/development.md
@@ -347,8 +347,22 @@ format, the JWKS document or the signing key.
 **Two 4xx to tell apart.** A **401** is "you have not proved who you are" —
 missing, expired, revoked, or signed by a key this install no longer uses. A
 **403** with `this token's scope does not permit this request` is "you have, and
-a `read` token cannot do that"; retrying will not help, and the fix is a `write`
-token or a different request.
+this credential does not reach that"; retrying will not help. There are two ways
+to earn it, and they have different fixes:
+
+- a **`read`** token against a state-changing method, or against
+  `/api/security/*` (which needs `write` whatever the method) — the fix is a
+  `write` token or a different request;
+- an **`llm`** token against *anything* under `/api`. That scope is the LLM
+  gateway's data plane and is disjoint from `read`/`write` by design, so no
+  `/api` route accepts it and a bigger `/api` token is not the fix — you want a
+  token of the right kind for the surface you are calling. The reverse holds
+  too: `read` and `write` tokens are refused by the gateway.
+
+That last one is worth knowing before it bites in dev: the debug build's
+`api-token` file holds a **`write`** token, so it will not work against the
+gateway. Mint an `llm` one through `POST /api/security/tokens` (or
+Settings → Security) first.
 
 **Regenerating the key in Settings → Security invalidates every token at once**,
 the dev file's included, which is exactly what it is for. The app window recovers

--- a/src-tauri/src/guards.rs
+++ b/src-tauri/src/guards.rs
@@ -902,6 +902,67 @@ pub(crate) mod tests {
         }
     }
 
+    /// **...and an `llm` token serves none of them** (#423).
+    ///
+    /// The gateway data plane's scope is disjoint from `read`/`write`, so a
+    /// credential minted for a tool config reaches nothing on `/api` — not the
+    /// safe methods, not the state-changing ones, and not the security routes.
+    /// It is a **403**: the signature verified and the token is exactly what it
+    /// claims to be, so retrying cannot help.
+    ///
+    /// This is the half of the disjointness that lives outside `Scope::covers`.
+    /// That function says `llm` grants nothing; this says the guard actually
+    /// asks it, on every method, rather than short-circuiting somewhere first.
+    #[test]
+    fn an_llm_token_serves_nothing_on_the_api() {
+        let llm = mint(Scope::Llm);
+        for method in [
+            Method::GET,
+            Method::HEAD,
+            Method::OPTIONS,
+            Method::POST,
+            Method::PUT,
+            Method::PATCH,
+            Method::DELETE,
+        ] {
+            for path in ["/api/agents", "/api/security/tokens", "/api/chats"] {
+                assert_eq!(
+                    reject(&authed_request(
+                        method.clone(),
+                        path,
+                        "localhost",
+                        "application/json",
+                        Some(&llm)
+                    )),
+                    Some(INSUFFICIENT_SCOPE),
+                    "an llm token must not serve {method} {path}"
+                );
+            }
+        }
+    }
+
+    /// The converse, and the reason the scope exists at all: the credentials
+    /// that *do* serve `/api` must not reach the gateway.
+    ///
+    /// Asserted at the lattice rather than through `reject`, because no route
+    /// here requires [`Scope::Llm`] — `required_scope` never returns it, which
+    /// is deliberate and documented at that function. So this is the only place
+    /// in the guard's own suite that can state the direction.
+    #[test]
+    fn no_api_credential_reaches_the_gateway() {
+        assert!(!Scope::Write.covers(Scope::Llm));
+        assert!(!Scope::Read.covers(Scope::Llm));
+        for method in [Method::GET, Method::POST, Method::DELETE] {
+            for path in ["/api/agents", "/api/security/tokens", "/api/chats/x"] {
+                assert_ne!(
+                    security::required_scope(&method, path),
+                    Scope::Llm,
+                    "no /api route may require the gateway's scope"
+                );
+            }
+        }
+    }
+
     /// The one route family where the scope is not a function of the method:
     /// a `read` token may not enumerate the machine's credentials.
     #[test]

--- a/src-tauri/src/native/security/mod.rs
+++ b/src-tauri/src/native/security/mod.rs
@@ -174,6 +174,15 @@ fn token_id(path: &str) -> Option<&str> {
 /// Written down because the argument is not visible from either file alone. If
 /// the guard is ever moved *after* `route_path`, this comment stops applying and
 /// the check should simply take the route path.
+///
+/// # This function returns only `read` or `write`, and must keep doing so
+///
+/// [`Scope::Llm`] is the gateway data plane's scope (#423) and no `/api` route
+/// asks for it. That is not an omission to be tidied up later — it is half of
+/// what makes the scope disjoint. `Scope::covers` says an `llm` token grants
+/// nothing on `/api`; this function says `/api` never asks for `llm`. An arm
+/// added here would hand some `/api` route to a credential that is, by design,
+/// pasted into tool configs in plaintext.
 pub fn required_scope(method: &Method, path: &str) -> Scope {
     if path.starts_with("/api/security/") || path == "/api/security" {
         return Scope::Write;
@@ -472,12 +481,15 @@ fn create_token(db_path: &std::path::Path, body: &[u8]) -> Result<Answer, WriteE
     }
     // Defaulting an absent scope to `read` is the safe direction, and it is what
     // the form sends anyway — the point is that a request that *forgot* the
-    // field does not get arbitrary command execution.
+    // field does not get arbitrary command execution. It stays `read` now that
+    // `llm` exists too: a forgotten field must not become a credential that can
+    // spend money either.
     let scope = if req.scope.is_empty() {
         Scope::Read
     } else {
-        Scope::parse(&req.scope)
-            .ok_or_else(|| WriteError::validation("scope", "scope must be \"read\" or \"write\""))?
+        Scope::parse(&req.scope).ok_or_else(|| {
+            WriteError::validation("scope", "scope must be \"read\", \"write\" or \"llm\"")
+        })?
     };
     let days = match req.expires_in_days {
         0 => DEFAULT_TOKEN_DAYS,

--- a/src-tauri/src/native/security/mod.rs
+++ b/src-tauri/src/native/security/mod.rs
@@ -607,6 +607,55 @@ mod tests {
         assert_eq!(token_id("/api/security/keys"), None);
     }
 
+    /// **The create route accepts exactly the three scopes, and says so** (#423).
+    ///
+    /// `Scope::parse` is unit-tested next door, but the *route* is what a
+    /// request reaches, and its message is what a caller reads. Without this, a
+    /// change that dropped `llm` from the accepted set — or that left the old
+    /// two-scope wording behind — passes the whole suite.
+    ///
+    /// **Installs no keypair**, which is what keeps this out of the
+    /// cross-module static hazard: `create_token` validates the name, the scope
+    /// and the TTL *before* it reads `keys::current()`, so every case here is
+    /// decided without touching process-wide state. The `llm` arm therefore
+    /// asserts only that the scope is not what the request was rejected for.
+    #[test]
+    fn the_create_route_takes_read_write_and_llm_and_nothing_else() {
+        let db = std::path::Path::new("/nonexistent/agento-create-token-test.db");
+        let scope_error = |scope: &str| -> Option<String> {
+            let body = format!(r#"{{"name":"tool config","scope":"{scope}"}}"#);
+            match create_token(db, body.as_bytes()) {
+                Err(e) => {
+                    let message = e.message();
+                    message.contains("scope must be").then_some(message)
+                }
+                Ok(_) => None,
+            }
+        };
+
+        for unknown in ["admin", "READ", "LLM", "llm ", "gateway"] {
+            let message = scope_error(unknown)
+                .unwrap_or_else(|| panic!("{unknown:?} must be refused as a scope"));
+            for spelling in ["read", "write", "llm"] {
+                assert!(
+                    message.contains(spelling),
+                    "the refusal must name every accepted scope, missing {spelling:?}: {message}"
+                );
+            }
+        }
+
+        // ...and the three real ones are never what the request is refused for.
+        // They get no further than this either — there is no signing key
+        // installed — but they fail for that reason rather than this one.
+        for accepted in ["read", "write", "llm"] {
+            assert_eq!(
+                scope_error(accepted),
+                None,
+                "{accepted:?} must pass scope validation"
+            );
+        }
+    }
+
     /// The one exception to the method-based scope map, and the reason for it:
     /// these reads *are* the credential system, so a `read` token must not be
     /// able to enumerate every credential on the machine.

--- a/src-tauri/src/native/security/token.rs
+++ b/src-tauri/src/native/security/token.rs
@@ -80,10 +80,11 @@ pub const WEBVIEW_SUBJECT: &str = "desktop-webview";
 
 /// What a credential is allowed to do.
 ///
-/// Two levels on purpose (#405): they map exactly onto the split
-/// `guards::is_state_changing` already encodes, so the guard has one definition
-/// of read-versus-write rather than a second permission table that can drift
-/// from the first.
+/// `read` and `write` are a **hierarchy** and map exactly onto the split
+/// `guards::is_state_changing` already encodes (#405), so the guard has one
+/// definition of read-versus-write rather than a second permission table that
+/// can drift from the first. [`Llm`](Self::Llm) is not part of that hierarchy —
+/// see its own note, and [`covers`](Self::covers).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Scope {
     /// Every safe method. **Not "harmless"** — a `read` token returns chat
@@ -94,6 +95,24 @@ pub enum Scope {
     /// Everything, including creating a `bypass`-permission agent and running
     /// it — i.e. arbitrary command execution on this machine.
     Write,
+    /// The LLM gateway's data plane, and **nothing else** (#423).
+    ///
+    /// Deliberately disjoint from the pair above rather than sitting under
+    /// `write`, because the two directions are both wrong:
+    ///
+    /// - A gateway token is what gets pasted into `OPENAI_API_KEY`,
+    ///   `ANTHROPIC_AUTH_TOKEN` and a Claude Code base-URL setup — plaintext on
+    ///   disk, in files other tools read. A `write` token in that position is
+    ///   arbitrary command execution; a `read` token in that position returns
+    ///   every chat transcript on the machine. Neither is an acceptable price
+    ///   for spending provider credits.
+    /// - Conversely, a credential whose job is to spend provider credits has no
+    ///   business reading chat history, so `llm` grants nothing on `/api`.
+    ///
+    /// The `aud` claim is still `agento-api` for all three: scope is the
+    /// capability axis, and a second audience would mean a parallel validation
+    /// path for no gain.
+    Llm,
 }
 
 impl Scope {
@@ -102,6 +121,7 @@ impl Scope {
         match self {
             Self::Read => "read",
             Self::Write => "write",
+            Self::Llm => "llm",
         }
     }
 
@@ -112,16 +132,29 @@ impl Scope {
         match raw {
             "read" => Some(Self::Read),
             "write" => Some(Self::Write),
+            "llm" => Some(Self::Llm),
             _ => None,
         }
     }
 
     /// Whether a credential carrying `self` may serve a request needing
-    /// `required`. `write` covers `read`; nothing covers `write`.
+    /// `required`. `write` covers `read`; nothing covers `write`; and `llm`
+    /// covers only itself, in both directions.
+    ///
+    /// **The arms are enumerated, and that is load-bearing.** This was
+    /// `(Self::Write, _) | (Self::Read, Scope::Read)` until #423, and the
+    /// wildcard was correct only while `Write` was the top of a two-element
+    /// lattice. Adding [`Llm`](Self::Llm) under that wildcard would have made a
+    /// `write` token a gateway credential — silently, with every existing test
+    /// still green, and defeating the one property the scope exists for. Do not
+    /// reintroduce a wildcard here: a new variant must be a deliberate line.
     pub fn covers(self, required: Scope) -> bool {
         matches!(
             (self, required),
-            (Self::Write, _) | (Self::Read, Scope::Read)
+            (Self::Write, Scope::Write)
+                | (Self::Write, Scope::Read)
+                | (Self::Read, Scope::Read)
+                | (Self::Llm, Scope::Llm)
         )
     }
 }
@@ -498,16 +531,57 @@ mod tests {
         );
         assert_eq!(Scope::parse("admin"), None);
         assert_eq!(Scope::parse("READ"), None, "the spelling is exact");
+        assert_eq!(Scope::parse("LLM"), None, "the spelling is exact");
     }
 
+    /// The whole lattice, stated as a 3×3 matrix rather than spot-checked.
+    ///
+    /// Exhaustive because the interesting cases are the *false* ones, and a
+    /// spot-check of the true ones is exactly what would have passed against the
+    /// `(Write, _)` wildcard this replaced (#423): `Write.covers(Llm)` is the
+    /// assertion that fails if a wildcard ever comes back.
     #[test]
     fn scope_covering_is_the_split_the_guard_needs() {
+        // write: the top of the /api hierarchy, and nothing more.
         assert!(Scope::Write.covers(Scope::Write));
         assert!(Scope::Write.covers(Scope::Read));
+        assert!(
+            !Scope::Write.covers(Scope::Llm),
+            "write must not reach the gateway: a token pasted into a tool config \
+             would carry arbitrary command execution"
+        );
+
+        // read: itself only.
         assert!(Scope::Read.covers(Scope::Read));
         assert!(!Scope::Read.covers(Scope::Write));
+        assert!(!Scope::Read.covers(Scope::Llm));
+
+        // llm: itself only, in both directions.
+        assert!(Scope::Llm.covers(Scope::Llm));
+        assert!(
+            !Scope::Llm.covers(Scope::Read),
+            "a gateway credential must not read chat transcripts"
+        );
+        assert!(!Scope::Llm.covers(Scope::Write));
+
         assert_eq!(Scope::Read.as_str(), "read");
         assert_eq!(Scope::Write.as_str(), "write");
+        assert_eq!(Scope::Llm.as_str(), "llm");
+    }
+
+    /// Every scope survives the wire, because the row stores the spelling and
+    /// the guard parses it back. A variant added to one match arm and not the
+    /// other is a token that mints and then never verifies.
+    #[test]
+    fn a_round_trip_through_the_wire_spelling_is_identity() {
+        for scope in [Scope::Read, Scope::Write, Scope::Llm] {
+            assert_eq!(
+                Scope::parse(scope.as_str()),
+                Some(scope),
+                "{:?} must survive the wire",
+                scope
+            );
+        }
     }
 
     /// Two mints are two tokens, so revoking one cannot touch the other.

--- a/src-tauri/src/native/security/tokens.rs
+++ b/src-tauri/src/native/security/tokens.rs
@@ -383,6 +383,38 @@ mod tests {
         assert!(get(&conn, "nope").expect("get").is_none());
     }
 
+    /// **Every scope stores and lists, including `llm`** (#423).
+    ///
+    /// The column is free-text and was already wide enough, which is why the
+    /// gateway scope needed no migration — but "wide enough" is a claim about
+    /// the schema, and this is what checks it against the code that writes and
+    /// reads the column. A scope that mints and then lists as something else
+    /// would show the wrong badge in the Security tab and, worse, revoke the
+    /// wrong thing.
+    #[test]
+    fn every_scope_round_trips_through_the_column() {
+        let conn = schema();
+        for (id, scope) in [
+            ("t-read", Scope::Read),
+            ("t-write", Scope::Write),
+            ("t-llm", Scope::Llm),
+        ] {
+            add(&conn, id, "tool config", scope);
+            let row = get(&conn, id).expect("get").expect("row");
+            assert_eq!(
+                row.scope,
+                scope.as_str(),
+                "{scope:?} must read back as its own wire spelling"
+            );
+            assert_eq!(
+                Scope::parse(&row.scope),
+                Some(scope),
+                "and must parse back to the same variant"
+            );
+        }
+        assert_eq!(list(&conn).expect("list").len(), 3);
+    }
+
     /// **Every timestamp on the wire is RFC 3339**, not the `time.Time.String()`
     /// text the column holds.
     ///

--- a/src/views/settings/SecurityPane.tsx
+++ b/src/views/settings/SecurityPane.tsx
@@ -95,12 +95,22 @@ const LLM_WARNING =
   "no spending limit of its own. It cannot read or change anything in Agento.";
 
 /**
+ * Shown when a scope has no copy of its own — i.e. a value was added to
+ * `SCOPES` and not to `SCOPE_WARNINGS`.
+ *
+ * Deliberately *not* one of the three real warnings. Each of those makes a
+ * positive claim about what the scope does and does not reach, and asserting any
+ * of them about a scope this file knows nothing about would be a guess shown to
+ * the person deciding whether to hand the token out.
+ */
+const UNKNOWN_SCOPE_WARNING =
+  "This build does not describe what this scope grants. Do not issue it.";
+
+/**
  * The capability note shown under the scope picker.
  *
  * A lookup rather than a ternary: at two scopes a ternary read fine, at three it
- * would nest, and the next scope would nest it again. An unknown value falls
- * back to the narrowest copy rather than to nothing, so a scope this build does
- * not know is never described as harmless.
+ * would nest, and the next scope would nest it again.
  */
 const SCOPE_WARNINGS: Record<string, string> = {
   read: READ_WARNING,
@@ -342,7 +352,7 @@ export function SecurityPane() {
 
         <FormRow
           label="Scope"
-          help={SCOPE_WARNINGS[scope] ?? READ_WARNING}
+          help={SCOPE_WARNINGS[scope] ?? UNKNOWN_SCOPE_WARNING}
         >
           <Dropdown value={scope} options={SCOPES} onChange={setScope} />
         </FormRow>

--- a/src/views/settings/SecurityPane.tsx
+++ b/src/views/settings/SecurityPane.tsx
@@ -58,6 +58,7 @@ interface CreatedToken extends TokenRow {
 const SCOPES = [
   { value: "read", label: "Read only" },
   { value: "write", label: "Read and write" },
+  { value: "llm", label: "LLM gateway" },
 ];
 
 /**
@@ -80,6 +81,42 @@ const WRITE_WARNING =
 const READ_WARNING =
   "A read token can read every chat transcript, agent system prompt and " +
   "integration list on this machine. It cannot change anything.";
+
+/**
+ * ...and `llm` is the one whose cost is money rather than access (#423).
+ *
+ * Says both halves, because both are the point: it spends real provider credits,
+ * and it reaches nothing else. A gateway token is meant to be pasted into tool
+ * configs where it sits in plaintext, so the honest thing to state is the actual
+ * ceiling rather than "limited access".
+ */
+const LLM_WARNING =
+  "An LLM gateway token can spend your configured LLM provider credits, with " +
+  "no spending limit of its own. It cannot read or change anything in Agento.";
+
+/**
+ * The capability note shown under the scope picker.
+ *
+ * A lookup rather than a ternary: at two scopes a ternary read fine, at three it
+ * would nest, and the next scope would nest it again. An unknown value falls
+ * back to the narrowest copy rather than to nothing, so a scope this build does
+ * not know is never described as harmless.
+ */
+const SCOPE_WARNINGS: Record<string, string> = {
+  read: READ_WARNING,
+  write: WRITE_WARNING,
+  llm: LLM_WARNING,
+};
+
+/**
+ * The badge class per scope. `write` is amber because it is the dangerous one;
+ * `llm` gets its own colour because three scopes reading as two visuals is how a
+ * gateway token gets mistaken for a read token at a glance.
+ */
+const SCOPE_BADGES: Record<string, string> = {
+  write: "badge badge--amber",
+  llm: "badge badge--purple",
+};
 
 export function SecurityPane() {
   const host = useHostInfo();
@@ -207,13 +244,15 @@ export function SecurityPane() {
 
         <FormRow
           label="Regenerate"
-          help="Creates a new keypair. Every token ever issued stops working immediately, including this window's — which recovers on its own."
+          help="Creates a new keypair. Every token ever issued stops working immediately. This window's recovers on its own; anything else holding one — a script, or a tool configured against the LLM gateway — starts getting 401s with no other signal and needs a new token issued by hand."
         >
           {confirmRegenerate ? (
             <div className="row">
               <span className="confirm" style={{ flex: 1 }}>
                 Replace the signing key? Every issued token stops working and
-                cannot be restored.
+                cannot be restored — including LLM gateway tokens, so any tool
+                configured against the gateway stops until you issue it a new
+                one.
               </span>
               <button
                 className="btn btn--ghost"
@@ -303,7 +342,7 @@ export function SecurityPane() {
 
         <FormRow
           label="Scope"
-          help={scope === "write" ? WRITE_WARNING : READ_WARNING}
+          help={SCOPE_WARNINGS[scope] ?? READ_WARNING}
         >
           <Dropdown value={scope} options={SCOPES} onChange={setScope} />
         </FormRow>
@@ -383,13 +422,7 @@ export function SecurityPane() {
                     {t.name}
                   </td>
                   <td>
-                    <span
-                      className={
-                        t.scope === "write"
-                          ? "badge badge--amber"
-                          : "badge"
-                      }
-                    >
+                    <span className={SCOPE_BADGES[t.scope] ?? "badge"}>
                       {t.scope}
                     </span>
                   </td>


### PR DESCRIPTION
Closes #423

Part of #421 (Embedded LLM Gateway). Blocks #424 and #427.

## What

Adds a third token scope, **`llm`**, to the #405 credential system — the LLM gateway's data-plane credential, **disjoint** from `read`/`write` in both directions.

- `Scope::Llm` in `native/security/token.rs`, wire spelling `"llm"`.
- `POST /api/security/tokens` accepts it; the `api_tokens.scope` column stores it verbatim. **No migration** — the column is already free-text.
- Settings → Security: the `llm` option with its own capability copy, its own badge colour, and regenerate-confirmation copy that names gateway clients.

Nothing consumes `Scope::Llm` at runtime yet — it can be minted and is refused everywhere. The gateway middleware that honours it is #424.

## Why

A gateway token is pasted into tool configs — `OPENAI_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, a Claude Code base-URL setup — where it sits in plaintext in files other tools read. A `write` token in that position is arbitrary command execution on the machine; a `read` token in that position returns every chat transcript and agent system prompt. Neither is an acceptable price for spending provider credits. The reverse also has to hold: a credential for spending provider credits has no business reading chat history.

## How

**The load-bearing edit is `Scope::covers`.** It was:

```rust
matches!((self, required), (Self::Write, _) | (Self::Read, Scope::Read))
```

That wildcard was correct only while `Write` was the top of a two-element lattice. Adding a variant under it would have made a `write` token a gateway credential — silently, with every existing test still green, defeating the one property this scope exists for. The arms are now enumerated, with a comment saying a wildcard must not come back.

**The disjointness has two halves, in two files, and neither is sufficient alone:**

| half | where | says |
|---|---|---|
| `Scope::covers` | `token.rs` | an `llm` token grants nothing on `/api` |
| `required_scope` | `mod.rs` | `/api` never *asks* for `llm` |

Relax either and the other still looks correct, so both are documented at their site and asserted.

`required_scope` is deliberately unchanged, and `verify_against` needed no signature change — it was already the pure `(presented, required, key, is_revoked)` function #424 will call, so no parallel validation path is introduced.

## Acceptance criteria

- [x] `Scope::Llm.covers(x)` only for `Llm`; neither `Read` nor `Write` covers `Llm`
- [x] Existing `read`/`write` lattice behaviour bit-for-bit unchanged
- [x] `parse`/`as_str` round-trip for all three; `"LLM"` still refused (spelling is exact)
- [x] An `llm` token stores, lists with its badge, and is revocable
- [x] An `llm` token is refused on every `/api` route with **403**, on all seven methods
- [x] UI shows distinct copy per scope; regenerate confirmation names gateway clients

## Tests

Both load-bearing changes were verified to **fail on revert**, not merely to pass:

- restoring the `(Write, _)` wildcard → `scope_covering_is_the_split_the_guard_needs` fails on `write must not reach the gateway`
- restoring the two-scope error message → `the_create_route_takes_read_write_and_llm_and_nothing_else` fails on `missing "llm"`

New: the full 3×3 lattice matrix, a wire round-trip, `an_llm_token_serves_nothing_on_the_api` (7 methods × 3 paths), `no_api_credential_reaches_the_gateway`, per-scope column round-trip, and the create-route scope validation. Suite run three times for the process-wide-static hazard #405 recorded; 1120 pass.

The create-route test **installs no keypair** — `create_token` validates name, scope and TTL *before* reading `keys::current()`, so that half of the route is testable without touching process-wide state.

## Deviations from the issue's HOW

None in substance. Review round 1 additionally corrected `docs/development.md`, whose 403 paragraph said the remedy is "a `write` token or a different request" — which this change makes wrong for the `llm` case, where a bigger `/api` token is not the fix.
