### PR TITLE
feat: right-click actions on a session row, and pin the inspector actions (#486)

### DIFF
--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -406,6 +406,11 @@ export function ContextMenu({
       left: Math.max(m, Math.min(at.x, window.innerWidth - width - m)),
       top: Math.max(m, Math.min(at.y, window.innerHeight - height - m)),
     });
+    // Reopening does not always remount: right-clicking a second row while the
+    // menu is open closes and reopens it in one batch, so this component is
+    // reused and a stale `active` would carry over — leaving a highlighted item
+    // the user never chose, which Enter would then fire.
+    setActive(-1);
   }, [at.x, at.y]);
 
   // Focus only once `pos` has made the menu visible: a `visibility: hidden`
@@ -470,11 +475,19 @@ export function ContextMenu({
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
+      // A chorded key is somebody else's: this listener is at the window's
+      // capture phase, so claiming Ctrl+Enter or Cmd+ArrowDown here would take
+      // it from every other handler in the app while a menu happens to be open.
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
       switch (e.key) {
         case "Escape":
-        case "Tab":
           onClose();
           break;
+        // Tab closes and is then left alone, the way `Dropdown` treats it, so
+        // focus still moves on to the next control rather than being trapped.
+        case "Tab":
+          onClose();
+          return;
         case "ArrowDown":
           move(1);
           break;

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -342,6 +342,205 @@ export function Dropdown({
   );
 }
 
+/* --- Context menu --------------------------------------------------------- */
+
+export interface ContextMenuItem {
+  label: string;
+  icon?: IconName;
+  danger?: boolean;
+  disabled?: boolean;
+  onSelect(): void;
+}
+
+/**
+ * A menu anchored to a **point** rather than to a control — what a right-click
+ * on a row opens.
+ *
+ * It is written beside `Dropdown` rather than by extracting a shared popover
+ * out of it. `Dropdown` is a working, keyboard-accessible listbox used across
+ * several views, and refactoring its internals is a larger and riskier change
+ * than the one consumer here justifies; extract the popover if a third one
+ * appears.
+ *
+ * Two things differ from `Dropdown`, and both follow from there being no
+ * trigger element:
+ *
+ * - **Placement is measured, not estimated.** `Dropdown` clamps against its
+ *   trigger's rect, which it has before the menu exists. Here the only input is
+ *   a pointer position, so the first pass renders at the origin, *hidden*, and
+ *   a layout effect clamps against the box the browser actually laid out —
+ *   before it paints, so there is no flash. Rendering that first pass at `at`
+ *   instead would measure a shrink-to-fit box squeezed by whatever room is left
+ *   to the right of the cursor, i.e. the wrong width near the edge this exists
+ *   to handle.
+ * - **Keys are taken from `window` in the capture phase, not from an
+ *   `onKeyDown` prop.** `Dropdown` can use the prop because its handler sits on
+ *   the trigger, which is inside the React root; this menu is portaled to
+ *   `<body>`, and a `keydown` there does not reach React's delegated listener —
+ *   measured in the running app, where Escape and the arrow keys did nothing
+ *   at all. Capturing at the window also puts this ahead of the sessions
+ *   list's own global Enter handler, so `stopPropagation` on a key the menu
+ *   claims is what stops Enter opening the session *and* picking the item. The
+ *   menu still takes focus on open, which is where a menu's focus belongs.
+ */
+export function ContextMenu({
+  at,
+  items,
+  onClose,
+}: {
+  /** Viewport coordinates — `clientX` / `clientY` of the opening event. */
+  at: { x: number; y: number };
+  items: ContextMenuItem[];
+  onClose(): void;
+}) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState<{ left: number; top: number }>();
+  const [active, setActive] = useState(-1);
+
+  useLayoutEffect(() => {
+    const el = menuRef.current;
+    if (!el) return;
+    const { width, height } = el.getBoundingClientRect();
+    const m = 4;
+    setPos({
+      left: Math.max(m, Math.min(at.x, window.innerWidth - width - m)),
+      top: Math.max(m, Math.min(at.y, window.innerHeight - height - m)),
+    });
+  }, [at.x, at.y]);
+
+  // Focus only once `pos` has made the menu visible: a `visibility: hidden`
+  // element is not focusable, so focusing in the measuring effect above is
+  // silently a no-op — which is exactly what it did until the running app was
+  // asked what `document.activeElement` was.
+  useEffect(() => {
+    if (pos) menuRef.current?.focus({ preventScroll: true });
+  }, [pos]);
+
+  // "Outside" is outside the menu alone: the point it was opened at belongs to
+  // whatever the user right-clicked, which must not swallow the dismissal.
+  // Any scroll or resize under an open menu would strand it, so close.
+  useEffect(() => {
+    const onDown = (e: MouseEvent) => {
+      if (menuRef.current?.contains(e.target as Node)) return;
+      onClose();
+    };
+    const onScroll = (e: Event) => {
+      if (menuRef.current?.contains(e.target as Node)) return;
+      onClose();
+    };
+    document.addEventListener("mousedown", onDown);
+    window.addEventListener("scroll", onScroll, true);
+    window.addEventListener("resize", onClose);
+    window.addEventListener("blur", onClose);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      window.removeEventListener("scroll", onScroll, true);
+      window.removeEventListener("resize", onClose);
+      window.removeEventListener("blur", onClose);
+    };
+  }, [onClose]);
+
+  /** Walk to the next enabled item, wrapping; a menu of only disabled items stays put. */
+  const move = useCallback(
+    (dir: 1 | -1) => {
+      setActive((i) => {
+        const n = items.length;
+        if (n === 0) return -1;
+        let next = i < 0 && dir === 1 ? -1 : Math.max(0, i);
+        for (let k = 0; k < n; k++) {
+          next = (next + dir + n) % n;
+          if (!items[next].disabled) return next;
+        }
+        return i;
+      });
+    },
+    [items]
+  );
+
+  // Close first, then act: an item may navigate away and unmount this tree.
+  const fire = useCallback(
+    (i: number) => {
+      const item = items[i];
+      if (!item || item.disabled) return;
+      onClose();
+      item.onSelect();
+    },
+    [items, onClose]
+  );
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      switch (e.key) {
+        case "Escape":
+        case "Tab":
+          onClose();
+          break;
+        case "ArrowDown":
+          move(1);
+          break;
+        case "ArrowUp":
+          move(-1);
+          break;
+        case "Home":
+          setActive(-1);
+          move(1);
+          break;
+        case "End":
+          setActive(-1);
+          move(-1);
+          break;
+        case "Enter":
+        case " ":
+          if (active < 0) return;
+          fire(active);
+          break;
+        default:
+          return;
+      }
+      // Only the keys the menu claims are swallowed, and only while it is open.
+      e.preventDefault();
+      e.stopPropagation();
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [active, move, fire, onClose]);
+
+  return createPortal(
+    <div
+      ref={menuRef}
+      className="menu ctxmenu"
+      role="menu"
+      tabIndex={-1}
+      style={
+        pos
+          ? { left: pos.left, top: pos.top }
+          : { left: 0, top: 0, visibility: "hidden" }
+      }
+    >
+      {items.map((item, i) => (
+        <button
+          key={item.label}
+          type="button"
+          role="menuitem"
+          data-index={i}
+          disabled={item.disabled}
+          className={`menu__item ${item.danger ? "menu__item--danger" : ""} ${
+            i === active ? "menu__item--active" : ""
+          }`}
+          onMouseEnter={() => setActive(i)}
+          onClick={() => fire(i)}
+        >
+          <span className="ctxmenu__icon">
+            {item.icon && <Icon name={item.icon} size={13} />}
+          </span>
+          <span className="truncate">{item.label}</span>
+        </button>
+      ))}
+    </div>,
+    document.body
+  );
+}
+
 /* --- Combobox ------------------------------------------------------------ */
 
 /**

--- a/src/styles/controls.css
+++ b/src/styles/controls.css
@@ -467,12 +467,18 @@ textarea.field-area:focus {
   text-align: left;
   transition: background var(--dur-fast), color var(--dur-fast);
 }
-.menu__item:hover {
+.menu__item:hover,
+.menu__item--active {
   background: var(--accent);
   color: var(--accent-fg);
 }
-.menu__item:hover .menu__hint {
+.menu__item:hover .menu__hint,
+.menu__item--active .menu__hint {
   color: rgba(255, 255, 255, 0.75);
+}
+.menu__item:disabled {
+  opacity: 0.4;
+  pointer-events: none;
 }
 .menu__item--danger {
   color: var(--red);
@@ -490,6 +496,27 @@ textarea.field-area:focus {
   height: var(--hairline);
   background: var(--line);
   margin: var(--sp-2) var(--sp-4);
+}
+
+/* The context menu — a portal to <body> anchored to a point, so it is fixed
+   like .dropdown__menu and sits at the same layer. It lives here rather than in
+   a per-view sheet because <ContextMenu> is a shared control: a rule in one
+   view's stylesheet would leave the next consumer unpositioned. */
+.ctxmenu {
+  position: fixed;
+  z-index: 300;
+  max-width: 320px;
+  outline: none;
+}
+.ctxmenu .menu__item {
+  gap: var(--sp-3);
+  padding-left: var(--sp-2);
+}
+.ctxmenu__icon {
+  width: 16px;
+  flex: none;
+  display: grid;
+  place-items: center;
 }
 
 /* --- Tooltip ------------------------------------------------------------- */

