### PR TITLE
feat(gateway): brand mark per provider row (#471)

### DIFF
--- a/src/components/BrandMark.tsx
+++ b/src/components/BrandMark.tsx
@@ -104,7 +104,7 @@ export type MarkKey =
 
 interface Mark {
   /** The monogram drawn in the tile, unless `icon` names a glyph instead. */
-  label: string;
+  label?: string;
   /** An icon from the house set — used only where no vendor is named. */
   icon?: IconName;
   /** One of `views.css`' existing `.avatar--*` tones. No new CSS. */
@@ -125,11 +125,18 @@ const MARKS: Record<MarkKey, Mark> = {
   mistral: { label: "MS", tone: "amber", title: "Mistral AI" },
   xai: { label: "XA", tone: "purple", title: "xAI" },
   fireworks: { label: "FW", tone: "red", title: "Fireworks AI" },
-  selfhosted: { label: "", icon: "cpu", tone: "teal", title: "Self-hosted endpoint" },
+  selfhosted: { icon: "cpu", tone: "teal", title: "Self-hosted endpoint" },
 };
 
-/** Hosts that are this machine. `new URL().hostname` keeps IPv6 bracketed. */
-const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "0.0.0.0", "[::1]", "::1"]);
+/**
+ * Hosts that mean "this machine". Two spellings to get right: `new URL()`
+ * serializes an IPv6 host **bracketed**, so `[::1]` is the only form that can
+ * ever reach here and a bare `::1` entry would be dead; and `0.0.0.0` is a
+ * bind-any address rather than a loopback one, but it is what a locally-run
+ * server's own printed URL often says, so it belongs in this set even though
+ * it makes the set wider than its name.
+ */
+const SELF_HOSTED_HOSTS = new Set(["localhost", "127.0.0.1", "0.0.0.0", "[::1]"]);
 
 /**
  * Suffixes that mean "somebody's own network". Note this is a *suffix* rule on
@@ -157,7 +164,7 @@ function hostOf(baseUrl: string): string | null {
 
 function isSelfHosted(host: string): boolean {
   return (
-    LOOPBACK_HOSTS.has(host) || SELF_HOSTED_SUFFIXES.some((s) => host.endsWith(s))
+    SELF_HOSTED_HOSTS.has(host) || SELF_HOSTED_SUFFIXES.some((s) => host.endsWith(s))
   );
 }
 
@@ -182,6 +189,8 @@ export function markFor(baseUrl: string, type: GatewayProviderType): MarkKey | n
   const host = hostOf(baseUrl);
   if (host === null) return typeMark(type);
   if (isSelfHosted(host)) return "selfhosted";
+  // First match wins; no two entries in the table can match one host today,
+  // and a new entry that overlaps an existing one has to be added above it.
   for (const domain of DOMAIN_KEYS) {
     if (host === domain || host.endsWith(`.${domain}`)) return DOMAIN_MARKS[domain];
   }
@@ -197,8 +206,8 @@ export function markFor(baseUrl: string, type: GatewayProviderType): MarkKey | n
    domains rather than hosts (which is the subdomain-collapse rule's table
    half), that GLM's type fallback is Z.AI's mark and not its own, and that
    `markFor` still answers `null` for the no-mark case rather than a default.
-   What they cannot cover is `new URL()` at runtime — that half is verified by
-   running the app.
+   What they cannot cover is `new URL()` at runtime, so that half is verified by
+   exercising `markFor` directly — see the PR for the cases and their answers.
    ------------------------------------------------------------------------- */
 
 /** A host, not a registrable domain, must never be a key — `api.openai.com`
@@ -223,23 +232,21 @@ export type PinNoMarkIsNull = Expect<Eq<ReturnType<typeof markFor>, MarkKey | nu
  */
 export function BrandMark({
   provider,
-  size = 14,
 }: {
   provider: Pick<GatewayProviderSummary, "base_url" | "type">;
-  size?: number;
 }) {
   const key = markFor(provider.base_url, provider.type);
   if (key === null) {
     return (
       <div className="avatar avatar--accent">
-        <Icon name="database" size={size} />
+        <Icon name="database" size={14} />
       </div>
     );
   }
   const mark = MARKS[key];
   return (
     <div className={`avatar avatar--${mark.tone}`} title={mark.title}>
-      {mark.icon ? <Icon name={mark.icon} size={size} /> : mark.label}
+      {mark.icon ? <Icon name={mark.icon} size={14} /> : mark.label}
     </div>
   );
 }

