### PR TITLE
feat(gateway): LLM Gateway sidebar section — Overview, Providers, Models, Settings (#427)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,11 +183,19 @@ src/
     newChatPrefs.ts  what the New Chat bar was last set to (localStorage)
     logs.ts      the log commands, and the line parser (target before level)
   components/    TitleBar, Sidebar, StatusBar, CommandPalette, ui.tsx,
-                 DirField (native picker + the /api/fs fallback), CopyButton
+                 DirField (native picker + the /api/fs fallback), CopyButton,
+                 TokenReveal (the show-once minted token, #427 — shared by
+                 SecurityPane and the gateway Overview)
   views/         one file per section
     settings/LogsPane.tsx      Settings → Logs: tail, follow, filter, save a copy
     settings/SecurityPane.tsx  Settings → Security: the public key, and issuing
                  and revoking scoped API tokens (#405)
+    gateway/     the LLM Gateway section (#427) — its own sidebar section,
+                 sharing nothing with Claude analytics or stats.ts
+      OverviewView.tsx  status, the mint-once `llm` token, and the env snippets
+      snippets.ts       the two base URLs and the type-level pin on them:
+                        OpenAI is `/v1`, Anthropic is `/anthropic` with no `/v1`
+      ProvidersView.tsx / ModelsView.tsx / SettingsView.tsx
   styles/        tokens → base → shell → controls → views (+ per-view files)
 
 src-tauri/src/

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,10 @@ import { SessionsView } from "./views/SessionsView";
 import { AnalyticsView } from "./views/AnalyticsView";
 import { SettingsView } from "./views/SettingsView";
 import { AboutView } from "./views/AboutView";
+import { GatewayOverviewView } from "./views/gateway/OverviewView";
+import { GatewayProvidersView } from "./views/gateway/ProvidersView";
+import { GatewayModelsView } from "./views/gateway/ModelsView";
+import { GatewaySettingsView } from "./views/gateway/SettingsView";
 import { SECTIONS, VIEW_TITLES, type ViewId } from "./lib/nav";
 import { useAppStats } from "./lib/stats";
 import { useHostInfo } from "./lib/host";
@@ -368,6 +372,24 @@ export default function App() {
           {view === "sessions" && <SessionsView inspectorOpen={inspectorOpen} />}
           {(view === "tokens" || view === "usage" || view === "insights") && (
             <AnalyticsView mode={view} inspectorOpen={inspectorOpen} />
+          )}
+          {/* The Overview takes `navigate` because its bind-failure card has
+              exactly one useful action — change the port — and that lives in a
+              sibling view rather than a pane of its own. */}
+          {view === "gateway" && (
+            <GatewayOverviewView
+              inspectorOpen={inspectorOpen}
+              onNavigate={navigate}
+            />
+          )}
+          {view === "gateway-providers" && (
+            <GatewayProvidersView inspectorOpen={inspectorOpen} />
+          )}
+          {view === "gateway-models" && (
+            <GatewayModelsView inspectorOpen={inspectorOpen} />
+          )}
+          {view === "gateway-settings" && (
+            <GatewaySettingsView inspectorOpen={inspectorOpen} />
           )}
           {view === "settings" && (
             <SettingsView theme={theme} onThemeChange={setTheme} />

--- a/src/components/TokenReveal.tsx
+++ b/src/components/TokenReveal.tsx
@@ -1,0 +1,61 @@
+import { CopyButton } from "./CopyButton";
+import { Icon } from "../lib/icons";
+import "../styles/security.css";
+
+/**
+ * The one-time reveal of a freshly minted API token.
+ *
+ * Lifted out of `settings/SecurityPane.tsx` when the LLM Gateway Overview (#427)
+ * became a second place that mints one. Two copies of this block is exactly the
+ * shape that drifts: the invariant it carries — **the token is shown once and
+ * nothing stores it** — is a property of where the value lives, and a second
+ * implementation is a second chance to put it somewhere durable.
+ *
+ * So the rules live here, in one place:
+ *
+ * - The caller holds the token in component state and nowhere else. There is no
+ *   prop for a persisted value because there is no persisted value: the
+ *   creation response is the only copy that will ever exist, and the list route
+ *   answers rows without a `token` field.
+ * - The banner has **no timer**. A toast that faded would lose the credential,
+ *   so it stays until the user dismisses it.
+ * - Dismissing is the caller's `onDismiss`, which must clear that state.
+ */
+export function TokenReveal({
+  name,
+  token,
+  onDismiss,
+  children,
+}: {
+  /** The token's name, so a user with two banners open can tell them apart. */
+  name: string;
+  token: string;
+  onDismiss(): void;
+  /** Extra copy under the token — e.g. what this credential is for. */
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="secnew">
+      <div className="secnew__head">
+        <Icon name="shield" size={14} />
+        <span>
+          <strong>{name}</strong> created. Copy it now — this is the only time it
+          is shown, and it is not stored anywhere.
+        </span>
+        <button className="iconbtn" title="Dismiss" onClick={onDismiss}>
+          <Icon name="close" size={12} />
+        </button>
+      </div>
+      <div className="secnew__token">
+        <code className="mono selectable">{token}</code>
+        <CopyButton
+          text={token}
+          title="Copy token"
+          className="btn"
+          label="Copy"
+        />
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -10,6 +10,10 @@ export type ViewId =
   | "tokens"
   | "usage"
   | "insights"
+  | "gateway"
+  | "gateway-providers"
+  | "gateway-models"
+  | "gateway-settings"
   | "settings"
   | "about";
 
@@ -53,6 +57,18 @@ export const SECTIONS: NavSection[] = [
       { id: "insights", label: "Insights", icon: "bulb", badge: "Beta" },
     ],
   },
+  // Its own section, sharing nothing with Claude Usage or Analytics — the
+  // gateway spends the user's *provider* credits, where everything above it
+  // reports on Claude Code runs. Mixing the two was ruled out at design time.
+  {
+    caption: "LLM Gateway",
+    items: [
+      { id: "gateway", label: "Overview", icon: "zap" },
+      { id: "gateway-providers", label: "Providers", icon: "database" },
+      { id: "gateway-models", label: "Models", icon: "layers" },
+      { id: "gateway-settings", label: "Gateway Settings", icon: "gear" },
+    ],
+  },
 ];
 
 export const VIEW_TITLES: Record<ViewId, string> = {
@@ -65,6 +81,10 @@ export const VIEW_TITLES: Record<ViewId, string> = {
   tokens: "Token Usage",
   usage: "General Usage",
   insights: "Insights",
+  gateway: "LLM Gateway",
+  "gateway-providers": "Gateway Providers",
+  "gateway-models": "Gateway Models",
+  "gateway-settings": "Gateway Settings",
   settings: "Settings",
   about: "About Agento",
 };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -653,3 +653,117 @@ export interface ClaudeSettingsProfile {
   file_path: string;
   is_default: boolean;
 }
+
+/* --- Security tokens (#405) ---------------------------------------------- */
+
+export interface ApiTokenRow {
+  id: string;
+  name: string;
+  scope: string;
+  created_at: string;
+  expires_at: string | null;
+  last_used_at: string | null;
+  revoked_at: string | null;
+}
+
+/**
+ * The creation response, and the **only** copy of the token that will ever
+ * exist — nothing stores it, so a second read is impossible rather than
+ * refused. Never put one of these anywhere but component state.
+ */
+export interface CreatedApiToken extends ApiTokenRow {
+  token: string;
+}
+
+/* --- LLM Gateway (#421) — the control plane, /api/gateway/* --------------- */
+
+/**
+ * Four, not five: `bedrock` is a real ferrox provider type this build cannot
+ * serve, so the server refuses it and the picker must not offer it.
+ */
+export type GatewayProviderType = "anthropic" | "openai" | "gemini" | "glm";
+
+export interface GatewayTimeouts {
+  connect_secs: number;
+  ttfb_secs: number;
+  idle_secs: number;
+}
+
+export interface GatewaySettings {
+  enabled: boolean;
+  port: number;
+  start_with_app: boolean;
+}
+
+/**
+ * Four states, and `start_failed` is the one a three-state UI drops.
+ *
+ * `bind_failed` carries the port it could not bind (something else has it);
+ * `start_failed` reached no port at all (a provider row this build could not
+ * turn into an adapter). They send the user to different places, which is why
+ * the server keeps them apart.
+ */
+export type GatewayState =
+  | "stopped"
+  | "running"
+  | "bind_failed"
+  | "start_failed";
+
+/**
+ * `port` and `error` are **omitted**, not null, on the states that have no such
+ * value — branch on presence.
+ */
+export interface GatewayStatus {
+  state: GatewayState;
+  port?: number;
+  error?: string;
+}
+
+/** A provider row as a read answers it: `has_api_key`, never the key. */
+export interface GatewayProviderSummary {
+  id: string;
+  name: string;
+  type: GatewayProviderType;
+  has_api_key: boolean;
+  base_url: string;
+  timeouts: GatewayTimeouts;
+  enabled: boolean;
+}
+
+/**
+ * A provider write.
+ *
+ * `api_key` is three-valued and this is the field the whole surface is built
+ * around: **absent** preserves the stored key, `""` clears it, a value replaces
+ * it. Every other field is overwritten from what the body carries, so a `PUT`
+ * has to send them all.
+ */
+export interface GatewayProviderRequest {
+  id?: string;
+  name: string;
+  type: GatewayProviderType;
+  api_key?: string;
+  base_url: string;
+  timeouts: GatewayTimeouts;
+  enabled: boolean;
+}
+
+export interface GatewayRouteTarget {
+  /** The provider's **name**, not its id — that is what routing refers to. */
+  provider: string;
+  /** The model id sent upstream, which is not the alias the client asked for. */
+  model_id: string;
+}
+
+/** `targets` is ordered and the order is the meaning; `fallbacks` follows it. */
+export interface GatewayRouting {
+  targets: GatewayRouteTarget[] | null;
+  fallbacks: GatewayRouteTarget[] | null;
+}
+
+export interface GatewayModelAlias {
+  id: string;
+  alias: string;
+  routing: GatewayRouting;
+  enabled: boolean;
+}

--- a/src/styles/gateway.css
+++ b/src/styles/gateway.css
@@ -1,0 +1,171 @@
+/* ============================================================================
+   LLM Gateway (#427) — Overview, Providers, Models, Gateway Settings.
+
+   Almost everything here reuses what already exists: `.panes`/`.pane-*`,
+   `.toolbar`, `.listrow*`, `.form`/`.formsec`/`.formrow`, `.msgline`,
+   `.savebar`, `.confirm`, `.codebox`, `.badge`, `.dot`. Only the pieces no
+   other view has are defined below.
+
+   Note where four of those come from: `.msgline*`, `.savebar*`, `.confirm` and
+   `.codebox` are declared in `integrations.css` and `settings.css` rather than
+   in a global sheet. Both are loaded unconditionally — `App.tsx` imports
+   `IntegrationsView` and `SettingsView` statically, so their stylesheets are in
+   the bundle whichever view is on screen — which is why this file does not
+   restate them for a third time.
+
+   Every colour is a token, so light and dark both come from `tokens.css` and
+   nothing here needs a media query — a colour whose only definition sat inside
+   one would have no light-mode value at all.
+   ========================================================================== */
+
+/* --- The status card on the Overview ------------------------------------- */
+
+.gw-status {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-4);
+  padding: var(--sp-5);
+  border: var(--hairline) solid var(--line);
+  border-radius: var(--r-md);
+  background: var(--bg-inset);
+}
+
+/* The two failure states get a visible left edge: a bind failure is the one
+   state a user has to act on, and a badge alone reads as decoration. */
+.gw-status--bind_failed,
+.gw-status--start_failed {
+  border-left: 2px solid var(--red);
+}
+
+.gw-status--running {
+  border-left: 2px solid var(--green);
+}
+
+.gw-status__head {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+}
+
+.gw-status__port {
+  font-size: var(--text-sm);
+  color: var(--fg-secondary);
+}
+
+.gw-status__text {
+  margin: 0;
+  font-size: var(--text-sm);
+  line-height: var(--leading-relaxed);
+  color: var(--fg-secondary);
+}
+
+/* The OS error, verbatim. It wraps rather than truncating: "Address already in
+   use (os error 98)" is the whole content, and an ellipsis would hide the half
+   that names the cause. */
+.gw-status__error {
+  display: block;
+  padding: var(--sp-4);
+  border-radius: var(--r-sm);
+  background: var(--red-soft);
+  color: var(--fg);
+  font-size: var(--text-xs);
+  line-height: var(--leading-normal);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.gw-statusline {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+  font-size: var(--text-sm);
+  color: var(--fg-secondary);
+}
+
+/* --- Copyable env snippets ------------------------------------------------ */
+
+.gw-snippet + .gw-snippet {
+  margin-top: var(--sp-5);
+}
+
+.gw-snippet__head {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+  margin-bottom: var(--sp-3);
+}
+
+.gw-snippet__title {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--fg);
+}
+
+.gw-snippet__note {
+  font-size: var(--text-xs);
+  color: var(--fg-tertiary);
+}
+
+/* `.codebox` comes from integrations.css and already sets the mono face and
+   the inset background; it does not preserve newlines, and these snippets are
+   two lines of shell. */
+.gw-snippet .codebox {
+  white-space: pre;
+  overflow-x: auto;
+}
+
+/* --- The ordered target rows on Models ------------------------------------ */
+
+.gw-target {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  padding: var(--sp-3) 0;
+}
+
+.gw-target + .gw-target {
+  border-top: var(--hairline) solid var(--line);
+}
+
+/* The position, stated rather than implied — the order *is* the fallback
+   chain, so a list that only looked ordered would be hiding the meaning. */
+.gw-target__ord {
+  flex: 0 0 auto;
+  width: 18px;
+  text-align: right;
+  font-size: var(--text-xs);
+  color: var(--fg-quaternary);
+}
+
+.gw-target__provider {
+  flex: 0 0 40%;
+  min-width: 0;
+}
+
+.gw-target__model {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+/* --- Explanatory prose ---------------------------------------------------- */
+
+.gw-help {
+  margin: 0 0 var(--sp-4);
+  font-size: var(--text-xs);
+  line-height: var(--leading-relaxed);
+  color: var(--fg-tertiary);
+}
+
+.gw-help--muted {
+  color: var(--fg-quaternary);
+}
+
+/* --- Overview scrolling --------------------------------------------------- */
+
+/* `.card` sets `overflow: hidden`, so a flex child of a scrolling column
+   collapses to zero min-content height and everything below the fold becomes a
+   sliver. Nothing here is a `.card`, but the same rule applies to the sections
+   inside this pane's scroller. */
+.gw-overview .form > * {
+  flex: 0 0 auto;
+}

--- a/src/styles/gateway.css
+++ b/src/styles/gateway.css
@@ -18,6 +18,16 @@
    one would have no light-mode value at all.
    ========================================================================== */
 
+/* --- Stacked read errors -------------------------------------------------- */
+
+/* Two failed reads produce two rows. `.msgline` carries no margin of its own —
+   it is normally a `.form` child, and `.form`'s gap does the spacing — so a
+   pane that renders them outside a form has to say so, or they read as one
+   block with a rule through it. */
+.gw-errors > .msgline + .msgline {
+  margin-top: var(--sp-4);
+}
+
 /* --- The status card on the Overview ------------------------------------- */
 
 .gw-status {

--- a/src/views/gateway/ModelsView.tsx
+++ b/src/views/gateway/ModelsView.tsx
@@ -134,14 +134,21 @@ export function GatewayModelsView({ inspectorOpen }: { inspectorOpen: boolean })
             screen to say why. */}
         {(aliases.error || providers.error) && (
           <div className="scroll" style={{ padding: "var(--sp-8)" }}>
-            {[aliases.error, providers.error]
-              .filter((e): e is string => !!e)
-              .map((message) => (
-                <div className="msgline msgline--error" key={message}>
+            {(
+              [
+                ["aliases", aliases.error],
+                ["providers", providers.error],
+              ] as const
+            ).map(([source, message]) =>
+              message ? (
+                // Keyed by which read failed, not by the text — two requests
+                // refused for the same reason carry the same message.
+                <div className="msgline msgline--error" key={source}>
                   <Icon name="alert" size={13} className="msgline__icon" />
                   <span>{message}</span>
                 </div>
-              ))}
+              ) : null
+            )}
           </div>
         )}
         {!aliases.error && selection.kind === "new" && (

--- a/src/views/gateway/ModelsView.tsx
+++ b/src/views/gateway/ModelsView.tsx
@@ -109,7 +109,13 @@ export function GatewayModelsView({ inspectorOpen }: { inspectorOpen: boolean })
               </div>
             </button>
           ))}
-          {!aliases.loading && filtered.length === 0 && (
+          {/* Not shown when either read failed: "No aliases" and "add a
+              provider first" are both claims about stored rows, and a failed
+              request knows nothing about them. */}
+          {!aliases.loading &&
+            !aliases.error &&
+            !providers.error &&
+            filtered.length === 0 && (
             <Empty
               icon="layers"
               title={rows.length === 0 ? "No aliases" : "No matches"}
@@ -133,7 +139,7 @@ export function GatewayModelsView({ inspectorOpen }: { inspectorOpen: boolean })
             which disables "Add alias" and every provider picker with nothing on
             screen to say why. */}
         {(aliases.error || providers.error) && (
-          <div className="scroll" style={{ padding: "var(--sp-8)" }}>
+          <div className="scroll gw-errors" style={{ padding: "var(--sp-8)" }}>
             {(
               [
                 ["aliases", aliases.error],

--- a/src/views/gateway/ModelsView.tsx
+++ b/src/views/gateway/ModelsView.tsx
@@ -1,0 +1,526 @@
+import { useEffect, useMemo, useState } from "react";
+import { api } from "../../lib/api";
+import { Dropdown, Empty, FormRow, Search, Splitter, Switch } from "../../components/ui";
+import { Icon } from "../../lib/icons";
+import { describeError, useResource } from "../../lib/hooks";
+import type {
+  GatewayModelAlias,
+  GatewayProviderSummary,
+  GatewayRouteTarget,
+} from "../../lib/types";
+import "../../styles/gateway.css";
+
+/* ============================================================================
+   LLM Gateway → Models (#427).
+
+   An alias is the entire routing key: whatever a client sends as `model` is
+   looked up here, with no prefix parsing anywhere. Each alias carries an
+   **ordered** list of targets and an ordered list of fallbacks, and the order
+   is the meaning — the first target is preferred, the rest are tried after it
+   fails, and the fallbacks are walked once every target has.
+
+   So the editor makes order explicit rather than implying it: targets are
+   numbered, moving one is a button, and the list says "tried in order" beside
+   itself. A drag handle would look nicer and would tell the user less.
+
+   A target names a provider by its **name**, and the server refuses an alias
+   whose target names no configured provider — so the picker offers exactly the
+   names that exist rather than a free-text field that 422s.
+   ========================================================================== */
+
+type Selection = { kind: "none" } | { kind: "new" } | { kind: "row"; id: string };
+
+export function GatewayModelsView({ inspectorOpen }: { inspectorOpen: boolean }) {
+  const aliases = useResource<GatewayModelAlias[] | null>(
+    (signal) => api.get("/gateway/models", signal),
+    []
+  );
+  const providers = useResource<GatewayProviderSummary[] | null>(
+    (signal) => api.get("/gateway/providers", signal),
+    []
+  );
+
+  const rows = useMemo(() => aliases.data ?? [], [aliases.data]);
+  const providerNames = useMemo(
+    () => (providers.data ?? []).map((p) => p.name),
+    [providers.data]
+  );
+
+  const [query, setQuery] = useState("");
+  const [selection, setSelection] = useState<Selection>({ kind: "none" });
+
+  useEffect(() => {
+    if (aliases.loading) return;
+    setSelection((current) => {
+      if (current.kind === "new") return current;
+      if (current.kind === "row" && rows.some((r) => r.id === current.id)) {
+        return current;
+      }
+      return rows.length > 0 ? { kind: "row", id: rows[0].id } : { kind: "none" };
+    });
+  }, [rows, aliases.loading]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return rows;
+    return rows.filter((r) => r.alias.toLowerCase().includes(q));
+  }, [rows, query]);
+
+  const selected =
+    selection.kind === "row" ? rows.find((r) => r.id === selection.id) : undefined;
+
+  return (
+    <div className="panes">
+      <div className="pane-list">
+        <div className="toolbar">
+          <Search value={query} onChange={setQuery} placeholder="Search aliases" />
+          <div className="spacer" />
+          <button
+            className="iconbtn"
+            title="Add an alias"
+            disabled={providerNames.length === 0}
+            onClick={() => setSelection({ kind: "new" })}
+          >
+            <Icon name="plus" size={14} />
+          </button>
+        </div>
+        <div className="list__scroll scroll">
+          {filtered.map((r) => (
+            <button
+              key={r.id}
+              className={`listrow ${
+                selection.kind === "row" && selection.id === r.id
+                  ? "listrow--active"
+                  : ""
+              }`}
+              onClick={() => setSelection({ kind: "row", id: r.id })}
+            >
+              <div className="avatar avatar--purple">
+                <Icon name="layers" size={14} />
+              </div>
+              <div className="listrow__body">
+                <div className="listrow__top">
+                  <span className="listrow__title truncate mono">{r.alias}</span>
+                  <span className={`dot ${r.enabled ? "dot--green" : "dot--idle"}`} />
+                </div>
+                <div className="listrow__preview truncate">
+                  {describeRouting(r)}
+                </div>
+              </div>
+            </button>
+          ))}
+          {!aliases.loading && filtered.length === 0 && (
+            <Empty
+              icon="layers"
+              title={rows.length === 0 ? "No aliases" : "No matches"}
+              text={
+                providerNames.length === 0
+                  ? "Add a provider first — an alias has to route somewhere."
+                  : rows.length === 0
+                    ? "An alias is the model name your tools will ask for."
+                    : "Nothing matches that search."
+              }
+            />
+          )}
+        </div>
+      </div>
+
+      <Splitter variable="--list-w" min={240} max={460} />
+
+      <div className="pane-detail">
+        {aliases.error && (
+          <div className="scroll" style={{ padding: "var(--sp-8)" }}>
+            <div className="msgline msgline--error">
+              <Icon name="alert" size={13} className="msgline__icon" />
+              <span>{aliases.error}</span>
+            </div>
+          </div>
+        )}
+        {!aliases.error && selection.kind === "new" && (
+          <AliasForm
+            key="new"
+            alias={undefined}
+            providerNames={providerNames}
+            onDone={(id) => {
+              aliases.reload();
+              setSelection({ kind: "row", id });
+            }}
+            onCancel={() => setSelection({ kind: "none" })}
+          />
+        )}
+        {!aliases.error && selected && (
+          <AliasForm
+            key={selected.id}
+            alias={selected}
+            providerNames={providerNames}
+            onDone={() => aliases.reload()}
+            onDeleted={() => {
+              setSelection({ kind: "none" });
+              aliases.reload();
+            }}
+          />
+        )}
+        {!aliases.error && selection.kind === "none" && !aliases.loading && (
+          <Empty
+            icon="layers"
+            title="No alias selected"
+            text="Pick one on the left, or define a new model name."
+          />
+        )}
+      </div>
+
+      {inspectorOpen && (
+        <>
+          <Splitter variable="--inspector-w" min={220} max={420} invert />
+          <aside className="pane-inspector">
+            <div className="inspector__head">Aliases</div>
+            <div className="inspector__scroll scroll">
+              <div className="insp-group">
+                <div className="insp-group__title">How dispatch works</div>
+                <p className="gw-help">
+                  The alias is what a client sends as <code className="mono">model</code>.
+                  Targets are tried in order; a retryable failure moves to the
+                  next one, and the fallbacks are walked only once every target
+                  has failed. A stream that has already sent bytes is never
+                  failed over — the answer would be two answers spliced together.
+                </p>
+              </div>
+            </div>
+          </aside>
+        </>
+      )}
+    </div>
+  );
+}
+
+function AliasForm({
+  alias,
+  providerNames,
+  onDone,
+  onDeleted,
+  onCancel,
+}: {
+  alias: GatewayModelAlias | undefined;
+  providerNames: string[];
+  onDone(id: string): void;
+  onDeleted?(): void;
+  onCancel?(): void;
+}) {
+  const creating = alias === undefined;
+
+  const [name, setName] = useState(alias?.alias ?? "");
+  const [enabled, setEnabled] = useState(alias?.enabled ?? true);
+  const [targets, setTargets] = useState<GatewayRouteTarget[]>(
+    alias?.routing.targets ?? []
+  );
+  const [fallbacks, setFallbacks] = useState<GatewayRouteTarget[]>(
+    alias?.routing.fallbacks ?? []
+  );
+
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string>();
+  const [notice, setNotice] = useState<string>();
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const original = useMemo(
+    () =>
+      JSON.stringify({
+        alias: alias?.alias ?? "",
+        enabled: alias?.enabled ?? true,
+        targets: alias?.routing.targets ?? [],
+        fallbacks: alias?.routing.fallbacks ?? [],
+      }),
+    [alias]
+  );
+  const current = JSON.stringify({ alias: name, enabled, targets, fallbacks });
+  const changed = creating || current !== original;
+
+  // The server's own rules, applied here so the button explains itself rather
+  // than the form 422-ing after a round trip.
+  const complete =
+    name.trim() !== "" &&
+    targets.length > 0 &&
+    [...targets, ...fallbacks].every(
+      (t) => t.provider !== "" && t.model_id.trim() !== ""
+    );
+  const canSave = changed && complete;
+
+  async function save() {
+    setBusy(true);
+    setError(undefined);
+    try {
+      const body = {
+        alias: name.trim(),
+        routing: {
+          targets: targets.map(trimTarget),
+          fallbacks: fallbacks.map(trimTarget),
+        },
+        enabled,
+      };
+      const saved = creating
+        ? await api.post<GatewayModelAlias>("/gateway/models", body)
+        : await api.put<GatewayModelAlias>(
+            `/gateway/models/${encodeURIComponent(alias.id)}`,
+            body
+          );
+      setNotice("Saved.");
+      onDone(saved.id);
+    } catch (err) {
+      setError(describeError(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function remove() {
+    if (!alias) return;
+    setBusy(true);
+    setError(undefined);
+    try {
+      await api.del(`/gateway/models/${encodeURIComponent(alias.id)}`);
+      onDeleted?.();
+    } catch (err) {
+      setError(describeError(err));
+      setConfirmDelete(false);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <>
+      <div className="toolbar">
+        <div className="toolbar__title truncate mono">
+          {creating ? "New alias" : alias.alias}
+        </div>
+        {!creating && (
+          <span className={`badge ${alias.enabled ? "badge--green" : ""}`}>
+            {alias.enabled ? "Enabled" : "Disabled"}
+          </span>
+        )}
+        <div className="spacer" />
+        {!creating &&
+          (confirmDelete ? (
+            <span className="confirm">
+              Delete {alias.alias}?
+              <button
+                className="btn btn--ghost"
+                onClick={() => setConfirmDelete(false)}
+              >
+                Cancel
+              </button>
+              <button className="btn btn--danger" onClick={remove} disabled={busy}>
+                Delete
+              </button>
+            </span>
+          ) : (
+            <button
+              className="btn btn--danger"
+              onClick={() => setConfirmDelete(true)}
+            >
+              <Icon name="trash" size={13} />
+              Delete
+            </button>
+          ))}
+      </div>
+
+      <div className="scroll" style={{ flex: 1, padding: "var(--sp-8)" }}>
+        <div className="form">
+          {error && (
+            <div className="msgline msgline--error">
+              <Icon name="alert" size={13} className="msgline__icon" />
+              <span>{error}</span>
+            </div>
+          )}
+          {notice && !changed && (
+            <div className="msgline msgline--ok">
+              <Icon name="check" size={13} className="msgline__icon" />
+              <span>{notice}</span>
+            </div>
+          )}
+
+          <div className="formsec">
+            <div className="formsec__title">Alias</div>
+            <FormRow
+              label="Model name"
+              help="What a client sends as `model`. This is the whole routing key — there is no prefix parsing."
+            >
+              <input
+                className="field mono"
+                value={name}
+                placeholder="e.g. fast-sonnet"
+                onChange={(e) => setName(e.target.value)}
+              />
+            </FormRow>
+            <FormRow
+              label="Enabled"
+              help="A disabled alias stays configured and is not routed."
+            >
+              <Switch on={enabled} onChange={setEnabled} />
+            </FormRow>
+          </div>
+
+          <div className="divider" />
+
+          <TargetList
+            title="Targets"
+            caption="Tried in order — the first is preferred, the rest are used when it fails."
+            targets={targets}
+            providerNames={providerNames}
+            onChange={setTargets}
+          />
+
+          <div className="divider" />
+
+          <TargetList
+            title="Fallbacks"
+            caption="Walked only after every target above has failed. Optional."
+            targets={fallbacks}
+            providerNames={providerNames}
+            onChange={setFallbacks}
+          />
+        </div>
+      </div>
+
+      {(changed || creating) && (
+        <div className="savebar">
+          <span className="savebar__text">
+            {canSave
+              ? "You have unsaved changes."
+              : name.trim() === ""
+                ? "A model name is required."
+                : targets.length === 0
+                  ? "Add at least one target."
+                  : "Every target needs a provider and a model id."}
+          </span>
+          {onCancel && (
+            <button className="btn" onClick={onCancel} disabled={busy}>
+              Cancel
+            </button>
+          )}
+          <button
+            className="btn btn--primary"
+            onClick={save}
+            disabled={!canSave || busy}
+          >
+            {busy ? "Saving…" : "Save"}
+          </button>
+        </div>
+      )}
+    </>
+  );
+}
+
+function TargetList({
+  title,
+  caption,
+  targets,
+  providerNames,
+  onChange,
+}: {
+  title: string;
+  caption: string;
+  targets: GatewayRouteTarget[];
+  providerNames: string[];
+  onChange(next: GatewayRouteTarget[]): void;
+}) {
+  const options = providerNames.map((n) => ({ value: n, label: n }));
+
+  function move(index: number, delta: number) {
+    const next = [...targets];
+    const to = index + delta;
+    if (to < 0 || to >= next.length) return;
+    [next[index], next[to]] = [next[to], next[index]];
+    onChange(next);
+  }
+
+  return (
+    <div className="formsec">
+      <div className="formsec__title">{title}</div>
+      <p className="gw-help">{caption}</p>
+
+      {targets.length === 0 && (
+        <p className="gw-help gw-help--muted">Nothing here yet.</p>
+      )}
+
+      {targets.map((t, i) => (
+        <div className="gw-target" key={i}>
+          <span className="gw-target__ord tnum">{i + 1}</span>
+          <Dropdown
+            value={t.provider}
+            options={options}
+            placeholder="Provider"
+            onChange={(v) =>
+              onChange(targets.map((x, j) => (j === i ? { ...x, provider: v } : x)))
+            }
+            className="gw-target__provider"
+          />
+          <input
+            className="field mono gw-target__model"
+            value={t.model_id}
+            placeholder="upstream model id"
+            onChange={(e) =>
+              onChange(
+                targets.map((x, j) =>
+                  j === i ? { ...x, model_id: e.target.value } : x
+                )
+              )
+            }
+          />
+          <button
+            className="iconbtn"
+            title="Move up"
+            disabled={i === 0}
+            onClick={() => move(i, -1)}
+          >
+            <Icon name="arrowUp" size={13} />
+          </button>
+          <button
+            className="iconbtn"
+            title="Move down"
+            disabled={i === targets.length - 1}
+            onClick={() => move(i, 1)}
+          >
+            <Icon name="arrowDown" size={13} />
+          </button>
+          <button
+            className="iconbtn"
+            title="Remove"
+            onClick={() => onChange(targets.filter((_, j) => j !== i))}
+          >
+            <Icon name="close" size={13} />
+          </button>
+        </div>
+      ))}
+
+      <div className="row">
+        <button
+          className="btn"
+          disabled={providerNames.length === 0}
+          onClick={() =>
+            onChange([
+              ...targets,
+              { provider: providerNames[0] ?? "", model_id: "" },
+            ])
+          }
+        >
+          <Icon name="plus" size={13} />
+          Add {title.toLowerCase().replace(/s$/, "")}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function trimTarget(t: GatewayRouteTarget): GatewayRouteTarget {
+  return { provider: t.provider, model_id: t.model_id.trim() };
+}
+
+function describeRouting(alias: GatewayModelAlias): string {
+  const targets = alias.routing.targets ?? [];
+  if (targets.length === 0) return "No targets";
+  const first = `${targets[0].provider} · ${targets[0].model_id}`;
+  const extra =
+    targets.length - 1 + (alias.routing.fallbacks ?? []).length;
+  return extra > 0 ? `${first} +${extra} more` : first;
+}

--- a/src/views/gateway/ModelsView.tsx
+++ b/src/views/gateway/ModelsView.tsx
@@ -128,12 +128,20 @@ export function GatewayModelsView({ inspectorOpen }: { inspectorOpen: boolean })
       <Splitter variable="--list-w" min={240} max={460} />
 
       <div className="pane-detail">
-        {aliases.error && (
+        {/* The provider read is surfaced too, and it is the one that would
+            otherwise be silent: a failed fetch leaves `providerNames` empty,
+            which disables "Add alias" and every provider picker with nothing on
+            screen to say why. */}
+        {(aliases.error || providers.error) && (
           <div className="scroll" style={{ padding: "var(--sp-8)" }}>
-            <div className="msgline msgline--error">
-              <Icon name="alert" size={13} className="msgline__icon" />
-              <span>{aliases.error}</span>
-            </div>
+            {[aliases.error, providers.error]
+              .filter((e): e is string => !!e)
+              .map((message) => (
+                <div className="msgline msgline--error" key={message}>
+                  <Icon name="alert" size={13} className="msgline__icon" />
+                  <span>{message}</span>
+                </div>
+              ))}
           </div>
         )}
         {!aliases.error && selection.kind === "new" && (
@@ -244,6 +252,16 @@ function AliasForm({
       (t) => t.provider !== "" && t.model_id.trim() !== ""
     );
   const canSave = changed && complete;
+
+  /** Back out of an edit in one click, the way every other form here does. */
+  function revert() {
+    if (!alias) return;
+    setName(alias.alias);
+    setEnabled(alias.enabled);
+    setTargets(alias.routing.targets ?? []);
+    setFallbacks(alias.routing.fallbacks ?? []);
+    setError(undefined);
+  }
 
   async function save() {
     setBusy(true);
@@ -393,9 +411,13 @@ function AliasForm({
                   ? "Add at least one target."
                   : "Every target needs a provider and a model id."}
           </span>
-          {onCancel && (
+          {onCancel ? (
             <button className="btn" onClick={onCancel} disabled={busy}>
               Cancel
+            </button>
+          ) : (
+            <button className="btn" onClick={revert} disabled={busy}>
+              Revert
             </button>
           )}
           <button

--- a/src/views/gateway/OverviewView.tsx
+++ b/src/views/gateway/OverviewView.tsx
@@ -135,14 +135,21 @@ export function GatewayOverviewView({
                 nastier of the two: `port` would fall back to 0 and the snippets
                 below would be replaced by "No port configured", which blames
                 the user's configuration for a failed request. */}
-            {[status.error, settings.error]
-              .filter((e): e is string => !!e)
-              .map((message) => (
-                <div className="msgline msgline--error" key={message}>
+            {(
+              [
+                ["status", status.error],
+                ["settings", settings.error],
+              ] as const
+            ).map(([source, message]) =>
+              message ? (
+                // Keyed by which read failed, not by the text — two requests
+                // refused for the same reason carry the same message.
+                <div className="msgline msgline--error" key={source}>
                   <Icon name="alert" size={13} className="msgline__icon" />
                   <span>{message}</span>
                 </div>
-              ))}
+              ) : null
+            )}
 
             {/* ── Status ──────────────────────────────────────────────────── */}
             <div className="formsec">

--- a/src/views/gateway/OverviewView.tsx
+++ b/src/views/gateway/OverviewView.tsx
@@ -131,12 +131,18 @@ export function GatewayOverviewView({
 
         <div className="scroll" style={{ flex: 1, padding: "var(--sp-8)" }}>
           <div className="form">
-            {status.error && (
-              <div className="msgline msgline--error">
-                <Icon name="alert" size={13} className="msgline__icon" />
-                <span>{status.error}</span>
-              </div>
-            )}
+            {/* Both reads are surfaced. A swallowed settings error is the
+                nastier of the two: `port` would fall back to 0 and the snippets
+                below would be replaced by "No port configured", which blames
+                the user's configuration for a failed request. */}
+            {[status.error, settings.error]
+              .filter((e): e is string => !!e)
+              .map((message) => (
+                <div className="msgline msgline--error" key={message}>
+                  <Icon name="alert" size={13} className="msgline__icon" />
+                  <span>{message}</span>
+                </div>
+              ))}
 
             {/* ── Status ──────────────────────────────────────────────────── */}
             <div className="formsec">
@@ -237,8 +243,12 @@ export function GatewayOverviewView({
               {snippets.length === 0 ? (
                 <Empty
                   icon="zap"
-                  title="No port configured"
-                  text="Set a port in Gateway Settings and the snippets appear here."
+                  title={settings.error ? "Settings unavailable" : "No port configured"}
+                  text={
+                    settings.error
+                      ? "The port could not be read, so there is nothing to build a snippet from."
+                      : "Set a port in Gateway Settings and the snippets appear here."
+                  }
                 />
               ) : (
                 snippets.map((s) => (

--- a/src/views/gateway/OverviewView.tsx
+++ b/src/views/gateway/OverviewView.tsx
@@ -1,0 +1,326 @@
+import { useCallback, useState } from "react";
+import { api } from "../../lib/api";
+import { CopyButton } from "../../components/CopyButton";
+import { TokenReveal } from "../../components/TokenReveal";
+import { Empty, FormRow, InspGroup, InspRow, Splitter } from "../../components/ui";
+import { Icon } from "../../lib/icons";
+import { describeError, usePoll, useResource } from "../../lib/hooks";
+import type { ViewId } from "../../lib/nav";
+import type {
+  CreatedApiToken,
+  GatewaySettings,
+  GatewayStatus,
+} from "../../lib/types";
+import {
+  effectivePort,
+  healthUrl,
+  snippetsFor,
+  TOKEN_PLACEHOLDER,
+} from "./snippets";
+import "../../styles/gateway.css";
+
+/* ============================================================================
+   LLM Gateway → Overview (#427).
+
+   Two jobs, and the second is the one the feature lives or dies on:
+
+   1. Say what the listener is doing — and when it is *not* doing it, say why in
+      a way the user can act on. A bind failure names the port and routes to the
+      setting that changes it, because that is the only lever they have.
+   2. Get a working tool configuration onto the clipboard in one click. The
+      distance between "the gateway is running" and "my tool is pointed at it"
+      is the whole adoption question, so the token is minted here rather than
+      sending the user to Settings → Security to do it by hand.
+
+   The token that mint produces exists in this component's state and nowhere
+   else. It is never written to localStorage, never lifted into a context, and
+   never re-fetched — `GET /api/security/tokens` answers rows without a `token`
+   field, so there is nothing to re-render it from. Navigating away loses it,
+   which is the #405 invariant working rather than a gap.
+   ========================================================================== */
+
+/** How the four states read, and what colour they carry. */
+const STATE_COPY: Record<
+  GatewayStatus["state"],
+  { label: string; dot: string; badge: string }
+> = {
+  running: { label: "Running", dot: "dot--green", badge: "badge--green" },
+  stopped: { label: "Stopped", dot: "dot--idle", badge: "badge" },
+  bind_failed: { label: "Port unavailable", dot: "dot--red", badge: "badge--red" },
+  start_failed: { label: "Failed to start", dot: "dot--red", badge: "badge--red" },
+};
+
+const UNKNOWN_STATE = {
+  label: "Unknown",
+  dot: "dot--amber",
+  badge: "badge--amber",
+};
+
+export function GatewayOverviewView({
+  inspectorOpen,
+  onNavigate,
+}: {
+  inspectorOpen: boolean;
+  onNavigate(view: ViewId): void;
+}) {
+  const status = useResource<GatewayStatus>(
+    (signal) => api.get("/gateway/status", signal),
+    []
+  );
+  const settings = useResource<GatewaySettings>(
+    (signal) => api.get("/gateway/settings", signal),
+    []
+  );
+
+  // A write answers before the listener has restarted — the reload is spawned,
+  // not awaited — so polling is the only truth about the port. Slower when the
+  // gateway is off, because then nothing is expected to change on its own.
+  const running = status.data?.state === "running";
+  usePoll(status.reload, running ? 10_000 : 4_000);
+
+  const [created, setCreated] = useState<CreatedApiToken>();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string>();
+
+  const mint = useCallback(async () => {
+    setBusy(true);
+    setError(undefined);
+    try {
+      // `llm` is disjoint from `read`/`write` (#423): this token spends provider
+      // credits and can reach nothing on `/api`. The app's own session is
+      // `write`-scoped, so it may mint one and can never use one.
+      const token = await api.post<CreatedApiToken>("/security/tokens", {
+        name: "LLM gateway client",
+        scope: "llm",
+        expires_in_days: 365,
+      });
+      setCreated(token);
+    } catch (err) {
+      setError(describeError(err));
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const state = status.data?.state;
+  const copy = (state && STATE_COPY[state]) || UNKNOWN_STATE;
+  const port = effectivePort(status.data, settings.data?.port ?? 0);
+  const snippets = port > 0 ? snippetsFor(port, created?.token) : [];
+
+  return (
+    <div className="panes">
+      <div className="pane-detail gw-overview">
+        <div className="toolbar">
+          <div className="toolbar__title">Overview</div>
+          <div className="toolbar__sep" />
+          <span className={`dot ${copy.dot}`} />
+          <span className="toolbar__sub">{copy.label}</span>
+          <div className="spacer" />
+          <button
+            className="btn"
+            onClick={() => {
+              status.reload();
+              settings.reload();
+            }}
+            title="Refresh"
+          >
+            <Icon name="refresh" size={13} />
+            Refresh
+          </button>
+        </div>
+
+        <div className="scroll" style={{ flex: 1, padding: "var(--sp-8)" }}>
+          <div className="form">
+            {status.error && (
+              <div className="msgline msgline--error">
+                <Icon name="alert" size={13} className="msgline__icon" />
+                <span>{status.error}</span>
+              </div>
+            )}
+
+            {/* ── Status ──────────────────────────────────────────────────── */}
+            <div className="formsec">
+              <div className="formsec__title">Listener</div>
+
+              <div className={`gw-status gw-status--${state ?? "unknown"}`}>
+                <div className="gw-status__head">
+                  <span className={`badge ${copy.badge}`}>{copy.label}</span>
+                  {status.data?.port !== undefined && (
+                    <span className="mono tnum gw-status__port">
+                      127.0.0.1:{status.data.port}
+                    </span>
+                  )}
+                </div>
+
+                <p className="gw-status__text">{explain(status.data, settings.data)}</p>
+
+                {status.data?.error && (
+                  <code className="gw-status__error mono selectable">
+                    {status.data.error}
+                  </code>
+                )}
+
+                {/* The one lever a failed or stopped listener leaves the user,
+                    so it is a link rather than a sentence telling them to go
+                    and find it. */}
+                {state !== "running" && (
+                  <div className="row">
+                    <button
+                      className="btn btn--primary"
+                      onClick={() => onNavigate("gateway-settings")}
+                    >
+                      <Icon name="gear" size={13} />
+                      {state === "bind_failed"
+                        ? "Change the port"
+                        : "Open gateway settings"}
+                    </button>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="divider" />
+
+            {/* ── The credential ──────────────────────────────────────────── */}
+            <div className="formsec">
+              <div className="formsec__title">Gateway token</div>
+
+              {created ? (
+                <TokenReveal
+                  name={created.name}
+                  token={created.token}
+                  onDismiss={() => setCreated(undefined)}
+                >
+                  <p className="gw-help">
+                    It is embedded in the snippets below while this banner is
+                    open. Leaving this view loses it — mint another if you need
+                    one.
+                  </p>
+                </TokenReveal>
+              ) : (
+                <div className="msgline msgline--warn">
+                  <Icon name="shield" size={13} className="msgline__icon" />
+                  <span>
+                    The snippets below show <code className="mono">{TOKEN_PLACEHOLDER}</code>{" "}
+                    until you mint a token. A gateway token can spend your
+                    provider credits and can reach nothing else in Agento.
+                  </span>
+                </div>
+              )}
+
+              {error && (
+                <div className="msgline msgline--error">
+                  <Icon name="alert" size={13} className="msgline__icon" />
+                  <span>{error}</span>
+                </div>
+              )}
+
+              <FormRow
+                label=""
+                help="Creates an llm-scoped token valid for a year. Manage and revoke tokens in Settings → Security."
+              >
+                <div className="row">
+                  <button className="btn btn--primary" disabled={busy} onClick={mint}>
+                    <Icon name="plus" size={14} />
+                    {busy ? "Creating…" : "Create gateway token"}
+                  </button>
+                </div>
+              </FormRow>
+            </div>
+
+            <div className="divider" />
+
+            {/* ── Snippets ────────────────────────────────────────────────── */}
+            <div className="formsec">
+              <div className="formsec__title">Point a tool at it</div>
+
+              {snippets.length === 0 ? (
+                <Empty
+                  icon="zap"
+                  title="No port configured"
+                  text="Set a port in Gateway Settings and the snippets appear here."
+                />
+              ) : (
+                snippets.map((s) => (
+                  <div className="gw-snippet" key={s.key}>
+                    <div className="gw-snippet__head">
+                      <span className="gw-snippet__title">{s.title}</span>
+                      <span className="gw-snippet__note">{s.note}</span>
+                      <div className="spacer" />
+                      <CopyButton
+                        text={s.body}
+                        title={`Copy the ${s.title} snippet`}
+                        className="btn"
+                        label="Copy"
+                      />
+                    </div>
+                    <pre className="codebox selectable">{s.body}</pre>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {inspectorOpen && (
+        <>
+          <Splitter variable="--inspector-w" min={220} max={420} invert />
+          <aside className="pane-inspector">
+            <div className="inspector__head">Gateway</div>
+            <div className="inspector__scroll scroll">
+              <InspGroup title="Listener">
+                <InspRow label="State">{copy.label}</InspRow>
+                <InspRow label="Port">
+                  {status.data?.port ?? settings.data?.port ?? "—"}
+                </InspRow>
+                <InspRow label="Enabled">
+                  {settings.data ? (settings.data.enabled ? "Yes" : "No") : "—"}
+                </InspRow>
+                <InspRow label="Start with app">
+                  {settings.data
+                    ? settings.data.start_with_app
+                      ? "Yes"
+                      : "No"
+                    : "—"}
+                </InspRow>
+              </InspGroup>
+              <InspGroup title="Endpoints">
+                <InspRow label="OpenAI">
+                  {port > 0 ? `:${port}/v1` : "—"}
+                </InspRow>
+                <InspRow label="Anthropic">
+                  {port > 0 ? `:${port}/anthropic` : "—"}
+                </InspRow>
+                <InspRow label="Health">
+                  {port > 0 ? healthUrl(port) : "—"}
+                </InspRow>
+              </InspGroup>
+            </div>
+          </aside>
+        </>
+      )}
+    </div>
+  );
+}
+
+/** One sentence per state, saying what happened and what to do about it. */
+function explain(
+  status: GatewayStatus | undefined,
+  settings: GatewaySettings | undefined
+): string {
+  switch (status?.state) {
+    case "running":
+      return "The gateway is accepting requests on the loopback address. Only this machine can reach it.";
+    case "bind_failed":
+      return `Another process is already listening on port ${status.port}. Pick a different port and save — nothing else needs to change.`;
+    case "start_failed":
+      return "The gateway could not be built from the configured providers, so no port was bound. Check the provider rows below the error.";
+    case "stopped":
+      return settings?.enabled === false
+        ? "The gateway is switched off. Enable it in Gateway Settings to bind the port."
+        : "The gateway is not listening.";
+    default:
+      return "Reading the listener's state…";
+  }
+}

--- a/src/views/gateway/ProvidersView.tsx
+++ b/src/views/gateway/ProvidersView.tsx
@@ -1,0 +1,501 @@
+import { useEffect, useMemo, useState } from "react";
+import { api, ApiError } from "../../lib/api";
+import { Dropdown, Empty, FormRow, Search, Splitter, Switch } from "../../components/ui";
+import { Icon } from "../../lib/icons";
+import { describeError, useResource } from "../../lib/hooks";
+import type {
+  GatewayProviderRequest,
+  GatewayProviderSummary,
+  GatewayProviderType,
+  GatewayTimeouts,
+} from "../../lib/types";
+import "../../styles/gateway.css";
+
+/* ============================================================================
+   LLM Gateway → Providers (#427).
+
+   The upstreams the gateway can dispatch to, and the one place in this section
+   that holds a secret.
+
+   Two rules, both load-bearing:
+
+   - **The API key is write-only.** No read answers one — `GET
+     /api/gateway/providers` returns `has_api_key`, a boolean computed in SQL —
+     so there is nothing to render, and the input starts empty on every load.
+     A masked value would be a lie about what this app knows.
+   - **A save with pending changes refuses until the key is re-entered.** The
+     server preserves a stored key when the field is *absent* (#426 built
+     `Option<String>` for exactly that), so this is the second half of a
+     belt-and-braces pair rather than the only guard: it is what stops the
+     integrations bug — a scrubbed read written straight back wiping the
+     secret — from ever depending on one side alone.
+
+   Deleting is refused by the server while an alias still routes to the
+   provider, which is checked in code because the reference lives inside a JSON
+   column and no foreign key can hold it. That 409's own sentence reads oddly
+   for a delete, so this view writes its own.
+   ========================================================================== */
+
+const TYPES: { value: GatewayProviderType; label: string }[] = [
+  { value: "anthropic", label: "Anthropic" },
+  { value: "openai", label: "OpenAI" },
+  { value: "gemini", label: "Google Gemini" },
+  { value: "glm", label: "Z.AI GLM" },
+];
+
+/** Matches `ferrox_providers`' own defaults, which the server applies too. */
+const DEFAULT_TIMEOUTS: GatewayTimeouts = {
+  connect_secs: 10,
+  ttfb_secs: 60,
+  idle_secs: 30,
+};
+
+/** What an empty base URL means, per type — shown as the input's placeholder. */
+const BASE_URL_HINT: Record<GatewayProviderType, string> = {
+  anthropic: "https://api.anthropic.com (default)",
+  openai: "https://api.openai.com/v1 (default)",
+  gemini: "the Gemini default endpoint",
+  glm: "https://api.z.ai/api/paas/v4 (required for GLM)",
+};
+
+type Selection =
+  | { kind: "none" }
+  | { kind: "new" }
+  | { kind: "row"; id: string };
+
+export function GatewayProvidersView({ inspectorOpen }: { inspectorOpen: boolean }) {
+  const providers = useResource<GatewayProviderSummary[] | null>(
+    (signal) => api.get("/gateway/providers", signal),
+    []
+  );
+  const rows = useMemo(() => providers.data ?? [], [providers.data]);
+
+  const [query, setQuery] = useState("");
+  const [selection, setSelection] = useState<Selection>({ kind: "none" });
+
+  // Never leave the selection pointing at a row that is gone, and select the
+  // first one once the list has actually loaded.
+  useEffect(() => {
+    if (providers.loading) return;
+    setSelection((current) => {
+      if (current.kind === "new") return current;
+      if (current.kind === "row" && rows.some((r) => r.id === current.id)) {
+        return current;
+      }
+      return rows.length > 0 ? { kind: "row", id: rows[0].id } : { kind: "none" };
+    });
+  }, [rows, providers.loading]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return rows;
+    return rows.filter(
+      (r) => r.name.toLowerCase().includes(q) || r.type.includes(q)
+    );
+  }, [rows, query]);
+
+  const selected =
+    selection.kind === "row"
+      ? rows.find((r) => r.id === selection.id)
+      : undefined;
+
+  return (
+    <div className="panes">
+      <div className="pane-list">
+        <div className="toolbar">
+          <Search value={query} onChange={setQuery} placeholder="Search providers" />
+          <div className="spacer" />
+          <button
+            className="iconbtn"
+            title="Add a provider"
+            onClick={() => setSelection({ kind: "new" })}
+          >
+            <Icon name="plus" size={14} />
+          </button>
+        </div>
+        <div className="list__scroll scroll">
+          {filtered.map((r) => (
+            <button
+              key={r.id}
+              className={`listrow ${
+                selection.kind === "row" && selection.id === r.id
+                  ? "listrow--active"
+                  : ""
+              }`}
+              onClick={() => setSelection({ kind: "row", id: r.id })}
+            >
+              <div className="avatar avatar--accent">
+                <Icon name="database" size={14} />
+              </div>
+              <div className="listrow__body">
+                <div className="listrow__top">
+                  <span className="listrow__title truncate">{r.name}</span>
+                  <span className={`dot ${r.enabled ? "dot--green" : "dot--idle"}`} />
+                </div>
+                <div className="listrow__preview truncate">
+                  {labelForType(r.type)}
+                  {r.has_api_key ? "" : " · no API key"}
+                </div>
+              </div>
+            </button>
+          ))}
+          {!providers.loading && filtered.length === 0 && (
+            <Empty
+              icon="database"
+              title={rows.length === 0 ? "No providers" : "No matches"}
+              text={
+                rows.length === 0
+                  ? "Add the upstream you want the gateway to dispatch to."
+                  : "Nothing matches that search."
+              }
+            />
+          )}
+        </div>
+      </div>
+
+      <Splitter variable="--list-w" min={240} max={460} />
+
+      <div className="pane-detail">
+        {providers.error && (
+          <div className="scroll" style={{ padding: "var(--sp-8)" }}>
+            <div className="msgline msgline--error">
+              <Icon name="alert" size={13} className="msgline__icon" />
+              <span>{providers.error}</span>
+            </div>
+          </div>
+        )}
+        {!providers.error && selection.kind === "new" && (
+          <ProviderForm
+            key="new"
+            provider={undefined}
+            onDone={(id) => {
+              providers.reload();
+              setSelection({ kind: "row", id });
+            }}
+            onCancel={() => setSelection({ kind: "none" })}
+          />
+        )}
+        {!providers.error && selected && (
+          <ProviderForm
+            key={selected.id}
+            provider={selected}
+            onDone={() => providers.reload()}
+            onDeleted={() => {
+              setSelection({ kind: "none" });
+              providers.reload();
+            }}
+          />
+        )}
+        {!providers.error &&
+          selection.kind === "none" &&
+          !providers.loading && (
+            <Empty
+              icon="database"
+              title="No provider selected"
+              text="Pick one on the left, or add a new upstream."
+            />
+          )}
+      </div>
+
+      {inspectorOpen && (
+        <>
+          <Splitter variable="--inspector-w" min={220} max={420} invert />
+          <aside className="pane-inspector">
+            <div className="inspector__head">Providers</div>
+            <div className="inspector__scroll scroll">
+              <div className="insp-group">
+                <div className="insp-group__title">How routing finds these</div>
+                <p className="gw-help">
+                  A model alias names a provider by its <strong>name</strong>,
+                  not its id, and nothing in SQL enforces that link. Renaming a
+                  provider that an alias routes to will break the alias, and
+                  deleting one is refused while any alias still names it.
+                </p>
+              </div>
+            </div>
+          </aside>
+        </>
+      )}
+    </div>
+  );
+}
+
+function ProviderForm({
+  provider,
+  onDone,
+  onDeleted,
+  onCancel,
+}: {
+  provider: GatewayProviderSummary | undefined;
+  onDone(id: string): void;
+  onDeleted?(): void;
+  onCancel?(): void;
+}) {
+  const creating = provider === undefined;
+
+  const [name, setName] = useState(provider?.name ?? "");
+  const [type, setType] = useState<GatewayProviderType>(provider?.type ?? "openai");
+  const [baseUrl, setBaseUrl] = useState(provider?.base_url ?? "");
+  const [enabled, setEnabled] = useState(provider?.enabled ?? true);
+  const [timeouts, setTimeouts] = useState<GatewayTimeouts>(
+    provider?.timeouts ?? DEFAULT_TIMEOUTS
+  );
+  // Write-only: it starts empty on every load and no response can fill it.
+  const [apiKey, setApiKey] = useState("");
+
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string>();
+  const [notice, setNotice] = useState<string>();
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const changed =
+    creating ||
+    name !== provider.name ||
+    type !== provider.type ||
+    baseUrl !== provider.base_url ||
+    enabled !== provider.enabled ||
+    timeouts.connect_secs !== provider.timeouts.connect_secs ||
+    timeouts.ttfb_secs !== provider.timeouts.ttfb_secs ||
+    timeouts.idle_secs !== provider.timeouts.idle_secs ||
+    apiKey.trim() !== "";
+
+  const hasKey = apiKey.trim() !== "";
+  const canSave = changed && name.trim() !== "" && hasKey;
+
+  async function save() {
+    setBusy(true);
+    setError(undefined);
+    try {
+      const body: GatewayProviderRequest = {
+        name: name.trim(),
+        type,
+        base_url: baseUrl.trim(),
+        timeouts,
+        enabled,
+        // Sent only when the user typed one. The server reads an absent key as
+        // "keep the stored one", so this field never destroys a secret.
+        ...(hasKey ? { api_key: apiKey.trim() } : {}),
+      };
+      const saved = creating
+        ? await api.post<GatewayProviderSummary>("/gateway/providers", body)
+        : await api.put<GatewayProviderSummary>(
+            `/gateway/providers/${encodeURIComponent(provider.id)}`,
+            body
+          );
+      setApiKey("");
+      setNotice("Saved.");
+      onDone(saved.id);
+    } catch (err) {
+      setError(describeError(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function remove() {
+    if (!provider) return;
+    setBusy(true);
+    setError(undefined);
+    try {
+      await api.del(`/gateway/providers/${encodeURIComponent(provider.id)}`);
+      onDeleted?.();
+    } catch (err) {
+      // The server's 409 is phrased for a create ("… already exists"), which
+      // reads as nonsense on a delete. The status is what carries the meaning.
+      setError(
+        err instanceof ApiError && err.status === 409
+          ? `A model alias still routes to ${provider.name}. Remove or re-point it first.`
+          : describeError(err)
+      );
+      setConfirmDelete(false);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <>
+      <div className="toolbar">
+        <div className="toolbar__title truncate">
+          {creating ? "New provider" : provider.name}
+        </div>
+        {!creating && (
+          <span className={`badge ${provider.enabled ? "badge--green" : ""}`}>
+            {provider.enabled ? "Enabled" : "Disabled"}
+          </span>
+        )}
+        <div className="spacer" />
+        {!creating &&
+          (confirmDelete ? (
+            <span className="confirm">
+              Remove {provider.name}?
+              <button
+                className="btn btn--ghost"
+                onClick={() => setConfirmDelete(false)}
+              >
+                Cancel
+              </button>
+              <button className="btn btn--danger" onClick={remove} disabled={busy}>
+                Remove
+              </button>
+            </span>
+          ) : (
+            <button
+              className="btn btn--danger"
+              onClick={() => setConfirmDelete(true)}
+            >
+              <Icon name="trash" size={13} />
+              Remove
+            </button>
+          ))}
+      </div>
+
+      <div className="scroll" style={{ flex: 1, padding: "var(--sp-8)" }}>
+        <div className="form">
+          {error && (
+            <div className="msgline msgline--error">
+              <Icon name="alert" size={13} className="msgline__icon" />
+              <span>{error}</span>
+            </div>
+          )}
+          {notice && !changed && (
+            <div className="msgline msgline--ok">
+              <Icon name="check" size={13} className="msgline__icon" />
+              <span>{notice}</span>
+            </div>
+          )}
+
+          <div className="formsec">
+            <div className="formsec__title">Upstream</div>
+
+            <FormRow
+              label="Name"
+              help="Model aliases route to this name, so changing it breaks any alias that uses it."
+            >
+              <input
+                className="field"
+                value={name}
+                placeholder="e.g. openai-main"
+                onChange={(e) => setName(e.target.value)}
+              />
+            </FormRow>
+
+            <FormRow label="Type" help="Which adapter serves this provider.">
+              <Dropdown
+                value={type}
+                options={TYPES}
+                onChange={(v) => setType(v as GatewayProviderType)}
+              />
+            </FormRow>
+
+            <FormRow
+              label="Base URL"
+              help="Leave empty to use the adapter's own endpoint."
+            >
+              <input
+                className="field"
+                value={baseUrl}
+                placeholder={BASE_URL_HINT[type]}
+                onChange={(e) => setBaseUrl(e.target.value)}
+              />
+            </FormRow>
+
+            <FormRow
+              label="Enabled"
+              help="A disabled provider stays configured and is not dispatched to."
+            >
+              <Switch on={enabled} onChange={setEnabled} />
+            </FormRow>
+          </div>
+
+          <div className="divider" />
+
+          <div className="formsec">
+            <div className="formsec__title">Credentials</div>
+
+            <div className="msgline msgline--warn">
+              <Icon name="shield" size={13} className="msgline__icon" />
+              <span>
+                {creating
+                  ? "The API key is stored locally and is never shown again."
+                  : provider.has_api_key
+                    ? "A key is stored. Agento cannot show it back to you, so any save has to be given one."
+                    : "No key is stored for this provider — it cannot serve a request until you add one."}
+              </span>
+            </div>
+
+            <FormRow
+              label="API key"
+              help="Sent only when you type one, and never returned by any read."
+            >
+              <input
+                className="field mono"
+                type="password"
+                autoComplete="off"
+                value={apiKey}
+                placeholder="sk-…"
+                onChange={(e) => setApiKey(e.target.value)}
+              />
+            </FormRow>
+          </div>
+
+          <div className="divider" />
+
+          <div className="formsec">
+            <div className="formsec__title">Timeouts</div>
+            {(
+              [
+                ["connect_secs", "Connect", "Seconds to establish the connection."],
+                ["ttfb_secs", "First byte", "Seconds to wait for the first token."],
+                ["idle_secs", "Idle", "Seconds between tokens before giving up."],
+              ] as const
+            ).map(([key, label, help]) => (
+              <FormRow key={key} label={label} help={help}>
+                <input
+                  className="field field--sm tnum"
+                  type="number"
+                  min={1}
+                  value={timeouts[key]}
+                  onChange={(e) =>
+                    setTimeouts((t) => ({
+                      ...t,
+                      [key]: Math.max(1, Number(e.target.value) || 1),
+                    }))
+                  }
+                />
+              </FormRow>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {(changed || creating) && (
+        <div className="savebar">
+          <span className="savebar__text">
+            {canSave
+              ? "You have unsaved changes."
+              : name.trim() === ""
+                ? "A name is required."
+                : "Enter the API key to save."}
+          </span>
+          {onCancel && (
+            <button className="btn" onClick={onCancel} disabled={busy}>
+              Cancel
+            </button>
+          )}
+          <button
+            className="btn btn--primary"
+            onClick={save}
+            disabled={!canSave || busy}
+          >
+            {busy ? "Saving…" : "Save"}
+          </button>
+        </div>
+      )}
+    </>
+  );
+}
+
+function labelForType(type: GatewayProviderType): string {
+  return TYPES.find((t) => t.value === type)?.label ?? type;
+}

--- a/src/views/gateway/ProvidersView.tsx
+++ b/src/views/gateway/ProvidersView.tsx
@@ -139,7 +139,10 @@ export function GatewayProvidersView({ inspectorOpen }: { inspectorOpen: boolean
               </div>
             </button>
           ))}
-          {!providers.loading && filtered.length === 0 && (
+          {/* Not shown when the read failed: "No providers" is a claim about
+              the stored rows, and a failed request knows nothing about them.
+              The detail pane carries the error. */}
+          {!providers.loading && !providers.error && filtered.length === 0 && (
             <Empty
               icon="database"
               title={rows.length === 0 ? "No providers" : "No matches"}

--- a/src/views/gateway/ProvidersView.tsx
+++ b/src/views/gateway/ProvidersView.tsx
@@ -262,6 +262,18 @@ function ProviderForm({
   const hasKey = apiKey.trim() !== "";
   const canSave = changed && name.trim() !== "" && hasKey;
 
+  /** Back out of an edit in one click, the way every other form here does. */
+  function revert() {
+    if (!provider) return;
+    setName(provider.name);
+    setType(provider.type);
+    setBaseUrl(provider.base_url);
+    setEnabled(provider.enabled);
+    setTimeouts(provider.timeouts);
+    setApiKey("");
+    setError(undefined);
+  }
+
   async function save() {
     setBusy(true);
     setError(undefined);
@@ -478,9 +490,13 @@ function ProviderForm({
                 ? "A name is required."
                 : "Enter the API key to save."}
           </span>
-          {onCancel && (
+          {onCancel ? (
             <button className="btn" onClick={onCancel} disabled={busy}>
               Cancel
+            </button>
+          ) : (
+            <button className="btn" onClick={revert} disabled={busy}>
+              Revert
             </button>
           )}
           <button

--- a/src/views/gateway/SettingsView.tsx
+++ b/src/views/gateway/SettingsView.tsx
@@ -1,0 +1,276 @@
+import { useEffect, useState } from "react";
+import { api } from "../../lib/api";
+import { FormRow, Splitter, Switch } from "../../components/ui";
+import { Icon } from "../../lib/icons";
+import { describeError, usePoll, useResource } from "../../lib/hooks";
+import type { GatewaySettings, GatewayStatus } from "../../lib/types";
+import "../../styles/gateway.css";
+
+/* ============================================================================
+   LLM Gateway → Settings (#427).
+
+   Three fields, one of which can fail after the save succeeds.
+
+   `PUT /api/gateway/settings` stores the row and then spawns the listener
+   reload without awaiting it — a save that blocked on a socket bind would feel
+   like a hang — so a `200` means "stored", never "listening". The status strip
+   below the form is therefore not decoration: it is the only place the outcome
+   of a port change actually shows up, and it is polled rather than read once.
+
+   The port rules are the server's, restated here so a bad value is refused
+   before the round trip rather than after it: `validate` refuses 0, and the
+   route refuses anything below 1024 because a lower port needs root. The
+   client check is a convenience, not the authority — the server's 422 is still
+   rendered if one gets past it.
+   ========================================================================== */
+
+/** The route's own floor. Below this a bind needs root on Unix. */
+const MIN_PORT = 1024;
+const MAX_PORT = 65535;
+
+export function GatewaySettingsView({ inspectorOpen }: { inspectorOpen: boolean }) {
+  const settings = useResource<GatewaySettings>(
+    (signal) => api.get("/gateway/settings", signal),
+    []
+  );
+  const status = useResource<GatewayStatus>(
+    (signal) => api.get("/gateway/status", signal),
+    []
+  );
+  usePoll(status.reload, 4_000);
+
+  const [enabled, setEnabled] = useState(false);
+  const [startWithApp, setStartWithApp] = useState(true);
+  const [port, setPort] = useState("");
+  const [loaded, setLoaded] = useState(false);
+
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string>();
+  const [notice, setNotice] = useState<string>();
+
+  // Seed the form from the stored row once, so a poll-driven re-render never
+  // overwrites what the user is typing.
+  useEffect(() => {
+    if (loaded || !settings.data) return;
+    setEnabled(settings.data.enabled);
+    setStartWithApp(settings.data.start_with_app);
+    setPort(String(settings.data.port));
+    setLoaded(true);
+  }, [settings.data, loaded]);
+
+  const portNumber = Number(port);
+  const portValid =
+    /^\d+$/.test(port.trim()) && portNumber >= MIN_PORT && portNumber <= MAX_PORT;
+
+  const changed =
+    !!settings.data &&
+    (enabled !== settings.data.enabled ||
+      startWithApp !== settings.data.start_with_app ||
+      portNumber !== settings.data.port);
+
+  const portChanged = !!settings.data && portNumber !== settings.data.port;
+  const canSave = changed && portValid;
+
+  async function save() {
+    setBusy(true);
+    setError(undefined);
+    try {
+      // All three keys every time: the request struct has no serde defaults, so
+      // an omitted field is a 400 rather than "leave it alone".
+      const saved = await api.put<GatewaySettings>("/gateway/settings", {
+        enabled,
+        port: portNumber,
+        start_with_app: startWithApp,
+      });
+      setNotice(
+        saved.enabled
+          ? "Saved. The listener is restarting — watch the status below."
+          : "Saved. The gateway is switched off."
+      );
+      settings.reload();
+      status.reload();
+    } catch (err) {
+      setError(describeError(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="panes">
+      <div className="pane-detail">
+        <div className="toolbar">
+          <div className="toolbar__title">Gateway Settings</div>
+          <div className="spacer" />
+        </div>
+
+        <div className="scroll" style={{ flex: 1, padding: "var(--sp-8)" }}>
+          <div className="form">
+            {settings.error && (
+              <div className="msgline msgline--error">
+                <Icon name="alert" size={13} className="msgline__icon" />
+                <span>{settings.error}</span>
+              </div>
+            )}
+            {error && (
+              <div className="msgline msgline--error">
+                <Icon name="alert" size={13} className="msgline__icon" />
+                <span>{error}</span>
+              </div>
+            )}
+            {notice && !changed && (
+              <div className="msgline msgline--ok">
+                <Icon name="check" size={13} className="msgline__icon" />
+                <span>{notice}</span>
+              </div>
+            )}
+
+            <div className="formsec">
+              <div className="formsec__title">Listener</div>
+
+              <FormRow
+                label="Enable the gateway"
+                help="When off, no port is bound and the feature costs nothing."
+              >
+                <Switch on={enabled} onChange={setEnabled} />
+              </FormRow>
+
+              <FormRow
+                label="Port"
+                help={`On 127.0.0.1 only. ${MIN_PORT}–${MAX_PORT}; lower ports need root, and the OS-assigned 0 is refused because this number is what you paste into tool configs.`}
+              >
+                <input
+                  className="field field--sm tnum"
+                  type="number"
+                  min={MIN_PORT}
+                  max={MAX_PORT}
+                  value={port}
+                  onChange={(e) => setPort(e.target.value)}
+                />
+              </FormRow>
+
+              <FormRow
+                label="Start with the app"
+                help="Bind the port at launch. Only takes effect while the gateway is enabled."
+              >
+                <Switch on={startWithApp} onChange={setStartWithApp} />
+              </FormRow>
+
+              {!portValid && port !== "" && (
+                <div className="msgline msgline--error">
+                  <Icon name="alert" size={13} className="msgline__icon" />
+                  <span>
+                    The port must be a whole number between {MIN_PORT} and{" "}
+                    {MAX_PORT}.
+                  </span>
+                </div>
+              )}
+
+              {portChanged && portValid && enabled && (
+                <div className="msgline msgline--warn">
+                  <Icon name="alert" size={13} className="msgline__icon" />
+                  <span>
+                    Saving restarts the listener on the new port. Anything
+                    already configured against the old one stops working until
+                    you update it.
+                  </span>
+                </div>
+              )}
+            </div>
+
+            <div className="divider" />
+
+            <div className="formsec">
+              <div className="formsec__title">Current state</div>
+              <div className="gw-statusline">
+                <span className={`dot ${dotFor(status.data)}`} />
+                <span>{sentenceFor(status.data)}</span>
+              </div>
+              {status.data?.error && (
+                <code className="gw-status__error mono selectable">
+                  {status.data.error}
+                </code>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {changed && (
+          <div className="savebar">
+            <span className="savebar__text">
+              {canSave ? "You have unsaved changes." : "Fix the port to save."}
+            </span>
+            <button
+              className="btn"
+              disabled={busy}
+              onClick={() => {
+                if (!settings.data) return;
+                setEnabled(settings.data.enabled);
+                setStartWithApp(settings.data.start_with_app);
+                setPort(String(settings.data.port));
+              }}
+            >
+              Revert
+            </button>
+            <button
+              className="btn btn--primary"
+              onClick={save}
+              disabled={!canSave || busy}
+            >
+              {busy ? "Saving…" : "Save"}
+            </button>
+          </div>
+        )}
+      </div>
+
+      {inspectorOpen && (
+        <>
+          <Splitter variable="--inspector-w" min={220} max={420} invert />
+          <aside className="pane-inspector">
+            <div className="inspector__head">Gateway Settings</div>
+            <div className="inspector__scroll scroll">
+              <div className="insp-group">
+                <div className="insp-group__title">Why a fixed port</div>
+                <p className="gw-help">
+                  The port is what you paste into a tool's configuration, so it
+                  has to be the number you chose and it has to survive a
+                  restart. Port 0 — "let the OS pick" — is refused for that
+                  reason rather than as an oversight.
+                </p>
+              </div>
+            </div>
+          </aside>
+        </>
+      )}
+    </div>
+  );
+}
+
+function dotFor(status: GatewayStatus | undefined): string {
+  switch (status?.state) {
+    case "running":
+      return "dot--green";
+    case "bind_failed":
+    case "start_failed":
+      return "dot--red";
+    case "stopped":
+      return "dot--idle";
+    default:
+      return "dot--amber";
+  }
+}
+
+function sentenceFor(status: GatewayStatus | undefined): string {
+  switch (status?.state) {
+    case "running":
+      return `Listening on 127.0.0.1:${status.port}.`;
+    case "bind_failed":
+      return `Port ${status.port} is already in use by another process. Choose a different one above.`;
+    case "start_failed":
+      return "The gateway could not be built from the configured providers, so no port was bound.";
+    case "stopped":
+      return "Not listening.";
+    default:
+      return "Reading the listener's state…";
+  }
+}

--- a/src/views/gateway/snippets.ts
+++ b/src/views/gateway/snippets.ts
@@ -1,0 +1,149 @@
+/* ============================================================================
+   The env snippets the Overview hands out (#427).
+
+   Everything a user copies out of this app to point a tool at the gateway is
+   built here, in one file, because the single most likely user-facing bug in
+   this feature is one character of base URL:
+
+       OpenAI      http://127.0.0.1:<port>/v1
+       Anthropic   http://127.0.0.1:<port>/anthropic      ← no /v1
+
+   The asymmetry is real and is not a typo. The OpenAI SDKs take a base URL that
+   already includes the version segment and append `/chat/completions` to it,
+   while the Anthropic SDK and Claude Code append `/v1/messages` themselves — so
+   an `/anthropic/v1` here would reach `/anthropic/v1/v1/messages`, which the
+   gateway does not route.
+
+   The frontend has no unit-test harness, so both strings are pinned **at the
+   type level** instead: the two functions declare template-literal return types
+   and the `Pin*` aliases below assert what they produce for a fixed port. That
+   makes `npm run build` — the repo's actual gate — fail on a changed literal,
+   which is the property a test would have bought.
+   ========================================================================== */
+
+import type { GatewayStatus } from "../../lib/types";
+
+/** The gateway binds `127.0.0.1` unconditionally; there is no public URL. */
+const HOST = "http://127.0.0.1";
+
+/** The placeholder a snippet shows before a token has been minted. */
+export const TOKEN_PLACEHOLDER = "<your gateway token>";
+
+export function openaiBaseUrl<P extends number>(
+  port: P
+): `http://127.0.0.1:${P}/v1` {
+  return `${HOST}:${port}/v1`;
+}
+
+export function anthropicBaseUrl<P extends number>(
+  port: P
+): `http://127.0.0.1:${P}/anthropic` {
+  return `${HOST}:${port}/anthropic`;
+}
+
+export function healthUrl<P extends number>(
+  port: P
+): `http://127.0.0.1:${P}/healthz` {
+  return `${HOST}:${port}/healthz`;
+}
+
+/* --- The compile-time pin ------------------------------------------------- */
+
+/** Exact type equality — `extends` alone would accept a wider literal. */
+type Eq<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+/**
+ * Change either literal above and these stop compiling. Exported so
+ * `noUnusedLocals` does not simply delete the guard by complaining about it.
+ */
+export type PinOpenAIBaseUrl = Expect<
+  Eq<ReturnType<typeof openaiBaseUrl<4141>>, "http://127.0.0.1:4141/v1">
+>;
+export type PinAnthropicBaseUrl = Expect<
+  Eq<
+    ReturnType<typeof anthropicBaseUrl<4141>>,
+    "http://127.0.0.1:4141/anthropic"
+  >
+>;
+export type PinHealthUrl = Expect<
+  Eq<ReturnType<typeof healthUrl<4141>>, "http://127.0.0.1:4141/healthz">
+>;
+
+/* --- The snippets --------------------------------------------------------- */
+
+export interface Snippet {
+  key: string;
+  title: string;
+  /** Why a user would pick this one, in one line. */
+  note: string;
+  body: string;
+}
+
+/**
+ * Build every snippet for a port and a token.
+ *
+ * `token` is the freshly minted credential when one exists in this render and
+ * [`TOKEN_PLACEHOLDER`] otherwise — there is no third state, because nothing
+ * stores a token and no response can return one.
+ */
+export function snippetsFor(port: number, token?: string): Snippet[] {
+  const secret = token ?? TOKEN_PLACEHOLDER;
+  const openai = openaiBaseUrl(port);
+  const anthropic = anthropicBaseUrl(port);
+
+  return [
+    {
+      key: "openai",
+      title: "OpenAI SDK",
+      note: "Any client that reads OPENAI_BASE_URL — the OpenAI SDKs, LiteLLM, Aider.",
+      body: [`export OPENAI_BASE_URL=${openai}`, `export OPENAI_API_KEY=${secret}`].join(
+        "\n"
+      ),
+    },
+    {
+      key: "anthropic",
+      title: "Anthropic SDK",
+      note: "The base URL has no /v1 — the SDK appends it.",
+      body: [
+        `export ANTHROPIC_BASE_URL=${anthropic}`,
+        `export ANTHROPIC_AUTH_TOKEN=${secret}`,
+      ].join("\n"),
+    },
+    {
+      key: "claude-code",
+      title: "Claude Code",
+      note: "Same two variables, exported before you launch the CLI.",
+      body: [
+        `export ANTHROPIC_BASE_URL=${anthropic}`,
+        `export ANTHROPIC_AUTH_TOKEN=${secret}`,
+        "claude",
+      ].join("\n"),
+    },
+    {
+      key: "curl",
+      title: "Check it with curl",
+      // The app cannot make this request itself: the webview's own session is
+      // a `write` token and the gateway only accepts `llm`, so an in-app "test
+      // connection" button could only ever answer 403. A copyable command is
+      // the honest version of that feature.
+      note: "Agento cannot run this for you — its own credential is scoped to /api, not to the gateway.",
+      body: [
+        `curl ${openai}/models \\`,
+        `  -H "Authorization: Bearer ${secret}"`,
+      ].join("\n"),
+    },
+  ];
+}
+
+/** The port a snippet should use: the live one when known, else the setting. */
+export function effectivePort(
+  status: GatewayStatus | undefined,
+  configured: number
+): number {
+  return status?.port ?? configured;
+}

--- a/src/views/settings/SecurityPane.tsx
+++ b/src/views/settings/SecurityPane.tsx
@@ -1,11 +1,13 @@
 import { useCallback, useState } from "react";
 import { api } from "../../lib/api";
 import { CopyButton } from "../../components/CopyButton";
+import { TokenReveal } from "../../components/TokenReveal";
 import { Dropdown, Empty, FormRow } from "../../components/ui";
 import { Icon } from "../../lib/icons";
 import { describeError, useResource } from "../../lib/hooks";
 import { dateTime, relativeTime, tildePath } from "../../lib/format";
 import { useHostInfo } from "../../lib/host";
+import type { ApiTokenRow, CreatedApiToken } from "../../lib/types";
 import "../../styles/security.css";
 
 /* ============================================================================
@@ -41,19 +43,10 @@ interface KeyInfo {
   public_key_path: string;
 }
 
-interface TokenRow {
-  id: string;
-  name: string;
-  scope: string;
-  created_at: string;
-  expires_at: string | null;
-  last_used_at: string | null;
-  revoked_at: string | null;
-}
-
-interface CreatedToken extends TokenRow {
-  token: string;
-}
+/* The two token shapes moved to `lib/types.ts` when the LLM Gateway Overview
+   (#427) became a second consumer of `POST /api/security/tokens`. */
+type TokenRow = ApiTokenRow;
+type CreatedToken = CreatedApiToken;
 
 const SCOPES = [
   { value: "read", label: "Read only" },
@@ -314,31 +307,11 @@ export function SecurityPane() {
             banner stays until dismissed for that reason: a toast that faded
             would lose the credential. */}
         {created && (
-          <div className="secnew">
-            <div className="secnew__head">
-              <Icon name="shield" size={14} />
-              <span>
-                <strong>{created.name}</strong> created. Copy it now — this is
-                the only time it is shown, and it is not stored anywhere.
-              </span>
-              <button
-                className="iconbtn"
-                title="Dismiss"
-                onClick={() => setCreated(undefined)}
-              >
-                <Icon name="close" size={12} />
-              </button>
-            </div>
-            <div className="secnew__token">
-              <code className="mono selectable">{created.token}</code>
-              <CopyButton
-                text={created.token}
-                title="Copy token"
-                className="btn"
-                label="Copy"
-              />
-            </div>
-          </div>
+          <TokenReveal
+            name={created.name}
+            token={created.token}
+            onDismiss={() => setCreated(undefined)}
+          />
         )}
 
         <FormRow label="Name" help="What this token is for. Shown in the list below.">


### PR DESCRIPTION
Closes #427

## What

A self-contained **LLM Gateway** sidebar section with four views, consuming `/api/gateway/*` (#426). Nothing is shared with the Claude analytics views or `stats.ts`.

- **Overview** — the listener's state, a mint-once `llm`-scoped token, and copyable env snippets for the OpenAI SDK, the Anthropic SDK, Claude Code and `curl`.
- **Providers** — three-pane CRUD; the API key is write-only and a save requires it re-entered.
- **Models** — alias CRUD with an explicitly *ordered* target list and a separate fallback list.
- **Gateway Settings** — enable toggle, port (validated), start-with-app, plus a live status strip.

## Files

- **New** — `src/views/gateway/{OverviewView,ProvidersView,ModelsView,SettingsView}.tsx`, `src/views/gateway/snippets.ts`, `src/styles/gateway.css`, `src/components/TokenReveal.tsx`.
- **Modified** — `src/lib/nav.ts` (4 view ids, the section, 4 titles), `src/lib/types.ts` (the gateway wire mirrors + the two token shapes), `src/App.tsx` (4 render arms), `src/views/settings/SecurityPane.tsx` (uses the extracted `TokenReveal`), `CLAUDE.md`.

## The base-URL pin, and why it is a real guard

The asymmetry the issue calls out — OpenAI is `…/v1`, Anthropic is `…/anthropic` with **no** `/v1`, because the Anthropic SDK appends it — is the most likely user-facing bug here.

There is no TS unit-test harness, so `snippets.ts` pins both strings **at the type level**: the URL builders declare template-literal return types and exported `Pin*` aliases assert what each produces for a fixed port. Reverting either literal fails `tsc --noEmit`, i.e. `npm run build`, i.e. CI. Verified by hand: changing `/anthropic` to `/anthropic/v1` produces

```
src/views/gateway/snippets.ts(68,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
```

## Deviations from the HOW, and why

- **Four gateway states, not three.** `status_body` also emits `start_failed` (no port was reached — a provider row that could not become an adapter), which is a different remedy from `bind_failed`. All four are handled and worded separately.
- **`toneFor` is not used for status colour.** It is a *hash* over a key for stable tile colours, not a status→tone map; status uses explicit `badge--*` / `dot--*` classes, which is what `SecurityPane` does.
- **The port floor is 1024, not 1.** `GatewaySettings::validate` only refuses `0`; `put_settings` adds `MIN_PORT = 1024` on top. The client check mirrors the pair, and the server's 422 is still rendered.
- **`onNavigate` prop on the Overview.** Overview and Gateway Settings are separate `ViewId`s (separate sidebar items), so the bind-failure route to the port setting cannot be a local state hop — `App.tsx` passes `navigate`.
- **`TokenReveal` extracted.** The issue permits it explicitly; `SecurityPane` moved onto it in the same change, so there is one implementation of "shown once, stored nowhere" rather than two.
- **The delete-conflict 409 is re-worded.** The server's body is `ConflictError`'s single format string — *"gateway provider (still routed to by X) with id "p1" already exists"* — which reads as nonsense on a delete. The view branches on the status code and writes its own sentence.

## Acceptance criteria

- [x] **No new Tauri command.** Everything here is `/api` over `api.ts`, so `generate_handler!`, `APP_COMMANDS` and `capabilities/default.json` are untouched and the three-place rule does not apply.
- [x] Bind failure shows the port, the OS error verbatim, and a button into Gateway Settings — not a generic "not running".
- [x] The minted token lives in component state only: no `localStorage`, no context, no query cache, and no response can re-render it (`GET /api/security/tokens` answers rows without `token`). Navigating away loses it; the snippets fall back to `<your gateway token>`.
- [x] Provider credentials are never rendered from a server response — the read answers `has_api_key`, and the input starts empty on every load. A save with pending changes refuses until the key is re-entered.
- [x] No `window.confirm`/`alert`/`prompt`; both deletes use inline confirmation.
- [x] No external links added, so nothing bypasses `openExternal`.
- [x] Every colour in `gateway.css` is a token from `tokens.css`; no media queries, so light and dark both resolve.
- [x] `npm run build` clean.

## Not done here

- **A packaged `npm run app:build` click-through has not been done** — this run is unattended and has no display to drive the installed window with. `cargo build --release` (which is what the bundle compiles) was run locally and is green, and CI builds it too.

  The risk that criterion exists for is an ACL gap, which fails *only* in a release build and fails silently. This change adds **no Tauri command and no plugin call**, so the ACL surface is byte-identical to `main`: `generate_handler!`, `APP_COMMANDS` and `capabilities/default.json` are untouched, and nothing new goes through `openExternal`, `pickDirectory` or the updater. Everything the four views do is `fetch("/api/...")` through `api.ts`. Still worth a click-through on the next installer.
- **Usage dashboards** are #428 and deliberately absent, so `GET /api/gateway/usage` has no consumer yet.
- The sidebar's `Mod+1..7` shortcut indexes the flat item list, which is now 12 long, so the four new items have no numeric shortcut. Pre-existing behaviour; left alone.
