### PR TITLE
feat: pick a gateway target's model id from the provider's catalog (#470)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -287,6 +287,28 @@ and the same line is in the log:
 binding the llm gateway on 127.0.0.1:8880: Address already in use (os error 98)
 ```
 
+### The model box on Models offers no list
+
+**LLM Gateway → Models** fills a target's model box from that provider's own
+catalog, and shows a note under the row when it could not. It never blocks the
+save — type the id and carry on. The note says which of these it was:
+
+- **No API key** — the provider row has none stored, so there is nobody to ask.
+  Set it in **LLM Gateway → Providers**.
+- **The provider answered 401 / 403** — the key is wrong, revoked, or not
+  entitled to the list endpoint. The same key is what serving a request would
+  use, so this is worth fixing whatever the model box does.
+- **The provider could not be reached** — a wrong base URL, no network, a proxy,
+  or an upstream that is simply slow; the fetch gives up after ten seconds.
+- **The answer was not a model list** — the base URL points at something that is
+  not that provider's API. Check it against **Providers**.
+- **No models returned** — the account is authenticated but the catalog is
+  empty, which usually means a project or region with nothing enabled on it.
+
+The list is fetched when you open the Models view, not when you save, so a slow
+provider never delays a save. It is not cached between visits: fix a key in
+**Providers** and come back to this view to see the list.
+
 ### The gateway answers 401
 
 The token is absent, malformed, expired, revoked, or was signed by a key this

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -471,6 +471,20 @@ A disabled provider stays configured and is not dispatched to.
   before fails.
 - **Fallbacks** — walked only after every target has failed.
 
+Pick a provider on a target row and the model box fills itself from **that
+provider's own catalog** — Agento asks the provider what it currently serves,
+using the key you configured for it. Start typing to filter the list. The
+strings are long and versioned (`gpt-4o-2024-11-20`, `claude-sonnet-4-6`,
+`glm-4.6`) and a typo is not caught when you save it, only by a 404 the first
+time something routes through the alias, so picking from the list is the way to
+get it right.
+
+**Typing an id by hand still works, always.** The list is a suggestion, not a
+constraint: a model released this morning, a fine-tune id, or anything the
+provider does not list is accepted and saved exactly as typed. If the catalog
+cannot be fetched the box falls back to a plain text field with a note saying
+so, and nothing about saving changes.
+
 Failure means a timeout, a connection error, a 429, or a 5xx. A provider
 answering **403** is failed over to the next target *without* being retried,
 because several providers report an exhausted plan that way and asking the same

--- a/parity/desktop_routes.json
+++ b/parity/desktop_routes.json
@@ -146,6 +146,13 @@
     },
     {
       "method": "GET",
+      "route": "/api/gateway/providers/{id}/models",
+      "status": "native",
+      "owner": "#470",
+      "reason": "the model ids that provider's own upstream reports, so an alias target is picked rather than typed; the only route here answered by the ASYNC registry, because it makes an outbound HTTPS call -- and the answer is ids alone, never the key and never the upstream body"
+    },
+    {
+      "method": "GET",
       "route": "/api/gateway/usage",
       "status": "native",
       "owner": "#426",

--- a/src-tauri/src/gateway/config.rs
+++ b/src-tauri/src/gateway/config.rs
@@ -377,6 +377,19 @@ impl ProviderRow {
         }
     }
 
+    /// The stored API key, or `""` when none is set.
+    ///
+    /// **A `&str` and nothing else**, which is rule 2 of the module header held
+    /// at its narrowest: the borrow cannot be serialized, logged through
+    /// `Debug`, or outlive the row it came from. Its one caller is
+    /// `native::gateway_api::catalog`, which puts it straight into an
+    /// `Authorization`/`x-api-key` header on one outbound request and drops it
+    /// with the request builder — the same "build at the point of use and drop"
+    /// shape [`Self::to_ferrox`] already has.
+    pub fn api_key(&self) -> &str {
+        &self.api_key
+    }
+
     /// The redacted view of this row.
     pub fn to_summary(&self) -> ProviderSummary {
         ProviderSummary {
@@ -455,6 +468,26 @@ fn load_providers_from(conn: &Connection) -> Result<Vec<ProviderRow>, String> {
         .map_err(|e| format!("reading gateway providers: {e}"))?;
     rows.collect::<rusqlite::Result<Vec<_>>>()
         .map_err(|e| format!("reading gateway providers: {e}"))
+}
+
+/// **One** provider by row id, with its key — `None` when no such row exists.
+///
+/// The second reader of [`PROVIDER_COLUMNS_SECRET`], and it exists for exactly
+/// one caller: `GET /api/gateway/providers/{id}/models` (#470), which has to
+/// authenticate to that provider's own upstream to ask what it serves. It goes
+/// through the secret projection rather than beside it, and answers the same
+/// [`ProviderRow`] that derives neither `Serialize` nor `Debug`, so the
+/// discipline in the module header covers this path unchanged.
+///
+/// It deliberately does **not** filter on `enabled`: the catalog is a
+/// configuration aid, and a provider a user has switched off is exactly one they
+/// may still be editing an alias against.
+pub fn load_provider_secret(db_path: &Path, id: &str) -> Result<Option<ProviderRow>, String> {
+    let conn = db::open_read_only(db_path)?;
+    let sql = format!("{PROVIDER_COLUMNS_SECRET}\n     WHERE id = ?1");
+    conn.query_row(&sql, [id], scan_provider_secret)
+        .optional()
+        .map_err(|e| format!("reading gateway provider: {e}"))
 }
 
 /// Every provider, redacted — the read the control API and UI use.

--- a/src-tauri/src/native/gateway_api.rs
+++ b/src-tauri/src/native/gateway_api.rs
@@ -51,6 +51,8 @@ use super::writes::{self, WriteError};
 use super::{Answer, Ctx, Request};
 use crate::gateway::{config, registry, usage};
 
+pub mod catalog;
+
 /// Every route this module claims.
 ///
 /// Asserted as **set equality** against `parity/desktop_routes.json` by
@@ -69,7 +71,30 @@ pub const ROUTES: &[(&str, &str)] = &[
     ("DELETE", "/api/gateway/models/{id}"),
     ("GET", "/api/gateway/status"),
     ("GET", "/api/gateway/usage"),
+    ("GET", "/api/gateway/providers/{id}/models"),
 ];
+
+/// The one route in [`ROUTES`] the **streaming** registry answers (#470).
+///
+/// It does not stream. `StreamEndpoint` is simply the only registry here that is
+/// `async`, and this route makes a network call: `Endpoint::serve` is a sync
+/// `fn` the proxy runs on `spawn_blocking`, which is exactly right for thirteen
+/// areas that read SQLite and wrong for an outbound HTTPS request. Returning a
+/// buffered JSON `Response` from the async registry is a smaller change than
+/// putting a runtime in front of the blocking one — see `StreamEndpoint`'s own
+/// header for why the two registries exist at all.
+///
+/// Consequences, both load-bearing:
+///
+/// - It stays in [`ROUTES`], because that const is what
+///   `parity/desktop_routes.json` is asserted against as **set equality** and a
+///   route recorded nowhere is the drift that file exists to stop.
+/// - [`claims`] must therefore *exclude* it, or both registries claim one path.
+///   `proxy.rs` checks `claims_stream` first, so the buffered handler would
+///   never run — it would merely sit there as a route claimed by a `serve` arm
+///   that answers "claimed but unhandled". `the_catalog_route_is_claimed_by_the
+///   _streaming_registry_alone` is the guard.
+const CATALOG_ROUTE: (&str, &str) = ("GET", "/api/gateway/providers/{id}/models");
 
 pub const ENDPOINT: super::Endpoint = super::Endpoint {
     name: "gateway",
@@ -77,10 +102,23 @@ pub const ENDPOINT: super::Endpoint = super::Endpoint {
     serve,
 };
 
+/// The async half — [`CATALOG_ROUTE`] and nothing else.
+pub const STREAM_ENDPOINT: super::StreamEndpoint = super::StreamEndpoint {
+    name: "gateway-catalog",
+    claims: claims_catalog,
+    serve: serve_catalog,
+};
+
 fn claims(method: &Method, path: &str) -> bool {
-    ROUTES
-        .iter()
-        .any(|(m, pattern)| method.as_str() == *m && path_matches(pattern, path))
+    !claims_catalog(method, path)
+        && ROUTES
+            .iter()
+            .any(|(m, pattern)| method.as_str() == *m && path_matches(pattern, path))
+}
+
+fn claims_catalog(method: &Method, path: &str) -> bool {
+    let (m, pattern) = CATALOG_ROUTE;
+    method.as_str() == m && path_matches(pattern, path)
 }
 
 /// Match a chi-style pattern against a concrete path.
@@ -118,6 +156,90 @@ fn id_under(path: &str, collection: &str) -> Option<String> {
         return None;
     }
     Some(rest.to_string())
+}
+
+/// The `{id}` of `/api/gateway/providers/{id}/models`.
+///
+/// [`id_under`] cannot answer this: it refuses a remainder containing a `/`,
+/// which is what keeps a one-segment route one segment. Here the suffix is part
+/// of the pattern, so the `/models` is stripped first and the same one-segment
+/// rule is applied to what is left.
+fn provider_id_for_catalog(path: &str) -> Option<String> {
+    let rest = path.strip_prefix("/api/gateway/providers/")?;
+    let id = rest.strip_suffix("/models")?;
+    if id.is_empty() || id.contains('/') {
+        return None;
+    }
+    Some(id.to_string())
+}
+
+/// `GET /api/gateway/providers/{id}/models` (#470) — what that provider's own
+/// upstream says it serves.
+///
+/// Async because it makes a network call; buffered because the answer is a
+/// finished document. See [`CATALOG_ROUTE`].
+///
+/// The database read is on this runtime worker and stays there deliberately:
+/// it is `open_read_only`, and a WAL reader does not wait on a writer, which is
+/// the same reasoning that leaves `runner::load` and `TurnSettings::stored` off
+/// `db::blocking`. The unbounded part of this handler is the HTTPS call, which
+/// is `await`ed rather than blocked on.
+fn serve_catalog(req: super::StreamRequest) -> super::BoxFuture<'static, Result<Response, String>> {
+    Box::pin(async move {
+        let Some(id) = provider_id_for_catalog(&req.path) else {
+            return Err(format!(
+                "{} {} is claimed but has no id",
+                req.method, req.path
+            ));
+        };
+
+        let Some(row) = config::load_provider_secret(&req.db_path, &id)? else {
+            // The same 404 every other `{id}` route here answers for a row that
+            // is not there.
+            return answer(Answer::error(StatusCode::NOT_FOUND, "provider not found")?);
+        };
+
+        // `row` holds the key. It goes no further than `catalog::fetch`, which
+        // puts it in one header and drops it with the request builder; nothing
+        // below this line can reach it, because only a `&str` ever leaves
+        // `ProviderRow` and the borrow ends here.
+        let body = match catalog::fetch(&row).await {
+            Ok(models) => super::gojson::to_vec(&CatalogBody { models })
+                .map_err(|e| format!("encoding gateway provider catalog: {e}"))?,
+            Err(e) => {
+                // Logged with the provider **id**, never its name, base URL or
+                // key: this line lands in a plain file on disk, and the id is
+                // already in the access line's path.
+                log::warn!("gateway model catalog for provider {id}: {}", e.message());
+                let status = match e {
+                    catalog::CatalogError::Unaskable(_) => StatusCode::BAD_REQUEST,
+                    catalog::CatalogError::Upstream(_) => StatusCode::BAD_GATEWAY,
+                };
+                return answer(Answer::error(status, e.message())?);
+            }
+        };
+        answer(Answer::json(body))
+    })
+}
+
+/// Render a buffered [`Answer`] as the streaming registry's `Response`.
+///
+/// The one thing this registry does not do for a handler, because a chat turn
+/// builds its own response from a body stream.
+fn answer(answer: Answer) -> Result<Response, String> {
+    Ok(super::response(answer))
+}
+
+type Response = axum::http::Response<axum::body::Body>;
+
+/// `{"models": ["id", …]}` — ids only, and **never** the upstream body.
+///
+/// Re-encoding somebody else's JSON would reorder its keys and respell its
+/// numbers, and forwarding it verbatim would hand a caller every field a
+/// catalog carries. This route answers the one thing it was asked for.
+#[derive(Serialize)]
+struct CatalogBody {
+    models: Vec<String>,
 }
 
 fn serve(ctx: &Ctx, req: &Request) -> Result<Answer, String> {
@@ -2109,5 +2231,339 @@ mod tests {
         let file = migrated();
         let ctx = ctx(&file);
         assert!(call_query(&ctx, "/api/gateway/usage", "tz=Mars/Olympus").is_err());
+    }
+
+    // ── The provider model catalog (#470) ─────────────────────────────────
+
+    /// What the fake upstream saw, so a test can assert on the request that was
+    /// built rather than only on the answer it produced.
+    #[derive(Default)]
+    struct Seen {
+        target: String,
+        headers: Vec<(String, String)>,
+    }
+
+    /// A loopback stand-in for a provider's list endpoint.
+    ///
+    /// **This is the whole test seam, and it is a parameter rather than a
+    /// `#[cfg(test)]` static.** A gateway provider's base URL comes out of the
+    /// row, so a test simply stores one pointing here — the narrower answer
+    /// #317 reached for Confluence, where GitHub's fixed API root forced a
+    /// `SetAPIBase`-shaped seam. Nothing test-only ships.
+    async fn fake_upstream(
+        status: StatusCode,
+        body: &'static str,
+    ) -> (String, std::sync::Arc<std::sync::Mutex<Seen>>) {
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(Seen::default()));
+        let recorder = seen.clone();
+        let app = axum::Router::new().fallback(move |req: axum::extract::Request| {
+            let recorder = recorder.clone();
+            async move {
+                {
+                    let mut seen = recorder.lock().expect("lock");
+                    seen.target = req.uri().to_string();
+                    seen.headers = req
+                        .headers()
+                        .iter()
+                        .map(|(k, v)| {
+                            (
+                                k.as_str().to_string(),
+                                v.to_str().unwrap_or_default().to_string(),
+                            )
+                        })
+                        .collect();
+                }
+                (status, body)
+            }
+        });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let base = format!("http://{}", listener.local_addr().expect("addr"));
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        (base, seen)
+    }
+
+    fn seed_provider(ctx: &Ctx, id: &str, kind: &str, key: &str, base: &str) {
+        let answer = call(
+            ctx,
+            "POST",
+            "/api/gateway/providers",
+            &format!(
+                r#"{{"id":"{id}","name":"{id}","type":"{kind}","api_key":"{key}",
+                    "base_url":"{base}","enabled":true}}"#
+            ),
+        )
+        .expect("created");
+        assert_eq!(answer.status, StatusCode::CREATED);
+    }
+
+    async fn catalog(ctx: &Ctx, id: &str) -> Response {
+        serve_catalog(crate::native::StreamRequest {
+            method: Method::GET,
+            path: format!("/api/gateway/providers/{id}/models"),
+            body: Vec::new(),
+            db_path: ctx.db_path.clone(),
+        })
+        .await
+        .expect("the handler answers its own 4xx rather than erroring")
+    }
+
+    async fn parts_of(response: Response) -> (StatusCode, String) {
+        let status = response.status();
+        let bytes = axum::body::to_bytes(response.into_body(), 1 << 20)
+            .await
+            .expect("body");
+        (status, String::from_utf8(bytes.to_vec()).expect("utf-8"))
+    }
+
+    fn header_of(seen: &std::sync::Arc<std::sync::Mutex<Seen>>, name: &str) -> String {
+        seen.lock()
+            .expect("lock")
+            .headers
+            .iter()
+            .find(|(k, _)| k == name)
+            .map(|(_, v)| v.clone())
+            .unwrap_or_default()
+    }
+
+    /// The four provider types, each asked the way its own API expects and each
+    /// answering the ids and nothing else.
+    ///
+    /// One test rather than four because the *table* is the thing under test:
+    /// four near-identical bodies would drift apart, and what matters is that
+    /// every arm of `Shape::of` builds a request the upstream would accept.
+    #[tokio::test]
+    async fn every_provider_type_is_asked_the_way_its_own_api_expects() {
+        let openai_body = r#"{"object":"list","data":[{"id":"gpt-4o-2024-11-20"},{"id":"o3"}]}"#;
+        let gemini_body = r#"{"models":[{"name":"models/gemini-2.5-pro"}]}"#;
+
+        for (kind, body, want_path, want_models) in [
+            (
+                "openai",
+                openai_body,
+                "/models",
+                vec!["gpt-4o-2024-11-20", "o3"],
+            ),
+            (
+                "glm",
+                openai_body,
+                "/models",
+                vec!["gpt-4o-2024-11-20", "o3"],
+            ),
+            (
+                "anthropic",
+                openai_body,
+                "/v1/models?limit=1000",
+                vec!["gpt-4o-2024-11-20", "o3"],
+            ),
+            (
+                "gemini",
+                gemini_body,
+                "/v1beta/models?pageSize=1000",
+                vec!["gemini-2.5-pro"],
+            ),
+        ] {
+            let file = migrated();
+            let ctx = ctx(&file);
+            let (base, seen) = fake_upstream(StatusCode::OK, body).await;
+            seed_provider(&ctx, "p1", kind, "sk-secret-value", &base);
+
+            let (status, answered) = parts_of(catalog(&ctx, "p1").await).await;
+            assert_eq!(status, StatusCode::OK, "{kind}");
+            assert_eq!(
+                answered,
+                format!(
+                    "{{\"models\":[{}]}}\n",
+                    want_models
+                        .iter()
+                        .map(|m| format!("\"{m}\""))
+                        .collect::<Vec<_>>()
+                        .join(",")
+                ),
+                "{kind}",
+            );
+
+            assert_eq!(seen.lock().expect("lock").target, want_path, "{kind}");
+            match kind {
+                "openai" | "glm" => {
+                    assert_eq!(header_of(&seen, "authorization"), "Bearer sk-secret-value")
+                }
+                "anthropic" => {
+                    assert_eq!(header_of(&seen, "x-api-key"), "sk-secret-value");
+                    assert_eq!(header_of(&seen, "anthropic-version"), "2023-06-01");
+                }
+                // The header form rather than `?key=`, so the credential is
+                // never in a URL.
+                _ => {
+                    assert_eq!(header_of(&seen, "x-goog-api-key"), "sk-secret-value");
+                    assert!(!seen.lock().expect("lock").target.contains("sk-"));
+                }
+            }
+        }
+    }
+
+    /// **The credential rule, asserted over the bytes.**
+    ///
+    /// A struct-level check only proves the field the test knows about is
+    /// absent; this is the sibling of
+    /// `a_scrubbed_read_written_straight_back_preserves_the_stored_key`, and it
+    /// covers the whole response including anything a future field might carry.
+    /// The upstream deliberately *echoes* the key back in its own body, which is
+    /// the shape a forwarded upstream document would leak.
+    #[tokio::test]
+    async fn the_catalog_answer_carries_no_api_key_and_no_upstream_body() {
+        let file = migrated();
+        let ctx = ctx(&file);
+        let (base, _) = fake_upstream(
+            StatusCode::OK,
+            r#"{"data":[{"id":"gpt-4o","owned_by":"sk-secret-value","secret":"sk-secret-value"}]}"#,
+        )
+        .await;
+        seed_provider(&ctx, "p1", "openai", "sk-secret-value", &base);
+
+        let (status, body) = parts_of(catalog(&ctx, "p1").await).await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(!body.contains("sk-secret-value"), "{body}");
+        // ...and the upstream's other fields did not come through either.
+        assert_eq!(body, "{\"models\":[\"gpt-4o\"]}\n");
+        assert!(!body.contains("owned_by"), "{body}");
+    }
+
+    /// The same 404 every other `{id}` route on this surface answers.
+    #[tokio::test]
+    async fn an_unknown_provider_id_is_a_404() {
+        let file = migrated();
+        let (status, body) = parts_of(catalog(&ctx(&file), "nope").await).await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(body, "{\"error\":\"provider not found\"}\n");
+    }
+
+    /// An upstream that refuses is a **502**, distinct from the 404 above, and
+    /// it names the status because that is the half a user can act on — a `401`
+    /// says "the key is wrong" better than any wording here could.
+    ///
+    /// Nothing else crosses: not the key, not the base URL, not the upstream's
+    /// own body, which this fake fills with both.
+    #[tokio::test]
+    async fn an_upstream_refusal_is_a_502_naming_the_status_and_nothing_else() {
+        let file = migrated();
+        let ctx = ctx(&file);
+        let (base, _) = fake_upstream(
+            StatusCode::UNAUTHORIZED,
+            r#"{"error":{"message":"incorrect api key sk-secret-value"}}"#,
+        )
+        .await;
+        seed_provider(&ctx, "p1", "openai", "sk-secret-value", &base);
+
+        let (status, body) = parts_of(catalog(&ctx, "p1").await).await;
+        assert_eq!(status, StatusCode::BAD_GATEWAY);
+        assert!(body.contains("401"), "{body}");
+        assert!(!body.contains("sk-secret-value"), "{body}");
+        assert!(!body.contains("127.0.0.1"), "{body}");
+        assert!(!body.contains("incorrect api key"), "{body}");
+    }
+
+    /// A provider with no key is answered **before** a request is built, so the
+    /// UI gets a cause it can act on rather than the upstream's `401` — and no
+    /// unauthenticated call is made in the user's name.
+    #[tokio::test]
+    async fn a_provider_with_no_key_is_refused_without_asking_anyone() {
+        let file = migrated();
+        let ctx = ctx(&file);
+        let (base, seen) = fake_upstream(StatusCode::OK, r#"{"data":[]}"#).await;
+        seed_provider(&ctx, "p1", "openai", "", &base);
+
+        let (status, body) = parts_of(catalog(&ctx, "p1").await).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(body.contains("no API key"), "{body}");
+        assert!(
+            seen.lock().expect("lock").target.is_empty(),
+            "a request was sent"
+        );
+    }
+
+    /// The guard `native/integrations/base_url.rs` exists for, at this call
+    /// site: `url::Url::parse` removes dot segments and would send the key to an
+    /// endpoint the user did not configure, so the request is refused instead —
+    /// and refused as `Unaskable`, since retrying cannot help.
+    #[tokio::test]
+    async fn a_base_url_that_resolves_elsewhere_is_refused_before_the_key_is_sent() {
+        let file = migrated();
+        let ctx = ctx(&file);
+        let (base, seen) = fake_upstream(StatusCode::OK, r#"{"data":[]}"#).await;
+        seed_provider(
+            &ctx,
+            "p1",
+            "openai",
+            "sk-secret-value",
+            &format!("{base}/v1/.."),
+        );
+
+        let (status, body) = parts_of(catalog(&ctx, "p1").await).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(body.contains("base URL"), "{body}");
+        assert!(
+            seen.lock().expect("lock").target.is_empty(),
+            "a request was sent"
+        );
+    }
+
+    /// A trailing slash is the same endpoint to a person and `//models` to
+    /// naive concatenation. `Base` concatenates because its two other callers
+    /// are ports of Go that does; this one trims first.
+    #[tokio::test]
+    async fn a_base_url_with_a_trailing_slash_reaches_the_same_endpoint() {
+        let file = migrated();
+        let ctx = ctx(&file);
+        let (base, seen) = fake_upstream(StatusCode::OK, r#"{"data":[{"id":"a"}]}"#).await;
+        seed_provider(&ctx, "p1", "openai", "sk-secret-value", &format!("{base}/"));
+
+        let (status, _) = parts_of(catalog(&ctx, "p1").await).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(seen.lock().expect("lock").target, "/models");
+    }
+
+    /// Both registries ask `claims`-shaped questions and `proxy.rs` asks the
+    /// streaming one first, so a route claimed by both would leave the buffered
+    /// arm permanently unreachable — a latent "claimed but unhandled" nobody
+    /// would trip over until the two disagreed.
+    #[test]
+    fn the_catalog_route_is_claimed_by_the_streaming_registry_alone() {
+        let path = "/api/gateway/providers/p1/models";
+        assert!(claims_catalog(&Method::GET, path));
+        assert!(!claims(&Method::GET, path));
+        // ...and the buffered half is untouched by the exclusion.
+        assert!(claims(&Method::GET, "/api/gateway/providers"));
+        assert!(claims(&Method::PUT, "/api/gateway/providers/p1"));
+        // The route is still in ROUTES, which is what `desktop_routes.json` is
+        // asserted against.
+        assert!(ROUTES.contains(&CATALOG_ROUTE));
+    }
+
+    /// `id_under` refuses a remainder holding a `/`, which is what keeps a
+    /// one-segment route one segment — so the two-segment suffix needs its own
+    /// extractor, and that extractor must keep the same one-segment rule.
+    #[test]
+    fn the_catalog_id_is_one_segment_and_nothing_else() {
+        assert_eq!(
+            provider_id_for_catalog("/api/gateway/providers/p1/models").as_deref(),
+            Some("p1")
+        );
+        assert_eq!(
+            provider_id_for_catalog("/api/gateway/providers//models"),
+            None
+        );
+        assert_eq!(
+            provider_id_for_catalog("/api/gateway/providers/a/b/models"),
+            None
+        );
+        assert_eq!(provider_id_for_catalog("/api/gateway/providers/p1"), None);
+        assert_eq!(
+            provider_id_for_catalog("/api/gateway/providers/p1/models/x"),
+            None
+        );
     }
 }

--- a/src-tauri/src/native/gateway_api.rs
+++ b/src-tauri/src/native/gateway_api.rs
@@ -2511,6 +2511,46 @@ mod tests {
         );
     }
 
+    /// **A redirect is refused rather than followed**, and this is the guard
+    /// `base_url::Base` cannot provide on its own: it checks where the *first*
+    /// request goes, and a `302` moves it afterwards. `reqwest` strips
+    /// `Authorization` across origins and strips nothing else, so a followed
+    /// redirect would carry `x-api-key`/`x-goog-api-key` to whichever host
+    /// answered — the credential leak this whole surface is built to prevent.
+    ///
+    /// The fake redirects to an absolute URL it also serves, so following it
+    /// would produce a perfectly good `200` and a green test; the assertion is
+    /// therefore that the **redirect itself** is the answer.
+    #[tokio::test]
+    async fn a_redirect_is_reported_rather_than_followed_with_the_key_attached() {
+        let file = migrated();
+        let ctx = ctx(&file);
+        let (elsewhere, elsewhere_seen) =
+            fake_upstream(StatusCode::OK, r#"{"data":[{"id":"leaked"}]}"#).await;
+
+        let target = format!("{elsewhere}/models");
+        let app = axum::Router::new().fallback(move || {
+            let target = target.clone();
+            async move { (StatusCode::FOUND, [(axum::http::header::LOCATION, target)]) }
+        });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let base = format!("http://{}", listener.local_addr().expect("addr"));
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        seed_provider(&ctx, "p1", "anthropic", "sk-secret-value", &base);
+
+        let (status, body) = parts_of(catalog(&ctx, "p1").await).await;
+        assert_eq!(status, StatusCode::BAD_GATEWAY);
+        assert!(body.contains("302"), "{body}");
+        assert!(
+            elsewhere_seen.lock().expect("lock").target.is_empty(),
+            "the redirect was followed, carrying the key to another host"
+        );
+    }
+
     /// A trailing slash is the same endpoint to a person and `//models` to
     /// naive concatenation. `Base` concatenates because its two other callers
     /// are ports of Go that does; this one trims first.

--- a/src-tauri/src/native/gateway_api/catalog.rs
+++ b/src-tauri/src/native/gateway_api/catalog.rs
@@ -1,0 +1,421 @@
+//! Asking one configured provider's own upstream which models it serves (#470).
+//!
+//! # Why this is new code rather than something reused
+//!
+//! Ferrox's `GET /v1/models` and `GET /anthropic/v1/models` list **ferrox's own
+//! configured aliases** — they are the client-facing discovery endpoint, i.e.
+//! the same thing `GET /api/gateway/models` already is here — and
+//! `ferrox-providers` exposes no model-listing capability at all, its adapters
+//! being completions-only. So neither can be lifted, and the per-provider
+//! catalog fetch is Agento's own.
+//!
+//! # What leaves this module
+//!
+//! **Model ids, and nothing else.** Not the key, not the resolved URL, not the
+//! upstream body. Every failure is a [`CatalogError`] whose `message` names a
+//! *cause* — a transport failure, an upstream status, a shape that did not
+//! parse — and interpolates neither the credential nor the endpoint, because
+//! the whole thing is rendered into a form the user is looking at and a base URL
+//! can carry a token in its path.
+//!
+//! # The base URL is model input reaching a URL
+//!
+//! `gateway_providers.base_url` is typed by a person, so it is the same class
+//! `native/integrations/base_url.rs` exists for: `url::Url::parse` — which
+//! `reqwest` builds every request through — applies WHATWG dot-segment removal,
+//! so a stored base of `https://api.openai.com/v1/..` would send the key
+//! somewhere the user did not configure. [`Base`] is that guard, and it is
+//! reused rather than re-derived; see its header for why comparing two parsers
+//! of the same string is not enough on its own.
+//!
+//! One adaptation: [`Base::new`] takes the base with trailing slashes already
+//! trimmed by whatever the caller's Go trimmed them with, because it
+//! *concatenates*. There is no Go here, and a user who stores
+//! `https://api.openai.com/v1/` means the same endpoint as one who does not — so
+//! this trims, the way `confluence::validate_site_url` does, rather than sending
+//! the `//models` that faithful concatenation would produce.
+//!
+//! # Where each path comes from
+//!
+//! Not from this issue's sketch but from what the *completions* call already
+//! does with the same column, because a stored base has to work for both:
+//!
+//! | type | ferrox appends | so the base is | and the catalog is |
+//! |---|---|---|---|
+//! | `openai`, `glm` | `/chat/completions` | the **versioned** root | `/models` |
+//! | `anthropic` | `/v1/messages` | the **host** root | `/v1/models` |
+//! | `gemini` | `/v1beta/models/…` | the **host** root | `/v1beta/models` |
+//!
+//! `glm` shares OpenAI's defaults because it *is* the OpenAI adapter with a
+//! custom base (`config::ProviderType::Glm`), and a GLM row that has not set one
+//! is misconfigured for completions in exactly the same way.
+
+use std::time::Duration;
+
+use serde::Deserialize;
+
+use crate::gateway::config::{ProviderRow, ProviderType};
+use crate::native::integrations::base_url::Base;
+
+/// How long one catalog fetch may take, end to end.
+///
+/// Short, and deliberately shorter than any integration client's: this is on a
+/// UI interaction — a user picked a provider in a form — not on a turn. A slow
+/// upstream must degrade to the free-text field quickly rather than leave a
+/// combobox spinning.
+const TIMEOUT: Duration = Duration::from_secs(10);
+
+/// The most catalog JSON this will read before giving up.
+///
+/// The largest real answer here is a few tens of kilobytes; the cap is the same
+/// belt-and-braces every integration client wears, so a misconfigured base
+/// pointing at something enormous cannot buffer it into this process.
+const MAX_BYTES: usize = 2 * 1024 * 1024;
+
+/// Why a catalog could not be produced.
+///
+/// `message` is what the UI renders, so it names a cause and never a value:
+/// no key, no URL, no upstream body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CatalogError {
+    /// The provider is configured in a way that makes the question unaskable —
+    /// no API key, or a `base_url` this build will not send a request through.
+    /// `400`, because nothing was asked and retrying will not change it.
+    Unaskable(String),
+    /// The provider was asked and the answer was not a catalog. `502`, because
+    /// this build did its part and somebody else's did not.
+    Upstream(String),
+}
+
+impl CatalogError {
+    pub fn message(&self) -> &str {
+        match self {
+            Self::Unaskable(m) | Self::Upstream(m) => m,
+        }
+    }
+}
+
+/// Every model id `row`'s upstream reports, in the order the upstream gave them.
+///
+/// Order is the upstream's own — OpenAI's is by creation, Anthropic's is newest
+/// first — and re-sorting it would bury the model a user most likely wants under
+/// an alphabetical accident. Duplicates are dropped, which costs nothing and
+/// stops a paginated answer that overlaps from listing an id twice.
+pub async fn fetch(row: &ProviderRow) -> Result<Vec<String>, CatalogError> {
+    let key = row.api_key();
+    if key.is_empty() {
+        return Err(CatalogError::Unaskable(
+            "this provider has no API key, so its model list cannot be fetched".into(),
+        ));
+    }
+
+    let shape = Shape::of(row.provider_type);
+    // Trailing slashes trimmed before `Base::new`, which concatenates: see the
+    // module header.
+    let raw = row.base_url.trim_end_matches('/');
+    let raw = if raw.is_empty() {
+        shape.default_base
+    } else {
+        raw
+    };
+    let base = Base::new(raw).map_err(|_| {
+        CatalogError::Unaskable(
+            "this provider's base URL is not one Agento can send a request to".into(),
+        )
+    })?;
+    let url = base.resolve(shape.path).ok_or_else(|| {
+        CatalogError::Unaskable(
+            "this provider's base URL is not one Agento can send a request to".into(),
+        )
+    })?;
+
+    let client = reqwest::Client::builder()
+        .timeout(TIMEOUT)
+        .build()
+        // `reqwest` loads the platform trust store inside `build()` and reports
+        // an unusable one as a *builder* error, so this is reachable without any
+        // network at all — see `native/integrations/github/client.rs`.
+        .map_err(|_| CatalogError::Unaskable("no usable TLS trust store on this machine".into()))?;
+
+    let request = match shape.auth {
+        Auth::Bearer => client.get(url).bearer_auth(key),
+        Auth::AnthropicKey => client
+            .get(url)
+            .header("x-api-key", key)
+            .header("anthropic-version", "2023-06-01"),
+        // The header form rather than `?key=`, so the credential is never in a
+        // URL — which is what an error string, a redirect and a proxy log all
+        // see.
+        Auth::GoogleKey => client.get(url).header("x-goog-api-key", key),
+    };
+
+    let response = request
+        .send()
+        .await
+        // Deliberately not `{e}`: a `reqwest::Error`'s `Display` carries the URL
+        // it was built from, which is the one thing this must not hand back.
+        .map_err(|_| CatalogError::Upstream("the provider could not be reached".into()))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        // The status is the useful half and leaks nothing — `401` says "the key
+        // is wrong" far better than any wording here could. The body is not
+        // read: it is the upstream's, and echoing it is what this module exists
+        // not to do.
+        return Err(CatalogError::Upstream(format!(
+            "the provider answered {}",
+            status.as_u16()
+        )));
+    }
+
+    let body = read_capped(response).await?;
+    let ids = shape.parse(&body)?;
+
+    let mut seen = std::collections::HashSet::new();
+    Ok(ids
+        .into_iter()
+        .filter(|id| !id.is_empty() && seen.insert(id.clone()))
+        .collect())
+}
+
+/// Read at most [`MAX_BYTES`], failing rather than truncating.
+///
+/// Truncation would be worse than an error here: a JSON document cut in half
+/// does not parse, so the only outcome it can produce is the same failure with a
+/// less accurate cause.
+async fn read_capped(response: reqwest::Response) -> Result<Vec<u8>, CatalogError> {
+    use tokio_stream::StreamExt;
+
+    let mut stream = Box::pin(response.bytes_stream());
+    let mut buf: Vec<u8> = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|_| {
+            CatalogError::Upstream("the provider's answer could not be read".into())
+        })?;
+        if buf.len() + chunk.len() > MAX_BYTES {
+            return Err(CatalogError::Upstream(
+                "the provider's model list is larger than Agento will read".into(),
+            ));
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    Ok(buf)
+}
+
+/// Which authentication one provider type's list endpoint takes.
+#[derive(Clone, Copy)]
+enum Auth {
+    /// `Authorization: Bearer <key>` — OpenAI and every compatible surface.
+    Bearer,
+    /// `x-api-key` plus the pinned `anthropic-version`.
+    AnthropicKey,
+    /// `x-goog-api-key`.
+    GoogleKey,
+}
+
+/// Everything that differs between the four providers' list endpoints.
+struct Shape {
+    default_base: &'static str,
+    path: &'static str,
+    auth: Auth,
+    body: BodyShape,
+}
+
+/// Which JSON shape the ids arrive in.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum BodyShape {
+    /// `{"data":[{"id":"…"}]}` — OpenAI, GLM and Anthropic all answer this.
+    DataId,
+    /// `{"models":[{"name":"models/…"}]}` — Gemini, whose `name` is a resource
+    /// path rather than the id a request carries.
+    ModelsName,
+}
+
+impl Shape {
+    fn of(provider_type: ProviderType) -> Self {
+        match provider_type {
+            // Same defaults for both, because `Glm` *is* the OpenAI adapter with
+            // a custom base — see the module header.
+            ProviderType::Openai | ProviderType::Glm => Self {
+                default_base: "https://api.openai.com/v1",
+                path: "/models",
+                auth: Auth::Bearer,
+                body: BodyShape::DataId,
+            },
+            // The two paginated endpoints are asked for their whole catalog in
+            // one request. Anthropic's defaults to 20 per page and Gemini's to
+            // 50, both capping at 1000 — which covers every real catalog many
+            // times over and keeps the handler's cost a fixed single round
+            // trip, where a follow-the-cursor loop would put an unbounded number
+            // of upstream calls behind one click. OpenAI's is not paginated and
+            // takes no such parameter.
+            ProviderType::Anthropic => Self {
+                default_base: "https://api.anthropic.com",
+                path: "/v1/models?limit=1000",
+                auth: Auth::AnthropicKey,
+                body: BodyShape::DataId,
+            },
+            ProviderType::Gemini => Self {
+                default_base: "https://generativelanguage.googleapis.com",
+                path: "/v1beta/models?pageSize=1000",
+                auth: Auth::GoogleKey,
+                body: BodyShape::ModelsName,
+            },
+        }
+    }
+
+    fn parse(&self, body: &[u8]) -> Result<Vec<String>, CatalogError> {
+        let unparseable = || {
+            CatalogError::Upstream(
+                "the provider's answer was not a model list Agento understands".into(),
+            )
+        };
+        match self.body {
+            BodyShape::DataId => {
+                let parsed: DataIdBody = serde_json::from_slice(body).map_err(|_| unparseable())?;
+                Ok(parsed.data.into_iter().map(|m| m.id).collect())
+            }
+            BodyShape::ModelsName => {
+                let parsed: ModelsNameBody =
+                    serde_json::from_slice(body).map_err(|_| unparseable())?;
+                Ok(parsed
+                    .models
+                    .into_iter()
+                    // `models/gemini-2.5-pro` is a resource path; the id a
+                    // request carries is the last segment, and storing the
+                    // prefix would produce an alias that 404s upstream — the
+                    // exact failure this issue exists to remove.
+                    .map(|m| m.name.rsplit('/').next().unwrap_or_default().to_string())
+                    .collect())
+            }
+        }
+    }
+}
+
+/// Unknown fields are ignored on purpose: a catalog carries pricing, context
+/// windows and capability flags this route deliberately does not answer with,
+/// and a provider adding one must not turn the list into an error.
+#[derive(Deserialize)]
+struct DataIdBody {
+    #[serde(default)]
+    data: Vec<DataIdEntry>,
+}
+
+#[derive(Deserialize)]
+struct DataIdEntry {
+    #[serde(default)]
+    id: String,
+}
+
+#[derive(Deserialize)]
+struct ModelsNameBody {
+    #[serde(default)]
+    models: Vec<ModelsNameEntry>,
+}
+
+#[derive(Deserialize)]
+struct ModelsNameEntry {
+    #[serde(default)]
+    name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn body_of(shape: BodyShape, raw: &str) -> Result<Vec<String>, CatalogError> {
+        Shape {
+            default_base: "",
+            path: "",
+            auth: Auth::Bearer,
+            body: shape,
+        }
+        .parse(raw.as_bytes())
+    }
+
+    #[test]
+    fn an_openai_shaped_catalog_yields_its_ids_in_order() {
+        let ids = body_of(
+            BodyShape::DataId,
+            r#"{"object":"list","data":[{"id":"gpt-4o-2024-11-20","object":"model"},
+                {"id":"gpt-4o-mini","created":1}]}"#,
+        )
+        .expect("parses");
+        assert_eq!(ids, ["gpt-4o-2024-11-20", "gpt-4o-mini"]);
+    }
+
+    /// Gemini names a model by its **resource path**. Keeping the prefix would
+    /// store `models/gemini-2.5-pro` as an alias target, which is precisely the
+    /// upstream-404-at-request-time this feature exists to prevent.
+    #[test]
+    fn a_gemini_name_is_reduced_to_the_id_a_request_carries() {
+        let ids = body_of(
+            BodyShape::ModelsName,
+            r#"{"models":[{"name":"models/gemini-2.5-pro","displayName":"Gemini"},
+                {"name":"models/gemini-2.5-flash"}]}"#,
+        )
+        .expect("parses");
+        assert_eq!(ids, ["gemini-2.5-pro", "gemini-2.5-flash"]);
+    }
+
+    /// A catalog carries pricing and capability metadata this route does not
+    /// answer with; a provider adding a field must not turn the list into an
+    /// error.
+    #[test]
+    fn unknown_fields_and_a_missing_list_are_both_tolerated() {
+        assert_eq!(
+            body_of(BodyShape::DataId, r#"{"data":[{"id":"a","nonesuch":{}}]}"#).unwrap(),
+            ["a"]
+        );
+        assert_eq!(
+            body_of(BodyShape::DataId, r#"{"object":"list"}"#).unwrap(),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn a_body_that_is_not_a_catalog_is_an_upstream_error_naming_no_value() {
+        let err = body_of(BodyShape::DataId, "<html>nope</html>").unwrap_err();
+        assert!(matches!(err, CatalogError::Upstream(_)));
+        assert!(!err.message().contains("html"), "{}", err.message());
+    }
+
+    /// The three bases each provider type falls back to must be ones the guard
+    /// itself accepts — a default that `Base::new` refuses would make every
+    /// row without an explicit `base_url` unaskable, and nothing else would say
+    /// so.
+    #[test]
+    fn every_default_base_survives_the_base_guard() {
+        for provider_type in [
+            ProviderType::Openai,
+            ProviderType::Glm,
+            ProviderType::Anthropic,
+            ProviderType::Gemini,
+        ] {
+            let shape = Shape::of(provider_type);
+            let base = Base::new(shape.default_base)
+                .unwrap_or_else(|e| panic!("{} base refused: {e:?}", provider_type.as_str()));
+            assert!(
+                base.resolve(shape.path).is_some(),
+                "{} path {} did not resolve",
+                provider_type.as_str(),
+                shape.path,
+            );
+        }
+    }
+
+    /// The guard's whole point, at this call site: a stored base carrying a dot
+    /// segment resolves somewhere other than it reads, so no request is built
+    /// at all rather than one carrying the API key there.
+    ///
+    /// It is refused by `Base::new` — `url` removes the dot segment while
+    /// nothing else does, so the rendered path differs from the raw text and
+    /// that *is* `Mismatch::PathEncoding` — which is why `fetch` maps both
+    /// `new` and `resolve` to the same `Unaskable`: which of the two notices is
+    /// an implementation detail of the guard, and a caller that only handled
+    /// `resolve` would let this through the day the other stopped catching it.
+    #[test]
+    fn a_base_with_a_dot_segment_is_refused_rather_than_followed() {
+        assert!(Base::new("https://api.openai.com/v1/..").is_err());
+    }
+}

--- a/src-tauri/src/native/gateway_api/catalog.rs
+++ b/src-tauri/src/native/gateway_api/catalog.rs
@@ -72,6 +72,38 @@ const TIMEOUT: Duration = Duration::from_secs(10);
 /// pointing at something enormous cannot buffer it into this process.
 const MAX_BYTES: usize = 2 * 1024 * 1024;
 
+/// The one client every catalog fetch goes through.
+///
+/// **Built once**, like `github::client`'s and for the same two reasons: a
+/// `reqwest::Client` owns a connection pool, and `build()` reads the *platform*
+/// trust store — so constructing one per request throws the pool away and
+/// re-parses every root certificate on the machine on each keystroke-adjacent
+/// interaction. It answers `Option` rather than panicking because that store can
+/// be unusable, which `build()` reports as a **builder** error reachable with no
+/// network at all.
+///
+/// **Redirects are refused, and that is a credential decision rather than a
+/// preference.** `base_url` is typed by a person and [`Base`] checks where the
+/// *first* request goes; a redirect moves it afterwards, which is precisely the
+/// hole that guard cannot see. `reqwest` strips `Authorization` on a cross-origin
+/// redirect — and strips nothing else, so a `302` would carry `x-api-key` and
+/// `x-goog-api-key` to whatever host answered it. A list endpoint has no
+/// legitimate need to redirect, so a `3xx` falls through to the non-success arm
+/// and is reported as the status it is, which is both safe and actionable.
+fn client() -> Option<&'static reqwest::Client> {
+    static CLIENT: std::sync::OnceLock<Option<reqwest::Client>> = std::sync::OnceLock::new();
+    CLIENT
+        .get_or_init(|| {
+            reqwest::Client::builder()
+                .timeout(TIMEOUT)
+                .redirect(reqwest::redirect::Policy::none())
+                .build()
+                .map_err(|e| log::warn!("gateway model catalog: no usable HTTP client: {e}"))
+                .ok()
+        })
+        .as_ref()
+}
+
 /// Why a catalog could not be produced.
 ///
 /// `message` is what the UI renders, so it names a cause and never a value:
@@ -129,13 +161,9 @@ pub async fn fetch(row: &ProviderRow) -> Result<Vec<String>, CatalogError> {
         )
     })?;
 
