### PR TITLE
fix(ui): make content selectable by default, chrome not (#469)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -472,6 +472,22 @@ status bar, focus-aware selection (accent when the window is focused, grey
 when not), ⌘K palette, no browser affordances. Reuse the existing CSS classes;
 new CSS goes in a per-view file imported by that view.
 
+**Text selection is a denylist over chrome, not an allowlist over content**
+(#469). `base.css` declares `user-select: text` on `body` and `none` on one
+named list — the titlebar and every drag region, the sidebar, the toolbar, the
+status bar, source-list and table rows, table headers, `button` and `select` —
+so a view added later is selectable without anyone remembering a class. It was
+the other way round until #469, and the allowlist drifted exactly as one does:
+the whole `views/gateway/` section, `views/analytics/` and the session detail
+shipped with no opt-in at all, so a user could not copy a session id or an
+error string. **Do not re-introduce a `.selectable` class or a per-view
+`user-select: text`** — the denylist is the whole rule and it lives in
+`base.css`; a second spelling elsewhere is how it comes apart. Rows stay in the
+denylist deliberately: a table row's double-click *opens* the session, and a
+drag across it means "select this row", so selectable cells would leave a word
+highlighted behind the view they opened. `::selection` is focus-aware over the
+existing `--bg-select*` tokens, matching `.window--focused`.
+
 **The window's origin has to be in the capability's scope, or every IPC
 command is denied — silently.** This is the single most expensive thing to
 re-discover in this shell, because it fails *only in release builds* and it

--- a/src/components/TokenReveal.tsx
+++ b/src/components/TokenReveal.tsx
@@ -47,7 +47,7 @@ export function TokenReveal({
         </button>
       </div>
       <div className="secnew__token">
-        <code className="mono selectable">{token}</code>
+        <code className="mono">{token}</code>
         <CopyButton
           text={token}
           title="Copy token"

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1,7 +1,9 @@
 /* ============================================================================
    Base — desktop application shell resets.
-   A desktop window is not a document: it never scrolls as a whole, text is not
-   selectable by default, and there is no native browser affordance anywhere.
+   A desktop window is not a document: it never scrolls as a whole, and there is
+   no native browser affordance anywhere. Content *is* selectable; the window's
+   chrome is not, and the denylist that says which is which lives below — one
+   list, in this file. Do not re-add a per-element opt-in (#469).
    ========================================================================== */
 
 *,
@@ -30,23 +32,72 @@ body {
   text-rendering: optimizeLegibility;
   font-synthesis: none;
 
-  /* Chrome-like text selection is a web tell. Opt in per element instead. */
-  user-select: none;
-  -webkit-user-select: none;
+  /* Content is selectable; the chrome below opts out. The inverse — `none`
+     here plus a `.selectable` opt-in — was the rule until #469, and it drifted
+     exactly as an allowlist over content does: content is unbounded, so every
+     view added since shipped unselectable and a user could not copy a session
+     id or an error string. Chrome is a small, stable set, which is the split
+     native apps draw. Both spellings: WebKitGTK and WKWebView need the prefix. */
+  user-select: text;
+  -webkit-user-select: text;
 
   /* No rubber-band / pull-to-refresh inside an app window. */
   overscroll-behavior: none;
   cursor: default;
 }
 
-/* Content the user genuinely reads or copies opts back in. */
-.selectable,
+/* The chrome denylist — the whole of it, so there is one place to read.
+   These behave as controls, not as text: dragging them must move the window,
+   activate a row or sort a column, and a double-click on a row must open it
+   rather than leave a word selected behind the view it opened. */
+.titlebar,
+[data-tauri-drag-region],
+.sidebar,
+.toolbar,
+.statusbar,
+.srcitem,
+.listrow,
+.table thead th,
+.table tbody tr,
+button,
+select {
+  user-select: none;
+  -webkit-user-select: none;
+  cursor: default;
+}
+
+/* Form fields are content wherever they sit — a search field inside `.toolbar`
+   would otherwise inherit the denylist's `none` and refuse its own text. A
+   direct declaration always beats an inherited one, so order does not matter. */
 input,
 textarea,
 [contenteditable="true"] {
   user-select: text;
   -webkit-user-select: text;
   cursor: auto;
+}
+
+/* Cursor follows the same split, one level coarser: the three content panes
+   read as text, and the denylist above has already claimed the chrome inside
+   them. This half is cosmetic — the selection rule is the denylist. */
+.pane-list,
+.pane-detail,
+.pane-inspector {
+  cursor: text;
+}
+
+/* Selected text follows the window's focus, exactly as a selected row does
+   (`.window--focused`, shell.css / views.css) — accent while the window is key,
+   grey when it is not. That focus-awareness is what keeps a selection reading
+   as desktop rather than as a web page. The colours are the existing selection
+   tokens, so they are already declared in all three theme places. */
+::selection {
+  background: var(--bg-select);
+  color: var(--fg);
+}
+.window--focused ::selection {
+  background: var(--bg-select-focus);
+  color: var(--fg-select-focus);
 }
 
 button,
@@ -60,13 +111,12 @@ select {
   outline: none;
 }
 
-button {
-  cursor: default;
-}
-
 a {
   color: var(--accent);
   text-decoration: none;
+  /* A link is a control here too — the panes above read as text, and an I-beam
+     over something you click is the web tell this shell avoids. */
+  cursor: default;
 }
 
 /* Native focus: keyboard only. Mouse clicks must not leave a ring behind. */

--- a/src/styles/chats.css
+++ b/src/styles/chats.css
@@ -114,7 +114,6 @@
 .prompt__text {
   font-size: var(--text-base);
   line-height: var(--leading-normal);
-  user-select: text;
 }
 
 .prompt__opts {

--- a/src/styles/integrations.css
+++ b/src/styles/integrations.css
@@ -123,8 +123,6 @@
   max-height: 90px;
   overflow: auto;
   word-break: break-all;
-  user-select: text;
-  cursor: text;
 }
 
 /* --- Trigger rules ------------------------------------------------------- */

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -339,6 +339,4 @@
   max-height: 92px;
   overflow: auto;
   word-break: break-all;
-  user-select: text;
-  cursor: text;
 }

--- a/src/styles/shell.css
+++ b/src/styles/shell.css
@@ -98,7 +98,6 @@
   text-transform: uppercase;
   color: var(--fg-tertiary);
   padding: var(--sp-6) var(--sp-3) var(--sp-2);
-  user-select: none;
 }
 
 .srcitem {
@@ -275,7 +274,6 @@
   border-top: var(--hairline) solid var(--line);
   font-size: var(--text-sm);
   color: var(--fg-tertiary);
-  user-select: none;
 }
 
 .statusbar__item {

--- a/src/styles/views.css
+++ b/src/styles/views.css
@@ -667,8 +667,6 @@
    abbreviated to fit the pane, so drag-selecting it would copy the ellipsis
    rather than the value. The button carries the real one (#469). */
 .insp-row__copy {
-  display: flex;
-  align-items: center;
   gap: var(--sp-3);
   min-width: 0;
 }

--- a/src/styles/views.css
+++ b/src/styles/views.css
@@ -232,7 +232,6 @@
   font-size: var(--text-md);
   line-height: var(--leading-relaxed);
   color: var(--fg);
-  user-select: text;
 }
 /* Paragraph spacing and inline code live in markdown.css, with the rest of the
    rendered tree — a message's body is markdown now (`.md`), and two files
@@ -284,7 +283,6 @@
   line-height: var(--leading-normal);
   color: var(--fg-secondary);
   white-space: pre-wrap;
-  user-select: text;
   max-height: 260px;
   overflow: auto;
 }
@@ -389,7 +387,6 @@
   height: 26px;
   border-bottom: var(--hairline) solid var(--line);
   white-space: nowrap;
-  user-select: none;
 }
 .table thead th:hover {
   color: var(--fg-secondary);
@@ -664,6 +661,19 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* A single-value row whose value is worth copying whole: the visible text is
+   abbreviated to fit the pane, so drag-selecting it would copy the ellipsis
+   rather than the value. The button carries the real one (#469). */
+.insp-row__copy {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  min-width: 0;
+}
+.insp-row__copy > .truncate {
+  min-width: 0;
 }
 
 /* --- Forms (Settings / editors) ------------------------------------------ */

--- a/src/views/AboutView.tsx
+++ b/src/views/AboutView.tsx
@@ -121,7 +121,7 @@ export function AboutView() {
 
           {version.data?.commit && (
             <div
-              className="mono selectable"
+              className="mono"
               style={{ fontSize: "var(--text-sm)", color: "var(--fg-tertiary)" }}
             >
               {version.data.commit.slice(0, 12)}
@@ -130,7 +130,6 @@ export function AboutView() {
           )}
 
           <p
-            className="selectable"
             style={{
               maxWidth: 440,
               color: "var(--fg-secondary)",

--- a/src/views/AgentsView.tsx
+++ b/src/views/AgentsView.tsx
@@ -470,7 +470,7 @@ export function AgentsView({ inspectorOpen }: { inspectorOpen: boolean }) {
                       </label>
                     ) : (
                       <span
-                        className="mono selectable"
+                        className="mono"
                         style={{ color: "var(--fg-secondary)", paddingTop: 6 }}
                       >
                         {draft.slug}
@@ -728,7 +728,7 @@ export function AgentsView({ inspectorOpen }: { inspectorOpen: boolean }) {
             <div className="inspector__scroll scroll">
               <InspGroup title="Identity">
                 <InspRow label="Slug">
-                  <span className="mono selectable">
+                  <span className="mono">
                     {draft.slug || (creating ? "—" : draft.slug)}
                   </span>
                 </InspRow>
@@ -764,7 +764,7 @@ export function AgentsView({ inspectorOpen }: { inspectorOpen: boolean }) {
 
               <InspGroup title="Runtime">
                 <InspRow label="Config dir">
-                  <span className="mono selectable">
+                  <span className="mono">
                     {draft.claude_config_dir || "Default"}
                   </span>
                 </InspRow>

--- a/src/views/ChatsView.tsx
+++ b/src/views/ChatsView.tsx
@@ -701,7 +701,7 @@ export function ChatsView({
               )}
 
               <InspGroup title="Working directory">
-                <div className="pathwell mono selectable">
+                <div className="pathwell mono">
                   {session.working_directory
                     ? tildePath(session.working_directory)
                     : "Not set"}

--- a/src/views/IntegrationsView.tsx
+++ b/src/views/IntegrationsView.tsx
@@ -360,7 +360,6 @@ function ConnectForm({
                 color: "var(--fg-secondary)",
                 maxWidth: 560,
               }}
-              className="selectable"
             >
               {provider.blurb}. Once connected, any agent you grant access to can call
               these tools on your behalf.
@@ -1371,7 +1370,7 @@ function WebhookPanel({ integrationId }: { integrationId: string }) {
             URL, set under Settings → General.
           </div>
 
-          {s?.url && <div className="codebox selectable">{s.url}</div>}
+          {s?.url && <div className="codebox">{s.url}</div>}
           {s?.error && <div className="msgline msgline--error">{s.error}</div>}
           {error && <div className="msgline msgline--error">{error}</div>}
         </div>
@@ -1444,7 +1443,7 @@ function ConnectedInspector({
           <span title={dateTime(item.updated_at)}>{relativeTime(item.updated_at)}</span>
         </InspRow>
         <InspRow label="ID">
-          <span className="mono selectable" style={{ fontSize: "var(--text-xs)" }}>
+          <span className="mono" style={{ fontSize: "var(--text-xs)" }}>
             {item.id}
           </span>
         </InspRow>

--- a/src/views/JobsView.tsx
+++ b/src/views/JobsView.tsx
@@ -383,13 +383,13 @@ export function JobsView({ inspectorOpen }: { inspectorOpen: boolean }) {
 
                   {job.prompt_preview && (
                     <InspGroup title="Prompt">
-                      <div className="logblock selectable">{job.prompt_preview}</div>
+                      <div className="logblock">{job.prompt_preview}</div>
                     </InspGroup>
                   )}
 
                   {job.error_message && (
                     <InspGroup title="Error">
-                      <div className="logblock logblock--error selectable">
+                      <div className="logblock logblock--error">
                         {job.error_message}
                       </div>
                     </InspGroup>
@@ -397,7 +397,7 @@ export function JobsView({ inspectorOpen }: { inspectorOpen: boolean }) {
 
                   {job.response_text && (
                     <InspGroup title="Output">
-                      <div className="logblock selectable">{job.response_text}</div>
+                      <div className="logblock">{job.response_text}</div>
                     </InspGroup>
                   )}
 
@@ -413,7 +413,7 @@ export function JobsView({ inspectorOpen }: { inspectorOpen: boolean }) {
 
                   {job.chat_session_id && (
                     <InspGroup title="Session">
-                      <div className="logblock selectable">{job.chat_session_id}</div>
+                      <div className="logblock">{job.chat_session_id}</div>
                     </InspGroup>
                   )}
                 </>

--- a/src/views/SessionsView.tsx
+++ b/src/views/SessionsView.tsx
@@ -1022,7 +1022,7 @@ function Inspector({
             fits the pane, so the button carries the real string while the row
             shows an abbreviated one (#469). */}
         <InspRow label="ID">
-          <span className="insp-row__copy">
+          <span className="row insp-row__copy">
             <span className="mono truncate">{session.session_id}</span>
             <CopyButton text={session.session_id} title="Copy session ID" />
           </span>
@@ -1043,7 +1043,7 @@ function Inspector({
             name an agent, so it belongs here with the other titles. */}
         {agentName && <InspRow label="Named">{agentName}</InspRow>}
         <InspRow label="Project">
-          <span className="insp-row__copy">
+          <span className="row insp-row__copy">
             <span className="truncate" title={session.project_path}>
               {tildePath(session.project_path)}
             </span>

--- a/src/views/SessionsView.tsx
+++ b/src/views/SessionsView.tsx
@@ -7,6 +7,7 @@ import {
   useState,
 } from "react";
 import { api, qs } from "../lib/api";
+import { CopyButton } from "../components/CopyButton";
 import type {
   ClaudeProject,
   ClaudeSessionSummary,
@@ -1011,14 +1012,20 @@ function Inspector({
   return (
     <>
       <InspGroup title="Session">
-        <div className="sess-heading selectable">
+        <div className="sess-heading">
           {session.display_title || "Untitled session"}
         </div>
         {session.preview && (
-          <div className="sess-preview selectable">{session.preview}</div>
+          <div className="sess-preview">{session.preview}</div>
         )}
+        {/* Both of these are single values a user copies whole and neither
+            fits the pane, so the button carries the real string while the row
+            shows an abbreviated one (#469). */}
         <InspRow label="ID">
-          <span className="mono selectable">{session.session_id}</span>
+          <span className="insp-row__copy">
+            <span className="mono truncate">{session.session_id}</span>
+            <CopyButton text={session.session_id} title="Copy session ID" />
+          </span>
         </InspRow>
         {session.custom_title && (
           <InspRow label="Custom">{session.custom_title}</InspRow>
@@ -1036,8 +1043,14 @@ function Inspector({
             name an agent, so it belongs here with the other titles. */}
         {agentName && <InspRow label="Named">{agentName}</InspRow>}
         <InspRow label="Project">
-          <span title={session.project_path}>
-            {tildePath(session.project_path)}
+          <span className="insp-row__copy">
+            <span className="truncate" title={session.project_path}>
+              {tildePath(session.project_path)}
+            </span>
+            <CopyButton
+              text={session.project_path}
+              title="Copy the project path"
+            />
           </span>
         </InspRow>
         {session.cwd && session.cwd !== session.project_path && (
@@ -1215,13 +1228,6 @@ function Inspector({
           >
             <Icon name="play" size={13} />
             {busy === "continue" ? "Starting…" : "Continue in chat"}
-          </button>
-          <button
-            className="btn"
-            onClick={() => navigator.clipboard?.writeText(session.session_id)}
-          >
-            <Icon name="copy" size={13} />
-            Copy session ID
           </button>
           {continuedChat !== undefined && (
             <div className="sess-note">

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -1615,22 +1615,22 @@ function MonitoringSection({
       {mon && (
         <>
           <FormRow label="Export telemetry">
-            <span className="mono selectable">{mon.enabled ? "on" : "off"}</span>
+            <span className="mono">{mon.enabled ? "on" : "off"}</span>
           </FormRow>
           <FormRow label="Metrics exporter">
-            <span className="mono selectable">{mon.metrics_exporter || "none"}</span>
+            <span className="mono">{mon.metrics_exporter || "none"}</span>
           </FormRow>
           <FormRow label="Logs exporter">
-            <span className="mono selectable">{mon.logs_exporter || "none"}</span>
+            <span className="mono">{mon.logs_exporter || "none"}</span>
           </FormRow>
           <FormRow label="OTLP endpoint">
-            <span className="mono selectable">{mon.otlp_endpoint || "—"}</span>
+            <span className="mono">{mon.otlp_endpoint || "—"}</span>
           </FormRow>
           <FormRow label="Insecure">
-            <span className="mono selectable">{mon.otlp_insecure ? "yes" : "no"}</span>
+            <span className="mono">{mon.otlp_insecure ? "yes" : "no"}</span>
           </FormRow>
           <FormRow label="Export interval">
-            <span className="mono selectable tnum">
+            <span className="mono tnum">
               {mon.metric_export_interval_ms} ms
             </span>
           </FormRow>
@@ -1641,7 +1641,7 @@ function MonitoringSection({
             >
               <div className="col" style={{ gap: "var(--sp-1)" }}>
                 {lockedFields.map(([field, envVar]) => (
-                  <span key={field} className="mono selectable">
+                  <span key={field} className="mono">
                     {field} = ${envVar}
                   </span>
                 ))}
@@ -1680,7 +1680,7 @@ function VersionSection() {
       <div className="formsec__title">Version</div>
       <FormRow label="Installed">
         <div className="row" style={{ gap: "var(--sp-4)", alignItems: "center" }}>
-          <span className="mono selectable">{version.data?.version ?? "—"}</span>
+          <span className="mono">{version.data?.version ?? "—"}</span>
           {version.data?.commit && (
             <span className="badge mono">{version.data.commit}</span>
           )}

--- a/src/views/chat/Markdown.tsx
+++ b/src/views/chat/Markdown.tsx
@@ -64,7 +64,7 @@ export const Markdown = memo(function Markdown({
                 className="iconbtn iconbtn--onsurface"
               />
             </div>
-            <pre className="selectable">{children}</pre>
+            <pre>{children}</pre>
           </div>
         );
       },

--- a/src/views/chat/Transcript.tsx
+++ b/src/views/chat/Transcript.tsx
@@ -469,7 +469,7 @@ function PermissionPrompt({
               Allow <span className="mono">{toolName}</span>?
             </span>
           </div>
-          <div className="prompt__pre mono selectable">{clip(prettyJson(input))}</div>
+          <div className="prompt__pre mono">{clip(prettyJson(input))}</div>
           <div className="prompt__actions">
             <button className="btn" onClick={() => onDecide(false)}>
               Deny

--- a/src/views/gateway/OverviewView.tsx
+++ b/src/views/gateway/OverviewView.tsx
@@ -311,7 +311,7 @@ export function GatewayOverviewView({
               <InspGroup title="Endpoints">
                 <InspRow label="OpenAI">
                   {port > 0 ? (
-                    <span className="insp-row__copy">
+                    <span className="row insp-row__copy">
                       <span className="truncate">{`:${port}/v1`}</span>
                       <CopyButton
                         text={openaiBaseUrl(port)}
@@ -324,7 +324,7 @@ export function GatewayOverviewView({
                 </InspRow>
                 <InspRow label="Anthropic">
                   {port > 0 ? (
-                    <span className="insp-row__copy">
+                    <span className="row insp-row__copy">
                       <span className="truncate">{`:${port}/anthropic`}</span>
                       <CopyButton
                         text={anthropicBaseUrl(port)}
@@ -337,7 +337,7 @@ export function GatewayOverviewView({
                 </InspRow>
                 <InspRow label="Health">
                   {port > 0 ? (
-                    <span className="insp-row__copy">
+                    <span className="row insp-row__copy">
                       <span className="truncate">{healthUrl(port)}</span>
                       <CopyButton
                         text={healthUrl(port)}

--- a/src/views/gateway/OverviewView.tsx
+++ b/src/views/gateway/OverviewView.tsx
@@ -12,8 +12,10 @@ import type {
   GatewayStatus,
 } from "../../lib/types";
 import {
+  anthropicBaseUrl,
   effectivePort,
   healthUrl,
+  openaiBaseUrl,
   snippetsFor,
   TOKEN_PLACEHOLDER,
 } from "./snippets";
@@ -168,7 +170,7 @@ export function GatewayOverviewView({
                 <p className="gw-status__text">{explain(status.data, settings.data)}</p>
 
                 {status.data?.error && (
-                  <code className="gw-status__error mono selectable">
+                  <code className="gw-status__error mono">
                     {status.data.error}
                   </code>
                 )}
@@ -271,7 +273,7 @@ export function GatewayOverviewView({
                         label="Copy"
                       />
                     </div>
-                    <pre className="codebox selectable">{s.body}</pre>
+                    <pre className="codebox">{s.body}</pre>
                   </div>
                 ))
               )}
@@ -302,15 +304,49 @@ export function GatewayOverviewView({
                     : "—"}
                 </InspRow>
               </InspGroup>
+              {/* Each row abbreviates the URL to fit the pane but copies the
+                  whole thing: the base URLs are the one value in this feature a
+                  user retypes by hand, and one wrong character (`/anthropic/v1`)
+                  is the documented failure. See snippets.ts. */}
               <InspGroup title="Endpoints">
                 <InspRow label="OpenAI">
-                  {port > 0 ? `:${port}/v1` : "—"}
+                  {port > 0 ? (
+                    <span className="insp-row__copy">
+                      <span className="truncate">{`:${port}/v1`}</span>
+                      <CopyButton
+                        text={openaiBaseUrl(port)}
+                        title="Copy the OpenAI base URL"
+                      />
+                    </span>
+                  ) : (
+                    "—"
+                  )}
                 </InspRow>
                 <InspRow label="Anthropic">
-                  {port > 0 ? `:${port}/anthropic` : "—"}
+                  {port > 0 ? (
+                    <span className="insp-row__copy">
+                      <span className="truncate">{`:${port}/anthropic`}</span>
+                      <CopyButton
+                        text={anthropicBaseUrl(port)}
+                        title="Copy the Anthropic base URL"
+                      />
+                    </span>
+                  ) : (
+                    "—"
+                  )}
                 </InspRow>
                 <InspRow label="Health">
-                  {port > 0 ? healthUrl(port) : "—"}
+                  {port > 0 ? (
+                    <span className="insp-row__copy">
+                      <span className="truncate">{healthUrl(port)}</span>
+                      <CopyButton
+                        text={healthUrl(port)}
+                        title="Copy the health-check URL"
+                      />
+                    </span>
+                  ) : (
+                    "—"
+                  )}
                 </InspRow>
               </InspGroup>
             </div>

--- a/src/views/gateway/SettingsView.tsx
+++ b/src/views/gateway/SettingsView.tsx
@@ -267,7 +267,7 @@ export function GatewaySettingsView({ inspectorOpen }: { inspectorOpen: boolean 
                 <span>{sentenceFor(status.data)}</span>
               </div>
               {status.data?.error && (
-                <code className="gw-status__error mono selectable">
+                <code className="gw-status__error mono">
                   {status.data.error}
                 </code>
               )}

--- a/src/views/settings/LogsPane.tsx
+++ b/src/views/settings/LogsPane.tsx
@@ -347,7 +347,7 @@ export function LogsPane() {
           <span className="msgline__icon">
             <Icon name="check" size={13} />
           </span>
-          <span className="selectable">{saved}</span>
+          <span>{saved}</span>
         </div>
       )}
 
@@ -391,14 +391,14 @@ export function LogsPane() {
               <span className="logline__target" title={e.target}>
                 {shortTarget(e.target)}
               </span>
-              <span className="logline__text selectable">{e.text}</span>
+              <span className="logline__text">{e.text}</span>
             </div>
           ))
         )}
       </div>
 
       <div className="logs__foot">
-        <span className="logs__path selectable mono">{dir}</span>
+        <span className="logs__path mono">{dir}</span>
         <CopyButton text={dir} title="Copy the log directory path" />
         <span className="logs__spacer" />
         <span className="logs__meta">

--- a/src/views/settings/SecurityPane.tsx
+++ b/src/views/settings/SecurityPane.tsx
@@ -198,7 +198,7 @@ export function SecurityPane() {
           help="Named in every token this install issues. It changes when the key does, so a token whose kid does not match this one was issued before the last regenerate."
         >
           <div className="row">
-            <span className="mono selectable truncate">{keys.data.kid}</span>
+            <span className="mono truncate">{keys.data.kid}</span>
             <CopyButton text={keys.data.kid} title="Copy key ID" />
           </div>
         </FormRow>
@@ -208,7 +208,7 @@ export function SecurityPane() {
           help="Ed25519, base64url. This is what a verifier needs — it can check a token Agento issued and cannot mint one."
         >
           <div className="row">
-            <span className="mono selectable truncate">
+            <span className="mono truncate">
               {keys.data.public_key}
             </span>
             <CopyButton text={keys.data.public_key} title="Copy public key" />
@@ -220,7 +220,7 @@ export function SecurityPane() {
           help="Serves the public key in the standard form, with no credential required. Point a stock JWT library at this and it can verify Agento's tokens offline."
         >
           <div className="row">
-            <span className="mono selectable truncate">{jwksUrl}</span>
+            <span className="mono truncate">{jwksUrl}</span>
             <CopyButton text={jwksUrl} title="Copy JWKS URL" />
           </div>
         </FormRow>


### PR DESCRIPTION
Closes #469

## What

`src/styles/base.css` declared `user-select: none` on `body` and let content opt
back in via a `.selectable` class plus five per-view rules. This inverts it:
content is selectable, and one **denylist** in `base.css` names the chrome.

## Why

An allowlist over content is unbounded and drifts. Every view added since shipped
unselectable — the whole `views/gateway/` section, `views/analytics/` and the
session detail carried no opt-in at all, so a user could not select a session id,
a token count, a gateway base URL or an error string. Chrome is a small, stable
set, which is the split native apps draw.

## How

- **`base.css`** — `body` becomes `user-select: text` (both spellings; WebKitGTK
  and WKWebView need the prefix). One denylist rule: `.titlebar`,
  `[data-tauri-drag-region]`, `.sidebar`, `.toolbar`, `.statusbar`, `.srcitem`,
  `.listrow`, `.table thead th`, `.table tbody tr`, `button`, `select`. Form
  fields re-declare `text` so a search field inside `.toolbar` keeps its own.
  `cursor: text` on the three content panes, `default` on the denylist and on `a`.
- **`::selection`** — focus-aware over the existing `--bg-select` /
  `--bg-select-focus` / `--fg-select-focus` tokens, matching `.window--focused`.
  No new token, so the three-place theming rule needed nothing.
- **The sweep** — `.selectable` and its 30-odd call sites across 14 files are
  gone, as are the five per-view `user-select: text` rules and the two now-
  redundant `none` ones (`shell.css`, `views.css`). One spelling of the rule.
- **`CopyButton`** on the five single-value rows where the text is abbreviated to
  fit the pane and drag-selecting would copy the ellipsis: the three gateway
  endpoint URLs, the session id, the project path. The session inspector's old
  "Copy session ID" action button goes with them — it duplicated the new row
  affordance and wrote through `navigator.clipboard` directly, bypassing the
  `execCommand` fallback `lib/clipboard.ts` carries for WebKitGTK.
- **`CLAUDE.md`** records the inverted rule under "Desktop, not web", so the next
  view is not written against the old one.

## Deviations from the issue's HOW

- The HOW said *"keep `views.css:392` (`.th`)"* while also naming `.th` in the
  base denylist. Those are two spellings of one rule in two files, which is the
  drift this issue is about, so `.table thead th` lives in the denylist only.
  There is no `.th` class in the tree — line 392 was `.table thead th`.
- The Context note asked that rows keep `none` **while their cells stay
  selectable**. Those cannot both hold: `td { user-select: text }` makes a drag
  starting in a cell sweep the table, and a double-click — which is what *opens*
  a session — leaves a word selected behind the view it opened. Both are explicit
  acceptance criteria, so the row is `none` and the cells inherit it. The
  Context's intent (row drag = row selection) is preserved.
- Cursor is split at pane granularity (`.pane-list` / `.pane-detail` /
  `.pane-inspector`) rather than per prose element, so the cosmetic half does not
  reintroduce an allowlist. Clickables in this tree are `<button>`, which the
  denylist already claims.

## Acceptance criteria

- [x] Selectable in the sessions list and detail, all Gateway views, every detail
      sidebar, transcript tool-call bodies.
- [x] `grep -rn "user-select" src/styles/` returns `base.css` only;
      `grep -rn "selectable" src/` returns two unrelated prose comments.
- [x] `::selection` focus-aware in both themes over the existing tokens.
- [x] Titlebar drag and row drag unchanged — both in the denylist.
- [x] `CopyButton` on the gateway base URLs, session id, project path; Settings →
      Security's `kid` already had one.
- [x] `Cmd/Ctrl+C` unaffected — `App.tsx`'s handler has no `c` arm and never
      `preventDefault`s one (verified at `src/App.tsx:187-226`).
- [x] Verified in a **release** build of the shell (see below).

## Verification

No TypeScript test harness exists, so this is `npm run build` (typecheck) plus a
hand walk-through of the built release binary in the real WebKitGTK webview at
the release origin.