### PR TITLE
fix: validate a cron task's expression at save time (#330)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3172,6 +3172,24 @@ subprocess instead of stopping it, so `close()` has to stay reachable.
 `schedule::cron::parse` returns a `Result` for that input, so there is nothing to
 catch and the row is skipped with a warning either way.
 
+**A cron expression is validated at save time, through the scheduler's own
+`setup`** (#330). `validate_task`'s `"cron"` arm calls
+`schedule::validate_cron`, so `POST`/`PUT /api/tasks` answer **422** for an
+expression that cannot parse (`CRON_TZ=UTC`, `TZ=`, a four-field spec) or that
+parses and never fires (`0 0 30 2 *`), and no row is written. Two things about
+it are load-bearing. It is a **wrapper over `setup`, never a second parser or a
+regex** — a validator with its own dialect refuses expressions the scheduler
+would have run, and `cron.rs`'s dialect is not the obvious one (descriptors are
+accepted, six-field seconds specs are not, `?` sets the same bit `*` does). And
+the location it validates against is `runtime::local_tz()`, the resolver whose
+result **is** `Scheduler::loc`, rather than the running scheduler's field: a
+write path has to work before `start` and in tests, and reading it off the
+scheduler would make validation depend on boot order.
+
+`schedule_task`'s log-and-skip is unchanged and is now about **rows stored
+before that check existed**. Do not remove it along with the gap — it is what
+keeps one bad legacy row from being worse than a warning line.
+
 **The notification subscriber is wired at last.** `internal/notification`'s
 handler was ported in #307 with its header noting the subscriber "cannot exist
 yet" — the publisher was the Go scheduler, in another process. It is now a direct
@@ -4060,11 +4078,3 @@ these are now simply Agento's bugs, and fixing them is unblocked.
   `writeProfileSettings` and `moveProfileFile` — while four sibling call sites
   check. A hand-edited index can therefore make an update write outside the
   settings directory. Both sites say so in a comment.
