### PR TITLE
feat(sessions): surface the advanced filters the backend already serves (#495)

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -331,12 +331,41 @@ This is your Claude Code history, indexed and searchable. It covers everything
 `claude` has ever done on this machine, not only what you ran through Agento.
 
 **The list** pages as you scroll and filters in the database, so it stays fast at
-thousands of sessions. Filter by project, model, date, cost or duration, search
-titles and message content, and sort by recent, cost, tokens, duration or message
-count.
+thousands of sessions. The toolbar carries search, project, account, sort and a
+favourites toggle; everything else is behind **Filters**.
 
 Each row carries its project, model, turn count, tokens, cost, duration, and
 badges for permission mode, linked pull requests and git branch.
+
+### Narrowing the list
+
+**Filters** in the toolbar opens a panel with the rest of them. The button shows
+how many are narrowing the list while the panel is shut.
+
+| Filter | Matches |
+| --- | --- |
+| **Mode** | the session's permission mode — Bypass, Plan, Accept, Don't ask, Default |
+| **Model** | the model the session ran on |
+| **Linked PRs** | sessions with, or without, a linked pull request |
+| **Messages** | a turn count, **main thread only** — sub-agent turns are not counted, matching the Msgs column |
+| **Active minutes** | active duration, parent and sub-agents together |
+| **Tokens in / out** | billable input and output tokens, sub-agents included |
+| **Cost** | US dollars, sub-agents included |
+| **Date range** | sessions still active on or after the first date, and started on or before the second |
+
+Every numeric filter is a **minimum and a maximum**, and either alone is enough:
+a minimum by itself reads "at least", a maximum by itself "at most", and both
+together "between".
+
+**Nothing is applied until you press Apply.** Each change re-runs the query and
+throws away the pages already loaded, so typing a number would otherwise filter
+on each digit in turn. The panel counts how many sessions the pending set
+matches, beside the button, so Apply is never a guess. **Clear all** resets the
+search and every filter at once.
+
+Mode, Model and Linked PRs appear only when the indexed sessions actually differ
+on them — one model on the machine means no Model dropdown, and it comes back the
+moment there are two.
 
 **Actions on a session:**
 

--- a/src/styles/sessions.css
+++ b/src/styles/sessions.css
@@ -17,8 +17,11 @@
   gap: var(--sp-2);
   white-space: nowrap;
 }
+/* The open state, on `.iconbtn--active`'s terms plus a ring: this button is the
+   only chrome saying a panel is below it, and a background alone reads as hover
+   on a control that is also a toggle. */
 .sess-filters__toggle--on {
-  color: var(--fg-primary);
+  background: var(--bg-active);
   box-shadow: inset 0 0 0 1px var(--accent);
 }
 /* The applied count, so a collapsed panel still says how much is hidden. */
@@ -100,7 +103,7 @@
   border-radius: var(--r-md);
   box-shadow: inset 0 0 0 var(--hairline) var(--line-strong);
   font-size: var(--text-sm);
-  color: var(--fg-primary);
+  color: var(--fg);
 }
 .sess-filters__num:focus,
 .sess-filters__date:focus {

--- a/src/styles/sessions.css
+++ b/src/styles/sessions.css
@@ -9,6 +9,148 @@
   max-width: 230px;
 }
 
