### PR TITLE
feat(search): indexing pipeline in the insight worker (#435)

### DIFF
--- a/src-tauri/src/native/insights/index.rs
+++ b/src-tauri/src/native/insights/index.rs
@@ -103,16 +103,21 @@ impl DocAccumulator {
     }
 
     fn observe_user(&mut self, content: &Value) {
-        let blocks = transcript::parse_content_blocks(content);
         let mut carried_a_result = false;
-        for block in blocks.iter().filter(|b| b.block_type == "tool_result") {
+        for payload in tool_result_payloads(content) {
             carried_a_result = true;
-            self.builder.push_tool(&tool_result_text(block));
+            self.builder
+                .push_tool(&transcript::extract_text_content(payload));
         }
         if carried_a_result {
             return;
         }
-        if transcript::is_user_turn_content(content) {
+        // `is_injected_user_content`, not `is_user_turn_content`. The latter is
+        // "no `tool_result` block **and** not injected", and the early return
+        // above has already settled the first half — so calling it here would
+        // re-run `parse_content_blocks` over the same array to re-derive an
+        // answer we have, and that call clones every block's `Value`.
+        if !transcript::is_injected_user_content(content) {
             self.builder
                 .push_user(&transcript::extract_text_content(content));
         }
@@ -167,14 +172,33 @@ pub fn normalize_title(raw: &str) -> String {
     normalize::normalize_text(raw, normalize::MESSAGE_CAP)
 }
 
-/// A `tool_result` block's payload as text.
+/// Each `tool_result` block's payload, borrowed straight out of the message's
+/// content array.
 ///
-/// The block's `content` is a string for most tools and an array of `text`
-/// blocks for the rest, which is exactly the shape
-/// [`transcript::extract_text_content`] already decides between — so this is
-/// that function plus the `is_error` note below, not a second decoder.
-fn tool_result_text(block: &ContentBlock) -> String {
-    transcript::extract_text_content(&block.content)
+/// **Deliberately not routed through [`transcript::ContentBlock`]**, which is
+/// the obvious way to write this and is the expensive one. That struct does not
+/// decode a `tool_result`'s `content`, and adding the field to it would reach
+/// far past this module: `parse_content_blocks` is called four times per message
+/// by the processors, and `parse_content_blocks_raw` is on the
+/// `GET /api/claude-sessions/{id}` read path — where the payload is currently
+/// skipped by the decoder entirely. A `Read` of a large file is a multi-megabyte
+/// `tool_result`, so adding the field would make every one of those callers
+/// materialize and retain payloads none of them look at, to serve one reader
+/// here.
+///
+/// Borrowing costs nothing instead: the content is already a `Value` on
+/// `Message`, so this only walks it. The block shape is checked by hand for the
+/// same reason — one `type` comparison against a shared type's whole decode.
+fn tool_result_payloads(content: &Value) -> impl Iterator<Item = &Value> {
+    content
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter(|block| block.get("type").and_then(Value::as_str) == Some("tool_result"))
+        // The payload a tool's output arrives in. Absent is `Value::Null`, which
+        // `extract_text_content` answers `""` to, so a malformed block
+        // contributes nothing rather than needing its own arm.
+        .map(|block| block.get("content").unwrap_or(&Value::Null))
 }
 
 /// A `tool_use` block as text: the tool's name, then the string leaves of its
@@ -202,11 +226,16 @@ fn tool_use_text(block: &ContentBlock) -> String {
 /// Append every string leaf of `value`, in document order, space separated.
 ///
 /// **Bounded by [`normalize::TOOL_RESULT_CAP`]**, which is the cap the result
-/// will be truncated to anyway: a `Write` call's input carries a whole file, and
-/// building a multi-megabyte `String` to hand `push_tool` two kilobytes of it is
-/// the shape #434's own "every forward scan needs a bound" note is about. The
-/// bound is checked between leaves rather than inside one, so a single enormous
-/// leaf is still materialized once — `normalize_text` is what trims it.
+/// will be truncated to anyway: building a multi-megabyte `String` so that
+/// `push_tool` can keep two kilobytes of it is the shape #434's own "every
+/// forward scan needs a bound" note is about.
+///
+/// The bound is applied **inside a leaf as well as between leaves**, and that is
+/// the half worth stating: the case it exists for is a `Write` call, whose input
+/// is `{"file_path": "…", "content": "<the whole file>"}` — *one* enormous leaf.
+/// A guard that only checked between leaves would leave the dominant case
+/// completely uncovered while looking as though it handled it. The many-small-
+/// leaves shape is real too, so both are tested.
 fn push_string_leaves(value: &Value, out: &mut String) {
     if out.len() >= normalize::TOOL_RESULT_CAP {
         return;
@@ -215,7 +244,10 @@ fn push_string_leaves(value: &Value, out: &mut String) {
         Value::String(s) => {
             if !s.is_empty() {
                 out.push(' ');
-                out.push_str(s);
+                out.push_str(truncate_on_boundary(
+                    s,
+                    normalize::TOOL_RESULT_CAP.saturating_sub(out.len()),
+                ));
             }
         }
         Value::Array(items) => {
@@ -234,6 +266,22 @@ fn push_string_leaves(value: &Value, out: &mut String) {
         // Numbers, booleans and nulls are not search terms.
         _ => {}
     }
+}
+
+/// `s` cut to at most `max` bytes, never through a character.
+///
+/// `normalize_text` applies its own cap afterwards, so this is only about not
+/// building the huge intermediate — but it still must not split a codepoint,
+/// because slicing a `str` mid-character panics.
+fn truncate_on_boundary(s: &str, max: usize) -> &str {
+    if s.len() <= max {
+        return s;
+    }
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
 }
 
 #[cfg(test)]
@@ -393,6 +441,56 @@ mod tests {
         assert_eq!((assistant.as_str(), tool.as_str()), ("", ""));
     }
 
+    /// The case the bound actually exists for: **one** enormous leaf, which is
+    /// what a `Write` call's `content` argument is.
+    ///
+    /// The many-small-leaves test below caught a guard checked only *between*
+    /// leaves; this one does not, and it is the commoner shape by far. A 4 MiB
+    /// file uploaded through `Write` is 4 MiB of `String` built to keep 2 KiB.
+    #[test]
+    fn a_single_enormous_leaf_is_truncated_rather_than_copied_whole() {
+        let file = "x".repeat(4 * 1024 * 1024);
+        let block = ContentBlock {
+            block_type: "tool_use".into(),
+            name: "Write".into(),
+            input: Some(
+                serde_json::value::RawValue::from_string(
+                    json!({"file_path": "/a.txt", "content": file}).to_string(),
+                )
+                .expect("raw"),
+            ),
+            ..Default::default()
+        };
+
+        let text = tool_use_text(&block);
+
+        assert!(
+            text.len() <= normalize::TOOL_RESULT_CAP + 16,
+            "collected {} bytes from a 4 MiB single-leaf input",
+            text.len(),
+        );
+        assert!(text.starts_with("Write "), "got {:?}", &text[..16]);
+        // `serde_json` sorts an object's keys, so `content` is walked before
+        // `file_path` and eats the whole budget — the path does not make it in.
+        // That is unchanged from building the string in full and letting
+        // `normalize_text` trim it, which cut at the same place; the only thing
+        // this fix changes is how much is built to get there.
+        assert!(text.contains('x'));
+    }
+
+    /// Truncating a leaf must not split a character — slicing a `str`
+    /// mid-codepoint panics, and a tool argument is arbitrary user text.
+    #[test]
+    fn truncating_a_leaf_never_splits_a_character() {
+        // Multi-byte throughout, so almost every byte offset is a split point.
+        let text = "é".repeat(normalize::TOOL_RESULT_CAP);
+        for max in [0, 1, 2, 3, 1_023, normalize::TOOL_RESULT_CAP - 1] {
+            let cut = truncate_on_boundary(&text, max);
+            assert!(cut.len() <= max, "{} > {max}", cut.len());
+            assert!(text.starts_with(cut));
+        }
+    }
+
     /// The bound on a tool call's input, which is what stops a `Write` of a
     /// large file materializing in full before the cap trims it.
     #[test]
@@ -415,6 +513,46 @@ mod tests {
             "collected {} bytes from a 64 KiB input",
             text.len()
         );
+    }
+
+    /// [`push_string_leaves`] recurses, so the depth it can reach has to be
+    /// bounded by something.
+    ///
+    /// It is, and by the parse rather than by a check here: `serde_json`'s
+    /// deserializer enforces a 128-level recursion limit, so a `Value` this
+    /// function is handed can never be deeper than that. Input past the limit
+    /// fails to parse and takes the "name only" arm — which is the same
+    /// keep-what-is-certain direction every rule in `normalize` fails in.
+    ///
+    /// Pinned rather than reasoned about, because the guarantee lives in a
+    /// dependency's default and a `Value` built in memory would not have it.
+    #[test]
+    fn a_deeply_nested_tool_input_is_bounded_by_the_parser() {
+        let deep = format!("{}\"x\"{}", "[".repeat(600), "]".repeat(600));
+        let block = ContentBlock {
+            block_type: "tool_use".into(),
+            name: "Deep".into(),
+            input: Some(serde_json::value::RawValue::from_string(deep).expect("raw")),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            tool_use_text(&block),
+            "Deep",
+            "input past serde_json's recursion limit must not parse, and must \
+             not recurse",
+        );
+
+        // …and a depth the parser *does* accept is walked normally, so the
+        // assertion above is about the limit rather than about all nesting.
+        let shallow = format!("{}\"found\"{}", "[".repeat(20), "]".repeat(20));
+        let block = ContentBlock {
+            block_type: "tool_use".into(),
+            name: "Deep".into(),
+            input: Some(serde_json::value::RawValue::from_string(shallow).expect("raw")),
+            ..Default::default()
+        };
+        assert_eq!(tool_use_text(&block), "Deep found");
     }
 
     /// An event with no message at all — a `file-history-snapshot` reaching here

--- a/src-tauri/src/native/insights/index.rs
+++ b/src-tauri/src/native/insights/index.rs
@@ -1,0 +1,487 @@
+//! One session's transcript → one `session_search` document (#435).
+//!
+//! This is the routing half of the indexer: which of a decoded event's text
+//! belongs in `user_text`, which in `assistant_text`, and which in `tool_text`.
+//! The *shaping* half — markdown and tag removal, whitespace collapsing and the
+//! three caps — is `search::normalize`'s (#434), and nothing here duplicates it.
+//!
+//! # It rides the read the processors already do
+//!
+//! The worker re-reads a changed session's transcript to recompute its nine
+//! insight passes, and that read is where every byte this module wants already
+//! is. So [`DocAccumulator`] is threaded into `processors::feed` and observes
+//! the same `Event` stream the processors see, rather than opening the file a
+//! second time. **Indexing therefore costs no additional file I/O**, which is
+//! the property the issue is built on: index freshness equals insight freshness
+//! for free.
+//!
+//! It also means the `file-history-snapshot` skip is inherited — `feed` drops
+//! those before anything observes them — and that sub-agent transcripts are
+//! indexed with the parent, additively, exactly as their tool calls and cost
+//! already are.
+//!
+//! # Routing is by content shape, never by `isSidechain`
+//!
+//! A `user` event is one of three things and only the first is a person typing:
+//!
+//! - a genuine turn ([`transcript::is_user_turn_content`]) → `user_text`;
+//! - a **carrier for `tool_result` blocks**, which is how a tool's output
+//!   reaches the transcript at all → `tool_text`;
+//! - **injected machinery** — `<command-name>`, a system reminder, an interrupt
+//!   marker — which is text no one wrote and no one will search for → dropped.
+//!
+//! `is_user_turn_content` answers `false` to the second *and* the third, so the
+//! `tool_result` check has to come first and be its own; using the predicate
+//! alone would file every tool result under "injected" and lose the whole
+//! column. `a_tool_result_carrier_is_indexed_as_tool_text_not_dropped` is that
+//! distinction.
+//!
+//! Deliberately **not** `is_turn_start`, which also requires `!is_sidechain`: a
+//! sub-agent's own transcript has the flag set on every event, so that predicate
+//! would route a delegated run's entire conversation into `tool_text`. The flag
+//! answers "was this delegated", which is a different question from "who wrote
+//! this".
+//!
+//! # What a tool contributes
+//!
+//! A `tool_use` block contributes its **name and the string leaves of its
+//! input** — a `Bash` command, a `Read` path, a `Grep` pattern, a `Task`
+//! prompt. Those are the things people remember and search for; the numbers and
+//! booleans beside them are noise that would only dilute the ranking.
+//!
+//! This is the one place a `tool_use` `input` is read through a
+//! `serde_json::Value`, and it is sound *here* precisely because nothing is
+//! re-encoded: the standing rule (`chats.rs`, `sessions/detail.rs`) is that a
+//! `Value` round trip sorts keys and respells numbers, which matters when the
+//! bytes go back on the wire. These bytes become tokens in an index and never
+//! travel anywhere, so the ordering is unobservable — and the raw form has no
+//! way to enumerate leaves without parsing it anyway.
+
+use serde_json::Value;
+
+use super::transcript::{self, ContentBlock, Event};
+use crate::native::search::{self, normalize};
+
+/// One session's three text columns, accumulated event by event.
+///
+/// A thin router over [`normalize::DocBuilder`], which owns the caps and the
+/// shared session budget. Constructing one costs nothing, so the worker builds
+/// one per session unconditionally.
+#[derive(Debug, Clone, Default)]
+pub struct DocAccumulator {
+    builder: normalize::DocBuilder,
+}
+
+impl DocAccumulator {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Route one decoded event's text into the right column.
+    ///
+    /// Called for every event of the parent transcript and of each sub-agent's,
+    /// in file order, from `processors::feed`.
+    pub fn observe(&mut self, ev: &Event) {
+        // The session budget is spent. Every `push` below would return
+        // immediately anyway; returning here is what stops a 400-message session
+        // parsing content blocks it can no longer index anything from.
+        if self.builder.remaining() == 0 {
+            return;
+        }
+        let Some(message) = ev.message.as_ref() else {
+            return;
+        };
+
+        match ev.event_type.as_str() {
+            "user" => self.observe_user(&message.content),
+            "assistant" => self.observe_assistant(&message.content),
+            // `summary`, `system`, and anything Claude Code adds later. None of
+            // it is conversation, and an unknown event type contributing to the
+            // index is how a format change silently becomes search noise.
+            _ => {}
+        }
+    }
+
+    fn observe_user(&mut self, content: &Value) {
+        let blocks = transcript::parse_content_blocks(content);
+        let mut carried_a_result = false;
+        for block in blocks.iter().filter(|b| b.block_type == "tool_result") {
+            carried_a_result = true;
+            self.builder.push_tool(&tool_result_text(block));
+        }
+        if carried_a_result {
+            return;
+        }
+        if transcript::is_user_turn_content(content) {
+            self.builder
+                .push_user(&transcript::extract_text_content(content));
+        }
+    }
+
+    fn observe_assistant(&mut self, content: &Value) {
+        for block in transcript::parse_content_blocks(content) {
+            match block.block_type.as_str() {
+                "text" => self.builder.push_assistant(&block.text),
+                // `thinking` is deliberately absent: current models redact it,
+                // so the field is an empty string plus a signature, and indexing
+                // it would add a column's worth of nothing.
+                "tool_use" => self.builder.push_tool(&tool_use_text(&block)),
+                _ => {}
+            }
+        }
+    }
+
+    /// Finish the document's three text columns, under the key it belongs to.
+    ///
+    /// **The `title` column is left empty**, and that is not an omission: the
+    /// title comes from the *cache row*, not from the transcript, so it is the
+    /// only column this accumulator cannot produce from what it saw. The writer
+    /// fills it with [`normalize_title`] inside the transaction that stores the
+    /// row, which is also what keeps the indexed title consistent with the cache
+    /// row the same transaction is reconciled against.
+    pub fn into_doc(self, session_id: &str, project_path: &str) -> search::SearchDoc {
+        let (user_text, assistant_text, tool_text) = self.builder.into_parts();
+        search::SearchDoc {
+            session_id: session_id.to_string(),
+            project_path: project_path.to_string(),
+            title: String::new(),
+            user_text,
+            assistant_text,
+            tool_text,
+        }
+    }
+}
+
+/// The `title` column, shaped like every other one.
+///
+/// A `custom_title` is text the user typed and a `preview` is the first 120
+/// characters of a prompt, so both can carry markdown, tags and runs of
+/// whitespace exactly as a message can. Capped at [`normalize::MESSAGE_CAP`],
+/// which no real title approaches — the cap is there so the column cannot become
+/// the one unbounded thing in a bounded row.
+///
+/// Deliberately outside the session budget: the title is the highest-weighted
+/// column in the ranking (8×), and a session whose conversation exhausted the
+/// budget would otherwise be indexed under no title at all.
+pub fn normalize_title(raw: &str) -> String {
+    normalize::normalize_text(raw, normalize::MESSAGE_CAP)
+}
+
+/// A `tool_result` block's payload as text.
+///
+/// The block's `content` is a string for most tools and an array of `text`
+/// blocks for the rest, which is exactly the shape
+/// [`transcript::extract_text_content`] already decides between — so this is
+/// that function plus the `is_error` note below, not a second decoder.
+fn tool_result_text(block: &ContentBlock) -> String {
+    transcript::extract_text_content(&block.content)
+}
+
+/// A `tool_use` block as text: the tool's name, then the string leaves of its
+/// input.
+///
+/// The name is included because it is a search term in its own right — someone
+/// looking for the session where they ran a `WebFetch` has nothing else to go
+/// on.
+fn tool_use_text(block: &ContentBlock) -> String {
+    let mut out = String::with_capacity(block.name.len() + 64);
+    out.push_str(&block.name);
+    let Some(raw) = block.input.as_ref() else {
+        return out;
+    };
+    // Undecodable input contributes its name and nothing else, which is the
+    // same direction every rule in `normalize` fails in: keep what is certainly
+    // text, drop what cannot be established.
+    let Ok(value) = serde_json::from_str::<Value>(raw.get()) else {
+        return out;
+    };
+    push_string_leaves(&value, &mut out);
+    out
+}
+
+/// Append every string leaf of `value`, in document order, space separated.
+///
+/// **Bounded by [`normalize::TOOL_RESULT_CAP`]**, which is the cap the result
+/// will be truncated to anyway: a `Write` call's input carries a whole file, and
+/// building a multi-megabyte `String` to hand `push_tool` two kilobytes of it is
+/// the shape #434's own "every forward scan needs a bound" note is about. The
+/// bound is checked between leaves rather than inside one, so a single enormous
+/// leaf is still materialized once — `normalize_text` is what trims it.
+fn push_string_leaves(value: &Value, out: &mut String) {
+    if out.len() >= normalize::TOOL_RESULT_CAP {
+        return;
+    }
+    match value {
+        Value::String(s) => {
+            if !s.is_empty() {
+                out.push(' ');
+                out.push_str(s);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                push_string_leaves(item, out);
+            }
+        }
+        // Keys are dropped and only values kept: an argument name is schema, not
+        // content, and `file_path` as an indexed token would match every session
+        // that ever read a file.
+        Value::Object(fields) => {
+            for item in fields.values() {
+                push_string_leaves(item, out);
+            }
+        }
+        // Numbers, booleans and nulls are not search terms.
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn event(event_type: &str, content: Value) -> Event {
+        Event {
+            event_type: event_type.to_string(),
+            message: Some(transcript::Message {
+                role: event_type.to_string(),
+                content,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    /// `(user_text, assistant_text, tool_text)` after observing `events`.
+    fn parts(events: Vec<Event>) -> (String, String, String) {
+        let mut doc = DocAccumulator::new();
+        for ev in &events {
+            doc.observe(ev);
+        }
+        doc.builder.into_parts()
+    }
+
+    #[test]
+    fn a_user_turn_and_an_assistant_reply_land_in_their_own_columns() {
+        let (user, assistant, tool) = parts(vec![
+            event("user", json!("how do I fix the auth bug")),
+            event(
+                "assistant",
+                json!([{"type": "text", "text": "check the token scope"}]),
+            ),
+        ]);
+
+        assert_eq!(user, "how do I fix the auth bug");
+        assert_eq!(assistant, "check the token scope");
+        assert_eq!(tool, "");
+    }
+
+    /// The distinction the module header is about: a `tool_result` carrier and
+    /// injected machinery are both "not a user turn", and they must not have the
+    /// same fate.
+    ///
+    /// Routing on `is_user_turn_content` alone drops both, which empties
+    /// `tool_text` of every real tool result — the column would still exist,
+    /// still be populated by `tool_use` blocks, and simply never contain an
+    /// error message. That is the failure this asserts against.
+    #[test]
+    fn a_tool_result_carrier_is_indexed_as_tool_text_not_dropped() {
+        let (user, _assistant, tool) = parts(vec![event(
+            "user",
+            json!([{
+                "type": "tool_result",
+                "tool_use_id": "t1",
+                "content": "error: connection refused",
+            }]),
+        )]);
+
+        assert_eq!(tool, "error: connection refused");
+        assert_eq!(user, "", "a carrier is not something a person typed");
+    }
+
+    /// A tool result whose content is an array of blocks, which is the other
+    /// shape the format allows.
+    #[test]
+    fn a_tool_results_array_content_is_indexed_too() {
+        let (_user, _assistant, tool) = parts(vec![event(
+            "user",
+            json!([{
+                "type": "tool_result",
+                "tool_use_id": "t1",
+                "content": [{"type": "text", "text": "panic at line 12"}],
+            }]),
+        )]);
+
+        assert_eq!(tool, "panic at line 12");
+    }
+
+    /// Injected content is machinery no one wrote, and it is dropped from every
+    /// column rather than being filed under one of them.
+    #[test]
+    fn injected_user_content_is_not_indexed() {
+        let (user, assistant, tool) = parts(vec![event(
+            "user",
+            json!("<command-name>/compact</command-name>"),
+        )]);
+
+        assert_eq!(
+            (user.as_str(), assistant.as_str(), tool.as_str()),
+            ("", "", "")
+        );
+    }
+
+    /// A tool call contributes its name and the strings inside its input, and
+    /// nothing else.
+    #[test]
+    fn a_tool_call_contributes_its_name_and_its_string_arguments() {
+        let (_user, _assistant, tool) = parts(vec![event(
+            "assistant",
+            json!([{
+                "type": "tool_use",
+                "id": "t1",
+                "name": "Bash",
+                "input": {"command": "cargo test --release", "timeout": 120, "quiet": false},
+            }]),
+        )]);
+
+        assert_eq!(tool, "Bash cargo test --release");
+    }
+
+    /// Object *keys* are schema and are dropped; only the values are content.
+    ///
+    /// Indexing `file_path` as a token would make every session that read a file
+    /// a hit for it.
+    #[test]
+    fn argument_names_are_not_indexed() {
+        let (_user, _assistant, tool) = parts(vec![event(
+            "assistant",
+            json!([{
+                "type": "tool_use",
+                "name": "Read",
+                "input": {"file_path": "/src/auth.rs"},
+            }]),
+        )]);
+
+        assert_eq!(tool, "Read /src/auth.rs");
+    }
+
+    /// Nested and array-valued arguments still contribute their strings.
+    #[test]
+    fn string_leaves_are_found_at_any_depth() {
+        let (_user, _assistant, tool) = parts(vec![event(
+            "assistant",
+            json!([{
+                "type": "tool_use",
+                "name": "Edit",
+                "input": {"edits": [{"old": "alpha"}, {"old": "beta"}]},
+            }]),
+        )]);
+
+        assert_eq!(tool, "Edit alpha beta");
+    }
+
+    /// Thinking is redacted by current models, so the block carries no text —
+    /// and it is not indexed even when it does.
+    #[test]
+    fn thinking_is_not_indexed() {
+        let (_user, assistant, tool) = parts(vec![event(
+            "assistant",
+            json!([{"type": "thinking", "thinking": "let me consider the options"}]),
+        )]);
+
+        assert_eq!((assistant.as_str(), tool.as_str()), ("", ""));
+    }
+
+    /// The bound on a tool call's input, which is what stops a `Write` of a
+    /// large file materializing in full before the cap trims it.
+    #[test]
+    fn a_huge_tool_input_is_bounded_rather_than_materialized_whole() {
+        let leaf = "x".repeat(1_024);
+        let input: Vec<Value> = (0..64).map(|_| json!(leaf)).collect();
+        let block = ContentBlock {
+            block_type: "tool_use".into(),
+            name: "Write".into(),
+            input: Some(
+                serde_json::value::RawValue::from_string(json!(input).to_string()).expect("raw"),
+            ),
+            ..Default::default()
+        };
+
+        let text = tool_use_text(&block);
+
+        assert!(
+            text.len() < normalize::TOOL_RESULT_CAP + leaf.len() + 8,
+            "collected {} bytes from a 64 KiB input",
+            text.len()
+        );
+    }
+
+    /// An event with no message at all — a `file-history-snapshot` reaching here
+    /// would be one, though `feed` already drops those — contributes nothing and
+    /// does not panic.
+    #[test]
+    fn an_event_without_a_message_is_ignored() {
+        let (user, assistant, tool) = parts(vec![Event {
+            event_type: "user".into(),
+            ..Default::default()
+        }]);
+
+        assert_eq!(
+            (user.as_str(), assistant.as_str(), tool.as_str()),
+            ("", "", "")
+        );
+    }
+
+    /// The key columns are carried and the title is left for the writer, which
+    /// is the only column that does not come from the transcript.
+    #[test]
+    fn the_key_columns_are_carried_and_the_title_is_the_writers() {
+        let mut doc = DocAccumulator::new();
+        doc.observe(&event("user", json!("hello")));
+
+        let built = doc.into_doc("s1", "/a");
+
+        assert_eq!(built.session_id, "s1");
+        assert_eq!(built.project_path, "/a");
+        assert_eq!(built.user_text, "hello");
+        assert_eq!(built.title, "", "the title comes from the cache row");
+    }
+
+    /// A title is shaped like every other column — a user's rename can hold
+    /// markdown and newlines just as a message can.
+    #[test]
+    fn a_title_is_normalized() {
+        assert_eq!(normalize_title("the  **auth**\nfix"), "the **auth** fix");
+        assert_eq!(normalize_title(""), "");
+    }
+
+    /// The whole-session budget is shared across the three columns, so a session
+    /// that is all tool output cannot cost more than one that is all
+    /// conversation. Asserted through the router rather than only in
+    /// `normalize`, because the router is what decides how many pushes happen.
+    #[test]
+    fn the_session_budget_bounds_every_column_together() {
+        let big = "word ".repeat(4 * 1024);
+        let events: Vec<Event> = (0..400)
+            .map(|_| {
+                event(
+                    "user",
+                    json!([{"type": "tool_result", "tool_use_id": "t", "content": big}]),
+                )
+            })
+            .collect();
+
+        let (user, assistant, tool) = parts(events);
+
+        assert!(
+            user.len() + assistant.len() + tool.len() <= normalize::SESSION_CAP,
+            "indexed {} bytes for one session",
+            user.len() + assistant.len() + tool.len()
+        );
+        assert!(
+            !tool.is_empty(),
+            "the cap must bound, not empty, the column"
+        );
+    }
+}

--- a/src-tauri/src/native/insights/mod.rs
+++ b/src-tauri/src/native/insights/mod.rs
@@ -4,6 +4,9 @@
 //!
 //! - [`processors`] recomputes one session's row from its transcripts. Pure
 //!   computation — a function from a transcript to a `SessionInsight`.
+//! - [`index`] routes the *same* decoded events into the three
+//!   `session_search` text columns (#435), so the search index is a second
+//!   product of one read rather than a second read.
 //! - [`store`] is the `session_insights` half: what needs recomputing, the
 //!   upsert, and the reconcile. **Every statement there keys on
 //!   `(session_id, project_path)`**, which is where it parts company with the
@@ -41,6 +44,7 @@
 //! must be bumped together when it changes — bumping one recreates exactly the
 //! drift the shared predicate exists to prevent.
 
+pub mod index;
 pub mod processors;
 pub mod store;
 pub mod summary;

--- a/src-tauri/src/native/insights/processors.rs
+++ b/src-tauri/src/native/insights/processors.rs
@@ -31,6 +31,7 @@ use std::collections::BTreeMap;
 
 use chrono::{DateTime, Utc};
 
+use super::index;
 use super::transcript::{self, is_turn_start, parse_content_blocks, Event};
 use crate::native::active_time::ActiveTimeTracker;
 use crate::native::pricing::{Cost, PricedUsage, Resolver};
@@ -139,19 +140,28 @@ pub struct Ctx<'a> {
 ///
 /// A sub-agent transcript that cannot be read is skipped; only a failure on the
 /// parent is fatal.
+///
+/// `doc` accumulates the session's `session_search` document from **this same
+/// read** (#435). It is a parameter rather than a tenth processor because a
+/// `Processor` finalizes into a `SessionInsight`, which has nowhere to put three
+/// text columns — and because passing it makes the extra work visible at the one
+/// call site rather than hidden in `PIPELINE`, whose order is load-bearing for
+/// the numbers. A caller that wants no document passes one and drops it; the
+/// accumulator is inert once its budget is spent, so that costs a struct.
 pub fn run(
     session_id: &str,
     files: &[std::path::PathBuf],
     ctx: &Ctx,
+    doc: &mut index::DocAccumulator,
 ) -> Result<SessionInsight, String> {
     let Some((parent, subagents)) = files.split_first() else {
         return Err(format!("no session files given for {session_id:?}"));
     };
 
     let mut processors = pipeline(ctx);
-    feed(parent, &mut processors)?;
+    feed(parent, &mut processors, doc)?;
     for file in subagents {
-        if let Err(e) = feed(file, &mut processors) {
+        if let Err(e) = feed(file, &mut processors, doc) {
             log::warn!("skipping unreadable sub-agent transcript: {e}");
         }
     }
@@ -166,15 +176,21 @@ pub fn run(
     Ok(insight)
 }
 
-fn feed(path: &std::path::Path, processors: &mut [Box<dyn Processor + '_>]) -> Result<(), String> {
+fn feed(
+    path: &std::path::Path,
+    processors: &mut [Box<dyn Processor + '_>],
+    doc: &mut index::DocAccumulator,
+) -> Result<(), String> {
     for ev in transcript::read(path)? {
         // Not a conversation event; Go skips it before any processor sees it.
+        // The indexer inherits the skip by sitting inside the same guard.
         if ev.event_type == "file-history-snapshot" {
             continue;
         }
         for p in processors.iter_mut() {
             p.process(&ev);
         }
+        doc.observe(&ev);
     }
     Ok(())
 }
@@ -775,6 +791,7 @@ mod tests {
                 idle_gap_ms: 600_000,
                 resolver: None,
             },
+            &mut index::DocAccumulator::new(),
         )
         .expect("run")
     }

--- a/src-tauri/src/native/insights/store.rs
+++ b/src-tauri/src/native/insights/store.rs
@@ -54,15 +54,51 @@ pub struct Pending {
 /// A row whose `file_path` is empty is skipped by the caller rather than here,
 /// matching `rescanOutdated`.
 pub fn needs_processing(conn: &Connection, version: i64) -> Result<Vec<Pending>, String> {
+    select_pending(conn, version, Scope::Outdated)
+}
+
+/// Which cached sessions a sweep should pick up.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Scope {
+    /// The ordinary rule: no insight row, or one behind the processor version.
+    Outdated,
+    /// **Every** cached session, whatever its insight row says.
+    ///
+    /// What a `search::SEARCH_INDEX_VERSION` bump needs, and it cannot be
+    /// expressed as a processor-version comparison: the insight rows are
+    /// perfectly current, and it is the *index* rows that were produced by a
+    /// reader this build no longer agrees with. Zeroing `processor_version` to
+    /// force them through would work by corrupting a column that means something
+    /// else — and would leave the corpus reporting itself unprocessed if the
+    /// rebuild were interrupted.
+    Everything,
+}
+
+/// Every cached session in `scope`, with the transcript to recompute it from.
+///
+/// The `LEFT JOIN` is kept under [`Scope::Everything`] rather than being
+/// switched to a bare `SELECT`, so both scopes are one statement shape and the
+/// pair-keyed join cannot be right in one and wrong in the other.
+pub fn select_pending(
+    conn: &Connection,
+    version: i64,
+    scope: Scope,
+) -> Result<Vec<Pending>, String> {
+    let filter = match scope {
+        Scope::Outdated => "i.session_id IS NULL OR i.processor_version < ?1",
+        // `?1` still has to appear or the binding is unused, and SQLite has no
+        // way to bind a parameter a statement never mentions.
+        Scope::Everything => "?1 IS NOT NULL",
+    };
     let mut stmt = conn
-        .prepare(
+        .prepare(&format!(
             "SELECT DISTINCT c.session_id, c.project_path, c.file_path
              FROM claude_session_cache c
              LEFT JOIN session_insights i
                     ON c.session_id = i.session_id
                    AND c.project_path = i.project_path
-             WHERE i.session_id IS NULL OR i.processor_version < ?1",
-        )
+             WHERE {filter}"
+        ))
         .map_err(|e| format!("preparing needs_processing: {e}"))?;
 
     let rows = stmt
@@ -77,6 +113,41 @@ pub fn needs_processing(conn: &Connection, version: i64) -> Result<Vec<Pending>,
 
     rows.collect::<Result<Vec<_>, _>>()
         .map_err(|e| format!("reading needs_processing: {e}"))
+}
+
+/// The label the search index files a session under, for one cache row.
+///
+/// `sessions::summary::resolve_display_title`'s precedence, read straight from
+/// the columns: the user's own rename first, then Claude Code's native title,
+/// then its AI-generated one, then the first prompt. Spelled here rather than
+/// reusing that function because it takes a fully built `SessionSummary`, which
+/// is a corpus read; four columns is the whole input.
+///
+/// A pair with no cache row answers `""` rather than failing: the row can be
+/// deleted between the sweep's read and the batch's write, and a session indexed
+/// without a title is better than a batch dropped. Its index row is an orphan by
+/// then and the next reconcile removes it.
+///
+/// **Note what this does not do**: `custom_title` is user-writable at any time
+/// through `PATCH /api/claude-sessions/{id}`, which changes neither `file_mtime`
+/// nor `processor_version`, so a rename alone does not re-index. The title
+/// catches up the next time the session's transcript changes. Making a rename
+/// re-index is a write-side concern and deliberately outside #435.
+pub fn display_title(conn: &Connection, session_id: &str, project_path: &str) -> String {
+    let row: Result<(String, String, String, String), _> = conn.query_row(
+        "SELECT custom_title, native_title, ai_title, preview
+           FROM claude_session_cache
+          WHERE session_id = ?1 AND project_path = ?2",
+        params![session_id, project_path],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+    );
+    let Ok((custom, native, ai, preview)) = row else {
+        return String::new();
+    };
+    [custom, native, ai, preview]
+        .into_iter()
+        .find(|candidate| !candidate.is_empty())
+        .unwrap_or_default()
 }
 
 /// The column list, shared by the insert and the conflict update so the two

--- a/src-tauri/src/native/insights/store.rs
+++ b/src-tauri/src/native/insights/store.rs
@@ -58,8 +58,12 @@ pub fn needs_processing(conn: &Connection, version: i64) -> Result<Vec<Pending>,
 }
 
 /// Which cached sessions a sweep should pick up.
+///
+/// `pub(super)` rather than `pub`: the only consumer is `insights::worker`, and
+/// keeping it module-local is what lets [`select_pending`]'s `format!` be
+/// provably constant by construction rather than by inspecting callers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Scope {
+pub(super) enum Scope {
     /// The ordinary rule: no insight row, or one behind the processor version.
     Outdated,
     /// **Every** cached session, whatever its insight row says.
@@ -79,16 +83,25 @@ pub enum Scope {
 /// The `LEFT JOIN` is kept under [`Scope::Everything`] rather than being
 /// switched to a bare `SELECT`, so both scopes are one statement shape and the
 /// pair-keyed join cannot be right in one and wrong in the other.
-pub fn select_pending(
+///
+/// `format!` into SQL, so: the interpolated string is one of two `&'static str`
+/// literals chosen by a fieldless enum, and no caller-supplied value can reach
+/// it. The **version** is bound, never interpolated.
+///
+/// `Scope::Everything` binds no parameter at all rather than neutralizing one
+/// with a tautology. `"?1 IS NOT NULL"` was the first version and it is safe
+/// only because an `i64` cannot bind SQL NULL — an invariant expressed nowhere,
+/// whose failure would be silent and severe: the predicate would be false, the
+/// query would answer no rows, and [`super::worker::sweep`] would take its
+/// "nothing pending" branch and stamp a version over an index it never built.
+pub(super) fn select_pending(
     conn: &Connection,
     version: i64,
     scope: Scope,
 ) -> Result<Vec<Pending>, String> {
     let filter = match scope {
         Scope::Outdated => "i.session_id IS NULL OR i.processor_version < ?1",
-        // `?1` still has to appear or the binding is unused, and SQLite has no
-        // way to bind a parameter a statement never mentions.
-        Scope::Everything => "?1 IS NOT NULL",
+        Scope::Everything => "1 = 1",
     };
     let mut stmt = conn
         .prepare(&format!(
@@ -101,8 +114,14 @@ pub fn select_pending(
         ))
         .map_err(|e| format!("preparing needs_processing: {e}"))?;
 
+    // Bound only where the statement mentions it: rusqlite rejects a parameter
+    // count that does not match, so the two arms cannot share one `params!`.
+    let bindings: Vec<rusqlite::types::Value> = match scope {
+        Scope::Outdated => vec![version.into()],
+        Scope::Everything => Vec::new(),
+    };
     let rows = stmt
-        .query_map(params![version], |row| {
+        .query_map(rusqlite::params_from_iter(bindings), |row| {
             Ok(Pending {
                 session_id: row.get(0)?,
                 project_path: row.get(1)?,
@@ -133,16 +152,41 @@ pub fn select_pending(
 /// nor `processor_version`, so a rename alone does not re-index. The title
 /// catches up the next time the session's transcript changes. Making a rename
 /// re-index is a write-side concern and deliberately outside #435.
+/// `prepare_cached` for [`upsert`]'s reason, which applies unchanged here: this
+/// runs in the same loop, once per session over a whole corpus, so re-preparing
+/// per row is the one avoidable cost in the write half.
+///
+/// A missing row and a *failed read* are told apart deliberately. Collapsing
+/// them was the first version, and it meant one `SQLITE_BUSY` could index a
+/// whole hundred-session batch titleless — under the highest-weighted column in
+/// the ranking — with nothing in the log to say it had happened. `scan.rs`'s
+/// `record_marker` sets the convention: best-effort, but named when it fails.
 pub fn display_title(conn: &Connection, session_id: &str, project_path: &str) -> String {
-    let row: Result<(String, String, String, String), _> = conn.query_row(
+    let mut stmt = match conn.prepare_cached(
         "SELECT custom_title, native_title, ai_title, preview
            FROM claude_session_cache
           WHERE session_id = ?1 AND project_path = ?2",
-        params![session_id, project_path],
-        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
-    );
-    let Ok((custom, native, ai, preview)) = row else {
-        return String::new();
+    ) {
+        Ok(stmt) => stmt,
+        Err(e) => {
+            log::warn!("search: cannot prepare the title read for {session_id}: {e}");
+            return String::new();
+        }
+    };
+    let row = stmt.query_row(params![session_id, project_path], |row| {
+        Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+    });
+    let (custom, native, ai, preview): (String, String, String, String) = match row {
+        Ok(row) => row,
+        // The documented case: the cache row was deleted between the sweep's
+        // read and this write. Its index row is an orphan by now and the next
+        // reconcile removes it, so an untitled document is the right answer and
+        // not worth a line.
+        Err(rusqlite::Error::QueryReturnedNoRows) => return String::new(),
+        Err(e) => {
+            log::warn!("search: cannot read the title for {session_id}: {e}");
+            return String::new();
+        }
     };
     [custom, native, ai, preview]
         .into_iter()

--- a/src-tauri/src/native/insights/transcript.rs
+++ b/src-tauri/src/native/insights/transcript.rs
@@ -492,23 +492,6 @@ pub struct ContentBlock {
         deserialize_with = "crate::native::gojson::null_is_zero_value"
     )]
     pub is_error: bool,
-
-    /// A `tool_result` block's payload: the tool's own output.
-    ///
-    /// A `Value` rather than a `RawValue`, and that is the opposite choice to
-    /// [`ContentBlock::input`] one field up — deliberately. `input` is echoed
-    /// back on the wire and into `chat_messages`, where a `Value` round trip
-    /// would sort its keys and respell its numbers with nothing to signal it.
-    /// This one has exactly one reader, `insights::index`, which turns it into
-    /// index tokens and never re-encodes it, so the parsed form is what that
-    /// reader wants and costs nothing anyone can observe.
-    ///
-    /// The format allows two shapes here — a bare string, or an array of `text`
-    /// blocks — which is why [`extract_text_content`] rather than a cast is what
-    /// reads it. Absent on every other block type, so `Value::Null` is the
-    /// ordinary case and `extract_text_content` answers `""` to it.
-    #[serde(default)]
-    pub content: serde_json::Value,
 }
 
 /// Decode array content into blocks **from the original bytes**, so a

--- a/src-tauri/src/native/insights/transcript.rs
+++ b/src-tauri/src/native/insights/transcript.rs
@@ -492,6 +492,23 @@ pub struct ContentBlock {
         deserialize_with = "crate::native::gojson::null_is_zero_value"
     )]
     pub is_error: bool,
+
+    /// A `tool_result` block's payload: the tool's own output.
+    ///
+    /// A `Value` rather than a `RawValue`, and that is the opposite choice to
+    /// [`ContentBlock::input`] one field up — deliberately. `input` is echoed
+    /// back on the wire and into `chat_messages`, where a `Value` round trip
+    /// would sort its keys and respell its numbers with nothing to signal it.
+    /// This one has exactly one reader, `insights::index`, which turns it into
+    /// index tokens and never re-encodes it, so the parsed form is what that
+    /// reader wants and costs nothing anyone can observe.
+    ///
+    /// The format allows two shapes here — a bare string, or an array of `text`
+    /// blocks — which is why [`extract_text_content`] rather than a cast is what
+    /// reads it. Absent on every other block type, so `Value::Null` is the
+    /// ordinary case and `extract_text_content` answers `""` to it.
+    #[serde(default)]
+    pub content: serde_json::Value,
 }
 
 /// Decode array content into blocks **from the original bytes**, so a

--- a/src-tauri/src/native/insights/worker.rs
+++ b/src-tauri/src/native/insights/worker.rs
@@ -69,6 +69,16 @@ const RESCAN_INTERVAL: Duration = Duration::from_secs(5 * 60);
 /// How many sessions one write transaction covers, matching
 /// `apply::SCAN_BATCH_SIZE`'s reasoning: large enough to amortize the commit,
 /// small enough that a failure loses a bounded amount of work.
+///
+/// Since #435 it also bounds **memory**, and the two constants that decide that
+/// live in different files: a batch holds one `search::SearchDoc` per session
+/// until the write, each up to `normalize::SESSION_CAP` (512 KiB), so the peak
+/// is ~51 MB of document text plus each reader thread's `Vec<Event>` for the
+/// transcript it is decoding. That is comfortable, and it is a product of two
+/// numbers neither of which mentions the other — so raising either wants a
+/// glance at this line. Bounding a batch by accumulated document bytes rather
+/// than by row count is the principled version, and is not worth it while the
+/// product is this far inside the budget.
 const BATCH_SIZE: usize = 100;
 
 /// The queue's capacity. Go's `insightWorkerQueueSize`.
@@ -176,7 +186,10 @@ fn run(db_path: &Path, rx: Receiver<Pending>) {
             Err(mpsc::RecvTimeoutError::Disconnected) => return,
         }
 
-        process_batch(db_path, batch);
+        // The queue is the incremental path, so a row for a pair may exist.
+        // Its return is deliberately ignored: only a rebuild needs to know
+        // whether a batch committed, and a rebuild is `sweep`'s alone.
+        let _ = process_batch(db_path, batch, Write::Replace);
 
         // Whatever `enqueue` could not deliver, picked up now rather than at
         // the next five-minute tick. The swap clears the flag before the sweep
@@ -210,6 +223,27 @@ fn run(db_path: &Path, rx: Receiver<Pending>) {
 /// The new version is stamped **after** the rebuild, and only if every batch in
 /// it committed. Stamping first would leave a partially indexed corpus that
 /// nothing ever finishes, because the mismatch driving the work would be gone.
+///
+/// ## A rebuild empties the index first, and that is a cost decision
+///
+/// `search::delete` is a **scan** of the FTS5 content table, so re-indexing a
+/// corpus with `search::replace` per session is quadratic — 1,178 scans of a
+/// table that grows with every insert, measured at 11–76 s of pure delete
+/// depending on document size, all of it inside a write transaction competing
+/// with the boot scan that `lib.rs` starts two lines later. `delete_all` once
+/// plus [`search::insert`] is the same end state for one scan-free `DELETE`.
+///
+/// It has a second effect worth having: after emptying, a session the rebuild
+/// **skips** has no row at all, where per-session replacement would have left
+/// its *previous* row in place — carrying text in the format this build has just
+/// declared it disagrees with, under a version stamp saying otherwise. Missing
+/// is a recoverable state that `needs_processing` can still describe; silently
+/// stale is not.
+///
+/// The cost is that search answers nothing for the length of a rebuild. That is
+/// accepted rather than overlooked: the rows it would otherwise return were
+/// produced by a reader this build no longer agrees with, which is what the
+/// version bump means. `delete_all`'s own header records the same intent.
 fn sweep(db_path: &Path) {
     let conn = match db::open_read_only(db_path) {
         Ok(conn) => conn,
@@ -260,14 +294,49 @@ fn sweep(db_path: &Path) {
         log::info!("insights: reprocessing {} outdated sessions", pending.len());
     }
 
+    // Emptied once, before the first batch, so the batches can insert without
+    // paying `search::delete`'s scan each — see the header. A failure here
+    // abandons the rebuild rather than proceeding: inserting into a table that
+    // still holds the old rows would duplicate every pair, and FTS5 has no
+    // unique index to refuse it.
+    if rebuild {
+        match db::open_read_write(db_path).and_then(|conn| search::delete_all(&conn)) {
+            Ok(()) => {}
+            Err(e) => {
+                log::warn!("search: cannot clear the index to rebuild it: {e}");
+                return;
+            }
+        }
+    }
+
     let mut every_batch_committed = true;
     for chunk in pending.chunks(BATCH_SIZE) {
-        every_batch_committed &= process_batch(db_path, chunk.iter().cloned().collect());
+        let write = if rebuild {
+            Write::Insert
+        } else {
+            Write::Replace
+        };
+        every_batch_committed &= process_batch(db_path, chunk.iter().cloned().collect(), write);
     }
 
     if rebuild && every_batch_committed {
         record_index_version(db_path);
     }
+}
+
+/// How a batch puts a session's document into the index.
+///
+/// The two differ only in whether the scan-costing delete runs first, and
+/// choosing wrongly is silent in both directions: `Insert` against a populated
+/// table duplicates rows, `Replace` during a rebuild is the quadratic cost
+/// [`sweep`]'s header describes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Write {
+    /// The incremental path: a row for this pair may already exist.
+    Replace,
+    /// The rebuild path, immediately after [`search::delete_all`], where no row
+    /// for any pair exists.
+    Insert,
 }
 
 /// Stamp `claude_cache_metadata.search_index_version`.
@@ -306,7 +375,7 @@ fn record_index_version(db_path: &Path) {
 /// What is left blocking a stamp is exactly the set of things that would make
 /// the rebuild genuinely incomplete and are worth retrying: the settings read,
 /// opening the database for writing, and the batch transaction itself.
-fn process_batch(db_path: &Path, batch: BTreeSet<Pending>) -> bool {
+fn process_batch(db_path: &Path, batch: BTreeSet<Pending>, write: Write) -> bool {
     let items: Vec<Pending> = batch
         .into_iter()
         // `rescanOutdated` skips a row with no file path, and so does this:
@@ -348,7 +417,7 @@ fn process_batch(db_path: &Path, batch: BTreeSet<Pending>) -> bool {
             return false;
         }
     };
-    match write_batch(&mut conn, &mut computed) {
+    match write_batch(&mut conn, &mut computed, write) {
         Ok(n) => {
             log::debug!("insights: stored {n} session insights and search rows");
             true
@@ -452,8 +521,12 @@ fn read_in_parallel(
 /// why `search/mod.rs` opens no connection of its own.
 ///
 /// The title is read here rather than carried from the read pass because it
-/// lives in the cache row, not the transcript. Inside the transaction, so it
-/// cannot be a value from before a concurrent rename.
+/// lives in the cache row, not the transcript. Reading it inside the transaction
+/// buys **batch-internal consistency** — every session in one batch sees one
+/// state of the cache — and deliberately not freshness: this is `BEGIN
+/// DEFERRED`, and a rename landing an instant after the commit is invisible
+/// either way. A rename does not re-index at all; `store::display_title` records
+/// why.
 ///
 /// `?` on either write aborts the whole batch, and the `Transaction`'s `Drop`
 /// rolls it back — so a failure leaves neither table changed for any session in
@@ -463,14 +536,21 @@ fn read_in_parallel(
 /// `SearchDoc` carries up to `normalize::SESSION_CAP` of text, and a batch is a
 /// hundred of them, so building a titled copy per row would clone tens of
 /// megabytes per batch to add a few dozen bytes to each.
-fn write_batch(conn: &mut Connection, computed: &mut [Computed]) -> Result<usize, String> {
+fn write_batch(
+    conn: &mut Connection,
+    computed: &mut [Computed],
+    write: Write,
+) -> Result<usize, String> {
     let scanned_at = store::scanned_at_now();
     let tx = conn.transaction().map_err(|e| e.to_string())?;
     for item in computed.iter_mut() {
         store::upsert(&tx, &item.insight, &item.project_path, &scanned_at)?;
         let title = store::display_title(&tx, &item.doc.session_id, &item.doc.project_path);
         item.doc.title = super::index::normalize_title(&title);
-        search::replace(&tx, &item.doc)?;
+        match write {
+            Write::Replace => search::replace(&tx, &item.doc)?,
+            Write::Insert => search::insert(&tx, &item.doc)?,
+        }
     }
     tx.commit().map_err(|e| e.to_string())?;
     Ok(computed.len())
@@ -673,6 +753,7 @@ mod tests {
         assert!(process_batch(
             &db_path,
             [pending_for("s1", "/a", &file)].into_iter().collect(),
+            Write::Replace,
         ));
 
         let conn = db::open_read_only(&db_path).expect("open");
@@ -713,6 +794,7 @@ mod tests {
         assert!(process_batch(
             &db_path,
             [pending_for("s1", "/a", &file)].into_iter().collect(),
+            Write::Replace,
         ));
 
         let conn = db::open_read_only(&db_path).expect("open");
@@ -720,6 +802,128 @@ mod tests {
             .query_row("SELECT title FROM session_search", [], |r| r.get(0))
             .expect("title");
         assert_eq!(title, "quarterly rollup");
+    }
+
+    /// The rest of the precedence, which the `custom_title` test above cannot
+    /// reach: native beats AI beats the first prompt, and a session with none of
+    /// them is indexed untitled rather than not at all.
+    #[test]
+    fn the_indexed_title_falls_back_through_the_display_precedence() {
+        for (columns, expected) in [
+            ("native_title = 'native', ai_title = 'ai'", "native"),
+            ("ai_title = 'ai'", "ai"),
+            (
+                "preview = 'the first thing they typed'",
+                "the first thing they typed",
+            ),
+            ("preview = ''", ""),
+        ] {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let db_path = fixture_db(&dir);
+            let file = seed_session(&dir, &db_path, "s1", "/a", "pagination");
+            let conn = db::open_read_write(&db_path).expect("open");
+            conn.execute(&format!("UPDATE claude_session_cache SET {columns}"), [])
+                .expect("set titles");
+            drop(conn);
+
+            assert!(process_batch(
+                &db_path,
+                [pending_for("s1", "/a", &file)].into_iter().collect(),
+                Write::Replace,
+            ));
+
+            let conn = db::open_read_only(&db_path).expect("open");
+            let title: String = conn
+                .query_row("SELECT title FROM session_search", [], |r| r.get(0))
+                .expect("title");
+            assert_eq!(title, expected, "for {columns}");
+        }
+    }
+
+    /// A rebuild must not leave a session carrying text this build's indexer no
+    /// longer produces.
+    ///
+    /// The failure it guards is silent and looks healthy: with per-session
+    /// replacement, a session the rebuild **skips** keeps its previous row — old
+    /// format — while the version stamp says the whole index is current, so
+    /// nothing ever revisits it. Emptying first makes a skip visible as a
+    /// *missing* row instead, which is a state `needs_processing` can still
+    /// describe.
+    ///
+    /// The marker row here stands in for "indexed by an older build": it is
+    /// present before the rebuild, belongs to a session the rebuild cannot read,
+    /// and must be gone afterwards.
+    #[test]
+    fn a_rebuild_leaves_no_row_from_the_previous_index_version() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = fixture_db(&dir);
+        seed_session(&dir, &db_path, "good", "/a", "pagination");
+
+        let conn = db::open_read_write(&db_path).expect("open");
+        // Still cached, but its transcript cannot be read — the shape an
+        // unmounted drive or a permissions change leaves, which `scan.rs`
+        // deliberately protects from deletion.
+        conn.execute(
+            "INSERT INTO claude_session_cache
+                 (session_id, project_path, file_path, file_mtime, start_time, last_activity)
+             VALUES ('unreadable', '/a', ?1, '2026-01-01 00:00:00+00:00',
+                     '2026-01-01 00:00:00+00:00', '2026-01-01 00:00:00+00:00')",
+            rusqlite::params![dir.path().join("absent.jsonl").to_string_lossy()],
+        )
+        .expect("cache row");
+        search::replace(
+            &conn,
+            &search::SearchDoc {
+                session_id: "unreadable".into(),
+                project_path: "/a".into(),
+                user_text: "obsoletemarker".into(),
+                ..Default::default()
+            },
+        )
+        .expect("seed a previous-version row");
+        search::record_version(&conn, search::SEARCH_INDEX_VERSION - 1).expect("age");
+        drop(conn);
+
+        sweep(&db_path);
+
+        let conn = db::open_read_only(&db_path).expect("open");
+        assert!(
+            search::search(&conn, "\"obsoletemarker\"", 10)
+                .expect("search")
+                .is_empty(),
+            "text from the previous index version survived the rebuild",
+        );
+        assert_eq!(indexed_pairs(&conn), vec![("good".into(), "/a".into())]);
+    }
+
+    /// The rebuild path must not leave two rows for one pair.
+    ///
+    /// It inserts without deleting, which is only sound because the index was
+    /// emptied first — and FTS5 has no unique index to refuse a duplicate, so
+    /// getting this wrong doubles every hit silently rather than failing.
+    #[test]
+    fn a_rebuild_does_not_duplicate_a_pair_that_was_already_indexed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = fixture_db(&dir);
+        seed_session(&dir, &db_path, "s1", "/a", "pagination");
+
+        // Index it once at the current version, then force a rebuild over it.
+        sweep(&db_path);
+        let conn = db::open_read_write(&db_path).expect("open");
+        search::record_version(&conn, search::SEARCH_INDEX_VERSION - 1).expect("age");
+        drop(conn);
+
+        sweep(&db_path);
+
+        let conn = db::open_read_only(&db_path).expect("open");
+        assert_eq!(indexed_pairs(&conn), vec![("s1".into(), "/a".into())]);
+        assert_eq!(
+            search::search(&conn, "\"pagination\"", 10)
+                .expect("search")
+                .len(),
+            1,
+            "the pair was indexed twice, so every hit for it is doubled",
+        );
     }
 
     /// The #362-family assertion, in its fifth form: one session id under two
@@ -740,6 +944,7 @@ mod tests {
             [pending_for("s1", "/a", &a), pending_for("s1", "/b", &b)]
                 .into_iter()
                 .collect(),
+            Write::Replace,
         ));
 
         let conn = db::open_read_only(&db_path).expect("open");
@@ -902,7 +1107,8 @@ mod tests {
         assert!(
             !process_batch(
                 &db_path,
-                [pending_for("s1", "/a", &file)].into_iter().collect()
+                [pending_for("s1", "/a", &file)].into_iter().collect(),
+                Write::Replace,
             ),
             "a batch that could not commit must report so",
         );
@@ -944,6 +1150,7 @@ mod tests {
         assert!(process_batch(
             &db_path,
             [pending_for("s1", "/a", &missing)].into_iter().collect(),
+            Write::Replace,
         ));
     }
 
@@ -1011,37 +1218,42 @@ mod tests {
         assert!(!process_batch(
             &db_path,
             [pending_for("s1", "/a", &file)].into_iter().collect(),
+            Write::Replace,
         ));
     }
 
-    /// The #366 pattern (`tests/scheduled_run.rs`, `tests/chat_turn.rs`), with
-    /// indexing active.
+    /// A batch meeting a contended write lock still commits, and does not stall
+    /// a runtime beside it.
     ///
-    /// The worker is a plain OS thread and deliberately holds no runtime handle
-    /// — its header says so — so what this pins is that the property survives
-    /// the extra database work #435 puts inside the batch transaction. A batch
-    /// now writes `session_insights` *and* an FTS5 row per session while holding
-    /// one write lock for longer, so "the worker's writes are off the runtime"
-    /// is a claim worth re-asserting rather than inheriting.
+    /// **Be precise about what this can and cannot catch**, because the #366
+    /// tests it is modelled on (`tests/scheduled_run.rs`, `tests/chat_turn.rs`)
+    /// catch something this one structurally cannot. There, the defect was
+    /// database work running inline on an axum worker, and the test drives the
+    /// real entry point, so reverting the `db::blocking` hand-off fails it.
+    /// Here the worker owns an OS thread by construction — its header explains
+    /// why — and `run()` is an unexported infinite loop, so this test spawns the
+    /// thread itself. **No change to non-test code can make it fail**: falsifying
+    /// it means editing the `std::thread::spawn` below into a `tokio::spawn`,
+    /// which does take the ticker from ~150 advances to 0.
     ///
-    /// The shape is the original's: **one** worker thread so a single parked
-    /// worker is the whole runtime; a plain OS thread holding the lock, so the
-    /// contention comes from outside exactly as the session scanner's batch
-    /// writer does; and `last` seeded **before** the spawn, because a starved
-    /// ticker is never polled and seeding on the first poll would start the
-    /// clock after the stall and measure nothing.
+    /// So it is named for the property it genuinely pins, which #435 makes worth
+    /// pinning: a batch now writes `session_insights` **and** an FTS5 row per
+    /// session, holding one write lock for longer than before, and it must still
+    /// commit inside `db::open_read_write`'s five-second `busy_timeout` against
+    /// an outside writer. The runtime assertions come with the borrowed harness
+    /// and are kept because they are free, not because they are the point.
     ///
-    /// **Calibrated rather than assumed.** Replacing the `std::thread::spawn`
-    /// below with `tokio::spawn` — i.e. putting the batch's rusqlite work on the
-    /// single worker, which is the defect this shape exists to catch — takes the
-    /// ticker from ~150 advances to **0** and fails the assertion. Note it must
-    /// be `tokio::spawn` to falsify it: calling `process_batch` inline in this
-    /// async body blocks the *calling* thread, which `block_on` runs the test
-    /// future on, and the ticker on the worker keeps going regardless. That
-    /// version of the test passes against the defect, which is the trap the
-    /// scheduler's copy documents too.
+    /// (Falsifying it against production code would need `run()`'s body split
+    /// into a testable `run_once`. Worth doing; it is not this change's scope.)
+    ///
+    /// The rest of the shape is the original's, each part load-bearing: **one**
+    /// worker thread so a single parked worker is the whole runtime; a plain OS
+    /// thread holding the lock, so contention comes from outside exactly as the
+    /// session scanner's batch writer does; and `last` seeded **before** the
+    /// spawn, because a starved ticker is never polled and seeding on the first
+    /// poll would start the clock after the stall and measure nothing.
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn a_contended_write_lock_does_not_stall_the_runtime() {
+    async fn a_contended_batch_still_commits_within_the_busy_timeout() {
         use std::sync::atomic::AtomicU64;
         use std::sync::Arc;
         use std::time::Instant;
@@ -1102,6 +1314,7 @@ mod tests {
             process_batch(
                 &batch_db,
                 [pending_for("s1", "/a", &file)].into_iter().collect(),
+                Write::Replace,
             )
         });
 

--- a/src-tauri/src/native/insights/worker.rs
+++ b/src-tauri/src/native/insights/worker.rs
@@ -51,9 +51,10 @@ use std::time::Duration;
 
 use rusqlite::Connection;
 
+use super::index::DocAccumulator;
 use super::processors::{self, SessionInsight, CURRENT_PROCESSOR_VERSION};
-use super::store::{self, Pending};
-use crate::native::{db, pricing::Resolver, settings};
+use super::store::{self, Pending, Scope};
+use crate::native::{db, pricing::Resolver, search, settings};
 
 /// How often the worker looks for rows a version bump or an idle-threshold
 /// change left behind. Go's `insightWorkerRescanInterval`.
@@ -186,13 +187,29 @@ fn run(db_path: &Path, rx: Receiver<Pending>) {
     }
 }
 
-/// `rescanOutdated`: everything with no insight row or an outdated one.
+/// `rescanOutdated`: everything with no insight row or an outdated one — **or
+/// the whole corpus, when the search index needs rebuilding** (#435).
 ///
 /// Processed directly rather than pushed through the queue, which Go does and
 /// this deliberately does not: a corpus of 2,000 unprocessed sessions against a
 /// 100-slot channel would drop 1,900 of them and report each drop, then find
 /// them again five minutes later. The queue is for the scan's incremental
 /// announcements; the sweep already has the whole list in hand.
+///
+/// ## The two versions are separate, and only one of them widens the scope
+///
+/// `CURRENT_PROCESSOR_VERSION` selects rows whose *insight* is stale;
+/// [`search::SEARCH_INDEX_VERSION`] selects rows whose *index text* is, which is
+/// every row at once because the constant is not stored per row. A bump to the
+/// second therefore reads every transcript again — through **this** thread, and
+/// **not** through the scanner: no staleness marker is touched, so
+/// `claude_session_cache.file_mtime` is left exactly as it was and the scan does
+/// not re-read a thing. That is `CURRENT_PROCESSOR_VERSION`'s own separation,
+/// applied to the second version constant.
+///
+/// The new version is stamped **after** the rebuild, and only if every batch in
+/// it committed. Stamping first would leave a partially indexed corpus that
+/// nothing ever finishes, because the mismatch driving the work would be gone.
 fn sweep(db_path: &Path) {
     let conn = match db::open_read_only(db_path) {
         Ok(conn) => conn,
@@ -201,7 +218,20 @@ fn sweep(db_path: &Path) {
             return;
         }
     };
-    let pending = match store::needs_processing(&conn, CURRENT_PROCESSOR_VERSION) {
+    let indexed_version = search::stored_version(&conn).unwrap_or_else(|e| {
+        // Treated as current rather than as 0: a read failure that answered
+        // "nothing indexed" would rebuild the entire corpus on every sweep for
+        // as long as the failure lasts.
+        log::warn!("insights: cannot read search_index_version: {e}");
+        search::SEARCH_INDEX_VERSION
+    });
+    let rebuild = indexed_version != search::SEARCH_INDEX_VERSION;
+    let scope = if rebuild {
+        Scope::Everything
+    } else {
+        Scope::Outdated
+    };
+    let pending = match store::select_pending(&conn, CURRENT_PROCESSOR_VERSION, scope) {
         Ok(pending) => pending,
         Err(e) => {
             log::warn!("insights: failed to list sessions needing processing: {e}");
@@ -211,18 +241,72 @@ fn sweep(db_path: &Path) {
     drop(conn);
 
     if pending.is_empty() {
+        // Nothing to index, so the version is trivially reached. Recording it
+        // here is what stops an empty corpus rebuilding on every five-minute
+        // tick for the life of the process.
+        if rebuild {
+            record_index_version(db_path);
+        }
         return;
     }
-    log::info!("insights: reprocessing {} outdated sessions", pending.len());
+    if rebuild {
+        log::info!(
+            "search: rebuilding the index for {} sessions (stored version {indexed_version}, \
+             this build writes {})",
+            pending.len(),
+            search::SEARCH_INDEX_VERSION,
+        );
+    } else {
+        log::info!("insights: reprocessing {} outdated sessions", pending.len());
+    }
 
+    let mut every_batch_committed = true;
     for chunk in pending.chunks(BATCH_SIZE) {
-        process_batch(db_path, chunk.iter().cloned().collect());
+        every_batch_committed &= process_batch(db_path, chunk.iter().cloned().collect());
+    }
+
+    if rebuild && every_batch_committed {
+        record_index_version(db_path);
+    }
+}
+
+/// Stamp `claude_cache_metadata.search_index_version`.
+///
+/// Best-effort, like every marker `scan.rs` records: losing it costs one
+/// redundant rebuild at the next sweep, where failing the sweep costs the
+/// corpus its insights too.
+fn record_index_version(db_path: &Path) {
+    let result = db::open_read_write(db_path)
+        .and_then(|conn| search::record_version(&conn, search::SEARCH_INDEX_VERSION));
+    match result {
+        Ok(()) => log::info!(
+            "search: index rebuilt at version {}",
+            search::SEARCH_INDEX_VERSION
+        ),
+        Err(e) => log::warn!("search: failed to record search_index_version: {e}"),
     }
 }
 
 /// Read every session in the batch in parallel, then write the results in one
 /// transaction.
-fn process_batch(db_path: &Path, batch: BTreeSet<Pending>) {
+///
+/// Answers whether the batch got as far as the database agreeing with it, which
+/// [`sweep`] needs in order to decide whether a rebuild may stamp its version.
+///
+/// **`false` means a *database* failure, never an unreadable transcript.** That
+/// distinction is the whole value of the return: a real corpus always contains
+/// some session whose file has been deleted, truncated or replaced since it was
+/// cached, and `read_in_parallel` skips those by design. Counting a skip as
+/// failure would mean the version is never recorded on any real machine, so
+/// every five-minute sweep would rebuild the entire index again — for ever, at
+/// full corpus cost, with nothing in the log to say why. A batch with nothing
+/// readable in it is therefore `true`: nothing was committed because there was
+/// nothing to commit.
+///
+/// What is left blocking a stamp is exactly the set of things that would make
+/// the rebuild genuinely incomplete and are worth retrying: the settings read,
+/// opening the database for writing, and the batch transaction itself.
+fn process_batch(db_path: &Path, batch: BTreeSet<Pending>) -> bool {
     let items: Vec<Pending> = batch
         .into_iter()
         // `rescanOutdated` skips a row with no file path, and so does this:
@@ -231,7 +315,7 @@ fn process_batch(db_path: &Path, batch: BTreeSet<Pending>) {
         .filter(|item| !item.file_path.is_empty())
         .collect();
     if items.is_empty() {
-        return;
+        return true;
     }
 
     // Read once per batch rather than once per session: a settings save landing
@@ -245,36 +329,50 @@ fn process_batch(db_path: &Path, batch: BTreeSet<Pending>) {
         ),
         Err(e) => {
             log::warn!("insights: cannot read settings, skipping a batch: {e}");
-            return;
+            return false;
         }
     };
 
-    let computed = read_in_parallel(&items, idle_gap_ms, resolver.as_ref());
+    let mut computed = read_in_parallel(&items, idle_gap_ms, resolver.as_ref());
     if computed.is_empty() {
-        return;
+        // Every transcript in this batch was unreadable. Nothing to commit, and
+        // **not a failure** — see the note on the return value: an unreadable
+        // transcript is a skip by design, not an error to block a rebuild on.
+        return true;
     }
 
     let mut conn = match db::open_read_write(db_path) {
         Ok(conn) => conn,
         Err(e) => {
             log::warn!("insights: cannot open the database to store a batch: {e}");
-            return;
+            return false;
         }
     };
-    match write_batch(&mut conn, &computed) {
-        Ok(n) => log::debug!("insights: stored {n} session insights"),
+    match write_batch(&mut conn, &mut computed) {
+        Ok(n) => {
+            log::debug!("insights: stored {n} session insights and search rows");
+            true
+        }
         // Dropped rather than retried, for `apply.rs`'s reason: the rows keep
         // their old `processor_version` (or none), so they still look
         // unprocessed to the next sweep and are recomputed then. Retrying here
         // risks looping on a persistent error.
-        Err(e) => log::warn!("insights: failed to store a batch, dropping it: {e}"),
+        Err(e) => {
+            log::warn!("insights: failed to store a batch, dropping it: {e}");
+            false
+        }
     }
 }
 
-/// One computed insight and the project path it belongs to.
+/// One computed insight, its search document, and the project path both belong
+/// to.
+///
+/// The two travel together from the read to the write because they are written
+/// together — see [`write_batch`].
 struct Computed {
     project_path: String,
     insight: SessionInsight,
+    doc: search::SearchDoc,
 }
 
 /// The reader pool, in `scanner/apply.rs`'s shape and for its reasons: decoding
@@ -313,12 +411,17 @@ fn read_in_parallel(
                     idle_gap_ms,
                     resolver,
                 };
-                match processors::run(&item.session_id, &files, &ctx) {
+                // The search document is built from the very same decode the
+                // processors consume — that is what makes indexing cost no
+                // additional file I/O. See `insights::index`.
+                let mut doc = DocAccumulator::new();
+                match processors::run(&item.session_id, &files, &ctx, &mut doc) {
                     Ok(insight) => out
                         .lock()
                         .unwrap_or_else(|e| e.into_inner())
                         .push(Computed {
                             project_path: item.project_path.clone(),
+                            doc: doc.into_doc(&item.session_id, &item.project_path),
                             insight,
                         }),
                     // One unreadable transcript must not cost the batch, which
@@ -337,11 +440,37 @@ fn read_in_parallel(
     out.into_inner().unwrap_or_else(|e| e.into_inner())
 }
 
-fn write_batch(conn: &mut Connection, computed: &[Computed]) -> Result<usize, String> {
+/// One transaction covering both writes, for every session in the batch.
+///
+/// **The `session_insights` row and the `session_search` row commit or fail
+/// together**, which is the acceptance criterion and also the only arrangement
+/// that stays consistent: `processor_version` is what tells the next sweep a
+/// session is done, so an index write that failed after the insight row landed
+/// would leave that session permanently unindexed with nothing reporting it.
+/// `search::replace` is itself a delete followed by an insert and is *not*
+/// atomic on its own — this transaction is what makes it so, which is exactly
+/// why `search/mod.rs` opens no connection of its own.
+///
+/// The title is read here rather than carried from the read pass because it
+/// lives in the cache row, not the transcript. Inside the transaction, so it
+/// cannot be a value from before a concurrent rename.
+///
+/// `?` on either write aborts the whole batch, and the `Transaction`'s `Drop`
+/// rolls it back — so a failure leaves neither table changed for any session in
+/// it, and every one of them still looks unprocessed to the next sweep.
+///
+/// `computed` is taken by `&mut` so the title can be filled **in place**. A
+/// `SearchDoc` carries up to `normalize::SESSION_CAP` of text, and a batch is a
+/// hundred of them, so building a titled copy per row would clone tens of
+/// megabytes per batch to add a few dozen bytes to each.
+fn write_batch(conn: &mut Connection, computed: &mut [Computed]) -> Result<usize, String> {
     let scanned_at = store::scanned_at_now();
     let tx = conn.transaction().map_err(|e| e.to_string())?;
-    for item in computed {
+    for item in computed.iter_mut() {
         store::upsert(&tx, &item.insight, &item.project_path, &scanned_at)?;
+        let title = store::display_title(&tx, &item.doc.session_id, &item.doc.project_path);
+        item.doc.title = super::index::normalize_title(&title);
+        search::replace(&tx, &item.doc)?;
     }
     tx.commit().map_err(|e| e.to_string())?;
     Ok(computed.len())
@@ -430,5 +559,579 @@ mod tests {
     fn a_queue_with_room_reports_no_overflow() {
         let (tx, _rx) = mpsc::sync_channel::<Pending>(4);
         assert_eq!(offer(&tx, (0..3).map(|i| pending(&format!("s{i}")))), 0);
+    }
+
+    // ─── the indexing pipeline (#435) ────────────────────────────────────────
+    //
+    // These drive `process_batch` and `sweep` against a real database and real
+    // transcript files, because every property below is about what the *rows*
+    // say after a pass — which is the same reason `scanner/` is verified against
+    // stored rows rather than a response.
+
+    use rusqlite::Connection;
+
+    /// A migrated database in `dir`, plus its path.
+    ///
+    /// `ensure_database` rather than `open_read_write`, which does **not** carry
+    /// `SQLITE_OPEN_CREATE` — the app's startup path is the only thing that
+    /// creates the file, and these tests take the same route it does.
+    fn fixture_db(dir: &tempfile::TempDir) -> PathBuf {
+        let db_path = dir.path().join("agento.db");
+        let mut conn = db::ensure_database(&db_path).expect("create");
+        crate::native::migrate::apply(&mut conn).expect("migrations");
+        db_path
+    }
+
+    /// Write a two-message transcript and register it as a cache row.
+    ///
+    /// The text is the fixture's whole point, so each session gets its own
+    /// distinctive word to search for.
+    fn seed_session(
+        dir: &tempfile::TempDir,
+        db_path: &Path,
+        session_id: &str,
+        project_path: &str,
+        word: &str,
+    ) -> PathBuf {
+        let file = dir.path().join(format!(
+            "{session_id}-{}.jsonl",
+            project_path.replace('/', "_")
+        ));
+        let lines = [
+            serde_json::json!({
+                "type": "user",
+                "timestamp": "2026-01-01T00:00:00Z",
+                "message": {"role": "user", "content": format!("please fix the {word} problem")},
+            }),
+            serde_json::json!({
+                "type": "assistant",
+                "timestamp": "2026-01-01T00:01:00Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "looking at it now"}],
+                },
+            }),
+        ];
+        let body: String = lines.iter().map(|l| format!("{l}\n")).collect();
+        std::fs::write(&file, body).expect("write transcript");
+
+        let conn = db::open_read_write(db_path).expect("open");
+        conn.execute(
+            "INSERT INTO claude_session_cache
+                 (session_id, project_path, file_path, file_mtime, start_time, last_activity)
+             VALUES (?1, ?2, ?3, '2026-01-01 00:00:00+00:00', '2026-01-01 00:00:00+00:00',
+                     '2026-01-01 00:00:00+00:00')",
+            rusqlite::params![session_id, project_path, file.to_string_lossy()],
+        )
+        .expect("cache row");
+        file
+    }
+
+    fn pending_for(session_id: &str, project_path: &str, file: &Path) -> Pending {
+        Pending {
+            session_id: session_id.into(),
+            project_path: project_path.into(),
+            file_path: file.to_string_lossy().into_owned(),
+        }
+    }
+
+    fn indexed_pairs(conn: &Connection) -> Vec<(String, String)> {
+        let mut stmt = conn
+            .prepare("SELECT session_id, project_path FROM session_search ORDER BY 1, 2")
+            .expect("prepare");
+        stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+            .expect("query")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("rows")
+    }
+
+    fn mtimes(conn: &Connection) -> Vec<(String, String, String)> {
+        let mut stmt = conn
+            .prepare(
+                "SELECT session_id, project_path, file_mtime
+                   FROM claude_session_cache ORDER BY 1, 2",
+            )
+            .expect("prepare");
+        stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))
+            .expect("query")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("rows")
+    }
+
+    /// The headline acceptance criterion: one pass over an announced session
+    /// leaves a *searchable* row, not merely a row.
+    ///
+    /// Asserted through `search::search` rather than by counting rows, because a
+    /// row holding the wrong columns — a title in `user_text`, or empty text —
+    /// counts exactly the same and answers nothing.
+    #[test]
+    fn one_pass_over_an_announced_session_leaves_a_searchable_row() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = fixture_db(&dir);
+        let file = seed_session(&dir, &db_path, "s1", "/a", "pagination");
+
+        assert!(process_batch(
+            &db_path,
+            [pending_for("s1", "/a", &file)].into_iter().collect(),
+        ));
+
+        let conn = db::open_read_only(&db_path).expect("open");
+        let hits = search::search(&conn, "\"pagination\"", 10).expect("search");
+        assert_eq!(
+            hits.iter()
+                .map(|h| (h.session_id.as_str(), h.project_path.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("s1", "/a")],
+        );
+        // The assistant's side of the conversation is indexed too, in its own
+        // column — a document built from user turns alone would pass the check
+        // above.
+        assert_eq!(
+            search::search(&conn, "\"looking at it now\"", 10)
+                .expect("search")
+                .len(),
+            1,
+        );
+    }
+
+    /// The title comes from the cache row, and follows the display precedence
+    /// the UI uses — the user's own rename first.
+    #[test]
+    fn the_indexed_title_is_the_cache_rows_display_title() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = fixture_db(&dir);
+        let file = seed_session(&dir, &db_path, "s1", "/a", "pagination");
+        let conn = db::open_read_write(&db_path).expect("open");
+        conn.execute(
+            "UPDATE claude_session_cache
+                SET custom_title = 'quarterly rollup', native_title = 'ignored'",
+            [],
+        )
+        .expect("rename");
+        drop(conn);
+
+        assert!(process_batch(
+            &db_path,
+            [pending_for("s1", "/a", &file)].into_iter().collect(),
+        ));
+
+        let conn = db::open_read_only(&db_path).expect("open");
+        let title: String = conn
+            .query_row("SELECT title FROM session_search", [], |r| r.get(0))
+            .expect("title");
+        assert_eq!(title, "quarterly rollup");
+    }
+
+    /// The #362-family assertion, in its fifth form: one session id under two
+    /// project paths is two transcripts and must be two independent index rows.
+    ///
+    /// Keyed on the id alone, `search::replace`'s delete would remove both and
+    /// the batch would end with one row holding the second transcript's text —
+    /// a session silently missing from the index with nothing to report it.
+    #[test]
+    fn one_session_id_under_two_projects_gets_two_index_rows() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = fixture_db(&dir);
+        let a = seed_session(&dir, &db_path, "s1", "/a", "kestrel");
+        let b = seed_session(&dir, &db_path, "s1", "/b", "petrel");
+
+        assert!(process_batch(
+            &db_path,
+            [pending_for("s1", "/a", &a), pending_for("s1", "/b", &b)]
+                .into_iter()
+                .collect(),
+        ));
+
+        let conn = db::open_read_only(&db_path).expect("open");
+        assert_eq!(
+            indexed_pairs(&conn),
+            vec![("s1".into(), "/a".into()), ("s1".into(), "/b".into())],
+        );
+        // …and each carries its own transcript's text, which a shared row could
+        // not.
+        for (word, project) in [("kestrel", "/a"), ("petrel", "/b")] {
+            let hits = search::search(&conn, &format!("\"{word}\""), 10).expect("search");
+            assert_eq!(
+                hits.iter()
+                    .map(|h| h.project_path.as_str())
+                    .collect::<Vec<_>>(),
+                vec![project],
+                "{word} must belong to {project} alone",
+            );
+        }
+    }
+
+    /// Bumping `SEARCH_INDEX_VERSION` rebuilds every row **without** the scanner
+    /// re-reading anything.
+    ///
+    /// The `file_mtime` assertion is the whole point and is easy to lose: a
+    /// rebuild driven by the scanner's staleness markers would also produce a
+    /// correct index, and would additionally re-read the entire corpus from
+    /// disk. Zeroed mtimes are what that looks like, so they are compared before
+    /// and after.
+    ///
+    /// The stored version is set to a value that is not `SEARCH_INDEX_VERSION`
+    /// rather than to a literal, so bumping the constant does not turn this into
+    /// a test of nothing.
+    #[test]
+    fn a_version_bump_reindexes_without_touching_the_scanners_mtimes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = fixture_db(&dir);
+        let file = seed_session(&dir, &db_path, "s1", "/a", "pagination");
+
+        // A first pass, at the current version.
+        sweep(&db_path);
+        let conn = db::open_read_only(&db_path).expect("open");
+        assert_eq!(indexed_pairs(&conn).len(), 1);
+        assert_eq!(
+            search::stored_version(&conn).expect("version"),
+            search::SEARCH_INDEX_VERSION,
+            "a completed sweep stamps the version it indexed at",
+        );
+        let before = mtimes(&conn);
+        drop(conn);
+
+        // Now pretend this build's indexer disagrees with what is stored, and
+        // empty the index the way a rebuild's first act would not: if the sweep
+        // does nothing, the rows stay gone and the assertion below fails.
+        let conn = db::open_read_write(&db_path).expect("open");
+        search::record_version(&conn, search::SEARCH_INDEX_VERSION - 1).expect("age the version");
+        search::delete_all(&conn).expect("empty the index");
+        drop(conn);
+
+        sweep(&db_path);
+
+        let conn = db::open_read_only(&db_path).expect("open");
+        assert_eq!(
+            indexed_pairs(&conn),
+            vec![("s1".into(), "/a".into())],
+            "a version mismatch must reindex every session",
+        );
+        assert_eq!(
+            search::stored_version(&conn).expect("version"),
+            search::SEARCH_INDEX_VERSION,
+            "and stamp the new version once the rebuild covered the corpus",
+        );
+        assert_eq!(
+            mtimes(&conn),
+            before,
+            "a search rebuild must not make the scanner re-read a transcript",
+        );
+        // The insight row is current throughout, which is what makes the
+        // ordinary `needs_processing` scope unable to express this rebuild.
+        let stale: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM session_insights WHERE processor_version < ?1",
+                rusqlite::params![CURRENT_PROCESSOR_VERSION],
+                |r| r.get(0),
+            )
+            .expect("count");
+        assert_eq!(stale, 0);
+        let _ = file;
+    }
+
+    /// An ordinary sweep, with the version already current, must not rebuild.
+    ///
+    /// Without the equality check this would re-index the whole corpus every
+    /// five minutes forever — correct output, and a permanent full-corpus read
+    /// nothing would ever report.
+    #[test]
+    fn a_sweep_at_the_current_version_reindexes_nothing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = fixture_db(&dir);
+        seed_session(&dir, &db_path, "s1", "/a", "pagination");
+
+        sweep(&db_path);
+        // Emptying the index without moving the version is how "did the second
+        // sweep decide to rebuild?" becomes observable at all.
+        let conn = db::open_read_write(&db_path).expect("open");
+        search::delete_all(&conn).expect("empty the index");
+        drop(conn);
+
+        sweep(&db_path);
+
+        let conn = db::open_read_only(&db_path).expect("open");
+        assert!(
+            indexed_pairs(&conn).is_empty(),
+            "nothing was stale, so nothing should have been re-read",
+        );
+    }
+
+    /// An empty corpus still reaches the new version, rather than asking for a
+    /// rebuild on every five-minute tick for the life of the process.
+    #[test]
+    fn a_rebuild_over_an_empty_corpus_still_records_the_version() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = fixture_db(&dir);
+        let conn = db::open_read_write(&db_path).expect("open");
+        search::record_version(&conn, search::SEARCH_INDEX_VERSION - 1).expect("age");
+        drop(conn);
+
+        sweep(&db_path);
+
+        let conn = db::open_read_only(&db_path).expect("open");
+        assert_eq!(
+            search::stored_version(&conn).expect("version"),
+            search::SEARCH_INDEX_VERSION,
+        );
+    }
+
+    /// The two writes are one transaction: if the index write fails, the insight
+    /// row must not survive either.
+    ///
+    /// Injected by dropping `session_search` before the batch, which makes
+    /// `search::replace` fail on a real `no such table` rather than on a
+    /// test-only hook — so this exercises the same `?` a genuine FTS5 error
+    /// would take.
+    ///
+    /// The consequence being pinned is not tidiness: `processor_version` is what
+    /// tells the next sweep a session is done, so an insight row that outlived a
+    /// failed index write would mark that session complete and it would never be
+    /// indexed again.
+    #[test]
+    fn a_failed_index_write_rolls_back_the_insight_row_with_it() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = fixture_db(&dir);
+        let file = seed_session(&dir, &db_path, "s1", "/a", "pagination");
+
+        let conn = db::open_read_write(&db_path).expect("open");
+        conn.execute("DROP TABLE session_search", [])
+            .expect("drop the index");
+        drop(conn);
+
+        assert!(
+            !process_batch(
+                &db_path,
+                [pending_for("s1", "/a", &file)].into_iter().collect()
+            ),
+            "a batch that could not commit must report so",
+        );
+
+        let conn = db::open_read_only(&db_path).expect("open");
+        let insights: i64 = conn
+            .query_row("SELECT COUNT(*) FROM session_insights", [], |r| r.get(0))
+            .expect("count");
+        assert_eq!(
+            insights, 0,
+            "the insight row committed without its index row",
+        );
+        // …and the session is therefore still pending, which is what makes the
+        // failure recoverable rather than permanent.
+        assert_eq!(
+            store::needs_processing(&conn, CURRENT_PROCESSOR_VERSION)
+                .expect("needs_processing")
+                .len(),
+            1,
+        );
+    }
+
+    /// An unreadable transcript is a **skip, not a failure**, and the batch says
+    /// so.
+    ///
+    /// This looks like the lenient answer and is the strict one. Every real
+    /// corpus holds a session whose file has since been deleted or truncated —
+    /// `insights_live.rs` allows a 10% shortfall for exactly that — so if a skip
+    /// counted as failure, [`sweep`] would never stamp the version on any real
+    /// machine and would rebuild the whole index every five minutes for the life
+    /// of the process. Correct output, unbounded cost, and nothing in the log
+    /// naming the cause.
+    #[test]
+    fn an_unreadable_transcript_is_a_skip_rather_than_a_batch_failure() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = fixture_db(&dir);
+        let missing = dir.path().join("absent.jsonl");
+
+        assert!(process_batch(
+            &db_path,
+            [pending_for("s1", "/a", &missing)].into_iter().collect(),
+        ));
+    }
+
+    /// …and the consequence, end to end: a corpus containing an unreadable
+    /// transcript still finishes its rebuild.
+    ///
+    /// The second sweep is what makes this an assertion about *termination*
+    /// rather than about one pass: with the skip counted as a failure the
+    /// version stays behind, so the second sweep rebuilds all over again.
+    #[test]
+    fn a_rebuild_completes_over_a_corpus_with_an_unreadable_transcript() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = fixture_db(&dir);
+        seed_session(&dir, &db_path, "good", "/a", "pagination");
+        // A cache row whose transcript does not exist — the ordinary shape of a
+        // session deleted from disk since it was scanned.
+        let conn = db::open_read_write(&db_path).expect("open");
+        conn.execute(
+            "INSERT INTO claude_session_cache
+                 (session_id, project_path, file_path, file_mtime, start_time, last_activity)
+             VALUES ('gone', '/a', ?1, '2026-01-01 00:00:00+00:00',
+                     '2026-01-01 00:00:00+00:00', '2026-01-01 00:00:00+00:00')",
+            rusqlite::params![dir.path().join("absent.jsonl").to_string_lossy()],
+        )
+        .expect("cache row");
+        search::record_version(&conn, search::SEARCH_INDEX_VERSION - 1).expect("age");
+        drop(conn);
+
+        sweep(&db_path);
+
+        let conn = db::open_read_only(&db_path).expect("open");
+        assert_eq!(
+            search::stored_version(&conn).expect("version"),
+            search::SEARCH_INDEX_VERSION,
+            "one unreadable transcript must not stop the rebuild concluding",
+        );
+        assert_eq!(indexed_pairs(&conn), vec![("good".into(), "/a".into())]);
+        drop(conn);
+
+        // Termination: with the version stamped, a second sweep has nothing to
+        // rebuild. Emptying the index first is what makes that observable.
+        let conn = db::open_read_write(&db_path).expect("open");
+        search::delete_all(&conn).expect("empty");
+        drop(conn);
+
+        sweep(&db_path);
+
+        let conn = db::open_read_only(&db_path).expect("open");
+        assert!(
+            indexed_pairs(&conn).is_empty(),
+            "the rebuild repeated, so it would repeat every five minutes for ever",
+        );
+    }
+
+    /// A batch that could not open the database for writing **is** a failure,
+    /// so the two arms of the return value are pinned against each other rather
+    /// than only the lenient one being asserted.
+    #[test]
+    fn a_database_failure_is_a_batch_failure() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = fixture_db(&dir);
+        let file = seed_session(&dir, &db_path, "s1", "/a", "pagination");
+        std::fs::remove_file(&db_path).expect("remove the database");
+
+        assert!(!process_batch(
+            &db_path,
+            [pending_for("s1", "/a", &file)].into_iter().collect(),
+        ));
+    }
+
+    /// The #366 pattern (`tests/scheduled_run.rs`, `tests/chat_turn.rs`), with
+    /// indexing active.
+    ///
+    /// The worker is a plain OS thread and deliberately holds no runtime handle
+    /// — its header says so — so what this pins is that the property survives
+    /// the extra database work #435 puts inside the batch transaction. A batch
+    /// now writes `session_insights` *and* an FTS5 row per session while holding
+    /// one write lock for longer, so "the worker's writes are off the runtime"
+    /// is a claim worth re-asserting rather than inheriting.
+    ///
+    /// The shape is the original's: **one** worker thread so a single parked
+    /// worker is the whole runtime; a plain OS thread holding the lock, so the
+    /// contention comes from outside exactly as the session scanner's batch
+    /// writer does; and `last` seeded **before** the spawn, because a starved
+    /// ticker is never polled and seeding on the first poll would start the
+    /// clock after the stall and measure nothing.
+    ///
+    /// **Calibrated rather than assumed.** Replacing the `std::thread::spawn`
+    /// below with `tokio::spawn` — i.e. putting the batch's rusqlite work on the
+    /// single worker, which is the defect this shape exists to catch — takes the
+    /// ticker from ~150 advances to **0** and fails the assertion. Note it must
+    /// be `tokio::spawn` to falsify it: calling `process_batch` inline in this
+    /// async body blocks the *calling* thread, which `block_on` runs the test
+    /// future on, and the ticker on the worker keeps going regardless. That
+    /// version of the test passes against the defect, which is the trap the
+    /// scheduler's copy documents too.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn a_contended_write_lock_does_not_stall_the_runtime() {
+        use std::sync::atomic::AtomicU64;
+        use std::sync::Arc;
+        use std::time::Instant;
+
+        /// Long enough that a parked worker is unmistakable, short enough to
+        /// stay well inside `open_read_write`'s 5s `busy_timeout` so the batch
+        /// itself still commits.
+        const HOLD: Duration = Duration::from_millis(1_500);
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = fixture_db(&dir);
+        let file = seed_session(&dir, &db_path, "s1", "/a", "pagination");
+
+        // The file must already be WAL. Left in the default rollback journal,
+        // `open_read_write`'s own `PRAGMA journal_mode=WAL` is a *mode change*
+        // needing an exclusive lock and fails outright in about a millisecond
+        // instead of waiting on `busy_timeout` — which would make this measure
+        // the wrong thing entirely.
+        db::open_read_write(&db_path).expect("convert the fixture to WAL");
+
+        let (holding_tx, holding_rx) = mpsc::channel();
+        let lock_db = db_path.clone();
+        let holder = std::thread::spawn(move || {
+            let mut conn = rusqlite::Connection::open(&lock_db).expect("open");
+            let tx = conn
+                .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+                .expect("begin immediate");
+            holding_tx.send(()).expect("signal");
+            std::thread::sleep(HOLD);
+            tx.rollback().expect("rollback");
+        });
+        holding_rx.recv().expect("the writer took the lock");
+
+        let worst_gap_ms = Arc::new(AtomicU64::new(0));
+        let ticks = Arc::new(AtomicU64::new(0));
+        let ticker = {
+            let (worst_gap_ms, ticks, mut last) = (
+                Arc::clone(&worst_gap_ms),
+                Arc::clone(&ticks),
+                Instant::now(),
+            );
+            tokio::spawn(async move {
+                loop {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                    let now = Instant::now();
+                    let gap =
+                        u64::try_from(now.duration_since(last).as_millis()).unwrap_or(u64::MAX);
+                    worst_gap_ms.fetch_max(gap, Ordering::Relaxed);
+                    ticks.fetch_add(1, Ordering::Relaxed);
+                    last = now;
+                }
+            })
+        };
+
+        // Exactly how production runs it: a plain thread, never a tokio task.
+        let batch_db = db_path.clone();
+        let batch = std::thread::spawn(move || {
+            process_batch(
+                &batch_db,
+                [pending_for("s1", "/a", &file)].into_iter().collect(),
+            )
+        });
+
+        let committed = tokio::task::spawn_blocking(move || batch.join().expect("batch"))
+            .await
+            .expect("join");
+        ticker.abort();
+        holder.join().expect("the writer finished");
+
+        assert!(committed, "the batch did not commit");
+
+        let worst = worst_gap_ms.load(Ordering::Relaxed);
+        assert!(
+            worst < 500,
+            "the runtime stalled for {worst} ms while the write lock was held \
+             (the hold is {} ms; anything near it means indexing blocked a worker)",
+            HOLD.as_millis(),
+        );
+        // The gap alone would read as healthy if the ticker had simply been
+        // cancelled early, so assert it really ran throughout.
+        let ticks = ticks.load(Ordering::Relaxed);
+        assert!(
+            ticks > 50,
+            "the ticker only advanced {ticks} times across a {} ms hold",
+            HOLD.as_millis(),
+        );
+
+        // …and both rows landed, so this is not passing because nothing
+        // happened.
+        let conn = db::open_read_only(&db_path).expect("open");
+        assert_eq!(indexed_pairs(&conn), vec![("s1".into(), "/a".into())]);
     }
 }

--- a/src-tauri/src/native/scan.rs
+++ b/src-tauri/src/native/scan.rs
@@ -540,6 +540,21 @@ fn run_scan(db_path: &Path) -> Result<(), String> {
         // scan costs the corpus.
         Err(e) => log::warn!("claude sessions: {e}"),
     }
+    // The search index's reconcile, on exactly the same terms and for the same
+    // reasons (#435): keyed on "no cache row for this pair remains" rather than
+    // on a path, and run **here** — after the delete pass — so it inherits the
+    // unreadable-config-dir protection instead of emptying an account's index
+    // when a drive is unmounted.
+    //
+    // A separate statement rather than a shared one: the two tables are
+    // reconciled against the same condition but a failure of one must not stop
+    // the other, and `session_search` is an FTS5 table whose delete scans, so
+    // the costs are not comparable either.
+    match super::search::delete_orphans(&conn) {
+        Ok(n) if n > 0 => log::info!("search: reconciled {n} orphaned index rows"),
+        Ok(_) => {}
+        Err(e) => log::warn!("claude sessions: {e}"),
+    }
     super::insights::worker::enqueue(outcome.notifications.iter().map(|n| {
         super::insights::store::Pending {
             session_id: n.session_id.clone(),

--- a/src-tauri/src/native/search/mod.rs
+++ b/src-tauri/src/native/search/mod.rs
@@ -161,8 +161,23 @@ pub fn match_sql() -> &'static str {
 /// Delete-then-insert rather than an upsert: an FTS5 table has no unique index
 /// to conflict on, so `ON CONFLICT` has nothing to name. The two statements are
 /// not atomic on their own — the caller's transaction is what makes them one.
+///
+/// **The delete is the expensive half** — see [`delete`] — so a caller that has
+/// just emptied the table has no reason to pay it. That is what [`insert`] is
+/// for, and why a full rebuild uses [`delete_all`] plus `insert` rather than
+/// `replace` per session.
 pub fn replace(conn: &Connection, doc: &SearchDoc) -> Result<(), String> {
     delete(conn, &doc.session_id, &doc.project_path)?;
+    insert(conn, doc)
+}
+
+/// Add a row, without first removing one for the same pair.
+///
+/// **Only safe where the caller knows no row for this pair exists** — after
+/// [`delete_all`], which is the rebuild path. FTS5 has no unique index, so a
+/// second row for the same key is not refused: it is a duplicate, and the pair
+/// would then return two hits and two `delete`s' worth of content for ever.
+pub fn insert(conn: &Connection, doc: &SearchDoc) -> Result<(), String> {
     conn.execute(
         "INSERT INTO session_search
              (title, user_text, assistant_text, tool_text, session_id, project_path)
@@ -185,6 +200,21 @@ pub fn replace(conn: &Connection, doc: &SearchDoc) -> Result<(), String> {
 /// Keyed on the pair. A claim shift moves a transcript to a different path and
 /// is an **update**, not a deletion (#245), so the caller decides what is gone;
 /// this only removes what it is told to.
+///
+/// **This scans, and the cost grows with the corpus.** FTS5's `xBestIndex`
+/// accepts only `rowid` and `MATCH`, so a predicate over the UNINDEXED key
+/// columns cannot use an index — SQLite answers `SCAN session_search VIRTUAL
+/// TABLE INDEX 0:` — and a content-storing table materializes each scanned row
+/// to serve it. Measured at ~9.5 ms against a 17 MB index and ~63 ms against a
+/// 176 MB one, per call.
+///
+/// Two consequences the callers are built around:
+///
+/// * A **rebuild must not call this per session** — 1,178 scans of a table that
+///   grows with every insert is quadratic. [`delete_all`] once, then [`insert`].
+/// * On the incremental path it is one scan per *changed* session, which is what
+///   #433 signed up for and what #439 owns measuring. Do not add a caller that
+///   turns it back into a per-corpus loop.
 pub fn delete(conn: &Connection, session_id: &str, project_path: &str) -> Result<(), String> {
     conn.execute(
         "DELETE FROM session_search WHERE session_id = ?1 AND project_path = ?2",
@@ -241,7 +271,9 @@ pub fn delete_orphans(conn: &Connection) -> Result<usize, String> {
 ///
 /// Missing metadata row reads as 0 — "nothing indexed" — which is the same
 /// answer migration 33's column default gives an upgraded database, and is what
-/// makes a first index and a rebuild one code path.
+/// makes a first index and a rebuild one code path. The `COALESCE` is belt and
+/// braces: migration 33 declares the column `NOT NULL DEFAULT 0`, so it can only
+/// fire against a database something else has altered.
 pub fn stored_version(conn: &Connection) -> Result<i64, String> {
     conn.query_row(
         "SELECT COALESCE(search_index_version, 0) FROM claude_cache_metadata WHERE id = 1",
@@ -258,9 +290,16 @@ pub fn stored_version(conn: &Connection) -> Result<i64, String> {
 ///
 /// Written **only after** a rebuild has covered the whole corpus, never before:
 /// a version recorded ahead of the work leaves a partial index that nothing will
-/// ever finish, because the mismatch that would have driven it is gone. Uses the
-/// same insert-or-update as `scan.rs`'s `last_scanned_at` so it also works on a
-/// database whose singleton metadata row does not exist yet.
+/// ever finish, because the mismatch that would have driven it is gone.
+///
+/// Insert-or-update rather than `scan.rs`'s bare `UPDATE … WHERE id = 1`, which
+/// affects nothing until `record_last_scanned` has created the singleton row.
+/// **The worker can be the first writer of that row**: on a fresh install the
+/// boot sweep runs before the boot scan (`lib.rs` starts the worker, then the
+/// scan), so an empty corpus stamps the version with no scan having happened.
+/// The `''` written to `last_scanned_at` here is what a never-scanned database
+/// holds anyway — `scan.rs` reads it as "never" and scans — so seeding the row
+/// early changes nothing about when the first scan runs.
 pub fn record_version(conn: &Connection, version: i64) -> Result<(), String> {
     conn.execute(
         "INSERT INTO claude_cache_metadata (id, last_scanned_at, search_index_version)

--- a/src-tauri/src/native/search/mod.rs
+++ b/src-tauri/src/native/search/mod.rs
@@ -74,6 +74,25 @@ use rusqlite::{params, Connection};
 /// weight they carry.
 pub const BM25_WEIGHTS: [f64; 4] = [8.0, 4.0, 2.0, 0.5];
 
+/// What this build's indexer produces, compared against
+/// `claude_cache_metadata.search_index_version` (#435).
+///
+/// Bump it whenever the *stored text* changes — a different column routing, a
+/// changed cap, a normalizer rule that keeps or drops different words. The
+/// worker's sweep then rebuilds every row (see
+/// [`crate::native::insights::worker`]).
+///
+/// **It is deliberately not one of the scanner's staleness markers**, which is
+/// the same separation `CURRENT_PROCESSOR_VERSION` has: rebuilding the index
+/// re-reads transcripts *through the worker*, and must not make the scanner
+/// re-read `claude_session_cache` — those rows are a function of the transcript
+/// and the pricing catalog, neither of which a search-text change touches.
+///
+/// 0 is reserved for "nothing indexed": migration 33 defaults the column to it,
+/// so an upgraded database and a fresh install are the same case, and both
+/// trigger a full first index.
+pub const SEARCH_INDEX_VERSION: i64 = 1;
+
 /// The ranking expression, spelled once so #436 and #437 cannot drift from the
 /// indexer or from each other.
 ///
@@ -187,6 +206,72 @@ pub fn delete_all(conn: &Connection) -> Result<(), String> {
     Ok(())
 }
 
+/// Drop index rows whose session is no longer in the cache.
+///
+/// The exact shape of `insights::store::delete_orphans`, and for exactly its
+/// reasons: **keyed on "no cache row for this pair remains", never on a path.**
+/// A claim shift moves a transcript to a new `file_path` and is an *update*
+/// (#245), so a path-keyed delete would drop a session that is still there.
+/// `session_search` carries no `file_path` at all, so path is not even available
+/// as a wrong answer.
+///
+/// It follows that this must run **after** the cache's own delete pass, which is
+/// where it inherits that pass's protection for free: a config dir that could
+/// not be listed keeps its cache rows, so its index rows are not orphans and are
+/// left alone. That is what stops an unmounted drive emptying an account's
+/// search index.
+///
+/// Note the cost, which is [`delete`]'s: FTS5 accepts no index on the UNINDEXED
+/// key columns, so the `NOT EXISTS` runs over the backing `%_content` table.
+/// One pass per scan, and #439 owns measuring it.
+pub fn delete_orphans(conn: &Connection) -> Result<usize, String> {
+    conn.execute(
+        "DELETE FROM session_search
+         WHERE NOT EXISTS (
+             SELECT 1 FROM claude_session_cache c
+              WHERE c.session_id = session_search.session_id
+                AND c.project_path = session_search.project_path
+         )",
+        [],
+    )
+    .map_err(|e| format!("reconciling orphaned search rows: {e}"))
+}
+
+/// The `search_index_version` the stored rows were produced by.
+///
+/// Missing metadata row reads as 0 — "nothing indexed" — which is the same
+/// answer migration 33's column default gives an upgraded database, and is what
+/// makes a first index and a rebuild one code path.
+pub fn stored_version(conn: &Connection) -> Result<i64, String> {
+    conn.query_row(
+        "SELECT COALESCE(search_index_version, 0) FROM claude_cache_metadata WHERE id = 1",
+        [],
+        |row| row.get(0),
+    )
+    .or_else(|e| match e {
+        rusqlite::Error::QueryReturnedNoRows => Ok(0),
+        other => Err(format!("reading search_index_version: {other}")),
+    })
+}
+
+/// Stamp the version the index now holds.
+///
+/// Written **only after** a rebuild has covered the whole corpus, never before:
+/// a version recorded ahead of the work leaves a partial index that nothing will
+/// ever finish, because the mismatch that would have driven it is gone. Uses the
+/// same insert-or-update as `scan.rs`'s `last_scanned_at` so it also works on a
+/// database whose singleton metadata row does not exist yet.
+pub fn record_version(conn: &Connection, version: i64) -> Result<(), String> {
+    conn.execute(
+        "INSERT INTO claude_cache_metadata (id, last_scanned_at, search_index_version)
+              VALUES (1, '', ?1)
+         ON CONFLICT(id) DO UPDATE SET search_index_version = excluded.search_index_version",
+        params![version],
+    )
+    .map_err(|e| format!("recording search_index_version: {e}"))?;
+    Ok(())
+}
+
 /// Run one FTS query and return its hits, best first.
 ///
 /// `query` is FTS5 query syntax, already built and quoted by the caller. The
@@ -242,6 +327,128 @@ mod tests {
             .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
             .expect("query");
         rows.collect::<Result<Vec<_>, _>>().expect("collect")
+    }
+
+    fn cache_row(conn: &Connection, session_id: &str, project_path: &str, file_path: &str) {
+        conn.execute(
+            "INSERT INTO claude_session_cache
+                 (session_id, project_path, file_path, file_mtime, start_time, last_activity)
+             VALUES (?1, ?2, ?3, '2026-01-01 00:00:00+00:00', '2026-01-01 00:00:00+00:00',
+                     '2026-01-01 00:00:00+00:00')",
+            params![session_id, project_path, file_path],
+        )
+        .expect("cache row");
+    }
+
+    /// The reconcile keys on the **pair**, so a session id that also exists
+    /// under another project keeps the row for the project still cached.
+    ///
+    /// Keyed on the id alone this would empty both, and the surviving session
+    /// would simply stop being findable — with the cache row, the insight row
+    /// and every count still intact, so nothing looks wrong anywhere.
+    #[test]
+    fn the_reconcile_drops_only_rows_with_no_cache_row() {
+        let (_file, conn) = migrated();
+        for (session, project) in [("s1", "/a"), ("s1", "/b"), ("gone", "/a")] {
+            cache_row(
+                &conn,
+                session,
+                project,
+                &format!("{project}/{session}.jsonl"),
+            );
+            replace(&conn, &doc(session, project)).expect("index");
+        }
+
+        conn.execute(
+            "DELETE FROM claude_session_cache WHERE session_id = 'gone' OR project_path = '/b'",
+            [],
+        )
+        .expect("reconcile the cache");
+
+        assert_eq!(delete_orphans(&conn).expect("delete_orphans"), 2);
+        assert_eq!(indexed_pairs(&conn), vec![("s1".into(), "/a".into())]);
+    }
+
+    /// A claim shift moves a transcript and is an **update**, not a deletion
+    /// (#245). The cache row survives under its new `file_path`, so the index
+    /// row must be left exactly where it is.
+    ///
+    /// `session_search` carries no `file_path` at all, which is what makes the
+    /// wrong formulation unavailable rather than merely unused — but the rule is
+    /// worth pinning, because the obvious way to add a path column later would
+    /// reintroduce it.
+    #[test]
+    fn a_moved_transcript_keeps_its_index_row() {
+        let (_file, conn) = migrated();
+        cache_row(&conn, "s1", "/a", "/old/s1.jsonl");
+        replace(&conn, &doc("s1", "/a")).expect("index");
+
+        conn.execute(
+            "UPDATE claude_session_cache SET file_path = '/new/s1.jsonl'",
+            [],
+        )
+        .expect("move the file");
+
+        assert_eq!(delete_orphans(&conn).expect("delete_orphans"), 0);
+        assert_eq!(indexed_pairs(&conn), vec![("s1".into(), "/a".into())]);
+    }
+
+    /// The version round trip, including the case that decides the upgrade
+    /// path: a database whose singleton metadata row does not exist yet reads 0
+    /// and can still be stamped.
+    ///
+    /// A bare `UPDATE … WHERE id = 1` — which is how `scan.rs` records its own
+    /// markers, after `record_last_scanned` has inserted the row — would affect
+    /// nothing here and the rebuild would repeat forever.
+    #[test]
+    fn the_index_version_round_trips_even_with_no_metadata_row() {
+        let (_file, conn) = migrated();
+
+        assert_eq!(
+            stored_version(&conn).expect("version"),
+            0,
+            "no metadata row means nothing indexed",
+        );
+
+        record_version(&conn, SEARCH_INDEX_VERSION).expect("record");
+        assert_eq!(
+            stored_version(&conn).expect("version"),
+            SEARCH_INDEX_VERSION
+        );
+
+        record_version(&conn, SEARCH_INDEX_VERSION + 1).expect("record again");
+        assert_eq!(
+            stored_version(&conn).expect("version"),
+            SEARCH_INDEX_VERSION + 1,
+        );
+    }
+
+    /// Stamping the version must not disturb the row's other columns — it shares
+    /// `claude_cache_metadata` with the scanner's three staleness markers, and
+    /// an `INSERT … ON CONFLICT` that named them would reset a marker and force
+    /// a full transcript re-read.
+    #[test]
+    fn recording_the_version_leaves_the_scanners_markers_alone() {
+        let (_file, conn) = migrated();
+        conn.execute(
+            "INSERT INTO claude_cache_metadata
+                 (id, last_scanned_at, scanner_version, pricing_rev, idle_threshold_ms)
+             VALUES (1, 'when', 7, 42, 900000)",
+            [],
+        )
+        .expect("seed");
+
+        record_version(&conn, SEARCH_INDEX_VERSION).expect("record");
+
+        let row: (String, i64, i64, i64) = conn
+            .query_row(
+                "SELECT last_scanned_at, scanner_version, pricing_rev, idle_threshold_ms
+                   FROM claude_cache_metadata WHERE id = 1",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+            )
+            .expect("row");
+        assert_eq!(row, ("when".to_string(), 7, 42, 900_000));
     }
 
     /// The table has to exist after a plain migrate, and it has to be the FTS5

--- a/src-tauri/tests/insights_live.rs
+++ b/src-tauri/tests/insights_live.rs
@@ -59,6 +59,24 @@ fn every_cached_session_gains_an_insight_row() {
     let dir = tempfile::tempdir().expect("tempdir");
     let db = copy_db(&src, dir.path());
 
+    // **Migrate the copy, exactly as the app migrates before starting the
+    // worker** (`lib.rs`: `migrate::apply` at startup, `worker::start` long
+    // after). The installed database is whatever version the last release left,
+    // and this test's whole premise is a *copy of that* — so without this the
+    // worker runs against a schema no shipped build ever presents it with.
+    //
+    // Found the hard way, and worth keeping the reason: with the machine's real
+    // database at migration 31, `session_search` did not exist, every batch's
+    // index write failed, and — because #435 deliberately commits the index row
+    // and the insight row in **one transaction** — the insight write rolled back
+    // with it. The result was 0 insight rows over 1,178 sessions: this test's own
+    // headline failure, reported against a build that is fine, for a schema
+    // reason nothing in the message pointed at.
+    {
+        let mut conn = rusqlite::Connection::open(&db).expect("open");
+        agento_lib::native::migrate::apply(&mut conn).expect("migrate the copy");
+    }
+
     let cached = {
         let conn = rusqlite::Connection::open(&db).expect("open");
         scalar(&conn, "SELECT COUNT(*) FROM claude_session_cache")
@@ -177,5 +195,58 @@ fn every_cached_session_gains_an_insight_row() {
     assert!(
         breakdowns > 0,
         "no row has a tool breakdown, over a corpus of {cached} real sessions"
+    );
+
+    // ─── the search index (#435) ─────────────────────────────────────────────
+    //
+    // The same argument as everything above, for the table the same transaction
+    // writes: the index is populated by the *worker*, so a build whose indexer
+    // never runs leaves `session_search` empty while every count here still
+    // passes — and search simply answers nothing, which is indistinguishable
+    // from a corpus with nothing in it. That is #408's failure mode, one table
+    // to the right.
+    let indexed = scalar(&conn, "SELECT COUNT(*) FROM session_search");
+    eprintln!("index rows: {indexed}");
+    assert_eq!(
+        indexed, written,
+        "the index and the insights are written in one transaction, so their \
+         row counts cannot differ"
+    );
+
+    // Rows are not enough: a document whose columns are all empty is a row, and
+    // matches nothing. Requiring *most* rows to carry text rather than all of
+    // them, because a session really can be a single injected preamble with no
+    // indexable content at all.
+    let with_text = scalar(
+        &conn,
+        "SELECT COUNT(*) FROM session_search
+          WHERE user_text <> '' OR assistant_text <> '' OR tool_text <> ''",
+    );
+    assert!(
+        with_text * 2 > indexed,
+        "only {with_text} of {indexed} index rows carry any text — \
+         the rows are being written but not built"
+    );
+
+    // …and the text has to be *reachable through FTS5*, which is the only thing
+    // any of this is for. A stored column that the tokenizer never indexed would
+    // satisfy every assertion above.
+    let hits = scalar(
+        &conn,
+        "SELECT COUNT(*) FROM session_search WHERE session_search MATCH '\"the\"'",
+    );
+    assert!(
+        hits > 0,
+        "no session in a corpus of {cached} matches the commonest word in \
+         English — the column is stored but not searchable"
+    );
+
+    // The version is stamped, so the next boot does not rebuild the whole
+    // corpus again.
+    assert_eq!(
+        agento_lib::native::search::stored_version(&conn).expect("stored_version"),
+        agento_lib::native::search::SEARCH_INDEX_VERSION,
+        "the index was built but its version was never recorded, so every \
+         later sweep rebuilds it"
     );
 }


### PR DESCRIPTION
Closes #435. Part of epic #432, on top of #433 (FTS5 foundation) and #434 (the normalizer).

## What

`session_search` is now populated by the insight worker. The per-session pass builds the index document from the **same decoded transcript** the nine insight processors already consume, and writes it in the **same transaction** as the `session_insights` row — so indexing costs no additional file I/O and index freshness equals insight freshness.

## How

- **`insights/index.rs`** (new) — routes a decoded event's text into the three columns. `search::normalize` (#434) still owns all the *shaping*; this module only decides where text goes.
- **`processors::run`** takes a `&mut DocAccumulator` and `feed` observes each event alongside the processors. A parameter rather than a tenth `Processor`, because a `Processor` finalizes into a `SessionInsight`, which has nowhere to put three text columns — and because `PIPELINE`'s order is load-bearing for the numbers.
- **`store::select_pending`** gains a `Scope`, and **`store::display_title`** reads the cache row's title with the UI's own precedence.
- **`search::{insert, delete_orphans, stored_version, record_version}`** plus `SEARCH_INDEX_VERSION`.
- **`scan.rs`** reconciles the index beside the insights, after the delete pass.

## The rules that are silent when wrong

- **Routing is by content shape, never by `isSidechain`.** `is_user_turn_content` answers `false` to a `tool_result` carrier *and* to injected machinery, so the `tool_result` check has to come first and be its own — routing on the predicate alone drops every real tool result, and `tool_text` would still look populated (from `tool_use` blocks) while never containing an error message.
- **Everything keys on `(session_id, project_path)`** — the #362 family in its sixth form. `session_search` is a *new* table, so nothing forced the pair on it; keyed on the id alone, `replace`'s delete removes both projects' rows.
- **The reconcile keys on "no cache row remains", never on a path** (#245), and runs *after* the cache's delete pass so it inherits the unreadable-config-dir protection.
- **A `SEARCH_INDEX_VERSION` bump touches no scanner staleness marker**, so `claude_session_cache.file_mtime` is untouched and the scanner re-reads nothing.
- **An unreadable transcript is a skip, not a batch failure.** This looks lenient and is strict: every real corpus holds a session whose file has since been deleted, so counting a skip as failure would mean the version is never recorded on any real machine and the whole index rebuilds every five minutes for ever.
- **A rebuild empties the index once rather than replacing per session** — see performance below.

## Performance

`search::delete` is keyed on the UNINDEXED key columns, and FTS5's `xBestIndex` accepts only `rowid` and `MATCH`, so it is a **full scan of the `%_content` table** (~9.5 ms at 17 MB, ~63 ms at 176 MB, per call). Re-indexing a corpus with `replace` per session is therefore quadratic, inside a write transaction competing with the boot scan `lib.rs` starts two lines later.

A rebuild now calls `delete_all` once and uses the new `search::insert`. Measured over the real corpus: **1,178 sessions rebuild in 20.7s, down from 54s.**

That also removes the worse half of a silent failure — a session the rebuild skips now has *no* row, where per-session replacement left its previous row carrying the old format's text under a version stamp saying otherwise. Missing is recoverable; silently stale is not.

## Acceptance criteria

- [x] A session announced as changed has a fresh index row after one queue pass — asserted through `search::search`, not a row count.
- [x] Reconcile removes an index row only when no cache row remains; a claim-shifted session keeps one updated row.
- [x] Bumping `SEARCH_INDEX_VERSION` reindexes every session while every `file_mtime` is untouched.
- [x] Index write and `session_insights` write commit or fail together (fault-injected by dropping the table).
- [x] The #366 contended-write-lock pattern passes with indexing active — see the honesty note below.
- [x] Two cache rows sharing a `session_id` across projects produce two independent index rows, each with its own transcript's text.

## Verification

Each core rule was **falsified before being trusted** — every test below fails against the specific defect it exists to catch:

| Injected defect | Test that fails |
|---|---|
| index delete keyed on `session_id` alone | `one_session_id_under_two_projects_gets_two_index_rows`, `the_reconcile_drops_only_rows_with_no_cache_row` |
| insight and index in two transactions | `a_failed_index_write_rolls_back_the_insight_row_with_it` |
| rebuild never widens the sweep's scope | `a_version_bump_reindexes_without_touching_the_scanners_mtimes` |
| a skipped transcript counted as batch failure | `a_rebuild_completes_over_a_corpus_with_an_unreadable_transcript` |
| batch moved onto a runtime task | the contention test (ticker: ~150 advances → 0) |

**One honesty note.** The contended-write-lock test is named `a_contended_batch_still_commits_within_the_busy_timeout`, not for #366's property, because the worker owns an OS thread by construction and `run()` is an unexported infinite loop — so no change to non-test code can make it fail. It genuinely pins that a batch (which now writes two tables) still commits inside the 5s `busy_timeout` under outside contention. Making it falsifiable against production code needs a `run_once` extraction: #447.

Local gates: `npm run build`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --no-fail-fast` (14 suites, green on repeated runs), `cargo build --release` — all re-run after rebasing onto the two gateway PRs that landed mid-review (which added migration 34; this change adds none).

**Against the real corpus** (`cargo test --test insights_live -- --ignored`): 1,178 cached sessions → **1,178 insight rows and 1,178 index rows**, reachable through FTS5, version stamped, in ~21s.

That run also caught a harness gap this PR fixes: `insights_live.rs` started the worker on an **unmigrated** copy of the installed database. The machine's real database is at migration 31, where `session_search` does not exist — so every batch's index write failed and, because the two writes are deliberately one transaction, took the insight write with it. The test reported *0 insight rows over 1,178 sessions* against a build that was fine. Production is unaffected (`lib.rs` migrates at startup, long before `worker::start`), but the copy has to be migrated the same way.

## Deferred

- **#446** — per-row index version, so a rebuild retries the sessions it skipped. The global stamp cannot describe a partial rebuild: an unreadable-but-still-cached session stays unindexed until its transcript next changes.
- **#447** — `run_once` extraction, plus queue-path and `scan.rs` reconcile-wiring coverage.

Out of scope: query-side changes (#436), snippet/sort (#437), the UI (#438), and the `CLAUDE.md` update, which #435 defers to epic close.

One limitation recorded at `store::display_title`: `custom_title` is user-writable through `PATCH /api/claude-sessions/{id}`, which changes neither `file_mtime` nor `processor_version` — so a rename alone does not re-index; the title catches up the next time the transcript changes.