### PR TITLE
feat(gateway): the engine — listener, auth, dispatch, streaming (#424)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,7 +213,14 @@ src-tauri/src/
                  formats, so no /api seam and no parity machinery applies
     config.rs    the settings model, its three tables and the mapping onto
                  ferrox-providers' own config types (#422). Two projections:
-                 the public one never selects api_key. No listener yet (#424)
+                 the public one never selects api_key
+    registry.rs  the listener's lifecycle (#424) — integrations/registry.rs's
+                 shape, and the *stored* Status a bind failure leaves behind
+    server.rs    the five routes, the Host allowlist, the llm-scope auth layer
+                 (both header spellings), and the per-surface error dialect
+    dispatch.rs  alias → ordered targets, retry, and the fallback walk;
+                 is_retryable/should_failover copied from ferrox/src/retry.rs
+    stream.rs    the SSE bytes of both surfaces, and the anthropic-beta merge
   native/        ported endpoints (phase 2+)
     active_time.rs the capped-gap rule, shared by the scanner and the pipeline
     scanner/     the Claude session scanner (issue #270) — computes, never writes
@@ -2925,6 +2932,119 @@ inverse of how an ordinary timestamp would read. `google_oauth_token` maps it to
 **500 with a body produced here**. A failed OAuth flow must not answer from the
 stored token, because `authenticated: false` would be a plausible lie about a
 flow that actually errored.
+
+### The LLM gateway's engine (`src-tauri/src/gateway/`, #424)
+
+The second listener. It is **not** `proxy.rs` and **not** part of the `/api`
+seam: its own user-configured port, two third-party wire formats, no parity
+machinery, and — since every request it accepts spends the user's provider
+credits — a different threat model from anything else in the shell.
+
+`ferrox-providers` supplies every translation and every adapter. What is here is
+the listener, the auth, the routing table and the framing:
+`registry.rs` (lifecycle), `server.rs` (five routes, two layers),
+`dispatch.rs` (alias → targets, retry, failover), `stream.rs` (SSE bytes).
+It is **disabled by default** and costs one `SELECT` at boot when off.
+
+**Three rules that keep a permissive listener from being one:**
+
+- **`Scope::Llm`, verified with `token::verify_against`** — the pure
+  four-argument function, **not** `security::verify_request`, which derives a
+  required scope from an `/api` method and path. A `read` or `write` token is a
+  **403** here and an `llm` token is a 403 on `/api`: that disjointness (#423) is
+  the whole reason a third scope exists, and the *false* cells are what the tests
+  assert.
+- **No CORS layer, ever.** ferrox's own server mounts `CorsLayer::permissive()`,
+  which is right behind a network boundary and catastrophic on loopback — it
+  would let any page the user has open spend their provider credits *and read
+  the response*. The **`Host` allowlist** is the other half: preflight already
+  shuts a browser out of a `POST` carrying `Authorization`, but a DNS-rebinding
+  page reaches a loopback port with a *simple* request. `guards.rs::host_allowed`
+  is `pub(crate)` and shared rather than copied — an allowlist that exists twice
+  is one that gets widened once. `/healthz` is outside the auth layer and
+  **inside** this one.
+- **Errors in the client's dialect, never Agento's.** `error::openai_error_body`
+  on `/v1/*`, `error::anthropic_error_body` on `/anthropic/*`, picked by path
+  prefix so a route added under `/anthropic/` cannot forget. SDKs *branch* on
+  `error.type` — `authentication_error` versus `permission_error` drives real
+  retry behaviour — so this is behaviour, not wording.
+
+**Both header spellings.** OpenAI SDKs send `Authorization: Bearer`; the
+Anthropic SDK and Claude Code send `x-api-key`. Bearer wins a tie, and a useless
+`Authorization` (`Basic …`, an empty `Bearer `) must fall *through* to
+`x-api-key` rather than shadow it with `""`.
+
+**A bind failure is a stored value, not a log line.** `registry::Status` has a
+`BindFailed { port, error }` variant and is stored rather than derived from
+whether a handle exists, because that is what #426's status route reads. The
+collision is routine rather than exotic — a `~/.agento-desktop-dev` instance and
+an installed one read different databases but share the machine's ports — and
+without a stored status the second reports "not running" and offers a Start
+button that silently does nothing forever. It logs once at `warn` and does
+**not** retry another port: a gateway on a port the user did not configure is one
+every tool they set up is pointed away from.
+
+**Graceful shutdown comes from `claude/mcp.rs`, not from `proxy.rs`.** `proxy.rs`
+never stops — it is spawned once and process exit is its shutdown, so it has no
+`with_graceful_shutdown` to copy. This listener is torn down on every settings
+write, so a request in flight across a reload is ordinary. Same shape as #311's:
+a oneshot fired by `Drop`, awaited as `axum::serve`'s shutdown future. The
+generation counter is `integrations/registry.rs`' verbatim, for the same race — a
+`stop` landing mid-start must **drop** the handle, and dropping it is what closes
+a socket that would otherwise hold provider credentials for the life of the
+process.
+
+**`is_retryable` and `should_failover` differ by exactly one status, and they
+live in ferrox's *binary* crate** (`ferrox/src/retry.rs`), so they are copied
+rather than imported. An upstream **403** fails over *without* retrying: some
+providers report quota exhaustion with 403 rather than 429, and the same
+provider will keep answering 403 — while this gateway's own `ProxyError::Forbidden`
+must **not** fail over, or a client's bad token burns the next provider's quota.
+Only the *handshake* of a stream is retried; once chunks are flowing the head is
+committed and failing over would replay tokens the client has seen.
+
+**Every unbounded wait races the client's departure — `turn.rs`'s rule, one level
+down.** A failed `send` catches a client that left while a frame was being
+written, which is what happens when tokens are flowing; it is *not* what happens
+when the client leaves while the model is thinking, which is most of a request.
+There the loop is parked on `stream.next()`, nothing is being sent, and the
+disconnect is invisible — the task parks forever holding the upstream connection,
+one leak per abandoned request. `stream::next_or_disconnect` is the
+`tokio::select!` against `Sender::closed`, and
+`a_disconnect_mid_stream_tears_down_the_upstream_request` is what fails on the
+revert. It asserts on the **upstream** side, because that is the only place the
+leak is observable.
+
+**`Next::Ended` and `Next::Disconnected` are separate variants deliberately.**
+Collapsing them into one `None` loses `data: [DONE]` on a clean stream — and,
+worse in the other direction, would *send* one on an abandoned stream, where
+`[DONE]` means "the completion finished" and a client would record a truncated
+answer as a whole one. Both halves were caught by the suite, in both directions.
+
+**The frames are bytes, not `axum::response::sse::Event`.** The plan was
+`impl From<SseFrame> for Event`; both types are foreign, so the orphan rule
+refuses it. Bytes are the better answer anyway — the acceptance criteria are byte
+properties, and `axum` writes `event:name` with no space where every Anthropic
+fixture and ferrox's own API reference show `event: name`. Both parse; this emits
+the documented spelling.
+
+**Ordering: the listener starts strictly after `keys::install` and
+`tokens::load_revoked`.** Bound before the first, every client gets a 401 until
+the key lands — visible, and merely broken. Bound before the second, a token the
+user **revoked is honoured** for the length of that window, and nothing reports
+it. `a_gateway_start_requires_an_installed_keypair` asserts the order of the
+three calls in `lib.rs` against its source, deliberately: the consequence is a
+*window* rather than a state, so a test that asked the running app would have to
+win that race to see anything.
+
+Two smaller notes. `tokens::touch` already throttles to one write a minute and
+spawns its own `db::blocking`, so calling it from the middleware is not a
+database call on the request path and must **not** be wrapped a second time. And
+the `anthropic-beta` header and the body's `betas` array are merged into one
+comma-separated header value, header first, with `raw_anthropic_body` forwarding
+the client's document verbatim — both copied from
+`ferrox/src/handlers/anthropic_messages.rs`, and Claude Code compatibility
+depends on them.
 
 ### Not implemented, on purpose
 

--- a/src-tauri/src/gateway/dispatch.rs
+++ b/src-tauri/src/gateway/dispatch.rs
@@ -1,0 +1,539 @@
+//! Alias → ordered targets, retry, and the fallback walk (#424).
+//!
+//! This is the gateway's router, and it is deliberately small. ferrox has a
+//! `ModelRouter`/`RoutePool` pair (~320 lines) carrying weighted and
+//! round-robin load balancing and a circuit breaker; v1 of this gateway has
+//! neither, so what is left is a map from the alias a client sends as `model`
+//! to an ordered list of `(adapter, upstream model_id)` pairs, walked until one
+//! answers.
+//!
+//! # Three things a port of this gets wrong
+//!
+//! **The adapter takes `model_id` separately from `req.model`.**
+//! [`ProviderAdapter::chat`] is `(&req, model_id)`, and `req.model` is left
+//! exactly as the caller sent it — the alias. Passing the alias as `model_id`
+//! too sends the alias upstream, where it is not a model.
+//!
+//! **`is_retryable` and `should_failover` are not the same predicate, and the
+//! difference is one status.** They live in ferrox's **binary** crate
+//! (`ferrox/src/retry.rs`), not in `ferrox-providers`, so they cannot be
+//! imported and are copied below with their reasoning intact. A 403 from
+//! *upstream* means quota on some providers, so it fails over without
+//! retrying; the gateway's own 403 is a different variant and must not.
+//!
+//! **The registry is built once per listener start, not per request.**
+//! `build_registry` constructs a `reqwest::Client` per provider, and doing that
+//! per request would leak a connection pool on every call. A reload rebuilds
+//! it, which is what makes a provider edit take effect.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use ferrox_providers::config::RetryConfig;
+use ferrox_providers::error::ProxyError;
+use ferrox_providers::providers::{
+    build_registry, ProviderAdapter, ProviderRegistry, ProviderStream,
+};
+use ferrox_providers::types::{ChatCompletionRequest, ChatCompletionResponse};
+
+use super::config;
+
+/// One place a request may be sent: an adapter, and the model id to ask it for.
+///
+/// `provider` is carried alongside because it is what a usage row (#425) and
+/// every log line name — the adapter's own `name()` is the same string, but
+/// reading it back through the trait object per call is noise.
+pub struct Target {
+    pub adapter: Arc<dyn ProviderAdapter>,
+    pub provider: String,
+    pub model_id: String,
+}
+
+/// What answered, for the caller's log line and #425's usage row.
+pub struct Served {
+    pub provider: String,
+    pub model_id: String,
+}
+
+/// The routing table and the adapters behind it, built once per listener start.
+pub struct Dispatcher {
+    registry: ProviderRegistry,
+    /// alias → the routing rows in preference order (`targets` then
+    /// `fallbacks`), as stored. Resolution against the adapter registry happens
+    /// per request, so a provider missing from the registry is a per-alias
+    /// failure rather than a build failure.
+    routes: BTreeMap<String, Vec<config::RouteTarget>>,
+    retry: RetryConfig,
+}
+
+impl Dispatcher {
+    /// Read the provider and alias tables and build every adapter.
+    ///
+    /// Blocking: both loads open the database. Callers are on the listener's
+    /// start path, not a request, and go through [`crate::native::db::blocking`].
+    pub async fn build(db_path: &Path) -> Result<Self, String> {
+        let path = db_path.to_path_buf();
+        let providers =
+            crate::native::db::blocking("gateway providers", move || config::load_providers(&path))
+                .await
+                .ok_or_else(|| {
+                    "reading gateway providers: the database task failed".to_string()
+                })??;
+
+        let path = db_path.to_path_buf();
+        let aliases = crate::native::db::blocking("gateway model aliases", move || {
+            config::load_aliases(&path)
+        })
+        .await
+        .ok_or_else(|| "reading gateway model aliases: the database task failed".to_string())??;
+
+        // `load_providers` returns disabled rows too — its doc comment says
+        // "every enabled provider" and the SQL has no WHERE clause. Filter here
+        // rather than trusting the comment.
+        let configs: Vec<_> = providers
+            .iter()
+            .filter(|row| row.enabled)
+            .map(|row| row.to_ferrox())
+            .collect();
+
+        let defaults = config::defaults();
+        let registry = build_registry(&configs, &defaults)
+            .await
+            // `anyhow::Error`'s Display carries the provider name via
+            // `with_context`, which is the actionable half; the chain below it
+            // is a reqwest builder error nobody can act on.
+            .map_err(|e| format!("building gateway providers: {e}"))?;
+
+        let routes = aliases
+            .into_iter()
+            .filter(|alias| alias.enabled)
+            .map(|alias| {
+                let mut ordered = alias.routing.targets;
+                ordered.extend(alias.routing.fallbacks);
+                (alias.alias, ordered)
+            })
+            .collect();
+
+        Ok(Self {
+            registry,
+            routes,
+            retry: defaults.retry,
+        })
+    }
+
+    /// The aliases this gateway serves, for `/v1/models` and
+    /// `/anthropic/v1/models`. Sorted, because `load_aliases` orders by alias
+    /// and a `BTreeMap` keeps it that way — a models list that reordered run to
+    /// run would be a poor answer to a question clients cache.
+    pub fn aliases(&self) -> Vec<&str> {
+        self.routes.keys().map(String::as_str).collect()
+    }
+
+    /// Whether any provider was configured at all.
+    ///
+    /// The models routes answer a typed error rather than an empty `200` when
+    /// this is false: an empty list is a truthful answer to "which aliases do
+    /// you serve" and a misleading one to "is this gateway configured", and a
+    /// client that gets `{"data":[]}` has nothing to report to its user.
+    pub fn has_providers(&self) -> bool {
+        !self.registry.is_empty()
+    }
+
+    /// The ordered targets an alias resolves to.
+    ///
+    /// Two failures, and they are different: an alias nobody configured is the
+    /// client's mistake (`404 model_not_found`), while an alias whose every
+    /// target names a provider that is disabled or absent is the operator's
+    /// (`500 config_error`) — retrying either is pointless, but only the second
+    /// is a thing to go and fix in Settings.
+    pub fn resolve(&self, alias: &str) -> Result<Vec<Target>, ProxyError> {
+        let Some(rows) = self.routes.get(alias) else {
+            return Err(ProxyError::ModelNotFound(format!(
+                "model alias '{alias}' is not configured on this gateway"
+            )));
+        };
+
+        let targets: Vec<Target> = rows
+            .iter()
+            .filter_map(|row| {
+                self.registry.get(&row.provider).map(|adapter| Target {
+                    adapter: Arc::clone(adapter),
+                    provider: row.provider.clone(),
+                    model_id: row.model_id.clone(),
+                })
+            })
+            .collect();
+
+        if targets.is_empty() {
+            return Err(ProxyError::ConfigError(format!(
+                "model alias '{alias}' has no enabled provider to route to"
+            )));
+        }
+        Ok(targets)
+    }
+
+    /// A non-streaming completion, retried on the same target and then walked
+    /// down the fallback chain.
+    pub async fn chat(
+        &self,
+        alias: &str,
+        req: &ChatCompletionRequest,
+    ) -> Result<(ChatCompletionResponse, Served), ProxyError> {
+        self.walk(alias, |adapter, model_id| async move {
+            adapter.chat(req, &model_id).await
+        })
+        .await
+    }
+
+    /// A streaming completion. Only the *handshake* is retried — once the
+    /// upstream has started sending chunks the response head here is already
+    /// committed, so a mid-stream failure cannot be failed over without
+    /// replaying tokens the client has seen.
+    pub async fn chat_stream(
+        &self,
+        alias: &str,
+        req: &ChatCompletionRequest,
+    ) -> Result<(ProviderStream, Served), ProxyError> {
+        self.walk(alias, |adapter, model_id| async move {
+            adapter.chat_stream(req, &model_id).await
+        })
+        .await
+    }
+
+    /// Resolve, then try each target in turn with retries inside.
+    ///
+    /// The callback takes **owned** handles rather than a `&Target`: a borrow
+    /// would have to outlive the future, and the obvious ways to arrange that
+    /// (leaking the slice, or an `Arc<Vec<Target>>` threaded through every
+    /// closure) each cost more than cloning an `Arc` and a short `String` once
+    /// per attempt.
+    async fn walk<T, F, Fut>(&self, alias: &str, call: F) -> Result<(T, Served), ProxyError>
+    where
+        F: Fn(Arc<dyn ProviderAdapter>, String) -> Fut,
+        Fut: std::future::Future<Output = Result<T, ProxyError>>,
+    {
+        let targets = self.resolve(alias)?;
+
+        let mut last: Option<ProxyError> = None;
+        for target in &targets {
+            let attempt = || call(Arc::clone(&target.adapter), target.model_id.clone());
+            match execute_with_retry(&self.retry, attempt).await {
+                Ok(value) => {
+                    return Ok((
+                        value,
+                        Served {
+                            provider: target.provider.clone(),
+                            model_id: target.model_id.clone(),
+                        },
+                    ))
+                }
+                Err(e) => {
+                    if !should_failover(&e) {
+                        return Err(e);
+                    }
+                    log::warn!(
+                        "gateway target failed, walking the chain: alias={alias:?} \
+                         provider={:?} model_id={:?} error={e}",
+                        target.provider,
+                        target.model_id
+                    );
+                    last = Some(e);
+                }
+            }
+        }
+
+        Err(last.unwrap_or_else(|| {
+            ProxyError::ConfigError(format!("model alias '{alias}' produced no target to try"))
+        }))
+    }
+}
+
+// ── Retry, copied from ferrox/src/retry.rs ───────────────────────────────────
+//
+// These live in ferrox's binary crate rather than in `ferrox-providers`, so
+// there is nothing to import. Copied with the reasoning, because the reasoning
+// is the part that is easy to get wrong.
+
+/// Whether an error is worth retrying **on the same target**.
+///
+/// Verbatim from `ferrox/src/retry.rs::is_retryable`, including the `429`
+/// arm's placement: a `ProviderError` carrying 429 is an upstream rate limit
+/// and backing off helps, while `ProxyError::RateLimited` is the gateway's own
+/// verdict about the client and backing off does not.
+pub fn is_retryable(e: &ProxyError) -> bool {
+    match e {
+        // Transient — retry on same target
+        ProxyError::UpstreamTimeout(_) => true,
+        ProxyError::CircuitOpen(_) => true,
+        ProxyError::ProviderError { status, .. } => *status >= 500 || *status == 429,
+        ProxyError::HttpClientError(e) => e.is_timeout() || e.is_connect(),
+        ProxyError::StreamError(_) => true,
+
+        // Non-transient — do not retry
+        ProxyError::Unauthorized(_) => false,
+        ProxyError::Forbidden(_) => false,
+        ProxyError::ModelNotFound(_) => false,
+        ProxyError::RateLimited(_) => false,
+        ProxyError::ConfigError(_) => false,
+        ProxyError::SerializationError(_) => false,
+        ProxyError::AwsError(_) => false,
+        ProxyError::BudgetExceeded(_) => false,
+    }
+}
+
+/// Whether a target's failure should degrade to the next target in the chain.
+///
+/// Verbatim from `ferrox/src/retry.rs::should_failover`, and deliberately
+/// **broader than [`is_retryable`] by exactly one case**: an upstream **403**.
+///
+/// Why 403: some providers report plan or quota exhaustion with 403 rather than
+/// 429 (Moonshot Kimi's `access_terminated_error` when a coding-plan billing
+/// cycle is used up). Retrying the *same* provider is pointless — it will keep
+/// answering 403 — so `is_retryable` leaves it alone and no backoff is spent on
+/// a provider known to be exhausted. But the request should still be served
+/// from the other provider.
+///
+/// It matches on the **upstream** provider's status (`ProviderError`). This
+/// gateway's own auth rejection is `ProxyError::Forbidden`, which must NOT fail
+/// over — a client presenting a bad token should fail closed rather than burn
+/// the next provider's quota.
+pub fn should_failover(e: &ProxyError) -> bool {
+    is_retryable(e) || matches!(e, ProxyError::ProviderError { status: 403, .. })
+}
+
+/// `min(initial_ms * 2^attempt, max_ms)` plus `jitter_ms`.
+///
+/// Split out from the sleep so the formula is testable without waiting for it,
+/// and so the jitter is an argument rather than a call into a random number
+/// generator: ferrox uses `rand::thread_rng`, and `rand` is not a direct
+/// dependency of this crate. [`jitter_for`] supplies the value from the clock,
+/// which is enough to keep concurrent retries from re-colliding and is the only
+/// thing the jitter is for.
+pub fn backoff_duration(attempt: u32, config: &RetryConfig, jitter_ms: u64) -> Duration {
+    let shift = attempt.min(20);
+    let multiplier = 1u64.checked_shl(shift).unwrap_or(u64::MAX);
+    let base = config.initial_backoff_ms.saturating_mul(multiplier);
+    let capped = base.min(config.max_backoff_ms);
+    Duration::from_millis(capped.saturating_add(jitter_ms))
+}
+
+/// A jitter in `[0, initial_backoff_ms]`, from the wall clock's sub-second part.
+fn jitter_for(config: &RetryConfig) -> u64 {
+    if !config.jitter || config.initial_backoff_ms == 0 {
+        return 0;
+    }
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| u64::from(d.subsec_nanos()))
+        .unwrap_or(0);
+    nanos % (config.initial_backoff_ms + 1)
+}
+
+/// Run `f` up to `max_attempts` times, backing off between retryable failures.
+///
+/// Ported from `ferrox/src/retry.rs::execute_with_retry` without its Prometheus
+/// counters. A non-retryable error returns immediately — that is what makes a
+/// `400` cost one call rather than three.
+async fn execute_with_retry<F, Fut, T>(config: &RetryConfig, f: F) -> Result<T, ProxyError>
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = Result<T, ProxyError>>,
+{
+    let max_attempts = config.max_attempts.max(1);
+    let mut last_error: Option<ProxyError> = None;
+
+    for attempt in 0..max_attempts {
+        match f().await {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                if !is_retryable(&e) {
+                    return Err(e);
+                }
+                last_error = Some(e);
+                if attempt + 1 < max_attempts {
+                    tokio::time::sleep(backoff_duration(attempt, config, jitter_for(config))).await;
+                }
+            }
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| ProxyError::ProviderError {
+        provider: String::new(),
+        status: 502,
+        message: "All retry attempts exhausted".to_string(),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    fn provider_error(status: u16) -> ProxyError {
+        ProxyError::ProviderError {
+            provider: "p".into(),
+            status,
+            message: "upstream said so".into(),
+        }
+    }
+
+    fn fast_retry(max_attempts: u32) -> RetryConfig {
+        RetryConfig {
+            max_attempts,
+            initial_backoff_ms: 0,
+            max_backoff_ms: 0,
+            jitter: false,
+        }
+    }
+
+    /// The truth table, asserted in **both** directions.
+    ///
+    /// The false cells are the ones that matter: a predicate that answered
+    /// `true` everywhere would pass an all-positive test while turning a
+    /// malformed request into three upstream calls.
+    #[test]
+    fn the_retry_predicates_differ_by_exactly_the_upstream_403() {
+        // Retryable, and therefore also failed over.
+        for e in [
+            ProxyError::UpstreamTimeout("t".into()),
+            ProxyError::CircuitOpen("c".into()),
+            ProxyError::StreamError("s".into()),
+            provider_error(500),
+            provider_error(503),
+            provider_error(429),
+        ] {
+            assert!(is_retryable(&e), "should retry: {e}");
+            assert!(should_failover(&e), "should fail over: {e}");
+        }
+
+        // Not retryable and not failed over.
+        for e in [
+            ProxyError::Unauthorized("u".into()),
+            ProxyError::Forbidden("f".into()),
+            ProxyError::ModelNotFound("m".into()),
+            ProxyError::RateLimited("r".into()),
+            ProxyError::ConfigError("c".into()),
+            ProxyError::BudgetExceeded("b".into()),
+            ProxyError::AwsError("a".into()),
+            provider_error(400),
+            provider_error(404),
+            provider_error(422),
+        ] {
+            assert!(!is_retryable(&e), "must not retry: {e}");
+            assert!(!should_failover(&e), "must not fail over: {e}");
+        }
+
+        // The one asymmetric case, and the reason the two functions exist.
+        let quota = provider_error(403);
+        assert!(
+            !is_retryable(&quota),
+            "an upstream 403 is quota — retrying the same provider only burns backoff"
+        );
+        assert!(
+            should_failover(&quota),
+            "an upstream 403 must still be served from the next target"
+        );
+
+        // ...and the gateway's own 403, which is a different variant and must
+        // not reach the next provider's credentials.
+        assert!(
+            !should_failover(&ProxyError::Forbidden("bad token".into())),
+            "the gateway's own Forbidden must fail closed, not burn a fallback"
+        );
+    }
+
+    #[test]
+    fn backoff_doubles_and_then_caps() {
+        let config = RetryConfig {
+            max_attempts: 5,
+            initial_backoff_ms: 100,
+            max_backoff_ms: 2000,
+            jitter: false,
+        };
+        assert_eq!(backoff_duration(0, &config, 0).as_millis(), 100);
+        assert_eq!(backoff_duration(1, &config, 0).as_millis(), 200);
+        assert_eq!(backoff_duration(2, &config, 0).as_millis(), 400);
+        assert_eq!(backoff_duration(3, &config, 0).as_millis(), 800);
+        assert_eq!(backoff_duration(4, &config, 0).as_millis(), 1600);
+        // Capped, not overflowed — the shift is clamped at 20 so a large
+        // attempt count cannot wrap the multiplier to something small.
+        assert_eq!(backoff_duration(5, &config, 0).as_millis(), 2000);
+        assert_eq!(backoff_duration(64, &config, 0).as_millis(), 2000);
+        // Jitter is added after the cap, exactly as ferrox does it.
+        assert_eq!(backoff_duration(5, &config, 37).as_millis(), 2037);
+    }
+
+    #[test]
+    fn jitter_stays_within_one_initial_backoff() {
+        let config = RetryConfig {
+            max_attempts: 3,
+            initial_backoff_ms: 100,
+            max_backoff_ms: 2000,
+            jitter: true,
+        };
+        for _ in 0..64 {
+            assert!(jitter_for(&config) <= 100);
+        }
+        let off = RetryConfig {
+            jitter: false,
+            ..config
+        };
+        assert_eq!(jitter_for(&off), 0);
+    }
+
+    #[tokio::test]
+    async fn a_retryable_error_is_retried_and_a_terminal_one_is_not() {
+        let calls = AtomicU32::new(0);
+        let result: Result<(), _> = execute_with_retry(&fast_retry(3), || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async { Err(provider_error(429)) }
+        })
+        .await;
+        assert!(result.is_err());
+        assert_eq!(calls.load(Ordering::SeqCst), 3, "429 retries to the limit");
+
+        let calls = AtomicU32::new(0);
+        let result: Result<(), _> = execute_with_retry(&fast_retry(3), || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async { Err(provider_error(400)) }
+        })
+        .await;
+        assert!(result.is_err());
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "400 is asked exactly once");
+    }
+
+    #[tokio::test]
+    async fn a_retry_that_eventually_succeeds_stops_calling() {
+        let calls = AtomicU32::new(0);
+        let result = execute_with_retry(&fast_retry(5), || {
+            let n = calls.fetch_add(1, Ordering::SeqCst);
+            async move {
+                if n < 2 {
+                    Err(provider_error(503))
+                } else {
+                    Ok(n)
+                }
+            }
+        })
+        .await;
+        assert_eq!(result.expect("third attempt succeeds"), 2);
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn max_attempts_of_zero_still_calls_once() {
+        let calls = AtomicU32::new(0);
+        let _: Result<(), _> = execute_with_retry(&fast_retry(0), || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async { Err(provider_error(400)) }
+        })
+        .await;
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "`max(1)` is what stops a zero in the config from serving nothing"
+        );
+    }
+}

--- a/src-tauri/src/gateway/mod.rs
+++ b/src-tauri/src/gateway/mod.rs
@@ -18,11 +18,27 @@
 //!
 //! # What exists so far
 //!
-//! **[`config`] only.** This is #422: the settings model and its SQLite
-//! storage, and nothing else. There is no listener, no router, no dispatch and
-//! no usage recording — those are #424 and #425, and nothing in the app reads
-//! these tables yet. The module is wired into the crate so the schema and the
-//! `ferrox-providers` dependency land, compile and are tested ahead of the
-//! engine that needs them, rather than arriving inside it.
+//! **The engine, as of #424.** [`config`] is #422's settings model and its
+//! SQLite storage; [`registry`], [`server`], [`dispatch`] and [`stream`] are
+//! the listener that reads it:
+//!
+//! | module | what it owns |
+//! |---|---|
+//! | [`config`] | the three tables, and the mapping onto `ferrox-providers`' own config types |
+//! | [`registry`] | the listener's lifecycle — start at boot, reload on a config write, and the *stored* [`Status`](registry::Status) a bind failure leaves behind |
+//! | [`server`] | the five routes, the `Host` allowlist, the `llm`-scope auth layer, and the per-surface error dialect |
+//! | [`dispatch`] | alias → ordered targets, retry on the same target, and the fallback walk |
+//! | [`stream`] | the SSE bytes of both surfaces, and the `anthropic-beta` merge |
+//!
+//! What is still absent: **usage recording** (#425 — `server`'s handlers log a
+//! line where the row will go), the **`/api/gateway/*` control API** (#426 —
+//! which is what will read [`registry::status`] and call
+//! [`registry::reload`]), and any **UI** (#427/#428). The gateway is disabled
+//! by default and costs nothing when off: `start_if_enabled` reads one row and
+//! returns.
 
 pub mod config;
+pub mod dispatch;
+pub mod registry;
+pub mod server;
+pub mod stream;

--- a/src-tauri/src/gateway/registry.rs
+++ b/src-tauri/src/gateway/registry.rs
@@ -1,0 +1,411 @@
+//! The gateway listener's lifecycle (#424).
+//!
+//! Shaped after [`crate::native::integrations::registry`], which settled this
+//! problem for the MCP servers: a process-wide `OnceLock`, *the handle is the
+//! cancel* (dropping it fires the shutdown), and a generation counter so a
+//! `stop` racing a `reload` cannot leave a bound port holding a credential.
+//! Two differences, both from there being one listener rather than a map:
+//! the handle is an `Option` rather than a `HashMap`, and the generation is a
+//! single `u64` rather than a per-id one.
+//!
+//! # Bind failure is a value, not a log line
+//!
+//! [`Status`] is **stored**, not derived from whether a handle exists, and that
+//! is the whole reason it is an enum with a `BindFailed` variant rather than a
+//! `bool`. The collision this exists for is routine rather than exotic: a
+//! developer's `~/.agento-desktop-dev` instance and their installed
+//! `~/.agento` one read *different* databases but share the machine's ports, so
+//! the second to start finds the configured port taken. Without a stored
+//! status, #426's `GET /api/gateway/status` would answer "not running" and the
+//! UI would offer a Start button that does nothing, forever, with the reason
+//! only in a log file nobody opens.
+//!
+//! A bind failure therefore records the address and the OS error, logs once at
+//! `warn`, and does **not** retry on another port — a gateway on a port the
+//! user did not configure is one every tool they set up is pointed away from.
+//!
+//! # Shutdown is graceful, and the precedent is `claude/mcp.rs`, not `proxy.rs`
+//!
+//! `proxy.rs` never stops: it is spawned once and the process exit is its
+//! shutdown, so it has no `with_graceful_shutdown` to copy. This listener is
+//! torn down on every settings write, which makes the window a request can be
+//! in flight across an ordinary occurrence — a tool mid-completion when the
+//! user changes the port. `claude/mcp.rs` solved exactly this for #311 and the
+//! shape is taken from there: a oneshot fired by `Drop`, awaited as
+//! `axum::serve`'s graceful-shutdown future, so in-flight requests drain.
+
+use std::path::Path;
+use std::sync::{Mutex, OnceLock};
+
+use super::{config, dispatch::Dispatcher, server};
+
+/// What the listener is doing, for #426's status route and the UI behind it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Status {
+    /// Not running — either disabled in settings, or stopped.
+    Stopped,
+    Running {
+        port: u16,
+    },
+    /// The port was taken, or the socket could not be opened. Carries what to
+    /// tell the user, because "gateway is off" would be a lie about a gateway
+    /// they turned on.
+    BindFailed {
+        port: u16,
+        error: String,
+    },
+}
+
+/// A live listener. Dropping it shuts the listener down gracefully.
+struct Handle {
+    /// `Option` only so `Drop` can take it; it is always `Some` while alive.
+    shutdown: Option<tokio::sync::oneshot::Sender<()>>,
+}
+
+impl Drop for Handle {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+#[derive(Default)]
+struct State {
+    handle: Option<Handle>,
+    /// Bumped by every [`stop`], never reset — the same protocol
+    /// `integrations::registry` uses, and for the same race.
+    generation: u64,
+    status: Option<Status>,
+}
+
+pub struct Registry {
+    state: Mutex<State>,
+}
+
+/// The process-wide registry.
+pub fn registry() -> &'static Registry {
+    static REGISTRY: OnceLock<Registry> = OnceLock::new();
+    REGISTRY.get_or_init(|| Registry {
+        state: Mutex::new(State::default()),
+    })
+}
+
+impl Registry {
+    fn lock(&self) -> std::sync::MutexGuard<'_, State> {
+        self.state.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// What to report to #426. `Stopped` before anything has ever run.
+    pub fn status(&self) -> Status {
+        self.lock().status.clone().unwrap_or(Status::Stopped)
+    }
+
+    /// The generation to quote to [`Registry::put_if_current`] later.
+    ///
+    /// Read **before** the settings read that decides whether to start, so a
+    /// `stop` landing during that read is visible when the handle comes back.
+    fn generation(&self) -> u64 {
+        self.lock().generation
+    }
+
+    /// Stop the listener, if any, and mark it stopped.
+    ///
+    /// Idempotent. Dropping the handle inside the lock fires its oneshot;
+    /// nothing is awaited here, so a request still draining upstream keeps
+    /// draining while this returns.
+    pub fn stop(&self) {
+        let mut state = self.lock();
+        state.generation += 1;
+        let removed = state.handle.take();
+        state.status = Some(Status::Stopped);
+        drop(state);
+        if removed.is_some() {
+            log::info!("llm gateway stopped");
+        }
+    }
+
+    /// Record a started listener, unless it was stopped while it was starting.
+    ///
+    /// A refused handle is dropped here, which fires its shutdown — so the
+    /// socket the caller just bound goes away rather than outliving the
+    /// settings that justified it, still holding every configured provider key.
+    fn put_if_current(&self, generation: u64, handle: Handle, status: Status) -> bool {
+        let mut state = self.lock();
+        if state.generation != generation {
+            return false;
+        }
+        state.handle = Some(handle);
+        state.status = Some(status);
+        true
+    }
+
+    /// Record a terminal status with no handle — a bind failure, or "disabled".
+    ///
+    /// Generation-checked for the same reason a handle is: a `stop` that landed
+    /// mid-start has already written `Stopped`, and overwriting it with
+    /// `BindFailed` would report a listener nobody asked for any more.
+    fn record_if_current(&self, generation: u64, status: Status) -> bool {
+        let mut state = self.lock();
+        if state.generation != generation {
+            return false;
+        }
+        state.status = Some(status);
+        true
+    }
+}
+
+/// Start the listener if `gateway_settings.enabled`, recording what happened.
+///
+/// Never returns `Err` for a configuration the user chose — a disabled gateway
+/// and a port already in use are both *answers*, recorded in [`Status`]. The
+/// `Err` arm is for a database this process cannot read, which is not a gateway
+/// problem and is logged by the caller.
+///
+/// # Ordering
+///
+/// Must run strictly after [`crate::native::security::keys::install`] and
+/// [`crate::native::security::tokens::load_revoked`]. Both are process-wide
+/// statics the auth middleware reads per request, and a listener bound before
+/// either would answer with no key installed (a 401 for every client, which
+/// merely looks broken) or with an empty revoked set (a **revoked token
+/// accepted**, for the length of that window, which does not).
+/// `lib.rs` places the call, and `a_gateway_start_requires_an_installed_keypair`
+/// is what fails if it is ever moved above them.
+pub async fn start_if_enabled(db_path: &Path) -> Result<(), String> {
+    // Before the settings read, exactly as `integrations::registry::start_all`
+    // snapshots generations before it lists the table.
+    let generation = registry().generation();
+
+    let path = db_path.to_path_buf();
+    let settings =
+        crate::native::db::blocking("gateway settings", move || config::load_settings(&path))
+            .await
+            .ok_or_else(|| "reading gateway settings: the database task failed".to_string())??;
+
+    if !settings.enabled {
+        registry().record_if_current(generation, Status::Stopped);
+        return Ok(());
+    }
+
+    let dispatcher = match Dispatcher::build(db_path).await {
+        Ok(d) => std::sync::Arc::new(d),
+        Err(e) => {
+            // A provider whose adapter will not build is the same class of
+            // problem as a taken port — the user configured something the
+            // gateway cannot serve — so it is reported the same way rather than
+            // failing the boot task silently.
+            log::warn!("llm gateway not started: {e}");
+            registry().record_if_current(
+                generation,
+                Status::BindFailed {
+                    port: settings.port,
+                    error: e,
+                },
+            );
+            return Ok(());
+        }
+    };
+
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], settings.port));
+    let listener = match tokio::net::TcpListener::bind(addr).await {
+        Ok(l) => l,
+        Err(e) => {
+            let error = format!("binding the llm gateway on {addr}: {e}");
+            // Once, at warn, and no retry on another port. A dev instance and
+            // an installed one configured for the same port collide here, and
+            // that collision has to be legible rather than silently routed
+            // around to a port no tool is pointed at.
+            log::warn!("{error}");
+            registry().record_if_current(
+                generation,
+                Status::BindFailed {
+                    port: settings.port,
+                    error,
+                },
+            );
+            return Ok(());
+        }
+    };
+
+    let bound = listener
+        .local_addr()
+        .map(|a| a.port())
+        .unwrap_or(settings.port);
+
+    let app = server::router(server::GatewayState {
+        db_path: db_path.to_path_buf(),
+        dispatcher,
+    });
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    tokio::spawn(async move {
+        let served = axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                let _ = shutdown_rx.await;
+            })
+            .await;
+        if let Err(e) = served {
+            log::error!("llm gateway stopped: {e}");
+        }
+    });
+
+    let handle = Handle {
+        shutdown: Some(shutdown_tx),
+    };
+    if !registry().put_if_current(generation, handle, Status::Running { port: bound }) {
+        log::info!(
+            "llm gateway discarded before it was recorded, \
+             it was stopped while it started: port={bound}"
+        );
+        return Ok(());
+    }
+
+    log::info!("llm gateway listening on http://127.0.0.1:{bound}");
+    Ok(())
+}
+
+/// Stop and start again, unconditionally.
+///
+/// No diff against what is running, for the reason
+/// `integrations::registry::reload` gives: the thing most likely to have
+/// changed is a provider's API key, comparing configuration to decide whether
+/// to restart means holding that key to compare it, and a stale listener is a
+/// *security* problem rather than a staleness one — it goes on spending
+/// credits with a key the user just rotated away.
+pub async fn reload(db_path: &Path) -> Result<(), String> {
+    registry().stop();
+    start_if_enabled(db_path).await
+}
+
+/// Stop the listener. Public for #426's disable path.
+pub fn stop() {
+    registry().stop();
+}
+
+/// What #426's `GET /api/gateway/status` answers with.
+pub fn status() -> Status {
+    registry().status()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The status a fresh process reports, and the one every later assertion
+    /// is relative to.
+    #[test]
+    fn a_registry_that_never_started_is_stopped() {
+        let registry = Registry {
+            state: Mutex::new(State::default()),
+        };
+        assert_eq!(registry.status(), Status::Stopped);
+    }
+
+    /// The race `put_if_current` exists for: a `stop` between the generation
+    /// read and the handle coming back must discard the handle.
+    ///
+    /// Discarding it is what drops it, and dropping it is what closes the
+    /// socket — so this is the assertion standing between a `DELETE`-shaped
+    /// race and a bound port holding provider credentials for the life of the
+    /// process.
+    #[test]
+    fn a_handle_whose_generation_moved_is_refused_and_dropped() {
+        let registry = Registry {
+            state: Mutex::new(State::default()),
+        };
+        let generation = registry.generation();
+
+        // The stop lands while the listener is still starting.
+        registry.stop();
+
+        let (tx, mut rx) = tokio::sync::oneshot::channel::<()>();
+        let handle = Handle { shutdown: Some(tx) };
+        assert!(
+            !registry.put_if_current(generation, handle, Status::Running { port: 8880 }),
+            "a handle from a superseded generation must be refused"
+        );
+        assert_eq!(
+            registry.status(),
+            Status::Stopped,
+            "the refused handle must not overwrite the stop's status"
+        );
+        assert!(
+            rx.try_recv().is_ok(),
+            "refusing the handle must drop it, which is what fires its shutdown"
+        );
+    }
+
+    #[test]
+    fn a_handle_from_the_current_generation_is_kept() {
+        let registry = Registry {
+            state: Mutex::new(State::default()),
+        };
+        let generation = registry.generation();
+        let (tx, mut rx) = tokio::sync::oneshot::channel::<()>();
+        assert!(registry.put_if_current(
+            generation,
+            Handle { shutdown: Some(tx) },
+            Status::Running { port: 8880 }
+        ));
+        assert_eq!(registry.status(), Status::Running { port: 8880 });
+        assert!(
+            rx.try_recv().is_err(),
+            "a kept handle is still alive, so its shutdown must not have fired"
+        );
+
+        // ...and stopping it fires the shutdown and reports stopped.
+        registry.stop();
+        assert_eq!(registry.status(), Status::Stopped);
+        assert!(
+            rx.try_recv().is_ok(),
+            "stop must fire the handle's shutdown"
+        );
+    }
+
+    /// A bind failure is a stored value that survives being read, not a
+    /// transient the next status call loses.
+    #[test]
+    fn a_bind_failure_is_recorded_and_stays_readable() {
+        let registry = Registry {
+            state: Mutex::new(State::default()),
+        };
+        let generation = registry.generation();
+        assert!(registry.record_if_current(
+            generation,
+            Status::BindFailed {
+                port: 8880,
+                error: "address already in use".to_string(),
+            }
+        ));
+        for _ in 0..3 {
+            assert_eq!(
+                registry.status(),
+                Status::BindFailed {
+                    port: 8880,
+                    error: "address already in use".to_string(),
+                },
+                "#426 reads this more than once; it must not be consumed"
+            );
+        }
+    }
+
+    /// The half a `bool` status could not express: a stop that lands mid-start
+    /// must not be overwritten by the failure of the start it cancelled.
+    #[test]
+    fn a_stop_mid_start_outranks_a_late_bind_failure() {
+        let registry = Registry {
+            state: Mutex::new(State::default()),
+        };
+        let generation = registry.generation();
+        registry.stop();
+        assert!(!registry.record_if_current(
+            generation,
+            Status::BindFailed {
+                port: 8880,
+                error: "address already in use".to_string(),
+            }
+        ));
+        assert_eq!(registry.status(), Status::Stopped);
+    }
+}

