### PR TITLE
docs: the LLM gateway — user guide, troubleshooting, dev notes and release notes (#429)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -370,8 +370,24 @@ as `null`, so every array field is `T[] | null` — handle it.
 `http://127.0.0.1:8990` with the user's real history and credentials.
 `curl -H "Content-Type: application/json" http://127.0.0.1:8990/api/...` is the
 ground truth for wire formats — better than reading Go structs. **GET only.**
-Never write to it. For write-path testing, start your own instance with
-`AGENTO_DATA_DIR` pointed at a scratch directory.
+Never write to it. For write-path testing, start your own instance against a
+scratch data directory.
+
+**`AGENTO_DATA_DIR` is not how you do that in a debug build**, and this file said
+it was until #429's cold-start test followed its own advice and wrote to the
+developer's real dev database. `paths.rs::data_dir` is `cfg`-split: the release
+arm reads the variable, and **the debug arm ignores the environment entirely**
+and always answers `~/.agento-desktop-dev` — deliberately, so that a shell
+exporting `AGENTO_DATA_DIR=~/.agento` cannot make `npm run app` collide with an
+installed Agento over one SQLite file and one scheduler. The lever a debug build
+*does* obey is `HOME`, since that is what `data_dir` joins onto:
+
+```bash
+HOME=/tmp/scratch-home ./target/debug/agento    # its own db, keypair and corpus
+```
+
+That also gives the instance an empty `~/.claude`, which is what makes it a cold
+install rather than a copy of yours.
 
 Every state-changing `/api` request needs `Content-Type: application/json` —
 `POST`, `PUT`, `PATCH`, `DELETE`; the server's guard (`isStateChanging` in
@@ -3253,6 +3269,41 @@ type. What stayed unshared is everything typed: `analytics/shared.tsx`'s
 ranked-list CSS (the gateway has its own `.gw-rank`). Prove a move like this
 rather than asserting it: building both sides and comparing the emitted CSS as a
 sorted set of rules gave 578 identical rules.
+
+### The gateway is documented, and where (#429)
+
+The epic closes with the docs, so the user-facing account of this feature lives
+outside this file and must not be duplicated back into it:
+
+| where | what it carries |
+|---|---|
+| `docs/user-guide.md` → **LLM Gateway** | the whole flow — enable, provider, alias, mint, point a tool, watch usage, and the retention horizon |
+| `docs/troubleshooting.md` → **LLM Gateway** | bind failure, 401 vs 403 in both directions, the model-name mismatch, empty Usage, the log lines |
+| `docs/development.md` → **The LLM gateway** | the `/api`-versus-listener split, the `ferrox-providers` feature policy, and the two curl commands |
+| `README.md` → *Route your other tools through Agento* | one bullet, flagged off by default |
+
+**Three claims a doc must keep making, because each is the inverse of what a
+reader assumes.** `0` retention days is *keep everything*, the **longest**
+horizon and not the shortest. The Anthropic base URL has **no** `/v1` while the
+OpenAI one does, because the Anthropic SDK appends its own — the measured failure
+is a 404 on `/anthropic/v1/v1/messages`. And the three scopes are **disjoint, not
+ranked**: `write` is not a superset of `llm`, so "use a bigger token" is never
+the fix for a gateway 403.
+
+**A cold-start test is the acceptance bar for this feature's docs, and it found
+things reading the code did not.** The one worth keeping: Claude Code pointed at
+the gateway with only `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` asks for
+*its own* default model, which is not a configured alias, and stops with "There's
+an issue with the selected model". The alias name is the whole routing key, so
+either `ANTHROPIC_MODEL` names an alias or an alias is named after what the
+client sends. The env snippets in `views/gateway/snippets.ts` show two variables
+and the user guide shows three, deliberately.
+
+**The `ferrox-providers` pin is a tag, and the crates.io question is open.**
+`Cargo.toml`'s comment defers "tag vs crates.io publish" to before the first
+shipping release; #429 records it as a release-gate item rather than deciding it,
+because a docs change must not settle a supply-chain choice. See
+[#453](https://github.com/shaharia-lab/agento/issues/453).
 
 ### Not implemented, on purpose
 

--- a/README.md
+++ b/README.md
@@ -240,6 +240,14 @@ added through `~/.agento/mcps.yaml`.
 
 </details>
 
+### Route your other tools through Agento
+
+Turn on the built-in **LLM Gateway** and Agento serves an OpenAI-compatible and an
+Anthropic-native endpoint on `127.0.0.1`, forwarding to providers you configure with your
+own keys. Point the OpenAI SDK, the Anthropic SDK or Claude Code at it and get ordered
+fallback between providers plus a record of what every tool spent. **Off by default** — a
+fresh install binds no port.
+
 ### Honest pricing, your data
 
 Rates for Anthropic, Moonshot, Z.ai and Alibaba models ship with the app and are
@@ -332,7 +340,7 @@ Everything lives in [`docs/`](docs/README.md).
 **User guide** — how to *use* it
 
 - [Installation](docs/installation.md)
-- [User guide](docs/user-guide.md): chats, agents, integrations, scheduled tasks, sessions, analytics, settings
+- [User guide](docs/user-guide.md): chats, agents, integrations, scheduled tasks, sessions, analytics, the LLM gateway, settings
 - [Troubleshooting](docs/troubleshooting.md)
 
 </td>

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@
 | Guide | What it covers |
 | --- | --- |
 | [Installation](installation.md) | Downloads per platform, first launch, updates, where your data lives, uninstalling |
-| [User Guide](user-guide.md) | Every section of the app: chats, agents, integrations, scheduled tasks, session history, analytics, settings |
+| [User Guide](user-guide.md) | Every section of the app: chats, agents, integrations, scheduled tasks, session history, analytics, the LLM gateway, settings |
 | [Troubleshooting](troubleshooting.md) | Common problems, and how to read the logs |
 
 Start with [Installation](installation.md).
@@ -16,7 +16,7 @@ Start with [Installation](installation.md).
 | --- | --- |
 | [Architecture](architecture.md) | Stack, process model, the native backend, the Claude SDK, design principles, and the frozen wire-format spec |
 | [Development](development.md) | Setup, running locally, tests, parity testing, conventions, debugging |
-| [Releasing](releasing.md) | Cutting a release, the guards, the update manifest, signing keys |
+| [Releasing](releasing.md) | Cutting a release, release notes, the guards, the update manifest, signing keys |
 
 [`CLAUDE.md`](../CLAUDE.md) is the full working notes: every decision,
 with the reasoning and the failures behind it. These guides are the map, that file

--- a/docs/development.md
+++ b/docs/development.md
@@ -11,8 +11,9 @@ notes, with the reasoning behind individual decisions, are in
 - [Running it](#running-it)
 - [Project layout](#project-layout)
 - [Tests](#tests)
-- [Parity testing](#parity-testing)
+- [The wire format is exact](#the-wire-format-is-exact)
 - [Conventions](#conventions)
+- [The LLM gateway](#the-llm-gateway)
 - [Debugging](#debugging)
 - [Branches and pull requests](#branches-and-pull-requests)
 
@@ -129,6 +130,7 @@ src-tauri/
   src/paths.rs       data directory and database path
   src/claude/        the Claude Agent SDK
   src/native/        the backend, one module per API area
+  src/gateway/       the embedded LLM gateway's own listener — not part of /api
   tests/             integration tests
 parity/              the frozen wire-format spec; see parity/README.md
 docs/                this documentation
@@ -289,6 +291,96 @@ line that quietly stops being emitted.
 
 ---
 
+## The LLM gateway
+
+`src-tauri/src/gateway/` is a **second HTTP listener**, and the thing to get
+straight before changing anything in it is that it is not part of `/api`.
+
+| | `/api`, in `native/` | the gateway, in `gateway/` |
+| --- | --- | --- |
+| Port | the app's own | the user's, 8880 by default |
+| Wire format | Agento's | OpenAI's and Anthropic's |
+| Credential | `read` / `write` | `llm`, and only `llm` |
+| Guards | `guards.rs`, before routing | its own Host and auth layers |
+| Route tables | `parity/read_routes.json`, `write_routes.json` | **none — they say nothing about it** |
+
+So the parity machinery does not apply to the five routes it serves
+(`/v1/chat/completions`, `/v1/models`, `/anthropic/v1/messages`,
+`/anthropic/v1/models`, `/healthz`): there is no Go ancestor to be byte-identical
+to, and the wire format that matters is somebody else's.
+
+Its **control plane is the opposite** and this is where the split gets confused.
+`/api/gateway/*` — twelve routes in `native/gateway_api.rs` — is ordinary `/api`
+surface, behind the ordinary guard with ordinary `read`/`write` scoping, and it
+is recorded in `parity/desktop_routes.json`. That file holds the routes with no
+Go ancestor, and its assertion is **set equality** against the union of every
+owning module's `ROUTES` const. Add a third owner and you must add it to that
+union, or the test silently weakens to a one-directional check and still passes.
+
+An `llm` token opens none of those twelve routes. That is the same disjointness
+seen from the other side: a credential issued to *spend* through the gateway must
+not be able to reconfigure which provider it spends with.
+
+### The `ferrox-providers` dependency
+
+Every translation and every provider adapter comes from `ferrox-providers`, the
+crate extracted from [ferrox](https://github.com/shaharia-lab/ferrox) with this
+app as its intended desktop consumer. What lives here is only the listener, the
+auth, the routing table and the framing.
+
+```toml
+ferrox-providers = { git = "https://github.com/shaharia-lab/ferrox",
+                     tag = "providers-v0.1.0", default-features = false,
+                     features = ["anthropic", "openai", "gemini"] }
+```
+
+Three parts of that line are load-bearing:
+
+- **`default-features = false`**, because the default feature set includes
+  `axum`, which pins **axum 0.7** while this crate is on **0.8**. Enabling it
+  compiles two axums or fails outright. The casualty is the crate's own Anthropic
+  SSE emitter, which is why `gateway/stream.rs` writes raw SSE bytes over the
+  framework-free `SseFrame` the crate emits instead.
+- **no `bedrock`**, because its AWS SDK pins Rust **1.94.1** against this crate's
+  declared **1.88** floor. That is also why `gateway_providers.type` accepts four
+  provider types and not five.
+- **a tag, not a commit SHA.** The design document predates the tag existing and
+  says to pin a SHA. A tag can be moved where a SHA cannot, which is accepted
+  here only because ferrox is our own repository and its README documents this
+  tag as the reference point.
+
+**Open, and due before the first release that ships the gateway:** whether to
+publish `ferrox-providers` to crates.io rather than depending on it by git —
+[#453](https://github.com/shaharia-lab/agento/issues/453).
+
+Two more things are copied rather than imported, and both are deliberate:
+`is_retryable` / `should_failover` (`gateway/dispatch.rs`) live in ferrox's
+*binary* crate, not in `ferrox-providers`; and there is **no `CorsLayer`**, which
+ferrox's own server mounts permissively. That is right behind a network boundary
+and catastrophic on loopback — it would let any page you have open spend your
+provider credits and read the answer.
+
+### Curling it in dev
+
+The gateway needs a credential of its own, and the debug build's `api-token` file
+is **not** it — that holds a `write` token, which the gateway refuses with a 403.
+Mint an `llm` one first:
+
+```bash
+API=$(cat ~/.agento-desktop-dev/api-token)
+LLM=$(curl -s -X POST -H "Authorization: Bearer $API" -H "Content-Type: application/json" \
+  -d '{"name":"dev","scope":"llm","expires_in_days":1}' \
+  http://127.0.0.1:8991/api/security/tokens | jq -r .token)
+
+curl -s http://127.0.0.1:8880/v1/models -H "Authorization: Bearer $LLM" | jq
+```
+
+That last line is the cheapest live check that the listener is up and the
+credential works; it answers with the configured **aliases**. `/healthz` on the
+same port needs no credential at all and is the check for "is anything bound".
+
+---
+
 ## Debugging
 
 **The webview inspector** is available in dev builds: right-click, Inspect
@@ -361,12 +453,26 @@ to earn it, and they have different fixes:
 
 That last one is worth knowing before it bites in dev: the debug build's
 `api-token` file holds a **`write`** token, so it will not work against the
-gateway. Mint an `llm` one through `POST /api/security/tokens` (or
-Settings → Security) first.
+gateway. [The LLM gateway](#the-llm-gateway) has the two commands that mint an
+`llm` one and check the listener with it.
 
 **Regenerating the key in Settings → Security invalidates every token at once**,
 the dev file's included, which is exactly what it is for. The app window recovers
-on its own; a shell holding an old token needs to re-read the file.
+on its own; a shell holding an old token needs to re-read the file, and any tool
+configured against the gateway needs a freshly minted one pasted in.
+
+**A scratch instance, for anything you would not want to do to your own data**,
+is a scratch `HOME` — **not** `AGENTO_DATA_DIR`, which a debug build ignores
+(`paths.rs::data_dir` is `cfg`-split and the debug arm always answers
+`~/.agento-desktop-dev`, so that an exported variable cannot make `npm run app`
+share a database and a scheduler with an installed Agento):
+
+```bash
+HOME=/tmp/scratch-home ./target/debug/agento
+```
+
+That gets its own database, its own signing keypair and an empty `~/.claude` —
+a genuinely cold install, which is the only way to test a first-run path.
 
 There is also a project skill, `local-verify`, describing how to reproduce a bug
 before fixing it and how to verify each hop separately: backend wire, browser

--- a/docs/development.md
+++ b/docs/development.md
@@ -301,7 +301,7 @@ straight before changing anything in it is that it is not part of `/api`.
 | Port | the app's own | the user's, 8880 by default |
 | Wire format | Agento's | OpenAI's and Anthropic's |
 | Credential | `read` / `write` | `llm`, and only `llm` |
-| Guards | `guards.rs`, before routing | its own Host and auth layers |
+| Guards | `guards.rs`, before routing | its own auth layer, and `guards::host_allowed` **shared** rather than copied |
 | Route tables | `parity/read_routes.json`, `write_routes.json` | **none — they say nothing about it** |
 
 So the parity machinery does not apply to the five routes it serves

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -155,7 +155,7 @@ exists:
 >
 > This adds a third token scope, **`llm`**, which reaches the gateway and nothing
 > else; existing `read` and `write` tokens are unaffected and are refused by the
-> gateway by design. It also adds two database tables and a usage-retention
+> gateway by design. It also adds four database tables and a usage-retention
 > setting (90 days by default; `0` keeps everything).
 >
 > Full walkthrough: [LLM Gateway in the user guide](https://github.com/shaharia-lab/agento/blob/main/docs/user-guide.md#llm-gateway).

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -24,6 +24,7 @@ it with nothing to promote.
 
 - [The flow](#the-flow)
 - [Cutting a release](#cutting-a-release)
+- [Release notes](#release-notes)
 - [The two guards](#the-two-guards)
 - [Release candidates and dry runs](#release-candidates-and-dry-runs)
 - [What gets built](#what-gets-built)
@@ -105,9 +106,59 @@ cannot download.
    and `latest.json` is there. Download one and launch it if the change was
    risky.
 
-5. **Publish the draft.** That fires `promote`, which copies the staged manifest
+5. **Write the release notes** into the draft's body, before publishing. See
+   [Release notes](#release-notes) below.
+
+6. **Publish the draft.** That fires `promote`, which copies the staged manifest
    to `desktop-latest`. Installed apps start seeing the update within their next
    check.
+
+---
+
+## Release notes
+
+The workflow does not generate them — the draft release's body is empty until
+somebody writes it, and once the draft is published that text is what every user
+sees in the in-app update prompt. Two rules:
+
+- **Say what changes for someone who does nothing.** Most releases change
+  behaviour for everyone; a release whose headline feature is off by default does
+  not, and the notes should say so plainly rather than leaving a reader to guess
+  whether they have just been given a new listening port.
+- **Anything needing a Gatekeeper or SmartScreen bypass gets a line**, with the
+  link to [Installation](installation.md) — builds are neither Apple notarised
+  nor Windows code signed.
+
+### Drafted: the first release carrying the LLM Gateway
+
+Ready to paste into that release's draft body, and the reason this section
+exists:
+
+> **LLM Gateway (new, and off by default).**
+>
+> Agento can now serve as a local LLM endpoint for your other tools. Enable it
+> and it listens on `127.0.0.1` speaking both the OpenAI and the Anthropic wire
+> formats, forwarding to providers you configure with your own API keys — so the
+> OpenAI SDK, the Anthropic SDK, Claude Code, LiteLLM or Aider can all be pointed
+> at one place. You get ordered fallback between providers when one fails, and a
+> Usage dashboard showing what each tool, alias and token spent.
+>
+> **If you do not turn it on, nothing changes.** No port is bound, no listener
+> starts, and the feature costs one database read at launch. It is off on a fresh
+> install and off after upgrading.
+>
+> To turn it on: **LLM Gateway → Gateway Settings**, then add a provider, define
+> a model alias, and mint a gateway token from **Overview**. The two base URLs
+> are not the same shape — `…:8880/v1` for OpenAI-style clients, `…:8880/anthropic`
+> with **no** `/v1` for the Anthropic SDK and Claude Code, which append it
+> themselves.
+>
+> This adds a third token scope, **`llm`**, which reaches the gateway and nothing
+> else; existing `read` and `write` tokens are unaffected and are refused by the
+> gateway by design. It also adds two database tables and a usage-retention
+> setting (90 days by default; `0` keeps everything).
+>
+> Full walkthrough: [LLM Gateway in the user guide](https://github.com/shaharia-lab/agento/blob/main/docs/user-guide.md#llm-gateway).
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -338,10 +338,11 @@ expect is missing or disabled, that is why traffic is not reaching it.
 
 ### Usage shows requests but no cost
 
-Cost is computed from the price catalog, which ships filled in for Claude models
-only. Anything else is recorded as unpriced rather than as free, which is why the
-total is labelled a floor. Add rates under **Settings → Pricing** for the models
-you actually use.
+Cost is computed from the price catalog, which ships filled in for Anthropic,
+Moonshot, Z.ai and Alibaba models — so OpenAI and Gemini traffic has no rate.
+Anything unpriced is recorded as such rather than as free, which is why the total
+is labelled a floor. Add rates under **Settings → Pricing** for the models you
+actually use.
 
 ### The gateway's log lines
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,6 +8,7 @@ Common problems and what to do about them.
 - [History and analytics](#history-and-analytics)
 - [Scheduled tasks](#scheduled-tasks)
 - [Integrations](#integrations)
+- [LLM Gateway](#llm-gateway)
 - [Updates](#updates)
 - [Reading the logs](#reading-the-logs)
 - [Still stuck](#still-stuck)
@@ -249,6 +250,109 @@ enabled inside it, and the tool is ticked on the agent.
 
 Agento does not support WhatsApp. An integration created by an older version is
 still listed and its data is safe, but it cannot be edited or used.
+
+---
+
+## LLM Gateway
+
+### Overview says "Port unavailable"
+
+Something else already holds that port. Change it in **LLM Gateway → Gateway
+Settings → Port** and save; the listener rebinds immediately.
+
+The usual culprit is a second Agento. A development build and an installed one
+read different databases but share the machine's ports, so both can be configured
+for 8880 and only the first to start gets it. The status carries the exact reason,
+and the same line is in the log:
+
+```
+binding the llm gateway on 127.0.0.1:8880: Address already in use (os error 98)
+```
+
+### The gateway answers 401
+
+The token is absent, malformed, expired, revoked, or was signed by a key this
+install no longer uses — regenerating the signing key does that to every token at
+once. Mint a new one from **LLM Gateway → Overview** and paste it into the tool
+again.
+
+Check the tool is actually sending it: the gateway accepts either
+`Authorization: Bearer <token>` or `x-api-key: <token>`, and an `Authorization`
+header that is present but not a `Bearer` is ignored in favour of `x-api-key`.
+
+### The gateway answers 403
+
+You used a `read` or `write` token. Those reach the Agento API and are refused
+here on purpose. Mint one with the **`llm`** scope — Overview's **Create gateway
+token** button does exactly that — and use it instead.
+
+A bigger Agento token is not the fix. The scopes are disjoint rather than ranked,
+so `write` does not include `llm`.
+
+### The Agento API answers 403 for a token that works on the gateway
+
+The same rule the other way round. An `llm` token reaches the gateway and nothing
+under `/api`; there is no Agento API route that accepts one. Use a `read` or
+`write` token for the API.
+
+### The tool connects but every request fails with a model error
+
+The name your tool sends as `model` has to be an alias you defined, exactly.
+There is no prefix parsing and no fuzzy matching, so an unconfigured name is a
+404:
+
+```
+model alias 'claude-opus-5' is not configured on this gateway
+```
+
+For Claude Code this is the default first experience, because it asks for its own
+default model unless told otherwise and stops with *"There's an issue with the
+selected model"*. Either `export ANTHROPIC_MODEL=<your alias>`, or name an alias
+after the model Claude Code asks for.
+
+### Claude Code cannot reach it at all
+
+Check the base URL has no `/v1`. Claude Code and the Anthropic SDK append
+`/v1/messages` themselves, so `ANTHROPIC_BASE_URL` ends at `/anthropic`:
+
+```bash
+export ANTHROPIC_BASE_URL=http://127.0.0.1:8880/anthropic   # right
+export ANTHROPIC_BASE_URL=http://127.0.0.1:8880/anthropic/v1 # 404 on every call
+```
+
+The OpenAI-shaped base URL is the opposite and does end in `/v1`.
+
+### Nothing appears in Usage
+
+A row is written per request the gateway *served*, so a request refused before it
+got that far — a bad token, a 404 on the base URL — records nothing on purpose.
+Confirm the listener is up and the request is arriving:
+
+```bash
+curl http://127.0.0.1:8880/healthz
+curl http://127.0.0.1:8880/v1/models -H "Authorization: Bearer <your gateway token>"
+```
+
+`/healthz` needs no credential. `/v1/models` lists your aliases; if the alias you
+expect is missing or disabled, that is why traffic is not reaching it.
+
+### Usage shows requests but no cost
+
+Cost is computed from the price catalog, which ships filled in for Claude models
+only. Anything else is recorded as unpriced rather than as free, which is why the
+total is labelled a floor. Add rates under **Settings → Pricing** for the models
+you actually use.
+
+### The gateway's log lines
+
+The same `Agento.log` as everything else — see [Reading the
+logs](#reading-the-logs). Gateway lines are prefixed `llm gateway` or `gateway`:
+
+```
+llm gateway listening on http://127.0.0.1:8880
+gateway completion streaming alias=fast provider=my-openai model_id=gpt-4o-mini
+gateway usage pruned rows=1204 older_than_days=90
+```
 
 ---
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -403,8 +403,9 @@ feature costs one database read at launch until you turn it on.
 **LLM Gateway → Gateway Settings**, under **Listener**:
 
 - **Enable the gateway.** Off by default. When off, no port is bound.
-- **Port**, 8880 by default. This is the number you paste into tool configs, so
-  Agento will not take an OS-assigned one. Ports below 1024 need root.
+- **Port**, 8880 by default, and between 1024 and 65535. This is the number you
+  paste into tool configs, so Agento will not accept `0` and take an OS-assigned
+  one, and it will not accept a port below 1024, which would need root.
 - **Start with the app.** On by default, and only meaningful while the gateway is
   enabled. Without it the port dies with every restart, which is not much of a
   gateway.
@@ -525,9 +526,9 @@ provider, surface, status and which token was used, with p50/p95/max latency.
 Two numbers are labelled as **floors** rather than reported as facts:
 
 - A model with no entry in the pricing catalogue is recorded as unpriced rather
-  than as free, so a cost total that is missing something says so. Provider
-  models are not in the shipped catalogue, so this is the usual case, not an edge
-  one — add rates under **Settings → Pricing** if you want real figures.
+  than as free, so a cost total that is missing something says so. The shipped
+  catalogue covers Anthropic, Moonshot, Z.ai and Alibaba models, so OpenAI and
+  Gemini traffic is unpriced until you add rates under **Settings → Pricing**.
 - A window reaching further back than the retention horizon reports what
   survives, which is not everything that happened.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -12,6 +12,7 @@ New here? Install first: [Installation](installation.md).
 - [Job history](#job-history)
 - [Claude sessions](#claude-sessions)
 - [Analytics](#analytics)
+- [LLM Gateway](#llm-gateway)
 - [Settings](#settings)
 - [Privacy](#privacy)
 
@@ -379,9 +380,189 @@ one.
 
 ---
 
+## LLM Gateway
+
+Everything above this point reports on Claude Code runs. This is the one feature
+that works the other way round: Agento becomes an endpoint your *other* tools
+call.
+
+The gateway is a local HTTP endpoint that speaks the OpenAI and Anthropic wire
+formats and forwards to providers you configure with your own API keys. Anything
+that can be pointed at a different base URL — the OpenAI SDK, the Anthropic SDK,
+Claude Code, LiteLLM, Aider — can go through it. In return you get one place to
+keep provider keys, ordered fallback between providers, and a record of what
+every tool spent.
+
+It binds `127.0.0.1` and nothing else, so it is reachable from your machine only.
+
+**It ships disabled.** A fresh install binds no port and starts no listener; the
+feature costs one database read at launch until you turn it on.
+
+### Turning it on
+
+**LLM Gateway → Gateway Settings**, under **Listener**:
+
+- **Enable the gateway.** Off by default. When off, no port is bound.
+- **Port**, 8880 by default. This is the number you paste into tool configs, so
+  Agento will not take an OS-assigned one. Ports below 1024 need root.
+- **Start with the app.** On by default, and only meaningful while the gateway is
+  enabled. Without it the port dies with every restart, which is not much of a
+  gateway.
+
+Changing the port restarts the listener, and anything already configured against
+the old one stops working until you update it. The view says so before you save.
+
+**Overview** shows whether the listener is actually up: **Running**, **Stopped**,
+**Port unavailable** or **Failed to start**.
+
+### Adding a provider
+
+**LLM Gateway → Providers → +**. A provider is one upstream account.
+
+- **Name** — how aliases refer to this provider. Renaming it breaks every alias
+  that routes to it.
+- **Type** — Anthropic, OpenAI, Google Gemini or Z.AI GLM. This picks the
+  adapter.
+- **Base URL** — leave empty for the provider's own endpoint. GLM requires one.
+- **API key** — yours. It is sent only when you type one and is never returned by
+  any read, so the field is empty every time you open the form. That is
+  deliberate rather than a bug: no read can echo it, so nothing can leak it back
+  through the UI, and leaving the field alone keeps the stored key.
+- **Timeouts** — connect, first byte, and idle between tokens.
+
+A disabled provider stays configured and is not dispatched to.
+
+### Defining an alias
+
+**LLM Gateway → Models → +**. An alias is the name your tools ask for.
+
+- **Model name** — exactly what the client sends as `model`. This is the whole
+  routing key; there is no prefix parsing and no pattern matching.
+- **Targets** — a provider plus that provider's own model id. **The order is the
+  meaning**: the first is preferred, and each one after it is tried when the one
+  before fails.
+- **Fallbacks** — walked only after every target has failed.
+
+Failure means a timeout, a connection error, a 429, or a 5xx. A provider
+answering **403** is failed over to the next target *without* being retried,
+because several providers report an exhausted plan that way and asking the same
+one again will not help.
+
+### Getting a token
+
+The gateway does not accept your provider keys as its own credential — it has
+one of its own, so that a tool config holds something you can revoke without
+touching anything else.
+
+**LLM Gateway → Overview → Create gateway token** mints one. It is an `llm`
+token, valid for a year, and it is shown **once**: it is not stored anywhere and
+cannot be shown again. Copy it then. While the banner is open the snippets below
+it have the real token embedded, ready to copy whole.
+
+Lost it? Mint another and revoke the old one in **Settings → Security**.
+
+### Pointing a tool at it
+
+Two environment variables, and **the two base URLs are not the same shape**:
+
+| Client | Base URL |
+| --- | --- |
+| OpenAI SDK, LiteLLM, Aider | `http://127.0.0.1:8880/v1` |
+| Anthropic SDK, Claude Code | `http://127.0.0.1:8880/anthropic` |
+
+The OpenAI one **ends in `/v1`** and the Anthropic one **does not**. That is
+because an OpenAI client takes a base URL that already includes the version
+segment and appends `/chat/completions` to it, while the Anthropic SDK and Claude
+Code append `/v1/messages` themselves. Writing `/anthropic/v1` therefore asks for
+`/anthropic/v1/v1/messages`, which is not a route and answers **404**. This is
+the single most common way to get this wrong.
+
+**OpenAI SDK:**
+
+```bash
+export OPENAI_BASE_URL=http://127.0.0.1:8880/v1
+export OPENAI_API_KEY=<your gateway token>
+```
+
+**Anthropic SDK:**
+
+```bash
+export ANTHROPIC_BASE_URL=http://127.0.0.1:8880/anthropic
+export ANTHROPIC_AUTH_TOKEN=<your gateway token>
+```
+
+**Claude Code:**
+
+```bash
+export ANTHROPIC_BASE_URL=http://127.0.0.1:8880/anthropic
+export ANTHROPIC_AUTH_TOKEN=<your gateway token>
+export ANTHROPIC_MODEL=<one of your aliases>
+claude
+```
+
+The third line matters. Without it Claude Code asks for whichever model it
+defaults to, which is not one of your aliases, and it stops with *"There's an
+issue with the selected model"*. Either export `ANTHROPIC_MODEL`, or name an
+alias after the model Claude Code asks for. Claude Code also warns that it does
+not recognise a made-up model name and will assume a 200k context window; that
+warning is its own and is harmless.
+
+To check the listener without any of that:
+
+```bash
+curl http://127.0.0.1:8880/v1/models \
+  -H "Authorization: Bearer <your gateway token>"
+```
+
+It answers with **your aliases**, not with a provider's catalogue — the aliases
+are what this endpoint routes.
+
+### Watching usage
+
+**LLM Gateway → Usage** is one row per served request, broken down by alias,
+provider, surface, status and which token was used, with p50/p95/max latency.
+
+Two numbers are labelled as **floors** rather than reported as facts:
+
+- A model with no entry in the pricing catalogue is recorded as unpriced rather
+  than as free, so a cost total that is missing something says so. Provider
+  models are not in the shipped catalogue, so this is the usual case, not an edge
+  one — add rates under **Settings → Pricing** if you want real figures.
+- A window reaching further back than the retention horizon reports what
+  survives, which is not everything that happened.
+
+**Keep usage rows for** (Gateway Settings → Usage log) is that horizon: 90 days
+by default, up to 3650, and **`0` keeps everything**. Shortening it deletes
+anything already older, the next time the log is pruned, and usage rows are not
+recoverable.
+
+### Tokens, and the one thing that revokes them all
+
+Agento has three token scopes and they are not a ladder:
+
+- **`read`** and **`write`** reach the Agento API. `write` includes `read`.
+- **`llm`** reaches the gateway, and nothing else.
+
+They are deliberately disjoint in both directions. A `read` or `write` token is
+refused by the gateway with **403**, and an `llm` token is refused everywhere in
+the Agento API with **403**. Neither is a bigger version of the other: a gateway
+token is pasted in plain text into tool configs, where `write` would be arbitrary
+command execution on your machine, and a credential for spending provider credits
+has no business reading your chat transcripts.
+
+**Regenerating the signing key in Settings → Security revokes every token at
+once** — the app's own session, every API token, and every gateway token with
+them. Every tool you configured starts getting 401s with nothing else to tell you
+why, and each one needs a freshly minted token pasted in again. That is the point
+of the button rather than a side effect, and it is an accepted trade-off for a
+single-user app: one key, one blast radius. To revoke a single gateway client
+instead, revoke that token by name in **Settings → Security**.
+
+---
+
 ## Settings
 
-`Ctrl ,` opens Settings. Seven panes.
+`Ctrl ,` opens Settings. Nine panes.
 
 ### General
 
@@ -437,6 +618,23 @@ Two separate actions, on purpose:
 
 Either way, your sessions are re-priced in the background afterwards.
 
+### Security
+
+The API tokens this install has issued, and the key that signs them.
+
+- **Issue a token** with a scope: `read` or `write` for the Agento API, or `llm`
+  for the [LLM Gateway](#llm-gateway). It is shown once and stored nowhere.
+- **Revoke** one by name, which stops it immediately and leaves every other token
+  working.
+- **Regenerate the signing key** invalidates *every* token at once, gateway
+  clients included. The app window recovers by itself; nothing else does.
+
+### Logs
+
+The app's own log file — tail it, follow it, filter by level, and save a copy to
+send with a bug report. It records one line per API request and what each write
+did, and no message bodies, prompts or credentials.
+
 ### Advanced
 
 Monitoring configuration, shown read-only. Agento does not export telemetry, so
@@ -452,9 +650,11 @@ reference, along with any `OTEL_*` environment variables pinning them.
   runs.
 - Agento has no account, no telemetry and no analytics of its own.
 - The only outbound network calls are the ones you asked for: agent runs, the
-  integrations you connected, and the update check (which you can switch off).
-- Integration credentials are stored in plain text in the local database. Its
-  protection is your user account and your disk. Treat `~/.agento` as sensitive.
+  integrations you connected, the update check (which you can switch off), and —
+  if you enable it — the providers the [LLM Gateway](#llm-gateway) forwards to.
+- Integration credentials and gateway provider keys are stored in plain text in
+  the local database. Their protection is your user account and your disk. Treat
+  `~/.agento` as sensitive.
 - Your Claude Code transcripts in `~/.claude` are read only, never modified.
 
 ---

--- a/src-tauri/src/gateway/mod.rs
+++ b/src-tauri/src/gateway/mod.rs
@@ -16,11 +16,11 @@
 //! function #405 built for a second caller — requiring the disjoint
 //! [`Scope::Llm`](crate::native::security::token::Scope::Llm) added by #423.
 //!
-//! # What exists so far
+//! # What is here
 //!
-//! **The engine, as of #424.** [`config`] is #422's settings model and its
-//! SQLite storage; [`registry`], [`server`], [`dispatch`] and [`stream`] are
-//! the listener that reads it:
+//! [`config`] is #422's settings model and its SQLite storage; [`registry`],
+//! [`server`], [`dispatch`] and [`stream`] are #424's listener that reads it;
+//! [`usage`] is #425's row per served request, plus #428's retention prune.
 //!
 //! | module | what it owns |
 //! |---|---|
@@ -29,13 +29,18 @@
 //! | [`server`] | the five routes, the `Host` allowlist, the `llm`-scope auth layer, and the per-surface error dialect |
 //! | [`dispatch`] | alias → ordered targets, retry on the same target, and the fallback walk |
 //! | [`stream`] | the SSE bytes of both surfaces, and the `anthropic-beta` merge |
+//! | [`usage`] | one row per served request, the cost resolved at write time, and the retention prune |
 //!
-//! What is still absent: **usage recording** (#425 — `server`'s handlers log a
-//! line where the row will go), the **`/api/gateway/*` control API** (#426 —
-//! which is what will read [`registry::status`] and call
-//! [`registry::reload`]), and any **UI** (#427/#428). The gateway is disabled
-//! by default and costs nothing when off: `start_if_enabled` reads one row and
-//! returns.
+//! **Nothing of the epic is absent any more.** The control plane is not here but
+//! it does exist: `/api/gateway/*` is twelve routes in
+//! [`crate::native::gateway_api`] (#426), under `native/` because it *is* the
+//! `/api` seam where this listener is not, and the **LLM Gateway** section in
+//! `src/views/gateway/` (#427) with its Usage dashboard (#428) is what drives
+//! them. See `docs/development.md` for that split and the `ferrox-providers`
+//! dependency policy, and `docs/user-guide.md` for the user-facing flow.
+//!
+//! The gateway is disabled by default and costs nothing when off:
+//! `start_if_enabled` reads one row and returns.
 
 pub mod config;
 pub mod dispatch;


### PR DESCRIPTION
Closes #429. Last child of epic #421 — the LLM gateway is complete and, until this, undocumented.

## What

No runtime change beyond three stale doc comments. Five documentation files, and the epic close-out.

| File | What it gains |
| --- | --- |
| `docs/user-guide.md` | a **LLM Gateway** section between Analytics and Settings — what it is, turning it on, a provider, an alias, minting a token, pointing a tool at it, watching usage, and the token/signing-key story |
| `docs/troubleshooting.md` | a symptom-first **LLM Gateway** section between Integrations and Updates — nine entries |
| `docs/development.md` | **The LLM gateway**: the `/api`-versus-listener split, the `ferrox-providers` feature policy, and the two curl commands that check the listener in dev |
| `docs/releasing.md` | a **Release notes** step, which did not exist at all, carrying the drafted notes for the release that ships the gateway |
| `README.md` | one *What you get* entry, flagged off by default |
| `CLAUDE.md` | where the docs live, the three inverted claims a doc must keep making, and a correction (below) |

## The cold-start test

The acceptance bar was walking the documented flow on a genuinely fresh install rather than writing from the code. Full transcript below; it passed end to end, **including a real Claude Code 2.1.224 streaming a turn through the gateway**.

<details>
<summary>Transcript</summary>

# Cold-start test — issue #429

Performed 2026-08-24 against `origin/main` @ `96d5bb6` on Linux, with a scratch
`HOME` (`/tmp/coldhome`) so the install is genuinely fresh: new database, new
signing keypair, no `~/.claude` corpus, no gateway configuration.

The upstream is a scripted fake OpenAI-compatible provider
(`/tmp/coldstart/fake_provider.py`) rather than a paid account — see
"What this does and does not prove" at the end.

---

## 0. A fresh install binds nothing

```
[INFO] api signing keypair created kid=6153f84c… path=/tmp/coldhome/.agento-desktop-dev/api-signing-key.pk8
[INFO] api server listening on 127.0.0.1:8991
```

No `llm gateway listening` line.

```
GET /api/gateway/status   → {"state":"stopped"}
GET /api/gateway/settings → {"enabled":false,"port":8880,"start_with_app":true,"usage_retention_days":90}
curl http://127.0.0.1:8880/healthz → connection refused
```

## 1. Turning it on

```
PUT /api/gateway/settings {"enabled":true,"port":8880,…}
GET /api/gateway/status → {"state":"running","port":8880}
curl http://127.0.0.1:8880/healthz → 200 "ok"   (no credential)
```

## 2. A provider, and the key is never echoed

```
POST /api/gateway/providers {"name":"my-openai","type":"openai","api_key":"sk-placeholder…",
                             "base_url":"http://127.0.0.1:9799/v1","enabled":true}
→ {"id":"6edaabaf…","name":"my-openai","type":"openai","has_api_key":true,
   "base_url":"http://127.0.0.1:9799/v1",
   "timeouts":{"connect_secs":10,"ttfb_secs":60,"idle_secs":30},"enabled":true}
```

`has_api_key` rather than the key. The list read is identical.

## 3. An alias

```
POST /api/gateway/models {"alias":"fast","routing":{"targets":[{"provider":"my-openai",
                          "model_id":"gpt-4o-mini"}],"fallbacks":[]},"enabled":true}
```

## 4. A token, and the whole scope matrix

```
POST /api/security/tokens {"name":"LLM gateway client","scope":"llm","expires_in_days":365}
```

| request | result |
|---|---|
| `write` token → `GET :8880/v1/models` | **403** `{"error":{"code":403,"message":"this token's scope does not permit gateway requests; mint one with the llm scope in Settings → Security","type":"forbidden"}}` |
| no token → `GET :8880/v1/models` | **401** `{"error":{"code":401,"message":"a valid llm-scoped Agento token is required","type":"unauthorized"}}` |
| `llm` token → `GET :8991/api/agents` | **403** `{"error":"this token's scope does not permit this request"}` |
| `llm` token → `GET :8880/v1/models` | **200** `{"object":"list","data":[{"id":"fast","object":"model","created":0,"owned_by":"agento"}]}` |

`/v1/models` lists the **aliases**, not the upstream catalogue.

## 5. A streamed completion, both surfaces

OpenAI surface, `POST /v1/chat/completions` with `"stream":true`: six
`data:` chunks, a final chunk carrying `finish_reason":"stop"` and `usage`, then
`data: [DONE]`.

Anthropic surface, `POST /anthropic/v1/messages` with `"stream":true`:
`event: message_start`, `event: ping`, `event: content_block_start`, six
`event: content_block_delta`, `event: content_block_stop` — note the space after
`event:`.

## 6. The base-URL asymmetry, measured

```
POST /anthropic/v1/v1/messages → 404      (what an /anthropic/v1 base produces)
POST /anthropic/v1/messages    → 200
```

## 7. The real Claude Code CLI

`claude --version` → `2.1.224 (Claude Code)`.

```
env -u ANTHROPIC_API_KEY \
  ANTHROPIC_BASE_URL=http://127.0.0.1:8880/anthropic \
  ANTHROPIC_AUTH_TOKEN=<the llm token> \
  ANTHROPIC_MODEL=fast \
  claude -p "say hello" --output-format text

→ Hello from the fake upstream.
```

**A streamed Claude Code turn completed through the gateway.**

## 8. Usage

```
GET /api/gateway/usage
totals: {"requests":3,"prompt_tokens":33,"completion_tokens":18,
         "cache_read_tokens":0,"cache_write_tokens":0,"cost_usd":0,
         "unpriced_requests":3,"unpriced_models":["gpt-4o-mini"]}
by_surface: anthropic 2 requests, openai 1
latency: {"p50_ms":3,"p95_ms":4,"max_ms":4}
```

Unpriced traffic is disclosed rather than priced at zero.

## 9. A bind failure

With another process holding 8881 and the gateway pointed at it:

```
GET /api/gateway/status
→ {"state":"bind_failed","port":8881,
   "error":"binding the llm gateway on 127.0.0.1:8881: Address already in use (os error 98)"}
[WARN] binding the llm gateway on 127.0.0.1:8881: Address already in use (os error 98)
```

Moving the port back to 8880 returned it to `running` with no restart.

---

## The three documentation bugs this found, all fixed in the same PR

1. **The shipped Claude Code snippet is not sufficient on its own.** With only
   `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` exported, Claude Code asks for
   its *own* default model, which is not a configured alias:

   ```
   There's an issue with the selected model (claude-opus-5). It may not exist or
   you may not have access to it. Run --model to pick a different model.
   ```

   The alias name has to be what the client sends. Documented in the user guide
   and given its own troubleshooting entry.

2. **`AGENTO_DATA_DIR` does not isolate a debug build.** `CLAUDE.md` tells you to
   point it at a scratch directory for write-path testing; `paths.rs:31-34`
   ignores the environment in `cfg(debug_assertions)` and always uses
   `~/.agento-desktop-dev`. Following that advice writes to the developer's real
   dev database. Corrected in `CLAUDE.md`, and the working recipe (a scratch
   `HOME`) added to `docs/development.md`.

3. **`gateway/mod.rs`'s module doc is stale** — it still says usage recording,
   the control API and the UI are absent. All four have merged.

## What this does and does not prove

It proves the whole documented path: every `/api/gateway/*` call the UI makes,
both wire surfaces, both header spellings, streaming, the scope matrix, the
error bodies, usage recording and a real third-party client (Claude Code)
driving it end to end.

It does **not** prove that a live Anthropic or OpenAI *account* answers, because
no provider key was available to this run and spending someone's credits was not
mine to authorise. That hop is `ferrox-providers`' adapters, covered by its own
suite; nothing in this PR changes it. Every documented command was run as
written — no snippet is from memory.


</details>

## What it found

Three documentation defects, all fixed here:

1. **The env snippets the Overview view ships are not sufficient for Claude Code.** With only `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` exported, Claude Code asks for *its own* default model, which is not a configured alias, and stops with `There's an issue with the selected model (claude-opus-5)`. The user guide shows three variables where the snippet shows two, and the mismatch has its own troubleshooting entry. **This is the first thing a Claude Code user will hit**, and nothing said so.
2. **`AGENTO_DATA_DIR` does not isolate a debug build.** `CLAUDE.md` told you to point it at a scratch directory for write-path testing; `paths.rs::data_dir` is `cfg`-split and the debug arm ignores the environment entirely, always answering `~/.agento-desktop-dev`. Following that advice writes to the developer's real dev database — which is what happened on the first attempt at this test. The lever a debug build obeys is `HOME`. Corrected in `CLAUDE.md` with the reason, and the working recipe added to `docs/development.md`.
3. **`gateway/mod.rs`'s module doc still said #425–#428 were absent.**

## Judgement calls

Made without a human, and each is reversible:

- **The Settings section said "Seven panes" and listed seven; there are nine.** Security and Logs were never documented. My gateway section points at **Settings → Security** for token management, so leaving that wrong would have been actively misleading. Corrected the count and added two short entries. Slightly wider than the issue asked for; the alternative was a section pointing somewhere the guide says does not exist.
- **The Privacy section claimed the only outbound calls are agent runs, integrations and the update check.** The gateway falsifies that, so it now names provider calls too. A privacy claim that a merged feature makes untrue is not something to leave for later.
- **`docs/README.md` was listed as unchanged in the issue** (no new guide file, which I agree with). I still updated two row *descriptions*, because the map is now incomplete.
- **A pre-existing broken anchor** in `development.md`'s TOC (`#parity-testing`, whose heading was renamed to "The wire format is exact") is fixed — it sits two lines above one I added.
- **The release notes went into `docs/releasing.md`.** The issue says to draft them "per `docs/releasing.md`'s flow", and that flow has no release-notes step — the draft body is simply empty until somebody writes it. Rather than put the text somewhere it would be lost, the file gains the step and the drafted notes together. No new file, as the issue requires.
- **`#453` is filed** for the deferred `ferrox-providers` tag-vs-crates.io decision, linked from `CLAUDE.md`, `docs/development.md` and the epic. The issue explicitly asked this PR to *force* the decision, not make it.

## Verification

- `npm run build`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — all green. **1,305 unit tests plus every integration suite pass**, unchanged.
- A script checked every internal Markdown link and anchor across the eight doc files; all resolve.
- Every command and snippet in the docs was copy-pasted and run. None is from memory.

**On regression guards:** this PR adds no test, and reverting it makes nothing fail. That is honest rather than an omission — the change is prose, and the repo has no docs-linting gate to hook into. What stands behind the prose is the transcript: the claims were measured against a running build, not reasoned about.

## Not proved

The cold-start test used a scripted fake OpenAI-compatible upstream, not a paid provider account. No provider key was available to this run and spending someone's credits was not mine to authorise. Everything Agento owns is exercised — both wire surfaces, both header spellings, streaming, the scope matrix, the error bodies, usage recording, and a real third-party client driving it. The hop it does not exercise is `ferrox-providers`' adapters talking to a live vendor, which this PR does not touch and which that crate's own suite covers.

---

## Review round 1 — five factual errors in my own text

Caught by re-deriving every claim from the tree rather than trusting the draft. All applied in `a9594f7`; CI re-verified green on the result.

| Sev | Location | Issue | Evidence |
| --- | --- | --- | --- |
| 🟠 | `docs/user-guide.md` | "Ports below 1024 need root" implies one works with root | Both `gateway_api.rs:210` and `SettingsView.tsx:28` **refuse** it |
| 🟠 | `docs/releasing.md` | "adds two database tables" | Migration 32 creates three, 34 creates a fourth |
| 🟠 | `docs/troubleshooting.md` | "catalog ships filled in for Claude models only" contradicted the same guide's Pricing section | `pricing_seed_vectors.json`: anthropic 25 / alibaba 7 / moonshot 2 / zhipu 1 — OpenAI and Gemini are what lack rates |
| 🟡 | `docs/user-guide.md` | "Provider models are not in the shipped catalogue" overstated | Same evidence |
| 🟡 | `docs/development.md` | "its own Host and auth layers" | The gateway shares `guards::host_allowed`; `CLAUDE.md` calls that sharing load-bearing |

A secret sweep over the whole diff for `sk-`, `eyJ` and long bearer values returned nothing.