+/* --- Advanced filter panel ------------------------------------------------ */
+/* A disclosure under the toolbar rather than more toolbar: nine controls do not
+   fit a 28px strip, and most listings never need them. */
+
+.sess-filters__toggle {
+  gap: var(--sp-2);
+  white-space: nowrap;
+}
+.sess-filters__toggle--on {
+  color: var(--fg-primary);
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+/* The applied count, so a collapsed panel still says how much is hidden. */
+.sess-filters__badge {
+  min-width: 15px;
+  height: 15px;
+  padding: 0 var(--sp-2);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: var(--accent);
+  color: var(--accent-fg);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+}
+
+.sess-filters {
+  flex: none;
+  padding: var(--sp-6) var(--sp-5);
+  border-bottom: var(--hairline) solid var(--line);
+  background: var(--bg-inset);
+}
+
+.sess-filters__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: var(--sp-5) var(--sp-6);
+}
+
+.sess-filters__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  min-width: 0;
+}
+
+.sess-filters__label {
+  display: flex;
+  align-items: baseline;
+  gap: var(--sp-3);
+  font-size: var(--text-sm);
+  color: var(--fg-secondary);
+}
+
+.sess-filters__hint {
+  font-size: var(--text-xs);
+  color: var(--fg-quaternary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* `.select` is inline-flex and sizes to its label, which in a grid of equal
+   cells leaves ragged controls; the cell is the width here. */
+.sess-filters__select {
+  width: 100%;
+}
+
+.sess-filters__range {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  min-width: 0;
+}
+
+.sess-filters__dash {
+  color: var(--fg-quaternary);
+  flex: none;
+}
+
+.sess-filters__num,
+.sess-filters__date {
+  flex: 1;
+  min-width: 0;
+  height: var(--control-h);
+  padding: 0 var(--sp-4);
+  background: var(--bg-content);
+  border-radius: var(--r-md);
+  box-shadow: inset 0 0 0 var(--hairline) var(--line-strong);
+  font-size: var(--text-sm);
+  color: var(--fg-primary);
+}
+.sess-filters__num:focus,
+.sess-filters__date:focus {
+  outline: none;
+  box-shadow: inset 0 0 0 1px var(--accent), 0 0 0 3px var(--accent-soft);
+}
+.sess-filters__num::placeholder {
+  color: var(--fg-quaternary);
+}
+/* The spinners eat most of a field this narrow, and a bound is typed rather
+   than stepped. */
+.sess-filters__num {
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+.sess-filters__num::-webkit-outer-spin-button,
+.sess-filters__num::-webkit-inner-spin-button {
+  appearance: none;
+  margin: 0;
+}
+/* WebKit renders the picker glyph nearly black in dark mode; the filter is what
+   both webviews honour, since the pseudo-element takes no colour. */
+.sess-filters__date::-webkit-calendar-picker-indicator {
+  opacity: 0.55;
+  cursor: pointer;
+}
+:root[data-theme="dark"] .sess-filters__date::-webkit-calendar-picker-indicator {
+  filter: invert(1);
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"])
+    .sess-filters__date::-webkit-calendar-picker-indicator {
+    filter: invert(1);
+  }
+}
+
+.sess-filters__foot {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  margin-top: var(--sp-6);
+  padding-top: var(--sp-5);
+  border-top: var(--hairline) solid var(--line);
+}
+
+.sess-filters__count {
+  font-size: var(--text-sm);
+  color: var(--fg-tertiary);
+}
+
 /* --- Session detail (read-only transcript) -------------------------------- */
 /* A failed "Continue in chat" from the full session view. Sits directly under
    the toolbar that carries the button, so it needs no scrolling to see. */

--- a/src/views/SessionsView.tsx
+++ b/src/views/SessionsView.tsx
@@ -260,19 +260,6 @@ function bound(v: string): string | undefined {
 }
 
 /**
- * A `YYYY-MM-DD` date input as the RFC 3339 instant the server parses.
- *
- * The bound is taken in the **local** zone, and the `to` side is the *end* of
- * that day: the server compares `start_time <= to`, so a `to` of midnight would
- * exclude every session that ran on the very day the user picked. `from` is the
- * start of its day against `last_activity >= from`, so the range reads as the
- * two dates inclusive.
- *
- * Anything that is not a whole date yields `undefined` rather than a plausible
- * wrong instant — the server ignores an unparseable bound too, so both sides
- * agree it is unbounded.
- */
-/**
  * A facet's option list with the current selection appended when the facet no
  * longer offers it.
  *
@@ -288,6 +275,19 @@ function withSelected(
   return selected && !list.includes(selected) ? [...list, selected] : list;
 }
 
+/**
+ * A `YYYY-MM-DD` date input as the RFC 3339 instant the server parses.
+ *
+ * The bound is taken in the **local** zone, and the `to` side is the *end* of
+ * that day: the server compares `start_time <= to`, so a `to` of midnight would
+ * exclude every session that ran on the very day the user picked. `from` is the
+ * start of its day against `last_activity >= from`, so the range reads as the
+ * two dates inclusive.
+ *
+ * Anything that is not a whole date yields `undefined` rather than a plausible
+ * wrong instant — the server ignores an unparseable bound too, so both sides
+ * agree it is unbounded.
+ */
 function dayBoundary(day: string, edge: "start" | "end"): string | undefined {
   const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(day.trim());
   if (!m) return undefined;

--- a/src/views/SessionsView.tsx
+++ b/src/views/SessionsView.tsx
@@ -284,18 +284,23 @@ function withSelected(
  * start of its day against `last_activity >= from`, so the range reads as the
  * two dates inclusive.
  *
- * Anything that is not a whole date yields `undefined` rather than a plausible
+ * Anything that is not a real date yields `undefined` rather than a plausible
  * wrong instant — the server ignores an unparseable bound too, so both sides
- * agree it is unbounded.
+ * agree it is unbounded. The shape check is not enough on its own: `Date`
+ * *normalizes* rather than rejecting, so `2026-02-30` would otherwise be sent
+ * as 2 March. Only the round trip catches that.
  */
 function dayBoundary(day: string, edge: "start" | "end"): string | undefined {
   const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(day.trim());
   if (!m) return undefined;
+  const [year, month, date] = [Number(m[1]), Number(m[2]) - 1, Number(m[3])];
   const t =
     edge === "start"
-      ? new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]), 0, 0, 0, 0)
-      : new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]), 23, 59, 59, 999);
-  return isFinite(t.getTime()) ? t.toISOString() : undefined;
+      ? new Date(year, month, date, 0, 0, 0, 0)
+      : new Date(year, month, date, 23, 59, 59, 999);
+  const real =
+    t.getFullYear() === year && t.getMonth() === month && t.getDate() === date;
+  return real ? t.toISOString() : undefined;
 }
 
 /**
@@ -402,16 +407,29 @@ const MODE_TONES: Record<string, string> = {
   dontAsk: "badge--teal",
 };
 
+/**
+ * `permission_mode` is a free-form column — the scanner copies whatever the
+ * transcript's `permission-mode` event carried, with no enum in between — so
+ * every read of these tables goes through a `typeof` check rather than `??`.
+ * A plain object inherits `toString`, `constructor` and `valueOf`, and `??`
+ * does not catch a function: the value would reach JSX as a React child and as
+ * a `className`. The `switch` these tables replaced was immune by construction.
+ */
+function lookup(table: Record<string, string>, key: string): string | undefined {
+  const v = table[key];
+  return typeof v === "string" ? v : undefined;
+}
+
 function modeLabel(mode: string): string {
-  return MODE_LABELS[mode] ?? mode;
+  return lookup(MODE_LABELS, mode) ?? mode;
 }
 
 function modeBadge(s: ClaudeSessionSummary): { label: string; tone: string } | null {
   // `omitempty` on the Go side, so the field is absent on a row that recorded
   // no mode — which is not the same as one whose mode this table does not know.
   const mode = s.permission_mode ?? "";
-  const label = MODE_LABELS[mode];
-  if (label) return { label, tone: MODE_TONES[mode] ?? "" };
+  const label = lookup(MODE_LABELS, mode);
+  if (label) return { label, tone: lookup(MODE_TONES, mode) ?? "" };
   return s.mode ? { label: s.mode, tone: "" } : null;
 }
 
