### PR TITLE
test(search): search_live real-corpus suite and the measurement pass (#439)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -988,6 +988,64 @@ scan's staleness markers deliberately do **not** cover
 re-read of `claude_session_cache`, so the five-minute sweep is the only thing
 that notices one.
 
+### The search index, measured (`src-tauri/tests/search_live.rs`, #439)
+
+The third `#[ignore]`d live suite over the corpus, and the only one whose output
+is as much of the point as its assertions. Run it by hand, like its siblings —
+and under `--release` when you care about the numbers, because the `bundled`
+SQLite is a C dependency compiled at the profile's optimization level, so a
+debug run measures a SQLite nobody ships:
+
+```bash
+cargo test --test search_live -- --ignored --nocapture            # correctness
+cargo test --release --test search_live -- --ignored --nocapture  # the numbers
+```
+
+It copies `~/.agento/agento.db`, **migrates the copy** (the installed database
+lags the repository — on the reference machine it had no `session_search` table
+at all), forces `search_index_version` to 0, drives the rebuild through
+`worker::start`, and then measures. `sweep` is private, so the terminal
+condition is the **version stamp** rather than a row count: `sweep` records it
+last and only when every batch committed, where a row count sits flat for the
+whole of each batch's read phase and a test waiting for it to settle declares
+success mid-sweep.
+
+**The reference numbers, release profile, 1,178 sessions** — a baseline for
+anything that claims to make this faster or smaller, not a promise:
+
+| | |
+|---|---|
+| cold full rebuild | **6.7 s** (5.7 ms/session) |
+| incremental `search::delete` | **45 ms** — this is the scan |
+| incremental `search::insert` | 11 ms |
+| one session through the worker | 207 ms, transcript read included |
+| `delete_orphans`, whole index | 35 ms |
+| index on disk | **188.7 MB** (164 KB/session) |
+| page query, common word | **33.6 s p50** · facets for the same query, 101 ms |
+| page query, rare word (16 hits) | 23 ms |
+| the suite itself | ~6 min release, ~25 min debug |
+
+Three things those numbers settled:
+
+- **`search::delete`'s scan is real and it is the incremental path's whole
+  cost.** 45 ms against a 188 MB index, against the 9.5 ms/17 MB and 63 ms/176 MB
+  already recorded — it tracks index size, as a scan does. The rowid side table
+  (#446) is what removes it; nothing here should add a second caller.
+- **`tool_text` is 86.5 % of the stored text** (122.2 MB of 141.3 MB), against
+  `assistant_text`'s 10.5 % and `user_text`'s 3.0 % — and it carries the *lowest*
+  bm25 weight (0.5). #434's caps were **left alone** anyway: they are per tool
+  result and already a quarter of `MESSAGE_CAP`, so what is large is the number
+  of tool calls in a Claude Code transcript rather than any one of them, and
+  `SESSION_CAP` already binds (the widest session indexes 523,339 of 524,288
+  bytes). Lowering the cap would trade recall for size against a budget nobody
+  has set, and would need a `SEARCH_INDEX_VERSION` bump to take effect.
+- **The expensive half of a search is the ranked join and the snippet, not the
+  index.** The same query answers its *facets* — which use the membership `IN`,
+  with no `bm25()` carried through and no `snippet()` — in 101 ms while the page
+  takes 33.6 s, and a term with 16 hits takes 23 ms either way, so the cost
+  tracks the number of hits rather than the corpus. Read that before optimizing
+  the index for it.
+
 ### The Claude Agent SDK (`src-tauri/src/claude/`)
 
 `github.com/shaharia-lab/claude-agent-sdk-go` reimplemented in Rust — the

--- a/docs/development.md
+++ b/docs/development.md
@@ -169,6 +169,14 @@ cargo test --test scan_live -- --ignored --nocapture
 
 # The MCP server, dialled by the real Claude Code CLI.
 cargo test --test claude_mcp_live -- --ignored --nocapture
+
+# The search index, against a copy of your real corpus: correctness, plus
+# printed build / index-size / query-latency numbers. Run it under --release
+# when you care about the numbers — the bundled SQLite is a C dependency
+# compiled at the profile's optimization level, so a debug run measures a
+# SQLite nobody ships.
+cargo test --test search_live -- --ignored --nocapture
+cargo test --release --test search_live -- --ignored --nocapture
 ```
 
 Verify scanner changes against real data, not a fixture. The failure that matters

--- a/src-tauri/tests/search_live.rs
+++ b/src-tauri/tests/search_live.rs
@@ -79,7 +79,7 @@ use agento_lib::native::search::{
 };
 use agento_lib::native::sessions::page::{facets, list_page};
 use agento_lib::native::sessions::query::{SessionQuery, Sort};
-use agento_lib::native::settings;
+use agento_lib::native::settings::{self, DataSettings};
 
 /// How long to wait for the boot rebuild. The sweep reads every transcript in
 /// the corpus, so this is minutes rather than seconds — the same 6-minute
@@ -415,9 +415,9 @@ fn the_index_is_correct_and_measured_over_the_real_corpus() {
     // the probe and every latency figure below measure a different query from
     // the one the product runs.
     let settings = settings::load(&conn);
-    let probe = find_probe(&conn).expect(
-        "no indexed session yielded a distinctive term — the index holds rows \
-         but nothing in them is reachable through FTS5",
+    let probe = find_probe(&conn, &settings).expect(
+        "no session the list would show yielded a distinctive term — the index \
+         holds rows but nothing in them is reachable through FTS5",
     );
     eprintln!(
         "probe: {:?} ({} hits) from session {}",
@@ -740,7 +740,16 @@ struct Probe {
 /// about ranking rather than a restatement of "the corpus is small". A term
 /// matching one row is ideal; up to [`MAX_PROBE_HITS`] is still decisive, since
 /// relevance sorts every index hit above every metadata-only one.
-fn find_probe(conn: &Connection) -> Option<Probe> {
+///
+/// **A candidate must be visible to the list before it can be probed**, and that
+/// is not the same as being indexed. `session_search` holds a row for every
+/// cached session, while `list_page` applies the stored `hidden_projects` and
+/// `indexed_config_dirs` — so on a machine that hides a project, a probe drawn
+/// straight from the index would name a session the list is *right* not to
+/// return, and the assertion would fail for a reason that has nothing to do with
+/// search. [`is_visible`] is the filter, asked of the same `list_page` the
+/// assertion uses rather than by re-deriving the scope here.
+fn find_probe(conn: &Connection, settings: &DataSettings) -> Option<Probe> {
     const MAX_PROBE_HITS: i64 = 20;
     const SESSIONS_TO_TRY: i64 = 200;
 
@@ -764,6 +773,9 @@ fn find_probe(conn: &Connection) -> Option<Probe> {
 
     for row in rows.flatten() {
         let (session_id, project_path, text) = row;
+        if !is_visible(conn, settings, &session_id, &project_path) {
+            continue;
+        }
         for term in candidate_terms(&text) {
             let hits = match_count(conn, &term);
             if (1..=MAX_PROBE_HITS).contains(&hits) {
@@ -777,6 +789,31 @@ fn find_probe(conn: &Connection) -> Option<Probe> {
         }
     }
     None
+}
+
+/// Would the sessions list return this session at all, under the settings stored
+/// in this database?
+///
+/// Asked by searching for the **session id**, which is one of the six columns the
+/// LIKE half of `add_search` matches, so the answer comes from the same
+/// `list_page` the probe's assertion goes through — including the hidden-project
+/// and config-dir scope — rather than from a second copy of that scope written
+/// here, which could agree with the wrong thing. A UUID is its own rare term, so
+/// this costs one cheap query per session tried.
+fn is_visible(
+    conn: &Connection,
+    settings: &DataSettings,
+    session_id: &str,
+    project_path: &str,
+) -> bool {
+    let Ok(q) = SessionQuery::parse(&format!("q={}", enc(session_id))) else {
+        return false;
+    };
+    list_page(conn, settings, &q).is_ok_and(|page| {
+        page.items
+            .iter()
+            .any(|s| s.session_id == session_id && s.project_path == project_path)
+    })
 }
 
 /// The project with the most cached sessions — the filter most likely to be

--- a/src-tauri/tests/search_live.rs
+++ b/src-tauri/tests/search_live.rs
@@ -1,0 +1,793 @@
+//! The `session_search` index against the machine's **real** corpus, on a copy
+//! of the database — correctness, and the numbers (#439).
+//!
+//! `#[ignore]`d, like `scan_live.rs` and `insights_live.rs` and for the same
+//! reason — CI has no `~/.claude` and no `~/.agento/agento.db`. Run it by hand:
+//!
+//! ```bash
+//! cargo test --test search_live -- --ignored --nocapture
+//! ```
+//!
+//! # Why this exists rather than a fixture
+//!
+//! Two failures live here that a fixture cannot see, and they are different
+//! failures.
+//!
+//! The first is `insights_live.rs`'s, one table to the right: an index that is
+//! built but empty answers nothing, which is indistinguishable from a corpus
+//! with nothing in it. A three-file fixture that gains three rows does not
+//! distinguish that from a healthy build.
+//!
+//! The second is the one this file is named for. #433 chose an FTS5 shape and
+//! #434 chose three byte caps (8 KB per message, 2 KB per tool result, 512 KB
+//! per session) **a priori**, and neither decision has ever met a real corpus.
+//! "Should be fast" and "should be about this big" are not measurements: a cap
+//! that turns out to bind on every session, or an index dominated by tool
+//! output, or a keyed delete that has quietly become the cost of a scan, are all
+//! invisible to a fixture whose documents are three sentences long.
+//!
+//! So this file does both jobs at once, on one copy of the real database:
+//!
+//! * **Asserts** what must be true of any corpus — strictly, and never
+//!   vacuously. Zero cached sessions, zero index rows, a zero-byte index or a
+//!   probe query that does not find its own session are failures, not passes.
+//! * **Measures** what varies between machines, and *prints* it: cold full-index
+//!   build, per-session incremental reindex (both the raw index write and the
+//!   whole worker round trip), the orphan sweep, index bytes with a per-column
+//!   breakdown, and p50/p95 query latency with filters and facets composed in.
+//!
+//! # Why there are no timing assertions
+//!
+//! Every printed duration is developer-hardware-dependent, and a corpus varies
+//! by an order of magnitude between machines — this one indexes ~1,200 sessions;
+//! a fresh install indexes none. A latency assertion tuned on one of those
+//! flakes on the other, and a flaky test is worse than no test. The bounds
+//! belong in the pull request that reads the numbers, not in an `assert!`.
+//!
+//! What *is* asserted is every **invariant** the numbers are measured against:
+//! the caps hold on real data, the index is populated, the version is stamped,
+//! and a query for known content finds it. Those hold on any corpus, so they can
+//! be strict.
+//!
+//! # Quote the release numbers, not the debug ones
+//!
+//! The assertions hold in either profile and the default `cargo test` invocation
+//! above is the one to run for correctness. The **timings** are worth a
+//! `--release` run, because the `bundled` SQLite is a C dependency compiled at
+//! the profile's optimization level: a debug build measures a SQLite nobody
+//! ships, and every figure it prints is several times the real one.
+//!
+//! ```bash
+//! cargo test --release --test search_live -- --ignored --nocapture
+//! ```
+//!
+//! Expect minutes rather than seconds either way. That is a property of what is
+//! being measured, not of the harness — see [`QUERY_ITERATIONS`].
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use rusqlite::Connection;
+
+use agento_lib::native::db;
+use agento_lib::native::insights::{processors::CURRENT_PROCESSOR_VERSION, store, worker};
+use agento_lib::native::search::{
+    self,
+    normalize::{MESSAGE_CAP, SESSION_CAP, TOOL_RESULT_CAP},
+    SearchDoc, SEARCH_INDEX_VERSION, SNIPPET_MARK_START,
+};
+use agento_lib::native::sessions::page::{facets, list_page};
+use agento_lib::native::sessions::query::{SessionQuery, Sort};
+use agento_lib::native::settings;
+
+/// How long to wait for the boot rebuild. The sweep reads every transcript in
+/// the corpus, so this is minutes rather than seconds — the same 6-minute
+/// budget `scan_live` and `insights_live` allow themselves.
+const BUILD_BUDGET: Duration = Duration::from_secs(6 * 60);
+const POLL: Duration = Duration::from_millis(200);
+
+/// Timed runs per query shape, and the floor and ceiling on them.
+///
+/// The floor exists because a p-value over fewer than three samples is not a
+/// distribution, and the **ceiling is in seconds rather than in runs** because
+/// this suite measured a page query that takes tens of seconds on a corpus this
+/// size. A fixed run count multiplies that into a suite nobody runs twice, and
+/// a smaller fixed count would hide the finding by never sampling the slow
+/// shapes at all — so a shape stops when it has spent its budget, and the table
+/// reports how many samples each figure came from.
+///
+/// It tightens itself: when a shape is fast, the budget is never reached and
+/// every shape gets the full [`QUERY_ITERATIONS`].
+const QUERY_ITERATIONS: usize = 15;
+const MIN_ITERATIONS: usize = 3;
+const SHAPE_BUDGET: Duration = Duration::from_secs(20);
+
+/// Sessions re-indexed one at a time for the incremental measurement. More than
+/// one, because a single session's document size is not representative and the
+/// figure that matters — `search::delete`'s scan — is the same for all of them.
+const INCREMENTAL_SAMPLES: usize = 5;
+
+// ─── locating and copying the corpus ────────────────────────────────────────
+
+/// The installed database, **not** `paths::database_path()`.
+///
+/// `cargo test` builds with `debug_assertions`, where `paths::data_dir` ignores
+/// the environment entirely and answers `~/.agento-desktop-dev` — deliberately,
+/// so a dev build cannot collide with an installed Agento. The corpus this test
+/// wants is the installed one, so it is named directly, exactly as `scan_live`
+/// and `insights_live` name it.
+fn real_db() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME")?;
+    let db = PathBuf::from(home).join(".agento/agento.db");
+    db.is_file().then_some(db)
+}
+
+/// Copy the database *and its WAL*, so the copy is not missing recent writes.
+fn copy_db(src: &Path, dir: &Path) -> PathBuf {
+    let db = dir.join("agento.db");
+    std::fs::copy(src, &db).expect("copy the database");
+    for ext in ["-wal", "-shm"] {
+        let from = PathBuf::from(format!("{}{ext}", src.display()));
+        if from.is_file() {
+            let _ = std::fs::copy(&from, dir.join(format!("agento.db{ext}")));
+        }
+    }
+    db
+}
+
+fn scalar(conn: &Connection, sql: &str) -> i64 {
+    conn.query_row(sql, [], |r| r.get(0)).unwrap_or(-1)
+}
+
+// ─── measuring ──────────────────────────────────────────────────────────────
+
+/// Nearest-rank percentile over an already-sorted slice — the definition
+/// `gateway::usage` uses, so the two report latency the same way.
+fn percentile(sorted: &[Duration], p: f64) -> Duration {
+    if sorted.is_empty() {
+        return Duration::ZERO;
+    }
+    let rank = ((p / 100.0) * sorted.len() as f64).ceil().max(1.0) as usize;
+    sorted[rank.min(sorted.len()) - 1]
+}
+
+fn median(mut xs: Vec<Duration>) -> Duration {
+    xs.sort_unstable();
+    percentile(&xs, 50.0)
+}
+
+/// Percent-encode one query-string value.
+///
+/// Hand-rolled rather than pulled from a crate because the whole requirement is
+/// three characters wide: `SessionQuery::parse` reads its input through
+/// `form_urlencoded::parse`, so a space in `"cargo test"` would otherwise arrive
+/// as a `+` and the quotes would end the value.
+fn enc(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for b in value.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(b as char);
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+/// How many index rows a single FTS5 term matches.
+fn match_count(conn: &Connection, term: &str) -> i64 {
+    conn.query_row(
+        "SELECT COUNT(*) FROM session_search WHERE session_search MATCH ?1",
+        [format!("\"{term}\"")],
+        |r| r.get(0),
+    )
+    .unwrap_or(-1)
+}
+
+/// A word from indexed text that is worth probing with: long enough to be
+/// distinctive, and made only of characters `unicode61` keeps as one token.
+fn candidate_terms(text: &str) -> Vec<String> {
+    let mut seen: Vec<String> = Vec::new();
+    for word in text.split(|c: char| !c.is_alphanumeric()) {
+        if word.len() < 8 || word.len() > 40 {
+            continue;
+        }
+        if !word.chars().any(|c| c.is_ascii_alphabetic()) || !word.is_ascii() {
+            continue;
+        }
+        let lower = word.to_ascii_lowercase();
+        if !seen.contains(&lower) {
+            seen.push(lower);
+        }
+        if seen.len() >= 24 {
+            break;
+        }
+    }
+    seen
+}
+
+// ─── the test ───────────────────────────────────────────────────────────────
+
+#[test]
+#[ignore = "needs the machine's real ~/.agento database and ~/.claude corpus"]
+fn the_index_is_correct_and_measured_over_the_real_corpus() {
+    let Some(src) = real_db() else {
+        eprintln!("skipping: no ~/.agento/agento.db");
+        return;
+    };
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = copy_db(&src, dir.path());
+
+    // **Migrate the copy**, exactly as `lib.rs` migrates before starting the
+    // worker, and for the reason `insights_live` records: the installed database
+    // is whatever version the last release left, and it lags the repository. On
+    // the machine this was written against it had no `session_search` table at
+    // all — so without this, every batch's index write fails and, because the
+    // index row and the insight row commit in one transaction, the insight write
+    // rolls back with it. The symptom is zero rows in both tables and nothing in
+    // the message pointing at a schema.
+    {
+        let mut conn = Connection::open(&db).expect("open");
+        agento_lib::native::migrate::apply(&mut conn).expect("migrate the copy");
+    }
+
+    let cached = {
+        let conn = db::open_read_only(&db).expect("open the copy read-only");
+        scalar(&conn, "SELECT COUNT(*) FROM claude_session_cache")
+    };
+    assert!(
+        cached > 0,
+        "the copied database has no cached sessions, so this proves nothing — \
+         open the app once against the real database first"
+    );
+
+    // ─── cold build ─────────────────────────────────────────────────────────
+    //
+    // Force the rebuild rather than relying on the copy's own state. `sweep`
+    // rebuilds when the stored version disagrees with this build's, and 0 is
+    // what a fresh install and a database that has never been indexed both
+    // carry — so writing it is the one lever that makes this a *cold* build on
+    // any developer's database, including one whose index is already current.
+    //
+    // `sweep` itself is private, so the build is driven the only way an
+    // integration test can drive it: start the worker and poll the terminal
+    // condition. The version stamp is that condition — `sweep` records it last,
+    // and only if every batch committed — which is stronger than a row count,
+    // because a row count sits flat for the whole of each batch's read phase and
+    // a test that waits for it to stop moving declares success mid-sweep.
+    {
+        let conn = db::open_read_write(&db).expect("open the copy read-write");
+        search::record_version(&conn, 0).expect("force a rebuild");
+        assert_eq!(
+            search::stored_version(&conn).expect("stored_version"),
+            0,
+            "the rebuild lever did not take"
+        );
+    }
+
+    let started = Instant::now();
+    worker::start(db.clone());
+
+    let mut built = false;
+    while started.elapsed() < BUILD_BUDGET {
+        let conn = db::open_read_only(&db).expect("open the copy read-only");
+        let stamped = search::stored_version(&conn).unwrap_or(0) == SEARCH_INDEX_VERSION;
+        drop(conn);
+        if stamped {
+            built = true;
+            break;
+        }
+        std::thread::sleep(POLL);
+    }
+    let cold_build = started.elapsed();
+    assert!(
+        built,
+        "the index was not rebuilt within {BUILD_BUDGET:?} — the version was \
+         never stamped, which `sweep` does only when every batch committed"
+    );
+
+    let conn = db::open_read_write(&db).expect("open the copy read-write");
+
+    // ─── non-vacuity ────────────────────────────────────────────────────────
+    //
+    // "An identical over an empty result set is not evidence." Everything below
+    // this point — every duration, every ratio, every probe — is meaningless if
+    // the index is empty, and an empty index is exactly what the failure this
+    // file exists for looks like. So the emptiness checks come first and are
+    // hard failures.
+    let indexed = scalar(&conn, "SELECT COUNT(*) FROM session_search");
+    assert!(
+        indexed > 0,
+        "the rebuild stamped its version over a corpus of {cached} cached \
+         sessions but wrote no index rows — search answers nothing, which is \
+         indistinguishable from an empty corpus"
+    );
+    let insights = scalar(&conn, "SELECT COUNT(*) FROM session_insights");
+    assert_eq!(
+        indexed, insights,
+        "the index row and the insight row are written in one transaction, so \
+         their counts cannot differ"
+    );
+    // Not an equality against `cached`: a transcript that cannot be read is
+    // skipped by design, and one whose file vanished between the copy and the
+    // read is a legitimate shortfall. A *large* shortfall is not.
+    assert!(
+        indexed * 10 >= cached * 9,
+        "only {indexed} of {cached} cached sessions were indexed"
+    );
+
+    let with_text = scalar(
+        &conn,
+        "SELECT COUNT(*) FROM session_search
+          WHERE user_text <> '' OR assistant_text <> '' OR tool_text <> ''",
+    );
+    assert!(
+        with_text * 2 > indexed,
+        "only {with_text} of {indexed} index rows carry any text — the rows are \
+         being written but not built"
+    );
+
+    // ─── index size, and where the bytes went ───────────────────────────────
+    let bytes = column_bytes(&conn);
+    let content_bytes: i64 = bytes.values().sum();
+    assert!(
+        content_bytes > 0,
+        "the index occupies zero bytes over {indexed} rows"
+    );
+    let index_bytes = shadow_bytes(&conn);
+    assert!(
+        index_bytes > 0,
+        "the FTS5 shadow tables occupy zero bytes over {indexed} rows"
+    );
+
+    // **The caps must hold on real data**, which is the half of #434 no unit
+    // test can reach: its fixtures are strings it wrote itself. `SESSION_CAP`
+    // bounds the three text columns together and is the one that decides how
+    // large this index can ever get.
+    let widest: i64 = scalar(
+        &conn,
+        "SELECT MAX(LENGTH(user_text) + LENGTH(assistant_text) + LENGTH(tool_text))
+           FROM session_search",
+    );
+    assert!(
+        widest <= SESSION_CAP as i64,
+        "a session's indexed text is {widest} bytes, over the {SESSION_CAP}-byte \
+         session cap — the builder's accounting does not hold on real input"
+    );
+
+    // ─── the incremental path ───────────────────────────────────────────────
+    //
+    // Two different numbers, and the distinction is the point.
+    //
+    // `search::replace` is delete-then-insert, and the delete **scans**: FTS5's
+    // `xBestIndex` accepts only `rowid` and `MATCH`, so a predicate over the
+    // UNINDEXED key columns cannot use an index, and a content-storing table
+    // materializes every scanned row to serve it. That cost grows with the
+    // corpus, and it is what a rowid side table would remove — so it is measured
+    // on its own, against a *full* index, which is the only state in which the
+    // figure means anything.
+    //
+    // The worker round trip is the other number: the whole incremental path a
+    // changed session actually takes, transcript read included.
+    let samples = sample_docs(&conn, INCREMENTAL_SAMPLES);
+    assert!(
+        !samples.is_empty(),
+        "no indexed session could be read back out of the index"
+    );
+    let mut deletes = Vec::new();
+    let mut inserts = Vec::new();
+    for doc in &samples {
+        let t = Instant::now();
+        search::delete(&conn, &doc.session_id, &doc.project_path).expect("delete");
+        deletes.push(t.elapsed());
+        let t = Instant::now();
+        search::insert(&conn, doc).expect("insert");
+        inserts.push(t.elapsed());
+    }
+    // Delete-then-insert of the same document is exactly `replace`, so the index
+    // is back where it started and every count above still holds.
+    assert_eq!(
+        scalar(&conn, "SELECT COUNT(*) FROM session_search"),
+        indexed,
+        "re-indexing the samples changed the row count — a delete missed its \
+         pair, or an insert duplicated one"
+    );
+
+    let t = Instant::now();
+    let orphans = search::delete_orphans(&conn).expect("delete_orphans");
+    let orphan_sweep = t.elapsed();
+    assert_eq!(
+        orphans, 0,
+        "{orphans} index rows have no cache row, immediately after a rebuild \
+         that read the cache"
+    );
+
+    drop(conn);
+    let round_trip = worker_round_trip(&db, &samples[0]);
+
+    // ─── correctness: a query for known content finds its own session ───────
+    let conn = db::open_read_only(&db).expect("open the copy read-only");
+    // Read from the copy rather than defaulted: the real database carries an
+    // `indexed_config_dirs` scope and a hidden-project list, and a search run
+    // without them answers over rows the app never shows — which would make both
+    // the probe and every latency figure below measure a different query from
+    // the one the product runs.
+    let settings = settings::load(&conn);
+    let probe = find_probe(&conn).expect(
+        "no indexed session yielded a distinctive term — the index holds rows \
+         but nothing in them is reachable through FTS5",
+    );
+    eprintln!(
+        "probe: {:?} ({} hits) from session {}",
+        probe.term, probe.hits, probe.session_id
+    );
+
+    let q = SessionQuery::parse(&format!("q={}", enc(&probe.term))).expect("parse the probe query");
+    // `q` with no explicit sort resolves to relevance (#437). Asserted rather
+    // than assumed, because the whole point of the probe is that the session is
+    // found *ranked*, not merely present somewhere in a recency-ordered list.
+    assert_eq!(q.sort, Sort::Relevance);
+    let page = list_page(&conn, &settings, &q).expect("the probe page");
+    let found = page
+        .items
+        .iter()
+        .find(|s| s.session_id == probe.session_id && s.project_path == probe.project_path);
+    let found = found.unwrap_or_else(|| {
+        panic!(
+            "session {} contains {:?} — one of only {} index rows that match it — \
+             yet it is not on the first page of {} results",
+            probe.session_id,
+            probe.term,
+            probe.hits,
+            page.items.len(),
+        )
+    });
+    // The row matched through the index by construction, so it must carry a
+    // snippet: a hit with no snippet means `attach_match_snippets` was reached
+    // with the wrong query, or not reached at all.
+    assert!(
+        found.match_snippet.contains(SNIPPET_MARK_START),
+        "the probe's row carries no highlighted snippet: {:?}",
+        found.match_snippet
+    );
+
+    // ─── report: everything measured before the latency loop ────────────────
+    eprintln!("\n── corpus ───────────────────────────────────────────────");
+    eprintln!("cached sessions      {cached}");
+    eprintln!("indexed sessions     {indexed} ({with_text} carrying text)");
+
+    eprintln!("\n── build ────────────────────────────────────────────────");
+    eprintln!(
+        "cold full rebuild    {:>9.2?}  ({:.1} ms/session)",
+        cold_build,
+        cold_build.as_secs_f64() * 1000.0 / indexed as f64
+    );
+    eprintln!(
+        "incremental: delete  {:>9.2?}  median of {INCREMENTAL_SAMPLES} (this is the scan)",
+        median(deletes)
+    );
+    eprintln!(
+        "incremental: insert  {:>9.2?}  median of {INCREMENTAL_SAMPLES}",
+        median(inserts)
+    );
+    eprintln!("incremental: worker  {round_trip:>9.2?}  one session, transcript read included");
+    eprintln!("orphan sweep         {orphan_sweep:>9.2?}  one pass over the whole index");
+
+    eprintln!("\n── index size ───────────────────────────────────────────");
+    eprintln!(
+        "shadow tables        {:>9}  ({:.1} KB/session)",
+        human(index_bytes),
+        index_bytes as f64 / 1024.0 / indexed as f64
+    );
+    for (column, size) in &bytes {
+        eprintln!(
+            "  {column:<18} {:>9}  {:>5.1}% of stored text",
+            human(*size),
+            *size as f64 * 100.0 / content_bytes as f64
+        );
+    }
+    eprintln!(
+        "caps                 message {MESSAGE_CAP}, tool result {TOOL_RESULT_CAP}, \
+         session {SESSION_CAP}; widest session {widest}"
+    );
+
+    // ─── query latency, with filters and facets composed in ─────────────────
+    let busiest = busiest_project(&conn);
+    let shapes: Vec<(&str, String)> = vec![
+        ("single common word", "q=error".to_string()),
+        ("single rare word", format!("q={}", enc(&probe.term))),
+        ("two words (implicit AND)", "q=test+failure".to_string()),
+        ("quoted phrase", format!("q={}", enc("\"cargo test\""))),
+        ("as-you-type prefix", "q=implement".to_string()),
+        (
+            "word + project filter",
+            format!("q=error&project={}", enc(&busiest)),
+        ),
+        (
+            "word + numeric + time sort",
+            "q=error&messages_min=5&sort=recent".to_string(),
+        ),
+    ];
+
+    eprintln!("\n── query latency ────────────────────────────────────────");
+    eprintln!(
+        "{:<26} {:>5} {:>4} {:>10} {:>10} {:>10} {:>10}",
+        "shape", "rows", "n", "page p50", "page p95", "facet p50", "facet p95"
+    );
+    let mut latency = Vec::new();
+    for (label, raw) in &shapes {
+        let q = SessionQuery::parse(raw).expect("parse a representative query");
+        let shape_started = Instant::now();
+        let mut page_times = Vec::with_capacity(QUERY_ITERATIONS);
+        let mut facet_times = Vec::with_capacity(QUERY_ITERATIONS);
+        let mut hits = 0usize;
+        // One extra run, whose sample is dropped: the first call through a shape
+        // pays for FTS5 opening its shadow tables, a cost no later query of the
+        // same session sees and which would otherwise land entirely in the p95.
+        for run in 0..=QUERY_ITERATIONS {
+            let t = Instant::now();
+            let page = list_page(&conn, &settings, &q).expect("page");
+            let page_time = t.elapsed();
+            let rows = page.items.len();
+
+            let t = Instant::now();
+            facets(&conn, &settings, &q).expect("facets");
+            let facet_time = t.elapsed();
+
+            if run > 0 {
+                page_times.push(page_time);
+                facet_times.push(facet_time);
+                hits = rows;
+            }
+            if page_times.len() >= MIN_ITERATIONS && shape_started.elapsed() > SHAPE_BUDGET {
+                break;
+            }
+        }
+        page_times.sort_unstable();
+        facet_times.sort_unstable();
+        // Printed per shape rather than in one table at the end: the slow shapes
+        // are slow enough that a silent run reads as a hang.
+        eprintln!(
+            "{label:<26} {hits:>5} {:>4} {:>10.2?} {:>10.2?} {:>10.2?} {:>10.2?}",
+            page_times.len(),
+            percentile(&page_times, 50.0),
+            percentile(&page_times, 95.0),
+            percentile(&facet_times, 50.0),
+            percentile(&facet_times, 95.0),
+        );
+        latency.push((*label, hits, page_times, facet_times));
+    }
+
+    // Every shape has to have answered *something*, or the latency figures are
+    // the cost of finding nothing. Not per shape — a corpus need not contain the
+    // word "failure" — but across the set, where the rare term alone guarantees
+    // a hit.
+    let answered = latency.iter().filter(|(_, hits, ..)| *hits > 0).count();
+    assert!(
+        answered > 0,
+        "no representative query returned a row, so the latency figures measure \
+         an empty index"
+    );
+
+    eprintln!(
+        "\n`n` is the sample count, bounded by {SHAPE_BUDGET:?} per shape rather \
+         than by a run count — see QUERY_ITERATIONS."
+    );
+    eprintln!();
+}
+
+// ─── helpers the test reads its numbers through ─────────────────────────────
+
+fn human(bytes: i64) -> String {
+    match bytes {
+        b if b >= 1 << 20 => format!("{:.1} MB", b as f64 / (1 << 20) as f64),
+        b if b >= 1 << 10 => format!("{:.1} KB", b as f64 / (1 << 10) as f64),
+        b => format!("{b} B"),
+    }
+}
+
+/// Stored bytes per indexed column — the answer to "does tool output dominate
+/// this index", which is what decides whether #434's caps need moving.
+///
+/// A `BTreeMap` so the report is in a fixed order whatever the query planner
+/// does.
+fn column_bytes(conn: &Connection) -> BTreeMap<&'static str, i64> {
+    ["title", "user_text", "assistant_text", "tool_text"]
+        .into_iter()
+        .map(|column| {
+            let total = scalar(
+                conn,
+                &format!("SELECT COALESCE(SUM(LENGTH({column})), 0) FROM session_search"),
+            );
+            (column, total.max(0))
+        })
+        .collect()
+}
+
+/// Bytes occupied by the FTS5 shadow tables — the index's real footprint,
+/// inverted index and stored content together.
+///
+/// `dbstat` is the right answer and is a **compile-time option**
+/// (`SQLITE_ENABLE_DBSTAT_VTAB`) that this build may or may not carry, so it is
+/// attempted and fallen back on rather than assumed. The fallback sums the
+/// shadow tables' own blobs, which undercounts page overhead but is the same
+/// order and, more importantly, is never zero when the index is not empty.
+fn shadow_bytes(conn: &Connection) -> i64 {
+    let via_dbstat: rusqlite::Result<i64> = conn.query_row(
+        "SELECT COALESCE(SUM(pgsize), 0) FROM dbstat WHERE name LIKE 'session_search%'",
+        [],
+        |r| r.get(0),
+    );
+    if let Ok(size) = via_dbstat {
+        if size > 0 {
+            return size;
+        }
+    }
+    let data = scalar(
+        conn,
+        "SELECT COALESCE(SUM(LENGTH(block)), 0) FROM session_search_data",
+    );
+    let docsize = scalar(
+        conn,
+        "SELECT COALESCE(SUM(LENGTH(sz)), 0) FROM session_search_docsize",
+    );
+    let content: i64 = column_bytes(conn).values().sum();
+    data.max(0) + docsize.max(0) + content
+}
+
+/// Read whole documents back out of the index, largest first.
+///
+/// Largest first on purpose: `search::delete`'s cost is a scan that materializes
+/// every row it passes, so the sessions worth timing a re-index of are the ones
+/// whose documents are big enough for the insert to register beside it.
+fn sample_docs(conn: &Connection, n: usize) -> Vec<SearchDoc> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT session_id, project_path, title, user_text, assistant_text, tool_text
+               FROM session_search
+              ORDER BY LENGTH(user_text) + LENGTH(assistant_text) + LENGTH(tool_text) DESC
+              LIMIT ?1",
+        )
+        .expect("prepare the sample read");
+    let rows = stmt
+        .query_map([n as i64], |r| {
+            Ok(SearchDoc {
+                session_id: r.get(0)?,
+                project_path: r.get(1)?,
+                title: r.get(2)?,
+                user_text: r.get(3)?,
+                assistant_text: r.get(4)?,
+                tool_text: r.get(5)?,
+            })
+        })
+        .expect("read the samples");
+    rows.filter_map(Result::ok).collect()
+}
+
+/// Time one session all the way around the worker's incremental path.
+///
+/// Dropping its insight row is what makes the session *pending*, which is both
+/// how the work is requested and how its completion is observed — `enqueue`
+/// answers nothing, so the terminal condition has to be a query. The row
+/// reappears as a side effect, which is why the count is asserted afterwards.
+fn worker_round_trip(db: &Path, doc: &SearchDoc) -> Duration {
+    let file_path: String = {
+        let conn = db::open_read_only(db).expect("open the copy read-only");
+        conn.query_row(
+            "SELECT file_path FROM claude_session_cache
+              WHERE session_id = ?1 AND project_path = ?2",
+            [&doc.session_id, &doc.project_path],
+            |r| r.get(0),
+        )
+        .unwrap_or_default()
+    };
+    assert!(
+        !file_path.is_empty(),
+        "indexed session {} has no cache row to re-read",
+        doc.session_id
+    );
+
+    {
+        let conn = db::open_read_write(db).expect("open the copy read-write");
+        conn.execute(
+            "DELETE FROM session_insights WHERE session_id = ?1 AND project_path = ?2",
+            [&doc.session_id, &doc.project_path],
+        )
+        .expect("drop one insight row");
+    }
+
+    let pending = store::Pending {
+        session_id: doc.session_id.clone(),
+        project_path: doc.project_path.clone(),
+        file_path,
+    };
+    let started = Instant::now();
+    worker::enqueue([pending.clone()]);
+
+    while started.elapsed() < BUILD_BUDGET {
+        let conn = db::open_read_only(db).expect("open the copy read-only");
+        let still = store::needs_processing(&conn, CURRENT_PROCESSOR_VERSION)
+            .expect("needs_processing")
+            .into_iter()
+            .any(|p| p.session_id == pending.session_id && p.project_path == pending.project_path);
+        drop(conn);
+        if !still {
+            return started.elapsed();
+        }
+        std::thread::sleep(POLL);
+    }
+    panic!(
+        "the worker never re-processed session {} — the incremental path is not \
+         reachable through the queue",
+        doc.session_id
+    )
+}
+
+struct Probe {
+    session_id: String,
+    project_path: String,
+    term: String,
+    hits: i64,
+}
+
+/// Pick a session and a term from *its own indexed text* that identifies it.
+///
+/// Chosen at run time rather than hardcoded, because the corpus is whatever this
+/// machine has. The term must match **few** rows — comfortably inside one page —
+/// so that "the session is on page one under relevance" is a real assertion
+/// about ranking rather than a restatement of "the corpus is small". A term
+/// matching one row is ideal; up to [`MAX_PROBE_HITS`] is still decisive, since
+/// relevance sorts every index hit above every metadata-only one.
+fn find_probe(conn: &Connection) -> Option<Probe> {
+    const MAX_PROBE_HITS: i64 = 20;
+    const SESSIONS_TO_TRY: i64 = 200;
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT session_id, project_path, user_text
+               FROM session_search
+              WHERE LENGTH(user_text) > 200
+              LIMIT ?1",
+        )
+        .ok()?;
+    let rows = stmt
+        .query_map([SESSIONS_TO_TRY], |r| {
+            Ok((
+                r.get::<_, String>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, String>(2)?,
+            ))
+        })
+        .ok()?;
+
+    for row in rows.flatten() {
+        let (session_id, project_path, text) = row;
+        for term in candidate_terms(&text) {
+            let hits = match_count(conn, &term);
+            if (1..=MAX_PROBE_HITS).contains(&hits) {
+                return Some(Probe {
+                    session_id,
+                    project_path,
+                    term,
+                    hits,
+                });
+            }
+        }
+    }
+    None
+}
+
+/// The project with the most cached sessions — the filter most likely to be
+/// composed with a search in practice, and the one that exercises the clause
+/// combination rather than a filter that removes everything.
+fn busiest_project(conn: &Connection) -> String {
+    conn.query_row(
+        "SELECT project_path FROM claude_session_cache
+          GROUP BY project_path ORDER BY COUNT(*) DESC LIMIT 1",
+        [],
+        |r| r.get(0),
+    )
+    .unwrap_or_default()
+}


