### PR TITLE
feat: read mcps.yaml in the native chat runner, and stop its mere presence refusing turns (#375)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,8 +294,12 @@ src-tauri/src/
     chat/        the SSE turn and the three routes that steer it (#276)
       live.rs    the process-local live-session registry — why the four move together
       runner.rs  an agent's config as SDK options; starts the local tools
-                 server (#310) and one per github integration (#311), and
-                 refuses only what it still cannot supply
+                 server (#310) and one per github integration (#311), passes
+                 an mcps.yaml server through (#375), and refuses only a name
+                 that resolves to neither
+      mcps_yaml.rs `<data dir>/mcps.yaml` — LoadMCPRegistry, the three
+                 transports and the `${ENV:…}` substitution (#375). The one
+                 YAML this app reads and the only caller of `serde_norway`
       turn.rs    spawn, stream, and the AskUserQuestion continuation
       persist.rs what a finished turn writes, and what an interrupted one does not
       sse.rs     the frame bytes: raw pass-through vs the two synthetic events
@@ -2160,20 +2164,42 @@ means a model mid-`create_issue` when the user hits Save is the ordinary case.
 `a_tool_call_in_flight_survives_the_handles_drop` pins it, and it fails with the
 two lines swapped.
 
-**What the runner still refuses.** `chat/runner.rs::build_options` serves an
-agent whose `capabilities.mcp` names hosted integrations, starting one filtered
-server per name and handing the handles to the turn beside the local-tools one.
-Three things it cannot serve, and each is a *refusal* rather than a fallback —
-a chat reports it, and a scheduled run records a failed `job_history` row: a
-name whose row is a type this build does not host (i.e. `whatsapp`), a name
-with **no** integration row at all, and — broader than it strictly needs to be
-— *any* `mcp` capability when `<data dir>/mcps.yaml` exists, because the
-original resolution order consults that file **before** the integrations and
-this build reads none. The server is registered under the **bare integration id**,
-not `github::server_name`'s `github-<id>`: the latter is `mcp.NewServer`'s
-implementation name and never appears on a tool, while the id is the
-`mcpServers` key and so the prefix on every qualified name already in an agent's
+**How the runner resolves an MCP name, and the one thing it still refuses**
+(#375). `chat/runner.rs::mcp_plan` walks `capabilities.mcp` in
+`resolveServerConfig`'s order: **the `mcps.yaml` registry first**
+(`native/chat/mcps_yaml.rs`), then the integrations. A registry hit is an
+*external* server — somebody else's subprocess or URL, handed to the CLI in
+`--mcp-config` with nothing bound here; an integration is a filtered in-process
+server started per turn. Either is registered under **the name the agent
+wrote** — the bare integration id, not `github::server_name`'s `github-<id>`:
+the latter is `mcp.NewServer`'s implementation name and never appears on a tool,
+while the key is the prefix on every qualified name already in an agent's
 allowlist.
+
+The order is Go's and it decides a real case: **a name in both is the yaml
+entry**, so a user who shadows an integration id in their own file gets their
+own server. One shape is refused, and it is a *refusal* rather than a fallback —
+a chat reports it, a scheduled run records a failed `job_history` row: **a name
+in neither**, which `whatsapp` reaches by construction since the type is dropped
+(#273). A malformed or unreadable `mcps.yaml` refuses too, rather than reading
+as "no external servers" and silently dropping a tool set.
+
+**What #375 removed is the check that was broader than it needed to be:** the
+mere *presence* of `<data dir>/mcps.yaml` used to refuse every `mcp` capability,
+including names that resolved perfectly to hosted integrations. It was guarding
+against a name resolving differently in the Go server than here — a hazard that
+needed both to exist, and #391 deleted the Go tree. Until it went, one leftover
+file (the normal state for anyone who ever ran `agento web` against the same
+data directory) disabled every MCP-backed agent on the machine.
+
+Two ordering rules keep that fix from being undone by accident. `mcp_plan` takes
+the registry's **path**, not a loaded registry, and loads it only after
+establishing that the agent names at least one MCP server — so a typo in the
+file cannot refuse a turn that never consults it. And the database is opened
+only for a name the registry did not answer, so an all-external agent reads no
+`integrations` rows at all. `MCPS_FILE` overrides the path, which is the only
+way to point a test at a fixture: a debug build's `paths::data_dir` ignores the
+environment by design.
 
 **Reading a credential is this module's job and nobody else's.** The rule in
 `native/integrations.rs` — `credentials` is never selected, `auth` collapses to
@@ -2992,7 +3018,9 @@ database".
 `Err` and let Go answer" is not available, because there is no request. So every
 path ends in a `job_history` row. That includes the one case Go has no
 equivalent for: `chat/runner.rs::build_options` can still refuse an agent whose
-tools this build cannot host (a name in `mcps.yaml`, or a `whatsapp` row), and
+tools this build cannot supply (a `capabilities.mcp` name that neither
+`mcps.yaml` nor a hostable integration resolves — a `whatsapp` row reaches that
+by construction — or one whose `mcps.yaml` could not be read), and
 where a chat forwards, a scheduled run records a **failed** row reading
 `agent tools unavailable in this build: …` and publishes the failed event.
 Silence is the one outcome that is not allowed, because a job history with no row

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2202,18 +2202,41 @@ unprefixed `MCPS_FILE` honoured behind it, because #375's acceptance criteria
 named that spelling), which is the only way to point a test at a fixture: a
 debug build's `paths::data_dir` ignores the environment by design.
 
-Three things in `mcps_yaml.rs` were **measured against `gopkg.in/yaml.v3`**
-rather than inferred from the JSON side, and each is wrong in a way nothing
-would report. A null *sequence element* is **dropped** where a null *map value*
-is `""` — so `args` is not a `GoList`, because `["--f", ~]` is
-`docs-mcp --f` and not `docs-mcp --f ""`. Merge keys (`<<: *anchor`) are
-expanded by `yaml.v3` during decode and need `Value::apply_merge` here, or a
-perfectly valid file refuses every MCP-backed agent with *"unknown transport"*.
-And **no decode failure quotes what it was decoding**: this file holds `Bearer`
-tokens and a refusal's text reaches a chat body, `job_history.error_message` and
-the exported log, so a syntax error reports its position and a shape error
-reports the server name — `native/integrations/registry.rs`'s rule, same
-reasoning.
+**Four things in `mcps_yaml.rs` were measured against `gopkg.in/yaml.v3` v3.0.1
+rather than inferred from the JSON side**, and each is wrong in a way nothing
+would report. Measure before changing any of them; the JSON intuition is wrong
+about three.
+
+- **Any scalar is a string.** `d.scalar` fills a `string` field from the node's
+  own text whatever it resolved to, so `env: {PORT: 8080}`, `command: 123` and
+  `DEBUG: true` all decode. `serde` type-checks and rejects them — which is
+  *Part A's regression re-entered through the parser*, because `mcp_plan` loads
+  the registry for **any** agent naming any MCP server, so one unquoted port
+  number would refuse every MCP-backed agent on the machine including ones with
+  no entry in the file. `YamlString` is the visitor that accepts them.
+- **A null *sequence element* is dropped where a null *map value* is `""`.** So
+  `args` is deliberately **not** a `GoList`: `["--f", ~]` is `docs-mcp --f`, not
+  `docs-mcp --f ""`. `env`/`headers` keep `GoMap`, which is right for maps.
+- **Merge keys (`<<: *anchor`) are expanded during decode** and need
+  `Value::apply_merge` here, or a perfectly valid file refuses every MCP-backed
+  agent with *"unknown transport"*.
+- **A duplicate server name is an error in Go and last-one-wins here** — the one
+  divergence left standing, as [#499](https://github.com/shaharia-lab/agento/issues/499),
+  because no `serde_yaml` fork exposes a flag for it.
+
+Two rules about what a failure here may *say*, both because this file holds
+credentials and a refusal's text reaches a chat body, `job_history.error_message`
+and the exported app log. **No decode failure quotes what it was decoding**: a
+syntax error reports its position and a shape error reports the server name —
+`native/integrations/registry.rs`'s rule, same reasoning. And **`McpSource`'s
+`Debug` is hand-written to withhold an external config**, because `${ENV:…}` is
+resolved at load, so the plan holds the live token the *file never contained*;
+`McpPlan` is formatted in every panic message in that module.
+
+The accepted cost of `apply_merge` is that a scalar is resolved before any field
+reads it, so a spelling that does not survive a `Value` round trip does not
+survive here: `1.50` is `"1.5"` and `0x10` is `"16"` where Go keeps the raw text.
+Integers, booleans and strings are exact. Pinned, not reconciled.
 
 **Reading a credential is this module's job and nobody else's.** The rule in
 `native/integrations.rs` — `credentials` is never selected, `auth` collapses to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2197,9 +2197,23 @@ the registry's **path**, not a loaded registry, and loads it only after
 establishing that the agent names at least one MCP server — so a typo in the
 file cannot refuse a turn that never consults it. And the database is opened
 only for a name the registry did not answer, so an all-external agent reads no
-`integrations` rows at all. `MCPS_FILE` overrides the path, which is the only
-way to point a test at a fixture: a debug build's `paths::data_dir` ignores the
-environment by design.
+`integrations` rows at all. `AGENTO_MCPS_FILE` overrides the path (with the
+unprefixed `MCPS_FILE` honoured behind it, because #375's acceptance criteria
+named that spelling), which is the only way to point a test at a fixture: a
+debug build's `paths::data_dir` ignores the environment by design.
+
+Three things in `mcps_yaml.rs` were **measured against `gopkg.in/yaml.v3`**
+rather than inferred from the JSON side, and each is wrong in a way nothing
+would report. A null *sequence element* is **dropped** where a null *map value*
+is `""` — so `args` is not a `GoList`, because `["--f", ~]` is
+`docs-mcp --f` and not `docs-mcp --f ""`. Merge keys (`<<: *anchor`) are
+expanded by `yaml.v3` during decode and need `Value::apply_merge` here, or a
+perfectly valid file refuses every MCP-backed agent with *"unknown transport"*.
+And **no decode failure quotes what it was decoding**: this file holds `Bearer`
+tokens and a refusal's text reaches a chat body, `job_history.error_message` and
+the exported log, so a syntax error reports its position and a shape error
+reports the server name — `native/integrations/registry.rs`'s rule, same
+reasoning.
 
 **Reading a credential is this module's job and nobody else's.** The rule in
 `native/integrations.rs` — `credentials` is never selected, `auth` collapses to

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -213,11 +213,13 @@ Three things worth knowing before you write one:
   put things there you would run yourself.
 - **A name in this file wins over an integration with the same id**, so you can
   deliberately point an agent at your own server instead of the built-in one.
-- **A broken file stops the agents that use it**, on purpose. An unknown
-  `transport`, YAML that will not parse, or a `${ENV:…}` variable that is unset
-  or empty makes a chat with one of those agents answer an error naming the
-  problem, rather than quietly running without the tools it asked for. An
-  *empty* or absent file is fine and affects nothing.
+- **A broken file stops every agent that names any MCP server** — not only the
+  ones with an entry in it — because the file is read whenever an agent's tools
+  have to be resolved. An unknown `transport`, YAML that will not parse, or a
+  `${ENV:…}` variable that is unset or empty makes those chats answer an error
+  naming the problem, rather than quietly running without the tools they asked
+  for. Agents that name no MCP server are unaffected, and so is an *empty* or
+  absent file.
 
 ### Template variables
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -187,7 +187,7 @@ There is no screen for this one. If a file called `mcps.yaml` exists in Agento's
 data directory (`~/.agento`, or `~/.agento-desktop-dev` for a development
 build), Agento reads it and any server it names can be used by an agent — under
 whatever name you gave it, which is also the name you put in that agent's
-`capabilities.mcp`. Set `MCPS_FILE` to read it from somewhere else.
+`capabilities.mcp`. Set `AGENTO_MCPS_FILE` to read it from somewhere else.
 
 ```yaml
 docs-mcp:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -181,6 +181,44 @@ Tools are an allowlist. An agent can use only what you tick.
 - **Integration tools**: individual tools from the integrations you have
   connected, for example "send a Slack message" or "create a GitHub issue".
 
+### External MCP servers (`mcps.yaml`)
+
+There is no screen for this one. If a file called `mcps.yaml` exists in Agento's
+data directory (`~/.agento`, or `~/.agento-desktop-dev` for a development
+build), Agento reads it and any server it names can be used by an agent — under
+whatever name you gave it, which is also the name you put in that agent's
+`capabilities.mcp`. Set `MCPS_FILE` to read it from somewhere else.
+
+```yaml
+docs-mcp:
+  transport: stdio            # or: streamable_http, sse
+  command: /usr/local/bin/docs-mcp
+  args: ["--root", "/srv/docs"]
+  env:
+    API_TOKEN: "${ENV:DOCS_TOKEN}"   # taken from Agento's own environment
+
+weather:
+  transport: streamable_http
+  url: https://weather.example/mcp
+  headers:
+    Authorization: "Bearer ${ENV:WEATHER_TOKEN}"
+```
+
+Three things worth knowing before you write one:
+
+- **A server here is a program Agento does not control.** A `stdio` entry is a
+  command the Claude Code CLI launches with your user account and your
+  environment; an `http`/`sse` entry is a URL it calls. Agento passes the entry
+  along and nothing more — it does not sandbox, supervise or restart it. Only
+  put things there you would run yourself.
+- **A name in this file wins over an integration with the same id**, so you can
+  deliberately point an agent at your own server instead of the built-in one.
+- **A broken file stops the agents that use it**, on purpose. An unknown
+  `transport`, YAML that will not parse, or a `${ENV:…}` variable that is unset
+  or empty makes a chat with one of those agents answer an error naming the
+  problem, rather than quietly running without the tools it asked for. An
+  *empty* or absent file is fine and affects nothing.
+
 ### Template variables
 
 System prompts support `{{current_date}}` and `{{current_time}}`, filled in at the

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -36,6 +36,7 @@ dependencies = [
  "schemars 1.2.2",
  "serde",
  "serde_json",
+ "serde_norway",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -4039,6 +4040,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_norway"
+version = "0.9.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml-norway",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5382,6 +5396,12 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
 
 [[package]]
 name = "untrusted"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,6 +41,22 @@ serde = { version = "1", features = ["derive"] }
 # numbers (`{"z":1.50,"a":1}` → `{"a":1,"z":1.5}`), so the value is carried as a
 # `RawValue` and written back as a raw fragment.
 serde_json = { version = "1", features = ["float_roundtrip", "raw_value"] }
+# `<data dir>/mcps.yaml` is the one YAML this app reads (#375) — a
+# hand-authored registry of external MCP servers, ported from Go's
+# `gopkg.in/yaml.v3`. One module (`native/chat/mcps_yaml.rs`) is the only
+# caller and there must not be a second.
+#
+# **`serde_norway` rather than the obvious `serde_yaml`, which its author
+# archived**, and rather than the two other live forks. All three are the same
+# dtolnay code; the difference is who is behind them. `serde_yml` has the most
+# downloads and is rejected anyway: its maintainer relicensed and bulk-published
+# generated churn over the fork, which is precisely the supply-chain shape a
+# shipped desktop app should not take on. `serde_yaml_ng` is credible but MIT
+# only and last published May 2024; `serde_norway` is dual MIT/Apache-2.0 like
+# the rest of this tree, was published more recently (Dec 2024), carries its own
+# maintained `unsafe-libyaml-norway` parser rather than depending on the
+# archived one, and is what the Nix/Zellij ecosystem settled on.
+serde_norway = "0.9"
 log = "0.4"
 
 # Local reverse proxy in front of the Go sidecar. No TLS backend: every hop is

--- a/src-tauri/src/native/chat/mcps_yaml.rs
+++ b/src-tauri/src/native/chat/mcps_yaml.rs
@@ -37,17 +37,45 @@
 //! one answer, or a typo in a YAML file silently removes every external server
 //! an agent depends on.
 //!
-//! # `null` is the zero value here too
+//! # `null` is the zero value — except inside a sequence, where it is not
 //!
-//! `yaml.v3` decodes a null into the zero value for every type in this struct,
-//! exactly as `encoding/json` does — and a YAML key written with nothing under
-//! it (`env:`, `args:`) **is** a null, which is a far more ordinary thing to
-//! type than a literal `null` in JSON ever was. So the same rule
-//! [`crate::native::gojson::GoList`] / [`crate::native::gojson::GoMap`] carry
-//! for the JSON side is applied here, one level down as well as at the field:
-//! `args:` with nothing under it is an empty list, and `env: {A: }` is
-//! `A: ""`. Bare `Option` covers the field; the two wrapper types cover the
-//! elements.
+//! A YAML key written with nothing under it (`env:`, `args:`) **is** a null,
+//! which is a far more ordinary thing to type than a literal `null` in JSON ever
+//! was, so this file needs the rule [`crate::native::gojson::GoMap`] carries for
+//! the JSON side. But `yaml.v3` and `encoding/json` **disagree one level down**,
+//! and only measuring says which way:
+//!
+//! | | `env: {A: }` | `args: ["--f", ~]` |
+//! |---|---|---|
+//! | `encoding/json` / `GoList` | `A: ""` | `["--f", ""]` |
+//! | `yaml.v3` | `A: ""` | **`["--f"]`** |
+//!
+//! `d.sequence` only appends an element when `d.unmarshal` reports it decoded
+//! something, and a null reports nothing — so the element is **dropped**, not
+//! zero-filled. That is `args`, i.e. an external server's argv: getting it wrong
+//! spawns `docs-mcp --f ""` where Go spawned `docs-mcp --f`. So `env` and
+//! `headers` use `GoMap` and `args` deliberately does not use `GoList`.
+//!
+//! # Merge keys are resolved, because `yaml.v3` resolves them
+//!
+//! `<<: *defaults` is the natural way to share an `env` block across several
+//! entries, and `yaml.v3` expands it during decode. `serde_norway` has to be
+//! asked ([`serde_norway::Value::apply_merge`]) and otherwise treats `<<` as an
+//! unknown key — which would leave `transport` empty and refuse the turn with
+//! *"unknown transport"* over a file that is perfectly valid. That is the same
+//! user-visible failure Part A of #375 removed, so it is not a nicety.
+//!
+//! # No decode failure quotes what it was decoding
+//!
+//! `mcps.yaml` holds credentials — a `Bearer` token under `headers` is the
+//! ordinary case — and a refusal's text becomes a chat 500 body, a stored
+//! `job_history.error_message` and a line in the exported app log. So a serde
+//! message never reaches any of them: a syntax error reports its **location**
+//! and a shape error reports the **server name**, which is what a reader
+//! searches the file for anyway. `native/integrations/registry.rs` established
+//! this rule for integration credentials and the reasoning is identical. (Go's
+//! own message truncates the value to eight characters; dropping it entirely is
+//! strictly safer and loses nothing a line number does not supply.)
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -55,7 +83,7 @@ use std::path::{Path, PathBuf};
 use serde::Deserialize;
 
 use crate::claude::options::{McpHttpServer, McpSseServer, McpStdioServer};
-use crate::native::gojson::{GoList, GoMap};
+use crate::native::gojson::GoMap;
 
 /// How many `${ENV:…}` substitutions one value may take before the expansion is
 /// declared circular.
@@ -74,16 +102,30 @@ const MAX_SUBSTITUTIONS: usize = 1000;
 ///
 /// `AppConfig.MCPsFile()` is `<data dir>/mcps.yaml` and `cmd/web.go` passed it
 /// with no override — the `--mcps-file` flag existed only on `agento ask`. The
-/// `MCPS_FILE` variable is this build's equivalent of that flag: the same lever
+/// override here is this build's equivalent of that flag: the same lever
 /// `AGENTO_CLAUDE_EXECUTABLE` is for the CLI binary, and the only way to point a
 /// test at a fixture without writing into the developer's real data directory
 /// (a debug build's [`crate::paths::data_dir`] ignores the environment by
 /// design).
+///
+/// **Two spellings, and the prefixed one is the real name.** Every variable
+/// Agento *invents* is `AGENTO_`-prefixed — `AGENTO_DATA_DIR`,
+/// `AGENTO_CLAUDE_EXECUTABLE`, `AGENTO_PUBLIC_URL`; the unprefixed ones it reads
+/// (`CLAUDE_CONFIG_DIR`, `TZ`) are somebody else's. A bare `MCPS_FILE` would be
+/// a new claim on an unqualified name in every user's environment, so
+/// `AGENTO_MCPS_FILE` wins. `MCPS_FILE` is honoured behind it because #375's
+/// acceptance criteria name it and this file's documentation shipped with it;
+/// dropping it would be a change to a published lever rather than a rename
+/// before anyone could depend on it.
 pub fn path() -> Option<PathBuf> {
-    match std::env::var("MCPS_FILE") {
-        Ok(file) if !file.is_empty() => Some(PathBuf::from(file)),
-        _ => crate::paths::data_dir().map(|dir| dir.join("mcps.yaml")),
+    for name in ["AGENTO_MCPS_FILE", "MCPS_FILE"] {
+        if let Ok(file) = std::env::var(name) {
+            if !file.is_empty() {
+                return Some(PathBuf::from(file));
+            }
+        }
     }
+    crate::paths::data_dir().map(|dir| dir.join("mcps.yaml"))
 }
 
 /// One entry as it is written in the file, before the transport decides which
@@ -98,8 +140,11 @@ struct RawEntry {
     transport: Option<String>,
     #[serde(default)]
     command: Option<String>,
+    /// `Vec<Option<_>>` and **not** `GoList`: a null element is *dropped* by
+    /// `yaml.v3`, where `GoList` would zero-fill it. See the module header —
+    /// this is argv, so the difference is an extra empty argument.
     #[serde(default)]
-    args: Option<GoList<String>>,
+    args: Option<Vec<Option<String>>>,
     #[serde(default)]
     env: Option<GoMap<String>>,
     #[serde(default)]
@@ -161,20 +206,62 @@ pub fn load(path: Option<&Path>) -> Result<Registry, String> {
 /// `LoadMCPRegistry` unwrapped, naming the server rather than the file, because
 /// the server name is what a reader searches the file for.
 fn parse(label: &str, data: &str) -> Result<Registry, String> {
-    // `Option` around the map, not just around each entry: an **empty** file is
-    // a YAML null, and so is one holding nothing but `---` or a comment. Go's
-    // `yaml.Unmarshal` leaves the destination map nil for all three and returns
-    // no error, and an empty `mcps.yaml` left behind by an earlier experiment is
-    // exactly the kind of file this issue exists to stop breaking turns.
-    let raw: Option<BTreeMap<String, RawEntry>> =
-        serde_norway::from_str(data).map_err(|e| format!("parsing MCP registry {label:?}: {e}"))?;
+    let mut root: serde_norway::Value =
+        serde_norway::from_str(data).map_err(|e| syntax_error(label, &e))?;
+
+    // An **empty** file is a YAML null, and so is one holding nothing but `---`
+    // or a comment. Go's `yaml.Unmarshal` leaves the destination map nil for all
+    // three and returns no error, and an empty `mcps.yaml` left behind by an
+    // earlier experiment is exactly the kind of file #375 exists to stop
+    // breaking turns.
+    if root.is_null() {
+        return Ok(Registry::default());
+    }
+    // `yaml.v3` expands `<<: *anchor` during decode; this has to be asked. The
+    // anchor's own entry stays in the map and is a server like any other, which
+    // is also what Go does with it.
+    root.apply_merge().map_err(|e| syntax_error(label, &e))?;
+
+    let raw: BTreeMap<String, serde_norway::Value> =
+        serde_norway::from_value(root).map_err(|_| {
+            format!(
+                "parsing MCP registry {label:?}: the top level is not a mapping of \
+             server name to configuration"
+            )
+        })?;
 
     let mut servers = BTreeMap::new();
-    for (name, entry) in raw.unwrap_or_default() {
+    for (name, value) in raw {
+        // The serde message is deliberately dropped — it quotes the offending
+        // value, and a `headers` written as a string instead of a map is a
+        // `Bearer` token. The server name is what a reader searches for.
+        let entry: RawEntry = serde_norway::from_value(value).map_err(|_| {
+            format!(
+                "MCP server {name:?}: the entry does not decode — transport, command and \
+                 url must be strings, args a list of strings, and env and headers \
+                 mappings of strings"
+            )
+        })?;
         let config = convert(&name, entry)?;
         servers.insert(name, config);
     }
     Ok(Registry { servers })
+}
+
+/// A parse failure reported by **position**, never by content.
+///
+/// See the module header: this text reaches a chat body, a stored
+/// `job_history.error_message` and the app log, and `serde_norway` prints the
+/// whole offending scalar.
+fn syntax_error(label: &str, e: &serde_norway::Error) -> String {
+    match e.location() {
+        Some(at) => format!(
+            "parsing MCP registry {label:?}: does not decode at line {} column {}",
+            at.line(),
+            at.column()
+        ),
+        None => format!("parsing MCP registry {label:?}: does not decode"),
+    }
 }
 
 /// `convertMCPEntry`: one raw entry to the SDK config its transport names.
@@ -184,7 +271,13 @@ fn convert(name: &str, entry: RawEntry) -> Result<serde_json::Value, String> {
         "stdio" => serde_json::to_value(McpStdioServer {
             server_type: "stdio".to_string(),
             command: entry.command.unwrap_or_default(),
-            args: entry.args.map(|a| a.0).unwrap_or_default(),
+            // `flatten` is the null-element drop `d.sequence` performs.
+            args: entry
+                .args
+                .unwrap_or_default()
+                .into_iter()
+                .flatten()
+                .collect(),
             env: interpolate_map(name, entry.env)?,
         }),
         "streamable_http" => serde_json::to_value(McpHttpServer {
@@ -326,7 +419,13 @@ ticker:
 
     /// A key written with nothing under it is a YAML null, which is how a person
     /// actually leaves a section empty — and it is the zero value, not a type
-    /// error. Elements too: `GoList`/`GoMap` are on the fields for that.
+    /// error.
+    ///
+    /// **One level down the two encodings part company, and this pins the
+    /// difference**: a null *map value* is `""` and a null *sequence element* is
+    /// **dropped**. Both measured against `gopkg.in/yaml.v3` v3.0.1 rather than
+    /// inferred from `encoding/json`, which zero-fills both — using `GoList`
+    /// here would put an extra empty argument in an external server's argv.
     #[test]
     fn a_null_is_the_zero_value_at_the_field_and_one_level_down() {
         let registry = parse(
@@ -356,10 +455,80 @@ holes:
             &serde_json::json!({
                 "type": "stdio",
                 "command": "run-me-too",
-                "args": ["--first", ""],
+                "args": ["--first"],
                 "env": {"EMPTY": ""},
+            }),
+            "a null argument is dropped, not sent as an empty one"
+        );
+    }
+
+    /// `<<: *anchor` is how a person shares an `env` block across entries, and
+    /// `yaml.v3` expands it during decode.
+    ///
+    /// Without `apply_merge` this file decodes with `transport` unset and the
+    /// turn is refused with *"unknown transport"* — a valid registry breaking
+    /// every MCP-backed agent, which is the failure #375 exists to remove.
+    #[test]
+    fn a_merge_key_is_expanded_the_way_yaml_v3_expands_it() {
+        let registry = parse(
+            "mcps.yaml",
+            r#"
+base: &base
+  transport: stdio
+  command: /usr/bin/shared
+docs:
+  <<: *base
+  args: ["--docs"]
+"#,
+        )
+        .expect("merge keys resolve");
+        assert_eq!(
+            registry.get("docs").expect("docs"),
+            &serde_json::json!({
+                "type": "stdio",
+                "command": "/usr/bin/shared",
+                "args": ["--docs"],
             })
         );
+        // The anchor's own entry stays and is a server like any other — Go's
+        // map holds it too, so it is not filtered out here either.
+        assert_eq!(
+            registry.get("base").expect("base"),
+            &serde_json::json!({"type": "stdio", "command": "/usr/bin/shared"})
+        );
+    }
+
+    /// **No refusal quotes what it was decoding.** A `Bearer` token under
+    /// `headers` is the ordinary content of this file, and a refusal's text
+    /// becomes a chat body, a stored `job_history.error_message` and a line in
+    /// the app log the docs tell users to attach to a bug report.
+    ///
+    /// Asserted on the token's *absence* rather than on the wording, which is
+    /// the only form that keeps holding when a message is reworded.
+    #[test]
+    fn a_decode_failure_never_echoes_the_value_it_failed_on() {
+        const SECRET: &str = "sk-live-NOTAREALTOKEN";
+
+        // A shape error: `headers` written as a string rather than a mapping.
+        let err = parse(
+            "mcps.yaml",
+            &format!(
+                "weather:\n  transport: streamable_http\n  url: https://w.example\n  \
+                 headers: \"Bearer {SECRET}\"\n"
+            ),
+        )
+        .expect_err("headers is not a mapping");
+        assert!(!err.contains(SECRET), "the value leaked: {err}");
+        assert!(err.contains(r#"MCP server "weather""#), "{err}");
+
+        // A syntax error, which is reported by position instead.
+        let err = parse(
+            "mcps.yaml",
+            &format!("weather:\n  url: \"Bearer {SECRET}\n"),
+        )
+        .expect_err("unterminated quote");
+        assert!(!err.contains(SECRET), "the value leaked: {err}");
+        assert!(err.contains("at line"), "{err}");
     }
 
     /// A file with nothing in it is an empty registry and **no** error. This is
@@ -386,6 +555,10 @@ holes:
 
         std::fs::write(&missing, "docs: [not, a, mapping]\n").expect("write");
         let err = load(Some(&missing)).expect_err("malformed");
+        assert!(err.contains(r#"MCP server "docs""#), "{err}");
+
+        std::fs::write(&missing, "- not\n- a\n- mapping\n").expect("write");
+        let err = load(Some(&missing)).expect_err("not a mapping at all");
         assert!(err.contains("parsing MCP registry"), "{err}");
         assert!(
             err.contains(&missing.display().to_string()),
@@ -471,24 +644,29 @@ holes:
         assert!(err.contains("is not set"), "{err}");
     }
 
-    /// `MCPS_FILE` wins over the data directory, and an empty value does not.
+    /// The override selects the file, the prefixed spelling wins the tie, and an
+    /// empty value is not a path.
     #[test]
     fn the_environment_override_selects_the_file() {
         let _env = env_lock();
+        let default = crate::paths::data_dir().map(|dir| dir.join("mcps.yaml"));
+
         {
-            let _set = EnvVar::set("MCPS_FILE", "/tmp/somewhere/else.yaml");
-            assert_eq!(path(), Some(PathBuf::from("/tmp/somewhere/else.yaml")));
+            let _unprefixed = EnvVar::set("MCPS_FILE", "/tmp/legacy.yaml");
+            let _none = EnvVar::unset("AGENTO_MCPS_FILE");
+            assert_eq!(path(), Some(PathBuf::from("/tmp/legacy.yaml")));
+
+            // #375's own spelling still works, but `AGENTO_`-prefixed is the
+            // name and takes precedence when both are set.
+            let _prefixed = EnvVar::set("AGENTO_MCPS_FILE", "/tmp/current.yaml");
+            assert_eq!(path(), Some(PathBuf::from("/tmp/current.yaml")));
         }
-        let _unset = EnvVar::unset("MCPS_FILE");
-        assert_eq!(
-            path(),
-            crate::paths::data_dir().map(|dir| dir.join("mcps.yaml"))
-        );
-        let _empty = EnvVar::set("MCPS_FILE", "");
-        assert_eq!(
-            path(),
-            crate::paths::data_dir().map(|dir| dir.join("mcps.yaml")),
-            "an empty value is not a path"
-        );
+
+        let _a = EnvVar::unset("AGENTO_MCPS_FILE");
+        let _b = EnvVar::unset("MCPS_FILE");
+        assert_eq!(path(), default);
+
+        let _empty = EnvVar::set("AGENTO_MCPS_FILE", "");
+        assert_eq!(path(), default, "an empty value is not a path");
     }
 }

--- a/src-tauri/src/native/chat/mcps_yaml.rs
+++ b/src-tauri/src/native/chat/mcps_yaml.rs
@@ -225,9 +225,26 @@ impl<'de> Deserialize<'de> for YamlString {
 /// structs, because that is the only thing any caller wants from them — the
 /// conversion happens once, at load, so a `transport` typo is reported when the
 /// file is read rather than when a turn happens to name that server.
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct Registry {
     servers: BTreeMap<String, serde_json::Value>,
+}
+
+/// **Hand-written, and it prints the server names without their configs** —
+/// `runner::McpSource`'s rule, applied to the type that holds the secret first.
+///
+/// [`convert`] runs [`interpolate_map`] before the value is stored, so every
+/// entry here holds the **resolved** `${ENV:…}` values: the live
+/// `Authorization: Bearer …` the file only pointed at. `integrations/registry.rs`
+/// states the rule twice — a `{row:?}` in a log line is the same leak as a
+/// response field, only later — and this struct is `pub`, so it is the one most
+/// likely to be formatted by something written later.
+impl std::fmt::Debug for Registry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Registry")
+            .field("servers", &self.servers.keys())
+            .finish()
+    }
 }
 
 impl Registry {
@@ -418,8 +435,8 @@ fn interpolate(value: &str) -> Result<String, String> {
     // is what the module's no-echo rule is about, and `interpolate_map` has
     // already named the server and the key it is under.
     Err(format!(
-        "more than {MAX_SUBSTITUTIONS} `${{ENV:…}}` substitutions, which means \
-         an environment variable expands to itself"
+        "more than {MAX_SUBSTITUTIONS} `${{ENV:…}}` substitutions, which almost \
+         certainly means an environment variable expands to itself"
     ))
 }
 
@@ -657,6 +674,29 @@ docs:
         .expect_err("unterminated quote");
         assert!(!err.contains(SECRET), "the value leaked: {err}");
         assert!(err.contains("at line"), "{err}");
+
+        // And the registry that succeeds is the one that actually holds the
+        // resolved token, so its own `Debug` must withhold it — the same rule as
+        // `runner::McpSource`, one struct earlier in the chain.
+        let _env = env_lock();
+        let _token = EnvVar::set("AGENTO_TEST_MCPS_REGISTRY_TOKEN", SECRET);
+        let registry = parse(
+            "mcps.yaml",
+            "weather:\n  transport: streamable_http\n  url: https://w.example\n  \
+             headers:\n    Authorization: \"Bearer ${ENV:AGENTO_TEST_MCPS_REGISTRY_TOKEN}\"\n",
+        )
+        .expect("resolvable");
+        assert_eq!(
+            registry.get("weather").expect("weather")["headers"]["Authorization"],
+            format!("Bearer {SECRET}"),
+            "the turn really does run with the resolved token"
+        );
+        let rendered = format!("{registry:?}");
+        assert!(!rendered.contains(SECRET), "Debug leaked it: {rendered}");
+        assert!(
+            rendered.contains("weather"),
+            "the names are still useful: {rendered}"
+        );
     }
 
     /// A file with nothing in it is an empty registry and **no** error. This is

--- a/src-tauri/src/native/chat/mcps_yaml.rs
+++ b/src-tauri/src/native/chat/mcps_yaml.rs
@@ -1,0 +1,494 @@
+//! `<data dir>/mcps.yaml` — the hand-authored registry of **external** MCP
+//! servers. Ports `LoadMCPRegistry` / `convertMCPEntry` / `interpolateEnv`
+//! (`internal/config/mcp.go`).
+//!
+//! # What an entry is, and what it is not
+//!
+//! Everything in this file describes **somebody else's server**: a subprocess
+//! the CLI spawns, or a URL it dials. Nothing here is hosted, health-checked or
+//! shut down by Agento — [`crate::claude::mcp`]'s header already draws that
+//! line, and this module stays on the config side of it. The desktop app has no
+//! UI for the file; it is read because a user who authored one for the retired
+//! `agento web` server points the app at the same data directory, and because
+//! it is the only way to reach an MCP server that is not one of the six
+//! integration types.
+//!
+//! # The three shapes, and the names that do not match
+//!
+//! The YAML `transport` key and the `type` the CLI is handed are **different
+//! spellings**, and only one of the three agrees:
+//!
+//! | `transport:` | `type` on the wire | struct |
+//! |---|---|---|
+//! | `stdio` | `stdio` | [`McpStdioServer`] |
+//! | `streamable_http` | `http` | [`McpHttpServer`] |
+//! | `sse` | `sse` | [`McpSseServer`] |
+//!
+//! Anything else is an error naming the server, which refuses the turn. Go's
+//! `convertMCPEntry` does the same and its wording is reproduced.
+//!
+//! # A missing file is an empty registry; a broken one is an error
+//!
+//! `LoadMCPRegistry` answers `os.IsNotExist` with an empty registry and **no**
+//! error — the overwhelmingly common case — while an unreadable or unparseable
+//! file is an error carrying the path. That asymmetry is the whole reason
+//! [`load`] returns `Result<Registry, String>` rather than an `Option`: "there
+//! is no registry" and "the registry could not be read" must not collapse into
+//! one answer, or a typo in a YAML file silently removes every external server
+//! an agent depends on.
+//!
+//! # `null` is the zero value here too
+//!
+//! `yaml.v3` decodes a null into the zero value for every type in this struct,
+//! exactly as `encoding/json` does — and a YAML key written with nothing under
+//! it (`env:`, `args:`) **is** a null, which is a far more ordinary thing to
+//! type than a literal `null` in JSON ever was. So the same rule
+//! [`crate::native::gojson::GoList`] / [`crate::native::gojson::GoMap`] carry
+//! for the JSON side is applied here, one level down as well as at the field:
+//! `args:` with nothing under it is an empty list, and `env: {A: }` is
+//! `A: ""`. Bare `Option` covers the field; the two wrapper types cover the
+//! elements.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::claude::options::{McpHttpServer, McpSseServer, McpStdioServer};
+use crate::native::gojson::{GoList, GoMap};
+
+/// How many `${ENV:…}` substitutions one value may take before the expansion is
+/// declared circular.
+///
+/// Go's loop rescans the **whole** string from the start after each
+/// substitution, so an environment variable whose value contains the pattern is
+/// expanded again — and `FOO=${ENV:FOO}` therefore spins forever, in Go too. A
+/// hang inside `build_options` is a chat that never answers and a scheduled run
+/// that never records a row, which is strictly worse than the divergence, so the
+/// loop is bounded and the bound is an error. Every terminating input behaves
+/// exactly as Go's does: a value needs one iteration per placeholder, and no
+/// legitimate one is anywhere near this many.
+const MAX_SUBSTITUTIONS: usize = 1000;
+
+/// Where the registry file lives.
+///
+/// `AppConfig.MCPsFile()` is `<data dir>/mcps.yaml` and `cmd/web.go` passed it
+/// with no override — the `--mcps-file` flag existed only on `agento ask`. The
+/// `MCPS_FILE` variable is this build's equivalent of that flag: the same lever
+/// `AGENTO_CLAUDE_EXECUTABLE` is for the CLI binary, and the only way to point a
+/// test at a fixture without writing into the developer's real data directory
+/// (a debug build's [`crate::paths::data_dir`] ignores the environment by
+/// design).
+pub fn path() -> Option<PathBuf> {
+    match std::env::var("MCPS_FILE") {
+        Ok(file) if !file.is_empty() => Some(PathBuf::from(file)),
+        _ => crate::paths::data_dir().map(|dir| dir.join("mcps.yaml")),
+    }
+}
+
+/// One entry as it is written in the file, before the transport decides which
+/// SDK shape it becomes. `rawMCPEntry`, field for field.
+///
+/// Every field is an `Option` so that a key present with nothing under it — the
+/// natural way to leave a list or a map empty in YAML — decodes to the zero
+/// value rather than failing the whole file. See the module header.
+#[derive(Debug, Default, Deserialize)]
+struct RawEntry {
+    #[serde(default)]
+    transport: Option<String>,
+    #[serde(default)]
+    command: Option<String>,
+    #[serde(default)]
+    args: Option<GoList<String>>,
+    #[serde(default)]
+    env: Option<GoMap<String>>,
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    headers: Option<GoMap<String>>,
+}
+
+/// The parsed registry: server name → the JSON the CLI is handed in
+/// `--mcp-config`.
+///
+/// The values are already `serde_json::Value` rather than an enum over the three
+/// structs, because that is the only thing any caller wants from them — the
+/// conversion happens once, at load, so a `transport` typo is reported when the
+/// file is read rather than when a turn happens to name that server.
+#[derive(Debug, Default)]
+pub struct Registry {
+    servers: BTreeMap<String, serde_json::Value>,
+}
+
+impl Registry {
+    /// `GetSDKConfig`: the config for `name`, or `None` when the file does not
+    /// name it.
+    pub fn get(&self, name: &str) -> Option<&serde_json::Value> {
+        self.servers.get(name)
+    }
+
+    /// How many servers the file named. Only the tests care.
+    #[cfg(test)]
+    fn count(&self) -> usize {
+        self.servers.len()
+    }
+}
+
+/// `LoadMCPRegistry`: read `path` and convert every entry.
+///
+/// `None` — no data directory to resolve — is an empty registry rather than an
+/// error, matching the missing-file case: neither is a registry that could not
+/// be read, and refusing a turn over a home directory this process could not
+/// find would be a strictly worse answer than the one the integrations already
+/// give for it.
+pub fn load(path: Option<&Path>) -> Result<Registry, String> {
+    let Some(path) = path else {
+        return Ok(Registry::default());
+    };
+    let label = path.display().to_string();
+    let data = match std::fs::read_to_string(path) {
+        Ok(data) => data,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Registry::default()),
+        Err(e) => return Err(format!("reading MCP registry {label:?}: {e}")),
+    };
+    parse(&label, &data)
+}
+
+/// The half of [`load`] that has no filesystem in it, so a fixture is a `&str`.
+///
+/// `label` is the path, and it appears **only** in the parse failure — which is
+/// where Go puts it. A `convertMCPEntry` failure is returned from
+/// `LoadMCPRegistry` unwrapped, naming the server rather than the file, because
+/// the server name is what a reader searches the file for.
+fn parse(label: &str, data: &str) -> Result<Registry, String> {
+    // `Option` around the map, not just around each entry: an **empty** file is
+    // a YAML null, and so is one holding nothing but `---` or a comment. Go's
+    // `yaml.Unmarshal` leaves the destination map nil for all three and returns
+    // no error, and an empty `mcps.yaml` left behind by an earlier experiment is
+    // exactly the kind of file this issue exists to stop breaking turns.
+    let raw: Option<BTreeMap<String, RawEntry>> =
+        serde_norway::from_str(data).map_err(|e| format!("parsing MCP registry {label:?}: {e}"))?;
+
+    let mut servers = BTreeMap::new();
+    for (name, entry) in raw.unwrap_or_default() {
+        let config = convert(&name, entry)?;
+        servers.insert(name, config);
+    }
+    Ok(Registry { servers })
+}
+
+/// `convertMCPEntry`: one raw entry to the SDK config its transport names.
+fn convert(name: &str, entry: RawEntry) -> Result<serde_json::Value, String> {
+    let transport = entry.transport.unwrap_or_default();
+    let value = match transport.as_str() {
+        "stdio" => serde_json::to_value(McpStdioServer {
+            server_type: "stdio".to_string(),
+            command: entry.command.unwrap_or_default(),
+            args: entry.args.map(|a| a.0).unwrap_or_default(),
+            env: interpolate_map(name, entry.env)?,
+        }),
+        "streamable_http" => serde_json::to_value(McpHttpServer {
+            server_type: "http".to_string(),
+            url: entry.url.unwrap_or_default(),
+            headers: interpolate_map(name, entry.headers)?,
+        }),
+        "sse" => serde_json::to_value(McpSseServer {
+            server_type: "sse".to_string(),
+            url: entry.url.unwrap_or_default(),
+            headers: interpolate_map(name, entry.headers)?,
+        }),
+        other => {
+            return Err(format!(
+                "MCP server {name:?}: unknown transport {other:?} \
+                 (must be stdio, streamable_http, or sse)"
+            ))
+        }
+    };
+    value.map_err(|e| format!("MCP server {name:?}: encoding the server config: {e}"))
+}
+
+/// `interpolateEnvMap`: `${ENV:VAR}` substitution over every value of a map.
+fn interpolate_map(
+    name: &str,
+    map: Option<GoMap<String>>,
+) -> Result<BTreeMap<String, String>, String> {
+    let mut out = BTreeMap::new();
+    for (key, value) in map.map(|m| m.0).unwrap_or_default() {
+        let expanded =
+            interpolate(&value).map_err(|e| format!("MCP server {name:?} key {key:?}: {e}"))?;
+        out.insert(key, expanded);
+    }
+    Ok(out)
+}
+
+/// `interpolateEnv`: replace every `${ENV:VAR}` with that variable's value.
+///
+/// Three details are Go's and each is easy to "improve" into a divergence:
+///
+/// - **An unset *or empty* variable is an error.** Go tests `value == ""`, so
+///   `FOO=` and an absent `FOO` are the same refusal — deliberate, because a
+///   silently empty credential in an MCP server's environment is the failure
+///   this check exists to catch.
+/// - **An unterminated `${ENV:` is left alone**, not an error: the scan stops at
+///   the missing `}` and returns what it has.
+/// - **The scan restarts from the beginning after each substitution**, so a
+///   substituted value containing the pattern is expanded in turn. See
+///   [`MAX_SUBSTITUTIONS`] for the one input where that does not terminate.
+fn interpolate(value: &str) -> Result<String, String> {
+    const OPEN: &str = "${ENV:";
+    let mut result = value.to_string();
+    for _ in 0..MAX_SUBSTITUTIONS {
+        let Some(start) = result.find(OPEN) else {
+            return Ok(result);
+        };
+        let Some(end) = result[start..].find('}').map(|at| at + start) else {
+            return Ok(result);
+        };
+        let var = &result[start + OPEN.len()..end];
+        let replacement = std::env::var(var).unwrap_or_default();
+        if replacement.is_empty() {
+            return Err(format!("required env var {var:?} is not set"));
+        }
+        result = format!("{}{replacement}{}", &result[..start], &result[end + 1..]);
+    }
+    Err(format!(
+        "expanding {value:?}: more than {MAX_SUBSTITUTIONS} substitutions, \
+         which means an environment variable expands to itself"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::paths::tests::{env_lock, EnvVar};
+
+    /// The three transports, at the bytes the CLI is handed.
+    ///
+    /// Pinned as whole JSON documents rather than field by field: the `type`
+    /// values are not the `transport` values, the keys are the SDK's spellings
+    /// and not the YAML's, and an empty `args`/`env`/`headers` is **absent**
+    /// rather than `[]`/`{}` — four independent ways to be quietly wrong that a
+    /// per-field assertion would each miss on its own.
+    #[test]
+    fn the_three_transports_reach_the_cli_in_the_sdk_shapes() {
+        let _env = env_lock();
+        let _token = EnvVar::set("AGENTO_TEST_MCPS_TOKEN", "s3cret");
+        let registry = parse(
+            "mcps.yaml",
+            r#"
+docs:
+  transport: stdio
+  command: /usr/bin/docs-mcp
+  args: ["--root", "/srv/docs"]
+  env:
+    LOG: debug
+    TOKEN: "Bearer ${ENV:AGENTO_TEST_MCPS_TOKEN}"
+weather:
+  transport: streamable_http
+  url: https://weather.example/mcp
+  headers:
+    X-Key: "${ENV:AGENTO_TEST_MCPS_TOKEN}"
+ticker:
+  transport: sse
+  url: https://ticker.example/sse
+"#,
+        )
+        .expect("a well-formed registry");
+        assert_eq!(registry.count(), 3);
+
+        assert_eq!(
+            registry.get("docs").expect("docs"),
+            &serde_json::json!({
+                "type": "stdio",
+                "command": "/usr/bin/docs-mcp",
+                "args": ["--root", "/srv/docs"],
+                "env": {"LOG": "debug", "TOKEN": "Bearer s3cret"},
+            })
+        );
+        // `streamable_http` in the file is `http` on the wire. The two spellings
+        // are not interchangeable and only this transport differs.
+        assert_eq!(
+            registry.get("weather").expect("weather"),
+            &serde_json::json!({
+                "type": "http",
+                "url": "https://weather.example/mcp",
+                "headers": {"X-Key": "s3cret"},
+            })
+        );
+        // No `headers` key at all, because the SDK struct skips an empty map —
+        // `{"headers":{}}` would be a different `--mcp-config` argument.
+        assert_eq!(
+            registry.get("ticker").expect("ticker"),
+            &serde_json::json!({"type": "sse", "url": "https://ticker.example/sse"})
+        );
+        assert!(registry.get("absent").is_none());
+    }
+
+    /// A key written with nothing under it is a YAML null, which is how a person
+    /// actually leaves a section empty — and it is the zero value, not a type
+    /// error. Elements too: `GoList`/`GoMap` are on the fields for that.
+    #[test]
+    fn a_null_is_the_zero_value_at_the_field_and_one_level_down() {
+        let registry = parse(
+            "mcps.yaml",
+            r#"
+bare:
+  transport: stdio
+  command: run-me
+  args:
+  env:
+holes:
+  transport: stdio
+  command: run-me-too
+  args: ["--first", ~]
+  env:
+    EMPTY:
+"#,
+        )
+        .expect("nulls decode");
+        assert_eq!(
+            registry.get("bare").expect("bare"),
+            &serde_json::json!({"type": "stdio", "command": "run-me"}),
+            "a null list and a null map are absent, not `[]` and `{{}}`"
+        );
+        assert_eq!(
+            registry.get("holes").expect("holes"),
+            &serde_json::json!({
+                "type": "stdio",
+                "command": "run-me-too",
+                "args": ["--first", ""],
+                "env": {"EMPTY": ""},
+            })
+        );
+    }
+
+    /// A file with nothing in it is an empty registry and **no** error. This is
+    /// the shape Part A of #375 is about: an unrelated leftover file must not
+    /// refuse a turn.
+    #[test]
+    fn an_empty_or_commentary_file_is_an_empty_registry() {
+        for data in ["", "\n", "---\n", "# nothing here yet\n", "null\n"] {
+            let registry =
+                parse("mcps.yaml", data).unwrap_or_else(|e| panic!("{data:?} should parse: {e}"));
+            assert_eq!(registry.count(), 0, "{data:?}");
+        }
+    }
+
+    /// A missing file is an empty registry; anything else about the file is an
+    /// error naming it, so a typo cannot read as "no external servers".
+    #[test]
+    fn a_missing_file_is_empty_and_a_broken_one_names_itself() {
+        assert_eq!(load(None).expect("no path").count(), 0);
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing = dir.path().join("mcps.yaml");
+        assert_eq!(load(Some(&missing)).expect("missing").count(), 0);
+
+        std::fs::write(&missing, "docs: [not, a, mapping]\n").expect("write");
+        let err = load(Some(&missing)).expect_err("malformed");
+        assert!(err.contains("parsing MCP registry"), "{err}");
+        assert!(
+            err.contains(&missing.display().to_string()),
+            "the message has to name the file: {err}"
+        );
+    }
+
+    /// An unknown transport is Go's sentence, naming the server and the value.
+    #[test]
+    fn an_unknown_transport_names_the_server() {
+        let err =
+            parse("mcps.yaml", "docs:\n  transport: websocket\n").expect_err("unknown transport");
+        assert_eq!(
+            err,
+            "MCP server \"docs\": unknown transport \"websocket\" \
+             (must be stdio, streamable_http, or sse)"
+        );
+        // A missing `transport` is the same refusal with the empty string in it,
+        // because Go's switch has no separate arm for it.
+        let err = parse("mcps.yaml", "docs:\n  command: x\n").expect_err("no transport");
+        assert!(err.contains(r#"unknown transport """#), "{err}");
+    }
+
+    /// `${ENV:…}` substitution, including the two Go behaviours that read as
+    /// bugs: an empty variable is "not set", and an unterminated pattern is left
+    /// alone rather than refused.
+    #[test]
+    fn env_interpolation_follows_gos_rules() {
+        let _env = env_lock();
+        let _set = EnvVar::set("AGENTO_TEST_MCPS_A", "alpha");
+        let _blank = EnvVar::set("AGENTO_TEST_MCPS_BLANK", "");
+        let _unset = EnvVar::unset("AGENTO_TEST_MCPS_MISSING");
+
+        assert_eq!(interpolate("plain").expect("no pattern"), "plain");
+        assert_eq!(
+            interpolate("a-${ENV:AGENTO_TEST_MCPS_A}-b-${ENV:AGENTO_TEST_MCPS_A}").expect("twice"),
+            "a-alpha-b-alpha"
+        );
+        // Unterminated: the scan stops, the text survives verbatim.
+        assert_eq!(
+            interpolate("${ENV:AGENTO_TEST_MCPS_A").expect("unterminated"),
+            "${ENV:AGENTO_TEST_MCPS_A"
+        );
+        assert_eq!(
+            interpolate("${ENV:AGENTO_TEST_MCPS_MISSING}").expect_err("unset"),
+            r#"required env var "AGENTO_TEST_MCPS_MISSING" is not set"#
+        );
+        // Set but empty is the same refusal — Go compares against `""`, not
+        // against presence.
+        assert!(interpolate("${ENV:AGENTO_TEST_MCPS_BLANK}").is_err());
+    }
+
+    /// Go's rescan-from-the-start expands a substituted value in turn — and
+    /// spins forever on one that expands to itself. The bound turns that hang
+    /// into an error; every terminating input is unaffected.
+    #[test]
+    fn a_self_referential_variable_is_an_error_rather_than_a_hang() {
+        let _env = env_lock();
+        let _outer = EnvVar::set("AGENTO_TEST_MCPS_OUTER", "${ENV:AGENTO_TEST_MCPS_INNER}");
+        let _inner = EnvVar::set("AGENTO_TEST_MCPS_INNER", "done");
+        assert_eq!(
+            interpolate("${ENV:AGENTO_TEST_MCPS_OUTER}").expect("nested expands"),
+            "done"
+        );
+
+        let _loop = EnvVar::set("AGENTO_TEST_MCPS_LOOP", "${ENV:AGENTO_TEST_MCPS_LOOP}");
+        let err = interpolate("${ENV:AGENTO_TEST_MCPS_LOOP}").expect_err("circular");
+        assert!(err.contains("expands to itself"), "{err}");
+    }
+
+    /// A failed substitution names the server **and** the key it was under, so
+    /// the message points at a line of the file.
+    #[test]
+    fn a_failed_substitution_names_the_server_and_the_key() {
+        let _env = env_lock();
+        let _unset = EnvVar::unset("AGENTO_TEST_MCPS_MISSING");
+        let err = parse(
+            "mcps.yaml",
+            "docs:\n  transport: stdio\n  command: x\n  env:\n    TOKEN: \"${ENV:AGENTO_TEST_MCPS_MISSING}\"\n",
+        )
+        .expect_err("unset variable");
+        assert!(err.contains(r#"MCP server "docs" key "TOKEN""#), "{err}");
+        assert!(err.contains("is not set"), "{err}");
+    }
+
+    /// `MCPS_FILE` wins over the data directory, and an empty value does not.
+    #[test]
+    fn the_environment_override_selects_the_file() {
+        let _env = env_lock();
+        {
+            let _set = EnvVar::set("MCPS_FILE", "/tmp/somewhere/else.yaml");
+            assert_eq!(path(), Some(PathBuf::from("/tmp/somewhere/else.yaml")));
+        }
+        let _unset = EnvVar::unset("MCPS_FILE");
+        assert_eq!(
+            path(),
+            crate::paths::data_dir().map(|dir| dir.join("mcps.yaml"))
+        );
+        let _empty = EnvVar::set("MCPS_FILE", "");
+        assert_eq!(
+            path(),
+            crate::paths::data_dir().map(|dir| dir.join("mcps.yaml")),
+            "an empty value is not a path"
+        );
+    }
+}

--- a/src-tauri/src/native/chat/mcps_yaml.rs
+++ b/src-tauri/src/native/chat/mcps_yaml.rs
@@ -137,20 +137,85 @@ pub fn path() -> Option<PathBuf> {
 #[derive(Debug, Default, Deserialize)]
 struct RawEntry {
     #[serde(default)]
-    transport: Option<String>,
+    transport: Option<YamlString>,
     #[serde(default)]
-    command: Option<String>,
+    command: Option<YamlString>,
     /// `Vec<Option<_>>` and **not** `GoList`: a null element is *dropped* by
     /// `yaml.v3`, where `GoList` would zero-fill it. See the module header —
     /// this is argv, so the difference is an extra empty argument.
     #[serde(default)]
-    args: Option<Vec<Option<String>>>,
+    args: Option<Vec<Option<YamlString>>>,
     #[serde(default)]
-    env: Option<GoMap<String>>,
+    env: Option<GoMap<YamlString>>,
     #[serde(default)]
-    url: Option<String>,
+    url: Option<YamlString>,
     #[serde(default)]
-    headers: Option<GoMap<String>>,
+    headers: Option<GoMap<YamlString>>,
+}
+
+/// A string field that accepts **any** scalar, because `yaml.v3` does.
+///
+/// `d.scalar` sets a `string` field from the node's own text whatever the node
+/// resolved to, so `env: {PORT: 8080}`, `command: 123` and `DEBUG: true` all
+/// decode with no error — measured against v3.0.1. `serde` type-checks instead
+/// and rejects every one of them.
+///
+/// **That is not a wording difference, it is Part A's regression re-entered
+/// through the parser.** [`super::runner::mcp_plan`] loads the registry for
+/// *any* agent naming *any* MCP server, so one unquoted port number in a
+/// leftover file would refuse every MCP-backed agent on the machine — including
+/// agents whose every name resolves to a hosted integration and which have no
+/// entry in that file at all. An unquoted scalar is the most ordinary thing
+/// there is to write in YAML.
+///
+/// **One residual divergence, measured and accepted.** `yaml.v3` keeps the
+/// node's *raw text*; this sees the value after `serde_norway` has resolved it,
+/// because [`serde_norway::Value::apply_merge`] forces a `Value` round trip
+/// before any field is read. So a spelling that does not survive that round trip
+/// does not survive here: `1.50` is `"1.5"` and `2.0` is `"2"` where Go says
+/// `"1.50"` and `"2.0"`. Integers, booleans and strings — which is everything
+/// anyone writes in this file — are exact, and the alternative is dropping merge
+/// keys, which breaks a whole valid idiom to fix a trailing zero. Pinned by
+/// `a_bare_scalar_is_read_as_its_text_the_way_yaml_v3_reads_one`.
+#[derive(Clone, Debug, Default, PartialEq)]
+struct YamlString(String);
+
+impl<'de> Deserialize<'de> for YamlString {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct AnyScalar;
+
+        impl serde::de::Visitor<'_> for AnyScalar {
+            type Value = YamlString;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("a scalar")
+            }
+
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<YamlString, E> {
+                Ok(YamlString(v.to_string()))
+            }
+            fn visit_string<E: serde::de::Error>(self, v: String) -> Result<YamlString, E> {
+                Ok(YamlString(v))
+            }
+            fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<YamlString, E> {
+                Ok(YamlString(v.to_string()))
+            }
+            fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<YamlString, E> {
+                Ok(YamlString(v.to_string()))
+            }
+            fn visit_f64<E: serde::de::Error>(self, v: f64) -> Result<YamlString, E> {
+                Ok(YamlString(v.to_string()))
+            }
+            fn visit_bool<E: serde::de::Error>(self, v: bool) -> Result<YamlString, E> {
+                Ok(YamlString(v.to_string()))
+            }
+        }
+
+        deserializer.deserialize_any(AnyScalar)
+    }
 }
 
 /// The parsed registry: server name → the JSON the CLI is handed in
@@ -220,7 +285,12 @@ fn parse(label: &str, data: &str) -> Result<Registry, String> {
     // `yaml.v3` expands `<<: *anchor` during decode; this has to be asked. The
     // anchor's own entry stays in the map and is a server like any other, which
     // is also what Go does with it.
-    root.apply_merge().map_err(|e| syntax_error(label, &e))?;
+    root.apply_merge().map_err(|_| {
+        // Its own sentence has no position and no user content, but it is a
+        // serde message and this module does not forward those. `<<` is the only
+        // thing `apply_merge` can fail on, so naming it is the whole diagnosis.
+        format!("parsing MCP registry {label:?}: a merge key (`<<`) does not name a mapping")
+    })?;
 
     let raw: BTreeMap<String, serde_norway::Value> =
         serde_norway::from_value(root).map_err(|_| {
@@ -237,9 +307,8 @@ fn parse(label: &str, data: &str) -> Result<Registry, String> {
         // `Bearer` token. The server name is what a reader searches for.
         let entry: RawEntry = serde_norway::from_value(value).map_err(|_| {
             format!(
-                "MCP server {name:?}: the entry does not decode — transport, command and \
-                 url must be strings, args a list of strings, and env and headers \
-                 mappings of strings"
+                "MCP server {name:?}: the entry does not decode — it must be a mapping, \
+                 with args a list and env and headers mappings"
             )
         })?;
         let config = convert(&name, entry)?;
@@ -266,28 +335,29 @@ fn syntax_error(label: &str, e: &serde_norway::Error) -> String {
 
 /// `convertMCPEntry`: one raw entry to the SDK config its transport names.
 fn convert(name: &str, entry: RawEntry) -> Result<serde_json::Value, String> {
-    let transport = entry.transport.unwrap_or_default();
+    let transport = entry.transport.unwrap_or_default().0;
     let value = match transport.as_str() {
         "stdio" => serde_json::to_value(McpStdioServer {
             server_type: "stdio".to_string(),
-            command: entry.command.unwrap_or_default(),
+            command: entry.command.unwrap_or_default().0,
             // `flatten` is the null-element drop `d.sequence` performs.
             args: entry
                 .args
                 .unwrap_or_default()
                 .into_iter()
                 .flatten()
+                .map(|arg| arg.0)
                 .collect(),
             env: interpolate_map(name, entry.env)?,
         }),
         "streamable_http" => serde_json::to_value(McpHttpServer {
             server_type: "http".to_string(),
-            url: entry.url.unwrap_or_default(),
+            url: entry.url.unwrap_or_default().0,
             headers: interpolate_map(name, entry.headers)?,
         }),
         "sse" => serde_json::to_value(McpSseServer {
             server_type: "sse".to_string(),
-            url: entry.url.unwrap_or_default(),
+            url: entry.url.unwrap_or_default().0,
             headers: interpolate_map(name, entry.headers)?,
         }),
         other => {
@@ -303,12 +373,12 @@ fn convert(name: &str, entry: RawEntry) -> Result<serde_json::Value, String> {
 /// `interpolateEnvMap`: `${ENV:VAR}` substitution over every value of a map.
 fn interpolate_map(
     name: &str,
-    map: Option<GoMap<String>>,
+    map: Option<GoMap<YamlString>>,
 ) -> Result<BTreeMap<String, String>, String> {
     let mut out = BTreeMap::new();
     for (key, value) in map.map(|m| m.0).unwrap_or_default() {
         let expanded =
-            interpolate(&value).map_err(|e| format!("MCP server {name:?} key {key:?}: {e}"))?;
+            interpolate(&value.0).map_err(|e| format!("MCP server {name:?} key {key:?}: {e}"))?;
         out.insert(key, expanded);
     }
     Ok(out)
@@ -344,9 +414,12 @@ fn interpolate(value: &str) -> Result<String, String> {
         }
         result = format!("{}{replacement}{}", &result[..start], &result[end + 1..]);
     }
+    // The value is **not** interpolated into this: it is raw file content, which
+    // is what the module's no-echo rule is about, and `interpolate_map` has
+    // already named the server and the key it is under.
     Err(format!(
-        "expanding {value:?}: more than {MAX_SUBSTITUTIONS} substitutions, \
-         which means an environment variable expands to itself"
+        "more than {MAX_SUBSTITUTIONS} `${{ENV:…}}` substitutions, which means \
+         an environment variable expands to itself"
     ))
 }
 
@@ -459,6 +532,61 @@ holes:
                 "env": {"EMPTY": ""},
             }),
             "a null argument is dropped, not sent as an empty one"
+        );
+    }
+
+    /// An unquoted scalar is a **string**, because `yaml.v3` reads a `string`
+    /// field from the node's own text whatever it resolved to.
+    ///
+    /// Rejecting these would be Part A's regression re-entered through the
+    /// parser: the registry is loaded for *any* agent naming *any* MCP server,
+    /// so one unquoted port number in a leftover file would refuse every
+    /// MCP-backed agent on the machine. Every row here was measured against
+    /// `gopkg.in/yaml.v3` v3.0.1 — including the last two, which are the
+    /// accepted divergence: `serde_norway` has already resolved the scalar by
+    /// the time this sees it, because `apply_merge` forces a `Value` round trip.
+    #[test]
+    fn a_bare_scalar_is_read_as_its_text_the_way_yaml_v3_reads_one() {
+        let registry = parse(
+            "mcps.yaml",
+            r#"
+a:
+  transport: stdio
+  command: 123
+  args: [--port, 8080, --ratio, 1.5, --on, true]
+  env:
+    PORT: 8080
+    DEBUG: true
+    RATE: 1.5
+    YES: yes
+"#,
+        )
+        .expect("bare scalars are strings");
+        assert_eq!(
+            registry.get("a").expect("a"),
+            &serde_json::json!({
+                "type": "stdio",
+                "command": "123",
+                "args": ["--port", "8080", "--ratio", "1.5", "--on", "true"],
+                // `yes` is a string to both — `yaml.v3` dropped YAML 1.1's
+                // boolean spellings, and serde_norway never had them.
+                "env": {"DEBUG": "true", "PORT": "8080", "RATE": "1.5", "YES": "yes"},
+            })
+        );
+
+        // The residual divergence, pinned rather than reconciled: `yaml.v3`
+        // keeps the node's raw text (`"0x10"`, `"1.50"`, `"2.0"`), and a
+        // resolved scalar has lost it. Reconciling would mean giving up
+        // `apply_merge`, which breaks a whole valid idiom to fix a trailing
+        // zero.
+        let registry = parse(
+            "mcps.yaml",
+            "a:\n  transport: stdio\n  env:\n    H: 0x10\n    T: 1.50\n    Z: 2.0\n",
+        )
+        .expect("resolved scalars");
+        assert_eq!(
+            registry.get("a").expect("a")["env"],
+            serde_json::json!({"H": "16", "T": "1.5", "Z": "2"})
         );
     }
 

--- a/src-tauri/src/native/chat/mod.rs
+++ b/src-tauri/src/native/chat/mod.rs
@@ -15,11 +15,13 @@
 //! forward — it is the answer. The three steering routes answer Go's own 409s
 //! (`handleProvideInput`, `handlePermissionResponse`, `handleStopSession` each
 //! had a distinct string; they are reproduced verbatim), and a chat this
-//! runtime cannot execute — `whatsapp` tools are dropped (#273), `mcps.yaml`
-//! is not read — is a 500 carrying the reason, produced *before* the
+//! runtime cannot execute — an agent naming an MCP server that neither
+//! [`mcps_yaml`] nor a hostable integration resolves, which `whatsapp` reaches
+//! by construction (#273) — is a 500 carrying the reason, produced *before* the
 //! subprocess is spawned. See `runner::build_options`.
 
 pub mod live;
+pub mod mcps_yaml;
 pub mod persist;
 pub mod runner;
 pub mod sse;

--- a/src-tauri/src/native/chat/runner.rs
+++ b/src-tauri/src/native/chat/runner.rs
@@ -416,7 +416,6 @@ pub async fn build_options(
 /// genuinely different things — one is a document to pass along, the other is a
 /// listener this process has to bind — so the distinction is a type rather than
 /// a convention.
-#[derive(Debug)]
 enum McpSource {
     /// A `mcps.yaml` entry: the `--mcp-config` document the CLI dials or
     /// spawns. Nothing in this process hosts it, so there is no handle and
@@ -426,6 +425,25 @@ enum McpSource {
     /// [`start_integration_servers`], not here, because a refusal must leave no
     /// listener behind.
     Integration,
+}
+
+/// **Hand-written, and it prints `External(..)` without the document.**
+///
+/// The obvious `#[derive(Debug)]` would be a credential leak with a long fuse.
+/// By the time a config reaches [`McpSource::External`] its `${ENV:…}`
+/// placeholders have been *resolved* — `mcps_yaml::interpolate` runs at load —
+/// so the value holds live `Authorization` headers and API tokens that the file
+/// itself never contained. `registry::HostingRow` derives neither `Serialize`
+/// **nor `Debug`** for exactly this reason: a `{plan:?}` in a log line is the
+/// same leak as a response field, only later. Every test here asserts on the
+/// *variant*, never on the formatting.
+impl std::fmt::Debug for McpSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::External(_) => f.write_str("External(..)"),
+            Self::Integration => f.write_str("Integration"),
+        }
+    }
 }
 
 /// One entry of `capabilities.mcp`, resolved far enough to say "this build can
@@ -451,9 +469,12 @@ struct McpServerSpec {
 /// [`crate::native::gojson::GoMap`], so that order is already stable — Go ranges
 /// a map here and its own argument differs run to run.
 ///
-/// `Debug` is safe and deliberate here, unlike on `registry::HostingRow`: this
-/// carries ids, tool names, a path and the contents of a file the user wrote,
-/// and no credential is *read* into it that was not already in that file.
+/// **This carries live credentials**, and the `Debug` derive is only safe
+/// because [`McpSource`]'s is hand-written to withhold them. An external
+/// server's config arrives with its `${ENV:…}` placeholders already resolved, so
+/// it holds the very `Authorization` headers and tokens the file only pointed
+/// at. Read `McpSource`'s `Debug` impl before adding a field here, and do not
+/// add `Serialize`.
 #[derive(Debug)]
 struct McpPlan {
     db_path: Option<std::path::PathBuf>,
@@ -1398,6 +1419,48 @@ mod tests {
                 "command": "/usr/bin/docs-mcp",
                 "args": ["--root", "/srv"],
             })
+        );
+    }
+
+    /// **The plan holds live credentials and its `Debug` must not print them.**
+    ///
+    /// `${ENV:…}` is resolved at load, so an external config carries the actual
+    /// `Authorization` header — a value the file itself never contained, which
+    /// is what makes the derive dangerous rather than merely untidy. Same rule
+    /// as `registry::HostingRow`, which derives neither `Debug` nor `Serialize`;
+    /// the difference here is that the plan *is* formatted, in every panic
+    /// message in this module.
+    ///
+    /// Asserted on the token's absence, which is the form that survives the
+    /// message being reworded.
+    #[test]
+    fn the_plans_debug_does_not_carry_an_interpolated_secret() {
+        const SECRET: &str = "sk-live-NOTAREALTOKEN";
+        let _env = crate::paths::tests::env_lock();
+        let _token = crate::paths::tests::EnvVar::set("AGENTO_TEST_PLAN_TOKEN", SECRET);
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = mcps_yaml(
+            dir.path(),
+            "weather:\n  transport: streamable_http\n  url: https://w.example/mcp\n  \
+             headers:\n    Authorization: \"Bearer ${ENV:AGENTO_TEST_PLAN_TOKEN}\"\n",
+        );
+        let plan = mcp_plan(Some(&caps_naming("weather", None)), None, Some(&path))
+            .expect("resolvable")
+            .expect("a plan");
+
+        // The turn really does run with the resolved token…
+        let McpSource::External(config) = &plan.servers[0].source else {
+            panic!("expected the yaml entry");
+        };
+        assert_eq!(
+            config["headers"]["Authorization"],
+            format!("Bearer {SECRET}")
+        );
+        // …and formatting the plan does not disclose it.
+        assert!(
+            !format!("{plan:?}").contains(SECRET),
+            "the plan's Debug leaked the token: {plan:?}"
         );
     }
 

--- a/src-tauri/src/native/chat/runner.rs
+++ b/src-tauri/src/native/chat/runner.rs
@@ -18,23 +18,46 @@
 //! life is the handle's — see [`crate::native::tools`]. That is what makes this
 //! function `async`.
 //!
-//! **#311 narrowed the `mcp` half rather than removing it.** An agent is served
-//! natively when *every* name in `capabilities.mcp` is an integration this build
-//! can host — `registry::HOSTED_TYPES`, which since #313 means **all six**:
-//! `github` (#312), `confluence` (#317), `jira` (#316), `slack` (#315),
-//! `telegram` (#314) and `google` (#313). Three things are still refused, and
-//! [`mcp_plan`] is where each is decided:
+//! **#311 narrowed the `mcp` half and #375 closed it.** [`mcp_plan`] now
+//! resolves a `capabilities.mcp` name exactly as `resolveServerConfig` does, in
+//! its order:
 //!
-//! - **A name whose type is not hosted.** A `whatsapp` row has no Rust starter
-//!   and will not get one; running the turn here would drop its tools.
-//! - **A name with no integration row at all.** Go would still resolve it if
-//!   `mcps.yaml` names it, and this build reads no `mcps.yaml`.
-//! - **Any `mcp` capability at all when `<data dir>/mcps.yaml` exists.** That
-//!   file is what `resolveServerConfig` consults *before* the integrations, so
-//!   with one on disk a name could resolve to a different server in each
-//!   implementation. It is the one check that is broader than it needs to be,
-//!   and it is deliberate: the file is opt-in, the desktop app has no UI for it,
-//!   and a wrong answer here is a turn run against the wrong tool server.
+//! 1. the **`mcps.yaml` registry** ([`super::mcps_yaml`]) — an external server,
+//!    somebody else's subprocess or URL, handed to the CLI in `--mcp-config`;
+//! 2. then the **integrations**, hosted in this process as a filtered
+//!    in-process MCP server — `registry::HOSTED_TYPES`, which since #313 means
+//!    **all six**: `github` (#312), `confluence` (#317), `jira` (#316), `slack`
+//!    (#315), `telegram` (#314) and `google` (#313).
+//!
+//! **The order is load-bearing and it is Go's, not a preference.** A name in
+//! *both* is the yaml entry, because `resolveServerConfig` returns the registry
+//! hit before it ever looks at the integrations — so a user who shadows an
+//! integration id in their own file gets their own server, which is the only
+//! answer that keeps a config authored for `agento web` meaning the same thing
+//! here.
+//!
+//! One shape is still refused, and it is the honest one: **a name in neither**.
+//! `whatsapp` reaches it by construction — the type is dropped rather than
+//! deferred (#273), so a `whatsapp` row is not hostable and nothing else can
+//! resolve the name unless the user's own `mcps.yaml` does. Running the turn
+//! anyway would silently drop that server's tools, and an agent that quietly
+//! loses a tool set gives a worse answer than one that says it cannot run.
+//!
+//! **What #375 removed is the check that was broader than it needed to be**: the
+//! mere *presence* of `<data dir>/mcps.yaml` used to refuse every `mcp`
+//! capability, including names that resolved perfectly to hosted integrations.
+//! Its stated reason was that a name could resolve to a different server in the
+//! Go server than in this port — a hazard that required both to exist, and #391
+//! deleted the Go tree. Until it went, one leftover file broke every MCP-backed
+//! agent on the machine, which is the state anyone who ever ran `agento web`
+//! against the same data directory was in.
+//!
+//! A **malformed or unreadable** registry is still an error, and it refuses only
+//! the turns that would have consulted it: [`mcp_plan`] loads the file after
+//! establishing that the agent names at least one MCP server, so an agent that
+//! names none is untouched by a typo in it. That ordering is Part A's own
+//! lesson applied to Part B, and it is why the file's *path* rather than a
+//! pre-loaded registry is what this function takes.
 
 use rusqlite::OptionalExtension;
 
@@ -243,7 +266,7 @@ pub async fn build_options(
     let mcp_plan = mcp_plan(
         caps,
         crate::paths::database_path().as_deref(),
-        mcps_yaml_exists(),
+        super::mcps_yaml::path().as_deref(),
     )?;
 
     // `--include-partial-messages` is unconditional in Go, and it is what makes
@@ -386,61 +409,105 @@ pub async fn build_options(
     Ok((opts, tool_servers))
 }
 
+/// Where one `capabilities.mcp` name resolved to.
+///
+/// `resolveServerConfig` returns a bare `any` and the caller cannot tell the two
+/// apart, because in Go both are already a finished SDK config. Here they are
+/// genuinely different things — one is a document to pass along, the other is a
+/// listener this process has to bind — so the distinction is a type rather than
+/// a convention.
+#[derive(Debug)]
+enum McpSource {
+    /// A `mcps.yaml` entry: the `--mcp-config` document the CLI dials or
+    /// spawns. Nothing in this process hosts it, so there is no handle and
+    /// nothing to shut down.
+    External(serde_json::Value),
+    /// An integration row this build can host. The listener is bound in
+    /// [`start_integration_servers`], not here, because a refusal must leave no
+    /// listener behind.
+    Integration,
+}
+
 /// One entry of `capabilities.mcp`, resolved far enough to say "this build can
 /// run this turn".
 #[derive(Debug)]
 struct McpServerSpec {
-    /// The integration id, which is both the `mcpServers` key and the prefix
-    /// the CLI puts on every tool that server hosts.
+    /// The server name — which is both the `mcpServers` key and the prefix the
+    /// CLI puts on every tool that server hosts. For an integration it is the
+    /// bare integration id; for an external server it is whatever the user
+    /// called it in `mcps.yaml`.
     id: String,
     tools: Vec<String>,
+    source: McpSource,
 }
 
-/// What this turn will host, and the database the rows came from.
+/// What this turn will run with, and the database the integration rows came
+/// from.
+///
+/// One `Vec` in the capabilities' own order rather than a collection per source:
+/// `--allowedTools` is built by walking it, and its order is part of the command
+/// line, so splitting the walk in two would group every integration's tools
+/// ahead of every external one for no reason. `capabilities.mcp` is a
+/// [`crate::native::gojson::GoMap`], so that order is already stable — Go ranges
+/// a map here and its own argument differs run to run.
 ///
 /// `Debug` is safe and deliberate here, unlike on `registry::HostingRow`: this
-/// carries ids, tool names and a path, and no credential ever reaches it.
+/// carries ids, tool names, a path and the contents of a file the user wrote,
+/// and no credential is *read* into it that was not already in that file.
 #[derive(Debug)]
 struct McpPlan {
-    db_path: std::path::PathBuf,
+    db_path: Option<std::path::PathBuf>,
     servers: Vec<McpServerSpec>,
 }
 
 /// `resolveExternalMCP`'s inputs, checked before any of them is acted on.
 ///
 /// `Ok(None)` is an agent that names no MCP server — the overwhelmingly common
-/// case, and one that must not open the database. `Err` refuses the whole
-/// turn; see the module header for the three shapes that take that path and why
-/// the third is broader than it strictly has to be.
+/// case, and one that must open **neither** the database nor `mcps.yaml`. `Err`
+/// refuses the whole turn: a name that resolves to nothing, or a registry file
+/// that exists and cannot be read.
 ///
-/// `db_path` and `mcps_yaml_present` are parameters rather than reads so the
-/// decision can be driven over a scratch database instead of the machine's own.
+/// `db_path` and `mcps_path` are parameters rather than reads so the decision
+/// can be driven over a scratch database and a fixture file instead of the
+/// machine's own. Note the second is a **path**, not a loaded registry: loading
+/// it in the caller would make a broken file refuse turns that never name an
+/// external server, which is the exact shape of the bug #375 removed.
+///
+/// The database is opened lazily too — only for a name the registry did not
+/// answer — so an agent whose every MCP server comes from `mcps.yaml` runs with
+/// no `integrations` read at all, exactly as `resolveServerConfig` short-circuits.
 fn mcp_plan(
     caps: Option<&Capabilities>,
     db_path: Option<&std::path::Path>,
-    mcps_yaml_present: bool,
+    mcps_path: Option<&std::path::Path>,
 ) -> Result<Option<McpPlan>, String> {
     let Some(mcp) = caps.and_then(|c| c.mcp.as_ref()).filter(|m| !m.is_empty()) else {
         return Ok(None);
     };
 
-    if mcps_yaml_present {
-        return Err(
-            "an mcps.yaml is present, and `resolveServerConfig` consults it before the \
-             integrations; this build reads none, so the turn goes to Go"
-                .to_string(),
-        );
-    }
-    let db_path = db_path.ok_or("no home directory to resolve the data dir".to_string())?;
+    let registry = super::mcps_yaml::load(mcps_path)?;
 
     let mut servers = Vec::with_capacity(mcp.len());
+    let mut needs_db = false;
     for (id, capability) in mcp.iter() {
-        if !crate::native::integrations::registry::can_host(db_path, id)? {
-            return Err(format!(
-                "agent uses MCP server {id:?}, which is not an integration this build \
-                 can host (#313)"
-            ));
-        }
+        // `resolveServerConfig` asks the registry first and returns on a hit,
+        // so a name in both is the yaml entry and the integrations are never
+        // consulted for it.
+        let source = match registry.get(id) {
+            Some(config) => McpSource::External(config.clone()),
+            None => {
+                let db_path =
+                    db_path.ok_or("no home directory to resolve the data dir".to_string())?;
+                if !crate::native::integrations::registry::can_host(db_path, id)? {
+                    return Err(format!(
+                        "agent uses MCP server {id:?}, which is named by no mcps.yaml entry \
+                         and is not an integration this build can host (#375)"
+                    ));
+                }
+                needs_db = true;
+                McpSource::Integration
+            }
+        };
         servers.push(McpServerSpec {
             id: id.clone(),
             tools: capability
@@ -449,24 +516,22 @@ fn mcp_plan(
                 .flat_map(|list| list.iter())
                 .cloned()
                 .collect(),
+            source,
         });
     }
     Ok(Some(McpPlan {
-        db_path: db_path.to_path_buf(),
+        // `Some` exactly when an integration has to be started from it. A plan
+        // made entirely of external servers carries no path, which is what makes
+        // "this turn read no database" assertable rather than assumed.
+        db_path: needs_db
+            .then(|| db_path.map(std::path::Path::to_path_buf))
+            .flatten(),
         servers,
     }))
 }
 
-/// `<data dir>/mcps.yaml` — `AppConfig.MCPsFile()`, which `cmd/web.go` passes to
-/// `LoadMCPRegistry` and which has no environment override on the `web` path.
-fn mcps_yaml_exists() -> bool {
-    crate::paths::data_dir()
-        .map(|dir| dir.join("mcps.yaml"))
-        .is_some_and(|path| path.is_file())
-}
-
-/// `resolveExternalMCP` over the integrations, once [`mcp_plan`] has
-/// said every one of them is hostable.
+/// `resolveExternalMCP`: register every resolved server and qualify the tool
+/// names the agent asked for, once [`mcp_plan`] has said each one resolves.
 ///
 /// Registered under the **bare integration id**, because that is the
 /// `mcpServers` key Go uses (`StartInProcessMCPServer(ctx, cfg.ID, …)`) and so
@@ -474,14 +539,21 @@ fn mcps_yaml_exists() -> bool {
 /// integration's *MCP implementation* name is `github-<id>`, a different string
 /// that never appears on a tool.
 ///
-/// Two departures from Go, both deliberate:
+/// An **external** server is registered under whatever the user named it in
+/// `mcps.yaml`, for the same reason: that key is the prefix the CLI puts on its
+/// tools, so it is already the string in the agent's stored allowlist.
+///
+/// Two departures from Go, both deliberate, and #375 extends the first to the
+/// external half:
 ///
 /// - **A start failure refuses the turn rather than being skipped.** The
 ///   reference `resolveServerConfig` discards the error and returns `nil`, so
 ///   the turn runs without that server's tools — silently, which is the
 ///   behaviour worth diverging from: an agent that quietly loses a tool set
 ///   gives a worse answer than one that says it cannot run. `start_local_tools`
-///   already follows this rule.
+///   already follows this rule, and an `mcps.yaml` entry that cannot be
+///   converted refuses in [`super::mcps_yaml`] rather than being dropped from
+///   the registry.
 /// - **The map is a `BTreeMap`, so the order is stable.** Go ranges a map, so
 ///   its own `--allowedTools` order for two MCP servers differs between runs.
 ///   Strictly better, and it matches one of the orders Go produces.
@@ -496,25 +568,39 @@ async fn start_integration_servers(
     };
 
     for spec in &plan.servers {
-        let server = crate::native::integrations::registry::start_filtered_server(
-            &plan.db_path,
-            &spec.id,
-            &spec.tools,
-        )
-        .await?;
-        opts = opts
-            .with_mcp_server(&spec.id, server.config())
-            .map_err(|e| format!("registering the MCP server for {:?}: {e}", spec.id))?
-            // `appendToolOpts` adds `--strict-mcp-config` whenever it registers
-            // any server at all, so the CLI does not also load the user's own
-            // `.mcp.json`. Setting a bool, so saying it once per server is the
-            // same as saying it once.
-            .with_strict_mcp_config();
+        opts = match &spec.source {
+            // Somebody else's server: the document goes on the command line and
+            // nothing is bound here, so there is no handle to push.
+            McpSource::External(config) => opts.with_mcp_server(&spec.id, config),
+            McpSource::Integration => {
+                // `Some` by construction — `mcp_plan` records the path exactly
+                // when it resolved a name against the database — but a plan is
+                // a value and this is the one place that would misbehave
+                // silently if that ever stopped being true.
+                let db_path = plan.db_path.as_deref().ok_or_else(|| {
+                    format!("no database to start the MCP server for {:?}", spec.id)
+                })?;
+                let server = crate::native::integrations::registry::start_filtered_server(
+                    db_path,
+                    &spec.id,
+                    &spec.tools,
+                )
+                .await?;
+                let registered = opts.with_mcp_server(&spec.id, server.config());
+                servers.push(server);
+                registered
+            }
+        }
+        .map_err(|e| format!("registering the MCP server for {:?}: {e}", spec.id))?
+        // `appendToolOpts` adds `--strict-mcp-config` whenever it registers
+        // any server at all, so the CLI does not also load the user's own
+        // `.mcp.json`. Setting a bool, so saying it once per server is the
+        // same as saying it once.
+        .with_strict_mcp_config();
         allowed.extend(crate::native::integrations::registry::allowed_tool_names(
             &spec.id,
             &spec.tools,
         ));
-        servers.push(server);
     }
     Ok(opts)
 }
@@ -1182,8 +1268,8 @@ mod tests {
     /// overwhelmingly common case, and the reason the plan is an `Option`.
     #[test]
     fn no_mcp_capability_is_no_plan_and_no_database_read() {
-        assert!(mcp_plan(None, None, false).expect("no caps").is_none());
-        assert!(mcp_plan(Some(&Capabilities::default()), None, false)
+        assert!(mcp_plan(None, None, None).expect("no caps").is_none());
+        assert!(mcp_plan(Some(&Capabilities::default()), None, None)
             .expect("no mcp")
             .is_none());
         // Present but empty is the same as absent, exactly as `local: []` is.
@@ -1192,43 +1278,48 @@ mod tests {
             local: None,
             mcp: Some(BTreeMap::new().into()),
         };
-        assert!(mcp_plan(Some(&empty), None, false)
-            .expect("empty")
-            .is_none());
+        assert!(mcp_plan(Some(&empty), None, None).expect("empty").is_none());
     }
 
-    /// The three shapes that are still refused, each for its own reason.
+    /// A `mcps.yaml` file holding these entries, at a path a test can pass.
+    fn mcps_yaml(dir: &std::path::Path, contents: &str) -> std::path::PathBuf {
+        let path = dir.join("mcps.yaml");
+        std::fs::write(&path, contents).expect("write mcps.yaml");
+        path
+    }
+
+    /// The refusal that survives #375: a name that resolves to **nothing**.
+    ///
+    /// The two that did not are pinned separately below — a name with no
+    /// integration row is now answered by `mcps.yaml`, and the presence of that
+    /// file no longer refuses anything on its own.
     #[test]
-    fn an_mcp_name_this_build_cannot_host_is_refused() {
+    fn an_mcp_name_that_resolves_to_nothing_is_refused() {
         let file = db_with_integration("gh-1", "github");
 
-        // A type with no Rust starter. The stand-in has to be a type that is
-        // genuinely unported, so it moved with each landing — and with #313 it
-        // has arrived at `whatsapp`, which is where it stays: whatsapp is not
-        // deferred but dropped, because its starter opens a live whatsmeow
-        // connection registered in a package global rather than merely a port.
+        // A type with no Rust starter, and the reason `whatsapp` is the
+        // stand-in: it is not deferred but dropped, because its starter opens a
+        // live whatsmeow connection registered in a package global rather than
+        // merely a port. With no `mcps.yaml` entry naming it, nothing resolves
+        // it.
         let whatsapp = db_with_integration("wa-1", "whatsapp");
         let err = mcp_plan(
             Some(&caps_naming("wa-1", None)),
             Some(whatsapp.path()),
-            false,
+            None,
         )
         .expect_err("whatsapp cannot be hosted");
         assert!(err.contains(r#"MCP server "wa-1""#), "{err}");
 
-        // A name with no integration row: `mcps.yaml` could still name it.
+        // A name with no integration row and no yaml entry.
         assert!(mcp_plan(
             Some(&caps_naming("not-an-integration", None)),
             Some(file.path()),
-            false
+            None
         )
         .is_err());
 
-        // An `mcps.yaml` on disk takes precedence over the integrations in Go,
-        // and this build reads none — so any MCP capability is refused.
-        assert!(mcp_plan(Some(&caps_naming("gh-1", None)), Some(file.path()), true).is_err());
-
-        // One unhostable name among several refuses the whole turn: a partial
+        // One unresolvable name among several refuses the whole turn: a partial
         // tool set is the failure the refusal exists to prevent.
         let mut mixed = caps_naming("gh-1", None);
         if let Some(mcp) = mixed.mcp.as_mut() {
@@ -1237,7 +1328,130 @@ mod tests {
                 crate::native::agents::McpCapability { tools: None }.into(),
             );
         }
-        assert!(mcp_plan(Some(&mixed), Some(file.path()), false).is_err());
+        assert!(mcp_plan(Some(&mixed), Some(file.path()), None).is_err());
+    }
+
+    /// **Part A of #375, and the whole of the regression it names.** An
+    /// `mcps.yaml` on disk that has nothing to say about this agent's servers
+    /// must not refuse it.
+    ///
+    /// Before #375 the mere existence of the file was an early `Err`, so one
+    /// leftover from an `agento web` install disabled every MCP-backed agent on
+    /// the machine — including the six integration types that are fully
+    /// implemented here and would have worked. Reverting the deleted arm fails
+    /// this test on its first assertion.
+    #[test]
+    fn a_registry_that_names_none_of_the_agents_servers_does_not_refuse_it() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = db_with_integration("gh-1", "github");
+        let caps = caps_naming("gh-1", Some(vec!["get_repo".into()]));
+
+        for contents in [
+            "",
+            "# left over from `agento web`\n",
+            "something-else:\n  transport: stdio\n  command: /usr/bin/other\n",
+        ] {
+            let path = mcps_yaml(dir.path(), contents);
+            let plan = mcp_plan(Some(&caps), Some(file.path()), Some(&path))
+                .unwrap_or_else(|e| panic!("{contents:?} must not refuse the turn: {e}"))
+                .expect("a plan");
+            let [spec] = &plan.servers[..] else {
+                panic!("one server");
+            };
+            assert!(
+                matches!(spec.source, McpSource::Integration),
+                "{contents:?} resolved somewhere unexpected: {:?}",
+                spec.source
+            );
+        }
+    }
+
+    /// Part B: a name the registry answers is an **external** server, resolved
+    /// without opening the database at all — `resolveServerConfig` returns on
+    /// the registry hit and never reaches the integrations.
+    #[test]
+    fn a_yaml_name_resolves_externally_and_reads_no_database() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = mcps_yaml(
+            dir.path(),
+            "docs:\n  transport: stdio\n  command: /usr/bin/docs-mcp\n  args: [--root, /srv]\n",
+        );
+        let caps = caps_naming("docs", Some(vec!["search".into()]));
+
+        // `db_path: None` is what makes "no database was read" an assertion
+        // rather than an assumption: any fall-through to the integrations is
+        // the `no home directory` error.
+        let plan = mcp_plan(Some(&caps), None, Some(&path))
+            .expect("the registry answers")
+            .expect("a plan");
+        assert!(plan.db_path.is_none(), "no integration, no database");
+        let [spec] = &plan.servers[..] else {
+            panic!("one server");
+        };
+        let McpSource::External(config) = &spec.source else {
+            panic!("expected the yaml entry, got {:?}", spec.source);
+        };
+        assert_eq!(
+            config,
+            &serde_json::json!({
+                "type": "stdio",
+                "command": "/usr/bin/docs-mcp",
+                "args": ["--root", "/srv"],
+            })
+        );
+    }
+
+    /// `resolveServerConfig` asks the registry **first**, so a name in both is
+    /// the yaml entry. Getting this backwards would run a turn against a
+    /// different tool server than the config the user wrote asks for.
+    #[test]
+    fn a_name_in_both_resolves_to_the_yaml_entry() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = db_with_integration("gh-1", "github");
+        let path = mcps_yaml(
+            dir.path(),
+            "gh-1:\n  transport: sse\n  url: https://mine.example/sse\n",
+        );
+
+        let plan = mcp_plan(
+            Some(&caps_naming("gh-1", Some(vec!["get_repo".into()]))),
+            Some(file.path()),
+            Some(&path),
+        )
+        .expect("resolvable")
+        .expect("a plan");
+        let [spec] = &plan.servers[..] else {
+            panic!("one server");
+        };
+        let McpSource::External(config) = &spec.source else {
+            panic!("the registry has to win: {:?}", spec.source);
+        };
+        assert_eq!(config["url"], "https://mine.example/sse");
+    }
+
+    /// A registry that exists and cannot be parsed refuses the turn, naming the
+    /// file — the one thing that must **not** be silently treated as "no
+    /// external servers", because that would drop a tool set without saying so.
+    #[test]
+    fn an_unreadable_registry_refuses_and_names_the_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = mcps_yaml(dir.path(), "docs:\n  transport: carrier-pigeon\n");
+        let err = mcp_plan(
+            Some(&caps_naming("docs", None)),
+            None,
+            Some(dir.path().join("mcps.yaml").as_path()),
+        )
+        .expect_err("a broken registry is not an empty one");
+        assert!(err.contains(r#"MCP server "docs""#), "{err}");
+        assert!(err.contains("unknown transport"), "{err}");
+
+        // …and it refuses **only** turns that reach it. An agent naming no MCP
+        // server is untouched by a typo in a file it never consults, which is
+        // Part A's lesson applied to the parser.
+        std::fs::write(&path, "\t not: [even, yaml\n").expect("write");
+        assert!(mcp_plan(Some(&Capabilities::default()), None, Some(&path))
+            .expect("no mcp capability, no registry read")
+            .is_none());
     }
 
     /// The whole of #311's runner half: a github-only agent runs natively, with
@@ -1250,7 +1464,7 @@ mod tests {
         let file = db_with_integration("gh-1", "github");
         let caps = caps_naming("gh-1", Some(vec!["get_repo".into()]));
 
-        let plan = mcp_plan(Some(&caps), Some(file.path()), false)
+        let plan = mcp_plan(Some(&caps), Some(file.path()), None)
             .expect("hostable")
             .expect("a plan");
         let mut allowed = allowed_tools(Some(&caps));
@@ -1284,7 +1498,7 @@ mod tests {
     async fn an_unhosted_tool_name_is_still_qualified() {
         let file = db_with_integration("gh-1", "github");
         let caps = caps_naming("gh-1", Some(vec!["get_repo".into(), "gone".into()]));
-        let plan = mcp_plan(Some(&caps), Some(file.path()), false)
+        let plan = mcp_plan(Some(&caps), Some(file.path()), None)
             .expect("hostable")
             .expect("a plan");
 
@@ -1298,6 +1512,66 @@ mod tests {
             vec![
                 "mcp__gh-1__get_repo".to_string(),
                 "mcp__gh-1__gone".to_string()
+            ]
+        );
+    }
+
+    /// An external server reaches `--mcp-config` verbatim, binds nothing, and is
+    /// walked in the **same** pass as an integration — so `--allowedTools` stays
+    /// in the capabilities' order rather than grouping by source.
+    ///
+    /// The three transports are pinned in `mcps_yaml`'s own tests, at the bytes.
+    /// What this adds is the half that is `runner`'s: registration under the
+    /// user's own name, no listener handle, and `--strict-mcp-config` set by an
+    /// external server alone (without it the CLI would also load the user's
+    /// `.mcp.json`, so the agent's allowlist would stop being the whole story).
+    #[tokio::test]
+    async fn an_external_server_is_registered_without_binding_anything() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = db_with_integration("gh-1", "github");
+        let path = mcps_yaml(
+            dir.path(),
+            "zz-docs:\n  transport: streamable_http\n  url: https://docs.example/mcp\n",
+        );
+        // `zz-` sorts after `gh-1`, so the order below is the map's and not an
+        // artefact of which source was walked first.
+        let mut caps = caps_naming("gh-1", Some(vec!["get_repo".into()]));
+        if let Some(mcp) = caps.mcp.as_mut() {
+            mcp.0.insert(
+                "zz-docs".to_string(),
+                crate::native::agents::McpCapability {
+                    tools: Some(vec!["search".to_string()].into()),
+                }
+                .into(),
+            );
+        }
+
+        let plan = mcp_plan(Some(&caps), Some(file.path()), Some(&path))
+            .expect("resolvable")
+            .expect("a plan");
+        let mut allowed = Vec::new();
+        let mut servers = Vec::new();
+        let opts =
+            start_integration_servers(Options::new(), Some(&plan), &mut allowed, &mut servers)
+                .await
+                .expect("started");
+
+        assert_eq!(
+            servers.len(),
+            1,
+            "only the integration binds a listener; an external server is somebody else's"
+        );
+        assert_eq!(
+            opts.mcp_servers.get("zz-docs"),
+            Some(&serde_json::json!({"type": "http", "url": "https://docs.example/mcp"})),
+            "the yaml document is handed over verbatim, under the user's own name"
+        );
+        assert!(opts.strict_mcp_config);
+        assert_eq!(
+            allowed,
+            vec![
+                "mcp__gh-1__get_repo".to_string(),
+                "mcp__zz-docs__search".to_string()
             ]
         );
     }

--- a/src-tauri/src/native/chat/turn.rs
+++ b/src-tauri/src/native/chat/turn.rs
@@ -105,8 +105,9 @@ pub struct TurnState {
 /// answered as a clean JSON error — a 404 for a missing chat, Go's fixed
 /// `500 "failed to start message"` for machinery failures (reason in the log,
 /// as Go logged it), and a 500 carrying the refusal reason for the cases that
-/// this build refuses outright (`whatsapp` tools are dropped, `mcps.yaml` is
-/// not read). Once the stream has begun, a failure ends the stream rather than
+/// this build refuses outright (an MCP name that neither `mcps.yaml` nor a
+/// hostable integration resolves, which `whatsapp` reaches by construction —
+/// #273). Once the stream has begun, a failure ends the stream rather than
 /// changing the status — the 200 is already committed.
 pub async fn run(
     db_path: std::path::PathBuf,
@@ -179,8 +180,9 @@ pub async fn run(
         // (#275), which is why this is a field rather than an unconditional.
         custom_session_id: chat_id.clone(),
     };
-    // Refuses for an agent whose tools this runtime cannot supply — `whatsapp`
-    // is dropped (#273), `mcps.yaml` is not read — before any subprocess
+    // Refuses for an agent whose tools this runtime cannot supply — an MCP name
+    // named by no `mcps.yaml` entry and backed by no hostable integration row,
+    // which `whatsapp` reaches by construction (#273) — before any subprocess
     // exists. The refusal reason is the response body: since #278 there is no
     // other implementation to hand the chat to, so an honest 500 naming what
     // is unsupported is the best available answer.

--- a/src-tauri/src/native/schedule/executor.rs
+++ b/src-tauri/src/native/schedule/executor.rs
@@ -15,7 +15,9 @@
 //! That last case is the one Go has no equivalent for. Go's `buildRunOptions`
 //! can always supply every tool, since it *is* the process that hosts them;
 //! [`crate::native::chat::runner::build_options`] can refuse (an agent naming an
-//! `mcps.yaml` server, or a `whatsapp` integration this build dropped). In a
+//! MCP server that neither `<data dir>/mcps.yaml` nor a hostable integration
+//! resolves — a `whatsapp` row reaches that by construction — or one whose
+//! `mcps.yaml` this process could not read). In a
 //! chat that refusal is a 500. Here it is a recorded failure with the reason in
 //! `error_message`, which is the only answer that leaves evidence — a job
 //! history with no row is indistinguishable from a task that was not due.

--- a/src-tauri/tests/chat_turn.rs
+++ b/src-tauri/tests/chat_turn.rs
@@ -1203,14 +1203,25 @@ async fn collect_with_timeout(
 ///
 /// [`run_turn`] makes its own agent-less chat; this is the same thing for the
 /// tests whose whole subject is *which agent* the chat names.
+///
+/// `mcps` points `build_options` at an `mcps.yaml` fixture. It is set **inside**
+/// the lock and removed before the lock is released, for the reason the lock's
+/// own doc gives: the variable is process-global and `build_options` reads it on
+/// every turn, so a `set_var` outside the guard races the sixteen other tests'
+/// `getenv`.
 async fn run_turn_on(
     cli: &Path,
     file: &tempfile::NamedTempFile,
     chat_id: &str,
     content: &str,
+    mcps: Option<&Path>,
 ) -> String {
     let _env = env_lock().lock().await;
     std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", cli);
+    match mcps {
+        Some(path) => std::env::set_var("AGENTO_MCPS_FILE", path),
+        None => std::env::remove_var("AGENTO_MCPS_FILE"),
+    }
 
     let response = agento_lib::native::chat::turn::run(
         file.path().to_path_buf(),
@@ -1222,7 +1233,11 @@ async fn run_turn_on(
 
     assert_eq!(response.status(), 200);
     let collected = collect_with_timeout(response).await;
-    String::from_utf8(collected.to_bytes().to_vec()).expect("utf8")
+    let body = String::from_utf8(collected.to_bytes().to_vec()).expect("utf8");
+    // Still holding the guard: a fixture left behind would outlive its TempDir
+    // and be read by whichever test ran next.
+    std::env::remove_var("AGENTO_MCPS_FILE");
+    body
 }
 
 /// The acceptance criterion of #310, end to end: an agent whose only tool is
@@ -1283,7 +1298,7 @@ async fn a_chat_using_a_local_tool_runs_natively_end_to_end() {
 
     let id = unique_id("localtool");
     let file = migrated_with_local_tool_agent(&id);
-    let body = run_turn_on(&cli, &file, &id, "what time is it in Tokyo?").await;
+    let body = run_turn_on(&cli, &file, &id, "what time is it in Tokyo?", None).await;
 
     // The tool really ran in this process: only the local server could have
     // produced this sentence, and only from Go's format string.
@@ -1342,11 +1357,6 @@ async fn a_chat_using_an_mcps_yaml_server_reaches_the_cli_with_it() {
          args: [\"--root\", \"/srv/docs\"]\n  env:\n    LOG_LEVEL: debug\n",
     )
     .expect("write mcps.yaml");
-    // The one lever that points this process at a fixture: a debug build's
-    // `paths::data_dir` ignores `AGENTO_DATA_DIR` by design, so `MCPS_FILE` is
-    // how a test reads a registry that is not the developer's own. No other
-    // test in this binary names an MCP server, so nothing else consults it.
-    std::env::set_var("MCPS_FILE", &registry);
 
     let cli = fake_cli(
         dir.path(),
@@ -1371,7 +1381,10 @@ async fn a_chat_using_an_mcps_yaml_server_reaches_the_cli_with_it() {
 
     let id = unique_id("mcpsyaml");
     let file = migrated_with_mcp_agent(&id, "docs-mcp");
-    let body = run_turn_on(&cli, &file, &id, "search the docs").await;
+    // `AGENTO_MCPS_FILE` is the one lever that points this process at a fixture
+    // — a debug build's `paths::data_dir` ignores the environment by design —
+    // and `run_turn_on` sets it under the same lock it sets the fake CLI under.
+    let body = run_turn_on(&cli, &file, &id, "search the docs", Some(&registry)).await;
 
     // The entry travels verbatim: the transport's *wire* spelling, the argv and
     // the environment the file declared. Asserted as one substring rather than

--- a/src-tauri/tests/chat_turn.rs
+++ b/src-tauri/tests/chat_turn.rs
@@ -124,8 +124,8 @@ fn migrated_with_chat(id: &str) -> tempfile::NamedTempFile {
 /// That is what makes `wrap_permission_handler` wrap the handler at all: an
 /// empty allowlist returns the inner one unwrapped, so a test that skipped the
 /// agent would exercise the bypass rather than the allowlist. `built_in` only,
-/// so the allowlist is exactly the one tool — the local server has its own
-/// fixture below, and an agent naming an MCP server still forwards to Go.
+/// so the allowlist is exactly the one tool — the local server and the
+/// `mcps.yaml` one each have their own fixture below.
 fn migrated_with_allowlisted_agent(id: &str) -> tempfile::NamedTempFile {
     let file = tempfile::NamedTempFile::new().expect("temp file");
     let mut conn = rusqlite::Connection::open(file.path()).expect("open");
@@ -162,6 +162,28 @@ fn migrated_with_local_tool_agent(id: &str) -> tempfile::NamedTempFile {
     conn.execute(
         "INSERT INTO chat_sessions (id, title, agent_slug, created_at, updated_at)
          VALUES (?1, 'New Chat', 'clock', '2026-01-01 00:00:00 +0000 UTC', '2026-01-01 00:00:00 +0000 UTC')",
+        [id],
+    )
+    .expect("seed chat");
+    file
+}
+
+/// A chat whose agent names one **external** MCP server — the `mcps.yaml`
+/// shape, which no integration row backs.
+fn migrated_with_mcp_agent(id: &str, server: &str) -> tempfile::NamedTempFile {
+    let file = tempfile::NamedTempFile::new().expect("temp file");
+    let mut conn = rusqlite::Connection::open(file.path()).expect("open");
+    agento_lib::native::migrate::apply(&mut conn).expect("migrate");
+    conn.execute(
+        "INSERT INTO agents (slug, name, capabilities) VALUES ('docs', 'Docs', ?1)",
+        [format!(
+            r#"{{"mcp":{{"{server}":{{"tools":["search"]}}}}}}"#
+        )],
+    )
+    .expect("seed agent");
+    conn.execute(
+        "INSERT INTO chat_sessions (id, title, agent_slug, created_at, updated_at)
+         VALUES (?1, 'New Chat', 'docs', '2026-01-01 00:00:00 +0000 UTC', '2026-01-01 00:00:00 +0000 UTC')",
         [id],
     )
     .expect("seed chat");
@@ -1291,6 +1313,88 @@ async fn a_chat_using_a_local_tool_runs_natively_end_to_end() {
         names,
         vec!["mcp__local-tools__current_time"],
         "renaming either half of this breaks every agent that already names it"
+    );
+}
+
+/// The acceptance criterion of #375, end to end: an agent whose MCP server is
+/// declared **only** in `mcps.yaml` runs, and the entry the user wrote reaches
+/// the CLI's `--mcp-config` argument.
+///
+/// Before #375 this turn was refused twice over — once because `docs-mcp` has
+/// no integration row, and once because an `mcps.yaml` existed at all — so it
+/// answered a 500 and no subprocess was ever spawned.
+///
+/// The fake CLI reports what it was actually invoked with rather than the test
+/// inspecting an `Options`: the whole chain under test is the file being read,
+/// the entry being converted, and `Options::build_args` putting it on a command
+/// line. A `KeyError` in there is the assertion.
+#[tokio::test]
+async fn a_chat_using_an_mcps_yaml_server_reaches_the_cli_with_it() {
+    let Some(_) = python3() else {
+        eprintln!("skipping: no python3");
+        return;
+    };
+    let dir = tempfile::tempdir().expect("tempdir");
+    let registry = dir.path().join("mcps.yaml");
+    std::fs::write(
+        &registry,
+        "docs-mcp:\n  transport: stdio\n  command: /usr/bin/docs-mcp\n  \
+         args: [\"--root\", \"/srv/docs\"]\n  env:\n    LOG_LEVEL: debug\n",
+    )
+    .expect("write mcps.yaml");
+    // The one lever that points this process at a fixture: a debug build's
+    // `paths::data_dir` ignores `AGENTO_DATA_DIR` by design, so `MCPS_FILE` is
+    // how a test reads a registry that is not the developer's own. No other
+    // test in this binary names an MCP server, so nothing else consults it.
+    std::env::set_var("MCPS_FILE", &registry);
+
+    let cli = fake_cli(
+        dir.path(),
+        r#"
+    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack(req.get("request_id") or msg.get("request_id"))
+    elif msg.get("type") == "user":
+        cfg = json.loads(sys.argv[sys.argv.index("--mcp-config") + 1])
+        seen = {"server": cfg["mcpServers"]["docs-mcp"],
+                "allowed": sys.argv[sys.argv.index("--allowedTools") + 1],
+                "strict": "--strict-mcp-config" in sys.argv}
+        # Compact separators so the text compares against `serde_json`'s own
+        # spelling; Python's default puts a space after ':' and ','.
+        seen = json.dumps(seen, sort_keys=True, separators=(",", ":"))
+        say({"type": "assistant", "message": {"content": [
+            {"type": "text", "text": seen}]}})
+        say({"type": "result", "subtype": "success", "is_error": False,
+             "result": "ok", "session_id": "sdk-external",
+             "usage": {"input_tokens": 1, "output_tokens": 1}})
+"#,
+    );
+
+    let id = unique_id("mcpsyaml");
+    let file = migrated_with_mcp_agent(&id, "docs-mcp");
+    let body = run_turn_on(&cli, &file, &id, "search the docs").await;
+
+    // The entry travels verbatim: the transport's *wire* spelling, the argv and
+    // the environment the file declared. Asserted as one substring rather than
+    // key by key, because a respelled key or a dropped `env` is exactly the
+    // failure a per-field check waves through.
+    let expected = serde_json::json!({
+        "allowed": "mcp__docs-mcp__search",
+        "server": {
+            "type": "stdio",
+            "command": "/usr/bin/docs-mcp",
+            "args": ["--root", "/srv/docs"],
+            "env": {"LOG_LEVEL": "debug"},
+        },
+        "strict": true,
+    });
+    let expected = serde_json::to_string(&expected).expect("encode");
+    // The CLI's line is passed through into the SSE body verbatim, so the text
+    // arrives with its quotes escaped — compare against that, not the raw JSON.
+    let escaped = serde_json::to_string(&expected).expect("escape");
+    let needle = &escaped[1..escaped.len() - 1];
+    assert!(
+        body.contains(needle),
+        "the mcps.yaml entry never reached the CLI.\nwanted: {needle}\nbody was: {body}"
     );
 }
 

--- a/src-tauri/tests/scheduled_run.rs
+++ b/src-tauri/tests/scheduled_run.rs
@@ -274,8 +274,9 @@ async fn an_error_result_is_a_failed_job_with_gos_wording() {
 /// With the sidecar started `AGENTO_SCHEDULER=off` there is no second
 /// implementation behind a fire, so a job history with no row would be
 /// indistinguishable from a task that was not due. `build_options` still
-/// refuses an agent naming an MCP server this build cannot host — here one with
-/// no integration row at all, which Go would still resolve from `mcps.yaml`.
+/// refuses an agent naming an MCP server nothing resolves — here one with no
+/// integration row and no `mcps.yaml` entry (#375 made the second half of that
+/// resolvable; a name in neither is still a refusal).
 #[tokio::test]
 async fn an_agent_whose_tools_this_build_cannot_host_is_a_recorded_failure() {
     let dir = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
Closes #375

## What

Two things, landed together because the second is what makes the first
complete — but the first is a **regression fix** and stands on its own.

**Part A — the regression.** `native/chat/runner.rs::mcp_plan` refused *any*
`capabilities.mcp` when `<data dir>/mcps.yaml` merely **existed** on disk. That
check guarded against a name resolving to a different server in the Go server
than in this port — a hazard that needs both to exist, and #391 deleted the Go
tree. Until now, one leftover file (the normal state for anyone who ever ran
`agento web` against the same data directory) disabled **every** MCP-backed
agent on the machine, including the six integration types that are fully
implemented here and would have worked. The file did not have to be *used*; its
existence alone was the trigger.

**Part B — the feature.** New `native/chat/mcps_yaml.rs` ports
`LoadMCPRegistry` / `convertMCPEntry` / `interpolateEnv`. `mcp_plan` now walks
`capabilities.mcp` in `resolveServerConfig`'s order — **registry first, then the
integrations** — so an external server reaches the CLI in `--mcp-config` with the
command, args, env or headers the file declares, and a name in *both* is the
yaml entry.

## Why the Go source is quoted rather than inferred

`internal/config/mcp.go` was deleted with the rest of the Go tree, so the schema
was recovered from git history (`git show daa8e69^:internal/config/mcp.go`) and
transcribed field for field rather than guessed from an example file, as the
issue's HOW asked. Everything below that reads as a quirk is Go's:

- the `transport` key and the `type` on the wire are **different spellings** and
  only `stdio` and `sse` agree — `streamable_http` becomes `http`;
- an `${ENV:VAR}` that is **set but empty** is the same refusal as an unset one
  (Go tests `value == ""`), and an unterminated `${ENV:` is left alone;
- a missing file is an empty registry with no error, while an unreadable or
  unparseable one is an error naming the path.

## What is still refused

A `capabilities.mcp` name that resolves to **neither** the registry nor a
hostable integration — which is where `whatsapp` lands, the type being dropped
rather than deferred (#273). A malformed registry refuses too, rather than
reading as "no external servers" and silently dropping a tool set: that is
`start_integration_servers`' existing divergence from Go (which discards the
error and runs degraded) applied to the new path. Both refusals happen **before
any subprocess exists** — a 500 carrying the reason in a chat, a failed
`job_history` row in a scheduled run.

## Two ordering rules that keep Part A's fix from being undone

- **`mcp_plan` takes the registry's *path*, not a loaded registry**, and loads it
  only after establishing that the agent names at least one MCP server. Loading
  in the caller would make a broken file refuse turns that never consult it —
  the exact shape of the bug Part A removes. (This is the one place the
  implementation departs from the HOW, which suggested a pre-resolved registry
  parameter; the stated property — "the decision can be driven over a scratch
  fixture" — is preserved, since a path is as injectable as `db_path` already is.)
- **The database is opened only for a name the registry did not answer**, so an
  all-external agent reads no `integrations` rows at all, matching
  `resolveServerConfig`'s short-circuit. `McpPlan.db_path` is `Option`, which is
  what makes "this turn read no database" an assertion rather than an assumption.

`MCPS_FILE` overrides the path. Go's `web` path had no override (the
`--mcps-file` flag was `agento ask`'s), so this is the desktop equivalent of
that flag — and the only way to point a test at a fixture, because a debug
build's `paths::data_dir` ignores the environment by design.

## The new dependency

`serde_norway = "0.9"` — **2 crates** added to the lock (`serde_norway`,
`unsafe-libyaml-norway`), one caller, justified in a comment at the site.

`serde_yaml` was archived by its author, so the choice is between its three live
forks. `serde_yml` has the most downloads and is rejected anyway — its maintainer
relicensed and bulk-published generated churn over the fork, which is precisely
the supply-chain shape a shipped desktop app should not take on. `serde_yaml_ng`
is credible but MIT-only and last published May 2024. `serde_norway` is dual
MIT/Apache-2.0 like the rest of this tree, was published more recently (Dec
2024), carries its own maintained `unsafe-libyaml-norway` rather than depending
on the archived parser, and is what the Nix/Zellij ecosystem settled on.

## One deliberate divergence from Go, documented at its site

Go's `interpolateEnv` rescans the whole string from the start after each
substitution, so `FOO=${ENV:FOO}` **spins forever** — in Go too. A hang inside
`build_options` is a chat that never answers and a scheduled run that never
records a row, so the loop is bounded at 1000 substitutions and the bound is an
error. Every terminating input behaves exactly as Go's does.

## Tests

Seven new, and **every one was verified to fail on the revert** (the blanket
`mcps_yaml_present` arm restored → 5 unit + 1 integration go red):

- `mcps_yaml.rs`: the three transports pinned as whole `--mcp-config`
  documents (an empty `env`/`headers` is *absent*, not `{}`); `null` as the zero
  value at the field and one level down (`args:` with nothing under it is how a
  person actually leaves it empty); an empty/comment-only file; a missing file
  vs a broken one; the unknown-transport sentence; `${ENV:…}` including the
  set-but-empty and unterminated cases; the self-reference bound; `MCPS_FILE`.
- `runner.rs`: **Part A's own guard** — a registry naming none of the agent's
  servers does not refuse it, over three file shapes including an empty one; a
  yaml name resolving externally with `db_path: None`, proving no database was
  read; a name in both resolving to the yaml entry; an unreadable registry
  refusing *and* not refusing an agent that names no MCP server; an external
  server registered without binding a listener, walked in the same allowlist
  pass as an integration.
- `tests/chat_turn.rs`: the end-to-end criterion — an agent whose server exists
  only in `mcps.yaml` runs, and the fake CLI reports back the `--mcp-config`
  entry, the `--allowedTools` value and `--strict-mcp-config` from its own argv.

## Acceptance criteria

- [x] An `mcps.yaml` on disk + an agent naming only hosted integrations → the turn runs (Part A)
- [x] A stdio server from the file reaches `--mcp-config` with its command, args and env
- [x] The same for `http` and `sse`
- [x] A name in both resolves to the yaml entry
- [x] A name in neither refuses before spawn
- [x] A malformed/unreadable file refuses with a message naming it
- [x] `MCPS_FILE` overrides the default location
- [x] `cargo test` green, including a `chat_turn.rs` case through the fake CLI

## Local gates

`npm run build` · `cargo fmt --check` · `cargo clippy --all-targets -- -D warnings` ·
`cargo test` (1442 lib + all integration suites) · `cargo build --release` — all green.

## Docs

`CLAUDE.md` — *What the runner still refuses* rewritten as *how the runner
resolves an MCP name*, plus the executor's copy of the same claim and the layout
tree. `docs/user-guide.md` — a new **External MCP servers (`mcps.yaml`)** section
under Agents → Tools, since there is no UI for the file, stating plainly that a
`stdio` entry is a program Agento does not sandbox or supervise.

## Out of scope

No UI for authoring `mcps.yaml`; no hosting or lifecycle management of an
external server; the `whatsapp` drop (#273) is untouched.