### PR TITLE
fix: stop an integration hosting zero tools silently (#501)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1517,6 +1517,43 @@ the union of *every enabled service's* `tools` list names it — **or when that
 union is empty**. So all-enabled-with-no-lists hosts all twenty, and one name
 anywhere narrows every service at once. Both halves are in the vectors.
 
+**That empty-union rule is kept, and #501 settled it rather than changing it.**
+It is ported, identical in all six integrations and asserted by each of their
+own suites, so an explicitly empty `tools` list still means *host everything*.
+What #501 closed is the two ways that read as the opposite of what the user
+asked for:
+
+- **`filter_config_tools` dropped a service that named no tools**, so an
+  integration row storing `{"enabled": true}` — what `POST /api/integrations`
+  accepts, and what every row written before the per-service lists carries —
+  hosted **zero** tools while `--allowedTools` still named them. A service with
+  no list of its own is now given the *whole* requested set, which is sound
+  because every integration gates on `service_enabled(group) && allowed(name)`,
+  so a name from another group is still rejected by the service gate.
+- **The Integrations UI could store `{"enabled": true, "tools": []}`** by
+  unchecking a service's last tool, which hosts every tool of that service —
+  the exact inverse of "Only the tools you leave on are exposed to agents".
+  `IntegrationsView.tsx` now turns the **service** off when its last tool goes,
+  so the copy is true of everything the app can store. The API can still store
+  that shape and it still hosts everything; refusing it would be a wire change
+  on a byte-exact endpoint.
+
+**And a turn now says what it hosted.** `chat/runner.rs::report_hosted_tools`
+logs one `info` line per started MCP server naming the tools it registered, plus
+a `warn` per requested tool it did not — read off the handle
+(`InProcessMcpServer::tool_names`), not off what was asked for, because the two
+disagreeing *is* the defect. It stays a warning: `start_local_tools`' rule is
+that a missing tool is the kinder failure than a refused run. Before it, `claude:
+mcp "google-7": serving on http://…` was the whole record and a server hosting
+nothing printed it byte for byte like a healthy one.
+
+`src-tauri/tests/mcp_e2e_probe.rs` is the `#[ignore]`d suite that would have
+caught it: it drives the real CLI through **`runner::build_options`' own
+output** — not a hand-built command line, which is what makes it able to see an
+option-assembly defect at all — and asserts the tool was both *listed* (it
+appears in the CLI's `init` event) and *called*. `claude_mcp_live.rs` remains
+its sibling and stops at the handshake on purpose.
+
 **Four surfaces are pinned, not one.** `parity/github_vectors.json` is
 taken from the real Go server over its real MCP transport, against a fake GitHub
 that **records the request each tool built**: the hosted tool set, each

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1527,9 +1527,22 @@ asked for:
   integration row storing `{"enabled": true}` — what `POST /api/integrations`
   accepts, and what every row written before the per-service lists carries —
   hosted **zero** tools while `--allowedTools` still named them. A service with
-  no list of its own is now given the *whole* requested set, which is sound
-  because every integration gates on `service_enabled(group) && allowed(name)`,
-  so a name from another group is still rejected by the service gate.
+  no list of its own is now given the request **narrowed to its own tools**,
+  through the integration's `SERVICE_TOOLS` table.
+
+  **Handing it the whole request instead is unsound, and it is the obvious
+  thing to write.** The tempting argument — a name from another group is
+  rejected by the service gate anyway — is *nearly* true and fails exactly
+  where it matters: `build_allowed_set` unions **every** enabled service, so a
+  name injected by a listless service satisfies the `allowed` half for a
+  **sibling**, whose own gate passes because it is enabled too. A row of
+  `{"gmail":{"enabled":true},"drive":{"enabled":true,"tools":["list_files"]}}`
+  would then host `create_file` — a write tool the user's own Drive list
+  excludes — on an integration whose every tool result carries attacker-authored
+  third-party content. `SERVICE_TOOLS` is the `push` table as data, and each
+  integration's `the_service_table_matches_what_is_registered` derives the truth
+  from its own registration function (one service enabled at a time) rather than
+  transcribing it, so the two cannot drift.
 - **The Integrations UI could store `{"enabled": true, "tools": []}`** by
   unchecking a service's last tool, which hosts every tool of that service —
   the exact inverse of "Only the tools you leave on are exposed to agents".

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1549,7 +1549,16 @@ asked for:
   `IntegrationsView.tsx` now turns the **service** off when its last tool goes,
   so the copy is true of everything the app can store. The API can still store
   that shape and it still hosts everything; refusing it would be a wire change
-  on a byte-exact endpoint.
+  on a byte-exact endpoint — so the editor also has to *render* such a row
+  honestly, and that rule reads backwards twice over. A listless enabled
+  service shows every tool ticked **only when no sibling names one**: "host
+  everything" is a property of `build_allowed_set`'s union over the *whole
+  integration*, not of one group being empty, so a listless `gmail` beside a
+  `drive: ["list_files"]` hosts **nothing** and must show nothing. Getting that
+  half wrong is worse than a misdisplay — the union is what makes unchecking
+  one box in the ticked-by-default group *grant* the others. Pinned from the
+  backend side by `an_enabled_service_with_an_empty_list_still_hosts_everything`,
+  which carries the mixed row for this reason.
 
 **And a turn now says what it hosted.** `chat/runner.rs::report_hosted_tools`
 logs one `info` line per started MCP server naming the tools it registered, plus

--- a/src-tauri/src/claude/mcp.rs
+++ b/src-tauri/src/claude/mcp.rs
@@ -143,6 +143,7 @@ pub(crate) fn credentials_match(a: &str, b: &str) -> bool {
 pub struct InProcessMcpServer {
     config: McpHttpServer,
     shutdown: Option<tokio::sync::oneshot::Sender<()>>,
+    tool_names: Vec<String>,
 }
 
 impl InProcessMcpServer {
@@ -154,6 +155,25 @@ impl InProcessMcpServer {
     /// The URL the CLI will dial.
     pub fn url(&self) -> &str {
         &self.config.url
+    }
+
+    /// The tools this listener actually registered, sorted — empty for a server
+    /// started through [`start_in_process_mcp_server`] with a handler that is
+    /// not a [`super::ToolServer`], which nothing in this app does.
+    ///
+    /// It exists because "the handshake succeeded" and "the model can see a
+    /// tool" are different facts and the log could not tell them apart (#501):
+    /// a filtered server that hosts nothing binds a port, serves `initialize`
+    /// and lists zero tools, which reads identically to a healthy one.
+    pub fn tool_names(&self) -> &[String] {
+        &self.tool_names
+    }
+
+    /// Records what the handler registered. Set by [`super::tool_server`],
+    /// which is the one constructor that knows.
+    pub(super) fn with_tool_names(mut self, names: Vec<String>) -> Self {
+        self.tool_names = names;
+        self
     }
 }
 
@@ -278,6 +298,7 @@ where
                 .into_iter()
                 .collect(),
         },
+        tool_names: Vec::new(),
         shutdown: Some(shutdown_tx),
     })
 }