### PR DESCRIPTION
Closes #439.

## What

Adds `src-tauri/tests/search_live.rs` — the third `#[ignore]`d live suite over the machine's real corpus, alongside `scan_live` and `insights_live` — and records what it measured.

It copies `~/.agento/agento.db`, **migrates the copy** (the installed database lags the repository; on the reference machine it had no `session_search` table at all), forces `search_index_version` to `0`, drives the rebuild through `worker::start`, and polls the **version stamp** as the terminal condition — `sweep` records it last and only when every batch committed, where a row count sits flat for the whole of each batch's read phase and a test waiting for it to settle declares success mid-sweep.

Then it asserts what holds on any corpus, and prints what varies.

## Why

#433 chose an FTS5 shape and #434 chose three byte caps a priori. Neither had met a real corpus, and a fixture cannot tell a healthy index from one that indexed nothing, nor reveal whether tool text dominates it.

## How — the assertions (strict, corpus-independent)

- cached sessions > 0, index rows > 0, and index rows **==** insight rows (they commit in one transaction, so they cannot differ)
- at least 90 % of cached sessions indexed; most index rows carry text
- stored bytes > 0 and shadow-table bytes > 0 — a zero-size index is a failure, not a pass
- **`SESSION_CAP` holds on real input**: `MAX(len(user)+len(assistant)+len(tool)) <= SESSION_CAP`
- `delete_orphans` returns 0 immediately after a rebuild
- re-indexing the samples leaves the row count unchanged (a missed delete or a duplicated insert would move it)
- a **probe term chosen from the corpus at run time** — one matching ≤ 20 index rows, taken out of a session's own indexed text — finds that session on page one, with `sort` resolved to `Relevance` and a `match_snippet` carrying `U+0001`
- at least one representative query shape returned a row, so the latency figures are not the cost of finding nothing