-- **A cron expression of exactly `CRON_TZ=UTC` is accepted at save time**
-  ([#330](https://github.com/shaharia-lab/agento/issues/330)). Schedule
-  validation checks only that the expression is non-empty. `native/schedule/cron.rs`
-  answers `Err` rather than panicking, so it cannot brick a boot here, but the
-  row is still stored and the task never fires. Note the obvious fix does not
-  work: the library's own validity check goes through the same parser and
-  panics on the same input, so validation needs its own guard or a prefix
-  pre-check.

--- a/src-tauri/src/native/schedule/mod.rs
+++ b/src-tauri/src/native/schedule/mod.rs
@@ -436,6 +436,25 @@ pub fn setup(
     }
 }
 
+/// Whether [`setup`] would accept this cron expression — the save-time check
+/// behind `POST`/`PUT /api/tasks` (#330).
+///
+/// It is a thin wrapper over [`setup`] rather than its own parse, and that is
+/// the whole point: a validator with a second parser is a validator that can
+/// refuse an expression the scheduler would have run, or accept one it will
+/// not. The `JobSchedule` is discarded because the caller is a write handler
+/// with no timer to install — validation happens before the row exists, so
+/// there is nothing to schedule yet.
+///
+/// The two errors it can answer are different mistakes and the caller reports
+/// them differently: [`ScheduleError::CronParse`] is an expression robfig's
+/// dialect cannot read at all (`CRON_TZ=UTC` with nothing after the prefix,
+/// a six-field seconds spec), while [`ScheduleError::CronInvalid`] parses and
+/// then never fires inside the five-year search (`0 0 30 2 *`).
+pub fn validate_cron(expr: &str, loc: Tz, now: DateTime<Utc>) -> Result<(), ScheduleError> {
+    setup(&JobDefinition::Cron(expr.to_string()), loc, now).map(|_| ())
+}
+
 impl JobSchedule {
     /// `jobSchedule.next(lastRun)`. The zero `Fire` in and out is Go's zero
     /// time, which is how an exhausted schedule answers — and feeding it back

--- a/src-tauri/src/native/schedule/runtime.rs
+++ b/src-tauri/src/native/schedule/runtime.rs
@@ -30,8 +30,16 @@
 //! reference parser, which historically took the whole process down on every
 //! boot (issue #330). [`super::cron::parse`] returns a `Result` for that input
 //! rather than panicking, so there is nothing to recover from here —
-//! the row is skipped with a warning either way. #330 is still a real bug in the
-//! Go server, and validating at save time is still its fix.
+//! the row is skipped with a warning either way.
+//!
+//! Since #330 landed, no *new* row can hold such an expression:
+//! [`super::validate_cron`] refuses it at save time, on both `POST` and
+//! `PUT /api/tasks`, so the write answers 422 instead of storing an `active`
+//! task with no timer. [`schedule_task`]'s log-and-skip is therefore about
+//! **rows already stored** — a database written before that check existed — and
+//! it stays exactly as it was. Do not remove it along with the gap it used to
+//! be the only defence against: it is what keeps one bad legacy row from being
+//! anything worse than a warning line.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -401,7 +409,15 @@ async fn sleep_until(target: DateTime<Utc>) {
 /// tool take, and the only one available: a fixed offset cannot answer "what is
 /// 09:00 tomorrow" across a DST transition, which is the whole reason a daily
 /// job is not a 24-hour duration job.
-fn local_tz() -> Tz {
+///
+/// It is `pub(crate)` because the **save-time** cron check needs the location
+/// the scheduler would have used, and it must answer the same thing whether or
+/// not a scheduler has started (a write path runs in tests and before `start`).
+/// Reading it off the running [`Scheduler`] would have made validation
+/// conditional on boot order; calling the same resolver is unconditional and
+/// agrees with `Scheduler::loc` by construction, since that field is this
+/// function's own result.
+pub(crate) fn local_tz() -> Tz {
     iana_time_zone::get_timezone()
         .ok()
         .and_then(|name| name.parse::<Tz>().ok())
@@ -609,6 +625,60 @@ mod tests {
         // calendar arithmetic can use.
         let tz = local_tz();
         let _ = Utc::now().with_timezone(&tz);
+    }
+
+    /// #330's containment half, which must outlive the save-time check that
+    /// made it unreachable for *new* rows. A database written before that check
+    /// existed can still hold `CRON_TZ=UTC`, and the guarantee is that loading
+    /// it is an `Err` the caller logs and steps over — never a panic, and never
+    /// a half-installed timer.
+    #[test]
+    fn a_stored_row_with_an_unusable_expression_is_skipped_rather_than_fatal() {
+        let scheduler = Arc::new(Scheduler {
+            db_path: PathBuf::from("/nonexistent/agento.db"),
+            loc: Tz::UTC,
+            jobs: Mutex::new(HashMap::new()),
+            swept: Mutex::new(HashMap::new()),
+            semaphore: Arc::new(Semaphore::new(MAX_CONCURRENCY)),
+        });
+        let task = ScheduledTask {
+            id: "legacy".to_string(),
+            name: "n".to_string(),
+            description: String::new(),
+            prompt: "p".to_string(),
+            agent_slug: String::new(),
+            working_directory: String::new(),
+            model: String::new(),
+            settings_profile_id: String::new(),
+            timeout_minutes: 30,
+            schedule_type: "cron".to_string(),
+            schedule_config: crate::native::tasks::ScheduleConfig {
+                expression: "CRON_TZ=UTC".to_string(),
+                ..Default::default()
+            },
+            stop_after_count: 0,
+            stop_after_time: None,
+            save_output: false,
+            status: "active".to_string(),
+            run_count: 0,
+            last_run_at: None,
+            last_run_status: String::new(),
+            next_run_at: None,
+            created_at: Default::default(),
+            updated_at: Default::default(),
+        };
+
+        let err = scheduler
+            .schedule_task(&task)
+            .expect_err("must not schedule");
+        assert!(
+            err.contains("schedule:cron_parse"),
+            "the class says which failure it was: {err}"
+        );
+        assert!(
+            scheduler.lock_jobs().is_empty(),
+            "a task that cannot be scheduled installs no timer"
+        );
     }
 
     #[test]

--- a/src-tauri/src/native/tasks.rs
+++ b/src-tauri/src/native/tasks.rs
@@ -1025,6 +1025,114 @@ mod tests {
         );
     }
 
+    /// #330. Before this check the expression was inspected only at *schedule*
+    /// time, after the row was committed — so every one of these answered 201
+    /// and left an `active` task with no timer and no `next_run_at`, which is
+    /// indistinguishable from a task that was simply never due.
+    #[test]
+    fn an_unusable_cron_expression_is_refused_at_save_time() {
+        let file = migrated();
+        let unparseable = r#"validation error for "schedule_config.expression": expression is not a valid cron schedule"#;
+        let cases = [
+            // A timezone prefix with nothing after it — the shape the issue is
+            // named for, and the one a user reaches by pasting the first line
+            // of a crontab example and forgetting the schedule.
+            ("CRON_TZ=UTC", unparseable),
+            ("TZ=", unparseable),
+            ("CRON_TZ=", unparseable),
+            ("TZ=Europe/Berlin", unparseable),
+            // Not a prefix problem at all: too few fields.
+            ("0 2 * *", unparseable),
+            // Parses, and then never fires: February has no 30th, so the
+            // five-year search inside `setup` comes back empty. A *different*
+            // mistake from a typo, and it says so.
+            (
+                "0 0 30 2 *",
+                r#"validation error for "schedule_config.expression": expression is a valid cron schedule but will never fire"#,
+            ),
+        ];
+        for (expr, want) in cases {
+            let body = format!(
+                r#"{{"name":"n","prompt":"p","schedule_type":"cron",
+                    "schedule_config":{{"expression":{}}}}}"#,
+                serde_json::to_string(expr).expect("encode")
+            );
+            let err = create_task(file.path(), body.as_bytes()).unwrap_err();
+            assert_eq!(err.message(), want, "for {expr:?}");
+            assert_eq!(
+                err.status(),
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "for {expr:?}"
+            );
+        }
+        assert!(
+            list_tasks(file.path()).expect("list").is_empty(),
+            "a refused cron expression stores no row"
+        );
+    }
+
+    /// The other half of the same check, and the one that matters more: the
+    /// validator delegates to the scheduler's own `setup`, so anything the
+    /// scheduler would have run has to survive the write path untouched.
+    #[test]
+    fn every_cron_expression_the_scheduler_accepts_still_saves() {
+        for expr in [
+            "@daily",
+            "@hourly",
+            "@every 1h30m",
+            "CRON_TZ=Local 0 9 * * *",
+            "CRON_TZ=Europe/Berlin 0 9 * * *",
+            "0 2 * * *",
+            "*/30 * * * *",
+            "0 0 29 2 *", // a leap day: rare, but it does fire
+        ] {
+            let file = migrated();
+            let body = format!(
+                r#"{{"name":"n","prompt":"p","schedule_type":"cron",
+                    "schedule_config":{{"expression":{}}}}}"#,
+                serde_json::to_string(expr).expect("encode")
+            );
+            let task = created(&file, &body);
+            assert_eq!(task.schedule_config.expression, expr);
+            assert_eq!(task.status, "active");
+        }
+    }
+
+    /// `update_task` shares `validate_task` but has its own handler, so a test
+    /// that only exercised create would pass against half a fix — and here the
+    /// stakes are higher, because a refusal that leaked through would overwrite
+    /// a *working* schedule with one that never fires.
+    #[test]
+    fn the_update_path_refuses_an_unusable_cron_expression_and_keeps_the_stored_row() {
+        let file = migrated();
+        let task = created(
+            &file,
+            r#"{"name":"n","prompt":"p","schedule_type":"cron",
+                "schedule_config":{"expression":"0 2 * * *"}}"#,
+        );
+
+        let err = update_task(
+            file.path(),
+            &task.id,
+            br#"{"name":"renamed","prompt":"p","schedule_type":"cron",
+                 "schedule_config":{"expression":"CRON_TZ=UTC"}}"#,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.message(),
+            r#"validation error for "schedule_config.expression": expression is not a valid cron schedule"#
+        );
+        assert_eq!(err.status(), StatusCode::UNPROCESSABLE_ENTITY);
+
+        // The refusal happens inside the transaction, before `update_task_in`,
+        // so not one column moved — including the name the same body renamed.
+        let stored = get_task(file.path(), &task.id)
+            .expect("read")
+            .expect("still there");
+        assert_eq!(stored.name, "n");
+        assert_eq!(stored.schedule_config.expression, "0 2 * * *");
+    }
+
     #[test]
     fn a_negative_timeout_is_rejected_but_zero_is_defaulted() {
         // The message says "between 1 and 240" while the check admits 0 — Go's
@@ -1642,11 +1750,39 @@ fn validate_task(task: &mut ScheduledTask) -> Result<(), WriteError> {
                 "at least one of every_minutes, every_hours, or every_days is required for interval schedules",
             ))
         }