--- a/src-tauri/src/claude/tool.rs
+++ b/src-tauri/src/claude/tool.rs
@@ -426,11 +426,21 @@ impl ServerHandler for ToolServer {
 /// The listener stops when the returned handle is dropped — the port's
 /// lifetime is the handle's, which is what stands in for Go's `ctx` throughout
 /// this SDK.
+///
+/// The names of the tools it registered travel back on the handle
+/// ([`InProcessMcpServer::tool_names`]): they are read off the assembled
+/// `ToolServer` rather than off the `tools` argument, so the handle reports what
+/// the *router* holds — `add_tool` replaces a duplicate name, so the two counts
+/// can differ.
 pub async fn tool_server(
     name: &str,
     tools: impl IntoIterator<Item = ToolDef>,
 ) -> Result<InProcessMcpServer> {
-    start_in_process_mcp_server(name, ToolServer::new(name).with_tools(tools)).await
+    let service = ToolServer::new(name).with_tools(tools);
+    let names = service.tool_names();
+    Ok(start_in_process_mcp_server(name, service)
+        .await?
+        .with_tool_names(names))
 }
 
 impl super::Options {
@@ -595,6 +605,27 @@ mod tests {
         }
 
         assert_eq!(server.tool_names(), vec!["add".to_string()]);
+    }
+
+    /// The handle reports what the router holds, which is what makes "how many
+    /// tools did this server actually register" answerable from outside (#501).
+    ///
+    /// The duplicate is the case that makes it worth reading off the assembled
+    /// server rather than off the argument: `add_tool` replaces a name, so the
+    /// two counts differ.
+    #[tokio::test]
+    async fn a_started_server_reports_the_tools_it_registered() {
+        let server = super::tool_server("calc", [add_tool()]).await.unwrap();
+        assert_eq!(server.tool_names(), ["add".to_string()]);
+
+        let duplicated = super::tool_server("calc", [add_tool(), add_tool()])
+            .await
+            .unwrap();
+        assert_eq!(
+            duplicated.tool_names(),
+            ["add".to_string()],
+            "two `ToolDef`s, one route — the handle reports the route"
+        );
     }
 
     #[test]

--- a/src-tauri/src/native/chat/runner.rs
+++ b/src-tauri/src/native/chat/runner.rs
@@ -1561,6 +1561,7 @@ mod tests {
     /// (`github-<id>`) must not appear anywhere on a tool.
     #[tokio::test]
     async fn a_github_agent_runs_natively_under_the_integration_id() {
+        crate::native::writes::testlog::install();
         let file = db_with_integration("gh-1", "github");
         let caps = caps_naming("gh-1", Some(vec!["get_repo".into()]));
 
@@ -1590,12 +1591,27 @@ mod tests {
         // `appendToolOpts` adds it whenever any MCP server is registered.
         assert!(opts.strict_mcp_config);
         assert_eq!(allowed, vec!["mcp__gh-1__get_repo".to_string()]);
+
+        // #501's line at the call site the bug was *reported* through. The
+        // local-tools tests cover the other one, and neither covers this,
+        // so the assertion lives here rather than in a third fixture.
+        let logged = crate::native::writes::testlog::matching(
+            r#"mcp server started server="gh-1" tools=["get_repo"]"#,
+        );
+        assert!(
+            !logged.is_empty(),
+            "an integration server logs what it hosts"
+        );
+        for line in &logged {
+            assert!(line.starts_with("INFO "), "a start logs at info: {line:?}");
+        }
     }
 
     /// Go appends a qualified name for whatever the agent asked for, registered
     /// or not — the same rule the local tools follow.
     #[tokio::test]
     async fn an_unhosted_tool_name_is_still_qualified() {
+        crate::native::writes::testlog::install();
         let file = db_with_integration("gh-1", "github");
         let caps = caps_naming("gh-1", Some(vec!["get_repo".into(), "gone".into()]));
         let plan = mcp_plan(Some(&caps), Some(file.path()), None)
@@ -1613,6 +1629,23 @@ mod tests {
                 "mcp__gh-1__get_repo".to_string(),
                 "mcp__gh-1__gone".to_string()
             ]
+        );
+
+        // …and #501's other line, on the integration path: the name travels
+        // anyway, and the log is the only thing that says it will not resolve.
+        let logged = crate::native::writes::testlog::matching(
+            r#"mcp tool not hosted server="gh-1" tool="gone""#,
+        );
+        assert!(!logged.is_empty(), "an unhosted integration tool warns");
+        for line in &logged {
+            assert!(line.starts_with("WARN "), "a mismatch warns: {line:?}");
+        }
+        assert!(
+            crate::native::writes::testlog::matching(
+                r#"mcp tool not hosted server="gh-1" tool="get_repo""#
+            )
+            .is_empty(),
+            "a tool the server does host must not warn"
         );
     }
 

--- a/src-tauri/src/native/chat/runner.rs
+++ b/src-tauri/src/native/chat/runner.rs
@@ -607,6 +607,7 @@ async fn start_integration_servers(
                     &spec.tools,
                 )
                 .await?;
+                report_hosted_tools(&spec.id, server.tool_names(), &spec.tools);
                 let registered = opts.with_mcp_server(&spec.id, server.config());
                 servers.push(server);
                 registered
@@ -660,12 +661,48 @@ async fn start_local_tools(
     let server = crate::native::tools::start_local_mcp_server()
         .await
         .map_err(|e| format!("starting local MCP server: {e}"))?;
+    report_hosted_tools(
+        crate::native::tools::LOCAL_MCP_SERVER_NAME,
+        server.tool_names(),
+        local,
+    );
     let opts = opts
         .with_mcp_server(crate::native::tools::LOCAL_MCP_SERVER_NAME, server.config())
         .map_err(|e| format!("registering the local MCP server: {e}"))?
         .with_strict_mcp_config();
     allowed.extend(crate::native::tools::allowed_tool_names(local.iter()));
     Ok((opts, Some(server)))
+}
+
+/// One line per MCP server a turn starts, naming what it registered — and a
+/// warning per requested tool it did not (#501).
+///
+/// This is the line that makes "the agent does not know about its tools"
+/// answerable from the log. Until it existed, `claude: mcp "google-7": serving
+/// on http://…` was the whole record, and a server hosting **zero** tools
+/// printed it byte for byte identically to one hosting eight: the handshake
+/// completes either way and `--allowedTools` names the tools regardless.
+///
+/// Both call sites pass the names the **handle** reports rather than the names
+/// they asked for, which is the point — the two disagreeing is exactly the
+/// defect this reports.
+///
+/// The mismatch is a `warn` and never a refusal. `start_local_tools`' header
+/// records why: an agent naming a tool that no longer exists gets a model that
+/// cannot call it rather than a turn that will not start, which is the kinder
+/// failure and is Go's. This makes it visible without making it fatal.
+///
+/// Follows `writes::service_log_convention` — `message key=value`, every string
+/// value `{:?}`, after the effect — with one departure it does not cover:
+/// the mismatch line is at `warn`, because the seam's own split puts failures
+/// there and a tool the model cannot reach is one.
+fn report_hosted_tools(server_key: &str, hosted: &[String], requested: &[String]) {
+    log::info!("mcp server started server={server_key:?} tools={hosted:?}");
+    for tool in requested {
+        if !hosted.iter().any(|name| name == tool) {
+            log::warn!("mcp tool not hosted server={server_key:?} tool={tool:?}");
+        }
+    }
 }
 
 fn capability_count(list: Option<&crate::native::gojson::GoList<String>>) -> usize {
@@ -1721,6 +1758,76 @@ mod tests {
         assert!(!opts.disallowed_tools.contains(&"Read".to_string()));
         assert!(opts.disallowed_tools.contains(&"Write".to_string()));
         assert_eq!(opts.disallowed_tools.len(), ALL_BUILT_IN_TOOLS.len() - 2);
+    }
+
+    /// #501: what a started server registered is on the record, and the names
+    /// come off the **handle** rather than off what was asked for.
+    ///
+    /// Driven through `build_options` rather than by calling
+    /// [`report_hosted_tools`] directly: the property is that the turn's own
+    /// assembly emits it, and a test that called the helper itself would pass
+    /// with both call sites deleted.
+    #[tokio::test]
+    async fn starting_a_server_for_a_turn_logs_the_tools_it_registered() {
+        crate::native::writes::testlog::install();
+        let spec = spec_for(Capabilities {
+            built_in: None,
+            local: Some(vec!["current_time".into()].into()),
+            mcp: None,
+        });
+        let (_opts, _servers) = build_options(&spec, no_op_handler())
+            .await
+            .expect("options");
+
+        let found = crate::native::writes::testlog::matching(
+            r#"mcp server started server="local-tools" tools=["current_time"]"#,
+        );
+        assert!(!found.is_empty(), "no line naming the registered tools");
+        for line in &found {
+            assert!(line.starts_with("INFO "), "a start logs at info: {line:?}");
+        }
+    }
+
+    /// The other half: a name in `--allowedTools` that the server does not host
+    /// is a `warn`, naming the server and the tool — and it is *only* a warn,
+    /// because `start_local_tools`' rule is that a missing tool is the kinder
+    /// failure.
+    ///
+    /// `"gone"` is the same fixture
+    /// [`built_ins_and_local_tools_share_one_allowlist_in_gos_order`] uses, and
+    /// that test asserts the qualified name still reaches the allowlist — so the
+    /// two together pin "reported, not refused".
+    #[tokio::test]
+    async fn a_requested_tool_the_server_does_not_host_logs_a_warning() {
+        crate::native::writes::testlog::install();
+        let spec = spec_for(Capabilities {
+            built_in: None,
+            local: Some(vec!["current_time".into(), "gone".into()].into()),
+            mcp: None,
+        });
+        let (opts, _servers) = build_options(&spec, no_op_handler())
+            .await
+            .expect("options");
+
+        let found = crate::native::writes::testlog::matching(
+            r#"mcp tool not hosted server="local-tools" tool="gone""#,
+        );
+        assert!(!found.is_empty(), "an unhosted tool goes unreported");
+        for line in &found {
+            assert!(line.starts_with("WARN "), "a mismatch warns: {line:?}");
+        }
+        assert!(
+            crate::native::writes::testlog::matching(
+                r#"mcp tool not hosted server="local-tools" tool="current_time""#
+            )
+            .is_empty(),
+            "a tool the server does host must not warn"
+        );
+        assert!(
+            opts.allowed_tools
+                .contains(&"mcp__local-tools__gone".to_string()),
+            "reported, not refused: the qualified name still travels"
+        );
     }
 
     /// No local tools means no listener and no MCP server — a port bound for an

--- a/src-tauri/src/native/integrations/confluence/mod.rs
+++ b/src-tauri/src/native/integrations/confluence/mod.rs
@@ -101,6 +101,20 @@ pub const CONFLUENCE_TOOL_NAMES: &[&str] = &[
     "update_page",
 ];
 
+/// Which service group registers each tool — the `push` table in
+/// [`confluence_tools`] as data.
+///
+/// It exists for `filter_config_tools` (#501), which has to answer "what are
+/// *this service's* tools" for a service whose stored row names none of its
+/// own. Handing that service the caller's whole request instead was the first
+/// fix and it was wrong in a way that widens privilege: `build_allowed_set` is
+/// a union over **every** enabled service, so a name injected by a listless
+/// service satisfies the `allowed` half for a *sibling* whose own list
+/// deliberately excludes it — and the sibling's service gate passes, because it
+/// is enabled too. `the_service_table_matches_what_is_registered` pins this table against what
+/// [`confluence_tools`] really registers, so the two cannot drift.
+pub const SERVICE_TOOLS: &[(&str, &[&str])] = &[("content", CONFLUENCE_TOOL_NAMES)];
+
 /// `fmt.Sprintf("confluence-%s", cfg.ID)` — `mcp.NewServer`'s implementation
 /// name.
 ///
@@ -607,5 +621,45 @@ mod tests {
                 "{site} is a site URL Go serves"
             );
         }
+    }
+    /// `SERVICE_TOOLS` is the `push` table as data, so it must be checked
+    /// against the `push` table itself rather than transcribed beside it —
+    /// enabling one service at a time makes the registration function report
+    /// exactly which tools that service contributes.
+    ///
+    /// It matters because `filter_config_tools` uses this table to bound a
+    /// service that stored no list of its own (#501). A tool listed under the
+    /// wrong service there would put its name into the integration-wide union
+    /// for an agent that never asked for it.
+    #[test]
+    fn the_service_table_matches_what_is_registered() {
+        for (group, tools) in SERVICE_TOOLS {
+            let only = BTreeMap::from([((*group).to_string(), service(true, &[]))]);
+            let want: Vec<String> = tools.iter().map(|t| (*t).to_string()).collect();
+            assert_eq!(names(&only), want, "service {group:?}");
+        }
+
+        // Every service group is present, in `SERVICES` order…
+        assert_eq!(
+            SERVICE_TOOLS
+                .iter()
+                .map(|(group, _)| *group)
+                .collect::<Vec<_>>(),
+            SERVICES
+        );
+        // …and the table partitions the tool set: no tool twice, none missing.
+        let flat: Vec<&str> = SERVICE_TOOLS
+            .iter()
+            .flat_map(|(_, tools)| tools.iter().copied())
+            .collect();
+        let mut unique = flat.clone();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(
+            unique.len(),
+            flat.len(),
+            "a tool is listed under two services"
+        );
+        assert_eq!(flat, CONFLUENCE_TOOL_NAMES);
     }
 }

