### PR TITLE
feat(search): FTS MATCH in add_search — safe query building + LIKE fallback (#436)

### DIFF
--- a/src-tauri/src/native/sessions/mod.rs
+++ b/src-tauri/src/native/sessions/mod.rs
@@ -196,6 +196,9 @@ fn serve(ctx: &Ctx, req: &Request) -> Result<Answer, String> {
 #[cfg(test)]
 mod tests_db;
 
+#[cfg(test)]
+mod tests_search;
+
 /// Whether this route is one that would have triggered a rescan in Go.
 ///
 /// A continuation — a request carrying a cursor — deliberately returns `false`,

--- a/src-tauri/src/native/sessions/page.rs
+++ b/src-tauri/src/native/sessions/page.rs
@@ -62,7 +62,12 @@ pub fn list_page(
     q: &SessionQuery,
 ) -> Result<SessionPage, String> {
     let (expr, is_time) = q.sort.expr();
-    let mut filter = build_filter(q, &settings.hidden_projects, &settings.indexed_config_dirs)?;
+    let mut filter = build_filter(
+        conn,
+        q,
+        &settings.hidden_projects,
+        &settings.indexed_config_dirs,
+    )?;
 
     if let Some(cur) = Cursor::decode(&q.cursor, q.sort)? {
         let bound = cur.bind(is_time)?;
@@ -142,7 +147,12 @@ pub fn facets(
     settings: &DataSettings,
     q: &SessionQuery,
 ) -> Result<SessionFacets, String> {
-    let filter = build_filter(q, &settings.hidden_projects, &settings.indexed_config_dirs)?;
+    let filter = build_filter(
+        conn,
+        q,
+        &settings.hidden_projects,
+        &settings.indexed_config_dirs,
+    )?;
     let where_clause = filter.where_clause();
 
     let totals_sql = format!(

--- a/src-tauri/src/native/sessions/query.rs
+++ b/src-tauri/src/native/sessions/query.rs
@@ -458,30 +458,47 @@ fn add_search(conn: &Connection, f: &mut Filter, text: &str) {
 /// an expression FTS5 refuses fails on the *first step* — and an unstepped
 /// statement never parses the MATCH argument at all. Stepping once against the
 /// inverted index is what a hit costs anyway.
+///
+/// The two failures are logged differently on purpose, and neither line carries
+/// the user's search text — `proxy.rs` keeps query strings out of this file, and
+/// FTS5's own syntax-error message quotes the text it choked on.
 fn usable_fts_query(conn: &Connection, text: &str) -> Option<String> {
     let query = build_fts_query(text);
     if query.is_empty() {
         return None;
     }
-    let probe = conn
-        .prepare("SELECT 1 FROM session_search WHERE session_search MATCH ?1 LIMIT 1")
-        .and_then(|mut stmt| stmt.exists(rusqlite::params![query]));
-    match probe {
-        Ok(_) => Some(query),
-        // Debug rather than warn: on a database with no index this is the
-        // ordinary answer for every keystroke, and a warning per keystroke is
-        // how a log stops being read.
-        Err(e) => {
-            log::debug!("claude sessions: search index unavailable, matching metadata only: {e}");
-            None
-        }
+    let mut stmt =
+        match conn.prepare("SELECT 1 FROM session_search WHERE session_search MATCH ?1 LIMIT 1") {
+            Ok(stmt) => stmt,
+            // Debug, and with the cause: on a database that has not migrated
+            // this is the ordinary answer for every keystroke, and a warning per
+            // keystroke is how a log stops being read. The message names the
+            // missing table, nothing the user typed.
+            Err(e) => {
+                log::debug!("claude sessions: no search index, matching metadata only: {e}");
+                return None;
+            }
+        };
+    if stmt.exists(rusqlite::params![&query]).is_err() {
+        // Warn, and *without* the cause: `build_fts_query` is meant to make this
+        // unreachable, so reaching it is a defect worth seeing rather than
+        // routine degradation — and the one thing rusqlite would tell us here is
+        // the FTS5 message, which quotes the search term back.
+        log::warn!(
+            "claude sessions: the search index refused a built query, matching metadata only"
+        );
+        return None;
     }
+    Some(query)
 }
 
-/// Below this, a trailing token is not extended into a prefix term.
+/// How many *alphanumeric* characters a trailing token needs before it is
+/// extended into a prefix term.
 ///
 /// `"a"*` matches roughly every session on the machine, so the first keystroke
-/// of a query would flash the whole corpus in and out.
+/// of a query would flash the whole corpus in and out. Counted over the
+/// alphanumerics rather than the whole token because those are what `unicode61`
+/// keeps: on the raw length, `-a` would clear the bar and still produce `a*`.
 const MIN_PREFIX_LEN: usize = 2;
 
 /// Turn what a user typed into an FTS5 query that can only ever be a conjunction
@@ -559,7 +576,8 @@ pub fn build_fts_query(text: &str) -> String {
         // because of how the loop above happens to be written.
         out.push_str(&text.replace('"', "\"\""));
         out.push('"');
-        if i == last && !closed && text.chars().count() >= MIN_PREFIX_LEN {
+        let terms = text.chars().filter(|c| c.is_alphanumeric()).count();
+        if i == last && !closed && terms >= MIN_PREFIX_LEN {
             out.push('*');
         }
     }
@@ -947,7 +965,9 @@ mod tests {
             ("wild*card", r#""wild*card"*"#),
             ("(group)", r#""(group)"*"#),
             ("col:val", r#""col:val"*"#),
-            ("NEAR(a b)", r#""NEAR(a" "b)"*"#),
+            // `b)` is two characters and one term, so it stays below the
+            // prefix bar — see `MIN_PREFIX_LEN`.
+            ("NEAR(a b)", r#""NEAR(a" "b)""#),
             // A lone quote opens a span that never closes and holds nothing.
             ("\"", ""),
             ("a\"", r#""a""#),
@@ -987,6 +1007,11 @@ mod tests {
         assert_eq!(build_fts_query("a"), r#""a""#);
         assert_eq!(build_fts_query("ab"), r#""ab"*"#);
         assert_eq!(build_fts_query("auth a"), r#""auth" "a""#);
+        // The bar is the alphanumerics, not the token's length: `-a` is two
+        // characters and one term, and `"-a"*` is the `a*` this rule exists to
+        // prevent.
+        assert_eq!(build_fts_query("-a"), r#""-a""#);
+        assert_eq!(build_fts_query("-ab"), r#""-ab"*"#);
     }
 
     /// A NUL reaching FTS5's parser is an error, and `%00` in a query string

--- a/src-tauri/src/native/sessions/query.rs
+++ b/src-tauri/src/native/sessions/query.rs
@@ -456,8 +456,16 @@ fn add_search(conn: &Connection, f: &mut Filter, text: &str) {
 /// session_search LIMIT 0` existence check, because the two failures it has to
 /// catch surface at different points: a missing table fails the *prepare*, while
 /// an expression FTS5 refuses fails on the *first step* — and an unstepped
-/// statement never parses the MATCH argument at all. Stepping once against the
-/// inverted index is what a hit costs anyway.
+/// statement never parses the MATCH argument at all — including against an
+/// **empty** index, which is what a fresh install has and where a probe that
+/// short-circuited would accept anything
+/// (`the_probe_still_rejects_a_bad_expression_against_an_empty_index`).
+///
+/// The cost is one extra inverted-index lookup per `build_filter`, i.e. one per
+/// call of `GET /api/claude-sessions` and one per `…/facets` — the same lookup
+/// the clause itself then performs, stopped at the first row. Worth knowing
+/// before #437, which composes this as a ranked join and may want to fold the
+/// two together.
 ///
 /// The two failures are logged differently on purpose, and neither line carries
 /// the user's search text — `proxy.rs` keeps query strings out of this file, and
@@ -522,7 +530,8 @@ const MIN_PREFIX_LEN: usize = 2;
 ///   unterminated quote is a phrase too — it is what half-typing one looks like.
 /// * **The final token becomes a prefix term** (`"efficien"*`) so the list
 ///   narrows as the user types, unless the user closed a quote — which says the
-///   word is finished — or the token is shorter than [`MIN_PREFIX_LEN`].
+///   word is finished — or the token carries fewer than [`MIN_PREFIX_LEN`]
+///   alphanumerics.
 /// * **Control characters are separators.** They are separators to `unicode61`
 ///   anyway, so this changes no result — but a NUL reaching FTS5's parser is an
 ///   error (`unterminated string`), and `%00` in a query string decodes to one.
@@ -576,8 +585,10 @@ pub fn build_fts_query(text: &str) -> String {
         // because of how the loop above happens to be written.
         out.push_str(&text.replace('"', "\"\""));
         out.push('"');
-        let terms = text.chars().filter(|c| c.is_alphanumeric()).count();
-        if i == last && !closed && terms >= MIN_PREFIX_LEN {
+        if i == last
+            && !closed
+            && text.chars().filter(|c| c.is_alphanumeric()).count() >= MIN_PREFIX_LEN
+        {
             out.push('*');
         }
     }

--- a/src-tauri/src/native/sessions/query.rs
+++ b/src-tauri/src/native/sessions/query.rs
@@ -14,10 +14,12 @@
 
 use std::collections::HashMap;
 
+use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 
 use crate::native::gojson;
 use crate::native::gotime::GoTime;
+use crate::native::search;
 
 /// Per-session figures as SQL over the summary select's `c` (session) and `sa`
 /// (sub-agent roll-up) aliases. Every one but `messages` sums the main thread
@@ -310,7 +312,12 @@ impl Filter {
 /// Turn a query into its WHERE clause, excluding pagination — the same
 /// predicate serves the page, the facet aggregate and the total count, so the
 /// counter in the toolbar and the rows below it cannot disagree.
+///
+/// `conn` is read only to decide whether the search term can go through the
+/// full-text index — see [`add_search`]. Every other term is a pure function of
+/// `q`.
 pub fn build_filter(
+    conn: &Connection,
     q: &SessionQuery,
     hidden_projects: &[String],
     indexed_dirs: &[String],
@@ -340,7 +347,7 @@ pub fn build_filter(
     if !q.model.is_empty() {
         f.add("c.model = ?", vec![Value::Text(q.model.clone())]);
     }
-    add_search(&mut f, &q.search);
+    add_search(conn, &mut f, &q.search);
     add_links(&mut f, q.links);
 
     add_range(&mut f, SQL_MESSAGE_COUNT, q.messages, 1.0);
@@ -371,26 +378,192 @@ pub fn add_config_dir_scope(f: &mut Filter, dirs: &[String]) {
     );
 }
 
-/// Match the same fields the client-side predicate did, case-insensitively.
+/// The six metadata columns the list has always matched, case-insensitively.
 ///
 /// `LOWER` on both sides rather than `COLLATE NOCASE`, because NOCASE is
-/// ASCII-only in SQLite and project paths and titles are not.
-fn add_search(f: &mut Filter, search: &str) {
-    let q = search.trim().to_lowercase();
-    if q.is_empty() {
-        return;
-    }
-    // Bound, not interpolated, so % and _ typed by the user match literally.
-    let pattern = format!("%{}%", escape_like(&q));
-    f.add(
-        r"(LOWER(c.session_id) LIKE ? ESCAPE '\'
+/// ASCII-only in SQLite and project paths and titles are not. Six `?`, in this
+/// order, all bound to the same pattern.
+const LIKE_COLUMNS: &str = r"LOWER(c.session_id) LIKE ? ESCAPE '\'
     OR LOWER(c.preview) LIKE ? ESCAPE '\'
     OR LOWER(c.custom_title) LIKE ? ESCAPE '\'
     OR LOWER(c.native_title) LIKE ? ESCAPE '\'
     OR LOWER(c.ai_title) LIKE ? ESCAPE '\'
-    OR LOWER(c.project_path) LIKE ? ESCAPE '\')",
-        vec![Value::Text(pattern); 6],
+    OR LOWER(c.project_path) LIKE ? ESCAPE '\'";
+
+/// Match the search term against the full-text index **or** the six metadata
+/// columns.
+///
+/// One `Filter` clause, deliberately: facets, the config-dir scope, every
+/// numeric and time bound and the keyset predicate all compose through the same
+/// funnel, so adding a term here is the whole change and nothing downstream has
+/// to know a content index exists.
+///
+/// The two halves are OR'd rather than one replacing the other, because they
+/// answer different questions and neither is a superset:
+///
+/// * the index holds a session's **content**, which the cache row never has —
+///   only a 120-char `preview` is stored;
+/// * the LIKE clause matches the **session id**, the **project path** and the
+///   titles, which are UNINDEXED in `session_search` and so can never be a
+///   content hit — and it matches sessions the worker has not indexed yet, which
+///   on a fresh install is all of them.
+///
+/// # The FTS half degrades rather than failing
+///
+/// A user's text reaches FTS5's own query grammar, where `-`, `OR`, `NOT`, `^`,
+/// `*`, `:` and `"` are operators. [`build_fts_query`] neutralizes them by
+/// quoting each token, which is a construction rule and not a sanitization one —
+/// but "the builder can never produce a syntax error" is a claim about a parser
+/// this code does not own, so it is *checked* rather than trusted: the built
+/// expression is run against the index once, and anything that errors (a missing
+/// table on a database that has not migrated, a query FTS5 refuses) falls back to
+/// the LIKE-only clause this route answered with before #436. Search must never
+/// answer 500 because of a character somebody typed.
+fn add_search(conn: &Connection, f: &mut Filter, text: &str) {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+    // Bound, not interpolated, so % and _ typed by the user match literally.
+    let pattern = format!("%{}%", escape_like(&trimmed.to_lowercase()));
+    let like_args = vec![Value::Text(pattern); 6];
+
+    let Some(fts) = usable_fts_query(conn, trimmed) else {
+        f.add(format!("({LIKE_COLUMNS})"), like_args);
+        return;
+    };
+
+    // The subquery is re-projected to two columns: `match_sql()` also selects
+    // `rank`, which #437 orders by and a row-value `IN` cannot accept.
+    let mut args = vec![Value::Text(fts)];
+    args.extend(like_args);
+    f.add(
+        format!(
+            "((c.session_id, c.project_path) IN (
+      SELECT session_id, project_path FROM (
+{}
+      ))
+    OR {LIKE_COLUMNS})",
+            search::match_sql()
+        ),
+        args,
     );
+}
+
+/// The FTS expression for `search`, or `None` when the index cannot answer it.
+///
+/// The probe is a real prepare-and-step rather than a `SELECT 1 FROM
+/// session_search LIMIT 0` existence check, because the two failures it has to
+/// catch surface at different points: a missing table fails the *prepare*, while
+/// an expression FTS5 refuses fails on the *first step* — and an unstepped
+/// statement never parses the MATCH argument at all. Stepping once against the
+/// inverted index is what a hit costs anyway.
+fn usable_fts_query(conn: &Connection, text: &str) -> Option<String> {
+    let query = build_fts_query(text);
+    if query.is_empty() {
+        return None;
+    }
+    let probe = conn
+        .prepare("SELECT 1 FROM session_search WHERE session_search MATCH ?1 LIMIT 1")
+        .and_then(|mut stmt| stmt.exists(rusqlite::params![query]));
+    match probe {
+        Ok(_) => Some(query),
+        // Debug rather than warn: on a database with no index this is the
+        // ordinary answer for every keystroke, and a warning per keystroke is
+        // how a log stops being read.
+        Err(e) => {
+            log::debug!("claude sessions: search index unavailable, matching metadata only: {e}");
+            None
+        }
+    }
+}
+
+/// Below this, a trailing token is not extended into a prefix term.
+///
+/// `"a"*` matches roughly every session on the machine, so the first keystroke
+/// of a query would flash the whole corpus in and out.
+const MIN_PREFIX_LEN: usize = 2;
+
+/// Turn what a user typed into an FTS5 query that can only ever be a conjunction
+/// of literal terms.
+///
+/// **Safe by construction, not by sanitization.** Nothing typed is ever passed
+/// through: the input is split into tokens and each token is *re-emitted* inside
+/// a double-quoted FTS5 string, where the grammar has no operators at all. So
+/// `-foo`, `a OR b`, `NOT`, `^x`, `a*b`, `(a)` and `a:b` are terms rather than
+/// syntax, and the function has no notion of "a character to escape" that a
+/// future FTS5 could add to.
+///
+/// The rules, in the order a user meets them:
+///
+/// * **Whitespace separates tokens, and tokens are AND'd** — FTS5's implicit
+///   operator between two phrases. `fix auth bug` finds a session containing all
+///   three words in any order, which is what the old single `LIKE '%fix auth
+///   bug%'` substring could not do.
+/// * **A user-typed `"…"` span is kept as one phrase**, so quoting is the one
+///   piece of query syntax that still means what people expect it to. An
+///   unterminated quote is a phrase too — it is what half-typing one looks like.
+/// * **The final token becomes a prefix term** (`"efficien"*`) so the list
+///   narrows as the user types, unless the user closed a quote — which says the
+///   word is finished — or the token is shorter than [`MIN_PREFIX_LEN`].
+/// * **Control characters are separators.** They are separators to `unicode61`
+///   anyway, so this changes no result — but a NUL reaching FTS5's parser is an
+///   error (`unterminated string`), and `%00` in a query string decodes to one.
+/// * **A token with no alphanumeric character is dropped.** `unicode61` indexes
+///   alphanumerics and treats everything else as a separator, so `"-"` is a
+///   phrase of *zero* terms — which matches no document, and AND'd with the rest
+///   empties the whole result. Without this, one stray dash in `fix auth -` costs
+///   the user every hit. Dropping can only widen the FTS half, and it discards
+///   nothing that could ever have matched; the LIKE half still sees the raw
+///   text, so a search for `---` is unaffected.
+///
+/// Returns an empty string when nothing survives — an input of only separators.
+/// An empty MATCH argument is itself a syntax error, so the caller reads that as
+/// "no FTS half" rather than passing it on.
+pub fn build_fts_query(text: &str) -> String {
+    // (text, the user closed a quote around it)
+    let mut tokens: Vec<(String, bool)> = Vec::new();
+    let mut buf = String::new();
+    let mut in_quote = false;
+
+    for raw in text.chars() {
+        let ch = if raw.is_control() { ' ' } else { raw };
+        if in_quote {
+            if ch == '"' {
+                tokens.push((std::mem::take(&mut buf), true));
+                in_quote = false;
+            } else {
+                buf.push(ch);
+            }
+        } else if ch == '"' {
+            tokens.push((std::mem::take(&mut buf), false));
+            in_quote = true;
+        } else if ch.is_whitespace() {
+            tokens.push((std::mem::take(&mut buf), false));
+        } else {
+            buf.push(ch);
+        }
+    }
+    tokens.push((buf, false));
+    tokens.retain(|(text, _)| text.chars().any(char::is_alphanumeric));
+
+    let last = tokens.len().saturating_sub(1);
+    let mut out = String::new();
+    for (i, (text, closed)) in tokens.iter().enumerate() {
+        if i > 0 {
+            out.push(' ');
+        }
+        out.push('"');
+        // A `"` cannot reach here — one opens or closes a span — but the escape
+        // is what makes the emitter safe on its own terms rather than safe
+        // because of how the loop above happens to be written.
+        out.push_str(&text.replace('"', "\"\""));
+        out.push('"');
+        if i == last && !closed && text.chars().count() >= MIN_PREFIX_LEN {
+            out.push('*');
+        }
+    }
+    out
 }
 
 /// Neutralize LIKE's wildcards so a search for "100%" does not match
@@ -745,5 +918,94 @@ mod tests {
         assert_eq!(escape_like("100%"), r"100\%");
         assert_eq!(escape_like("a_b"), r"a\_b");
         assert_eq!(escape_like(r"back\slash"), r"back\\slash");
+    }
+
+    /// Whitespace separates, tokens are AND'd, and the last one is a prefix.
+    #[test]
+    fn an_fts_query_ands_one_quoted_term_per_word() {
+        assert_eq!(build_fts_query("fix auth bug"), r#""fix" "auth" "bug"*"#);
+        assert_eq!(build_fts_query("  spaced   out  "), r#""spaced" "out"*"#);
+        assert_eq!(build_fts_query("single"), r#""single"*"#);
+    }
+
+    /// Every character FTS5 treats as syntax is re-emitted inside a quoted
+    /// string, so it reaches the tokenizer as text.
+    ///
+    /// The table is the acceptance criterion written out: `- * ^ ( ) : "` and
+    /// the bare boolean keywords. What each *matches* is the tokenizer's
+    /// business — what matters here is that none of them can still be an
+    /// operator, and none of them can end a string early.
+    #[test]
+    fn every_fts_metacharacter_is_emitted_as_a_literal_term() {
+        for (input, want) in [
+            ("-foo", r#""-foo"*"#),
+            ("foo -bar", r#""foo" "-bar"*"#),
+            ("a OR b", r#""a" "OR" "b""#),
+            ("NOT auth", r#""NOT" "auth"*"#),
+            ("a AND b", r#""a" "AND" "b""#),
+            ("^start", r#""^start"*"#),
+            ("wild*card", r#""wild*card"*"#),
+            ("(group)", r#""(group)"*"#),
+            ("col:val", r#""col:val"*"#),
+            ("NEAR(a b)", r#""NEAR(a" "b)"*"#),
+            // A lone quote opens a span that never closes and holds nothing.
+            ("\"", ""),
+            ("a\"", r#""a""#),
+            // A token of pure punctuation is a phrase of zero terms, which
+            // would AND the whole query down to nothing.
+            ("auth *", r#""auth"*"#),
+            ("-", ""),
+            ("fix auth ---", r#""fix" "auth"*"#),
+        ] {
+            assert_eq!(build_fts_query(input), want, "input {input:?}");
+        }
+    }
+
+    /// A user-typed phrase is the one piece of query syntax kept, because it is
+    /// the one people mean.
+    #[test]
+    fn a_user_typed_phrase_stays_one_phrase() {
+        assert_eq!(
+            build_fts_query("\"auth failed\" retry"),
+            r#""auth failed" "retry"*"#
+        );
+        // Closing the quote says the word is finished, so no prefix is added.
+        assert_eq!(build_fts_query("\"auth failed\""), r#""auth failed""#);
+        // Half-typed, though, is still as-you-type.
+        assert_eq!(build_fts_query("\"auth fail"), r#""auth fail"*"#);
+        // A doubled quote in the *input* is not read as FTS5's escape — every
+        // `"` opens or closes a span, so this is two phrases. That is the point
+        // of quoting on the way out rather than interpreting on the way in:
+        // there is no input spelling that reaches the grammar.
+        assert_eq!(build_fts_query("\"say \"\"hi\""), r#""say " "hi""#);
+    }
+
+    /// `"a"*` matches most of a corpus, so the first keystroke must not flash
+    /// every session into the list.
+    #[test]
+    fn a_one_character_final_token_is_not_extended_into_a_prefix() {
+        assert_eq!(build_fts_query("a"), r#""a""#);
+        assert_eq!(build_fts_query("ab"), r#""ab"*"#);
+        assert_eq!(build_fts_query("auth a"), r#""auth" "a""#);
+    }
+
+    /// A NUL reaching FTS5's parser is an error, and `%00` in a query string
+    /// decodes to one — so control characters are separators here, which is
+    /// what they already are to `unicode61`.
+    #[test]
+    fn control_characters_are_separators_rather_than_text() {
+        assert_eq!(build_fts_query("fix\u{0}auth"), r#""fix" "auth"*"#);
+        assert_eq!(build_fts_query("line\nbreak"), r#""line" "break"*"#);
+        assert_eq!(build_fts_query("\u{0}"), "");
+        assert_eq!(build_fts_query("tab\tsep"), r#""tab" "sep"*"#);
+    }
+
+    /// Nothing left to search for is not an empty query — an empty MATCH
+    /// argument is a syntax error, so it has to read as "no FTS half".
+    #[test]
+    fn an_input_of_only_separators_produces_no_expression() {
+        for input in ["\"\"", "\"\"\"\"", " ", "\u{0}\u{1}", "-", "***", "()", ":"] {
+            assert_eq!(build_fts_query(input), "", "input {input:?}");
+        }
     }
 }

--- a/src-tauri/src/native/sessions/tests_db.rs
+++ b/src-tauri/src/native/sessions/tests_db.rs
@@ -582,6 +582,7 @@ fn a_drilldown_window_replaces_the_range_rather_than_narrowing_it() {
     }]);
 
     let filter = build_filter(
+        &conn,
         &SessionQuery::parse("windows=1000-2000&from=2026-01-01T00:00:00Z").expect("parse"),
         &[],
         &[],
@@ -602,8 +603,47 @@ fn a_drilldown_window_replaces_the_range_rather_than_narrowing_it() {
         2,
         "one window binds exactly its two ends"
     );
+}
 
-    let _ = conn;
+/// The search answers exactly as it did before #436 on a database with no
+/// `session_search` table — which is what this whole fixture is, since `SCHEMA`
+/// above is the pre-#436 subset. It is the honest form of the degradation case:
+/// `tests_search.rs` can only reach it by dropping a table it created, which
+/// leaves the migration behind and could mask a difference between "never
+/// existed" and "removed".
+///
+/// The six metadata columns still match, and nothing errors.
+#[test]
+fn a_search_still_matches_metadata_with_no_index_table() {
+    let conn = fixture(&[
+        TestSession {
+            id: "wanted",
+            project: "/home/u/alpha",
+            ..Default::default()
+        },
+        TestSession {
+            id: "other",
+            project: "/home/u/beta",
+            ..Default::default()
+        },
+    ]);
+
+    let q = SessionQuery::parse("q=wanted").expect("parse");
+    let page = list_page(&conn, &no_settings(), &q).expect("page");
+    assert_eq!(
+        page.items.iter().map(|s| &s.session_id).collect::<Vec<_>>(),
+        vec!["wanted"]
+    );
+    // And the toolbar's counters agree, over the same predicate.
+    assert_eq!(facets(&conn, &no_settings(), &q).expect("facets").total, 1);
+
+    // A multi-word query is still the old substring match: nothing here can
+    // answer word-order-independently, and it must not error trying.
+    let words = SessionQuery::parse("q=alpha+wanted").expect("parse");
+    assert!(list_page(&conn, &no_settings(), &words)
+        .expect("page")
+        .items
+        .is_empty());
 }
 
 #[test]

--- a/src-tauri/src/native/sessions/tests_search.rs
+++ b/src-tauri/src/native/sessions/tests_search.rs
@@ -491,3 +491,33 @@ fn the_search_clause_keys_on_the_pair_not_the_session_id() {
         "the other project's row shares the id but not the content"
     );
 }
+
+/// The availability probe has to reject a bad expression against an **empty**
+/// index, not just a populated one.
+///
+/// `usable_fts_query` learns that an expression is invalid by stepping the
+/// statement, and it would be sound to imagine SQLite short-circuiting a query
+/// over a table with no rows without ever asking FTS5 to parse the MATCH
+/// argument. If it did, the probe would accept anything on a fresh install —
+/// which is exactly the machine where the index is empty — and the *real* query
+/// would then error, turning the fallback this issue is built on into a 500 for
+/// the one user it most needs to protect. It does not; pinned here rather than
+/// assumed, because it is a property of SQLite rather than of this code.
+#[test]
+fn the_probe_still_rejects_a_bad_expression_against_an_empty_index() {
+    let conn = migrated();
+    let mut stmt = conn
+        .prepare("SELECT 1 FROM session_search WHERE session_search MATCH ?1 LIMIT 1")
+        .expect("prepare");
+
+    assert!(
+        stmt.exists(params!["\"unterminated"]).is_err(),
+        "an empty index must still parse the MATCH argument"
+    );
+    assert!(
+        !stmt
+            .exists(params!["\"auth\""])
+            .expect("a valid expression answers"),
+        "and a valid one is simply a miss"
+    );
+}

--- a/src-tauri/src/native/sessions/tests_search.rs
+++ b/src-tauri/src/native/sessions/tests_search.rs
@@ -177,7 +177,7 @@ fn a_session_with_no_index_row_still_matches_on_its_metadata() {
 /// The two halves are a union, and a query hitting one session through each
 /// returns both.
 #[test]
-fn the_index_and_the_metadata_clause_are_ord_together() {
+fn the_index_and_the_metadata_clause_are_a_union() {
     let conn = corpus();
     let mut ids = found(&conn, "q=auth");
     ids.sort();
@@ -309,6 +309,13 @@ fn the_last_word_matches_as_a_prefix() {
 /// alphabet is every character FTS5's grammar reads plus the ones that broke a
 /// draft of this — a NUL (reachable as `%00` in a query string, and an
 /// `unterminated string` error to FTS5's parser) and whitespace.
+///
+/// (1) runs over every case; (2) runs over the hand-written ones and every
+/// string of length ≤2, because `facets` alone is seven statements and the two
+/// endpoints together take the exhaustive length-3 sweep from ~1s to ~12s on
+/// every `cargo test`. What they cover is the same seam — a `Filter` whose
+/// arguments do not line up with its `?`s — and that is a property of the clause
+/// rather than of the input.
 #[test]
 fn no_input_string_can_make_the_search_error() {
     let conn = corpus();
@@ -336,6 +343,9 @@ fn no_input_string_can_make_the_search_error() {
         "a".repeat(2000),
         "\"".repeat(64),
     ];
+    // Everything above goes through both assertions.
+    let end_to_end = inputs.len();
+
     // Every string of length 1..=3 over the alphabet, walked as a mixed-radix
     // counter — 22 + 484 + 10,648 cases, exhaustive rather than sampled.
     let n = alphabet.len();
@@ -351,7 +361,7 @@ fn no_input_string_can_make_the_search_error() {
         }
     }
 
-    for raw in &inputs {
+    for (i, raw) in inputs.iter().enumerate() {
         let expr = build_fts_query(raw);
         if !expr.is_empty() {
             search::search(&conn, &expr, 1).unwrap_or_else(|e| {
@@ -359,6 +369,9 @@ fn no_input_string_can_make_the_search_error() {
             });
         }
 
+        if i >= end_to_end && raw.chars().count() > 2 {
+            continue;
+        }
         // Straight through the query struct rather than through a URL, so a
         // byte percent-encoding would refuse is still exercised.
         let q = SessionQuery {

--- a/src-tauri/src/native/sessions/tests_search.rs
+++ b/src-tauri/src/native/sessions/tests_search.rs
@@ -1,0 +1,480 @@
+//! The sessions list's search, over a real `session_search` index (#436).
+//!
+//! Separate from `tests_db.rs` on purpose, and the separation is itself an
+//! assertion. `tests_db`'s fixture is a hand-written subset schema with **no
+//! `session_search` table**, so a search driven through it is the degradation
+//! case on a database that genuinely lacks the index rather than one this suite
+//! dropped it from — `a_search_still_matches_metadata_with_no_index_table` is
+//! that test, and it lives over there for that reason. These tests are the other
+//! half: they build their database with `migrate::apply`, so the FTS5 table is
+//! migration 33's own DDL rather than a second spelling of it that could drift.
+//!
+//! What is deliberately *not* here: anything about ranking. #436 composes a
+//! membership test; the score is #437's, and `native::search`'s own tests
+//! already pin it.
+
+use rusqlite::{params, Connection};
+
+use super::page::{facets, list_page};
+use super::query::{build_fts_query, SessionQuery};
+use crate::native::migrate;
+use crate::native::search::{self, SearchDoc};
+use crate::native::settings::DataSettings;
+
+/// A migrated database — the schema the app actually runs on.
+fn migrated() -> Connection {
+    let mut conn = Connection::open_in_memory().expect("in-memory database");
+    migrate::apply(&mut conn).expect("apply migrations");
+    conn
+}
+
+/// One cache row, with the metadata columns the LIKE clause reads.
+fn session(
+    conn: &Connection,
+    session_id: &str,
+    project_path: &str,
+    preview: &str,
+    native_title: &str,
+) {
+    conn.execute(
+        "INSERT INTO claude_session_cache
+             (session_id, project_path, file_path, file_mtime, start_time, last_activity,
+              preview, native_title)
+         VALUES (?1, ?2, ?3, '2026-08-01 10:00:00 +0000 UTC',
+                 '2026-08-01 10:00:00 +0000 UTC', '2026-08-01 12:00:00 +0000 UTC', ?4, ?5)",
+        params![
+            session_id,
+            project_path,
+            format!("{project_path}/{session_id}.jsonl"),
+            preview,
+            native_title,
+        ],
+    )
+    .expect("insert session");
+}
+
+/// Index one session's content. Hand-populated rather than produced by the
+/// worker, which is what makes this suite independent of #435.
+fn index(conn: &Connection, session_id: &str, project_path: &str, user_text: &str) {
+    search::replace(
+        conn,
+        &SearchDoc {
+            session_id: session_id.to_string(),
+            project_path: project_path.to_string(),
+            user_text: user_text.to_string(),
+            ..Default::default()
+        },
+    )
+    .expect("index");
+}
+
+fn query(q: &str) -> SessionQuery {
+    SessionQuery::parse(q).expect("parse query")
+}
+
+/// The session ids one search returns, in page order.
+fn found(conn: &Connection, q: &str) -> Vec<String> {
+    list_page(conn, &DataSettings::default(), &query(q))
+        .expect("page")
+        .items
+        .into_iter()
+        .map(|s| s.session_id)
+        .collect()
+}
+
+/// A corpus whose sessions are distinguishable by *where* their text lives:
+/// `content-only` is findable only through the index, `metadata-only` only
+/// through the LIKE clause, and `unindexed` has no index row at all.
+fn corpus() -> Connection {
+    let conn = migrated();
+
+    session(&conn, "content-only", "/home/u/alpha", "", "");
+    index(
+        &conn,
+        "content-only",
+        "/home/u/alpha",
+        "please fix the auth bug in the login handler",
+    );
+
+    session(
+        &conn,
+        "metadata-only",
+        "/home/u/beta",
+        "a preview mentioning auth",
+        "",
+    );
+    index(&conn, "metadata-only", "/home/u/beta", "unrelated content");
+
+    session(&conn, "unindexed", "/home/u/gamma", "", "auth in the title");
+
+    session(&conn, "quiet", "/home/u/delta", "", "");
+    index(&conn, "quiet", "/home/u/delta", "nothing of interest here");
+
+    conn
+}
+
+/// The acceptance criterion this issue exists for: all words, any order.
+///
+/// The old single `LIKE '%fix auth bug%'` could only match the words in the
+/// order they were typed and adjacent, so every one of these but the first was
+/// a miss.
+#[test]
+fn a_multi_word_search_matches_all_words_in_any_order() {
+    let conn = corpus();
+
+    for q in ["fix+auth+bug", "bug+auth+fix", "auth+bug", "login+auth"] {
+        assert_eq!(
+            found(&conn, &format!("q={q}")),
+            vec!["content-only"],
+            "query {q}"
+        );
+    }
+}
+
+/// AND, not OR: one word the session does not contain excludes it.
+#[test]
+fn every_word_must_match_not_just_one() {
+    let conn = corpus();
+    assert!(
+        found(&conn, "q=auth+quasarflux").is_empty(),
+        "a word nothing contains must exclude the session"
+    );
+}
+
+/// Content is what the index adds, and it is invisible to the six metadata
+/// columns — this session's cache row holds none of these words.
+#[test]
+fn content_is_findable_and_was_not_before() {
+    let conn = corpus();
+    assert_eq!(found(&conn, "q=handler"), vec!["content-only"]);
+
+    // The same query with the index dropped finds nothing, which is what the
+    // list did before #436 — so the assertion above is about the index rather
+    // than about some other column happening to hold the word.
+    conn.execute("DROP TABLE session_search", [])
+        .expect("drop the index");
+    assert!(found(&conn, "q=handler").is_empty());
+}
+
+/// The LIKE half stays OR'd in, so the three things the index cannot answer
+/// still match: the session id and project path (UNINDEXED in `session_search`),
+/// and a session the worker has not reached — which on a fresh install is all
+/// of them.
+#[test]
+fn a_session_with_no_index_row_still_matches_on_its_metadata() {
+    let conn = corpus();
+
+    // No index row at all.
+    assert_eq!(found(&conn, "q=title"), vec!["unindexed"]);
+    // Preview, on a session whose indexed content says something else.
+    assert_eq!(found(&conn, "q=preview"), vec!["metadata-only"]);
+    // The session id itself.
+    assert_eq!(found(&conn, "q=metadata-only"), vec!["metadata-only"]);
+    // The project path.
+    assert_eq!(found(&conn, "q=gamma"), vec!["unindexed"]);
+}
+
+/// The two halves are a union, and a query hitting one session through each
+/// returns both.
+#[test]
+fn the_index_and_the_metadata_clause_are_ord_together() {
+    let conn = corpus();
+    let mut ids = found(&conn, "q=auth");
+    ids.sort();
+    assert_eq!(ids, vec!["content-only", "metadata-only", "unindexed"]);
+}
+
+/// With `session_search` gone the list answers exactly as it did before #436 —
+/// no error, no 500, and the metadata match is untouched.
+#[test]
+fn with_the_index_table_dropped_search_answers_as_it_did_before() {
+    let conn = corpus();
+    conn.execute("DROP TABLE session_search", [])
+        .expect("drop the index");
+
+    let mut ids = found(&conn, "q=auth");
+    ids.sort();
+    assert_eq!(
+        ids,
+        vec!["metadata-only", "unindexed"],
+        "only the six metadata columns are left"
+    );
+    // And the facets over the same predicate agree rather than erroring.
+    let f = facets(&conn, &DataSettings::default(), &query("q=auth")).expect("facets");
+    assert_eq!(f.total, 2);
+}
+
+/// A `%` or `_` typed by a user is still a literal to the LIKE half. The FTS
+/// half cannot see them at all — `unicode61` drops both — so the metadata
+/// behaviour is the whole of this, and it is what
+/// `search_wildcards_are_escaped_so_they_match_literally` pins at the string
+/// level.
+#[test]
+fn like_wildcards_are_still_literal_with_the_index_present() {
+    let conn = migrated();
+    session(&conn, "s-percent", "/p", "100% done", "");
+    session(&conn, "s-plain", "/p", "1000 things", "");
+    index(&conn, "s-percent", "/p", "");
+    index(&conn, "s-plain", "/p", "");
+
+    assert_eq!(found(&conn, "q=100%25"), vec!["s-percent"]);
+}
+
+/// Every FTS5 metacharacter a user can type reaches the tokenizer as text.
+///
+/// Each row is chosen so the two readings give **different** answers — a table
+/// where the operator and the literal happen to agree would pass against a raw
+/// interpolation and prove nothing. `content-only`'s indexed text is `please fix
+/// the auth bug in the login handler`, and the `note` on each row is what FTS5
+/// would have answered had the characters stayed syntax.
+#[test]
+fn fts_metacharacters_are_matched_literally_rather_than_as_operators() {
+    // The only session in this corpus whose text is reachable through the index.
+    let hit = vec!["content-only".to_string()];
+    let none: Vec<String> = Vec::new();
+
+    let conn = corpus();
+    for (q, want, note) in [
+        ("-auth", &hit, "a leading `-` excludes the term: no rows"),
+        (
+            "%5Ebug",
+            &hit,
+            "`^` anchors to a column's first token: no rows",
+        ),
+        ("auth+*", &hit, "a bare `*` is a syntax error"),
+        ("(auth", &hit, "an unbalanced paren is a syntax error"),
+        ("auth%22", &hit, "an unterminated string is a syntax error"),
+        (
+            "auth+NOT+quasarflux",
+            &none,
+            "`NOT` excludes a word this session does not have: one row",
+        ),
+        ("auth+OR+quasarflux", &none, "`OR` unions: one row"),
+        (
+            "user_text%3Aauth",
+            &none,
+            "`:` selects the column this word is in: one row",
+        ),
+    ] {
+        let ids = found(&conn, &format!("q={q}"));
+        assert_eq!(&ids, want, "query {q} — as syntax this would be: {note}");
+    }
+}
+
+/// A user-typed phrase is honoured as a phrase — adjacent, in order.
+#[test]
+fn a_quoted_phrase_matches_as_a_phrase() {
+    let conn = migrated();
+    session(&conn, "ordered", "/p", "", "");
+    index(&conn, "ordered", "/p", "the auth bug is here");
+    session(&conn, "reversed", "/p", "", "");
+    index(&conn, "reversed", "/p", "the bug auth is here");
+
+    let mut both = found(&conn, "q=auth+bug");
+    both.sort();
+    assert_eq!(both, vec!["ordered", "reversed"], "unquoted is AND");
+
+    assert_eq!(
+        found(&conn, "q=%22auth+bug%22"),
+        vec!["ordered"],
+        "quoted is a phrase"
+    );
+}
+
+/// The trailing token is a prefix term, which is what makes the list narrow as
+/// somebody types rather than only on a completed word.
+#[test]
+fn the_last_word_matches_as_a_prefix() {
+    let conn = corpus();
+    assert_eq!(found(&conn, "q=hand"), vec!["content-only"]);
+    // ...but not a word before it, which is finished.
+    assert!(found(&conn, "q=hand+bug").is_empty());
+}
+
+/// No string a user can type may make the query error.
+///
+/// Two assertions per input, and they pin different things:
+///
+/// 1. **`build_fts_query`'s output is a valid MATCH expression.** This is the
+///    acceptance criterion — safety by construction — and it is the one the
+///    fallback would otherwise hide: a builder that emitted raw text would fail
+///    the probe, degrade to LIKE, and answer 200 with nothing to say the index
+///    had stopped being consulted.
+/// 2. **`list_page` and `facets` both answer.** Two statements built from the
+///    same `Filter`, only one of them on the obvious path — and this is what
+///    stays true even if (1) ever regresses.
+///
+/// The generator is deterministic rather than randomised: a fuzz test that
+/// fails one run in fifty and passes on a re-run is worse than no test. Its
+/// alphabet is every character FTS5's grammar reads plus the ones that broke a
+/// draft of this — a NUL (reachable as `%00` in a query string, and an
+/// `unterminated string` error to FTS5's parser) and whitespace.
+#[test]
+fn no_input_string_can_make_the_search_error() {
+    let conn = corpus();
+    let settings = DataSettings::default();
+
+    let alphabet: Vec<char> = "\"'-*^():+ \t\u{0}aOR\\%_.".chars().collect();
+    let mut inputs: Vec<String> = vec![
+        String::new(),
+        " ".into(),
+        "\u{0}".into(),
+        "\"".into(),
+        "\"\"".into(),
+        "\"\"\"".into(),
+        "-".into(),
+        "*".into(),
+        "^".into(),
+        "NEAR".into(),
+        "NEAR(a b)".into(),
+        "a:b:c".into(),
+        "\\".into(),
+        "(((((".into(),
+        "auth\u{0}bug".into(),
+        "\u{feff}\u{200b}".into(),
+        "é".repeat(50),
+        "a".repeat(2000),
+        "\"".repeat(64),
+    ];
+    // Every string of length 1..=3 over the alphabet, walked as a mixed-radix
+    // counter — 22 + 484 + 10,648 cases, exhaustive rather than sampled.
+    let n = alphabet.len();
+    for len in 1..=3usize {
+        let total = n.pow(len as u32);
+        for mut code in 0..total {
+            let mut s = String::new();
+            for _ in 0..len {
+                s.push(alphabet[code % n]);
+                code /= n;
+            }
+            inputs.push(s);
+        }
+    }
+
+    for raw in &inputs {
+        let expr = build_fts_query(raw);
+        if !expr.is_empty() {
+            search::search(&conn, &expr, 1).unwrap_or_else(|e| {
+                panic!("{raw:?} built the invalid MATCH expression {expr:?}: {e}")
+            });
+        }
+
+        // Straight through the query struct rather than through a URL, so a
+        // byte percent-encoding would refuse is still exercised.
+        let q = SessionQuery {
+            search: raw.clone(),
+            ..Default::default()
+        };
+        list_page(&conn, &settings, &q)
+            .unwrap_or_else(|e| panic!("list_page errored on {raw:?} (fts {expr:?}): {e}"));
+        facets(&conn, &settings, &q)
+            .unwrap_or_else(|e| panic!("facets errored on {raw:?} (fts {expr:?}): {e}"));
+    }
+}
+
+/// The `Filter` is shared, so the toolbar's counters and the rows below them
+/// are the same predicate — asserted rather than assumed, because a search that
+/// composed into only one of the two would still look right on either half
+/// alone.
+#[test]
+fn facets_agree_with_the_rows_a_search_returns() {
+    let conn = corpus();
+
+    for q in [
+        "q=auth",
+        "q=handler",
+        "q=nothing-at-all",
+        "q=%22auth+bug%22",
+    ] {
+        let page = list_page(&conn, &DataSettings::default(), &query(q)).expect("page");
+        let f = facets(&conn, &DataSettings::default(), &query(q)).expect("facets");
+        assert_eq!(
+            f.total,
+            page.items.len() as i64,
+            "{q}: facets counted {} against {} rows",
+            f.total,
+            page.items.len()
+        );
+    }
+}
+
+/// A search is one more `Filter` clause, so everything else composes untouched.
+/// The project filter, the config-dir scope and a hidden project each narrow a
+/// search the same way they narrow an unfiltered list.
+#[test]
+fn a_search_composes_with_the_other_filters() {
+    let conn = migrated();
+    session(&conn, "in-alpha", "/home/u/alpha", "", "");
+    index(&conn, "in-alpha", "/home/u/alpha", "the auth bug");
+    session(&conn, "in-beta", "/home/u/beta", "", "");
+    index(&conn, "in-beta", "/home/u/beta", "the auth bug");
+
+    let mut both = found(&conn, "q=auth+bug");
+    both.sort();
+    assert_eq!(both, vec!["in-alpha", "in-beta"]);
+
+    assert_eq!(
+        found(&conn, "q=auth+bug&project=%2Fhome%2Fu%2Falpha"),
+        vec!["in-alpha"],
+        "the project filter still applies under a search"
+    );
+
+    let hidden = DataSettings {
+        hidden_projects: vec!["/home/u/beta".to_string()],
+        ..Default::default()
+    };
+    let page = list_page(&conn, &hidden, &query("q=auth+bug")).expect("page");
+    assert_eq!(page.items.len(), 1, "a hidden project stays hidden");
+    assert_eq!(page.items[0].session_id, "in-alpha");
+}
+
+/// Keyset pagination pages a search the way it pages anything else: every
+/// matching session appears exactly once across the pages, and none twice.
+///
+/// Worth its own test because the search clause is the first one whose argument
+/// list is longer than one — a cursor bound in the wrong position would page a
+/// plausible-looking subset.
+#[test]
+fn a_search_pages_through_its_whole_result_set() {
+    let conn = migrated();
+    for i in 0..7 {
+        let id = format!("s{i}");
+        session(&conn, &id, "/p", "", "");
+        index(&conn, &id, "/p", "the auth bug appears here");
+    }
+
+    let mut seen: Vec<String> = Vec::new();
+    let mut cursor = String::new();
+    for _ in 0..10 {
+        let q = query(&format!("q=auth+bug&limit=2&cursor={cursor}"));
+        let page = list_page(&conn, &DataSettings::default(), &q).expect("page");
+        seen.extend(page.items.into_iter().map(|s| s.session_id));
+        cursor = page.next_cursor.clone();
+        if !page.has_more {
+            break;
+        }
+    }
+    seen.sort();
+    seen.dedup();
+    assert_eq!(seen.len(), 7, "every match paged exactly once: {seen:?}");
+}
+
+/// A session id living under two project paths is two rows (#362 family), and
+/// the index keys on the pair — so a search must return the row whose project
+/// was indexed and only that one.
+#[test]
+fn the_search_clause_keys_on_the_pair_not_the_session_id() {
+    let conn = migrated();
+    session(&conn, "shared", "/home/u/alpha", "", "");
+    session(&conn, "shared", "/home/u/beta", "", "");
+    index(&conn, "shared", "/home/u/alpha", "the quasarflux incident");
+    index(&conn, "shared", "/home/u/beta", "something else entirely");
+
+    let page = list_page(&conn, &DataSettings::default(), &query("q=quasarflux")).expect("page");
+    let paths: Vec<String> = page.items.into_iter().map(|s| s.project_path).collect();
+    assert_eq!(
+        paths,
+        vec!["/home/u/alpha".to_string()],
+        "the other project's row shares the id but not the content"
+    );
+}


### PR DESCRIPTION
Closes #436

## What

`sessions/query.rs::add_search` was one `LIKE '%q%'` substring over six metadata
columns. It now composes the `session_search` FTS5 index (#433/#434/#435) into
the same `Filter`:

```sql
((c.session_id, c.project_path) IN (
   SELECT session_id, project_path FROM ( <search::match_sql()> ))
 OR <the existing six-column LIKE clause>)
```

- **Multi-word, any order.** `fix auth bug` finds a session containing all three
  words anywhere in its content — implicit AND between quoted terms.
- **Every FTS metacharacter is literal.** `- * ^ ( ) : "` and bare
  `OR`/`NOT`/`AND` reach the tokenizer as text.
- **User-typed `"…"` is honoured as a phrase**; the final token becomes a prefix
  term (`"efficien"*`) so the list narrows as you type.
- **Total LIKE fallback.** No index table, or an expression FTS5 refuses → the
  route answers exactly as it did before this PR. Search never 500s.

## How

`build_fts_query` is the injection boundary and it is **safe by construction,
not by sanitization**: nothing typed is ever passed through. The input is split
into tokens and each token is *re-emitted* inside a double-quoted FTS5 string,
where the grammar has no operators at all — so there is no notion of "a
character to escape" that a future FTS5 could add to.

Two rules came out of running it rather than reading the grammar:

- **Control characters are separators.** A NUL reaching FTS5's parser is an
  error (`unterminated string`), and `%00` in a query string decodes to one.
- **A token with no alphanumeric character is dropped.** `unicode61` indexes
  alphanumerics, so `"-"` is a phrase of *zero* terms — it matches no document
  and, AND'd with the rest, empties the whole result. One stray dash in
  `fix auth -` would otherwise cost every hit. The LIKE half still sees the raw
  text, so a search for `---` is unaffected.

Degradation is **checked, not trusted**: "the builder can never produce a syntax
error" is a claim about a parser this code does not own, so `usable_fts_query`
runs the built expression against the index once and falls back on any error. It
is a real prepare-and-step rather than a `LIMIT 0` existence probe, because a
missing table fails the *prepare* while a refused expression fails the *first
step* — an unstepped statement never parses the MATCH argument at all.

`build_filter` takes a `&Connection` for that one decision; every other term is
still a pure function of the query.

## Tests

`src-tauri/src/native/sessions/tests_search.rs` is new — built with
`migrate::apply`, so the FTS5 table is migration 33's own DDL rather than a
second spelling of it, and its index rows are hand-populated, which keeps it
independent of #435. Plus pure string tests in `query.rs` and one degradation
test in `tests_db.rs`, whose fixture is the pre-#436 subset schema and so is a
database that genuinely has no index table.

Acceptance criteria, each with its test:

| criterion | test |
|---|---|
| all words, any order | `a_multi_word_search_matches_all_words_in_any_order` |
| metacharacters literal | `fts_metacharacters_are_matched_literally_rather_than_as_operators` |
| no input can error | `no_input_string_can_make_the_search_error` |
| unindexed session still matches | `a_session_with_no_index_row_still_matches_on_its_metadata` |
| index absent → answers as today | `a_search_still_matches_metadata_with_no_index_table` (+ the drop-table sibling) |
| facets agree with the rows | `facets_agree_with_the_rows_a_search_returns` |
| `%`/`_` escaping unchanged | `search_wildcards_are_escaped_so_they_match_literally` (untouched) |

Two of those are worth calling out:

- **The metacharacter table only holds rows where the operator and the literal
  reading give _different_ answers** — a row where they agree passes against a
  raw interpolation and proves nothing. Each row carries the answer FTS5 would
  have given as syntax.
- **The fuzz test asserts on the builder directly**, not just on "the request
  did not 500". Exhaustive over every string of length 1–3 from an alphabet of
  FTS5's grammar characters plus NUL and whitespace (11,154 cases), plus a
  hand-written set. Deterministic, not randomised. Without the direct assertion
  the fallback hides a broken builder: it would degrade to LIKE and answer 200
  with nothing to say the index had stopped being consulted.

**Verified as regression guards** by reverting the change under test:

- builder returns raw input → `no_input_string_can_make_the_search_error`,
  `fts_metacharacters_…` and `the_last_word_matches_as_a_prefix` fail
- availability probe removed → `with_the_index_table_dropped_…` and
  `content_is_findable_and_was_not_before` fail

## Out of scope

Snippets, relevance sort and cursor changes (#437); the UI (#438); the FTS
delete-scan cost (#439).

## Gates

`cargo fmt --check` · `cargo clippy --all-targets -D warnings` · `cargo test`
(1269 lib + all integration suites) · `npm run build` — all green locally.