### PR TITLE
fix: port Go's Windows filepath semantics and un-gate the three 501 surfaces (#374)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,3 +152,54 @@ jobs:
       - name: Compile Rust (ci profile)
         working-directory: src-tauri
         run: cargo build --profile ci
+
+  # Windows x86_64 is a shipped release target (`release.yml` builds
+  # `x86_64-pc-windows-msvc`) and nothing compiled the `cfg(windows)` arms until
+  # #374 ported Go's Windows `filepath`. Without this job that port is
+  # unverified on the only platform it targets: `cfg(not(windows))` code
+  # compiles everywhere and the Windows arm compiles nowhere, which is the
+  # shape a `cfg` split fails in silently.
+  #
+  # **`--lib`, and that is a recorded limitation rather than an oversight.** The
+  # integration suites under `src-tauri/tests/` are Unix-only by construction —
+  # `chat_turn.rs`, `claude_sdk.rs` and `scheduled_run.rs` drive a fake Claude
+  # CLI that is a shebang'd Python script made executable through
+  # `std::os::unix::fs::PermissionsExt`, which does not exist on Windows and so
+  # will not even compile there. Porting the fake CLI is its own piece of work
+  # and is not what this job is for. What `--lib` does cover is every unit test
+  # in `native/` — `gopath`'s two rule sets and both vector files, the three
+  # surfaces #374 un-gated, and the four call sites it audited.
+  #
+  # Lints run here too: `clippy` on a Linux host never sees the `cfg(windows)`
+  # arms at all, so `-D warnings` there says nothing about them.
+  windows_rules:
+    name: Windows unit tests
+    runs-on: windows-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          components: clippy
+
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          workspaces: src-tauri -> target
+          key: windows
+
+      # The frontend is not built here, so `tauri-build` has no `../dist` to
+      # embed. It is only read in a release build, and this job compiles the
+      # test profile — but the directory has to exist for the config to
+      # validate.
+      - name: Stub the frontend bundle
+        shell: bash
+        run: mkdir -p dist && echo '<!doctype html>' > dist/index.html
+
+      - name: Rust lints (windows arms)
+        working-directory: src-tauri
+        run: cargo clippy --lib -- -D warnings
+
+      - name: Rust unit tests
+        working-directory: src-tauri
+        run: cargo test --lib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,15 +166,27 @@ jobs:
   # a Linux `clippy --all-targets` never sees those arms at all, so `-D
   # warnings` there says nothing about them.
   #
-  # **The test step is deliberately filtered, and that is a recorded limitation
-  # rather than an oversight.** `cargo test --lib` was tried first and is red at
-  # 1388/1422: every one of the 34 is a **Unix-shaped test fixture**, not a
-  # defect — `absolute_dir("/var/lib/claude")` is correctly `None` on Windows,
+  # **The test step is deliberately filtered, and that is a measured limitation
+  # rather than an oversight.** An unfiltered `cargo test --lib` was run here
+  # twice. With the runner's default `core.autocrlf=true` it is red at
+  # **1388/1422**; with the `autocrlf=false` step above — which is the one that
+  # counts — it is red at **1394/1422**, so six of those were pure CRLF against
+  # the byte-exact goldens and are now fixed rather than excluded.
+  #
+  # Of the 28 that remain, **27 are Unix-shaped test fixtures rather than
+  # defects**: `native::settings::tests` (10), `native::claude_settings` (9),
+  # `native::fs::tests` (5), `native::scanner::walk` (2) and
+  # `native::uploads::tests` (1) assert Unix path spellings —
+  # `absolute_dir("/var/lib/claude")` is correctly `None` on Windows,
   # `validate_path_within_dir("/h/.claude/x", "/h/.claude")` is correctly
-  # refused, and the byte-exact goldens compare against files whose line endings
-  # the checkout decides. Porting ~34 fixtures is general Windows support, which
-  # #374 lists as out of scope, so the filter names the modules that issue owns:
-  # `gopath` (both rule sets and both vector files, ~200 cases against the real
+  # refused, `HOME=/home//u` correctly cleans to `\home\u`. The 28th is
+  # `integrations::telegram::client::tests::a_body_that_dies_mid_stream_still_names_nothing_secret`,
+  # which is a **stream-timing** difference and not a path fixture at all —
+  # pre-existing, newly visible, and its own piece of work.
+  #
+  # Porting those is general Windows support, which #374 lists under *Risks* as
+  # the scope creep to avoid, so the filter names the modules that issue owns:
+  # `gopath` (both rule sets and both vector files, 248 cases against the real
   # target), the `sessions::projects` call site it fixed, and the Windows arm of
   # the profile path guard. **Widening this needs those fixtures ported first**
   # — see `CLAUDE.md`'s *Known gaps*.
@@ -219,21 +231,6 @@ jobs:
       - name: Rust lints (windows arms)
         working-directory: src-tauri
         run: cargo clippy --lib -- -D warnings
-
-      # TEMPORARY (#374): the unfiltered run, non-blocking, so the number the
-      # comment above quotes is measured *with* `core.autocrlf=false` rather
-      # than inherited from the first push, which ran with the runner's default.
-      # Removed in the follow-up commit that records the result.
-      - name: MEASURE ONLY — unfiltered lib tests
-        continue-on-error: true
-        shell: bash
-        working-directory: src-tauri
-        run: |
-          cargo test --lib 2>&1 | tee unfiltered.log || true
-          echo "===== SUMMARY ====="
-          grep -E '^test result:' unfiltered.log || true
-          echo "===== FAILURES ====="
-          sed -n '/^failures:$/,/^test result:/p' unfiltered.log | grep -E '^    ' || true
 
       # Three filters, not the whole lib — see the comment above the job.
       #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,11 +220,44 @@ jobs:
         working-directory: src-tauri
         run: cargo clippy --lib -- -D warnings
 
-      # Three filters, not the whole lib — see the comment above the job.
-      - name: Rust unit tests (the Windows path rules and their call sites)
+      # TEMPORARY (#374): the unfiltered run, non-blocking, so the number the
+      # comment above quotes is measured *with* `core.autocrlf=false` rather
+      # than inherited from the first push, which ran with the runner's default.
+      # Removed in the follow-up commit that records the result.
+      - name: MEASURE ONLY — unfiltered lib tests
+        continue-on-error: true
+        shell: bash
         working-directory: src-tauri
-        run: >
-          cargo test --lib --
-          native::gopath
-          native::sessions::projects
-          native::claude_settings::profiles::tests::a_windows_path_outside_the_dir_is_refused
+        run: |
+          cargo test --lib 2>&1 | tee unfiltered.log || true
+          echo "===== SUMMARY ====="
+          grep -E '^test result:' unfiltered.log || true
+          echo "===== FAILURES ====="
+          sed -n '/^failures:$/,/^test result:/p' unfiltered.log | grep -E '^    ' || true
+
+      # Three filters, not the whole lib — see the comment above the job.
+      #
+      # **The floor is not decoration.** `cargo test` treats "the filter matched
+      # nothing" as **success**, so an allowlist that goes stale — a module
+      # renamed, a test moved — would leave the only job that runs these rules
+      # on Windows green with zero assertions executed. That is the same shape
+      # as a vector loop with no truncation floor, and the same shape as the
+      # allowlist `base.css` was rewritten away from in #469. Denylisting was
+      # the alternative and is worse here: it would have to name ~30 individual
+      # Unix-shaped fixtures, and each stale entry is itself invisible.
+      - name: Rust unit tests (the Windows path rules and their call sites)
+        shell: bash
+        working-directory: src-tauri
+        run: |
+          set -o pipefail
+          cargo test --lib -- \
+            native::gopath \
+            native::sessions::projects \
+            native::claude_settings::profiles::tests::a_windows_path_outside_the_dir_is_refused \
+            | tee filtered.log
+          passed=$(grep -oE '^test result: ok\. [0-9]+ passed' filtered.log | grep -oE '[0-9]+' | head -1)
+          echo "ran ${passed:-0} tests"
+          if [ -z "$passed" ] || [ "$passed" -lt 25 ]; then
+            echo "::error::expected at least 25 tests to run, got ${passed:-0} — the filter has gone stale"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,23 +160,43 @@ jobs:
   # compiles everywhere and the Windows arm compiles nowhere, which is the
   # shape a `cfg` split fails in silently.
   #
-  # **`--lib`, and that is a recorded limitation rather than an oversight.** The
-  # integration suites under `src-tauri/tests/` are Unix-only by construction —
-  # `chat_turn.rs`, `claude_sdk.rs` and `scheduled_run.rs` drive a fake Claude
-  # CLI that is a shebang'd Python script made executable through
-  # `std::os::unix::fs::PermissionsExt`, which does not exist on Windows and so
-  # will not even compile there. Porting the fake CLI is its own piece of work
-  # and is not what this job is for. What `--lib` does cover is every unit test
-  # in `native/` — `gopath`'s two rule sets and both vector files, the three
-  # surfaces #374 un-gated, and the four call sites it audited.
+  # **`clippy --lib` is the broad half and it is the important one.** It
+  # type-checks and lints *every* line of the library for this target, which is
+  # the only thing that can catch a `cfg(windows)` arm that does not compile —
+  # a Linux `clippy --all-targets` never sees those arms at all, so `-D
+  # warnings` there says nothing about them.
   #
-  # Lints run here too: `clippy` on a Linux host never sees the `cfg(windows)`
-  # arms at all, so `-D warnings` there says nothing about them.
+  # **The test step is deliberately filtered, and that is a recorded limitation
+  # rather than an oversight.** `cargo test --lib` was tried first and is red at
+  # 1388/1422: every one of the 34 is a **Unix-shaped test fixture**, not a
+  # defect — `absolute_dir("/var/lib/claude")` is correctly `None` on Windows,
+  # `validate_path_within_dir("/h/.claude/x", "/h/.claude")` is correctly
+  # refused, and the byte-exact goldens compare against files whose line endings
+  # the checkout decides. Porting ~34 fixtures is general Windows support, which
+  # #374 lists as out of scope, so the filter names the modules that issue owns:
+  # `gopath` (both rule sets and both vector files, ~200 cases against the real
+  # target), the `sessions::projects` call site it fixed, and the Windows arm of
+  # the profile path guard. **Widening this needs those fixtures ported first**
+  # — see `CLAUDE.md`'s *Known gaps*.
+  #
+  # The integration suites under `src-tauri/tests/` are a different and harder
+  # case: `chat_turn.rs`, `claude_sdk.rs` and `scheduled_run.rs` drive a fake
+  # Claude CLI that is a shebang'd Python script made executable through
+  # `std::os::unix::fs::PermissionsExt`, so they do not compile on Windows at
+  # all. `--lib` is what excludes them.
   windows_rules:
     name: Windows unit tests
     runs-on: windows-latest
     timeout-minutes: 60
     steps:
+      # The runner's default is `core.autocrlf=true`, which rewrites every text
+      # file on checkout — including `notifications/email.html` and the `parity/`
+      # goldens, whose whole point is that they are byte-exact. Turning it off
+      # here rather than adding a repository-wide `.gitattributes`: this is the
+      # only Windows checkout there is, so the narrower lever is the right one.
+      - name: Check out with the repository's own line endings
+        run: git config --global core.autocrlf false
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
 
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
@@ -200,6 +220,11 @@ jobs:
         working-directory: src-tauri
         run: cargo clippy --lib -- -D warnings
 
-      - name: Rust unit tests
+      # Three filters, not the whole lib — see the comment above the job.
+      - name: Rust unit tests (the Windows path rules and their call sites)
         working-directory: src-tauri
-        run: cargo test --lib
+        run: >
+          cargo test --lib --
+          native::gopath
+          native::sessions::projects
+          native::claude_settings::profiles::tests::a_windows_path_outside_the_dir_is_refused

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4044,10 +4044,21 @@ because each one cost real time to find:
   `claude_settings::write_file` reproduces it rather than building a DACL, and
   says so at its site. A file under `%USERPROFILE%` is readable by local
   administrators where `0600` would not be.
-- **`src-tauri/tests/` does not run on Windows.** `chat_turn.rs`,
+- **The Windows CI job type-checks everything and *tests* three modules.**
+  `ci.yml`'s `windows_rules` runs `cargo clippy --lib -- -D warnings`, which
+  covers every line of the library for that target — the thing a Linux run
+  cannot do. Its test step is filtered to `native::gopath`,
+  `native::sessions::projects` and one profiles guard, because a full
+  `cargo test --lib` there is red at **1388/1422** and every one of the 34 is a
+  **Unix-shaped fixture** rather than a defect: `absolute_dir("/var/lib/claude")`
+  is correctly `None` on Windows, `validate_path_within_dir("/h/.claude/x",
+  "/h/.claude")` is correctly refused, `HOME=/home//u` cleans to `\home\u`.
+  Porting those fixtures is general Windows support and is the work that has to
+  land before the filter can be widened.
+- **`src-tauri/tests/` does not run on Windows at all.** `chat_turn.rs`,
   `claude_sdk.rs` and `scheduled_run.rs` make their fake Claude CLI executable
-  through `std::os::unix::fs::PermissionsExt`, so they do not compile there;
-  `ci.yml`'s `windows_rules` job runs `cargo test --lib` only.
+  through `std::os::unix::fs::PermissionsExt`, so they do not compile there —
+  which is what `--lib` excludes.
 - **`GET /api/fs` answers 500 where it should answer 404 or 400.** The
   directory picker reports "internal server error" for a path the user simply
   mistyped. The three typed bodies (404 missing, 400 unreadable, 500 no home)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -650,9 +650,9 @@ something that still runs.
   `native/gopath.rs` carried only the Unix rules; it now carries both, selected
   by `cfg(windows)`, with **both compiled and both vector-tested on every
   host** — which is what lets a Linux CI run catch a Windows regression. The
-  `windows_rules` job in `ci.yml` compiles and runs the `cfg(windows)` arms
-  (`cargo test --lib`; the integration suites drive a shebang'd fake CLI and are
-  Unix-only by construction).
+  `windows_rules` job in `ci.yml` type-checks the `cfg(windows)` arms with an
+  unfiltered `cargo clippy --lib` and *runs* three modules of them; see *Known
+  gaps* for why its test step is filtered and what has to land to widen it.
 
 ### The endpoint registry
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,8 +309,8 @@ src-tauri/src/
       body.rs    json.Marshal over a Go map, and encoding/json's unmarshal errors
       repos.rs / issues.rs / pulls.rs / actions.rs / releases.rs  one per service
     settings.rs  GET+PUT /api/settings and /settings/claude-config-dirs (a
-                 filesystem probe; Unix, 501 on Windows); the preferences +
-                 config dirs a read is scoped to
+                 filesystem probe; answered on both platforms since #374); the
+                 preferences + config dirs a read is scoped to
     claude_settings/ Claude Code's own settings.json and the profiles beside it (#304) —
       mod.rs     the run config dir, Go's `any`/`MarshalIndent`/`Indent`, GET+PUT
                  /api/claude-settings, and the request decoder that is NOT writes::decode_body