There is deliberately **no timing assertion**: a bound tuned on one machine's corpus flakes on another's, and a flaky test is worse than no test. The bounds are here in the PR.

## The numbers — release, 1,178 sessions, `cargo test --release --test search_live -- --ignored --nocapture`

```
── corpus ───────────────────────────────────────────────
cached sessions      1178
indexed sessions     1178 (1128 carrying text)

── build ────────────────────────────────────────────────
cold full rebuild        6.66s  (5.7 ms/session)
incremental: delete    44.57ms  median of 5 (this is the scan)
incremental: insert    11.08ms  median of 5
incremental: worker   207.14ms  one session, transcript read included
orphan sweep           34.55ms  one pass over the whole index

── index size ───────────────────────────────────────────
shadow tables         188.7 MB  (164.0 KB/session)
  assistant_text       14.9 MB   10.5% of stored text
  title                48.8 KB    0.0% of stored text
  tool_text           122.2 MB   86.5% of stored text
  user_text             4.2 MB    3.0% of stored text
caps                 message 8192, tool result 2048, session 524288; widest session 523339

── query latency ────────────────────────────────────────
shape                       rows    n   page p50   page p95  facet p50  facet p95
single common word            50    3     33.59s     34.20s   101.06ms   114.95ms
single rare word              16   15    23.44ms    36.78ms    12.52ms    20.52ms
two words (implicit AND)      50    3     19.94s     20.32s    90.42ms    91.18ms
quoted phrase                 46   15   354.47ms   419.65ms    20.89ms    24.90ms
as-you-type prefix            50    3     18.63s     19.84s    77.30ms    79.51ms
word + project filter         50    3     11.36s     11.55s    91.94ms   100.10ms
word + numeric + time sort    50   15   163.28ms   172.65ms    90.83ms    97.95ms
```