--- a/src-tauri/src/native/integrations/github/mod.rs
+++ b/src-tauri/src/native/integrations/github/mod.rs
@@ -112,6 +112,50 @@ pub const GITHUB_TOOL_NAMES: &[&str] = &[
     "list_tags",
 ];
 
+/// Which service group registers each tool — the `push` table in
+/// [`github_tools`] as data.
+///
+/// It exists for `filter_config_tools` (#501), which has to answer "what are
+/// *this service's* tools" for a service whose stored row names none of its
+/// own. Handing that service the caller's whole request instead was the first
+/// fix and it was wrong in a way that widens privilege: `build_allowed_set` is
+/// a union over **every** enabled service, so a name injected by a listless
+/// service satisfies the `allowed` half for a *sibling* whose own list
+/// deliberately excludes it — and the sibling's service gate passes, because it
+/// is enabled too. `the_service_table_matches_what_is_registered` pins this table against what
+/// [`github_tools`] really registers, so the two cannot drift.
+pub const SERVICE_TOOLS: &[(&str, &[&str])] = &[
+    ("repos", &["list_repos", "get_repo", "search_code"]),
+    (
+        "issues",
+        &["list_issues", "get_issue", "create_issue", "update_issue"],
+    ),
+    (
+        "pull_requests",
+        &[
+            "list_pulls",
+            "get_pull",
+            "create_pull",
+            "get_pull_diff",
+            "list_pull_comments",
+        ],
+    ),
+    (
+        "actions",
+        &[
+            "list_workflows",
+            "list_workflow_runs",
+            "trigger_workflow",
+            "get_workflow_run",
+            "get_run_logs",
+        ],
+    ),
+    (
+        "releases",
+        &["list_releases", "create_release", "list_tags"],
+    ),
+];
+
 /// `fmt.Sprintf("github-%s", cfg.ID)` — the server's name, and the half of
 /// `mcp__github-<id>__<tool>` that is not the tool.
 pub fn server_name(integration_id: &str) -> String {
@@ -315,5 +359,45 @@ mod tests {
         )]);
         assert!(build_allowed_set(&services).is_empty());
         assert_eq!(names(&services), ["list_repos", "get_repo", "search_code"]);
+    }
+    /// `SERVICE_TOOLS` is the `push` table as data, so it must be checked
+    /// against the `push` table itself rather than transcribed beside it —
+    /// enabling one service at a time makes the registration function report
+    /// exactly which tools that service contributes.
+    ///
+    /// It matters because `filter_config_tools` uses this table to bound a
+    /// service that stored no list of its own (#501). A tool listed under the
+    /// wrong service there would put its name into the integration-wide union
+    /// for an agent that never asked for it.
+    #[test]
+    fn the_service_table_matches_what_is_registered() {
+        for (group, tools) in SERVICE_TOOLS {
+            let only = BTreeMap::from([((*group).to_string(), service(true, &[]))]);
+            let want: Vec<String> = tools.iter().map(|t| (*t).to_string()).collect();
+            assert_eq!(names(&only), want, "service {group:?}");
+        }
+
+        // Every service group is present, in `SERVICES` order…
+        assert_eq!(
+            SERVICE_TOOLS
+                .iter()
+                .map(|(group, _)| *group)
+                .collect::<Vec<_>>(),
+            SERVICES
+        );
+        // …and the table partitions the tool set: no tool twice, none missing.
+        let flat: Vec<&str> = SERVICE_TOOLS
+            .iter()
+            .flat_map(|(_, tools)| tools.iter().copied())
+            .collect();
+        let mut unique = flat.clone();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(
+            unique.len(),
+            flat.len(),
+            "a tool is listed under two services"
+        );
+        assert_eq!(flat, GITHUB_TOOL_NAMES);
     }
 }

--- a/src-tauri/src/native/integrations/google/mod.rs
+++ b/src-tauri/src/native/integrations/google/mod.rs
@@ -84,6 +84,24 @@ pub const GOOGLE_TOOL_NAMES: &[&str] = &[
     "download_file",
 ];
 
+/// Which service group registers each tool — the `push` table in
+/// [`google_tools`] as data.
+///
+/// It exists for `filter_config_tools` (#501), which has to answer "what are
+/// *this service's* tools" for a service whose stored row names none of its
+/// own. Handing that service the caller's whole request instead was the first
+/// fix and it was wrong in a way that widens privilege: `build_allowed_set` is
+/// a union over **every** enabled service, so a name injected by a listless
+/// service satisfies the `allowed` half for a *sibling* whose own list
+/// deliberately excludes it — and the sibling's service gate passes, because it
+/// is enabled too. `the_service_table_matches_what_is_registered` pins this table against what
+/// [`google_tools`] really registers, so the two cannot drift.
+pub const SERVICE_TOOLS: &[(&str, &[&str])] = &[
+    ("calendar", &["create_event", "view_events"]),
+    ("gmail", &["send_email", "read_email", "search_email"]),
+    ("drive", &["list_files", "create_file", "download_file"]),
+];
+
 /// `fmt.Sprintf("google-%s", cfg.ID)` — `mcp.NewServer`'s implementation name,
 /// **not** the prefix on a qualified tool name (that is the bare integration id).
 pub fn server_name(integration_id: &str) -> String {
@@ -340,5 +358,45 @@ mod tests {
             .collect();
         assert!(build_allowed_set(&services).is_empty());
         assert_eq!(names(&services), GOOGLE_TOOL_NAMES);
+    }
+    /// `SERVICE_TOOLS` is the `push` table as data, so it must be checked
+    /// against the `push` table itself rather than transcribed beside it —
+    /// enabling one service at a time makes the registration function report
+    /// exactly which tools that service contributes.
+    ///
+    /// It matters because `filter_config_tools` uses this table to bound a
+    /// service that stored no list of its own (#501). A tool listed under the
+    /// wrong service there would put its name into the integration-wide union
+    /// for an agent that never asked for it.
+    #[test]
+    fn the_service_table_matches_what_is_registered() {
+        for (group, tools) in SERVICE_TOOLS {
+            let only = BTreeMap::from([((*group).to_string(), service(true, &[]))]);
+            let want: Vec<String> = tools.iter().map(|t| (*t).to_string()).collect();
+            assert_eq!(names(&only), want, "service {group:?}");
+        }
+
+        // Every service group is present, in `SERVICES` order…
+        assert_eq!(
+            SERVICE_TOOLS
+                .iter()
+                .map(|(group, _)| *group)
+                .collect::<Vec<_>>(),
+            SERVICES
+        );
+        // …and the table partitions the tool set: no tool twice, none missing.
+        let flat: Vec<&str> = SERVICE_TOOLS
+            .iter()
+            .flat_map(|(_, tools)| tools.iter().copied())
+            .collect();
+        let mut unique = flat.clone();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(
+            unique.len(),
+            flat.len(),
+            "a tool is listed under two services"
+        );
+        assert_eq!(flat, GOOGLE_TOOL_NAMES);
     }
 }

--- a/src-tauri/src/native/integrations/jira/mod.rs
+++ b/src-tauri/src/native/integrations/jira/mod.rs
@@ -107,6 +107,20 @@ pub const JIRA_TOOL_NAMES: &[&str] = &[
     "transition_issue",
 ];
 
+/// Which service group registers each tool — the `push` table in
+/// [`jira_tools`] as data.
+///
+/// It exists for `filter_config_tools` (#501), which has to answer "what are
+/// *this service's* tools" for a service whose stored row names none of its
+/// own. Handing that service the caller's whole request instead was the first
+/// fix and it was wrong in a way that widens privilege: `build_allowed_set` is
+/// a union over **every** enabled service, so a name injected by a listless
+/// service satisfies the `allowed` half for a *sibling* whose own list
+/// deliberately excludes it — and the sibling's service gate passes, because it
+/// is enabled too. `the_service_table_matches_what_is_registered` pins this table against what
+/// [`jira_tools`] really registers, so the two cannot drift.
+pub const SERVICE_TOOLS: &[(&str, &[&str])] = &[("project_management", JIRA_TOOL_NAMES)];
+
 /// `fmt.Sprintf("jira-%s", cfg.ID)` — `mcp.NewServer`'s implementation name.
 ///
 /// **Not** the prefix on a qualified tool name: that is the bare integration id,
@@ -349,5 +363,45 @@ mod tests {
         ] {
             assert_eq!(names_for(&services, site), JIRA_TOOL_NAMES, "{site}");
         }
+    }
+    /// `SERVICE_TOOLS` is the `push` table as data, so it must be checked
+    /// against the `push` table itself rather than transcribed beside it —
+    /// enabling one service at a time makes the registration function report
+    /// exactly which tools that service contributes.
+    ///
+    /// It matters because `filter_config_tools` uses this table to bound a
+    /// service that stored no list of its own (#501). A tool listed under the
+    /// wrong service there would put its name into the integration-wide union
+    /// for an agent that never asked for it.
+    #[test]
+    fn the_service_table_matches_what_is_registered() {
+        for (group, tools) in SERVICE_TOOLS {
+            let only = BTreeMap::from([((*group).to_string(), service(true, &[]))]);
+            let want: Vec<String> = tools.iter().map(|t| (*t).to_string()).collect();
+            assert_eq!(names(&only), want, "service {group:?}");
+        }
+
+        // Every service group is present, in `SERVICES` order…
+        assert_eq!(
+            SERVICE_TOOLS
+                .iter()
+                .map(|(group, _)| *group)
+                .collect::<Vec<_>>(),
+            SERVICES
+        );
+        // …and the table partitions the tool set: no tool twice, none missing.
+        let flat: Vec<&str> = SERVICE_TOOLS
+            .iter()
+            .flat_map(|(_, tools)| tools.iter().copied())
+            .collect();
+        let mut unique = flat.clone();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(
+            unique.len(),
+            flat.len(),
+            "a tool is listed under two services"
+        );
+        assert_eq!(flat, JIRA_TOOL_NAMES);
     }
 }