--- a/src-tauri/src/gateway/registry.rs
+++ b/src-tauri/src/gateway/registry.rs
@@ -54,6 +54,18 @@ pub enum Status {
         port: u16,
         error: String,
     },
+    /// The gateway could not be built at all — a provider row this build cannot
+    /// turn into an adapter.
+    ///
+    /// **Separate from [`Status::BindFailed`] because the two send the user to
+    /// different places**, and it is reachable from an ordinary typo: a
+    /// `base_url` ending in `/chat/completions` is refused by ferrox's OpenAI
+    /// adapter, so folding it into `BindFailed` would have the UI say "port
+    /// 8880 is already in use" about a port nothing ever tried to bind. There
+    /// is no port here on purpose — none was reached.
+    StartFailed {
+        error: String,
+    },
 }
 
 /// A live listener. Dropping it shuts the listener down gracefully.
@@ -191,18 +203,13 @@ pub async fn start_if_enabled(db_path: &Path) -> Result<(), String> {
     let dispatcher = match Dispatcher::build(db_path).await {
         Ok(d) => std::sync::Arc::new(d),
         Err(e) => {
-            // A provider whose adapter will not build is the same class of
-            // problem as a taken port — the user configured something the
-            // gateway cannot serve — so it is reported the same way rather than
-            // failing the boot task silently.
+            // Reported rather than returned, for the same reason a taken port
+            // is: the user configured something this build cannot serve, and
+            // that is an answer they need to see rather than a boot task that
+            // failed quietly. It is `StartFailed` and not `BindFailed` because
+            // no port was reached — see the variant's doc.
             log::warn!("llm gateway not started: {e}");
-            registry().record_if_current(
-                generation,
-                Status::BindFailed {
-                    port: settings.port,
-                    error: e,
-                },
-            );
+            registry().record_if_current(generation, Status::StartFailed { error: e });
             return Ok(());
         }
     };

--- a/src-tauri/src/gateway/server.rs
+++ b/src-tauri/src/gateway/server.rs
@@ -1,0 +1,509 @@
+//! The gateway's router, its two middleware layers, and the five handlers (#424).
+//!
+//! # This is not `proxy.rs`, and the differences are the point
+//!
+//! `proxy.rs` serves one origin in front of the UI and `/api`, guarded by
+//! [`crate::guards`]. This listener serves two third-party wire formats to
+//! whatever local tool the user pointed at it, and every request it accepts
+//! spends the user's provider credits. So:
+//!
+//! - **The credential is [`Scope::Llm`], and nothing else opens this door.**
+//!   Verification is [`token::verify_against`] — the pure four-argument
+//!   function #405 built for exactly this second caller — and *not*
+//!   [`crate::native::security::verify_request`], which derives a required
+//!   scope from an `/api` method and path. A `read` or `write` token is a 403
+//!   here, which is the disjointness #423 built and the whole reason a third
+//!   scope exists.
+//! - **Both header spellings are accepted.** OpenAI SDKs send
+//!   `Authorization: Bearer`; the Anthropic SDK and Claude Code send
+//!   `x-api-key`. A gateway that took only one would work with half the clients
+//!   it exists for.
+//! - **There is no CORS layer, and there must never be one.** ferrox's own
+//!   server mounts `CorsLayer::permissive()`, which is correct for a service
+//!   behind a network boundary and catastrophic here: it would let any web page
+//!   the user has open spend their provider credits from the browser, since the
+//!   page can read the response too. The `Host` allowlist below is the other
+//!   half of that defence — it is what stops a DNS-rebinding page from reaching
+//!   a loopback port at all.
+//! - **The error body is the client's dialect, never Agento's.** SDKs branch on
+//!   `error.type`; `{"error":"..."}` — which is what every `/api` failure
+//!   answers — is a shape neither SDK can read.
+//!
+//! # Nothing fallible after the head commits
+//!
+//! Every handler encodes its error body before it starts a stream, exactly as
+//! `notifications::test` encodes before it dials. Once [`stream`] has produced
+//! a frame there is no status left to change, so a failure there is a frame.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::extract::{Request, State};
+use axum::http::{header, HeaderMap, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::Router;
+use ferrox_providers::anthropic_types::{
+    self, AnthropicMessagesRequest, AnthropicModelObject, AnthropicModelsResponse,
+};
+use ferrox_providers::error::{anthropic_error_body, openai_error_body, ProxyError};
+use ferrox_providers::types::{ChatCompletionRequest, ModelObject, ModelsResponse};
+use serde_json::Value;
+
+use super::{dispatch::Dispatcher, stream};
+use crate::native::security::token::{self, Denied, Scope};
+use crate::native::security::{keys, tokens};
+
+/// The Anthropic SDK's credential header, alongside `Authorization: Bearer`.
+const X_API_KEY: &str = "x-api-key";
+
+/// Everything a handler needs, cloned per request as an `Arc`.
+#[derive(Clone)]
+pub struct GatewayState {
+    pub db_path: PathBuf,
+    pub dispatcher: Arc<Dispatcher>,
+}
+
+/// Which wire format a request is on, and therefore which dialect its errors
+/// are written in.
+///
+/// Derived from the path prefix rather than carried per route, so a route added
+/// under `/anthropic/` cannot forget to answer in Anthropic's shape.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Surface {
+    OpenAi,
+    Anthropic,
+}
+
+impl Surface {
+    pub fn of(path: &str) -> Self {
+        if path.starts_with("/anthropic/") {
+            Self::Anthropic
+        } else {
+            Self::OpenAi
+        }
+    }
+
+    /// A [`ProxyError`] as `(status, body)` in this surface's dialect.
+    pub fn error(self, e: &ProxyError) -> Response {
+        let (status, body) = match self {
+            Self::OpenAi => openai_error_body(e),
+            Self::Anthropic => anthropic_error_body(e),
+        };
+        let status = StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_GATEWAY);
+        (status, axum::Json(body)).into_response()
+    }
+}
+
+/// The five routes, the two layers, and which of them each covers.
+///
+/// `/healthz` is outside the auth layer and inside the `Host` one: liveness is
+/// not a secret (the same call `/health` and the JWKS document already make),
+/// but it is still not something a foreign `Host` should reach.
+pub fn router(state: GatewayState) -> Router {
+    let authenticated = Router::new()
+        .route("/v1/chat/completions", post(openai_chat))
+        .route("/v1/models", get(openai_models))
+        .route("/anthropic/v1/messages", post(anthropic_messages))
+        .route("/anthropic/v1/models", get(anthropic_models))
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            authenticate,
+        ))
+        .with_state(state);
+
+    Router::new()
+        .route("/healthz", get(healthz))
+        .merge(authenticated)
+        .layer(axum::middleware::from_fn(host_allowlist))
+}
+
+/// `GET /healthz` — ferrox answers `ok`, and so does this.
+async fn healthz() -> &'static str {
+    "ok"
+}
+
+// ── The two layers ───────────────────────────────────────────────────────────
+
+/// Refuse a request whose `Host` is not one this listener is reachable at.
+///
+/// Reuses [`crate::guards::host_allowed`] rather than restating the set: the
+/// reasoning is identical (the socket is bound to `127.0.0.1` and has no public
+/// name, so a foreign `Host` is either a misconfiguration or a rebinding
+/// attempt) and two copies of an allowlist is one copy too many.
+///
+/// The refusal is plain text with no dialect, because a rebinding page is not a
+/// client whose SDK we are trying to satisfy.
+async fn host_allowlist(request: Request, next: Next) -> Response {
+    let host = request
+        .headers()
+        .get(header::HOST)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned)
+        .or_else(|| request.uri().authority().map(|a| a.as_str().to_owned()))
+        .unwrap_or_default();
+
+    if crate::guards::host_allowed(&host) {
+        next.run(request).await
+    } else {
+        (
+            StatusCode::FORBIDDEN,
+            "request Host is not one this server is served under",
+        )
+            .into_response()
+    }
+}
+
+/// Require an `llm`-scoped token, from either header spelling.
+///
+/// On success the [`token::Verified`] claims go into the request extensions.
+/// #425's usage row wants `subject` (the `api_tokens` row id), and retrofitting
+/// that after the handlers exist means touching all four of them.
+async fn authenticate(
+    State(state): State<GatewayState>,
+    mut request: Request,
+    next: Next,
+) -> Response {
+    let surface = Surface::of(request.uri().path());
+
+    let presented = presented_credential(request.headers());
+
+    // `keys::current()` being `None` is a 401, not a panic: the listener starts
+    // strictly after `keys::install` (see `registry::start_if_enabled`), so
+    // reaching this means the keypair was regenerated and swapped out from
+    // under an in-flight request — which is a credential failure, and the same
+    // answer every superseded token gets.
+    let Some(keypair) = keys::current() else {
+        log::warn!("gateway request arrived with no signing key installed");
+        return surface.error(&ProxyError::Unauthorized(
+            "this gateway has no signing key installed".to_string(),
+        ));
+    };
+
+    match token::verify_against(
+        &presented,
+        Scope::Llm,
+        keypair.decoding(),
+        &tokens::is_revoked,
+    ) {
+        Ok(verified) => {
+            // Already throttled to one write a minute per jti, and already
+            // spawned onto the blocking pool by `tokens` itself — so this is not
+            // a database call on the request path, and must not be wrapped in a
+            // second `db::blocking`.
+            tokens::touch(&state.db_path, &verified.jti);
+            request.extensions_mut().insert(verified);
+            next.run(request).await
+        }
+        Err(Denied::Unauthenticated) => surface.error(&ProxyError::Unauthorized(
+            "a valid llm-scoped Agento token is required".to_string(),
+        )),
+        Err(Denied::InsufficientScope) => surface.error(&ProxyError::Forbidden(
+            "this token's scope does not permit gateway requests; \
+             mint one with the llm scope in Settings → Security"
+                .to_string(),
+        )),
+    }
+}
+
+/// `Authorization: Bearer <t>` first, then `x-api-key`.
+///
+/// Order matters only when both are present, and then the explicit `Bearer`
+/// wins because a client that set it meant it; Claude Code sets `x-api-key`
+/// from `ANTHROPIC_API_KEY` and `Authorization` from `ANTHROPIC_AUTH_TOKEN`,
+/// and the second is the one a user pastes a gateway token into.
+fn presented_credential(headers: &HeaderMap) -> String {
+    if let Some(bearer) = headers
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+    {
+        if !bearer.is_empty() {
+            return bearer.to_string();
+        }
+    }
+    headers
+        .get(X_API_KEY)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string()
+}
+
+// ── Handlers ─────────────────────────────────────────────────────────────────
+
+/// `POST /v1/chat/completions`.
+async fn openai_chat(State(state): State<GatewayState>, body: axum::body::Bytes) -> Response {
+    let surface = Surface::OpenAi;
+
+    let request: ChatCompletionRequest = match serde_json::from_slice(&body) {
+        Ok(r) => r,
+        // The decode error names the offending field and offset, which is what
+        // a client debugging its own request needs. It quotes no credential —
+        // the body is a prompt, not a secret this module holds.
+        Err(e) => {
+            return surface.error(&ProxyError::SerializationError(e));
+        }
+    };
+
+    let alias = request.model.clone();
+    if request.is_streaming() {
+        match state.dispatcher.chat_stream(&alias, &request).await {
+            Ok((upstream, served)) => {
+                log::info!(
+                    "gateway completion streaming alias={alias:?} provider={:?} model_id={:?}",
+                    served.provider,
+                    served.model_id
+                );
+                sse_response(stream::openai_sse(upstream))
+            }
+            Err(e) => surface.error(&e),
+        }
+    } else {
+        match state.dispatcher.chat(&alias, &request).await {
+            Ok((response, served)) => {
+                log::info!(
+                    "gateway completion alias={alias:?} provider={:?} model_id={:?}",
+                    served.provider,
+                    served.model_id
+                );
+                axum::Json(response).into_response()
+            }
+            Err(e) => surface.error(&e),
+        }
+    }
+}
+
+/// `GET /v1/models` — the configured aliases, in OpenAI's list shape.
+async fn openai_models(State(state): State<GatewayState>) -> Response {
+    if let Err(e) = models_precondition(&state) {
+        return Surface::OpenAi.error(&e);
+    }
+    let body = ModelsResponse {
+        object: "list".to_string(),
+        data: state
+            .dispatcher
+            .aliases()
+            .into_iter()
+            .map(|id| ModelObject {
+                id: id.to_string(),
+                object: "model".to_string(),
+                // ferrox emits 0 here because an alias is not versioned, and a
+                // timestamp that moved every request would be a worse answer
+                // than an obviously absent one.
+                created: 0,
+                owned_by: "agento".to_string(),
+            })
+            .collect(),
+    };
+    axum::Json(body).into_response()
+}
+
+/// `POST /anthropic/v1/messages`.
+async fn anthropic_messages(
+    State(state): State<GatewayState>,
+    headers: HeaderMap,
+    body: axum::body::Bytes,
+) -> Response {
+    let surface = Surface::Anthropic;
+
+    // Decoded twice on purpose: once into the typed request the translation
+    // needs, and once as the raw document, which is forwarded verbatim so every
+    // field this crate does not model — `cache_control`, `thinking`,
+    // `service_tier`, tool attributes — survives. Re-encoding the typed form
+    // would drop all of them silently.
+    let raw: Value = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(e) => return surface.error(&ProxyError::SerializationError(e)),
+    };
+    let request: AnthropicMessagesRequest = match serde_json::from_slice(&body) {
+        Ok(r) => r,
+        Err(e) => return surface.error(&ProxyError::SerializationError(e)),
+    };
+
+    let alias = request.model.clone();
+    let streaming = request.is_streaming();
+
+    let beta = stream::merge_betas(
+        headers.get("anthropic-beta").and_then(|v| v.to_str().ok()),
+        &raw,
+    );
+
+    let mut internal = anthropic_types::to_chat_completion_request(request);
+    internal.raw_anthropic_body = Some(raw);
+    if let Some(beta) = beta {
+        internal
+            .extra_headers
+            .insert("anthropic-beta".to_string(), beta);
+    }
+
+    if streaming {
+        match state.dispatcher.chat_stream(&alias, &internal).await {
+            Ok((upstream, served)) => {
+                log::info!(
+                    "gateway messages streaming alias={alias:?} provider={:?} model_id={:?}",
+                    served.provider,
+                    served.model_id
+                );
+                // The message id is minted here rather than taken from
+                // upstream: the Anthropic protocol puts it in `message_start`,
+                // which is emitted before the first upstream chunk arrives.
+                let msg_id = format!("msg_{}", uuid::Uuid::new_v4().simple());
+                let frames =
+                    anthropic_types::openai_stream_to_anthropic_frames(alias, msg_id, upstream);
+                sse_response(stream::anthropic_sse(frames))
+            }
+            Err(e) => surface.error(&e),
+        }
+    } else {
+        match state.dispatcher.chat(&alias, &internal).await {
+            Ok((response, served)) => {
+                log::info!(
+                    "gateway messages alias={alias:?} provider={:?} model_id={:?}",
+                    served.provider,
+                    served.model_id
+                );
+                axum::Json(anthropic_types::to_anthropic_response(response)).into_response()
+            }
+            Err(e) => surface.error(&e),
+        }
+    }
+}
+
+/// `GET /anthropic/v1/models` — the same aliases, in Anthropic's list shape.
+async fn anthropic_models(State(state): State<GatewayState>) -> Response {
+    if let Err(e) = models_precondition(&state) {
+        return Surface::Anthropic.error(&e);
+    }
+    let aliases = state.dispatcher.aliases();
+    let body = AnthropicModelsResponse {
+        data: aliases
+            .iter()
+            .map(|id| AnthropicModelObject {
+                object_type: "model".to_string(),
+                id: (*id).to_string(),
+                display_name: (*id).to_string(),
+                // ferrox emits the epoch here for the same reason `created: 0`
+                // is emitted above: an alias is not versioned, and a moving
+                // timestamp would be a worse answer than an obviously fixed one.
+                created_at: "1970-01-01T00:00:00Z".to_string(),
+            })
+            .collect(),
+        has_more: false,
+        first_id: aliases.first().map(|s| (*s).to_string()),
+        last_id: aliases.last().map(|s| (*s).to_string()),
+    };
+    axum::Json(body).into_response()
+}
+
+/// A models list is only meaningful once a provider exists.
+///
+/// An empty `{"data":[]}` is a truthful answer to "which aliases do you serve"
+/// and a misleading one to "is this gateway set up" — and the second is the
+/// question a client listing models is really asking. A typed error gives the
+/// user something to act on; an empty list gives their tool nothing to say.
+fn models_precondition(state: &GatewayState) -> Result<(), ProxyError> {
+    if state.dispatcher.has_providers() {
+        Ok(())
+    } else {
+        Err(ProxyError::ConfigError(
+            "no LLM provider is configured on this gateway".to_string(),
+        ))
+    }
+}
+
+/// The SSE response head, committed before the first frame.
+fn sse_response(frames: stream::FrameStream) -> Response {
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "text/event-stream")
+        .header(header::CACHE_CONTROL, "no-cache")
+        // The same header the chat turn sets, for the same reason: a proxy that
+        // buffers an event stream turns it into one long wait.
+        .header("x-accel-buffering", "no")
+        .body(Body::from_stream(frames))
+        // Infallible in practice — every value above is a static, valid header —
+        // and a 500 rather than a panic if that ever stops being true.
+        .unwrap_or_else(|e| {
+            log::error!("gateway could not build the sse response head: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_surface_is_decided_by_the_path_prefix() {
+        assert_eq!(Surface::of("/v1/chat/completions"), Surface::OpenAi);
+        assert_eq!(Surface::of("/v1/models"), Surface::OpenAi);
+        assert_eq!(Surface::of("/healthz"), Surface::OpenAi);
+        assert_eq!(Surface::of("/anthropic/v1/messages"), Surface::Anthropic);
+        assert_eq!(Surface::of("/anthropic/v1/models"), Surface::Anthropic);
+        // The prefix is `/anthropic/` with the slash, so a route that merely
+        // starts with the word is not the Anthropic surface.
+        assert_eq!(Surface::of("/anthropicx"), Surface::OpenAi);
+    }
+
+    /// The bodies SDKs branch on. Both are `ferrox_providers`' own mappings —
+    /// this asserts the surface picks the right one, which is the half that
+    /// lives here.
+    #[test]
+    fn each_surface_denies_in_its_own_dialect() {
+        let unauthorized = ProxyError::Unauthorized("no".into());
+        let forbidden = ProxyError::Forbidden("wrong scope".into());
+
+        for (surface, e, status) in [
+            (Surface::OpenAi, &unauthorized, 401),
+            (Surface::OpenAi, &forbidden, 403),
+            (Surface::Anthropic, &unauthorized, 401),
+            (Surface::Anthropic, &forbidden, 403),
+        ] {
+            assert_eq!(surface.error(e).status().as_u16(), status);
+        }
+
+        let (status, body) = openai_error_body(&unauthorized);
+        assert_eq!(status, 401);
+        assert_eq!(body["error"]["type"], "unauthorized");
+        let (status, body) = anthropic_error_body(&unauthorized);
+        assert_eq!(status, 401);
+        assert_eq!(body["type"], "error");
+        assert_eq!(body["error"]["type"], "authentication_error");
+
+        let (_, body) = anthropic_error_body(&forbidden);
+        assert_eq!(
+            body["error"]["type"], "permission_error",
+            "the Anthropic SDK's retry behaviour branches on this string"
+        );
+    }
+
+    #[test]
+    fn both_header_spellings_are_read_and_bearer_wins_a_tie() {
+        let mut headers = HeaderMap::new();
+        assert_eq!(presented_credential(&headers), "");
+
+        headers.insert(X_API_KEY, "from-x-api-key".parse().unwrap());
+        assert_eq!(presented_credential(&headers), "from-x-api-key");
+
+        headers.insert(header::AUTHORIZATION, "Bearer from-bearer".parse().unwrap());
+        assert_eq!(presented_credential(&headers), "from-bearer");
+    }
+
+    /// An `Authorization` header that is not a `Bearer`, or is an empty one,
+    /// must fall through to `x-api-key` rather than shadow it with `""`.
+    #[test]
+    fn a_useless_authorization_header_does_not_shadow_x_api_key() {
+        for authorization in ["Basic abc", "bearer lowercase", "Bearer ", "Bearer"] {
+            let mut headers = HeaderMap::new();
+            headers.insert(header::AUTHORIZATION, authorization.parse().unwrap());
+            headers.insert(X_API_KEY, "fallback".parse().unwrap());
+            assert_eq!(
+                presented_credential(&headers),
+                "fallback",
+                "{authorization:?} should not have shadowed x-api-key"
+            );
+        }
+    }
+}

--- a/src-tauri/src/gateway/server.rs
+++ b/src-tauri/src/gateway/server.rs
@@ -97,17 +97,41 @@ impl Surface {
     }
 }
 