Reproduced across two runs (the first, before the sampling budget landed, took 1404 s and gave 7.87 s / 48.05 ms / 188.7 MB / 32.65 s — same figures).

### What they settle

**1. `search::delete`'s scan is real, and it is the whole of the incremental cost.** 45 ms against a 188 MB index, against the 9.5 ms/17 MB and 63 ms/176 MB already recorded — it tracks index size, as a scan does. The rowid side table (#446) is what removes it. Cold rebuild is 6.7 s for the whole corpus, so the `delete_all` + `insert` decision from #435 is holding.

**2. Build time is comfortably within any bound; index size is the number to watch.** 188.7 MB for 1,178 sessions, 164 KB/session.

**3. `tool_text` is 86.5 % of the stored text** (122.2 MB of 141.3 MB) against `assistant_text`'s 10.5 % and `user_text`'s 3.0 % — while carrying the *lowest* bm25 weight (0.5).

**4. The expensive half of a search is the ranked join and the snippet, not the index.** The same query answers its *facets* — membership `IN`, no `bm25()` carried through, no `snippet()` — in 101 ms while the page takes 33.6 s. A term with 16 hits is 23 ms either way, and a 46-hit phrase is 354 ms, so the cost tracks the number of hits rather than the corpus size. **This is a user-visible defect** (a common-word search in the sessions list is tens of seconds) and it is **out of scope here** — this issue owns measuring. Worth a follow-up issue; the maintainer's call to open it.