--- a/src-tauri/src/native/integrations/registry.rs
+++ b/src-tauri/src/native/integrations/registry.rs
@@ -792,7 +792,11 @@ pub async fn start_filtered_server(
             "integration {id:?} is not enabled or not authenticated"
         ));
     }
-    let filtered = filter_config_tools(&row.services(), tools);
+    let filtered = filter_config_tools(
+        &row.services(),
+        tools,
+        service_tool_table(&row.integration_type),
+    );
     match row.integration_type.as_str() {
         "github" => start_github(&row.id, &filtered, &row.credentials).await,
         "confluence" => start_confluence(&row.id, &filtered, &row.credentials).await,
@@ -1036,15 +1040,30 @@ pub fn can_host(db_path: &Path, id: &str) -> Result<bool, String> {
 /// integration hosted **zero tools** — with `--allowedTools` still naming them,
 /// so the only symptom was a model that did not know about its own tools.
 ///
-/// A service naming no tools of its own means "every tool of this service", so
-/// it is given the whole requested set. That is sound for the same reason
-/// `buildAllowedSet`'s empty union is: every integration gates a tool on
-/// `service_enabled(services, group) && allowed.contains(name)`, so a name
-/// belonging to another group is still rejected by the *service* gate, and this
-/// map can only widen a service from "nothing" towards "what was asked for".
+/// A service naming no tools of its own means "every tool of **this** service",
+/// so it is given the request narrowed to its own tool set — `table`, which is
+/// the integration's `SERVICE_TOOLS`.
+///
+/// **Handing it the whole request instead is unsound, and that was the first
+/// attempt at this fix.** The tempting argument is that a name from another
+/// group is rejected by the service gate anyway, so the widening is harmless.
+/// It is not, because `build_allowed_set` is a union over *every* enabled
+/// service and `push` is `service_enabled(group) && allowed.contains(name)`:
+/// the union is integration-wide, so a name injected by a listless service
+/// satisfies the `allowed` half for a **sibling** service — and that sibling's
+/// gate passes too, since it is enabled. So
+/// `{"gmail":{"enabled":true},"drive":{"enabled":true,"tools":["list_files"]}}`
+/// with a request naming `create_file` would host `create_file`, a write tool
+/// the user's own Drive list deliberately excludes. Narrowing per service is
+/// what makes the widening argument true rather than nearly true.
+///
+/// An unknown integration type has an empty table, so a listless service under
+/// one contributes nothing — the same answer as before #501, and the starter
+/// refuses that row a few lines later regardless.
 fn filter_config_tools(
     services: &BTreeMap<String, ServiceConfig>,
     tools: &[String],
+    table: &[(&str, &[&str])],
 ) -> BTreeMap<String, ServiceConfig> {
     if tools.is_empty() {
         return services.clone();
@@ -1057,7 +1076,16 @@ fn filter_config_tools(
         }
         let listed: &[String] = service.tools.as_ref().map_or(&[], |list| list.as_slice());
         let kept: Vec<String> = if listed.is_empty() {
-            tools.to_vec()
+            let own: &[&str] = table
+                .iter()
+                .find(|(group, _)| group == name)
+                .map_or(&[], |(_, tools)| *tools);
+            // Request order, since the service supplied none of its own.
+            tools
+                .iter()
+                .filter(|tool| own.contains(&tool.as_str()))
+                .cloned()
+                .collect()
         } else {
             listed
                 .iter()
@@ -1077,6 +1105,25 @@ fn filter_config_tools(
         );
     }
     out
+}
+
+/// Which tools each of an integration type's service groups registers.
+///
+/// The one place the six `SERVICE_TOOLS` tables are dispatched on, so
+/// [`filter_config_tools`] stays type-agnostic. A type this build does not host
+/// has no table; [`start_filtered_server`]'s own `match` is what answers it.
+fn service_tool_table(
+    integration_type: &str,
+) -> &'static [(&'static str, &'static [&'static str])] {
+    match integration_type {
+        "github" => super::github::SERVICE_TOOLS,
+        "confluence" => super::confluence::SERVICE_TOOLS,
+        "jira" => super::jira::SERVICE_TOOLS,
+        "slack" => super::slack::SERVICE_TOOLS,
+        "telegram" => super::telegram::SERVICE_TOOLS,
+        "google" => super::google::SERVICE_TOOLS,
+        _ => &[],
+    }
 }
 
 // ─── Reads ────────────────────────────────────────────────────────────────────
@@ -1747,11 +1794,13 @@ mod tests {
         )
         .expect("services");
 
+        let github = service_tool_table("github");
+
         // An empty request list is a no-op — including on the disabled service,
         // which the starter skips on its own.
-        assert_eq!(filter_config_tools(&services, &[]), services);
+        assert_eq!(filter_config_tools(&services, &[], github), services);
 
