### PR TITLE
test(insights): make the worker loop testable (run_once), and cover the queue path and the scan wiring (#447)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,6 +372,8 @@ src-tauri/src/
     diff.rs      byte comparison + reporting for shadow mode
 
 src-tauri/tests/ integration suites (the live-diff ones went with the Go tree)
+                 insights_worker.rs  the worker through the real `worker::start`
+                 (#447) — not `#[ignore]`d, and one `start` per binary
 parity/          frozen goldens from the Go server; see parity/README.md
 ```
 
@@ -975,6 +977,13 @@ Three rules, each silent when wrong:
   `session_insights` has no `file_path` to get this wrong with. Running it after
   the scan's own delete pass is what inherits the unreadable-config-dir
   protection: those cache rows survive, so their insights are not orphans.
+  **The ordering is asserted in `scan.rs`'s own tests since #447**, over a
+  two-config-dir fixture corpus under a swapped `HOME`: a removed session loses
+  its index row, and a session under a `chmod 0o000` config dir keeps its cache,
+  insight *and* index rows. Both `delete_orphans` functions had unit tests
+  against a hand-built database, and what those cannot say is *where they are
+  called from* — moving `search::delete_orphans` above `apply_changes` finds
+  every row still present, deletes nothing, and changes no other observable.
 - **A full queue asks for a sweep; it does not drop and wait.** The scan
   announces changed sessions on a 100-slot channel, and a first scan announces
   ten times that. Go warns per dropped item and waits for the next five-minute
@@ -987,6 +996,28 @@ scan's staleness markers deliberately do **not** cover
 `CURRENT_PROCESSOR_VERSION`: a processor-only bump must not force a full
 re-read of `claude_session_cache`, so the five-minute sweep is the only thing
 that notices one.
+
+**`run` is the boot sweep plus `loop { run_once(..) }`** (#447), and where the
+two tests of it live is the decision worth knowing:
+
+- **`run_once` is private, and it exists for the *unit* tests.** It returns a
+  `Pass` so one deterministic pass is assertable — the `BATCH_SIZE` cutoff, the
+  remainder waiting for the next pass, the `SWEEP_REQUESTED` follow-up, and
+  `enqueue`'s own path end to end. Before the split, every test called
+  `process_batch` directly and none of that was reachable. It takes the timeout
+  as a parameter purely so a test does not wait five minutes; `RESCAN_INTERVAL`
+  is production's only value for it.
+- **`run_once` does *not* make "the worker's database work is off the runtime"
+  testable**, and that is the trap the split invites. A test calling it from a
+  `tokio::spawn` is still the test choosing where the work runs — the same
+  non-falsifiability under a new name. The thing under test is **`start`'s
+  `std::thread::spawn`**, so it is driven from `src-tauri/tests/insights_worker.rs`
+  through the real `start`/`enqueue`, in #366's harness. That binary may hold
+  **exactly one** test calling `start`, because `QUEUE` is a process-wide
+  `OnceLock` — a second gets `already started` and silently drives the first
+  test's worker against the first test's database.
+
+It is **not** `#[ignore]`d: it needs no corpus, only a tempdir.
 
 ### The search index, measured (`src-tauri/tests/search_live.rs`, #439)
 

--- a/src-tauri/src/native/insights/worker.rs
+++ b/src-tauri/src/native/insights/worker.rs
@@ -20,6 +20,22 @@
 //! `scan::ensure_scan` already does with `std::thread::spawn`. So there is no
 //! `db::blocking` here and no `async` anywhere in this module.
 //!
+//! **That `std::thread::spawn` is pinned by `tests/insights_worker.rs`** (#447),
+//! not by anything here: the property is a claim about where [`start`] puts the
+//! loop, so only a test driving `start` itself can falsify it. That binary may
+//! hold exactly one such test, because [`QUEUE`] is a process-wide `OnceLock`;
+//! its own header says so.
+//!
+//! ## `run` and `run_once`
+//!
+//! [`run`] is the boot sweep plus `loop { run_once(..) }`, and the split is a
+//! pure extraction (#447). The whole of the loop's behaviour — `recv_timeout`,
+//! the batch accumulation, the [`BATCH_SIZE`] cutoff, the [`SWEEP_REQUESTED`]
+//! follow-up — lives in [`run_once`], which returns a [`Pass`] so a unit test
+//! can drive **one deterministic pass** and assert which arm it took. Polling a
+//! started worker cannot give that, and every one of those steps was previously
+//! covered only by the unit tests on [`offer`].
+//!
 //! ## Why one worker rather than Go's pool of four
 //!
 //! Go runs four goroutines each upserting on its own connection. SQLite
@@ -150,54 +166,93 @@ pub fn start(db_path: PathBuf) {
 
 /// The worker loop: sweep, then drain the queue, forever.
 ///
-/// `recv_timeout` is both halves at once — it delivers enqueued work
-/// immediately and falls out every [`RESCAN_INTERVAL`] to sweep, with no
-/// separate ticker thread and no way for the two to run concurrently.
+/// The body is [`run_once`] so a test can drive **one deterministic pass** —
+/// see its header for what that buys and what it deliberately does not.
 fn run(db_path: &Path, rx: Receiver<Pending>) {
     // The sweep runs first, before any event can arrive, so a fresh install
     // gets its whole corpus processed without waiting for a scan to report
     // anything — which is the state the issue was filed about.
     sweep(db_path);
 
-    loop {
-        let mut batch: BTreeSet<Pending> = BTreeSet::new();
+    while run_once(db_path, &rx, RESCAN_INTERVAL) != Pass::Disconnected {}
+}
 
-        match rx.recv_timeout(RESCAN_INTERVAL) {
-            Ok(item) => {
-                batch.insert(item);
-                // Take whatever else is already queued, so a scan that
-                // announced 300 sessions is a handful of transactions rather
-                // than 300.
-                while batch.len() < BATCH_SIZE {
-                    match rx.try_recv() {
-                        Ok(item) => {
-                            batch.insert(item);
-                        }
-                        Err(_) => break,
+/// What one pass of [`run`] did.
+///
+/// It exists so a unit test can assert which arm a pass took — the batch
+/// accumulation and the `BATCH_SIZE` cutoff are otherwise observable only as
+/// "the rows eventually appear", which is true of any number of passes.
+/// Deliberately private and deliberately narrow: it is not a contract, it is
+/// what the tests in this file assert on, and the follow-up sweep is asserted
+/// through its **effect** on the database rather than by growing a variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Pass {
+    /// A batch came off the queue and was processed. `committed` is
+    /// [`process_batch`]'s answer, which carries its own careful definition of
+    /// failure.
+    Batch { size: usize, committed: bool },
+    /// `recv_timeout` expired into the periodic sweep.
+    Swept,
+    /// Every sender is gone, so [`run`] returns.
+    Disconnected,
+}
+
+/// One pass: take a batch off the queue (or time out into a sweep), process it,
+/// then honour a requested sweep.
+///
+/// `recv_timeout` is both halves of the schedule at once — it delivers enqueued
+/// work immediately and falls out every `timeout` to sweep, with no separate
+/// ticker thread and no way for the two to run concurrently.
+///
+/// **`timeout` is a parameter only so a test does not wait five minutes.**
+/// Production has exactly one value for it, [`RESCAN_INTERVAL`], passed by
+/// [`run`]; nothing else should ever pass another.
+///
+/// This being callable does **not** make "the worker's database work is off the
+/// runtime" testable — a test choosing to call it from a `tokio::spawn` is
+/// still the test choosing where the work runs. What puts that property under
+/// test is [`start`]'s `std::thread::spawn`, and the thing that drives it is
+/// `tests/insights_worker.rs`.
+fn run_once(db_path: &Path, rx: &Receiver<Pending>, timeout: Duration) -> Pass {
+    let mut batch: BTreeSet<Pending> = BTreeSet::new();
+
+    match rx.recv_timeout(timeout) {
+        Ok(item) => {
+            batch.insert(item);
+            // Take whatever else is already queued, so a scan that announced
+            // 300 sessions is a handful of transactions rather than 300.
+            while batch.len() < BATCH_SIZE {
+                match rx.try_recv() {
+                    Ok(item) => {
+                        batch.insert(item);
                     }
+                    Err(_) => break,
                 }
             }
-            Err(mpsc::RecvTimeoutError::Timeout) => {
-                sweep(db_path);
-                continue;
-            }
-            // Every sender is gone, which cannot happen while the static holds
-            // one — but exiting is the only correct answer if it ever does.
-            Err(mpsc::RecvTimeoutError::Disconnected) => return,
         }
-
-        // The queue is the incremental path, so a row for a pair may exist.
-        // Its return is deliberately ignored: only a rebuild needs to know
-        // whether a batch committed, and a rebuild is `sweep`'s alone.
-        let _ = process_batch(db_path, batch, Write::Replace);
-
-        // Whatever `enqueue` could not deliver, picked up now rather than at
-        // the next five-minute tick. The swap clears the flag before the sweep
-        // begins, so an overflow during it is not lost.
-        if SWEEP_REQUESTED.swap(false, Ordering::AcqRel) {
+        Err(mpsc::RecvTimeoutError::Timeout) => {
             sweep(db_path);
+            return Pass::Swept;
         }
+        // Every sender is gone, which cannot happen while the static holds
+        // one — but exiting is the only correct answer if it ever does.
+        Err(mpsc::RecvTimeoutError::Disconnected) => return Pass::Disconnected,
     }
+
+    // The queue is the incremental path, so a row for a pair may exist. The
+    // answer is reported rather than acted on: only a rebuild needs to know
+    // whether a batch committed, and a rebuild is [`sweep`]'s alone.
+    let size = batch.len();
+    let committed = process_batch(db_path, batch, Write::Replace);
+
+    // Whatever `enqueue` could not deliver, picked up now rather than at the
+    // next five-minute tick. The swap clears the flag before the sweep begins,
+    // so an overflow during it is not lost.
+    if SWEEP_REQUESTED.swap(false, Ordering::AcqRel) {
+        sweep(db_path);
+    }
+
+    Pass::Batch { size, committed }
 }
 
 /// `rescanOutdated`: everything with no insight row or an outdated one — **or
@@ -1222,128 +1277,204 @@ mod tests {
         ));
     }
 
-    /// A batch meeting a contended write lock still commits, and does not stall
-    /// a runtime beside it.
-    ///
-    /// **Be precise about what this can and cannot catch**, because the #366
-    /// tests it is modelled on (`tests/scheduled_run.rs`, `tests/chat_turn.rs`)
-    /// catch something this one structurally cannot. There, the defect was
-    /// database work running inline on an axum worker, and the test drives the
-    /// real entry point, so reverting the `db::blocking` hand-off fails it.
-    /// Here the worker owns an OS thread by construction — its header explains
-    /// why — and `run()` is an unexported infinite loop, so this test spawns the
-    /// thread itself. **No change to non-test code can make it fail**: falsifying
-    /// it means editing the `std::thread::spawn` below into a `tokio::spawn`,
-    /// which does take the ticker from ~150 advances to 0.
-    ///
-    /// So it is named for the property it genuinely pins, which #435 makes worth
-    /// pinning: a batch now writes `session_insights` **and** an FTS5 row per
-    /// session, holding one write lock for longer than before, and it must still
-    /// commit inside `db::open_read_write`'s five-second `busy_timeout` against
-    /// an outside writer. The runtime assertions come with the borrowed harness
-    /// and are kept because they are free, not because they are the point.
-    ///
-    /// (Falsifying it against production code would need `run()`'s body split
-    /// into a testable `run_once`. Worth doing; it is not this change's scope.)
-    ///
-    /// The rest of the shape is the original's, each part load-bearing: **one**
-    /// worker thread so a single parked worker is the whole runtime; a plain OS
-    /// thread holding the lock, so contention comes from outside exactly as the
-    /// session scanner's batch writer does; and `last` seeded **before** the
-    /// spawn, because a starved ticker is never polled and seeding on the first
-    /// poll would start the clock after the stall and measure nothing.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn a_contended_batch_still_commits_within_the_busy_timeout() {
-        use std::sync::atomic::AtomicU64;
-        use std::sync::Arc;
-        use std::time::Instant;
+    // ─── the loop itself (#447) ──────────────────────────────────────────────
+    //
+    // Everything below drives `run_once`, which is `run`'s whole body. Until it
+    // was split out, `recv_timeout` → batch accumulation → the `BATCH_SIZE`
+    // cutoff → the `SWEEP_REQUESTED` follow-up were reachable from no test at
+    // all; only `offer` was covered.
+    //
+    // The contended-write-lock test that used to sit here has moved to
+    // `tests/insights_worker.rs`, because the property it is named for is a
+    // claim about `start` and only a test driving `start` can falsify it.
 
-        /// Long enough that a parked worker is unmistakable, short enough to
-        /// stay well inside `open_read_write`'s 5s `busy_timeout` so the batch
-        /// itself still commits.
-        const HOLD: Duration = Duration::from_millis(1_500);
+    /// Serialises the tests that drive [`run_once`].
+    ///
+    /// [`SWEEP_REQUESTED`] is process-wide and a pass **clears** it, so two of
+    /// these running concurrently would steal each other's flag — the sweep
+    /// test would see it already consumed, and a queue-path test would take an
+    /// unasked-for sweep that indexes its fixture for the wrong reason. Each
+    /// test also stores `false` on entry, so none of them depends on another's
+    /// leftovers either.
+    fn run_once_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// #435's first acceptance criterion, at last driven through the code that
+    /// implements it: a session announced by a scan is searchable **after one
+    /// queue pass**.
+    ///
+    /// Every other test in this file calls `process_batch` directly, which
+    /// skips `recv_timeout` and the accumulation entirely. Here the only input
+    /// is a `Pending` on a channel, exactly as `enqueue` delivers one.
+    ///
+    /// The flag is cleared first and the arm is asserted, which together are
+    /// what make this a test *of the queue*: a pass that swept would index the
+    /// same session for a completely different reason and look identical.
+    #[test]
+    fn one_pass_over_a_queued_session_leaves_a_searchable_row() {
+        let _serialised = run_once_lock();
+        SWEEP_REQUESTED.store(false, Ordering::Release);
 
         let dir = tempfile::tempdir().expect("tempdir");
         let db_path = fixture_db(&dir);
         let file = seed_session(&dir, &db_path, "s1", "/a", "pagination");
 
-        // The file must already be WAL. Left in the default rollback journal,
-        // `open_read_write`'s own `PRAGMA journal_mode=WAL` is a *mode change*
-        // needing an exclusive lock and fails outright in about a millisecond
-        // instead of waiting on `busy_timeout` — which would make this measure
-        // the wrong thing entirely.
-        db::open_read_write(&db_path).expect("convert the fixture to WAL");
+        let (tx, rx) = mpsc::sync_channel::<Pending>(QUEUE_SIZE);
+        tx.send(pending_for("s1", "/a", &file)).expect("announce");
 
-        let (holding_tx, holding_rx) = mpsc::channel();
-        let lock_db = db_path.clone();
-        let holder = std::thread::spawn(move || {
-            let mut conn = rusqlite::Connection::open(&lock_db).expect("open");
-            let tx = conn
-                .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
-                .expect("begin immediate");
-            holding_tx.send(()).expect("signal");
-            std::thread::sleep(HOLD);
-            tx.rollback().expect("rollback");
-        });
-        holding_rx.recv().expect("the writer took the lock");
+        assert_eq!(
+            run_once(&db_path, &rx, Duration::from_millis(50)),
+            Pass::Batch {
+                size: 1,
+                committed: true
+            },
+            "the item must arrive as a batch, not as a timed-out sweep",
+        );
 
-        let worst_gap_ms = Arc::new(AtomicU64::new(0));
-        let ticks = Arc::new(AtomicU64::new(0));
-        let ticker = {
-            let (worst_gap_ms, ticks, mut last) = (
-                Arc::clone(&worst_gap_ms),
-                Arc::clone(&ticks),
-                Instant::now(),
-            );
-            tokio::spawn(async move {
-                loop {
-                    tokio::time::sleep(Duration::from_millis(10)).await;
-                    let now = Instant::now();
-                    let gap =
-                        u64::try_from(now.duration_since(last).as_millis()).unwrap_or(u64::MAX);
-                    worst_gap_ms.fetch_max(gap, Ordering::Relaxed);
-                    ticks.fetch_add(1, Ordering::Relaxed);
-                    last = now;
+        let conn = db::open_read_only(&db_path).expect("open");
+        let hits = search::search(&conn, "\"pagination\"", 10).expect("search");
+        assert_eq!(
+            hits.iter()
+                .map(|h| (h.session_id.as_str(), h.project_path.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("s1", "/a")],
+            "one pass over an announced session must leave a searchable row",
+        );
+    }
+
+    /// The accumulation stops at [`BATCH_SIZE`], and the remainder is taken by
+    /// the next pass rather than dropped.
+    ///
+    /// Both halves matter and they fail in opposite directions: no cutoff makes
+    /// one transaction unbounded in size (and, since #435, in memory — see
+    /// `BATCH_SIZE`'s own header), while a cutoff that consumed the rest would
+    /// silently lose every announcement past the hundredth.
+    ///
+    /// The transcripts do not exist, so nothing is committed; this is a test of
+    /// how many items one pass *takes*, which `Pass::size` reports directly.
+    #[test]
+    fn a_pass_takes_at_most_batch_size_and_the_rest_waits_for_the_next() {
+        let _serialised = run_once_lock();
+        SWEEP_REQUESTED.store(false, Ordering::Release);
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = fixture_db(&dir);
+
+        const EXTRA: usize = 5;
+        let (tx, rx) = mpsc::sync_channel::<Pending>(BATCH_SIZE + EXTRA);
+        for i in 0..BATCH_SIZE + EXTRA {
+            tx.send(pending(&format!("s{i:04}"))).expect("announce");
+        }
+
+        assert!(
+            matches!(
+                run_once(&db_path, &rx, Duration::from_millis(50)),
+                Pass::Batch {
+                    size: BATCH_SIZE,
+                    ..
                 }
-            })
-        };
-
-        // Exactly how production runs it: a plain thread, never a tokio task.
-        let batch_db = db_path.clone();
-        let batch = std::thread::spawn(move || {
-            process_batch(
-                &batch_db,
-                [pending_for("s1", "/a", &file)].into_iter().collect(),
-                Write::Replace,
-            )
-        });
-
-        let committed = tokio::task::spawn_blocking(move || batch.join().expect("batch"))
-            .await
-            .expect("join");
-        ticker.abort();
-        holder.join().expect("the writer finished");
-
-        assert!(committed, "the batch did not commit");
-
-        let worst = worst_gap_ms.load(Ordering::Relaxed);
-        assert!(
-            worst < 500,
-            "the runtime stalled for {worst} ms while the write lock was held \
-             (the hold is {} ms; anything near it means indexing blocked a worker)",
-            HOLD.as_millis(),
+            ),
+            "one pass must not take more than BATCH_SIZE",
         );
-        // The gap alone would read as healthy if the ticker had simply been
-        // cancelled early, so assert it really ran throughout.
-        let ticks = ticks.load(Ordering::Relaxed);
         assert!(
-            ticks > 50,
-            "the ticker only advanced {ticks} times across a {} ms hold",
-            HOLD.as_millis(),
+            matches!(
+                run_once(&db_path, &rx, Duration::from_millis(50)),
+                Pass::Batch { size: EXTRA, .. }
+            ),
+            "the remainder must be taken by the next pass, not dropped",
+        );
+    }
+
+    /// A pass with [`SWEEP_REQUESTED`] set runs the sweep and leaves the flag
+    /// clear.
+    ///
+    /// Asserted through the sweep's **effect**: `swept` is never announced, so
+    /// the only thing that can index it is the follow-up sweep. A `bool` on
+    /// [`Pass`] would have been cheaper and would have pinned the branch rather
+    /// than the work.
+    ///
+    /// This is what makes a full queue cost one sweep instead of a five-minute
+    /// hole — `SWEEP_REQUESTED`'s own header records why that matters, and
+    /// `everything_past_the_queues_capacity_is_reported_as_overflow` covers the
+    /// half that *sets* the flag.
+    #[test]
+    fn a_requested_sweep_runs_at_the_end_of_the_pass_and_clears_the_flag() {
+        let _serialised = run_once_lock();
+        SWEEP_REQUESTED.store(false, Ordering::Release);
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = fixture_db(&dir);
+        let queued = seed_session(&dir, &db_path, "queued", "/a", "pagination");
+        // Cached, needing an insight row, and deliberately never announced —
+        // the shape of an announcement `enqueue` had to drop.
+        seed_session(&dir, &db_path, "swept", "/a", "overflowed");
+
+        let (tx, rx) = mpsc::sync_channel::<Pending>(QUEUE_SIZE);
+        tx.send(pending_for("queued", "/a", &queued))
+            .expect("announce");
+        SWEEP_REQUESTED.store(true, Ordering::Release);
+
+        assert_eq!(
+            run_once(&db_path, &rx, Duration::from_millis(50)),
+            Pass::Batch {
+                size: 1,
+                committed: true
+            },
         );
 
-        // …and both rows landed, so this is not passing because nothing
-        // happened.
+        assert!(
+            !SWEEP_REQUESTED.load(Ordering::Acquire),
+            "the flag must be cleared, or every later pass sweeps for ever",
+        );
+        let conn = db::open_read_only(&db_path).expect("open");
+        assert_eq!(
+            search::search(&conn, "\"overflowed\"", 10)
+                .expect("search")
+                .len(),
+            1,
+            "a session that was only ever dropped from the queue must be \
+             picked up by the sweep the overflow requested",
+        );
+    }
+
+    /// Every sender gone ends the loop, which is the one arm `run`'s `while`
+    /// condition reads.
+    #[test]
+    fn a_disconnected_queue_ends_the_loop() {
+        let _serialised = run_once_lock();
+        SWEEP_REQUESTED.store(false, Ordering::Release);
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = fixture_db(&dir);
+        let (tx, rx) = mpsc::sync_channel::<Pending>(1);
+        drop(tx);
+
+        assert_eq!(
+            run_once(&db_path, &rx, Duration::from_millis(50)),
+            Pass::Disconnected,
+        );
+    }
+
+    /// …and an idle queue times out into the periodic sweep rather than
+    /// spinning.
+    #[test]
+    fn an_idle_queue_times_out_into_a_sweep() {
+        let _serialised = run_once_lock();
+        SWEEP_REQUESTED.store(false, Ordering::Release);
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = fixture_db(&dir);
+        seed_session(&dir, &db_path, "s1", "/a", "pagination");
+
+        // Held, so the channel is idle rather than disconnected.
+        let (_tx, rx) = mpsc::sync_channel::<Pending>(1);
+
+        assert_eq!(
+            run_once(&db_path, &rx, Duration::from_millis(50)),
+            Pass::Swept,
+        );
         let conn = db::open_read_only(&db_path).expect("open");
         assert_eq!(indexed_pairs(&conn), vec![("s1".into(), "/a".into())]);
     }

--- a/src-tauri/src/native/scan.rs
+++ b/src-tauri/src/native/scan.rs
@@ -924,6 +924,188 @@ mod tests {
         }
     }
 
+    // ─── the reconcile's wiring (#447) ───────────────────────────────────────
+    //
+    // The block at the end of `run_scan` is where the search index and the
+    // insight rows are reconciled against the cache, and until #447 nothing
+    // asserted that `run_scan` calls either — the only test reaching `run_scan`
+    // is the cooldown one above, which returns at the no-readable-dir branch
+    // long before them. `search::delete_orphans` and
+    // `insights::store::delete_orphans` have unit tests of their own against a
+    // hand-built database; what those cannot say is *where* they are called
+    // from, and the ordering is the whole correctness argument.
+
+    /// Build `<dir>/projects/<encoded>/<session>.jsonl`, returning the file.
+    fn seed_transcript(config_dir: &Path, encoded_project: &str, session: &str) -> PathBuf {
+        let project = config_dir.join("projects").join(encoded_project);
+        std::fs::create_dir_all(&project).expect("project dir");
+        let file = project.join(format!("{session}.jsonl"));
+        std::fs::write(
+            &file,
+            "{\"type\":\"user\",\"timestamp\":\"2026-03-15T12:00:00Z\",\"cwd\":\"/w\",\
+              \"message\":{\"role\":\"user\",\"content\":\"do the thing\"}}\n\
+             {\"type\":\"assistant\",\"timestamp\":\"2026-03-15T12:01:00Z\",\
+              \"message\":{\"role\":\"assistant\",\"model\":\"claude-opus-5\",\
+              \"content\":[{\"type\":\"text\",\"text\":\"done\"}],\
+              \"usage\":{\"input_tokens\":10,\"output_tokens\":4}}}\n",
+        )
+        .expect("transcript");
+        file
+    }
+
+    fn pairs(conn: &rusqlite::Connection, table: &str) -> Vec<(String, String)> {
+        let mut stmt = conn
+            .prepare(&format!(
+                "SELECT session_id, project_path FROM {table} ORDER BY 1, 2"
+            ))
+            .expect("prepare");
+        stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+            .expect("query")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("rows")
+    }
+
+    /// A removed session loses its index row, and one under a config dir that
+    /// could not be listed keeps both its rows.
+    ///
+    /// **The first half is the ordering assertion**, and it is the one that
+    /// fails on the revert: `search::delete_orphans` keys on "no cache row for
+    /// this pair remains", so moving it *above* `apply_changes` — which is where
+    /// the cache's own delete pass runs — finds the row still present, deletes
+    /// nothing, and leaves an index row for a session that no longer exists.
+    /// Every other observable stays identical, which is why this needs a test
+    /// rather than a comment.
+    ///
+    /// **The second half is what that ordering buys**, and it is the failure the
+    /// argument is actually about: an unlistable config dir is an unplugged
+    /// drive, its cache rows are deliberately protected from the delete pass,
+    /// and the reconcile running afterwards inherits that protection for free.
+    /// Reconciling on a path instead, or before the delete pass, empties that
+    /// account's index with nothing to report it.
+    ///
+    /// The index rows are written directly rather than by running the worker:
+    /// this is a test of the reconcile, and `insights/worker.rs` owns the
+    /// question of what a correct index row contains.
+    #[cfg(unix)]
+    #[test]
+    fn the_reconcile_drops_a_removed_sessions_rows_and_spares_a_protected_dirs() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _serialised = scan_state_lock();
+        // `HOME` is a second global, and `paths::tests` read it — without this
+        // they fail on a value this test swapped underneath them.
+        let _env = crate::paths::tests::env_lock();
+
+        let home = tempfile::tempdir().expect("tempdir");
+        // RAII rather than a trailing restore, for the reason the cooldown test
+        // above records: a failed assertion panics past any epilogue.
+        let _home_var = crate::paths::tests::EnvVar::set("HOME", home.path());
+        // `run_config_dir` reads this before the stored setting, so a developer
+        // who exports it would otherwise have their own corpus walked.
+        let _run_dir = crate::paths::tests::EnvVar::unset("CLAUDE_CONFIG_DIR");
+
+        // Two config dirs: the default one, and an extra the settings row names.
+        let default_dir = home.path().join(".claude");
+        let extra_dir = home.path().join("second");
+        seed_transcript(&default_dir, "-tmp-alpha", "alpha");
+        seed_transcript(&extra_dir, "-tmp-beta", "beta");
+
+        let file = migrated();
+        let conn = rusqlite::Connection::open(file.path()).expect("open");
+        conn.execute(
+            "INSERT INTO user_settings (id, claude_config_dirs) VALUES (1, ?1)
+             ON CONFLICT(id) DO UPDATE SET claude_config_dirs = excluded.claude_config_dirs",
+            [format!("[{:?}]", extra_dir.to_string_lossy())],
+        )
+        .expect("seed the extra config dir");
+        drop(conn);
+
+        run_scan(file.path()).expect("the first scan");
+
+        // An assertion over an empty result set is not evidence, so the corpus
+        // is confirmed before anything is removed from it.
+        let conn = super::super::db::open_read_write(file.path()).expect("open");
+        let cached = pairs(&conn, "claude_session_cache");
+        assert_eq!(
+            cached.len(),
+            2,
+            "both config dirs must have been walked: {cached:?}"
+        );
+        for (session_id, project_path) in &cached {
+            super::super::search::replace(
+                &conn,
+                &super::super::search::SearchDoc {
+                    session_id: session_id.clone(),
+                    project_path: project_path.clone(),
+                    user_text: "do the thing".into(),
+                    ..Default::default()
+                },
+            )
+            .expect("index");
+            // The sibling reconcile's input. Written with SQL rather than
+            // through the worker for the same reason as the index row: what a
+            // correct insight row contains is `insights/`'s question.
+            conn.execute(
+                "INSERT INTO session_insights (session_id, project_path, scanned_at)
+                 VALUES (?1, ?2, '2026-03-15 12:00:00+00:00')",
+                rusqlite::params![session_id, project_path],
+            )
+            .expect("insight row");
+        }
+        assert_eq!(pairs(&conn, "session_search"), cached);
+        assert_eq!(pairs(&conn, "session_insights"), cached);
+        drop(conn);
+
+        // `alpha` is deleted from a dir that still lists; `beta`'s dir becomes
+        // unlistable, which is what an unplugged drive looks like from here.
+        std::fs::remove_file(default_dir.join("projects/-tmp-alpha/alpha.jsonl"))
+            .expect("remove the transcript");
+        let locked = extra_dir.join("projects");
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000))
+            .expect("lock the projects dir");
+        if std::fs::read_dir(&locked).is_ok() {
+            // Running as root, where the mode is not enforced. Skipping beats
+            // passing vacuously.
+            std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755))
+                .expect("restore");
+            eprintln!("skipping: this user can read a 0o000 directory");
+            return;
+        }
+
+        let scanned = run_scan(file.path());
+
+        // Restored before the assertions, so a failure still leaves the tempdir
+        // removable.
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).expect("restore");
+        scanned.expect("the second scan");
+
+        let conn = rusqlite::Connection::open(file.path()).expect("open");
+        let survivor: Vec<(String, String)> = cached
+            .iter()
+            .filter(|(session_id, _)| session_id == "beta")
+            .cloned()
+            .collect();
+        assert_eq!(survivor.len(), 1, "the fixture named its sessions wrongly");
+        assert_eq!(
+            pairs(&conn, "claude_session_cache"),
+            survivor,
+            "a session under an unlistable config dir must keep its cache row, \
+             and a deleted one must lose it",
+        );
+        assert_eq!(
+            pairs(&conn, "session_search"),
+            survivor,
+            "the reconcile must drop the removed session's index row — and must \
+             run after the delete pass, or it finds nothing to drop",
+        );
+        assert_eq!(
+            pairs(&conn, "session_insights"),
+            survivor,
+            "the sibling reconcile is wired on exactly the same terms, and an \
+             unmounted drive must not cost an account its insights either",
+        );
+    }
+
     /// `EnsureScan` admits one scan, so a double-click cannot start a second
     /// full re-read on top of the first.
     #[test]

--- a/src-tauri/src/native/scan.rs
+++ b/src-tauri/src/native/scan.rs
@@ -936,6 +936,10 @@ mod tests {
     // from, and the ordering is the whole correctness argument.
 
     /// Build `<dir>/projects/<encoded>/<session>.jsonl`, returning the file.
+    ///
+    /// `cfg(unix)` with its only caller: the reconcile test needs a `chmod`ped
+    /// directory, so on Windows both would be dead code under `-D warnings`.
+    #[cfg(unix)]
     fn seed_transcript(config_dir: &Path, encoded_project: &str, session: &str) -> PathBuf {
         let project = config_dir.join("projects").join(encoded_project);
         std::fs::create_dir_all(&project).expect("project dir");
@@ -953,6 +957,7 @@ mod tests {
         file
     }
 
+    #[cfg(unix)]
     fn pairs(conn: &rusqlite::Connection, table: &str) -> Vec<(String, String)> {
         let mut stmt = conn
             .prepare(&format!(
@@ -1012,10 +1017,13 @@ mod tests {
 
         let file = migrated();
         let conn = rusqlite::Connection::open(file.path()).expect("open");
+        // The column is a JSON string array, read back through
+        // `gojson::decode_string_list` — so it is encoded by a JSON encoder and
+        // not by `{:?}`, whose escapes are Rust's (`\u{a0}`) rather than JSON's.
         conn.execute(
             "INSERT INTO user_settings (id, claude_config_dirs) VALUES (1, ?1)
              ON CONFLICT(id) DO UPDATE SET claude_config_dirs = excluded.claude_config_dirs",
-            [format!("[{:?}]", extra_dir.to_string_lossy())],
+            [serde_json::json!([extra_dir]).to_string()],
         )
         .expect("seed the extra config dir");
         drop(conn);

--- a/src-tauri/tests/insights_worker.rs
+++ b/src-tauri/tests/insights_worker.rs
@@ -208,6 +208,11 @@ fn the_worker_does_its_database_work_off_the_runtime() {
         // delivers the same session down the queue, so the pass that indexes it
         // is whichever reaches the lock first — both on the thread `start`
         // chose.
+        //
+        // Called from **inside** `block_on` deliberately: `tokio::spawn` panics
+        // outside a runtime, so calling `start` out here would make the revert
+        // fail on "there is no reactor running" rather than on the stall this
+        // measures — a red test for the wrong reason.
         worker::start(db_path.clone());
         worker::enqueue([Pending {
             session_id: "s1".into(),

--- a/src-tauri/tests/insights_worker.rs
+++ b/src-tauri/tests/insights_worker.rs
@@ -1,0 +1,274 @@
+//! The insight worker, driven through its **real entry point** (#447).
+//!
+//! ## This binary may contain exactly one test that calls `worker::start`
+//!
+//! That is the whole reason the file exists. `start` fills a process-wide
+//! `QUEUE` `OnceLock`; a second call logs `insights: worker already started`
+//! and **returns without spawning anything**, so a second `start`-driving test
+//! in this binary would silently drive the *first* test's worker, against the
+//! *first* test's database. `src-tauri/tests/*.rs` is one binary per file, so
+//! one file is the unit of "once".
+//!
+//! It fails loudly rather than quietly if anyone adds one: every assertion here
+//! waits on a row appearing in *this* test's database, so a no-op `start` ends
+//! at the poll deadline with a named failure rather than a green run. Another
+//! test needing `start` needs another file.
+//!
+//! ## Why this is not a unit test in `worker.rs`
+//!
+//! The property below is a claim about **where `start` puts the loop**, and a
+//! unit test cannot make that claim: `run`/`run_once` are private, so a test
+//! inside the module has to spawn the thread itself — at which point the test,
+//! not `start`, decides whether the work is on the runtime, and no change to
+//! non-test code can falsify it. That is exactly what the version of this test
+//! that lived in `worker.rs` said about itself, and #447 is the issue filed to
+//! fix it. The shape here is `tests/scheduled_run.rs`'s and
+//! `tests/chat_turn.rs`' (#366), for the same reason: drive the real entry
+//! point, measure a runtime beside it.
+
+use std::path::{Path, PathBuf};
+
+use agento_lib::native::insights::store::Pending;
+use agento_lib::native::insights::worker;
+use agento_lib::native::{db, migrate, search};
+
+/// A migrated database in `dir`, plus its path.
+///
+/// `ensure_database` rather than `open_read_write`, which does **not** carry
+/// `SQLITE_OPEN_CREATE` — the app's startup path is the only thing that creates
+/// the file, and this takes the same route it does.
+///
+/// A copy of `worker.rs`'s test helper rather than a widened production
+/// visibility: `tests/chat_turn.rs` already carries its own copy of a log sink
+/// for the same reason, and adding `pub` to reach a helper from a test is the
+/// thing this issue's design deliberately avoided.
+fn fixture_db(dir: &Path) -> PathBuf {
+    let db_path = dir.join("agento.db");
+    let mut conn = db::ensure_database(&db_path).expect("create");
+    migrate::apply(&mut conn).expect("migrations");
+    db_path
+}
+
+/// Write a two-message transcript and register it as a cache row.
+///
+/// The text is the fixture's whole point, so the session gets a distinctive
+/// word to search for. Also a copy of `worker.rs`'s helper.
+fn seed_session(
+    dir: &Path,
+    db_path: &Path,
+    session_id: &str,
+    project_path: &str,
+    word: &str,
+) -> PathBuf {
+    let file = dir.join(format!(
+        "{session_id}-{}.jsonl",
+        project_path.replace('/', "_")
+    ));
+    let lines = [
+        serde_json::json!({
+            "type": "user",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "message": {"role": "user", "content": format!("please fix the {word} problem")},
+        }),
+        serde_json::json!({
+            "type": "assistant",
+            "timestamp": "2026-01-01T00:01:00Z",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "looking at it now"}],
+            },
+        }),
+    ];
+    let body: String = lines.iter().map(|l| format!("{l}\n")).collect();
+    std::fs::write(&file, body).expect("write transcript");
+
+    let conn = db::open_read_write(db_path).expect("open");
+    conn.execute(
+        "INSERT INTO claude_session_cache
+             (session_id, project_path, file_path, file_mtime, start_time, last_activity)
+         VALUES (?1, ?2, ?3, '2026-01-01 00:00:00+00:00', '2026-01-01 00:00:00+00:00',
+                 '2026-01-01 00:00:00+00:00')",
+        rusqlite::params![session_id, project_path, file.to_string_lossy()],
+    )
+    .expect("cache row");
+    file
+}
+
+/// Whether the session is searchable yet — a WAL read, which never waits on the
+/// writer holding the lock, so polling it cannot itself perturb the measurement.
+fn indexed(db_path: &Path) -> bool {
+    let Ok(conn) = db::open_read_only(db_path) else {
+        return false;
+    };
+    search::search(&conn, "\"pagination\"", 10)
+        .map(|hits| !hits.is_empty())
+        .unwrap_or(false)
+}
+
+/// The worker's database work runs off the tokio runtime, and a batch meeting a
+/// contended write lock still commits (#366, #447).
+///
+/// **The thing under test is `start`'s `std::thread::spawn`.** Everything the
+/// worker does is blocking — `rusqlite` with a five-second `busy_timeout`, plus
+/// transcript reads measured in seconds for a full corpus — so a worker on a
+/// tokio task parks a runtime worker for the whole of it. Tokio runs one worker
+/// per core, so on this one-worker runtime that is the entire runtime, and in
+/// production it is the SPA and every SSE stream sharing it.
+///
+/// **Verified against the defect, which is the only thing that makes this test
+/// worth its runtime**: with `start`'s `std::thread::spawn(move || run(..))`
+/// changed to `tokio::spawn(async move { run(..) })`, this fails in 1.8 s with
+/// *the ticker only advanced 0 times across a 1500 ms hold*. Note **which**
+/// assertion catches it: a ticker that is never polled records no gap either,
+/// so `worst` stays at 0 and reads as healthy — which is exactly why the tick
+/// count is asserted beside it rather than the gap alone. A contention test
+/// that passes either way is precisely the mistake #447 exists to fix.
+///
+/// It also covers the queue path against the real `enqueue`: the session is
+/// announced exactly as `scan.rs` announces one, and the assertion is a
+/// **searchable** row rather than a row, because a row holding the wrong
+/// columns counts the same and answers nothing.
+///
+/// The rest of the shape is #366's, each part load-bearing:
+///
+/// - **one worker thread**, so a single parked worker is the whole runtime;
+/// - the fixture converted to WAL **before** the contention begins — left on
+///   the default rollback journal, `open_read_write`'s own
+///   `PRAGMA journal_mode=WAL` is a *mode change* needing an exclusive lock and
+///   fails outright in about a millisecond instead of waiting on
+///   `busy_timeout`, which would measure the wrong thing entirely;
+/// - **a plain OS thread** holds the lock, so the contention comes from outside
+///   the runtime exactly as the session scanner's batch writer does;
+/// - `last` seeded **before** the work starts, because a starved ticker is
+///   never polled and seeding on the first poll would start the clock after the
+///   stall and measure nothing.
+#[test]
+fn the_worker_does_its_database_work_off_the_runtime() {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+
+    /// How long the lock is held. Long enough that a parked worker is
+    /// unmistakable, short enough to stay well inside `open_read_write`'s 5s
+    /// `busy_timeout` so the worker's write still commits.
+    const HOLD: Duration = Duration::from_millis(1_500);
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = fixture_db(dir.path());
+    let file = seed_session(dir.path(), &db_path, "s1", "/a", "pagination");
+
+    db::open_read_write(&db_path).expect("convert the fixture to WAL");
+
+    // A writer outside the runtime, holding the lock the worker needs.
+    let (holding_tx, holding_rx) = std::sync::mpsc::channel();
+    let lock_db = db_path.clone();
+    let holder = std::thread::spawn(move || {
+        let mut conn = rusqlite::Connection::open(&lock_db).expect("open");
+        let tx = conn
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+            .expect("begin immediate");
+        holding_tx.send(()).expect("signal");
+        std::thread::sleep(HOLD);
+        tx.rollback().expect("rollback");
+    });
+    holding_rx.recv().expect("the writer took the lock");
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .enable_all()
+        .build()
+        .expect("runtime");
+
+    let worst_gap_ms = Arc::new(AtomicU64::new(0));
+    let ticks = Arc::new(AtomicU64::new(0));
+    let committed = runtime.block_on(async {
+        // The thing that must keep running. It records the **longest** gap
+        // between its own ticks, which is what a parked worker shows up as.
+        let ticker = {
+            let (worst_gap_ms, ticks, mut last) = (
+                Arc::clone(&worst_gap_ms),
+                Arc::clone(&ticks),
+                Instant::now(),
+            );
+            tokio::spawn(async move {
+                loop {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                    let now = Instant::now();
+                    let gap =
+                        u64::try_from(now.duration_since(last).as_millis()).unwrap_or(u64::MAX);
+                    worst_gap_ms.fetch_max(gap, Ordering::Relaxed);
+                    ticks.fetch_add(1, Ordering::Relaxed);
+                    last = now;
+                }
+            })
+        };
+
+        // The real entry point, and the real announcement. `start` runs its
+        // boot sweep immediately and meets the held lock there; `enqueue` then
+        // delivers the same session down the queue, so the pass that indexes it
+        // is whichever reaches the lock first — both on the thread `start`
+        // chose.
+        worker::start(db_path.clone());
+        worker::enqueue([Pending {
+            session_id: "s1".into(),
+            project_path: "/a".into(),
+            file_path: file.to_string_lossy().into_owned(),
+        }]);
+
+        // Comfortably longer than HOLD plus a batch, and short enough to fail
+        // rather than hang. A `start` that no-opped — see the file header —
+        // ends here.
+        //
+        // **`std::thread::sleep`, not `tokio::time::sleep`, and that is not a
+        // slip.** This runs on `block_on`'s calling thread rather than on a
+        // worker, so blocking it starves nothing, while awaiting would depend
+        // on the very runtime under test: on the revert, `run`'s loop owns the
+        // only worker and never yields, so nothing is left to fire a timer and
+        // an `await` here would wait for ever instead of reporting.
+        let deadline = Instant::now() + Duration::from_secs(20);
+        let mut committed = false;
+        while Instant::now() < deadline {
+            if indexed(&db_path) {
+                committed = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        ticker.abort();
+        committed
+    });
+
+    // **The runtime is torn down before a single assertion runs, and with a
+    // deadline.** On the revert, `run` is an endless loop on the only worker
+    // and it parks in a blocking `recv_timeout` between passes, so an ordinary
+    // drop — which is what `#[tokio::test]` does after the body, including
+    // while unwinding from a failed assertion — waits for a thread that will
+    // never return. Measured: the test hung indefinitely rather than failing,
+    // which in CI is a wedged job instead of a red one. `shutdown_timeout`
+    // gives up and leaks the thread, so the assertions below are reached in
+    // both directions, which is the whole point of writing them.
+    runtime.shutdown_timeout(Duration::from_millis(200));
+    holder.join().expect("the writer finished");
+
+    assert!(
+        committed,
+        "the worker never indexed the announced session — if a second test in \
+         this binary calls `worker::start`, that is why (see the file header)",
+    );
+
+    let worst = worst_gap_ms.load(Ordering::Relaxed);
+    assert!(
+        worst < 500,
+        "the runtime stalled for {worst} ms while the write lock was held \
+         (the hold is {} ms; anything near it means the worker is on the runtime)",
+        HOLD.as_millis(),
+    );
+    // The gap alone would read as healthy if the ticker had simply been
+    // cancelled early, so assert it really ran throughout.
+    let ticks = ticks.load(Ordering::Relaxed);
+    assert!(
+        ticks > 50,
+        "the ticker only advanced {ticks} times across a {} ms hold",
+        HOLD.as_millis(),
+    );
+}


### PR DESCRIPTION
Closes #447.

## What

`insights::worker::run` was an unexported infinite loop, so nothing in the suite
drove the worker's entry point. Three correctness arguments the search and
insights pipeline rests on were asserted by prose in doc comments rather than by
a test, and each is silent when broken.

**The production change is one pure extraction.** `run`'s loop body becomes
`run_once(db_path, rx, timeout) -> Pass`; `run` is the boot sweep plus
`while run_once(..) != Pass::Disconnected {}`. No behaviour moves. `Pass` is
private and narrow — it reports only what a test asserts on, and the
`SWEEP_REQUESTED` follow-up is asserted through its *effect* rather than by
growing a variant.

`start` is deliberately **unchanged**: its `std::thread::spawn` is the thing
under test.

## The decision the issue left open, and how it landed

`run_once` alone does *not* make "the worker's database work is off the runtime"
falsifiable — a test calling it from a `tokio::spawn` is still the test choosing
where the work runs. What has to be under test is **`start`'s spawn**, so the
contention test moved to its own integration binary and drives the real
`worker::start` / `worker::enqueue`. Both are already `pub`, so this needed
**no production visibility change at all** — option 1 of the three the issue
weighed, for the reason it gave.

`run_once` is still what the *unit* tests want, because criteria 3 and 4 need a
deterministic single pass that polling a started worker cannot give.

## Files

| file | what |
|---|---|
| `src-tauri/src/native/insights/worker.rs` | the `run` / `run_once` split; the contention test removed; five new unit tests; module header |
| `src-tauri/tests/insights_worker.rs` | **new** — one test, driving the real `start` |
| `src-tauri/src/native/scan.rs` | one new test in the existing `mod tests` |
| `CLAUDE.md` | the split, where each half is tested, and the new `scan.rs` coverage beside the reconcile-ordering rule |

## Assert the revert fails

Each test was checked by making the corresponding change locally and watching it
go red, then reverting.

| revert | test | result |
|---|---|---|
| `start`'s `std::thread::spawn(move \|\| run(..))` → `tokio::spawn(async move { run(..) })` | `the_worker_does_its_database_work_off_the_runtime` | **FAILED** in 1.8 s — `the ticker only advanced 0 times across a 1500 ms hold` |
| `search::delete_orphans` moved above `apply_changes` | `the_reconcile_drops_a_removed_sessions_rows_and_spares_a_protected_dirs` | **FAILED** — `left: [("alpha", …), ("beta", …)] right: [("beta", …)]` |
| the `SWEEP_REQUESTED` swap short-circuited (flag still cleared) | `a_requested_sweep_runs_at_the_end_of_the_pass_and_clears_the_flag` | **FAILED** — the never-announced session was not indexed |
| the `BATCH_SIZE` cutoff removed | `a_pass_takes_at_most_batch_size_and_the_rest_waits_for_the_next` | **FAILED** — `one pass must not take more than BATCH_SIZE` |

Two things that came out of doing it rather than asserting it:

- **Which assertion catches the first revert is not the obvious one.** A ticker
  that is never polled records no *gap* either, so `worst` stays at 0 and reads
  as healthy — the tick-count assertion beside it is what fires. That is exactly
  what it was written for, and it is now said so in the doc comment.
- **The first draft of that test hung instead of failing.** Under the revert,
  `run`'s endless loop owns the only worker and parks in a blocking
  `recv_timeout` between passes, so an ordinary runtime drop — which is what
  `#[tokio::test]` does after the body, including while unwinding from a failed
  assertion — waits for a thread that never returns. Measured: it ran for over
  ten minutes with nothing reported, i.e. a wedged CI job rather than a red one.
  The test therefore builds its runtime itself and calls
  `shutdown_timeout(200ms)` **before** the first assertion, so the assertions are
  reached in both directions. A falsification that hangs is not a falsification.

## Deviations from the HOW

- **`scan.rs` already has a `#[cfg(test)] mod tests`** (ten tests). The HOW said
  it has none. The new test joins it and reuses its `migrated()`,
  `scan_state_lock()` and — the part that made a hermetic corpus possible at all
  — the `paths::tests::{env_lock, EnvVar}` recipe the cooldown test established.
  Nothing else changed as a result.
- **The scan test also seeds `session_insights` rows** and asserts the sibling
  reconcile on the same terms. The issue asked only about the index row; the
  insight reconcile's wiring was equally unasserted and it is one line of test.
- **`CLAUDE_CONFIG_DIR` is unset** for the duration alongside `HOME`, which the
  HOW did not mention: `run_config_dir` reads it *before* the stored setting, so
  a developer who exports it would otherwise have their own corpus walked by a
  unit test.
- The test is `#[cfg(unix)]` and **skips rather than passes vacuously** when the
  user can read a `0o000` directory (root), probed by actually trying to list it
  rather than by `geteuid` — no new dependency.

## Not in scope

No behavioural change to indexing, sweeping or the reconcile. `QUEUE`'s
`OnceLock` is untouched and there is no second start path. #446's `sweep`
rewrite is untouched — different function, and landing this first gives it a
safety net.

## Gates

`npm ci && npm run build` · `cargo fmt --check` · `cargo clippy --all-targets -D warnings`
· `cargo test --no-fail-fast` (1323 lib + every integration binary, **0 failed**)
· `cargo build --profile ci`. The lib suite was run three times and
`insights_worker` three times, because both new test groups touch a process-wide
static (`SWEEP_REQUESTED`, and `HOME`) — stable every time.
