### PR TITLE
feat(gateway): check provider credentials before saving (#472)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3369,6 +3369,15 @@ both answered by `catalog::fetch`. Four things about that pair:
   *request* being wrong (undecodable body, a type this build cannot serve, an
   `id` naming no row, nothing to check at all). A route that 4xx'd its verdicts
   would make the form unpack `err.body` to render its own result.
+- **The stored-key fallback compares the row's type against the request's**, and
+  it is not defensive padding: the form sends the Type dropdown's current value
+  with no `api_key`, because an untouched key field is the default for any
+  configured provider. Changing Type and pressing Check would otherwise put an
+  Anthropic key in an `Authorization: Bearer` header addressed to
+  `api.openai.com` — no attacker in it, and the credential lands in a third
+  party's request log. An empty `base_url` makes it worse rather than better,
+  since it resolves to the *requested* type's production default. A key supplied
+  in the body needs no such check.
 - **`CatalogError` has three variants because the verdict needs them.** The
   catalog route maps all three onto 400/502 and could not care;
   `unauthorized` / `unreachable` / `unexpected` *is* the question #472 asks, so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -332,9 +332,12 @@ src-tauri/src/
     agents.rs    GET /api/agents and /api/agents/{slug}
     chats.rs     GET /api/chats and /api/chats/{id}; compact() is Go's, byte for byte
     tasks.rs     GET /api/tasks, /api/job-history and the three reads between them
-    gateway_api.rs the LLM gateway's control plane (#426) — twelve
+    gateway_api.rs the LLM gateway's control plane (#426) — fourteen
                  /api/gateway/* routes; under native/ because it IS the /api
-                 seam, where gateway/'s listener is not
+                 seam, where gateway/'s listener is not. Two of them are
+                 answered by the ASYNC registry, because they call an upstream:
+                 the model catalog (#470) and the credential check (#472), which
+                 share one dialect table in gateway_api/catalog.rs
     security/    what `/api` accepts as proof of identity (#405)
       keys.rs    the per-install Ed25519 keypair: create-if-absent, 0600, and
                  the one path that replaces it
@@ -3294,7 +3297,7 @@ win that race to see anything.
 `gateway/`** (#426, `native/gateway_api.rs`). The split is the seam, not the
 feature: `gateway/` speaks somebody else's wire formats on its own port, this
 speaks Agento's, behind Agento's guard with ordinary `read`/`write` scoping —
-and `Scope::Llm` opens none of its twelve routes, which is the disjointness
+and `Scope::Llm` opens none of its fourteen routes, which is the disjointness
 #423 built seen from the other side (a credential issued to *spend* through the
 gateway must not be able to reconfigure which provider it spends with).
 
@@ -3336,6 +3339,57 @@ one place — and a `#335`-convention log line with a test. `reload` is not
 awaited: it is stop-then-start over a socket bind, and a save that blocked on it
 would feel like a hang. `a_provider_save_reloads_without_cutting_an_in_flight_stream`
 pins both halves at once, which is where they pull against each other.
+
+**Two of the fourteen routes call an upstream, and they share one dialect
+table** — `GET /api/gateway/providers/{id}/models` (#470) and `POST
+/api/gateway/providers/validate` (#472), both in `gateway_api::ASYNC_ROUTES` and
+both answered by `catalog::fetch`. Four things about that pair:
+
+- **`ASYNC_ROUTES` is a const rather than two literals**, because the property
+  that matters is per route and easy to forget on the second one: a route
+  claimed by *both* registries leaves the buffered arm permanently unreachable,
+  since `proxy.rs` asks `claims_stream` first. `claims` excludes the whole
+  const and the guard iterates it, so a third async route inherits the check.
+  Note `StreamEndpoint` is the **async** registry, not the long-lived one —
+  neither of these streams; `Endpoint::serve` is a sync `fn` on
+  `spawn_blocking`, which is right for reading SQLite and wrong for an outbound
+  HTTPS call.
+- **One dialect table, and #472's spec asked for a second.** That spec predates
+  #470 and describes a per-type table in a new `gateway/validate.rs`, sending
+  OpenAI to `{base}/v1/models` and putting the Gemini key in `?key=`. All three
+  are superseded: the stored OpenAI base is already the versioned root, a
+  credential in a URL is what an error string, a redirect and a proxy log all
+  see (hence `x-goog-api-key`), and there are **four** provider types, not
+  three. `catalog::fetch` therefore takes `(ProviderType, base_url, key)` rather
+  than a `ProviderRow`, because #472's caller validates a draft that has no row.
+- **A verdict is a `200`, whatever it says.** The outcome of the check is what
+  was asked for, so a refused key is a successful answer to "is this key
+  refused?" — the same doctrine `ModelsView` already states for the catalog: *a
+  failure is a value, not a throw*. The 4xx statuses are reserved for the
+  *request* being wrong (undecodable body, a type this build cannot serve, an
+  `id` naming no row, nothing to check at all). A route that 4xx'd its verdicts
+  would make the form unpack `err.body` to render its own result.
+- **`CatalogError` has three variants because the verdict needs them.** The
+  catalog route maps all three onto 400/502 and could not care;
+  `unauthorized` / `unreachable` / `unexpected` *is* the question #472 asks, so
+  `Upstream` carries the status and a transport failure is its own
+  `Unreachable`. `401`/`403` are one bucket (some providers report an exhausted
+  quota as `403`) and `404` is grouped with the transport failures, because it
+  means the base URL rather than the key — the pair a user otherwise mixes up.
+
+**The form's key field is not a gate, and it was one until #472.** `canSave`
+required a freshly typed key on *every* save, described in `ProvidersView.tsx`
+as belt-and-braces over the server's `Option<String>`. It was not: the server
+has always preserved an omitted key, so what the rule actually did was block
+every edit to a timeout on a provider configured months ago — against a secret
+no provider dashboard shows twice. It is now `hasKey || (!creating &&
+provider.has_api_key)`, a stored key renders as `••• stored` behind an explicit
+*Replace key*, and an untouched field still sends **no** `api_key` rather than
+`""`, which is the whole distance between preserving a secret and clearing one.
+**The validation gate that replaced it is soft on purpose**: a base serving
+completions but no model list can never go green, so "Save anyway" is always one
+click away. A validation gate with no override is a lockout — do not remove it
+to simplify.
 
 **Usage recording is one row per served request, written off the request path**
 (#425, `gateway/usage.rs`, migration 34). Four things about it are decisions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3343,7 +3343,7 @@ pins both halves at once, which is where they pull against each other.
 **Two of the fourteen routes call an upstream, and they share one dialect
 table** — `GET /api/gateway/providers/{id}/models` (#470) and `POST
 /api/gateway/providers/validate` (#472), both in `gateway_api::ASYNC_ROUTES` and
-both answered by `catalog::fetch`. Four things about that pair:
+both answered by `catalog::fetch`. Five things about that pair:
 
 - **`ASYNC_ROUTES` is a const rather than two literals**, because the property
   that matters is per route and easy to forget on the second one: a route

--- a/docs/development.md
+++ b/docs/development.md
@@ -318,14 +318,14 @@ So the parity machinery does not apply to the five routes it serves
 to, and the wire format that matters is somebody else's.
 
 Its **control plane is the opposite** and this is where the split gets confused.
-`/api/gateway/*` — twelve routes in `native/gateway_api.rs` — is ordinary `/api`
+`/api/gateway/*` — fourteen routes in `native/gateway_api.rs` — is ordinary `/api`
 surface, behind the ordinary guard with ordinary `read`/`write` scoping, and it
 is recorded in `parity/desktop_routes.json`. That file holds the routes with no
 Go ancestor, and its assertion is **set equality** against the union of every
 owning module's `ROUTES` const. Add a third owner and you must add it to that
 union, or the test silently weakens to a one-directional check and still passes.
 
-An `llm` token opens none of those twelve routes. That is the same disjointness
+An `llm` token opens none of those fourteen routes. That is the same disjointness
 seen from the other side: a credential issued to *spend* through the gateway must
 not be able to reconfigure which provider it spends with.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -287,6 +287,41 @@ and the same line is in the log:
 binding the llm gateway on 127.0.0.1:8880: Address already in use (os error 98)
 ```
 
+### "Check these credentials" says the key is refused, or the provider is unreachable
+
+**LLM Gateway → Providers → Check these credentials** asks the provider to list
+its models, which authenticates the same credential a real request would. What
+it answers means:
+
+- **Key refused** (`401`/`403`) — the key is wrong, revoked, or out of credit.
+  Some providers report an exhausted plan as `403` rather than `429`, so a
+  key that worked yesterday can land here. Re-issue it and use **Replace key**.
+- **Unreachable** — nothing answered at the Base URL, or it answered `404`. That
+  is the base URL rather than the key: a `404` means the address is not this
+  provider's API root. Leave it empty to use the provider's own endpoint, except
+  on GLM, which requires one.
+- **Unexpected** — the provider answered something else, and the status is shown
+  beside the verdict. A `5xx` is usually theirs rather than yours.
+
+The check never sends your key anywhere but the provider, and no answer, log
+line or error message carries it back.
+
+**It can be wrong in one direction, and Save anyway is the answer.** A base that
+serves completions but no model list — a proxy, something self-hosted, some
+OpenAI-compatible vendors — cannot produce a green verdict however correct the
+key is. Save anyway is beside Save for exactly that, and nothing is ever blocked
+behind a check.
+
+### Editing a provider asks for the API key I no longer have
+
+It no longer does. A provider with a key stored shows `••••••••••• stored` and
+saves without one — the save simply sends no `api_key` field, and the server
+keeps what it has. **Replace key** is what puts the input back on screen.
+
+On a build predating that change the form did require a re-typed key on every
+save. There is no way to recover the stored one — it is write-only by design —
+so either update, or issue a new key at the provider and paste that in.
+
 ### The model box on Models offers no list
 
 **LLM Gateway → Models** fills a target's model box from that provider's own

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -304,7 +304,11 @@ it answers means:
   beside the verdict. A `5xx` is usually theirs rather than yours.
 
 The check never sends your key anywhere but the provider, and no answer, log
-line or error message carries it back.
+line or error message carries it back. That is also why changing **Type** on a
+provider that already has a key refuses with *"the stored key belongs to a
+different provider type"* rather than checking: the stored key is that vendor's,
+and the new type decides which vendor it would be sent to. Enter the key for the
+type you have selected.
 
 **It can be wrong in one direction, and Save anyway is the answer.** A base that
 serves completions but no model list — a proxy, something self-hosted, some

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -452,13 +452,40 @@ the old one stops working until you update it. The view says so before you save.
 - **Type** — Anthropic, OpenAI, Google Gemini or Z.AI GLM. This picks the
   adapter.
 - **Base URL** — leave empty for the provider's own endpoint. GLM requires one.
-- **API key** — yours. It is sent only when you type one and is never returned by
-  any read, so the field is empty every time you open the form. That is
-  deliberate rather than a bug: no read can echo it, so nothing can leak it back
-  through the UI, and leaving the field alone keeps the stored key.
+- **API key** — yours. It is never returned by any read, so a provider that has
+  one shows `••••••••••• stored` rather than the value. That is deliberate
+  rather than a bug: no read can echo it, so nothing can leak it back through
+  the UI. **Editing anything else does not need it.** Leave the field alone and
+  the save sends no key at all, which the server reads as "keep the stored one";
+  use **Replace key** when you actually want to change it.
 - **Timeouts** — connect, first byte, and idle between tokens.
 
 A disabled provider stays configured and is not dispatched to.
+
+#### Checking the credentials before you save
+
+**Check these credentials** asks the provider to list its models. That
+authenticates exactly what an inference request would, costs nothing and
+generates no tokens — and it is the only way to tell a working provider from a
+broken one without routing a real request through the gateway and reading the
+failure inside whichever tool sent it.
+
+You do not have to re-type the key to run it: leave the field alone and it
+checks the one already stored.
+
+Four verdicts:
+
+| verdict | what it means | what to do |
+|---|---|---|
+| **Working** | the provider accepted the key, and lists these models | save |
+| **Key refused** | `401` or `403` — the key is wrong, revoked, or out of credit | re-issue the key |
+| **Unreachable** | nothing answered, or the base URL is not this provider's API root | check the Base URL |
+| **Unexpected** | it answered something else — the status is shown | check the provider's status page |
+
+**Save anyway** is always available beside Save, and it is there for a real
+case: a proxy, a self-hosted server or an OpenAI-compatible vendor may implement
+completions and no model list, so it can never produce a green verdict while
+working perfectly. A check is a help, not a gate you can be locked behind.
 
 ### Defining an alias
 

--- a/parity/desktop_routes.json
+++ b/parity/desktop_routes.json
@@ -152,6 +152,13 @@
       "reason": "the model ids that provider's own upstream reports, so an alias target is picked rather than typed; the only route here answered by the ASYNC registry, because it makes an outbound HTTPS call -- and the answer is ids alone, never the key and never the upstream body"
     },
     {
+      "method": "POST",
+      "route": "/api/gateway/providers/validate",
+      "status": "native",
+      "owner": "#472",
+      "reason": "asks a provider's own free list-models endpoint whether a credential is one it accepts, so a typo is caught at the form rather than as a 401 inside whichever tool was pointed at the gateway; an OMITTED api_key checks the stored one, so an existing provider is re-testable without a secret the user can no longer retrieve. Answered by the ASYNC registry, like the catalog route it shares its dialects with -- and with 200 whatever the verdict, because the outcome of the check is what was asked for"
+    },
+    {
       "method": "GET",
       "route": "/api/gateway/usage",
       "status": "native",

--- a/src-tauri/src/gateway/mod.rs
+++ b/src-tauri/src/gateway/mod.rs
@@ -32,7 +32,7 @@
 //! | [`usage`] | one row per served request, the cost resolved at write time, and the retention prune |
 //!
 //! **Nothing of the epic is absent any more.** The control plane is not here but
-//! it does exist: `/api/gateway/*` is twelve routes in
+//! it does exist: `/api/gateway/*` is fourteen routes in
 //! [`crate::native::gateway_api`] (#426), under `native/` because it *is* the
 //! `/api` seam where this listener is not, and the **LLM Gateway** section in
 //! `src/views/gateway/` (#427) with its Usage dashboard (#428) is what drives

--- a/src-tauri/src/native/gateway_api.rs
+++ b/src-tauri/src/native/gateway_api.rs
@@ -6,7 +6,7 @@
 //! is the `/api` seam, with Agento's own shapes, Agento's own guard and
 //! Agento's own `read`/`write` scoping. The two are on opposite sides of that
 //! line, which is why the control plane is here and the data plane is there —
-//! and why `Scope::Llm` opens nothing on these twelve routes while a `read`
+//! and why `Scope::Llm` opens nothing on these fourteen routes while a `read`
 //! token opens every one of their GETs.
 //!
 //! # The one question the issue left open was already answered in the tree
@@ -72,12 +72,13 @@ pub const ROUTES: &[(&str, &str)] = &[
     ("GET", "/api/gateway/status"),
     ("GET", "/api/gateway/usage"),
     ("GET", "/api/gateway/providers/{id}/models"),
+    ("POST", "/api/gateway/providers/validate"),
 ];
 
-/// The one route in [`ROUTES`] the **streaming** registry answers (#470).
+/// The routes in [`ROUTES`] the **streaming** registry answers (#470, #472).
 ///
-/// It does not stream. `StreamEndpoint` is simply the only registry here that is
-/// `async`, and this route makes a network call: `Endpoint::serve` is a sync
+/// Neither streams. `StreamEndpoint` is simply the only registry here that is
+/// `async`, and both routes make a network call: `Endpoint::serve` is a sync
 /// `fn` the proxy runs on `spawn_blocking`, which is exactly right for thirteen
 /// areas that read SQLite and wrong for an outbound HTTPS request. Returning a
 /// buffered JSON `Response` from the async registry is a smaller change than
@@ -86,15 +87,33 @@ pub const ROUTES: &[(&str, &str)] = &[
 ///
 /// Consequences, both load-bearing:
 ///
-/// - It stays in [`ROUTES`], because that const is what
+/// - They stay in [`ROUTES`], because that const is what
 ///   `parity/desktop_routes.json` is asserted against as **set equality** and a
 ///   route recorded nowhere is the drift that file exists to stop.
-/// - [`claims`] must therefore *exclude* it, or both registries claim one path.
-///   `proxy.rs` checks `claims_stream` first, so the buffered handler would
-///   never run — it would merely sit there as a route claimed by a `serve` arm
-///   that answers "claimed but unhandled". `the_catalog_route_is_claimed_by_the
-///   _streaming_registry_alone` is the guard.
+/// - [`claims`] must therefore *exclude* them, or both registries claim one
+///   path. `proxy.rs` checks `claims_stream` first, so the buffered handler
+///   would never run — it would merely sit there as a route claimed by a `serve`
+///   arm that answers "claimed but unhandled".
+///   `the_async_routes_are_claimed_by_the_streaming_registry_alone` is the
+///   guard, and it is written over this const rather than over one literal so a
+///   third async route cannot be added without it.
+///
+/// #472's own spec said to use `trigger::block_on_result` from the buffered
+/// registry and *not* to add a stream endpoint. That predates #470, which
+/// settled the question the other way for exactly this shape; following it
+/// would have put a second answer to one question in the same module.
+const ASYNC_ROUTES: &[(&str, &str)] = &[CATALOG_ROUTE, VALIDATE_ROUTE];
+
 const CATALOG_ROUTE: (&str, &str) = ("GET", "/api/gateway/providers/{id}/models");
+
+/// `POST /api/gateway/providers/validate` (#472) — does this credential work?
+///
+/// A **literal** segment where its siblings capture an `{id}`, which is safe
+/// here only because no `POST /api/gateway/providers/{id}` route exists: the
+/// two `{id}` writes are `PUT` and `DELETE`, and the collection `POST` is the
+/// exact string one segment up. A future `POST /api/gateway/providers/{id}`
+/// would have to be ordered after this one.
+const VALIDATE_ROUTE: (&str, &str) = ("POST", "/api/gateway/providers/validate");
 
 pub const ENDPOINT: super::Endpoint = super::Endpoint {
     name: "gateway",
@@ -102,23 +121,24 @@ pub const ENDPOINT: super::Endpoint = super::Endpoint {
     serve,
 };
 
-/// The async half — [`CATALOG_ROUTE`] and nothing else.
+/// The async half — [`ASYNC_ROUTES`] and nothing else.
 pub const STREAM_ENDPOINT: super::StreamEndpoint = super::StreamEndpoint {
-    name: "gateway-catalog",
-    claims: claims_catalog,
-    serve: serve_catalog,
+    name: "gateway-upstream",
+    claims: claims_async,
+    serve: serve_async,
 };
 
 fn claims(method: &Method, path: &str) -> bool {
-    !claims_catalog(method, path)
+    !claims_async(method, path)
         && ROUTES
             .iter()
             .any(|(m, pattern)| method.as_str() == *m && path_matches(pattern, path))
 }
 
-fn claims_catalog(method: &Method, path: &str) -> bool {
-    let (m, pattern) = CATALOG_ROUTE;
-    method.as_str() == m && path_matches(pattern, path)
+fn claims_async(method: &Method, path: &str) -> bool {
+    ASYNC_ROUTES
+        .iter()
+        .any(|(m, pattern)| method.as_str() == *m && path_matches(pattern, path))
 }
 
 /// Match a chi-style pattern against a concrete path.
@@ -173,53 +193,64 @@ fn provider_id_for_catalog(path: &str) -> Option<String> {
     Some(id.to_string())
 }
 
+/// The async registry's dispatch, mirroring [`serve`]'s shape for
+/// [`ASYNC_ROUTES`].
+fn serve_async(req: super::StreamRequest) -> super::BoxFuture<'static, Result<Response, String>> {
+    Box::pin(async move {
+        if (req.method.as_str(), req.path.as_str()) == (VALIDATE_ROUTE.0, VALIDATE_ROUTE.1) {
+            return validate_provider(&req.db_path, &req.body).await;
+        }
+        serve_catalog(req).await
+    })
+}
+
 /// `GET /api/gateway/providers/{id}/models` (#470) — what that provider's own
 /// upstream says it serves.
 ///
 /// Async because it makes a network call; buffered because the answer is a
-/// finished document. See [`CATALOG_ROUTE`].
+/// finished document. See [`ASYNC_ROUTES`].
 ///
 /// The database read is on this runtime worker and stays there deliberately:
 /// it is `open_read_only`, and a WAL reader does not wait on a writer, which is
 /// the same reasoning that leaves `runner::load` and `TurnSettings::stored` off
 /// `db::blocking`. The unbounded part of this handler is the HTTPS call, which
 /// is `await`ed rather than blocked on.
-fn serve_catalog(req: super::StreamRequest) -> super::BoxFuture<'static, Result<Response, String>> {
-    Box::pin(async move {
-        let Some(id) = provider_id_for_catalog(&req.path) else {
-            return Err(format!(
-                "{} {} is claimed but has no id",
-                req.method, req.path
-            ));
-        };
+async fn serve_catalog(req: super::StreamRequest) -> Result<Response, String> {
+    let Some(id) = provider_id_for_catalog(&req.path) else {
+        return Err(format!(
+            "{} {} is claimed but has no id",
+            req.method, req.path
+        ));
+    };
 
-        let Some(row) = config::load_provider_secret(&req.db_path, &id)? else {
-            // The same 404 every other `{id}` route here answers for a row that
-            // is not there.
-            return answer(Answer::error(StatusCode::NOT_FOUND, "provider not found")?);
-        };
+    let Some(row) = config::load_provider_secret(&req.db_path, &id)? else {
+        // The same 404 every other `{id}` route here answers for a row that
+        // is not there.
+        return answer(Answer::error(StatusCode::NOT_FOUND, "provider not found")?);
+    };
 
-        // `row` holds the key. It goes no further than `catalog::fetch`, which
-        // puts it in one header and drops it with the request builder; nothing
-        // below this line can reach it, because only a `&str` ever leaves
-        // `ProviderRow` and the borrow ends here.
-        let body = match catalog::fetch(&row).await {
-            Ok(models) => super::gojson::to_vec(&CatalogBody { models })
-                .map_err(|e| format!("encoding gateway provider catalog: {e}"))?,
-            Err(e) => {
-                // Logged with the provider **id**, never its name, base URL or
-                // key: this line lands in a plain file on disk, and the id is
-                // already in the access line's path.
-                log::warn!("gateway model catalog for provider {id}: {}", e.message());
-                let status = match e {
-                    catalog::CatalogError::Unaskable(_) => StatusCode::BAD_REQUEST,
-                    catalog::CatalogError::Upstream(_) => StatusCode::BAD_GATEWAY,
-                };
-                return answer(Answer::error(status, e.message())?);
-            }
-        };
-        answer(Answer::json(body))
-    })
+    // `row` holds the key. It goes no further than `catalog::fetch`, which
+    // puts it in one header and drops it with the request builder; nothing
+    // below this line can reach it, because only a `&str` ever leaves
+    // `ProviderRow` and the borrow ends here.
+    let body = match catalog::fetch(row.provider_type, &row.base_url, row.api_key()).await {
+        Ok(models) => super::gojson::to_vec(&CatalogBody { models })
+            .map_err(|e| format!("encoding gateway provider catalog: {e}"))?,
+        Err(e) => {
+            // Logged with the provider **id**, never its name, base URL or
+            // key: this line lands in a plain file on disk, and the id is
+            // already in the access line's path.
+            log::warn!("gateway model catalog for provider {id}: {}", e.message());
+            let status = match e {
+                catalog::CatalogError::Unaskable(_) => StatusCode::BAD_REQUEST,
+                catalog::CatalogError::Unreachable(_) | catalog::CatalogError::Upstream { .. } => {
+                    StatusCode::BAD_GATEWAY
+                }
+            };
+            return answer(Answer::error(status, e.message())?);
+        }
+    };
+    answer(Answer::json(body))
 }
 
 /// Render a buffered [`Answer`] as the streaming registry's `Response`.
@@ -240,6 +271,168 @@ type Response = axum::http::Response<axum::body::Body>;
 #[derive(Serialize)]
 struct CatalogBody {
     models: Vec<String>,
+}
+
+// ─── Credential validation (#472) ─────────────────────────────────────────────
+
+/// The body of `POST /api/gateway/providers/validate`.
+///
+/// Deliberately the *provider* shape minus the fields a credential check cannot
+/// use, so a form can post what it already has. `api_key` is `Option<String>`
+/// with the same three meanings the `PUT` gives it, and the reason is the same:
+/// an edit form holds no key, because no read ever answered one. **Absent means
+/// "the one already stored for `id`"**, which is what lets a provider
+/// configured last month be re-tested without the user finding a secret their
+/// provider's dashboard will not show them again.
+#[derive(Debug, Deserialize)]
+struct ValidateRequest {
+    /// Which stored provider's key to fall back on. Empty when creating.
+    #[serde(default)]
+    id: String,
+    #[serde(default, rename = "type")]
+    provider_type: String,
+    #[serde(default)]
+    api_key: Option<String>,
+    #[serde(default)]
+    base_url: String,
+}
+
+/// What a credential check found.
+///
+/// **Answered with `200` whatever it found**, and that is a decision rather than
+/// laxity: the outcome of the check is the thing that was asked for, so a
+/// refused key is a successful answer to "is this key refused?". `ModelsView`
+/// already states the same doctrine for #470's catalog — *a failure is a value,
+/// not a throw* — and a form that has to unpack `err.body` to render its own
+/// result is the shape that gets it wrong. The 4xx statuses here are reserved
+/// for the *request* being wrong: a body that will not decode, a type this
+/// build cannot serve, an `id` naming no row, no key to check at all.
+///
+/// `models` is what the provider listed, so a green verdict shows the user the
+/// catalog their key actually reaches — and it is empty unless `ok`.
+#[derive(Serialize)]
+struct ValidationBody {
+    ok: bool,
+    /// `valid` · `unauthorized` · `unreachable` · `unexpected`.
+    outcome: &'static str,
+    /// The upstream's status, when one was received. Absent otherwise — a
+    /// connect failure has no status, and `0` would read as one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    status: Option<u16>,
+    /// One sentence naming a **cause**. It comes from `catalog::CatalogError`
+    /// unchanged, which is what keeps the no-key/no-URL/no-upstream-body
+    /// discipline in one place rather than restated here where a second author
+    /// would eventually interpolate the thing under test.
+    message: String,
+    models: Vec<String>,
+}
+
+/// `POST /api/gateway/providers/validate` (#472) — is this credential one the
+/// provider accepts?
+///
+/// It asks the same free list-models endpoint #470 already asks, which
+/// authenticates exactly what an inference call would and spends nothing. That
+/// is the whole reason this is not a completions request.
+async fn validate_provider(db_path: &std::path::Path, body: &[u8]) -> Result<Response, String> {
+    let req: ValidateRequest = match writes::decode_body(body) {
+        Ok(req) => req,
+        Err(e) => return answer(writes::finish(Err(e))?),
+    };
+
+    let Some(provider_type) = config::ProviderType::parse(&req.provider_type) else {
+        // The caller's `type` value is not quoted back, exactly as
+        // `ProviderRequest::validated` does not quote it.
+        return refuse(WriteError::validation(
+            "type",
+            "type must be \"anthropic\", \"openai\", \"gemini\" or \"glm\"",
+        ));
+    };
+
+    let id = req.id.trim();
+    let key = match req.api_key {
+        Some(key) => key,
+        None => {
+            // No key supplied and no row to take one from: there is nothing to
+            // check. A verdict here would be a claim about a credential that
+            // does not exist.
+            if id.is_empty() {
+                return refuse(WriteError::validation(
+                    "api_key",
+                    "an api_key is required unless id names a provider whose stored key should be checked",
+                ));
+            }
+            let Some(row) = config::load_provider_secret(db_path, id)? else {
+                return answer(Answer::error(StatusCode::NOT_FOUND, "provider not found")?);
+            };
+            row.api_key().to_string()
+        }
+    };
+    if key.is_empty() {
+        return refuse(WriteError::validation(
+            "api_key",
+            "there is no API key to check",
+        ));
+    }
+
+    let verdict = match catalog::fetch(provider_type, &req.base_url, &key).await {
+        Ok(models) => ValidationBody {
+            ok: true,
+            outcome: "valid",
+            status: None,
+            message: "the provider accepted this API key".to_string(),
+            models,
+        },
+        Err(e) => {
+            let (outcome, status) = classify(&e);
+            // The **outcome** and the status, and neither the key, the base URL
+            // nor the provider's name: this line lands in a plain file on disk,
+            // and a user-typed base URL can carry a token in its path.
+            log::warn!(
+                "gateway provider validation: outcome={outcome} status={status:?} id={id:?}"
+            );
+            ValidationBody {
+                ok: false,
+                outcome,
+                status,
+                message: e.message().to_string(),
+                models: Vec::new(),
+            }
+        }
+    };
+
+    let body = super::gojson::to_vec(&verdict)
+        .map_err(|e| format!("encoding gateway provider validation: {e}"))?;
+    answer(Answer::json(body))
+}
+
+/// Which of the four outcomes a failure is, and the status behind it.
+///
+/// The `401`/`403` split from everything else is the one the issue names: some
+/// providers report an exhausted quota with `403` rather than `429`, and both
+/// mean "this credential will not serve a request", which is what the user is
+/// asking. A `404` is the *base URL* being wrong rather than the key, and is
+/// therefore grouped with the transport failures — that is the pair a user
+/// otherwise mixes up, since both present as "it does not work".
+fn classify(e: &catalog::CatalogError) -> (&'static str, Option<u16>) {
+    match e {
+        // Nothing was asked, because the configuration made it unaskable — a
+        // base URL this build will not send a request through, or no usable
+        // trust store. Nothing was reached, so this is `unreachable`.
+        catalog::CatalogError::Unaskable(_) | catalog::CatalogError::Unreachable(_) => {
+            ("unreachable", None)
+        }
+        catalog::CatalogError::Upstream { status, .. } => match status {
+            Some(401) | Some(403) => ("unauthorized", *status),
+            Some(404) => ("unreachable", *status),
+            _ => ("unexpected", *status),
+        },
+    }
+}
+
+/// Render a request-level refusal through `writes`' own envelope, so this route
+/// answers `{"error": …}` exactly like every buffered write on this surface.
+fn refuse(e: WriteError) -> Result<Response, String> {
+    answer(writes::finish(Err(e))?)
 }
 
 fn serve(ctx: &Ctx, req: &Request) -> Result<Answer, String> {
@@ -2570,17 +2763,47 @@ mod tests {
     /// streaming one first, so a route claimed by both would leave the buffered
     /// arm permanently unreachable — a latent "claimed but unhandled" nobody
     /// would trip over until the two disagreed.
+    ///
+    /// Written over [`ASYNC_ROUTES`] rather than over one literal path, so a
+    /// third async route inherits the check instead of needing to remember it.
     #[test]
-    fn the_catalog_route_is_claimed_by_the_streaming_registry_alone() {
-        let path = "/api/gateway/providers/p1/models";
-        assert!(claims_catalog(&Method::GET, path));
-        assert!(!claims(&Method::GET, path));
+    fn the_async_routes_are_claimed_by_the_streaming_registry_alone() {
+        for (method, pattern) in ASYNC_ROUTES {
+            let method = Method::from_bytes(method.as_bytes()).expect("method");
+            let path = pattern.replace("{id}", "p1");
+            assert!(claims_async(&method, &path), "{method} {path}");
+            assert!(!claims(&method, &path), "{method} {path}");
+            // Every async route is still in ROUTES, which is what
+            // `desktop_routes.json` is asserted against as set equality.
+            assert!(
+                ROUTES.iter().any(|r| r == &(method.as_str(), *pattern)),
+                "{method} {pattern} is not in ROUTES",
+            );
+        }
         // ...and the buffered half is untouched by the exclusion.
         assert!(claims(&Method::GET, "/api/gateway/providers"));
+        assert!(claims(&Method::POST, "/api/gateway/providers"));
         assert!(claims(&Method::PUT, "/api/gateway/providers/p1"));
-        // The route is still in ROUTES, which is what `desktop_routes.json` is
-        // asserted against.
-        assert!(ROUTES.contains(&CATALOG_ROUTE));
+    }
+
+    /// `validate` is a literal segment on a collection whose siblings capture an
+    /// `{id}`. Nothing shadows it today because no `POST
+    /// /api/gateway/providers/{id}` exists — this is what would fail if one were
+    /// added above it.
+    #[test]
+    fn the_validate_path_is_not_shadowed_by_a_sibling_provider_route() {
+        assert!(claims_async(
+            &Method::POST,
+            "/api/gateway/providers/validate"
+        ));
+        // The collection POST is one segment up and is still the buffered one.
+        assert!(!claims_async(&Method::POST, "/api/gateway/providers"));
+        // ...and no other method on the literal path is claimed by either half.
+        assert!(!claims_async(
+            &Method::GET,
+            "/api/gateway/providers/validate"
+        ));
+        assert!(!claims(&Method::GET, "/api/gateway/providers/validate"));
     }
 
     /// `id_under` refuses a remainder holding a `/`, which is what keeps a
@@ -2605,5 +2828,331 @@ mod tests {
             provider_id_for_catalog("/api/gateway/providers/p1/models/x"),
             None
         );
+    }
+
+    // ── Credential validation (#472) ──────────────────────────────────────
+
+    async fn validate(ctx: &Ctx, body: &str) -> Response {
+        serve_async(crate::native::StreamRequest {
+            method: Method::POST,
+            path: VALIDATE_ROUTE.1.to_string(),
+            body: body.as_bytes().to_vec(),
+            db_path: ctx.db_path.clone(),
+        })
+        .await
+        .expect("the handler answers its own 4xx rather than erroring")
+    }
+
+    fn verdict_of(body: &str) -> serde_json::Value {
+        serde_json::from_str(body).expect("json")
+    }
+
+    /// A key typed into the form is the one that reaches the upstream, and a
+    /// green answer carries the catalog it reached.
+    #[tokio::test]
+    async fn a_supplied_key_is_checked_against_the_upstream_and_reported_valid() {
+        let file = migrated();
+        let ctx = ctx(&file);
+        let (base, seen) =
+            fake_upstream(StatusCode::OK, r#"{"data":[{"id":"gpt-4o"},{"id":"o3"}]}"#).await;
+
+        let (status, body) = parts_of(
+            validate(
+                &ctx,
+                &format!(r#"{{"type":"openai","api_key":"sk-typed-now","base_url":"{base}"}}"#),
+            )
+            .await,
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        let v = verdict_of(&body);
+        assert_eq!(v["ok"], true);
+        assert_eq!(v["outcome"], "valid");
+        assert_eq!(v["models"], serde_json::json!(["gpt-4o", "o3"]));
+        assert!(v.get("status").is_none(), "a success has no status: {body}");
+        // The dialect is `catalog`'s, so the request shape is already pinned by
+        // `every_provider_type_is_asked_the_way_its_own_api_expects`; what is
+        // this route's own is *which key* it sent.
+        assert_eq!(header_of(&seen, "authorization"), "Bearer sk-typed-now");
+        assert_eq!(seen.lock().expect("lock").target, "/models");
+    }
+
+    /// **The half of this issue the backend already supported.** An edit form
+    /// holds no key, because no read ever answered one — so an omitted
+    /// `api_key` checks the stored one, exactly as an omitted `api_key`
+    /// *preserves* the stored one on the `PUT`.
+    #[tokio::test]
+    async fn an_omitted_api_key_checks_the_stored_one() {
+        let file = migrated();
+        let ctx = ctx(&file);
+        let (base, seen) = fake_upstream(StatusCode::OK, r#"{"data":[{"id":"gpt-4o"}]}"#).await;
+        seed_provider(&ctx, "p1", "openai", "sk-secret-value", &base);
+
+        let (status, body) = parts_of(
+            validate(
+                &ctx,
+                &format!(r#"{{"id":"p1","type":"openai","base_url":"{base}"}}"#),
+            )
+            .await,
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(verdict_of(&body)["outcome"], "valid");
+        assert_eq!(header_of(&seen, "authorization"), "Bearer sk-secret-value");
+    }
+
+    /// A key in the body is the one being asked about — it must win over the
+    /// stored one, or a user retyping a corrected key would be told about the
+    /// broken one they are replacing.
+    #[tokio::test]
+    async fn a_supplied_key_wins_over_the_stored_one() {
+        let file = migrated();
+        let ctx = ctx(&file);
+        let (base, seen) = fake_upstream(StatusCode::OK, r#"{"data":[]}"#).await;
+        seed_provider(&ctx, "p1", "openai", "sk-secret-value", &base);
+
+        let (status, _) = parts_of(
+            validate(
+                &ctx,
+                &format!(
+                    r#"{{"id":"p1","type":"openai","api_key":"sk-replacement","base_url":"{base}"}}"#
+                ),
+            )
+            .await,
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(header_of(&seen, "authorization"), "Bearer sk-replacement");
+    }
+
+    /// Nothing to check is a **request** problem, not a verdict: answering
+    /// `ok:false` would be a claim about a credential that does not exist.
+    #[tokio::test]
+    async fn nothing_to_check_is_refused_rather_than_given_a_verdict() {
+        let file = migrated();
+        let ctx = ctx(&file);
+
+        // Creating: no id to fall back on, and no key typed.
+        let (status, body) =
+            parts_of(validate(&ctx, r#"{"type":"openai","base_url":""}"#).await).await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert!(body.contains("api_key"), "{body}");
+
+        // An id whose row holds no key at all.
+        let (base, seen) = fake_upstream(StatusCode::OK, r#"{"data":[]}"#).await;
+        seed_provider(&ctx, "p1", "openai", "", &base);
+        let (status, body) = parts_of(
+            validate(
+                &ctx,
+                &format!(r#"{{"id":"p1","type":"openai","base_url":"{base}"}}"#),
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert!(body.contains("api_key"), "{body}");
+        assert!(
+            seen.lock().expect("lock").target.is_empty(),
+            "an unauthenticated request was made in the user's name"
+        );
+    }
+
+    /// An `id` naming no row is the same 404 every other `{id}` route on this
+    /// surface answers — distinct from "the key was refused", which is a 200.
+    #[tokio::test]
+    async fn an_unknown_id_with_no_key_is_a_404() {
+        let file = migrated();
+        let (status, body) = parts_of(
+            validate(
+                &ctx(&file),
+                r#"{"id":"nope","type":"openai","base_url":""}"#,
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(body, "{\"error\":\"provider not found\"}\n");
+    }
+
+    /// The same refusal `ProviderRequest::validated` gives, and it does not
+    /// quote the caller's value back.
+    #[tokio::test]
+    async fn a_type_this_build_cannot_serve_is_a_422() {
+        let file = migrated();
+        let (status, body) = parts_of(
+            validate(
+                &ctx(&file),
+                r#"{"type":"bedrock","api_key":"sk-x","base_url":""}"#,
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert!(body.contains("type"), "{body}");
+        assert!(!body.contains("bedrock"), "{body}");
+    }
+
+    /// **The three outcomes the acceptance criteria ask to be distinguishable**,
+    /// each a `200` carrying a verdict rather than an HTTP error.
+    ///
+    /// A refused key and a wrong base URL are the pair a user otherwise mixes
+    /// up, because both present as "it does not work" — so they are asserted
+    /// side by side, from one table, rather than as three tests that could
+    /// drift into agreeing.
+    #[tokio::test]
+    async fn a_refused_key_a_wrong_base_url_and_a_surprise_are_told_apart() {
+        for (upstream, want_outcome, want_status) in [
+            (StatusCode::UNAUTHORIZED, "unauthorized", Some(401)),
+            // Some providers report an exhausted quota with 403 rather than
+            // 429, and both mean this credential will not serve a request.
+            (StatusCode::FORBIDDEN, "unauthorized", Some(403)),
+            // Not the key: the base URL is not this provider's API root.
+            (StatusCode::NOT_FOUND, "unreachable", Some(404)),
+            (StatusCode::INTERNAL_SERVER_ERROR, "unexpected", Some(500)),
+        ] {
+            let file = migrated();
+            let ctx = ctx(&file);
+            let (base, _) = fake_upstream(upstream, r#"{"error":"nope"}"#).await;
+
+            let (status, body) = parts_of(
+                validate(
+                    &ctx,
+                    &format!(r#"{{"type":"openai","api_key":"sk-x","base_url":"{base}"}}"#),
+                )
+                .await,
+            )
+            .await;
+
+            assert_eq!(status, StatusCode::OK, "{upstream}");
+            let v = verdict_of(&body);
+            assert_eq!(v["ok"], false, "{upstream}");
+            assert_eq!(v["outcome"], want_outcome, "{upstream}");
+            assert_eq!(v["status"], serde_json::json!(want_status), "{upstream}");
+            assert_eq!(v["models"], serde_json::json!([]), "{upstream}");
+        }
+
+        // ...and a base URL nothing answers on has no status at all, which is
+        // what `skip_serializing_if` is for — `0` would read as one.
+        //
+        // The address is one the OS *did* hand out and then took back, so the
+        // connect is refused rather than filtered: picking a number would risk
+        // hitting something else on the machine, and a hostname would need DNS.
+        let file = migrated();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let dead = format!("http://{}", listener.local_addr().expect("addr"));
+        drop(listener);
+
+        let (status, body) = parts_of(
+            validate(
+                &ctx(&file),
+                &format!(r#"{{"type":"openai","api_key":"sk-x","base_url":"{dead}"}}"#),
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let v = verdict_of(&body);
+        assert_eq!(v["outcome"], "unreachable", "{body}");
+        assert!(v.get("status").is_none(), "{body}");
+    }
+
+    /// A base URL the guard refuses is reported as a verdict too — and no
+    /// request carrying the key is built, which is the guard's whole point.
+    #[tokio::test]
+    async fn a_base_url_that_resolves_elsewhere_is_a_verdict_not_a_request() {
+        let file = migrated();
+        let (base, seen) = fake_upstream(StatusCode::OK, r#"{"data":[]}"#).await;
+
+        let (status, body) = parts_of(
+            validate(
+                &ctx(&file),
+                &format!(r#"{{"type":"openai","api_key":"sk-x","base_url":"{base}/v1/.."}}"#),
+            )
+            .await,
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(verdict_of(&body)["outcome"], "unreachable");
+        assert!(body.contains("base URL"), "{body}");
+        assert!(
+            seen.lock().expect("lock").target.is_empty(),
+            "a request was sent"
+        );
+    }
+
+    /// **The credential rule, asserted over the bytes**, on both the path that
+    /// supplies a key and the path that reads the stored one.
+    ///
+    /// A struct-level check only proves the field the test knows about is
+    /// absent. The upstream deliberately echoes the key back in its own body
+    /// and in its status line's company, which is the shape a forwarded
+    /// upstream document would leak.
+    #[tokio::test]
+    async fn no_validation_answer_carries_the_api_key_or_the_upstream_body() {
+        for (supplied, refuse) in [(true, false), (false, false), (false, true)] {
+            let file = migrated();
+            let ctx = ctx(&file);
+            let (base, _) = fake_upstream(
+                if refuse {
+                    StatusCode::UNAUTHORIZED
+                } else {
+                    StatusCode::OK
+                },
+                r#"{"data":[{"id":"gpt-4o","owned_by":"sk-secret-value"}],
+                    "error":"incorrect api key sk-secret-value"}"#,
+            )
+            .await;
+            seed_provider(&ctx, "p1", "openai", "sk-secret-value", &base);
+
+            let key = if supplied {
+                r#","api_key":"sk-secret-value""#
+            } else {
+                ""
+            };
+            let (_, body) = parts_of(
+                validate(
+                    &ctx,
+                    &format!(r#"{{"id":"p1","type":"openai"{key},"base_url":"{base}"}}"#),
+                )
+                .await,
+            )
+            .await;
+
+            assert!(!body.contains("sk-secret-value"), "{body}");
+            assert!(!body.contains("incorrect api key"), "{body}");
+            assert!(!body.contains("owned_by"), "{body}");
+            assert!(!body.contains("127.0.0.1"), "{body}");
+        }
+    }
+
+    /// The body goes through `writes::decode_body`, so it inherits every shape
+    /// rule the buffered writes have — including the positional-array form
+    /// serde would otherwise accept.
+    #[tokio::test]
+    async fn a_body_that_is_not_an_object_is_a_400() {
+        let file = migrated();
+        let ctx = ctx(&file);
+        for body in ["", "[\"openai\"]", "\"openai\""] {
+            let (status, _) = parts_of(validate(&ctx, body).await).await;
+            assert_eq!(status, StatusCode::BAD_REQUEST, "{body:?}");
+        }
+    }
+
+    /// `POST` is state-changing, so the guard requires `write` — and an `llm`
+    /// token, which is disjoint from both `read` and `write` (#423), opens
+    /// nothing on `/api` including this.
+    #[test]
+    fn the_validate_route_is_write_scoped_and_closed_to_an_llm_token() {
+        use crate::native::security::{required_scope, token::Scope};
+        let scope = required_scope(&Method::POST, VALIDATE_ROUTE.1);
+        assert_eq!(scope, Scope::Write);
+        assert!(!Scope::Llm.covers(scope));
+        assert!(Scope::Write.covers(scope));
     }
 }

--- a/src-tauri/src/native/gateway_api.rs
+++ b/src-tauri/src/native/gateway_api.rs
@@ -364,6 +364,24 @@ async fn validate_provider(db_path: &std::path::Path, body: &[u8]) -> Result<Res
             let Some(row) = config::load_provider_secret(db_path, id)? else {
                 return answer(Answer::error(StatusCode::NOT_FOUND, "provider not found")?);
             };
+            // **The stored key belongs to the stored type, and the request's
+            // type decides where it is sent.** Changing the Type dropdown on a
+            // configured provider and pressing Check would otherwise put an
+            // Anthropic key in an `Authorization: Bearer` header addressed to
+            // `api.openai.com` — reachable by ordinary use, with no attacker
+            // in it, and it would land the credential in a third party's
+            // request log. Whose base URL is used does not matter: an empty
+            // `base_url` resolves to the *requested* type's production default.
+            //
+            // A key supplied in the body has no such problem — it is the
+            // credential the user is asking about, for the type they are
+            // asking about.
+            if row.provider_type != provider_type {
+                return refuse(WriteError::validation(
+                    "api_key",
+                    "the stored key belongs to a different provider type; enter the key for this type",
+                ));
+            }
             row.api_key().to_string()
         }
     };
@@ -2958,6 +2976,56 @@ mod tests {
             seen.lock().expect("lock").target.is_empty(),
             "an unauthenticated request was made in the user's name"
         );
+    }
+
+    /// **A stored key is never sent to a different vendor's endpoint.**
+    ///
+    /// The reachable shape is ordinary use, not an attack: open a configured
+    /// Anthropic provider, change the Type dropdown to OpenAI, press Check. The
+    /// form sends the *new* type with no `api_key` — because the key field is
+    /// untouched by default — and an empty `base_url` resolves to the requested
+    /// type's production default, so the Anthropic key would arrive at
+    /// `api.openai.com` in an `Authorization: Bearer` header and stay in a third
+    /// party's request log.
+    ///
+    /// The assertion that matters is the second one: **nothing was sent**.
+    #[tokio::test]
+    async fn a_stored_key_is_not_checked_against_a_different_providers_endpoint() {
+        let file = migrated();
+        let ctx = ctx(&file);
+        let (base, seen) = fake_upstream(StatusCode::OK, r#"{"data":[]}"#).await;
+        seed_provider(&ctx, "p1", "anthropic", "sk-ant-secret", &base);
+
+        let (status, body) = parts_of(
+            validate(
+                &ctx,
+                &format!(r#"{{"id":"p1","type":"openai","base_url":"{base}"}}"#),
+            )
+            .await,
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert!(body.contains("different provider type"), "{body}");
+        assert!(
+            seen.lock().expect("lock").target.is_empty(),
+            "the stored key was sent to another provider type's endpoint"
+        );
+
+        // ...and a key supplied in the body is unaffected: it is the credential
+        // the user is asking about, for the type they are asking about.
+        let (status, _) = parts_of(
+            validate(
+                &ctx,
+                &format!(
+                    r#"{{"id":"p1","type":"openai","api_key":"sk-openai","base_url":"{base}"}}"#
+                ),
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(header_of(&seen, "authorization"), "Bearer sk-openai");
     }
 
     /// An `id` naming no row is the same 404 every other `{id}` route on this

--- a/src-tauri/src/native/gateway_api/catalog.rs
+++ b/src-tauri/src/native/gateway_api/catalog.rs
@@ -1,4 +1,20 @@
-//! Asking one configured provider's own upstream which models it serves (#470).
+//! Asking one provider's own upstream which models it serves (#470), and — since
+//! #472 — whether a credential the user has just typed is one it accepts.
+//!
+//! # One dialect table, two callers
+//!
+//! `GET /api/gateway/providers/{id}/models` asks a **stored** row; `POST
+//! /api/gateway/providers/validate` asks an **unsaved** draft. They are the same
+//! request to the same endpoint with the same authentication, differing only in
+//! where the three inputs came from — so [`fetch`] takes those three rather than
+//! a [`ProviderRow`], and there is exactly one [`Shape::of`] in the tree.
+//!
+//! That is deliberate and it is what #472's spec asked to be done differently:
+//! it predates #470 and describes a second per-type table in
+//! `gateway/validate.rs`. Two tables of provider endpoints is two things to keep
+//! in step with four upstreams, and the failure when they drift is silent — one
+//! surface would validate a credential against an endpoint the other never
+//! calls.
 //!
 //! # Why this is new code rather than something reused
 //!
@@ -54,7 +70,7 @@ use std::time::Duration;
 
 use serde::Deserialize;
 
-use crate::gateway::config::{ProviderRow, ProviderType};
+use crate::gateway::config::ProviderType;
 use crate::native::integrations::base_url::Base;
 
 /// How long one catalog fetch may take, end to end.
@@ -108,43 +124,79 @@ fn client() -> Option<&'static reqwest::Client> {
 ///
 /// `message` is what the UI renders, so it names a cause and never a value:
 /// no key, no URL, no upstream body.
+///
+/// **Three variants rather than two, because #472 has to tell them apart.** The
+/// catalog route maps all three onto two statuses and could not care; a
+/// validation verdict is precisely the question "which of these happened" — a
+/// refused credential, a base URL nothing answers on, and an upstream that
+/// answered something unexpected are three different things for a user to fix.
+/// Splitting the old `Upstream` in two costs the catalog route nothing: its
+/// mapping is unchanged, because [`Self::Unreachable`] carries the message that
+/// arm already produced.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CatalogError {
     /// The provider is configured in a way that makes the question unaskable —
     /// no API key, or a `base_url` this build will not send a request through.
     /// `400`, because nothing was asked and retrying will not change it.
     Unaskable(String),
-    /// The provider was asked and the answer was not a catalog. `502`, because
+    /// The request could not be delivered at all: DNS, TLS, connect, or a body
+    /// that stopped arriving. Nobody answered, so there is no status to report.
+    Unreachable(String),
+    /// The provider answered, and the answer was not a catalog — either because
+    /// of its `status`, or because a `200` carried something else. `502`, since
     /// this build did its part and somebody else's did not.
-    Upstream(String),
+    Upstream {
+        message: String,
+        /// The upstream's status, when there was one. `None` means a `200`
+        /// whose body did not parse.
+        status: Option<u16>,
+    },
 }
 
 impl CatalogError {
     pub fn message(&self) -> &str {
         match self {
-            Self::Unaskable(m) | Self::Upstream(m) => m,
+            Self::Unaskable(m) | Self::Unreachable(m) => m,
+            Self::Upstream { message, .. } => message,
+        }
+    }
+
+    /// A `200` that did not carry a catalog.
+    fn unparseable(message: &str) -> Self {
+        Self::Upstream {
+            message: message.to_string(),
+            status: None,
         }
     }
 }
 
-/// Every model id `row`'s upstream reports, in the order the upstream gave them.
+/// Every model id this provider's upstream reports, in the order it gave them.
 ///
 /// Order is the upstream's own — OpenAI's is by creation, Anthropic's is newest
 /// first — and re-sorting it would bury the model a user most likely wants under
 /// an alphabetical accident. Duplicates are dropped, which costs nothing and
 /// stops a paginated answer that overlaps from listing an id twice.
-pub async fn fetch(row: &ProviderRow) -> Result<Vec<String>, CatalogError> {
-    let key = row.api_key();
+///
+/// The three arguments are the three things a request needs, rather than a
+/// `ProviderRow`, because #472's caller has no row: it validates a draft the
+/// user is still typing. `key` is borrowed and never stored — the same
+/// discipline `ProviderRow`'s private field enforces on the other side of the
+/// call.
+pub async fn fetch(
+    provider_type: ProviderType,
+    base_url: &str,
+    key: &str,
+) -> Result<Vec<String>, CatalogError> {
     if key.is_empty() {
         return Err(CatalogError::Unaskable(
             "this provider has no API key, so its model list cannot be fetched".into(),
         ));
     }
 
-    let shape = Shape::of(row.provider_type);
+    let shape = Shape::of(provider_type);
     // Trailing slashes trimmed before `Base::new`, which concatenates: see the
     // module header.
-    let raw = row.base_url.trim_end_matches('/');
+    let raw = base_url.trim_end_matches('/');
     let raw = if raw.is_empty() {
         shape.default_base
     } else {
@@ -182,7 +234,7 @@ pub async fn fetch(row: &ProviderRow) -> Result<Vec<String>, CatalogError> {
         .await
         // Deliberately not `{e}`: a `reqwest::Error`'s `Display` carries the URL
         // it was built from, which is the one thing this must not hand back.
-        .map_err(|_| CatalogError::Upstream("the provider could not be reached".into()))?;
+        .map_err(|_| CatalogError::Unreachable("the provider could not be reached".into()))?;
 
     let status = response.status();
     if !status.is_success() {
@@ -190,10 +242,10 @@ pub async fn fetch(row: &ProviderRow) -> Result<Vec<String>, CatalogError> {
         // is wrong" far better than any wording here could. The body is not
         // read: it is the upstream's, and echoing it is what this module exists
         // not to do.
-        return Err(CatalogError::Upstream(format!(
-            "the provider answered {}",
-            status.as_u16()
-        )));
+        return Err(CatalogError::Upstream {
+            message: format!("the provider answered {}", status.as_u16()),
+            status: Some(status.as_u16()),
+        });
     }
 
     let body = read_capped(response).await?;
@@ -218,11 +270,11 @@ async fn read_capped(response: reqwest::Response) -> Result<Vec<u8>, CatalogErro
     let mut buf: Vec<u8> = Vec::new();
     while let Some(chunk) = stream.next().await {
         let chunk = chunk.map_err(|_| {
-            CatalogError::Upstream("the provider's answer could not be read".into())
+            CatalogError::Unreachable("the provider's answer could not be read".into())
         })?;
         if buf.len() + chunk.len() > MAX_BYTES {
-            return Err(CatalogError::Upstream(
-                "the provider's model list is larger than Agento will read".into(),
+            return Err(CatalogError::unparseable(
+                "the provider's model list is larger than Agento will read",
             ));
         }
         buf.extend_from_slice(&chunk);
@@ -294,8 +346,8 @@ impl Shape {
 
     fn parse(&self, body: &[u8]) -> Result<Vec<String>, CatalogError> {
         let unparseable = || {
-            CatalogError::Upstream(
-                "the provider's answer was not a model list Agento understands".into(),
+            CatalogError::unparseable(
+                "the provider's answer was not a model list Agento understands",
             )
         };
         match self.body {
@@ -404,7 +456,10 @@ mod tests {
     #[test]
     fn a_body_that_is_not_a_catalog_is_an_upstream_error_naming_no_value() {
         let err = body_of(BodyShape::DataId, "<html>nope</html>").unwrap_err();
-        assert!(matches!(err, CatalogError::Upstream(_)));
+        // A `200` whose body is not a catalog: the provider answered, so it is
+        // `Upstream` — with **no** status, which is what tells #472's verdict
+        // that there is nothing about the status code to report.
+        assert!(matches!(err, CatalogError::Upstream { status: None, .. }));
         assert!(!err.message().contains("html"), "{}", err.message());
     }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -779,6 +779,41 @@ export interface GatewayProviderRequest {
   enabled: boolean;
 }
 
+/**
+ * `POST /api/gateway/providers/validate` (#472) — the body of a credential
+ * check.
+ *
+ * `api_key` is three-valued in the same way `GatewayProviderRequest`'s is, and
+ * for the same reason: an edit form holds no key, because no read ever answered
+ * one. **Absent means "check the key already stored for `id`"**, which is what
+ * lets a provider configured months ago be re-tested. Creating a provider has
+ * no `id`, so it must supply one.
+ */
+export interface GatewayProviderValidateRequest {
+  id?: string;
+  type: GatewayProviderType;
+  api_key?: string;
+  base_url: string;
+}
+
+/**
+ * What the check found. **Answered with 200 whatever the verdict** — the
+ * outcome of the check is the thing that was asked for, so a refused key is a
+ * successful answer. Only a malformed request (an unknown `id`, a type this
+ * build cannot serve, nothing to check) is a 4xx, and that arrives as an
+ * `ApiError` like anywhere else.
+ */
+export interface GatewayProviderValidation {
+  ok: boolean;
+  outcome: "valid" | "unauthorized" | "unreachable" | "unexpected";
+  /** The upstream's status, when there was one — absent for a connect failure. */
+  status?: number;
+  /** One sentence naming a cause. Never carries the key or the base URL. */
+  message: string;
+  /** What the provider listed. Empty unless `ok`. */
+  models: string[];
+}
+
 export interface GatewayRouteTarget {
   /** The provider's **name**, not its id — that is what routing refers to. */
   provider: string;

--- a/src/styles/gateway.css
+++ b/src/styles/gateway.css
@@ -173,6 +173,19 @@
   min-width: 0;
 }
 
+/* --- The stored-key row, and the credential verdict beside it (#472) ------- */
+
+/* One horizontal run inside a `.formrow__control`, which is a column flex: the
+   `••• stored` placeholder plus its Replace control, and the verdict badge plus
+   its status. Two callers, one shape. */
+.gw-storedkey {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+  min-height: var(--control-h);
+  color: var(--fg-secondary);
+}
+
 /* --- Explanatory prose ---------------------------------------------------- */
 
 .gw-help {

--- a/src/views/gateway/ProvidersView.tsx
+++ b/src/views/gateway/ProvidersView.tsx
@@ -8,6 +8,8 @@ import type {
   GatewayProviderRequest,
   GatewayProviderSummary,
   GatewayProviderType,
+  GatewayProviderValidateRequest,
+  GatewayProviderValidation,
   GatewayTimeouts,
 } from "../../lib/types";
 import "../../styles/gateway.css";
@@ -24,12 +26,27 @@ import "../../styles/gateway.css";
      /api/gateway/providers` returns `has_api_key`, a boolean computed in SQL —
      so there is nothing to render, and the input starts empty on every load.
      A masked value would be a lie about what this app knows.
-   - **A save with pending changes refuses until the key is re-entered.** The
-     server preserves a stored key when the field is *absent* (#426 built
-     `Option<String>` for exactly that), so this is the second half of a
-     belt-and-braces pair rather than the only guard: it is what stops the
-     integrations bug — a scrubbed read written straight back wiping the
-     secret — from ever depending on one side alone.
+   - **An untouched key field sends no `api_key` at all**, which the server
+     reads as "leave the stored one alone" (#426 built `Option<String>` for
+     exactly that). It must never send `""`, which *clears* the key: that is
+     the whole distance between preserving a secret and destroying one, and it
+     is the `PUT /api/integrations/{id}` data-loss bug this surface exists not
+     to repeat.
+
+   Until #472 there was a second rule here — a save refused until the key was
+   re-typed — described as belt-and-braces over the server's `Option<String>`.
+   It was not. The server has always preserved an omitted key, and provider
+   dashboards do not show a key twice, so what the rule actually did was block
+   every edit to a *timeout* on a provider configured months ago. It is gone,
+   and `canSave` requires a typed key only when there is no stored one to fall
+   back on.
+
+   What replaced it is a check that answers a different and more useful
+   question: **`POST /api/gateway/providers/validate` asks the provider itself**
+   whether the credential works, before it is stored. The gate is deliberately
+   **soft** — a base that serves no list-models endpoint (a proxy, something
+   self-hosted) would otherwise be permanently unsaveable, so "Save anyway" is
+   always one click away. A validation gate with no override is a lockout.
 
    Deleting is refused by the server while an alias still routes to the
    provider, which is checked in code because the reference lives inside a JSON
@@ -63,6 +80,34 @@ type Selection =
   | { kind: "none" }
   | { kind: "new" }
   | { kind: "row"; id: string };
+
+/**
+ * What is known about the credential as currently typed (#472).
+ *
+ * `undefined` is "not asked yet", which is the state every edit to `type`,
+ * `base_url` or the key returns it to — a verdict about fields that have since
+ * changed is worse than no verdict, because it reads as one about what is on
+ * screen.
+ */
+type Check =
+  | { state: "checking" }
+  | { state: "done"; result: GatewayProviderValidation }
+  | { state: "failed"; message: string };
+
+/** Which `badge` modifier an outcome wears. */
+const OUTCOME_BADGE: Record<GatewayProviderValidation["outcome"], string> = {
+  valid: "badge--green",
+  unauthorized: "badge--red",
+  unreachable: "badge--amber",
+  unexpected: "badge--amber",
+};
+
+const OUTCOME_LABEL: Record<GatewayProviderValidation["outcome"], string> = {
+  valid: "Working",
+  unauthorized: "Key refused",
+  unreachable: "Unreachable",
+  unexpected: "Unexpected",
+};
 
 export function GatewayProvidersView({ inspectorOpen }: { inspectorOpen: boolean }) {
   const providers = useResource<GatewayProviderSummary[] | null>(
@@ -244,11 +289,22 @@ function ProviderForm({
   );
   // Write-only: it starts empty on every load and no response can fill it.
   const [apiKey, setApiKey] = useState("");
+  /**
+   * Whether the key input is on screen at all. A configured provider shows
+   * `••• stored` until the user asks to replace it, so the ordinary edit — a
+   * timeout, the enabled flag — never puts an empty secret field in front of
+   * someone who has no secret to put in it.
+   */
+  const [replacingKey, setReplacingKey] = useState(creating || !provider?.has_api_key);
 
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string>();
   const [notice, setNotice] = useState<string>();
   const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const [check, setCheck] = useState<Check>();
+  /** Set by "Save anyway", and cleared by the same edits a verdict is. */
+  const [overridden, setOverridden] = useState(false);
 
   const changed =
     creating ||
@@ -262,7 +318,28 @@ function ProviderForm({
     apiKey.trim() !== "";
 
   const hasKey = apiKey.trim() !== "";
-  const canSave = changed && name.trim() !== "" && hasKey;
+  /**
+   * A key to check: one just typed, or one already on the server.
+   *
+   * This is the whole of what #472 relaxes. The server has always read an
+   * absent `api_key` as "keep the stored one", so requiring a fresh one was a
+   * UI-only rule — and one the user usually could not satisfy, because a
+   * provider shows a key once at issuance and never again.
+   */
+  const haveCredential = hasKey || (!creating && provider.has_api_key);
+  const checked = check?.state === "done" && check.result.ok;
+  const canSave =
+    changed && name.trim() !== "" && haveCredential && (checked || overridden);
+
+  /**
+   * A verdict is about the fields it was taken against, so the three inputs it
+   * depends on invalidate it. `name`, `enabled` and the timeouts do not: none
+   * of them reaches the request.
+   */
+  function credentialsChanged() {
+    setCheck(undefined);
+    setOverridden(false);
+  }
 
   /** Back out of an edit in one click, the way every other form here does. */
   function revert() {
@@ -273,7 +350,39 @@ function ProviderForm({
     setEnabled(provider.enabled);
     setTimeouts(provider.timeouts);
     setApiKey("");
+    setReplacingKey(!provider.has_api_key);
     setError(undefined);
+    credentialsChanged();
+  }
+
+  /**
+   * Ask the provider whether this credential works, without spending a token:
+   * the route dials the same free list-models endpoint #470 already uses.
+   *
+   * A failure is a **value**, not a throw — the same doctrine `ModelsView`
+   * states for the catalog. Only a malformed request reaches the `catch`, and
+   * that one really is an error rather than a verdict.
+   */
+  async function runCheck() {
+    setCheck({ state: "checking" });
+    setError(undefined);
+    try {
+      const body: GatewayProviderValidateRequest = {
+        type,
+        base_url: baseUrl.trim(),
+        // Exactly the same rule the save uses: a key is sent only when typed,
+        // and an absent one asks the server to check the stored one.
+        ...(creating ? {} : { id: provider.id }),
+        ...(hasKey ? { api_key: apiKey.trim() } : {}),
+      };
+      const result = await api.post<GatewayProviderValidation>(
+        "/gateway/providers/validate",
+        body
+      );
+      setCheck({ state: "done", result });
+    } catch (err) {
+      setCheck({ state: "failed", message: describeError(err) });
+    }
   }
 
   async function save() {
@@ -297,7 +406,9 @@ function ProviderForm({
             body
           );
       setApiKey("");
+      setReplacingKey(false);
       setNotice("Saved.");
+      credentialsChanged();
       onDone(saved.id);
     } catch (err) {
       setError(describeError(err));
@@ -398,7 +509,10 @@ function ProviderForm({
               <Dropdown
                 value={type}
                 options={TYPES}
-                onChange={(v) => setType(v as GatewayProviderType)}
+                onChange={(v) => {
+                  setType(v as GatewayProviderType);
+                  credentialsChanged();
+                }}
               />
             </FormRow>
 
@@ -410,7 +524,10 @@ function ProviderForm({
                 className="field"
                 value={baseUrl}
                 placeholder={BASE_URL_HINT[type]}
-                onChange={(e) => setBaseUrl(e.target.value)}
+                onChange={(e) => {
+                  setBaseUrl(e.target.value);
+                  credentialsChanged();
+                }}
               />
             </FormRow>
 
@@ -433,23 +550,105 @@ function ProviderForm({
                 {creating
                   ? "The API key is stored locally and is never shown again."
                   : provider.has_api_key
-                    ? "A key is stored. Agento cannot show it back to you, so any save has to be given one."
+                    ? "A key is stored. Agento cannot show it back to you, and does not need to — leave this alone and the stored one is kept."
                     : "No key is stored for this provider — it cannot serve a request until you add one."}
               </span>
             </div>
 
             <FormRow
               label="API key"
-              help="Sent only when you type one, and never returned by any read."
+              help={
+                replacingKey
+                  ? "Sent only when you type one, and never returned by any read."
+                  : "Untouched, so the save sends no key at all and the stored one survives."
+              }
             >
-              <input
-                className="field mono"
-                type="password"
-                autoComplete="off"
-                value={apiKey}
-                placeholder="sk-…"
-                onChange={(e) => setApiKey(e.target.value)}
-              />
+              {replacingKey ? (
+                <input
+                  className="field mono"
+                  type="password"
+                  autoComplete="off"
+                  value={apiKey}
+                  placeholder="sk-…"
+                  onChange={(e) => {
+                    setApiKey(e.target.value);
+                    credentialsChanged();
+                  }}
+                />
+              ) : (
+                <div className="gw-storedkey">
+                  <span className="mono">••••••••••• stored</span>
+                  <button
+                    className="btn btn--ghost"
+                    onClick={() => {
+                      setReplacingKey(true);
+                      credentialsChanged();
+                    }}
+                  >
+                    Replace key
+                  </button>
+                </div>
+              )}
+            </FormRow>
+
+            <FormRow
+              label="Check"
+              help={
+                haveCredential
+                  ? "Asks the provider to list its models — it authenticates the same credential a request would, and spends nothing."
+                  : "Enter an API key first."
+              }
+            >
+              <button
+                className="btn"
+                style={{ alignSelf: "flex-start" }}
+                onClick={runCheck}
+                disabled={!haveCredential || check?.state === "checking" || busy}
+              >
+                <Icon name="check" size={13} />
+                {check?.state === "checking"
+                  ? "Checking…"
+                  : "Check these credentials"}
+              </button>
+
+              {check?.state === "done" && (
+                <>
+                  <div className="gw-storedkey">
+                    <span className={`badge ${OUTCOME_BADGE[check.result.outcome]}`}>
+                      {OUTCOME_LABEL[check.result.outcome]}
+                    </span>
+                    {check.result.status !== undefined && (
+                      <span className="gw-help" style={{ margin: 0 }}>
+                        HTTP {check.result.status}
+                      </span>
+                    )}
+                  </div>
+                  <div
+                    className={`msgline ${check.result.ok ? "msgline--ok" : "msgline--error"}`}
+                  >
+                    <span>
+                      {check.result.message}
+                      {check.result.ok && check.result.models.length > 0 && (
+                        <>
+                          {" "}
+                          It serves {check.result.models.length} model
+                          {check.result.models.length === 1 ? "" : "s"}, including{" "}
+                          <span className="mono">
+                            {check.result.models.slice(0, 3).join(", ")}
+                          </span>
+                          .
+                        </>
+                      )}
+                    </span>
+                  </div>
+                </>
+              )}
+
+              {check?.state === "failed" && (
+                <div className="msgline msgline--error">
+                  <span>{check.message}</span>
+                </div>
+              )}
             </FormRow>
           </div>
 
@@ -490,7 +689,9 @@ function ProviderForm({
               ? "You have unsaved changes."
               : name.trim() === ""
                 ? "A name is required."
-                : "Enter the API key to save."}
+                : !haveCredential
+                  ? "Enter the API key to save."
+                  : "Check the credentials, or save anyway."}
           </span>
           {onCancel ? (
             <button className="btn" onClick={onCancel} disabled={busy}>
@@ -499,6 +700,24 @@ function ProviderForm({
           ) : (
             <button className="btn" onClick={revert} disabled={busy}>
               Revert
+            </button>
+          )}
+          {/*
+            The override, and it is not optional. A base that serves no
+            list-models endpoint — a proxy, something self-hosted, an
+            OpenAI-compatible vendor that implements only completions — cannot
+            ever produce a green verdict, so a gate without this would make it
+            permanently unsaveable. It is offered whenever the check has not
+            passed, including before it has been run at all: a user who knows
+            their setup should not have to fail a check first.
+          */}
+          {!checked && !overridden && haveCredential && name.trim() !== "" && (
+            <button
+              className="btn"
+              onClick={() => setOverridden(true)}
+              disabled={busy}
+            >
+              Save anyway
             </button>
           )}
           <button

--- a/src/views/gateway/ProvidersView.tsx
+++ b/src/views/gateway/ProvidersView.tsx
@@ -710,11 +710,21 @@ function ProviderForm({
             permanently unsaveable. It is offered whenever the check has not
             passed, including before it has been run at all: a user who knows
             their setup should not have to fail a check first.
+
+            It **saves**, rather than merely arming Save. Setting `overridden`
+            alone would make the button vanish on click — the condition below is
+            what renders it — leaving the user hunting for the Save it just
+            enabled, from a label that promised the save itself. `save()` reads
+            neither `overridden` nor `canSave`, so calling it here is the whole
+            of it; the flag is still set, so a failed save leaves Save armed.
           */}
           {!checked && !overridden && haveCredential && name.trim() !== "" && (
             <button
               className="btn"
-              onClick={() => setOverridden(true)}
+              onClick={() => {
+                setOverridden(true);
+                void save();
+              }}
               disabled={busy}
             >
               Save anyway


### PR DESCRIPTION
Closes #472

## What

Two problems in the LLM Gateway provider form (**Gateway → Providers**), failing in the same direction — the user could not tell a working provider from a broken one until a request spent, or failed to spend, credits.

**1. A credential is now checkable before it is stored.** New write route `POST /api/gateway/providers/validate` asks the provider to list its models. That authenticates exactly what an inference call would, costs nothing and returns no completion. An **omitted `api_key` checks the stored one**, so a provider configured months ago is re-testable without a secret no provider dashboard shows twice.

**2. Editing a non-credential field no longer demands the API key.** `canSave` required a freshly typed key on *every* save. The view described that as belt-and-braces over the server's `Option<String>` — it was not: `config::update_provider` has always preserved an omitted key, and `a_scrubbed_read_written_straight_back_preserves_the_stored_key` has always pinned it. What the rule actually did was block every edit to a timeout on an existing provider.

## How

### Deviation from the `HOW` — recorded, and [commented on the issue](https://github.com/shaharia-lab/agento/issues/472#issuecomment-5419023285)

The spec was written before #470 (PR #476) merged, and #470 already built the per-provider list-models dialects in `native/gateway_api/catalog.rs`. Three of its instructions are superseded, and following them verbatim would have regressed decisions made two commits ago:

| the `HOW` says | what landed, and why |
|---|---|
| new `src-tauri/src/gateway/validate.rs` with its own per-type table | **reuse `catalog.rs`.** Two tables of provider endpoints is two things to keep in step with four upstreams, and they drift silently — one surface would validate against an endpoint the other never calls |
| three provider types | **four.** `glm` since #422 |
| OpenAI → `{base}/v1/models`; Gemini key in `?key=` | **`/models`** (the stored OpenAI base is already the *versioned* root, because that is what completions needs), and **`x-goog-api-key`** — #470 refused a key in a URL deliberately, since that is what an error string, a redirect and a proxy log all see |
| use `trigger::block_on_result`, do **not** add a `StreamEndpoint` | **`StreamEndpoint`.** #470 settled this for exactly this shape: `Endpoint::serve` is a sync `fn` on `spawn_blocking`, right for reading SQLite and wrong for an outbound HTTPS call |

Every acceptance criterion is unaffected by all four.

### Backend

- **`gateway_api/catalog.rs`** — `fetch` takes `(ProviderType, base_url, key)` rather than a `&ProviderRow`, because #472's caller validates a draft that has no row. `CatalogError` splits `Upstream` into `Unreachable` (nothing answered) and `Upstream { message, status }` (something did), so the verdict has the status it needs. The catalog route's own status mapping is unchanged.
- **`gateway_api.rs`** — `ASYNC_ROUTES` replaces the single `CATALOG_ROUTE` literal, and it is a **const rather than two literals**: a route claimed by both registries leaves the buffered arm permanently unreachable (`proxy.rs` asks `claims_stream` first), so the guard iterates the const and a third async route inherits the check instead of having to remember it.
- **Statuses.** A verdict is a **200 whatever it says** — the outcome of the check is the thing that was asked for, so a refused key is a successful answer to "is this key refused?". That is the doctrine `ModelsView` already states for #470's catalog (*a failure is a value, not a throw*), and a route that 4xx'd its verdicts would make the form unpack `err.body` to render its own result. 4xx is reserved for the *request* being wrong: undecodable body (400), a type this build cannot serve or nothing to check at all (422), an `id` naming no row (404).
- **Classification.** `401`/`403` are one bucket, because several providers report an exhausted quota as `403` rather than `429` and both mean "this credential will not serve a request". `404` is grouped with the transport failures, because it means the *base URL* rather than the key — the pair a user otherwise mixes up, since both present as "it does not work".
- **Nothing leaks.** The verdict's `message` comes from `CatalogError` unchanged rather than being restated here, which is what keeps the no-key/no-URL/no-upstream-body discipline in one place. The log line carries the outcome, the status and the provider id — never the base URL, which is user-typed and can carry a token in its path.
- **`write`-scoped by construction** (`required_scope` maps every state-changing method), so an `llm` token opens none of it — #423's disjointness, asserted rather than assumed.

### Frontend

- `canSave` → `changed && name && (hasKey || (!creating && provider.has_api_key)) && (checked || overridden)`.
- A stored key renders as `••••••••••• stored` behind an explicit **Replace key**; an untouched field still sends **no** `api_key` rather than `""` — that is the whole distance between preserving a secret and clearing one.
- The verdict invalidates on `type`, `base_url` or the key changing, and on nothing else: `name`, `enabled` and the timeouts do not reach the request.
- **Save anyway** is always one click away when the check has not passed, including before it has been run. A base serving completions but no model list — a proxy, something self-hosted, some OpenAI-compatible vendors — can never go green while working perfectly, so a gate with no override is a lockout.

## Tests

Nine new backend tests, all against a **local `axum` fake** (`fake_upstream`, built for #470) — no network, no keys, nothing `#[ignore]`d:

- a supplied key is the one that reaches the upstream, and a green verdict carries the catalog it reached
- **an omitted `api_key` checks the stored one**; a supplied one wins over it
- nothing to check is a 422 — on both the creating path and a row whose key is empty — and **no unauthenticated request is made in the user's name** (asserted on the fake having seen nothing)
- an unknown `id` is a 404; a type this build cannot serve is a 422 that does not quote the caller's value back
- **the four outcomes are told apart from one table** — 401, 403, 404, 500, plus a genuinely dead address (bound then dropped, so the connect is refused rather than filtered) for the no-status case
- a base URL the dot-segment guard refuses is a verdict, not a request
- **no answer carries the key or the upstream body**, asserted over the **bytes** on all three paths, with the fake echoing the key into its own body and error text
- the async routes are claimed by one registry, iterated over `ASYNC_ROUTES`; `validate` is not shadowed by a sibling provider route
- the route is `write`-scoped and closed to an `llm` token

**Reverting the change makes them fail** — verified, not assumed: making an omitted key stop falling back to the stored one fails `an_omitted_api_key_checks_the_stored_one`, and collapsing the 401/403/404 classification fails `a_refused_key_a_wrong_base_url_and_a_surprise_are_told_apart`.

### Review findings, fixed in this PR

Three rounds of automated review; the first two found real defects:

1. **A stored key could be checked against a *different* vendor's endpoint.** The fallback took `row.api_key()` while the *request's* `type` decided where it went — and the form sends the Type dropdown's current value with no `api_key`, because an untouched key field is the default for a configured provider. Changing Type on a stored Anthropic provider and pressing Check put `sk-ant-…` in an `Authorization: Bearer` header addressed to `api.openai.com`. No attacker in it, and an empty `base_url` made it worse rather than better, resolving to the *requested* type's production default. Fixed with a type comparison before the key is read, plus `a_stored_key_is_not_checked_against_a_different_providers_endpoint`, whose load-bearing assertion is that the fake upstream saw **nothing** — verified to fail when the guard is disabled.
2. **"Save anyway" only armed Save.** It set `overridden` and then unmounted itself, since that flag is what renders it — a button labelled with an action that performed none. It now calls `save()`.
3. A miscount in `CLAUDE.md` ("Four things" above five bullets).

**One gap, stated plainly:** the frontend has no test harness in this repo (`npm run build` is `tsc --noEmit && vite build`, and that is the whole gate). The `canSave` relaxation and "Save anyway" are therefore covered by typecheck and review only — the backend half they depend on is what carries the regression guards.

## Gates

`cargo fmt --check` · `cargo clippy --all-targets -D warnings` · `cargo test` (1358 + 82 integration, 0 failed) · `cargo build --release` · `npm run build`.

## Docs

`CLAUDE.md` (the async-route pair, the one dialect table, why a verdict is a 200, and why the key field stopped being a gate), `docs/user-guide.md` (the check and its four verdicts, and that Replace key is what puts the input back), `docs/troubleshooting.md` (two new entries), `docs/development.md` + `gateway/mod.rs` (the route count, which was already stale at twelve after #470 and is now fourteen).