-        "cron" if cfg.expression.is_empty() => {
-            return Err(WriteError::validation(
-                "schedule_config.expression",
-                "expression is required for cron schedules",
-            ))
+        "cron" => {
+            if cfg.expression.is_empty() {
+                return Err(WriteError::validation(
+                    "schedule_config.expression",
+                    "expression is required for cron schedules",
+                ));
+            }
+            // #330: the expression is checked *here*, not at schedule time.
+            // `create_task` commits the row and only then calls
+            // `schedule_task`, whose failure is a log line — so before this
+            // check an unusable expression produced a 201, an `active` task,
+            // no timer and no `next_run_at`, forever, with the reconcile sweep
+            // failing on it identically every minute. A validation error is
+            // the only place the user can be told.
+            //
+            // The location is the scheduler's own, so a `CRON_TZ=Local` prefix
+            // resolves at save time to what it will resolve to at run time.
+            let loc = super::schedule::runtime::local_tz();
+            let now = chrono::Utc::now();
+            if let Err(err) = super::schedule::validate_cron(&cfg.expression, loc, now) {
+                // Two different mistakes, so two different sentences: one is a
+                // typo, the other is a date that does not exist.
+                let message = match err {
+                    super::schedule::ScheduleError::CronInvalid => {
+                        "expression is a valid cron schedule but will never fire"
+                    }
+                    _ => "expression is not a valid cron schedule",
+                };
+                return Err(WriteError::validation(
+                    "schedule_config.expression",
+                    message,
+                ));
+            }
         }
         _ => {}
     }

