### PR TITLE
feat(gateway): tab the Overview snippets and drop the duplicated status card (#473)

### DIFF
--- a/src/styles/gateway.css
+++ b/src/styles/gateway.css
@@ -94,34 +94,44 @@
 
 /* --- Copyable env snippets ------------------------------------------------ */
 
-.gw-snippet + .gw-snippet {
-  margin-top: var(--sp-5);
-}
+/* There is exactly one of these now: since #473 the four snippets are tabs
+   within one block rather than four stacked cards, so nothing sets a gap
+   between siblings. */
 
+/* The tab strip on the left, the Copy button on the right (#473). It wraps
+   rather than overflowing, because the strip is `flex: none` and a narrow
+   detail pane would otherwise push the button out of the column. */
 .gw-snippet__head {
   display: flex;
   align-items: center;
-  gap: var(--sp-4);
+  flex-wrap: wrap;
+  gap: var(--sp-3) var(--sp-4);
   margin-bottom: var(--sp-3);
 }
 
-.gw-snippet__title {
-  font-size: var(--text-sm);
-  font-weight: var(--weight-medium);
-  color: var(--fg);
-}
-
+/* One line at the column width — `.form` caps at 620px and the longest note is
+   comfortably inside that — which is half of why switching tabs does not move
+   the page. The other half is the fixed body height below. */
 .gw-snippet__note {
   font-size: var(--text-xs);
+  line-height: var(--leading-normal);
   color: var(--fg-tertiary);
+  min-height: calc(var(--text-xs) * var(--leading-normal));
+  margin-bottom: var(--sp-3);
 }
 
 /* `.codebox` comes from integrations.css and already sets the mono face and
    the inset background; it does not preserve newlines, and these snippets are
-   two lines of shell. */
+   two or three lines of shell.
+
+   The `min-height` is the tallest snippet — three lines plus the box's own
+   padding — so the two-line ones do not shrink the block and reflow everything
+   under it when the user moves between tabs. It stays under `.codebox`'s own
+   90px `max-height`, so a longer snippet added later still scrolls. */
 .gw-snippet .codebox {
   white-space: pre;
   overflow-x: auto;
+  min-height: calc(3 * var(--text-xs) * var(--leading-normal) + 2 * var(--sp-4));
 }
 
 /* --- The ordered target rows on Models ------------------------------------ */

--- a/src/views/gateway/OverviewView.tsx
+++ b/src/views/gateway/OverviewView.tsx
@@ -2,7 +2,14 @@ import { useCallback, useState } from "react";
 import { api } from "../../lib/api";
 import { CopyButton } from "../../components/CopyButton";
 import { TokenReveal } from "../../components/TokenReveal";
-import { Empty, FormRow, InspGroup, InspRow, Splitter } from "../../components/ui";
+import {
+  Empty,
+  FormRow,
+  InspGroup,
+  InspRow,
+  Segmented,
+  Splitter,
+} from "../../components/ui";
 import { Icon } from "../../lib/icons";
 import { describeError, usePoll, useResource } from "../../lib/hooks";
 import type { ViewId } from "../../lib/nav";
@@ -84,6 +91,12 @@ export function GatewayOverviewView({
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string>();
 
+  // Which snippet is on show. `curl` unconditionally, because "does it answer
+  // at all" is the first thing to try — even though it cannot succeed until a
+  // token exists, which is what the amber banner above the tabs already says.
+  // Deliberately not persisted: one view, one visit, no state worth carrying.
+  const [tab, setTab] = useState("curl");
+
   const mint = useCallback(async () => {
     setBusy(true);
     setError(undefined);
@@ -108,6 +121,10 @@ export function GatewayOverviewView({
   const copy = (state && STATE_COPY[state]) || UNKNOWN_STATE;
   const port = effectivePort(status.data, settings.data?.port ?? 0);
   const snippets = port > 0 ? snippetsFor(port, created?.token) : [];
+  // `tab` is a key rather than an index, so it survives the list being rebuilt
+  // on every mint. The fallback covers a key that is no longer in the list; it
+  // is never read when `snippets` is empty, which the `Empty` branch guards.
+  const active = snippets.find((s) => s.key === tab) ?? snippets[0];
 
   return (
     <div className="panes">
@@ -153,48 +170,60 @@ export function GatewayOverviewView({
               ) : null
             )}
 
-            {/* ── Status ──────────────────────────────────────────────────── */}
-            <div className="formsec">
-              <div className="formsec__title">Listener</div>
+            {/* ── Status ──────────────────────────────────────────────────────
+                Only when the listener is *not* running (#473). A running one is
+                already reported three times over — the toolbar dot and label
+                above, the inspector's Listener/Endpoints groups, and the port
+                printed inside every snippet — so in the state users spend all
+                their time in this card is pure duplication pushing the snippets
+                past the fold. What it uniquely carries is the failure
+                explanation, `status.error`, and the button to Gateway Settings,
+                and none of those exist while it runs. */}
+            {state !== "running" && (
+              <>
+                <div className="formsec">
+                  <div className="formsec__title">Listener</div>
 
-              <div className={`gw-status gw-status--${state ?? "unknown"}`}>
-                <div className="gw-status__head">
-                  <span className={`badge ${copy.badge}`}>{copy.label}</span>
-                  {status.data?.port !== undefined && (
-                    <span className="mono tnum gw-status__port">
-                      127.0.0.1:{status.data.port}
-                    </span>
-                  )}
+                  <div className={`gw-status gw-status--${state ?? "unknown"}`}>
+                    <div className="gw-status__head">
+                      <span className={`badge ${copy.badge}`}>{copy.label}</span>
+                      {status.data?.port !== undefined && (
+                        <span className="mono tnum gw-status__port">
+                          127.0.0.1:{status.data.port}
+                        </span>
+                      )}
+                    </div>
+
+                    <p className="gw-status__text">
+                      {explain(status.data, settings.data)}
+                    </p>
+
+                    {status.data?.error && (
+                      <code className="gw-status__error mono">
+                        {status.data.error}
+                      </code>
+                    )}
+
+                    {/* The one lever a failed or stopped listener leaves the
+                        user, so it is a link rather than a sentence telling
+                        them to go and find it. */}
+                    <div className="row">
+                      <button
+                        className="btn btn--primary"
+                        onClick={() => onNavigate("gateway-settings")}
+                      >
+                        <Icon name="gear" size={13} />
+                        {state === "bind_failed"
+                          ? "Change the port"
+                          : "Open gateway settings"}
+                      </button>
+                    </div>
+                  </div>
                 </div>
 
-                <p className="gw-status__text">{explain(status.data, settings.data)}</p>
-
-                {status.data?.error && (
-                  <code className="gw-status__error mono">
-                    {status.data.error}
-                  </code>
-                )}
-
-                {/* The one lever a failed or stopped listener leaves the user,
-                    so it is a link rather than a sentence telling them to go
-                    and find it. */}
-                {state !== "running" && (
-                  <div className="row">
-                    <button
-                      className="btn btn--primary"
-                      onClick={() => onNavigate("gateway-settings")}
-                    >
-                      <Icon name="gear" size={13} />
-                      {state === "bind_failed"
-                        ? "Change the port"
-                        : "Open gateway settings"}
-                    </button>
-                  </div>
-                )}
-              </div>
-            </div>
-
-            <div className="divider" />
+                <div className="divider" />
+              </>
+            )}
 
             {/* ── The credential ──────────────────────────────────────────── */}
             <div className="formsec">
@@ -260,22 +289,33 @@ export function GatewayOverviewView({
                   }
                 />
               ) : (
-                snippets.map((s) => (
-                  <div className="gw-snippet" key={s.key}>
-                    <div className="gw-snippet__head">
-                      <span className="gw-snippet__title">{s.title}</span>
-                      <span className="gw-snippet__note">{s.note}</span>
-                      <div className="spacer" />
-                      <CopyButton
-                        text={s.body}
-                        title={`Copy the ${s.title} snippet`}
-                        className="btn"
-                        label="Copy"
-                      />
-                    </div>
-                    <pre className="codebox">{s.body}</pre>
+                /* One block, four tabs — the user reads exactly one of these,
+                   so stacking all four cost ~330px of scroll to show three
+                   snippets nobody was looking at. `Segmented` is the repo's tab
+                   primitive and brings role="tablist"/aria-selected with it. */
+                <div className="gw-snippet">
+                  <div className="gw-snippet__head">
+                    <Segmented
+                      value={active.key}
+                      options={snippets.map((s) => ({
+                        value: s.key,
+                        label: s.title,
+                      }))}
+                      onChange={setTab}
+                    />
+                    <div className="spacer" />
+                    {/* Straight from `snippetsFor()` — the clipboard text is
+                        the snippet's own bytes, never re-derived here. */}
+                    <CopyButton
+                      text={active.body}
+                      title={`Copy the ${active.title} snippet`}
+                      className="btn"
+                      label="Copy"
+                    />
                   </div>
-                ))
+                  <p className="gw-snippet__note">{active.note}</p>
+                  <pre className="codebox">{active.body}</pre>
+                </div>
               )}
             </div>
           </div>


### PR DESCRIPTION
Closes #473

## What

**LLM Gateway → Overview** fits on one screen.

1. **The four snippets are one tabbed block.** A `Segmented` strip — the repo's
   own tab primitive, used a view away in `UsageView` — replaces the
   `snippets.map(...)` that stacked four full-width `.gw-snippet` cards. One
   Copy button, reading the active snippet's own bytes. Default tab is `curl`,
   unconditionally, in local `useState` with no persistence.
2. **The `Listener` card renders only when the listener is not running.** While
   running it restated State, Port and the endpoints the inspector pane is
   showing at the same moment, plus the port already printed inside every
   snippet. Everything it uniquely carries — the `explain()` sentence,
   `status.error` and the button to Gateway Settings — exists only in
   `stopped` / `bind_failed` / `start_failed`, so those states keep it in full.
3. **A fixed body height** on `.gw-snippet .codebox` (three lines + the box's own
   padding, still under `.codebox`'s 90px `max-height`) so switching between the
   two- and three-line snippets does not reflow the page.

`src/views/gateway/snippets.ts` is **untouched**: the clipboard text is the same
bytes, and the OpenAI-has-`/v1` / Anthropic-has-none asymmetry keeps its `Pin*`
compile-time guard.

## Why

Reported from a real window: the page scrolled ~840px, the top ~150px of it
duplicating the inspector and the bottom ~500px showing four code cards the user
reads exactly one of. Four stacked code cards read as a web docs page; the rest
of the app reads as a native tool.

## How it was verified

`npm run build` (tsc + Vite) green, and driven in the **real Tauri webview** via
`ui-verify`, at a layout constrained to 1440×900 with the inspector open:

| criterion | measured |
|---|---|
| no vertical scroll when running | `scrollHeight` 797 = `clientHeight` 797, code block bottom at 447px |
| `Listener` card hidden when running | `.gw-status` absent; present in `stopped` and `bind_failed` |
| tab switching does not move the page | form 519.78px / code 63.84px / note 15.94px — identical on all four tabs |
| copy text unchanged | all four buttons produced byte-identical `snippetsFor()` output |
| not-running states keep their lever | `bind_failed` rendered the sentence, `binding the llm gateway on 127.0.0.1:8991: Address already in use (os error 98)`, and a **Change the port** button that routed to Gateway Settings |

`start_failed` was not force-reproduced; it shares the single `state !== "running"`
condition with the two states that were.

## Deviations from the issue's HOW

- The HOW spells the code block `className="codebox selectable"`. `.selectable`
  was removed by #469 — text selection is now a denylist over chrome in
  `base.css` — so the class stays `codebox`, as it is today.
- **Widening the content column was already rejected in refinement** and is not
  done here; `.form` stays at its shared 620px.