@@ -333,10 +333,13 @@ src-tauri/src/
     scan.rs      GET /api/claude-sessions/status, POST /refresh — and the scan
                  itself: the shell owns it (#289)
     fs.rs        GET /api/fs and POST /api/fs/mkdir — the working-dir picker's
-                 listing and its one create (Unix; forwards on Windows)
+                 listing and its one create (both platforms since #374; note
+                 mkdir's guard is filepath.IsAbs, where rooted != absolute)
     uploads.rs   POST /api/uploads — the one multipart body, and the extension
                  allowlist that is the route's whole security boundary
-    gopath.rs    Go's filepath.Clean/Dir/Join, pinned to vectors generated from Go
+    gopath.rs    Go's filepath.Clean/Dir/Join/Base/IsAbs — BOTH rule sets, Unix
+                 and Windows (#374), selected by cfg(windows) and both compiled
+                 and vector-tested on every host
     gourl.rs     the path chi routes on — Go decodes only canonical escaping
     query.rs     one query parameter, read the way r.URL.Query().Get reads it
     pricing.rs   GET /api/pricing/catalog, plus the rate Resolver — and the
@@ -642,9 +645,14 @@ something that still runs.
   monitoring writes (#309), never a version-mismatch-shaped 404.
 - **`GET /api/version/update-check` short-circuits for every build** — offering
   an update there would duplicate the Tauri updater.
-- **On Windows, the three `filepath` surfaces answer 501** (`fs.rs`,
-  `claude_settings/`, the config-dir probe). Implementing Windows path
-  semantics is outstanding work.
+- **The three `filepath` surfaces are answered on Windows too** since #374
+  (`fs.rs`, `claude_settings/`, the config-dir probe). They answered 501 while
+  `native/gopath.rs` carried only the Unix rules; it now carries both, selected
+  by `cfg(windows)`, with **both compiled and both vector-tested on every
+  host** — which is what lets a Linux CI run catch a Windows regression. The
+  `windows_rules` job in `ci.yml` compiles and runs the `cfg(windows)` arms
+  (`cargo test --lib`; the integration suites drive a shebang'd fake CLI and are
+  Unix-only by construction).
 
 ### The endpoint registry
 
@@ -4030,8 +4038,16 @@ because each one cost real time to find:
   thing to invalidate correctly, and nothing about the response depends on one.
 
 **Known gaps**
-- **Windows `filepath` semantics are unimplemented.** `fs.rs`,
-  `claude_settings/` and the config-dir probe answer 501 there.
+- **Windows file modes are the parent directory's ACL, not `0600`/`0700`.**
+  That is Go's own behaviour — `syscall.Open` there maps `perm` onto the
+  read-only attribute alone and `syscall.Mkdir` ignores it outright — so
+  `claude_settings::write_file` reproduces it rather than building a DACL, and
+  says so at its site. A file under `%USERPROFILE%` is readable by local
+  administrators where `0600` would not be.
+- **`src-tauri/tests/` does not run on Windows.** `chat_turn.rs`,
+  `claude_sdk.rs` and `scheduled_run.rs` make their fake Claude CLI executable
+  through `std::os::unix::fs::PermissionsExt`, so they do not compile there;
+  `ci.yml`'s `windows_rules` job runs `cargo test --lib` only.
 - **`GET /api/fs` answers 500 where it should answer 404 or 400.** The
   directory picker reports "internal server error" for a path the user simply
   mistyped. The three typed bodies (404 missing, 400 unreadable, 500 no home)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4048,13 +4048,25 @@ because each one cost real time to find:
   `ci.yml`'s `windows_rules` runs `cargo clippy --lib -- -D warnings`, which
   covers every line of the library for that target — the thing a Linux run
   cannot do. Its test step is filtered to `native::gopath`,
-  `native::sessions::projects` and one profiles guard, because a full
-  `cargo test --lib` there is red at **1388/1422** and every one of the 34 is a
-  **Unix-shaped fixture** rather than a defect: `absolute_dir("/var/lib/claude")`
-  is correctly `None` on Windows, `validate_path_within_dir("/h/.claude/x",
-  "/h/.claude")` is correctly refused, `HOME=/home//u` cleans to `\home\u`.
-  Porting those fixtures is general Windows support and is the work that has to
-  land before the filter can be widened.
+  `native::sessions::projects` and one profiles guard, and **floored at 25
+  tests**, because `cargo test` treats "the filter matched nothing" as success
+  and an allowlist with no floor is a job that goes silently vacuous on a
+  rename.
+
+  The filter is measured, not assumed. An unfiltered `cargo test --lib` there is
+  red at **1394/1422** (it was 1388 before `core.autocrlf=false` was set on the
+  checkout; those six were pure CRLF against the byte-exact goldens). **27 of
+  the 28 are Unix-shaped fixtures** rather than defects — `settings::tests` 10,
+  `claude_settings` 9, `fs::tests` 5, `scanner::walk` 2, `uploads::tests` 1:
+  `absolute_dir("/var/lib/claude")` is correctly `None` on Windows,
+  `validate_path_within_dir("/h/.claude/x", "/h/.claude")` is correctly refused,
+  `HOME=/home//u` correctly cleans to `\home\u`. Porting them is general
+  Windows support and is the work that has to land before the filter widens.
+- **The 28th Windows failure is not a path fixture.**
+  `integrations::telegram::client::tests::a_body_that_dies_mid_stream_still_names_nothing_secret`
+  fails there with *"must fail in the body stream, not the send"* — a
+  stream-timing difference, pre-existing and newly visible. Nothing to do with
+  #374; it needs its own look.
 - **`src-tauri/tests/` does not run on Windows at all.** `chat_turn.rs`,
   `claude_sdk.rs` and `scheduled_run.rs` make their fake Claude CLI executable
   through `std::os::unix::fs::PermissionsExt`, so they do not compile there —

--- a/parity/README.md
+++ b/parity/README.md
@@ -41,11 +41,50 @@ That is the property to copy. Anything added here later must do the same: expose
 its routes as one const, and assert equality both ways. A hand-maintained list
 asserted in one direction is a list that goes stale.
 
+## `gopath_windows_vectors.json` has a generator, and it is the only one that does
+
+Everything else here was recorded from the Go server. Go's Windows
+`path/filepath` is not that server — it is the *standard library*, and it still
+exists — so `gopath_windows_vectors.json` (#374) is regenerable, and it is the
+one file in this directory you may re-record without changing the contract:
+
+```bash
+go run parity/generators/gopath_windows_vectors.go > parity/gopath_windows_vectors.json
+```
+
+`parity/generators/gopath_windows_vectors.go` needs no `go.mod` and no network.
+Two things about it are deliberate:
+
+- **It vendors Go's Windows source; it does not re-implement it.** The
+  `lazybuf`, `Clean`, `Base`, `Dir`, `VolumeName`, `IsAbs`, `volumeNameLen`,
+  `postClean` and `Join` bodies are copied verbatim from
+  `internal/filepathlite/path.go`, `internal/filepathlite/path_windows.go` and
+  `path/filepath/path_windows.go`, with only the build constraints and two
+  `internal/` helpers replaced. That is what makes it a *second opinion* about
+  the Rust port rather than a restatement of it — the lesson #268 learned when
+  `filepath.Clean` transcribed by eye produced `/a//c` for `/a/b/../c/`. A
+  generator that shares the port's belief agrees with a wrong port.
+- **The inputs are Go's own test tables**, not invented ones: `cleantests` +
+  `wincleantests`, `basetests` + `winbasetests`, `dirtests` + `windirtests`,
+  `jointests` + `winjointests`, `isabstests` + `winisabstests` from
+  `path/filepath/path_test.go`, plus the paths Agento's own Windows surfaces
+  build. The vendored code reproduces every expectation in those tables exactly,
+  which is the check that says the vendoring is faithful.
+
+Regenerating it against a newer Go is a **contract change** like any other here:
+state the Go version and what moved. The header records the version it was
+produced with.
+
+It also carries the one array that has no home elsewhere: `unix_base` pins
+`filepath.Base` under the **Unix** rules, produced by the generator host's real
+`path/filepath`. `Base` is new to the port (`sessions/projects.rs` needs it) and
+`gopath_vectors.json` is frozen, so it lives here rather than growing that file.
+
 ## Recovering a generator
 
-The generators were deleted in #391 (`07b6212`) along with the implementation
-they ran against. If you ever need to see how one of these files was produced,
-they are in history:
+The other generators were deleted in #391 (`07b6212`) along with the
+implementation they ran against. If you ever need to see how one of those files
+was produced, they are in history:
 
 ```bash
 git show 07b6212^:desktop/parity/

--- a/parity/generators/gopath_windows_vectors.go
+++ b/parity/generators/gopath_windows_vectors.go
@@ -1,0 +1,530 @@
+// Command gopath_windows_vectors generates parity/gopath_windows_vectors.json.
+//
+// It does NOT re-implement Go's Windows `path/filepath`; it vendors it. The
+// three sections below are copied verbatim from the Go distribution:
+//
+//	internal/filepathlite/path.go          — lazybuf, Clean, Split, Base, Dir,
+//	                                         VolumeName, FromSlash
+//	internal/filepathlite/path_windows.go  — Separator, IsPathSeparator,
+//	                                         volumeNameLen, pathHasPrefixFold,
+//	                                         uncLen, cutPath, postClean, toUpper
+//	path/filepath/path_windows.go          — join (filepath.Join's Windows body)
+//
+// The only edits are mechanical: the build constraints are dropped so the
+// Windows arm compiles on any host, `internal/stringslite` and
+// `internal/bytealg` calls become their `strings` equivalents, and
+// `os.IsPathSeparator` becomes the local `IsPathSeparator`. Nothing about the
+// algorithm is retyped, because a generator that shares the port's belief
+// about the rules agrees with a wrong port instead of failing it.
+//
+// The inputs are Go's own `path/filepath/path_test.go` tables — cleantests +
+// wincleantests, jointests + winjointests, basetests + winbasetests, dirtests +
+// windirtests — plus the Agento-shaped paths the three un-gated surfaces
+// actually build.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	gofilepath "path/filepath"
+
+	"os"
+	"runtime"
+	"slices"
+	"strings"
+)
+
+// ───────────────────────── vendored: internal/filepathlite ────────────────────
+
+const Separator = '\\'
+
+func IsPathSeparator(c uint8) bool { return c == '\\' || c == '/' }
+
+type lazybuf struct {
+	path       string
+	buf        []byte
+	w          int
+	volAndPath string
+	volLen     int
+}
+
+func (b *lazybuf) index(i int) byte {
+	if b.buf != nil {
+		return b.buf[i]
+	}
+	return b.path[i]
+}
+
+func (b *lazybuf) append(c byte) {
+	if b.buf == nil {
+		if b.w < len(b.path) && b.path[b.w] == c {
+			b.w++
+			return
+		}
+		b.buf = make([]byte, len(b.path))
+		copy(b.buf, b.path[:b.w])
+	}
+	b.buf[b.w] = c
+	b.w++
+}
+
+func (b *lazybuf) prepend(prefix ...byte) {
+	b.buf = slices.Insert(b.buf, 0, prefix...)
+	b.w += len(prefix)
+}
+
+func (b *lazybuf) string() string {
+	if b.buf == nil {
+		return b.volAndPath[:b.volLen+b.w]
+	}
+	return b.volAndPath[:b.volLen] + string(b.buf[:b.w])
+}
+
+func Clean(path string) string {
+	originalPath := path
+	volLen := volumeNameLen(path)
+	path = path[volLen:]
+	if path == "" {
+		if volLen > 1 && IsPathSeparator(originalPath[0]) && IsPathSeparator(originalPath[1]) {
+			// should be UNC
+			return FromSlash(originalPath)
+		}
+		return originalPath + "."
+	}
+	rooted := IsPathSeparator(path[0])
+
+	n := len(path)
+	out := lazybuf{path: path, volAndPath: originalPath, volLen: volLen}
+	r, dotdot := 0, 0
+	if rooted {
+		out.append(Separator)
+		r, dotdot = 1, 1
+	}
+
+	for r < n {
+		switch {
+		case IsPathSeparator(path[r]):
+			r++
+		case path[r] == '.' && (r+1 == n || IsPathSeparator(path[r+1])):
+			r++
+		case path[r] == '.' && path[r+1] == '.' && (r+2 == n || IsPathSeparator(path[r+2])):
+			r += 2
+			switch {
+			case out.w > dotdot:
+				out.w--
+				for out.w > dotdot && !IsPathSeparator(out.index(out.w)) {
+					out.w--
+				}
+			case !rooted:
+				if out.w > 0 {
+					out.append(Separator)
+				}
+				out.append('.')
+				out.append('.')
+				dotdot = out.w
+			}
+		default:
+			if rooted && out.w != 1 || !rooted && out.w != 0 {
+				out.append(Separator)
+			}
+			for ; r < n && !IsPathSeparator(path[r]); r++ {
+				out.append(path[r])
+			}
+		}
+	}
+
+	if out.w == 0 {
+		out.append('.')
+	}
+
+	postClean(&out)
+	return FromSlash(out.string())
+}
+
+func FromSlash(path string) string { return replaceStringByte(path, '/', Separator) }
+
+func replaceStringByte(s string, old, new byte) string {
+	if strings.IndexByte(s, old) == -1 {
+		return s
+	}
+	n := []byte(s)
+	for i := range n {
+		if n[i] == old {
+			n[i] = new
+		}
+	}
+	return string(n)
+}
+
+func Base(path string) string {
+	if path == "" {
+		return "."
+	}
+	for len(path) > 0 && IsPathSeparator(path[len(path)-1]) {
+		path = path[0 : len(path)-1]
+	}
+	path = path[len(VolumeName(path)):]
+	i := len(path) - 1
+	for i >= 0 && !IsPathSeparator(path[i]) {
+		i--
+	}
+	if i >= 0 {
+		path = path[i+1:]
+	}
+	if path == "" {
+		return string(Separator)
+	}
+	return path
+}
+
+func Dir(path string) string {
+	vol := VolumeName(path)
+	i := len(path) - 1
+	for i >= len(vol) && !IsPathSeparator(path[i]) {
+		i--
+	}
+	dir := Clean(path[len(vol) : i+1])
+	if dir == "." && len(vol) > 2 {
+		// must be UNC
+		return vol
+	}
+	return vol + dir
+}
+
+func VolumeName(path string) string { return FromSlash(path[:volumeNameLen(path)]) }
+
+func toUpper(c byte) byte {
+	if 'a' <= c && c <= 'z' {
+		return c - ('a' - 'A')
+	}
+	return c
+}
+
+func volumeNameLen(path string) int {
+	switch {
+	case len(path) >= 2 && path[1] == ':':
+		return 2
+	case len(path) == 0 || !IsPathSeparator(path[0]):
+		return 0
+	case pathHasPrefixFold(path, `\\.\UNC`):
+		return uncLen(path, len(`\\.\UNC\`))
+	case pathHasPrefixFold(path, `\\.`) ||
+		pathHasPrefixFold(path, `\\?`) || pathHasPrefixFold(path, `\??`):
+		if len(path) == 3 {
+			return 3 // exactly \\.
+		}
+		_, rest, ok := cutPath(path[4:])
+		if !ok {
+			return len(path)
+		}
+		return len(path) - len(rest) - 1
+	case len(path) >= 2 && IsPathSeparator(path[1]):
+		return uncLen(path, 2)
+	}
+	return 0
+}
+
+func pathHasPrefixFold(s, prefix string) bool {
+	if len(s) < len(prefix) {
+		return false
+	}
+	for i := 0; i < len(prefix); i++ {
+		if IsPathSeparator(prefix[i]) {
+			if !IsPathSeparator(s[i]) {
+				return false
+			}
+		} else if toUpper(prefix[i]) != toUpper(s[i]) {
+			return false
+		}
+	}
+	if len(s) > len(prefix) && !IsPathSeparator(s[len(prefix)]) {
+		return false
+	}
+	return true
+}
+
+func uncLen(path string, prefixLen int) int {
+	count := 0
+	for i := prefixLen; i < len(path); i++ {
+		if IsPathSeparator(path[i]) {
+			count++
+			if count == 2 {
+				return i
+			}
+		}
+	}
+	return len(path)
+}
+
+func cutPath(path string) (before, after string, found bool) {
+	for i := range path {
+		if IsPathSeparator(path[i]) {
+			return path[:i], path[i+1:], true
+		}
+	}
+	return path, "", false
+}
+
+func postClean(out *lazybuf) {
+	if out.volLen != 0 || out.buf == nil {
+		return
+	}
+	for _, c := range out.buf {
+		if IsPathSeparator(c) {
+			break
+		}
+		if c == ':' {
+			out.prepend('.', Separator)
+			return
+		}
+	}
+	if len(out.buf) >= 3 && IsPathSeparator(out.buf[0]) && out.buf[1] == '?' && out.buf[2] == '?' {
+		out.prepend(Separator, '.')
+	}
+}
+
+// IsAbs reports whether the path is absolute. Vendored from
+// internal/filepathlite/path_windows.go.
+func IsAbs(path string) (b bool) {
+	l := volumeNameLen(path)
+	if l == 0 {
+		return false
+	}
+	// If the volume name starts with a double slash, this is an absolute path.
+	if IsPathSeparator(path[0]) && IsPathSeparator(path[1]) {
+		return true
+	}
+	path = path[l:]
+	if path == "" {
+		return false
+	}
+	return IsPathSeparator(path[0])
+}
+
+// ─────────────────── vendored: path/filepath/path_windows.go ──────────────────
+
+func Join(elem ...string) string {
+	var b strings.Builder
+	var lastChar byte
+	for _, e := range elem {
+		switch {
+		case b.Len() == 0:
+			// Add the first non-empty path element unchanged.
+		case IsPathSeparator(lastChar):
+			for len(e) > 0 && IsPathSeparator(e[0]) {
+				e = e[1:]
+			}
+			if b.Len() == 1 && strings.HasPrefix(e, "??") && (len(e) == len("??") || IsPathSeparator(e[2])) {
+				b.WriteString(`.\`)
+			}
+		case lastChar == ':':
+			// Keep the path relative to the current directory on a drive.
+		default:
+			b.WriteByte('\\')
+			lastChar = '\\'
+		}
+		if len(e) > 0 {
+			b.WriteString(e)
+			lastChar = e[len(e)-1]
+		}
+	}
+	if b.Len() == 0 {
+		return ""
+	}
+	return Clean(b.String())
+}
+
+// ────────────────────────────────── inputs ────────────────────────────────────
+
+// Go's `cleantests` + `wincleantests` (path_test.go), then the Agento-shaped
+// paths the un-gated surfaces build.
+var cleanInputs = []string{
+	"abc", "abc/def", "a/b/c", ".", "..", "../..", "../../abc", "/abc", "/",
+	"",
+	"abc/", "abc/def/", "a/b/c/", "./", "../", "../../", "/abc/",
+	"abc//def//ghi", "abc//",
+	"abc/./def", "/./abc/def", "abc/.",
+	"abc/def/ghi/../jkl", "abc/def/../ghi/../jkl", "abc/def/..", "abc/def/../..",
+	"/abc/def/../..", "abc/def/../../..", "/abc/def/../../..",
+	"abc/def/../../../ghi/jkl/../../../mno", "/../abc", "a/../b:/../../c",
+	"abc/./../def", "abc//./../def", "abc/../../././../def",
+	"//abc", "///abc", "//abc//",
+	`c:`, `c:\`, `c:\abc`, `c:abc\..\..\.\.\..\def`, `c:\abc\def\..\..`,
+	`c:\..\abc`, `c:..\abc`, `c:\b:\..\..\..\d`, `\`, `/`,
+	`\\i\..\c$`, `\\i\..\i\c$`, `\\i\..\I\c$`,
+	`\\host\share\foo\..\bar`, `//host/share/foo/../baz`,
+	`\\host\share\foo\..\..\..\..\bar`,
+	`\\.\C:\a\..\..\..\..\bar`, `\\.\C:\\\\a`, `\\a\b\..\c`, `\\a\b`,
+	`.\c:`, `.\c:\foo`, `.\c:foo`,
+	`\\?\C:\`, `\\?\C:\a`,
+	`a/../c:`, `a\..\c:`, `a/../c:/a`, `a/../../c:`, `foo:bar`,
+	`/a/../??/a`,
+	// Agento shapes: the three surfaces and the four un-gated callers.
+	`C:\Users\u\.claude`, `C:\Users\u\.claude\`, `C:\Users\u\.claude\projects`,
+	`C:\Users\u/.claude-work`, `C:/Users/u/.claude`,
+	`C:\Users\u\AppData\Roaming\..\Local`,
+	`\\?\C:\Users\u\.claude\settings.json`,
+	`\\nas\home\u\.claude`,
+	`~`, `~/Projects`,
+	"C:\\Users\\ü\\Projekte\\..\\.claude",
+}
+
+// Go's `basetests` + `winbasetests`, plus the encoded project-directory shape
+// `sessions/projects.rs` derives.
+var baseInputs = []string{
+	"", ".", "/.", "/", "////", "x/", "abc", "abc/def", "a/b/.x", "a/b/c.",
+	"a/b/c.x",
+	`c:\`, `c:.`, `c:\a\b`, `c:a\b`, `c:a\b\c`,
+	`\\host\share\`, `\\host\share\a`, `\\host\share\a\b`,
+	`C:\Users\u\.claude\projects\-C--Users-u-proj`,
+	`C:\Users\u\.claude\projects\-C--Users-u-proj\`,
+}
+
+// Go's `dirtests` + `windirtests`, plus the Agento shapes.
+var dirInputs = []string{
+	"", ".", "/.", "/", "/foo", "x/", "abc", "abc/def", "a/b/.x", "a/b/c.",
+	"a/b/c.x", "////",
+	`c:\`, `c:.`, `c:\a\b`, `c:a\b`, `c:a\b\c`,
+	`\\host\share`, `\\host\share\`, `\\host\share\a`, `\\host\share\a\b`,
+	`\\\\`,
+	`C:\Users\u\.claude`, `C:\Users\u\.claude\projects\-C--Users-u-proj\s.jsonl`,
+	`C:/Users/u/.claude`,
+	`\\?\C:\Users\u\.claude`,
+}
+
+// Go's `jointests` + `winjointests`, plus the Agento shapes.
+var joinInputs = [][]string{
+	{},
+	{""}, {"/"}, {"a"},
+	{"a", "b"}, {"a", ""}, {"", "b"}, {"/", "a"}, {"/", "a/b"}, {"/", ""},
+	{"/a", "b"}, {"a", "/b"}, {"/a", "/b"}, {"a/", "b"}, {"a/", ""}, {"", ""},
+	{"/", "a", "b"},
+	{"//", "a"},
+	{`directory`, `file`},
+	{`C:\Windows\`, `System32`}, {`C:\Windows\`, ``}, {`C:\`, `Windows`},
+	{`C:`, `a`}, {`C:`, `a\b`}, {`C:`, `a`, `b`}, {`C:`, ``, `b`},
+	{`C:`, ``, ``, `b`}, {`C:`, ``}, {`C:`, ``, ``}, {`C:`, `\a`},
+	{`C:`, ``, `\a`}, {`C:.`, `a`}, {`C:a`, `b`}, {`C:a`, `b`, `d`},
+	{`\\host\share`, `foo`}, {`\\host\share\foo`}, {`//host/share`, `foo/bar`},
+	{`\`}, {`\`, ``}, {`\`, `a`}, {`\\`, `a`}, {`\`, `a`, `b`},
+	{`\\`, `a`, `b`}, {`\`, `\\a\b`, `c`}, {`\\a`, `b`, `c`},
+	{`\\a\`, `b`, `c`}, {`//`, `a`},
+	{`a:\b\c`, `x\..\y:\..\..\z`}, {`\`, `??\a`},
+	// Agento shapes.
+	{`C:\Users\u`, `.claude`},
+	{`C:\Users\u\.claude`, `settings.json`},
+	{`C:\Users\u\.claude`, `settings_profiles.json`},
+	{`C:\Users\u\.claude`, `todos`, `abc-agent-abc.json`},
+	{`C:\Users\u`, `.claude-work`},
+	{`C:\Users\u\.claude`, `projects`},
+	{`C:\Users\u\AppData\Local\agento\uploads`, `1-uuid.png`},
+	{`C:\Users\ü`, `文档`},
+	{`\\nas\home\u`, `.claude`},
+	{`C:\Users\u`, `/Projects`},
+}
+
+// Go's `basetests` (path_test.go), read through the host's real path/filepath,
+// plus the encoded project-directory shape sessions/projects.rs derives.
+var unixBaseInputs = []string{
+	"", ".", "/.", "/", "////", "x/", "abc", "abc/def", "a/b/.x", "a/b/c.",
+	"a/b/c.x",
+	"/home/u/.claude/projects/-home-u-proj",
+	"/home/u/.claude/projects/-home-u-proj/",
+	"/home/ü/文档",
+}
+
+// Go's `isabstests` + `winisabstests` (path_test.go), plus the shapes
+// `POST /api/fs/mkdir` has to accept and refuse.
+var isAbsInputs = []string{
+	"", "/", "/usr/bin/gcc", "..", "/a/../bb", ".", "./", "lala",
+	`C:\`, `c\`, `c::`, `c:`, `/`, `\`, `\Windows`, `c:a\b`, `c:\a\b`,
+	`c:/a/b`, `\\host\share`, `\\host\share\`, `\\host\share\foo`,
+	`//host/share/foo/bar`, `\\?\a\b\c`, `\??\a\b\c`,
+	`C:\Users\u\Projects`, `C:\Users\u\..\evil`,
+}
+
+// Inputs whose volume prefix is the thing under test.
+var volumeInputs = []string{
+	"", `c:`, `c:\`, `c:\a`, `C:/a`, `\`, `/`, `\\`, `\\host`, `\\host\share`,
+	`\\host\share\a`, `//host/share/a`, `\\.\C:\a`, `\\?\C:\a`, `\??\C:\a`,
+	`\\.\UNC\host\share\a`, `\\.`, `\\.\`, `\\?\`, `foo:bar`, `a/b`,
+	`C:\Users\u\.claude`,
+}
+
+type pathCase struct {
+	Value string `json:"value"`
+	Want  string `json:"want"`
+}
+
+type boolCase struct {
+	Value string `json:"value"`
+	Want  bool   `json:"want"`
+}
+
+type joinCase struct {
+	Elems []string `json:"elems"`
+	Want  string   `json:"want"`
+}
+
+type vectors struct {
+	Comment    []string   `json:"_comment"`
+	Clean      []pathCase `json:"clean"`
+	Dir        []pathCase `json:"dir"`
+	Join       []joinCase `json:"join"`
+	Base       []pathCase `json:"base"`
+	VolumeName []pathCase `json:"volume_name"`
+	UnixBase   []pathCase `json:"unix_base"`
+	IsAbs      []boolCase `json:"is_abs"`
+}
+
+func main() {
+	v := vectors{Comment: []string{
+		"Cross-language parity vectors for Go's path/filepath, WINDOWS rules.",
+		"Sibling of gopath_vectors.json (Unix). 'want' is what Go's own",
+		"internal/filepathlite and path/filepath Windows source produces, so a",
+		"divergence fails the Rust port against Go's real output rather than",
+		"against a belief about it. Read by src-tauri/src/native/gopath.rs on",
+		"every host, not only on Windows.",
+		"Generated from " + runtime.Version() + " with:",
+		"  go run parity/generators/gopath_windows_vectors.go > parity/gopath_windows_vectors.json",
+		"Inputs are Go's own path_test.go tables (cleantests+wincleantests,",
+		"basetests+winbasetests, dirtests+windirtests, jointests+winjointests)",
+		"plus the paths Agento's own Windows surfaces build.",
+	}}
+	for _, s := range cleanInputs {
+		v.Clean = append(v.Clean, pathCase{s, Clean(s)})
+	}
+	for _, s := range dirInputs {
+		v.Dir = append(v.Dir, pathCase{s, Dir(s)})
+	}
+	for _, e := range joinInputs {
+		if e == nil {
+			e = []string{}
+		}
+		v.Join = append(v.Join, joinCase{e, Join(e...)})
+	}
+	for _, s := range baseInputs {
+		v.Base = append(v.Base, pathCase{s, Base(s)})
+	}
+	for _, s := range volumeInputs {
+		v.VolumeName = append(v.VolumeName, pathCase{s, VolumeName(s)})
+	}
+	// The one Unix-rules array with no home in the frozen gopath_vectors.json:
+	// filepath.Base is new to this port (sessions/projects.rs needs it), and
+	// that file may not move. Produced by the host's real path/filepath, which
+	// is the Unix build here.
+	for _, s := range unixBaseInputs {
+		v.UnixBase = append(v.UnixBase, pathCase{s, gofilepath.Base(s)})
+	}
+	for _, s := range isAbsInputs {
+		v.IsAbs = append(v.IsAbs, boolCase{s, IsAbs(s)})
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/parity/generators/gopath_windows_vectors.go
+++ b/parity/generators/gopath_windows_vectors.go
@@ -3,8 +3,8 @@
 // It does NOT re-implement Go's Windows `path/filepath`; it vendors it. The
 // three sections below are copied verbatim from the Go distribution:
 //
-//	internal/filepathlite/path.go          — lazybuf, Clean, Split, Base, Dir,
-//	                                         VolumeName, FromSlash
+//	internal/filepathlite/path.go          — lazybuf, Clean, Base, Dir,
+//	                                         VolumeName, IsAbs, FromSlash
 //	internal/filepathlite/path_windows.go  — Separator, IsPathSeparator,
 //	                                         volumeNameLen, pathHasPrefixFold,
 //	                                         uncLen, cutPath, postClean, toUpper
@@ -478,6 +478,18 @@ type vectors struct {
 }
 
 func main() {
+	// The `unix_base` array is taken from the **host's own** path/filepath, so
+	// this generator is only correct on a Unix host: run on Windows it would
+	// silently fill that array with Windows answers, and the array exists
+	// precisely because `gopath_vectors.json` is frozen and cannot hold it.
+	// Loud rather than silent, per parity/README.md.
+	if runtime.GOOS == "windows" || runtime.GOOS == "plan9" {
+		fmt.Fprintf(os.Stderr,
+			"refusing to run on %s: unix_base is read from the host's path/filepath and needs the Unix rules\n",
+			runtime.GOOS)
+		os.Exit(1)
+	}
+
 	v := vectors{Comment: []string{
 		"Cross-language parity vectors for Go's path/filepath, WINDOWS rules.",
 		"Sibling of gopath_vectors.json (Unix). 'want' is what Go's own",

--- a/parity/gopath_windows_vectors.json
+++ b/parity/gopath_windows_vectors.json
@@ -1,0 +1,1204 @@
+{
+  "_comment": [
+    "Cross-language parity vectors for Go's path/filepath, WINDOWS rules.",
+    "Sibling of gopath_vectors.json (Unix). 'want' is what Go's own",
+    "internal/filepathlite and path/filepath Windows source produces, so a",
+    "divergence fails the Rust port against Go's real output rather than",
+    "against a belief about it. Read by src-tauri/src/native/gopath.rs on",
+    "every host, not only on Windows.",
+    "Generated from go1.26.5 with:",
+    "  go run parity/generators/gopath_windows_vectors.go > parity/gopath_windows_vectors.json",
+    "Inputs are Go's own path_test.go tables (cleantests+wincleantests,",
+    "basetests+winbasetests, dirtests+windirtests, jointests+winjointests)",
+    "plus the paths Agento's own Windows surfaces build."
+  ],
+  "clean": [
+    {
+      "value": "abc",
+      "want": "abc"
+    },
+    {
+      "value": "abc/def",
+      "want": "abc\\def"
+    },
+    {
+      "value": "a/b/c",
+      "want": "a\\b\\c"
+    },
+    {
+      "value": ".",
+      "want": "."
+    },
+    {
+      "value": "..",
+      "want": ".."
+    },
+    {
+      "value": "../..",
+      "want": "..\\.."
+    },
+    {
+      "value": "../../abc",
+      "want": "..\\..\\abc"
+    },
+    {
+      "value": "/abc",
+      "want": "\\abc"
+    },
+    {
+      "value": "/",
+      "want": "\\"
+    },
+    {
+      "value": "",
+      "want": "."
+    },
+    {
+      "value": "abc/",
+      "want": "abc"
+    },
+    {
+      "value": "abc/def/",
+      "want": "abc\\def"
+    },
+    {
+      "value": "a/b/c/",
+      "want": "a\\b\\c"
+    },
+    {
+      "value": "./",
+      "want": "."
+    },
+    {
+      "value": "../",
+      "want": ".."
+    },
+    {
+      "value": "../../",
+      "want": "..\\.."
+    },
+    {
+      "value": "/abc/",
+      "want": "\\abc"
+    },
+    {
+      "value": "abc//def//ghi",
+      "want": "abc\\def\\ghi"
+    },
+    {
+      "value": "abc//",
+      "want": "abc"
+    },
+    {
+      "value": "abc/./def",
+      "want": "abc\\def"
+    },
+    {
+      "value": "/./abc/def",
+      "want": "\\abc\\def"
+    },
+    {
+      "value": "abc/.",
+      "want": "abc"
+    },
+    {
+      "value": "abc/def/ghi/../jkl",
+      "want": "abc\\def\\jkl"
+    },
+    {
+      "value": "abc/def/../ghi/../jkl",
+      "want": "abc\\jkl"
+    },
+    {
+      "value": "abc/def/..",
+      "want": "abc"
+    },
+    {
+      "value": "abc/def/../..",
+      "want": "."
+    },
+    {
+      "value": "/abc/def/../..",
+      "want": "\\"
+    },
+    {
+      "value": "abc/def/../../..",
+      "want": ".."
+    },
+    {
+      "value": "/abc/def/../../..",
+      "want": "\\"
+    },
+    {
+      "value": "abc/def/../../../ghi/jkl/../../../mno",
+      "want": "..\\..\\mno"
+    },
+    {
+      "value": "/../abc",
+      "want": "\\abc"
+    },
+    {
+      "value": "a/../b:/../../c",
+      "want": "..\\c"
+    },
+    {
+      "value": "abc/./../def",
+      "want": "def"
+    },
+    {
+      "value": "abc//./../def",
+      "want": "def"
+    },
+    {
+      "value": "abc/../../././../def",
+      "want": "..\\..\\def"
+    },
+    {
+      "value": "//abc",
+      "want": "\\\\abc"
+    },
+    {
+      "value": "///abc",
+      "want": "\\\\\\abc"
+    },
+    {
+      "value": "//abc//",
+      "want": "\\\\abc\\\\"
+    },
+    {
+      "value": "c:",
+      "want": "c:."
+    },
+    {
+      "value": "c:\\",
+      "want": "c:\\"
+    },
+    {
+      "value": "c:\\abc",
+      "want": "c:\\abc"
+    },
+    {
+      "value": "c:abc\\..\\..\\.\\.\\..\\def",
+      "want": "c:..\\..\\def"
+    },
+    {
+      "value": "c:\\abc\\def\\..\\..",
+      "want": "c:\\"
+    },
+    {
+      "value": "c:\\..\\abc",
+      "want": "c:\\abc"
+    },
+    {
+      "value": "c:..\\abc",
+      "want": "c:..\\abc"
+    },
+    {
+      "value": "c:\\b:\\..\\..\\..\\d",
+      "want": "c:\\d"
+    },
+    {
+      "value": "\\",
+      "want": "\\"
+    },
+    {
+      "value": "/",
+      "want": "\\"
+    },
+    {
+      "value": "\\\\i\\..\\c$",
+      "want": "\\\\i\\..\\c$"
+    },
+    {
+      "value": "\\\\i\\..\\i\\c$",
+      "want": "\\\\i\\..\\i\\c$"
+    },
+    {
+      "value": "\\\\i\\..\\I\\c$",
+      "want": "\\\\i\\..\\I\\c$"
+    },
+    {
+      "value": "\\\\host\\share\\foo\\..\\bar",
+      "want": "\\\\host\\share\\bar"
+    },
+    {
+      "value": "//host/share/foo/../baz",
+      "want": "\\\\host\\share\\baz"
+    },
+    {
+      "value": "\\\\host\\share\\foo\\..\\..\\..\\..\\bar",
+      "want": "\\\\host\\share\\bar"
+    },
+    {
+      "value": "\\\\.\\C:\\a\\..\\..\\..\\..\\bar",
+      "want": "\\\\.\\C:\\bar"
+    },
+    {
+      "value": "\\\\.\\C:\\\\\\\\a",
+      "want": "\\\\.\\C:\\a"
+    },
+    {
+      "value": "\\\\a\\b\\..\\c",
+      "want": "\\\\a\\b\\c"
+    },
+    {
+      "value": "\\\\a\\b",
+      "want": "\\\\a\\b"
+    },
+    {
+      "value": ".\\c:",
+      "want": ".\\c:"
+    },
+    {
+      "value": ".\\c:\\foo",
+      "want": ".\\c:\\foo"
+    },
+    {
+      "value": ".\\c:foo",
+      "want": ".\\c:foo"
+    },
+    {
+      "value": "\\\\?\\C:\\",
+      "want": "\\\\?\\C:\\"
+    },
+    {
+      "value": "\\\\?\\C:\\a",
+      "want": "\\\\?\\C:\\a"
+    },
+    {
+      "value": "a/../c:",
+      "want": ".\\c:"
+    },
+    {
+      "value": "a\\..\\c:",
+      "want": ".\\c:"
+    },
+    {
+      "value": "a/../c:/a",
+      "want": ".\\c:\\a"
+    },
+    {
+      "value": "a/../../c:",
+      "want": "..\\c:"
+    },
+    {
+      "value": "foo:bar",
+      "want": "foo:bar"
+    },
+    {
+      "value": "/a/../??/a",
+      "want": "\\.\\??\\a"
+    },
+    {
+      "value": "C:\\Users\\u\\.claude",
+      "want": "C:\\Users\\u\\.claude"
+    },
+    {
+      "value": "C:\\Users\\u\\.claude\\",
+      "want": "C:\\Users\\u\\.claude"
+    },
+    {
+      "value": "C:\\Users\\u\\.claude\\projects",
+      "want": "C:\\Users\\u\\.claude\\projects"
+    },
+    {
+      "value": "C:\\Users\\u/.claude-work",
+      "want": "C:\\Users\\u\\.claude-work"
+    },
+    {
+      "value": "C:/Users/u/.claude",
+      "want": "C:\\Users\\u\\.claude"
+    },
+    {
+      "value": "C:\\Users\\u\\AppData\\Roaming\\..\\Local",
+      "want": "C:\\Users\\u\\AppData\\Local"
+    },
+    {
+      "value": "\\\\?\\C:\\Users\\u\\.claude\\settings.json",
+      "want": "\\\\?\\C:\\Users\\u\\.claude\\settings.json"
+    },
+    {
+      "value": "\\\\nas\\home\\u\\.claude",
+      "want": "\\\\nas\\home\\u\\.claude"
+    },
+    {
+      "value": "~",
+      "want": "~"
+    },
+    {
+      "value": "~/Projects",
+      "want": "~\\Projects"
+    },
+    {
+      "value": "C:\\Users\\ü\\Projekte\\..\\.claude",
+      "want": "C:\\Users\\ü\\.claude"
+    }
+  ],
+  "dir": [
+    {
+      "value": "",
+      "want": "."
+    },
+    {
+      "value": ".",
+      "want": "."
+    },
+    {
+      "value": "/.",
+      "want": "\\"
+    },
+    {
+      "value": "/",
+      "want": "\\"
+    },
+    {
+      "value": "/foo",
+      "want": "\\"
+    },
+    {
+      "value": "x/",
+      "want": "x"
+    },
+    {
+      "value": "abc",
+      "want": "."
+    },
+    {
+      "value": "abc/def",
+      "want": "abc"
+    },
+    {
+      "value": "a/b/.x",
+      "want": "a\\b"
+    },
+    {
+      "value": "a/b/c.",
+      "want": "a\\b"
+    },
+    {
+      "value": "a/b/c.x",
+      "want": "a\\b"
+    },
+    {
+      "value": "////",
+      "want": "\\\\\\\\"
+    },
+    {
+      "value": "c:\\",
+      "want": "c:\\"
+    },
+    {
+      "value": "c:.",
+      "want": "c:."
+    },
+    {
+      "value": "c:\\a\\b",
+      "want": "c:\\a"
+    },
+    {
+      "value": "c:a\\b",
+      "want": "c:a"
+    },
+    {
+      "value": "c:a\\b\\c",
+      "want": "c:a\\b"
+    },
+    {
+      "value": "\\\\host\\share",
+      "want": "\\\\host\\share"
+    },
+    {
+      "value": "\\\\host\\share\\",
+      "want": "\\\\host\\share\\"
+    },
+    {
+      "value": "\\\\host\\share\\a",
+      "want": "\\\\host\\share\\"
+    },
+    {
+      "value": "\\\\host\\share\\a\\b",
+      "want": "\\\\host\\share\\a"
+    },
+    {
+      "value": "\\\\\\\\",
+      "want": "\\\\\\\\"
+    },
+    {
+      "value": "C:\\Users\\u\\.claude",
+      "want": "C:\\Users\\u"
+    },
+    {
+      "value": "C:\\Users\\u\\.claude\\projects\\-C--Users-u-proj\\s.jsonl",
+      "want": "C:\\Users\\u\\.claude\\projects\\-C--Users-u-proj"
+    },
+    {
+      "value": "C:/Users/u/.claude",
+      "want": "C:\\Users\\u"
+    },
+    {
+      "value": "\\\\?\\C:\\Users\\u\\.claude",
+      "want": "\\\\?\\C:\\Users\\u"
+    }
+  ],
+  "join": [
+    {
+      "elems": [],
+      "want": ""
+    },
+    {
+      "elems": [
+        ""
+      ],
+      "want": ""
+    },
+    {
+      "elems": [
+        "/"
+      ],
+      "want": "\\"
+    },
+    {
+      "elems": [
+        "a"
+      ],
+      "want": "a"
+    },
+    {
+      "elems": [
+        "a",
+        "b"
+      ],
+      "want": "a\\b"
+    },
+    {
+      "elems": [
+        "a",
+        ""
+      ],
+      "want": "a"
+    },
+    {
+      "elems": [
+        "",
+        "b"
+      ],
+      "want": "b"
+    },
+    {
+      "elems": [
+        "/",
+        "a"
+      ],
+      "want": "\\a"
+    },
+    {
+      "elems": [
+        "/",
+        "a/b"
+      ],
+      "want": "\\a\\b"
+    },
+    {
+      "elems": [
+        "/",
+        ""
+      ],
+      "want": "\\"
+    },
+    {
+      "elems": [
+        "/a",
+        "b"
+      ],
+      "want": "\\a\\b"
+    },
+    {
+      "elems": [
+        "a",
+        "/b"
+      ],
+      "want": "a\\b"
+    },
+    {
+      "elems": [
+        "/a",
+        "/b"
+      ],
+      "want": "\\a\\b"
+    },
+    {
+      "elems": [
+        "a/",
+        "b"
+      ],
+      "want": "a\\b"
+    },
+    {
+      "elems": [
+        "a/",
+        ""
+      ],
+      "want": "a"
+    },
+    {
+      "elems": [
+        "",
+        ""
+      ],
+      "want": ""
+    },
+    {
+      "elems": [
+        "/",
+        "a",
+        "b"
+      ],
+      "want": "\\a\\b"
+    },
+    {
+      "elems": [
+        "//",
+        "a"
+      ],
+      "want": "\\\\a"
+    },
+    {
+      "elems": [
+        "directory",
+        "file"
+      ],
+      "want": "directory\\file"
+    },
+    {
+      "elems": [
+        "C:\\Windows\\",
+        "System32"
+      ],
+      "want": "C:\\Windows\\System32"
+    },
+    {
+      "elems": [
+        "C:\\Windows\\",
+        ""
+      ],
+      "want": "C:\\Windows"
+    },
+    {
+      "elems": [
+        "C:\\",
+        "Windows"
+      ],
+      "want": "C:\\Windows"
+    },
+    {
+      "elems": [
+        "C:",
+        "a"
+      ],
+      "want": "C:a"
+    },
+    {
+      "elems": [
+        "C:",
+        "a\\b"
+      ],
+      "want": "C:a\\b"
+    },
+    {
+      "elems": [
+        "C:",
+        "a",
+        "b"
+      ],
+      "want": "C:a\\b"
+    },
+    {
+      "elems": [
+        "C:",
+        "",
+        "b"
+      ],
+      "want": "C:b"
+    },
+    {
+      "elems": [
+        "C:",
+        "",
+        "",
+        "b"
+      ],
+      "want": "C:b"
+    },
+    {
+      "elems": [
+        "C:",
+        ""
+      ],
+      "want": "C:."
+    },
+    {
+      "elems": [
+        "C:",
+        "",
+        ""
+      ],
+      "want": "C:."
+    },
+    {
+      "elems": [
+        "C:",
+        "\\a"
+      ],
+      "want": "C:\\a"
+    },
+    {
+      "elems": [
+        "C:",
+        "",
+        "\\a"
+      ],
+      "want": "C:\\a"
+    },
+    {
+      "elems": [
+        "C:.",
+        "a"
+      ],
+      "want": "C:a"
+    },
+    {
+      "elems": [
+        "C:a",
+        "b"
+      ],
+      "want": "C:a\\b"
+    },
+    {
+      "elems": [
+        "C:a",
+        "b",
+        "d"
+      ],
+      "want": "C:a\\b\\d"
+    },
+    {
+      "elems": [
+        "\\\\host\\share",
+        "foo"
+      ],
+      "want": "\\\\host\\share\\foo"
+    },
+    {
+      "elems": [
+        "\\\\host\\share\\foo"
+      ],
+      "want": "\\\\host\\share\\foo"
+    },
+    {
+      "elems": [
+        "//host/share",
+        "foo/bar"
+      ],
+      "want": "\\\\host\\share\\foo\\bar"
+    },
+    {
+      "elems": [
+        "\\"
+      ],
+      "want": "\\"
+    },
+    {
+      "elems": [
+        "\\",
+        ""
+      ],
+      "want": "\\"
+    },
+    {
+      "elems": [
+        "\\",
+        "a"
+      ],
+      "want": "\\a"
+    },
+    {
+      "elems": [
+        "\\\\",
+        "a"
+      ],
+      "want": "\\\\a"
+    },
+    {
+      "elems": [
+        "\\",
+        "a",
+        "b"
+      ],
+      "want": "\\a\\b"
+    },
+    {
+      "elems": [
+        "\\\\",
+        "a",
+        "b"
+      ],
+      "want": "\\\\a\\b"
+    },
+    {
+      "elems": [
+        "\\",
+        "\\\\a\\b",
+        "c"
+      ],
+      "want": "\\a\\b\\c"
+    },
+    {
+      "elems": [
+        "\\\\a",
+        "b",
+        "c"
+      ],
+      "want": "\\\\a\\b\\c"
+    },
+    {
+      "elems": [
+        "\\\\a\\",
+        "b",
+        "c"
+      ],
+      "want": "\\\\a\\b\\c"
+    },
+    {
+      "elems": [
+        "//",
+        "a"
+      ],
+      "want": "\\\\a"
+    },
+    {
+      "elems": [
+        "a:\\b\\c",
+        "x\\..\\y:\\..\\..\\z"
+      ],
+      "want": "a:\\b\\z"
+    },
+    {
+      "elems": [
+        "\\",
+        "??\\a"
+      ],
+      "want": "\\.\\??\\a"
+    },
+    {
+      "elems": [
+        "C:\\Users\\u",
+        ".claude"
+      ],
+      "want": "C:\\Users\\u\\.claude"
+    },
+    {
+      "elems": [
+        "C:\\Users\\u\\.claude",
+        "settings.json"
+      ],
+      "want": "C:\\Users\\u\\.claude\\settings.json"
+    },
+    {
+      "elems": [
+        "C:\\Users\\u\\.claude",
+        "settings_profiles.json"
+      ],
+      "want": "C:\\Users\\u\\.claude\\settings_profiles.json"
+    },
+    {
+      "elems": [
+        "C:\\Users\\u\\.claude",
+        "todos",
+        "abc-agent-abc.json"
+      ],
+      "want": "C:\\Users\\u\\.claude\\todos\\abc-agent-abc.json"
+    },
+    {
+      "elems": [
+        "C:\\Users\\u",
+        ".claude-work"
+      ],
+      "want": "C:\\Users\\u\\.claude-work"
+    },
+    {
+      "elems": [
+        "C:\\Users\\u\\.claude",
+        "projects"
+      ],
+      "want": "C:\\Users\\u\\.claude\\projects"
+    },
+    {
+      "elems": [
+        "C:\\Users\\u\\AppData\\Local\\agento\\uploads",
+        "1-uuid.png"
+      ],
+      "want": "C:\\Users\\u\\AppData\\Local\\agento\\uploads\\1-uuid.png"
+    },
+    {
+      "elems": [
+        "C:\\Users\\ü",
+        "文档"
+      ],
+      "want": "C:\\Users\\ü\\文档"
+    },
+    {
+      "elems": [
+        "\\\\nas\\home\\u",
+        ".claude"
+      ],
+      "want": "\\\\nas\\home\\u\\.claude"
+    },
+    {
+      "elems": [
+        "C:\\Users\\u",
+        "/Projects"
+      ],
+      "want": "C:\\Users\\u\\Projects"
+    }
+  ],
+  "base": [
+    {
+      "value": "",
+      "want": "."
+    },
+    {
+      "value": ".",
+      "want": "."
+    },
+    {
+      "value": "/.",
+      "want": "."
+    },
+    {
+      "value": "/",
+      "want": "\\"
+    },
+    {
+      "value": "////",
+      "want": "\\"
+    },
+    {
+      "value": "x/",
+      "want": "x"
+    },
+    {
+      "value": "abc",
+      "want": "abc"
+    },
+    {
+      "value": "abc/def",
+      "want": "def"
+    },
+    {
+      "value": "a/b/.x",
+      "want": ".x"
+    },
+    {
+      "value": "a/b/c.",
+      "want": "c."
+    },
+    {
+      "value": "a/b/c.x",
+      "want": "c.x"
+    },
+    {
+      "value": "c:\\",
+      "want": "\\"
+    },
+    {
+      "value": "c:.",
+      "want": "."
+    },
+    {
+      "value": "c:\\a\\b",
+      "want": "b"
+    },
+    {
+      "value": "c:a\\b",
+      "want": "b"
+    },
+    {
+      "value": "c:a\\b\\c",
+      "want": "c"
+    },
+    {
+      "value": "\\\\host\\share\\",
+      "want": "\\"
+    },
+    {
+      "value": "\\\\host\\share\\a",
+      "want": "a"
+    },
+    {
+      "value": "\\\\host\\share\\a\\b",
+      "want": "b"
+    },
+    {
+      "value": "C:\\Users\\u\\.claude\\projects\\-C--Users-u-proj",
+      "want": "-C--Users-u-proj"
+    },
+    {
+      "value": "C:\\Users\\u\\.claude\\projects\\-C--Users-u-proj\\",
+      "want": "-C--Users-u-proj"
+    }
+  ],
+  "volume_name": [
+    {
+      "value": "",
+      "want": ""
+    },
+    {
+      "value": "c:",
+      "want": "c:"
+    },
+    {
+      "value": "c:\\",
+      "want": "c:"
+    },
+    {
+      "value": "c:\\a",
+      "want": "c:"
+    },
+    {
+      "value": "C:/a",
+      "want": "C:"
+    },
+    {
+      "value": "\\",
+      "want": ""
+    },
+    {
+      "value": "/",
+      "want": ""
+    },
+    {
+      "value": "\\\\",
+      "want": "\\\\"
+    },
+    {
+      "value": "\\\\host",
+      "want": "\\\\host"
+    },
+    {
+      "value": "\\\\host\\share",
+      "want": "\\\\host\\share"
+    },
+    {
+      "value": "\\\\host\\share\\a",
+      "want": "\\\\host\\share"
+    },
+    {
+      "value": "//host/share/a",
+      "want": "\\\\host\\share"
+    },
+    {
+      "value": "\\\\.\\C:\\a",
+      "want": "\\\\.\\C:"
+    },
+    {
+      "value": "\\\\?\\C:\\a",
+      "want": "\\\\?\\C:"
+    },
+    {
+      "value": "\\??\\C:\\a",
+      "want": "\\??\\C:"
+    },
+    {
+      "value": "\\\\.\\UNC\\host\\share\\a",
+      "want": "\\\\.\\UNC\\host\\share"
+    },
+    {
+      "value": "\\\\.",
+      "want": "\\\\."
+    },
+    {
+      "value": "\\\\.\\",
+      "want": "\\\\.\\"
+    },
+    {
+      "value": "\\\\?\\",
+      "want": "\\\\?\\"
+    },
+    {
+      "value": "foo:bar",
+      "want": ""
+    },
+    {
+      "value": "a/b",
+      "want": ""
+    },
+    {
+      "value": "C:\\Users\\u\\.claude",
+      "want": "C:"
+    }
+  ],
+  "unix_base": [
+    {
+      "value": "",
+      "want": "."
+    },
+    {
+      "value": ".",
+      "want": "."
+    },
+    {
+      "value": "/.",
+      "want": "."
+    },
+    {
+      "value": "/",
+      "want": "/"
+    },
+    {
+      "value": "////",
+      "want": "/"
+    },
+    {
+      "value": "x/",
+      "want": "x"
+    },
+    {
+      "value": "abc",
+      "want": "abc"
+    },
+    {
+      "value": "abc/def",
+      "want": "def"
+    },
+    {
+      "value": "a/b/.x",
+      "want": ".x"
+    },
+    {
+      "value": "a/b/c.",
+      "want": "c."
+    },
+    {
+      "value": "a/b/c.x",
+      "want": "c.x"
+    },
+    {
+      "value": "/home/u/.claude/projects/-home-u-proj",
+      "want": "-home-u-proj"
+    },
+    {
+      "value": "/home/u/.claude/projects/-home-u-proj/",
+      "want": "-home-u-proj"
+    },
+    {
+      "value": "/home/ü/文档",
+      "want": "文档"
+    }
+  ],
+  "is_abs": [
+    {
+      "value": "",
+      "want": false
+    },
+    {
+      "value": "/",
+      "want": false
+    },
+    {
+      "value": "/usr/bin/gcc",
+      "want": false
+    },
+    {
+      "value": "..",
+      "want": false
+    },
+    {
+      "value": "/a/../bb",
+      "want": false
+    },
+    {
+      "value": ".",
+      "want": false
+    },
+    {
+      "value": "./",
+      "want": false
+    },
+    {
+      "value": "lala",
+      "want": false
+    },
+    {
+      "value": "C:\\",
+      "want": true
+    },
+    {
+      "value": "c\\",
+      "want": false
+    },
+    {
+      "value": "c::",
+      "want": false
+    },
+    {
+      "value": "c:",
+      "want": false
+    },
+    {
+      "value": "/",
+      "want": false
+    },
+    {
+      "value": "\\",
+      "want": false
+    },
+    {
+      "value": "\\Windows",
+      "want": false
+    },
+    {
+      "value": "c:a\\b",
+      "want": false
+    },
+    {
+      "value": "c:\\a\\b",
+      "want": true
+    },
+    {
+      "value": "c:/a/b",
+      "want": true
+    },
+    {
+      "value": "\\\\host\\share",
+      "want": true
+    },
+    {
+      "value": "\\\\host\\share\\",
+      "want": true
+    },
+    {
+      "value": "\\\\host\\share\\foo",
+      "want": true
+    },
+    {
+      "value": "//host/share/foo/bar",
+      "want": true
+    },
+    {
+      "value": "\\\\?\\a\\b\\c",
+      "want": true
+    },
+    {
+      "value": "\\??\\a\\b\\c",
+      "want": true
+    },
+    {
+      "value": "C:\\Users\\u\\Projects",
+      "want": true
+    },
+    {
+      "value": "C:\\Users\\u\\..\\evil",
+      "want": true
+    }
+  ]
+}

--- a/parity/read_routes.json
+++ b/parity/read_routes.json
@@ -128,7 +128,7 @@
       "route": "/api/fs",
       "status": "native",
       "owner": "#296",
-      "reason": "the working-dir picker's listing; 501 on Windows since #278"
+      "reason": "the working-dir picker's listing; answered on Windows too since #374"
     },
     {
       "method": "GET",
@@ -240,7 +240,7 @@
       "route": "/api/settings/claude-config-dirs",
       "status": "native",
       "owner": "#305",
-      "reason": "the config-dir probe; 501 on Windows since #278"
+      "reason": "the config-dir probe; answered on Windows too since #374"
     },
     {
       "method": "GET",

--- a/src-tauri/src/native/agents.rs
+++ b/src-tauri/src/native/agents.rs
@@ -468,6 +468,14 @@ fn normalize_config_dir(agent: &mut Agent) -> Result<(), WriteError> {
 
 /// `config.NormalizeClaudeConfigDir`: trim, expand a leading `~`, then
 /// `filepath.Clean`.
+///
+/// **An OS path** (#374): it is a directory on the machine the app is running
+/// on, so `join` and `clean` here are the target's rules and the result is
+/// `C:\Users\u\.claude` on Windows rather than `C:\Users\u/.claude`. That
+/// matters twice over — the caller then rejects anything `Path::is_absolute`
+/// declines, and the stored value is compared against
+/// `GET /api/settings/claude-config-dirs`' own suggestions, which are built the
+/// same way.
 fn normalize_claude_config_dir(raw: &str) -> String {
     let trimmed = raw.trim();
     if trimmed.is_empty() {

--- a/src-tauri/src/native/claude_settings/mod.rs
+++ b/src-tauri/src/native/claude_settings/mod.rs
@@ -121,6 +121,23 @@ pub fn profiles_path(dir: &str) -> String {
 /// The mode matters: these files carry API keys and hook commands, and
 /// `std::fs::write` would create them `0666 & ~umask`.
 ///
+/// **On Windows the mode is dropped, and that is Go's behaviour rather than a
+/// hole** (#374). `syscall.Open` on Windows maps `perm` onto exactly one bit —
+/// the read-only attribute, set when no write bit is present — and `0600` has
+/// one, so Go's own `os.WriteFile(path, data, 0600)` there creates a file with
+/// the parent directory's inherited ACL and nothing else. A file inside
+/// `%USERPROFILE%` inherits that profile's ACL, which grants the user, SYSTEM
+/// and the local Administrators group; the practical difference from `0600` is
+/// that an administrator can read it without taking ownership first, which on
+/// Windows they can do anyway.
+///
+/// The alternative — building an explicit DACL through `SetSecurityInfo` — was
+/// considered and declined: it needs a new `windows-sys` surface that this
+/// crate does not otherwise use, it diverges from what the file's other writer
+/// (Claude Code itself) does, and there is nothing to pin it against. The
+/// decision is recorded here rather than left as a silent `cfg` gap, which is
+/// what it was until #374.
+///
 /// **Truncate-then-write, not temp-file-then-rename**, and that is a choice.
 /// `os.WriteFile` truncates, so a crash between the truncate and the write
 /// leaves an empty file — and for `settings_profiles.json` an empty index
@@ -143,6 +160,10 @@ pub fn write_file(path: &str, data: &[u8]) -> io::Result<()> {
 }
 
 /// `os.MkdirAll(dir, 0700)`.
+///
+/// The Windows story is [`write_file`]'s: `syscall.Mkdir` ignores `perm`
+/// outright there, so Go creates the directory with the parent's inherited ACL
+/// and so does this.
 pub fn mkdir_all(dir: &str) -> io::Result<()> {
     let mut builder = std::fs::DirBuilder::new();
     builder.recursive(true);
@@ -723,15 +744,6 @@ fn claims(method: &Method, path: &str) -> bool {
 }
 
 fn serve(ctx: &super::Ctx, req: &super::Request) -> Result<super::Answer, String> {
-    // Go's modes and Go's `filepath` are what this module writes with, and
-    // neither is verified on Windows — the same decision `super::fs` makes,
-    // answered as a 501 since #278 removed the sidecar that used to take it.
-    if !cfg!(unix) {
-        return super::Answer::error(
-            axum::http::StatusCode::NOT_IMPLEMENTED,
-            "the Claude settings surface is not supported on Windows in this build",
-        );
-    }
     // Resolved once, here: every handler below works inside one directory, and
     // a failure to resolve it is answered before anything is written.
     let dir = &run_dir(&ctx.db_path)?;

--- a/src-tauri/src/native/claude_settings/mod.rs
+++ b/src-tauri/src/native/claude_settings/mod.rs
@@ -125,11 +125,15 @@ pub fn profiles_path(dir: &str) -> String {
 /// hole** (#374). `syscall.Open` on Windows maps `perm` onto exactly one bit —
 /// the read-only attribute, set when no write bit is present — and `0600` has
 /// one, so Go's own `os.WriteFile(path, data, 0600)` there creates a file with
-/// the parent directory's inherited ACL and nothing else. A file inside
-/// `%USERPROFILE%` inherits that profile's ACL, which grants the user, SYSTEM
-/// and the local Administrators group; the practical difference from `0600` is
-/// that an administrator can read it without taking ownership first, which on
-/// Windows they can do anyway.
+/// the parent directory's inherited ACL and nothing else.
+///
+/// **The file is therefore only as tight as wherever the config dir points**,
+/// and that is a user-supplied location: under the default
+/// `%USERPROFILE%\.claude` it inherits the profile's ACL (the user, SYSTEM and
+/// the local Administrators group), but `CLAUDE_CONFIG_DIR=C:\ProgramData\claude`
+/// inherits a world-readable one. `0600` would have bounded that and this does
+/// not — which is the honest statement of the trade, and it is on the
+/// known-gaps list in `CLAUDE.md`.
 ///
 /// The alternative — building an explicit DACL through `SetSecurityInfo` — was
 /// considered and declined: it needs a new `windows-sys` surface that this

--- a/src-tauri/src/native/claude_settings/profiles.rs
+++ b/src-tauri/src/native/claude_settings/profiles.rs
@@ -303,13 +303,20 @@ fn resolve_profile_file_path(dir: &str, id: &str) -> Result<String, WriteError> 
 /// a different process's and unknowable here. Every path this surface writes is
 /// absolute, so this only fires on a hand-edited index.
 fn validate_path_within_dir(path: &str, dir: &str) -> Result<(), WriteError> {
-    if !path.starts_with('/') {
+    // `filepath.IsAbs`, and on Windows that is a volume test rather than a
+    // leading separator — `\Users\u\settings_x.json` is rooted but names no
+    // drive, so it is relative for this purpose exactly as `settings_x.json`
+    // is. See [`super::super::gopath::is_abs`] (#374).
+    if !gopath::is_abs(path) {
         return Err(WriteError::Fallback(format!(
             "profile file path {path:?} is relative; only the Go server knows its working directory"
         )));
     }
     let abs = gopath::clean(path);
-    if !abs.starts_with(&format!("{dir}/")) {
+    // `dir + string(os.PathSeparator)`, so the prefix is `\` on Windows —
+    // where `gopath::clean` has just normalised every `/` away, and a `/`
+    // spelled here would match nothing.
+    if !abs.starts_with(&format!("{dir}{}", std::path::MAIN_SEPARATOR)) {
         return Err(WriteError::Fallback(format!(
             "path {abs:?} escapes settings directory"
         )));
@@ -763,6 +770,27 @@ mod tests {
             });
         }
         assert_eq!(deduplicate_id("work", &profiles), "work-3");
+    }
+
+    /// The Windows half of the same guard (#374). It runs only there, because
+    /// `validate_path_within_dir` uses the dispatching `gopath::is_abs`/`clean`
+    /// and `std::path::MAIN_SEPARATOR` — all three of which are the point.
+    /// A *rooted* path naming no drive is relative for this purpose, which is
+    /// the case a `starts_with('/')` check got backwards in both directions.
+    #[test]
+    #[cfg(windows)]
+    fn a_windows_path_outside_the_dir_is_refused() {
+        let dir = r"C:\Users\u\.claude";
+        assert!(validate_path_within_dir(r"C:\Users\u\.claude\settings_a.json", dir).is_ok());
+        assert!(validate_path_within_dir(dir, dir).is_err());
+        assert!(validate_path_within_dir(r"C:\Users\u\.claude-evil\x.json", dir).is_err());
+        assert!(validate_path_within_dir(r"C:\Users\u\.claude\..\x.json", dir).is_err());
+        // Rooted, but on no particular drive: only the Go server's process
+        // knows which, so it is refused exactly as a bare filename is.
+        assert!(matches!(
+            validate_path_within_dir(r"\Users\u\.claude\settings_a.json", dir).unwrap_err(),
+            WriteError::Fallback(_)
+        ));
     }
 
     #[test]

--- a/src-tauri/src/native/fs.rs
+++ b/src-tauri/src/native/fs.rs
@@ -27,14 +27,20 @@
 //! path, and reproducing Go's policy would mean hand-rolling the conversion for
 //! a case the picker cannot act on, so this is documented rather than fixed.
 //!
-//! **Answered on Unix only.** The endpoint is `filepath.Clean`/`Dir`/`Join`
-//! wrapped in a response, and Windows `filepath` strips a volume name before
-//! cleaning and accepts both separators — a different algorithm, with no Windows
-//! machine in this loop to verify an implementation of it against. The route is
-//! still *claimed* there and [`serve`] answers a 501 naming the gap: gating
-//! `claims` instead would leave a registry entry that claims nothing, and the
-//! two registry tests exist precisely to catch that shape. See
-//! [`super::gopath`].
+//! **Answered on Windows too, since #374.** The endpoint is
+//! `filepath.Clean`/`Dir`/`Join` wrapped in a response, and Windows `filepath`
+//! is a different algorithm — a volume name is split off before cleaning and
+//! both separators are accepted — so this used to answer a 501 naming the gap.
+//! [`super::gopath`] now carries both rule sets, pinned by
+//! `parity/gopath_windows_vectors.json`, and every path here goes through the
+//! dispatching `gopath::clean`/`dir`/`join`/`is_abs`, so the listing is
+//! platform-correct by construction rather than by a gate.
+//!
+//! One thing to keep in mind when reading `mkdir`: **its guard is
+//! `filepath.IsAbs`, not `starts_with('/')`**, and on Windows *rooted is not
+//! absolute*. `\Users\u` names no drive, so `MkdirAll` would resolve it against
+//! whichever drive the process happens to be on — which is why the check moved
+//! into `gopath` rather than staying inline.
 //!
 //! `POST /api/fs/mkdir` is here too (#296). It was deferred by #293 as one of
 //! the two routes that escaped every category — ~20 lines, no database, no
@@ -188,8 +194,10 @@ pub fn mkdir(body: &[u8]) -> Result<super::Answer, WriteError> {
     }
 
     let clean = gopath::clean(&req.path);
-    // `filepath.IsAbs` is `strings.HasPrefix(path, "/")` on Unix.
-    if !clean.starts_with('/') || clean.contains("..") {
+    // `filepath.IsAbs`, which is `strings.HasPrefix(path, "/")` on Unix and a
+    // volume-name test on Windows — where a *rooted* path like `\Users\u` names
+    // no drive and is therefore not absolute. See [`super::gopath::is_abs`].
+    if !gopath::is_abs(&clean) || clean.contains("..") {
         return Err(WriteError::BadRequest("invalid path".to_string()));
     }
 
@@ -215,10 +223,20 @@ fn create_dir_all_0750(path: &str) -> std::io::Result<()> {
         .create(path)
 }
 
+/// `os.MkdirAll(path, 0750)` — with the mode dropped, which is what Go itself
+/// does here.
+///
+/// `syscall.Mkdir` on Windows ignores its `perm` argument entirely, so Go's own
+/// `MkdirAll(path, 0750)` creates a directory inheriting the parent's ACL. This
+/// reproduces that rather than reaching for `SetSecurityInfo`: a working
+/// directory the user picked is not a secret, it is created inside a tree the
+/// user already chose, and diverging from Go here would be a Windows-only
+/// permission model with nothing pinning it. The credential-bearing files are
+/// [`super::claude_settings`]'s, and that module states the same decision at
+/// more length.
 #[cfg(not(unix))]
-fn create_dir_all_0750(_path: &str) -> std::io::Result<()> {
-    // Unreachable: `serve` refuses this route off Unix before it is called.
-    Err(std::io::Error::other("not ported for Windows"))
+fn create_dir_all_0750(path: &str) -> std::io::Result<()> {
+    std::fs::DirBuilder::new().recursive(true).create(path)
 }
 
 /// The `path` query parameter. No rule of its own on top of the decoding —
@@ -250,16 +268,6 @@ fn claims(method: &Method, path: &str) -> bool {
 const PATH_MKDIR: &str = "/api/fs/mkdir";
 
 fn serve(_ctx: &super::Ctx, req: &super::Request) -> Result<super::Answer, String> {
-    // Windows `filepath` is a different algorithm and unverified here. The
-    // honest answer is a 501 naming the gap, not a listing built with Unix path
-    // arithmetic — `gopath::dir` on `C:\Users\u` finds no `/` and answers
-    // `"."`, so the picker would silently browse the wrong directory.
-    if !cfg!(unix) {
-        return super::Answer::error(
-            axum::http::StatusCode::NOT_IMPLEMENTED,
-            "the filesystem browser is not supported on Windows in this build",
-        );
-    }
     if req.path == PATH_MKDIR {
         return finish(mkdir(req.body));
     }

--- a/src-tauri/src/native/gopath.rs
+++ b/src-tauri/src/native/gopath.rs
@@ -1,4 +1,4 @@
-//! Go's `path/filepath`, for the Unix rules.
+//! Go's `path/filepath`, for **both** the Unix and the Windows rules.
 //!
 //! `GET /api/fs` is little more than `Clean`, `Dir` and `Join` wrapped in a
 //! response, so porting it means porting those — and they are not Rust's
@@ -15,15 +15,43 @@
 //!
 //! Every one of those produces a path the working-directory picker then offers
 //! the user, so a divergence is a real answer about the wrong directory rather
-//! than a cosmetic one. `desktop/parity/gopath_vectors.json` is generated from
-//! Go and read by both languages' tests, so these functions are pinned to what
-//! Go actually does rather than to what this comment believes.
+//! than a cosmetic one. `parity/gopath_vectors.json` (Unix) and
+//! `parity/gopath_windows_vectors.json` (Windows) are generated from Go and read
+//! by this module's tests, so these functions are pinned to what Go actually
+//! does rather than to what this comment believes.
 //!
-//! **Unix only.** Windows `filepath` is a different algorithm — a volume name is
-//! stripped before cleaning and both separators are accepted — and there is no
-//! Windows machine in this loop to verify it on. [`super::fs`] therefore still
-//! claims its route there but answers a 501 naming the gap, rather than the
-//! sidecar.
+//! # Two rule sets, selected by target and tested on every host (#374)
+//!
+//! Windows `filepath` is a **different algorithm**, not a tweak: a volume name
+//! is split off and cleaned separately, `\` and `/` are both separators, the
+//! output is normalised to `\`, a `\\?\` or `\??\` prefix is left alone, and
+//! `Join` has its own drive-relative and UNC rules before it re-cleans. Both
+//! implementations are therefore compiled everywhere and both vector files are
+//! asserted everywhere; only [`clean`], [`dir`], [`join`] and [`base`] dispatch,
+//! and they dispatch on `cfg(windows)` rather than on a runtime flag — a runtime
+//! switch would let a Unix build be handed Windows rules by accident, and it is
+//! the *target* that decides what a path on this machine means.
+//!
+//! That is what lets a Linux CI run catch a Windows regression, which matters
+//! because there is still no Windows machine in this loop: `windows_rules` in
+//! `.github/workflows/ci.yml` compiles and runs the `cfg(windows)` arms, but the
+//! path arithmetic itself is proven on every runner by the vectors.
+//!
+//! **The Unix arms below are byte-for-byte what they were** — the Unix vectors
+//! are frozen and pass unchanged. A diff there is a bug in a change, never a
+//! vector to regenerate.
+//!
+//! **On the port's fidelity.** The Windows half is transcribed from Go's own
+//! source branch for branch — `internal/filepathlite/path.go` (the `lazybuf`,
+//! `Clean`, `Base`, `Dir`, `VolumeName`), `internal/filepathlite/path_windows.go`
+//! (`volumeNameLen`, `postClean` and friends) and `path/filepath/path_windows.go`
+//! (`Join`'s Windows body). The `lazybuf`'s laziness is **load-bearing rather
+//! than an allocation trick**: `postClean` returns early when the buffer was
+//! never allocated, i.e. when the output has not diverged from the input, so an
+//! eager buffer turns `Clean(`\??\a`)` into `\.\??\a`. That is exactly the shape
+//! of bug the vectors exist to catch.
+
+// ─── Unix rules ───────────────────────────────────────────────────────────────
 
 /// Go's `filepath.Clean`, transcribed from `path/filepath/path.go`.
 ///
@@ -31,7 +59,7 @@
 /// the loop, and it is reproduced branch for branch rather than approximated by
 /// splitting on separators — a split-and-rejoin gets `""` (which is `"."`) and
 /// the rooted-`..` case wrong, and both reach this code from a user-typed path.
-pub fn clean(path: &str) -> String {
+pub fn clean_unix(path: &str) -> String {
     if path.is_empty() {
         return ".".to_string();
     }
@@ -115,19 +143,19 @@ pub fn clean(path: &str) -> String {
 
 /// Go's `filepath.Dir`: `Clean` of everything up to and including the last
 /// separator. A path with no separator answers `"."`, not `""`.
-pub fn dir(path: &str) -> String {
+pub fn dir_unix(path: &str) -> String {
     let bytes = path.as_bytes();
     let mut i = bytes.len() as isize - 1;
     while i >= 0 && bytes[i as usize] != b'/' {
         i -= 1;
     }
-    clean(&path[..(i + 1) as usize])
+    clean_unix(&path[..(i + 1) as usize])
 }
 
 /// Go's `filepath.Join`: concatenate the non-empty elements with a separator,
 /// then `Clean` the result — which is why an element may escape the one before
 /// it, and why an empty element vanishes instead of leaving a `//`.
-pub fn join(elems: &[&str]) -> String {
+pub fn join_unix(elems: &[&str]) -> String {
     let mut joined = String::new();
     for elem in elems {
         if elem.is_empty() {
@@ -143,7 +171,540 @@ pub fn join(elems: &[&str]) -> String {
     if joined.is_empty() {
         return String::new();
     }
-    clean(&joined)
+    clean_unix(&joined)
+}
+
+/// Go's `filepath.IsAbs` on Unix: `strings.HasPrefix(path, "/")`, and nothing
+/// else. Spelled out here so the Windows arm has a sibling rather than an
+/// inline `starts_with('/')` at the one call site that would then be wrong.
+pub fn is_abs_unix(path: &str) -> bool {
+    path.starts_with('/')
+}
+
+/// Go's `filepath.Base`: the last element, with trailing separators stripped
+/// first. `""` is `"."` and a path of only separators is `"/"` — neither is the
+/// empty string a `rsplit('/')` answers, which is why this exists rather than a
+/// split at the one call site that wanted it (`sessions::projects`).
+pub fn base_unix(path: &str) -> String {
+    if path.is_empty() {
+        return ".".to_string();
+    }
+    let mut b = path.as_bytes();
+    while !b.is_empty() && b[b.len() - 1] == b'/' {
+        b = &b[..b.len() - 1];
+    }
+    // Go throws away the volume name here; on Unix it is always empty.
+    let mut i = b.len() as isize - 1;
+    while i >= 0 && b[i as usize] != b'/' {
+        i -= 1;
+    }
+    if i >= 0 {
+        b = &b[(i + 1) as usize..];
+    }
+    if b.is_empty() {
+        return "/".to_string();
+    }
+    from_utf8_or(b, path)
+}
+
+// ─── Windows rules ────────────────────────────────────────────────────────────
+
+/// `os.PathSeparator` on Windows. `Clean` normalises every separator to this
+/// one, which is why its output never contains a `/`.
+const SEPARATOR_WINDOWS: u8 = b'\\';
+
+/// Go's `filepathlite.IsPathSeparator` on Windows: **both** slashes separate.
+fn is_sep_windows(c: u8) -> bool {
+    c == b'\\' || c == b'/'
+}
+
+/// Go's `filepathlite.toUpper` — ASCII only, deliberately: it backs
+/// `pathHasPrefixFold`, which compares against `\\.\UNC` and friends.
+fn to_upper_ascii(c: u8) -> u8 {
+    if c.is_ascii_lowercase() {
+        c - (b'a' - b'A')
+    } else {
+        c
+    }
+}
+
+/// Go's `filepathlite.FromSlash` on Windows: every `/` becomes `\`. Multiple
+/// slashes become multiple separators — it is not a `Clean`.
+fn from_slash_windows(b: &[u8]) -> String {
+    let mut out = b.to_vec();
+    for c in out.iter_mut() {
+        if *c == b'/' {
+            *c = SEPARATOR_WINDOWS;
+        }
+    }
+    // `/` and `\` are both ASCII, so replacing one with the other cannot split
+    // a multi-byte sequence.
+    String::from_utf8(out).unwrap_or_else(|_| String::from_utf8_lossy(b).into_owned())
+}
+
+fn from_utf8_or(b: &[u8], fallback: &str) -> String {
+    std::str::from_utf8(b)
+        .map(str::to_string)
+        .unwrap_or_else(|_| fallback.to_string())
+}
+
+/// Go's `filepathlite.pathHasPrefixFold`: case-insensitive, every separator
+/// equivalent, and if `s` is longer than `prefix` the next byte must separate.
+fn path_has_prefix_fold(s: &[u8], prefix: &[u8]) -> bool {
+    if s.len() < prefix.len() {
+        return false;
+    }
+    for i in 0..prefix.len() {
+        if is_sep_windows(prefix[i]) {
+            if !is_sep_windows(s[i]) {
+                return false;
+            }
+        } else if to_upper_ascii(prefix[i]) != to_upper_ascii(s[i]) {
+            return false;
+        }
+    }
+    if s.len() > prefix.len() && !is_sep_windows(s[prefix.len()]) {
+        return false;
+    }
+    true
+}
+
+/// Go's `filepathlite.uncLen`: the volume prefix of a UNC path runs to the
+/// second separator after the host.
+fn unc_len(path: &[u8], prefix_len: usize) -> usize {
+    let mut count = 0;
+    let mut i = prefix_len;
+    while i < path.len() {
+        if is_sep_windows(path[i]) {
+            count += 1;
+            if count == 2 {
+                return i;
+            }
+        }
+        i += 1;
+    }
+    path.len()
+}
+
+/// Go's `filepathlite.cutPath`: the index of the first separator, if any.
+fn cut_path(path: &[u8]) -> Option<usize> {
+    path.iter().position(|&c| is_sep_windows(c))
+}
+
+/// Go's `filepathlite.volumeNameLen`, transcribed whole.
+///
+/// Five shapes, and the order of the arms is the specification: a drive letter
+/// (`C:`), a Local Device UNC (`\\.\UNC\host\share`), a Local or Root Local
+/// Device path (`\\.\`, `\\?\`, `\??\`), and a plain UNC (`\\host\share`).
+/// The `\\?\` arm is why `Clean(`\\?\C:\`)` keeps its trailing separator: the
+/// component after the prefix is part of the volume, so there is nothing left
+/// for `Clean` to trim.
+fn volume_name_len(path: &[u8]) -> usize {
+    if path.len() >= 2 && path[1] == b':' {
+        // Path starts with a drive letter. Go does not check that the letter is
+        // in A-Z, and neither does this.
+        return 2;
+    }
+    if path.is_empty() || !is_sep_windows(path[0]) {
+        return 0;
+    }
+    if path_has_prefix_fold(path, br"\\.\UNC") {
+        return unc_len(path, br"\\.\UNC\".len());
+    }
+    if path_has_prefix_fold(path, br"\\.")
+        || path_has_prefix_fold(path, br"\\?")
+        || path_has_prefix_fold(path, br"\??")
+    {
+        if path.len() == 3 {
+            return 3; // exactly \\.
+        }
+        return match cut_path(&path[4..]) {
+            None => path.len(),
+            Some(i) => 4 + i,
+        };
+    }
+    if path.len() >= 2 && is_sep_windows(path[1]) {
+        return unc_len(path, 2);
+    }
+    0
+}
+
+/// Go's `filepath.VolumeName` on Windows: the leading volume, `\`-normalised.
+pub fn volume_name_windows(path: &str) -> String {
+    let b = path.as_bytes();
+    from_slash_windows(&b[..volume_name_len(b)])
+}
+
+/// Go's `filepathlite.lazybuf`, and it is lazy for a *behavioural* reason —
+/// see the module header. `buf` stays `None` until the output diverges from the
+/// input, and `postClean` keys on exactly that.
+struct LazyBuf<'a> {
+    path: &'a [u8],
+    buf: Option<Vec<u8>>,
+    w: usize,
+    vol_and_path: &'a [u8],
+    vol_len: usize,
+}
+
+impl<'a> LazyBuf<'a> {
+    fn new(path: &'a [u8], vol_and_path: &'a [u8], vol_len: usize) -> Self {
+        Self {
+            path,
+            buf: None,
+            w: 0,
+            vol_and_path,
+            vol_len,
+        }
+    }
+
+    fn index(&self, i: usize) -> u8 {
+        match &self.buf {
+            Some(buf) => buf[i],
+            None => self.path[i],
+        }
+    }
+
+    fn append(&mut self, c: u8) {
+        if self.buf.is_none() {
+            if self.w < self.path.len() && self.path[self.w] == c {
+                self.w += 1;
+                return;
+            }
+            // Go's `make([]byte, len(b.path))` — the tail is zeroed, and
+            // `post_clean` walks the whole slice rather than `buf[..w]`, so the
+            // length here is part of the algorithm.
+            let mut buf = vec![0u8; self.path.len()];
+            buf[..self.w].copy_from_slice(&self.path[..self.w]);
+            self.buf = Some(buf);
+        }
+        let buf = self.buf.as_mut().expect("just allocated");
+        buf[self.w] = c;
+        self.w += 1;
+    }
+
+    fn prepend(&mut self, prefix: &[u8]) {
+        let buf = self
+            .buf
+            .as_mut()
+            .expect("prepend is only reached with a buffer");
+        buf.splice(0..0, prefix.iter().copied());
+        self.w += prefix.len();
+    }
+
+    fn finish(&self) -> Vec<u8> {
+        match &self.buf {
+            None => self.vol_and_path[..self.vol_len + self.w].to_vec(),
+            Some(buf) => {
+                let mut out = self.vol_and_path[..self.vol_len].to_vec();
+                out.extend_from_slice(&buf[..self.w]);
+                out
+            }
+        }
+    }
+}
+
+/// Go's `filepathlite.postClean`: stop a *relative* path from cleaning itself
+/// into a rooted one.
+///
+/// Two rewrites, both security-shaped rather than cosmetic. `a/../c:` would
+/// otherwise clean to `c:`, a drive-relative path; and `\a\..\??\c:\x` would
+/// clean to `\??\c:\x`, a Root Local Device path equivalent to `c:\x`. Go
+/// inserts `.\` and `\.` respectively.
+fn post_clean(out: &mut LazyBuf) {
+    if out.vol_len != 0 || out.buf.is_none() {
+        return;
+    }
+    // Go ranges the whole buffer, not `buf[..w]`; the tail is zeros, which are
+    // neither a separator nor a colon, so the loop is unchanged by that — but
+    // it is transcribed as written rather than tightened.
+    let buf = out.buf.as_ref().expect("checked above");
+    let mut colon_first = false;
+    for &c in buf.iter() {
+        if is_sep_windows(c) {
+            break;
+        }
+        if c == b':' {
+            colon_first = true;
+            break;
+        }
+    }
+    if colon_first {
+        out.prepend(&[b'.', SEPARATOR_WINDOWS]);
+        return;
+    }
+    let buf = out.buf.as_ref().expect("checked above");
+    if buf.len() >= 3 && is_sep_windows(buf[0]) && buf[1] == b'?' && buf[2] == b'?' {
+        out.prepend(&[SEPARATOR_WINDOWS, b'.']);
+    }
+}
+
+/// Go's `filepath.Clean` under the Windows rules.
+///
+/// The shape that surprises: a **bare volume is not a root**. `Clean("c:")` is
+/// `c:.` — the drive's current directory — while `Clean(`c:\`)` is `c:\`. The
+/// volume is split off before the loop and never rewritten except by
+/// `FromSlash`, which is what keeps `Clean("//host/share/../x")` at
+/// `\\host\share\x` rather than eating the share.
+pub fn clean_windows(path: &str) -> String {
+    let original = path.as_bytes();
+    let vol_len = volume_name_len(original);
+    let p = &original[vol_len..];
+    if p.is_empty() {
+        if vol_len > 1 && is_sep_windows(original[0]) && is_sep_windows(original[1]) {
+            // should be UNC
+            return from_slash_windows(original);
+        }
+        return format!("{path}.");
+    }
+    let rooted = is_sep_windows(p[0]);
+
+    let n = p.len();
+    let mut out = LazyBuf::new(p, original, vol_len);
+    let mut r = 0usize;
+    let mut dotdot = 0usize;
+    if rooted {
+        out.append(SEPARATOR_WINDOWS);
+        r = 1;
+        dotdot = 1;
+    }
+
+    while r < n {
+        if is_sep_windows(p[r]) {
+            // empty path element
+            r += 1;
+        } else if p[r] == b'.' && (r + 1 == n || is_sep_windows(p[r + 1])) {
+            // . element
+            r += 1;
+        } else if p[r] == b'.' && p[r + 1] == b'.' && (r + 2 == n || is_sep_windows(p[r + 2])) {
+            // `p[r + 1]` cannot be out of range: the arm above already caught
+            // every `.` with nothing after it, so reaching here with `p[r]` a
+            // dot means `r + 1 < n`. Go relies on the same ordering.
+            //
+            // .. element: remove to last separator
+            r += 2;
+            if out.w > dotdot {
+                // can backtrack
+                out.w -= 1;
+                while out.w > dotdot && !is_sep_windows(out.index(out.w)) {
+                    out.w -= 1;
+                }
+            } else if !rooted {
+                // cannot backtrack, but not rooted, so append .. element.
+                if out.w > 0 {
+                    out.append(SEPARATOR_WINDOWS);
+                }
+                out.append(b'.');
+                out.append(b'.');
+                dotdot = out.w;
+            }
+        } else {
+            // real path element: add a separator if needed, then copy it.
+            if (rooted && out.w != 1) || (!rooted && out.w != 0) {
+                out.append(SEPARATOR_WINDOWS);
+            }
+            while r < n && !is_sep_windows(p[r]) {
+                out.append(p[r]);
+                r += 1;
+            }
+        }
+    }
+
+    // Turn empty string into "."
+    if out.w == 0 {
+        out.append(b'.');
+    }
+
+    post_clean(&mut out); // avoid creating absolute paths on Windows
+    let bytes = out.finish();
+    from_slash_windows(&bytes)
+}
+
+/// Go's `filepath.Dir` under the Windows rules.
+///
+/// `Dir` never crosses the volume — the scan stops at `len(vol)` — so
+/// `Dir(`c:\`)` is `c:\` and `Dir(`\\host\share`)` is `\\host\share`. The
+/// `len(vol) > 2` arm answers the bare volume for a UNC share whose remainder
+/// cleans to `"."`, where a drive would answer `c:.`.
+pub fn dir_windows(path: &str) -> String {
+    let b = path.as_bytes();
+    let vol_len = volume_name_len(b);
+    let vol = from_slash_windows(&b[..vol_len]);
+    let mut i = b.len() as isize - 1;
+    while i >= vol_len as isize && !is_sep_windows(b[i as usize]) {
+        i -= 1;
+    }
+    let rest = &b[vol_len..(i + 1) as usize];
+    // Every byte between the volume and a separator came from `path`, and both
+    // bounds land on ASCII, so this slice is still valid UTF-8.
+    let dir = clean_windows(&from_utf8_or(rest, path));
+    if dir == "." && vol_len > 2 {
+        // must be UNC
+        return vol;
+    }
+    format!("{vol}{dir}")
+}
+
+/// Go's `filepath.Base` under the Windows rules: trailing separators stripped,
+/// then the volume thrown away, then the last element.
+pub fn base_windows(path: &str) -> String {
+    if path.is_empty() {
+        return ".".to_string();
+    }
+    let mut b = path.as_bytes();
+    while !b.is_empty() && is_sep_windows(b[b.len() - 1]) {
+        b = &b[..b.len() - 1];
+    }
+    // Go recomputes the volume on the *trimmed* path, which is why
+    // `Base(`c:\`)` is `\` and not `c:`.
+    b = &b[volume_name_len(b)..];
+    let mut i = b.len() as isize - 1;
+    while i >= 0 && !is_sep_windows(b[i as usize]) {
+        i -= 1;
+    }
+    if i >= 0 {
+        b = &b[(i + 1) as usize..];
+    }
+    if b.is_empty() {
+        return (SEPARATOR_WINDOWS as char).to_string();
+    }
+    from_utf8_or(b, path)
+}
+
+/// Go's `filepath.IsAbs` under the Windows rules.
+///
+/// Rooted is not absolute: `\Windows` and `c:a\b` are both **false**, because
+/// the first names no drive and the second is drive-*relative*. A UNC path is
+/// absolute as soon as it has a volume, so `\\host\share` is true with no
+/// trailing separator at all.
+pub fn is_abs_windows(path: &str) -> bool {
+    let b = path.as_bytes();
+    let l = volume_name_len(b);
+    if l == 0 {
+        return false;
+    }
+    // If the volume name starts with a double slash, this is an absolute path.
+    if is_sep_windows(b[0]) && is_sep_windows(b[1]) {
+        return true;
+    }
+    let rest = &b[l..];
+    if rest.is_empty() {
+        return false;
+    }
+    is_sep_windows(rest[0])
+}
+
+/// Go's `filepath.Join` under the Windows rules — `path/filepath/path_windows.go`.
+///
+/// Three special cases before the final `Clean`, and none of them is derivable
+/// from the Unix version: an element following a separator has *its* leading
+/// separators stripped, so joining onto `\` cannot manufacture a UNC path; an
+/// element following a `:` is appended with no separator, so `Join("C:", "a")`
+/// is `C:a` (drive-relative) while `Join("C:", "\a")` is `C:\a`; and `\` joined
+/// with `??…` gets an extra `.\` so the result is not a Root Local Device path.
+pub fn join_windows(elems: &[&str]) -> String {
+    let mut b = String::new();
+    let mut last_char = 0u8;
+    for elem in elems {
+        let mut e: &str = elem;
+        if b.is_empty() {
+            // Add the first non-empty path element unchanged.
+        } else if is_sep_windows(last_char) {
+            // If the path ends in a slash, strip any leading slashes from the
+            // next element to avoid creating a UNC path from non-UNC elements.
+            while !e.is_empty() && is_sep_windows(e.as_bytes()[0]) {
+                e = &e[1..];
+            }
+            // If the path is \ and the next element is ??, add an extra .\ so
+            // the result is \.\?? rather than \??\ (a Root Local Device path).
+            if b.len() == 1
+                && e.starts_with("??")
+                && (e.len() == 2 || is_sep_windows(e.as_bytes()[2]))
+            {
+                b.push_str(".\\");
+            }
+        } else if last_char == b':' {
+            // Keep the path relative to the current directory on a drive and
+            // don't add a separator: Join(`C:`, `f`) == `C:f`.
+        } else {
+            b.push(SEPARATOR_WINDOWS as char);
+            last_char = SEPARATOR_WINDOWS;
+        }
+        if !e.is_empty() {
+            b.push_str(e);
+            last_char = *e.as_bytes().last().expect("non-empty");
+        }
+    }
+    if b.is_empty() {
+        return String::new();
+    }
+    clean_windows(&b)
+}
+
+// ─── The dispatching API ──────────────────────────────────────────────────────
+//
+// `cfg`, not a runtime flag: what a path on this machine means is a property of
+// the target, and a runtime switch would let a Unix build be handed the Windows
+// rules by accident. Every caller in `native/` uses these four and is therefore
+// correct on both platforms by construction.
+
+/// `filepath.Clean` for this target.
+#[cfg(not(windows))]
+pub fn clean(path: &str) -> String {
+    clean_unix(path)
+}
+
+/// `filepath.Clean` for this target.
+#[cfg(windows)]
+pub fn clean(path: &str) -> String {
+    clean_windows(path)
+}
+
+/// `filepath.Dir` for this target.
+#[cfg(not(windows))]
+pub fn dir(path: &str) -> String {
+    dir_unix(path)
+}
+
+/// `filepath.Dir` for this target.
+#[cfg(windows)]
+pub fn dir(path: &str) -> String {
+    dir_windows(path)
+}
+
+/// `filepath.Join` for this target.
+#[cfg(not(windows))]
+pub fn join(elems: &[&str]) -> String {
+    join_unix(elems)
+}
+
+/// `filepath.Join` for this target.
+#[cfg(windows)]
+pub fn join(elems: &[&str]) -> String {
+    join_windows(elems)
+}
+
+/// `filepath.Base` for this target.
+#[cfg(not(windows))]
+pub fn base(path: &str) -> String {
+    base_unix(path)
+}
+
+/// `filepath.Base` for this target.
+#[cfg(windows)]
+pub fn base(path: &str) -> String {
+    base_windows(path)
+}
+
+/// `filepath.IsAbs` for this target.
+#[cfg(not(windows))]
+pub fn is_abs(path: &str) -> bool {
+    is_abs_unix(path)
+}
+
+/// `filepath.IsAbs` for this target.
+#[cfg(windows)]
+pub fn is_abs(path: &str) -> bool {
+    is_abs_windows(path)
 }
 
 #[cfg(test)]
@@ -170,11 +731,36 @@ mod tests {
         join: Vec<JoinCase>,
     }
 
+    #[derive(Deserialize)]
+    struct BoolCase {
+        value: String,
+        want: bool,
+    }
+
+    #[derive(Deserialize)]
+    struct WindowsVectors {
+        clean: Vec<Case>,
+        dir: Vec<Case>,
+        join: Vec<JoinCase>,
+        base: Vec<Case>,
+        volume_name: Vec<Case>,
+        unix_base: Vec<Case>,
+        is_abs: Vec<BoolCase>,
+    }
+
+    fn read(name: &str) -> String {
+        let path = format!("{}/../parity/{name}", env!("CARGO_MANIFEST_DIR"));
+        std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("reading {path}: {e} — regenerate it from Go"))
+    }
+
     fn vectors() -> Vectors {
-        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../parity/gopath_vectors.json");
-        let raw = std::fs::read_to_string(path)
-            .unwrap_or_else(|e| panic!("reading {path}: {e} — regenerate it from Go"));
-        serde_json::from_str(&raw).expect("parsing gopath vectors")
+        serde_json::from_str(&read("gopath_vectors.json")).expect("parsing gopath vectors")
+    }
+
+    fn windows_vectors() -> WindowsVectors {
+        serde_json::from_str(&read("gopath_windows_vectors.json"))
+            .expect("parsing gopath windows vectors")
     }
 
     /// The whole point of the file: Rust is asserted against what Go actually
@@ -184,14 +770,19 @@ mod tests {
         let v = vectors();
         assert!(v.clean.len() >= 30, "vectors look truncated");
         for case in v.clean {
-            assert_eq!(clean(&case.value), case.want, "Clean({:?})", case.value);
+            assert_eq!(
+                clean_unix(&case.value),
+                case.want,
+                "Clean({:?})",
+                case.value
+            );
         }
     }
 
     #[test]
     fn dir_matches_the_go_vectors() {
         for case in vectors().dir {
-            assert_eq!(dir(&case.value), case.want, "Dir({:?})", case.value);
+            assert_eq!(dir_unix(&case.value), case.want, "Dir({:?})", case.value);
         }
     }
 
@@ -199,7 +790,7 @@ mod tests {
     fn join_matches_the_go_vectors() {
         for case in vectors().join {
             let elems: Vec<&str> = case.elems.iter().map(String::as_str).collect();
-            assert_eq!(join(&elems), case.want, "Join({:?})", case.elems);
+            assert_eq!(join_unix(&elems), case.want, "Join({:?})", case.elems);
         }
     }
 
@@ -209,16 +800,184 @@ mod tests {
     #[test]
     fn the_two_cases_a_naive_implementation_misses() {
         // Empty is ".", not "".
-        assert_eq!(clean(""), ".");
+        assert_eq!(clean_unix(""), ".");
         // A rooted ".." has nowhere to go and is dropped; an unrooted one is kept.
-        assert_eq!(clean("/a/../.."), "/");
-        assert_eq!(clean("a/../.."), "..");
+        assert_eq!(clean_unix("/a/../.."), "/");
+        assert_eq!(clean_unix("a/../.."), "..");
     }
 
     /// Multi-byte path elements survive the byte-level loop intact.
     #[test]
     fn non_ascii_elements_round_trip() {
-        assert_eq!(clean("/home/ü/Projekte/../.claude"), "/home/ü/.claude");
-        assert_eq!(join(&["/home/ü", "文档"]), "/home/ü/文档");
+        assert_eq!(clean_unix("/home/ü/Projekte/../.claude"), "/home/ü/.claude");
+        assert_eq!(join_unix(&["/home/ü", "文档"]), "/home/ü/文档");
+    }
+
+    // ─── Windows (#374) ───────────────────────────────────────────────────────
+    //
+    // Asserted on **every** host, not only on Windows: the rule set is selected
+    // by target but both are compiled, so a Linux CI run catches a Windows
+    // regression. That is the whole reason the two halves are not `cfg`'d out.
+
+    #[test]
+    fn windows_clean_matches_the_go_vectors() {
+        let v = windows_vectors();
+        assert!(v.clean.len() >= 60, "windows vectors look truncated");
+        for case in v.clean {
+            assert_eq!(
+                clean_windows(&case.value),
+                case.want,
+                "Clean({:?})",
+                case.value
+            );
+        }
+    }
+
+    #[test]
+    fn windows_dir_matches_the_go_vectors() {
+        for case in windows_vectors().dir {
+            assert_eq!(dir_windows(&case.value), case.want, "Dir({:?})", case.value);
+        }
+    }
+
+    #[test]
+    fn windows_join_matches_the_go_vectors() {
+        for case in windows_vectors().join {
+            let elems: Vec<&str> = case.elems.iter().map(String::as_str).collect();
+            assert_eq!(join_windows(&elems), case.want, "Join({:?})", case.elems);
+        }
+    }
+
+    #[test]
+    fn windows_base_matches_the_go_vectors() {
+        for case in windows_vectors().base {
+            assert_eq!(
+                base_windows(&case.value),
+                case.want,
+                "Base({:?})",
+                case.value
+            );
+        }
+    }
+
+    #[test]
+    fn windows_volume_name_matches_the_go_vectors() {
+        for case in windows_vectors().volume_name {
+            assert_eq!(
+                volume_name_windows(&case.value),
+                case.want,
+                "VolumeName({:?})",
+                case.value
+            );
+        }
+    }
+
+    /// `filepath.Base` under the Unix rules. Its cases live in the *Windows*
+    /// vector file because `gopath_vectors.json` is frozen and may not gain an
+    /// array; the generator produces them from the host's real `path/filepath`,
+    /// which is the Unix build.
+    #[test]
+    fn unix_base_matches_the_go_vectors() {
+        for case in windows_vectors().unix_base {
+            assert_eq!(base_unix(&case.value), case.want, "Base({:?})", case.value);
+        }
+    }
+
+    #[test]
+    fn windows_is_abs_matches_the_go_vectors() {
+        for case in windows_vectors().is_abs {
+            assert_eq!(
+                is_abs_windows(&case.value),
+                case.want,
+                "IsAbs({:?})",
+                case.value
+            );
+        }
+    }
+
+    /// `POST /api/fs/mkdir`'s guard is `IsAbs`, and the two rule sets disagree
+    /// about every Windows path — including in the direction that matters, a
+    /// *rooted but drive-less* path that must still be refused.
+    #[test]
+    fn is_abs_is_the_mkdir_guard_on_both_platforms() {
+        assert!(is_abs_unix("/home/u/x"));
+        assert!(!is_abs_unix(r"C:\Users\u\x"));
+
+        assert!(is_abs_windows(r"C:\Users\u\x"));
+        assert!(is_abs_windows(r"\\host\share"));
+        // Rooted is not absolute: no drive, so `MkdirAll` would resolve it
+        // against the process's current drive.
+        assert!(!is_abs_windows(r"\Users\u"));
+        assert!(!is_abs_windows(r"c:a\b"));
+        assert!(!is_abs_windows("relative"));
+    }
+
+    /// The failure this whole issue is named for: the Unix rules applied to a
+    /// Windows path answer about the wrong directory rather than failing.
+    #[test]
+    fn the_unix_rules_are_wrong_about_a_windows_path() {
+        assert_eq!(dir_unix(r"C:\Users\u\.claude"), ".");
+        assert_eq!(dir_windows(r"C:\Users\u\.claude"), r"C:\Users\u");
+
+        assert_eq!(clean_unix(r"C:\a\b\..\c"), r"C:\a\b\..\c");
+        assert_eq!(clean_windows(r"C:\a\b\..\c"), r"C:\a\c");
+
+        // The config-dir probe's own case: a `configured` entry can only ever
+        // match its own suggestion if `join` builds the same separator.
+        assert_eq!(
+            join_unix(&[r"C:\Users\u", ".claude-work"]),
+            r"C:\Users\u/.claude-work"
+        );
+        assert_eq!(
+            join_windows(&[r"C:\Users\u", ".claude-work"]),
+            r"C:\Users\u\.claude-work"
+        );
+    }
+
+    /// The `lazybuf`'s laziness is behaviour, not an allocation trick:
+    /// `post_clean` returns early when the buffer was never allocated. An eager
+    /// buffer rewrites a path that needed no rewriting.
+    #[test]
+    fn post_clean_only_fires_when_the_output_diverged() {
+        // Already a Root Local Device path — the volume swallows the prefix and
+        // nothing is inserted.
+        assert_eq!(clean_windows(r"\??\c:\x"), r"\??\c:\x");
+        // Reached by cleaning, so it is rewritten.
+        assert_eq!(clean_windows(r"\a\..\??\c:\x"), r"\.\??\c:\x");
+        // The colon half of the same rule.
+        assert_eq!(clean_windows("a/../c:"), r".\c:");
+        assert_eq!(clean_windows("foo:bar"), "foo:bar");
+    }
+
+    /// Multi-byte elements survive the Windows byte loop too, and the volume
+    /// split never lands mid-character.
+    #[test]
+    fn windows_non_ascii_elements_round_trip() {
+        assert_eq!(
+            clean_windows(r"C:\Users\ü\Projekte\..\.claude"),
+            r"C:\Users\ü\.claude"
+        );
+        assert_eq!(join_windows(&[r"C:\Users\ü", "文档"]), r"C:\Users\ü\文档");
+        assert_eq!(base_windows(r"C:\Users\ü\文档"), "文档");
+    }
+
+    /// The dispatching functions answer their target's rules — the property
+    /// every un-gated caller in `native/` now relies on.
+    #[test]
+    fn the_public_functions_follow_the_target() {
+        #[cfg(windows)]
+        {
+            assert_eq!(dir(r"C:\Users\u\.claude"), r"C:\Users\u");
+            assert_eq!(join(&[r"C:\Users\u", ".claude"]), r"C:\Users\u\.claude");
+            assert_eq!(base(r"C:\a\b"), "b");
+            assert_eq!(clean("C:/a/b/../c"), r"C:\a\c");
+        }
+        #[cfg(not(windows))]
+        {
+            assert_eq!(dir("/home/u/.claude"), "/home/u");
+            assert_eq!(join(&["/home/u", ".claude"]), "/home/u/.claude");
+            assert_eq!(base("/a/b"), "b");
+            assert_eq!(clean("/a/b/../c"), "/a/c");
+        }
     }
 }

--- a/src-tauri/src/native/gopath.rs
+++ b/src-tauri/src/native/gopath.rs
@@ -781,14 +781,18 @@ mod tests {
 
     #[test]
     fn dir_matches_the_go_vectors() {
-        for case in vectors().dir {
+        let v = vectors().dir;
+        assert!(v.len() >= 20, "vectors look truncated");
+        for case in v {
             assert_eq!(dir_unix(&case.value), case.want, "Dir({:?})", case.value);
         }
     }
 
     #[test]
     fn join_matches_the_go_vectors() {
-        for case in vectors().join {
+        let v = vectors().join;
+        assert!(v.len() >= 12, "vectors look truncated");
+        for case in v {
             let elems: Vec<&str> = case.elems.iter().map(String::as_str).collect();
             assert_eq!(join_unix(&elems), case.want, "Join({:?})", case.elems);
         }
@@ -835,14 +839,18 @@ mod tests {
 
     #[test]
     fn windows_dir_matches_the_go_vectors() {
-        for case in windows_vectors().dir {
+        let v = windows_vectors().dir;
+        assert!(v.len() >= 20, "windows vectors look truncated");
+        for case in v {
             assert_eq!(dir_windows(&case.value), case.want, "Dir({:?})", case.value);
         }
     }
 
     #[test]
     fn windows_join_matches_the_go_vectors() {
-        for case in windows_vectors().join {
+        let v = windows_vectors().join;
+        assert!(v.len() >= 45, "windows vectors look truncated");
+        for case in v {
             let elems: Vec<&str> = case.elems.iter().map(String::as_str).collect();
             assert_eq!(join_windows(&elems), case.want, "Join({:?})", case.elems);
         }
@@ -850,7 +858,9 @@ mod tests {
 
     #[test]
     fn windows_base_matches_the_go_vectors() {
-        for case in windows_vectors().base {
+        let v = windows_vectors().base;
+        assert!(v.len() >= 15, "windows vectors look truncated");
+        for case in v {
             assert_eq!(
                 base_windows(&case.value),
                 case.want,
@@ -862,7 +872,9 @@ mod tests {
 
     #[test]
     fn windows_volume_name_matches_the_go_vectors() {
-        for case in windows_vectors().volume_name {
+        let v = windows_vectors().volume_name;
+        assert!(v.len() >= 15, "windows vectors look truncated");
+        for case in v {
             assert_eq!(
                 volume_name_windows(&case.value),
                 case.want,
@@ -878,14 +890,18 @@ mod tests {
     /// which is the Unix build.
     #[test]
     fn unix_base_matches_the_go_vectors() {
-        for case in windows_vectors().unix_base {
+        let v = windows_vectors().unix_base;
+        assert!(v.len() >= 10, "vectors look truncated");
+        for case in v {
             assert_eq!(base_unix(&case.value), case.want, "Base({:?})", case.value);
         }
     }
 
     #[test]
     fn windows_is_abs_matches_the_go_vectors() {
-        for case in windows_vectors().is_abs {
+        let v = windows_vectors().is_abs;
+        assert!(v.len() >= 20, "windows vectors look truncated");
+        for case in v {
             assert_eq!(
                 is_abs_windows(&case.value),
                 case.want,

--- a/src-tauri/src/native/sessions/detail.rs
+++ b/src-tauri/src/native/sessions/detail.rs
@@ -475,6 +475,11 @@ fn derive_preview(messages: &[SessionMessage]) -> String {
 
 /// `loadTodos`: `<config dir>/todos/<id>-agent-<id>.json`, absent or malformed
 /// reading as none.
+///
+/// **An OS path** (#374): the result is handed straight to `std::fs::read`, so
+/// `gopath::join` has to be the target's rules. `is_valid_session_id` is what
+/// keeps the interpolated id out of the path arithmetic, and it is unchanged —
+/// it already refuses every separator on both platforms.
 fn load_todos(config_dir: &str, session_id: &str) -> Vec<SessionTodo> {
     if !is_valid_session_id(session_id) {
         return Vec::new();

--- a/src-tauri/src/native/sessions/projects.rs
+++ b/src-tauri/src/native/sessions/projects.rs
@@ -93,9 +93,16 @@ pub fn list(db_path: &Path, include_hidden: bool) -> Result<Vec<ClaudeProject>, 
 
 /// `filepath.Base(filepath.Dir(filePath))` — the project directory's own name,
 /// which is the encoded form Claude Code writes.
+///
+/// **`file_path` is an OS path, not a corpus-canonical one** (#374). It is the
+/// transcript's real location on disk, so on Windows it is
+/// `C:\Users\u\.claude\projects\-C--Users-u-proj\<id>.jsonl` and both halves of
+/// this have to be the target's rules. It used to be `dir.rsplit('/')`, which
+/// on Windows finds no `/` at all and answers the *whole directory path* as the
+/// project's name — the identity every later lookup keys on. `gopath::base` is
+/// what the doc comment always claimed this was.
 fn encoded_name(file_path: &str) -> String {
-    let dir = gopath::dir(file_path);
-    dir.rsplit('/').next().unwrap_or(&dir).to_string()
+    gopath::base(&gopath::dir(file_path))
 }
 
 /// `include_hidden=true`, and nothing else. Go compares the raw value against
@@ -230,6 +237,29 @@ mod tests {
             encoded_name("/home/u/.claude/projects/-p/sess/subagents/agent-1.jsonl"),
             "subagents"
         );
+    }
+
+    /// The same rule under the Windows path rules (#374).
+    ///
+    /// `encoded_name` dispatches on the target, so on a Unix host the
+    /// composition is asserted through the Windows functions directly and the
+    /// call itself only on Windows — which is what the `windows_rules` CI job
+    /// is for. The third assertion is what the code did before: `rsplit('/')`
+    /// finds no separator in a Windows directory and answers the whole path, so
+    /// every project's identity would have been its own absolute path.
+    #[test]
+    fn the_encoded_name_is_the_directorys_own_name_under_the_windows_rules() {
+        let file = r"C:\Users\u\.claude\projects\-C--Users-u-Projects-agento\abc.jsonl";
+        let dir = gopath::dir_windows(file);
+        assert_eq!(
+            dir,
+            r"C:\Users\u\.claude\projects\-C--Users-u-Projects-agento"
+        );
+        assert_eq!(gopath::base_windows(&dir), "-C--Users-u-Projects-agento");
+        assert_eq!(dir.rsplit('/').next(), Some(dir.as_str()));
+
+        #[cfg(windows)]
+        assert_eq!(encoded_name(file), "-C--Users-u-Projects-agento");
     }
 
     /// Field order is the Go struct's declaration order, and `hidden` is always

--- a/src-tauri/src/native/settings.rs
+++ b/src-tauri/src/native/settings.rs
@@ -954,12 +954,11 @@ pub const ENDPOINT: super::Endpoint = super::Endpoint {
 /// removed it — one commit, one owner, no window in which two processes
 /// disagree about the row.
 ///
-/// `/api/settings/claude-config-dirs` is claimed on **every** platform but
-/// answered only on Unix: the probe is `filepath` arithmetic and
-/// `native/gopath.rs` implements the Unix rules, so on Windows [`serve`]
-/// answers 501 — the same decision `native/fs.rs` makes. Windows x86_64 is a
-/// shipped target (`.github/workflows/desktop-release.yml`) while desktop CI is
-/// ubuntu-only, so nothing else would catch it.
+/// `/api/settings/claude-config-dirs` is claimed and answered on **every**
+/// platform. It answered a 501 on Windows until #374, because the probe is
+/// `filepath` arithmetic and `native/gopath.rs` carried only the Unix rules;
+/// it now carries both, selected by target and pinned on every host by
+/// `parity/gopath_windows_vectors.json`.
 fn claims(method: &Method, path: &str) -> bool {
     match path {
         "/api/settings" => method == Method::GET || method == Method::PUT,
@@ -970,22 +969,13 @@ fn claims(method: &Method, path: &str) -> bool {
 
 fn serve(ctx: &super::Ctx, req: &super::Request) -> Result<super::Answer, String> {
     // The config-dir probe is `filepath` arithmetic on the real filesystem, and
-    // this port implements the **Unix** `filepath` (see `native/gopath.rs`,
-    // whose vectors are Unix-shaped). On Windows `gopath::dir` finds no `/` in
-    // `C:\Users\u\.claude` and answers `"."`, so the probe would list the
-    // process working directory instead of `$HOME`, and `gopath::join` would
-    // build `C:\Users\u/.claude-work`, which no `configured` entry can match —
-    // silently empty suggestions at best, an outright wrong list at worst.
-    // A 501 naming the gap is the honest answer since #278 removed the sidecar
-    // that used to take this — the same decision `native/fs.rs` makes.
-    // `GET /api/settings` is a plain row read and is deliberately still
-    // answered.
-    if !cfg!(unix) && req.path == "/api/settings/claude-config-dirs" {
-        return super::Answer::error(
-            axum::http::StatusCode::NOT_IMPLEMENTED,
-            "the Claude config-dir probe is not supported on Windows in this build",
-        );
-    }
+    // it answered a 501 on Windows until #374: this port carried only the Unix
+    // `filepath`, so `gopath::dir` found no `/` in `C:\Users\u\.claude` and
+    // answered `"."` — listing the process working directory instead of the
+    // home directory — while `gopath::join` built `C:\Users\u/.claude-work`,
+    // which no `configured` entry could ever match. Both are now the
+    // target's rules (`parity/gopath_windows_vectors.json` pins them), so the
+    // probe is answered everywhere and the gate is gone.
     if req.method == Method::PUT {
         return super::writes::finish(update(&ctx.db_path, req.body));
     }
@@ -1336,9 +1326,12 @@ mod tests {
     /// Both halves of the endpoint, against Go's own answers over a home
     /// directory built from the vectors.
     ///
-    /// `#[cfg(unix)]` for the same reason the vectors are Unix-shaped and
-    /// [`serve`] answers 501 on Windows: the layout needs a symlink, and the
-    /// rule is `filepath` arithmetic implemented for Unix only.
+    /// `#[cfg(unix)]` because the layout needs a **symlink**, which is one of
+    /// the four exclusions this pins (`os.ReadDir`'s `IsDir` does not follow
+    /// one) and which needs a privilege on Windows that a CI runner does not
+    /// have. The rule itself is no longer Unix-only — [`serve`] answers this
+    /// route everywhere since #374 — and the `filepath` arithmetic underneath
+    /// is pinned for both targets by `parity/gopath_windows_vectors.json`.
     #[test]
     #[cfg(unix)]
     fn the_candidate_probe_matches_gos_discovery_rule() {

--- a/src-tauri/src/native/settings.rs
+++ b/src-tauri/src/native/settings.rs
@@ -307,8 +307,13 @@ fn clean(p: &str) -> String {
 /// Absolute paths only. A relative config dir means two different things at
 /// once — Agento resolves it against the server's working directory, Claude
 /// Code against the subprocess's — so Go drops it and so does this.
+///
+/// `gopath::is_abs` rather than `Path::is_absolute` (#374): Go's test is
+/// `filepath.IsAbs`, and on Windows the two disagree on a Root Local Device
+/// path — `\??\C:\x` is absolute to `volumeNameLen` and has no prefix Rust
+/// recognises. On Unix they are the same function.
 pub(crate) fn absolute_dir(p: &str) -> Option<String> {
-    if p.is_empty() || !Path::new(p).is_absolute() {
+    if p.is_empty() || !super::gopath::is_abs(p) {
         return None;
     }
     Some(p.to_string())
@@ -764,7 +769,9 @@ fn validate_claude_config_dir(raw: &str) -> Result<(), WriteError> {
     if normalized.is_empty() {
         return Ok(());
     }
-    if !Path::new(&normalized).is_absolute() {
+    // `filepath.IsAbs`, the same one [`absolute_dir`] uses — not
+    // `Path::is_absolute`, which disagrees on a Windows device path.
+    if !super::gopath::is_abs(&normalized) {
         return Err(WriteError::BadRequest(format!(
             "claude config dir must be an absolute path, got {normalized:?}"
         )));

--- a/src-tauri/src/native/uploads.rs
+++ b/src-tauri/src/native/uploads.rs
@@ -112,6 +112,13 @@ fn upload(content_type: &str, body: &[u8], upload_dir: &Path) -> Result<super::A
     // Go's traversal guard. It cannot fire on a generated name, and it is
     // reproduced rather than reasoned away: it is the check that would catch a
     // later change to how the name is built.
+    //
+    // **An OS path** (#374): `upload_dir` is a real directory under the data
+    // dir, so `clean`/`join` are the target's rules and `MAIN_SEPARATOR` is the
+    // separator they emit. The two agree by construction on both platforms —
+    // which they did *not* before, when `clean` was Unix-only and would have
+    // produced `C:\…\uploads/name` against a `\` prefix, failing every upload
+    // on Windows with `invalid filename`.
     let prefix = format!(
         "{}{}",
         super::gopath::clean(&upload_dir.to_string_lossy()),
@@ -183,6 +190,16 @@ fn unix_millis() -> i64 {
 /// the caller's filename reaches the filesystem through this function and
 /// nothing else — a `..`, a separator, a second dot or a NUL all yield `""`
 /// rather than being cleaned, because the rule is an allowlist.
+///
+/// **Deliberately Unix-only, on both platforms** (#374). `go_base`/`go_ext`
+/// below treat only `/` as a separator, where a Windows build of the original
+/// would also split on `\`. That is left alone because the *answer* cannot
+/// differ: the allowlist runs over whatever the scan produced, and every string
+/// on which the two rules disagree contains a `\`, which the allowlist rejects
+/// — so both spellings yield `""`. Making it dispatch would widen a security
+/// boundary for no observable gain. The `filepath` this reaches is a caller's
+/// **filename**, not a path on this machine, which is the distinction the four
+/// audited `gopath::` call sites turn on.
 fn sanitize_extension(filename: &str) -> String {
     let ext = go_ext(&go_base(filename));
     // `cleaned` is the extension without its dot, and an **empty** one passes:

--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -8,8 +8,19 @@
 
 use std::path::PathBuf;
 
-/// The user's home directory, by the same variables Go's `os.UserHomeDir`
-/// consults.
+/// The user's home directory.
+///
+/// **Not `os.UserHomeDir`, and the difference only shows on Windows** — this
+/// comment claimed it was until #374 un-gated the three surfaces that reach it.
+/// Go switches on `GOOS` and reads `$HOME` on Unix and `%USERPROFILE%` on
+/// Windows, *never both*; this is a fallback chain, so a Windows shell that
+/// exports `HOME` (MSYS2, Git Bash) wins over `USERPROFILE` and Agento then
+/// resolves a different home than the Claude Code CLI does.
+///
+/// Left as a chain deliberately rather than fixed here: [`data_dir`] is built
+/// on this, so switching the precedence relocates the database of any Windows
+/// install that has `HOME` set. That is a migration, not a path fix, and it is
+/// out of scope for #374.
 pub fn home() -> Option<PathBuf> {
     std::env::var_os("HOME")
         .or_else(|| std::env::var_os("USERPROFILE"))

--- a/src/components/DirField.tsx
+++ b/src/components/DirField.tsx
@@ -13,7 +13,8 @@ import type { FSEntry } from "../lib/types";
  * `pickDirectory` is the OS's own dialog and is what a desktop app should
  * offer — it browses the real filesystem, honours symlinks and bookmarks, and
  * costs no round trip. `DirBrowser` is an in-app listing over `GET /api/fs`,
- * which is Unix-only and cannot see outside what the backend will list.
+ * which cannot see outside what the backend will list. (It was Unix-only until
+ * #374; `GET /api/fs` is answered on Windows too now.)
  *
  * The native one is tried first and the in-app one is the fallback, and the
  * fallback is not only for `npm run dev` in a browser tab: the dialog plugin is


### PR DESCRIPTION
Closes #374

## What

`native/gopath.rs` implemented only the **Unix** `path/filepath` rules, so three
surfaces answered **501 on Windows** — a shipped release target — and four more
call sites ran Unix path arithmetic there with no gate at all.

This ports Go's Windows `filepath` (`Clean`, `Dir`, `Join`, `Base`, `IsAbs`,
`VolumeName`), pins it with vectors generated from Go, un-gates the three
surfaces, and audits the four un-gated callers.

## How

- **Both rule sets, selected by target.** `clean_unix`/`clean_windows` (etc.)
  are both compiled and both vector-tested **on every host**; only five
  one-line `clean`/`dir`/`join`/`base`/`is_abs` dispatchers are `cfg(windows)`.
  A Linux CI run therefore catches a Windows regression. The Unix arms are
  byte-for-byte what they were and `gopath_vectors.json` is untouched.
- **The Windows half is transcribed from Go's own source**, branch for branch:
  `internal/filepathlite/path.go` (the `lazybuf`, `Clean`, `Base`, `Dir`,
  `VolumeName`), `internal/filepathlite/path_windows.go` (`volumeNameLen`,
  `postClean`, `pathHasPrefixFold`, `uncLen`) and
  `path/filepath/path_windows.go` (`Join`). The `lazybuf`'s laziness is
  **load-bearing, not an allocation trick** — `postClean` returns early when the
  buffer was never allocated, so an eager buffer turns `Clean(\??\a)` into
  `\.\??\a`.
- **`parity/gopath_windows_vectors.json`** (**248** cases: clean 80, join 59,
  dir 26, is_abs 26, volume_name 22, base 21, unix_base 14) is produced by
  `parity/generators/gopath_windows_vectors.go`, which **vendors** Go's Windows
  source rather than re-implementing it — the #268 lesson that a generator
  sharing the port's belief agrees with a wrong port. Inputs are Go's own
  `path_test.go` tables (`cleantests`+`wincleantests`, `basetests`+`winbasetests`,
  `dirtests`+`windirtests`, `jointests`+`winjointests`,
  `isabstests`+`winisabstests`) plus the paths Agento's Windows surfaces build.
  The vendored code reproduces every expectation in those tables exactly.
- **Un-gated:** `fs.rs::serve`, `claude_settings/mod.rs::serve`,
  `settings.rs::serve` (the `claude-config-dirs` arm). Module headers updated.
- **`filepath.IsAbs` is new and it is a real guard**, not tidiness. On Windows
  **rooted is not absolute**: `\Users\u` names no drive, so `MkdirAll` would
  resolve it against whatever drive the process is on. All four sites that
  tested "is this absolute" now use it — `fs::mkdir`,
  `profiles::validate_path_within_dir`, `settings::absolute_dir` and
  `settings::validate_claude_config_dir`. On Unix it is
  `strings.HasPrefix(path, "/")`, so nothing there moves.

### The four un-gated callers, per site

| site | verdict |
| --- | --- |
| `agents.rs::normalize_claude_config_dir` | OS path — dispatching `join`/`clean`, correct by construction |
| `uploads.rs` destination + traversal guard | OS path — `clean` and `MAIN_SEPARATOR` now agree; before, every Windows upload would have failed `invalid filename` |
| `sessions/detail.rs::load_todos` | OS path — handed to `std::fs::read` |
| `sessions/projects.rs::encoded_name` | **the real bug** — `rsplit('/')` finds no separator in a Windows directory and answered the *whole path* as the project's identity. Now `gopath::base(&gopath::dir(..))`, which is what its doc comment always claimed |

`uploads.rs::sanitize_extension` is recorded as **deliberately Unix-only on both
platforms**: it splits a caller's *filename*, not a path on this machine, and
every string on which the two rules disagree contains a `\`, which the
alphanumeric allowlist already rejects — so both spellings answer `""`.

### The file-mode decision (the `cfg` hole)

`claude_settings::write_file`/`mkdir_all` set `0600`/`0700` under `#[cfg(unix)]`
and nothing under Windows. Resolved as a **documented decision rather than an
ACL**: Go's own `syscall.Open` on Windows maps `perm` onto the read-only
attribute alone and `syscall.Mkdir` ignores it outright, so Go there also
inherits the parent's ACL. Building a DACL through `SetSecurityInfo` would need
a `windows-sys` surface this crate does not use, would diverge from what the
file's other writer (Claude Code) does, and has nothing to pin it. The note
states the limit honestly — the file is only as tight as wherever
`CLAUDE_CONFIG_DIR` points — and it is on `CLAUDE.md`'s *Known gaps*.

## Tests

- `gopath.rs`: 23 unit tests, every vector loop with a truncation floor, and
  three that fail on a revert — `the_unix_rules_are_wrong_about_a_windows_path`,
  `post_clean_only_fires_when_the_output_diverged`,
  `is_abs_is_the_mkdir_guard_on_both_platforms`.
- `sessions/projects.rs`: `the_encoded_name_is_the_directorys_own_name_under_the_windows_rules`
  — asserts the composition through the Windows functions on any host, and
  `encoded_name` itself only on Windows. **Reverting `encoded_name` fails only
  on the `windows_rules` job**, which is honest: Unix behaviour is unchanged by
  design (the two spellings differ only for a transcript at the filesystem root,
  which cannot occur).
- `claude_settings/profiles.rs`: `a_windows_path_outside_the_dir_is_refused`
  (`#[cfg(windows)]`).
- Full suite: **1428 lib tests + 17 binaries, all green**; `cargo fmt --check`,
  `cargo clippy --all-targets -D warnings`, `npm run build` green.

## CI — the `windows_rules` job, and what it deliberately does not run

New job on `windows-latest`, with `core.autocrlf=false` before checkout so the
byte-exact goldens and `notifications/email.html` are not rewritten by the
runner's default.

- **`cargo clippy --lib -- -D warnings` is unfiltered**, and it is the broad
  half: it type-checks and lints *every* line of the library for this target,
  which is the only thing that can catch a `cfg(windows)` arm that does not
  compile. A Linux `clippy --all-targets` never sees those arms.
- **`cargo test --lib` is filtered** to `native::gopath`,
  `native::sessions::projects` and the profiles Windows guard.

That filter is a **measured** limitation, not an assumed one — the unfiltered
`cargo test --lib` was run on this runner twice:

| run | `core.autocrlf` | result |
| --- | --- | --- |
| [33075565936](https://github.com/shaharia-lab/agento/actions/runs/33075565936) | `true` (runner default) | 1388 / 1422 |
| [33078904617](https://github.com/shaharia-lab/agento/actions/runs/33078904617) | `false` | **1394 / 1422** |

Six of the original 34 were **pure CRLF** against the byte-exact goldens
(`analytics`, `pricing`, `notifications::template`, `sessions::{detail,journey,search}`)
and are fixed rather than excluded. Of the 28 that remain:

- **27 are Unix-shaped fixtures**, not defects — `native::settings::tests` (10),
  `native::claude_settings` (9), `native::fs::tests` (5),
  `native::scanner::walk` (2), `native::uploads::tests` (1).
  `absolute_dir("/var/lib/claude")` is correctly `None` on Windows,
  `validate_path_within_dir("/h/.claude/x", "/h/.claude")` is correctly refused,
  `EnvVar::set("HOME", "/home//u/")` correctly cleans to `\home\u`.
- **The 28th is not a path fixture at all**:
  `integrations::telegram::client::tests::a_body_that_dies_mid_stream_still_names_nothing_secret`
  fails with *"must fail in the body stream, not the send"* — a stream-timing
  difference, pre-existing and newly visible. It needs its own look and is
  recorded in `CLAUDE.md`.

Porting those fixtures is general Windows support, which #374 lists under
*Risks* as the scope creep to avoid, and its own acceptance criterion allows
recording the reason instead. `CLAUDE.md`'s *Known gaps* names this as the work
that has to land before the filter can be widened.

**The filter is floored at 25 tests.** `cargo test` treats "the filter matched
nothing" as **success**, so an allowlist with no floor leaves the only job that
runs these rules on Windows green with zero assertions executed on a rename —
the same shape as a vector loop with no truncation floor. Denylisting was the
alternative and is worse here: it would have to name ~28 individual fixtures,
each stale entry invisible in turn.

The integration suites under `src-tauri/tests/` are a harder case and `--lib`
excludes them: `chat_turn.rs`, `claude_sdk.rs` and `scheduled_run.rs` drive a
fake Claude CLI that is a shebang'd Python script made executable through
`std::os::unix::fs::PermissionsExt`, so they do not compile on Windows at all.

## Not done, deliberately

- A **manual Windows smoke pass**. There is no Windows machine in this loop;
  the `windows_rules` job and the vectors stand in for it.
- **`paths::home()`'s `HOME`-before-`USERPROFILE` precedence.** Go's
  `os.UserHomeDir` reads one *or* the other, so a Windows shell exporting `HOME`
  (MSYS2, Git Bash) makes Agento resolve a different home than the Claude Code
  CLI — newly reachable now the three surfaces are un-gated. `data_dir` is built
  on the same function, so changing it relocates the database of any Windows
  install with `HOME` set: that is a migration, not a path fix. Recorded at the
  site with the reasoning; worth its own issue.

## Follow-ups **not** opened as issues

This PR is produced by an unattended job that is authorised to implement one
board-`Ready` issue and nothing else; opening new issues is the maintainer's
call. Two are worth one:

1. **`paths::home()`'s `HOME`-before-`USERPROFILE` precedence** (above).
2. **`a_body_that_dies_mid_stream_still_names_nothing_secret` on Windows** — a
   stream-timing difference in the telegram client test, pre-existing and made
   visible by the new runner.
