### PR TITLE
feat(search): the sessions list shows why a row matched (#438)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,18 @@ src/
     clipboard.ts copyText, with the execCommand fallback WebKitGTK needs
     newChatPrefs.ts  what the New Chat bar was last set to (localStorage)
     logs.ts      the log commands, and the line parser (target before level)
+    snippet.ts   the U+0001/U+0002 highlight sentinels, mirrored once from
+                 native/search/mod.rs, and snippetParts() (#438). They are
+                 **markers, not markup**: a snippet carries the transcript's own
+                 bytes, so every run is handed to JSX as a text child and
+                 nothing here builds an HTML string
+    typeAssert.ts  Eq / Expect — the compile-time value pin, lifted out of
+                 views/gateway/snippets.ts by #438 for its second consumer.
+                 **This is the repo's only regression guard for a value**, since
+                 there is no TypeScript test harness: give the value a literal
+                 type and assert it exactly, and respelling it fails `tsc`.
+                 `Eq`, never `extends` (`"a" extends string` pins nothing), and
+                 export the alias or `noUnusedLocals` deletes the guard
   components/    TitleBar, Sidebar, StatusBar, CommandPalette, ui.tsx,
                  DirField (native picker + the /api/fs fallback), CopyButton,
                  TokenReveal (the show-once minted token, #427 — shared by
@@ -201,8 +213,9 @@ src/
     gateway/     the LLM Gateway section (#427) — its own sidebar section,
                  sharing nothing with Claude analytics or stats.ts
       OverviewView.tsx  status, the mint-once `llm` token, and the env snippets
-      snippets.ts       the two base URLs and the type-level pin on them:
-                        OpenAI is `/v1`, Anthropic is `/anthropic` with no `/v1`
+      snippets.ts       the two base URLs and the type-level pin on them
+                        (through lib/typeAssert.ts): OpenAI is `/v1`, Anthropic
+                        is `/anthropic` with no `/v1`
       UsageView.tsx     the gateway's own dashboard (#428) over
                         GET /api/gateway/usage — and the two places a total is
                         labelled a *floor* rather than reported as a fact

--- a/src/lib/snippet.ts
+++ b/src/lib/snippet.ts
@@ -18,20 +18,14 @@
  * pass that could be forgotten one call site later.
  */
 
+import type { Eq, Expect } from "./typeAssert";
+
 export const SNIPPET_MARK_START = "\u0001";
 export const SNIPPET_MARK_END = "\u0002";
 
-/* These two are a wire contract with `native/search/mod.rs`, and this repo has
-   no TypeScript test harness — `npm run build` is `tsc --noEmit && vite build`
-   and that is the whole frontend gate. So they are pinned at the *type* level,
-   the way `views/gateway/snippets.ts` pins the gateway's two base URLs (#427):
-   respelling either constant fails `tsc`, i.e. CI. Exported so `noUnusedLocals`
-   does not flag the guard away. */
-type Eq<A, B> =
-  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
-    ? true
-    : false;
-type Expect<T extends true> = T;
+/* These two are a wire contract with `native/search/mod.rs`, so they are pinned
+   at the type level — see `lib/typeAssert.ts` for why that is this repo's only
+   guard for a value. Respelling either constant fails `tsc`, i.e. CI. */
 export type PinnedSnippetMarkStart = Expect<
   Eq<typeof SNIPPET_MARK_START, "\u0001">
 >;

--- a/src/lib/snippet.ts
+++ b/src/lib/snippet.ts
@@ -1,0 +1,96 @@
+/**
+ * `match_snippet` — the server's answer to "why did this row match?" — and the
+ * one place its highlight sentinels are spelled on this side of the wire.
+ *
+ * The backend wraps every matched term in **U+0001 / U+0002**
+ * (`native/search/mod.rs`'s `SNIPPET_MARK_START` / `SNIPPET_MARK_END`, emitted
+ * by FTS5's `snippet()` as `char(1)` / `char(2)`). Those two are unambiguous
+ * *by construction* rather than by convention: `normalize_text` collapses every
+ * control character to a space before a byte is indexed, so neither can occur
+ * in the transcript text a snippet is cut from.
+ *
+ * **They are markers, not markup.** The snippet carries the transcript's own
+ * bytes — a session about web development genuinely contains `<script>` — so
+ * the only safe renderer is one that splits on the sentinels and hands the
+ * segments to React as text. Nothing here produces HTML, and nothing
+ * downstream may use `dangerouslySetInnerHTML`: the inertness #438 asks for is
+ * a property of never building markup in the first place, not of an escaping
+ * pass that could be forgotten one call site later.
+ */
+
+export const SNIPPET_MARK_START = "\u0001";
+export const SNIPPET_MARK_END = "\u0002";
+
+/* These two are a wire contract with `native/search/mod.rs`, and this repo has
+   no TypeScript test harness — `npm run build` is `tsc --noEmit && vite build`
+   and that is the whole frontend gate. So they are pinned at the *type* level,
+   the way `views/gateway/snippets.ts` pins the gateway's two base URLs (#427):
+   respelling either constant fails `tsc`, i.e. CI. Exported so `noUnusedLocals`
+   does not flag the guard away. */
+type Eq<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+    ? true
+    : false;
+type Expect<T extends true> = T;
+export type PinnedSnippetMarkStart = Expect<
+  Eq<typeof SNIPPET_MARK_START, "\u0001">
+>;
+export type PinnedSnippetMarkEnd = Expect<
+  Eq<typeof SNIPPET_MARK_END, "\u0002">
+>;
+
+/** One run of snippet text, either inside a highlight or outside every one. */
+export interface SnippetPart {
+  text: string;
+  hit: boolean;
+}
+
+/** Neither marker may survive into rendered text, however malformed the input. */
+function stripMarkers(s: string): string {
+  return s.replace(/[\u0001\u0002]/g, "");
+}
+
+/**
+ * Split a `match_snippet` into its highlighted and plain runs.
+ *
+ * Empty runs are dropped, so a snippet opening on a match does not lead with an
+ * empty text node. An **unterminated** highlight — a start marker with no end —
+ * highlights to the end of the snippet rather than emitting the sentinel: a
+ * snippet that highlights too much is a display defect, a visible U+0001 reads
+ * as corruption.
+ */
+export function snippetParts(snippet: string): SnippetPart[] {
+  const parts: SnippetPart[] = [];
+  const push = (text: string, hit: boolean) => {
+    const t = stripMarkers(text);
+    if (t) parts.push({ text: t, hit });
+  };
+
+  let rest = snippet;
+  while (rest) {
+    const open = rest.indexOf(SNIPPET_MARK_START);
+    if (open < 0) {
+      push(rest, false);
+      break;
+    }
+    push(rest.slice(0, open), false);
+    rest = rest.slice(open + SNIPPET_MARK_START.length);
+
+    const close = rest.indexOf(SNIPPET_MARK_END);
+    if (close < 0) {
+      push(rest, true);
+      break;
+    }
+    push(rest.slice(0, close), true);
+    rest = rest.slice(close + SNIPPET_MARK_END.length);
+  }
+  return parts;
+}
+
+/**
+ * The snippet with its markers removed — for a `title` tooltip, where the whole
+ * line is worth reading but the cell has already ellipsised it. Never for HTML.
+ */
+export function snippetText(snippet: string): string {
+  return stripMarkers(snippet);
+}

--- a/src/lib/typeAssert.ts
+++ b/src/lib/typeAssert.ts
@@ -1,0 +1,36 @@
+/**
+ * Compile-time assertions — the repo's only regression guard for a *value*.
+ *
+ * There is no TypeScript test harness here: `npm run build` is
+ * `tsc --noEmit && vite build`, and that is the whole frontend gate. So a value
+ * that must not drift — a wire sentinel, a base URL a third-party SDK appends
+ * to — is pinned by giving it a literal type and asserting that type exactly.
+ * Respelling the value then fails `tsc`, i.e. fails CI.
+ *
+ * The shape, at every call site:
+ *
+ * ```ts
+ * export const MARKER = "\u0001";
+ * export type PinMarker = Expect<Eq<typeof MARKER, "\u0001">>;
+ * ```
+ *
+ * Two rules the idiom depends on, both easy to lose:
+ *
+ * * **`Eq`, not `extends`.** `"a" extends string` is true, so an `extends` check
+ *   passes against a value widened to `string` and pins nothing.
+ * * **Export the alias.** `noUnusedLocals` deletes an unused local type, and a
+ *   guard the compiler is allowed to ignore is decoration.
+ *
+ * Introduced by #427 for the gateway base URLs and lifted here by #438, whose
+ * snippet sentinels needed the same thing — a second byte-identical copy is how
+ * an idiom quietly becomes two idioms that disagree.
+ */
+
+/** Exact type equality — `extends` alone would accept a wider literal. */
+export type Eq<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+    ? true
+    : false;
+
+/** Fails to compile unless `T` is exactly `true`. */
+export type Expect<T extends true> = T;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -296,6 +296,16 @@ export interface ClaudeSessionSummary {
   subagent_cost_by_model?: Record<string, SessionCost>;
   unpriced_models?: string[];
   unpriced_tokens?: number;
+  /**
+   * Why this row matched, when the match came through the content index (#437).
+   * FTS5's `snippet()` over the highest-matching column, with every matched
+   * term wrapped in the U+0001/U+0002 markers `lib/snippet.ts` splits on.
+   *
+   * Last, and optional, because the server omits the key entirely when it is
+   * empty — which is every response that is not a search, *and* a search row
+   * that matched only on its id, path or title. Default it (`?? ""`).
+   */
+  match_snippet?: string;
 }
 
 /** One content block of an assistant turn, normalized by the scanner. */

--- a/src/styles/sessions.css
+++ b/src/styles/sessions.css
@@ -83,6 +83,34 @@
   color: var(--amber);
   flex: none;
 }
+
+/* The "why this row matched" line (#438). It is a second line inside the title
+   cell, so it only exists on a content match — an ordinary listing keeps the
+   28px row and this rule never applies. `.table tbody td` already clips the
+   cell, but its `text-overflow` belongs to the cell's own inline box, so the
+   snippet needs its own block-level clamp to ellipsise rather than be cut. */
+.sess-snippet {
+  display: block;
+  margin-top: 1px;
+  font-size: var(--text-sm);
+  color: var(--fg-tertiary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* A tint rather than a colour: `.table tbody tr.is-selected td *` forces
+   `color: inherit !important` on a focused row, so a foreground-only highlight
+   would vanish exactly where the user is looking. Same reasoning — and the same
+   shape — as `.badge` and `.meter` in views.css. */
+.sess-snippet__hit {
+  background: var(--accent-soft);
+  color: inherit;
+  border-radius: var(--r-sm);
+  padding: 0 1px;
+}
+.window--focused .table tbody tr.is-selected .sess-snippet__hit {
+  background: rgba(255, 255, 255, 0.28);
+}
 .sess-dim {
   color: var(--fg-quaternary);
   font-size: var(--text-sm);

--- a/src/views/SessionsView.tsx
+++ b/src/views/SessionsView.tsx
@@ -66,21 +66,30 @@ const SORTS: { value: Sort; label: string }[] = [
 
 interface Filters {
   project: string;
+  /** The ordering while no search term is active. */
+  sort: Sort;
   /**
-   * The sort the user picked, or `""` while it follows the server's default.
+   * The ordering while one is — `""` meaning "follow the server", which for a
+   * search is relevance.
    *
-   * The empty value is what makes "reflect the server default" possible without
-   * a second source of truth: the effective sort is [`resolveSort`], a mirror of
-   * `sessions/query.rs::resolve_sort`, so the dropdown's label always states
-   * what the server will actually do.
+   * **Two slots rather than one, because the sort a search wants and the sort a
+   * listing wants are different questions.** With a single field, "restore the
+   * previous sort when the query clears" has nowhere to restore *from*, and the
+   * control becomes one-way: relevance is what an unchosen sort already resolves
+   * to while searching, so recording that pick would store a `relevance` that
+   * reads as `recent` the moment the term goes, silently discarding whatever the
+   * user had picked before. Keeping the browsing sort untouched by anything done
+   * during a search is what makes both directions work with no effect, no
+   * remembered transition and no extra request.
    */
-  sort: Sort | "";
+  searchSort: Sort | "";
   favorites: boolean;
 }
 
 const INITIAL_FILTERS: Filters = {
   project: "",
-  sort: "",
+  sort: "recent",
+  searchSort: "",
   favorites: false,
 };
 
@@ -92,12 +101,10 @@ const INITIAL_FILTERS: Filters = {
  *
  * * **No explicit choice plus a search term is `relevance`.** Somebody who typed
  *   a query wants the best match first; somebody who did not has no ranking to
- *   sort by. An explicit pick always wins, so a user who chose "Recent" keeps it
- *   while typing.
+ *   sort by. An explicit pick always wins, so a user who chose "Recent" for this
+ *   search keeps it while typing.
  * * **`relevance` with no search term is `recent`**, because without a `MATCH`
- *   there is no rank. That is also what restores the pre-search ordering when
- *   the query is cleared: the relevance the search selected simply stops
- *   applying, and an explicit pick made before the search is still in `filters`.
+ *   there is no rank.
  */
 function resolveSort(chosen: Sort | "", searching: boolean): Sort {
   if (!chosen) return searching ? "relevance" : "recent";
@@ -236,7 +243,10 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
   // still typing would flicker the option in and out per keystroke and refetch
   // the list ahead of the debounce it exists to respect.
   const searching = q.trim() !== "";
-  const sort = resolveSort(filters.sort, searching);
+  const sort = resolveSort(
+    searching ? filters.searchSort : filters.sort,
+    searching
+  );
 
   // Every filter and the *resolved* sort belong to the key: the keyset cursor
   // encodes the sort, so re-using one across a change is a 400 from the server —
@@ -565,6 +575,7 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
           <div
             style={{ width: 260, display: "flex" }}
             title={
+              "Searches session titles and message content. " +
               "Words are matched together, in any order. " +
               'Wrap text in "double quotes" to match it as a phrase. ' +
               "The last word matches as a prefix while you type."
@@ -609,7 +620,14 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
               SORTS.find((s) => s.value === sort)?.label ?? "Recent"
             }`}
             value={sort}
-            onChange={(v) => patchFilters({ sort: v as Sort })}
+            onChange={(v) =>
+              // Written into the slot the current mode reads, so a sort picked
+              // for a search never outlives it and a sort picked while browsing
+              // is never what a search silently inherits.
+              patchFilters(
+                searching ? { searchSort: v as Sort } : { sort: v as Sort }
+              )
+            }
             options={SORTS.filter(
               (s) => s.value !== "relevance" || searching
             ).map((s) => ({ value: s.value, label: s.label }))}

--- a/src/views/SessionsView.tsx
+++ b/src/views/SessionsView.tsx
@@ -28,6 +28,7 @@ import {
   usd,
 } from "../lib/format";
 import { Icon } from "../lib/icons";
+import { snippetParts, snippetText } from "../lib/snippet";
 import { sessionAgentName } from "../lib/sessionAgent";
 import { openExternal } from "../lib/tauri";
 import {
@@ -52,9 +53,10 @@ import "../styles/sessions.css";
 
 const PAGE_SIZE = 50;
 
-type Sort = "recent" | "cost" | "tokens" | "duration" | "messages";
+type Sort = "recent" | "cost" | "tokens" | "duration" | "messages" | "relevance";
 
 const SORTS: { value: Sort; label: string }[] = [
+  { value: "relevance", label: "Relevance" },
   { value: "recent", label: "Recent" },
   { value: "cost", label: "Cost" },
   { value: "tokens", label: "Tokens" },
@@ -64,15 +66,44 @@ const SORTS: { value: Sort; label: string }[] = [
 
 interface Filters {
   project: string;
-  sort: Sort;
+  /**
+   * The sort the user picked, or `""` while it follows the server's default.
+   *
+   * The empty value is what makes "reflect the server default" possible without
+   * a second source of truth: the effective sort is [`resolveSort`], a mirror of
+   * `sessions/query.rs::resolve_sort`, so the dropdown's label always states
+   * what the server will actually do.
+   */
+  sort: Sort | "";
   favorites: boolean;
 }
 
 const INITIAL_FILTERS: Filters = {
   project: "",
-  sort: "recent",
+  sort: "",
   favorites: false,
 };
+
+/**
+ * The sort a request will really run under — `sessions/query.rs::resolve_sort`,
+ * mirrored so the control cannot claim an ordering the server would not use.
+ *
+ * Two rules, both the server's:
+ *
+ * * **No explicit choice plus a search term is `relevance`.** Somebody who typed
+ *   a query wants the best match first; somebody who did not has no ranking to
+ *   sort by. An explicit pick always wins, so a user who chose "Recent" keeps it
+ *   while typing.
+ * * **`relevance` with no search term is `recent`**, because without a `MATCH`
+ *   there is no rank. That is also what restores the pre-search ordering when
+ *   the query is cleared: the relevance the search selected simply stops
+ *   applying, and an explicit pick made before the search is still in `filters`.
+ */
+function resolveSort(chosen: Sort | "", searching: boolean): Sort {
+  if (!chosen) return searching ? "relevance" : "recent";
+  if (chosen === "relevance" && !searching) return "recent";
+  return chosen;
+}
 
 /** Rows accumulated across pages, tagged with the filter set that produced them. */
 interface Loaded {
@@ -154,6 +185,38 @@ function modeBadge(s: ClaudeSessionSummary): { label: string; tone: string } | n
 }
 
 /**
+ * The second line under a row's title: why this row matched.
+ *
+ * Rendered only for a **content** match — a row that matched on its id, its
+ * project path or its title carries no snippet, and gets no extra line, which
+ * is what keeps an ordinary listing at its 28px row height.
+ *
+ * **The markers are the only markup honoured.** Every segment goes through JSX
+ * as a text child, so a transcript containing `<script>` renders as the literal
+ * characters; nothing here builds an HTML string and nothing may reach for
+ * `dangerouslySetInnerHTML`. `snippetParts` also strips any stray sentinel, so
+ * a malformed snippet cannot leak a control character into the cell.
+ */
+function MatchSnippet({ snippet }: { snippet?: string }) {
+  const raw = snippet ?? "";
+  const parts = useMemo(() => snippetParts(raw), [raw]);
+  if (parts.length === 0) return null;
+  return (
+    <span className="sess-snippet" title={snippetText(raw)}>
+      {parts.map((p, i) =>
+        p.hit ? (
+          <mark className="sess-snippet__hit" key={i}>
+            {p.text}
+          </mark>
+        ) : (
+          <Fragment key={i}>{p.text}</Fragment>
+        )
+      )}
+    </span>
+  );
+}
+
+/**
  * A scan that has never run reports a zero timestamp, which must read as
  * "not indexed yet" rather than as an empty index.
  */
@@ -169,11 +232,18 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
   const q = useDebounced(query, 250);
   const [filters, setFilters] = useState<Filters>(INITIAL_FILTERS);
 
-  // Every filter and the sort belong to the key: the keyset cursor encodes the
-  // sort, so re-using one across a change is a 400 from the server.
+  // The debounced term, not the raw one: gating relevance on what the user is
+  // still typing would flicker the option in and out per keystroke and refetch
+  // the list ahead of the debounce it exists to respect.
+  const searching = q.trim() !== "";
+  const sort = resolveSort(filters.sort, searching);
+
+  // Every filter and the *resolved* sort belong to the key: the keyset cursor
+  // encodes the sort, so re-using one across a change is a 400 from the server —
+  // and it is the resolved value the request carries.
   const listKey = useMemo(
-    () => JSON.stringify({ q, ...filters }),
-    [q, filters]
+    () => JSON.stringify({ q, ...filters, sort }),
+    [q, filters, sort]
   );
 
   const [paging, setPaging] = useState({ key: "", cursor: "" });
@@ -202,7 +272,7 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
       api.get<SessionPage>(
         `/claude-sessions${qs({
           ...filterParams,
-          sort: filters.sort,
+          sort,
           limit: PAGE_SIZE,
           cursor: cursor || undefined,
         })}`,
@@ -487,11 +557,23 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
         ) : (
           <>
         <div className="toolbar">
-          <div style={{ width: 260, display: "flex" }}>
+          {/* The placeholder carries the one piece of query syntax that is not
+              guessable — words are AND'ed, so quoting is the only way to ask
+              for a phrase — and the tooltip carries the rest. It sits on the
+              wrapper because `Search` takes no `title`, and widening a shared
+              component for one caller's hint is the larger change. */}
+          <div
+            style={{ width: 260, display: "flex" }}
+            title={
+              "Words are matched together, in any order. " +
+              'Wrap text in "double quotes" to match it as a phrase. ' +
+              "The last word matches as a prefix while you type."
+            }
+          >
             <Search
               value={query}
               onChange={onQuery}
-              placeholder="Search titles and messages"
+              placeholder={'Search — "quotes" match a phrase'}
             />
           </div>
 
@@ -516,15 +598,21 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
             ]}
           />
 
+          {/* Relevance is offered only while a term is active, because without
+              a MATCH there is no rank — the server would answer `recent` and
+              the label would be a lie. The value shown is the resolved sort,
+              so "Sort: Relevance" appears the moment a search selects it. */}
           <Dropdown
             small
             className="sess-select"
             label={`Sort: ${
-              SORTS.find((s) => s.value === filters.sort)?.label ?? "Recent"
+              SORTS.find((s) => s.value === sort)?.label ?? "Recent"
             }`}
-            value={filters.sort}
+            value={sort}
             onChange={(v) => patchFilters({ sort: v as Sort })}
-            options={SORTS.map((s) => ({ value: s.value, label: s.label }))}
+            options={SORTS.filter(
+              (s) => s.value !== "relevance" || searching
+            ).map((s) => ({ value: s.value, label: s.label }))}
           />
 
           <button
@@ -685,6 +773,7 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
                                 {s.display_title || "Untitled session"}
                               </span>
                             </span>
+                            <MatchSnippet snippet={s.match_snippet} />
                           </td>
                           <td title={s.project_path}>
                             <span

--- a/src/views/gateway/snippets.ts
+++ b/src/views/gateway/snippets.ts
@@ -22,6 +22,7 @@
    ========================================================================== */
 
 import type { GatewayStatus } from "../../lib/types";
+import type { Eq, Expect } from "../../lib/typeAssert";
 
 /** The gateway binds `127.0.0.1` unconditionally; there is no public URL. */
 const HOST = "http://127.0.0.1";
@@ -48,14 +49,6 @@ export function healthUrl<P extends number>(
 }
 
 /* --- The compile-time pin ------------------------------------------------- */
-
-/** Exact type equality — `extends` alone would accept a wider literal. */
-type Eq<A, B> =
-  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
-    ? true
-    : false;
-
-type Expect<T extends true> = T;
 
 /**
  * Change either literal above and these stop compiling. Exported so


### PR DESCRIPTION
Closes #438 · part of epic #432 · builds on #437 (PR #455).

## What

The user-facing half of the search epic. #437 put `match_snippet` and the
`relevance` sort **on the wire**; nothing in the UI read either. This makes a
search result explain itself.

- A row that matched through the content index shows a second line under its
  title — FTS5's snippet, with the matched terms highlighted. A metadata-only
  match (id, path, title) has no snippet to show and keeps its 28px row.
- The sort control gains **Relevance**, offered only while a search term is
  active, and it reflects the server's own default rather than overriding it.
- The search placeholder says that `"quotes"` mean a phrase; the field's
  tooltip carries the rest — titles *and* message content are searched, words
  are AND'ed, the last word is a live prefix.

## How

**`src/lib/snippet.ts`** (new) — the U+0001/U+0002 sentinels spelled once on
this side of the wire, plus `snippetParts`, which splits a snippet into
highlighted and plain runs.

They are **markers, not markup**, and that is the whole security argument: the
snippet carries the transcript's own bytes, so a session about web development
genuinely contains `<script>`. Every run is handed to JSX as a text child —
nothing here builds an HTML string, and `dangerouslySetInnerHTML` appears
nowhere in this repo. Stray and unterminated sentinels are stripped rather than
rendered, so a malformed snippet cannot leak a control character into the cell.

**`src/lib/typeAssert.ts`** (new) — `Eq` / `Expect`, lifted out of
`views/gateway/snippets.ts` for its second consumer. It is the repo's only
regression guard for a *value*, so it is worth having in one place with the two
rules it depends on written down: `Eq` rather than `extends`, and export the
alias or `noUnusedLocals` deletes the guard.

**`src/views/SessionsView.tsx`** — a `MatchSnippet` component in the title cell,
and `resolveSort`, a mirror of `sessions/query.rs::resolve_sort`:

```
no explicit pick + a term  ->  relevance
relevance + no term        ->  recent
an explicit pick           ->  itself
```

`Filters` carries **two** sort slots rather than one: `sort`, the ordering while
browsing, and `searchSort`, the ordering while a term is active (`""` = follow
the server). The dropdown writes whichever slot the current mode reads, and the
**resolved** sort is what the request and the `listKey` carry — so the control's
label always states what the server will actually do, and the keyset cursor
still resets on every change.

One slot does not work, and that is worth stating because the first version had
one. Relevance is already what an unchosen sort resolves to while searching, so
recording that pick stores a `relevance` which reads as `recent` the moment the
term goes — silently discarding whatever the user had picked before, with no way
back to "follow the server". Two slots make #438's *"leaving search restores the
previous sort"* fall out with no effect, no remembered transition and no extra
request: browsing order is simply never touched by anything done during a search.

**`src/lib/types.ts`** — `match_snippet?: string`, last, optional because the
server omits the key entirely when empty.

**`src/styles/sessions.css`** — `.sess-snippet` (its own clamp: the cell's
`text-overflow` belongs to the cell's inline box) and `.sess-snippet__hit`, an
`--accent-soft` tint. The tint rather than a colour is deliberate:
`.table tbody tr.is-selected td *` forces `color: inherit !important` on a
focused row, so a foreground-only highlight would vanish exactly where the user
is looking — the same shape as `.badge` and `.meter` in `views.css`.

**`CLAUDE.md`** — a Layout entry for each new module, and the type-pin reference
now points at the shared helper rather than at the gateway file.

## Proof

This repo has **no TypeScript test harness** — `npm run build` is
`tsc --noEmit && vite build` and that is the whole frontend gate — so the
committed regression guard is a **type-level pin** on the two sentinels.
Verified rather than assumed, in both directions after the extraction:
respelling `SNIPPET_MARK_END` fails `tsc` with `TS2344`, and breaking the
Anthropic base URL still fails with `TS2322`.

The parser was additionally exercised at runtime (esbuild -> node; not
committed, as there is nowhere in-repo for it to live): golden-shaped snippet,
leading hit, two hits, unterminated highlight, stray end marker, and a
`<script>` payload surviving as literal text. All ten checks passed.

## Not in scope

Backend changes; the command palette's search; the chats view.
