### PR TITLE
fix: land the user in the chat "Continue in chat" creates (#485)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,19 @@ src/
     hooks.ts     useResource / useDebounced / usePoll / describeError
     format.ts    compactNumber, usd, duration, relativeTime, toneFor, …
     stats.ts     cross-view counters for sidebar + status bar
-    nav.ts       sidebar sections, view ids, titles
+    nav.ts       sidebar sections, view ids, titles — and the cross-view
+                 hand-off (#485): `NavTarget`, `NavProvider` and `useNavigate`.
+                 **Two mechanisms, and which one to use is decided by where the
+                 caller is rendered.** A view `App.tsx` renders directly takes
+                 `onNavigate={navigate}` as a prop (the three gateway views);
+                 the context is for a caller several levels down, where the prop
+                 would have to be threaded through every parent — the Sessions
+                 inspector and `SessionDetail`. `NavTarget` is a view id plus
+                 *one optional row id*, and it must stay that: it is a hand-off,
+                 not a router, and query state, filters and scroll positions do
+                 not belong in it. `App` clears the target on any navigation
+                 that carries none, or a consumed chat id would be re-applied on
+                 every later visit to that section
     icons.tsx    16px / 1.5-stroke icon set
     tauri.ts     window + menu bridge; degrades to a plain browser tab
     clipboard.ts copyText, with the execCommand fallback WebKitGTK needs
@@ -3954,9 +3966,6 @@ because each one cost real time to find:
   serde's recursion limit, a site URL `url::Url` rejects. Each is documented at
   its site. They were invisible while something else could answer; they are
   user-visible 500s now, and each is a small piece of work to resolve properly.
-- Cross-view navigation: "Continue in chat" on a session can only report the
-  new `chat_id`; it cannot switch to the Chats view. Needs a nav context in
-  `App.tsx`.
 - `useAppStats` counters refresh on a 30s poll and on window focus, not on
   mutation, so a create in one view lags in the sidebar briefly.
 - Session table is not virtualised; 900+ rows render eagerly after "Load more".

--- a/src-tauri/src/native/chat/persist.rs
+++ b/src-tauri/src/native/chat/persist.rs
@@ -127,7 +127,7 @@ fn append_message(
 ///
 /// Runes, not bytes — a title of accented text would otherwise be cut mid
 /// character and stored as invalid UTF-8.
-fn truncate_title(content: &str, max: usize) -> String {
+pub(crate) fn truncate_title(content: &str, max: usize) -> String {
     let count = content.chars().count();
     if count <= max {
         return content.to_string();

--- a/src-tauri/src/native/sessions/continue_chat.rs
+++ b/src-tauri/src/native/sessions/continue_chat.rs
@@ -79,11 +79,12 @@ pub fn continue_session(db_path: &std::path::Path, session_id: &str) -> Result<A
     //
     // This is a deliberate divergence from the inherited behaviour, which left
     // every continued chat titled "New Chat".
-    let title = crate::native::chat::persist::truncate_title(&detail.summary.display_title, 60);
-    let title = if title.is_empty() {
+    let from_source =
+        crate::native::chat::persist::truncate_title(&detail.summary.display_title, 60);
+    let title = if from_source.is_empty() {
         session.title.as_str()
     } else {
-        title.as_str()
+        from_source.as_str()
     };
 
     // `chatService.UpdateSession`, which stamps its own `updated_at` — so this

--- a/src-tauri/src/native/sessions/continue_chat.rs
+++ b/src-tauri/src/native/sessions/continue_chat.rs
@@ -69,13 +69,35 @@ pub fn continue_session(db_path: &std::path::Path, session_id: &str) -> Result<A
         },
     )?;
 
+    // The chat is titled from the session it continues, so it is identifiable
+    // in the Chats list instead of joining the pile of untitled "New Chat" rows
+    // (#485). `display_title` falls all the way through to the transcript's
+    // first-message preview, which is unbounded, so it goes through the *same*
+    // 60-rune cut a chat's own derived title takes — one spelling of "how long
+    // a chat title may be", not two. An empty one keeps `insert_session`'s
+    // default rather than storing a blank.
+    //
+    // This is a deliberate divergence from the inherited behaviour, which left
+    // every continued chat titled "New Chat".
+    let title = crate::native::chat::persist::truncate_title(&detail.summary.display_title, 60);
+    let title = if title.is_empty() {
+        session.title.as_str()
+    } else {
+        title.as_str()
+    };
+
     // `chatService.UpdateSession`, which stamps its own `updated_at` — so this
     // is a second statement with a second clock reading rather than a value
-    // folded into the insert above. It writes every column, but only these two
-    // can differ from what was just inserted.
+    // folded into the insert above. It writes every column, but only these
+    // three can differ from what was just inserted.
     tx.execute(
-        "UPDATE chat_sessions SET sdk_session_id = ?1, updated_at = ?2 WHERE id = ?3",
-        rusqlite::params![session_id, crate::native::gotime::now_go_text(), session.id],
+        "UPDATE chat_sessions SET title = ?1, sdk_session_id = ?2, updated_at = ?3 WHERE id = ?4",
+        rusqlite::params![
+            title,
+            session_id,
+            crate::native::gotime::now_go_text(),
+            session.id
+        ],
     )
     .map_err(|e| WriteError::Fallback(format!("linking claude session: {e}")))?;
 
@@ -142,10 +164,10 @@ mod tests {
             .to_string();
 
         let conn = rusqlite::Connection::open(&db).expect("open");
-        let (count, sdk, cwd, model, slug): (i64, String, String, String, String) = conn
-            .query_row(
+        let (count, sdk, cwd, model, slug, title): (i64, String, String, String, String, String) =
+            conn.query_row(
                 "SELECT (SELECT COUNT(*) FROM chat_sessions), sdk_session_id,
-                        working_directory, model, agent_slug
+                        working_directory, model, agent_slug, title
                  FROM chat_sessions WHERE id = ?1",
                 [&chat_id],
                 |row| {
@@ -155,6 +177,7 @@ mod tests {
                         row.get(2)?,
                         row.get(3)?,
                         row.get(4)?,
+                        row.get(5)?,
                     ))
                 },
             )
@@ -165,6 +188,89 @@ mod tests {
         assert_eq!(cwd, "/home/u/proj");
         assert_eq!(model, "claude-opus-5");
         assert_eq!(slug, "", "a continued conversation has no agent");
+        assert_eq!(
+            title, "do the thing",
+            "the chat is titled from the session it continues, not left \"New Chat\""
+        );
+    }
+
+    /// The title is the source session's, cut the way a chat's own derived
+    /// title is cut — `display_title` falls through to an unbounded transcript
+    /// preview, so a long first message must not become a 4 KB title.
+    #[test]
+    fn a_long_source_title_is_cut_at_sixty_runes() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let claude = dir.path().join(".claude");
+        let project = claude.join("projects").join("-home-u-proj");
+        std::fs::create_dir_all(&project).expect("project dir");
+
+        let session_id = "77777777-8888-9999-aaaa-bbbbbbbbbbbb";
+        let long = "x".repeat(200);
+        let transcript = format!(
+            "{{\"type\":\"user\",\"uuid\":\"u1\",\"parentUuid\":null,\
+             \"timestamp\":\"2026-08-01T10:00:00Z\",\"cwd\":\"/home/u/proj\",\
+             \"message\":{{\"role\":\"user\",\"content\":\"{long}\"}}}}\n"
+        );
+        std::fs::write(project.join(format!("{session_id}.jsonl")), transcript).expect("write");
+
+        let db = dir.path().join("agento.db");
+        {
+            let mut conn = rusqlite::Connection::open(&db).expect("open");
+            crate::native::migrate::apply(&mut conn).expect("migrate");
+            conn.execute(
+                "INSERT INTO user_settings (id, claude_config_dir) VALUES (1, ?1)",
+                [claude.to_string_lossy()],
+            )
+            .expect("settings row");
+        }
+
+        continue_session(&db, session_id).expect("continue");
+
+        let conn = rusqlite::Connection::open(&db).expect("open");
+        let title: String = conn
+            .query_row("SELECT title FROM chat_sessions", [], |r| r.get(0))
+            .expect("the chat row");
+        assert_eq!(title, format!("{}...", "x".repeat(60)));
+    }
+
+    /// A source session with nothing to take a title from keeps the store's own
+    /// default, rather than being written as an empty string — a blank row in
+    /// the Chats list is worse than "New Chat".
+    #[test]
+    fn a_source_session_with_no_title_keeps_the_default() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let claude = dir.path().join(".claude");
+        let project = claude.join("projects").join("-home-u-proj");
+        std::fs::create_dir_all(&project).expect("project dir");
+
+        let session_id = "cccccccc-dddd-eeee-ffff-000000000000";
+        // Assistant-only: nothing this session can derive a display title from.
+        let transcript = concat!(
+            r#"{"type":"assistant","uuid":"a1","parentUuid":null,"timestamp":"2026-08-01T10:00:05Z","#,
+            r#""cwd":"/home/u/proj","message":{"role":"assistant","model":"claude-opus-5",""#,
+            r#"content":[{"type":"text","text":"done"}],"usage":{"input_tokens":10,"output_tokens":5}}}"#,
+            "\n"
+        );
+        std::fs::write(project.join(format!("{session_id}.jsonl")), transcript).expect("write");
+
+        let db = dir.path().join("agento.db");
+        {
+            let mut conn = rusqlite::Connection::open(&db).expect("open");
+            crate::native::migrate::apply(&mut conn).expect("migrate");
+            conn.execute(
+                "INSERT INTO user_settings (id, claude_config_dir) VALUES (1, ?1)",
+                [claude.to_string_lossy()],
+            )
+            .expect("settings row");
+        }
+
+        continue_session(&db, session_id).expect("continue");
+
+        let conn = rusqlite::Connection::open(&db).expect("open");
+        let title: String = conn
+            .query_row("SELECT title FROM chat_sessions", [], |r| r.get(0))
+            .expect("the chat row");
+        assert_eq!(title, "New Chat");
     }
 
     /// A session that exists nowhere is Go's 404 with its own fixed wording,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,14 @@ import { GatewayProvidersView } from "./views/gateway/ProvidersView";
 import { GatewayModelsView } from "./views/gateway/ModelsView";
 import { GatewayUsageView } from "./views/gateway/UsageView";
 import { GatewaySettingsView } from "./views/gateway/SettingsView";
-import { SECTIONS, VIEW_TITLES, type ViewId } from "./lib/nav";
+import {
+  NavProvider,
+  SECTIONS,
+  VIEW_TITLES,
+  type NavTarget,
+  type NavigateFn,
+  type ViewId,
+} from "./lib/nav";
 import { useAppStats } from "./lib/stats";
 import { useHostInfo } from "./lib/host";
 import { useBackgroundUpdate } from "./lib/useBackgroundUpdate";
@@ -46,6 +53,11 @@ export default function App() {
   const [paletteOpen, setPaletteOpen] = useState(false);
   // Bumped by every "New Chat" entry point; ChatsView opens a draft on change.
   const [newChatNonce, setNewChatNonce] = useState(0);
+  // What the destination view should open on arrival, and a nonce so the same
+  // hand-off twice still fires. Cleared by any navigation that carries no
+  // target, or a stale chat id would be re-selected on every later visit.
+  const [navTarget, setNavTarget] = useState<NavTarget>();
+  const [navNonce, setNavNonce] = useState(0);
   const [focused, setFocused] = useState(true);
   const [theme, setTheme] = useState<Theme>(
     () => (localStorage.getItem("agento.theme") as Theme) || "system"
@@ -66,9 +78,11 @@ export default function App() {
   useEffect(() => onWindowFocus(setFocused), []);
 
   /* --- Navigation with history ------------------------------------------- */
-  const navigate = useCallback(
-    (id: ViewId) => {
+  const navigate = useCallback<NavigateFn>(
+    (id, target) => {
       setView(id);
+      setNavTarget(target);
+      if (target) setNavNonce((n) => n + 1);
       setHistory((h) => {
         const trimmed = h.slice(0, cursor + 1);
         if (trimmed[trimmed.length - 1] === id) return trimmed;
@@ -306,111 +320,123 @@ export default function App() {
         canForward={cursor < history.length - 1}
       />
 
-      <div className="body">
-        <Sidebar
-          open={sidebarOpen}
-          active={view}
-          onSelect={navigate}
-          counts={counts}
-          onNewChat={newChat}
-        />
+      {/* Everything below can navigate. The provider is what lets a view
+          nested several levels down — the Sessions inspector, the full session
+          view — hand the user to another section without a callback threaded
+          through every parent (#485). */}
+      <NavProvider value={navigate}>
+        <div className="body">
+          <Sidebar
+            open={sidebarOpen}
+            active={view}
+            onSelect={navigate}
+            counts={counts}
+            onNewChat={newChat}
+          />
 
-        <main className="main">
-          {update.available && (
-            <div className="banner">
-              <Icon name="sparkle" size={14} />
-              <span>
-                {update.installing
-                  ? `Installing version ${update.available.version} — Agento will restart.`
-                  : `Version ${update.available.version} is available.`}
-              </span>
-              {!update.installing && (
+          <main className="main">
+            {update.available && (
+              <div className="banner">
+                <Icon name="sparkle" size={14} />
+                <span>
+                  {update.installing
+                    ? `Installing version ${update.available.version} — Agento will restart.`
+                    : `Version ${update.available.version} is available.`}
+                </span>
+                {!update.installing && (
+                  <button
+                    className="btn"
+                    style={{ marginLeft: "auto", height: 20 }}
+                    onClick={() => navigate("about")}
+                  >
+                    Details
+                  </button>
+                )}
                 <button
-                  className="btn"
-                  style={{ marginLeft: "auto", height: 20 }}
-                  onClick={() => navigate("about")}
+                  className="iconbtn"
+                  style={update.installing ? { marginLeft: "auto" } : undefined}
+                  onClick={update.dismiss}
+                  title="Dismiss"
                 >
-                  Details
+                  <Icon name="close" size={13} />
                 </button>
-              )}
-              <button
-                className="iconbtn"
-                style={update.installing ? { marginLeft: "auto" } : undefined}
-                onClick={update.dismiss}
-                title="Dismiss"
-              >
-                <Icon name="close" size={13} />
-              </button>
-            </div>
-          )}
-          {claudeMissing && !claudeNoticeDismissed && (
-            <div className="banner">
-              <Icon name="alert" size={14} />
-              <span>
-                Claude Code is not installed, so agents cannot run. Install it
-                with <code>npm i -g @anthropic-ai/claude-code</code>, sign in
-                with <code>claude</code>, then restart Agento.
-              </span>
-              <button
-                className="iconbtn"
-                style={{ marginLeft: "auto" }}
-                onClick={() => setClaudeNoticeDismissed(true)}
-                title="Dismiss"
-              >
-                <Icon name="close" size={13} />
-              </button>
-            </div>
-          )}
-          {view === "chats" && (
-            <ChatsView inspectorOpen={inspectorOpen} newChatNonce={newChatNonce} />
-          )}
-          {view === "agents" && <AgentsView inspectorOpen={inspectorOpen} />}
-          {view === "integrations" && (
-            <IntegrationsView inspectorOpen={inspectorOpen} />
-          )}
-          {view === "tasks" && <TasksView inspectorOpen={inspectorOpen} />}
-          {view === "jobs" && <JobsView inspectorOpen={inspectorOpen} />}
-          {view === "sessions" && <SessionsView inspectorOpen={inspectorOpen} />}
-          {(view === "tokens" || view === "usage" || view === "insights") && (
-            <AnalyticsView mode={view} inspectorOpen={inspectorOpen} />
-          )}
-          {/* Three of the five gateway views take `navigate`, and all three for
-              the same reason: the useful action on what they are reporting
-              lives in a sibling view rather than a pane of their own — change
-              the port (Overview), add the provider an alias has to route to
-              (Models), and configure the two things the listener needs before
-              it can be switched on at all (Gateway Settings, #474). There is
-              still no nav context; the prop is the whole mechanism. */}
-          {view === "gateway" && (
-            <GatewayOverviewView
-              inspectorOpen={inspectorOpen}
-              onNavigate={navigate}
-            />
-          )}
-          {view === "gateway-providers" && (
-            <GatewayProvidersView inspectorOpen={inspectorOpen} />
-          )}
-          {view === "gateway-models" && (
-            <GatewayModelsView
-              inspectorOpen={inspectorOpen}
-              onNavigate={navigate}
-            />
-          )}
-          {view === "gateway-usage" && (
-            <GatewayUsageView inspectorOpen={inspectorOpen} />
-          )}
-          {view === "gateway-settings" && (
-            <GatewaySettingsView
-              inspectorOpen={inspectorOpen}
-              onNavigate={navigate}
-            />
-          )}
-          {view === "settings" && (
-            <SettingsView theme={theme} onThemeChange={setTheme} />
-          )}
-          {view === "about" && <AboutView />}
-        </main>
-      </div>
+              </div>
+            )}
+            {claudeMissing && !claudeNoticeDismissed && (
+              <div className="banner">
+                <Icon name="alert" size={14} />
+                <span>
+                  Claude Code is not installed, so agents cannot run. Install it
+                  with <code>npm i -g @anthropic-ai/claude-code</code>, sign in
+                  with <code>claude</code>, then restart Agento.
+                </span>
+                <button
+                  className="iconbtn"
+                  style={{ marginLeft: "auto" }}
+                  onClick={() => setClaudeNoticeDismissed(true)}
+                  title="Dismiss"
+                >
+                  <Icon name="close" size={13} />
+                </button>
+              </div>
+            )}
+            {view === "chats" && (
+              <ChatsView
+                inspectorOpen={inspectorOpen}
+                newChatNonce={newChatNonce}
+                openChatId={navTarget?.chatId}
+                openChatNonce={navNonce}
+              />
+            )}
+            {view === "agents" && <AgentsView inspectorOpen={inspectorOpen} />}
+            {view === "integrations" && (
+              <IntegrationsView inspectorOpen={inspectorOpen} />
+            )}
+            {view === "tasks" && <TasksView inspectorOpen={inspectorOpen} />}
+            {view === "jobs" && <JobsView inspectorOpen={inspectorOpen} />}
+            {view === "sessions" && <SessionsView inspectorOpen={inspectorOpen} />}
+            {(view === "tokens" || view === "usage" || view === "insights") && (
+              <AnalyticsView mode={view} inspectorOpen={inspectorOpen} />
+            )}
+            {/* Three of the five gateway views take `navigate`, and all three for
+                the same reason: the useful action on what they are reporting
+                lives in a sibling view rather than a pane of their own — change
+                the port (Overview), add the provider an alias has to route to
+                (Models), and configure the two things the listener needs before
+                it can be switched on at all (Gateway Settings, #474). All three
+                are rendered right here, so the prop stays the mechanism for them;
+                `NavProvider` above exists for views that are not. */}
+            {view === "gateway" && (
+              <GatewayOverviewView
+                inspectorOpen={inspectorOpen}
+                onNavigate={navigate}
+              />
+            )}
+            {view === "gateway-providers" && (
+              <GatewayProvidersView inspectorOpen={inspectorOpen} />
+            )}
+            {view === "gateway-models" && (
+              <GatewayModelsView
+                inspectorOpen={inspectorOpen}
+                onNavigate={navigate}
+              />
+            )}
+            {view === "gateway-usage" && (
+              <GatewayUsageView inspectorOpen={inspectorOpen} />
+            )}
+            {view === "gateway-settings" && (
+              <GatewaySettingsView
+                inspectorOpen={inspectorOpen}
+                onNavigate={navigate}
+              />
+            )}
+            {view === "settings" && (
+              <SettingsView theme={theme} onThemeChange={setTheme} />
+            )}
+            {view === "about" && <AboutView />}
+          </main>
+        </div>
+      </NavProvider>
 
       <StatusBar
         running={stats.runningJobs}

--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -1,3 +1,4 @@
+import { createContext, useContext } from "react";
 import type { IconName } from "./icons";
 
 export type ViewId =
@@ -91,3 +92,41 @@ export const VIEW_TITLES: Record<ViewId, string> = {
   settings: "Settings",
   about: "About Agento",
 };
+
+/* --- Cross-view navigation ------------------------------------------------ */
+
+/**
+ * What a view wants the *next* view to open, beyond the section itself.
+ *
+ * Deliberately one optional row id per destination: this is a hand-off, not a
+ * router, and it must not grow query state, filters or scroll positions. A
+ * second destination adds a second optional field here, and nothing else.
+ */
+export interface NavTarget {
+  /** A chat `chats` should preselect on arrival (#485). */
+  chatId?: string;
+}
+
+export type NavigateFn = (id: ViewId, target?: NavTarget) => void;
+
+/**
+ * `App`'s `navigate`, reachable from a nested view without threading a callback
+ * through every parent.
+ *
+ * The prop form is still the norm — three gateway views take `onNavigate`
+ * because they are rendered directly by `App` and have nothing to thread
+ * through. This exists for the other case: `SessionsView`'s inspector and
+ * `SessionDetail` are several levels down, and "Continue in chat" needs to land
+ * the user in the Chats view.
+ */
+const NavContext = createContext<NavigateFn>(() => {
+  // Not fatal — but a hand-off that silently does nothing is exactly the bug
+  // #485 was filed for, so it must not be invisible.
+  console.warn("navigate() called outside a NavProvider; nothing happened");
+});
+
+export const NavProvider = NavContext.Provider;
+
+export function useNavigate(): NavigateFn {
+  return useContext(NavContext);
+}

--- a/src/styles/sessions.css
+++ b/src/styles/sessions.css
@@ -10,6 +10,16 @@
 }
 
 /* --- Session detail (read-only transcript) -------------------------------- */
+/* A failed "Continue in chat" from the full session view. Sits directly under
+   the toolbar that carries the button, so it needs no scrolling to see. */
+.sess-detail__error {
+  flex: none;
+  padding: var(--sp-3) var(--sp-7);
+  border-bottom: var(--hairline) solid var(--line);
+  font-size: var(--text-sm);
+  color: var(--red);
+}
+
 .sess-detail__meta {
   flex: none;
   display: flex;

--- a/src/views/ChatsView.tsx
+++ b/src/views/ChatsView.tsx
@@ -51,9 +51,14 @@ async function fetchDetail(id: string, signal: AbortSignal): Promise<ChatDetail>
 export function ChatsView({
   inspectorOpen,
   newChatNonce = 0,
+  openChatId,
+  openChatNonce = 0,
 }: {
   inspectorOpen: boolean;
   newChatNonce?: number;
+  /** A chat another view handed over; applied when `openChatNonce` moves. */
+  openChatId?: string;
+  openChatNonce?: number;
 }) {
   const chats = useResource<ChatSession[]>(
     (signal) => api.get<ChatSession[]>("/chats", signal),
@@ -192,6 +197,23 @@ export function ChatsView({
     seenNonce.current = newChatNonce;
     startNew();
   }, [newChatNonce, startNew]);
+
+  // Sessions → "Continue in chat" hands a freshly created chat over (#485), the
+  // same way the nonce above hands over "open a draft".
+  //
+  // The id is applied without waiting for `/chats` to resolve: `detail` fetches
+  // by id, so the transcript and the composer are live immediately and the row
+  // simply highlights once the list arrives. `autoSelected` is claimed so the
+  // "select the most recent conversation" effect cannot overwrite the hand-off
+  // when that list lands.
+  const seenOpenNonce = useRef(0);
+  useEffect(() => {
+    if (openChatNonce === seenOpenNonce.current) return;
+    seenOpenNonce.current = openChatNonce;
+    if (!openChatId) return;
+    autoSelected.current = true;
+    select(openChatId);
+  }, [openChatId, openChatNonce, select]);
 
   const send = useCallback(async () => {
     const content = draft.trim();

--- a/src/views/ChatsView.tsx
+++ b/src/views/ChatsView.tsx
@@ -207,12 +207,17 @@ export function ChatsView({
   // "select the most recent conversation" effect cannot overwrite the hand-off
   // when that list lands.
   const seenOpenNonce = useRef(0);
+  const [composerFocus, setComposerFocus] = useState(0);
   useEffect(() => {
     if (openChatNonce === seenOpenNonce.current) return;
     seenOpenNonce.current = openChatNonce;
     if (!openChatId) return;
     autoSelected.current = true;
     select(openChatId);
+    // "Ready to type" is the point of the hand-off, so the caret goes to the
+    // composer — which mounts in this same commit, since `selected` is what
+    // renders it.
+    setComposerFocus((n) => n + 1);
   }, [openChatId, openChatNonce, select]);
 
   const send = useCallback(async () => {
@@ -628,6 +633,7 @@ export function ChatsView({
               stopping={stream.stopping}
               onStop={stream.stop}
               placeholder={`Message ${agentLabel}…`}
+              focusNonce={composerFocus}
               meta={
                 <span className="composer__meta">
                   {session?.model || stream.system?.model || "Default model"}

--- a/src/views/SessionsView.tsx
+++ b/src/views/SessionsView.tsx
@@ -472,7 +472,14 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
   /* --- Row actions -------------------------------------------------------- */
 
   const [busy, setBusy] = useState<"favorite" | "continue">();
-  const [actionError, setActionError] = useState<string>();
+  /**
+   * Which action failed, not just what it said. The two surfaces render it in
+   * different places — the inspector under its own three buttons, the full
+   * session view under its one — so a favourite failure must not surface as
+   * text under a "Continue in chat" button that was never pressed.
+   */
+  const [actionError, setActionError] =
+    useState<{ action: "favorite" | "continue"; message: string }>();
   const navigate = useNavigate();
 
   const applyPatch = useCallback(
@@ -502,7 +509,7 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
         applyPatch(s.session_id, { is_favorite: next });
         reloadFacets();
       } catch (err) {
-        setActionError(describeError(err));
+        setActionError({ action: "favorite", message: describeError(err) });
       } finally {
         setBusy(undefined);
       }
@@ -532,7 +539,7 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
         if (!res?.chat_id) throw new Error("the server returned no chat id");
         navigate("chats", { chatId: res.chat_id });
       } catch (err) {
-        setActionError(describeError(err));
+        setActionError({ action: "continue", message: describeError(err) });
       } finally {
         setBusy(undefined);
       }
@@ -612,7 +619,9 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
             onBack={() => setOpenId(undefined)}
             onContinue={continueInChat}
             continuing={busy === "continue"}
-            continueError={actionError}
+            continueError={
+              actionError?.action === "continue" ? actionError.message : undefined
+            }
           />
         ) : (
           <>
@@ -982,7 +991,7 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
                 <Inspector
                   session={selected}
                   busy={busy}
-                  error={actionError}
+                  error={actionError?.message}
                   onOpen={(s) => setOpenId(s.session_id)}
                   onToggleFavorite={toggleFavorite}
                   onContinue={continueInChat}

--- a/src/views/SessionsView.tsx
+++ b/src/views/SessionsView.tsx
@@ -29,6 +29,7 @@ import {
   usd,
 } from "../lib/format";
 import { Icon } from "../lib/icons";
+import { useNavigate } from "../lib/nav";
 import { snippetParts, snippetText } from "../lib/snippet";
 import { sessionAgentName } from "../lib/sessionAgent";
 import { openExternal } from "../lib/tauri";
@@ -472,7 +473,7 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
 
   const [busy, setBusy] = useState<"favorite" | "continue">();
   const [actionError, setActionError] = useState<string>();
-  const [continuedChat, setContinuedChat] = useState<string>();
+  const navigate = useNavigate();
 
   const applyPatch = useCallback(
     (id: string, patch: Partial<ClaudeSessionSummary>) => {
@@ -509,25 +510,38 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
     [applyPatch, reloadFacets]
   );
 
-  const continueInChat = useCallback(async (s: ClaudeSessionSummary) => {
-    setBusy("continue");
-    setActionError(undefined);
-    setContinuedChat(undefined);
-    try {
-      const res = await api.post<{ chat_id: string }>(
-        `/claude-sessions/${s.session_id}/continue`
-      );
-      setContinuedChat(res?.chat_id ?? "");
-    } catch (err) {
-      setActionError(describeError(err));
-    } finally {
-      setBusy(undefined);
-    }
-  }, []);
+  /**
+   * Create the resuming chat and **go to it**.
+   *
+   * Reporting the new `chat_id` in place was the whole defect (#485): the note
+   * rendered at the bottom of a scrolling inspector, so a success and a 404
+   * looked identical — like nothing happening. Navigating is also what guards
+   * a double-click: this view unmounts, so the second click has no button to
+   * land on, and `busy` covers the window before that.
+   */
+  const continueInChat = useCallback(
+    async (s: ClaudeSessionSummary) => {
+      setBusy("continue");
+      setActionError(undefined);
+      try {
+        const res = await api.post<{ chat_id: string }>(
+          `/claude-sessions/${s.session_id}/continue`
+        );
+        // A 201 with no id is not a success to navigate on — it would land on
+        // an empty Chats view, which is the symptom this issue is about.
+        if (!res?.chat_id) throw new Error("the server returned no chat id");
+        navigate("chats", { chatId: res.chat_id });
+      } catch (err) {
+        setActionError(describeError(err));
+      } finally {
+        setBusy(undefined);
+      }
+    },
+    [navigate]
+  );
 
   useEffect(() => {
     setActionError(undefined);
-    setContinuedChat(undefined);
   }, [selectedId]);
 
   /* --- Derived view data --------------------------------------------------- */
@@ -596,6 +610,9 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
           <SessionDetail
             session={openSession}
             onBack={() => setOpenId(undefined)}
+            onContinue={continueInChat}
+            continuing={busy === "continue"}
+            continueError={actionError}
           />
         ) : (
           <>
@@ -966,7 +983,6 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
                   session={selected}
                   busy={busy}
                   error={actionError}
-                  continuedChat={continuedChat}
                   onOpen={(s) => setOpenId(s.session_id)}
                   onToggleFavorite={toggleFavorite}
                   onContinue={continueInChat}
@@ -988,7 +1004,6 @@ function Inspector({
   session,
   busy,
   error,
-  continuedChat,
   onOpen,
   onToggleFavorite,
   onContinue,
@@ -996,7 +1011,6 @@ function Inspector({
   session: ClaudeSessionSummary;
   busy: "favorite" | "continue" | undefined;
   error: string | undefined;
-  continuedChat: string | undefined;
   onOpen(s: ClaudeSessionSummary): void;
   onToggleFavorite(s: ClaudeSessionSummary): void;
   onContinue(s: ClaudeSessionSummary): void;
@@ -1229,12 +1243,8 @@ function Inspector({
             <Icon name="play" size={13} />
             {busy === "continue" ? "Starting…" : "Continue in chat"}
           </button>
-          {continuedChat !== undefined && (
-            <div className="sess-note">
-              Continued as chat <span className="mono">{continuedChat}</span> —
-              open Chats to resume it.
-            </div>
-          )}
+          {/* Success navigates away, so the only thing left to render here is a
+              failure — directly under the button the user just pressed. */}
           {error && <div className="sess-note sess-note--error">{error}</div>}
         </div>
       </InspGroup>

--- a/src/views/chat/Composer.tsx
+++ b/src/views/chat/Composer.tsx
@@ -11,6 +11,7 @@ export function Composer({
   stopping,
   onStop,
   meta,
+  focusNonce = 0,
 }: {
   value: string;
   onChange(v: string): void;
@@ -20,8 +21,24 @@ export function Composer({
   stopping: boolean;
   onStop(): void;
   meta?: React.ReactNode;
+  /**
+   * Bumped by a caller that wants the cursor here. A nonce rather than
+   * `autoFocus`, which React only applies on mount — this textarea survives a
+   * change of chat, so the attribute would never fire again.
+   */
+  focusNonce?: number;
 }) {
   const box = useRef<HTMLTextAreaElement>(null);
+
+  // Deliberately not on mount: focus is only ever taken when somebody asked
+  // for it, so opening the app or clicking through the list does not steal the
+  // caret from wherever the user put it.
+  const seenFocus = useRef(0);
+  useEffect(() => {
+    if (focusNonce === seenFocus.current) return;
+    seenFocus.current = focusNonce;
+    box.current?.focus();
+  }, [focusNonce]);
 
   // Grow with the draft rather than scrolling a two-line box.
   useEffect(() => {

--- a/src/views/sessions/SessionDetail.tsx
+++ b/src/views/sessions/SessionDetail.tsx
@@ -23,9 +23,20 @@ import { Markdown } from "../chat/Markdown";
 export function SessionDetail({
   session,
   onBack,
+  onContinue,
+  continuing,
+  continueError,
 }: {
   session: ClaudeSessionSummary;
   onBack(): void;
+  /**
+   * Shared with the list inspector's own button rather than duplicated: both
+   * surfaces must create the chat *and* navigate, and two copies is where one
+   * of them stops doing the second half (#485).
+   */
+  onContinue(s: ClaudeSessionSummary): void;
+  continuing: boolean;
+  continueError?: string;
 }) {
   const detail = useResource<ClaudeSessionDetail>(
     (signal) =>
@@ -98,7 +109,23 @@ export function SessionDetail({
               (session.subagent_cost?.total_usd ?? 0)
           )}
         </span>
+        <div className="toolbar__sep" />
+        <button
+          className="btn"
+          disabled={continuing}
+          onClick={() => onContinue(session)}
+        >
+          <Icon name="play" size={13} />
+          {continuing ? "Starting…" : "Continue in chat"}
+        </button>
       </div>
+
+      {/* A success leaves this view entirely, so this only ever renders a
+          failure — and it renders in the toolbar's own band rather than in a
+          pane the user would have to scroll. */}
+      {continueError && (
+        <div className="sess-detail__error">{continueError}</div>
+      )}
 
       <div className="sess-detail__meta">
         <span className="mono" title={session.project_path}>


### PR DESCRIPTION
Closes #485

## What

**Continue in chat** now takes the user to the resumed conversation instead of
silently creating a chat nobody is shown.

## Why

The backend was always healthy — `POST /api/claude-sessions/{id}/continue`
answers `201 {"chat_id"}` and `chat/runner.rs` already passes `sdk_session_id`
as `--resume`. Everything missing was on the frontend: `continueInChat`
resolved the POST and only set a note string, rendered as a small grey
`.sess-note` appended below the button at the bottom of a scrolling inspector.
No view change, no selection, no composer. The **error** rendered in the same
off-screen spot, so a 404 was visually indistinguishable from a success.

## How

- **`src/lib/nav.ts`** — `NavTarget` (a view id plus *one* optional row id),
  `NavProvider` and `useNavigate()`. Deliberately a hand-off, not a router.
  Two mechanisms now exist and which to use is decided by where the caller is
  rendered: a view `App.tsx` renders directly keeps `onNavigate` as a prop (the
  three gateway views); the context is for callers several levels down, where
  the prop would have to be threaded through every parent.
- **`src/App.tsx`** — `navigate` takes an optional target, stored beside `view`
  with a nonce so the same hand-off twice still fires. It is **cleared by any
  navigation that carries none**, or a consumed chat id would be re-applied on
  every later visit to Chats.
- **`src/views/ChatsView.tsx`** — `openChatId` / `openChatNonce`, mirroring
  `newChatNonce`. The id is applied without waiting for `/chats`: `detail`
  fetches by id, so the transcript and composer are live immediately and the row
  highlights when the list arrives. It claims `autoSelected` so the "select the
  most recent conversation" effect cannot overwrite the hand-off.
- **`src/views/SessionsView.tsx`** — navigates on success, `continuedChat` and
  its render are gone. The remaining note is only ever the failure, directly
  under the button pressed.
- **`src/views/sessions/SessionDetail.tsx`** — gains the same action, wired to
  the *same* handler rather than a second copy of the `api.post` (two copies is
  where one of them stops navigating), with its failure in the toolbar's own
  band.
- **`src-tauri/src/native/sessions/continue_chat.rs`** — the chat is titled from
  the source session's `display_title`, through `persist::truncate_title`'s
  existing 60-rune cut rather than a second spelling of it (`display_title`
  falls through to an unbounded transcript preview). An empty one keeps the
  store's `New Chat` default. A deliberate divergence from the inherited
  behaviour, which is now allowed.
- **`CLAUDE.md`** — the "Cross-view navigation" **Known gap** is removed and the
  nav context is documented on the `nav.ts` line.

The response body is unchanged (`{"chat_id"}`), so no golden moves and
`parity/write_routes.json` still records the route as `native`.

## Acceptance

- [x] Clicking **Continue in chat** switches to Chats with the new chat selected
      and its composer ready.
- [x] The continued chat is titled from the source session's `display_title`.
- [x] Sending the first message resumes the Claude conversation — untouched;
      `runner.rs` already passes `--resume`.
- [x] A failed continue shows an error without scrolling, and does not navigate.
- [x] The same action exists in `SessionDetail.tsx`.
- [x] Repeat clicks are bounded: `busy` disables the button in flight, and
      success unmounts the view.

## Tests

Three unit tests over `continue_session` in `continue_chat.rs`: the title is the
source session's, a long one is cut at 60 runes, and an untitled source keeps
`New Chat`. **Verified as a regression guard** — reverting the `title = ?1`
column out of the UPDATE fails the first two with
`left: "New Chat"`, and leaves the third passing (it asserts the fallback).

There is no TypeScript test harness in this repo, so the nav path is covered by
`tsc` and review rather than by a test.

## Out of scope

Replaying the source transcript into the chat view; the row context menu and
moving the inspector actions above the fold (#486); backend idempotency for a
session continued twice (see the issue's **Context** — branching a session twice
is legitimate, and after the first turn `persist.rs` rewrites `sdk_session_id`
from the stream).