## Judgement call: the #434 caps are left alone

The acceptance criteria offer "within agreed bounds, **or** the caps are adjusted and re-measured in the same PR". Tool text dominating by byte count is real, but it is not *disproportionate* in the sense the cap could fix:

- `TOOL_RESULT_CAP` is **per tool result** and already a quarter of `MESSAGE_CAP`. What is large is the *number* of tool calls in a Claude Code transcript, not any one of them — a byte cap per result does not address that.
- `SESSION_CAP` already binds: the widest session indexes 523,339 of 524,288 bytes.
- Lowering the cap trades recall for size against a size budget nobody has set, and would need a `SEARCH_INDEX_VERSION` bump to take effect on existing installs.
- The dominant cost the measurement actually found is query latency, which the caps influence only weakly (a 16-hit query is 23 ms at the current document sizes). Picking a cap to attack it would be tuning by superstition.

So the numbers are recorded as the baseline instead, in `CLAUDE.md`, which is what a future "this halves the index" claim gets measured against.

## Docs

- `CLAUDE.md` — a new **"The search index, measured (#439)"** section: the run commands, why the terminal condition is the version stamp, the reference table, and the three findings.
- `docs/development.md` — the run command beside `scan_live`'s, in both profiles.

## Why `--release` is called out

The `bundled` SQLite is a C dependency compiled at the profile's optimization level, so a debug run measures a SQLite nobody ships. The assertions hold in either profile; the timings are worth a `--release` run. The suite takes ~6 min release / ~25 min debug, which is a property of what it measures rather than of the harness — `QUERY_ITERATIONS` bounds each shape by *time* (20 s, min 3 samples) rather than by a run count, and reports `n`, so the slow shapes are still sampled instead of skipped. It tightens itself once queries are fast.