--- a/src-tauri/src/native/tasks.rs
+++ b/src-tauri/src/native/tasks.rs
@@ -1772,11 +1772,28 @@ fn validate_task(task: &mut ScheduledTask) -> Result<(), WriteError> {
             if let Err(err) = super::schedule::validate_cron(&cfg.expression, loc, now) {
                 // Two different mistakes, so two different sentences: one is a
                 // typo, the other is a date that does not exist.
+                //
+                // Both arms are named. `setup` on a `JobDefinition::Cron` can
+                // reach exactly these two of `ScheduleError`'s eight — the
+                // other six belong to the one-time, duration and daily job
+                // types — so the wildcard is unreachable rather than a default,
+                // and it is spelled `unreachable-ish` on purpose: under a bare
+                // `_ =>` a variant added later would silently inherit the
+                // *parse* wording and every test would stay green.
                 let message = match err {
+                    super::schedule::ScheduleError::CronParse => {
+                        "expression is not a valid cron schedule"
+                    }
                     super::schedule::ScheduleError::CronInvalid => {
                         "expression is a valid cron schedule but will never fire"
                     }
-                    _ => "expression is not a valid cron schedule",
+                    other => {
+                        log::warn!(
+                            "cron validation got an unexpected schedule error: {}",
+                            other.class()
+                        );
+                        "expression is not a valid cron schedule"
+                    }
                 };
                 return Err(WriteError::validation(
                     "schedule_config.expression",


### PR DESCRIPTION
Closes #330

## What

A `cron` task's expression is now validated **at save time**, on both
`POST /api/tasks` and `PUT /api/tasks/{id}`, so an expression the scheduler
cannot use is refused with **422** instead of stored as an `active` task that
silently never fires.

Two refusals, deliberately worded differently because they are different
mistakes:

| expression | answer |
|---|---|
| `CRON_TZ=UTC`, `TZ=`, `CRON_TZ=`, `TZ=Europe/Berlin`, `0 2 * *` | `validation error for "schedule_config.expression": expression is not a valid cron schedule` |
| `0 0 30 2 *` | `validation error for "schedule_config.expression": expression is a valid cron schedule but will never fire` |

The empty-expression refusal is untouched. No row is written in any of these
cases; on `PUT` the refusal happens inside the transaction and before
`update_task_in`, so not one column moves.

## Why

`create_task` inserts the row, commits, and *then* calls `schedule_task`, whose
failure is only a log line — matching Go's ordering deliberately. So a bad
expression produced a `201`, a stored `active` task, no timer and no
`next_run_at`, forever. The reconcile sweep does not rescue it: `schedule_task`
fails identically every pass. The user gets no signal at all, and an absent
`job_history` is indistinguishable from "nothing was due".

The original DoS half of the report is already gone with the Go tree (#391):
`schedule::cron::parse` returns a `Result` where robfig panicked. What survived
was the save-time gap, which is what this closes.

## How

`validate_task`'s `"cron"` arm keeps the empty check and then calls a new
`schedule::validate_cron(expr, loc, now)` — a **thin wrapper over the
scheduler's own `setup`**, not a second parser and not a regex. That is the
whole design constraint: `cron.rs`'s dialect is not the obvious one (descriptors
are accepted, six-field seconds specs are not, `?` sets the same bit `*` does),
so a validator with its own idea of valid would refuse expressions the scheduler
would have run. `ScheduleError::CronParse` / `CronInvalid` already distinguish
the two failures, so nothing new parses anything.

The location is `runtime::local_tz()`, made `pub(crate)`. That resolver's result
**is** `Scheduler::loc`, so validation agrees with the running scheduler by
construction — while reading the field off the running scheduler would have made
the write path depend on boot order, and it has to work in tests and before
`start`.

`runtime.rs`'s module header said "#330 is still a real bug in the Go server, and
validating at save time is still its fix". Rewritten: `schedule_task`'s
log-and-skip is now about **rows stored before this check existed**, and it must
not be removed along with the gap it used to be the only defence against.

## Tests

Three in `native/tasks.rs` beside the existing `validate_task` cases, one in
`native/schedule/runtime.rs`:

- `an_unusable_cron_expression_is_refused_at_save_time` — six shapes, each
  asserting the **full** `validation error for "schedule_config.expression": …`
  message, the 422, and that `list_tasks` is empty afterwards.
- `every_cron_expression_the_scheduler_accepts_still_saves` — the over-rejection
  guard: `@daily`, `@hourly`, `@every 1h30m`, `CRON_TZ=Local 0 9 * * *`,
  `CRON_TZ=Europe/Berlin 0 9 * * *`, `0 2 * * *`, `*/30 * * * *`, `0 0 29 2 *`.
- `the_update_path_refuses_an_unusable_cron_expression_and_keeps_the_stored_row`
  — `PUT` has its own handler, so a create-only test would pass against half a
  fix; asserts the stored name *and* expression are unchanged.
- `a_stored_row_with_an_unusable_expression_is_skipped_rather_than_fatal` —
  the containment path, pinned so it is not removed with the gap.

**Revert-check:** disabling the `validate_cron` call fails
`an_unusable_cron_expression_is_refused_at_save_time` and
`the_update_path_…` and leaves `every_cron_expression_…` green — i.e. the first
two are genuine regression guards and the third is the guard against the fix
over-reaching, exactly as intended.

Local gates: `cargo fmt --check`, `cargo clippy --all-targets -D warnings`,
`cargo test` (1415 lib + every integration suite) all green. `npm run build` was
not run locally (no `node_modules` in the worktree); this change touches no
frontend file, so CI covers it.

## Out of scope

Per the issue: no change to `interval`/`one_off`/`run_immediately` validation
(the `at_time` fallback stays as documented), no migration or repair of rows
already stored with a bad expression, and no form-level validation in
`views/tasks/` — the API refusal surfaces through the existing error path.
