### PR TITLE
docs: settle the ferrox-providers pin on the git tag (#453)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -357,9 +357,13 @@ Three parts of that line are load-bearing:
   here only because ferrox is our own repository and its README documents this
   tag as the reference point.
 
-**Open, and due before the first release that ships the gateway:** whether to
-publish `ferrox-providers` to crates.io rather than depending on it by git —
-[#453](https://github.com/shaharia-lab/agento/issues/453).
+**Settled in [#453](https://github.com/shaharia-lab/agento/issues/453): the tag
+stays and crates.io is declined for now.** `Cargo.lock` records the resolved
+commit, so a moved tag changes what a *fresh* resolve picks and nothing that is
+already checked out or already released. Publishing would buy an immutable
+registry artifact at the cost of a release process in a repository we own and
+are the only consumer of. Revisit if `ferrox-providers` gains a consumer outside
+this app.
 
 Two more things are copied rather than imported, and both are deliberate:
 `is_retryable` / `should_failover` (`gateway/dispatch.rs`) live in ferrox's

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -279,8 +279,15 @@ ring = "0.17"
 # Pinned to the `providers-v0.1.0` **tag**, which ferrox#150/#153 made real; the
 # design document predates it and says to pin a SHA. A tag can be moved where a
 # SHA cannot — accepted because ferrox is our own repository and its README now
-# documents this tag as the reference point. Revisit at the crates.io publish
-# decision, before the first shipping release.
+# documents this tag as the reference point.
+#
+# **Settled in #453: the tag stays**, and crates.io is declined for now. What
+# actually protects a build is `Cargo.lock`, which records the resolved commit —
+# so a moved tag changes what a *fresh* resolve picks and nothing that is already
+# checked out or already released. Publishing would buy an immutable registry
+# artifact at the cost of a release process in a repo we own and are the only
+# consumer of. Revisit if `ferrox-providers` ever gains a consumer outside this
+# app, or if the tag is ever moved in anger.
 ferrox-providers = { git = "https://github.com/shaharia-lab/ferrox", tag = "providers-v0.1.0", default-features = false, features = [
     "anthropic",
     "openai",


### PR DESCRIPTION
Closes #453.

Option 1 of the three: **keep the tag**, decline crates.io for now.

The reasoning, recorded beside the dependency in `src-tauri/Cargo.toml` and in `docs/development.md`:

- `Cargo.lock` records the resolved commit, so a moved tag changes what a *fresh* resolve picks and nothing that is already checked out or already released.
- Publishing buys an immutable registry artifact at the cost of a release process in a repo we own and are the only consumer of.
- Revisit if `ferrox-providers` ever gains a consumer outside this app, or if the tag is moved in anger.

Comments only — no code change.