-        let filtered = filter_config_tools(&services, &["get_repo".to_string()]);
+        let filtered = filter_config_tools(&services, &["get_repo".to_string()], github);
         assert_eq!(
             filtered.keys().collect::<Vec<_>>(),
             vec!["repos"],
@@ -1764,7 +1813,7 @@ mod tests {
         assert!(filtered["repos"].enabled);
 
         // A disabled service contributes nothing even when it names the tool.
-        let filtered = filter_config_tools(&services, &["list_workflows".to_string()]);
+        let filtered = filter_config_tools(&services, &["list_workflows".to_string()], github);
         assert!(filtered.is_empty());
     }
 
@@ -1778,14 +1827,15 @@ mod tests {
     /// saw an empty map, and the integration hosted nothing at all while
     /// `--allowedTools` still named the tools.
     #[test]
-    fn a_service_naming_no_tools_contributes_the_whole_request() {
+    fn a_service_naming_no_tools_contributes_its_own_tools() {
+        let google = service_tool_table("google");
         for spelling in [
             r#"{"gmail":{"enabled":true},"drive":{"enabled":true,"tools":["list_files"]}}"#,
             r#"{"gmail":{"enabled":true,"tools":[]},"drive":{"enabled":true,"tools":["list_files"]}}"#,
         ] {
             let services: BTreeMap<String, ServiceConfig> =
                 serde_json::from_str(spelling).expect("services");
-            let filtered = filter_config_tools(&services, &["read_email".to_string()]);
+            let filtered = filter_config_tools(&services, &["read_email".to_string()], google);
 
             assert_eq!(
                 filtered.keys().collect::<Vec<_>>(),
@@ -1796,7 +1846,32 @@ mod tests {
             assert_eq!(
                 filtered["gmail"].tools.as_ref().expect("tools").0,
                 vec!["read_email".to_string()],
-                "it is given the request, not its own (absent) list: {spelling}"
+                "it is given the request narrowed to its own tools: {spelling}"
+            );
+
+            // **The sibling case, and the reason this is per service rather
+            // than the whole request.** `build_allowed_set` unions every
+            // enabled service, so a name the listless `gmail` entry carried
+            // would satisfy `allowed` for `drive` — whose own list names only
+            // `list_files`. `create_file` must not survive into either entry.
+            let filtered = filter_config_tools(
+                &services,
+                &[
+                    "read_email".to_string(),
+                    "list_files".to_string(),
+                    "create_file".to_string(),
+                ],
+                google,
+            );
+            assert_eq!(
+                filtered["gmail"].tools.as_ref().expect("tools").0,
+                vec!["read_email".to_string()],
+                "a listless service takes no name belonging to a sibling: {spelling}"
+            );
+            assert_eq!(
+                filtered["drive"].tools.as_ref().expect("tools").0,
+                vec!["list_files".to_string()],
+                "the sibling's own list still bounds it: {spelling}"
             );
         }
     }
@@ -1805,11 +1880,14 @@ mod tests {
     ///
     /// `filter_config_tools` producing a sensible map is only half the claim —
     /// the tools are chosen by each integration's `push`, which gates on the
-    /// service **and** the union. Giving a listless service the whole request is
-    /// sound because a name belonging to another group is still rejected by the
-    /// service gate, and this is where that is asserted rather than argued.
+    /// service **and** on an integration-wide union. This is where the
+    /// interaction between those two is asserted rather than argued, because
+    /// arguing it is exactly what went wrong: the first version of this fix gave
+    /// a listless service the caller's *whole* request, and the union carried
+    /// the surplus names into every other enabled service.
     #[test]
     fn a_service_with_no_tool_list_hosts_exactly_what_was_asked_for() {
+        let google = service_tool_table("google");
         let tokens = std::sync::Arc::new(super::super::google::client::TokenSource::new(
             "CID",
             "CSECRET",
@@ -1832,21 +1910,43 @@ mod tests {
         // The reported symptom: two Gmail tools requested, zero hosted.
         let want = ["read_email".to_string(), "search_email".to_string()];
         assert_eq!(
-            hosted(&filter_config_tools(&services, &want)),
+            hosted(&filter_config_tools(&services, &want, google)),
             want,
             "an enabled service with no stored tool list hosts the requested tools"
         );
 
-        // A requested name that belongs to a *different* group is rejected by
-        // the service gate, which is what makes handing over the whole request
-        // safe.
+        // A requested name belonging to a group that is not enabled at all is
+        // rejected by the service gate.
         assert_eq!(
             hosted(&filter_config_tools(
                 &services,
-                &["read_email".to_string(), "list_files".to_string()]
+                &["read_email".to_string(), "list_files".to_string()],
+                google
             )),
             ["read_email".to_string()],
-            "the service gate still bounds the widened request"
+            "a name from a service that is not enabled reaches nothing"
+        );
+
+        // …and the case the service gate does **not** cover, which is why the
+        // narrowing above exists: `drive` is enabled, with its own list naming
+        // only `list_files`. Handing `gmail` the whole request would put
+        // `create_file` in the union, and `drive`'s gate would pass it.
+        let mixed: BTreeMap<String, ServiceConfig> = serde_json::from_str(
+            r#"{"gmail":{"enabled":true},"drive":{"enabled":true,"tools":["list_files"]}}"#,
+        )
+        .expect("services");
+        assert_eq!(
+            hosted(&filter_config_tools(
+                &mixed,
+                &[
+                    "read_email".to_string(),
+                    "list_files".to_string(),
+                    "create_file".to_string(),
+                ],
+                google
+            )),
+            ["read_email".to_string(), "list_files".to_string()],
+            "a write tool the user's own Drive list excludes is not hosted"
         );
     }
 
@@ -1885,7 +1985,7 @@ mod tests {
             // No agent-side request, so nothing narrows it — `filter_config_tools`
             // returns the map untouched and the union is empty.
             let hosted: Vec<String> = super::super::google::google_tools(
-                &filter_config_tools(&services, &[]),
+                &filter_config_tools(&services, &[], service_tool_table("google")),
                 tokens.clone(),
             )
             .iter()

--- a/src-tauri/src/native/integrations/registry.rs
+++ b/src-tauri/src/native/integrations/registry.rs
@@ -1492,6 +1492,30 @@ mod tests {
         }
     }
 
+    /// The same coverage question for the *second* dispatch on `HOSTED_TYPES`,
+    /// and it is the one that fails silently.
+    ///
+    /// `service_tool_table`'s `_ => &[]` arm is the right answer for a type this
+    /// build does not host — the starter refuses that row anyway. For a type
+    /// that **is** hosted it is #501 reintroduced with nothing to report it:
+    /// every service storing no tool list of its own goes back to being dropped,
+    /// so the integration hosts zero tools while `--allowedTools` names them.
+    /// A missing `match` arm is exactly how that lands.
+    #[test]
+    fn a_hosted_type_always_has_a_service_tool_table() {
+        for integration_type in HOSTED_TYPES {
+            let table = service_tool_table(integration_type);
+            assert!(
+                !table.is_empty(),
+                "{integration_type} is in HOSTED_TYPES with no SERVICE_TOOLS table"
+            );
+            assert!(
+                table.iter().all(|(_, tools)| !tools.is_empty()),
+                "{integration_type} has a service group naming no tools"
+            );
+        }
+    }
+
     /// The race `reload` opens by design, and the guard that closes it: a
     /// `DELETE` between the row read and the handle being recorded must not
     /// leave a bound port holding the credential of a row that is gone.

--- a/src-tauri/src/native/integrations/registry.rs
+++ b/src-tauri/src/native/integrations/registry.rs
@@ -1026,6 +1026,22 @@ pub fn can_host(db_path: &Path, id: &str) -> Result<bool, String> {
 /// starters skip on their own), and a service left with no kept tools is dropped
 /// entirely rather than kept empty — which matters, because an empty `tools`
 /// list is what `buildAllowedSet` reads as "host everything".
+///
+/// The third half is the one that **was** an oversight (#501). A service stored
+/// as `{"enabled": true}` — no `tools` key at all, which is what
+/// `POST /api/integrations` accepts and what rows written before the per-service
+/// lists existed carry — has nothing to intersect the request against, so it
+/// came out empty and was dropped by the rule above. `build_allowed_set` then
+/// saw an **empty map**, every `service_enabled` answered false, and the
+/// integration hosted **zero tools** — with `--allowedTools` still naming them,
+/// so the only symptom was a model that did not know about its own tools.
+///
+/// A service naming no tools of its own means "every tool of this service", so
+/// it is given the whole requested set. That is sound for the same reason
+/// `buildAllowedSet`'s empty union is: every integration gates a tool on
+/// `service_enabled(services, group) && allowed.contains(name)`, so a name
+/// belonging to another group is still rejected by the *service* gate, and this
+/// map can only widen a service from "nothing" towards "what was asked for".
 fn filter_config_tools(
     services: &BTreeMap<String, ServiceConfig>,
     tools: &[String],
@@ -1039,13 +1055,16 @@ fn filter_config_tools(
         if !service.enabled {
             continue;
         }
-        let kept: Vec<String> = service
-            .tools
-            .iter()
-            .flat_map(|list| list.iter())
-            .filter(|tool| want.contains(tool.as_str()))
-            .cloned()
-            .collect();
+        let listed: &[String] = service.tools.as_ref().map_or(&[], |list| list.as_slice());
+        let kept: Vec<String> = if listed.is_empty() {
+            tools.to_vec()
+        } else {
+            listed
+                .iter()
+                .filter(|tool| want.contains(tool.as_str()))
+                .cloned()
+                .collect()
+        };
         if kept.is_empty() {
             continue;
         }
@@ -1747,6 +1766,137 @@ mod tests {
         // A disabled service contributes nothing even when it names the tool.
         let filtered = filter_config_tools(&services, &["list_workflows".to_string()]);
         assert!(filtered.is_empty());
+    }
+
+    /// The third half (#501): a service that names **no** tools of its own is
+    /// "every tool of this service", not "no tools".
+    ///
+    /// Both spellings reach it — `{"enabled":true}` with no key at all, which is
+    /// what `POST /api/integrations` accepts and what pre-list rows carry, and
+    /// `{"enabled":true,"tools":[]}`, which the Integrations UI could store
+    /// until this issue. Before the fix both were dropped, `build_allowed_set`
+    /// saw an empty map, and the integration hosted nothing at all while
+    /// `--allowedTools` still named the tools.
+    #[test]
+    fn a_service_naming_no_tools_contributes_the_whole_request() {
+        for spelling in [
+            r#"{"gmail":{"enabled":true},"drive":{"enabled":true,"tools":["list_files"]}}"#,
+            r#"{"gmail":{"enabled":true,"tools":[]},"drive":{"enabled":true,"tools":["list_files"]}}"#,
+        ] {
+            let services: BTreeMap<String, ServiceConfig> =
+                serde_json::from_str(spelling).expect("services");
+            let filtered = filter_config_tools(&services, &["read_email".to_string()]);
+
+            assert_eq!(
+                filtered.keys().collect::<Vec<_>>(),
+                vec!["gmail"],
+                "the listless service survives and the listed one that names \
+                 nothing requested is still dropped: {spelling}"
+            );
+            assert_eq!(
+                filtered["gmail"].tools.as_ref().expect("tools").0,
+                vec!["read_email".to_string()],
+                "it is given the request, not its own (absent) list: {spelling}"
+            );
+        }
+    }
+
+    /// The same thing one level out: what the *server* ends up hosting.
+    ///
+    /// `filter_config_tools` producing a sensible map is only half the claim —
+    /// the tools are chosen by each integration's `push`, which gates on the
+    /// service **and** the union. Giving a listless service the whole request is
+    /// sound because a name belonging to another group is still rejected by the
+    /// service gate, and this is where that is asserted rather than argued.
+    #[test]
+    fn a_service_with_no_tool_list_hosts_exactly_what_was_asked_for() {
+        let tokens = std::sync::Arc::new(super::super::google::client::TokenSource::new(
+            "CID",
+            "CSECRET",
+            super::super::google::client::Token {
+                access_token: "ACCESS".to_string(),
+                refresh_token: "REFRESH".to_string(),
+                expiry: None,
+            },
+        ));
+        let hosted = |services: &BTreeMap<String, ServiceConfig>| -> Vec<String> {
+            super::super::google::google_tools(services, tokens.clone())
+                .iter()
+                .map(|tool| tool.name().to_string())
+                .collect()
+        };
+
+        let services: BTreeMap<String, ServiceConfig> =
+            serde_json::from_str(r#"{"gmail":{"enabled":true}}"#).expect("services");
+
+        // The reported symptom: two Gmail tools requested, zero hosted.
+        let want = ["read_email".to_string(), "search_email".to_string()];
+        assert_eq!(
+            hosted(&filter_config_tools(&services, &want)),
+            want,
+            "an enabled service with no stored tool list hosts the requested tools"
+        );
+
+        // A requested name that belongs to a *different* group is rejected by
+        // the service gate, which is what makes handing over the whole request
+        // safe.
+        assert_eq!(
+            hosted(&filter_config_tools(
+                &services,
+                &["read_email".to_string(), "list_files".to_string()]
+            )),
+            ["read_email".to_string()],
+            "the service gate still bounds the widened request"
+        );
+    }
+
+    /// #501's second criterion, settled and pinned: an **empty union stays
+    /// "host everything"**.
+    ///
+    /// The alternative — an explicitly empty list meaning "no tools" — would
+    /// diverge from behaviour that is ported deliberately, identical in all six
+    /// integrations and asserted by each of their own suites. So the semantics
+    /// are kept and the *inverting shape* is closed one level up instead:
+    /// `IntegrationsView.tsx` turns a service **off** when its last tool is
+    /// unchecked, so "Only the tools you leave on are exposed to agents" is true
+    /// of everything the app can store.
+    ///
+    /// The gap that remains is the API's, and it is deliberate: `POST
+    /// /api/integrations` still accepts `{"enabled":true,"tools":[]}` and that
+    /// row hosts the service's whole tool set. Refusing it would be a wire
+    /// change on a byte-exact endpoint.
+    #[test]
+    fn an_enabled_service_with_an_empty_list_still_hosts_everything() {
+        let tokens = std::sync::Arc::new(super::super::google::client::TokenSource::new(
+            "CID",
+            "CSECRET",
+            super::super::google::client::Token {
+                access_token: "ACCESS".to_string(),
+                refresh_token: "REFRESH".to_string(),
+                expiry: None,
+            },
+        ));
+        for spelling in [
+            r#"{"gmail":{"enabled":true}}"#,
+            r#"{"gmail":{"enabled":true,"tools":[]}}"#,
+        ] {
+            let services: BTreeMap<String, ServiceConfig> =
+                serde_json::from_str(spelling).expect("services");
+            // No agent-side request, so nothing narrows it — `filter_config_tools`
+            // returns the map untouched and the union is empty.
+            let hosted: Vec<String> = super::super::google::google_tools(
+                &filter_config_tools(&services, &[]),
+                tokens.clone(),
+            )
+            .iter()
+            .map(|tool| tool.name().to_string())
+            .collect();
+            assert_eq!(
+                hosted,
+                ["send_email", "read_email", "search_email"],
+                "an empty union is 'host everything', bounded by the service gate: {spelling}"
+            );
+        }
     }
 
     /// The qualified name is built from the **bare id**, which is what every

--- a/src-tauri/src/native/integrations/registry.rs
+++ b/src-tauri/src/native/integrations/registry.rs
@@ -2021,6 +2021,32 @@ mod tests {
                 "an empty union is 'host everything', bounded by the service gate: {spelling}"
             );
         }
+
+        // **And "empty" is a property of the whole union, not of one group.**
+        // The same listless `gmail` beside a service that *does* name a tool
+        // hosts **nothing**: `build_allowed_set` unions every enabled service,
+        // so the union is `{list_files}` and no Gmail name is in it. Reading
+        // "this group stored no list" as "this group hosts everything" is the
+        // mistake, and `IntegrationsView.tsx` has to make the same distinction
+        // to render an untouched row honestly — which is why it is pinned here
+        // rather than left to the UI to be right about on its own.
+        let mixed: BTreeMap<String, ServiceConfig> = serde_json::from_str(
+            r#"{"gmail":{"enabled":true},"drive":{"enabled":true,"tools":["list_files"]}}"#,
+        )
+        .expect("services");
+        let hosted: Vec<String> = super::super::google::google_tools(
+            &filter_config_tools(&mixed, &[], service_tool_table("google")),
+            tokens.clone(),
+        )
+        .iter()
+        .map(|tool| tool.name().to_string())
+        .collect();
+        assert_eq!(
+            hosted,
+            ["list_files"],
+            "a sibling's stored list makes the union non-empty, so the listless \
+             service matches nothing"
+        );
     }
 
     /// The qualified name is built from the **bare id**, which is what every

--- a/src-tauri/src/native/integrations/slack/mod.rs
+++ b/src-tauri/src/native/integrations/slack/mod.rs
@@ -89,6 +89,20 @@ pub const SLACK_TOOL_NAMES: &[&str] = &[
     "search_messages",
 ];
 
+/// Which service group registers each tool — the `push` table in
+/// [`slack_tools`] as data.
+///
+/// It exists for `filter_config_tools` (#501), which has to answer "what are
+/// *this service's* tools" for a service whose stored row names none of its
+/// own. Handing that service the caller's whole request instead was the first
+/// fix and it was wrong in a way that widens privilege: `build_allowed_set` is
+/// a union over **every** enabled service, so a name injected by a listless
+/// service satisfies the `allowed` half for a *sibling* whose own list
+/// deliberately excludes it — and the sibling's service gate passes, because it
+/// is enabled too. `the_service_table_matches_what_is_registered` pins this table against what
+/// [`slack_tools`] really registers, so the two cannot drift.
+pub const SERVICE_TOOLS: &[(&str, &[&str])] = &[("messaging", SLACK_TOOL_NAMES)];
+
 /// `fmt.Sprintf("slack-%s", cfg.ID)` — `mcp.NewServer`'s implementation name,
 /// **not** the prefix on a qualified tool name (that is the bare integration id).
 pub fn server_name(integration_id: &str) -> String {
@@ -234,5 +248,45 @@ mod tests {
         )]);
         assert!(build_allowed_set(&services).is_empty());
         assert_eq!(names(&services), SLACK_TOOL_NAMES);
+    }
+    /// `SERVICE_TOOLS` is the `push` table as data, so it must be checked
+    /// against the `push` table itself rather than transcribed beside it —
+    /// enabling one service at a time makes the registration function report
+    /// exactly which tools that service contributes.
+    ///
+    /// It matters because `filter_config_tools` uses this table to bound a
+    /// service that stored no list of its own (#501). A tool listed under the
+    /// wrong service there would put its name into the integration-wide union
+    /// for an agent that never asked for it.
+    #[test]
+    fn the_service_table_matches_what_is_registered() {
+        for (group, tools) in SERVICE_TOOLS {
+            let only = BTreeMap::from([((*group).to_string(), service(true, &[]))]);
+            let want: Vec<String> = tools.iter().map(|t| (*t).to_string()).collect();
+            assert_eq!(names(&only), want, "service {group:?}");
+        }
+
+        // Every service group is present, in `SERVICES` order…
+        assert_eq!(
+            SERVICE_TOOLS
+                .iter()
+                .map(|(group, _)| *group)
+                .collect::<Vec<_>>(),
+            SERVICES
+        );
+        // …and the table partitions the tool set: no tool twice, none missing.
+        let flat: Vec<&str> = SERVICE_TOOLS
+            .iter()
+            .flat_map(|(_, tools)| tools.iter().copied())
+            .collect();
+        let mut unique = flat.clone();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(
+            unique.len(),
+            flat.len(),
+            "a tool is listed under two services"
+        );
+        assert_eq!(flat, SLACK_TOOL_NAMES);
     }
 }

--- a/src-tauri/src/native/integrations/telegram/mod.rs
+++ b/src-tauri/src/native/integrations/telegram/mod.rs
@@ -87,6 +87,20 @@ pub const TELEGRAM_TOOL_NAMES: &[&str] = &[
     "pin_message",
 ];
 
+/// Which service group registers each tool — the `push` table in
+/// [`telegram_tools`] as data.
+///
+/// It exists for `filter_config_tools` (#501), which has to answer "what are
+/// *this service's* tools" for a service whose stored row names none of its
+/// own. Handing that service the caller's whole request instead was the first
+/// fix and it was wrong in a way that widens privilege: `build_allowed_set` is
+/// a union over **every** enabled service, so a name injected by a listless
+/// service satisfies the `allowed` half for a *sibling* whose own list
+/// deliberately excludes it — and the sibling's service gate passes, because it
+/// is enabled too. `the_service_table_matches_what_is_registered` pins this table against what
+/// [`telegram_tools`] really registers, so the two cannot drift.
+pub const SERVICE_TOOLS: &[(&str, &[&str])] = &[("messaging", TELEGRAM_TOOL_NAMES)];
+
 /// `fmt.Sprintf("telegram-%s", cfg.ID)` — `mcp.NewServer`'s implementation name,
 /// **not** the prefix on a qualified tool name (that is the bare integration id).
 pub fn server_name(integration_id: &str) -> String {
@@ -239,5 +253,45 @@ mod tests {
         )]);
         assert!(build_allowed_set(&services).is_empty());
         assert_eq!(names(&services), TELEGRAM_TOOL_NAMES);
+    }
+    /// `SERVICE_TOOLS` is the `push` table as data, so it must be checked
+    /// against the `push` table itself rather than transcribed beside it —
+    /// enabling one service at a time makes the registration function report
+    /// exactly which tools that service contributes.
+    ///
+    /// It matters because `filter_config_tools` uses this table to bound a
+    /// service that stored no list of its own (#501). A tool listed under the
+    /// wrong service there would put its name into the integration-wide union
+    /// for an agent that never asked for it.
+    #[test]
+    fn the_service_table_matches_what_is_registered() {
+        for (group, tools) in SERVICE_TOOLS {
+            let only = BTreeMap::from([((*group).to_string(), service(true, &[]))]);
+            let want: Vec<String> = tools.iter().map(|t| (*t).to_string()).collect();
+            assert_eq!(names(&only), want, "service {group:?}");
+        }
+
+        // Every service group is present, in `SERVICES` order…
+        assert_eq!(
+            SERVICE_TOOLS
+                .iter()
+                .map(|(group, _)| *group)
+                .collect::<Vec<_>>(),
+            SERVICES
+        );
+        // …and the table partitions the tool set: no tool twice, none missing.
+        let flat: Vec<&str> = SERVICE_TOOLS
+            .iter()
+            .flat_map(|(_, tools)| tools.iter().copied())
+            .collect();
+        let mut unique = flat.clone();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(
+            unique.len(),
+            flat.len(),
+            "a tool is listed under two services"
+        );
+        assert_eq!(flat, TELEGRAM_TOOL_NAMES);
     }
 }

--- a/src-tauri/tests/mcp_e2e_probe.rs
+++ b/src-tauri/tests/mcp_e2e_probe.rs
@@ -1,0 +1,170 @@
+//! Can a real turn **see and call** an in-process MCP tool? (#501)
+//!
+//! `claude_mcp_live.rs` is the sibling of this file and stops one step short on
+//! purpose: it proves the CLI completes the `initialize` handshake against our
+//! stateless transport, and its own comment leaves the tool list to the unit
+//! tests. That gap is what #501 was reported through — an integration hosting
+//! **zero** tools binds a port, serves `initialize`, and logs the same
+//! `serving on http://…` line as a healthy one, so "Connected" was true of a
+//! server the model could reach nothing through.
+//!
+//! So this asserts the two facts that were missing, against the real CLI:
+//!
+//! 1. the tool is **listed** — it appears in the `init` system event's `tools`,
+//!    which is the CLI telling us what the model was actually given; and
+//! 2. the tool is **called** — a `tool_use` for it appears and its
+//!    `tool_result` carries the text our handler produced.
+//!
+//! **It is driven through `runner::build_options`, not through a hand-built
+//! command line**, and that is the point of promoting the scratch probe rather
+//! than committing it as it was. The bug was never in the transport (triage
+//! confirmed a hand-built `claude -p` reached the tool perfectly); it was in
+//! what the option assembly handed that transport. A probe that rebuilds the
+//! arguments itself agrees with whatever the test author wrote and cannot see
+//! that class of defect at all. Here the server, the `--mcp-config` document,
+//! `--strict-mcp-config`, `--allowedTools` and the permission mode all come
+//! from the same function a chat turn and a scheduled run use.
+//!
+//! The local-tools server (#310) is the fixture because it needs no credentials
+//! and no database row — the `mcp_plan` branch that reads `integrations` is
+//! never entered for an agent whose capabilities name only local tools. What it
+//! covers is the assembly, which is shared with every integration.
+//!
+//! `#[ignore]`d on the same terms as its siblings — it needs the CLI installed,
+//! a signed-in profile, and it spends tokens:
+//!
+//! ```text
+//! cargo test --test mcp_e2e_probe -- --ignored --nocapture
+//! ```
+
+use std::process::Command;
+use std::sync::Arc;
+
+use agento_lib::native::agents::{Agent, Capabilities};
+use agento_lib::native::chat::runner::{build_options, RunSpec, TurnSettings};
+
+/// Skips rather than fails when the CLI is absent, as `claude_mcp_live.rs` does.
+fn have_claude_cli() -> bool {
+    Command::new("claude")
+        .arg("--version")
+        .output()
+        .ok()
+        .is_some_and(|out| out.status.success())
+}
+
+/// An agent whose only capability is the one local tool.
+///
+/// `permission_mode` is empty, which in the **no-handler** branch of
+/// `build_options` is bypass — the mode a scheduled run gets, and the only one
+/// under which nothing is waiting to answer a prompt.
+fn spec() -> RunSpec {
+    RunSpec {
+        agent: Some(Agent {
+            name: "probe".into(),
+            slug: "probe".into(),
+            description: String::new(),
+            model: String::new(),
+            thinking: "disabled".into(),
+            permission_mode: String::new(),
+            system_prompt: String::new(),
+            capabilities: Capabilities {
+                built_in: None,
+                local: Some(vec!["current_time".to_string()].into()),
+                mcp: None,
+            },
+            claude_config_dir: String::new(),
+        }),
+        no_agent_model: Box::new(String::new),
+        settings: Arc::new(TurnSettings::none()),
+        working_dir: String::new(),
+        settings_profile_id: String::new(),
+        permission_mode: String::new(),
+        resume_session_id: None,
+        custom_session_id: String::new(),
+    }
+}
+
+// A multi-thread runtime for `claude_mcp_live.rs`' reason: the listener task has
+// to be scheduled while this test is awaiting the subprocess, or the CLI dials a
+// server that never answers.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "needs the real claude CLI and a signed-in profile, and spends tokens"]
+async fn a_turn_lists_and_calls_a_tool_through_the_options_a_turn_builds() {
+    if !have_claude_cli() {
+        eprintln!("skipping: no claude CLI on PATH");
+        return;
+    }
+
+    let spec = spec();
+    // `_servers` is the listener's lifetime — dropping it stops the server and
+    // cancels every handler's token, so it has to outlive the stream.
+    let (options, _servers) = build_options(&spec, None)
+        .await
+        .expect("the turn's own option assembly");
+
+    // The assembly's own claims, before a subprocess exists. If these are wrong
+    // the CLI half below fails for a reason that is hard to read out of a model
+    // transcript, so they are asserted here where the message is exact.
+    assert!(
+        options.mcp_servers.contains_key("local-tools"),
+        "the server is registered under the key the CLI prefixes tool names with"
+    );
+    assert!(options.strict_mcp_config, "the user's own .mcp.json is out");
+    assert_eq!(
+        options.allowed_tools,
+        vec!["mcp__local-tools__current_time".to_string()]
+    );
+
+    let mut stream = agento_lib::claude::query(
+        "Call the current_time tool with timezone \"Asia/Tokyo\". \
+         Reply with exactly the text the tool returned and nothing else.",
+        options,
+    )
+    .await
+    .expect("the CLI spawns");
+
+    // The raw lines are what Agento's SSE forwards verbatim, so collecting them
+    // is both the assertion material and the thing a `--nocapture` run shows
+    // when this fails.
+    let mut listed = false;
+    let mut called = false;
+    let mut answered = false;
+    let mut transcript = String::new();
+
+    while let Some(event) = stream.next_event().await {
+        let Some(raw) = event.raw.as_ref() else {
+            continue;
+        };
+        let line = raw.get();
+        transcript.push_str(line);
+        transcript.push('\n');
+
+        // The `init` system event carries the tool list the CLI gave the model.
+        // This is the half no unit test can reach: our own `--allowedTools` says
+        // what we asked for, and only the CLI can say what it found.
+        if event.system.as_ref().is_some_and(|s| s.subtype == "init")
+            && line.contains("mcp__local-tools__current_time")
+        {
+            listed = true;
+        }
+        if line.contains("\"tool_use\"") && line.contains("mcp__local-tools__current_time") {
+            called = true;
+        }
+        // `current_time`'s RFC 1123 output for Asia/Tokyo ends in the zone
+        // abbreviation, which is the one part of the answer the model cannot
+        // have invented from the prompt.
+        if line.contains("JST") {
+            answered = true;
+        }
+    }
+
+    assert!(
+        listed,
+        "the CLI never listed the tool for the model:\n{transcript}"
+    );
+    assert!(called, "the model never called the tool:\n{transcript}");
+    assert!(
+        answered,
+        "the tool's own output never came back:\n{transcript}"
+    );
+}

--- a/src-tauri/tests/mcp_e2e_probe.rs
+++ b/src-tauri/tests/mcp_e2e_probe.rs
@@ -150,9 +150,10 @@ async fn a_turn_lists_and_calls_a_tool_through_the_options_a_turn_builds() {
         if line.contains("\"tool_use\"") && line.contains("mcp__local-tools__current_time") {
             called = true;
         }
-        // `current_time`'s RFC 1123 output for Asia/Tokyo ends in the zone
-        // abbreviation, which is the one part of the answer the model cannot
-        // have invented from the prompt.
+        // The tool's own text coming back. A weak signal on its own — a model
+        // knows Tokyo is JST — so it is a corroboration of `called` rather
+        // than an independent assertion; `listed` and `called` carry the
+        // weight, and both are facts only the CLI can report.
         if line.contains("JST") {
             answered = true;
         }

--- a/src/views/IntegrationsView.tsx
+++ b/src/views/IntegrationsView.tsx
@@ -492,24 +492,36 @@ function ServiceEditor({
         const svc = services[info.key] ?? { enabled: false, tools: [] };
         const stored = svc.tools ?? [];
         // What this service actually exposes today, which is not the same as
-        // what it stores (#501). Two shapes have to be translated:
+        // what it stores (#501). Three shapes have to be translated:
         //
         // - **disabled** exposes nothing whatever its list says, so the boxes
         //   read empty — otherwise a row saved as
         //   `{enabled: false, tools: [...]}` shows ticks for tools no agent can
         //   reach, and checking one more silently restores the rest.
-        // - **enabled with no list** exposes *every* tool of the group, because
-        //   the backend reads an empty union as "host everything". Rendering
-        //   that as nothing ticked is the exact inverse of the truth, and it is
-        //   the shape `POST /api/integrations` and every pre-list row carry —
-        //   so it is what a user is most likely to be looking at. Showing it
-        //   ticked is also self-healing: unchecking one then stores the rest by
-        //   name, and the row stops being ambiguous.
+        // - **enabled with no list, and no sibling has one either** exposes
+        //   *every* tool of the group. Rendering that as nothing ticked is the
+        //   exact inverse of the truth, and it is the shape
+        //   `POST /api/integrations` and every pre-list row carry — so it is
+        //   what a user is most likely to be looking at.
+        // - **enabled with no list while a sibling has one** exposes
+        //   **nothing**, and this is the case that reads backwards. "Host
+        //   everything" is a property of `build_allowed_set`, which unions
+        //   *every* enabled service across the whole integration — not of one
+        //   group being empty. So a listless `gmail` beside a
+        //   `drive: ["list_files"]` matches no name in that union and hosts
+        //   zero tools. Ticking it here would not only misreport it: the union
+        //   is what makes unchecking one box *grant* the other two.
+        const unionEmpty = provider.services.every((other) => {
+          const svcOther = services[other.key];
+          return !svcOther?.enabled || !svcOther.tools?.length;
+        });
         const chosen = !svc.enabled
           ? []
           : stored.length
             ? stored
-            : info.tools.map((t) => t.name);
+            : unionEmpty
+              ? info.tools.map((t) => t.name)
+              : [];
         return (
           <div
             key={info.key}

--- a/src/views/IntegrationsView.tsx
+++ b/src/views/IntegrationsView.tsx
@@ -511,10 +511,15 @@ function ServiceEditor({
         //   `drive: ["list_files"]` matches no name in that union and hosts
         //   zero tools. Ticking it here would not only misreport it: the union
         //   is what makes unchecking one box *grant* the other two.
-        const unionEmpty = provider.services.every((other) => {
-          const svcOther = services[other.key];
-          return !svcOther?.enabled || !svcOther.tools?.length;
-        });
+        // Over the **stored** map, not `provider.services`: `build_allowed_set`
+        // unions `services.values()`, so a key outside this app's catalog — one
+        // `POST /api/integrations` accepted, since it validates no service
+        // names — contributes to the real union while a catalog walk cannot see
+        // it. Same answer for every catalog key, since an absent service
+        // contributes nothing either way.
+        const unionEmpty = Object.values(services).every(
+          (other) => !other?.enabled || !other.tools?.length,
+        );
         const chosen = !svc.enabled
           ? []
           : stored.length

--- a/src/views/IntegrationsView.tsx
+++ b/src/views/IntegrationsView.tsx
@@ -490,7 +490,11 @@ function ServiceEditor({
     <div>
       {provider.services.map((info) => {
         const svc = services[info.key] ?? { enabled: false, tools: [] };
-        const chosen = svc.tools ?? [];
+        // A disabled service exposes nothing whatever its stored list says, so
+        // the boxes read empty — otherwise a row saved as
+        // `{enabled: false, tools: [...]}` would render ticks for tools no agent
+        // can reach, and checking one more would silently restore the rest.
+        const chosen = svc.enabled ? (svc.tools ?? []) : [];
         return (
           <div
             key={info.key}
@@ -516,40 +520,45 @@ function ServiceEditor({
                 }
               />
             </div>
-            {svc.enabled && (
-              <div className="svcblock__tools">
-                {info.tools.map((t) => (
-                  <label className="svctool" key={t.name}>
-                    <Checkbox
-                      on={chosen.includes(t.name)}
-                      onChange={(on) => {
-                        const next = on
-                          ? [...chosen, t.name]
-                          : chosen.filter((x) => x !== t.name);
-                        onChange({
-                          ...services,
-                          // Unchecking the **last** tool turns the service off
-                          // rather than storing `{enabled: true, tools: []}`
-                          // (#501). The backend reads an empty tool list as
-                          // "host everything" — the semantics are ported and
-                          // pinned in all six integrations — so that shape means
-                          // the exact opposite of what the user just asked for,
-                          // and of what the copy above this editor promises.
-                          [info.key]: {
-                            enabled: next.length > 0,
-                            tools: next,
-                          },
-                        });
-                      }}
-                    />
-                    <span className="svctool__body">
-                      <span className="svctool__name">{t.name}</span>
-                      <span className="svctool__desc">{t.description}</span>
-                    </span>
-                  </label>
-                ))}
-              </div>
-            )}
+            {/* The checkboxes stay mounted when the service is off, and that is
+                not cosmetic (#501): unchecking the last tool now turns the
+                service off, so hiding them would make the state it lands in a
+                dead end — going from "only get_repo" to "only list_repos" would
+                mean re-enabling the service, which grants *every* tool. The
+                block is already greyed by `svcblock--off`. */}
+            <div className="svcblock__tools">
+              {info.tools.map((t) => (
+                <label className="svctool" key={t.name}>
+                  <Checkbox
+                    on={chosen.includes(t.name)}
+                    onChange={(on) => {
+                      const next = on
+                        ? [...chosen, t.name]
+                        : chosen.filter((x) => x !== t.name);
+                      onChange({
+                        ...services,
+                        // Unchecking the **last** tool turns the service off
+                        // rather than storing `{enabled: true, tools: []}`
+                        // (#501). The backend reads an empty tool list as
+                        // "host everything" — the semantics are ported and
+                        // pinned in all six integrations — so that shape means
+                        // the exact opposite of what the user just asked for,
+                        // and of what the copy above this editor promises.
+                        // Checking one is the way back on.
+                        [info.key]: {
+                          enabled: next.length > 0,
+                          tools: next,
+                        },
+                      });
+                    }}
+                  />
+                  <span className="svctool__body">
+                    <span className="svctool__name">{t.name}</span>
+                    <span className="svctool__desc">{t.description}</span>
+                  </span>
+                </label>
+              ))}
+            </div>
           </div>
         );
       })}

--- a/src/views/IntegrationsView.tsx
+++ b/src/views/IntegrationsView.tsx
@@ -522,17 +522,25 @@ function ServiceEditor({
                   <label className="svctool" key={t.name}>
                     <Checkbox
                       on={chosen.includes(t.name)}
-                      onChange={(on) =>
+                      onChange={(on) => {
+                        const next = on
+                          ? [...chosen, t.name]
+                          : chosen.filter((x) => x !== t.name);
                         onChange({
                           ...services,
+                          // Unchecking the **last** tool turns the service off
+                          // rather than storing `{enabled: true, tools: []}`
+                          // (#501). The backend reads an empty tool list as
+                          // "host everything" — the semantics are ported and
+                          // pinned in all six integrations — so that shape means
+                          // the exact opposite of what the user just asked for,
+                          // and of what the copy above this editor promises.
                           [info.key]: {
-                            enabled: true,
-                            tools: on
-                              ? [...chosen, t.name]
-                              : chosen.filter((x) => x !== t.name),
+                            enabled: next.length > 0,
+                            tools: next,
                           },
-                        })
-                      }
+                        });
+                      }}
                     />
                     <span className="svctool__body">
                       <span className="svctool__name">{t.name}</span>

--- a/src/views/IntegrationsView.tsx
+++ b/src/views/IntegrationsView.tsx
@@ -490,11 +490,26 @@ function ServiceEditor({
     <div>
       {provider.services.map((info) => {
         const svc = services[info.key] ?? { enabled: false, tools: [] };
-        // A disabled service exposes nothing whatever its stored list says, so
-        // the boxes read empty — otherwise a row saved as
-        // `{enabled: false, tools: [...]}` would render ticks for tools no agent
-        // can reach, and checking one more would silently restore the rest.
-        const chosen = svc.enabled ? (svc.tools ?? []) : [];
+        const stored = svc.tools ?? [];
+        // What this service actually exposes today, which is not the same as
+        // what it stores (#501). Two shapes have to be translated:
+        //
+        // - **disabled** exposes nothing whatever its list says, so the boxes
+        //   read empty — otherwise a row saved as
+        //   `{enabled: false, tools: [...]}` shows ticks for tools no agent can
+        //   reach, and checking one more silently restores the rest.
+        // - **enabled with no list** exposes *every* tool of the group, because
+        //   the backend reads an empty union as "host everything". Rendering
+        //   that as nothing ticked is the exact inverse of the truth, and it is
+        //   the shape `POST /api/integrations` and every pre-list row carry —
+        //   so it is what a user is most likely to be looking at. Showing it
+        //   ticked is also self-healing: unchecking one then stores the rest by
+        //   name, and the row stops being ambiguous.
+        const chosen = !svc.enabled
+          ? []
+          : stored.length
+            ? stored
+            : info.tools.map((t) => t.name);
         return (
           <div
             key={info.key}


### PR DESCRIPTION
Closes #501

## What

An agent's MCP tool set could collapse to **zero** with nothing anywhere saying so — and, from the other direction, widen to **every** tool of a service the user had emptied.

## Why it happened

`filter_config_tools` intersected the agent's requested tool names with each enabled service's stored `tools` list. A service stored as `{"enabled": true}` — no list at all, which is what `POST /api/integrations` accepts and what every row written before the per-service lists carries — had nothing to intersect, so `kept` was empty and the whole service was dropped. `build_allowed_set` then saw an empty map, `service_enabled` was false for every group, and the integration hosted zero tools **while `--allowedTools` still named them**. The log could not tell that apart from a healthy run: `claude: mcp "google-7": serving on http://…` is printed byte for byte identically whether the server registered eight tools or none.

## How

- **`registry.rs::filter_config_tools`** — an enabled service naming no tools of its own now means "every tool of **that** service", and is given the request narrowed to its own names via the integration's new `SERVICE_TOOLS` table.

  The obvious shortcut — hand it the caller's *whole* request — is unsound and was this PR's first attempt. `build_allowed_set` unions **every** enabled service, so the surplus names satisfy the `allowed` half for a **sibling** whose own list excludes them, and the sibling's service gate passes because it is enabled. Review reproduced it: `{"gmail":{"enabled":true},"drive":{"enabled":true,"tools":["list_files"]}}` would have hosted `create_file`.
- **`SERVICE_TOOLS`, derived not transcribed** — each integration exports its `push` table as data, and `the_service_table_matches_what_is_registered` checks it by enabling one service at a time and asking the real registration function. It caught a missing `list_pull_comments` on its first run. `service_tool_table` is a second `match` over `HOSTED_TYPES`, so it gets its own coverage guard beside `a_hosted_type_always_has_a_starter`.
- **The empty-union rule is kept, not changed.** An explicitly empty `tools` list still means "host everything" — ported deliberately, identical in all six integrations. What is closed is the *inverting shape*: the editor turns a service **off** when its last tool is unchecked, and renders a listless enabled service as fully ticked **only when no sibling names a tool** (because "host everything" is a property of the integration-wide union, not of one group). The checkboxes stay mounted when a service is off, so the state that produces is not a dead end.
- **Observability** — `InProcessMcpServer::tool_names()` carries what the handler registered, and `runner::report_hosted_tools` emits one `info` line per server a turn starts plus a `warn` per requested tool it does not host. Both call sites pass the **handle's** names, not the request's — the two disagreeing is the defect. It stays a warning: a missing tool is the kinder failure than a refused run.
- **`tests/mcp_e2e_probe.rs`** (`#[ignore]`d, beside `claude_mcp_live.rs`) drives the real `claude` CLI through **`runner::build_options`' own output** and asserts the tool was *listed* (it appears in the CLI's `init` event) and *called*. Triage had already shown the transport was fine; a probe that rebuilds the arguments itself cannot see an option-assembly defect.

## Acceptance criteria

- [x] A service row with no `tools` list hosts that service's tools when an agent names a subset — `a_service_naming_no_tools_contributes_its_own_tools` (both spellings, plus the sibling-leak case) and `a_service_with_no_tool_list_hosts_exactly_what_was_asked_for` (the whole chain through `google_tools`).
- [x] The empty-list semantics are decided, tested and matched by the UI — `an_enabled_service_with_an_empty_list_still_hosts_everything` (single **and** mixed rows), the `IntegrationsView` changes, and a `CLAUDE.md` note.
- [x] Starting a server logs the tool names it registered — asserted at **both** call sites (local-tools and github).
- [x] An allowlisted tool no server hosts logs a warning — asserted at both call sites, alongside a check that the qualified name still reaches `--allowedTools`.
- [x] A test drives the real CLI through the turn's own option assembly — `mcp_e2e_probe.rs`.

## Verification

- `npm run build`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --no-fail-fast` (1459 lib tests + 17 other binaries), `cargo build --release` — all green, re-run after every round.
- **Revert-checked** at each round: backing out each production change turns the corresponding new tests red. The one exception is `an_enabled_service_with_an_empty_list_still_hosts_everything`, which passes either way by design — it pins semantics this PR deliberately preserves.
- `cargo test --test mcp_e2e_probe -- --ignored` **run against the real signed-in CLI** and passing: the tool was listed in the `init` event, called, and its output came back.
- Three independent automated review rounds; each found a real defect, all three fixed here.

## ⚠️ One thing needs a maintainer: the red `CodeQL` check

`Typecheck, lint and build` (the only required check), `Windows unit tests` and all five `Analyze (…)` jobs pass. The `CodeQL` aggregate reports one new high alert, `rust/cleartext-logging`, on `runner.rs`'s new `log::info!`.

**It is a false positive**, confirmed independently by all three review rounds: the logged value is `server.tool_names()`, which is `ToolRouter::list_all()`'s `tool.name` — static literals passed to `new_tool`. The credential lives only inside the handler closure. The taint is container-level: the `ToolDef` closures capture the OAuth token, so CodeQL taints the whole `ToolServer` and everything read back off it. `main` already carries **12 open alerts of the same rule**.

There is no code change that removes it without re-deriving the log data from the per-service tool table this PR just centralised, so it is left honest. **This PR should not be merged until the alert is dismissed as a false positive** — a security-dashboard decision, not a code one.

## Out of scope

Refusing a turn whose tool set comes out empty (documented as the worse failure), the MCP transport, and the API-side acceptance of `{"enabled":true,"tools":[]}` (refusing it would be a wire change on a byte-exact endpoint).