@@ -1000,11 +1018,14 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
 
   /**
    * The Mode and Model option sets, on the same terms as `accountOptions`: the
-   * facet is computed over every visible session rather than the filtered one,
-   * and a live selection keeps its own option even when the facet stops
-   * offering it — which happens when the last session of a model is filtered
-   * out from underneath by some *other* control. Without it the dropdown loses
-   * the only entry that could clear it.
+   * facet is computed over every *visible* session rather than the filtered
+   * one, so picking a model never removes the others.
+   *
+   * A live selection keeps its own option even when the facet stops offering
+   * it. That is not the filter narrowing the facet — it cannot — but the corpus
+   * moving underneath a selection: a rescan dropping the last session of a
+   * model, a project hidden in Settings, or a config dir leaving the indexed
+   * set. Without it the dropdown loses the only entry that could clear it.
    */
   const modeOptions = useMemo(
     () => withSelected(facets.data?.permission_modes, draft.permissionMode),

--- a/src/views/SessionsView.tsx
+++ b/src/views/SessionsView.tsx
@@ -69,6 +69,28 @@ const SORTS: { value: Sort; label: string }[] = [
   { value: "messages", label: "Messages" },
 ];
 
+/**
+ * An inclusive numeric bound, held as the **input's own strings**.
+ *
+ * `""` and `0` are different answers — unbounded versus "at most zero" — and a
+ * number-typed state would collapse them. One min/max pair also expresses every
+ * comparison the list needs: min alone reads "at least", max alone "at most",
+ * both "between", so no operator control sits beside each field.
+ */
+interface Range {
+  min: string;
+  max: string;
+}
+
+const NO_RANGE: Range = { min: "", max: "" };
+
+function rangeSet(r: Range): boolean {
+  return r.min.trim() !== "" || r.max.trim() !== "";
+}
+
+/** Whether a session must have a linked PR, must have none, or either. */
+type LinkFilter = "" | "with" | "without";
+
 interface Filters {
   project: string;
   /**
@@ -100,6 +122,25 @@ interface Filters {
    */
   searchSort: Sort | "";
   favorites: boolean;
+
+  /* --- The advanced set, edited as a draft in the Filters panel ----------- */
+
+  /** `""` matches every mode; otherwise the raw `permission_mode` column. */
+  permissionMode: string;
+  /** `""` matches every model. */
+  model: string;
+  links: LinkFilter;
+  /** Main-thread messages only — the column the Msgs cell renders. */
+  messages: Range;
+  /** *Active* minutes, parent plus sub-agents; never the wall-clock span. */
+  duration: Range;
+  tokensIn: Range;
+  tokensOut: Range;
+  /** USD. */
+  cost: Range;
+  /** `YYYY-MM-DD` as the date inputs hold it; `""` is unbounded. */
+  from: string;
+  to: string;
 }
 
 const INITIAL_FILTERS: Filters = {
@@ -108,7 +149,154 @@ const INITIAL_FILTERS: Filters = {
   sort: "recent",
   searchSort: "",
   favorites: false,
+  permissionMode: "",
+  model: "",
+  links: "",
+  messages: NO_RANGE,
+  duration: NO_RANGE,
+  tokensIn: NO_RANGE,
+  tokensOut: NO_RANGE,
+  cost: NO_RANGE,
+  from: "",
+  to: "",
 };
+
+/**
+ * How many of the advanced filters are narrowing the list.
+ *
+ * A min/max pair counts once and the date range counts once, so the number
+ * matches the fields the panel shows rather than the parameters the request
+ * carries — the badge is answering "how much is hidden behind this button".
+ */
+function advancedCount(f: Filters): number {
+  let n = 0;
+  if (f.permissionMode) n += 1;
+  if (f.model) n += 1;
+  if (f.links) n += 1;
+  for (const r of [f.messages, f.duration, f.tokensIn, f.tokensOut, f.cost]) {
+    if (rangeSet(r)) n += 1;
+  }
+  if (f.from || f.to) n += 1;
+  return n;
+}
+
+/**
+ * The parameter names `sessions/query.rs::SessionQuery::parse` reads, spelled
+ * exactly as it reads them.
+ *
+ * A closed union rather than `Record<string, …>` because a misspelled parameter
+ * is **silent on both sides**: the server ignores what it does not recognise
+ * and answers the unfiltered set, so a `permission_mode` typed `permissionMode`
+ * would look like a filter that simply matches everything. There is no
+ * TypeScript test harness here, so making the compiler reject the typo is the
+ * only guard available. Keep it in step with that parser.
+ */
+type FilterParamKey =
+  | "q"
+  | "project"
+  | "config_dir"
+  | "favorites"
+  | "permission_mode"
+  | "model"
+  | "links"
+  | "messages_min"
+  | "messages_max"
+  | "duration_min"
+  | "duration_max"
+  | "tokens_in_min"
+  | "tokens_in_max"
+  | "tokens_out_min"
+  | "tokens_out_max"
+  | "cost_min"
+  | "cost_max"
+  | "from"
+  | "to";
+
+type FilterParams = Partial<Record<FilterParamKey, string | number | boolean>>;
+
+/**
+ * Serialize a filter set into request parameters.
+ *
+ * One function for three callers — the list, the facet aggregate beside it, and
+ * the panel's pending count — because they must describe the *same* set. Two
+ * call sites narrowing by two slightly different query strings is exactly how a
+ * row count and the total printed above it come to disagree.
+ *
+ * An unset filter is **absent**, never an empty value: `qs()` drops both, but
+ * the distinction is the server's — `model=` would ask for a model named `""`.
+ */
+function filterParamsOf(search: string, f: Filters): FilterParams {
+  return {
+    q: search.trim() || undefined,
+    project: f.project || undefined,
+    config_dir: f.configDir || undefined,
+    favorites: f.favorites ? true : undefined,
+    permission_mode: f.permissionMode || undefined,
+    model: f.model || undefined,
+    links: f.links || undefined,
+
+    messages_min: bound(f.messages.min),
+    messages_max: bound(f.messages.max),
+    // The filter's unit is minutes and the column's is milliseconds; the server
+    // scales the bound rather than the column (`add_range(…, 60_000.0)`), so
+    // what goes on the wire is minutes.
+    duration_min: bound(f.duration.min),
+    duration_max: bound(f.duration.max),
+    tokens_in_min: bound(f.tokensIn.min),
+    tokens_in_max: bound(f.tokensIn.max),
+    tokens_out_min: bound(f.tokensOut.min),
+    tokens_out_max: bound(f.tokensOut.max),
+    cost_min: bound(f.cost.min),
+    cost_max: bound(f.cost.max),
+
+    from: dayBoundary(f.from, "start"),
+    to: dayBoundary(f.to, "end"),
+  };
+}
+
+/** One side of a range, sent verbatim — the server ignores what it cannot parse. */
+function bound(v: string): string | undefined {
+  return v.trim() || undefined;
+}
+
+/**
+ * A `YYYY-MM-DD` date input as the RFC 3339 instant the server parses.
+ *
+ * The bound is taken in the **local** zone, and the `to` side is the *end* of
+ * that day: the server compares `start_time <= to`, so a `to` of midnight would
+ * exclude every session that ran on the very day the user picked. `from` is the
+ * start of its day against `last_activity >= from`, so the range reads as the
+ * two dates inclusive.
+ *
+ * Anything that is not a whole date yields `undefined` rather than a plausible
+ * wrong instant — the server ignores an unparseable bound too, so both sides
+ * agree it is unbounded.
+ */
+/**
+ * A facet's option list with the current selection appended when the facet no
+ * longer offers it.
+ *
+ * The escape hatch every option-set control here needs: without it a control
+ * disappears at the one moment it is the only thing that could clear itself,
+ * leaving the list pinned to a value nothing on screen mentions.
+ */
+function withSelected(
+  options: string[] | null | undefined,
+  selected: string
+): string[] {
+  const list = options?.filter(Boolean) ?? [];
+  return selected && !list.includes(selected) ? [...list, selected] : list;
+}
+
+function dayBoundary(day: string, edge: "start" | "end"): string | undefined {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(day.trim());
+  if (!m) return undefined;
+  const t =
+    edge === "start"
+      ? new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]), 0, 0, 0, 0)
+      : new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]), 23, 59, 59, 999);
+  return isFinite(t.getTime()) ? t.toISOString() : undefined;
+}
 
 /**
  * The sort a request will really run under — `sessions/query.rs::resolve_sort`,
@@ -191,21 +379,40 @@ function totalDuration(s: ClaudeSessionSummary): number {
 
 /* --- Presentation helpers ------------------------------------------------- */
 