--- a/src/styles/sessions.css
+++ b/src/styles/sessions.css
@@ -203,14 +203,28 @@
   margin-bottom: var(--sp-3);
 }
 
-.sess-actions {
+/* The inspector's action strip. `flex: none` under `.pane-inspector`'s column,
+   between the head and `.inspector__scroll`, so it is pinned rather than being
+   the last thing in a scrolling pane. Icon-only because it has to survive the
+   220px `Splitter` minimum. */
+.sess-strip {
+  flex: none;
   display: flex;
   flex-direction: column;
   gap: var(--sp-3);
+  padding: var(--sp-3) var(--sp-5);
+  border-bottom: var(--hairline) solid var(--line);
 }
-.sess-actions .btn {
-  justify-content: flex-start;
+.sess-strip__row {
+  display: flex;
+  gap: var(--sp-3);
 }
+.sess-strip__btn {
+  width: var(--control-h);
+  padding: 0;
+  flex: none;
+}
+
 .sess-fav--on {
   color: var(--amber);
 }

--- a/src/views/SessionsView.tsx
+++ b/src/views/SessionsView.tsx
@@ -33,7 +33,10 @@ import { useNavigate } from "../lib/nav";
 import { snippetParts, snippetText } from "../lib/snippet";
 import { sessionAgentName } from "../lib/sessionAgent";
 import { openExternal } from "../lib/tauri";
+import { copyText } from "../lib/clipboard";
 import {
+  ContextMenu,
+  type ContextMenuItem,
   Dropdown,
   Empty,
   InspGroup,
@@ -479,7 +482,7 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
    * text under a "Continue in chat" button that was never pressed.
    */
   const [actionError, setActionError] =
-    useState<{ action: "favorite" | "continue"; message: string }>();
+    useState<{ action: "favorite" | "continue" | "copy"; message: string }>();
   const navigate = useNavigate();
 
   const applyPatch = useCallback(
@@ -547,9 +550,73 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
     [navigate]
   );
 
+  /**
+   * Only a *failure* is reported. A successful copy is silent because that is
+   * what a right-click Copy does everywhere else, and the menu closing is the
+   * acknowledgement; a failure is not silent because `copyText` can genuinely
+   * refuse under WebKitGTK (see its own note), and a menu item that looks the
+   * same either way is one the user only finds out about by pasting.
+   */
+  const copyValue = useCallback(async (what: string, value: string) => {
+    if (await copyText(value)) return;
+    setActionError({
+      action: "copy",
+      message: `Could not copy the ${what} to the clipboard.`,
+    });
+  }, []);
+
   useEffect(() => {
     setActionError(undefined);
   }, [selectedId]);
+
+  /* --- Row context menu ---------------------------------------------------- */
+
+  /**
+   * The row is held by **id**, not by value: the list reloads on a poll and a
+   * favourite toggle patches it in place, so a captured row would let the
+   * menu's own "Add / Remove favourite" label go stale against the state it is
+   * about to flip.
+   */
+  const [menu, setMenu] = useState<{ at: { x: number; y: number }; id: string }>();
+  const closeMenu = useCallback(() => setMenu(undefined), []);
+  const menuSession = useMemo(
+    () => (menu ? items.find((s) => s.session_id === menu.id) : undefined),
+    [menu, items]
+  );
+
+  const menuItems = useMemo<ContextMenuItem[]>(() => {
+    const s = menuSession;
+    if (!s) return [];
+    return [
+      {
+        label: "View session",
+        icon: "chat",
+        onSelect: () => setOpenId(s.session_id),
+      },
+      {
+        label: s.is_favorite ? "Remove favourite" : "Add to favourites",
+        icon: "star",
+        disabled: busy !== undefined,
+        onSelect: () => toggleFavorite(s),
+      },
+      {
+        label: "Continue in chat",
+        icon: "play",
+        disabled: busy !== undefined,
+        onSelect: () => continueInChat(s),
+      },
+      {
+        label: "Copy session ID",
+        icon: "copy",
+        onSelect: () => copyValue("session ID", s.session_id),
+      },
+      {
+        label: "Copy project path",
+        icon: "copy",
+        onSelect: () => copyValue("project path", s.project_path),
+      },
+    ];
+  }, [menuSession, busy, toggleFavorite, continueInChat, copyValue]);
 
   /* --- Derived view data --------------------------------------------------- */
 
@@ -865,6 +932,21 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
                             select(s);
                             setOpenId(s.session_id);
                           }}
+                          // Select first, so the inspector is showing the row
+                          // the menu is about to act on. `main.tsx` already
+                          // suppresses the webview's own menu on chrome, but
+                          // this preventDefault is what makes a row's menu
+                          // unconditional — it wins even where a selection
+                          // elsewhere on the page would have let the native one
+                          // through.
+                          onContextMenu={(e) => {
+                            e.preventDefault();
+                            select(s);
+                            setMenu({
+                              at: { x: e.clientX, y: e.clientY },
+                              id: s.session_id,
+                            });
+                          }}
                         >
                           <td title={s.display_title}>
                             <span className="sess-title">
@@ -986,16 +1068,74 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
           <Splitter variable="--inspector-w" min={220} max={420} invert />
           <aside className="pane-inspector">
             <div className="inspector__head">Session</div>
+            {/* Outside `.inspector__scroll` on purpose: as the last group of a
+                scrolling pane these three were below the fold on any session
+                with a full metadata block, which is the whole of #486. */}
+            {selected && (
+              <div className="sess-strip">
+                <div className="sess-strip__row">
+                  <button
+                    className="btn btn--primary sess-strip__btn"
+                    title="View session"
+                    aria-label="View session"
+                    onClick={() => setOpenId(selected.session_id)}
+                  >
+                    <Icon name="chat" size={13} />
+                  </button>
+                  <button
+                    className="btn sess-strip__btn"
+                    disabled={busy !== undefined}
+                    // `!!` because the field is `omitempty`: a session that is
+                    // not a favourite has no `is_favorite` key at all, and
+                    // `undefined` makes React drop the attribute rather than
+                    // render "false" — a toggle that only announces its state
+                    // in one of its two states.
+                    aria-pressed={!!selected.is_favorite}
+                    title={
+                      selected.is_favorite
+                        ? "Remove favourite"
+                        : "Add to favourites"
+                    }
+                    aria-label={
+                      selected.is_favorite
+                        ? "Remove favourite"
+                        : "Add to favourites"
+                    }
+                    onClick={() => toggleFavorite(selected)}
+                  >
+                    <Icon
+                      name="star"
+                      size={13}
+                      className={
+                        selected.is_favorite ? "sess-fav--on" : undefined
+                      }
+                    />
+                  </button>
+                  <button
+                    className="btn sess-strip__btn"
+                    disabled={busy !== undefined}
+                    title={
+                      busy === "continue" ? "Starting…" : "Continue in chat"
+                    }
+                    aria-label="Continue in chat"
+                    onClick={() => continueInChat(selected)}
+                  >
+                    <Icon name="play" size={13} />
+                  </button>
+                </div>
+                {/* A successful continue navigates away and a successful copy
+                    is silent, so the only thing left to render is a failure —
+                    directly under the buttons, where it is now always in view. */}
+                {actionError && (
+                  <div className="sess-note sess-note--error">
+                    {actionError.message}
+                  </div>
+                )}
+              </div>
+            )}
             <div className="inspector__scroll scroll">
               {selected ? (
-                <Inspector
-                  session={selected}
-                  busy={busy}
-                  error={actionError?.message}
-                  onOpen={(s) => setOpenId(s.session_id)}
-                  onToggleFavorite={toggleFavorite}
-                  onContinue={continueInChat}
-                />
+                <Inspector session={selected} />
               ) : (
                 <div className="sess-note">No session selected.</div>
               )}
@@ -1003,27 +1143,21 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
           </aside>
         </>
       )}