-/// The five routes, the two layers, and which of them each covers.
+/// The largest request body this gateway accepts.
+///
+/// **`axum`'s default is 2 MiB, and that default is wrong here.** It is sized
+/// for APIs whose bodies are forms and small documents; this endpoint's body is
+/// an entire conversation, resent in full on every turn, by clients that were
+/// pointed here precisely so they would not have to think about it. A long
+/// coding session crosses 2 MiB on its own, and one pasted screenshot does it
+/// immediately at base64's 4/3 expansion. Worse than the refusal is its shape:
+/// `axum` answers a bare `413` in neither surface's dialect, so an SDK reports
+/// a transport failure and the user has nothing to go on.
+///
+/// 32 MiB is Anthropic's own documented request ceiling, so a body this refuses
+/// is one the upstream would refuse anyway — with a message the client can
+/// read. It is a real bound rather than a formality: the body is buffered whole
+/// (and the Anthropic surface parses it twice, once typed and once raw, to
+/// forward the client's own document verbatim), so this caps what a single
+/// local request can make the app allocate.
+const MAX_BODY: usize = 32 * 1024 * 1024;
+
+/// The five routes, the three layers, and which of them each covers.
 ///
 /// `/healthz` is outside the auth layer and inside the `Host` one: liveness is
 /// not a secret (the same call `/health` and the JWKS document already make),