--- a/src/components/BrandMark.tsx
+++ b/src/components/BrandMark.tsx
@@ -1,0 +1,245 @@
+/* ============================================================================
+   Provider brand marks (#471).
+
+   The LLM Gateway's Providers list drew the same `database` icon on every row,
+   so four upstreams read as four identical grey squares. This resolves a mark
+   per row instead — and the interesting part is what it is keyed on.
+
+   **The key is the registrable domain of `base_url`, not the provider type.**
+   `type` is one of four *adapter dialects*, so OpenRouter, Groq, Together,
+   DeepSeek and Fireworks all carry `type: "openai"` and would all show one
+   mark. The base URL is the thing that actually distinguishes them, and it is
+   not shown in the list at all.
+
+   **The marks are bundled and cost zero network requests.** The obvious
+   alternative — fetch the host's favicon, or ask a third-party favicon
+   service — is refused deliberately: `tauri.conf.json`'s CSP is `img-src 'self'
+   data: blob: asset: http://asset.localhost`, so a remote `<img>` is blocked
+   and the feature would have to *widen the CSP to arbitrary remote origins*
+   first. Beyond that it would make a settings pane phone out to third parties
+   on render, leaking the user's configured endpoints — private and
+   self-hosted hostnames included — to those hosts; and it breaks offline,
+   behind a proxy, and on any self-hosted endpoint with no favicon at all.
+
+   **The table is keyed on registrable domains and matched on a label
+   boundary**, so `api.openai.com` collapses onto `openai.com` while
+   `notopenai.com` does not. It is an allowlist rather than a computation
+   because correct eTLD+1 needs a public suffix list (the naive "last two
+   labels" rule is wrong for `api.foo.co.uk`), and shipping a PSL for a
+   decorative feature is not a trade worth making.
+
+   ## Adding a provider mark
+
+   1. Add the registrable domain to `DOMAIN_MARKS` (no subdomain — the match
+      already collapses those).
+   2. If it is a new vendor, give it a key in `MARKS`. `MarkKey` is *derived*
+      from the two tables, so `MARKS` being `Record<MarkKey, Mark>` makes `tsc`
+      fail until you do — that completeness check is the guard here, and it is
+      why the tables carry `as const satisfies`.
+   3. Leave the fallback chain alone: unknown domain falls back to the type
+      mark, and an unknown type falls back to the generic `database` icon. An
+      unlisted provider therefore degrades to something sensible and never to
+      an empty slot, which is what keeps this table additive and never urgent.
+
+   ## Why every vendor mark is a monogram
+
+   The refinement authorised two forms — a monochrome silhouette for marks
+   whose brand guidelines permit redistribution, a lettered monogram for any
+   that do not — and asked the implementing change to say which it used. This
+   uses **the monogram for every vendor**, and ships no vendor artwork at all.
+   Confirming redistribution terms for eleven separate trademark holders is not
+   something this change can do, and a hand-drawn approximation of a logo is
+   both the legally riskier option and the less legible one at 28px. Swapping
+   any one of them for a licensed silhouette later is a one-row edit: give that
+   `Mark` an `icon` (or an inline `<svg>`) instead of a `label`.
+
+   Only `selfhosted` is a glyph, and it is the house icon set's own `cpu` —
+   nobody's brand.
+   ========================================================================== */
+
+import type { Tone } from "../lib/format";
+import { Icon, type IconName } from "../lib/icons";
+import type { Eq, Expect } from "../lib/typeAssert";
+import type { GatewayProviderSummary, GatewayProviderType } from "../lib/types";
+
+/**
+ * Registrable domain → mark key. Matched on a label boundary, so every
+ * subdomain of a listed domain collapses onto the same mark.
+ */
+const DOMAIN_MARKS = {
+  "openai.com": "openai",
+  "anthropic.com": "anthropic",
+  "googleapis.com": "gemini",
+  "google.com": "gemini",
+  "z.ai": "zai",
+  "openrouter.ai": "openrouter",
+  "groq.com": "groq",
+  "together.ai": "together",
+  "together.xyz": "together",
+  "deepseek.com": "deepseek",
+  "mistral.ai": "mistral",
+  "x.ai": "xai",
+  "fireworks.ai": "fireworks",
+} as const satisfies Record<string, string>;
+
+/**
+ * The fallback when the base URL names no listed domain — including the empty
+ * base URL, which means "this provider's own default endpoint".
+ */
+const TYPE_MARKS = {
+  anthropic: "anthropic",
+  openai: "openai",
+  gemini: "gemini",
+  glm: "zai",
+} as const satisfies Record<GatewayProviderType, string>;
+
+/**
+ * Derived from the tables rather than declared, so a domain or type mapped to
+ * a mark that `MARKS` does not draw fails the build.
+ */
+export type MarkKey =
+  | (typeof DOMAIN_MARKS)[keyof typeof DOMAIN_MARKS]
+  | (typeof TYPE_MARKS)[keyof typeof TYPE_MARKS]
+  | "selfhosted";
+
+interface Mark {
+  /** The monogram drawn in the tile, unless `icon` names a glyph instead. */
+  label: string;
+  /** An icon from the house set — used only where no vendor is named. */
+  icon?: IconName;
+  /** One of `views.css`' existing `.avatar--*` tones. No new CSS. */
+  tone: Tone;
+  /** The tile's `title`, so the mark is readable as well as scannable. */
+  title: string;
+}
+
+const MARKS: Record<MarkKey, Mark> = {
+  openai: { label: "OA", tone: "green", title: "OpenAI" },
+  anthropic: { label: "AN", tone: "amber", title: "Anthropic" },
+  gemini: { label: "GE", tone: "accent", title: "Google Gemini" },
+  zai: { label: "ZA", tone: "purple", title: "Z.AI" },
+  openrouter: { label: "OR", tone: "teal", title: "OpenRouter" },
+  groq: { label: "GQ", tone: "red", title: "Groq" },
+  together: { label: "TG", tone: "green", title: "Together AI" },
+  deepseek: { label: "DS", tone: "accent", title: "DeepSeek" },
+  mistral: { label: "MS", tone: "amber", title: "Mistral AI" },
+  xai: { label: "XA", tone: "purple", title: "xAI" },
+  fireworks: { label: "FW", tone: "red", title: "Fireworks AI" },
+  selfhosted: { label: "", icon: "cpu", tone: "teal", title: "Self-hosted endpoint" },
+};
+
+/** Hosts that are this machine. `new URL().hostname` keeps IPv6 bracketed. */
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "0.0.0.0", "[::1]", "::1"]);
+
+/**
+ * Suffixes that mean "somebody's own network". Note this is a *suffix* rule on
+ * the whole host, so `llm.internal.acme.corp` is **not** self-hosted — it ends
+ * in `.corp` — and correctly falls through to the provider's type mark.
+ */
+const SELF_HOSTED_SUFFIXES = [".local", ".internal", ".lan", ".localdomain"];
+
+const DOMAIN_KEYS = Object.keys(DOMAIN_MARKS) as (keyof typeof DOMAIN_MARKS)[];
+
+/**
+ * A stored `base_url` is user-typed and need not parse — and an empty one is
+ * the ordinary case, meaning the provider's own default endpoint. Both answer
+ * `null`, which is what sends the caller to the type fallback.
+ */
+function hostOf(baseUrl: string): string | null {
+  const raw = baseUrl.trim();
+  if (raw === "") return null;
+  try {
+    return new URL(raw).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function isSelfHosted(host: string): boolean {
+  return (
+    LOOPBACK_HOSTS.has(host) || SELF_HOSTED_SUFFIXES.some((s) => host.endsWith(s))
+  );
+}
+
+/**
+ * `type` is `GatewayProviderType` on the wire, but the column is a string and
+ * a newer backend can hold a dialect this build does not know — so the lookup
+ * is guarded rather than indexed, and an unknown type answers `null`.
+ */
+function typeMark(type: GatewayProviderType): MarkKey | null {
+  return Object.prototype.hasOwnProperty.call(TYPE_MARKS, type)
+    ? TYPE_MARKS[type]
+    : null;
+}
+
+/**
+ * The whole keying rule, exported separately from the component so it can be
+ * pinned and reused (`ModelsView` / `UsageView` name providers too).
+ *
+ * `null` means "no mark applies" — the caller draws the generic icon.
+ */
+export function markFor(baseUrl: string, type: GatewayProviderType): MarkKey | null {
+  const host = hostOf(baseUrl);
+  if (host === null) return typeMark(type);
+  if (isSelfHosted(host)) return "selfhosted";
+  for (const domain of DOMAIN_KEYS) {
+    if (host === domain || host.endsWith(`.${domain}`)) return DOMAIN_MARKS[domain];
+  }
+  return typeMark(type);
+}
+
+/* ----------------------------------------------------------------------------
+   Type-level pins (see lib/typeAssert.ts). There is no TypeScript test harness
+   here, so `tsc --noEmit` is the whole frontend gate and a value that must not
+   drift is pinned by giving it a literal type and asserting it exactly.
+
+   What these cover is the *mapping*: that the table stays keyed on registrable
+   domains rather than hosts (which is the subdomain-collapse rule's table
+   half), that GLM's type fallback is Z.AI's mark and not its own, and that
+   `markFor` still answers `null` for the no-mark case rather than a default.
+   What they cannot cover is `new URL()` at runtime — that half is verified by
+   running the app.
+   ------------------------------------------------------------------------- */
+
+/** A host, not a registrable domain, must never be a key — `api.openai.com`
+ *  reaches `openai.com` through the label-boundary match instead. */
+export type PinDomainsAreRegistrable = Expect<
+  Eq<"api.openai.com" extends keyof typeof DOMAIN_MARKS ? true : false, false>
+>;
+
+/** The registrable domain both `https://api.openai.com/v1` and
+ *  `https://openai.com/v1` collapse onto. */
+export type PinOpenAiDomain = Expect<Eq<(typeof DOMAIN_MARKS)["openai.com"], "openai">>;
+
+/** An empty `base_url` keys on the type, and GLM's upstream is Z.AI. */
+export type PinGlmTypeFallback = Expect<Eq<(typeof TYPE_MARKS)["glm"], "zai">>;
+
+/** The unknown case is `null` — not a silently-chosen default mark. */
+export type PinNoMarkIsNull = Expect<Eq<ReturnType<typeof markFor>, MarkKey | null>>;
+
+/**
+ * The provider's tile: its brand mark, or the generic icon when nothing in the
+ * tables applies.
+ */
+export function BrandMark({
+  provider,
+  size = 14,
+}: {
+  provider: Pick<GatewayProviderSummary, "base_url" | "type">;
+  size?: number;
+}) {
+  const key = markFor(provider.base_url, provider.type);
+  if (key === null) {
+    return (
+      <div className="avatar avatar--accent">
+        <Icon name="database" size={size} />
+      </div>
+    );
+  }
+  const mark = MARKS[key];
+  return (
+    <div className={`avatar avatar--${mark.tone}`} title={mark.title}>
+      {mark.icon ? <Icon name={mark.icon} size={size} /> : mark.label}
+    </div>
+  );
+}

--- a/src/views/gateway/ProvidersView.tsx
+++ b/src/views/gateway/ProvidersView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { api, ApiError } from "../../lib/api";
+import { BrandMark } from "../../components/BrandMark";
 import { Dropdown, Empty, FormRow, Search, Splitter, Switch } from "../../components/ui";
 import { Icon } from "../../lib/icons";
 import { describeError, useResource } from "../../lib/hooks";
@@ -124,9 +125,7 @@ export function GatewayProvidersView({ inspectorOpen }: { inspectorOpen: boolean
               }`}
               onClick={() => setSelection({ kind: "row", id: r.id })}
             >
-              <div className="avatar avatar--accent">
-                <Icon name="database" size={14} />
-              </div>
+              <BrandMark provider={r} />
               <div className="listrow__body">
                 <div className="listrow__top">
                   <span className="listrow__title truncate">{r.name}</span>


### PR DESCRIPTION
Closes #471

## What

The LLM Gateway → Providers list drew `<Icon name="database" />` on every row, so a list of four upstreams was four identical grey squares distinguished only by a text line. Each row now carries a brand mark instead.

`src/components/BrandMark.tsx` is new — the mark tables plus the resolver, beside `components/charts.tsx` as the precedent for shared presentation lifted out of a view. It cannot live in `lib/icons.tsx`: that set is deliberately one path per name, 1.5 stroke, 16px grid.

`src/views/gateway/ProvidersView.tsx` is the one render site: the avatar block becomes `<BrandMark provider={r} />`.

**The key is the registrable domain of `base_url`, not the provider type.** `type` is one of four adapter *dialects*, so OpenRouter, Groq, Together, DeepSeek and Fireworks all carry `openai` and a type icon would give them all one mark. The fallback chain is domain → type → today's `database` icon, so an unlisted provider degrades to something sensible and never to an empty slot.

The table is an allowlist matched on a label boundary (`api.openai.com` collapses onto `openai.com`; `notopenai.com` does not) rather than a computed eTLD+1, because correct eTLD+1 needs a public suffix list and "last two labels" is wrong for `api.foo.co.uk`.

## Which form each mark takes

The refinement authorised two forms — a monochrome silhouette where brand guidelines permit redistribution, a lettered monogram where they do not — and asked this PR to say which it used per mark.

**Every vendor mark is a monogram; no vendor artwork ships.** Confirming redistribution terms for eleven separate trademark holders is not something this change can do, and a hand-drawn approximation of a logo is both the legally riskier option and the less legible one at 28px. Swapping any one for a licensed silhouette later is a one-row edit — give that `Mark` an `icon` or an inline `<svg>` instead of a `label`.

| mark | form | tone |
|---|---|---|
| OpenAI `OA`, Anthropic `AN`, Gemini `GE`, Z.AI `ZA`, OpenRouter `OR`, Groq `GQ`, Together `TG`, DeepSeek `DS`, Mistral `MS`, xAI `XA`, Fireworks `FW` | monogram | existing `.avatar--*` tones |
| self-hosted (loopback, `.local`, `.internal`, `.lan`, `.localdomain`) | the house icon set's own `cpu` — nobody's brand | `teal` |

A two-letter monogram in a 28px `.avatar` is already a shipped pattern here — `AgentsView` and `ChatsView` render `initials()` in the same tile — so this needed no CSS.

## Why bundled and not a favicon

`tauri.conf.json`'s CSP is `img-src 'self' data: blob: asset: http://asset.localhost`, so a remote `<img>` is blocked and a favicon feature would have to **widen the shipped CSP to arbitrary remote origins** first. Beyond the CSP it would make a settings pane phone out to third parties on render, leaking the user's configured endpoints — private and self-hosted hostnames included — to those hosts; and it breaks offline, behind a proxy, and on any self-hosted endpoint with no favicon. The **keying** rule from the original idea is kept; only the transport changes.

## How it is guarded

There is no TypeScript test harness here, so `tsc --noEmit` is the whole frontend gate.

- **`MarkKey` is derived from the two tables**, so `MARKS: Record<MarkKey, Mark>` fails the build for a domain or type mapped to a mark nothing draws. That is the structural guard, and it is why the tables carry `as const satisfies`.
- Four `Eq`/`Expect` pins from `lib/typeAssert.ts` cover the mapping: the table stays keyed on registrable domains rather than hosts, `openai.com` → the OpenAI mark, GLM's type fallback is Z.AI's mark, and `markFor` still answers `null` for the no-mark case rather than a silently-chosen default.
- **All five were verified to fail on their revert** (TS2344 ×4, TS2741 for the completeness check) — an unverified pin is decoration.

What the pins cannot cover is `new URL()` at runtime. That half was verified by bundling `markFor` with esbuild and running the 22 cases the acceptance criteria name — subdomain collapse, empty `base_url` → type, `llm.internal.acme.corp` + `openai` → OpenAI's mark, unknown host + unknown type → `null`, `notopenai.com` not matching, loopback/IPv6/`.lan`/`.local`, an unparseable URL, and uppercase hosts. All 22 pass. The probe is throwaway rather than committed: wiring a test runner is out of scope and `package.json` gains no dependency.

## Acceptance criteria

- [x] `https://api.openai.com/v1` and `https://openai.com/v1` render the same mark.
- [x] Empty `base_url` → type mark; unknown host + `openai` → OpenAI's mark; unknown host + unknown type → `database`, no console error.
- [x] `tauri.conf.json`'s `csp` unchanged; no `<img src="http…">`, no non-loopback `fetch`, no favicon service; zero network requests, renders offline.
- [x] Legible at 28px in light and dark. Verified by rendering the marks against the app's **own compiled stylesheet** (`dist/assets/index-*.css`, real tokens, `.listrow`/`.avatar` markup) in both themes and screenshotting, rather than by launching `npm run app` — the markup is byte-identical in shape to `AgentsView`'s shipped monogram avatar and the change adds no CSS, so the app launch had nothing extra to prove.
- [x] `npm run build` passes; no dependency added; no `.avatar` / `views.css` change.

## Out of scope

`ModelsView`/`UsageView` also name providers; `BrandMark` is written so they can adopt it (`provider` is a `Pick<…, "base_url" | "type">`), but wiring them is a follow-up. Integrations keeps its own `catalog.ts`. No backend, wire-format or migration change.

## Review round 1 (applied in `0155014`)

- `LOOPBACK_HOSTS` held a bare `::1` that `new URL().hostname` can never produce — it serializes IPv6 hosts bracketed — so the entry was dead and invited the next one to be added the same unreachable way. It also held `0.0.0.0`, which is not loopback. Renamed `SELF_HOSTED_HOSTS`, dead entry dropped, both spellings written down.
- `BrandMark`'s `size` prop scaled the *icon*, so it silently did nothing on eleven of the twelve marks, and no caller passed it. Dropped.
- `Mark.label` was required, so the one glyph mark carried `label: ""` as a sentinel. Optional instead.
- Plus a note that the domain walk is first-match-wins.

Rebase onto `main` was a no-op — `main` has not moved since the branch point, so the green CI run is on exactly the tree that merges.