+
+      {menu && menuSession && (
+        <ContextMenu at={menu.at} items={menuItems} onClose={closeMenu} />
+      )}
     </div>
   );
 }
 
 /* --- Inspector ------------------------------------------------------------ */
 
-function Inspector({
-  session,
-  busy,
-  error,
-  onOpen,
-  onToggleFavorite,
-  onContinue,
-}: {
-  session: ClaudeSessionSummary;
-  busy: "favorite" | "continue" | undefined;
-  error: string | undefined;
-  onOpen(s: ClaudeSessionSummary): void;
-  onToggleFavorite(s: ClaudeSessionSummary): void;
-  onContinue(s: ClaudeSessionSummary): void;
-}) {
+/**
+ * The metadata groups alone. The actions live in `.sess-strip` above the
+ * scrolling pane this renders into, so nothing here takes a handler.
+ */
+function Inspector({ session }: { session: ClaudeSessionSummary }) {
   const usage = usageOf(session.usage);
   const sub = usageOf(session.subagent_usage);
   const cost = costOf(session.cost);
@@ -1226,37 +1360,6 @@ function Inspector({
         </InspGroup>
       )}
 
-      <InspGroup title="Actions">
-        <div className="sess-actions">
-          <button className="btn btn--primary" onClick={() => onOpen(session)}>
-            <Icon name="chat" size={13} />
-            View session
-          </button>
-          <button
-            className="btn"
-            disabled={busy !== undefined}
-            onClick={() => onToggleFavorite(session)}
-          >
-            <Icon
-              name="star"
-              size={13}
-              className={session.is_favorite ? "sess-fav--on" : undefined}
-            />
-            {session.is_favorite ? "Remove favourite" : "Add to favourites"}
-          </button>
-          <button
-            className="btn"
-            disabled={busy !== undefined}
-            onClick={() => onContinue(session)}
-          >
-            <Icon name="play" size={13} />
-            {busy === "continue" ? "Starting…" : "Continue in chat"}
-          </button>
-          {/* Success navigates away, so the only thing left to render here is a
-              failure — directly under the button the user just pressed. */}
-          {error && <div className="sess-note sess-note--error">{error}</div>}
-        </div>
-      </InspGroup>
     </>
   );
 }