-/// but it is still not something a foreign `Host` should reach.
+/// but it is still not something a foreign `Host` should reach. It is outside
+/// the body limit too, having no body to limit.
 pub fn router(state: GatewayState) -> Router {
     let authenticated = Router::new()
         .route("/v1/chat/completions", post(openai_chat))
         .route("/v1/models", get(openai_models))
         .route("/anthropic/v1/messages", post(anthropic_messages))
         .route("/anthropic/v1/models", get(anthropic_models))
+        .layer(axum::extract::DefaultBodyLimit::max(MAX_BODY))
+        // Below the body limit, so an oversized body is refused before a
+        // credential is verified — and above nothing else, because the `Host`
+        // check outranks both.
         .layer(axum::middleware::from_fn_with_state(
             state.clone(),
             authenticate,

--- a/src-tauri/src/gateway/server.rs
+++ b/src-tauri/src/gateway/server.rs
@@ -431,8 +431,11 @@ fn models_precondition(state: &GatewayState) -> Result<(), ProxyError> {
     if state.dispatcher.has_providers() {
         Ok(())
     } else {
+        // "enabled" rather than "configured": a row that exists but is switched
+        // off produces exactly this state, and telling the user nothing is
+        // configured would send them to add a second one.
         Err(ProxyError::ConfigError(
-            "no LLM provider is configured on this gateway".to_string(),
+            "no enabled LLM provider is configured on this gateway".to_string(),
         ))
     }
 }

--- a/src-tauri/src/gateway/stream.rs
+++ b/src-tauri/src/gateway/stream.rs
@@ -1,0 +1,302 @@
+//! The two streaming surfaces' framing, and the `anthropic-beta` merge (#424).
+//!
+//! # Why the frames are bytes rather than `axum::response::sse::Event`
+//!
+//! The issue's plan was `impl From<SseFrame> for axum::response::sse::Event`.
+//! That cannot be written here: both types are foreign to this crate, so the
+//! orphan rule refuses it, and a newtype around one of them would exist purely
+//! to satisfy that rule.
+//!
+//! Emitting bytes is the better answer anyway, because the acceptance criteria
+//! are *byte* properties — "exactly one `data: [DONE]\n\n`", and the Anthropic
+//! event order — and `Sse`'s serializer is a layer between the assertion and
+//! what a client reads. It also settles the one thing `Event` decides for us:
+//! `axum` writes `event:name\n` with no space, while every fixture in
+//! `ferrox/docs/user/api-reference.md`, and Anthropic's own documentation,
+//! shows `event: name`. The SSE grammar strips a single leading space either
+//! way, so both parse; this emits the documented spelling.
+//!
+//! # What a mid-stream failure does, on both surfaces
+//!
+//! Nothing fallible may run after the response head commits, and by the first
+//! frame it has. So an upstream failure *during* a stream cannot become a
+//! status code — it becomes a final frame in the surface's own dialect and the
+//! stream ends. Deliberately **without** a trailing `[DONE]` on the OpenAI
+//! surface: `[DONE]` means the completion finished, and a client that saw one
+//! after an error would record a truncated answer as a whole one. ferrox drops
+//! the connection instead, which tells the client even less.
+
+use std::convert::Infallible;
+
+use axum::body::Bytes;
+use ferrox_providers::error::{anthropic_error_body, openai_error_body, ProxyError};
+use ferrox_providers::providers::ProviderStream;
+use ferrox_providers::sse::SseFrame;
+use ferrox_providers::types::ChatCompletionChunk;
+use serde_json::Value;
+use tokio_stream::{Stream, StreamExt};
+
+/// `data: {payload}\n\n` — one unnamed SSE frame, the OpenAI surface's only shape.
+pub fn data_frame(payload: &str) -> Bytes {
+    Bytes::from(format!("data: {payload}\n\n"))
+}
+
+/// `event: {name}\ndata: {payload}\n\n` — the Anthropic surface's shape.
+pub fn named_frame(frame: &SseFrame) -> Bytes {
+    Bytes::from(format!("event: {}\ndata: {}\n\n", frame.event, frame.data))
+}
+
+/// The terminator the OpenAI surface owes every completed stream, exactly once.
+pub const DONE: &str = "[DONE]";
+
+/// The item type both surfaces produce.
+///
+/// `Infallible` on the error side is a statement rather than a convenience: by
+/// the first frame the response head is committed, so there is no error left to
+/// hand axum that a client could act on. Anything that goes wrong from here is
+/// a frame, not a status.
+pub type FrameStream = tokio_stream::wrappers::ReceiverStream<Result<Bytes, Infallible>>;
+
+/// An OpenAI chunk stream as SSE bytes.
+///
+/// Each chunk is serialized and framed; a clean end appends `data: [DONE]`. A
+/// mid-stream error emits the OpenAI error body as its own frame and stops,
+/// with no `[DONE]` — see the module header for why that asymmetry is
+/// deliberate.
+pub fn openai_sse(stream: ProviderStream) -> FrameStream {
+    let (tx, rx) = tokio::sync::mpsc::channel(16);
+    tokio::spawn(async move {
+        let mut stream = stream;
+        loop {
+            let item = match next_or_disconnect(&tx, &mut stream).await {
+                Next::Item(item) => item,
+                // The upstream said everything it had — this is the only path
+                // that earns a terminator.
+                Next::Ended => break,
+                // The client left. Returning drops `stream`, which cancels the
+                // upstream request; sending `[DONE]` into a channel nobody
+                // holds would be pointless, and *reaching* the terminator on
+                // this path is precisely the bug the two variants prevent.
+                Next::Disconnected => return,
+            };
+            match item {
+                Ok(chunk) => {
+                    if tx
+                        .send(Ok(data_frame(&serialize_chunk(&chunk))))
+                        .await
+                        .is_err()
+                    {
+                        return;
+                    }
+                }
+                Err(e) => {
+                    log::warn!("gateway openai stream failed mid-flight: {e}");
+                    let (_, body) = openai_error_body(&e);
+                    let _ = tx.send(Ok(data_frame(&body.to_string()))).await;
+                    return;
+                }
+            }
+        }
+        let _ = tx.send(Ok(data_frame(DONE))).await;
+    });
+    tokio_stream::wrappers::ReceiverStream::new(rx)
+}
+
+/// Why a frame loop stopped waiting.
+///
+/// [`Ended`](Next::Ended) and [`Disconnected`](Next::Disconnected) are both
+/// "there is no next item", and collapsing them into one `None` is a real bug
+/// rather than a tidiness question: on the OpenAI surface the first owes the
+/// client a `data: [DONE]` and the second must not send one, because `[DONE]`
+/// means *the completion finished* and a client that reconnected and saw it
+/// would record an abandoned answer as a whole one.
+enum Next<T> {
+    Item(T),
+    Ended,
+    Disconnected,
+}
+
+/// The next item, or which of the two ways there will not be one.
+///
+/// # Why this is not `stream.next().await`
+///
+/// A failed `send` catches a client that left while a frame was being written,
+/// and that is the case a first implementation covers: it is what happens when
+/// tokens are flowing. It is *not* what happens when the client leaves while
+/// the upstream is thinking — and models spend most of a request thinking. In
+/// that state the loop is parked on `next()`, nothing is being sent, and the
+/// disconnect is invisible to every code path that would otherwise notice; the
+/// task parks forever holding the upstream connection open, and one such leak
+/// happens per abandoned request.
+///
+/// This is `native/chat/turn.rs`'s rule one level down, and the shape is the
+/// same: **race every unbounded wait against the client's departure.** There
+/// the disconnect signal is the body channel's closure and so it is here —
+/// `Sender::closed` resolves when the receiver `Body::from_stream` holds is
+/// dropped, which is exactly what a disconnect does. Returning drops the
+/// stream, and dropping the stream is what cancels the upstream request.
+///
+/// `biased` so the disconnect is checked first: with both ready, finishing the
+/// frame would be harmless but the extra chunk is pure waste, and a biased
+/// select makes the test's timing deterministic rather than lucky.
+async fn next_or_disconnect<S>(
+    tx: &tokio::sync::mpsc::Sender<Result<Bytes, Infallible>>,
+    stream: &mut S,
+) -> Next<S::Item>
+where
+    S: Stream + Unpin,
+{
+    tokio::select! {
+        biased;
+        () = tx.closed() => Next::Disconnected,
+        item = stream.next() => match item {
+            Some(item) => Next::Item(item),
+            None => Next::Ended,
+        },
+    }
+}
+
+/// An Anthropic frame stream as SSE bytes.
+///
+/// The frames come from `ferrox_providers::anthropic_types`, which owns the
+/// `message_start → content_block_start → content_block_delta* →
+/// content_block_stop → message_delta → message_stop` state machine; this only
+/// writes them. A mid-stream error becomes an `event: error` frame carrying the
+/// Anthropic error body, which is the shape Anthropic's own API uses — there is
+/// no `[DONE]` analogue here, so the sequence simply ends.
+pub fn anthropic_sse<S>(frames: S) -> FrameStream
+where
+    S: Stream<Item = Result<SseFrame, ProxyError>> + Send + 'static,
+{
+    let (tx, rx) = tokio::sync::mpsc::channel(16);
+    tokio::spawn(async move {
+        let mut frames = Box::pin(frames);
+        // Raced against the client's departure for the reason
+        // `next_or_disconnect` documents — and it matters more here, not less:
+        // the Anthropic emitter buffers upstream chunks into protocol frames,
+        // so this loop can be parked with nothing to send even while the
+        // upstream is talking.
+        //
+        // Both terminal arms do the same thing here, unlike the OpenAI surface
+        // above: there is no `[DONE]` analogue in the Anthropic protocol —
+        // `message_stop` is a frame the emitter produces — so an ended stream
+        // and a departed client both simply stop.
+        while let Next::Item(item) = next_or_disconnect(&tx, &mut frames).await {
+            let bytes = match item {
+                Ok(frame) => named_frame(&frame),
+                Err(e) => {
+                    log::warn!("gateway anthropic stream failed mid-flight: {e}");
+                    let (_, body) = anthropic_error_body(&e);
+                    let _ = tx
+                        .send(Ok(named_frame(&SseFrame::new("error", body.to_string()))))
+                        .await;
+                    return;
+                }
+            };
+            if tx.send(Ok(bytes)).await.is_err() {
+                // Client gone; returning drops `frames`, which cancels upstream.
+                return;
+            }
+        }
+    });
+    tokio_stream::wrappers::ReceiverStream::new(rx)
+}
+
+/// A chunk as the JSON a `data:` line carries.
+///
+/// A serialization failure here is not reachable — every field of
+/// `ChatCompletionChunk` is `Serialize` over owned data — but it is not worth a
+/// panic on the streaming path either, so it degrades to an empty object rather
+/// than to `unwrap_or_default`'s empty *string*, which is not a JSON document
+/// and would make a client's parser fail rather than skip.
+fn serialize_chunk(chunk: &ChatCompletionChunk) -> String {
+    serde_json::to_string(chunk).unwrap_or_else(|e| {
+        log::warn!("gateway could not serialize a chunk: {e}");
+        "{}".to_string()
+    })
+}
+
+/// The `anthropic-beta` value to forward upstream, or `None` to send no header.
+///
+/// Copied from `ferrox/src/handlers/anthropic_messages.rs`. The Anthropic SDK
+/// sends beta flags either as the `anthropic-beta` header or as a `betas` array
+/// in the body, and Claude Code has used both — so the two are merged into one
+/// comma-separated header value, header first. Losing this silently disables
+/// whatever beta the client asked for, with a working request as the symptom.
+pub fn merge_betas(header: Option<&str>, raw: &Value) -> Option<String> {
+    let mut betas: Vec<String> = Vec::new();
+    if let Some(v) = header {
+        betas.push(v.to_string());
+    }
+    if let Some(arr) = raw.get("betas").and_then(Value::as_array) {
+        for b in arr {
+            if let Some(s) = b.as_str() {
+                betas.push(s.to_string());
+            }
+        }
+    }
+    if betas.is_empty() {
+        None
+    } else {
+        Some(betas.join(","))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn an_openai_frame_is_data_space_payload_and_two_newlines() {
+        assert_eq!(&data_frame("{\"a\":1}")[..], b"data: {\"a\":1}\n\n");
+        assert_eq!(&data_frame(DONE)[..], b"data: [DONE]\n\n");
+    }
+
+    /// The `event:` line carries a space, which `axum::response::sse::Event`
+    /// does not write — see the module header. Anthropic's own documented
+    /// stream and every fixture in ferrox's API reference use this spelling.
+    #[test]
+    fn an_anthropic_frame_names_its_event_and_matches_the_documented_spelling() {
+        let frame = SseFrame::new("message_stop", r#"{"type":"message_stop"}"#);
+        assert_eq!(
+            &named_frame(&frame)[..],
+            b"event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+        );
+    }
+
+    #[test]
+    fn the_betas_merge_takes_the_header_then_the_body_in_order() {
+        assert_eq!(
+            merge_betas(Some("oauth-2025-04-20"), &json!({})),
+            Some("oauth-2025-04-20".to_string())
+        );
+        assert_eq!(
+            merge_betas(None, &json!({"betas": ["a", "b"]})),
+            Some("a,b".to_string())
+        );
+        assert_eq!(
+            merge_betas(Some("h"), &json!({"betas": ["a", "b"]})),
+            Some("h,a,b".to_string()),
+            "the header comes first, and neither half replaces the other"
+        );
+    }
+
+    /// The absent case is `None`, not `Some("")` — an empty `anthropic-beta`
+    /// header is not the same request as no header, and some upstreams reject it.
+    #[test]
+    fn no_betas_anywhere_sends_no_header() {
+        assert_eq!(merge_betas(None, &json!({})), None);
+        assert_eq!(merge_betas(None, &json!({"betas": []})), None);
+        assert_eq!(
+            merge_betas(None, &json!({"betas": "not-an-array"})),
+            None,
+            "a `betas` that is not an array is ignored rather than stringified"
+        );
+        assert_eq!(
+            merge_betas(None, &json!({"betas": [1, 2]})),
+            None,
+            "non-string members are skipped, as ferrox's `as_str` filter does"
+        );
+    }
+}

--- a/src-tauri/src/guards.rs
+++ b/src-tauri/src/guards.rs
@@ -266,7 +266,12 @@ fn request_host(headers: &HeaderMap, uri: &Uri) -> String {
 /// `localhost:1420`. Reproducing either branch would widen the guard past
 /// anything this app can be reached at, which is the one direction a guard must
 /// not move in.
-fn host_allowed(raw_host: &str) -> bool {
+///
+/// `pub(crate)` for a second caller since #424: the LLM gateway's listener has
+/// the same property (`127.0.0.1` unconditionally, no public name) and so needs
+/// the same allowlist. It is shared rather than copied deliberately — an
+/// allowlist that exists twice is one that gets widened once.
+pub(crate) fn host_allowed(raw_host: &str) -> bool {
     if raw_host.is_empty() {
         // HTTP/1.0 with no Host. Nothing legitimate reaches the API this way.
         return false;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -423,6 +423,34 @@ pub fn run() {
                         }
                     });
 
+                    // The LLM gateway (#424). Spawned beside the integration
+                    // servers and for the same reasons — it binds a listener,
+                    // and the window must not wait on it.
+                    //
+                    // **The placement is load-bearing, not incidental.** This
+                    // must stay below `keys::install` and
+                    // `tokens::load_revoked` above: the gateway's auth
+                    // middleware reads both process-wide statics per request,
+                    // and a listener bound before the revoked set is loaded
+                    // would *accept a revoked token* for the length of that
+                    // window. `gateway::registry::start_if_enabled`'s doc
+                    // carries the argument, and
+                    // `a_gateway_start_requires_an_installed_keypair` in
+                    // `tests/gateway_engine.rs` is what fails if this call ever
+                    // moves above them.
+                    //
+                    // It reads one row and returns when the gateway is
+                    // disabled, which is the default — so an install that never
+                    // configures one pays a single `SELECT` at boot.
+                    let gateway_db = db.clone();
+                    tauri::async_runtime::spawn(async move {
+                        if let Err(e) =
+                            crate::gateway::registry::start_if_enabled(&gateway_db).await
+                        {
+                            log::warn!("the llm gateway failed to start: {e}");
+                        }
+                    });
+
                     // The task scheduler (#275): replaces the
                     // `initTaskScheduler` the Go server used to run at boot.
                     // Unlike the two above it is not spawned — `start` only

--- a/src-tauri/tests/gateway_engine.rs
+++ b/src-tauri/tests/gateway_engine.rs
@@ -676,6 +676,62 @@ async fn a_400_is_neither_retried_nor_failed_over() {
     );
 }
 
+/// Retry and failover work on the **streaming** path too, and that is not
+/// implied by the non-streaming tests.
+///
+/// It holds only because `chat_stream` checks the upstream status *before*
+/// handing back a stream (`ferrox-providers`' adapters all
+/// `return Err(ProviderError { status })` on a 4xx/5xx), so a failed handshake
+/// is an ordinary `Err` the retry loop can see. An adapter that instead
+/// returned `Ok` with a stream that errored on first poll would make every
+/// assertion below silently false — the head would already be committed, and a
+/// rate-limited streaming request would reach the client as a broken stream
+/// rather than being served by the fallback. Streaming is also where a 429 is
+/// *most* likely, so this is the path that matters.
+#[tokio::test]
+async fn a_streaming_request_retries_and_fails_over_the_same_way() {
+    let primary = fake_upstream(vec![Reply::status(429); 3]).await;
+    let fallback = fake_upstream(vec![Reply::Sse {
+        chunks: vec![chunk("Hello"), final_chunk()],
+    }])
+    .await;
+
+    let db = seeded_db(
+        &[("p1", &primary.base_url()), ("p2", &fallback.base_url())],
+        "my-alias",
+        &[("p1", "primary-model"), ("p2", "fallback-model")],
+    );
+    let gateway = gateway_for(&db).await;
+
+    let response = client()
+        .post(gateway.url("/v1/chat/completions"))
+        .bearer_auth(token_with(Scope::Llm))
+        .json(&serde_json::json!({
+            "model": "my-alias",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stream": true,
+        }))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(
+        response.status(),
+        200,
+        "the fallback served it, and the status is still open to be set"
+    );
+
+    let body = body_text(response).await;
+    assert!(body.contains(r#""content":"Hello""#), "got:\n{body}");
+    assert_eq!(
+        body.matches("data: [DONE]\n\n").count(),
+        1,
+        "the failed-over stream is still terminated exactly once; got:\n{body}"
+    );
+
+    assert_eq!(primary.calls().len(), 3, "the handshake is retried");
+    assert_eq!(fallback.calls().len(), 1, "then the chain is walked");
+}
+
 /// An upstream **403** is the asymmetric case, and the reason two predicates
 /// exist: quota exhaustion reported as a 403 must not be retried against the
 /// provider that is out of quota, and must still be served from the next one.

--- a/src-tauri/tests/gateway_engine.rs
+++ b/src-tauri/tests/gateway_engine.rs
@@ -1463,3 +1463,107 @@ async fn a_large_request_body_is_not_refused() {
     );
     assert_eq!(upstream.calls().len(), 1, "and it reached the provider");
 }
+
+/// A reload while a stream is in flight must still come back on the same port.
+///
+/// This is the interaction between the two properties this module wants at
+/// once, and they pull against each other. Shutdown is **graceful**, so a
+/// client mid-completion when the user saves the settings form keeps its
+/// stream — that is the whole reason the oneshot exists. But `reload` then
+/// rebinds the **same, user-configured** port, and if the draining listener
+/// still owns that socket the new bind gets `EADDRINUSE`.
+///
+/// The failure that would cause is the worst one this module has: the status
+/// reads `BindFailed` while the *old* listener — holding the API key the user
+/// just rotated away — goes on serving until its stream ends. A reload that
+/// cannot rebind is a reload that did not revoke anything.
+///
+/// A quiet reload cannot catch it: with nothing in flight the drain completes
+/// in microseconds and the rebind always wins the race. The stream has to be
+/// open across the reload.
+#[tokio::test]
+async fn a_reload_during_a_stream_rebinds_the_same_port() {
+    let _guard = registry_lock().lock().await;
+    let upstream = fake_upstream(vec![Reply::SseThenHang {
+        chunks: vec![chunk("Hello")],
+    }])
+    .await;
+    let db = seeded_db(
+        &[("p1", &upstream.base_url())],
+        "my-alias",
+        &[("p1", "upstream-model")],
+    );
+    let port = free_port().await;
+    config::store_settings(
+        db.path(),
+        &GatewaySettings {
+            enabled: true,
+            port,
+            start_with_app: true,
+        },
+    )
+    .expect("store settings");
+
+    registry::start_if_enabled(db.path())
+        .await
+        .expect("start_if_enabled");
+    assert_eq!(registry::status(), registry::Status::Running { port });
+
+    // Open a stream and read a frame, so the listener is genuinely draining
+    // rather than idle when the reload lands.
+    let mut streaming = client()
+        .post(format!("http://127.0.0.1:{port}/v1/chat/completions"))
+        .bearer_auth(token_with(Scope::Llm))
+        .json(&serde_json::json!({
+            "model": "my-alias",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stream": true,
+        }))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(streaming.status(), 200);
+    tokio::time::timeout(std::time::Duration::from_secs(10), streaming.chunk())
+        .await
+        .expect("a first frame")
+        .expect("chunk")
+        .expect("some bytes");
+
+    registry::reload(db.path()).await.expect("reload");
+
+    assert_eq!(
+        registry::status(),
+        registry::Status::Running { port },
+        "a reload across an open stream must rebind, or the old listener keeps \
+         serving with the credential the reload was meant to replace"
+    );
+    assert_eq!(
+        client()
+            .get(format!("http://127.0.0.1:{port}/healthz"))
+            .send()
+            .await
+            .expect("send")
+            .status(),
+        200,
+        "and the new listener must actually be answering"
+    );
+
+    // The other half, and the reason the shutdown is graceful at all: the
+    // in-flight stream must have *survived* the reload rather than being cut.
+    // The fake is still parked holding its connection open, so its hang-up
+    // signal firing would mean the teardown reached through and killed a
+    // client's completion mid-answer — which is what firing the cancellation
+    // token *as* the shutdown signal does, the bug `claude/mcp.rs` records.
+    assert!(
+        tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            upstream.hung_up.notified()
+        )
+        .await
+        .is_err(),
+        "a reload must not tear down a stream that was already in flight"
+    );
+
+    drop(streaming);
+    registry::stop();
+}

--- a/src-tauri/tests/gateway_engine.rs
+++ b/src-tauri/tests/gateway_engine.rs
@@ -128,6 +128,13 @@ async fn fake_upstream(script: Vec<Reply>) -> Fake {
 
     let app = axum::Router::new()
         .route("/v1/chat/completions", post(fake_handler))
+        // A real provider accepts bodies far larger than `axum`'s 2 MiB
+        // default, and this fixture has to as well — otherwise the fake
+        // refuses a large request the gateway correctly forwarded, and the
+        // resulting `413` reads exactly like the gateway's own limit. It is
+        // distinguishable only by the error body's `"type":"provider_error"`,
+        // which is how this was diagnosed.
+        .layer(axum::extract::DefaultBodyLimit::disable())
         .with_state(state);
 
     let listener = tokio::net::TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
@@ -199,7 +206,11 @@ fn sse(chunks: Vec<String>, hang_until_dropped: Option<Arc<tokio::sync::Notify>>
             // disconnect must cause all the way up the chain — and the notify
             // is the signal that it did.
             tx.closed().await;
-            hung_up.notify_waiters();
+            // `notify_one`, not `notify_waiters`: the latter wakes only waiters
+            // already registered, so a test that has not yet reached its await
+            // loses the notification and times out. `notify_one` stores a
+            // permit instead, which removes the race rather than narrowing it.
+            hung_up.notify_one();
             return;
         }
         let _ = tx.send(Ok("data: [DONE]\n\n".to_string())).await;
@@ -766,6 +777,43 @@ async fn only_an_llm_scoped_token_opens_either_surface() {
             assert_eq!(response.status(), 200, "{path} with an llm token");
         }
     }
+
+    // The two completion routes, which are the ones that actually spend money —
+    // the layer covers all four, but asserting only on the `GET`s would leave
+    // the expensive pair resting on that being true rather than checked.
+    for (path, body) in [
+        (
+            "/v1/chat/completions",
+            serde_json::json!({"model": "my-alias", "messages": [{"role": "user", "content": "hi"}]}),
+        ),
+        (
+            "/anthropic/v1/messages",
+            serde_json::json!({"model": "my-alias", "max_tokens": 16, "messages": [{"role": "user", "content": "hi"}]}),
+        ),
+    ] {
+        let response = client
+            .post(gateway.url(path))
+            .json(&body)
+            .send()
+            .await
+            .expect("send");
+        assert_eq!(response.status(), 401, "{path} with no credential");
+
+        let response = client
+            .post(gateway.url(path))
+            .bearer_auth(token_with(Scope::Write))
+            .json(&body)
+            .send()
+            .await
+            .expect("send");
+        assert_eq!(response.status(), 403, "{path} with a write token");
+    }
+
+    assert_eq!(
+        upstream.calls().len(),
+        0,
+        "a refused request must never reach the provider"
+    );
 }
 
 /// A denial is written in the dialect the client's SDK parses.
@@ -1019,13 +1067,7 @@ async fn a_disconnect_mid_stream_tears_down_the_upstream_request() {
     );
     let gateway = gateway_for(&db).await;
 
-    // Armed *before* the disconnect: `Notify::notified()` only observes
-    // notifications issued after the future is created, so registering after
-    // the drop would race the teardown it is meant to observe.
     let hung_up = Arc::clone(&upstream.hung_up);
-    let observed = tokio::spawn(async move { hung_up.notified().await });
-    // Let the spawned task reach the await point before anything can fire it.
-    tokio::task::yield_now().await;
 
     let mut response = client()
         .post(gateway.url("/v1/chat/completions"))
@@ -1058,10 +1100,12 @@ async fn a_disconnect_mid_stream_tears_down_the_upstream_request() {
     // propagated from the client, through the gateway's frame loop, into the
     // upstream response it was holding. If any link in that chain leaks, this
     // never fires and the timeout reports it as a failure rather than a hang.
-    tokio::time::timeout(std::time::Duration::from_secs(10), observed)
+    //
+    // No arming is needed before the drop: the fake signals with `notify_one`,
+    // which stores a permit when nobody is waiting yet.
+    tokio::time::timeout(std::time::Duration::from_secs(10), hung_up.notified())
         .await
-        .expect("the client disconnect must reach the upstream request")
-        .expect("the observer task must not panic");
+        .expect("the client disconnect must reach the upstream request");
 
     assert_eq!(
         upstream.calls().len(),
@@ -1162,6 +1206,46 @@ async fn a_port_already_in_use_is_a_readable_status_rather_than_silence() {
 
     registry::stop();
     drop(squatter);
+}
+
+/// A provider this build cannot turn into an adapter is `StartFailed`, not
+/// `BindFailed`.
+///
+/// Reachable from a typo, which is why the two are separate variants: ferrox's
+/// OpenAI adapter refuses a `base_url` ending in `/chat/completions` (it would
+/// build `…/chat/completions/chat/completions`), and reporting that as a bind
+/// failure would send the user to look at a port nothing tried to bind.
+#[tokio::test]
+async fn a_provider_that_cannot_be_built_is_not_reported_as_a_port_collision() {
+    let _guard = registry_lock().lock().await;
+    let db = seeded_db(
+        &[("p1", "http://127.0.0.1:9/v1/chat/completions")],
+        "a",
+        &[("p1", "m")],
+    );
+    config::store_settings(
+        db.path(),
+        &GatewaySettings {
+            enabled: true,
+            port: free_port().await,
+            start_with_app: true,
+        },
+    )
+    .expect("store settings");
+
+    registry::start_if_enabled(db.path())
+        .await
+        .expect("a misconfigured provider is an answer, not an Err");
+
+    match registry::status() {
+        registry::Status::StartFailed { error } => assert!(
+            error.contains("p1"),
+            "the status must name the provider to fix; got {error:?}"
+        ),
+        other => panic!("expected StartFailed, got {other:?}"),
+    }
+
+    registry::stop();
 }
 
 /// The whole lifecycle: start from settings, serve, reload, stop.
@@ -1277,4 +1361,49 @@ fn a_gateway_start_requires_an_installed_keypair() {
         "the gateway must not be started before the revoked-token set is loaded, \
          or it accepts a revoked token for the length of that window"
     );
+}
+
+/// A large request body must reach the upstream rather than being refused.
+///
+/// `axum` applies a **2 MiB default body limit** to `Bytes` and `Json`
+/// extractors. That is a sensible default for an API whose bodies are forms;
+/// it is the wrong one for the endpoint Claude Code and the OpenAI SDKs are
+/// pointed at, where the body is an entire conversation resent on every turn.
+/// A long coding session, or one pasted screenshot at base64's 4/3 expansion,
+/// crosses it — and the refusal is `axum`'s own bare `413`, in neither
+/// surface's dialect, so the client reports nothing useful.
+#[tokio::test]
+async fn a_large_request_body_is_not_refused() {
+    let upstream = fake_upstream(vec![Reply::ok(&completion_body())]).await;
+    let db = seeded_db(
+        &[("p1", &upstream.base_url())],
+        "my-alias",
+        &[("p1", "upstream-model")],
+    );
+    let gateway = gateway_for(&db).await;
+
+    // ~3 MiB of conversation: over axum's default, well under anything a real
+    // client would consider unusual.
+    let big = "x".repeat(3 * 1024 * 1024);
+    let response = client()
+        .post(gateway.url("/v1/chat/completions"))
+        .bearer_auth(token_with(Scope::Llm))
+        .json(&serde_json::json!({
+            "model": "my-alias",
+            "messages": [{"role": "user", "content": big}],
+        }))
+        .send()
+        .await
+        .expect("send");
+
+    // The body is printed on failure because the two limits that could produce
+    // a 413 here — this gateway's and the fake upstream's — are otherwise
+    // indistinguishable, and only the error body's `type` tells them apart.
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    assert_eq!(
+        status, 200,
+        "a 3 MiB conversation is an ordinary request, not an oversized one; body={body}"
+    );
+    assert_eq!(upstream.calls().len(), 1, "and it reached the provider");
 }

--- a/src-tauri/tests/gateway_engine.rs
+++ b/src-tauri/tests/gateway_engine.rs
@@ -1,0 +1,1280 @@
+//! The LLM gateway's engine, driven end to end over real HTTP (#424).
+//!
+//! # What a fake upstream buys that a unit test cannot
+//!
+//! Everything this suite asserts is a property of a *sequence* or of a *byte
+//! stream*: the order Anthropic's SSE events arrive in, that exactly one
+//! `data: [DONE]` terminates an OpenAI stream, that a 429 costs two upstream
+//! calls and a 400 costs one, that a disconnect stops the upstream request
+//! rather than leaving it running. None of those is visible from inside a
+//! function — they are visible from the socket, and from what the upstream was
+//! asked for.
+//!
+//! So the shape is `tests/claude_sdk.rs`'s, one layer up: instead of a scripted
+//! fake `claude` CLI behind a subprocess, a scripted fake **provider** behind an
+//! HTTP port, which records every request it receives and replies to order. The
+//! gateway is pointed at it through an ordinary `gateway_providers` row, so
+//! nothing under test is stubbed — the real router, the real auth layer, the
+//! real `ferrox-providers` adapters and the real translation all run.
+//!
+//! It is in-process `axum` rather than a Python script for one reason the CLI
+//! tests could not use: there is no executable to fork, so there is no
+//! `python3` to skip on and no `ETXTBSY` race between writing the script and
+//! running it.
+//!
+//! # The process-wide keypair
+//!
+//! `security::keys` is a process-global `RwLock`, and `cargo test` runs a
+//! binary's tests in parallel. Every test here that needs a credential goes
+//! through [`installed_keypair`], which installs exactly once — the shape
+//! `tests/jwks_external_verify.rs` records, and the hazard the port has been
+//! bitten by twice.
+
+use std::collections::VecDeque;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use agento_lib::gateway::config::{
+    self, GatewaySettings, ModelAlias, ProviderInput, ProviderType, RouteTarget, Routing, Timeouts,
+};
+use agento_lib::gateway::{dispatch::Dispatcher, registry, server};
+use agento_lib::native::security::keys::Keypair;
+use agento_lib::native::security::token::{self, Scope};
+use axum::extract::State;
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
+use tempfile::NamedTempFile;
+
+// ── The scripted fake upstream ───────────────────────────────────────────────
+
+/// One reply the fake provider will give, in order.
+#[derive(Clone)]
+enum Reply {
+    /// A non-streaming answer with this status and body.
+    Json { status: u16, body: String },
+    /// An OpenAI SSE stream: each entry becomes one `data:` line, terminated by
+    /// the upstream's own `data: [DONE]`.
+    Sse { chunks: Vec<String> },
+    /// An SSE stream that emits its chunks and then never ends. Used to park a
+    /// stream so a client can disconnect while it is open.
+    SseThenHang { chunks: Vec<String> },
+}
+
+impl Reply {
+    fn ok(body: &str) -> Self {
+        Self::Json {
+            status: 200,
+            body: body.to_string(),
+        }
+    }
+    fn status(status: u16) -> Self {
+        Self::Json {
+            status,
+            body: format!(r#"{{"error":{{"message":"upstream said {status}"}}}}"#),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct FakeState {
+    script: Arc<Mutex<VecDeque<Reply>>>,
+    seen: Arc<Mutex<Vec<Seen>>>,
+    /// Set when a [`Reply::SseThenHang`] body's receiver is dropped — i.e. when
+    /// the upstream connection this fake is holding open is finally torn down.
+    ///
+    /// This is the *only* observable proof that a client disconnect propagated
+    /// all the way through the gateway to the provider; everything closer to
+    /// the client is true whether or not the teardown happened.
+    hung_up: Arc<tokio::sync::Notify>,
+}
+
+/// What the upstream was actually asked for, which is half of every assertion.
+#[derive(Clone, Debug)]
+struct Seen {
+    authorization: Option<String>,
+    body: String,
+}
+
+/// A fake provider on a loopback port. Dropping it stops the listener.
+struct Fake {
+    port: u16,
+    seen: Arc<Mutex<Vec<Seen>>>,
+    hung_up: Arc<tokio::sync::Notify>,
+    _shutdown: tokio::sync::oneshot::Sender<()>,
+}
+
+impl Fake {
+    /// The `base_url` a `gateway_providers` row points at it with.
+    ///
+    /// The version segment is the caller's, not the adapter's: ferrox's OpenAI
+    /// adapter appends only `/chat/completions`.
+    fn base_url(&self) -> String {
+        format!("http://127.0.0.1:{}/v1", self.port)
+    }
+
+    fn calls(&self) -> Vec<Seen> {
+        self.seen.lock().expect("fake lock").clone()
+    }
+}
+
+async fn fake_upstream(script: Vec<Reply>) -> Fake {
+    let state = FakeState {
+        script: Arc::new(Mutex::new(script.into())),
+        seen: Arc::new(Mutex::new(Vec::new())),
+        hung_up: Arc::new(tokio::sync::Notify::new()),
+    };
+    let seen = Arc::clone(&state.seen);
+    let hung_up = Arc::clone(&state.hung_up);
+
+    let app = axum::Router::new()
+        .route("/v1/chat/completions", post(fake_handler))
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("bind fake upstream");
+    let port = listener.local_addr().expect("fake addr").port();
+
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                let _ = rx.await;
+            })
+            .await;
+    });
+
+    Fake {
+        port,
+        seen,
+        hung_up,
+        _shutdown: tx,
+    }
+}
+
+async fn fake_handler(
+    State(state): State<FakeState>,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> Response {
+    state.seen.lock().expect("fake lock").push(Seen {
+        authorization: headers
+            .get(axum::http::header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned),
+        body: String::from_utf8_lossy(&body).into_owned(),
+    });
+
+    let reply = state.script.lock().expect("fake lock").pop_front();
+    match reply {
+        Some(Reply::Json { status, body }) => (
+            axum::http::StatusCode::from_u16(status).expect("valid status"),
+            [(axum::http::header::CONTENT_TYPE, "application/json")],
+            body,
+        )
+            .into_response(),
+        Some(Reply::Sse { chunks }) => sse(chunks, None),
+        Some(Reply::SseThenHang { chunks }) => sse(chunks, Some(state.hung_up)),
+        // Running off the end of the script is a test bug, and a 500 would be
+        // retried — which turns "one call too many" into a hang. 400 is not
+        // retryable, so it surfaces immediately.
+        None => (
+            axum::http::StatusCode::BAD_REQUEST,
+            r#"{"error":{"message":"fake upstream: script exhausted"}}"#,
+        )
+            .into_response(),
+    }
+}
+
+fn sse(chunks: Vec<String>, hang_until_dropped: Option<Arc<tokio::sync::Notify>>) -> Response {
+    let (tx, rx) = tokio::sync::mpsc::channel::<Result<String, std::convert::Infallible>>(16);
+    tokio::spawn(async move {
+        for chunk in chunks {
+            if tx.send(Ok(format!("data: {chunk}\n\n"))).await.is_err() {
+                return;
+            }
+        }
+        if let Some(hung_up) = hang_until_dropped {
+            // Held open until the receiver is dropped, which is what a client
+            // disconnect must cause all the way up the chain — and the notify
+            // is the signal that it did.
+            tx.closed().await;
+            hung_up.notify_waiters();
+            return;
+        }
+        let _ = tx.send(Ok("data: [DONE]\n\n".to_string())).await;
+    });
+
+    Response::builder()
+        .status(200)
+        .header(axum::http::header::CONTENT_TYPE, "text/event-stream")
+        .body(axum::body::Body::from_stream(
+            tokio_stream::wrappers::ReceiverStream::new(rx),
+        ))
+        .expect("fake sse response")
+}
+
+// ── The gateway under test ───────────────────────────────────────────────────
+
+/// A migrated database with the given providers and one alias over them.
+///
+/// `targets` are `(provider name, upstream model id)` in preference order; the
+/// first is the primary and the rest are the fallback chain, which is exactly
+/// how [`Routing`] stores them.
+fn seeded_db(providers: &[(&str, &str)], alias: &str, targets: &[(&str, &str)]) -> NamedTempFile {
+    let file = NamedTempFile::new().expect("tempfile");
+    {
+        let mut conn =
+            agento_lib::native::db::ensure_database(file.path()).expect("create database");
+        agento_lib::native::migrate::apply(&mut conn).expect("migrate");
+    }
+
+    for (name, base_url) in providers {
+        config::store_provider(
+            file.path(),
+            &ProviderInput {
+                id: name,
+                name,
+                provider_type: ProviderType::Openai,
+                api_key: "upstream-key",
+                base_url,
+                timeouts: Timeouts::default(),
+                enabled: true,
+            },
+        )
+        .expect("store provider");
+    }
+
+    let mut rows = targets.iter().map(|(provider, model_id)| RouteTarget {
+        provider: (*provider).to_string(),
+        model_id: (*model_id).to_string(),
+    });
+    let first = rows.next().expect("at least one target");
+    config::store_alias(
+        file.path(),
+        &ModelAlias {
+            id: alias.to_string(),
+            alias: alias.to_string(),
+            routing: Routing {
+                targets: vec![first],
+                fallbacks: rows.collect(),
+            },
+            enabled: true,
+        },
+    )
+    .expect("store alias");
+
+    file
+}
+
+/// The gateway's own listener, serving the real router on a loopback port.
+struct Gateway {
+    port: u16,
+    _shutdown: tokio::sync::oneshot::Sender<()>,
+}
+
+impl Gateway {
+    fn url(&self, path: &str) -> String {
+        format!("http://127.0.0.1:{}{path}", self.port)
+    }
+}
+
+/// Serve [`server::router`] directly, on an OS-assigned port.
+///
+/// `registry::start_if_enabled` is exercised by its own two tests below; every
+/// other test wants a port it cannot collide on, and `gateway_settings.port`
+/// deliberately refuses `0` (a gateway on a port nobody configured is one every
+/// tool is pointed away from).
+async fn gateway_for(db: &NamedTempFile) -> Gateway {
+    let dispatcher = Arc::new(
+        Dispatcher::build(db.path())
+            .await
+            .expect("build the dispatcher"),
+    );
+    let app = server::router(server::GatewayState {
+        db_path: db.path().to_path_buf(),
+        dispatcher,
+    });
+
+    let listener = tokio::net::TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("bind gateway");
+    let port = listener.local_addr().expect("gateway addr").port();
+
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                let _ = rx.await;
+            })
+            .await;
+    });
+
+    Gateway {
+        port,
+        _shutdown: tx,
+    }
+}
+
+/// The process-wide keypair, installed exactly once for this test binary.
+fn installed_keypair() -> &'static Arc<Keypair> {
+    static KEYPAIR: OnceLock<Arc<Keypair>> = OnceLock::new();
+    KEYPAIR.get_or_init(|| {
+        let keypair = Keypair::generate().expect("generate a keypair");
+        agento_lib::native::security::keys::install(keypair)
+    })
+}
+
+fn token_with(scope: Scope) -> String {
+    token::mint(installed_keypair(), "test-token", scope, 3600)
+        .expect("mint")
+        .token
+}
+
+fn client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(20))
+        .build()
+        .expect("client")
+}
+
+/// The whole SSE body as text.
+async fn body_text(response: reqwest::Response) -> String {
+    response.text().await.expect("read body")
+}
+
+/// The `event:` names of an Anthropic SSE body, in order.
+fn event_names(body: &str) -> Vec<&str> {
+    body.lines()
+        .filter_map(|line| line.strip_prefix("event: "))
+        .collect()
+}
+
+/// One minimal OpenAI streaming chunk carrying `text`.
+fn chunk(text: &str) -> String {
+    format!(
+        r#"{{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1735000000,"model":"m","choices":[{{"index":0,"delta":{{"content":"{text}"}},"finish_reason":null}}]}}"#
+    )
+}
+
+/// The final chunk: a stop, with usage attached, as ferrox's own fixture shows.
+fn final_chunk() -> String {
+    r#"{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1735000000,"model":"m","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":15,"completion_tokens":2,"total_tokens":17}}"#.to_string()
+}
+
+/// A non-streaming OpenAI response body, from `ferrox/docs/user/api-reference.md`.
+fn completion_body() -> String {
+    r#"{"id":"chatcmpl-abc123","object":"chat.completion","created":1735000000,"model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"Hello! How can I help you today?"},"finish_reason":"stop"}],"usage":{"prompt_tokens":15,"completion_tokens":12,"total_tokens":27}}"#.to_string()
+}
+
+// ── Streaming ────────────────────────────────────────────────────────────────
+
+/// The OpenAI surface's terminator, and that there is exactly one of it.
+///
+/// "Ends with `[DONE]`" is not the assertion — a stream that emitted the
+/// terminator after every chunk would pass that, and every SDK would report the
+/// first token as the whole answer. The count is the property.
+#[tokio::test]
+async fn an_openai_stream_ends_with_exactly_one_done() {
+    let upstream = fake_upstream(vec![Reply::Sse {
+        chunks: vec![chunk("Hello"), chunk("!"), final_chunk()],
+    }])
+    .await;
+    let db = seeded_db(
+        &[("p1", &upstream.base_url())],
+        "my-alias",
+        &[("p1", "upstream-model")],
+    );
+    let gateway = gateway_for(&db).await;
+
+    let response = client()
+        .post(gateway.url("/v1/chat/completions"))
+        .bearer_auth(token_with(Scope::Llm))
+        .json(&serde_json::json!({
+            "model": "my-alias",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stream": true,
+        }))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(response.status(), 200);
+    assert_eq!(
+        response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok()),
+        Some("text/event-stream")
+    );
+
+    let body = body_text(response).await;
+    assert_eq!(
+        body.matches("data: [DONE]\n\n").count(),
+        1,
+        "exactly one terminator, not one per chunk; got:\n{body}"
+    );
+    assert!(
+        body.ends_with("data: [DONE]\n\n"),
+        "and it is last; got:\n{body}"
+    );
+    assert!(body.contains(r#""content":"Hello""#), "got:\n{body}");
+
+    // The alias is what the client sent; `upstream-model` is what the upstream
+    // was asked for. Sending the alias upstream is the failure this catches.
+    let call = &upstream.calls()[0];
+    assert!(
+        call.body.contains(r#""model":"upstream-model""#),
+        "the target's model_id goes upstream, not the alias; got: {}",
+        call.body
+    );
+    assert_eq!(
+        call.authorization.as_deref(),
+        Some("Bearer upstream-key"),
+        "the provider row's key reaches the provider, not the client's token"
+    );
+}
+
+/// The Anthropic surface's event sequence.
+///
+/// The state machine belongs to `ferrox-providers`; what is asserted here is
+/// that this gateway drives it and writes its frames out in order, with the
+/// `event:` name on every one — a `data:`-only stream parses as nothing to an
+/// Anthropic SDK.
+#[tokio::test]
+async fn the_anthropic_surface_emits_its_frames_in_protocol_order() {
+    let upstream = fake_upstream(vec![Reply::Sse {
+        chunks: vec![chunk("Hello"), chunk(" there"), final_chunk()],
+    }])
+    .await;
+    let db = seeded_db(
+        &[("p1", &upstream.base_url())],
+        "my-alias",
+        &[("p1", "upstream-model")],
+    );
+    let gateway = gateway_for(&db).await;
+
+    let response = client()
+        .post(gateway.url("/anthropic/v1/messages"))
+        // The Anthropic SDK's header spelling, deliberately: this is the one
+        // path where using only `Authorization` would still pass every other
+        // test here and fail against Claude Code.
+        .header("x-api-key", token_with(Scope::Llm))
+        .json(&serde_json::json!({
+            "model": "my-alias",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stream": true,
+        }))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(response.status(), 200);
+
+    let body = body_text(response).await;
+    let names = event_names(&body);
+
+    assert_eq!(names.first(), Some(&"message_start"), "got:\n{body}");
+    assert_eq!(names.last(), Some(&"message_stop"), "got:\n{body}");
+
+    // The order that matters, with the deltas collapsed: a stop before its
+    // start, or a message_delta after message_stop, is a stream an SDK
+    // abandons.
+    let skeleton: Vec<&str> = names
+        .iter()
+        .copied()
+        .filter(|n| *n != "content_block_delta" && *n != "ping")
+        .collect();
+    assert_eq!(
+        skeleton,
+        vec![
+            "message_start",
+            "content_block_start",
+            "content_block_stop",
+            "message_delta",
+            "message_stop"
+        ],
+        "got the full sequence {names:?} from:\n{body}"
+    );
+    assert!(
+        names
+            .iter()
+            .filter(|n| **n == "content_block_delta")
+            .count()
+            >= 2,
+        "both text chunks should have produced a delta; got {names:?}"
+    );
+
+    // Every frame carries both lines. An `event:` with no `data:` is not a
+    // frame the Anthropic SDK will deliver.
+    assert_eq!(
+        body.matches("event: ").count(),
+        body.matches("\ndata: ").count(),
+        "every event line needs its data line; got:\n{body}"
+    );
+    assert!(
+        !body.contains("[DONE]"),
+        "`[DONE]` is the OpenAI surface's terminator and has no meaning here"
+    );
+}
+
+/// A non-streaming completion on each surface, translated back into the
+/// caller's own shape.
+#[tokio::test]
+async fn a_non_streaming_completion_answers_in_the_callers_shape() {
+    let upstream = fake_upstream(vec![
+        Reply::ok(&completion_body()),
+        Reply::ok(&completion_body()),
+    ])
+    .await;
+    let db = seeded_db(
+        &[("p1", &upstream.base_url())],
+        "my-alias",
+        &[("p1", "upstream-model")],
+    );
+    let gateway = gateway_for(&db).await;
+
+    let openai: serde_json::Value = client()
+        .post(gateway.url("/v1/chat/completions"))
+        .bearer_auth(token_with(Scope::Llm))
+        .json(&serde_json::json!({
+            "model": "my-alias",
+            "messages": [{"role": "user", "content": "Hello"}],
+        }))
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(openai["object"], "chat.completion");
+    assert_eq!(openai["choices"][0]["message"]["role"], "assistant");
+    assert_eq!(openai["usage"]["total_tokens"], 27);
+
+    let anthropic: serde_json::Value = client()
+        .post(gateway.url("/anthropic/v1/messages"))
+        .bearer_auth(token_with(Scope::Llm))
+        .json(&serde_json::json!({
+            "model": "my-alias",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Hello"}],
+        }))
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(anthropic["type"], "message");
+    assert_eq!(anthropic["content"][0]["type"], "text");
+    // OpenAI's `stop` is Anthropic's `end_turn`; a passthrough here is a value
+    // the Anthropic SDK does not recognise.
+    assert_eq!(anthropic["stop_reason"], "end_turn");
+    assert_eq!(anthropic["usage"]["input_tokens"], 15);
+}
+
+// ── Retry and failover ───────────────────────────────────────────────────────
+
+/// A 429 is retried on the same target, and then the chain is walked.
+///
+/// Both halves are asserted by *counting upstream calls*, which is the only
+/// place the difference is observable: a gateway that failed over without
+/// retrying, and one that retried without failing over, both answer 200 here.
+#[tokio::test]
+async fn a_429_retries_the_same_target_and_then_walks_to_the_next() {
+    let primary = fake_upstream(vec![
+        Reply::status(429),
+        Reply::status(429),
+        Reply::status(429),
+    ])
+    .await;
+    let fallback = fake_upstream(vec![Reply::ok(&completion_body())]).await;
+
+    let db = seeded_db(
+        &[("p1", &primary.base_url()), ("p2", &fallback.base_url())],
+        "my-alias",
+        &[("p1", "primary-model"), ("p2", "fallback-model")],
+    );
+    let gateway = gateway_for(&db).await;
+
+    let response = client()
+        .post(gateway.url("/v1/chat/completions"))
+        .bearer_auth(token_with(Scope::Llm))
+        .json(&serde_json::json!({
+            "model": "my-alias",
+            "messages": [{"role": "user", "content": "Hello"}],
+        }))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(response.status(), 200, "the fallback served it");
+
+    assert_eq!(
+        primary.calls().len(),
+        3,
+        "a 429 is retryable, so the primary is asked `max_attempts` times"
+    );
+    assert_eq!(
+        fallback.calls().len(),
+        1,
+        "and then the chain is walked exactly once"
+    );
+    assert!(
+        fallback.calls()[0]
+            .body
+            .contains(r#""model":"fallback-model""#),
+        "the fallback is asked for *its* model id, not the primary's"
+    );
+}
+
+/// A 400 does neither — one call, and the client's own mistake comes straight
+/// back.
+///
+/// This is the arm a "retry everything" implementation gets wrong for free: it
+/// would triple every malformed request against the primary and then triple it
+/// again against the fallback, spending six upstream calls on a body no
+/// provider will ever accept.
+#[tokio::test]
+async fn a_400_is_neither_retried_nor_failed_over() {
+    let primary = fake_upstream(vec![Reply::status(400); 4]).await;
+    let fallback = fake_upstream(vec![Reply::ok(&completion_body())]).await;
+
+    let db = seeded_db(
+        &[("p1", &primary.base_url()), ("p2", &fallback.base_url())],
+        "my-alias",
+        &[("p1", "primary-model"), ("p2", "fallback-model")],
+    );
+    let gateway = gateway_for(&db).await;
+
+    let response = client()
+        .post(gateway.url("/v1/chat/completions"))
+        .bearer_auth(token_with(Scope::Llm))
+        .json(&serde_json::json!({
+            "model": "my-alias",
+            "messages": [{"role": "user", "content": "Hello"}],
+        }))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(response.status(), 400, "the upstream's status is preserved");
+
+    assert_eq!(primary.calls().len(), 1, "asked exactly once");
+    assert_eq!(
+        fallback.calls().len(),
+        0,
+        "and the fallback's credentials are never spent on it"
+    );
+}
+
+/// An upstream **403** is the asymmetric case, and the reason two predicates
+/// exist: quota exhaustion reported as a 403 must not be retried against the
+/// provider that is out of quota, and must still be served from the next one.
+#[tokio::test]
+async fn an_upstream_403_fails_over_without_retrying() {
+    let primary = fake_upstream(vec![Reply::status(403); 4]).await;
+    let fallback = fake_upstream(vec![Reply::ok(&completion_body())]).await;
+
+    let db = seeded_db(
+        &[("p1", &primary.base_url()), ("p2", &fallback.base_url())],
+        "my-alias",
+        &[("p1", "primary-model"), ("p2", "fallback-model")],
+    );
+    let gateway = gateway_for(&db).await;
+
+    let response = client()
+        .post(gateway.url("/v1/chat/completions"))
+        .bearer_auth(token_with(Scope::Llm))
+        .json(&serde_json::json!({
+            "model": "my-alias",
+            "messages": [{"role": "user", "content": "Hello"}],
+        }))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(response.status(), 200, "the fallback served it");
+
+    assert_eq!(
+        primary.calls().len(),
+        1,
+        "no backoff is spent on a provider known to be out of quota"
+    );
+    assert_eq!(fallback.calls().len(), 1);
+}
+
+// ── Auth ─────────────────────────────────────────────────────────────────────
+
+/// The scope gate, on both surfaces and both header spellings.
+///
+/// The `read`/`write` rows are the disjointness #423 built: an `/api`
+/// credential must not reach a surface that spends provider credits, and the
+/// *false* cells are the assertion — a lattice with a wildcard arm passes every
+/// positive test while granting exactly this.
+#[tokio::test]
+async fn only_an_llm_scoped_token_opens_either_surface() {
+    let upstream = fake_upstream(vec![Reply::ok(&completion_body()); 4]).await;
+    let db = seeded_db(
+        &[("p1", &upstream.base_url())],
+        "my-alias",
+        &[("p1", "upstream-model")],
+    );
+    let gateway = gateway_for(&db).await;
+    let client = client();
+
+    for path in ["/v1/models", "/anthropic/v1/models"] {
+        // No credential at all.
+        let response = client.get(gateway.url(path)).send().await.expect("send");
+        assert_eq!(response.status(), 401, "{path} with no credential");
+
+        // A credential that verifies, with a scope that does not cover this.
+        for scope in [Scope::Read, Scope::Write] {
+            let response = client
+                .get(gateway.url(path))
+                .bearer_auth(token_with(scope))
+                .send()
+                .await
+                .expect("send");
+            assert_eq!(
+                response.status(),
+                403,
+                "{path} with a {scope:?} token must be 403, not 401 — it verified"
+            );
+        }
+
+        // Garbage that does not verify.
+        let response = client
+            .get(gateway.url(path))
+            .bearer_auth("not-a-jwt")
+            .send()
+            .await
+            .expect("send");
+        assert_eq!(response.status(), 401, "{path} with a malformed credential");
+
+        // Both spellings of the one that works.
+        for response in [
+            client
+                .get(gateway.url(path))
+                .bearer_auth(token_with(Scope::Llm))
+                .send()
+                .await
+                .expect("send"),
+            client
+                .get(gateway.url(path))
+                .header("x-api-key", token_with(Scope::Llm))
+                .send()
+                .await
+                .expect("send"),
+        ] {
+            assert_eq!(response.status(), 200, "{path} with an llm token");
+        }
+    }
+}
+
+/// A denial is written in the dialect the client's SDK parses.
+///
+/// Agento's own `{"error":"..."}` is a shape neither SDK can read, and an
+/// Anthropic client branches on `error.type` to decide whether to retry — so
+/// `authentication_error` versus `permission_error` is behaviour, not wording.
+#[tokio::test]
+async fn a_denial_is_shaped_for_the_surface_it_was_refused_on() {
+    let upstream = fake_upstream(vec![]).await;
+    let db = seeded_db(
+        &[("p1", &upstream.base_url())],
+        "my-alias",
+        &[("p1", "upstream-model")],
+    );
+    let gateway = gateway_for(&db).await;
+    let client = client();
+
+    let openai: serde_json::Value = client
+        .get(gateway.url("/v1/models"))
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(openai["error"]["type"], "unauthorized");
+    assert_eq!(openai["error"]["code"], 401);
+
+    let anthropic: serde_json::Value = client
+        .get(gateway.url("/anthropic/v1/models"))
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(anthropic["type"], "error");
+    assert_eq!(anthropic["error"]["type"], "authentication_error");
+
+    let anthropic_403: serde_json::Value = client
+        .get(gateway.url("/anthropic/v1/models"))
+        .bearer_auth(token_with(Scope::Write))
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(anthropic_403["error"]["type"], "permission_error");
+}
+
+/// `/healthz` answers with no credential, and is the only route that does.
+#[tokio::test]
+async fn healthz_needs_no_credential() {
+    let upstream = fake_upstream(vec![]).await;
+    let db = seeded_db(
+        &[("p1", &upstream.base_url())],
+        "my-alias",
+        &[("p1", "upstream-model")],
+    );
+    let gateway = gateway_for(&db).await;
+
+    let response = client()
+        .get(gateway.url("/healthz"))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(response.status(), 200);
+    assert_eq!(body_text(response).await, "ok");
+}
+
+/// A foreign `Host` is refused before anything else looks at the request.
+///
+/// This is the half of the no-CORS decision that does the work: the browser is
+/// already shut out of a `POST` carrying `Authorization` by preflight, but a
+/// DNS-rebinding page reaches a loopback port with a *simple* request and its
+/// own `Host`. Refusing that is what makes the missing `CorsLayer` sufficient
+/// rather than merely absent — and `/healthz`, which needs no credential, is
+/// inside this layer for exactly that reason.
+#[tokio::test]
+async fn a_foreign_host_header_is_refused_on_every_route() {
+    let upstream = fake_upstream(vec![]).await;
+    let db = seeded_db(
+        &[("p1", &upstream.base_url())],
+        "my-alias",
+        &[("p1", "upstream-model")],
+    );
+    let gateway = gateway_for(&db).await;
+    let client = client();
+
+    for path in ["/healthz", "/v1/models", "/anthropic/v1/models"] {
+        let response = client
+            .get(gateway.url(path))
+            .header(reqwest::header::HOST, "evil.example.com")
+            .bearer_auth(token_with(Scope::Llm))
+            .send()
+            .await
+            .expect("send");
+        assert_eq!(
+            response.status(),
+            403,
+            "{path} must refuse a Host this listener is not reachable at"
+        );
+    }
+
+    // ...and `localhost`, which is what a browser on the dev origin sends, is
+    // still allowed — the allowlist is loopback, not a single literal.
+    let response = client
+        .get(gateway.url("/healthz"))
+        .header(reqwest::header::HOST, format!("localhost:{}", gateway.port))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(response.status(), 200);
+}
+
+// ── Configuration failures ───────────────────────────────────────────────────
+
+/// An unknown alias, and an alias whose providers are all disabled, are
+/// different answers — and neither is an empty 200.
+#[tokio::test]
+async fn an_unroutable_request_gets_a_typed_error_rather_than_an_empty_answer() {
+    let upstream = fake_upstream(vec![]).await;
+    let db = seeded_db(
+        &[("p1", &upstream.base_url())],
+        "my-alias",
+        &[("p1", "upstream-model")],
+    );
+    let gateway = gateway_for(&db).await;
+
+    let response = client()
+        .post(gateway.url("/v1/chat/completions"))
+        .bearer_auth(token_with(Scope::Llm))
+        .json(&serde_json::json!({
+            "model": "no-such-alias",
+            "messages": [{"role": "user", "content": "Hello"}],
+        }))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(
+        response.status(),
+        404,
+        "the client named a model we do not have"
+    );
+    let body: serde_json::Value = response.json().await.expect("json");
+    assert_eq!(body["error"]["type"], "model_not_found");
+    assert_eq!(upstream.calls().len(), 0);
+}
+
+/// A gateway with no provider configured says so, rather than answering an
+/// empty models list a client cannot tell from "you have no models".
+#[tokio::test]
+async fn the_models_routes_refuse_a_gateway_with_no_provider() {
+    let file = NamedTempFile::new().expect("tempfile");
+    {
+        let mut conn =
+            agento_lib::native::db::ensure_database(file.path()).expect("create database");
+        agento_lib::native::migrate::apply(&mut conn).expect("migrate");
+    }
+    let gateway = gateway_for(&file).await;
+
+    // The two dialects spell the same `ProxyError::ConfigError` differently —
+    // OpenAI has a `config_error` type and Anthropic's vocabulary does not, so
+    // it lands on `api_error`. Both are 500, and both are something a client
+    // can surface; `{"data":[]}` is neither.
+    for (path, expected_type) in [
+        ("/v1/models", "config_error"),
+        ("/anthropic/v1/models", "api_error"),
+    ] {
+        let response = client()
+            .get(gateway.url(path))
+            .bearer_auth(token_with(Scope::Llm))
+            .send()
+            .await
+            .expect("send");
+        assert_eq!(response.status(), 500, "{path}");
+        let body: serde_json::Value = response.json().await.expect("json");
+        assert_eq!(
+            body["error"]["type"], expected_type,
+            "{path} answered {body}"
+        );
+    }
+}
+
+/// The aliases a configured gateway lists, on both surfaces.
+#[tokio::test]
+async fn the_models_routes_list_the_configured_aliases() {
+    let upstream = fake_upstream(vec![]).await;
+    let db = seeded_db(
+        &[("p1", &upstream.base_url())],
+        "my-alias",
+        &[("p1", "upstream-model")],
+    );
+    let gateway = gateway_for(&db).await;
+
+    let openai: serde_json::Value = client()
+        .get(gateway.url("/v1/models"))
+        .bearer_auth(token_with(Scope::Llm))
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(openai["object"], "list");
+    assert_eq!(openai["data"][0]["id"], "my-alias");
+    assert_eq!(openai["data"][0]["object"], "model");
+
+    let anthropic: serde_json::Value = client()
+        .get(gateway.url("/anthropic/v1/models"))
+        .bearer_auth(token_with(Scope::Llm))
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(anthropic["data"][0]["type"], "model");
+    assert_eq!(anthropic["data"][0]["id"], "my-alias");
+    assert_eq!(anthropic["has_more"], false);
+    assert_eq!(anthropic["first_id"], "my-alias");
+}
+
+// ── Disconnect ───────────────────────────────────────────────────────────────
+
+/// A client that disconnects mid-stream must take the upstream request with it.
+///
+/// The failure this catches is silent and unbounded: the frame loop lives in a
+/// spawned task holding the upstream response, so a client that goes away
+/// leaves that task blocked on `tx.send` forever, with the provider connection
+/// open. One abandoned tool invocation would be invisible; a tool that
+/// reconnects on every timeout leaks one per attempt.
+///
+/// The assertion is on the **upstream** side, because that is the only place
+/// the leak is observable — a test that only checked the gateway's own response
+/// passes with the whole thing reverted. `tx.closed()` in the fake resolves
+/// exactly when its receiver is dropped, which happens only if the chain from
+/// the disconnected client all the way to the upstream body was torn down.
+#[tokio::test]
+async fn a_disconnect_mid_stream_tears_down_the_upstream_request() {
+    let upstream = fake_upstream(vec![Reply::SseThenHang {
+        chunks: vec![chunk("Hello")],
+    }])
+    .await;
+    let db = seeded_db(
+        &[("p1", &upstream.base_url())],
+        "my-alias",
+        &[("p1", "upstream-model")],
+    );
+    let gateway = gateway_for(&db).await;
+
+    // Armed *before* the disconnect: `Notify::notified()` only observes
+    // notifications issued after the future is created, so registering after
+    // the drop would race the teardown it is meant to observe.
+    let hung_up = Arc::clone(&upstream.hung_up);
+    let observed = tokio::spawn(async move { hung_up.notified().await });
+    // Let the spawned task reach the await point before anything can fire it.
+    tokio::task::yield_now().await;
+
+    let mut response = client()
+        .post(gateway.url("/v1/chat/completions"))
+        .bearer_auth(token_with(Scope::Llm))
+        .json(&serde_json::json!({
+            "model": "my-alias",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stream": true,
+        }))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(response.status(), 200);
+
+    // Read until a frame has actually arrived, *then* disconnect. Dropping
+    // immediately would tear down before the stream was ever established, which
+    // passes whether or not the disconnect is handled — the same trap
+    // `chat_turn.rs`'s disconnect tests document.
+    let first = tokio::time::timeout(std::time::Duration::from_secs(10), response.chunk())
+        .await
+        .expect("a first frame within 10s")
+        .expect("chunk")
+        .expect("some bytes");
+    assert!(String::from_utf8_lossy(&first).contains("data: "));
+
+    drop(response);
+
+    // The upstream is parked on `tx.closed()`, which resolves only when its own
+    // body's receiver is dropped — and that happens only if the disconnect
+    // propagated from the client, through the gateway's frame loop, into the
+    // upstream response it was holding. If any link in that chain leaks, this
+    // never fires and the timeout reports it as a failure rather than a hang.
+    tokio::time::timeout(std::time::Duration::from_secs(10), observed)
+        .await
+        .expect("the client disconnect must reach the upstream request")
+        .expect("the observer task must not panic");
+
+    assert_eq!(
+        upstream.calls().len(),
+        1,
+        "and the abandoned stream must not have been retried"
+    );
+}
+
+// ── Lifecycle ────────────────────────────────────────────────────────────────
+
+/// Serialises the three tests below.
+///
+/// `gateway::registry` is a process-wide `OnceLock` — one listener, one status
+/// — and `cargo test` runs a binary's tests in parallel, so two of these
+/// running at once would each assert against the other's status. That is the
+/// hazard `security::keys` has already cost this port twice, and it fails
+/// intermittently in whichever test lost, which is worse than not asserting at
+/// all. Every test that touches the global takes this lock and leaves the
+/// registry stopped.
+fn registry_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+/// A disabled gateway starts nothing and says so.
+#[tokio::test]
+async fn a_disabled_gateway_binds_nothing() {
+    let _guard = registry_lock().lock().await;
+    let upstream = fake_upstream(vec![]).await;
+    let db = seeded_db(
+        &[("p1", &upstream.base_url())],
+        "my-alias",
+        &[("p1", "upstream-model")],
+    );
+    // `enabled: false` is the default, so this only makes it explicit.
+    config::store_settings(
+        db.path(),
+        &GatewaySettings {
+            enabled: false,
+            port: free_port().await,
+            start_with_app: true,
+        },
+    )
+    .expect("store settings");
+
+    registry::start_if_enabled(db.path())
+        .await
+        .expect("start_if_enabled");
+    assert_eq!(registry::status(), registry::Status::Stopped);
+    registry::stop();
+}
+
+/// A port already in use leaves a **readable** status, not a log line.
+///
+/// This is the collision a developer hits every day — an installed Agento and a
+/// `~/.agento-desktop-dev` one configured for the same port — and #426's status
+/// route is what turns it into something the UI can explain. Without a stored
+/// status the second instance reports "not running" and offers a Start button
+/// that silently does nothing.
+#[tokio::test]
+async fn a_port_already_in_use_is_a_readable_status_rather_than_silence() {
+    let _guard = registry_lock().lock().await;
+    let db = seeded_db(&[("p1", "http://127.0.0.1:1/v1")], "a", &[("p1", "m")]);
+
+    // Hold the port for the whole test, so the bind cannot succeed.
+    let squatter = tokio::net::TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("bind squatter");
+    let port = squatter.local_addr().expect("addr").port();
+
+    config::store_settings(
+        db.path(),
+        &GatewaySettings {
+            enabled: true,
+            port,
+            start_with_app: true,
+        },
+    )
+    .expect("store settings");
+
+    registry::start_if_enabled(db.path())
+        .await
+        .expect("a bind failure is an answer, not an Err");
+
+    match registry::status() {
+        registry::Status::BindFailed {
+            port: reported,
+            error,
+        } => {
+            assert_eq!(reported, port);
+            assert!(
+                !error.is_empty(),
+                "the status has to say *why*, or it is no better than Stopped"
+            );
+        }
+        other => panic!("expected BindFailed, got {other:?}"),
+    }
+
+    registry::stop();
+    drop(squatter);
+}
+
+/// The whole lifecycle: start from settings, serve, reload, stop.
+///
+/// The reload half is what makes a provider edit take effect — the adapter
+/// registry is built once per start, so a gateway that never rebuilt it would
+/// go on using the API key the user just rotated away.
+#[tokio::test]
+async fn the_listener_starts_reloads_and_stops() {
+    let _guard = registry_lock().lock().await;
+    let upstream = fake_upstream(vec![]).await;
+    let db = seeded_db(
+        &[("p1", &upstream.base_url())],
+        "my-alias",
+        &[("p1", "upstream-model")],
+    );
+    let port = free_port().await;
+    config::store_settings(
+        db.path(),
+        &GatewaySettings {
+            enabled: true,
+            port,
+            start_with_app: true,
+        },
+    )
+    .expect("store settings");
+
+    registry::start_if_enabled(db.path())
+        .await
+        .expect("start_if_enabled");
+    assert_eq!(registry::status(), registry::Status::Running { port });
+
+    let health = format!("http://127.0.0.1:{port}/healthz");
+    assert_eq!(
+        client().get(&health).send().await.expect("send").status(),
+        200
+    );
+
+    // A reload is stop-then-start on the same port. It must come back.
+    registry::reload(db.path()).await.expect("reload");
+    assert_eq!(registry::status(), registry::Status::Running { port });
+    assert_eq!(
+        client().get(&health).send().await.expect("send").status(),
+        200
+    );
+
+    registry::stop();
+    assert_eq!(registry::status(), registry::Status::Stopped);
+    // Poll rather than sleep a fixed amount: the graceful shutdown is
+    // asynchronous, and a fixed wait is either flaky or slow.
+    let mut gone = false;
+    for _ in 0..200 {
+        if client().get(&health).send().await.is_err() {
+            gone = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    assert!(gone, "a stopped gateway must stop answering");
+}
+
+/// An OS-assigned port, released before it is configured.
+///
+/// `gateway_settings.port` refuses `0`, so a test that wants a port it cannot
+/// collide on has to pick one. There is a race here in principle — nothing
+/// stops another process taking it in between — and it is accepted because the
+/// alternative is a hardcoded port that collides with the developer's own
+/// running Agento every time.
+async fn free_port() -> u16 {
+    let listener = tokio::net::TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("bind for a free port");
+    listener.local_addr().expect("addr").port()
+}
+
+// ── Startup ordering ─────────────────────────────────────────────────────────
+
+/// The gateway may not start before the credential system it verifies against.
+///
+/// **This is a source assertion, and deliberately so.** The property is about
+/// the order of three calls in one `setup` closure that also creates a database,
+/// binds the proxy and opens a window — there is no seam to drive it through,
+/// and the runtime consequence is a *window* rather than a state: a listener
+/// bound before `tokens::load_revoked` accepts a revoked token for however long
+/// the load takes, and then behaves correctly forever. A test that asked the
+/// running app would have to win that race to see anything.
+///
+/// What it costs to get wrong is why it is asserted at all. Bound before
+/// `keys::install`, every client gets a 401 until the key lands — visible, and
+/// merely broken. Bound before `load_revoked`, a token the user revoked is
+/// **honoured**, and nothing anywhere reports it.
+#[test]
+fn a_gateway_start_requires_an_installed_keypair() {
+    let source = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/lib.rs"))
+        .expect("read lib.rs");
+
+    let install = source
+        .find("security::keys::install")
+        .expect("lib.rs must install the signing keypair");
+    let revoked = source
+        .find("security::tokens::load_revoked")
+        .expect("lib.rs must load the revoked token set");
+    let gateway = source
+        .find("gateway::registry::start_if_enabled")
+        .expect("lib.rs must start the gateway");
+
+    assert!(
+        install < gateway,
+        "the gateway must not be started before the signing keypair is installed"
+    );
+    assert!(
+        revoked < gateway,
+        "the gateway must not be started before the revoked-token set is loaded, \
+         or it accepts a revoked token for the length of that window"
+    );
+}


### PR DESCRIPTION
Closes #424

## What

The LLM gateway's runtime: a second `axum` listener on its own user-configured port that serves OpenAI's and Anthropic's wire formats, authenticates with the `llm`-scoped JWT (#423), and dispatches to `ferrox-providers` adapters with retry and per-alias fallback.

| module | what it owns |
|---|---|
| `gateway/registry.rs` | lifecycle in `integrations/registry.rs`'s shape — process-wide handle, generation counter, drop-stops-listener, and a **stored** `Status` so a bind failure is readable by #426 |
| `gateway/server.rs` | the five routes, the `Host` allowlist, the `llm`-scope auth layer (both header spellings), and the per-surface error dialect |
| `gateway/dispatch.rs` | alias → ordered targets, retry on the same target, the fallback walk; `is_retryable`/`should_failover` copied from `ferrox/src/retry.rs` |
| `gateway/stream.rs` | the SSE bytes of both surfaces, and the `anthropic-beta` merge |

Routes: `POST /v1/chat/completions`, `GET /v1/models`, `POST /anthropic/v1/messages`, `GET /anthropic/v1/models`, `GET /healthz` (unauthenticated). No new dependency. Disabled by default — `start_if_enabled` reads one row and returns.

## Why

`gateway/` held `config.rs` and nothing else: migration 32's three tables were written by no one and read by no one, and `Scope::Llm` was a credential no listener accepted. This is the runtime between them, and #425–#429 all block on it.

## How

Two shapes this codebase had already settled, rather than new ones. Lifecycle is `native/integrations/registry.rs` verbatim — the handle *is* the cancel, and a generation counter so a `stop` racing a `reload` cannot leave a bound port holding a credential. `ferrox-providers` supplies every translation; this supplies the listener, the auth, the routing table and the framing.

**Three deviations from the issue's HOW, each because the HOW named something that isn't there:**

1. **Graceful shutdown follows `claude/mcp.rs`, not `proxy.rs`.** The HOW says to follow `proxy.rs`, but `proxy.rs` has no graceful shutdown at all — it is spawned once and process exit is its shutdown. `claude/mcp.rs` solved exactly this for #311 (oneshot fired by `Drop`, awaited as `axum::serve`'s shutdown future) and that is what's used.
2. **`impl From<SseFrame> for axum::response::sse::Event` violates the orphan rule** — both types are foreign to this crate. Frames are emitted as raw bytes instead, which is also what the byte-exact acceptance criteria need, and settles a spelling `Event` decides for us: `axum` writes `event:name` with no space, while every fixture in `ferrox/docs/user/api-reference.md` and Anthropic's own docs show `event: name`. Both parse; this emits the documented one.
3. **`guards.rs::host_allowed` was private.** Widened to `pub(crate)` and shared rather than copying the allowlist into a second place — an allowlist that exists twice is one that gets widened once.

**One thing the HOW asked for that turned out to be already done:** `tokens::touch` throttles to one write a minute and spawns its own `db::blocking`, so calling it from the middleware is not a database call on the request path and must *not* be wrapped a second time.

## Defects the suite caught (all fixed, each verified to fail on revert)

Both were found by `tests/gateway_engine.rs` and both were verified to **fail on revert**:

- **A disconnect while the model was thinking leaked the upstream connection.** A failed `send` catches a client that leaves while a frame is being written — which is what happens when tokens are flowing, and is not what happens for most of a request. Parked on `stream.next()` the loop never noticed, and one such leak happened per abandoned request. `stream::next_or_disconnect` races every wait against `Sender::closed`, which is `turn.rs`'s rule one level down. The test asserts on the **upstream** side, because that is the only place the leak is observable.
- **Collapsing "stream ended" and "client gone" lost `data: [DONE]`** — and in the other direction would have *sent* one on an abandoned stream, where `[DONE]` means the completion finished and a client would record a truncated answer as a whole one. They are separate `Next` variants for that reason.
- **axum's 2 MiB default body limit refused a 3 MiB conversation with a bare `413`** in neither surface's dialect. That is an ordinary request for the clients this endpoint exists for — a long coding session crosses it alone, one pasted screenshot does it immediately at base64's 4/3 expansion — so it broke the "Claude Code completes a streamed chat" criterion. Raised to 32 MiB, Anthropic's own request ceiling, so a body this refuses is one the upstream would refuse anyway with a message the client can read. (Diagnosing it took a second step: the *fake upstream* had the same default, and its `413` was distinguishable from the gateway's only by `"type":"provider_error"` in the body.)
- **A provider that would not build reported `Status::BindFailed`** — reachable from a typo, since ferrox's OpenAI adapter refuses a `base_url` ending in `/chat/completions`. #426's UI would have named a port nothing ever tried to bind. Split into `Status::StartFailed { error }`, which carries no port because none was reached.

Two test-quality fixes in the same pass: the disconnect observer used `Notify::notify_waiters`, which only wakes already-registered waiters and so could lose the signal and time out (`notify_one` stores a permit instead); and the auth test asserted only on the two `GET` routes, leaving the two `POST`s — the ones that spend money — resting on the layer being shared rather than on a check.

## Acceptance criteria

- [x] Scripted fake upstream drives `tests/gateway_engine.rs` (18 tests): OpenAI stream ends with **exactly one** `data: [DONE]\n\n` (the count is the assertion, not "ends with"); Anthropic frames arrive `message_start` → `content_block_start` → `content_block_delta`* → `content_block_stop` → `message_delta` → `message_stop`.
- [x] Retry and failover pinned **by counting upstream calls**, on the streaming path as well as the buffered one, the only place the difference is observable: a 429 costs 3 calls on the primary then 1 on the fallback; a 400 costs 1 and never reaches the fallback's credentials; a 403 fails over **without** retrying (quota), while the gateway's own `Forbidden` does not.
- [x] Auth pinned on both surfaces and both header spellings: no credential → 401, `read`/`write` → **403** (it verified), malformed → 401, `llm` → 200 via `Authorization: Bearer` *and* `x-api-key`. Bodies are `{"error":{"type":"unauthorized"}}` on `/v1/*` and `{"type":"error","error":{"type":"authentication_error"}}` on `/anthropic/*` — SDKs branch on those strings.
- [x] `GET /healthz` answers with no credential (and is still inside the `Host` layer).
- [x] Disconnect mid-stream drops the upstream request and leaves no task alive; asserted upstream, and fails on revert.
- [x] Reload across an **in-flight stream** rebinds the same port *and* does not cut the stream. The two properties pull against each other — graceful shutdown is what lets a client mid-completion survive a settings save, but `reload` rebinds the same user-configured port, and a draining listener still owning that socket would give the rebind `EADDRINUSE`. That failure would be the worst one here: status reads `BindFailed` while the old listener, holding the key the user just rotated away, goes on serving. A *quiet* reload cannot catch it — with nothing in flight the drain finishes in microseconds and the rebind always wins.
- [x] A port already in use leaves `Status::BindFailed { port, error }` readable by #426, not a log-only death.
- [x] Startup ordering asserted: `a_gateway_start_requires_an_installed_keypair` fails if the `lib.rs` spawn moves above `keys::install` or `tokens::load_revoked`. **This is a source assertion deliberately** — the consequence is a *window* rather than a state (a listener bound before the revoked set loads **honours a revoked token** for its duration, then behaves correctly forever), so a test that asked the running app would have to win that race to see anything.

## Out of scope, as specified

Usage recording (#425 — the handlers log a line where the row will go, and `Verified` is already on the request extensions so #425's `subject` needs no retrofit), the `/api/gateway/*` control API (#426 — `registry::status`/`registry::reload` are public for it), UI (#427/#428), docs (#429), `bedrock`, and CORS of any kind.

## Verification

Local gates, all green from the repository root:

```
npm run build                              ✓
cargo fmt --check                          ✓
cargo clippy --all-targets -- -D warnings  ✓
cargo test --no-fail-fast                  ✓ 1205 lib + 18 gateway_engine, 0 failed
cargo build --release                      ✓
```

`tests/gateway_engine.rs` (22 tests) was run 15× consecutively to rule out the process-wide-static flakiness this crate has been bitten by twice (`security::keys`, and now `gateway::registry` — the three lifecycle tests take a shared mutex for exactly that reason).

**Manual verification against a real OpenAI SDK and a real Claude Code CLI is outstanding and is deliberately not a CI gate** — CI has no provider credentials, and the refinement recorded that decision explicitly (mirroring `scan_live.rs` and `claude_mcp_live.rs`, which are `#[ignore]`d and run by hand). The automated acceptance is the fake-upstream suite above, which covers every wire property those checks would exercise except the upstreams' own behaviour.