-    let client = reqwest::Client::builder()
-        .timeout(TIMEOUT)
-        .build()
-        // `reqwest` loads the platform trust store inside `build()` and reports
-        // an unusable one as a *builder* error, so this is reachable without any
-        // network at all — see `native/integrations/github/client.rs`.
-        .map_err(|_| CatalogError::Unaskable("no usable TLS trust store on this machine".into()))?;
+    let client = client().ok_or_else(|| {
+        CatalogError::Unaskable("no usable TLS trust store on this machine".into())
+    })?;
 
     let request = match shape.auth {
         Auth::Bearer => client.get(url).bearer_auth(key),

--- a/src-tauri/src/native/mod.rs
+++ b/src-tauri/src/native/mod.rs
@@ -242,8 +242,15 @@ pub struct StreamRequest {
 
 pub type BoxFuture<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output = T> + Send + 'a>>;
 
-/// Areas whose answer streams. Only chat execution, and likely only ever.
-const STREAM_ENDPOINTS: &[StreamEndpoint] = &[chat::ENDPOINT];
+/// Areas the **async** registry answers.
+///
+/// Chat execution, whose answer genuinely streams — and, since #470, one route
+/// whose answer does not: `GET /api/gateway/providers/{id}/models` makes an
+/// outbound HTTPS call, which the buffered registry's sync `fn` on
+/// `spawn_blocking` is the wrong shape for. Returning a finished body from the
+/// async registry is a smaller change than putting a runtime in front of the
+/// blocking one; see `gateway_api::CATALOG_ROUTE`.
+const STREAM_ENDPOINTS: &[StreamEndpoint] = &[chat::ENDPOINT, gateway_api::STREAM_ENDPOINT];
 
 /// Whether this request is answered by a *streaming* native handler.
 pub fn claims_stream(method: &Method, path: &str) -> bool {

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -331,6 +331,258 @@ export function Dropdown({
   );
 }
 
+/* --- Combobox ------------------------------------------------------------ */
+
+/**
+ * A text field with a filtered list of suggestions — an **open** set, where
+ * `Dropdown` above is a closed one.
+ *
+ * The distinction is the whole reason this exists rather than a `Dropdown` with
+ * an extra prop. A `Dropdown`'s value must be one of its options; here the
+ * options are only a *catalog*, and a value that is not in the list is a
+ * first-class answer — a model released this morning, a fine-tune id, a
+ * provider whose list endpoint this build could not reach. So the value lives in
+ * the input, `onChange` fires on every keystroke exactly as the plain `<input>`
+ * this replaces did, and picking a suggestion is a shortcut rather than the only
+ * route. Nothing here can reject what the user typed.
+ *
+ * With no options it is deliberately indistinguishable from that plain input:
+ * the menu never opens and no chevron is drawn, which is what lets a caller
+ * degrade to free text by passing an empty list rather than by branching.
+ */
+export function Combobox({
+  value,
+  options,
+  onChange,
+  placeholder,
+  className,
+  disabled,
+  ariaLabel,
+}: {
+  value: string;
+  /** Suggestions. Empty means "behave as a plain text field". */
+  options: string[];
+  onChange(v: string): void;
+  placeholder?: string;
+  className?: string;
+  disabled?: boolean;
+  ariaLabel?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [active, setActive] = useState(-1);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState<{
+    left: number;
+    top: number;
+    minWidth: number;
+    maxHeight: number;
+    up: boolean;
+  }>();
+
+  // Filtered by what is typed, case-insensitively and as a substring rather
+  // than a prefix — model ids are versioned and vendor-prefixed, so the part a
+  // user remembers ("sonnet", "4o") is rarely at the front.
+  const needle = value.trim().toLowerCase();
+  const matches = needle
+    ? options.filter((o) => o.toLowerCase().includes(needle))
+    : options;
+
+  const close = useCallback(() => setOpen(false), []);
+
+  const openMenu = useCallback(() => {
+    const el = wrapRef.current;
+    if (!el || options.length === 0) return;
+    const r = el.getBoundingClientRect();
+    const below = window.innerHeight - r.bottom - 8;
+    const above = r.top - 8;
+    const up = below < 160 && above > below;
+    setPos({
+      left: Math.max(4, Math.min(r.left, window.innerWidth - r.width - 4)),
+      top: up ? r.top - 4 : r.bottom + 4,
+      minWidth: r.width,
+      maxHeight: Math.min(320, up ? above : below),
+      up,
+    });
+    setActive(-1);
+    setOpen(true);
+  }, [options.length]);
+
+  // Same portal rules as Dropdown: "outside" spans the trigger and the menu,
+  // and any scroll or resize underneath would strand the menu.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      const t = e.target as Node;
+      if (menuRef.current?.contains(t) || wrapRef.current?.contains(t)) return;
+      close();
+    };
+    const onScroll = (e: Event) => {
+      if (menuRef.current?.contains(e.target as Node)) return;
+      close();
+    };
+    document.addEventListener("mousedown", onDown);
+    window.addEventListener("scroll", onScroll, true);
+    window.addEventListener("resize", close);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      window.removeEventListener("scroll", onScroll, true);
+      window.removeEventListener("resize", close);
+    };
+  }, [open, close]);
+
+  // A filter that empties the list leaves an open menu with nothing in it, and
+  // an active index pointing past the end.
+  useEffect(() => {
+    if (open && matches.length === 0) close();
+    setActive((i) => (i >= matches.length ? matches.length - 1 : i));
+  }, [matches.length, open, close]);
+
+  useEffect(() => {
+    if (!open || active < 0) return;
+    menuRef.current
+      ?.querySelector(`[data-index="${active}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [open, active]);
+
+  function pick(v: string) {
+    setOpen(false);
+    onChange(v);
+    inputRef.current?.focus();
+  }
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      // Only swallow Escape when there is a menu to close, so it still reaches
+      // whatever the field sits inside.
+      if (open) {
+        e.preventDefault();
+        close();
+      }
+      return;
+    }
+    if (!open) {
+      if (e.key === "ArrowDown" && matches.length > 0) {
+        e.preventDefault();
+        openMenu();
+      }
+      return;
+    }
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setActive((i) => Math.min(matches.length - 1, i + 1));
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setActive((i) => Math.max(0, i - 1));
+        break;
+      case "Enter":
+        // Enter commits the highlighted suggestion, and otherwise does
+        // nothing but close — what is typed is already the value, so
+        // "confirming" it must never rewrite it to the nearest match.
+        if (active >= 0 && matches[active]) {
+          e.preventDefault();
+          pick(matches[active]);
+        } else {
+          close();
+        }
+        break;
+      case "Tab":
+        close();
+        break;
+    }
+  };
+
+  return (
+    <>
+      <div
+        ref={wrapRef}
+        className={`combo ${options.length > 0 ? "combo--suggesting" : ""} ${
+          className ?? ""
+        }`}
+      >
+        <input
+          ref={inputRef}
+          className="field mono combo__input"
+          value={value}
+          placeholder={placeholder}
+          disabled={disabled}
+          aria-label={ariaLabel}
+          role="combobox"
+          aria-expanded={open}
+          aria-autocomplete="list"
+          onChange={(e) => {
+            onChange(e.target.value);
+            if (!open) openMenu();
+          }}
+          onFocus={openMenu}
+          onKeyDown={onKeyDown}
+        />
+        {options.length > 0 && (
+          <button
+            type="button"
+            className="combo__chevron"
+            tabIndex={-1}
+            disabled={disabled}
+            aria-label="Show model ids"
+            onClick={() => (open ? close() : (inputRef.current?.focus(), openMenu()))}
+          >
+            <Icon name="chevronUD" size={12} />
+          </button>
+        )}
+      </div>
+
+      {open &&
+        pos &&
+        matches.length > 0 &&
+        createPortal(
+          <div
+            ref={menuRef}
+            className="menu dropdown__menu scroll"
+            role="listbox"
+            style={{
+              left: pos.left,
+              ...(pos.up
+                ? { bottom: window.innerHeight - pos.top }
+                : { top: pos.top }),
+              minWidth: pos.minWidth,
+              maxHeight: pos.maxHeight,
+            }}
+          >
+            {matches.map((o, i) => (
+              <button
+                key={o}
+                type="button"
+                role="option"
+                data-index={i}
+                aria-selected={o === value}
+                className={`dropdown__item mono ${
+                  i === active ? "dropdown__item--active" : ""
+                }`}
+                onMouseEnter={() => setActive(i)}
+                // `mousedown` rather than `click`: the input's blur would
+                // otherwise close the menu and unmount the row before the click
+                // landed on it.
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  pick(o);
+                }}
+              >
+                <span className="dropdown__check">
+                  {o === value && <Icon name="check" size={11} />}
+                </span>
+                <span className="truncate">{o}</span>
+              </button>
+            ))}
+          </div>,
+          document.body
+        )}
+    </>
+  );
+}
+
 /* --- Draggable splitter -------------------------------------------------- */
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -747,6 +747,21 @@ export interface GatewayProviderSummary {
 }
 
 /**
+ * `GET /api/gateway/providers/{id}/models` (#470) — the model ids that
+ * provider's own upstream reports.
+ *
+ * **Ids and nothing else.** No pricing, no context window, no capability flags,
+ * and above all nothing of the upstream's own body: the route answers the one
+ * thing it was asked. Always an array — this route has no Go ancestor and
+ * always sends `[]` rather than the `null` an empty Go slice would have
+ * produced — and the list is a *suggestion*, so a target's `model_id` is never
+ * constrained to it.
+ */
+export interface GatewayProviderModels {
+  models: string[];
+}
+
+/**
  * A provider write.
  *
  * `api_key` is three-valued and this is the field the whole surface is built

--- a/src/styles/controls.css
+++ b/src/styles/controls.css
@@ -280,6 +280,46 @@ textarea.field-area:focus {
   place-items: center;
 }
 
+/* --- Combobox ------------------------------------------------------------ */
+
+/* An open set, where .select is a closed one: the value lives in a real text
+   input and the list only suggests. So the surface is .field's — the same
+   inset hairline and focus ring every other typed field wears — rather than
+   .select's raised one, because what it *is* is a text field. It reuses
+   .dropdown__menu for the popup, since a suggestion list and a select menu are
+   the same object on screen. */
+.combo {
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+.combo__input {
+  flex: 1;
+  min-width: 0;
+}
+/* Room for the chevron, but only when one is drawn — with no suggestions the
+   control is a plain field and must look like one. A modifier rather than
+   `:has(.combo__chevron)`, which WebKitGTK only learned recently and this app
+   ships against whatever GTK the distro has. */
+.combo--suggesting .combo__input {
+  padding-right: var(--sp-8);
+}
+.combo__chevron {
+  position: absolute;
+  right: var(--sp-4);
+  display: grid;
+  place-items: center;
+  color: var(--fg-tertiary);
+}
+.combo__chevron:hover {
+  color: var(--fg-secondary);
+}
+.combo__chevron:disabled {
+  opacity: 0.45;
+  pointer-events: none;
+}
+
 /* --- Switch -------------------------------------------------------------- */
 .switch {
   /* Flex, not the button default: the knob is a <span>, and an inline span

--- a/src/styles/gateway.css
+++ b/src/styles/gateway.css
@@ -127,14 +127,30 @@
 /* --- The ordered target rows on Models ------------------------------------ */
 
 .gw-target {
+  padding: var(--sp-3) 0;
+}
+
+/* The controls are one row; the degraded-catalog note (#470) sits under them,
+   so the row keeps its 28px rhythm whether or not a note is present. */
+.gw-target__main {
   display: flex;
   align-items: center;
   gap: var(--sp-3);
-  padding: var(--sp-3) 0;
 }
 
 .gw-target + .gw-target {
   border-top: var(--hairline) solid var(--line);
+}
+
+/* A note, never an error: the model list is a suggestion and a provider that
+   could not be listed leaves the field exactly as usable as a plain one. So it
+   is styled like the section's own prose rather than like `.msgline--error`,
+   which would read as something the user has to fix before saving. */
+.gw-target__note {
+  margin: var(--sp-2) 0 0 calc(18px + var(--sp-3));
+  font-size: var(--text-xs);
+  line-height: var(--leading-relaxed);
+  color: var(--fg-quaternary);
 }
 
 /* The position, stated rather than implied — the order *is* the fallback

--- a/src/views/gateway/ModelsView.tsx
+++ b/src/views/gateway/ModelsView.tsx
@@ -1,10 +1,19 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../../lib/api";
-import { Dropdown, Empty, FormRow, Search, Splitter, Switch } from "../../components/ui";
+import {
+  Combobox,
+  Dropdown,
+  Empty,
+  FormRow,
+  Search,
+  Splitter,
+  Switch,
+} from "../../components/ui";
 import { Icon } from "../../lib/icons";
 import { describeError, useResource } from "../../lib/hooks";
 import type {
   GatewayModelAlias,
+  GatewayProviderModels,
   GatewayProviderSummary,
   GatewayRouteTarget,
 } from "../../lib/types";
@@ -30,6 +39,72 @@ import "../../styles/gateway.css";
 
 type Selection = { kind: "none" } | { kind: "new" } | { kind: "row"; id: string };
 
+/** What is known about one provider's upstream model catalog (#470). */
+type Catalog =
+  | { state: "loading" }
+  | { state: "ready"; models: string[] }
+  | { state: "failed"; message: string };
+
+/**
+ * Fetch each provider's model catalog **once per view mount**, on demand.
+ *
+ * Three properties, each of them an acceptance criterion rather than a
+ * nicety:
+ *
+ * - **Never on the save path.** This is driven by rendering a target row, not
+ *   by submitting the form, so a slow upstream delays a suggestion list and
+ *   nothing else. Saving does not read it at all.
+ * - **Once per provider.** `asked` is a ref rather than state precisely because
+ *   it must not re-trigger a render — several target rows can name the same
+ *   provider, and each of them asks on every keystroke in a sibling field.
+ * - **A failure is a value, not a throw.** Every outcome lands in the map, so a
+ *   provider that could not be listed is a *known* empty rather than a request
+ *   retried forever.
+ *
+ * Nothing is cached beyond the mount, which is what the issue's "in-memory per
+ * session at most" asks for: a key or base URL edited in the Providers tab is
+ * picked up the next time this view is opened.
+ */
+function useProviderCatalogs() {
+  const [catalogs, setCatalogs] = useState<Record<string, Catalog>>({});
+  const asked = useRef<Set<string>>(new Set());
+  // A response arriving after the view closed must not set state on an
+  // unmounted tree.
+  const alive = useRef(true);
+  useEffect(() => {
+    alive.current = true;
+    return () => {
+      alive.current = false;
+    };
+  }, []);
+
+  const request = useCallback((providerId: string) => {
+    if (!providerId || asked.current.has(providerId)) return;
+    asked.current.add(providerId);
+    setCatalogs((c) => ({ ...c, [providerId]: { state: "loading" } }));
+    api
+      .get<GatewayProviderModels>(
+        `/gateway/providers/${encodeURIComponent(providerId)}/models`
+      )
+      .then((r) => {
+        if (!alive.current) return;
+        setCatalogs((c) => ({
+          ...c,
+          [providerId]: { state: "ready", models: r.models ?? [] },
+        }));
+      })
+      .catch((err) => {
+        if (!alive.current) return;
+        setCatalogs((c) => ({
+          ...c,
+          [providerId]: { state: "failed", message: describeError(err) },
+        }));
+      });
+  }, []);
+
+  return { catalogs, request };
+}
+
 export function GatewayModelsView({ inspectorOpen }: { inspectorOpen: boolean }) {
   const aliases = useResource<GatewayModelAlias[] | null>(
     (signal) => api.get("/gateway/models", signal),
@@ -41,10 +116,12 @@ export function GatewayModelsView({ inspectorOpen }: { inspectorOpen: boolean })
   );
 
   const rows = useMemo(() => aliases.data ?? [], [aliases.data]);
+  const providerRows = useMemo(() => providers.data ?? [], [providers.data]);
   const providerNames = useMemo(
-    () => (providers.data ?? []).map((p) => p.name),
-    [providers.data]
+    () => providerRows.map((p) => p.name),
+    [providerRows]
   );
+  const catalogs = useProviderCatalogs();
 
   const [query, setQuery] = useState("");
   const [selection, setSelection] = useState<Selection>({ kind: "none" });
@@ -161,7 +238,8 @@ export function GatewayModelsView({ inspectorOpen }: { inspectorOpen: boolean })
           <AliasForm
             key="new"
             alias={undefined}
-            providerNames={providerNames}
+            providers={providerRows}
+            catalogs={catalogs}
             onDone={(id) => {
               aliases.reload();
               setSelection({ kind: "row", id });
@@ -173,7 +251,8 @@ export function GatewayModelsView({ inspectorOpen }: { inspectorOpen: boolean })
           <AliasForm
             key={selected.id}
             alias={selected}
-            providerNames={providerNames}
+            providers={providerRows}
+            catalogs={catalogs}
             onDone={() => aliases.reload()}
             onDeleted={() => {
               setSelection({ kind: "none" });
@@ -216,13 +295,15 @@ export function GatewayModelsView({ inspectorOpen }: { inspectorOpen: boolean })
 
 function AliasForm({
   alias,
-  providerNames,
+  providers,
+  catalogs,
   onDone,
   onDeleted,
   onCancel,
 }: {
   alias: GatewayModelAlias | undefined;
-  providerNames: string[];
+  providers: GatewayProviderSummary[];
+  catalogs: ReturnType<typeof useProviderCatalogs>;
   onDone(id: string): void;
   onDeleted?(): void;
   onCancel?(): void;
@@ -397,7 +478,8 @@ function AliasForm({
             title="Targets"
             caption="Tried in order — the first is preferred, the rest are used when it fails."
             targets={targets}
-            providerNames={providerNames}
+            providers={providers}
+            catalogs={catalogs}
             onChange={setTargets}
           />
 
@@ -407,7 +489,8 @@ function AliasForm({
             title="Fallbacks"
             caption="Walked only after every target above has failed. Optional."
             targets={fallbacks}
-            providerNames={providerNames}
+            providers={providers}
+            catalogs={catalogs}
             onChange={setFallbacks}
           />
         </div>
@@ -450,15 +533,18 @@ function TargetList({
   title,
   caption,
   targets,
-  providerNames,
+  providers,
+  catalogs,
   onChange,
 }: {
   title: string;
   caption: string;
   targets: GatewayRouteTarget[];
-  providerNames: string[];
+  providers: GatewayProviderSummary[];
+  catalogs: ReturnType<typeof useProviderCatalogs>;
   onChange(next: GatewayRouteTarget[]): void;
 }) {
+  const providerNames = providers.map((p) => p.name);
   const options = providerNames.map((n) => ({ value: n, label: n }));
 
   function move(index: number, delta: number) {
@@ -479,53 +565,21 @@ function TargetList({
       )}
 
       {targets.map((t, i) => (
-        <div className="gw-target" key={i}>
-          <span className="gw-target__ord tnum">{i + 1}</span>
-          <Dropdown
-            value={t.provider}
-            options={options}
-            placeholder="Provider"
-            onChange={(v) =>
-              onChange(targets.map((x, j) => (j === i ? { ...x, provider: v } : x)))
-            }
-            className="gw-target__provider"
-          />
-          <input
-            className="field mono gw-target__model"
-            value={t.model_id}
-            placeholder="upstream model id"
-            onChange={(e) =>
-              onChange(
-                targets.map((x, j) =>
-                  j === i ? { ...x, model_id: e.target.value } : x
-                )
-              )
-            }
-          />
-          <button
-            className="iconbtn"
-            title="Move up"
-            disabled={i === 0}
-            onClick={() => move(i, -1)}
-          >
-            <Icon name="arrowUp" size={13} />
-          </button>
-          <button
-            className="iconbtn"
-            title="Move down"
-            disabled={i === targets.length - 1}
-            onClick={() => move(i, 1)}
-          >
-            <Icon name="arrowDown" size={13} />
-          </button>
-          <button
-            className="iconbtn"
-            title="Remove"
-            onClick={() => onChange(targets.filter((_, j) => j !== i))}
-          >
-            <Icon name="close" size={13} />
-          </button>
-        </div>
+        <TargetRow
+          key={i}
+          target={t}
+          providers={providers}
+          providerOptions={options}
+          catalogs={catalogs}
+          first={i === 0}
+          last={i === targets.length - 1}
+          ordinal={i + 1}
+          onChange={(next) =>
+            onChange(targets.map((x, j) => (j === i ? next : x)))
+          }
+          onMove={(delta) => move(i, delta)}
+          onRemove={() => onChange(targets.filter((_, j) => j !== i))}
+        />
       ))}
 
       <div className="row">
@@ -543,6 +597,112 @@ function TargetList({
           Add {title.toLowerCase().replace(/s$/, "")}
         </button>
       </div>
+    </div>
+  );
+}
+
+/**
+ * One routing target: which provider, and which of that provider's models.
+ *
+ * Its own component because the model field has to *ask* — a row that names a
+ * provider requests that provider's catalog on mount and whenever the provider
+ * changes, which needs an effect, and an effect cannot live inside a `.map`.
+ *
+ * **The model id is never constrained to the catalog.** The list is a
+ * suggestion: an id typed by hand is saved verbatim, whether or not the fetch
+ * succeeded, whether or not it returned anything, and whether or not the typed
+ * value appears in it. That is what `Combobox` is for, and it is why the
+ * failure path below is a *note* rather than an error — a provider whose list
+ * endpoint cannot be reached must leave the row exactly as usable as it was
+ * before this feature existed.
+ */
+function TargetRow({
+  target,
+  providers,
+  providerOptions,
+  catalogs,
+  first,
+  last,
+  ordinal,
+  onChange,
+  onMove,
+  onRemove,
+}: {
+  target: GatewayRouteTarget;
+  providers: GatewayProviderSummary[];
+  providerOptions: { value: string; label: string }[];
+  catalogs: ReturnType<typeof useProviderCatalogs>;
+  first: boolean;
+  last: boolean;
+  ordinal: number;
+  onChange(next: GatewayRouteTarget): void;
+  onMove(delta: number): void;
+  onRemove(): void;
+}) {
+  // A target names its provider by **name**; the catalog route is keyed by row
+  // id. A name with no matching row is possible — an alias stored before a
+  // provider was renamed — and simply has no catalog, which is the same
+  // degraded state a failed fetch produces.
+  const providerId = providers.find((p) => p.name === target.provider)?.id ?? "";
+  const { catalogs: known, request } = catalogs;
+
+  useEffect(() => {
+    request(providerId);
+  }, [providerId, request]);
+
+  const catalog = known[providerId];
+  const models = catalog?.state === "ready" ? catalog.models : [];
+
+  // Only ever a *note*, never an error: nothing here can stop a save.
+  const note =
+    catalog?.state === "failed"
+      ? `Could not list this provider's models — type the id. (${catalog.message})`
+      : catalog?.state === "ready" && catalog.models.length === 0
+        ? "This provider returned no models — type the id."
+        : undefined;
+
+  return (
+    <div className="gw-target">
+      <div className="gw-target__main">
+        <span className="gw-target__ord tnum">{ordinal}</span>
+        <Dropdown
+          value={target.provider}
+          options={providerOptions}
+          placeholder="Provider"
+          onChange={(v) => onChange({ ...target, provider: v })}
+          className="gw-target__provider"
+        />
+        <Combobox
+          value={target.model_id}
+          options={models}
+          ariaLabel="Upstream model id"
+          placeholder={
+            catalog?.state === "loading" ? "loading models…" : "upstream model id"
+          }
+          onChange={(v) => onChange({ ...target, model_id: v })}
+          className="gw-target__model"
+        />
+        <button
+          className="iconbtn"
+          title="Move up"
+          disabled={first}
+          onClick={() => onMove(-1)}
+        >
+          <Icon name="arrowUp" size={13} />
+        </button>
+        <button
+          className="iconbtn"
+          title="Move down"
+          disabled={last}
+          onClick={() => onMove(1)}
+        >
+          <Icon name="arrowDown" size={13} />
+        </button>
+        <button className="iconbtn" title="Remove" onClick={onRemove}>
+          <Icon name="close" size={13} />
+        </button>
+      </div>
+      {note && <p className="gw-target__note truncate" title={note}>{note}</p>}
     </div>
   );
 }


### PR DESCRIPTION
Closes #470

## What

`LLM Gateway → Models` renders a routing target's `model_id` as free text with `placeholder="upstream model id"`. Nothing validates it at save time, so a typo in a long versioned string — a wrong date suffix on `gpt-4o-2024-11-20`, a dropped digit in `claude-sonnet-4-6` — is stored happily and surfaces as an upstream 404 the first time something routes through that alias, far from the action that caused it.

Now: pick a provider on a target row and the model box fills itself from **that provider's live catalog**, filterable by typing. Typing an id by hand still works, always.

## How

**`GET /api/gateway/providers/{id}/models`** (`native/gateway_api.rs` + new `gateway_api/catalog.rs`). Loads one provider row through `config`'s **secret** projection and asks that provider's own list endpoint, per type:

| type | base (from the row, else this default) | path | auth |
|---|---|---|---|
| `openai`, `glm` | `https://api.openai.com/v1` | `/models` | `Authorization: Bearer` |
| `anthropic` | `https://api.anthropic.com` | `/v1/models?limit=1000` | `x-api-key` + `anthropic-version` |
| `gemini` | `https://generativelanguage.googleapis.com` | `/v1beta/models?pageSize=1000` | `x-goog-api-key` |

Those paths come from what the **completions** call already does with the same column, not from the issue's sketch — a stored `base_url` has to work for both, and ferrox appends `/v1/messages` to Anthropic's base and `/chat/completions` to OpenAI's, so the two conventions differ. `gemini` uses the header form rather than `?key=` so the credential is never in a URL.

Three things about it are deliberate:

- **It is on the async registry.** `Endpoint::serve` is a sync `fn` the proxy runs on `spawn_blocking` — right for thirteen areas that read SQLite, wrong for an outbound HTTPS call. `StreamEndpoint` is already async and nothing obliges it to stream, so it returns a buffered body. The route stays in `gateway_api::ROUTES` (that const is what `parity/desktop_routes.json` is asserted against as **set equality**) and the buffered `claims` excludes it, so exactly one registry answers it.
- **The stored `base_url` goes through `integrations::base_url::Base`.** It is user-typed input reaching a URL: `url::Url::parse` applies WHATWG dot-segment removal where nothing else here does, so `…/v1/..` would send the API key to an endpoint the user did not configure. One adaptation — trailing slashes are trimmed first, because `Base` concatenates for two callers that port Go and there is no Go here.
- **Ids only leave the module.** Not the key, not the resolved URL, not the upstream body. `401` becomes "the provider answered 401"; a transport failure is not `{e}`, because a `reqwest::Error`'s `Display` carries the URL.

Statuses: `404` unknown provider · `400` unaskable (no key, or a base URL this build refuses — answered *before* any request is built) · `502` upstream refused/unreachable/unparseable.

**UI.** `Combobox` beside `Dropdown` in `components/ui.tsx` — an **open** set where that one is closed. The value lives in a real `<input>`, `onChange` fires per keystroke exactly as the plain field did, and a suggestion is a shortcut rather than the only route; with no options it is indistinguishable from the input it replaces, which is how the degraded path works without branching. `ModelsView` fetches per provider once per view mount, driven by rendering a target row rather than by saving, and a failure lands as a **note** under the row that cannot block a save.

## Tests

Rust, against a loopback fake upstream — the seam is a *parameter* (a gateway base URL comes out of the row), so nothing test-only ships:

- `every_provider_type_is_asked_the_way_its_own_api_expects` — all four types: the target built, the auth headers, the ids parsed, and that gemini's `models/x` resource path is reduced to `x`.
- `the_catalog_answer_carries_no_api_key_and_no_upstream_body` — asserted over the **bytes**, with the fake echoing the key back in its own body. Sibling of `a_scrubbed_read_written_straight_back_preserves_the_stored_key`.
- `an_upstream_refusal_is_a_502_naming_the_status_and_nothing_else` — no key, no base URL, no upstream body in the answer.
- `a_provider_with_no_key_…` / `a_base_url_that_resolves_elsewhere_is_refused_before_the_key_is_sent` — both assert **no request was sent**, so removing the guard fails them.
- `a_base_url_with_a_trailing_slash_reaches_the_same_endpoint`, `the_catalog_route_is_claimed_by_the_streaming_registry_alone`, `the_catalog_id_is_one_segment_and_nothing_else`, plus five parse-level cases in `catalog.rs`.
- `the_desktop_only_routes_are_recorded_in_both_directions` covers the route table by construction.

Reverting the guards fails the corresponding test in each case.

## Out of scope (per the issue)

No caching in SQLite (in-memory per view mount at most) · no validation or migration of already-stored aliases · ids only, no pricing/context-window metadata · `bedrock` is not compiled into this build.

## Docs

`docs/user-guide.md` → Defining an alias; `docs/troubleshooting.md` → "The model box on Models offers no list", enumerating each cause and stating that it never blocks a save.