### PR DESCRIPTION
Closes #486

## What

Two ways to reach the session actions without hunting for them.

**A right-click menu on a session row** — View session, Add / Remove favourite,
Continue in chat, Copy session ID, Copy project path. Right-clicking selects the
row first, so the inspector agrees with what the menu is about to act on.

**The inspector's actions pinned above the fold** — the bottom `Actions` group is
now a compact icon strip between `.inspector__head` and `.inspector__scroll`, so
it cannot scroll away on a session with a full metadata block.

Both surfaces call the same `toggleFavorite` / `continueInChat` / `setOpenId`.

## How

- `src/components/ui.tsx` — a new `ContextMenu({ at, items, onClose })`, written
  beside `Dropdown` rather than by refactoring `Dropdown`'s internals into a
  shared popover (see the issue's flagged judgement call; extract it if a third
  consumer appears).
- `src/views/SessionsView.tsx` — `onContextMenu` on the row, a `menu` state
  holding the point and the **row id**, and the strip.
- `src/styles/controls.css` — `.ctxmenu` positioning and `.menu__item--active`.
- `src/styles/sessions.css` — `.sess-strip`, replacing `.sess-actions`.

## Three things the running app corrected

Verified through the WebKit inspector against the real Tauri webview
(`.claude/skills/ui-verify`), which is what found all three — none is visible
from the source:

1. **A `keydown` on a `<body>` portal does not reach React's delegated
   listener.** Written first as an `onKeyDown` prop the way `Dropdown` has it,
   Escape and the arrow keys did nothing at all. Keys are taken from `window` in
   the **capture** phase instead, which also puts the menu ahead of the sessions
   list's own global Enter handler — so `stopPropagation` on a claimed key is
   what stops Enter both opening the session and picking the item.
2. **`focus()` on a `visibility: hidden` element is a silent no-op.** The first
   pass renders hidden so the box can be measured and clamped; focusing in that
   same layout effect never took. Focus now happens once `pos` has made the menu
   visible.
3. **`is_favorite` is `omitempty`.** A session that is not a favourite has no
   such key, so `aria-pressed={selected.is_favorite}` made React drop the
   attribute — a toggle announcing its state in only one of its two states.
   Coerced with `!!`.

## Verification

There is no TypeScript test harness in this repo, so this is by hand in the
running app. `npm run build` (`tsc --noEmit` + `vite build`) is green; nothing
under `src-tauri/` is touched.

Confirmed in the webview:

- right-click selects the row and opens the menu at the cursor with all five
  items; `defaultPrevented` is true over a row and **false over an `<input>`**,
  where the webview's own Copy/Paste menu must still win
- arrows / Home / End / wrap-around move the active item, Enter fires it,
  Escape closes; menu focused on open
