### PR TITLE
feat(gateway): gate enabling on a routable configuration, and suggest a free port (#474)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -332,12 +332,14 @@ src-tauri/src/
     agents.rs    GET /api/agents and /api/agents/{slug}
     chats.rs     GET /api/chats and /api/chats/{id}; compact() is Go's, byte for byte
     tasks.rs     GET /api/tasks, /api/job-history and the three reads between them
-    gateway_api.rs the LLM gateway's control plane (#426) — fourteen
+    gateway_api.rs the LLM gateway's control plane (#426) — fifteen
                  /api/gateway/* routes; under native/ because it IS the /api
                  seam, where gateway/'s listener is not. Two of them are
                  answered by the ASYNC registry, because they call an upstream:
                  the model catalog (#470) and the credential check (#472), which
-                 share one dialect table in gateway_api/catalog.rs
+                 share one dialect table in gateway_api/catalog.rs. The
+                 fifteenth is the port probe (#474) — buffered, because a
+                 `bind` is not an HTTPS call
     security/    what `/api` accepts as proof of identity (#405)
       keys.rs    the per-install Ed25519 keypair: create-if-absent, 0600, and
                  the one path that replaces it
@@ -3399,6 +3401,52 @@ provider.has_api_key)`, a stored key renders as `••• stored` behind an exp
 completions but no model list can never go green, so "Save anyway" is always one
 click away. A validation gate with no override is a lockout — do not remove it
 to simplify.
+
+**The enable gate is UI-only, and the port probe is advisory** (#474). Two
+guardrails over the same first-run path, and what makes each of them safe is the
+same thing: neither can refuse a save.
+
+- **`config::GatewaySettings::validate` was deliberately left alone.** A
+  server-side refusal of `enabled: true` with no aliases reads as the honest
+  one, and it would **422 an existing row whose aliases were later deleted** —
+  on a body the form posts *on every save*, so an unrelated retention edit would
+  start failing. A deleted provider is already a 409 when an alias references
+  it; nothing stops deleting every alias, and that has to stay a save-able
+  state. So the gate lives in `SettingsView.tsx` and gates the **switches**,
+  never Save.
+- **It gates turning-on, not the switch**, and that asymmetry is the whole of
+  it: `disabled={!canTurnOn && !enabled}`. A flat `disabled` would lock an
+  install that *is* enabled out of switching its own listener off, which is
+  exactly what someone whose last alias went away wants to do. Nothing rewrites
+  a stored value either — a forced `false` would disable a working gateway on
+  the next unrelated save, which is what "existing installs are unaffected by
+  the upgrade" means.
+- **A failed readiness read is a third state**, not "empty". `Readiness` is
+  `loading | unknown | ready | unroutable`, because a request that errored knows
+  nothing about stored rows — the rule `ModelsView`'s list column already
+  states. It shuts the switches the same way and says something different.
+- **"Configured" counts alias *rows*, not enabled ones.** Gating on
+  `alias.enabled` would make the gateway switch unusable the moment somebody
+  toggles their last alias off, which is a legitimate temporary state.
+- **`GET /api/gateway/port-availability?port=N` is the one thing a webview
+  cannot do** — bind a socket. Buffered, not async: it is a `bind`, so
+  `spawn_blocking` is right and the #470/#472 reasoning does not apply. Three
+  rules on it. The **running listener's own port reads as available**
+  (`own_port_of`), or the probe finds the port held by the very process being
+  configured and offers to move it on every visit — note `BindFailed` carries a
+  port too and that one is precisely *not* held, so only `Running` counts. The
+  walk is **capped** at `PORT_SCAN_SPAN` above the request and the body says how
+  far it looked (`scanned_to`), so "no free port" is a bounded claim rather than
+  65535 `bind` syscalls behind a form somebody is typing into. And the answer is
+  **never applied for the user**: the port is what gets pasted into
+  `OPENAI_BASE_URL` / `ANTHROPIC_BASE_URL`, so a silent rewrite points every
+  already-configured tool at nothing.
+- **The probe is a TOCTOU check by construction** — the listener is dropped
+  immediately, so nothing is reserved. `Status::BindFailed` stays the authority
+  and the status strip stays where the real outcome shows up; what this buys is
+  moving the *routine* collision (a `~/.agento-desktop-dev` instance and an
+  installed one share the machine's ports) to before the save, which a `200`
+  from `PUT /gateway/settings` can never do.
 
 **Usage recording is one row per served request, written off the request path**
 (#425, `gateway/usage.rs`, migration 34). Four things about it are decisions:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -278,6 +278,12 @@ still listed and its data is safe, but it cannot be edited or used.
 Something else already holds that port. Change it in **LLM Gateway → Gateway
 Settings → Port** and save; the listener rebinds immediately.
 
+The Settings form now checks the port as you type and offers a free one — "Port
+8880 is already in use by another process. Port 8881 is free." — so this state
+is usually avoidable. It is still only a check, not a reservation: something can
+take the port between the check and the bind, and *this* status is the
+authority on what actually happened.
+
 The usual culprit is a second Agento. A development build and an installed one
 read different databases but share the machine's ports, so both can be configured
 for 8880 and only the first to start gets it. The status carries the exact reason,
@@ -286,6 +292,27 @@ and the same line is in the log:
 ```
 binding the llm gateway on 127.0.0.1:8880: Address already in use (os error 98)
 ```
+
+### "Enable the gateway" is greyed out and will not turn on
+
+The gateway has nothing to route to. Both **Enable the gateway** and **Start
+with the app** stay shut until there is at least one provider *and* at least one
+model alias — without both, the listener would bind a port that fails to route
+every model name a client sends, which is the mismatch below with nothing to
+mismatch against.
+
+The message beside the switches says which of the two is missing and links to
+it. Add it, come back, and the switches are live; nothing needs restarting.
+
+Two things it is not. It never turns a gateway *off*: an install that was
+already enabled keeps its switch usable in the off direction, so deleting your
+last alias does not lock you out of stopping the listener. And it never blocks
+**Save** — a retention or port edit still saves while the switches are shut.
+
+If it instead says *"could not check whether the gateway has anything to
+route"*, the providers or aliases read failed rather than coming back empty. The
+switches are held for the same reason, and the message carries the underlying
+error.
 
 ### "Check these credentials" says the key is refused, or the provider is unreachable
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -427,6 +427,13 @@ feature costs one database read at launch until you turn it on.
 
 ### Turning it on
 
+**Both switches need something to route first.** A gateway with no provider, or
+with a provider and no alias, binds a port that fails to route every model name
+a client sends — so **Enable the gateway** and **Start with the app** stay shut
+until **at least one provider and at least one alias exist**. Until they do, the
+view says which of the two is missing and links straight to it. Add them
+(below), come back, and the switches are live — no restart.
+
 **LLM Gateway → Gateway Settings**, under **Listener**:
 
 - **Enable the gateway.** Off by default. When off, no port is bound.
@@ -436,6 +443,14 @@ feature costs one database read at launch until you turn it on.
 - **Start with the app.** On by default, and only meaningful while the gateway is
   enabled. Without it the port dies with every restart, which is not much of a
   gateway.
+
+**If the port is already taken, the form says so before you save** — "Port 8880
+is already in use by another process. Port 8881 is free." — with a button that
+fills the free one in. It is never applied for you: the port is what you paste
+into `OPENAI_BASE_URL` and `ANTHROPIC_BASE_URL`, so a value that changed itself
+would point every tool you had already configured at nothing. The check is also
+advisory, not a reservation — something can still take the port between the
+check and the save, which is what **Overview** is for.
 
 Changing the port restarts the listener, and anything already configured against
 the old one stops working until you update it. The view says so before you save.

--- a/parity/desktop_routes.json
+++ b/parity/desktop_routes.json
@@ -146,6 +146,13 @@
     },
     {
       "method": "GET",
+      "route": "/api/gateway/port-availability",
+      "status": "native",
+      "owner": "#474",
+      "reason": "is 127.0.0.1:N bindable, and if not what is the next port that is -- the one thing the settings form cannot answer for itself, because a webview cannot bind a socket. Advisory by nature (a port free at probe time can be taken before the bind), so Status::BindFailed stays the authority; what it buys is that the routine collision is reported BEFORE the save rather than after it. The running listener's own port reads as available, or the user could never re-save their own configuration"
+    },
+    {
+      "method": "GET",
       "route": "/api/gateway/providers/{id}/models",
       "status": "native",
       "owner": "#470",

--- a/src-tauri/src/native/gateway_api.rs
+++ b/src-tauri/src/native/gateway_api.rs
@@ -70,6 +70,7 @@ pub const ROUTES: &[(&str, &str)] = &[
     ("PUT", "/api/gateway/models/{id}"),
     ("DELETE", "/api/gateway/models/{id}"),
     ("GET", "/api/gateway/status"),
+    ("GET", "/api/gateway/port-availability"),
     ("GET", "/api/gateway/usage"),
     ("GET", "/api/gateway/providers/{id}/models"),
     ("POST", "/api/gateway/providers/validate"),
@@ -466,6 +467,7 @@ fn serve(ctx: &Ctx, req: &Request) -> Result<Answer, String> {
         ("POST", "/api/gateway/models") => writes::finish(create_alias(db, req.body)),
 
         ("GET", "/api/gateway/status") => read_status(),
+        ("GET", "/api/gateway/port-availability") => read_port_availability(req.query),
         ("GET", "/api/gateway/usage") => read_usage(db, req.query),
 
         ("PUT", path) => match (id_under(path, "providers"), id_under(path, "models")) {
@@ -976,6 +978,133 @@ fn status_body(status: registry::Status) -> StatusBody {
             port: None,
             error: Some(error),
         },
+    }
+}
+
+// ─── Port availability ────────────────────────────────────────────────────────
+
+/// How far above the requested port the walk looks for a free one.
+///
+/// A cap rather than a walk to 65535, because the walk is 65535 `bind` syscalls
+/// in the pathological case and it runs on the settings form while somebody is
+/// typing. 64 is plenty for the collision this exists for — a
+/// `~/.agento-desktop-dev` instance and an installed one sharing the machine's
+/// ports — and the body says how far it looked rather than reporting "no free
+/// port" as if it had asked the whole range.
+const PORT_SCAN_SPAN: u16 = 64;
+
+/// `GET /api/gateway/port-availability?port=N` (#474).
+///
+/// **Advisory, and deliberately so.** It is a TOCTOU check by nature: a port
+/// free at probe time can be taken before `registry::start` binds it, so
+/// `Status::BindFailed` stays the authority and the status strip stays where the
+/// real outcome shows up. What this buys is that the routine collision is
+/// reported *before* the save rather than after it, since
+/// `PUT /api/gateway/settings` spawns the reload without awaiting it and a `200`
+/// therefore means "stored", never "listening".
+///
+/// The answer is never applied for the user. The port is what they paste into
+/// `OPENAI_BASE_URL` / `ANTHROPIC_BASE_URL`, so a silent rewrite would point
+/// every tool they had already configured at nothing.
+#[derive(Debug, Serialize)]
+struct PortAvailabilityBody {
+    port: u16,
+    available: bool,
+    /// The first free port **above** `port`, when `port` itself is taken.
+    ///
+    /// Absent when `port` is available (there is nothing to suggest) and also
+    /// when the capped walk found nothing — the two are told apart by
+    /// `available`, and by `scanned_to` being present in the second.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    suggested: Option<u16>,
+    /// The last port the walk looked at, so "no free port" is a bounded claim
+    /// rather than an unqualified one. Present only when a walk happened.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    scanned_to: Option<u16>,
+}
+
+fn read_port_availability(query: &str) -> Result<Answer, String> {
+    let raw = super::query::value(query, "port");
+    let Some(port) = raw.parse::<u16>().ok().filter(|p| *p >= MIN_PORT) else {
+        // The same refusal `PUT /api/gateway/settings` gives the same value, so
+        // a form that got past its own check hears one story rather than two.
+        return writes::finish(Err(WriteError::validation(
+            "port",
+            format!(
+                "port must be a whole number between {MIN_PORT} and {}",
+                u16::MAX
+            ),
+        )));
+    };
+
+    let body = availability(port, own_port_of(registry::status()), port_is_bindable);
+    let encoded = super::gojson::to_vec(&body)
+        .map_err(|e| format!("encoding gateway port availability: {e}"))?;
+    Ok(Answer::json(encoded))
+}
+
+/// The port the listener currently holds, if it holds one.
+///
+/// **The running gateway's own port must read as available**, or the user can
+/// never re-save their own configuration: the probe would find the port taken by
+/// the very process being configured and offer to move it somewhere else on
+/// every visit to the form.
+///
+/// Split from the registry read for the reason [`status_body`] is — that state
+/// is a process-wide global, and a test that installed one would break tests in
+/// files it never touched.
+fn own_port_of(status: registry::Status) -> Option<u16> {
+    match status {
+        registry::Status::Running { port } => Some(port),
+        // `BindFailed` carries a port too, and it is precisely a port this
+        // process does *not* hold — so it must fall through to a real probe.
+        registry::Status::Stopped
+        | registry::Status::BindFailed { .. }
+        | registry::Status::StartFailed { .. } => None,
+    }
+}
+
+/// Can this process bind `127.0.0.1:port` right now?
+///
+/// The listener is dropped at the end of the expression, so nothing is held —
+/// which is also why the answer is advisory rather than a reservation.
+fn port_is_bindable(port: u16) -> bool {
+    std::net::TcpListener::bind(("127.0.0.1", port)).is_ok()
+}
+
+/// The decision, with the prober injected.
+///
+/// Split from [`read_port_availability`] so the walk, the cap, the overflow at
+/// the top of the range and the own-port rule are all testable without binding
+/// real sockets — a test that raced the machine's actual port table would be
+/// exactly the flaky test this repository's fixtures go out of their way to
+/// avoid.
+fn availability(
+    port: u16,
+    own: Option<u16>,
+    bindable: impl Fn(u16) -> bool,
+) -> PortAvailabilityBody {
+    let free = |p: u16| own == Some(p) || bindable(p);
+
+    if free(port) {
+        return PortAvailabilityBody {
+            port,
+            available: true,
+            suggested: None,
+            scanned_to: None,
+        };
+    }
+
+    // `saturating_add` rather than `+`: a port near the top of the range would
+    // otherwise overflow, and the walk has to stop at 65535 either way.
+    let last = port.saturating_add(PORT_SCAN_SPAN);
+    let suggested = (port.saturating_add(1)..=last).find(|p| free(*p));
+
+    PortAvailabilityBody {
+        port,
+        available: false,
+        suggested,
+        scanned_to: Some(last),
     }
 }
 
@@ -2802,6 +2931,173 @@ mod tests {
         assert!(claims(&Method::GET, "/api/gateway/providers"));
         assert!(claims(&Method::POST, "/api/gateway/providers"));
         assert!(claims(&Method::PUT, "/api/gateway/providers/p1"));
+    }
+
+    // ── Port availability (#474) ──────────────────────────────────────────
+
+    /// A prober built from a set of ports that are *taken*; everything else is
+    /// free. The real one binds a socket, and a test that did would race the
+    /// machine's actual port table.
+    fn taken(ports: &[u16]) -> impl Fn(u16) -> bool + '_ {
+        move |p| !ports.contains(&p)
+    }
+
+    #[test]
+    fn a_free_port_is_available_and_suggests_nothing() {
+        let body = availability(8880, None, taken(&[]));
+        assert_eq!(body.port, 8880);
+        assert!(body.available);
+        assert_eq!(body.suggested, None);
+        // No walk happened, so there is nothing to say about how far it looked.
+        assert_eq!(body.scanned_to, None);
+    }
+
+    #[test]
+    fn a_taken_port_suggests_the_first_free_one_above_it() {
+        let body = availability(8880, None, taken(&[8880, 8881, 8882]));
+        assert!(!body.available);
+        assert_eq!(body.suggested, Some(8883));
+        assert_eq!(body.scanned_to, Some(8880 + PORT_SCAN_SPAN));
+    }
+
+    /// **The rule that locks a working install out of its own settings when it
+    /// is missing.** The gateway holds its configured port, so an honest probe
+    /// finds it taken — by the very process being configured — and would offer
+    /// to move it somewhere else every time the form is opened.
+    #[test]
+    fn the_running_gateways_own_port_reads_as_available() {
+        // Nothing is bindable, so the only way this can answer "available" is
+        // the own-port comparison.
+        let body = availability(8880, Some(8880), taken(&[8880]));
+        assert!(body.available);
+        assert_eq!(body.suggested, None);
+
+        // ...and a *different* running port does not launder this one.
+        let body = availability(8880, Some(8881), taken(&[8880]));
+        assert!(!body.available);
+    }
+
+    /// `BindFailed` carries a port and that port is precisely one this process
+    /// does **not** hold, so it must not be treated as the listener's own.
+    #[test]
+    fn only_a_running_listener_contributes_an_own_port() {
+        assert_eq!(
+            own_port_of(registry::Status::Running { port: 8880 }),
+            Some(8880)
+        );
+        assert_eq!(own_port_of(registry::Status::Stopped), None);
+        assert_eq!(
+            own_port_of(registry::Status::BindFailed {
+                port: 8880,
+                error: "address in use".into(),
+            }),
+            None,
+            "a bind failure names a port this process does NOT hold"
+        );
+        assert_eq!(
+            own_port_of(registry::Status::StartFailed {
+                error: "no adapter".into(),
+            }),
+            None
+        );
+    }
+
+    /// A walk that finds nothing says how far it looked, rather than reporting
+    /// "no free port" as though it had asked the whole range.
+    #[test]
+    fn a_walk_that_finds_nothing_reports_how_far_it_looked() {
+        let all: Vec<u16> = (8880..=9000).collect();
+        let body = availability(8880, None, taken(&all));
+        assert!(!body.available);
+        assert_eq!(body.suggested, None);
+        assert_eq!(body.scanned_to, Some(8944));
+    }
+
+    /// The walk stops at the top of the port range instead of overflowing.
+    #[test]
+    fn the_walk_saturates_at_the_top_of_the_port_range() {
+        let all: Vec<u16> = (65_500..=65_535).collect();
+        let body = availability(65_500, None, taken(&all));
+        assert_eq!(body.scanned_to, Some(u16::MAX));
+        assert_eq!(body.suggested, None);
+
+        // The last port in the range is reachable — an exclusive upper bound
+        // would silently skip 65535.
+        let body = availability(65_500, None, taken(&all[..all.len() - 1]));
+        assert_eq!(body.suggested, Some(u16::MAX));
+    }
+
+    /// The real prober, against a socket this test holds — the one thing the
+    /// injected one cannot say anything about.
+    #[test]
+    fn the_real_prober_sees_a_bound_port_as_taken() {
+        let held = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind");
+        let port = held.local_addr().expect("addr").port();
+        assert!(!port_is_bindable(port));
+        drop(held);
+        assert!(port_is_bindable(port));
+    }
+
+    #[test]
+    fn the_route_answers_the_three_fields_in_wire_order() {
+        let held = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind");
+        let port = held.local_addr().expect("addr").port();
+
+        let file = migrated();
+        let answer = call_query(
+            &ctx(&file),
+            "/api/gateway/port-availability",
+            &format!("port={port}"),
+        )
+        .expect("answered");
+        assert_eq!(answer.status, StatusCode::OK);
+
+        let body = body_of(&answer);
+        assert!(
+            body.starts_with(&format!(
+                "{{\"port\":{port},\"available\":false,\"suggested\":"
+            )),
+            "{body}"
+        );
+        assert!(body.contains("\"scanned_to\":"), "{body}");
+    }
+
+    /// An absent or unusable `port` is the route's own 422, worded exactly as
+    /// `PUT /api/gateway/settings` words the same refusal — not a panic, and not
+    /// a silent fallback to the default.
+    #[test]
+    fn a_missing_or_unusable_port_is_a_validation_error() {
+        let file = migrated();
+        let ctx = ctx(&file);
+        for query in ["", "port=", "port=abc", "port=80", "port=70000", "port=-1"] {
+            let answer = call_query(&ctx, "/api/gateway/port-availability", query)
+                .unwrap_or_else(|e| panic!("{query}: {e}"));
+            assert_eq!(
+                answer.status,
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "{query} → {}",
+                body_of(&answer)
+            );
+            assert!(
+                body_of(&answer).contains("port must be a whole number"),
+                "{query} → {}",
+                body_of(&answer)
+            );
+        }
+    }
+
+    /// The buffered registry claims it, and the async one does not — it opens no
+    /// socket to a third party and reads no database, so it belongs on
+    /// `spawn_blocking` with its thirteen siblings.
+    #[test]
+    fn the_port_availability_route_is_claimed_by_the_buffered_registry() {
+        assert!(claims(&Method::GET, "/api/gateway/port-availability"));
+        assert!(!claims_async(
+            &Method::GET,
+            "/api/gateway/port-availability"
+        ));
+        // A write on it is nobody's.
+        assert!(!claims(&Method::POST, "/api/gateway/port-availability"));
     }
 
     /// `validate` is a literal segment on a collection whose siblings capture an

--- a/src-tauri/src/native/gateway_api.rs
+++ b/src-tauri/src/native/gateway_api.rs
@@ -1017,8 +1017,13 @@ struct PortAvailabilityBody {
     /// `available`, and by `scanned_to` being present in the second.
     #[serde(skip_serializing_if = "Option::is_none")]
     suggested: Option<u16>,
-    /// The last port the walk looked at, so "no free port" is a bounded claim
-    /// rather than an unqualified one. Present only when a walk happened.
+    /// How far the walk was **allowed** to look, so "no free port" is a bounded
+    /// claim rather than an unqualified one. Present only when a walk happened.
+    ///
+    /// Not the last port examined: the walk stops at the first free one, so a
+    /// found suggestion is normally well below this. It is the cap, and it
+    /// means the same thing in both arms — read it as the range that was on
+    /// offer, never as evidence that anything up here was tried.
     #[serde(skip_serializing_if = "Option::is_none")]
     scanned_to: Option<u16>,
 }
@@ -3070,9 +3075,14 @@ mod tests {
         assert!(body.contains("\"scanned_to\":"), "{body}");
     }
 
-    /// An absent or unusable `port` is the route's own 422, worded exactly as
-    /// `PUT /api/gateway/settings` words the same refusal — not a panic, and not
-    /// a silent fallback to the default.
+    /// An absent or unusable `port` is the route's own 422 — not a panic, and
+    /// not a silent fallback to `DEFAULT_PORT`.
+    ///
+    /// Its sentence is **wider** than the `PUT`'s, because this decodes a raw
+    /// query string and that decodes a `u16` serde has already accepted. The
+    /// assertion is therefore on the prefix the two genuinely share; see
+    /// [`read_port_availability`] for why unifying them would mean narrowing
+    /// this one.
     #[test]
     fn a_missing_or_unusable_port_is_a_validation_error() {
         let file = migrated();

--- a/src-tauri/src/native/gateway_api.rs
+++ b/src-tauri/src/native/gateway_api.rs
@@ -1026,8 +1026,16 @@ struct PortAvailabilityBody {
 fn read_port_availability(query: &str) -> Result<Answer, String> {
     let raw = super::query::value(query, "port");
     let Some(port) = raw.parse::<u16>().ok().filter(|p| *p >= MIN_PORT) else {
-        // The same refusal `PUT /api/gateway/settings` gives the same value, so
-        // a form that got past its own check hears one story rather than two.
+        // A refusal, never a fallback to `DEFAULT_PORT`: probing a port the
+        // caller did not ask about and answering as though they had is a wrong
+        // answer wearing a `200`.
+        //
+        // The wording is **wider** than the `PUT`'s `port must be {MIN_PORT} or
+        // above` and deliberately not shared with it. That one refuses a `u16`
+        // serde has already decoded, so the only thing left to say is the
+        // floor; this reads a raw query string and has to cover "not a number
+        // at all" and "past 65535" as well. Two routes, two decode positions,
+        // two sentences — do not "unify" them by narrowing this one.
         return writes::finish(Err(WriteError::validation(
             "port",
             format!(

--- a/src-tauri/src/native/gateway_api.rs
+++ b/src-tauri/src/native/gateway_api.rs
@@ -3080,9 +3080,10 @@ mod tests {
     ///
     /// Its sentence is **wider** than the `PUT`'s, because this decodes a raw
     /// query string and that decodes a `u16` serde has already accepted. The
-    /// assertion is therefore on the prefix the two genuinely share; see
-    /// [`read_port_availability`] for why unifying them would mean narrowing
-    /// this one.
+    /// assertion is therefore on the stable part of *this route's own*
+    /// sentence, excluding the interpolated bounds — it is not a claim about
+    /// anything the two share. See [`read_port_availability`] for why unifying
+    /// them would mean narrowing this one.
     #[test]
     fn a_missing_or_unusable_port_is_a_validation_error() {
         let file = migrated();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -374,9 +374,13 @@ export default function App() {
           {(view === "tokens" || view === "usage" || view === "insights") && (
             <AnalyticsView mode={view} inspectorOpen={inspectorOpen} />
           )}
-          {/* The Overview takes `navigate` because its bind-failure card has
-              exactly one useful action — change the port — and that lives in a
-              sibling view rather than a pane of its own. */}
+          {/* Three of the five gateway views take `navigate`, and all three for
+              the same reason: the useful action on what they are reporting
+              lives in a sibling view rather than a pane of their own — change
+              the port (Overview), add the provider an alias has to route to
+              (Models), and configure the two things the listener needs before
+              it can be switched on at all (Gateway Settings, #474). There is
+              still no nav context; the prop is the whole mechanism. */}
           {view === "gateway" && (
             <GatewayOverviewView
               inspectorOpen={inspectorOpen}
@@ -387,13 +391,19 @@ export default function App() {
             <GatewayProvidersView inspectorOpen={inspectorOpen} />
           )}
           {view === "gateway-models" && (
-            <GatewayModelsView inspectorOpen={inspectorOpen} />
+            <GatewayModelsView
+              inspectorOpen={inspectorOpen}
+              onNavigate={navigate}
+            />
           )}
           {view === "gateway-usage" && (
             <GatewayUsageView inspectorOpen={inspectorOpen} />
           )}
           {view === "gateway-settings" && (
-            <GatewaySettingsView inspectorOpen={inspectorOpen} />
+            <GatewaySettingsView
+              inspectorOpen={inspectorOpen}
+              onNavigate={navigate}
+            />
           )}
           {view === "settings" && (
             <SettingsView theme={theme} onThemeChange={setTheme} />

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -68,14 +68,22 @@ export function Empty({
 export function Switch({
   on,
   onChange,
+  disabled,
+  title,
 }: {
   on: boolean;
   onChange(v: boolean): void;
+  /** Refuses the click *and* says so to assistive tech — `aria-disabled` alone
+      would leave a switch that reads as unavailable and still toggles. */
+  disabled?: boolean;
+  title?: string;
 }) {
   return (
     <button
       role="switch"
       aria-checked={on}
+      disabled={disabled}
+      title={title}
       className={`switch ${on ? "switch--on" : ""}`}
       onClick={() => onChange(!on)}
     >

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -69,21 +69,24 @@ export function Switch({
   on,
   onChange,
   disabled,
-  title,
 }: {
   on: boolean;
   onChange(v: boolean): void;
-  /** Refuses the click *and* says so to assistive tech — `aria-disabled` alone
-      would leave a switch that reads as unavailable and still toggles. */
+  /**
+   * Refuses the click *and* says so to assistive tech — `aria-disabled` alone
+   * would leave a switch that reads as unavailable and still toggles.
+   *
+   * It carries no `title`, and that is deliberate rather than an omission: a
+   * `disabled` button receives no mouse events, so a tooltip on one never
+   * shows. A switch that is shut has to say why in something beside it.
+   */
   disabled?: boolean;
-  title?: string;
 }) {
   return (
     <button
       role="switch"
       aria-checked={on}
       disabled={disabled}
-      title={title}
       className={`switch ${on ? "switch--on" : ""}`}
       onClick={() => onChange(!on)}
     >

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -735,6 +735,26 @@ export interface GatewayStatus {
   error?: string;
 }
 
+/**
+ * `GET /api/gateway/port-availability?port=N` (#474).
+ *
+ * **Advisory.** A port free at probe time can be taken before the listener
+ * binds it, so `GatewayStatus.state === "bind_failed"` stays the authority —
+ * this only moves the routine collision to *before* the save, which a `200`
+ * from `PUT /gateway/settings` can never do (it means "stored", never
+ * "listening").
+ *
+ * `suggested` is absent both when `port` is available and when the capped walk
+ * found nothing; `available` tells the two apart, and `scanned_to` — present
+ * only when a walk happened — is what makes "no free port" a bounded claim.
+ */
+export interface GatewayPortAvailability {
+  port: number;
+  available: boolean;
+  suggested?: number;
+  scanned_to?: number;
+}
+
 /** A provider row as a read answers it: `has_api_key`, never the key. */
 export interface GatewayProviderSummary {
   id: string;

--- a/src/styles/controls.css
+++ b/src/styles/controls.css
@@ -349,6 +349,13 @@ textarea.field-area:focus {
 .switch--on .switch__knob {
   transform: translateX(14px);
 }
+/* A switch the current configuration cannot support (#474). Reads as
+   unavailable rather than as off — the two are different states, and the
+   gateway's `enabled` can legitimately be *on* while it is un-turn-on-able. */
+.switch:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
 
 /* --- Checkbox ------------------------------------------------------------ */
 .checkbox {

--- a/src/styles/gateway.css
+++ b/src/styles/gateway.css
@@ -347,3 +347,20 @@
   font-size: var(--text-xs);
   color: var(--fg-quaternary);
 }
+
+/* --- The readiness gate and the port suggestion (#474) -------------------- */
+
+/* A `.msgline` is a two-column flex — icon, then one child. These carry a
+   sentence *and* the actions that resolve it, so the second column stacks
+   rather than the buttons joining the icon on the main axis. */
+.gw-gate__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+  min-width: 0;
+}
+.gw-gate__actions {
+  display: flex;
+  gap: var(--sp-3);
+  flex-wrap: wrap;
+}

--- a/src/views/gateway/ModelsView.tsx
+++ b/src/views/gateway/ModelsView.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../components/ui";
 import { Icon } from "../../lib/icons";
 import { describeError, useResource } from "../../lib/hooks";
+import type { ViewId } from "../../lib/nav";
 import type {
   GatewayModelAlias,
   GatewayProviderModels,
@@ -105,7 +106,13 @@ function useProviderCatalogs() {
   return { catalogs, request };
 }
 
-export function GatewayModelsView({ inspectorOpen }: { inspectorOpen: boolean }) {
+export function GatewayModelsView({
+  inspectorOpen,
+  onNavigate,
+}: {
+  inspectorOpen: boolean;
+  onNavigate(view: ViewId): void;
+}) {
   const aliases = useResource<GatewayModelAlias[] | null>(
     (signal) => api.get("/gateway/models", signal),
     []
@@ -260,13 +267,40 @@ export function GatewayModelsView({ inspectorOpen }: { inspectorOpen: boolean })
             }}
           />
         )}
-        {!aliases.error && selection.kind === "none" && !aliases.loading && (
-          <Empty
-            icon="layers"
-            title="No alias selected"
-            text="Pick one on the left, or define a new model name."
-          />
-        )}
+        {/* Two empty states, and which one shows is the difference between a
+            dead end and a next step. With no providers there is nothing an
+            alias could route to — `POST /api/gateway/models` refuses a target
+            naming no configured provider — so "pick one on the left" is advice
+            that cannot be taken, and the list column's own prose says why with
+            no way to act on it. The provider read is included in the guard for
+            the reason the list column already states: a failed request knows
+            nothing about stored rows, so a fetch that errored must never
+            produce the "no providers" claim. */}
+        {!aliases.error &&
+          selection.kind === "none" &&
+          !aliases.loading &&
+          !providers.loading &&
+          (!providers.error && providerNames.length === 0 ? (
+            <Empty
+              icon="database"
+              title="No model provider configured"
+              text="An alias is a model name your tools ask for, and it has to route somewhere. Add a provider first."
+              action={
+                <button
+                  className="btn btn--primary"
+                  onClick={() => onNavigate("gateway-providers")}
+                >
+                  Configure a provider
+                </button>
+              }
+            />
+          ) : (
+            <Empty
+              icon="layers"
+              title="No alias selected"
+              text="Pick one on the left, or define a new model name."
+            />
+          ))}
       </div>
 
       {inspectorOpen && (

--- a/src/views/gateway/SettingsView.tsx
+++ b/src/views/gateway/SettingsView.tsx
@@ -80,10 +80,13 @@ export function GatewaySettingsView({
   );
   usePoll(status.reload, 4_000);
 
-  // The two reads the gate is derived from. Both are the same lists the
-  // Providers and Models views load, and both `reload()` on their own — so a
-  // provider added in a sibling view opens these switches on the next visit
-  // with no restart and no page reload.
+  // The two reads the gate is derived from — the same lists the Providers and
+  // Models views load. Neither is polled and neither needs to be: `App.tsx`
+  // renders the gateway section conditionally, so this view **remounts** on
+  // every visit and both reads run again. That is what makes a provider added
+  // in a sibling view open these switches with no restart. Keeping the gateway
+  // views mounted across a section switch would stale the gate silently, so
+  // that change and a poll here have to arrive together.
   const providers = useResource<GatewayProviderSummary[] | null>(
     (signal) => api.get("/gateway/providers", signal),
     []
@@ -269,10 +272,21 @@ export function GatewaySettingsView({
                   <div className="gw-gate__body">
                     <span>
                       {readiness.needsProvider && readiness.needsAlias
-                        ? "The gateway has no provider and no model alias, so there is nothing for it to route to. It cannot be switched on until both exist."
+                        ? "The gateway has no provider and no model alias, so there is nothing for it to route to. "
                         : readiness.needsProvider
-                          ? "The gateway has no provider, so there is nothing for it to route to. It cannot be switched on until one exists."
-                          : "The gateway has a provider but no model alias, so every model name a client sends would fail to route. It cannot be switched on until one exists."}
+                          ? "The gateway has no provider, so there is nothing for it to route to. "
+                          : "The gateway has a provider but no model alias, so no model name a client sends can route. "}
+                      {/* An *enabled* gateway keeps a live switch (below), so
+                          this sentence is read beside a switch that is on —
+                          which is exactly the state someone whose last alias
+                          was just deleted is in. "It cannot be switched on" is
+                          false there, and it describes the wrong problem: the
+                          listener is up and answering nothing. */}
+                      {enabled
+                        ? "It is listening and every request is failing to route until that is fixed."
+                        : readiness.needsProvider && readiness.needsAlias
+                          ? "It cannot be switched on until both exist."
+                          : "It cannot be switched on until one exists."}
                     </span>
                     <div className="gw-gate__actions">
                       {readiness.needsProvider && (

--- a/src/views/gateway/SettingsView.tsx
+++ b/src/views/gateway/SettingsView.tsx
@@ -1,9 +1,21 @@
 import { useEffect, useState } from "react";
-import { api } from "../../lib/api";
+import { api, qs } from "../../lib/api";
 import { FormRow, Splitter, Switch } from "../../components/ui";
 import { Icon } from "../../lib/icons";
-import { describeError, usePoll, useResource } from "../../lib/hooks";
-import type { GatewaySettings, GatewayStatus } from "../../lib/types";
+import {
+  describeError,
+  useDebounced,
+  usePoll,
+  useResource,
+} from "../../lib/hooks";
+import type { ViewId } from "../../lib/nav";
+import type {
+  GatewayModelAlias,
+  GatewayPortAvailability,
+  GatewayProviderSummary,
+  GatewaySettings,
+  GatewayStatus,
+} from "../../lib/types";
 import "../../styles/gateway.css";
 
 /* ============================================================================
@@ -37,7 +49,27 @@ const MAX_PORT = 65535;
  */
 const MAX_RETENTION_DAYS = 3650;
 
-export function GatewaySettingsView({ inspectorOpen }: { inspectorOpen: boolean }) {
+/**
+ * Whether the listener has anything to answer with (#474).
+ *
+ * Three states, not two, and the third is the point: a *failed* readiness read
+ * must disable the switches with an honest "could not check" rather than the
+ * "nothing configured" claim, because a failed request knows nothing about
+ * stored rows.
+ */
+type Readiness =
+  | { state: "loading" }
+  | { state: "unknown"; message: string }
+  | { state: "ready" }
+  | { state: "unroutable"; needsProvider: boolean; needsAlias: boolean };
+
+export function GatewaySettingsView({
+  inspectorOpen,
+  onNavigate,
+}: {
+  inspectorOpen: boolean;
+  onNavigate(view: ViewId): void;
+}) {
   const settings = useResource<GatewaySettings>(
     (signal) => api.get("/gateway/settings", signal),
     []
@@ -47,6 +79,19 @@ export function GatewaySettingsView({ inspectorOpen }: { inspectorOpen: boolean 
     []
   );
   usePoll(status.reload, 4_000);
+
+  // The two reads the gate is derived from. Both are the same lists the
+  // Providers and Models views load, and both `reload()` on their own — so a
+  // provider added in a sibling view opens these switches on the next visit
+  // with no restart and no page reload.
+  const providers = useResource<GatewayProviderSummary[] | null>(
+    (signal) => api.get("/gateway/providers", signal),
+    []
+  );
+  const aliases = useResource<GatewayModelAlias[] | null>(
+    (signal) => api.get("/gateway/models", signal),
+    []
+  );
 
   const [enabled, setEnabled] = useState(false);
   const [startWithApp, setStartWithApp] = useState(true);
@@ -99,6 +144,58 @@ export function GatewaySettingsView({ inspectorOpen }: { inspectorOpen: boolean 
   })();
 
   const canSave = changed && portValid && retentionValid;
+
+  // "Configured" is ≥1 provider row and ≥1 alias row, **regardless of the
+  // alias's own `enabled` flag**: gating on enabled aliases would make the
+  // gateway switch unusable the moment a user toggles their last alias off,
+  // which is a legitimate temporary state.
+  const readiness: Readiness = (() => {
+    if (providers.error || aliases.error) {
+      return {
+        state: "unknown",
+        message: providers.error ?? aliases.error ?? "",
+      };
+    }
+    if (providers.loading || aliases.loading) return { state: "loading" };
+    const needsProvider = (providers.data ?? []).length === 0;
+    const needsAlias = (aliases.data ?? []).length === 0;
+    if (!needsProvider && !needsAlias) return { state: "ready" };
+    return { state: "unroutable", needsProvider, needsAlias };
+  })();
+
+  // **Gate the turning-on, not the switch.** Turning a gateway *off* is always
+  // safe and is exactly what someone whose aliases were all deleted wants to
+  // do, so a switch that is simply `disabled` on an unroutable configuration
+  // would lock an existing `enabled: true` install out of its own listener.
+  // Nothing here ever writes a value the user did not ask for either: an
+  // upgrade that forced these to `false` would disable a working gateway on
+  // the next unrelated retention edit.
+  const canTurnOn = readiness.state === "ready";
+
+  // ── The port probe ────────────────────────────────────────────────────────
+  //
+  // Advisory, and never applied on its own: the port is what gets pasted into
+  // `OPENAI_BASE_URL` / `ANTHROPIC_BASE_URL`, so a silent rewrite would point
+  // every already-configured tool at nothing. `PUT /gateway/settings` spawns
+  // the reload without awaiting it, so a `200` means "stored", never
+  // "listening" — without this, a collision first appears in the polled status
+  // strip *after* the save.
+  const debouncedPort = useDebounced(port, 400);
+  const probePort = portValid && debouncedPort.trim() === port.trim() ? portNumber : 0;
+  const availability = useResource<GatewayPortAvailability | undefined>(
+    async (signal) =>
+      probePort === 0
+        ? undefined
+        : api.get<GatewayPortAvailability>(
+            `/gateway/port-availability${qs({ port: probePort })}`,
+            signal
+          ),
+    [probePort]
+  );
+  const taken =
+    availability.data && !availability.data.available && availability.data.port === portNumber
+      ? availability.data
+      : undefined;
 
   async function save() {
     setBusy(true);
@@ -161,11 +258,70 @@ export function GatewaySettingsView({ inspectorOpen }: { inspectorOpen: boolean 
             <div className="formsec">
               <div className="formsec__title">Listener</div>
 
+              {/* Why the switches are shut, and the two places that fixes it.
+                  Without a provider and an alias, `enabled` binds a port that
+                  answers a routing failure for every model name a client
+                  sends — the model-name mismatch `docs/troubleshooting.md`
+                  documents, with nothing to mismatch against. */}
+              {readiness.state === "unroutable" && (
+                <div className="msgline msgline--warn gw-gate">
+                  <Icon name="alert" size={13} className="msgline__icon" />
+                  <div className="gw-gate__body">
+                    <span>
+                      {readiness.needsProvider && readiness.needsAlias
+                        ? "The gateway has no provider and no model alias, so there is nothing for it to route to. It cannot be switched on until both exist."
+                        : readiness.needsProvider
+                          ? "The gateway has no provider, so there is nothing for it to route to. It cannot be switched on until one exists."
+                          : "The gateway has a provider but no model alias, so every model name a client sends would fail to route. It cannot be switched on until one exists."}
+                    </span>
+                    <div className="gw-gate__actions">
+                      {readiness.needsProvider && (
+                        <button
+                          className="btn"
+                          onClick={() => onNavigate("gateway-providers")}
+                        >
+                          Configure providers
+                        </button>
+                      )}
+                      {readiness.needsAlias && (
+                        <button
+                          className="btn"
+                          onClick={() => onNavigate("gateway-models")}
+                        >
+                          Configure models
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              )}
+              {/* A read that failed is not an empty configuration. It shuts the
+                  switches the same way — enabling on an unknown state is the
+                  thing this gate exists to prevent — but it must not claim the
+                  rows are absent. */}
+              {readiness.state === "unknown" && (
+                <div className="msgline msgline--warn">
+                  <Icon name="alert" size={13} className="msgline__icon" />
+                  <span>
+                    Could not check whether the gateway has anything to route:{" "}
+                    {readiness.message} Switching it on is held back until that
+                    read succeeds.
+                  </span>
+                </div>
+              )}
+
               <FormRow
                 label="Enable the gateway"
                 help="When off, no port is bound and the feature costs nothing."
               >
-                <Switch on={enabled} onChange={setEnabled} />
+                <Switch
+                  on={enabled}
+                  disabled={!canTurnOn && !enabled}
+                  onChange={(v) => {
+                    if (v && !canTurnOn) return;
+                    setEnabled(v);
+                  }}
+                />
               </FormRow>
 
               <FormRow
@@ -186,7 +342,14 @@ export function GatewaySettingsView({ inspectorOpen }: { inspectorOpen: boolean 
                 label="Start with the app"
                 help="Bind the port at launch. Only takes effect while the gateway is enabled."
               >
-                <Switch on={startWithApp} onChange={setStartWithApp} />
+                <Switch
+                  on={startWithApp}
+                  disabled={!canTurnOn && !startWithApp}
+                  onChange={(v) => {
+                    if (v && !canTurnOn) return;
+                    setStartWithApp(v);
+                  }}
+                />
               </FormRow>
 
               {!portValid && port !== "" && (
@@ -196,6 +359,33 @@ export function GatewaySettingsView({ inspectorOpen }: { inspectorOpen: boolean 
                     The port must be a whole number between {MIN_PORT} and{" "}
                     {MAX_PORT}.
                   </span>
+                </div>
+              )}
+
+              {/* Offered, never applied. The suggestion is one explicit click
+                  away and the typed value is left exactly as typed until then;
+                  and because the probe is a TOCTOU check by nature, the status
+                  strip below stays the authority on what actually bound. */}
+              {taken && (
+                <div className="msgline msgline--warn gw-gate">
+                  <Icon name="alert" size={13} className="msgline__icon" />
+                  <div className="gw-gate__body">
+                    <span>
+                      {taken.suggested !== undefined
+                        ? `Port ${taken.port} is already in use by another process. Port ${taken.suggested} is free.`
+                        : `Port ${taken.port} is already in use by another process, and nothing up to ${taken.scanned_to} is free either.`}
+                    </span>
+                    {taken.suggested !== undefined && (
+                      <div className="gw-gate__actions">
+                        <button
+                          className="btn"
+                          onClick={() => setPort(String(taken.suggested))}
+                        >
+                          Use {taken.suggested}
+                        </button>
+                      </div>
+                    )}
+                  </div>
                 </div>
               )}
 

--- a/src/views/gateway/SettingsView.tsx
+++ b/src/views/gateway/SettingsView.tsx
@@ -314,13 +314,19 @@ export function GatewaySettingsView({
                   thing this gate exists to prevent — but it must not claim the
                   rows are absent. */}
               {readiness.state === "unknown" && (
-                <div className="msgline msgline--warn">
+                <div className="msgline msgline--warn gw-gate">
                   <Icon name="alert" size={13} className="msgline__icon" />
-                  <span>
-                    Could not check whether the gateway has anything to route:{" "}
-                    {readiness.message} Switching it on is held back until that
-                    read succeeds.
-                  </span>
+                  {/* `describeError` returns an unpunctuated message, so it is
+                      given a line of its own rather than embedded between two
+                      prose fragments — every other error site in this section
+                      renders it alone for the same reason. */}
+                  <div className="gw-gate__body">
+                    <span>
+                      Could not check whether the gateway has anything to route.
+                      Switching it on is held back until that read succeeds.
+                    </span>
+                    <span>{readiness.message}</span>
+                  </div>
                 </div>
               )}
 


### PR DESCRIPTION
Closes #474

## What

Three dead-end states removed from the LLM Gateway's first-run path, plus one additive read route.

1. **`Models` empty state.** With no providers configured, the detail pane now shows *"No model provider configured"* with a **Configure a provider** button that navigates to `Providers`. Previously the list column carried the prose *"Add a provider first"* with no way to act on it, and the detail pane said nothing at all.
2. **Enabling the gateway is gated on there being something to route.** Both `Enable the gateway` and `Start with the app` are shut while there are zero providers **or** zero aliases, with an inline alert naming which is missing and linking to it.
3. **`GET /api/gateway/port-availability?port=N`** — is `127.0.0.1:N` bindable, and if not what is the next port that is. Surfaced on the Settings form as *"Port 8880 is already in use. Port 8881 is free."* with a button that applies it.

## Why

`PUT /api/gateway/settings` spawns `registry::reload` without awaiting it, so a `200` means *stored*, never *listening*. Every one of these three failures therefore surfaced after the save, or not at all.

## How

**The gate is UI-only, deliberately.** `config::GatewaySettings::validate` is untouched. A server-side refusal of `enabled: true` with no aliases reads as the honest one, but that route takes the same body the form posts on *every* save — so it would `422` an unrelated retention edit on a row whose aliases were later deleted, and deleting every alias has to stay a save-able state.

**It gates turning-on, not the switch** — `disabled={!canTurnOn && !enabled}`. A flat `disabled` would lock an install that *is* enabled out of switching its own listener off, which is exactly what someone whose last alias went away needs to do. Nothing rewrites a stored value either, which is what "existing installs are unaffected" means.

**`Readiness` is four states, not two** (`loading | unknown | ready | unroutable`). A read that *errored* shuts the switches the same way while saying something different — a failed request knows nothing about stored rows.

**The port probe is advisory by construction.** The listener is dropped immediately, so nothing is reserved; `Status::BindFailed` stays the authority. Three rules on it, each with a test: the **running listener's own port reads as available** (or the user could never re-save their own configuration — note `BindFailed` carries a port this process does *not* hold, so only `Running` counts); the walk is **capped** and the body reports the cap; and the suggestion is **never applied for the user**, because the port is what gets pasted into `OPENAI_BASE_URL` / `ANTHROPIC_BASE_URL`.

Buffered registry, not `ASYNC_ROUTES`: a `bind` is not an outbound HTTPS call. Registered in `ROUTES` **and** `parity/desktop_routes.json`, which is asserted as set equality.

## Tests

8 new tests in `gateway_api.rs`. The prober is **injected** so the walk, the cap, the `saturating_add` at the top of the range and the own-port rule are deterministic rather than racing the machine's port table; one real-socket test covers the injected prober's blind spot. Verified by reverting: dropping the own-port comparison, the `saturating_add` or the `MIN_PORT` filter each fails its named test.

`cargo test` 1369/1369 · clippy `-D warnings` clean · `cargo fmt --check` clean · `npm run build` clean · `cargo build --release` clean.

## Acceptance criteria

- [x] Zero providers → `Models` renders the empty state; its button lands on `Providers`
- [x] Zero providers **or** zero aliases → both switches shut, the alert names which and links to it
- [x] ≥1 provider and ≥1 alias → both switches interactive, no restart (the views remount per visit)
- [x] `GET /api/gateway/port-availability?port=N` answers bindability + the next free port; the running gateway's own port reads available
- [x] The form surfaces "8880 is in use — 8881 is free" and applies it only on an explicit click
- [x] A user-typed port is never silently replaced
- [x] Existing `enabled: true` installs unaffected — no migration, no forced disable, no 422 on an unrelated save

## Out of scope, found while here

`gateway_settings.start_with_app` is stored, returned and logged but **never consulted** — `registry::start_if_enabled` branches on `settings.enabled` alone, so the switch is a no-op today and its "Bind the port at launch" help text is inaccurate. This predates the change (#426/#427 era); flagged rather than fixed.
