### PR TITLE
ci: a dedicated `ci` cargo profile (#449)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,11 +156,11 @@ jobs:
       - name: Rust tests
         working-directory: src-tauri
         run: |
-          cargo nextest run
           # nextest does not run doctests at all — it has no way to. This repo
           # has 2, and without this line they would silently stop being
           # checked rather than fail.
           cargo test --doc
+          cargo nextest run
 
       # A full `tauri build` here would double CI time; compiling a
       # release-derived profile is what actually catches the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,16 +117,38 @@ jobs:
         working-directory: src-tauri
         run: cargo clippy --all-targets -- -D warnings
 
+      # `cargo test` runs the 11 test binaries strictly one after another;
+      # nextest runs them as parallel processes, which is ~25-30s of the run.
+      # The action fetches a prebuilt binary, so this costs seconds rather than
+      # the minutes a `cargo install` compile would.
+      - uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2.86.7
+        with:
+          tool: nextest
+
       # Covers every endpoint, including the frozen goldens in parity/. This is
       # their only reader, so a change to one of those files is only ever
       # noticed here — see parity/README.md before editing any of them.
       - name: Rust tests
         working-directory: src-tauri
-        run: cargo test
+        run: |
+          cargo nextest run
+          # nextest does not run doctests at all — it has no way to. This repo
+          # has 2, and without this line they would silently stop being
+          # checked rather than fail.
+          cargo test --doc
 
-      # A full `tauri build` here would double CI time; compiling the release
-      # profile is what actually catches the `cfg(not(debug_assertions))` code
-      # that never builds during development.
-      - name: Compile Rust (release)
+      # A full `tauri build` here would double CI time; compiling a
+      # release-derived profile is what actually catches the
+      # `cfg(not(debug_assertions))` code that never builds during development.
+      #
+      # `ci` rather than `release`, and the difference is the point: that goal
+      # is a *compilation* property — `cfg(debug_assertions)` keys off the
+      # profile's `debug-assertions` flag, which `[profile.ci]` inherits — while
+      # `lto = true` + `codegen-units = 1` spend ~4 minutes re-optimizing all
+      # 594 crates' bitcode as one largely single-threaded unit, for a binary
+      # this job throws away. The installers users actually install are built by
+      # release.yml through `tauri build`, which uses `--release` and so cannot
+      # reach this profile. See `[profile.ci]` in src-tauri/Cargo.toml.
+      - name: Compile Rust (ci profile)
         working-directory: src-tauri
-        run: cargo build --release
+        run: cargo build --profile ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,13 +117,38 @@ jobs:
         working-directory: src-tauri
         run: cargo clippy --all-targets -- -D warnings
 
-      # `cargo test` runs the 11 test binaries strictly one after another;
-      # nextest runs them as parallel processes, which is ~25-30s of the run.
-      # The action fetches a prebuilt binary, so this costs seconds rather than
-      # the minutes a `cargo install` compile would.
-      - uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2.86.7
-        with:
-          tool: nextest
+      # `cargo test` runs the test binaries strictly one after another; nextest
+      # runs them as parallel processes, which is most of the test step's
+      # execution time.
+      #
+      # A prebuilt binary, not `cargo install cargo-nextest`, which would pay a
+      # multi-minute compile and undo the point of this change. And a direct
+      # download rather than `taiki-e/install-action`, which is the obvious way
+      # to write this and does not work here: the org pins
+      # `allowed_actions = "selected"` with an explicit `patterns_allowed`
+      # allowlist (terraform/github-shaharia-lab/actions.tf), and an action
+      # outside it fails the run at *startup* — no job, no log, only "this run
+      # likely failed because of a workflow file issue". Adding an entry there
+      # is an org-wide security change and belongs in that repository, not this
+      # one.
+      #
+      # The version and the digest are both pinned, which is the same
+      # supply-chain property the SHA-pinned `uses:` lines above have — and
+      # strictly stronger, since it pins the *artifact* rather than the
+      # installer that chooses it. `--check` fails the step on a mismatch.
+      # Bumping the version means bumping the checksum beside it; the upstream
+      # value is published as `<asset>.sha256` on the same release.
+      - name: Install cargo-nextest
+        env:
+          NEXTEST_VERSION: 0.9.143
+          NEXTEST_SHA256: 66786b9abe23920d022a182d1416b1bbc8130dd4872a9553d76985a1708dcd1e
+        run: |
+          asset="cargo-nextest-${NEXTEST_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          curl -fsSL --retry 3 -o /tmp/nextest.tar.gz \
+            "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-${NEXTEST_VERSION}/${asset}"
+          echo "${NEXTEST_SHA256}  /tmp/nextest.tar.gz" | sha256sum --check -
+          tar -xzf /tmp/nextest.tar.gz -C "$HOME/.cargo/bin" cargo-nextest
+          cargo nextest --version
 
       # Covers every endpoint, including the frozen goldens in parity/. This is
       # their only reader, so a change to one of those files is only ever

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,50 +117,25 @@ jobs:
         working-directory: src-tauri
         run: cargo clippy --all-targets -- -D warnings
 
-      # `cargo test` runs the test binaries strictly one after another; nextest
-      # runs them as parallel processes, which is most of the test step's
-      # execution time.
-      #
-      # A prebuilt binary, not `cargo install cargo-nextest`, which would pay a
-      # multi-minute compile and undo the point of this change. And a direct
-      # download rather than `taiki-e/install-action`, which is the obvious way
-      # to write this and does not work here: the org pins
-      # `allowed_actions = "selected"` with an explicit `patterns_allowed`
-      # allowlist (terraform/github-shaharia-lab/actions.tf), and an action
-      # outside it fails the run at *startup* — no job, no log, only "this run
-      # likely failed because of a workflow file issue". Adding an entry there
-      # is an org-wide security change and belongs in that repository, not this
-      # one.
-      #
-      # The version and the digest are both pinned, which is the same
-      # supply-chain property the SHA-pinned `uses:` lines above have — and
-      # strictly stronger, since it pins the *artifact* rather than the
-      # installer that chooses it. `--check` fails the step on a mismatch.
-      # Bumping the version means bumping the checksum beside it; the upstream
-      # value is published as `<asset>.sha256` on the same release.
-      - name: Install cargo-nextest
-        env:
-          NEXTEST_VERSION: 0.9.143
-          NEXTEST_SHA256: 66786b9abe23920d022a182d1416b1bbc8130dd4872a9553d76985a1708dcd1e
-        run: |
-          asset="cargo-nextest-${NEXTEST_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
-          curl -fsSL --retry 3 -o /tmp/nextest.tar.gz \
-            "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-${NEXTEST_VERSION}/${asset}"
-          echo "${NEXTEST_SHA256}  /tmp/nextest.tar.gz" | sha256sum --check -
-          tar -xzf /tmp/nextest.tar.gz -C "$HOME/.cargo/bin" cargo-nextest
-          cargo nextest --version
-
       # Covers every endpoint, including the frozen goldens in parity/. This is
       # their only reader, so a change to one of those files is only ever
       # noticed here — see parity/README.md before editing any of them.
+      #
+      # `cargo test` and not `cargo nextest run`, and that was measured rather
+      # than assumed (#449). nextest does run the 14 test binaries as parallel
+      # processes and it does win there — 37-41s against `cargo test`'s ~59s of
+      # strictly sequential execution. But nextest cannot run doctests, so the
+      # step becomes two cargo invocations, and the second one's compile phase
+      # does not overlap the first's the way a single `cargo test` overlaps
+      # building the doctest lib with building the test binaries. That costs
+      # ~40s, more than the ~20s parallelism saves: three consecutive runs
+      # measured the split step at 155s against this one's 130-162s, and
+      # reversing the order of the two commands changed nothing (155s again).
+      # If you revisit it, the thing to beat is the serialized second compile,
+      # not the execution time.
       - name: Rust tests
         working-directory: src-tauri
-        run: |
-          # nextest does not run doctests at all — it has no way to. This repo
-          # has 2, and without this line they would silently stop being
-          # checked rather than fail.
-          cargo test --doc
-          cargo nextest run
+        run: cargo test
 
       # A full `tauri build` here would double CI time; compiling a
       # release-derived profile is what actually catches the

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -331,6 +331,19 @@ opt-level = "s"
 panic = "unwind"
 strip = true
 
+# CI compiles the release profile only to type-check and codegen the
+# `cfg(not(debug_assertions))` paths that never build during development
+# (see .github/workflows/ci.yml) — it throws the binary away. `inherits`
+# carries `debug-assertions = false`, which is the entire point; fat LTO and
+# codegen-units = 1 cost ~4 minutes and buy CI nothing. The shipped installers
+# are built by release.yml through `tauri build`, which uses [profile.release]
+# above and is unaffected by this profile.
+[profile.ci]
+inherits = "release"
+lto = false
+codegen-units = 16
+opt-level = 0
+
 [dev-dependencies]
 tempfile = "3.27.0"
 # Collecting a streamed SSE body in the turn tests.


### PR DESCRIPTION
Closes #449

## What

One change, CI-only, no source change:

**`[profile.ci]`** in `src-tauri/Cargo.toml`, inheriting `release` with `lto = false`, `codegen-units = 16`, `opt-level = 0`. `ci.yml`'s build step becomes `cargo build --profile ci`.

`[profile.release]` is byte-identical. The shipped installers come from `release.yml`'s `tauri build`, which uses `--release`, so this profile cannot reach a shipped artifact.

**The issue's change 2 (nextest) is not here.** It was implemented, measured over four CI runs, and dropped — see below.

## Result: 9m08s → 4m57s, −46%

Warm-cache run [32801151386](https://github.com/shaharia-lab/agento/actions/runs/32801151386) against the last three successful `main` runs:

| Step | `main` (n=3) | this PR | Δ |
|---|---|---|---|
| **Compile Rust (release → ci profile)** | **246s / 277s / 282s** | **33s** | **−235s** |
| Rust tests | 130s / 132s / 162s | 134s | — |
| Rust lints | ~22s | 22s | — |
| everything else (apt, cache, node, frontend) | ~90s | ~90s | — |
| **total run** | **547s / 548s / 559s** | **297s** | **−251s** |

The build step compiles only `agento`, exactly as it does on `main` — `Swatinem/rust-cache` reports `full match: true`, so it retains `target/ci/`'s dependency artifacts and the fallback to `CARGO_PROFILE_RELEASE_*` env overrides is not needed. That was the biggest risk in the issue and it is resolved by measurement, not argument.

The **first** run under the new profile is a cache reseed and took 8m11s ([32799655485](https://github.com/shaharia-lab/agento/actions/runs/32799655485)); every run after it is the 4m57s above.

## Test inventory unchanged

`1318` lib + `86` integration + `2` doctests, `4` `#[ignore]`d live suites still ignored (`claude_mcp_live`, `insights_live`, `scan_live`, `search_live` — the fourth arrived with #439, after the issue was refined). Identical to `main`.

## Why nextest was dropped

The issue's own rule: *"if `cargo nextest run` does not beat `cargo test` on the measured run, drop change 2 and keep change 1, which carries ~93% of the benefit."*

It does not beat it. Measured on the runner:

| | build | execution | second invocation | step |
|---|---|---|---|---|
| `cargo test` (`main`) | 67s | ~59s sequential | — | **130s** |
| `cargo nextest run` then `cargo test --doc` | 69s | **37.6s** | 46s | **155s** |
| `cargo test --doc` then `cargo nextest run` | 70s | **41.2s** | 43s | **155s** |

nextest wins the part it is supposed to win — 37–41s against ~59s of strictly sequential execution across 14 binaries. It loses more than that to something structural: nextest cannot run doctests, so the step becomes **two cargo invocations**, and the second one's compile phase cannot overlap the first's the way a single `cargo test` overlaps building the doctest lib with building the test binaries. On a 2-core runner that costs ~40s against a ~20s win.

Reversing the two commands was the obvious rescue and it changed nothing — 155s again, a third identical measurement. That is what ruled the hypothesis out rather than left it open.

Dropping it also removes two things this PR would otherwise have carried: a pinned third-party binary in CI, and the process-per-test flake risk on a 2-core runner that the issue's three-green-runs criterion existed for. Why it did not work is recorded at the step so the next attempt measures the right thing.

## Also worth knowing: `taiki-e/install-action` cannot be used in this org

Not relevant to the merged diff, but it cost a run and it will cost the next person one. The org sets `allowed_actions = "selected"` with an explicit `patterns_allowed` allowlist (`terraform/github-shaharia-lab/actions.tf` in `infrastructure`); `taiki-e/install-action` is not on it. An action outside the allowlist is refused **before any job starts** — `startup_failure`, no job, no log, no annotation, only *"This run likely failed because of a workflow file issue"* ([run 32799409332](https://github.com/shaharia-lab/agento/actions/runs/32799409332)). Adding an entry is an org-wide security change in another repository. Detail on #449.

## Verification

- Local gates green: `npm run build`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo build --profile ci`.
- Three consecutive green CI runs on the final shape.