- clamped inside the viewport when opened at the bottom-right corner
  (`right: 1279 / 1280`, `bottom: 818 / 820`)
- closes on outside mousedown, on scroll, and on choosing an item
- favourite toggles from the menu and the label flips `Add` ↔ `Remove`; View
  session opens the transcript
- the strip fits the 220px `Splitter` minimum (199px row, no overflow)

**One criterion could not be proven on this machine, and it is not a
regression:** the clipboard. WebKitGTK refuses `writeText` outside a user
gesture it recognises, and this box has no `xdotool`/`xclip` for real OS input —
so under synthetic clicks the two new copy items fail *and so does the existing,
shipped `CopyButton` in the inspector*, identically. The menu items call the
same `copyText` from the same synchronous position inside a real `<button>`
click handler, so there is no behavioural difference between the new call sites
and the proven one. A failure is surfaced rather than swallowed: `copyValue`
renders "Could not copy the … to the clipboard." in the strip, which is what
that check actually exercised.

## Deviation from the issue's HOW

`.ctxmenu`'s rules are in `styles/controls.css` beside `.dropdown__menu`, not in
`styles/sessions.css` as the HOW suggests. `ContextMenu` is a shared control in
`components/ui.tsx`; positioning it from one view's stylesheet would leave the
next consumer unpositioned. The strip's own rules are in `sessions.css`, per the
per-view convention.

## Out of scope

What Continue in chat does once invoked (#485, merged), context menus on other
views' rows, multi-select, and a native OS context menu.