+/**
+ * The permission modes Claude Code writes, and how each reads.
+ *
+ * One table for the row badge and the Mode filter, so the option a user picks
+ * is spelled exactly as the column they picked it from. An unknown value keeps
+ * its raw text in both places rather than being dropped — the corpus predates
+ * some of these names.
+ */
+const MODE_LABELS: Record<string, string> = {
+  bypassPermissions: "Bypass",
+  plan: "Plan",
+  acceptEdits: "Accept",
+  dontAsk: "Don't ask",
+  default: "Default",
+};
+
+const MODE_TONES: Record<string, string> = {
+  bypassPermissions: "badge--amber",
+  plan: "badge--purple",
+  acceptEdits: "badge--teal",
+  dontAsk: "badge--teal",
+};
+
+function modeLabel(mode: string): string {
+  return MODE_LABELS[mode] ?? mode;
+}
+
 function modeBadge(s: ClaudeSessionSummary): { label: string; tone: string } | null {
-  switch (s.permission_mode) {
-    case "bypassPermissions":
-      return { label: "Bypass", tone: "badge--amber" };
-    case "plan":
-      return { label: "Plan", tone: "badge--purple" };
-    case "acceptEdits":
-      return { label: "Accept", tone: "badge--teal" };
-    case "dontAsk":
-      return { label: "Don't ask", tone: "badge--teal" };
-    case "default":
-      return { label: "Default", tone: "" };
-    default:
-      return s.mode ? { label: s.mode, tone: "" } : null;
-  }
+  // `omitempty` on the Go side, so the field is absent on a row that recorded
+  // no mode — which is not the same as one whose mode this table does not know.
+  const mode = s.permission_mode ?? "";
+  const label = MODE_LABELS[mode];
+  if (label) return { label, tone: MODE_TONES[mode] ?? "" };
+  return s.mode ? { label: s.mode, tone: "" } : null;
 }
 
 /**
@@ -251,10 +458,133 @@ function neverScanned(st: SessionScanStatus | undefined): boolean {
   return !isFinite(t) || new Date(t).getFullYear() < 2000;
 }
 
+/* --- The advanced filter panel ------------------------------------------- */
+
+const LINK_LABELS: Record<LinkFilter, string> = {
+  "": "Any",
+  with: "With a linked PR",
+  without: "Without a linked PR",
+};
+
+function FilterField({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="sess-filters__field">
+      <div className="sess-filters__label">
+        {label}
+        {hint && <span className="sess-filters__hint">{hint}</span>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+/**
+ * One inclusive min/max pair. Both sides are plain `<input>` text, so a
+ * part-typed value is never coerced — and nothing here fires a request, because
+ * the panel edits a draft.
+ */
+function RangeField({
+  label,
+  hint,
+  step,
+  value,
+  onChange,
+}: {
+  label: string;
+  hint?: string;
+  step?: string;
+  value: Range;
+  onChange(r: Range): void;
+}) {
+  return (
+    <FilterField label={label} hint={hint}>
+      <div className="sess-filters__range">
+        <input
+          className="sess-filters__num tnum"
+          type="number"
+          min="0"
+          step={step}
+          inputMode="decimal"
+          placeholder="Min"
+          aria-label={`${label} minimum`}
+          value={value.min}
+          onChange={(e) => onChange({ ...value, min: e.target.value })}
+        />
+        <span className="sess-filters__dash">–</span>
+        <input
+          className="sess-filters__num tnum"
+          type="number"
+          min="0"
+          step={step}
+          inputMode="decimal"
+          placeholder="Max"
+          aria-label={`${label} maximum`}
+          value={value.max}
+          onChange={(e) => onChange({ ...value, max: e.target.value })}
+        />
+      </div>
+    </FilterField>
+  );
+}
+
+/**
+ * How many sessions the *draft* would match, so Apply is not a leap in the
+ * dark — the facet aggregate is the cheap half of a search (~101 ms against the
+ * page's seconds on a common term), and this asks for nothing else.
+ *
+ * It is a child component so the request exists only while the panel is open,
+ * rather than doubling facet traffic for every user who never opens it. The
+ * params object is referentially stable between draft edits, so debouncing it
+ * directly is what keeps a keystroke from becoming a request.
+ */
+function DraftMatchCount({ params }: { params: FilterParams }) {
+  const settled = useDebounced(params, 300);
+  const preview = useResource<SessionFacets>(
+    (signal) =>
+      api.get<SessionFacets>(`/claude-sessions/facets${qs(settled)}`, signal),
+    [settled]
+  );
+
+  // A failed read knows nothing about how many rows match, and saying "0" about
+  // a request that never landed would read as an answer.
+  if (preview.error && !preview.data) {
+    return <span className="sess-filters__count">Count unavailable</span>;
+  }
+  if (!preview.data) {
+    return <span className="sess-filters__count">Counting…</span>;
+  }
+  const n = preview.data.total;
+  return (
+    <span className="sess-filters__count tnum">
+      {integer(n)} {n === 1 ? "session" : "sessions"} match
+    </span>
+  );
+}
+
 export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
   const [query, setQuery] = useState("");
   const q = useDebounced(query, 250);
   const [filters, setFilters] = useState<Filters>(INITIAL_FILTERS);
+
+  /**
+   * What the Filters panel edits, applied to `filters` on the button.
+   *
+   * Deliberately not live. Every change here resets the keyset cursor and
+   * discards every accumulated page, so typing `50` into a minimum would run a
+   * query for `5` and throw the list away and back mid-keystroke — a server
+   * round trip per character, not a client-side re-filter. The pending count
+   * beside Apply is what keeps that from being a leap in the dark.
+   */
+  const [draft, setDraft] = useState<Filters>(INITIAL_FILTERS);
+  const [panelOpen, setPanelOpen] = useState(false);
 
   // The debounced term, not the raw one: gating relevance on what the user is
   // still typing would flicker the option in and out per keystroke and refetch
@@ -285,15 +615,7 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
   const items = loaded.key === listKey ? loaded.items : NO_ROWS;
   const hasMore = loaded.key === listKey && loaded.hasMore;
 
-  const filterParams = useMemo(
-    () => ({
-      q: q.trim() || undefined,
-      project: filters.project || undefined,
-      config_dir: filters.configDir || undefined,
-      favorites: filters.favorites ? true : undefined,
-    }),
-    [q, filters.project, filters.configDir, filters.favorites]
-  );
+  const filterParams = useMemo(() => filterParamsOf(q, filters), [q, filters]);
 
   const page = useResource<SessionPage>(
     (signal) =>
@@ -353,7 +675,24 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
     // Batched with the filter change so no request ever carries a stale cursor.
     setPaging({ key: "", cursor: "" });
     setFilters((f) => ({ ...f, ...patch }));
+    // The panel's draft carries the *whole* filter set, so a toolbar control
+    // writing only `filters` would make Apply silently revert it. Patching both
+    // is what keeps the two halves of one filter set from drifting apart.
+    setDraft((d) => ({ ...d, ...patch }));
   }, []);
+
+  /** Applied and draft together — the empty state's escape hatch. */
+  const clearFilters = useCallback(() => {
+    setQuery("");
+    setPaging({ key: "", cursor: "" });
+    setFilters(INITIAL_FILTERS);
+    setDraft(INITIAL_FILTERS);
+  }, []);
+
+  const applyDraft = useCallback(() => {
+    setPaging({ key: "", cursor: "" });
+    setFilters(draft);
+  }, [draft]);
 
   const onQuery = useCallback((v: string) => {
     setPaging({ key: "", cursor: "" });
@@ -654,16 +993,40 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
    * Without this the control disappears at the moment it is the only thing that
    * could clear itself, leaving the list pinned to an account with no rows.
    */
-  const accountOptions = useMemo(() => {
-    const dirs = facets.data?.config_dirs?.filter(Boolean) ?? [];
-    return filters.configDir && !dirs.includes(filters.configDir)
-      ? [...dirs, filters.configDir]
-      : dirs;
-  }, [facets.data, filters.configDir]);
-
-  const filtersActive = Boolean(
-    query.trim() || filters.project || filters.configDir || filters.favorites
+  const accountOptions = useMemo(
+    () => withSelected(facets.data?.config_dirs, filters.configDir),
+    [facets.data, filters.configDir]
   );
+
+  /**
+   * The Mode and Model option sets, on the same terms as `accountOptions`: the
+   * facet is computed over every visible session rather than the filtered one,
+   * and a live selection keeps its own option even when the facet stops
+   * offering it — which happens when the last session of a model is filtered
+   * out from underneath by some *other* control. Without it the dropdown loses
+   * the only entry that could clear it.
+   */
+  const modeOptions = useMemo(
+    () => withSelected(facets.data?.permission_modes, draft.permissionMode),
+    [facets.data, draft.permissionMode]
+  );
+
+  const modelOptions = useMemo(
+    () => withSelected(facets.data?.models, draft.model),
+    [facets.data, draft.model]
+  );
+
+  const activeCount = advancedCount(filters);
+  const draftParams = useMemo(() => filterParamsOf(q, draft), [q, draft]);
+  const draftDiffers = useMemo(
+    () => JSON.stringify(draft) !== JSON.stringify(filters),
+    [draft, filters]
+  );
+
+  const filtersActive =
+    Boolean(
+      query.trim() || filters.project || filters.configDir || filters.favorites
+    ) || activeCount > 0;
   const loadingMore = page.loading && cursor !== "";
   const remaining = facets.data ? facets.data.total - items.length : 0;
 
@@ -797,6 +1160,27 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
             <Icon name="star" size={14} />
           </button>
 
+          {/* The eight advanced filters live behind this, collapsed by default:
+              the toolbar is already dense at 28px rows, and most listings are
+              narrowed by search and project alone. The badge is the applied
+              count, not the draft's — it answers "how much of what I am looking
+              at is hidden behind this button". */}
+          <button
+            className={`btn sess-filters__toggle ${
+              panelOpen ? "sess-filters__toggle--on" : ""
+            }`}
+            aria-expanded={panelOpen}
+            aria-controls="sess-filters-panel"
+            title="Advanced filters"
+            onClick={() => setPanelOpen((v) => !v)}
+          >
+            <Icon name="filter" size={13} />
+            Filters
+            {activeCount > 0 && (
+              <span className="sess-filters__badge tnum">{activeCount}</span>
+            )}
+          </button>
+
           <div className="spacer" />
 
           {scanning && status.data && (
@@ -823,6 +1207,168 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
             <Icon name="refresh" size={14} />
           </button>
         </div>
+
+        {panelOpen && (
+          <div className="sess-filters" id="sess-filters-panel">
+            <div className="sess-filters__grid">
+              {/* Both dropdowns follow the account control's rule: rendered
+                  only when there is a choice to make, and always while one is
+                  selected. */}
+              {(modeOptions.length > 1 || draft.permissionMode !== "") && (
+                <FilterField label="Mode">
+                  <Dropdown
+                    small
+                    className="sess-filters__select"
+                    ariaLabel="Permission mode"
+                    label={
+                      draft.permissionMode
+                        ? modeLabel(draft.permissionMode)
+                        : "Any mode"
+                    }
+                    value={draft.permissionMode}
+                    onChange={(v) => setDraft((d) => ({ ...d, permissionMode: v }))}
+                    options={[
+                      { value: "", label: "Any mode" },
+                      ...modeOptions.map((m) => ({
+                        value: m,
+                        label: modeLabel(m),
+                      })),
+                    ]}
+                  />
+                </FilterField>
+              )}
+
+              {(modelOptions.length > 1 || draft.model !== "") && (
+                <FilterField label="Model">
+                  <Dropdown
+                    small
+                    className="sess-filters__select"
+                    ariaLabel="Model"
+                    label={draft.model || "Any model"}
+                    value={draft.model}
+                    onChange={(v) => setDraft((d) => ({ ...d, model: v }))}
+                    options={[
+                      { value: "", label: "Any model" },
+                      ...modelOptions.map((m) => ({ value: m, label: m })),
+                    ]}
+                  />
+                </FilterField>
+              )}
+
+              {/* Nothing in the corpus is linked to a PR on most machines, and
+                  a control whose every state shows the same rows is noise. */}
+              {(facets.data?.has_prs || draft.links !== "") && (
+                <FilterField label="Linked PRs">
+                  <Dropdown
+                    small
+                    className="sess-filters__select"
+                    ariaLabel="Linked pull requests"
+                    label={LINK_LABELS[draft.links]}
+                    value={draft.links}
+                    onChange={(v) =>
+                      setDraft((d) => ({ ...d, links: v as LinkFilter }))
+                    }
+                    options={(["", "with", "without"] as LinkFilter[]).map(
+                      (v) => ({ value: v, label: LINK_LABELS[v] })
+                    )}
+                  />
+                </FilterField>
+              )}
+
+              <RangeField
+                label="Messages"
+                // SQL_MESSAGE_COUNT is bare `c.message_count`, where cost,
+                // duration and the token ranges all fold sub-agents in. That is
+                // deliberate on both sides — each filter matches the column its
+                // own cell renders — but it has to be said, or a "Messages"
+                // filter would silently promise a total it does not use.
+                hint="Main thread only"
+                value={draft.messages}
+                onChange={(r) => setDraft((d) => ({ ...d, messages: r }))}
+              />
+
+              <RangeField
+                label="Active minutes"
+                // Active duration, not the wall-clock span: a resumed session's
+                // span counts every idle day between sittings, which is exactly
+                // why the column the list sorts and renders is not that one.
+                hint="Active time, not elapsed"
+                value={draft.duration}
+                onChange={(r) => setDraft((d) => ({ ...d, duration: r }))}
+              />
+
+              <RangeField
+                label="Tokens in"
+                hint="Incl. sub-agents"
+                value={draft.tokensIn}
+                onChange={(r) => setDraft((d) => ({ ...d, tokensIn: r }))}
+              />
+
+              <RangeField
+                label="Tokens out"
+                hint="Incl. sub-agents"
+                value={draft.tokensOut}
+                onChange={(r) => setDraft((d) => ({ ...d, tokensOut: r }))}
+              />
+
+              <RangeField
+                label="Cost"
+                hint="USD, incl. sub-agents"
+                step="0.01"
+                value={draft.cost}
+                onChange={(r) => setDraft((d) => ({ ...d, cost: r }))}
+              />
+
+              <FilterField
+                label="Date range"
+                hint="Active on or after / started on or before"
+              >
+                <div className="sess-filters__range">
+                  <input
+                    className="sess-filters__date"
+                    type="date"
+                    aria-label="Active on or after"
+                    value={draft.from}
+                    max={draft.to || undefined}
+                    onChange={(e) =>
+                      setDraft((d) => ({ ...d, from: e.target.value }))
+                    }
+                  />
+                  <span className="sess-filters__dash">–</span>
+                  <input
+                    className="sess-filters__date"
+                    type="date"
+                    aria-label="Started on or before"
+                    value={draft.to}
+                    min={draft.from || undefined}
+                    onChange={(e) =>
+                      setDraft((d) => ({ ...d, to: e.target.value }))
+                    }
+                  />
+                </div>
+              </FilterField>
+            </div>
+
+            <div className="sess-filters__foot">
+              <DraftMatchCount params={draftParams} />
+              <div className="spacer" />
+              <button
+                className="btn"
+                disabled={!filtersActive && !draftDiffers}
+                onClick={clearFilters}
+              >
+                Clear all
+              </button>
+              <button
+                className="btn btn--primary"
+                disabled={!draftDiffers}
+                onClick={applyDraft}
+              >
+                Apply
+              </button>
+            </div>
+          </div>
+        )}
 
         {page.error && items.length === 0 ? (
           <Empty
@@ -860,13 +1406,7 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
               title="No matching sessions"
               text="No indexed session matches the current search and filters."
               action={
-                <button
-                  className="btn"
-                  onClick={() => {
-                    setQuery("");
-                    patchFilters(INITIAL_FILTERS);
-                  }}
-                >
+                <button className="btn" onClick={clearFilters}>
                   Clear filters
                 </button>
               }


### PR DESCRIPTION
Closes #495

## What

The sessions toolbar sent five of the thirteen parameters `SessionQuery::parse`
reads. This surfaces the other eight, behind a **Filters** disclosure under the
toolbar: Mode, Model, Linked PRs, and min/max pairs for messages, active
minutes, tokens in, tokens out and cost, plus a date range.

No backend change, no migration, no wire change — every parameter was already
parsed and applied, and `GET /api/claude-sessions/facets` was already returning
`models`, `permission_modes` and `has_prs`, three fields nothing in `src/` read.

## How

- `Filters` grows the eight fields, so `listKey` — `JSON.stringify({q,
  ...filters, sort})` — covers them **by construction** and the keyset cursor is
  invalidated on any change. Numeric bounds are held as the input's own strings:
  `""` and `0` are unbounded versus "at most zero".
- `filterParamsOf(search, filters)` is the single serializer for all three
  callers (list, facets, pending count), so the list and the total printed above
  it cannot be narrowed by two different query strings.
- The panel edits a **draft** applied on a button. Live edits would reset the
  cursor and discard every accumulated page per keystroke — a server round trip
  per character. A debounced facet request beside Apply says how many sessions
  the pending set matches, so it is not a leap in the dark. It is a child
  component, so the request exists only while the panel is open.
- Mode/Model/Links follow the account control's rule: rendered only when there
  is a choice to make, and always while one is selected. `withSelected` is that
  escape hatch, and `accountOptions` now uses it too rather than a second
  spelling.
- `advancedCount` drives both the collapsed badge and `filtersActive`, so the
  empty state still offers "Clear filters" when only an advanced filter is
  narrowing.

## Two semantics the labels carry, because both are silent when wrong

- **Messages is main-thread only** (`SQL_MESSAGE_COUNT` is bare
  `c.message_count`) where cost, duration and the token ranges fold sub-agents
  in. Each filter matches the column its own cell renders; the hints say which.
- **Duration is *active* time, not the wall-clock span**, and the filter's unit
  is minutes against a millisecond column — the server scales the bound.

## Tests

There is no TypeScript test harness in this repo, so the guard is at the type
level, as `src/lib/typeAssert.ts` establishes. `FilterParams` is a closed union
of the parameter names `sessions/query.rs` reads, rather than
`Record<string, …>`: a misspelled parameter is silent on **both** sides — the
server ignores what it does not recognise and answers the unfiltered set, so
`permissionMode` for `permission_mode` reads as a filter that matches
everything.

Verified by reverting: renaming that one key fails `tsc` with

```
TS2561: Object literal may only specify known properties, but 'permissionMode'
does not exist in type 'Partial<Record<FilterParamKey, …>>'.
Did you mean to write 'permission_mode'?
```

Backend coverage is unchanged and already there —
`sessions_query_parses_every_parameter` asserts these exact names, and the
malformed-bound case asserts the ignore-rather-than-reject rule the number
inputs depend on.

## Review rounds

Three rounds of `lab-workflow:review-pr`; five `now` findings, all verified against
the code before being applied.

- `dayBoundary`'s doc block had been detached from its function by the
  `withSelected` insertion — moved back.
- **`var(--fg-primary)` is not a defined token** (the tokens are `--fg`,
  `--fg-secondary/-tertiary/-quaternary/-inverse`, plus `--accent-fg`). Nothing
  lints CSS custom properties here, and an undefined one is invalid only at
  computed-value time, so the toggle's active-state colour was a silent no-op.
  It is now `background: var(--bg-active)` plus the accent ring, on
  `.iconbtn--active`'s terms.
- The `modeOptions`/`modelOptions` comment named the wrong cause for the escape
  hatch — the facet cannot be filter-narrowed; what moves is the corpus.
- `dayBoundary` claimed to reject anything that is not a real date while
  `isFinite` could never be false: `Date` *normalizes*, so `2026-02-30` would
  have gone out as 2 March. Now a `getFullYear`/`getMonth`/`getDate` round trip.
  Unreachable from `<input type="date">`, but the doc was a specification.
- `MODE_LABELS`/`MODE_TONES` resolved up the prototype chain, where the `switch`
  they replaced was immune. `permission_mode` is a free-form column copied from
  the transcript, so a value of `toString` would have reached JSX as a function.
  All three reads go through one `typeof v === "string"` lookup.

CI green on every pushed head (`Typecheck, lint and build`, `Windows unit tests`
and all five CodeQL analyses).
