### PR TITLE
chore: release v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agento-desktop",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agento-desktop",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.1.1",
         "@tauri-apps/plugin-dialog": "^2.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agento-desktop",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agento"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agento"
-version = "1.1.0"
+version = "1.2.0"
 description = "Personal AI agent platform for Claude Code"
 authors = ["Shaharia Lab"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Agento",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "identifier": "com.shaharialab.agento",
   "mainBinaryName": "agento",
   "build": {


### PR DESCRIPTION
Bumps the version in all five enforced places for the `v1.2.0` release.

- `src-tauri/tauri.conf.json`
- `package.json`
- `package-lock.json` (both fields)
- `src-tauri/Cargo.toml`
- `src-tauri/Cargo.lock`

Tag `v1.2.0` follows once this is on `main`.