## Gates

`npm run build`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --no-fail-fast` (1,406 passed, 0 failed, 4 ignored — the live suites), `cargo build --release` — all green locally.

---

## Review round 1 — one finding, applied

**🟠 The probe was drawn straight from the index, which is not the same as being visible.** `session_search` holds a row for every cached session while `list_page` applies the stored `hidden_projects` and `indexed_config_dirs` — so on a machine that hides a project, the probe would name a session the list is *right* not to return, and the assertion would fail for a reason unrelated to search. `find_probe` now filters candidates through the same `list_page`, asked by session id (one of `add_search`'s six LIKE columns) rather than by re-deriving the scope here, which could agree with the wrong thing.

Re-verified after the fix — third release run, same corpus:

```
cold full rebuild        9.10s  (7.7 ms/session)
incremental: delete    46.03ms   insert 8.44ms   worker 207.53ms   orphans 36.84ms
shadow tables         188.7 MB  (tool_text 86.5%)
single common word      35.62s p50   /  facets 99.48ms p50
single rare word (16)   23.16ms p50  /  facets 13.18ms p50
```

Three independent release runs agree: cold build 6.7–9.1 s, delete 44.6–48.1 ms, index 188.7 MB exactly, common-word page 32.7–35.6 s.

## Is this a regression guard?

There is no production code change to revert, so the usual "revert it and watch the test fail" check does not apply — the suite *is* the deliverable. What it guards is the pipeline: it fails if the worker stops writing index rows, if index and insight counts diverge, if a cap stops holding on real input, if `delete_orphans` starts dropping live rows, or if a term in a session's own indexed text stops finding that session ranked on page one. All of those are silent today.
