### PR TITLE
feat(site): documentation and blog site on GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,6 +20,13 @@ on:
     types: [published]
   workflow_dispatch:
 
+# Every action is pinned to a full commit SHA, and only GitHub-owned actions are
+# used. Both are policy on this organisation: `sha_pinning_required` is on, and
+# `allowed_actions` is a selected allowlist. A workflow that breaks either fails
+# at startup with "This run likely failed because of a workflow file issue" and
+# no job logs, which is a slow thing to diagnose — so check the policy before
+# adding an action here.
+
 permissions:
   contents: read
   pages: write
@@ -34,9 +41,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v4
         with:
           node-version: 22
           cache: npm
@@ -55,8 +62,8 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: npm run build
 
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: web/dist
 
@@ -68,4 +75,4 @@ jobs:
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - id: deploy
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,71 @@
+name: Site
+
+# Publishes the documentation and blog site to GitHub Pages.
+#
+# It runs on a release as well as on a push, and that is not redundant: the
+# landing page bakes in the latest release's version and its per-platform
+# installer URLs (web/scripts/fetch-release.mjs), because asset filenames carry
+# the version and so cannot be addressed by GitHub's `releases/latest/download`
+# redirect. Without the release trigger the site would advertise the previous
+# version until somebody happened to push a docs change.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'web/**'
+      - 'src-tauri/tauri.conf.json'
+      - '.github/workflows/pages.yml'
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One deploy at a time; a queued run is superseded rather than racing.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install
+        working-directory: web
+        run: npm ci
+
+      - name: Build
+        working-directory: web
+        # The token lifts the release API's unauthenticated rate limit. The
+        # build falls back to the version in tauri.conf.json without it, so a
+        # rate limit degrades the download list rather than failing the run.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: npm run build
+
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: web/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/site-check.yml
+++ b/.github/workflows/site-check.yml
@@ -14,6 +14,13 @@ on:
       - 'src-tauri/tauri.conf.json'
       - '.github/workflows/site-check.yml'
 
+# Every action is pinned to a full commit SHA, and only GitHub-owned actions are
+# used. Both are policy on this organisation: `sha_pinning_required` is on, and
+# `allowed_actions` is a selected allowlist. A workflow that breaks either fails
+# at startup with "This run likely failed because of a workflow file issue" and
+# no job logs, which is a slow thing to diagnose — so check the policy before
+# adding an action here.
+
 permissions:
   contents: read
 
@@ -21,9 +28,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v4
         with:
           node-version: 22
           cache: npm
@@ -39,16 +46,10 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: npm run build
 
+      # A script rather than a link-checking action: this organisation allows
+      # only GitHub-owned actions plus a named allowlist, so a third-party
+      # checker would mean widening that policy for a docs job. See
+      # web/scripts/check-links.mjs for what it does and does not check.
       - name: Check links
-        uses: lycheeverse/lychee-action@v2
-        with:
-          # Offline: internal links and their fragments only. External links
-          # would make this job fail on somebody else's outage, and a rate
-          # limit from GitHub would fail it on every second run.
-          args: >-
-            --offline
-            --include-fragments
-            --root-dir ${{ github.workspace }}/web/dist
-            --exclude-path web/dist/pagefind
-            'web/dist/**/*.html'
-          fail: true
+        working-directory: web
+        run: npm run check:links

--- a/.github/workflows/site-check.yml
+++ b/.github/workflows/site-check.yml
@@ -1,0 +1,54 @@
+name: Site check
+
+# Builds the site on any pull request that could break it, and checks every
+# link in the output.
+#
+# The link check earns its place: docs/ cross-links by heading anchor
+# (`troubleshooting.md#the-claude-code-cli`), and renaming a heading breaks
+# those silently — the markdown still renders, the link just goes nowhere.
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'web/**'
+      - 'src-tauri/tauri.conf.json'
+      - '.github/workflows/site-check.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install
+        working-directory: web
+        run: npm ci
+
+      - name: Build
+        working-directory: web
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: npm run build
+
+      - name: Check links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          # Offline: internal links and their fragments only. External links
+          # would make this job fail on somebody else's outage, and a rate
+          # limit from GitHub would fail it on every second run.
+          args: >-
+            --offline
+            --include-fragments
+            --root-dir ${{ github.workspace }}/web/dist
+            --exclude-path web/dist/pagefind
+            'web/dist/**/*.html'
+          fail: true

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,11 @@
+# Generated from ../docs by scripts/sync-docs.mjs — never edit, never commit.
+src/content/docs/docs/
+public/screenshots/
+
+# Resolved from the GitHub Releases API by scripts/fetch-release.mjs.
+src/data/release.json
+src/data/repo.json
+
+dist/
+.astro/
+node_modules/

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -20,6 +20,16 @@ const sidebar = [
   })),
 ];
 
+/**
+ * Code blocks are inverted relative to the page in *both* themes, so their
+ * ground is a constant rather than a token. It has to be a literal here:
+ * Expressive Code parses every styleOverride colour with a colour library at
+ * build time, and a `var(--…)` string is not a colour it can parse — feeding
+ * it one produced a stylesheet whose whole `@layer` block was discarded, so
+ * every code block on the site rendered unstyled.
+ */
+const INK = '#0B0C07';
+
 export default defineConfig({
   site: SITE,
   base: BASE,
@@ -36,7 +46,31 @@ export default defineConfig({
         // One theme for both site themes: code blocks are always inverted
         // relative to the page, which is the design's own rule.
         themes: ['github-dark'],
-        styleOverrides: { borderRadius: '2px', borderWidth: '1.5px' },
+        styleOverrides: {
+          borderRadius: '2px',
+          borderWidth: '1.5px',
+          codeBackground: INK,
+          codeFontSize: '0.82rem',
+          // Expressive Code draws a title bar above shell blocks, and left at
+          // its defaults that bar takes the *page* background — so every `bash`
+          // block rendered as a bare light strip stacked on a dark body. The
+          // frame is flattened into the code ground instead, which makes a
+          // fenced block here look like the hand-written ones on the landing
+          // page: one solid rectangle.
+          frames: {
+            frameBoxShadowCssValue: 'none',
+            editorBackground: INK,
+            editorTabBarBackground: INK,
+            editorActiveTabBackground: INK,
+            editorActiveTabBorderColor: 'transparent',
+            editorActiveTabIndicatorTopColor: 'transparent',
+            editorTabBarBorderBottomColor: 'transparent',
+            terminalBackground: INK,
+            terminalTitlebarBackground: INK,
+            terminalTitlebarBorderBottomColor: 'transparent',
+            terminalTitlebarDotsOpacity: '0',
+          },
+        },
       },
       description:
         'Cost analytics, session history and scheduled agents for Claude Code — a desktop app that reads what is already on your disk.',

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -1,0 +1,58 @@
+// @ts-check
+import { defineConfig } from 'astro/config';
+import starlight from '@astrojs/starlight';
+import sitemap from '@astrojs/sitemap';
+import { SITE, BASE, REPO } from './site.config.mjs';
+import { GROUPS, PAGES } from './docs.manifest.mjs';
+
+/** The sidebar is derived from the manifest, so it cannot drift from the pages. */
+const sidebar = [
+  ...PAGES.filter((p) => p.group === null).map((p) => ({
+    label: p.label,
+    slug: p.slug === 'index' ? 'docs' : `docs/${p.slug}`,
+  })),
+  ...GROUPS.map((g) => ({
+    label: g.label,
+    items: PAGES.filter((p) => p.group === g.id).map((p) => ({
+      label: p.label,
+      slug: `docs/${p.slug}`,
+    })),
+  })),
+];
+
+export default defineConfig({
+  site: SITE,
+  base: BASE,
+  trailingSlash: 'always',
+  integrations: [
+    starlight({
+      title: 'Agento',
+      customCss: [
+        './src/styles/fonts.css',
+        './src/styles/tokens.css',
+        './src/styles/starlight.css',
+      ],
+      expressiveCode: {
+        // One theme for both site themes: code blocks are always inverted
+        // relative to the page, which is the design's own rule.
+        themes: ['github-dark'],
+        styleOverrides: { borderRadius: '2px', borderWidth: '1.5px' },
+      },
+      description:
+        'Cost analytics, session history and scheduled agents for Claude Code — a desktop app that reads what is already on your disk.',
+      social: [{ icon: 'github', label: 'GitHub', href: REPO }],
+      editLink: { baseUrl: `${REPO}/edit/main/` },
+      sidebar,
+      // The docs pages are generated from ../docs by scripts/sync-docs.mjs.
+      // Editing them in src/content/ has no effect; the next build overwrites.
+      // The 404 is a site page (src/pages/404.astro), not a docs page: landing
+      // on the docs sidebar reads as "this documentation page is missing"
+      // rather than "this address is wrong".
+      disable404Route: true,
+      lastUpdated: false,
+      pagination: true,
+      credits: false,
+    }),
+    sitemap(),
+  ],
+});

--- a/web/design/site-mockup.html
+++ b/web/design/site-mockup.html
@@ -1,0 +1,1029 @@
+<title>Agento Paper Press</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Newsreader:ital,opsz,wght@0,6..72,400;0,600;0,700;1,6..72,400&family=Karla:ital,wght@0,400;0,500;0,600;0,700;1,400&family=JetBrains+Mono:wght@400;500;700&display=swap">
+
+<style>
+/* ==========================================================================
+   AGENTO — site design tokens
+   Neo-brutalist editorial: bone paper, hard ink borders, solid offset
+   shadows, one electric accent. Light is the native state; dark inverts the
+   ground and the ink and keeps everything else.
+   ========================================================================== */
+:root {
+  --paper:       #F0EEE6;
+  --raised:      #F7F5EE;
+  --sunken:      #E6E3D9;
+  --ink:         #0B0C07;
+  --ink-soft:    #5A574D;
+  --ink-faint:   #8A8779;
+  --blue:        #1DC1FF;
+  --blue-tint:   #C9E6F6;
+  --blue-deep:   #0B7FA8;
+  --code-bg:     #0B0C07;
+  --code-fg:     #EFECE2;
+  --code-border: #0B0C07;
+  --warn:        #E8A33D;
+
+  --bw: 1.5px;
+  --bw-strong: 2px;
+  --offset: 8px 8px 0 var(--ink);
+  --offset-sm: 5px 5px 0 var(--ink);
+  --radius: 2px;
+
+  --font-display: "Instrument Serif", "Iowan Old Style", Georgia, serif;
+  --font-sub: "Newsreader", "Iowan Old Style", Georgia, serif;
+  --font-serif-text: "Newsreader", "Iowan Old Style", Georgia, serif;
+  --font-sans-text: "Karla", "Helvetica Neue", Arial, sans-serif;
+  --font-body: var(--font-sans-text);
+  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+
+  --measure: 68ch;
+  --shell: 1120px;
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --paper:       #14150F;
+    --raised:      #1C1D16;
+    --sunken:      #0D0E09;
+    --ink:         #F1EEE5;
+    --ink-soft:    #A29F92;
+    --ink-faint:   #6E6C61;
+    --blue:        #1DC1FF;
+    --blue-tint:   #0E3A4C;
+    --blue-deep:   #7FDCFF;
+    --code-bg:     #0A0B06;
+    --code-fg:     #EFECE2;
+    --code-border: #F1EEE5;
+    --warn:        #E8A33D;
+  }
+}
+:root[data-theme="dark"] {
+  --paper:       #14150F;
+  --raised:      #1C1D16;
+  --sunken:      #0D0E09;
+  --ink:         #F1EEE5;
+  --ink-soft:    #A29F92;
+  --ink-faint:   #6E6C61;
+  --blue:        #1DC1FF;
+  --blue-tint:   #0E3A4C;
+  --blue-deep:   #7FDCFF;
+  --code-bg:     #0A0B06;
+  --code-fg:     #EFECE2;
+  --code-border: #F1EEE5;
+  --warn:        #E8A33D;
+}
+
+/* Review switch: the reference sets body copy in a serif. Both are wired so
+   the choice can be made by looking, not by arguing. */
+:root[data-body="serif"] { --font-body: var(--font-serif-text); }
+:root[data-body="serif"] body { font-size: 17.5px; line-height: 1.62; }
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--font-body);
+  font-size: 16px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+a { color: inherit; }
+img { max-width: 100%; display: block; }
+
+/* --- shared primitives --------------------------------------------------- */
+.label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+.serif { font-family: var(--font-display); font-weight: 400; letter-spacing: -0.01em; }
+.sheet {
+  background: var(--raised);
+  border: var(--bw) solid var(--ink);
+  border-radius: var(--radius);
+  box-shadow: var(--offset);
+}
+.sheet--flat { box-shadow: none; }
+.sheet--dashed { border-style: dashed; box-shadow: none; background: transparent; }
+.rule { height: var(--bw); background: var(--ink); border: 0; margin: 0; }
+.rule--dashed { height: 0; background: none; border-top: 1.5px dashed var(--ink-faint); }
+
+/* The signature device: a mono label prefixed by an em rule, set into the
+   top-left of the panel it names. */
+.eyebrow {
+  display: flex; align-items: center; gap: 9px;
+  font-family: var(--font-mono);
+  font-size: 11px; font-weight: 500;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--ink-soft);
+  margin-bottom: 18px;
+}
+.eyebrow::before {
+  content: ""; width: 16px; height: 1.5px; background: var(--ink-soft); flex: none;
+}
+.eyebrow__end { margin-left: auto; letter-spacing: 0.04em; text-transform: none; }
+.eyebrow__end a { text-decoration: none; border-bottom: 1.5px solid var(--blue); }
+
+/* Hairline rows stacked inside a panel. The panel carries the shadow; rows
+   never do. */
+.rows { display: flex; flex-direction: column; gap: 8px; }
+.row {
+  display: flex; align-items: center; gap: 14px;
+  padding: 12px 15px;
+  border: 1px solid var(--ink-faint);
+  border-radius: var(--radius);
+  background: var(--raised);
+  text-decoration: none;
+}
+.row:hover { border-color: var(--ink); background: var(--sunken); }
+.row__t { font-family: var(--font-sub); font-weight: 600; font-size: 16.5px; }
+.row__m { font-family: var(--font-mono); font-size: 12.5px; }
+.row__m .q { color: var(--blue-deep); }
+.row__r { margin-left: auto; font-size: 14px; color: var(--ink-soft); text-align: right; }
+.row__go { color: var(--ink-faint); font-family: var(--font-mono); }
+.row:hover .row__go { color: var(--blue-deep); }
+
+.badge {
+  font-family: var(--font-mono); font-size: 10px; font-weight: 700;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  padding: 3px 7px; border-radius: var(--radius);
+  background: var(--sunken); border: 1px solid var(--ink-faint);
+  color: var(--ink-soft); flex: none;
+}
+
+.pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 3px 10px;
+  border: var(--bw) solid var(--ink);
+  border-radius: 999px;
+  background: var(--blue-tint);
+  font-family: var(--font-mono);
+  font-size: 11px; font-weight: 500;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  white-space: nowrap;
+}
+.pill--plain { background: transparent; }
+
+.btn {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 11px 20px;
+  border: var(--bw-strong) solid var(--ink);
+  border-radius: var(--radius);
+  background: var(--raised);
+  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 12px; font-weight: 700;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  text-decoration: none;
+  box-shadow: var(--offset-sm);
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+.btn:hover { transform: translate(2px, 2px); box-shadow: 2px 2px 0 var(--ink); }
+.btn:active { transform: translate(4px, 4px); box-shadow: 0 0 0 var(--ink); }
+.btn:focus-visible { outline: 3px solid var(--blue); outline-offset: 3px; }
+.btn--primary { background: var(--blue); color: #0B0C07; }
+.btn--ink { background: var(--ink); color: var(--paper); }
+@media (prefers-reduced-motion: reduce) {
+  .btn { transition: none; }
+  .btn:hover, .btn:active { transform: none; box-shadow: var(--offset-sm); }
+}
+
+/* --- review chrome (scaffolding, not part of the site) ------------------- */
+.review {
+  position: sticky; top: 0; z-index: 50;
+  display: flex; flex-wrap: wrap; align-items: center; gap: 10px;
+  padding: 10px 18px;
+  background: var(--ink);
+  color: var(--paper);
+  border-bottom: var(--bw-strong) solid var(--ink);
+}
+.review__tag {
+  font-family: var(--font-mono); font-size: 10px; font-weight: 700;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--blue);
+  padding-right: 6px;
+}
+.review__tabs { display: flex; flex-wrap: wrap; gap: 6px; }
+.review__tab {
+  font-family: var(--font-mono); font-size: 11px; font-weight: 500;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  padding: 5px 12px; border-radius: 2px;
+  border: 1px solid var(--paper);
+  background: transparent; color: var(--paper);
+  cursor: pointer;
+}
+.review__tab[aria-selected="true"] { background: var(--paper); color: var(--ink); }
+.review__tab:focus-visible { outline: 2px solid var(--blue); outline-offset: 2px; }
+.review__spacer { flex: 1 1 auto; }
+
+/* --- site header --------------------------------------------------------- */
+.shell { max-width: var(--shell); margin: 0 auto; padding: 0 24px; }
+.masthead {
+  border-bottom: var(--bw-strong) solid var(--ink);
+  background: var(--paper);
+}
+.masthead__in {
+  display: flex; align-items: center; gap: 18px;
+  padding: 16px 24px;
+  max-width: var(--shell); margin: 0 auto;
+}
+.wordmark {
+  font-family: var(--font-display);
+  font-size: 26px; line-height: 1;
+  text-decoration: none;
+  display: flex; align-items: baseline; gap: 8px;
+}
+.wordmark__dot {
+  width: 9px; height: 9px; border-radius: 999px;
+  background: var(--blue); border: 1.5px solid var(--ink);
+  display: inline-block;
+}
+.nav { display: flex; gap: 20px; margin-left: auto; align-items: center; }
+.nav a {
+  font-family: var(--font-mono); font-size: 12px; font-weight: 500;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  text-decoration: none; padding-bottom: 2px;
+  border-bottom: 2px solid transparent;
+}
+.nav a:hover { border-bottom-color: var(--blue); }
+.nav a[aria-current] { border-bottom-color: var(--ink); }
+
+/* --- landing ------------------------------------------------------------- */
+.hero { padding: 64px 0 40px; }
+.hero__eyebrow { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 22px; }
+.hero__title {
+  font-family: var(--font-display);
+  font-size: clamp(44px, 7vw, 82px);
+  line-height: 0.98;
+  letter-spacing: -0.02em;
+  margin: 0 0 20px;
+  text-wrap: balance;
+  max-width: 15ch;
+}
+.hero__title em { font-style: italic; color: var(--blue-deep); }
+.hero__lede {
+  font-size: 19px; line-height: 1.55;
+  max-width: 54ch; color: var(--ink-soft);
+  margin: 0 0 30px;
+}
+.hero__cta { display: flex; flex-wrap: wrap; gap: 14px; align-items: center; }
+.hero__note { font-family: var(--font-mono); font-size: 11px; color: var(--ink-faint); letter-spacing: 0.04em; }
+
+.stats {
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  margin: 44px 0 0;
+  border: var(--bw) solid var(--ink);
+  border-radius: var(--radius);
+  background: var(--raised);
+  box-shadow: var(--offset);
+  overflow: hidden;
+}
+.stat { padding: 16px 18px; border-right: var(--bw) solid var(--ink); }
+.stat:last-child { border-right: 0; }
+.stat__n {
+  font-family: var(--font-mono); font-size: 21px; font-weight: 700;
+  font-variant-numeric: tabular-nums; line-height: 1.2;
+}
+.stat__k { margin-top: 3px; }
+
+.shot {
+  margin: 40px 0 0;
+  border: var(--bw-strong) solid var(--ink);
+  border-radius: var(--radius);
+  box-shadow: var(--offset);
+  background: var(--raised);
+  overflow: hidden;
+}
+.shot__bar {
+  display: flex; align-items: center; gap: 8px;
+  padding: 8px 12px;
+  border-bottom: var(--bw) solid var(--ink);
+  background: var(--sunken);
+}
+.shot__dot { width: 9px; height: 9px; border-radius: 999px; border: 1.2px solid var(--ink); background: var(--paper); }
+.shot__name { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink-soft); margin-left: 4px; }
+.shot__cap {
+  padding: 10px 14px; border-top: var(--bw) solid var(--ink);
+  font-family: var(--font-mono); font-size: 11px; color: var(--ink-soft);
+}
+
+.section { padding: 70px 0 0; }
+.section__head { display: flex; align-items: baseline; gap: 16px; margin-bottom: 26px; }
+.section__head h2 {
+  font-family: var(--font-display); font-weight: 400;
+  font-size: 38px; line-height: 1.05; letter-spacing: -0.01em; margin: 0;
+}
+.section__head .label { margin-left: auto; }
+
+.split { display: grid; grid-template-columns: 1fr 1fr; gap: 22px; }
+.panel { padding: 26px; }
+.panel h3 {
+  font-family: var(--font-sub); font-weight: 600;
+  font-size: 25px; line-height: 1.2; margin: 0 0 10px; letter-spacing: -0.01em;
+}
+.panel p { margin: 0 0 14px; color: var(--ink-soft); font-size: 15px; }
+.panel ul { margin: 0; padding-left: 18px; color: var(--ink-soft); font-size: 15px; }
+.panel li { margin-bottom: 6px; }
+.panel li b { color: var(--ink); font-weight: 600; }
+
+.grid3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.card { padding: 20px; }
+.card h4 {
+  font-family: var(--font-sub); font-weight: 600;
+  font-size: 19.5px; margin: 12px 0 8px; line-height: 1.25; letter-spacing: -0.01em;
+}
+.card p { margin: 0; font-size: 14.5px; color: var(--ink-soft); line-height: 1.55; }
+
+.steps { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0; border: var(--bw) solid var(--ink); border-radius: var(--radius); box-shadow: var(--offset); background: var(--raised); overflow: hidden; }
+.step { padding: 24px; border-right: var(--bw) solid var(--ink); }
+.step:last-child { border-right: 0; }
+.step__n {
+  font-family: var(--font-mono); font-size: 11px; font-weight: 700;
+  letter-spacing: 0.1em; color: var(--ink);
+  border: var(--bw) solid var(--ink); border-radius: 999px;
+  width: 26px; height: 26px; display: grid; place-items: center;
+  background: var(--blue-tint);
+}
+.step h4 { font-family: var(--font-sub); font-weight: 600; font-size: 20px; margin: 14px 0 8px; }
+.step p { margin: 0 0 12px; font-size: 14.5px; color: var(--ink-soft); }
+
+.code {
+  background: var(--code-bg); color: var(--code-fg);
+  border: var(--bw) solid var(--code-border); border-radius: var(--radius);
+  font-family: var(--font-mono); font-size: 12.5px; line-height: 1.7;
+  padding: 14px 16px; overflow-x: auto; margin: 0;
+}
+.code .c { color: #8A8779; }
+.code .s { color: var(--blue); }
+.code .k { color: #FFFFFF; font-weight: 700; }
+:root[data-theme="dark"] .code .k, :root:not([data-theme="light"]) .code .k { color: var(--code-fg); }
+
+.closer {
+  margin: 76px 0 0; padding: 46px 34px;
+  background: var(--ink); color: var(--paper);
+  border-radius: var(--radius);
+  box-shadow: var(--offset-sm);
+}
+.closer h2 { font-family: var(--font-display); font-weight: 400; font-size: 40px; margin: 0 0 12px; line-height: 1.05; }
+.closer p { margin: 0 0 24px; color: #C9C6BB; max-width: 52ch; }
+.closer .btn { border-color: var(--paper); }
+.closer .btn--primary { border-color: var(--paper); box-shadow: 4px 4px 0 var(--paper); }
+.closer .btn--ghost { background: transparent; color: var(--paper); box-shadow: 4px 4px 0 var(--paper); }
+
+.foot {
+  margin-top: 60px; border-top: 1.5px dashed var(--ink-faint);
+  padding: 22px 0 46px;
+  display: flex; flex-wrap: wrap; gap: 18px; align-items: center;
+}
+.foot .label { margin-right: auto; letter-spacing: 0.06em; }
+.foot__end { margin-left: auto; }
+.foot a { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; text-decoration: none; border-bottom: 1.5px solid var(--ink); }
+
+/* --- docs ---------------------------------------------------------------- */
+.docs { display: grid; grid-template-columns: 232px minmax(0,1fr) 190px; gap: 34px; padding: 34px 0 60px; align-items: start; }
+.sidebar { position: sticky; top: 78px; }
+.sidebar__group { margin-bottom: 22px; }
+.sidebar__group > .label { display: block; padding-bottom: 8px; border-bottom: var(--bw) solid var(--ink); margin-bottom: 8px; }
+.sidebar a {
+  display: block; padding: 5px 9px; text-decoration: none;
+  font-size: 14.5px; border-radius: 2px; border: 1.5px solid transparent;
+}
+.sidebar a:hover { background: var(--sunken); }
+.sidebar a[aria-current="page"] {
+  background: var(--blue-tint); border-color: var(--ink); font-weight: 600;
+}
+.searchbox {
+  display: flex; align-items: center; gap: 8px; width: 100%;
+  padding: 8px 10px; margin-bottom: 22px;
+  background: var(--raised); border: var(--bw) solid var(--ink); border-radius: var(--radius);
+  font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.06em;
+  text-transform: uppercase; color: var(--ink-soft); cursor: pointer;
+}
+.searchbox kbd {
+  margin-left: auto; font-family: var(--font-mono); font-size: 10px;
+  border: 1.2px solid var(--ink-faint); border-radius: 2px; padding: 1px 5px; color: var(--ink-soft);
+}
+
+.article { max-width: var(--measure); }
+.crumbs { display: flex; gap: 8px; align-items: center; margin-bottom: 14px; }
+.crumbs span { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--ink-faint); }
+.article h1 {
+  font-family: var(--font-display); font-weight: 400;
+  font-size: 52px; line-height: 1.02; letter-spacing: -0.02em;
+  margin: 0 0 10px;
+}
+.article__sub { font-size: 18px; color: var(--ink-soft); margin: 0 0 26px; max-width: 56ch; }
+.article h2 {
+  font-family: var(--font-display); font-weight: 400; font-size: 31px;
+  margin: 40px 0 12px; padding-bottom: 8px;
+  border-bottom: var(--bw) solid var(--ink); line-height: 1.15;
+}
+.article h3 { font-family: var(--font-sub); font-weight: 700; font-size: 19px; margin: 28px 0 8px; }
+.article p { margin: 0 0 15px; }
+.article ul { margin: 0 0 15px; padding-left: 20px; }
+.article li { margin-bottom: 6px; }
+.article code:not(.code code) {
+  font-family: var(--font-mono); font-size: 0.87em;
+  background: var(--sunken); border: 1px solid var(--ink-faint);
+  border-radius: 2px; padding: 1px 5px;
+}
+.article a.link { color: var(--blue-deep); text-decoration: none; border-bottom: 1.5px solid var(--blue); }
+.article .code { margin: 0 0 18px; }
+
+.table-wrap { overflow-x: auto; margin: 0 0 20px; border: var(--bw) solid var(--ink); border-radius: var(--radius); }
+table { border-collapse: collapse; width: 100%; background: var(--raised); font-size: 14.5px; }
+th, td { text-align: left; padding: 9px 12px; border-bottom: 1px solid var(--ink-faint); }
+th {
+  font-family: var(--font-mono); font-size: 10.5px; font-weight: 700;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  background: var(--sunken); border-bottom: var(--bw) solid var(--ink);
+}
+tr:last-child td { border-bottom: 0; }
+td code { font-family: var(--font-mono); font-size: 12.5px; }
+
+.note {
+  display: grid; grid-template-columns: auto 1fr; gap: 12px;
+  padding: 14px 16px; margin: 0 0 20px;
+  border: var(--bw) dashed var(--ink); border-radius: var(--radius);
+  background: transparent;
+}
+.note__k { font-family: var(--font-mono); font-size: 10.5px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink); white-space: nowrap; padding-top: 2px; }
+.note p { margin: 0; font-size: 14.5px; color: var(--ink-soft); }
+.note--warn { border-style: solid; border-color: var(--warn); }
+.note--warn .note__k { color: var(--warn); }
+
+.toc { position: sticky; top: 78px; }
+.toc > .label { display: block; padding-bottom: 8px; border-bottom: var(--bw) solid var(--ink); margin-bottom: 10px; }
+.toc a { display: block; font-size: 13.5px; padding: 4px 0 4px 10px; text-decoration: none; color: var(--ink-soft); border-left: 2px solid var(--ink-faint); }
+.toc a[aria-current] { color: var(--ink); border-left-color: var(--blue); border-left-width: 3px; font-weight: 600; }
+
+.pager { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 48px; }
+.pager a { text-decoration: none; padding: 16px 18px; display: block; }
+.pager .label { display: block; margin-bottom: 6px; }
+.pager .t { font-family: var(--font-display); font-size: 22px; }
+.pager .r { text-align: right; }
+
+/* --- blog ---------------------------------------------------------------- */
+.blog { padding: 46px 0 60px; }
+.blog__title { font-family: var(--font-display); font-weight: 400; font-size: 62px; line-height: 1; margin: 0 0 10px; letter-spacing: -0.02em; }
+.blog__sub { font-size: 18px; color: var(--ink-soft); margin: 0 0 38px; max-width: 50ch; }
+.posts { display: flex; flex-direction: column; gap: 0; border-top: var(--bw-strong) solid var(--ink); }
+.post {
+  display: grid; grid-template-columns: 130px 1fr auto; gap: 24px; align-items: start;
+  padding: 24px 4px; border-bottom: var(--bw) solid var(--ink);
+  text-decoration: none;
+}
+.post:hover { background: var(--sunken); }
+.post__date { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.06em; color: var(--ink-soft); padding-top: 7px; text-transform: uppercase; }
+.post__body h3 { font-family: var(--font-sub); font-weight: 600; font-size: 26px; line-height: 1.18; margin: 0 0 7px; letter-spacing: -0.01em; }
+.post__body p { margin: 0 0 10px; color: var(--ink-soft); font-size: 15px; max-width: 62ch; }
+.post__tags { display: flex; gap: 7px; flex-wrap: wrap; }
+.post__go { font-family: var(--font-mono); font-size: 15px; padding-top: 6px; color: var(--ink-faint); }
+.post:hover .post__go { color: var(--blue-deep); }
+.post--feature { grid-template-columns: 1fr; padding: 30px; margin-bottom: 26px; background: var(--raised); border: var(--bw-strong) solid var(--ink); border-radius: var(--radius); box-shadow: var(--offset); }
+.post--feature h3 { font-size: 40px; margin-bottom: 10px; max-width: 20ch; }
+.post--feature .post__meta { display: flex; gap: 12px; align-items: center; margin-bottom: 14px; }
+
+/* --- blog post ----------------------------------------------------------- */
+.entry { max-width: var(--measure); margin: 0 auto; padding: 46px 0 70px; }
+.entry__meta { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; margin-bottom: 20px; }
+.entry h1 { font-family: var(--font-display); font-weight: 400; font-size: 58px; line-height: 1.0; letter-spacing: -0.025em; margin: 0 0 16px; text-wrap: balance; }
+.entry__lede { font-size: 20px; line-height: 1.5; color: var(--ink-soft); margin: 0 0 30px; padding-bottom: 26px; border-bottom: var(--bw-strong) solid var(--ink); }
+.entry p { margin: 0 0 17px; font-size: 17px; line-height: 1.68; }
+.entry h2 { font-family: var(--font-display); font-weight: 400; font-size: 32px; margin: 38px 0 12px; line-height: 1.12; }
+.entry .code { margin: 0 0 20px; }
+.entry blockquote {
+  margin: 26px 0; padding: 20px 24px;
+  border: var(--bw) solid var(--ink); border-left: 6px solid var(--blue);
+  border-radius: var(--radius); background: var(--raised);
+  font-family: var(--font-display); font-size: 25px; line-height: 1.3;
+}
+.byline { display: flex; align-items: center; gap: 12px; margin-top: 34px; padding-top: 22px; border-top: var(--bw) solid var(--ink); }
+.byline__av { width: 40px; height: 40px; border-radius: 999px; border: var(--bw) solid var(--ink); background: var(--blue-tint); display: grid; place-items: center; font-family: var(--font-mono); font-weight: 700; font-size: 14px; }
+.byline__n { font-weight: 700; font-size: 15px; }
+.byline__r { font-size: 13.5px; color: var(--ink-soft); }
+
+/* --- tokens sheet -------------------------------------------------------- */
+.tokens { padding: 40px 0 70px; display: flex; flex-direction: column; gap: 34px; }
+.swatches { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px,1fr)); gap: 14px; }
+.sw { border: var(--bw) solid var(--ink); border-radius: var(--radius); overflow: hidden; }
+.sw__chip { height: 64px; border-bottom: var(--bw) solid var(--ink); }
+.sw__meta { padding: 8px 10px; background: var(--raised); }
+.sw__n { font-family: var(--font-mono); font-size: 11px; font-weight: 700; }
+.sw__v { font-family: var(--font-mono); font-size: 10.5px; color: var(--ink-soft); }
+.typescale > div { display: flex; align-items: baseline; gap: 18px; padding: 10px 0; border-bottom: 1px solid var(--ink-faint); }
+.typescale .label { width: 190px; flex: none; }
+.compbar { display: flex; flex-wrap: wrap; gap: 14px; align-items: center; }
+
+/* --- responsive ---------------------------------------------------------- */
+@media (max-width: 1000px) {
+  .docs { grid-template-columns: 200px minmax(0,1fr); }
+  .toc { display: none; }
+  .grid3 { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 760px) {
+  .stats { grid-template-columns: 1fr 1fr; }
+  .stat:nth-child(2) { border-right: 0; }
+  .stat:nth-child(1), .stat:nth-child(2) { border-bottom: var(--bw) solid var(--ink); }
+  .split, .grid3, .steps, .pager { grid-template-columns: 1fr; }
+  .step { border-right: 0; border-bottom: var(--bw) solid var(--ink); }
+  .step:last-child { border-bottom: 0; }
+  .docs { grid-template-columns: 1fr; }
+  .sidebar { position: static; }
+  .post { grid-template-columns: 1fr; gap: 8px; }
+  .nav { display: none; }
+}
+
+[hidden] { display: none !important; }
+</style>
+
+<!-- ====================== REVIEW CHROME (not the site) ==================== -->
+<div class="review">
+  <span class="review__tag">Design review</span>
+  <div class="review__tabs" role="tablist">
+    <button class="review__tab" role="tab" aria-selected="true" data-view="landing">Landing</button>
+    <button class="review__tab" role="tab" aria-selected="false" data-view="docs">Docs page</button>
+    <button class="review__tab" role="tab" aria-selected="false" data-view="blog">Blog index</button>
+    <button class="review__tab" role="tab" aria-selected="false" data-view="post">Blog post</button>
+    <button class="review__tab" role="tab" aria-selected="false" data-view="tokens">Tokens</button>
+  </div>
+  <span class="review__spacer"></span>
+  <button class="review__tab" id="bodyToggle">Body: sans</button>
+  <button class="review__tab" id="themeToggle">Toggle theme</button>
+</div>
+
+<!-- ============================== MASTHEAD =============================== -->
+<header class="masthead">
+  <div class="masthead__in">
+    <a class="wordmark" href="#"><span class="wordmark__dot"></span>Agento</a>
+    <nav class="nav">
+      <a href="#" id="navDocs">Docs</a>
+      <a href="#" id="navBlog">Blog</a>
+      <a href="#">Changelog</a>
+      <a href="#">GitHub</a>
+    </nav>
+  </div>
+</header>
+
+<!-- ============================== LANDING ================================ -->
+<main id="view-landing">
+  <div class="shell">
+    <section class="hero">
+      <div class="hero__eyebrow">
+        <span class="pill">v1.2.0</span>
+        <span class="pill pill--plain">macOS · Windows · Linux</span>
+        <span class="pill pill--plain">MIT licensed</span>
+      </div>
+      <h1 class="hero__title">See what Claude Code <em>really</em> costs you.</h1>
+      <p class="hero__lede">
+        Agento reads the session files Claude Code already writes to your disk and turns them into
+        cost analytics, productivity insights and a searchable, replayable history of every run.
+        Then it lets you build agents, schedule them, and connect them to your tools.
+      </p>
+      <div class="hero__cta">
+        <a class="btn btn--primary" href="#">Download 1.2.0 →</a>
+        <a class="btn btn--ink" href="#">Read the docs</a>
+        <span class="hero__note">No API key. No account. No telemetry.</span>
+      </div>
+
+      <div class="stats">
+        <div class="stat">
+          <div class="stat__n">0</div>
+          <div class="stat__k label">Bytes sent anywhere</div>
+        </div>
+        <div class="stat">
+          <div class="stat__n">1</div>
+          <div class="stat__k label">SQLite file, on your disk</div>
+        </div>
+        <div class="stat">
+          <div class="stat__n">6</div>
+          <div class="stat__k label">Integrations built in</div>
+        </div>
+        <div class="stat">
+          <div class="stat__n">~60s</div>
+          <div class="stat__k label">Install to first session</div>
+        </div>
+      </div>
+
+      <figure class="shot">
+        <div class="shot__bar">
+          <span class="shot__dot"></span><span class="shot__dot"></span><span class="shot__dot"></span>
+          <span class="shot__name">Agento — Insights</span>
+        </div>
+        <img src="data:image/webp;base64,UklGRqCUAABXRUJQVlA4IJSUAADQpQKdASqwBO4CPmEulEgkIiShoZDKGJAMCWlu+7G0bodYL2Axk+i/G85C8j7HJKx2vfhFy5hR4UQJ/ufKVlf07+I/MfWYMi/g7j//q/3v8u/m5/rPUp5gH6m+nn/efrN7tf6l/y/UB/Mf8F+2nvN/7n1CegB/If+F6YHsHfud7EH7eemp+0HwgfuJ+5PtOf/rWj/Ln+J/u37Y/BH4x+r/3z/AfuH/afS/8Y+a/vf9z/cj+3e1T/yf5Dyq+j/yX/b/2nqV/JvuF+i/vv+b/6n+M9r/9v/e/E38z/Xv93/fP89+0/yC/kX8s/z/9w/yX/k/0Pxbe5f9//Lf7jvV8//2P/I/zvsC+rn0n/jf5H/Wf+v/Re2t61/rP8L+9fuJ+c/2r/cf3//I/sr9gP8l/pv+r/u37y/5P////r7I/xP/W/1X7/+h99x/0P/d/2nwBfy/+sf8T+//6/9o/pO/nv/L/nf9p+5ntW/Ov8//6P9D8Av8x/sH/U/xf+r//H+6////4+/b/5+7n96f//7t/7n//8UzW4LQxB8m6EKLBRHGY4ARB5UL1qYdlRyOQgZCfU+Dkcg0HmarvJf0MP93RtzcF5HDIT6nwcjkIGQn1Pg5HIQLqBjLoa5M8X2eXZE6azGf2NrGAcznoGJY5CLxckn9Veof7vWLkk/qrzKLOZiiEe/5zR4i//d1vdKzcf+5tJ6zf1V6h/u4SE+p8HIhuFTnCLcjx/r8+BxJe4hXlEngGV6PL5v9Xg+6pFHHvZH9L+X1SaJTrgtp4s0ghw1ujm+BuXXeRNhXN2H3e4/9ZUWulf3XwD8rnS0GHn8Hyl5aE1HaW/ua2tlFuzeozBWjeCjIwlosH+7wO5JP6q9Q/1IQb6CslwgDmwQwN9aQWTITkmP5vhVyME0/rvGy6v4PYx5Dp07vR0gmTH2rLruOPpexNvLRYP93lf0B0RCBv1NiVGqzBBjZWURcIV20OVNwVq+Q7N7Y6kkf/P4gLRVsVlkLFNJANVaLet4Jj1mq8gch53BLtr3e7fAMUz0hqnvsbpD3W2kiO616mUvoj8W/Ge/qwQRSVivSQZQfPjiT11MwV5UxNii1UDBzfH+TBJW4ZCfU+DkcCeK8f54ut8UH0Jzk1vUu0P1OKqSMnee8dqYRvr6FwzSrJd8wzYUqOSsqS0dRQgAGj/3esXJJyuLCGJsszFQ313DN4kKSbszm1Mhv89+REZ2rPIuWYXbm7KeqkSxXcGxsG8hdB3mNely/u9YtKiSQ/sdu5aLB/rRRNFf+lV4Qvew/Q+u/WL9Ud46e7mzawjZ6AcORs+nwcjkGbV8GskYPyXOOngwStTDQC942ALPO0TLSUGQcEmnAPQoQM9V/RH38aUUpOhOpXVA5N1E6KHUNUs4xwXooyyCvcOnmcvUB7isNA9e8qGC30lrni1jhRMrHnhY2Sv1T2X+J+G2FfPSspZiRM+JmevJT7/iCm8BOWjAStjKHBwnDqtk4DlevFoSPhAotfiHob7cra5HEHOH4YLNQbd8kGqsaQp7N+sNK/E3A4eRbui/OFSQdnp5wbF6KYIXxqYDFmXFlZfCpjrgsGm4z6pZ3YuRg+wr1O8G7mmwuUOwQ/2GW5NP3xohnrLXnEv6NcaCtTZ0KWF+/ZQE/nfw7KTe4PmCYxhM5Yc+6gdiS571CPkGNkn0hnP5qM6EBQqpNLcVLMgTj0SHEYQHn+zBmQfgSmeXpYgqB8N/w8Jvv1szna/kagdFDdQ9SdxVlnzKiaNAG1/Uxs6oobwPF20t/yRlwAnFEwTcTPHYz94ZDb/eXv2wMALTAwryrXP9AOj/7pvH+0wNrePhDBCSkB72R4z8ISa5gGWpl1yPDt87KBhizd0/oaMoAVDhzGmdT4OmudeklpzMB0kVEH69piy+w2cIR97CQIhdG9rnrCrknbNz1x5Slbo5tUYXlGpeejJIzr4SHFlTjBDNFddSLYgQX1AxJ/vGqtvwZ9855hegHsLj+77oQpdWHOHb7gshAyg1/ZbggMDoQO2DDobmtMGrFBYJM694mNm7lo3onw6UVPKfIEBUVf9RmA2rA9EAm7TJtLymHh21Zk9HYohHe3bkUHRaSfOucGqR9exmyy/dWDI/96wdkWoFAb3BkjGUsXjk26tvY56TX3j+0SgZDj0tR08+2H7E3H5/yGv4FYHZb2dXMecWFD8xvYpOViOmBcbtFAO+uwIEpTwiRZ6US/BnL6yqG2zSSkaLSQtNfLEWeZdVJvtVMQzgQHo38blCfjTI3is56vQHWHt23nXGNBvR4ynCEk951X5yx3ffGgmXKDx+cxUhPYgYAnwI0iF9Bs2USrYgzdqUUndCWKs8GJ+9ynEuthA0D8QHl+H9VeofGncG9lBvVb7HepiYP9QLjBQGyQ/P1V6cJPht3THm1wTrldpDaT0jH7zIJbq9NdjXsnuUd9sNI3JymN0Gusdx4dT4B0iw1HRsa2+3iRNLgeBPFMC/UArnMBcgfAWTisdP8C02dqvWOA6tGbTefThZ7iFyS4oS2jGnUfs5N0wBykzL0XbN7GSt12GlCcWgJZ0LQiFybOdZvgaFzmWZN602wOx1cqYJOZ2xJ1/GUWgKrlghGQcNvsIYcnpZK5H9T4ORyjfyUs8VKgToUASFsWOjLagvJUABp2qhengjnMMSXXqbdzwpa+UTbbICejoVlzUXAeFc7oH4Fd3xYwPYD0jptEBtErMB2cfRAdp9YOkXY1O9UuI98YzYhCY3GAuC/DQXOUSZ8qFH6oBIKYrHDxLsP/wklohqXKr1rVsaUe3x9N7/pLggVkLGkgJpd40xSkdeZnxcI2SJcJ7tYS5eFNNMNTDtCdXJP9+mEFQi/GmETLNQUG6DIVuh0yGTJSl6bpBUKoEO0PNWwbw+IHIQ39MNW5uEtup8PaX5N7p8HTbM+BNoKKNZP6WLJW5grLN87k0pa5q0DxgBJo78TqSjsL7EuihgiDg+8SA7iIaRFnkMWO15CR9uOz+gaPP0dwOWzgcCVw1MOypTRxC01Z/GGNvE94DsUxqB/yD/birEw0A/pqW4Dd+9C8JarGcXe4Z4bh0KlYgs1NlmC/JliY4IiBhxkWWBCa4GzBSP8Ydq7tyk3w0FtW61hEKnTgR4c62mn4XnTGhKwhAhdNsR+LOS0F8EfmKkEGD4QMhPl5DnGByKlJ1+iYGyIjh9HBwjIyOILDCdHTjL1UgG9U2WqksbjGGpgcDAH1/HmNlKw+mJ+e63W8TRTfGNoa/exyOUHm+Ib77QJi7XoY5BsCd1OI8pA7ZN8+ZQANNdlDrUij4TlwbNJ5sweQ9ySz6QbM8/U/UkqGsnwcjkIXYQjhRf9tKFGWm3TjVqYdXpYP53hAShYkqojDLB1gWWK/gyzCStOMsldqvUP7WnFyPI9Ndy4Bg/3esXJJ/VXqH+71i5A+I+dseQPYB4jSYlRS74o+G8m4ZCfTvSJ4VqJ39RnpAGZSVG+hAyEoMIGWcDKDmU7sAI9H1XrXtVqN3Zf0vc1uOsiT72XvpEh+1XFI1gi+xeCAvhy0YvxgGsKVkEeAXzjv2pphFpDPNgH+/GtCJjnnDg5rdtRnCReqSjjhcxWkSz/dJUwN5knclz7GNRcgj8m7HRNb/3wLMCu8gwxBvectJW4ZCfU+DkchAyHJC/f8Ibt6dw2HyoT/dPurZf8s4+9rPxcPWXNzDK584Y//JaHeIZR+7aIWH+6kfshoyXma9z+cHP54sIh1Hhg+FGdJKW+3WQNX8wwSIUPsDj8gYlgzkJisWAWwW4q3vDS7q4YLJQyCgIULXgslDIYLJQyGCyUMhgslDIYKd1hl1Srm6EftyYDdvVcYiCUO6i8dAiJqCBg44gnLhe7LWX+42c9ldiq9y2qm4cc43EhBjNC2Nr8XfeCbqytJv5LurhgslDIYLJQyGCyUMhgslDIYLJQyGCyUMhgpEkgqVweTL/IMxJvI1fo++w67LkPDv84XNOeY6Jwp6PVjkduHnbbn9NNUZqvuFaL4KHPiNhb2qrU+2lomebC0ay8hv45t3mmIjdn2vY5jZLh2wdAtgyE+p8HCnGAMv3SDdC1gWXkn2ACDEq+vgE3cmmt+jkchAyDw4EQu6GcY1zVsxZ7Fbm/7BuFKrW/5qQJwAnbBJW4du3Bf3GHyQ6fiUzHadr7ijtJckIYp7q6nwWgtyB4arJpmSbFiXia+ebfWA6U74JY86QHusEoa8XC/RLqnBd78hxBhfQZT/WQ+1+95HCgga+t+ZzoxXj+EDIT6nvMwLJglPkhFQ7wlvuQoeFI6YamHZUcIoVRy8plvPrTLW5b4k3srYJK3DKwQuihFQdkqPR7uZ4q02eRIAV1mlwR54FcGjfTDUR/l/QOEyEnzYRa5jyq2gCZ+b37nuq6feLAoXM474iYlntO8mRi+fBYORyD/Nwr5MjRNl2mDI6PgAcwVn7gjvxbhl1x9Pg5HHW5NXyC0TnGcjz++qYlMEq1U/00Kg/2QFpEUkbla3EkVsqOR58Wfr0y2BvQxs72BSyEFkmg+7Ps/7qHmZVAoCfcqYamHZXM1u4f5BSRn3NNy2ezFgYoVa61l4Vhwu7jTVxu3eJ+fTSH790mAYO1Er1AvQB8CKCBLGYGm4SCycI0m4qHYUSlCN8HcpFOpqKES5U+r+J5CBkJ9Z3uCWvj3AHdlhqYdlRyOQgc/gQSuFWmoPWs3mHwvOK0SnDe67kANEzi/+c2VXBeWrNrhcBUdfjP/4ckb0VRD5HWe3SEULZXcEaVW1BJIS+CHUnWcmXZdvt8YXbg98oWuT87IcSnIrPtQ26oWToiZFRaQvrmRT1eP1Q5mJmSJHoefk968gJOz9RzB/u9YuN3tMksTRQsSVuGQn1Pg5HIQMhuscepLvI7MB/azjoZ5+qnTrwq+11IjE7m2ESpMzY9V6dnbdYuST+qkYTyrKQn1Pg5HIQMhPqfCZsS5n4h5PPcCgMAU3LiiHqfsbIGi+9HmaxhJDVjqK68obeuZe4ZCfU+DJDM/CGMavbJcO5aK5kNpPjb/lgoaCtL1QKWrMF13EVVYOs5yc5Cl19wCaEAgCYIe/LqfByOQcl/U2AjkIGQn1Pg5HIQMhy/dMkoHAOnNqvgJnmKZnpX2k9Zv6q9Q+cvMV6pDfx8uxJBAsqm8pb/wcTSwb7iF96LllEzD9Veof7vUrwRyEDIT6nwcjkIGQ2re0Wmb4tn5arKIbD9mHZUcjkIGQnOwBiBBFawsDKWUhoVwhT9MwJ72b9sxtQ1zTXg8Fu7dYuST+o+VpRPlGmS5OxjUlbhkJ9T4ORyEDIUZtiXXAm1hxeQo6nD3/oOIDJMXGh4kpqyusbX4tWddOhtgk0TKWYXDAk2zMhYSggE385sMomU1ZXWNr8Xf+g4gMkxcaHiSg1oKBASVuGQn1Pg5HIQOOOnNDudbIo4X8q5Qtja/F3/oOIDJMXCzuF553GT3esWFqqOob8uqi02JRAm9lGgnsagu8Vbi4KF8m2g2mnFpO+u+yPX1cHl9lRoeJKasrrGrIUtpzcf9oZvePNewEQLlh/U+DkchAyE+p8HI76kEoPwHztoDczb1UOr8OGXKjQ8SU1ZXWNpaNqH+4FY87F+42c6uWVDpxwatVY0gOfi7/0HEBkmLjBu2dOah+xAAH29atn1/yxqStwyE+p8HI5CBkKM81jtsWeyrgIHRS8IdpIcDnY4B61Sv3X7ITYI2wJ8r+nYmCNsCfK/gPyf71i5Iy/yEhPOyjflYDgyxDbzBe5DRMRBi+i/kDLKHuO3TB+gcHG6K/fDfmZ5Hm7UPbHJMS7MBZROqsElbhkJ9T4ORyEDKHBEZa4moqrE4oeT8lwe/Viry1WvWb+qjYpk+LCUPKCKLhzKcs2hhp21JLFE+BhH6NCtVSMmSf04PfniV7m0nrN+5/gT9Fa7Dqyo5HIQMhPqfByOQs9YrnT5GkNr8Xf+g3b/OKazj/3NpPWUvL1B9wKC6yEI8oJqIVayjVMtsStz7DrG17k4ANx/VXqH+71djCNwGS0wDXzOOWD1cNTDsqORyEDIT6ny0H1p7meLSH1u88Q1gwlxfs9tTDUw7KjkbkmPWvfDGI833xlbhkJ9ddbEX1eAJchMTyEDIT6nwcjkIGQozdGMBE2ghfPMrIBu0W0r/4wwJb1m/qr1D/drIFUkZfdPIVRyOQgZCfU+DkchC9U+DkchAyE+p8HI5OFnDQH+OMqZNheA6uRiK+JKB2Q79ibj/3NpPWbwRDKbkpePIhNl6Tw/4T6nwcjkIGQn1PhTTTDUw7KjkchAyE+sGqHCJ+X/G7PWUBFbh/3NpPWb+qvUP6Q8L2Su3cjlmcMhPqfByOQgZCfVEHwgZCfU+DkchAyE/K5LqmHo5enpSiT7F5P1nmGRmD/d6xckn9VeoMZFJnhUMBon01oOdMw7KjkchAyE+p8HI5R/IQMHI5CBkJ9T4OTIE75O342I1oD+w9iWLzr4MQe/qr1D/d6xckns4hcbms4dT4ORyEDIT6nwcjzVqYdlRyOPmGYQYb+qsddEzMNFDh24fmTv/IF8RZ2Cr+2c9HheAAt+5VG4nIMNZ17R6o08ukdTCMtxSr4kHeibdxHXhaoGQn1Pg5HIQMhPqfOYQMhPqfBvcXeSmV+nlMj++nQ/3ZmEbmuSpNHwIYAbSbDNT/VRKgCPJuJ4NsPLRYP93rFySeEbbtoIAXk6NDwn1Pg5HIQMhPqfB1qmGph2VHHTqcJFEkVDJvRydiJuCZAsqqnEfCfWDJaD2ubWpFHusIdMzwHYtaij7GNiYCCFIKxNgpcv0Sh/u9YuST+mCQImBu3Yi4MHI5CBkJ9T4ORyEDsgYORyEDH/+9xl481neDOJtvCdbWTc5E/nRWXhWQzFmxi3hO0McUlDPIsqgqfywHUg1AaCd9gxStN0rrDt4MWuQIsNYc8vAYmkMAxeTiOMaZy1C5hv6q9Q/3ertQOk6OLfdiUsMIGDkchAyE+p8HI5R/IQMHI5B4egBCXU6Didxeud3jBSnyzyPVeof7vWLkk/CX6zf1V6h/u9YuST+qvUP9Lpp8dy0WD5MgesTcQh8M3ouErmQf+ZRcIOFmIvysc9TlQTC59qJvWyITlCFTObTIBexIXOeowOFaGEnHahLOCvuWZxh4s+qCKYAjVN4cZr87HHkIGQn1Pg5HIQMhPqfByOQgZCfU+Dkcg3MJmjzVc7ePCQAzudthhQuGALFtP8U7qvPZ2ency1pQwLdIK/8DgAAP7oATAeCsBxUPJLirj6SDViUEBwV5OyRAPcH+4UEO9DtV4Gi5AV9azxUa5PDl+94dbRZvSrKYA+b2OWjs7v78VvNJpYz5oHO4lvGfATB7rMv2zYoCxnq9EXZb/5dxutqh68JcgONIgXU6e7FGnt6DhcYy3FrZTkEX/VK0JiVfJFoaF2BggqzL7rss1FMSaz0K4m1j6tLJHtGGz9OT40VGIM1XmpbxNSDyX+I4xl3wVkPNK05wddbH+CeBI4v1dGTotGFJkEdQbbWUQAQIPQh6G6IdxKY7SUTHYwn5EvZk9YWuVGeP+Qtu1o/E7Fh5QV7toAt4Z0ZC8yilstamrbuWrU7URYoHsoV3iKmPaQZIyGu28nUPWEOTa31jPvqWEsuQExTZPl5ixZVCPjim4xd3LwhLM/pPAz+ar1Cs/6aytj4b9sDkfLErswHhaW6JgaScvlhGq31Izxk5TuCYKh/cqFEvCq+VF6OAL5uebT8MKD0pnHHkYeMMEDkG0RanTDux9HQVdIZBV/+JKN2pjQfDT6B+rW/QZOPYPUG/uOWylTTUNRzxK83QI2mwXJJrYqRBPJtZJsbKtfYxGItSGmj8E4yOLO0dDClt/oz+VR2K2KA/HJeSYSS3eOFMHfhXLyqi85rdNsOf4B7SdNV8nvx294CPKPvfuxcYQ7yeCi0Q1AqjuQi7/YlaqC/BqhOxaB4uAYLA+KsdfA8fQ4cjn0UgfEoiSkXc0I35Gsg/23XXxTuMx78f8vj6IdGRx8vUSpVG5fVEwWTTRap+sKP6kIt+3oB/PE2MdPdDUKUpQZEZX7WUlVqt/ulLJ1r+COGLVR8TkueDOPztWm3iGGo0d6eiMb+jAnazjVp/ls8ePOmlDDTyCA62mQmAjKjNDbcnwMnBCuSplNaaTd4G30WxH4jB+DkI6v+vO+/z5vee2mn0iPJxjqT8BBPz7Ii5gIQqqy0dm03IGMfsXJGKKCUf185I11f25Chz4fcCpbI3d7Zd1Rm9C65pRQ5yuN7bv4yJwWtDwc8I8Qlqwn9rVFj5D2X3Vpv8VmsaBeA2zEs3E/GpP2fd0rONH52WYCfx5Yh/hAFikk/BSzYLVwj0aZJsFyLT9S/F5TnUGe19ehWt1CWtbm/lQDZqV3ALPW5bIg5GXns1ytRaanf5Nje3im+Znt182dCSza/RwuIDovTa9e4IIZcBtVgm3VnEgYQswj7Q6MNQr6z6gpVf0QyZkLbEyMbRaLZ3zMMbiM1SzoVMZbQexrLgMOM/Yjw5l175AYeNbkMfaf/MB8pyGNo9ppxf0AVP7UpWcA3Wy2JpG6IAvyXnkjp8r6XTIoFjvHBs4PGv2TCuMIf5oAFeBF/4e9FYUPwKafntiDA1a1ZTNAmVdKyF0EpbXg9odOlkWfY5xSc1gnu7rTF/dOg79yioP54MkVRH3BIC3oSNoEYs9XRiBuBKftAXeTC1bNim8awq16O7A4crR5P+RjayL4vF40h6qCJ+6iLIe2pAombPJc77vgnj9UJGUzPtIvEQWNgEL6+8yo0t99VUGm5JwI1zBADXcI9tjNhuZ7oZyBmDbL9zF28NnImZE/X+KpBeX3CvQA6jhbgquRLYy9I1ldpEub9+TSXXG8epSsOabH+Owtah7WtPZtIsutP4pf4IyUt1nytWgJkpJJRx2C2/3hGptm/XaHDA20tsnzdidJoFFxU0CR5FlvKiPoktLgEdkCUU5TqPmc3Ch++dlD98mjnVtkwN5Ca+2+t23h/Nql25QLH3PPvwRLjKkqQnXrAzxa2vkQyDaP/DoM3xpFQQcyd3TNyIDoaYA51khEASy+q+LDUwR6olEntPY1O6u03VzAkSnthYHWNfTkYFWNmuWXf9Fbz8LR+Zp2xXdwieYtSACiHgeSaLwXPhGJ+OKVwVugJEHg4qQVwzSgaYcSTOKSDg2X4aPB7MoNaSe135k6u4gAduBQGAYpUTjMfUvqdB4caycqNH78RpOSBScFUU9jRPn9mSIcdwRwcEctsJXwG2l9yyGJlZx2MMre65ok3uXfNs+xIXrX3Q0rLYXOBMUC2kjF6p+UyKdMmizq+7WtAZWwGM2k51g2LaoAbinf0qyJW3ysb+5OLvd/gylf8dmJUqEZDvVxLTVjPxAFY3y8Jx/6+y8qZtRsyUt8ZZOzMspfHvYX7BmDuQ9n+MCsDrtfAq/PMcaU27Ddib6lIrF6WacocBsRFGBxyVvE5Yp6YlqrGUoesDdEy8bgfDb1Srrb0vl0o14mTsWcU1JNxwYnesbeCwOt8KHwZLWZj6l1yabhKt/3q2RRU22aIAsd8s6txMRE1L99R/PvTYS9WQblLmoEi1h7VVUBdJUYH0t0oSPNpToOIVoof/7v6BWnagB4JATS4fBGLpE5lT8tnKk5ktfdfAG9pTnXiFIoQzV8H/LJg++gZquwtJh05GPeEDJp8SJCssMvBUs55AvaRFvfhmb0AbX3eu+0QGXEKgLoZA23nI9og4z7c1l+KPJBcMkzq2HMIUV73fseHTRHlRBiWDOhBnwrEPJsEYEJ0dFjwEiEa1vHOrK/+jykDB+iWmnaq9WGERRaQgRfnh9FVJjK1NPSx1dcrjg3MlArUrlq5W/DF7luC860iPtN5AuMQuhgvMhcMdqpsLkTwi8uck+OIx4wyMgvqO0il/ijH4xQfI5vyh1t3EE0XuxNEKk264EkwtXvGrLbu3G2Pqiw4Cxq8EIm+hAixNaG2Bn2Aq7h4O/zPBvcQvg2LGrrJo42Rix1qja7caPU0fc6KqIN6TnzygmT5n0hpzgwS985N9rdrcxyxn+HPnR7U2DF12K7RuJCozI0XJVzcd786jVlEudPolz+3DfCCTbl17pWhg208Mb549XSmWxIG0GjL7sVtB9IB/X5MkI7PrR2yvSl2B+J//dyQNtyGYoxuI9FaRNivG/Jd9bbWmRuniArgOhUz8FFKtGjx8mW/3wzZ18iUQfWYFt8dFJlF5HLjpz+ijgAe4ykW8fBoOBaJ854mrxL0AU/fLDeNClTDVALr5a+lslpwwn6POdhlHNN2zhRTH0QDxr7zKDpO+H54RTYTORIRMB1en/NzKKhT4AJWNq0u4FpxoYKUpcS7Fl0b25A+mV7OIIvCqjqNP3I//rZ6eKG0xHWB7RzK9JpIhW0tkd67swLRFrpx6/6f1hr1Vv0++Vy7BBFESUMSM7rfeG/t+fKRGLoVCPTNsMfiKPSr1JkWxbFr6JfejXw5Ue96ELT9VNX+nHJ5TfB6la+l7kfmU5ROtXH893ixW5ojvwqoAuligXSttOqQcLPo2FT55ex+PZ8RqZnot2RV+8VzKwkVGBI98XMdC61vZ2GUC5M6kOQwAQYhNMFDa6ZsjjXAAEkI1a6dJEwwoXFoLEZFkdLIleNyB6Bmzzwe2IM6sLCTw3dy1WLZoWZ8ev+qqzeXKQV+93vcqIl8HoyputsZYig+bwGi1iSixMOFYFFpp8rx4OWstJ/MHTbDpZKNQngjyN8RBAinx5Do9Sgbj4gIdta0whbwzS+zi1/ku5KH+iYsr8ExXW7eezgF0GUMIZTaWjG8xE7umNoqYRT0Y6iAZEtr7miyA4KSmyw1llU8M2bsCXanuNkDB2me7GwL7XNPu6R6uQZiIjwaV0BgzpRkRuVmjQUTOyEcg50k7uV5QmKnLo7eMt+wHckjGgrgL2FCMK+GViNcAE4BPpskhyTWuBPzVOcPViRYHYMj2hdyGXfU0T2O3Oqr4MkuT0ArYo55eWaGLWprMTMrf8ReXobpeZNH9gnjc1UPn9NqD3CQry9c3WUkcS6/xrv4t4A3KTTRXrT9DZGUToZ0mRwJdVloFbDRO2uKzauWZvjYmfjei68LgOAZh6IEmU7ChoPRNBJpGBFCoyYUvp5uZQIoAVOslUEEKSfoCKXbkcnK3QvK+mOkj49HEG+CTI3NTqazjRSHWTywlCXLmqwv9JU7hB64pmL7VuGUiEMUWzeoaQ4W5IU1xQGQ6y6/c3ApXv840knLHdzeovRVGcSrPsswFhS4hY0woLRC5EH0htjvRuYJRjGFQd1WgyK2iXxF3XrfiwcwE+IwBpwZSTtvSBW4tRWpTPYj1fmUU6rljGmprbPX3fapK2+HeYP1XliaiBN+U35INRGknavSW6XNI0o9aME5RF3npbCuDpAUTHVi9geD5kZSWsgct9VJK7muOR5VfZKkJg/i/gAukXP2XYe6cGGDvUFJ1IPI9xXJabq67+AFInxfKGieXv8j/eQITLKbRgm5J6jpWZidwCwINDIIs5qyepQm4lL3Q0C3W6C+JLaGIbkyQgj+L3ImNl0mieH+KhNlzvv7f651XKMeZRQfkHMdShOrYsJ2zmrS1XFBJSFHUN+zAkbboHD2zDBmM+hfh2ilEg2CF2iwlqjcmkRYuOOEMnz13x8mpImyhcc+DFAUrTj1EoBjnYoJhVmOYJ8BiSIeT7dJPIly345EVsgaYcpqS4RRqSh5Qs8bkKPUGYj5chc2JTTQzESq54dwnaEXTYhV0Y3L2eBpDD3HrsfN7diIDteClab1V1s9zyo6lccirk/I6neYjbDPYHC5PH3/O64nXrXS/cMRcG3aMVGSBffHTPhvCrb7avHCiycmMEFTI/11zoaM9GaFS3ej3b7GnpuU+6XexRvr5Ws/fFDPIzGw2zRtsqTV+DCyOCOYi6syEbSxPZWMkc21sdcKzOGNKyNQRLkn8zQu0Gr0Od90oRUVPiuJSB4dxR4oFebCa46RAOv0QVBsFjDxM8Uk8VVETuMwQlw3oz4GA/Jo4ZGTM+wGm3t0a5EVsNMdi+RL4DQP7EsMLF4P1GQ34IO6/utVY5/8+oJyOE0QM21hrKLxJEJpEPpzde9Ws71Mhya8UmrxquqBMelmbzn3vGga/scawzpARvtOV7tuazyb3eisDIp+BDpQR29ZLTSYAyAjs8557yE1ga2GPoEnd0w2I8UmtX9LS0Gc5++E7+oC6iC4OXQqk5DTERaLEzw5F7YDSMUK2R+E9RT9zhcbPylsyVwJPyXqFoWbQd4gWhAhpLKlP7mMsOVDpTGvAHIaWCS3ExEjwoJU6wBi8qt2KDILstPx7hjh/SA/uLhRbKy2xyfX3LNKLrLFMugHkJ88d0XW5481op0LHgQF/aLVXqkdtVPPdRt5VCz2HcCghpDLMu88F5lPtcsySsCB+J3Lc/2BNVtDT/GwpgOioFSDsyHwCDmILvu0J+VYbyKOMZQrYULTZExiMIyav0K7XlIGY9hQG0KyfrgaHl4HSziSo6fBHE1qtfxRkMouhGhvLjtla2FKRq/Qay41s+MxIskifPBIxqICF4xiTRQB5hAcerxBMJOBOt+yBHG3/mITxpQWTTSsdvHZ8VZKnBFyH2sRBrLiXp0MDryNGKenR+gcXFVO6aIgWGw1VZXH4GVmmIyCkc5g66byz99AtcHnArGrwwULXrkJQwgAGBYorgg6ytVxy3IFVRWSWoQRv34xbU/YPy9IKftvuxO8FFNfmLc6G7653fuIHv21KyxvxDA+i45Jy0oJnQdMxWsCdxpg3r9nJM5lLA8CNYtsAG3p0XkKYcR8mZekKC93MFj06ZzMAo0EFap37cPUkuGixOaJy30oHLl4zwlcd8KB4VlT2XSl2iN/L1bpSqO9GQUhdxVes/Of4fIQegekLAByvVRet/doROThgSdQg73ab52kITjkCWmegZXuEHcEpGLRD5HUmmNgaPyBG9nZn73aJHe1pCitIUfa5JuCayGSjzUT28JYnmBDQJoRDCzhxkLB2nYDdmn2FFpG3BpqyvoWyUN3sunzVl52f5o/WVwrQZl0DJNxB42GEEMCwvOycPZ9pLmOcLTjcEcbCe/vYSk5x4/QQvgu7C3xGFSQpepm1v6F05pjdT2Mh+rBtbdcZXgWHnbfnIAJeI1wmkiDo9/fySFry+C/OF1GB/ekzIRIsyaNf/eg+juTY5R+/dTrTWayn3wnYyjDtr4beXImrSP440ECXp8UOgUD9CBPewfNRElQWG6slqlDdSPhxVecKeuz8QyG0EQVdZb3LmY4KRuykjpJ7WRESFVurmLSEQVreYKx0ibXy+6TY1X3rkAW6gqOvNeU2YQES9lNKBkZqdQUCjehDAF5n/XTA6SSFTquO2msz2qx7M4QKPLxVeBD9oGfq9B+8UJmrJOmaMiCnAJC3/qKzsz7pKZ9H5vwQfW4NL54uC+mDme/BjtF8KxPjogGyyO2bA9QH9UdjTz70t6tErV5JG9kfdeoPVCSYZPukVvyVQinZaT80c2NFF2fBtjV9rj//aHE2jC2fkupHy/kEHZ2SXXgJ71qmzKQWq6TIWcbBPm19loUoEj1pqOnp7yz5bETtso8A22i8EzklpxPH3T6GsAwx+quM58EHhdLHU2mexa7YU0p+5bl3xYAzW8Jb1KpL0T7Z2v8Lyy3lHthlJAegJ/Y6NDH7LzMqFy1LaJjHvOvWdmvWRN/PMgjj0YPIo+unSBViwpwR9EVsmf2wdC1bVPPtX3ZbnQ7IOzpLRYxD96tmR4xgao/CLxJkm4g7bV1hhKsPlH/h/nGnyLc3EhI6buFrERqBLnX54x/NFKaTFKC7f+X7YDJutwNaZBa2kKGZZHx4R7cWr9ZvKCeIjhR0s6CwfdNjYdX1zAzoM17vV/1RGZToOL0z3ZfpFnLWu0VirN+i7KBq/NGIZW50EoH31gcTjR10VnNR8ebYsibCJ9e2SThlojjC6c7WKUqu2gTBQcWgUfsRdrBUYCwv5gbPN+OXHPFy6Yg8TvP7MbSIEHZ3eEKSEpZpt31uS8kvAmuhrzWWwL+eH8uKEdQ1JJOAR9kmLqSvc3qCcoqHYPzDolIARfRKw82xOvoq+g7jlU9jbIYko3hq3+03xvnvj3P3I3r8N7E8EyuaVnRVYFYo69kha8HMYw+h4BXqf7UIE1+wTdUth1mbyFLiG7kEODc4SkkRc8B9YDZfJPmn2Xx+mFuDfrB7dyEe8Uk5l8a7852Rem2Al0X2v/CC/T/A31HR4oOYvleEV+nMeCInRsZ9APuEHk9HLunAyk0/tjGJWi5q60P3dffz5FzOdgx6AoMXRUY/jwVknZA7FoLbesBGciMFZboZQ755m+enIXibXaBsDDqgIJ/p12vkSCLFcelrSoIrRGqhOCCf32oqcNBfan8qDJp5uS3SO3L+PL8o3vmhHqPvAQWvdj1Oj+TqKXUJm6jkvd15mgnJyxWvbjrf5udQaL7MyjaDNhcKrorb40sd0efuLabDIvWXSox7+0sdmgclXynn+PLZzCxyWh+YVS4i86L/1cbEHm6KbrRYBcWOnQapUe9bYyILyhR5SNkDB2o+kDvCOYIgKMDD92xI3Ou0iNLvAGGBhC1WHrSuORI/F1RFIkcAIacvLIG1rhsCTIl6vZMi9jphawuwf5Qpb8rNACaBdnGBQfKn01yh+sEfAKyTMGD8DXCCUAeeeYcPd2WRK8jOG5Y4cbGQyeFleiM90m87+rXSs/lWzMxqIvcwoV0vI2gyornYRmWY2dV5Q/PMvlNF6TQVlOWTFXXoQCv/qpByaC8Lz0Zex62w5rN3KRn9rserrFGUk+HQY5nooOL7E0+MzzZIKPxdqnlmG5Zy5CzOVv4Ayr8SR5Cpy83m4NuAg9396qh7pGfwt0V3GSOeRdh/5M5OvyVDVRargoeq/EGngf1S2eN/7hQk11VJHcYcdpxP44ZvwXGmRt4rNzfKMwu4v4/oooVIIM8Jtn9ZYO8OZBy9hlxp2Zie152S6pSAefUKi43UJfBCfhVjJjFvtbW+CGmOGxhRo3C/66AbATI2yx5EttppH13YQdS41ez15RbPB4cSqOd2qxw9GstylIPqflXvoMspJIFXCGcm6NkzXWaVtGDFlOJBi3FaU6nmJ6NrjsUTxL+Q50D7mb9cK06MyQpb80k6O9hkRNV9bJZDXntLT26iYppLdoWa+QAJaY7bt3FWeT8RBdaNgIw+0OiChQAVr+B7X2IyQVB5QTrKbbj6qRr7jyIZ3/jwORQqB86cpcLxuBngD+2CtrB5eEGAD1sZQ4KuCeBMrk+PLvd/PEZH/L8SZ8Gtwdec05T+OlZuQa8Ihgq2sl+F6Ewpe8EhI9Yis5NpVcnHDdqsqoWYgdINOPdIxI7fWaaDpKwKhEqHNqTJVNSEXaenrzTcUcu7f0zW2uoBaK3n0ZXP2DLzPU3/9k6yuLHKD6RQ5by0ph4yhciJQXXpdcVTpf6Gedgr0T4EcPEqiwoGwt+ReX4NQqfxwb/mLkX03uYiHn4FBaEyDfms2lBuXXfdfHPjp7XHfFq8ml9zuTVKj8AkIUAeQpSEGO+FXLVwJuiNz9Hi9om2hMuPJos6zCi/3WKcDP2m3XMDYNIjyZMEjf8/8/a+GhZbKpdUD8Fj3iieppQcU0fAIMZv267FX7j8NJ/uKPdFOgxViyCZPX9Qt9OLHwC7BicfCugLZf7V0ITGxF8VXVZfzLjz+tTegkFXnUuO/E3swFEUZ7AVzj5s6MUEpxd/PPlQLC8ymDzMwZ4yeGhq2rkXjIcnBYpyXGqy7/Mz3NlI7QsRbH4HaO+DVYlYdEAxee0y6Y8i+hYKj2U/Pfr/lMJ5NT08+XfFaLA3g0SORMVeb+aiccAyTsNyDNQEZyz8hQjmfSyxktHaXt25w4Um/HyZCxbVhydsgyqoofDj5FnHltPOeKskFBY2ZbBsV82X7t7NO6BBtPHNoYM3ZJYQYrK/mxwg9+T9e1c7Cnh8PQm6ize2t44PD6sTPQf1BbRYBiMa89oC7slDGdWLR++wfZ0IG2AUpxIXpifSl54GnejcQzC89iYDNsfLTbVQEwxvCBALqWwypQ2AGNXGuNogykL6WZW0qHOZkXE3KMbbopuwDZU+HTnl/xufbYTUjoE0K9UIxK0R06YlFltsAZBpJbU0/WJvl7sifn1hegu3neovSkv9xLnU0NhivIke15T9pLX16K6rIThsdp51j2jODyXjo3ttoRl+FZ4EsMZtHw2zJ8jJIbeVcY2NO+o916oHXkmWEjMFTnkFJSabFVZGu9/F68+kmfZJSdlC5fZBFu1IANn9WCTVFgVO9xT89xnjVfXNEod7cldbf5rQ9s2xv2kpRlPegJgeH0oYStyCM2nlNfogJoVSHn/Ren835ldgLke9+P+an13twTh6gsubvgTD2vDtiN7VIs+6dD6XyA36Kwrc8iQuSkEIUDo4eJsYg/cZiHo61Rh7ofzWSYaozCyab7lFa2MpSG1+XVp9LTkjuaFl911FVy9cnG/9kK+vVFvIb1YH0KsfGSiQzOQNN/yjonKs3ux06g7wa+yLNfgA7x971W7OtSltvEsuCQAdSGkxyPF3QvQGsy8FHi7eVrwHA4mxeiS5DNrPEk7s7Y39X16TVdpdOAdxBcOsdX8fdGb53V1kvvgHUDNjXW3t14n9mzF7F2ESbWG1ko+6uEogEfChnOgNSXpkP/b7KqI25RuZjnmHiw1yR5yw0Ne8kHiHfRBBP85wjp3/g0OGqyMlf/8sKkuNvsU8d6bfOPzxg4LzDI8prp6UJxlBenxeqUyet3A6TLiYuJHk3ZkR34t9lE7lUOYJWVGyeBjMPaLXZZwqoiQTyvmEubTmoQraFM7upwAW/lqvXlJkCk6x83XMQNKxRK3oi3+8EGUfKEKi3m/INYf5e1QS7bvLnSw66VoWXq8G8h82JYbsiqAh4pKZZD/cwpyxlH59Z5pTqTGbZT5VZHY05Cc+SOMl9W/bJcOmJwOoYqcMEOefkE+/xNJlyS8kQi3zoUBC+Ybluz5P2+VMr2sOH5eU30Cvugp14vAS81XsYBQqc1PDlAr+yuNE/h3PBQ8g4A41G2D1apiMqIRqu8nXAMlJESw3BI2l0YUMOsoynuGDpzh1+TW/5eiIKvTrQ1xADScBpXq9v/MyU69la4niuZqyi+4Bt/yeqLNjf4SfTFYWH6FAwYblQh4w4rt+lCDzbnDycsjQpnKuKG+w5drhRJ+CVKv8Jv0k8IBjvCRJC0gMqcjJGdoVA9Opv6HFT4NEkjUDkpJg4BzLo8i+GptCKIH7bX5q8ryG61llWauCzGKtVjzu7DwKFcy5mqkbV3+5ntAklVbR9xcHanz1WqX1kafvoKob0shUx5jAKjRKB4jYFTOzqx9gMytf575Z7CXetLdkeBYfdR0Zqn0/GorFqYYPOe8bwrFOah6hcuRGTuMCdqiz9QQT7mEkpqUEqtvEZKRNn0o9dX+CbGcs8TatHv/rtTRHMozGWh7dO8xG9XoH2taFFpVBeahpgheULYsTI2zTLGJNbrBM0bHHk0j7RHT9Le2C5a7R0aGhSwkGdFmq2E0rNqucKVGMUWOoWQZkPO+sEhd/wt4NUPR02C5nfPxGdyj4SuQPqGMuMb5XMKDPTFcaSH48I6pxNciN4Qk34DSBY8d3KXcBgZK27UkUZJx6JLIZnTf5h4SaA028t4K9NbMBUgxtKJk72PFwuzJul/eGjopxLcTdWjV7FESH/2loK87YgWaOdasy4mLcYCk1+lB1l6K2ebdJDeVwspktEcU4gwFCEt0VeixhJKnd6a1uQ2ggyFbbrIX1Ht7lmBV8hWCTuEX5HalufDHPnR5Ty8O2mgA7o7U2hsCr3T/CCPLsai2x7w7/nLEXbZcZV2cKO7UFp9DZ/FCqgkhwWoqgBC9G+DrOCC9JCdQHVjHJC+92D6RR7fbd/IBjjpt7ODbfP14CQLOwtPmW/fHhIFR/qMcB1QLCiRwOZkeMooN3rZ3/lcOTiEj1UlOE5aluHYcMt9/XD803yiXO9bNmveoFTWwWn7NJmhJtFFUIpdmv6a/82ih+uc48yLueUQ5wZk31ImQ1aC9Vn/0AkhNqhj4RgFrQP1ltAjrvCLgByTDVk3YBJvtfkilF4N7qGaBVvlt/YhUpFGjtSiQJKU0lcmh/+CHxNZ2HmRC3Vk/pnyVaA2X32GM0RgHO8Eor+W5Hk4w6++yRuxFPJ8vAQtYzjZrLib7/92eacdEkwPCa4DD9ynSST6RKNbns26uzuznNwlUtS+t7AU6wEy6m23jgKL0W94HBWspCAHDa6bXwcxi8zM+SZUslVpig5XEmB3eeJrKOrVEa0qqNXfBdeAZ88p2QPlPQ8pCk7laZwDx9OmxD84H3mICA3CPKnAlY2ev2O96EzdzbvAHor+KvB7wt03HSW/BqKlDUnq1gObZ9N4Lx43awnw5BlNHtLZM+J9kO3NnirHVEPdudoACLXrchaL4jTKfLYALyuVczBlyfWy7vMOfIRxQQmRpbLCt4bqKkDbYKl1SHnsIEMWYPXHl4qz7lkpIttsiRNyeosN95z/FQudciHAwSLLfOblBBiRf8384aUGxzvPu0Gr0ZIKITox0JBkgorZUgrd113r0Eno1k/bR1qGcNpwFKgf/ZkuFsBF5JKTWKsAoLXI9EMutYE3LwxEEkwarAMhIvxlzcJCINR6vZ+FDcZ80Q0XJEDYTnL9xx/uBXPpaQKYCnBelO9bSyNzDeab55jkxgUbnHBgvfiTmZCuxy6fG6vE4qi4ZisbBHGdMdmwCm+kqF+VbhFHD8LklZNcpI/MzGV3oDb3APkInk7MLgsi9b0cpzMdj5i9j0mO87gR5drf24iQkcLYwgU0o5H38rNif8IWX+5L6wKvblq9CB3n+V6P+Lbbcl1Ii/1CK0sBPOx64lRAhJ4mhwYSCOHO3FwK3JDIbmjrjTypdiivLtxHEDIkrWzvnnfvweq3Asohe7r3uvSQP1blMcT4eUi8B85vSwa8Xln5qjCbGdWCcUl7Pt0NdR7Ef1uubDWOPAA1XCqduHVgU5qtvu3Q9UrVnqwOK33lHkofMFR9zQEUCF6nMOSm1uzX7LOpn0kVGaJPg3ku/xCR5ZvoUDLavPUS+aK3AJ5bLeIpHw4rlXl6/NKJtbMilhdufOHCtKmPWyLU4xgTqeFsr6butIOqQ0aVGiI/FQ8pTioGzcfWZifUIqoGz8zyrkcOG5RyxYw0W1XvHK0JbdGKisPKxLmHAPMQx8AM1ONf8JqVr9Wtj2VPPc7ZzCDAWQbNL9+jjkCA8xObBEYlz1qoB1RaXm6XbvpVUnwuSoQxozIFKSdP1Bpo464UdAC8jB5PKMM1+Rsns1OvZOXIRAkA33Y3G8wQLcNIarcJA+SkCFYEv+coxpfokSwwXRUAnezw9NlJmVXw3J+N8fzMale03sTlUVdOMWnrlE/NvkaOIjM65XAdhMbR4n21gsVckRpyY9TV5nzN3T8UI8sh+Ss1ly4x1J4mumbaqE7Z5jSkfruWsJvuZWIgVfd8RcB+PKZXDjEw/QA2/zVOniKQpUM3uActL91zffAOkdaPCs8xcS4N0hwzt9JO2l07M+BpLBGWg5fMXjuA6C7Ym9QFcpyukoSiimNzdK6ShPP/RckKJE7wJtUTnWcuLMc27tsze+HDTGhWcjUl0UdFipyQ1AKFFByxVsJunBytnl0Jyh8Q+l6kd3eAWGne8CD0eKUdC+qo+bE84JMf5yGN8vJbSorHlIovrxgO4IY6OytuTjr/dDRLTlb+lyEervnou+dJlzQGEYQebMefS79sbYD9GC9CFqDUH5NNpYxwkp8uoAjvce1wL0FuUD8RNWq9XWvtMGjTTcgIV7lIA3N8pxuPbBgll2qMdlkcsmjHKZr8Y8EVtetOB9PCoieQ4lxsjgoL2clIboVUF5BFM8o74rG0sRPi5ejnw/X1uY/kpWcjo1bE8apYdQv33TdfP8rcOLDHMeR3viPonL+RJv+N0mZHIrvOt4T15gbbGPB6D4lZhzhQ/9PsYz5ozk9vAjPM6B29OkhXJS5NG7cYt3CdckCxNE0SSoB+CuD1+kDzP6aAN+FxWEXBMt4UeRQ6MscNd91fceHEmFdhmeBB7HnpdsdhC2fRReAulD4CELZa0CadeCDEirenLlI9irotoitgPLqJSjEviEVyVFhaHXL057wYUMBAAeHinl9wET3qSxKL9sVlba4WS3BwL3Lq6FMozqujyPe6l4QISKPdjg8dDTwfL/icExKnM51PhDwmiv7wFGI/3PEPBXCTI6W0H6LmdHtBtQ3onbvjHoNQmOeJQqepxOft+OrQuQ40sSCvYfVYs8zy/juI5Mn1J2WyRM3HfmYqwJSOXrp8OWF6p5ZVkGcTnv6dmVOoHDHyG0kYcLTNemp8BmXCHAopdQmNCi5OOPaM7ot97lPMVSStuSsjDKJxq4puuuTmfA0SyLEqfQdZ7HGoCjahIdcObXriuzu/l8ElLixSCjfncHmHdZdIUfXkE2Ak69WpmGmdqeXEk3G+H+Za8b6kY8JetyFf2y1qg4qEJ1ZvkzF1PxXXizTVxk1PVLKbGxNhjih1FhugKH8gZ7zTAr0U7Md2+InqN/LxLkmUiF8BgPZweQoLPhZNqXc8NGpgGN7ryr8o2wwd1dBXk7fV0PulFFQxbuM8Ll7jba/d3Z6nf2wWUYGTHKPM1M26F+Jef3cvTfoN0erq4FNkQR1PG+wrKYEuVY699WIt7efExeeWUJgTSq/4X/vrwJLC8Sw4cuz/7Q+VSmcY748FcJJ16g89CreyHGTMjV0jY+7WCwGv0UgY7y+4kosDtwNhEoK66LX9A/3bJuKlKD6o9LE3L0AZW3m7JLwlx6pp4qbCkGWAP4pT7Q+LgttJUytFr6ycRviZrCXRh9Z+1Q+C7CPUPT8OEAleLStUfFgJJIKEhiBXZ+Pw6zrN48hmoJDyriYXBNwYXqa5To4QcI6hOrkHL69hVNn+MWgo65dQj66G80WyHAqHSatISBgomxoUwkOBMJZmv5aru0na6yY6WcQPbk3Fd9n2W/5aNO8DjTehy1jTGD16fVcW4E1cOglfh7MQV6/dadXMSgTbZHXzQWNqlUxObeBKQi9BQbJoFP2B4Lk9cCWGzLhDdYSdlJAfiyrLjsAiR9nH7pKVVfigYyzUChkDDgkO/psCLd2fSEMFxmCBJsLfn1boEbqJz3ndkpftS1BmQRXiPTbIkmku3r3Jt1wwHyujseCNS4zEdHIZVNLOQtZM0WJrSlrbzikJTW1xPgwskzm+CBIrAZNkeBWDfDWmoKwXhBe2kldZaku7Ll2ZEZynmu/BcibbTLJhrEjoKCvw8hVv3ir80G2Sydc3O9tEyl7sxFk6MNWZBAtH0KHQVLTxrTz6wmgZLd+TPkYaZr4ZKZTureqHeiJ8t7/+wcndM2L//1wS5XZ8kA3AvJbAYkFAVOMUSIo5KWbXplSKcAKZ5QXrOnmo0hpbRzLiLEuZjQQFe3DarlhQ7RFCsZOAq02KRsMueWgTy0wjswJl8ru/JKP9vaAkgb28YtG6uqRXA9WBGr0AWEP8gQPw0r/YxL6Up0p3Ur2u04q8+t4fSIjAcAFLNNVtWR6x18yIcoP16mB1McfbL3/pNIhs7Irhy9A8/a1cQqFkjfDjKld8moxZAev6kOjrsROlickHTws9tTn8jX0aEuiO983flhr7Fp7CbTBiPFdStua0qgkUypMAxCK48B1E2J0DUOaij7SKXIjJW4sN3N4w29B0ywxIgO35r6PGqV+1yX6zGKJmutVmgZrSM9lKBMGu6qc4+CyXg/wlVrdeamZdvGf+DQpWvFA0D1Bwj08zSVUxug8JRlLR/L2ggr0SJDNrYrQSI5ru7EX7RgdLmAzvPBVm76m+97hJ971TEBJw5cWLegRA+gSD6ujD7ojvcnGk1KaH3uPPfaU7i/QGmKnXJH0qWgvxE/9ezX63W7jWlWBaG0FRsdwK3ZZLU1dMWbVA25RTeFXhOMVagLBct4nd3BnuhGqQv4oeqkL7tM9f1O4JskYifIpgSM1MHIgSTrZFt29auB9H7zgE7wF3EOS1w4diRv9GWy5U2cA0HhWoL+JCyo9DSYjgkOUidmVr1eshuD9DKMt2+A7tF37AOybf5fTcCa4PikSxBop/fadlZZ6O5g8FW5gAfhtw63tWMfsSHdztgYjAu2iwsIxE2amUqcNqvznnAeWoVenoGuHaCEU/UvKk78wcydyetQLEhy9CFQ1tigAdJQNz+DE19eNThjqN3wigouCLGPs7NO57FKZWriO6LKd1+hAqqIO3bJbJhrDoGhOnWBR+E6lO+b86eT1xYRs7Z6GWQ2iKYUISyj0L+vcKQMbEeiFTlGqU/PnWwi7YfV3pzRG/EkpCdEgrmrtzQGGwqOSHetqELRKlscJmzGfuj4crZqgMETvL3C7VfaUbEA2d6RaZWgmRXcN2C57yIcYA4SDrZoVsmLsmd5UZvsdnsKHkpKN8rVSZIA/oPP0HZLwzhACKvsUE7KOh/C5X+sXOrFYo7zpkPSVmTHMHod73y1TdhlUe7OyaSaCcWvlh2jJ9PjItGL7IumM62ci9jODbQ+7O0K49xla90G+g/WXenKwyYJ1V5ENIHU99U6U4HLqtct0VYRhAczu5dU/Szty1z5oWCiGbuEqrSR4MuHQXm5FRxYnKaaKBwdmdCBpurlylLARoQcMNHs6iZu9ggttqcqcMVTSoa/gFUfNEjuxCtwwoWmpvmK/sFgonupPSf5NLUYkCYIzw6KAxIpitEUdyLLtV0AKciMjRfe82LsIKnptPY0HSZcquRvKoCm8ID7KnU+2yXL4jg4jBgfyvTxLr91pQWJwIdamX5zSsRvBDzroav89NbOWaH7fxOjdBWoN6ipBDc6BySl1gTzUQiGcXUtv8jO23cFWf/X2hof/3pOjQ7TRuP/O1/IvTsIrpYhcaE+jkzSa3zFNvxhN9wAJ3hGqcSdPsFZqh0NrHLDjW+sPpke2dvhsQU553BipHcpufpv5PkRI2VSYED8KeQbtwzF5RLy+e3sjsJRJ0Zhsb0tuB/Yx6weWJ0O4Ie9Za+xf3J1aqR/ctbUZ1WNJdCKs9YD7/VkeOVeNVmX5wErGABGo0HBRXtyM6ro8VE0FJcScYVsNSNS6I7iDWovgs1tZ7vVOBbBXXcgTUsKBNsQOm3rlCzFzq/pTN1eFYFMzks3R01gvHIR369LFW+qMCP2xPkga0ll/88ik8gnO7nnauwUtuO0wVsf5dhvj92ALuQwanDCOp7+Dkby/WPru3wBNBk9jXh5EF9mMLt4TRk33vxs7LxrkWUgleXON4NWOO//CcRP1RvXHNQ8yla2ne4C3nH8t6R2OWQ9oHRs1EcdJE2UZDjA6YxNofuh1ktf8FYCivNQK1d02RQ3ZJE/D00yp5eHBH5OezP/vR/VmgJWn3rloiEgVjOHROfZotvRcrm3MhBQl0JCHZIIubfEXocWg4zrJO+GyJkZm+4rHqWxadhMfd8B4dgYCC+LywgbxYP2RlQxt43jx9BpBHz2LS6WVjtdhetGiZgwtP9ojcK2G+f2odJVv+OndJGdLrQYyjkx1JrZt7lOfNzVVEQdaUmukQT/04c5yiEQHNM+1XY8k41ROfYfsXzv3KBxn22Xfhf0N5gmu6TJUPIya85WgLNI120Z2lyfquj4AdGnC4q1peAfi7cGWAvuM4+P5/IGzCfxjzVBj9h5HccotV7C5idtTJl2mLisHmpL47nxs0RJi9JVWPHl7rLdYClMJQlbEorjWfkKgEw0ZibzB6rtHu+KmKdmc5vNsghb87MB394xLxosTRDCzYGUVF9d8D/0diwbN9iDEz3BDuVTkcz7ZaLJftrnJz4fpaQWKTopxsciJPnqXuoOros/iFKn0GI8z/lDZcbXWb80819S972WCWGwEG4XurDyBRL9fi17/LfQUTncmq4lAU6O5fUx9Hlh+dczY6X6EYELYvQjAzzor1HYkn5fFnKRrrdISHBRr1GBzPbJtqxyHMJ3ens+SBBgdmH/HlX5+m1Ii9BLqzPolkDNBJX4FRLe9FLVYoqnB4e59cLXMqUkLH+PbWZh/kuTc7K3/LZy7HIqWRa5k8MtoDcIXBdf276Hyb+D5l0hVxMjUNbn8zB9l+kzp+6c8pq8lweeGjBu2XB/X6/xktOSs26yk2Hb0aMKWGbUqFAWtsHBiWPzGslUMR8Z2emkD5YaDWdOCy+FchlXJtt3sejFzcae8HMhU092+aNVDkOpx5mnkuRT5oJa8NxUGBs0rXcLg36374xA5HjIrerxdk7Nqcv4iVJxFVZp1ROS2g64xVZlakjVfG5Xg7HphGw0JnW70jXeg49nBK7yotJe8iQ8nMytrgfY2YIyQSi9+IzfKEvNqGBeORWe+6GIGw7NW4jkgp1VwWdy8+DgRPisDo/h+S1VvmemmDUcWKsIKEc9MAeOFM5TGueDiOGK5CDYg4I6qOQ6eYEtzA2refIjqraICQQw5SWZERurrD6LAfLXAPZVyVTEfhXZmsVY7jdmMhw4j+S3rQBIpbJt02UgSBVpBHQuPQqMaRQlhLf5w2OzWXM3gE4kqTNK+bnO8/xTjdbmossdW8YQrr9/a+KiEwz5PxGpQzsoO05fdo5NLZce+Ht1H6eObw44e25zdWrt9BkIH2EV2UbZAIIEmegUt+6JL7FMIDcvXXdwLsVLo9IHUEXRj/F1N5/akubWaA5q/kBJP/LZDUZVPkvQCaQpxHXoi+ZhiGvhg1oLCUQwrJ5UH7n0Z/uYRswtj7b/+mx5JqglsnRDuGLfqw8jYDtXfpAV067MO1C6d8K1/v9Wa8UCiQnkAQYtLQiQkUai4Or1b9yksKJGO+bKa2UC7VT7BzR3q+AYBZ5UHMihr6o1gAUSlY+09z5y8xECOrwR83rLm6FsCrs935LuluJ79al9DAH8lVBHi3h8pfXv4/HTt/hcQr0bNjcT23PTmppnzO8w995kcE4UZu2UzJ6wkiJXgzZ3Uv3o6Sbh3XPtUJoTUrt6xJJgKmudOfRqAs15ldl+k9kfhHDkeMm5wes38Ot6DN+Lg6ouwUxPiuImFRr24ojwtdU0EqiJvJ156DLuyu4w1uj5GfMUiilRr4GOboL56brzmx8TY96dfQF0tx/Zg/OIZoMY3C73xi5y+tZboDtGyXDd9zJTLIW5VBl83k5aC3SMErTCI9hptC7ZiZvrjFxsQOIPF/CA+Agf5hJQPwjlF0KezZDKUWwO3WqfJgwYSR2/oxb3n7Ev0xYhY6W5N8oL4OOn3tuFgj21WQpSuI5Esk6s8QfyCS3JMTe/8s6JtzIPT1jNI8EqiH7wPc9sJG5X6fs6PZVTqsJNOgzzIVLYuKD54gTEBb4gyF18ZJBSsYJ39+dIvT9ZP9rz5yJG6keQSX8zEaDVOP/R5B2S7Wk+gZQy/QJcXN2E7AmOm0YAsZSGtf8V6HaZNAPMaJYmhBX/zXTiebFwSRGwIwKxjuMK8s5hOtWHxQNmN/OcDPYtHo2K0aD3CAM9Htalz8F9sXJ9dZFIJGOWoREsHNhjskuqdV7uYq/jWwqUPHbTWkHAiriPpB4vbg2E3iehYPJile/8NztTo87rrOD/OlMvkBDww8Wgz+p8D9c0z7pmws93doGgrO5NdEwhT25cyDXvoLfebKhdTfGQ6mW8j4Dw4VjBUFmQFDaZAtst01ykSgu8hZL2ccE4KuZI5VfKsf3Ji4rl0S/YO0vqHAvYD/83/1tx3VDZUbIL5XjHiYhJgU4LPaQ3Qzx2fg3acn5ZuOxvrzeE90nOxUFN8wVZMmAEpB89z/OqdyDsXdxWJx4lPYMBgV6duGeHW1wMZRJQgqKKYiqOlJtPHVMeGNrj9FdR32hBbU6dUdQxt5RXAhsd/YhJtwrySNL2SFDLP9J/VuFxOIY8at9KPU5XTmdA8IxSohCQ2GnOgBclfITtFNrHUN3GoP8iad1mMOLh8D1MJUn0Z/T2xpVf9sEoXAQDhe00lsMwa6Y39Dd8eqVMYdRVHxn0/pjIZNgPlZZUOMvUFaadSi6ADVaSSH4VobHrJIT7rrhfdJks0FMWzXF6HIJpvftUVZkQaSUsrXs2CEhDyjKeAUT+ShVDxbQF8uA775mNQWJA6sKN57cAURYSUOPkgZOJMcS2wiVEzBhqK0hVjLT/UmSoZ+IeBd8bU/NTHlgZ28F1/Qry4R95fi0MPNgwLRlfs5cBdtfANL9x9Az02mr8BfhYE+Ha2b2DglwMgr2fXRBm6Jip5JtC4QSjUlfDJvm+l7eghIvzz3ny2bef44tWkELG7ngRMahc0vjYbhclZUeg0mq4KRczPoZzAYUY3K2wy3zLKHU86yzyB1qxHhenbLTYqHyjF7AQiF6XW1MT1xMhQDUTKljuCdWSuYSXwPumIcnLXRd6KI1g2WBfT3x/MJsYl02Qwg9iRkjI+G/zSok9blQGLA7kmvQ7pzUMjKwL5tkQ+twXHB0V7PYjvIFpIzmwtguKovOyME6i+lTbXYc8O4ezixIgapwiU483OCW5n4ic2RnYuO+cqosY6Dcil6Dddim5ySxtDwdVbLtPJeOVzu223MxYKiyun6074VE7wNlnGRxgpRhPCkJigJ/QW+5xBeuUplM+2tfcd1UcSnlZiZjhFqf5D5mFvK0+vt3o+x/Hxw9KdchFQLwkohSCajnBvK+SxzhBPYi3iECG6//XxFfxYbN+g+RmKq+ju1/5OCqyMXF1d49DD1v3Oh1JVQAfjLYHTvMhLuElBo4GE667r/CvhxQRvtnrumDraykUZ/7zxYcSoLSLW4+MiFnfVDEdleP06nr5/La7u6YUdIXjffv6OcciNicTiDcru8RKSTiAP0J07Rim2lioXGetoS08ZEskv8BcjwCQm+2ZsyE75opNcDXXHFyE3swDn1drC1MqrrRsrCcb5h+lNuCO9B7BRiB37CrUrPZke63Sb4vVMcF722wIW5OGqDv2UzQIt0aGbJbiJS9stv6fuwEOOcdtNXGuxsqDap+c3mQLOEuJgt6Qgi+m03tUaD7DLIAg4Qb+6SxPm2hTU5pAQitut7MrPjt+Z7qgEkAPhWkCubPkIbYY6PDA55r1tRWIEkrg/bbWTi12eMU8mXEckxH3+M4y8F5CyZ0mnyV38YcLGhNIm5WLAHOP89uEW9g3CS2KgE42K+0spCkryzNwbwjO5j2DvEM/MO3rvHm1Uk1B+2nYDdocqaBAm+wt6CdtmCfxTImq40mUXggHzRXUEM+DRqCH3a1wMD4cYmwxs0yimbOxQHIOKSkob9P+QaBkOZjrt61D5Bg8K444txaYawparmqCGa19RqsbkvbS+0S7f5lPhgc3iLKKi4TISCscXZMeQfTCbkJ/vDU153pCMT6xIj0MUWNJBHIUOX9KZp77NHmwdW9iqCwlf9V5xZ533t5qgreCo20noATKroAByRsxsJD2bs9T3eK4A/mLhElcxu3AXKLywkzmJctQEevPt0ygrFAVzvpixqVbY3B8WqSSNaHnQ/FGu2psufaDh9g2NYayPZ0GNCn0/u/jonQp2HfoRVo8SVZnEE9FuzlFBygmB4QfHZQOs455/32Ed3SQPD+R2M/VRLr7Ph2br7HaZUBLKlZo2g6dp1yr6EdGslnuAR9WpUq4b4YZQ6e/Z1lVer2xrQjqyVbAzlYerglhnbTRTrAYyEN8pC34QIUImoPgVfRjnLt0h8AXzObTgILAHkM4VfOb5EfP5p1iqU8/NLreBe26bddiSLCqmMqudvlzINVV2wOcG5YObddiAa+y7OhImd84APReduqZjtJoAmKi4Uae+Zeha3ws2Md/pfJ1RAmlsnDv+rsuqCTYaMZo+ekfNxL1DcWwNWIF5MuVP2X5qFKsKCesDvRYsYImT/s7AhSgbfCGzdDLoSWpOdkMzdeGhNzQr7ogLbNwUpvFdxqAwgeSiySN06z6XXMFtSk9GeXsa9F6dm4bALNLzKxxa7nYdX44mdXbtNrlrYI0SKk4HhxAmJgoIAYRJL2+DUv6dAMTOhmZpf8GMjLByRgOAyWxT6XN0odt8qcWptP5rCPV3MCL95WoXGfKANMgqH690z/jhMJucvNA4WbdEomyfBh8jC+vtVgi198Rv8OF1ZS+291QWoJJ4QMKhv/g8dY+nNLYJElrZsefp9/JIxV7xTWFb+v4jmWPNf59N2V9kOfvKLR+j42NrG/mz5DRbBZy2olEIn9sSgSGWAf4rSdN5rKHIHV6jJb6g9UJil/zWT/iDPbkOGGUGNYUz4RbRnC30vvhKdGZHSllWvcC4lxWHLFSt2OlTFxhHm6QbMUVdsHlHIDBqsd6S63KJgvQgAes5tIXsvP86jO9xGUYpCBij2TUpwMeHE5B7zV3snT6wZybIP9UPvHK6hX7IDJqiB5HxHRM08vVnXgXQM2VWHItnfnQauKEWR8qUtlPPqMlSY3B2IkhYzINyK+dmBU5U6QpbUFal+Bvl606FW7ZouKNUI9NohzRxKAGKi2TsOFFag84EE9nySci6putJM+AiweeDMBXc/7/SX41kAaeRWFr52mAcjLEJZtDVNmShfhqwfAMj68GfsqbTuzIxhkpwxmtBS8fjHrv+UYbIQqJ5XG8Uat3rssXKQrdhTSI0kf6MyqvKbWIPBi0aJSnRuGyfqbNWG3FvfIPzv9NLXyZs6l9LbeQVnnPkEbxITxdVi+3JhwpuKneM3HFHrCw5TuNRKvIbOU/26lGJKf5UZZP35yKeaVKyWpU7o9PWkRmzHvxOsQP1HRnW2dqBUCx/s7gwV+PvqwfdVElT8ArFMtY/hep26Rgw8X15nn7uUDJX02BKRqoZQKpt1idFbVGROg0It8yCCAWljBH4AMGGOPpIJKO1qTLjcsS6TXuVI/2nxwhopy8KmvRLb/I/ffx1yNhiQIXA7w24CgdAQcT0dSfaVq9jzMNVq9aYhXR306jCJlUkYuDCrz2ambDbWGLnDitciy28ZxdOzpRQWBloQQitHjjuQvxluQcoX+Cy+SGiKrofvtNz4fRVVWkakDIxrF7xz4ctjn8DxAhuxLmkBEhx+P61T+Nw8ZXLi2WuWGnlTGKB+iVzbbo6P46EUyKFR7IjRZIB04l9Fw21QphOygIm2Gyow4A4D+D/uYMkdcXkLlUzfmP778TxGBrsdBq7s/4egTDaetU2X4XoQZWXegttdFpqnHfRtDbUg/u3omcMiOaj3SXDmMHhv2/x1UTYIusrtVmiklUJcDxMi3x1GMlQy/RcrHjikKimzf+WV8WQV63UzXT0bj2943eY6SITMKHAxxhsl14ABEUDfvE0XQsLQ4Sra2RIp7maDhFpvGRsg3C7m6WFQD1J3BSBtgOT/bHxp1IyGJ4UBDZ0c/MuaRrGuI+X4juqG7hJOO4OCOJ6LGi4t0xn6lXAd0AL0cUk+mTIWwAvUkbVHjPniOv5wYV1xKUA3vH97Gi2Y9LWcKWHW6+Z/qR9w6ouv7jFLdi/bG0+eZtHVbY6r9JhIUiGQruvTVOZig2wF2RCaTobIj17qVpr45JZbJL+GF3rqVTOMYcBO7qlRcI0lQrLHGkY26gVWx13Ck7dQLk1grHLJRN6yPUvc8m36x41u1WJVlRE/ueSScZ2NFUjZfo605NUy+6tS0R7D8701OycSTtbnEzkcRPccTLQbk1W2Hd/5kXy7UHWM18qBPnbFGRlGgDRzFZYmQ40Ezuw35EBC7i4uaU83AFc6UBrUiQF2+L3KEvWx5K+xE+/1TQKpghcpYmjejyGSa1myjgkrnQVtDw3n8FeEbOxe6J9VY8O0lisq9smXo5KMYRkTN5cE09wmxi5JQQI3Z4/whPNKvRWtayofFD4DExDAndzXdVUdoMDzJMzs282p1LzWQqkv6tYP3VsrZQpVFmQMyGSNQgxAw7Oq1pTL4Nyjkco8HPna13dpmCqrChTGQKJF7rDiV6S2PdVBuWu1PrBEDzgbl0Lh1dPookfl+WAgyXVrtF/x3Z0mcwKZdR9GixV71eb0TiE/pFPV7R7jdRaMgilQwxuBwzbB/54SC69enh83cJZbd6PpM6BO3f5Qx6V2/eLb73RY/of41OzO/8OrNNrnl5wikuWfi9vHAymTJQ58n2Qgv6OYvfG9jDyQHWI5Jehxcgmi8E9sLm5UUnNdscrf0mbm+VpnCjDy0PgrXcFI8SZSC0WXT4fOzV5zIbiJQ88c3LFGvULD4aGrTcNja5WDvouiQJbraKpo1lrGgTWjeaMDhzV/ECuLYeEkMMnovghg4ZdXI+5s4ESnmlkgDmo9f4PT9lyPMJVaEcXvdGo7KE/Zdm3QUueUkaQnE0HGoMeXIuOLSINBH4mKk1hyIGdNS8+U14A2+xJAr48BKSym1DBW/mOIAa686UnxE8E0Zx7F+7IsVsi33HihOHfep4vOR6PhJQ2+yaSB4yRN2/EJcQCqa8q5P8dYMzLzRgDspVXMAsEDedLSr7dlbOSl20NEdcFRfKMIrZonxKcYFMy4hxsgaIAqD8tUSeWoXE14Brdwzsu9N7/0yU6Omlyq7yNh/+L+GGT6Ow4o9D0zUqx3vgA+IA9FnNnnidedb9Q1UCuUAaX+XGvx/MRBUFCJw/poon4KcKZT/clUe9vJymjPusMtwZ6yU6effbyoj1rgA8keYb3wQ0TVUL7Eqzp5wjXNDNknlpdCYUUiQV7VR6FzgL8+S0rGFrMN0XfqAKqFs8s4v1mzuyO9sC3+GHjJchmsvezgfd7EJoxZAfFl0aJZdYu5bvSQN4tHKLQH+IREk1DZdyQNgJTAhS1i+p4SyoSrGdylSqRm0HYuA9PLpNqgFX34ReHx2O7+gLwIWz2PVkXEQ4sJq0soHJNuMiWcdGGoTshzWO8uT41Pw6noQP58FLnrUgW0Q9kwXBDgSj/DnCEb15pf+rN95SBx1qUP9cmF1JAP7Sbdl25mVRDTvVtj06xMoqD2ErnM+fCashhxBqQk8/eOWZhvwV5FiqMIt09JmtWFn9l5M41xEOEr07pLKiGUOM7qVcxArkZY2ZaNrGO4jsgavVndQ8j5fIdNfyDMGIsk08YQ5WGwa56tWdDeWII947o0EK4O5ec/pEndLRPRD9Dv1O7QfCNteFKCwdzsl0q+9w62Ev0YwUtM+7z5WchyaiQdmUzC4kh/N6dyWnNndqRhXSUrBEM3Bn6f1ljAY6QD5enciSzLVjgunQRipv7I8GkJOwsRA85zFRiiO0KD/wGYRYgXJduhUm1/CmBOI18+vBssri2DFlLbN9PJkgyhXRsWvNoheWc70OV0RrhunqGFKXULNMKGn9l0i4Je9x9UiQlzFaswg2Uiw2Ky/XoMXAzABYNRvJI71wb+ffcobYIYobQTSdEz9NTmNFL/8GiuS1ZrgEhSpa5vUnURstEpYUi+tREe9g/ec0N1tX23f0YjI3mdl4kulJKKRyQkBkvsM6/eMXjBD4NnbyLP4ET3ix0Bri8CbkskRYO+hAhdjfClqNqTWXEw7/Z6dcdL849c5OL4gxcYVEY6TCgSzfWz67O5yPLHZq9XeP9la0inXMz/4HyQbv1IqjyZr4C5kWAnBjGROmVWXX4Nk499UyRGF4qjTubhZ2aG/wT/xuxO07HXvLlHR5DKI6Tjf+wbxDekSNKtPlRpm/WcAnolrhvGQhyRG/rOh4J12NcO0r9Wi2TuYQvVIfvQYnJM6OdqoPLxXUjPh2+gx1FF/Mst37N77TkXMIGd5TzWEPAT4TVTm34xWo3fuapd1M37ucbjPy2gCnvGrOW2ij5q3SBVy1QhYyjAItS9vkHW8EqanfkPE9q0pj4Bco1xoxI/d8FvMHFHe7fFI7VIfz0dpoAo7HtLzxOA8db/kW7AUsfpik9ynmxnEg4Jtrccy8DIZggZzC/LB5UgWX2GbCCqRlZSKFRk5QpPNQYv7RmLQfFu4qc0tTDUmEZmFcjVIKWrDqUK+1WTSXr5OjcJd1KUxa/lJxsf7+V8SFeq9LA418YBXPYVFtnsrsT064EG4EG4EG4EG4EG4EG4EG4EG4EG4EG4EG4EG4EG4EG4EG4EG4EG4EUUyHGNmfmhEr6yzArGElVs5DoSC5gvXkFt1ujLh+W0aRf45LfGze9lcc+djZvM0vREbaccCUtksIr4npIx7lB7ZplVbd+rQfU/PrpLiicl8JQ5EBx7gvI5X0j3UhPdUdRbs9fVgn6agwZQHN8iJO6w8eqw2YSbRNHAcHzEdUN+e6DpVUlp+564L8Fcrj7rEwFsHg90HuudWvtaRmE7Au4LaGuafaUs/npWG/hI3+1X3wUNiCLv3qgxEu7M7d84GkyRkTz/T1vBWrTmclzUAiqZX0DJLQsL09SSfIt3J94Qdc0YWMJ5cgx1pB1q7BrMFhRfpaBP32g2mHnOj3Ny62oCbTSiwoTtEqIBsTCa77COIAiRhMXaFUpCwXCoxQZ2VD+xwbqvzxnN71hp1c85ep2CdbpDjlOTwJQF9xmJCDk0Sd5Ecv9fUsqgY1YttvtlYq/jOZ5I2kX7gZdZ2a9McSYKEL2bQD8PEm+TyfqwPRc7pTWRgCGtEjIDlC9QADblbdYNYiEbtcBRijB5lnbl4FiHHe2wuVjOVvTVKzOsfbQRrquCF1VOBp3Lz2VoEvATmEGpuRRz19rGH58E7dc84CVQaqmUXjpPRUdk1nxll0Y5wXtoDd2q99ngXFV66udA11cb74vBI2KI448oyU9p8vxiPGNN10dJRnhELaF4HafEtWq+xY6hMetpHXNRhKDB2QasUVBB4OvqcSNjrf81vuLlA9uPq+vkQegxNNWo0Ng9KfKDUdD7AytJHOMQ0++TY6OH7rNl2aDyabJ87lGXvdEKNKxy0J3pIZQOzU87BCMAJgalv8fmli9/YnFwU4Jl2mWowuszgoM9QaKLdosYE1ah0rl0KwqRBUyBzVD3AD674QqcIbfTiDjSBn6k2b0iB/RbHD+GfFKgvSIfyHoRChGchxQsHbwF+yQh75tAwIRHMmr0HKqp/Mdi6ibNKWz55fqAln+3QQUhbFL8d0+3DzK1Rk6a2ZSFI1GDCaLQTTdKATQPHcWLlUpo6I4MdX6dEso3RkhybeAPwGKi3MRZ7owDfLrhxPMuaiY6Kn3VyJ79dbRWKvmtL7VeSQ+V76bdGs5ccFYvXrFNSq/vngXMY468lYVJizv0rAvPaiSwzlNGdhMablx5ZbLGeqvKdzcMvzsEpAu3lDsaqEAiT9pHkEb9LplOxCKuCfO1F3xRv/BAlXJ+8V7eco/PAyIqcal7Fdme0V6imQrso0jLOYdzdFN4wyXx0aenLTwCslzOV9igsYaq5FoJmWWX95rZKFc24YztEmjjw85i9vNqQqOXljZlzPTG3aqT2AbHAI4uQSMdbcA9WoxGSCRkW7KQE+OWve1k8+i4x0cDUwmM1iZ3PjqRrJTgOpBKUNXf81dLVQIxApkcAd19t17O6HCvAHFnJCuvlzpyc1Wd0lRXI0ZJthwPKHHqrYezLyncaPDcPRuGSGXbM7x7rSbMhYGzWgV9lELud19W4fnCkbVKBg/rIQziUNCGE9C26Vu8Yn+fVxhipOtPyM8ETd9DIvpPUvq/Gw8Lv8/hJ32kXJ9ytWuIy/J/m3+j5+Uk1sZufcxP/9redndPUhcqZrWOvW9fJPv2ALiNq4BpOi8vYDkbov2/Vw8/tvQAnn9WHSTimwvbqfPm+4cqfL7YZC7G9J+Z2W+1WYb67La7Q2r5dyPEu81Itm99nRVp/fn4LsV4l8YQ95XwiQOwArxa6E43Btrbwa2P0NEOXziIxsLpKTQK0vnVgf4+DYOy8+QGEN1EE4WuiL5UNYntVl6TEOV5KxbpzJJOK6EF6VT2uKFopZSTDGwvo4A/N06X3urIm8n+8K5h27Z6jSnKoh8Xnbh9EfqfSQGzzDXTs1mFWOLZ7G9t/8KlL3Lg/YxX0fKsB6FG1qH+eHB55zY1vG2Mqxx35mWsmmI0WDeG44idnvU4gef0BZyFa/f3tS/A/dD/+PA5bJSfuCvsKeUlfH9U5noHuX4w/ybufEmUuoK8CzH3nF3iNO4KJl8W+xZggC07pB4eAsOdru/cZvGaaEPwXFNKKQPWkhvyQ80U/8Kbp8u7tKcB4YDL8tl0VgXX2SnjqPP3F15vUGgO+MgLRlZJWkpv7OnSGRAqkyG4WHjJSWsnkAqkHKjHMS+9Hud0LODzP8UCRrZWfw9wTBVX7D5me7ac+Iye4OBLeQ/6NYbb64yIqnbPsywlzQrzuV8XbEqCZz/BD0YojQ5PfeBEedaM4vuY1K/mrWsm0HXM7Ii6dH57QwH4b/gNJv8Wl3GmHK0JXWhwqjadd7zbXIPDzLA1MZyVJw58UL40A9dip0nFWa2mCwOY0VsEqWXdBWZdNqWEYHVXsdC96+2S6eH4dtrnMXwTQDgqGzz3cdbIPxCjHK1tgDIvRLrfWGE0qv2xAZmNK8sKUVfZ29fme7mWxBB3E3YgTuV1VczorG+TggYyMkEvMMmVjURG9tlRzu8+Q4jgVAwhtZH9UOaCcL6gXm4/oe2uJsvViqPaJfi4jf00PIio0JkvqKff8bkknYBk/VOmH8mJ2ALK1nXVF+KfretHgOz2lCuXOzKW0FFwskqwPAPtsoFqKgaCO+spemP+vNXCUqxGaNeBgcWWQ6CBXbOSqZBC4vtkj3fENb3NUW4J33620ruDe3w5ZN0Y08OAhxE4gBBJ/xAf/1eBhgI92JjLH4e+yPuoxjsXgtmfk9+CoY2o+ajvPUP8upp3fmcqNerSGwtkKWdTRONponY/RasPDWXPNllfxVVURrcI/0RyuTEhqEsOzWg3pAOPF92sFAPI2Et0v0hPom8Wjv/A+s731/dTb/7KucxehDres5d2ovbUh2s6ysr+OeMjxl2M7yh62ryaVkGvCLWUlVVOk64wgQLk2sy00xxXzs+v3QD7YE1mYqB0sHVMJMvnYca84g229AndHmVuGHgH2f5RzxwLXmgyN/A+G0l6GsuLvIlpPXZiekj1YtASzUxX0D6fRdSJ+f2FnhrbFE8gxDt/TyYz6VpLfaHuqq/zwY9UaiShxo0w8yZHvdEa/T8iHYDqFI8m+km5BqzCItazvPLFPD1jMA0Bgk5IYb3MskoJ0uA0ORQ6ujmdCmPdfm6H9kEUdP3LrwdNmEX+cd+eKHpCKmkkuHiX9F7WXI+Rx6Q1B0ORVpksBv7I8oWU8OUwpxLTViUwrvFGrBfOuk39/82ypEVqvvZsBrf0VjiaC0ycEvH51BmVkKYsZ9fS8PBU/tjIDv1s31FR+NqALkIYDFH1GTkXcB6iVGNeRFH0LLtBSgrc7UTxpOpallu4a91KQK+t8lVmoycYqgLLTkiJE/hilhVWN2plxINW10OqXtsNBekU15DbpS5vyFZDBB6QtB7qLPUByuR8IgHpbdBHOvr5HXdMEyjWGMf9rqAhisJdS2dv30trBVA3kleFKQOQ2eKSIUc2Mmnnnrh8HQCEdvyVIKKxIUnfvjtA6nA9heCjLFmEfvk298YXQR5HBcUU/+aRj46zTJANXi00gDOuVo4J08+io0t01MAzBtcw2qaVp0FYIpa1X31UCWsLU4AXtwKQwZi5m+j4BCEelnX+5ERWPBXuMI2PKx3wBUZMXugYt1deYhivHjlQthNeVQD6ku2BgITaXTvOg6AK9p2JJQpnzMnFLhi6XENN0Qz1tKMjerFY+CmI0sYnzA3MlscZE/ZmXZj5gOLresI6x4m7xSIfIIlVH1NKPyGQWKpXWzPPzeJ10CRQ/abo7XM37h/yNonUwKc8TsHdH9Bnw87Odcrm4wNUKjwR3ZrmIIbXg9CxWDM0HKAcSgod/QTVmMHH4VR2F2p5Sm2Ct6IfumpwfG7JRjRv04mOEkFDqWo17ppGEaIG+lzg+3OUjzsruwmseb25GoK65iGewv2+FatA+craTGXuPk3inzR8oBL2xAXD3fGZCqqetDCrx3iTpPD6xQgGuvfgHeJ/+7cgoPWdUrNIF5SYD2kIXfJp/ogVSZIW2SopU7GksQBlYi2quSxXdlJvfGpQGRp76w3GpbWj3k9D7EiGmC7tvIfwTwPFG9E2YEFNMRixyC+oBbKKUplj+fMOwBFbBOZ8+W3zIX3kV77esSjU0MPRsTQ5jtVgQvNpqSzY87u2AvnhFU4ytd4Jfht2t55242cUSEpei/5hmSVQ6aSXbzMCO40EeM941P5XVywyiSvbsyWA9tkjyhNFCCsFjYk3Y5gV9pX1XULi3V68MwOJNNb8FXYmD28ynjvszDJn+0Xqe1WoUAE7dt3/Ng9LlirPxt37V16EDACJMj8z9wsHx/1uJaK132DOTemQnKuEZMZrIm9vdbdTxoo6F6Qgjnbc92RSnfF9id4S8nEVOVPRWd3izWazJffn6krBn4yt8kiWapGQaaaP5+EBPdyBo4uee/ESUl539nVGqZCW0bRjlmoUjmFkq1PBYgekPNlZ3Aa4qUyNYv/ZzqZgTNxzyFwWN/MUI5WQprQn6/cRwV+6D88L37eVvTC/cM0R/HcMZD4MIvJo2LXxTlPycBlLlIDWm68udYyEKRTjRuehtnwsbxi1DiOqGOoH97j/BzlzzDW+m87252e9xkA7Y7Abl6nfbCVNloqqbpQ3QdC8mTNdJALnGvrZfmPHcymVIDkk2hgi8E2uyOH2WtdO99w/vDFwh2RkrFfRD3QY3k5FO+wOdxD6M771MahYNoEkhpD97ucPgih4XEk0+hjcor7Xv5HX4EumFt1IaY9vKJyuOiwbT+iTm3D0Tm/kRAHcI/GggVAfcRfQCfahfX08Tnde6G/wtpC9Wt6UIqzX741a9dZZauv8VYkJeKtTxQkcU3ajag4csn5t8xsjGKZhydWIpBN5KMUcvPkkwPbw2qbGxSCgMx03I53Es/iD8q/zJ3Va8E5ZZArAaMNYQZzcTCobpQd7RIAhBFNwOi1w/Qzfchh2PWjYXR/7pDHy6XYwNQZ4bzm+XdLW/jApWj7cr/1EOhMRz1+l55BUqLszrrwoWHowEqb05Z64aPhNRfDAOtBPvNR6AzcFgbjQ6T+pPegVwuK4cn/m8x8PGt8Y4r1lf8rpa98iRmGPZ8u1OMvS0K7P6LsGgEwvPgKh+dUu0LVlQimDD7rKgX7Ve+HeUhBtJnWrq0cbomajuIwJPnO0r34DX7kfGVzcS3epqE+I0L9zPFiDBjP/ljQk1Y9++mWzF0r42q3iDxLCjCCJWc9iX8A7PtCRyfvquHD475F7m3pIZCmF5BLZmmkwkN2dwWuwnGv+cyo7CHtCIDqKfzi9prb9Dfs+0KzIwm0H+lHYWW9QD9lsBdyZ7RAYA6YvG9fxiqP2h6nFsUAyGyDrvKlyMyhLviNtSaSZeWoM/lkKpWCAun+4DpmG+QH8UDs/nJIYd9zZtgZhw2uP0IWLaIcSJXPKfrLzjzdxCqlNK7LkxSy8h6rYMGLOJCjpxbkF2I96u2V5QIxQMcnhhmuEim0VqGWyTLOMABZraYXdr1hJuYJODCHqQ2IAB/2Flofna6maDzrju3slzQsuD0nOb2Jzq333qPgD/ShBHCFkhgEalNg8X7o9RtMseigOoq+XW9jRbA7SQUAd3qm30/SnywH/iGsStf3Jf+driGA4tfi9lLrD1mfLMeQH51jQAg7Ldb96Q8n9hG0x7JOmO2YUyvva8qP7dFx4IA8M3AM1QIVxZROkYOp8ebPXXFlbmFP310n/UEIPMeko3eLvvurHfPid0R89jvGVN1Wwo6VdVxDkff0Kcu25UgfrMfwMGseB6cXBQUAhpG31enYbBYHoLfoXZzo6CnKcabyelUMI7GbhRXXBz5vGEtGrMkwxfxTpOM4XJ+A3p1uugcDfBpEPmwG7cf5Z1XO0ohWMgIosPJGCGCJaWPE4wdfhXoARxEkuDfusHNjC1uydfZjCq/21/as9iDKVMf1SxKIsCDl8YLDW2zD2Y5RFinUDfM4umZS7TXatu2G/uMNrZaPCDE0rSA0deFBITztoe6i4MjWSU7LNmL5qi/SyedeluIMhFBNnRqwEU9RcTD9OibO8CAELJ8o2/rfnI5F9qQ3620WAkyfHG6o4OQrSdZ5E/5UYKWI7mumYu83/ZkalfZ4SbliaCdBU3ost6zz6eE0rcWmaD9UtRB9Xb90ABaFaSEj6FG/XMXDu8DRnYNB5jAB2h5OaiB9n1fdq+Snq67tiwqCgFe7Thveu2HPuoZIC+//qW3rv4PbPEO7aSkNeiGQjkmvKHlOEaacmH6bw6qh9wFpoA+War9+Xmhzge0MbA5IquHGv8Ow69nCm7y2iqNv+0d3cVrrm3s0Mf9fJYHma32fuI69Gd66GrxDIHa4ZKODnCfxcDhdAknKFSS3pWgjzQCRsHxmdzuhDOeoBLQG43VksTmDKW0drj9VJBsMlk3mvMVVP3F8eOLNRU8txzXKxDyAU3LivLHYoaWfpA29BOMrvL3dE1srMGokKaE6i6KZCH20cXxr90mJyCruOffBBlJqpkDdSWwTDUE62eEhCKRXYb3DICBn/yyua9X95g0Ny1qr7ohLTEYJ795eTR0BssNZ635TidtS2h2HWFXXSEfZXu7cUMpJJiovaZgUXb9TgmYFt3KnrWv838eiwFqPGuGaQ+vc+YKjDSi9g8vfFc9jBoCjadwJwO0V0pxuy1un6FkCsniiDPDjnVbI4zivRUqW5yTDXh8dbKRvYHysBVzXQ30rCGhn7mn1rjDSPNZdfj1P6c8Tqv/P98hFnLVF88gVi0BlL32X6I7sx76E2noscgAKEYvY89PmtWkqK3IVFgx2RnKh56L0ElVDCWENE46AyhRT4P/GdUEqO6RBOMKLLSQ2JWoFdh67TDyD2wdVxF4eZUpz7erPm/wNZVjesTDvzMKxgohOLcDowrKrHcEjkGoHhwKLenNcJZpy/7XkJeXUdgEdb+rYqyAN+XsfJhfkhjYt9oW8pF3xrGffZrDqgAwaUTK/KuRCCQHcr+xHXR4GtAHWmMrACf8fALQB1elUKo0jPRa31ToGmVC6oQRBgJPY52mhjMRTYlFMSiVzJnTsocgkc6va3cB95rTAx7lVfT/K90yiO73m1TPP2nEgXvhTi5mLwiDweGVPFCNafrw4EnRZNrmteB/bhupcpzQNJ9HYVh7oBRS/ss5laO1hWR1QdAEx53NOG02pNthL7nhkPDXXRB9vJTFftCuOjhogii0TrUtSAfc5+bxMkHTiezthDoiM5sUPKuy2Y4Pe/E84RxbTD1e8sDym7cBYKK3uJ44RhjqTzTRc4xSFRHbxNuD74ZaGAbQKSC7hun/KmwSMpNF6Ia9OJYjkIE50Myq3O3JoPjjcBHS1+ftdviZ6ud8CLYD86q3DqyxZ+pn6K0WHjmX4DNB5pVrIwQnSd0Dm7LPhpR9BzMA4ApKA0ZzFi61CcS80C9K/lsPlUF51GowjNP6Rn8Q65zkkEb6kbbflAC5IEPJ1ntBeszgbGSB/RnoiOST01CUki4V9YEr1QOHsKhwG01+3N72KH7MS68pzpwRcWGXON+d5xp/+2hhuqa1fnZRJxY2YKMqlxBtkY+QV//5l1l+9TcjfAeuFP7uKWLcy/xLzf6Iww1YlUjoZSGdpYP+9RxU6S46dg/F0lTgYkvrMGd1pRBebMzghlxY6e0552AQWppNN/p4j0N5gxGVUFlp1CwLQWr58PmhcL3ek8zjQMLdmCNBZszn+d3sDIaciHbOHmFpIcLpzhRnZFC+h8+0h7mHHM8r8zmCAr6ESZQhC10Z1WiHw6cceAYMO5Jxl4skXLgca5GhbCkNrrAzDSBVL1rHnzL7XY4p3/xQAJTAsmpTGq/yjRpJSlEbmKIyrZ4moRVyf+4RFGnPtWCek1xvQs501YCH8e95wnaN9W7yGkHRDf+VdGa6tOsoegSvXSc97MOluXONKDpeB1HbXmT5GnqFyBqrEF8myAehSNA5tPL2Q6MQ/mPXVvLJJljO/9ySHlcTeAA/43xOlBC6p+4Cb8xLQvjsXTs4jFQIlIIJxg8NlRslXYf9zX28/xH97etq3iLjfrzpK0lT3EqmtCr3nOQFpVXmyMzf6eAyN5ToXyKkNs7nw6lmFEmBzP4gu0RPL/Iy+iaryeSiHfNJnvNUsrAK0zeoAMwEQv9ERAmxtFemIqgKtNkYHirhfpER7j6ny7QAebB9rhKMRqmU7pAuwF5glgwZfuBb8nyXYU/jMYZ3ltsxyOxlS0PTOnl/+TiBCIOv+96Vo2jv5ut4Mbbhm//K+05D6iroegBFzNFDGesoU6GNHNmB04C95X3vj7CSZxYYKre3nu3eEA6nwkKsGmGlJzSfU6o2dhQce0OTA5M1s5efV5fAKTTq4wynq74IFHecGp3jsOXxrH9NjfL8oGksZakj9dV0cuoumim1px3Geytj7aWdWoegAuM0dePSVmXkMkVZt83vF0kjSVAz9rth7xueDhoYqGNPTCLptcdNTqdTvKdTpPhcJ2+iUfTXQXzbDpH4tWkiPEHV7vPFpdekmTEbH5rDhpd6en2pGKyh9hZmWs0MV78IuhiU1WCeyYcpIarWh2LW/tjQ9BFdWUy298FEKoADY5S5P2M7Wk6Kr/4lZqSHHD6axEQfghd0HRulmxfXNG4e9KVCY4z/Xr45OGbAWlLPVfoAm9nRZonMC/pSSMLNMtmcKOwCjg1bf5R3NTXUuVZHmLI382eObvEqf0caDZErWyfRYF8OQ5lL10xL5iFXdYo+CYFAtTA5WwLiNLkNQ6M61yUjfpDrS75L30qusTrzlyt/eR4TtjwrJD4HoLNyChKAa54P78mh3bIKBxoYnbJjbbHKXn82tOBXrNwIkTAIopE+iDzjHV796YXIUvrd9vMhvuxGY69C0ZcGCaJumbFVe+BknJx1R4ur9xNdAODcNa4xk8Wyk173EXOsLarNq/fx6KtLkHS6VKHdCqEX3hKTL+dEEIUwt/S2zTqcJClFl72hDKmiqnpstwGovPbVoVR8HPPnY7js9TxUSGLKjXDreCVUnkH31YIGav5UjoUsRS/7CHpkpr/Pf4Ozpe/+B6gbR03m2I5drqooAb5R4nSOBfvmK6eLipZXKesnXLf4JnQ5rLwILzG9E2jZJ1mSLSXE1fCBcS2m2KKMrvMRGVy8iBjE82lw0UY9/KRRiYXnc0nebMjALgGWb1uBxXv13UcEeOZWzfi3cQ+YkPI5tpprlwSObtrIkRqDe6bmrJuEWg1Y5e+xl4fhtJJmS8dSwAbB8qetXiaxzRQqep9+1R2zcBEagEqlBHbvf+nOB+EDXw5/Gosi35R/kFuzZoKwEMiOqWskp0OGIk78LLzcYs2KjydS62L4vwxPbWKQ7ZF0WiO2bX3PZqAqzLUHYPfF37jzZb8BHZLFNbOQ9nGAqBiLh8BFy/h8RpIIrwkCA8ZAKOwidDRTNHgmMt0YMEsNUMc8/LAHWPTEmcJNgPRpXWUEhhBNJqbXpEJzy+Yft6hD9m3zBc+NpFbE2TvkFHTPhTp1Ha+PU5+zUIB0HeY5OZipsj0vPIZa8UNC9YBeT39LqtqGJiT5YVXb0dRVwLDKACE1msBm8lqd8xNgrgb5Adpz2rqg6oh4vQ0fd/tImkkKPhQdJgz1EvNco5mfUJtfMqNBdLWU8YIE9fbfpEEufGBsMt8sTMyqZGIsibBd4sAHBRUp5Int1NNHjH7SloDdpvvlUsmg8Ukfbk2LexHPzBx66qeQld5KojLfoeOokdah5iSVkf+06LT1guJJ5GsBVxV7UCm77ae6qE4CDc1TiQak+MEA0zEYAsfOWlNN5t9uVUG1OZ8xRcS/h+oj/NJ6qTKUUCjAAANdQ6KEQ+kBKy/gfciDcVcXWWXfJ6DokqB9P/mZ7AzgFtowAH/tTmzJHj1uTh/IB99We8gpuMLGwQnKnbsKh9oCSzDM1tAUftteW4ZTpdno3Q/0a8+yVCc4OvCtrfm3poDu2xshv2i7qxz88s/hxDCDEm9b5fqulXpoYxFAn61H3l/PuAgwDYvKWIxDRVYCLkjitouTXaxATdgIWM31dKUUZBxMgvP5717teCWjUnvL60QDWyok+3C+TLVmov9lWE1UZmoH0H3B1Gbvs2etit9/rKznqZq0s0X0038Tt1cSEJ9lrk91bEquSiyJ6WztPW4JVoJDGHczyhaNiVzKcqEs3WO3npOVhV7UBcdPVUeMUAx7IZKo7bIT7sRhUj3H0MWMH/TRaVwuJlrLFM7xy44Lcdunzsm7fmFhO3/kH/cc3X3bHGqU7Tl7oz3BI5AtqHZiShtkASMkXGQKTPnt5JcHsP3o/uuvy08QUUrNG7nFHMqSEFOf3XopvOUKSa6jB3pNoS79mY3ivJrxiKRF+Mu6MzicOf5EFQtAwq8Rv5dDOPvJZnpx9G0+V1adnBYgy6IYco/e37LwRvmSDkpHtLRHnpCM4WNKzH7gerVv3YArCMjWfAcRX6T4hPaqfwj6xPxYVsDedYYpWzjnXOuiERU8XCMVtBoCUHHCGT569Js9cvYuUV7pbdEGjC9vikut8cv4DTRElv5gxHAWr9nkcZf8Ya6MejugwmuXDVK6ntxrjgZiDX5Ly7pzhzv65obR5PgBrQNo2fGISah7G7fBnTVBoocc6lhXQziAnVPBWRcZxuZmeFdMfBaWCAUdPGjMBoKAczGYzGYzGYzGYzGYzGYzGYzGY1Oy2/vyzATMl4kW5tXtEFhZxgXlijYg+UtZfraR69YpW4tw8jaGp62sjgHR9BGDH2Bchm9bg5GDDNcdUCB619Om/TQeLYRuYCEJw5ZlmH10rmPmRWyN9lRaw6cIi8NgweLDp3hteCZ/1mKjeQDc/yUjsxJWoFm43gH/XLtj3OEypbByT7S8vsusbU1svBOCl5i62TY8xaoMBOowXT3ugCHw224neZ6wVsM3x0LWOJmOX8ATR2lgVsphWa7HdMTqOHFXZMLsR72QpPOfp7WPWGLPjjsJBMpu9OLv8aZcN1PEtzNvfgz5zSyk1EBDSuV6XEsAxRXr777iAjKdoWX5M78zmznNnObOc2c5s5zZzmznNnObOcbX8XDWOoMSqUHPvavik0m+MUKFxWO7uTy06heJ58f1htgEqb7Sm9cvrFBLeSeT7jC8c2j2H8z96vDqUeKX7qltut7woMiqihIrIzlRprOxG1FjfQgzb/2Fz0+qVop2kPubNf6AD2JrfDUkhBfkCnWCRLZ3TXQqpwy1S3R4eLVKXdc6OFti5v0w33b69uqCYGOHgMcxektmECcajhAlBcy5ahWecHLX2My5sZKuSTwlTegZCLkwYDKTA/9cEXhsYOxfWffZAtT5gIcRjp3eRtfge/vGRjlNYf8nXYb3HMChiABOEV7D9qWPARqlYnHXaprN8elXAYxtdmnnhw8iOuQyr1Em7ZWKff1WMcbTS+I+g0Gf4A8RVBr+7FKDg4siRB/q6waA6q26xc2qRsERou6aPNP0v4X5Vb5jWvCl/yzy1ZRGYC9UBeNAuX8G+cshwau9yx21P7QQZx8z8BOM89LAw87ydkQSL37PknTuyjjGJ1vhaVMTWFaImeLzKfx6RdDPjiA7Za20ILB6GQYFDZbJm4IMbfprw7prcKfTgzhA7KmiUrdWV49PYNbo5YpWHOpkORN7bFUUohuEVONJwxGzHFrPh5vqQwg2UW/rDcMvBVUIY+U5JQcHGUaHePi1Uc2KYPr1UnVKfHVGjrEXyThRsrHf7l2mfgZpgRErvbDFyK9Ksy5L6LDOgjPrnEyHas2f1g/tV30I41nb+PD7JTarn3G+w4Hv2mfOe8rnzCeR8+gR3jYaQxd6o90QnUHUXf4+lQKnqqBelzlcRWDOwEe+y9UyOW0KG2UZNIU6hHis/rJjWprTDsQ6+Nj+AE+VOod1sXhVa1BYKYeKkor9/9ReIjWDJHJ1yPxyB6qXboG93bMncAACJQNuiQ6GJcZOA9qD89d33HxRvGl400Iv/lH9eqozG6XRvq1Abz8iHrYkaIcS19VorNRcfUdfdIIKXpXuxd3MFwEt+CxPU3MWpXv3l6BIYTnRJzbbadvt1/Z8vVv+bMB/cESZZwS5KD8Ku8+uxpUhQcFB2q4II36qqv6Z3026O207UyzZccG62oBTUYqOraEQGVsK4PAJz+L9AT2y71Q39c4tYuJLa7uAHaVFSFAFoPfwrpXI+J/9buoFe1UlPVO+97LO/gDXWjbfSATeqZcjPMMgI3MfVVXjQJL962IIj5L0AvQ8CoLgSxqYjS3CgPC1e0Ps5lmV4jlnZRVgxIZFJ0nSdJ0nSdJ29wZ3VKOkhne301SbWd8NSDyT00nbOGf94IZoG5Re9tRJvKXlMzyFLdg0tAjK+zXvbDNMobStuetn+ECZilJjkFdFlojdvofXxp5YRjul207sVjj+gehxd9B/v/ajns83z24DmLy9+KFkvRJreBWw91fhvC0S9P0zLX5/XVai4bAJYzTI/LzgZxbGNb5886ls724JXdzAOE2NrdNAUG4eGYj23dF+gFUDMl43OZGxNSc4C2n5yn91XYYqkXu6DQH9EEfpJdyzlfaEUrzLY/3ML9ZmUPmfGRMeFixeIjLE9P1T38eKKjx5/JmlhFTnkHvcR4fTZvAMPaXAK/SdJZZSNkN37qmr9o+VgZB/568SWozS64okMgEqbP6OZjs+aVBTJh6yLZLpyjmcGEkl8pw0lxcvhca3fTWYb+WEjbE950LOJ8mnhY1L+ro9/vWjpaNddJd+PedKKrMI7ybjpnLdnk6yti1xNpXAAdNdYmmXiYXiH/JbIGxeP5NBTZOdUdYxzH6vMHKFOc6HH/2MZ1mKqPoGMh/0C+KMK6TREcmAlclfM53oJRFBRI9bfuoDH8yC0g7XHkze77FTsOv0J9plYDN7vS0NHdGhJ0jJdwqWZhFGg3GcMOLCpUmPfdTUCyCxnHMdMoYVJiGcC4yhev6X4aL+yz16+gEMlPP6PRRAR3RdXNNDkOQxoY4zUwFfwXO7GDPhR9f+7KYh1iVHi12PgDFDdopZimDnOBRHElr+BTKxDtYItl0rl8wD8tInR0D5tpDdtTM8Z4ExHSMcnrk+7qE6MPOcJUbWMJ6nHyBOrmHmmzVHwiZLK7kedJNnkLvD6frvudD1q5kb6rznQjU9VkHIFBpLb23IbR9Vel0SpvZtHpMlA8fy6+HXYz/bQtIsqscY78D256z1+e85wstZizF20h2lA3ZJEB7VxrbvGEaS/zacJg2HWa6EElbNouMDC1PQWt+8v4AU4TdO0L4sXB41cjSE2f6yZdZ5IypdpIKGw/tdC7qsThAlMLwBazYtcNfzgAGpQyWXST06GdsxXgKRPes+L7f6RQNAKnUg3GV1lKPMmi7cBmjfdfH7LVAq5GqrParParParParParGtNau+tTUsUzcEZsJI+cr2sCWxZNUhUDe7tmTuT7su4YyBkBnDJiYz3ytzimFRBoL1WOdlOl4b4sdAolWTH6JD7YoqoMoC80qEcGLjqo1xpj0ze2LSjETr6piJDxy4qPJz3+yvNkOQfcvt/KPmMQNiT2/f1wHVP4GsEd/BxSYVHLy+18vsnv0L8bHhUQA4UdB9tC2eqQIrAk6edGQ6TMZS+xGRd0meElExpfu9PzVWfoDcymK3xaMeWZ5sobaSYWpoN3bFkwDNNF3CWWFoqAU1/dGwLfmZbRwAQv5LC+92sgEuXtAg82+5MsE01nZ0XipcV+TS+HO++Joccpm3F+CPQisKmzNbg4oeDjauTPsriQydvAaq7DbO+e91xWsCRvU6Cagq24vNm2RbZb6THHzWLVlGMkqMWMCN21iHinbEHWHIqxk4oBm7U2vB0Lx1MN4co0HlBdKlKQDNZCUJESG/OCKLcTsxgr55OOibDHw7TUF5F9dXcYM/W8FjAlEojQpwJQfFnZGokdfSw9R3VWyzeWcMk1CV8fz9UY7Rh36bilu21ShtT9Y6Px3Uj7QeIa3J84VH4tBelq4AAAG80wh5bdpuQ2PwMBP6vYSlBgdqCoNvajaenSIJ6AMdp7daKTmqmiHJqo+azruOO5D/CzjNGdytwEPJ40a/5YIllGDIxwjUR627PAKd+LE8cvlM0G3i4SktUeO2ST/CxG43OObw5i56r/jB4JENZYBe2xoaAxuMaMgABUrI2BWjgKSK7QvR/WcB7V+g6Qe7ZdomA2622hfS+8rp2Pv304kDs891Dw0LHdFD4BQOmCoNTmJpymlsJoEY7Jo0PvSzymvkSRQGiyyLSXD5q1OSHJWbvR+9BY8MrsNwderdYOe/t82E2d90ESVHZd7M1gTMRiQGMf7fy0A/DytibvAxdxx4KGobNEwuCyFS3ybSCVByRmR5h8PtbzMU06yYj2HHee0seZLP3+oQnkNy+v4sYSySOop1kkg13w7ElrQ4iA6T/xw36l4ZtBa0rnAAArTK4Q3sA+HkLWVftD+nB/HJQewWnBB5pHeaVRc3UUX3jdi2fcvaYw0knYxXUUSFf68Z0nPutfPanUfr/tltuaqNTIpnb6XR7VP9P9oWAn9sla2fAygLD5hl0OPfPtk0DshEDZKCMCxMPIcl0XX+RfWxD/naOTMghqAoaoV4xWP9fiYbnOfzB4iWJY0fWA/hlFhFcaNnn6SasBiJfzoAAINZMMwGPqIt3lZF6mE0qU1Qn8s53m7HA44e610I75dQ3FshWmTbRXRZ37pVIEAO42zKuC4ELC8YQmHAc50FiwOlkk/3/AABqLkq3V/vZsWyGCGdqpLlNnGDN4gwyCv1MHIW8WVF8i+RfFxiRYclAIXw4BfMxDAzgSCE2WcO84GB6pTn5nUCwgXV5Q+wAASXVz9x4uQwA4dRaCdexVAbCT1wRSTfRArFF+kferkrIdM3s1xAMmvNeUJ0BzO2j99+x7BgU5OxN+KN7iTopcvlWQorNTs7QIX2AdB6V+bnPiME5/ku981AKADrHDLSBsodUngF1L+rcboCh0vUkXbjtsh9zyB+AzHbr97sABX6nOPExVxFr8vCh2N+S7mkv94iyyCfUotkSInFnIrqRThZuSP8u1IaTaeob6tpPio+1OCQ6u6p8RYIAAvFenllJihZIkFPyTfOoA8tFYKAdFcaYqn1kfqT1TEcQWdOcArU31H7ohVcXXmsn/QQbj2GZDTuTgHWK4iqxxIYOo303rVSHx9WbssUGGkH9jjTRph/145YZH8gbsO12EdAAAAlioFH8IAnaf8EwAb/1Kcqzq1lkE42+oQ+EHfjhtP0/hUZvYZSxF2Ccb0EkrpEKdGt6Hz52u0guAxfYLgwxOQjjjjdHShk2tut2+R4qBQYejFAU2fzIfFmHdVAJzHHOZ/97ALw8juHDaPmaSUWqAAlhiLG2ObniKv1vgqTihjNBFC+ef8C9ShS5fhAHO7IfWOvetR+/f5IbFasdMSP7yA4jDwFg+KEa9HBDHV0g7HygMcdJKGdx17MaHRwb6bS6yv7jjbcKkWSgorDNjthlpLZc69yFZ2qO6LLxn7YkPZMm86SaGDaw31zJCnjYq0Eqrl9+6qSFtFYkf6aSc5HedXou8rwYfR/zTr4pHepVoEAs6tX68HO8MFk1gT96aVBHhEMG0q2VTRfxc4xoiAoLAa1ok42vuR5q0QeaLo6uURXBiLtPpd/7srunPljIQhjLVpPN2YVthXYRUgtzvCm1EEDhvpIZ6wpdogTkYlYzMnBN/9mbUq6C+AAKqNHW2wY1zgdEo/4Ie/o+4Ppb5TiUmr8ierKiIKpjq+GlCOsnbk7zMD9uinYX+T7IkUAFesXeyRnFMHF+qtAtXQAG5gBwhhSs/7KVWAWS2Hyb56X+2NTzR8gke9oF2PPqgUVGSYlOCtJtqQAy90+MkSQwSRVoZXn3rjMgR1fldedYI58BdJ3j4K5uRuulBuO17QOilm3H6ktYPAw6Cl0G5qGoeMGzdQSy39JdiUw+Xi/72EBwG53DnCsZJajyNNOQoOFuQhmP7UAc9dtrSRrwYFvTBLobB0fV6gXyrmuOkzx/87vI4aHTQbVd0dq19bXTVnf3LZqg0Tgkx+9L1XOW8rwj2LRqtUbFIftUkMKZ/lJyr8cp8poFUYaMAigmzGJrLd4nUmcDpF4PWIdEDq7VbWsPfbjeeLdu9qJAvKIvCmZedkPF85RbZki5LGS5Elp/k0HzlhmH1X4LevLA0A18K1x/BQ6mctOLkledeupXLgCiruS5546zZOeo0X2LVprck6Zpn9zHx3T37IQ6pGKlZH9KBh4FjXlv6/2+N1toXI92XILZuxvikBz6n2nBonaUbLggcLuQA3Ot7rrl22H0iQkyaPsYb58IQKwA9uAA40Sq/KZVmO8b/0xcyN7y82pfX7OfKF0ZssBJKQb4Un7wFfr0qvaXL5cVx50gpMwAcVRW51a3QVMHOeCfMgLDAZarPKyOldSj7ZaYq/q0mLno87lBq0lMOmOXLA8BkVqoKS7AEIod79HKntQBF48Mp827L8SEnAFMt78EqlG3IbqEW71wtVhpK9cM+5u3ToHQjHAbMpSdB9tzfHrmTuJdv2u5CXdg+m7LcM0tepSEgsCUVcBUf+I3jAw7pvY1d3QEPJ8tR61CjVan/kuL1S/mKPoc7CaXfRK/iCD4Ba8ot5s7IyxmmhrfCyRLpWCXV1XzPubTzxVAjA2i9yJL5DPpZ5QFVSvPZKTLVf1K5jz7jGvMF3NWDMgcew8T0THiSmkgz0osllEEaWgcjtEW2tUFFrZg1pDyoQWRViK9I+TXyGZ/guBTIOtlapT3uBzOmFgXukZLhLJElKLWWDWCgGf/GjnP3FCaZsQxOZ9705b85GpYR+j//6quEYMsgWJ3PsG1GCTXKRryh0BlxLxNuG1rnUKQTA4VVU6nSi5WmI9rV9f5GLJ0k9937BkkSFTPWFDzzOg/huheyJEGq5HfuLMueOvCWifWe/woN4/dFfX8+7vLhLJcAeoGCTIwHBVUe657YxqKvnpM7VpJ2J4Lii3VQUWd9DnTg1mP0ZpMYZGVd3i2RqeIUiWIe5CAcr0RGEhjCejfS2ILC2JMCJlQ+UiXJcaHlBSmYG529O+PjpcoU0GhKzsMPQJcLKsrfdBrnogsifdjDyYQKNDDJ/QsBLDFfOFiVHOOdSigKrQfiLlw0X2iDj2XdXeZatzxlCbdoSOAQBSuODEdpblPn/c3TYYcrHudVRReRperE2GfAkq5YPU1acT2poqOEBK22/3ZkAFonD4RbDpirpsxpLC4Dp0/zCuUhCA/o2Ts3xOhRGW91V/2Zi8uvXce18NPh+/IyuhtFUHOwba3jRHcxdvyv2G4fsVigRPEsyIn0vqFQ4z94wc0ctVGqnS2hXcUc+CLKq1g8h6JCjzhyRakcwQxsr2Br/7Wl3QHVeOWZL54pz9dpVQf0Yd+8R/ROKhKb0QSegCvIVYT11A2EapgAVE7Uy3wAGrNZOTFd6AAAKUZGC1QRCBoU4MQgc1VyJrjm3gjIVJuolvaN4jUche57B3Nw2pVMSNCi5aZmFodbp4EWHe0rCwEebwvk9z6maRLM3ipFdcdkhGHXyE2YVh6yw+0HrXPbiSNfefcjp2EMxga2KBMVpiXSI6XBL5btZ84w0pd0XtmDoh3CMtDXcHGHfvx3NxHdna2FAtcFxejj1nACgMv44coIxgCEZR7kf4+lAAEffdoL5JZF62L9a25936QGZru8gEQx5kYn2vtpMgK6Yt160H8wWmByloDwbpu8Wy3SOfAO456Nw2ldW52uLL9IE7Z2+3TirfQ2alN8hFtLjivI8AnZmVBhy+/kH2NQyFJ1ytOHfuBKrR/tEjkXpv0h6Q34QQcykTxkeairDY/M42cF/ctF2HPlUJzMZtCwyOPhmMZDYgvGxZQLL9nGdyWHRnQ6wa1CoYJEEXRXI8QN76vUPIydXkAyqI9W298TeXIrnjUaoDVFNyzV4IVZjnn+ltD7BLPq06oTtpt/ZqzgRDgDqMp9cfsXVC22UbjVrhdo938kKqbdu1heBNfS7tApSNzWopBV0be76V2tDkgZabrlPY0xlm2+fALgRXl4Q+s7hltvvGV4nPfYkRvjrA4jjOHyn/MCniADuu3pmmAc64XsGNLiT3d2Pbnk/FnRSDjWjUhEl4ubwqPbhl4L3g0D4DtwZQAAArki2gDBsM3igT7n1JDThcvePsN0OXDXCRC2NQ9+uV9gzcd4+/nPHyQTgJ2X93W9WiTqBg/B+j9F67pIOd+B5XO7wlUpExSHSIuaNhAg1mvgRiJlGAPnSu6jCo7g8I8Ms9Q3K7eaT8FdPxZBeiMrRpuRfLbl8ZtDWcYL0+BwnoofbmjBmpHagAn1fOqV1vkHl+dI20VNtIPz3KjARPQ/GIr1qjetkzmGGkdON2d5P3Ye8pMhGKAhoi/FaIJkmXpJkvzx6fJoq7y9w7IiL4c0zyIq9WP2fa3s/hYxJ/w1FDaAdAf7GSbfo62hbe/Iq63sYaaoCl4Qz3xXb5iLC8zJGN7mxESbed+zqhZcOSUixs8oprhNkydFaPk7wxOTLJK4rlohYqv24obAoOmKB3d3gbaQL+ZbuTfRr03IHI0bQkbeKYSChWiJYYI9gUcmQCVvP+L9b7ZtRk/NxvEgAAAAA==" alt="Agento's Insights view: cost, autonomy, cache-hit and tool-error cards over Claude Code sessions">
+        <figcaption class="shot__cap">Every tool call attributed to a skill, MCP server or sub-agent.</figcaption>
+      </figure>
+    </section>
+
+    <section class="section">
+      <div class="section__head">
+        <h2>Two halves, one window.</h2>
+        <span class="label">What you get</span>
+      </div>
+      <div class="split">
+        <div class="sheet panel">
+          <div class="eyebrow">Looks backward</div>
+          <h3>Your history, made legible</h3>
+          <p>Agento never asks you to change how you work. It reads what Claude Code already wrote.</p>
+          <ul>
+            <li><b>Cost per session</b>, priced at the rate in effect when each message ran.</li>
+            <li><b>Full-text search</b> across every transcript, ranked, with snippets.</li>
+            <li><b>Session journey</b> — turn by turn, sub-agents nested under the task that spawned them.</li>
+          </ul>
+        </div>
+        <div class="sheet sheet--dashed panel">
+          <div class="eyebrow">Looks forward</div>
+          <h3>Agents that do the work</h3>
+          <p>Build one, give it tools, hand it a schedule, and read the job history in the morning.</p>
+          <ul>
+            <li><b>Agent builder</b> with system prompts, tool allowlists and permission modes.</li>
+            <li><b>Scheduled tasks</b> — cron, intervals, or a one-off at a fixed instant.</li>
+            <li><b>GitHub, Slack, Jira, Confluence, Telegram, Google</b> as in-process MCP servers.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section__head">
+        <h2>Every section, one keystroke away.</h2>
+        <span class="label">⌘K</span>
+      </div>
+      <div class="grid3">
+        <div class="sheet card"><span class="label">01 · Chats</span><h4>Talk to your agents</h4><p>Streaming turns, tool calls rendered inline, and a permission prompt you can actually answer.</p></div>
+        <div class="sheet card"><span class="label">02 · Agents</span><h4>Build and version them</h4><p>Prompt templates with variables, tool allowlists, and a Claude settings profile per agent.</p></div>
+        <div class="sheet card"><span class="label">03 · Tasks</span><h4>Put them on a clock</h4><p>Cron expressions validated at save time, so a schedule that can never fire is refused.</p></div>
+        <div class="sheet card"><span class="label">04 · Sessions</span><h4>Replay any run</h4><p>Ranked search over 1,000+ transcripts, then continue any one of them as a live chat.</p></div>
+        <div class="sheet card"><span class="label">05 · Analytics</span><h4>Where the money went</h4><p>Cost by model and project, cache-hit rate, and an activity heatmap in your own timezone.</p></div>
+        <div class="sheet card"><span class="label">06 · Gateway</span><h4>Route your other tools</h4><p>One OpenAI- and Anthropic-compatible endpoint on loopback, with usage and cost per request.</p></div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section__head">
+        <h2>Three steps, about a minute.</h2>
+        <span class="label">Install</span>
+      </div>
+      <div class="steps">
+        <div class="step">
+          <div class="step__n">1</div>
+          <h4>Have Claude Code</h4>
+          <p>Agento runs every agent through the CLI you already have, and reuses its sign-in.</p>
+          <pre class="code"><span class="c"># if this works, you are ready</span>
+<span class="k">claude</span> --version</pre>
+        </div>
+        <div class="step">
+          <div class="step__n">2</div>
+          <h4>Download</h4>
+          <p>Pick your platform from the latest release. Updates arrive in-app after that.</p>
+          <pre class="code"><span class="c"># or on macOS</span>
+<span class="k">brew</span> install --cask <span class="s">agento</span></pre>
+        </div>
+        <div class="step">
+          <div class="step__n">3</div>
+          <h4>Open it</h4>
+          <p>Agento scans your existing sessions on first launch. Nothing leaves the machine.</p>
+          <pre class="code"><span class="c"># your data, one file</span>
+~/.agento/agento.db</pre>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section__head">
+        <h2>Built for the desk, not the tab.</h2>
+        <span class="label">Design</span>
+      </div>
+      <div class="split">
+        <figure class="shot" style="margin:0">
+          <div class="shot__bar">
+            <span class="shot__dot"></span><span class="shot__dot"></span><span class="shot__dot"></span>
+            <span class="shot__name">Agento — Agent builder</span>
+          </div>
+          <img src="data:image/webp;base64,UklGRiq0AABXRUJQVlA4IB60AACQqAKdASqwBO4CPmEwlEekIqIhonE5oIAMCWlu/EIcIEJ4Xz/cTnPnmZVKSrrmYf9d/KTZ+/FflL/QOrj6vlfubeVv9/92Ha//PHsAfqN+sfmge97+lf8j1Afzb+ifsN7sf+h/ZD3M/sz7AH6q+sf/r/Ym/cb2AP4758n7e/B7/aP+h+5/wG/tT//9Z68hf3n/D/tF5l/03+5f3b9rf7Z6W/inyv9t/sf+U/3H959lX/E/x/lL9H/hv9j6D/x77bfmv7n/nv+5/jPaj/a/3z8mPQ38n/Uf9p/gf85/5/8/8gv5D/K/8j/aP8Z+x/xMfGf93+6/7Tvbc6/zn/C/zP+a9wX1K+c/7r+7/6L/0/5f2x/U/8t/cv9D/y/8P////d9Cfkn9R/1P96/eD/B////u/oD/If6D/nP73+73+E////6+sv8d/xv8/5Iv2T/L/9D/Sfkj9gP8o/pv+t/uv+l/+f+a//////Ef+U/7f+T/2v7d+1P83/yf/f/zH+0/cX7Bf5b/Wv+X/gf9F+1P/////34///3Qfu3/+Pdt/az///8AUtrLkVCT9Bu3vJrAViS+8K1tv7+TYWVVgH275NhZVWAfLPl+qaXC8RaqJV58K2bqkhNt2DzA1UmXfJsLKqwD7d8mwsqrAPtTgxl4/dRjyrXfvLCAYoMSzlcEx2h9WsJaFsqrAPt3ybCHAI7q4luowBh1Mk1N3GuUu/9lEPyVo41dXCdgLBuBCGSionqG/qaw4b+prDhv6lKQktC2VKuUeyA6AZkdDN3F4rJxHIbvISH6YhUvBAUfw+0T/yTQuNbDCgwkgSdhlecza2p+6JFyPoZyYg0SvElgXHI1qhs2veusRKoqGW8Q7htW0M/1weFQxZ+X3L9Wsa+2J74gO0JC4Q7r+3UCUSNZXDf1NYcN/U1hwoNn/BxP+hwI5jj823jGMrYyPcTTx3VxLQeJtruuRGRg4jKOrzUdAf8CPfty7awBr6uvHSawrevuF8fz8IkpVFmbpuYrHnejNhuVjOaRt8Nt2FF5gSTwPmD6HpNvP/ky1xICUdH7LlIEsLGbWq1KJ3nUBzHc0AbPYi0ySLtoL5gTiFVtB/0j6+8NY+ypcsyLRofHAkZo4CocEd/edotlVYB9u+TYWVUse5JD8MXn0eEcUsOG/qavSk00yGWxizpvcAQV0ybZzfZd+GGzbUn6Q/LxUeQkqjJwOGtXHqZYiQ4TwcJ4OE/o9A72pUbrf9UFXA62J7uiMvk+zdSBhJ0jXmkgLD+/gSiJ2B+c2FfxIjuriaeO6uJp47q4mnjt8wVEcB62gIVwzAyJ16bA8z0HktC2S4qynWlOG4ylqJc8akI3pCmeq2hNA7RP2Ct4m+B5iTvXBpAk7scCut1fWXx7g3slshFip0puW5Yl6cW8QZPcCkuyLT0azP/AvsFJUTpk6XscmEHr+Sjt/EnmtwkWhbKqwD7d8mwsqrAQD5VL7QbzYSgr7yVv8wLVDCYvE6MEge2KS5nJ1fbgzF0AH879djGiv3kQFKKoRLQNl8TmBU3+YbPYylh4DOuaIgRUcSdJ4ACVje+czO/6QKvBdcQ3Wgf5yJrkC1ZPDsRqmzEhefaZ7nzhncDvcv9be220S0KxpHkPQlTaXFh8QWAs7P6lXYRo+xvJ5bG1oKQGBUqtSk3sMVBa1e6pO3C2wqx0j9lUHks1buIukoOLildmTvfrlDACt8lxLQtlV2fL9X/C3LFkiw6NjzbO2uE2p+rZDmu7oE7ujZnkKHcxwxBiJ+kO5mEPe2UyHlFcOT9hjRgvjw6nWJWkC7JwKTyA8njrcSXzwvvpjH7OjPxdh2TMhhEkHuazNSkJSCWHlHUbzRrp0tsqq/wXQM6OFR7mk75ULZVWCxLlxlAiteYMPxj/uh82BnIAF7sNWaQ3qvXHCvYAUtcikC52ro2cLbjUg7X2wxZaJO/strwaLMyjuoin7ANBymxU9ZJqCSa5DDwD7d2PCHSTvwotroceafsByWAfbqCNqzMyW3r3Mhz5PqmkqHzCvKkHk9DdtHdEWOXStDmpBs62I+ZoAM9W0UxMgxXI4j2XK3JsK5Z/ksmWfkfEuO1Zn8rau7IhQ3jSEkyYsmqfe/3DjQfj5KbVNoSSHkdsYSfIJm++TYWSQuBJV8EjPilTy5un5ZCfEV6ekZU5neVF+GYiRa2G4slV+WR/+VTzP7ckhrAPt4Kg2vCq3R4I62oWbBC5lsQeFTSYVSElVcEv4b2MwtSG4bsd8KfixY4ouv8MCmX9GrquvJoyzUWWxyMJL41/Hcyq6ktySq/I4FS0ssbzzebt0D4qog8glsQ1q/6dsdru0Cghk+f9XfXAxTZVdoUhJaFZGPta+RRG1iTJ+PNhZLcSLjtYtjkJn66xbNcAN0gkhSKrKFopEs4Yd/P5+2xl2QTIwbuLcRtByfneS7imdLjR6WDWd+7RS/sfuzI+3f4P5sVE+qjhJrp/ZPPE5NT8JYc4Yl1Mz/wWUd+2qVcWRLvlS0HFD05s+5b8FfwOezu1yNU9ySFbUV+lD8OLu76JyOsrYgDOm5jEAtxXTYWVVeb9EQ+NBbRWs3AeQwL6JXOUjoNrhqy5PAfWOrjzD1/hW/B04qle7zwKfZMBXCWwlGlsqq5fmtWaBRDaqjCuuUhJaFm2fAbvVQs9DJqN/DxBzckfDo42omQccqdSTP5KICimqbo8O9IcXswIxpLvtbPyXGBi/Dnhmuu5Ku2jvQXrfyoaqkHktByiAXoZbkzIuirZOgfbsdHOmsN1b4akJZGazH4oBOGq2vCyl8DooB9u21TAAqB9zbaaAqe1++TXsM1DMdDYrWeKaGG0SbFbDbH/tHs1e48N1yzNNE7OTCn6CQWnaiU0+ZIJz9n1dKNvB+kHktC1U84l0HDxn4XIjCkJKwMzESun+M5/WlBohetFzWoC5EJZVWCxL3AFCJrTWlz1t/SnpnBLZ89obWd43LaKBrhAMbkaToSDc80WmkNI13En7rK2V2sG2e1i/jbsqrAUurAPt3m5M79+AfCwTaufH9P/j4sIgigdT3L1ixwD7ZOK9E9pZARIOiAyZSmc/cmccprYgyioIJ8DXWCPACGyNExmZ4ClygQDvXAXxaQsSJ8dltE5hBvU3sA+rTFk/TjoZfYag2zZeFIkZxePOd0X+l2X4f4aqwE2OwbnwAMHjGI7k8eDaDH6XsA5oNL5KprGkB5wImgbqtcrQKeEPt3yjyzO8qLkpDFZXnVs6DRcnNkZCltjgrjW1holcxUJ+V3G1bVOyMrCl9Kyzh1DdKE/A2QCVE6BUvgcm/AfeQFjx80GYOOFISWgsVOhBOd5UiKj2D3r1alRyiCcwM3gR1z3SjQhPsiWohI/pBlIyCNALqyLBxiE9HV12PLfdp1J5K0LZVTeBudDKQhJqgin9eR3xKvaU8m54mJeYB9r77d9BWBKEiga8g5uZ62FlVWQ472GA7i7kKuq0MiSGpsQC2VXZ8ZcFkuU++3a9wXHejSVHZLMQgX4dg3hz89fQWKqwWKquUT4peW+k8Lzh+sDWCndykphxe/yEByiAY40P+zuP0toBS9+Xa/2D8utO9pXaLAE98uZZkwAC9t3FLvKkHktC2VVmi/6G/JH0otwzmEXnHqvzEXLcneF8bvk17DORtamX6cER/uQhYJHv/7FN3CxBtMtzpchrkTieBS5LQptGjKqRE1iBlWq/EgYEkUSXb9bK4lykJLI8SZmKS0VBEYOmQzuQeGPCGEt2PN/41WAfbvk1m1P/NMUpaEH9otlVYAtkoDXRFm/x/zZ2hdlE6o5WjdTwcB8QFmPhE96DJEa70dR276OQeS0K0WGELamfXenW8FqG8MaVUDB6E7wYfuvAvAXMLrvKjZE0zpq1VL2V51T/BIVAINf5Ug8loH50Xq+GN2RMe6wLnXN8fCKboGS9Hw3xBjrYPu/EN3Nkui/52kUGQBCDtdQK1I+FiqGTYXSWhvQiC0CYGABQi1uAZD51sF5Qg3OejkCaE2QW7b5m61q9aZqUnw+yoehAOS8IRGTzFuVWu2Z7DoTaCAvRRfRCwB6UKRZU8pC0LZMCGja5pjiRH3EtD6gLlVRt7bwxb7NH8oJXFQDuE4S67lDmFhG68oZ7nVqeoUITROwGH/UaIU0UplSDnZ/xLZvBVOAK4eRret9RovVb+92/bj66e96gr5M4WA8fkkNLuvpQ48hBUMn7LsoESnF8C/ZoAMB6GqcEjl1Rzg2jOzmsCrClFVQU1en2qKkqzcm9rB+Rv1U/m452lopzqfT6GuBDXGQ9YqTp/BxqirDnlL6LTXr0/ESSIxekDVfJOAQNa5oT9uafm36Uu+3/4pRh8ouAIGNh4B9q8oBumdku1LgXw66pl0mFZAEm5mFZUTr1LV3vpS3QFiVIVs3UkKQkslNIt8WgKsIz1TOl3r8Y8K/R5ge1PySXYxYdGm48nprqpQL8LKE5sdh9gY2VulrY5ze71vQsVjxn5OcCsXDB+t/ZhSieirHytYiEloZbChH/dY94ueA/2m0rZVWAfbvk3ShOJMWn200TC+9oTA0HKsCi2XQ6PYk90IE+LLR6md5Ug6620i73YNNu7MpgE/pfQFGpu0OWrJFl7GvfCUvulWsnIF3TmxEQ9oUhJ6oTI7pZu+TYWVVgH3l/veRzv5SIxehtsUnrd8oJdufplm75N0pneVIO2brrpndYQTfAraE/9gRaUJdKpB9uxqg6ER8+QmYG4m4tJvsW/82FL3TYWbqSFISWhbKqwD7d8oXkCeYlXKiYHW1Ih4D6jUK9iwLl0VJxQzpBqT7M49JuJi0Vd6gDRS9wE0yF6bIR2TXBGh6md5Ug8EdIYsbHzVU1iQWJNYy48hCk90a6326QRdV6HM+r4paXxCQR2GLxAS+0J6V5gZxIwGdKEgnd8m6UzvKkHktC2VVgH2/VANMSsF0rS9yGDB51gLEONye1YaHUrPZz1MK0vniUeooa/En4at8Vd0frrT3wbFN1JCkJLLqEQl45bUTRFiguO1OAGS/6a3ERcCGK1j/wXcpySYook3CS0MtneVIPJaFsqrAPt4PyFO1JMqT9m72xQPEQffE5jDnklTg0tMxpnLVUg8loUsJI6qItGKIXwsQw/Dgboje7p+Umdpojz1mWpcsPEO7cC+njfiOieL2wmvynm/WNLAtlWAgH2Afbvk2FlVYB9u+jjAarQAwc5ynJgI6GoGKIrwHUOqfuexWYBQtVVCuCNfe63jV6ElxL0HY0hJaFspuJvUF3zlD1B37YEhwxvmhBJbEA8FtOqhQueuLuxkxoWlU/+P24WVVgH275NitneVIPJaFsqrAPt4P1GEi0swimEOkJLQtn9Nq2pCS0LZU5Z0zZo6nk6khSEloWyqsA+3fKPLM7ypB5LR6md5Ug5tgUKBF41cEo1LWrGDkBZHkiNCHlZkg00URNxjTne7SaEvgkqMXHcT0M8A+W02qaQnSH41C96PmomA6XQpFG2cp8zKs+sAUyTqSFISWhbKqwD7d8o8szvKkHktHqZ3lSDq3Ikso6MsguBu2XDDv+coiVnj01SITGL0gar5JwCBmERmx6md5Ug8loWyqsA+36A+3fJsLKrtCkJLQrhkmCugw4ZVHsfsJ/RtOe8Fv8P7mov8jL1n5qRpGVUn924D6bSqMeptwBOLkdWBa5AUOiw0AC1I9howV/AIUJ275oYMsDhn1UuRLKq0OkJLQtlVYB9u+TYXyCSFISWhbN1JCkJLMX2cwZZNoK47w6Hc/kAMXBNI3yq9XhLL2Ne+EpjTkesorHN02yqPf4cmsA+9mA+3fJsLKqwD7d8o8szvKkHktHqZ3lSDtnMbATdKQZoZs7H3J8Gx2Mv/4Cljgg6DVoSQtTXUg6aC98vVFkFBNkMukYcCrTQeAgH2Afbvk2FlVYB9u+jkHktC2VVgsVVgH27o3w8jjFEmT3lAH7uYrMlXa77A6vgBQEYpaFMkZqUj9Qslq5EiUaqxsxCxcHjuHhh8MT87ypunAfbvk2FlVYB9u+jkHktC2VVgsVVgH267wG1AIusJl+tj/ednEii4eAgngS0LZVdoUhJaFsqrAPt3ybFbO8qQeS0LfIJIUhJYSSGauImwSbkRzHWfr/jkfIQnR4h62wTy0A3tMngH275NhZVWh0hJaFsqrAPt3ybC+QSQpCS0LZupIUhJZKuxpTuDwVo8tQ3kbWjO86mgbI7StlVLlesTmc/ctcmoBKf1MqFHLCV2Rs0D6md5Ug8loWyqsA+36A+3fJsLKrtCkJLQrokzeJOHJ6NLHsM28FBAJsEGyZCGoPfRwxJofwoszvKjE69quKVGAlGT2Q65f6hDnKEXYX9/qA8JNHMXe416MuUhJaFsqrAPt3ybpTO8qQeS0MtneVIPIOOQx5C5ddck1xQRmeHy0aicEj7vbKDZ9hDcVEDqjBs9oSyZqgRPBpk6ZKUPExEakLJ/v51IQeEN4P0g8loWyqoYZgwOG/qJdWEloWyqsA+9mA+3fJqYuEWK9siZUjHnKSoor7+d8zDOimZiNrG8N2nQE7fvmRriqY2EepChqQeS0LZVP8yPwkTfpnBUDB1I8N6Y+7EH275NhZVdoUhJaFcHH2KewSu+dssejTja8aXnuYBwpoM4B+2wXq2xQ8A8LEdApw59B+CxPyRFN1SSdWTdi8oyd30zKLfK2F8+z5z2QiraFJYzbMAq6bVEkp0/7Tq0m6SXtc002VxLlISWhbKS81sdgVKQgiCEx144z9tt48mwvkEkKQktC2bqSFISWYvvwRP6sHrqxysNxJAIi4IY+VGsFW8af86/D4+gLQdWfE8UKafKkHoakHktC2VRr4tbrZ8Ws46wh9kVQTuPrQ2A4XUCfp7vIBQKPZ8prH4WbqSFISWhbK4lykJLQgMuxJurZbyiqGCr0Gl0+PIc031DvJ1XiYE9GLBbK01bv1yOi2YsN1s7ypunAfbvk2E3EnJcEVEiS/uavgDyv8SWHDf1NX4HWNCO6uJp448VRqyCQONu6L02okAOnhkXcjos8l9QlC9Eo7eHgrZa78ZFHMyF9CDIAcu8mmTsZ4l/IjuriaeO5db9kfUelLkdF9WOS7CuLujy+I3q59qJvWv5Exe9D7hxknxbY76LnEBVeEPXw0UUHOA2YgS1q91BeEWXPbFi0NW6D1qG75NhZVWAfbvk2Fn9OA+3fJsLR2cB+DPHTZj6RRyc3ADA2763gFLmeGtHcAeFO+2T/3lpP+a8YJuNkYXgFYz+YFKUYAAD+1AEswvSAeJKfqSpbLpzGZhwmxbmjNN60r/lw/C52Sg/I+FUTGwpvrAuiH6P0YMG/GY8bJxX2d5AI2lzlP7hD67CarDbRdH5DLYsyHOqVxHtAhiy1Dpo4Bta36QGUE/6tbVS0Hx96BrjaSq1uAQtfZM7dWj7PhyP1YHdsb3gF3ZtNYwDGSnXPRUyal3ikqMU0T5/a9J1g/JW8rrNbaY4mxdwBSp8H0IH2KLipMv/aFJXDtJ+JdwjsDEvfd/5nf+Zcxd3GhRPLwY2eCFtT5ZuHM5ykuR1S5rvPjHEPXp1/P6onRyWC4gAvTplwk/+h93YdKlXxv9pSDkNcSLC++eyOC1JGGCczG6peNM2p5YCjCi2xdJsXNBBcL4qNxF/f4Pqj1KflJPJKJFQvAb1oAdyI5YCwK7/STyyMJw7UURrSy67bOiLqX09CJoS7cFW/c3Io9PYX5kLpx7TkKOCSkYjOCRSmYKihnJ6GLNp0qvWZWaAqfdUiHwU3Gu3lkswwOmcaN0ATnnEBsBgqVdkCF7iDJ/dhkHQoKZC9iT2EaS4kehXNdSGTRio3MhTiKAF6xzgGe1kR8kFFwpRkx9Ld+M839yvH8EnPhKwnWgQwCpw5EhrShIRhkJrPpd+NvETl3NJWCII73gk11y44q2NmRGmp0Ry4dxF9eCkP+6iNkLAMlUcnFOTvYHJuKcRQCm/LHK08d00ahZ+HVxVPEg2iAaJvD50A4fK7hKPh55LscuJBXpOiRqsmrPot1WU1IZXzwIpHBvaiWJzh3hURF+mhiE2xnKvmjOnllKmnbeEFEt54jTQtryqtBW6+717S7J6xZuUEqu4OWtmu85lqITqp1LuJK9T3tVqdz6OPmAn37fPGqNI/rnDN5Or1M1BP4RxdwCFFFs2OdrA1Rg/K6tzmu/zu0JgA6dzSCI82exxIzb0OSLEfg2ytIWcqDazwmQ8hodX9SloD72vWLVw4AjQTei2HRoQA1n/7otz+g1uzaUjA3EMZlyoU/MMeo+CL+E9eKs9Rf7bnBc7dGbv0brsB/SfvpawB6z5RlWbCB4YCXTBgHY03ZERsX0RIqPDfXr5061eapDk15Qb3j0Iu7tSwpB9eaMastsDxUB4hfcG3Ye0HE9pHEtdm1AKa2TLx1Z1ixCvxMqUdW2fpB7MeNT28E7sMBQclZEmlpDn3G1Hkt+TyWeKFGwPdIc6re44TX6W0FXyP9c3v/rLT+2yxhrt7f/oI5VP12b2cblMzipE8rjLd0eXKJW4sAFn1OBVxTpM2Drg1wBsYxVvdKdk3VLp+IljUUuY8N3aoH8u+oeQqnVHzepH7n1qyUXc9n8He7FpQCYvPMer1KES/sHgfrQ3uy+Tg0v++GbYep8tIPz06LyRQ5+KVp9vWEPlBA42aPVUtY7RndEGPp1evRe44jDMQj0amZxnlj4nConxOIMapMF6f3NAH4O+mNiDUgWzx23HzCNZmwsKbxuC50HUhHhD5nmbcu4tF78zAvL4MM41ddspI/ir2VOlaektIqZy/BpG+vFHW2EXEwid61+ScxmSpU8vybu89ZDYT1/+1rqm5iuqttcpNQnlOutAsA23nxubm+zaXCK3Ilu7LGrW89g1v0/jALmFhuwGzFpGnAhRddV0QphxSpCbmU3QKfDqN13yq8eV2sqzKyYoyJ5AMuLPZYtCv1Ac0ulIWIWN/M5/Q7frA3sNPUlFnerkj6N7Uj+LjH+X8y7LCwJF1NXSjSWpwqCXbgZCI2l+rEQaXd5oJELH/H/oGiCnqldab7nlZYN/bg0AjVK+2iXCnB1c3RXNo4+pC068XiRF4OcNcZuEky70W0Ge4BNJDcUwDhXo/5fVjtG0/8AT2OS1q3wPSA+0lU7qnE+eBRbFPH5db8gw0aH0QzzWAPwF8QbYe3NZ2je8HNOSVl55mF7Ty2cy53UyIzqIY/VHbCDGEVSL/r9+45sPZZjmwumffd4dmqzRcmIa6bIKBqMou0IkMRy41bIssx64ww0PVzlhADMYAnof1MojvX79+kmcVrHK8zbDE6D+bQfA159TEWHlpQsD8dgC8LhCexSBzx5LeXnars+0WTiu9V7Df4sVFczy/+S1HmOhNFSnt9IeAwjYos38Aa7B2dauGj++NVztIIodGhqN4uJqqTWtN4GTTKlCXlisuLAbG+wENB1+/vUhnhLyNFD5i0FoBeqXWCu1nL1+Rx6th7AG9A4pmzeKSwcTi+zP3JqbC2P8+zVZWd/l5OcMoMXh/vnk0A8EdVvR+AxTaj4MrdmdgdEAjpbCzHRWkg3EM1LMD7IYDejBQRvEWwco7CDMVM0za2wU3gOwR/kYN8r8MKuCwuUVXSpyEsYt9J9aod2HfxObzRxyvHfK6eQ9ttfdeh1G3JWWkABI2DtNpd4DnkZYdETgajeUeoM1U4THm/K9X8RHMHFeWXYGIp1dGWFLhtuBtoaWhyyaVBLoh1a0pG5BGbBtl7dCmrbrxZBq4fQQ2FQJxkV2JmyVf0f/e5u0k9iX3RgVhLVtjwiO/gPf41axv3gq4yHZt/q1mKypwa1U1YYgR3MGVDUUVV0zcoGd0Q2mCj4htZf1nUYI2CwFomx9aA31t/y5WSrzdVqz2bDS+lTErAMkPfssxkqeDRYM6jzUEcNQ64ZXVAiM+y9waTqwpb96Kyy4d0L1JH1ahqFUngOA+FRpZEJsuN9/mMV7dVrtfjbBkniAiQ/zzTu1vLOcf1wROr/BSOcayFV3pwUObPYlXuDOT0/5Mv3VcJkzz23MhqfsX4JYgxyIcNds40H8uYTRIMcojvveYd6uL8fWzKzGMomNSnQAGxnXboQrQ6R2AED2v5o7eXH87DIvus3okad3y9ngEL6eV/SkNbmOSbB2X9mQ4TmF4nqMOndPXolctOdfaFbEsGKfMv45amYjVK/4zt5sgF79H5kA95rYy2wsF5VrArUNB3x7w0l/0NT3KwRkz7TImcvWb2qpx0CXIiMwt1TQ6MDuJTu6hAbXI1KhdlvjgQM5t9/w6RubCyEYelJThPLtfEl5HGauH1uehCMyVTtXnSs1BgAsIV7bz+3/QUl1Je88NKb0bBWnRSXcUjPYz3w5CxJ+j4ehPDHSYjyHX6Ab10rEBXBletF0UGN5fK8BeN9Mhfqtm4OCxHUI9OQOWKd5PUqGbESPVomZJJ0l1wzDsfI8Q8kSxWwZgWcytPOujfs8E/K+6/BhjZKURQOgF0Ix1iWrhB2oQ4apF+NUvvjYOFyXmz+IBy4cV0xqXM1EWb8WBomBjvmlFJWFEoPeuMxVEUzHCZzApNb5in7mPh1m5ss7SjCidys+h7bqskmwKTLui91sLRd0RDQFecFkvKbNAmwrFCpSePi8xrGE8ObjEF/6AnOOdCGM01ZoAHc0LXVIfAJzRz64tA79qv52rgdYJh/mkMwokHPri0DvstEuBcADBHpSAA8gPl7NIQ4x/NyWHSZCHuY2SArjsLaFsyCMFVvc5hIqsoGCb8y0ab7fXipbM4fWiLqLSnnzNLklQBAPJg/gBz2xtRZ5ubE/m6GPwFOn133G6+ZgjcfWNzOM/ZCLkUAQ0oo4cEvmDDuM/zYCxCvaNTHOKtRvljAvQq1E1Gd+R/xUcig9nG3ODydPsmsY+KI+ZsvRY/mG+2WcUdhXKm5Lcd4NTi/myjvJNGLmuJu6h/2tunch8uJ8QJtcmER3UAjA4k3F16L0bCcPQHWYp2Y3KNVs8GxebWq6RmpBAbSPPQok/1WgJZZ0zpZzDGly3PYww7xhwSYrLTqzpI4I3sZFx4Yx4Zmgjftoz/ybPPkZdGgLUfKBe8oW06MFHM37zBOs6yOj86dAMwM+hc5xQKtCOZpnnDnzqvlg1ocryrklJYxG8EwLzg6on0K1ncq/Jqj30Yy3mhdTzrerirLGskVTJaRzn7np/EfWi2DuC/ouPWM9i7jMv31dWzCwa+BvM+gTFAOy/t8Zrw2475L6aecIfNNo53WcAMv2wU0XEUdPFqAUc17gv3rQEWqf1sLdY9ioZLsaAaVK+e7/9z0qLD+IauSxdo2EKaKcKTI7Frhl4PojLrY+wrNBu6T3h8lP+dN5/mHctwOSyHIibhCcsjlG/yCm4A8o+0a1LlUYg29FnMj4n/L8zWohljmt32yCKxwCmpfIwz+Nw6TmCNU5K7Us0xIYtFlB2YrEgLfl37aZhMRB9gk/ndvM0i1CEvoDrtodzarL3mu/cIS8/1EUHI7dMQ7AFqMQ/T9xTsLRxNlqfqcj+cAgCJZ2/JXTzIXJ7/8QS74hDkG2WdqmiRh6h8QfosuveWNrCe05QhAVBahCtwhW4QrcIUZODFFSlyfijzFeziQAfhk5ol4ohax3yDQoTkSJFgu6UJrNGt38ha6oRHx/V10yoAceU30Zz/wfDCBeTva7piAvWd+1AEPrZQf3rxgoDWzNGm254ATKBTjyRzvDzLkch3KxbDeEFcCRh/fcAZaxfbnK05jLRxUmTf3Qpgg5Y9X4ySj9ZDSlVsvbrzQpnuW1TPRbGrKA8z+eQsbBXGIP3gO4CTyZNRV9P+NhbcXv3R8YAYC3Fa+mIrF3LBWamRmfHJPjM3+Okmb1gtmVsNh0Ejpk1df5bXIIED0fMmluyhjDKlVblfE9UBS4cSRxdHJgnHzAyreJszdhT2etBgqwXPMXhEUGAA0gd5aCQUAhld1ZUEGPKV/2U6XPhMK/Liu1jV8FGr+Ypo5ifmaGivqzHZr1MEjF+zlgvB6gH9nTqb1KLd/gEjJHz/rxPNr9oCnM6mIyDgZnawtR0bOKIyQxhKHFYBxzQPDOqEuxumUkIjoFx3r9cKbmZVziGi4rvChgzyapyjZ6E3C9Qal/VGRe0PoFb6qahAML2/CmZ9lVSVItNgsDclPcb9GWpszsk1IrRsvlJrMoZNy+2Gf8sFpu/EmhZ24apLLOE2rlbHBHKEOSNzdPWxcWaG3f8C0p9qsWkZLUFzp3//i5nZ88OFqOiABC1huClmX6y6/ADhxsd6gblGmWZ/Aji9jbjB0Vruw6nvivENsQwyE+onik9ucAAAjzVpNznSI7cN9D2lhM6bBZDBQzmymlq/+RaXIFP3HPa3YJx6f4DAjdc2q4Fgw3YxEqXZz/wmuPCEzp1GhHtoqOdH8fpwsZ/OQ/NtIx3JN8XFotV7TIQmhuXv0ho/QndXmvEJD1xAHrngS3MJFT1Oe1iZQ6wdFtm0JC2qXYXrqfwpqvLqU+8P11t+FIeK0b1k1Y2iwE13Ge3oiair+7hUOegJ+aaN922DSrBCpsFdbN+JOtImWrzdMu5SpSqYqU8JJB7O9cvGtrecw+jxppcL91jKcmWTgfofE+fF0f71KUslWiQHcoGBjyke34MwqoRZApuRE10FS3GpPHS/L4JMlrPQ6yPa8CnAomrYtP6vY3SQhhUYABlStAy0MDLUDZkgs3X88DHPXEp7+tm2kjaxzE/Zu9A+9c8DM2YDKTUZ/nW/XZWABoSuQUXuQBT2VXXSTzRk4Qn7wejMihQYBW2Jo3K3yEART6sqEc6y6Euu3w4avYcEpcIXXxd4PCtldPGQTOocvcFiSa2PHcWZdXqj4e2kuQGemoSPiKpYLD0bdTb+ejFc5Kjh2p1Uz6VQ4iZOGvkXSHqFIiSxaU+e5IcVETWI7uGvBvQMtQyPFMHONPruY3RL9HHgrli4aVGwHPexTvr+yDQS99Y0JUEWWkq70q5demv6RsjKpT6xghmOOxgrsz5wVqP5pnQTvOB3yLRhYuOCG7M2evcGAWAmhhIeVmDaoTaO9QE6m5vKlKvJM0nwXW0ePahk1iNpdM29I1Bx1lmDLnxamgCtBPFGL7bhFhCuv7qyU9kYEvlTh8IUWTACbox9FbPWnNxr1a6faWLr59y9mp6RHYsq+7Zsvt3S8BmBbgsZU/wc/UFaPKATMtneUzpnzQd9dM1Z8I8S/0RK+0JUanv/dcarna8eXjZiA7odOqwYcxG2OVyDYQxEcRbVTd3XPMjMwMDpz8D7JbyXE6UN2KHZaCz7sr2sv8a64YhuWgI20r20T6duq4mqe60fGwmRNeRuvjw34zdY1Zhu91QVaE7vs6vmdTiYflGmKAz7aPSVC/SYJIib4Ju/QUT2Tu6QG/8jiRwHmsNxCfxaDkwIa350LUS4naup5fMMe/uz1yc8DeJc0pb/OqccdeQESoJCUJL9p4MzBFm3uIWnoFDqIW7yCZRCIERu0lB9LRd7owr1kiZz8CqNCUDwaTzwFw9is+S4XCqPmz//sLO+iXtTABGlJwyKHjo0G8v5GXUn2n8Wa71c4EU3vrY0Oc5LPyFSVW7GxyEd3vXBbqsgMRQzK+UU0cQHIVR2uaYNcy47zV8112zgSjTzJovrN5o9/Ttj2BfdtqvoonNfEKj7lfxii5VvIY6KfvaT/S/UTIoVdKgMRdU6OVJW0GyNRzbbNg9zB7rLm1h5m0WjYhss+5Be02KDluwVXX++t93lCuaW7fstlbXLjqeNBnHznP6vW5esNf9CY86+pyWH50Af+lvKnazywWV5Bx26ssIuSm4fvv5oMWf7r/F9pwJLngQw4hdyPrnKMANs1YQ0KUJU48Fi2+1HlkK8NT9XCWSzGr5T3LRcF6rcMGcS7sxcVUjwm6jcR93Fsl5rBJgc00K7ePFcHlNT9qZDrPb1zDpC5Aq33Gkj281rydR58WRCFkw5UA3adm1FzSu/ZH+6WgJeal2Sktq1UJAN2ie+hlCNkmkJmFH/lRnUugRbD09i7F6KQSYadbp1CvwPKHDc4hrYf6UrHgqqoU+2nFOixTxluK3bCpc+2+eZV3MmShSxJKrPOimIDkNd7w+ekJUYcUtiJWe5XE4yjpukJe4ik9JWzKZO2Ua5CO2UTfHsPPBlexw/nY91XI1QWtZEimHI8qEgtJrWi6KG4z0mPfRAozLPCvHGkZye7m6BgpVJfJ2OpmDP1Lx1lLdw3aFP4n5ux8lkcmDrTc34Ry93PJhNGccXwJNjIGNpxszGl+VkL9C+42WSlc2sYi/zlaB5IYJbGMssn0Bg6So3FlGIxL+doMQT0qqZRrRa68gMFY6OW/Ns4ZmwJvcW+82t/3eiCbQFn5NiTbNYF5vHLIgVvzwrywG2bCx2q4t7353Xqku7z3DUUP2/wJVXiZeSlTURbzcOsuu+FYLsE3XDMfrj2bXnrp1M9cagTRned++o8s83mi0wG573L5wlCZiw/aUuCwp/o2sCy94/C2YP8SgORhlCJQp9FIuWhMDcINPQkcrfFS4bE1xFrikjLobNqAPxQQFhrHww9PaWksNnXEOzX8FXtdR+RbqE1PTkeR4XL3JGPTtgikWRXiCfh9PpP5Fx2ltnMEn4YAevIEZbtSIgKv3Dp/fvBkGKERzLgfqlEXtz1f+TCjCXg0QRC9sB8j+JaJgJidvVxBfl9CYn2fXQcRIpW2+43mg/FnTxphGLmib8YazKHo0QFm6KMJsXvpFmvConnd1FMNt3t+MB4iUhg5MJdn67KUqXvXUKxUDaayUzRYt2fxHtnzS3+1lOB1Dp1ThHNaWUh5Khrp+6ztN/SP2OlC3eT0K8A6v9VYQkW//mWHg0E5F2JX9PwSXv6O+Rjbfwg97NBEIjpObn73PtxBxHtnmwPRF38vzIebonlAyO73Q9JP/z0b5hXTIBu19Du5m0wBfVF83+xnVES0mMkuOyKxTR7xFmgET81VhfhPlaZ+Rnud3eF94oxxku0jjMG8JiCZ/oL0rSyo163IyP/q5ltk5Ink7c4HAYeABFa50ngyVazZF57V9oNLnmfTE2yZMLQpmI6G4rgDTHWsnxwaSRi/uRo/pxwcUX6T45Ag2KJkdt8tLRd9zYYcWelNBAPFPmMAQq16qljOeCNm2pTxfVhwcbnwzLPHIp6GE+zV54D424dyfj2+b5hFZayzmjWobtod0hCgGdxqrRH3CfmwaG0bQ7HiWOLz3ef0MJR/r94qqPmMxXl1/6K5Izr6cfdM11Dn3pAefNgP0KxcA8Re3yAPda3VLYJxwcl8iHV7BSJi/LdQi4eHe3I9Gu7KgtA7lsznr3whGGGugFTh9F+vGMyoEkTuBxj5qj5FPs4rPRzGoDMNtbqdCsCtvF6xmeuKB1ChR6FPVW+8OesrwrRDDhECQ8kgTN3fDOL4KhAYIXIoQVukAnjNBfJDFwk3SXZbQHY0yk5yeB7V//ITP2iyNJ8AUfnZq8oSCL15jClbkTXbPC3h9Lnf6MpuExCw0GTFYU9bm8UxL/fMTU6yFFNuggfeZHorHHM0nV5EBMx/pRMtgSsSSPtx3YtO+2TKVQzgo84I16zpxNI8JpCYFSltf82AaUo+wCQnZi6fF5t4xpy7+C23eEpXkurgqTnc1rRm8r5C5QdrJlXoW4qaik4O8kaImj26LERC+ELR1tNN5CNreLwO2ad452p2rbAvKoGZR1LLcgSUVLRLMhdTj7bOyRH7RqbNa0DiWtR5uNmm2FP/aC5xmKOOXODRp50AwBHKhjUwMEAdVPqQ6KdXv8ueEs74Dxqppd924T1wI1taxeUKwccVdLsrPszcaOpYAASanxtQEQpWb7jLKg2gAAZZOaRyjSR691C7Mgiufc5RmGZn4/KfZen7FWIwOIei/HGzYmw2coeUm0UdTopv6FtrtxzMbuNiR9JI+m0O3YOkkRhTI3GsIOFH2Mv/DjzXktol/O2YVHrH2CdicPshdAOSMPUuPCc8EAFjsY0QnR//IUKkwQA/xwaYDTA4gd7uB6OK7NB4xqfWW0LH741vA0fzApKHnSZUi23eslLaL70w5vaktSTyXP8gDHOSAZr04ikAH9XoEK+cwnS7gMyEytecPV1z7JBGceiyjfxc5woCenMOpw90aszTX6bjkekMqlhNnfI1Li09wvsEmzHPhNJuKs1y6mZgwOIvu0LW7Mwz1C9KAKv5oCMaG1sjOyNKZVJ+TlY/3Kp8cmdwdwoqm6hxov00lsDmufU8W97+qJRSld3wDCtEE7GVpehVIozBjKKVzPV64FiRcZF2opRwYvav06QQ8a5qkEWKUnuDApgqYDiQzoRNr09Rh+Teu67DxA4212VukZDpQU4NMw1OfQhGAEgmLOm2yn8V/p55tij+NNDc3OBCNE8XhEq/0/+6a0kJ9D1sPjNRrL0ddm+4/d2CBqkB2fzuznvyVvo4ABdEH+8NhCsGGOFcBqdR1UqNdtFasokp8b7aaqmGHvAOl4GoBTMRlAXytQq6FlDAinOHtTUOs48Ad5ldAgiHsf4kSQ6mIvskk3/7LM82gaD31sMvWJPgFazSvPpuKI8ifuSN66qKu1PfMhetT8sYouXvSSdz4HmWT2PL2b1c7emTjLujo6IBRKaNdn2m5otYLUT1qpP2//8tdUkxomUD+CYKxpbNE3FmVyMh1CtuzMFya6h+eTCcHzs9Oqr21e2EzFr/LGV2Fk9rnI4JUkZQgR0B18QPlHAB5N2scPvvTAK67s+QP/ofjNmksBC+SCSO3+6AT44+JAnk/azkqs8S1KaASOEifGv9RIGmiVnBaRVPo5eStqoKF3hilM9NPXGsr99TluyAMwLadAUdVaHuAzuJOJtMuJ1IKzN7RUQEHGUCzlo3YPg5jnOMedHCdoTDWWZwB4CaWiDRgzH1sgg4HZrrcLYUSTYZpGNPmuMjCSVFfFCmnSehONmI3s6ZwbaM8Ym0MRGuZJdTzqakPhTG8o6S6NdinFVxQ5oqYH3uzptoS6kK8sYSFqqRo0KmlSjNqd416B9IUEzyBg3V8hm9gFGLaINTXHxHgSHGe8ixLsioOR7Bf01znQNY0wsItatGiI+1BAOkpeGeOmz4qBtdEyLHnvFSIQgXm+cgs8ptK8ItYSkp2xe1fbUqdcJrw+fGQl9r23F3gV2YEqCEkVNJlhRdnI+pcQ8DaHKWy8qWJeOyfdZBwVp3Vh9ibXcVlzAhUWk3gEzWPaDEqkIeeoD4k2odjgc6xbGq6kZzmvnTIJgUXdICMiHB0Yn+1K7vgwwM7tvx5cq2wRuHDkxJoKGcu/wFyrOqUcvu3eXUaqETP9LMVshDmFxfq41KJPudQu8b3ijyl32lfOHgqEle8zgSGM2Dy6zSrFSxzh2QpSdtpFP2BSPvRBcvOB4HytBwUrk75GpEeAHNSKBgRFiN4QMURFi2Ou1XVaGhCHFzXVJqiFRjRPprDKTycVpzHQQHoKNipwzPjinG6KI85NUsUGfutCLCEcU6EL8UhQAq91FBIJtrKtbKTTqO6eWATy0CFrHWxesUQuPMmWk+Y9pAjv6tkw60njPwPSRhEAwXfyaE7vygGkqqEoiFDbHc7lmp+Njoh7UNBByfbUr70FscO/bSnmHPa2Vq1SMCxv3mY77p+KM7qhVeHOtNvA7XxVNBsrEZj1lreGE3ZEvT6dICyrp2VxdLUCuvk5Bo12605pp0AJBUH+LAGtLPIAtOrunI6aQiK8QK+kSGC23qJ87865zxDtC8OMLIqsebVCDXijFIXEUb8ViqKuYNIDDd2iYEUQYsQ6+b5eCuoIl7rngSUUMlMLiX6VAeUq7OdubmBVpL9oa9V58MHbX/GnzER4NtLkfkE+DTA7Uey542Ad07wxfoARqlKFjXqwnSTWQtg4/r7zN4Rdk/DyFmqRgTrt8nh0FAyP86WGyZ/YgW13eXb3HT6K502lRaeYbVvW1D/4aqLVxh/9SEZw5LcOn3DpOjeUZXAyP2In953rusdZ4Z4FGgxA1uvNokety8AAnoyoYUSabO+Ovtf2d96GNFET9YaKrcbby3xE/E8XacRbdpFGzFAz31eaGkz+VF5bdn39n12Qiytk7aPPtkFr76F4yRNgvrvQMvOk4gziIGsS0ahQO/QsWQumslzprpQ5GCXtYOyd1fNvZfRqsMVQR1oRa9ypXPv/i6pFN6qh0fHsbsUBNHvnumJoNkts3LM1XoeAwgm7aKb8npwCEnuM9nYVnCt8P5iplftxR7nnFFp2/Txl8sa0itrTDK117vFtbNpeNnsXd5e1Dhixl/ztDnQoBI8KqFgIK0YmpVf22SUS2hWE/Wg2WXVUcptZCLjondX20jnkSEiVntl9gSL5v+QU0iTXYu2kGl0ISqVWyapiGd+h6hyE40gqNkm8Pmqs0pEZsdRZ+F3k1geWS4GLeukyaXDr2tILTc8vQEIR28zVpUeqjIUBhK7+Bw9/eOzzsceL20gPzgdCU4cPvel2H1Mv8KeVW6VnadqARNsQq4iv/q+a4wGurXGoBnBf/uy73IyizNqdhnWCDlUDPk75qAOIDRJMbSMQeiz8gDHzvQxle8l6+2LfaDF9wPJpidAYYFlTk+msCQH0/aewh4pCVjswElJHKJlBr+r/TXKnR9IZ3LZJM8yDAh5pRHH5ZG/8pssjTJr40++DHRsGbBffZxal4dTWnq7btcEUUcFluIaHFNDCyqgH1CKhvhZj3GruN/tGYHJQu+RJFtZrL6IOB2zabLEK375riqcIbt5zIlTZXDLcg4SaZjiymUeTXBHfyyRdX+Pp/jJG/DKkbxP28oMlVoNtfpONUYwYsbiVCgh/Shbe/Z+pcXQmW39oW5GJ1eNDdBvhP7sgUQOxFrgS2mOUa0hek94SEK6LKsvX0PM287ezoh9fSCl8yv/LoT1/QPNfV25QHCVS5Qxo+osMf8Q9bJlJLlmS3rVvEW0Mjb3gi29itga/1e3EfWRaKqzJQy7cy8K81cj15P8VINvJxmBnobDdiuS3vN9fiB+I1tB4eYO5NNi/wkUDE97jAYYFBPoiNKCtojwdkwC3QfAIklyzPA+DaQh2FoL2t1dcpdHaPfgQVw9dkn01gpXefgYcuIe8zLzK1bZfMS1fuavPI32oft5jQfCZrE1NeLHaFrxPhWVr3VxOEWu5dVH1K81EkGjN2/sdatBTeIikf4l1EJbwVnszaJnPryqnFTGJFMs1ISmTVG+6MIFhFQ+jfrWUVQJMoInDe3Dk0SkoZy9WrLIWYhfIqHMWfNikJ5I4pgNiHFJ3ibiX5MrytIKKFtcZI2dbI7SjWamGqPlyNaflAm8/4RfDUNCWaAjAI3AC4XZfthV4+YLwMyhAQE27NkFBEAt04nE0IS6j3eKjjFQwobCx8fMhmTa9M+JIdL0R2f9sALUnpyKKtsAMhP81saxwE5azlYtiBpa4MP1ELHkMMERlUdIuGKt4nOJ2x0VO7jxY64thIKG8UFnDQbfCB4a/om4k0veJrcPM5wMUE62/MpnnzlwVxzZO3arFwKG0UrV7K1E8M1ALu6Zi4TXRjPcFBP08jroYkV1G00KpYD75LWExe3tzuP77YV26pCo702p7dNGIDbMICSGtJDxM1NwzHxvcfWuQdoM3J7D17TwL4s/h3xcKBTbf3fvH89DiOid35qdzkN4/v+lEpFbKvX1Zn0AsfdUm70w0OQUu02nbqq2RbtJb9rOZnov9v24qrp7EHP/O+5icn4IKhm9zekR+0BInRLG2sbsoyPoyibZEw7FKMPGT3v8VL3nmBLU+0mwPDju1Tax7AVRjNpl475InS0QCxUhYv054FsxbSFtRAjdW1gwOeGI7C/FdqR5+6EPqY5mZNVlpGmsCr8/yHGXkiPtKJWjuhAtcOfGXeaIlv0J5GUabdZe5utwvAbFGWm62+1aDfr6WOFL5xPWMu6myveh7+hU/S0ChV8QBDcewmT8oYEgvU6i5b66iuJEFXwIGv4i17AqL7ivXVPCdvz4pEmO/tWNGG6u+m8MSY+1iqnwsdOgK/NmCxPfS7lHc8wKzg2YE7+4j8dNf51v71ajFJ47/qzyoa/3CXwEH7m8oR94A9/mVV4b/9DmtYXCy/eDPtkX3xuTP1NEWwyt1/eqWoCm7rgPIQPQlzf5ql8EQdVQWT64HHJKiiMuB9I2DqInBQpopNXJDZkcNJj2dScm7VuFcnYOUezC1hEXNZDe3tHLtSXNV+Bz++KgxBkqOqXvWwLQfkj/GIyRtswGz4GU9YajwmPj7XaqMqpd6BFwILZ1yPMiWUkK6BuAcm+Es44U+u0em6A2pp1lvJvsI/gD5KYHRasrlOkiRVsFLfHpTil+E1Avqm4PysAD0hh2pcKZk8X4msxV7sJSv74oyizyH5BHCYnlHU3cOBU9fW0pzjb/cnvytYDfjCR3q4xj9Vf5K8v6+uwouClmEdqtg7IrvuWgqZ0A2Ftja7nDW/F9Dk3fT3GRYfsNn/1F5Lo65BkLaSRfjJR1LrSCYpMckWZ99yKaWXPD+SZBah0175EauqD9IsiuP+xAYozetyLu5XJtVsLDgxdxr/s7uG+pj2vCNA3imKD/Cr9qymSdJopVm8CpPKscUwL5u6XWzKnvOfU2z5GALc4xelU3tin0AbynyZTc/8FHkAs8QuIYNu0WTxrBdRPb9Nx8kAbUGr/s48oWL+Mka7VcYSJJq26q6uo3wgsDCFnAC78pRWE8dbkZ0VpSnCSDzGV8wMimoE4Zetu9lfnSOhWxVGAejD4I1CEKivoNIyESne8IYs5j6NnsWpJB8LlMRw7VnCDBCCGju3quOIfTcMrIXDjZY1/OaYVUoou1E3YXYfPjGSITfm8evcIswWs4Ql57IQGFtvSAliaIpY9yJbQ1fix1ZMO6LTY1xuZBqeNoONt+Wj1AGH2uOxGdaTWraDjPpCh2vSRtyFgefnTHPDGNxwMEemTOWjk1QkAwT/6fmB603SFHy9yvk6/fQbiWhqJF9ODqKrGtNSDHXVDyMDyitRFwDkBTvLEz4xANZ3CFSIHdHLVbTC5rQhX+JGmyDSj5/x6Y+Il+FvDYN6Yf4njMKuYKG99XOMNJMO0stmrzEfJUkvACPhLG7r+gEHbbGsWWDoGOdplAWWA3XvctWtDXvz+ZWsjGStYDgEMDvMQZT7laS/wzofSY05jNQH4uCTsFCcFRo7+g9LoXsClh8nX1DIbT9ZGd0Xeyz5w9t8pO0eROOrC7+CrltCwOPtn4m4ngot17bUBpwgpeZR0hpga/POPxw2tRzfxUIZYRQ7MNHAVdsOLcqHTLWoA4vv7cmjB0s+RPr5uLmydi9fu4zqH9wW1+jg+z1Hu25llNk33hZA9gv/2LP+bzp6HRlEx0YsbOlIvgLftCbXHyFhg8IEI1lOReJ7f8BBphvbYSk8Lgu7AQxjUlWtd84NceKoHbDwOhSZUPBkfkIBOaTH4ta63T4KrCCcCYDzZh3/sHKvZAO/aN0S15PgyIbMj9xkiiY8ibNhtFLjB9ZS50D0SGDVlKM7obd6W7+U5w5Mv4AVjK9kEpl78Wpl3FZnFY0/sha9LUUmP/xrINHYyQ5dEWm1KTkX/6ctdJaZqpgMUx8NubH65i+om1H9khRfNF5PH8rMR7CEjd+TdJyxSStFLOZjDLLP81NH0g/L6OLeZw9krcI7gcVTbLUUSYF48NVXiW/KX3bGWoXyCMz7XfaJsTpSfgrTKWA+kF9ugrWRU2o9gPwTt1hDKXHhmUSouOEm5VzuA+QIeBf6iSUtAVXApuLnFtszvsv9jKeXulSlNaF+8iinMidH/Aog6U7HkGsq7Yg9PL51PY+6NntSVh+935pPtFDSBnFarcnmS5F4Mrf2t+Suj9L6hkMzBbdE7GLMWPJCpoExAQL2Dc4IMIx/+ECzF/PrVPTDbumuFQOcqP1OKmhmtHoSkm32PfL48+EyQ2ApV/fW2dPx2J7bDMLo5JiyjkPuIL5d8yzddMsf1NIVjjEX77IbiFLZuUQiBPq5gnRNcC7vfLdQSF+j5iwhG2vKzFsc/dfZYOS7d11ytigR3buw7vpOItSk9zgOYc7NHoaP3e7QbTUHfrE1UEmyMSsAX4BES//9R4UzV3f6sAYd/J3T8BrMp4JCBbK67Sv8AUfoChATPeOZVbXpOrURgytbzJPWq8I1g5Wibe0KpHjBO9Rj3fADg1waPE203kznFkBJKrES4xe/8qEAR9C8QOO4awUrb1YB0EDeSucJWGub/quWY+JXY4P0QHE7/qcEn8HHN40j0QXLyLFjhsJuBhfQd1JB/5lkZ8lgNX0H2scgY03Qh+PSGti1aE0MW2GlOthFNM2qy42VyJo5TE0iuTHQlNYOQEEOqAxAg81mm+fSWILC1MJz2Lwx3ntIqY97b+w/gocbEaBkU/g+ekRt6N+SwfbcyphJkLVR2qKZnf5YKmDunh8l4GHrbvXBORvZzxa8G4WgofQW0Ea0wxUCAmhmFlnNVxCfZ8lQLMdCjIZ87hNtIWrmoZG4OD0dXUknoSi11ary63WSdtD6dD4bo+nZ5Dum/Vy/mFQppGUSn7WFMwdaGMvHfTFKU+MyoF7PZP43+RtkdYAa76rJw5ivYTg2LLVEUp7UHVIYG7/WCndQAr6A8wXWeNFzeqSZJwlqZ/Eo+INKh3RKmdkVnN5at6msQcPEeICqCpTRC+jLv/CKDAtzZLd4F2yYSQ+xKpJzJ2BkhiKtah6bGhQus081liBKYKt3P8gJZsM2Dn5sSGq6yykD+t90UeiCSHgaJReAo1F//Di9QpmZB8xxvtKiX+Uq/Cyf8kD8gu+SKA/ukORjAFsb63HDddzCZNsx/klotRpSQ2eRudSnOi0TKAPjbB8cO5GVu9AdYere3OiX7C1ePEexLTC90RakDY1AJmPddjex2kqVp4TbMpTREavBqSenN3EvTlu5pWvbb1ur+ueag9s/B3CdQs0gDVT4zUcM69FAsMpOmRLjklkimuXPqMqonTSMRIrhfwvnGzVbtNMDMMzpko562bml84a4nMMFBsNxPE7eDqHNKHezYAkzKEW5zgm5dTj5WGvbCKgVickmSy83MHPL9R6nGBFPFrxKnxFt5XdOnaMuwOj4f33mv+6qSI8uiN9vJS3NJUaA+8QXFwHSwI81sgLPXOqcdLBKLTLUj/U0ovB67WoStnkwu/+m4TeImZ1T9Jzn6Wnk2Z/5iLlbYCcAEPuw+1ykMyS/J/GpZVayvicXG+sHk+BhraOrapqh3TVwgSU5MFRXRN5FKzxhTW2evCyuBOMTyysVAcsRUYBmePP1hFbJ0gPIv+HBQATI4GxBh3sMifc5r62VqEQzdGjaP7+knv//K8pnOo3STCyUg02R5HXgG1yYeMkFIA1MpyofN0A7oFI56Kbb2SvR8q4K7QMUES0hSSLVh7Fx64mF7Ma9phL6hLcZZan8s+bd7kRJoqO3RKP3Faw0vMMk9S6RzsOPl7zdVyKvyZIeHilqL/0UYTZ9Yb29aqJ0S9Cp9IN29lxvnbL8KxziZWaKEKhD52q7CoWG+ktIJnGtADOQnaEefTDAcGgnvAlftf1xKVhAhsWBq4rgC50C5b7jwghVPuq3FS78J+lwaO+HUGGUZ4vM7uaP5k/SZ0mQYzznWu2ccDT9D2oR8zPtxMnP7FPUq8NwN8nIFpF9PxcWtS0HxrHpa+2XNLqyZP6wilXJro/CIVIw08srMD3i+Atdn+VTMfV8yPeC6EKPfHO8Eai4/rGZY07wKGgku+2wygASJK4LEDsn7KwHNF/MQYI0+1FGiUQI0CRBLDezl7TPjJ/39CLs4AdYjzFEDociAt6Dqlbs5oZTUiXT1C5ueql6PiXSUDqTKbh762/bb6YK8k45DsxeziUqLIgTj7ly6u60tdaMr+zzP6lBF9ii+foyhlgn6J+wwkGVK/K3XwgT5Rz+Vxi3RK8vvfBCmp6cuf7fwcaZM14zEpBTfWRvnX0o1zpmYsxf6uJ2pYm/xKkdY4EH8C6IOZAzCvzjvlWjiFqGA2oo+Lcuj5BkZA68unMADNDsBOWKc8D2af5ZOWQxgtwBt3OY4IvCDbPbgyJ8O+8USDV/bJrHNj7GLSqXbA8TtsKjhV7oMFP4NFAkYRzyNRz5FEh708Sj0SvAT0fGjmqYApwo7gvgzDABZazV6usHIESd1ZCHC6KYGIu3siN0QOVjvFhlvQ5gPwsl1ElWtl6brSb2XkoMWCOQ9+lXUjqsrd1Bmt6p/T/R2Y3MLan5a2zBLrw+sTOCoC+G0rzJU6VvhdiRrOFNPcD2fLS4xEjXkjWTVTkR6pMgyJl+CfYLUGA6tGH2mN589krnq+UpcHK51q4OcVp0BsbsbuO1PQePdpbiqMHfEfht9PEmTyklrGo+8SgO3ktqI1///4T0yQFbGR4OV18DC+UDta5UCMd6MoBdf541eth9L+yN0PBvG6DVN5hOQ1d05ViDavTKN2Uzw5vcOuTfz92A14s5urVozhVWdc9zZE7Pyik1PpgbbSYRHNNygZu01pZlIZuPwKdu4TjvNfg5KrxBoSd50aX9YW6ruFw8b8wzXK7I+/IplzzwdINe4/1zqIgK4MukD1KSsyX735ZHHykkSkeNJujzl9gbjf07qcxXLV2YkJFeIyIrpQ6Urj2lMwYDXWFlDPKhR97Cp31WHWfOi+y47FcF4TsxOnGIBdcjg1QfmU4ZJz2L+4gTgeT8tZxzFxrbCjSspx2i3WqnwH7IWndAKt2d3KFS2OFbK9O9Y5Ex5AhCM4OVeRravmtkDbpL7V459rfxEZA0xBttdYjpC6PeL9cf+bzlJ2tKpkgPQ03bJPxRcTiPhpScGtfxVNrl+CGFgP3qb6XKCQmEXxbdxYexj4ep3jkkQHKh3Awm7kyxaalyDiypIDZAZuEhjXiJBh0lsVIM2U2hhSt0xlq1gwTo/98HqRTLdO/IoDeNQEOPBY7TAi6huvYYB8qFrwCkMivAf/Q/R1VF27KdLiZQPK0AiBqdfPXYlFfvct/5AipzEZSrf0W24+cD10ut9qYKF3cgk+KV+kUufx/dIBTgyOeWS82k1bsM5CA7gRy4B/xAuYvZMvzNEJ9dQru/DVTem9vMJqc04wACAqk2Sc6EzmAil/Uqg4q1Ptww5NFIoMx5lpH3i2BbD7RXtWoRJJjcUVsoUkLu/UY8OXew+Q+pexevex1naXmM5muw2HQkyoEXSQT474pminVd7mFNZ0GlAH+qqDMtvEiyzkQct/bBu09/K+A17RDlnXsmHIGtfsnfmpsI4bShRtTaatUiLsbKf0toP8TIY6jCgsKHqeoa3RCz2sZyY8fgG2mALwFd+v0+8RjtZ9su4HTLjCcOxHGKzwzK1mCDCBDuhLgxDGbALrcuaFLf4TIAh1ANCKexLNJYQAlMrAAsDEVR8bPHXiSoyUQ1ycrbG4NaM51gxROh6n//eGBEc2SQ1SMR8EkemxnHaD+VhqoQCmaSG8n2mX6rkxvConnbwAQpA78ngbCbB+uyjG4lME4OodzC0lW83sre0oAKCecE5Azv6A9Leg3XU2jysChyiQGf2Z/ITJvL0Haa+OOCW1KbJJ7dr6ekdUMGsMmhRjQq1DuFJhfUySBVOQ1AThoBz0ofTQGWPPG/8lSNRCMnFOy8eyYGQCX3VfXw97zcregSAVaS42+L6y5wb13aO0gVDDdnZ3XoLvaxcqvAf12fYWORrlDhy9dyZgVY5sBuME1Ak/MlHmWcYoPkph4w/6xT6M3kH13jFTyDhDDZX97dDagoFUDQ7lpjyefzLsHwZ/IKcizWXE12LJQ0OHxqer6hWl538pqJ09/m+CgDTfdJjAVmCe5xBTcL1n+GUA0Gd7TxdAVLZqo8EVt1B+a7WasAaNCbPjg/nHYPlFHhMJTbvhGLriklQg+RQ4lLnMyKKul29dQ745trfQU0aJzJlB7jePLqlDbR9k83wjQxZvxrpXLI6ua4H89IopXc9AtnWXeBrP9aUOSBVTLy55S3sREbQIFlQjDnEqHRCFRU3LsAu4TNBlm/hCmrGYhUtmKdIRqp8PQsU3I/pNkxg1lSE5dHF57ycp/WrJV5g3x/liPyzOEYnZikIprGX1xBkR7O/yjSIRKpIbuCr2V+Ho8TkxzUZhomq3lQoF1k1MqUzkSqrZXZkbYeIkaN6sGc3BE0vMuGIwFM2IVH9x08fV6vq/ymsL/ovQE392GHBnMFWc/IRC/OOecLmka4wEgjaooN2DHMr3ZyeTp7Gh+H7S64JiTOeRT7HK6HoBRJdVkQNk5Zw36xMk9u3Y/03U3wYKqEkxSt+wPPTPdmAfaMfmA69Cs8t6rSv/17aOIOYPQF3HHkUithhZhxfSoiLULlQXn3JjmGhlBLPnmrEHYB4+PyFbHQNKEcnzzQwVNyOG9ocL/OQTAjRWZWtQ/6IW+Rhg0GiHmm7e5dPeFRNtFQSRVET9ppyxAe84D+Z8BZqcilt12BJIsO8iBdgMdQkCNqyHbNXdZU0VbyPe0lXGYCJmd3S6UMs3+utWs7goWewF288vryHEtN4YQsravA2JNtOx8t9Xj84NTMySfOszVvNS1Mguz2RuV99JEcIMTshPWNiXN8U7CkRu+tum3FPRYwHqde4A5uk/QqRp6oI3ztAbfKCfYEhpZT0MyQMxeDuIY802vXt9lu6L4lbUPDWP99kWOJEL0aOKXhsuVAKOev+ideQVvVc9ckI1XPJEmC1yMjlXhVPaCHOtXmL4QJIqKQym6jPcBnmeRW0a2JZ0yPfSPOvedoiYOuhNGNjVkNAPVl2RHMhTH8Y8sUPziWh8r898Q7NMu5ZTGSobtS0bUBDRcVjjVdJqij6MeDoSu2xodU5+HydXgbf0V74cJ6gtm6girqvYiM41zFaMSfq79siSbO/iYd3b8d0haQ7BEuHTn52PD25kKhGsgS+gj8uO8vNl/ATuNOCI9uPC4V8QBth1+ZtdxhsRcC2bO01jmu13ZPxLjsIhLf//2sHInNE2GY0yXbCkg9VzqDbX37YA5Zy2EGJRGaVuaTdQ/yKk2PEy7r1cs9gFELn0ZiPxUlDtoYD90yY01DKpdtLcP3pEJfA8eRFURABeYhbSr89HxRKAa2dPMde8M8sXxi0+Vzs6mIQ75DKqKmdDPii5ngRhxw5SCnJH+p+KchlIHe8i7qzW6LhTCrTUk6OmYsY7ogFi0lyiIAidFfmFvM6RPkJ9U9MOhGHXmaWK0tTk1mUrFUz/f8g0T5UbXZMZtD69kZWCelruSejnECUCH4Jd7mPiSuDGuTIhSaz7t0F2F2BylxrpXlHalyhjkXRxp4BWYmq7qq1+zcQEDVXYr/6io4+ivtx7/O8FVqstXq756tgFdsL3nFxQwHAGjp8r43T5lBbP/MJby+px6sppwpVUQpRqkSdktArlQgrpc7VS8L6PzAzFPLNVh99xeP/eYvM7ogQwe1PH/d2VHizxnuKOjT1S3QR34GwGsUXDF0UY4dcd6IkJxb6xm5GsRDRJbAuAjjmwhzkyapd4I1h+1nZKNjDZSw8JlCaT2cgFRYxAWMVhWnjZgFR+cGMWlBsTJ3y3DOmB3z6Oz9JDMOX/l9dy6asA9gd6mqUCSHvXdQAQWqFIK0nXH3qNM8L91EgJng4ZJkhrY5gbVepry5La8/8ah3o/KvPq8EqBiK7BPg+MCduc6AFh/smPtU0ov7Z7ICBeHDYyhoWoF+C3iP1L7wc+zbS5+gaTIO8OD0r/NNivHddBJq0xEaAkzYcnAVirxbwyaS3ZnYRrbtlpbsIQy+Z9XGA20zxSRvYvby+GDyoRD+QlOhXG/GtuU+0uuPVYIrLRy4ETVtdsBbdE4uLDUXTvhFjA+16UqhhSZEuEVKkiNQmo3ibPDWK23BDK5ft0G7dTNVznCAdsy8iBZgNwKVliA2Ke1u+HHpNCFJpOHPwWlmy7+go5LvS3J/zrI0RJ+4zVgEysQJqkB5dzLkYlXxHS5JHutjnbUBVJ+jLXZJAgwaM/K+7L7+w50Lz4MfLlRzgqzIgmeFOsLvSR78JOrk1Bm1U5R3Xwq2ZKc2PTBu6ErDltd8GpaYq/FwYZqhu/nozRqeZcCuw69KPZfr6FuN2E31tYeu8enVW6eN5tOInMERG+qKgKwch9ES90i1lbLyYMu4cxaR4qksJPsPkBUP2yyj1mRhaCWptXIxawcAkSzbv070uPi9bNAuH+RCWRLMfW+m7drmF65zxMvMQo0Hi8wi2cwEyLXt0rXrvqQUorbtFZKOVKgjbECqTQnq18rp6cfM7AcBEcp+OXSUg9gkByQVsvFGvCl0EPS0tnvPt4PRjMp1Vr0k3fh3IN8dUHLlgqw9qQcwbF6zxGMHKS330VMtfb9dSzOVIAdQoxrNwTjIuCwIN+SzEkVz3V0AJmBeuIZsN+uCV7uK0q6sDU8Kkx0bDMkUhh7OQEZB57oHgWo5ng3UP2LK/DyfT85EZOQNEStu2C6MGCq8bD3P+Z1a1vf692yhjg+WhTfvgkhIOXWhNdmGE5XHgX5kCl4gznkuBfhNkjlT2jQza5yuiaJZA8F7b30mNpiiIViol/1jHYN39ZYtYAWFFRsfJDe2W+WvxodKAqDUxUQFuIFUxh6ZeLKm9SE0oCgjeJ+mGhSWkws8QMtl7Y7a4tewCiEWFNk6Ecro/k8JtnJE7qmNMEkhsGfE7eV0i7HFSxT6Yh/vRtAUcHhyFv8QufgWCGhJHBI0OcMcCLKkyJqa1MdyCyTmMUqpZvh5rfkVaN44G5inj3mP/MJW/V1VYSXGEhEERoEpGp2Do9VnAHnyZpzWgf0Hblzl79Hl7zbzrL6u5EF8ts0NzpiGUjeYNtjDwYXpXbTaa2zWs66pD/HxoQbuZaAEMK4NCVjfJ2VIlqCuNA67RdRY1ahinZD20kVyHwgFCQ1qPKyZmy4mOnPQiuBOwLjLob4aFHas/gU5AcMdxkDzlVOqa/AUtJmEA2w35mBgzH6wN6l60O5kWzOroA14xA275bYEryvDH71j0V+AkROMCXtsHcfEjSb4rXTbucTbdObPJeHdRQRNb9hb3R5jjQpYWy8ah/CnjOg8L1AOkbnbiPnlMf31bfBy3Q4uQpRBwPfI9YuXkQrj1f9WrGWdcv7DJaSwibtNVd6d580jKfWTGquC4mzcI9W2UGrs1hIHEoJxbUZtSZ8ZsWXA7w2wgykWX7zXy8pJb3/fbvxA6Krj0BNFRJjdA5L3Sk90ZCBcB7ZaW0xA2WCuXz2PDswItaxFfQ3kcyLAAaCErZJOoACXwMkHWHMpd5JUigRq9pg3PgXPouJxHq0P9qCLXQCWIvGRsOwyeor2MCnxHpe+vhYbahN5Jk7k7mtQAgpWqNPUX5pz5sjmTN0kAu/oSaGtGPezM0L/zz3FXZenwV5DeW80OwkrMEhuoL1ib/h6oiHnmvpETuwxw7Zl5VKwUX4a5kA3LFF4HyZhdkIShzClmEbwfHVCXN4NCUFiu9qIr/iz5a814ZUH+LuPhZTUHoDcwK+f9kSuBCBXWlEDrdfO5f1Lbw6iyGyydh3wvTQTzgcduWGrN6OhFpRbwAsNBdMXWfv2xOWNL4uRmYNmtttlJUDFqjZKH+U/zjdB0Az+cawM/8Zo/iv7DXL+RWwB1NMfLyAa8WloTBqo65RRTNxn0qONkKvBtafxBAOHLgmVXNZoHCgyJgNcC3AqOxHtPNblNCvONs/h6LnZzYd8EJDHJ2oNBDVKZfgNaL/52fDJwUCA+LmkTV5u13rDi6AMjdZ+PVRMKePZpOjwpbx+/A3dZDq6DzXCI+nLGFETzbNb4XQKsPx34ENcNH1HdANXo20ndPvGlpfNHNbs77jRC/WuBoKpcAUoPvNgv5yoe+RM+oFoR7hB5UztokLEVDJi26Rn9TI8sjYWkXdfsvMsMpv4DltgFqIkghe5EDZ4vwXDOEi9biM6YL61BThvQJ4oC25EIfz+DNR14DJ1P3fGM/o9jWoFZIVsqW98rXh0PqVwu0YlIb065PHjifbwqRJDL6po0AJh8K+fAvktXbG7D7HumzlhR/EfYNwPPzMoDUDXvtvTMTJxTqpuVihhl+ZobMBRC3cKaB3xxooqYIxfEenAKNRcELLriVhrupstweQTJYKvfnqM8n3piSJJorzr4XrzAOgH9UTR0bKDlIzYGLFDFmXJ8zk6o8TZ+co7xR026z78FdsUP+4p9XOSiTAx/NIxErh6ZujE4AmsonSmE+RzeQbUJKjtdktrhfXXz7G2n5m5d9BkWlIMpE0R354wAb3wYaWJ8tTQsW/M4CWADnUAubqrrxSq1HEDaMaUry9eCCzKE/VmKHGvV9HNtXQE3wmoXnYaLDTyFG+WbfM0E9u7qmIQgtGEXSUpqF2xkVLx4MULJnW6YU0SfYdJY5KjPbqYmLB2gHQXaGx2dD2y1gPcCtthfFhe0rmdcXW88o+/ku7up5Sk/10pKZKUmu06yx30VUB1MRa0UqhlBsKbBdqqCqc+24GwwAsfbZS2bPJ0qsQDnguU9lYBxIf+0vmeQeqiYqLrLmyL30zAEClVIk4DMvSDMZyigYrbAyjI7ME0pO5xMxbz8YrIOmAjjjChC4wUihsSmgFgFKnN1UcQ/7lBkC9Y0rgKr1sFVGkHtWCHABHJ0n77UB4wblnir1svRTKMf+2OZcUbu1SYX9LTebeajuXmpgaAviwcrSD5qrn8ylSmG0R3Tra6M0BCC/wy/GMU2CIBVZ9FQrvqJMilIUQxqlRn+5buqu/ESC4MSwBmJCWnNfbIbFv43c+DY4ANy5nPzt6mBEMqE5GfZnqDmRysRLMQZmHzfVXi7ParQ055ufBf7H7o8XjsNERYNShuIXxtlS0bllFdKf96EJetczpy3sEoSHUBWSJTLwD5EmX54TS+ls2u2TSQbgLtqJ003Wr7rAhTKqkcG1zBlZoElN/7UdUwhmqp1wxb4Yp704NHg3BpR9tVmKWxixVVXLpmy9TNrV2++RABJ2dWVkquc1ywOHw3Q19Th7aQYyc7Uus21t/JWjrL+K5cHcMvS8dWErD4iC47LfptLiFuYeV1UuYOUd/uIKHDQ7Mw0VuQF1XaiR9ZSkAmbBgCJ2apUhXqjGlxyCKfL9UlKckxraqZCvVY7QHUTdJJBDF0g9u0mnCPa9LD1KKIXeb8O0Iu4+JHTzuQ2nkEdnvs3SThcD6zmsbMZ99JOHRxchlVWNmg9HQTkawKHsOkez6u4XWlT/Up9yPcJU9ngO22ExVkVuiCIWCUlHDthzIp5I//N8abRCZNaSR2ZNxVDLu8ppj1hUla5Fvsny1xe4l2U79k3ybQUQAFywOxzkoRGNHA3mz22tUMEa8VK/e/wsyX/6oIuAhufqsvmGYJ/58RyO8H8pG7tjpeMlCIYbbto2pi/aGO5wB1bprwhAOWi/Oag1Zg/2xVUewFx7KPrRu3UPe9hZfCufxU8KLqPiukFDDAtuYFnqcgIaQVO7dYrNuAPErlOAIvhSdZRM7GvGs42L1UUwdWnxOV6j3OqGyP55wqCrpZDugVNPKNxGJiiDPpzxfobIQFzYSmvhIk8YbT0dqB7xgH808BfDwRpfBCn3kiVRitIz0/65pTMRcYDivUU+FBiAeiiso1LYN33Loo5soh+OMgbkDt3SW4Ccvd7vr6o+wjAed4hUM/yp9LQjWiPrPHK9ByFo3XIsA76DIqCfHCQQZeZSga2ZjVpJ2NQ2vSQsQeHmqsOhj1McEn7UleK56nhtpo0ucHGe1YVzSPIhHoBt+Jv8Tuq5sFUmkLnPJr4Cxxei/VDj4h8wcBs8ksezE2o4VTLmQNgC0HI+IRkc6WNERtLrpLu2hcPgLqwRhYSwCMyRAzlftrhuGBr7SqH7VOr9K6GZxvUeUZ96IEV5lXC3DYN3oBldUgGKISidVsUcQe5fOEoTKWcAyPY1/hgjR0ynx+Fswf4lAcjDKESitPonZs3D5sbZK3AU5/2pXDYmuIs3azjiM7NLow8bNHXb9RkWea+Ke2FxsOuxYrjTbvjBFtwDH5IDzxg2ZTrCQjy4QF/8+uEp+P45f3Qj5ErD3p2eGN+yemyJ7dc/W5ezg+P3fsBIQYAa4Ab/f1cTe6Ve6Iu9ZZG47JM2TvJgFl3iJeoFVU4kUWGbkI8xbcqEbq1iJF4INvL+1VWgFBtEx1N77nbUO/S3InlHyGyfnHRTkp5GYCkRNGhUcr++NHR04lR8kYcREEKa7cbYIEajIbD7+l8hAkV2T6dSHCaHB0ShoAAjLw+LJF5aJ63j9RpYaTwA8/XbLR/ONICZCpK0QSb8pe1mmVNiT4s/kKN809PZARMigNIQ4Redaxpg48739ndAjWr6D0Js55BQdJHnzxn/ueqWBkpPHa076QXSK0F1VUc9op0tvZwadWALSWoMrZeuhjnco7lY6CsBlDCFDHaH/OW0k+gZkLk18qWoehX2osIobsdSLBd2BGLOELHPJodKIeVHu2FFwuS3OUDPIlfwTmqhs8811o/vxW5pxCzoI6nB9RHxFZbRwWcblqiMkMN8zX+lAvJeyl54BAdEtxldMw4Dpf6qt8898Drp3qqfalmygjfIWAMK1pyhuJdy549VJgrDfgyRzwz5sXV3vq3LywGreVUfLkPYvPFFboCImH0cYHzl2LwU636hUK/+c/S8pi6zdxu3QlsLXWHyyZVWbAcPkE7xQFWruy8qSfDGngYaApTN8Oekd69d3lGNnjGYX6L7GUGdH37Lc3ZN9AlImnfKYg6F3zi/W+scd5rxkw9Ioc9pY9QoPyKAYR2hXa6GBRHjC9XvmLIQxzOVpI3Z88kRa7Jz9mO8wBoi0vBZh3bn6XYb2hISMbnFzMLVN3vMjElvdG65wk8OyhlGX2cocLOBks2auW58/vwkaWu83Zk3loUM8pTMuS06EBrZCo/nywmmofhVJy0Stx0sELK4DZluc2Cs4Nqj/kxBkhFePBNvGoUkajO96AKDbx+zPZ+4nSnC8Mptzgwp4N2HGgIaq3Td6WgVdeH9Ij/eWJPPeuuzwTSBtcH3EvxfxinNzViQxh9VbZDHbgrfaSz4LwMWzdlJf6ovTAln/IpdAcSHEDCbCmlm/NxqlTtC3l3bDFBHam1eAnLvK84twQ3Rc+tUX6wZcSBU4/BXl45OWkjlWbrp01XAOXZ2qlYoOdJ9fbKi+2A4G+OudN5YhrofE2UL8kQycI9IEIWFFuoIMUYU4fWmvxXBKVYT2nL3ImKKtITiepM1KBF5paTaOYfEqmWJscA+DFhqnwJc9PUd6UTD1buWxGHrDhMVov+AIaTsNMnQ5WftqHa6rDByLl00UryfLnaBY6tYkPjO8l/AcijYmKF+i9vd3KL0Em45AoOWBkuDqtdHs58F9SMjEtJQURY95ofJ98TVm7/oFwB3IDKlWzHgz6ZOy2W4wkmDhkKdGdZ5N+krMSPDhu6GISdqDoysdkGg0GKRzbgGM5KkzCEPlYG/WQV6yi3TRbnNN8FdWUAqBljlhSbHH83eiUt3MO154JmLlVQQIZ23WLT18wNjYSWB822/Nxfx+wXmaW5OySyl5R1msGjhhBs2AAKQlDyQ0QAFzWbknkhgsoKownztSFA1jwsWT71eO1FH8upI1x1AF9tAHk39TIpmYNBSXYevS+xJtmCmbkzhaFPVIyzdzRMJ60B4ULvELdQOlVFmWj+lDM4hLDBC2tnpoqW74O8fv3426bRh5q/9rG9tfntQVuQmlU6xaS3je6m+HdIlzMSprlwrY41GjyS3Rq6zVCa+XwsysiUA2xQLu70ZCA1aZgfDlTE78btWI0wt+NC+CQUqyL4j8aD9jmtFFC5WNV0++9Uw+7CgoOcgFWJ4gQW5rqK7MwakR4Edy08pbxnuqP9+BI7FpmrdwGXPxmnTULpy29z+4DL9tjZoPv9QAQciUw2AD/4P3BFK0gsGQ7tyilrcSxxga6qIQ1j9vQArDtl+1TxuNo2o9tB19mnjyqoT/XLQIHRPIEXW6Dn5dfRCYHJjIPP0g+xck27mHDLX3Amw9A6HRw6ydkg3oyt9sSAORTRA0+F5IxZeH7cpIDOiaw+ipTFTp/2nLT7XKsigpwKx/NgWTO+UGchEPl66o8pee6gTGw3pjNRl6ajLf0487fHm1F8rOm7qK2Z0RFcM1MvjsASiW+rNHW6XdAaXZjJWyg2kuKb4RJbNOKqXZWPB0d3TWZRbQW5jR92ZLpUWfaqz5Uyjg8+TYRfFHBw8r3LbY+0oNnHJPRdpp6pzV7InewDx8x5O9NTcGqcymyS/uo9lrEniA5aaFs1Q/rV56N2hFnfATTV4EWfNoNRSvejSHp37zrhZXA25gtTtAISO0r0zy6qJmQIwtvXQxj9yqFjD8h6aMyO9ph/vjug5HLQONzmIZpFFZedAzCmIjewL81gYt7YOqYanjnuPvxIk6FFJiVh9Gsggh3O4AcGi1kjDxYKCP/wAio4gtIUp+XokWpGpN7GR2UdkKmCc+v9LynXVjggqpITUOepkhxCmtVTHOMJHYnk8iGR+mPIAFuQKhU2bcJbpoi//EPyAVT95gMOfNb0Sg57Fmw2N7ojo+2bL21Rz3qo8QWbQfE8MJC7DZ4OkYBfTkLn6D2PdF0X21dChOA43/78shnFKFR9opgVvwh96Vea/NT7r9L8Y+rTZ5SOLNIg0j4B3SZ0zsh4WzgjB91GjCjeBznASbhnimZm65zgi16By01cYOWMBHQKhLxsOBPOtWPYgb/Ii+XzABnrNO419cNk2feMBgP3yWgCWMemQOu4hlnDnK12BxJfsmyJvIiWzQ0zBncrYTKVJ0O5x53lGsVz2SYuzsAf0GNFxCtEhmHwq+SdHTMOdixH6PE/y4R4vdzwUmcejeoj+sHrFDrBMOhEPzclpMpzNRVjnPFFlSbih48Ytyq6j7Q1HsjA7c2WUIyW+7zTybHeedzplBxI1PsHkuM95wC9MV7DKdM0I+7SFv9VolEY/wjuupT7mpCcbT3vsz3Ae7dl16M/h7bay6qHodcaywZ1Qy7GSVr/Mt74HG1a7w1lApT3TgE7HlsNeJGULDf76DTITOYCVETQxP2W5vP2/lDXAB2zl6DyFUiiJov4BQtAdE9zqsbI+f0SHgXKFgwUHoxDfMYivhFPuFa5ChYycAe2nHTRxmDdFLtKdgi7J3BLgXWI5183/CUPeNhO4E6awBO3Luv803Lv/FXNteKGgh6D/9haKJAGBAMvp93wKi3EFa1oxnvFl5ZcVbQ22UL81W6zTzdmGdiYhjS9Yp+ZAcmTSuSZr0uQDjNRY1VXxZBCDRUJblm2Oau3qk2N5SowYEDxsWgvs9QXEhM322BvFlzFBp7PqeQw4Uxq1o9tEoZPwMtXlcUlVhG2H27JVszeb15B8s+O82XzPikrW3CtOi2rKHTA5q7rIfsr1lgAKSe5m3OzFpF/r6EFmAP9nl4ONx4AgNjqiUhQuvER+5LdSHTXQqYNwbWH4ab6G5+RRkdkLGUBdWr5fC/f8SlQinCGDWspOuuMTQsH48InGjbbznR3Vq2Sh005alZU7Fbc/bvSDfp3tZnqfDi72y7n/RmeAu8gaM6NniDn3rjqr2Cdjk2VrKdrY7CWVCnLh7VuNAD9pH584Xz9JHCdC9gHGsmm/ECShllRWu393qMDOlFo4z84IA8Mta3+Uy97KlMUaEmVy47I90b5QLfyuxkJfULllt8X9sXWgaS8me7tL+NIRqXYJVg+wHiYllZDNO/vBRhfnGcu2YTaiRbaa2hfLSMX8quCuENUrCagw5Dx9WFoJ1anyZkOEyubgOyfV/eaWf+bMSzmlt2Ig/3ipd+OILW2QbyDDDn/5T2qKfFe6IrE1VGO1EO9hmZwiPPdeS0I+9SJhCizUSHYgqxtg2/pgvGg1Uha1XzVesp3x3CqrF4Z4dHIVtEpCwluqkxG4oTHplqa/D3+Fafn0GATUYV/oMlNxEzGXkMFS4PD/lpxX0N3YxKuB0I8ExfeVIGgPNRiUOVfggT8xMrxYp1XJNuzINB6sDLlA7ZiNm/Eh7cer9nUQSfkkEtY07QDHJoCC5Gj7JVBbnAl2Sd39RF/huEYCqW4iXRWxtkNh3KApYLcr+GSQYNDKiE8Utc3Rk6sW1rcSWZJhqZvlE8AFv3HTMc97UmwGgvJjbn9cURu1h+PtJokoNK2PTzVol0ul3Oj4hI/FCXC7R87/epjLUtJyE/I1dw9zmj3cUMqNEEAMqYmOPDQnonLQctmNPgOfUO9GNYtiT6oaFe+x5Sohvw02CP9wngljmMFSbT33B3W6IERCVoT+Tla/B2ENp2aHzsM1eYNe1TA5dYR3IiyJXUFd0UmtmqvQWwU25DRf9rGufnFmJMxxaImGXmLjshLq4QdQ6gh1YMqr2MiQYv+Pw5YXM5tbswIsn6rjzeviHNXb1WUE50cWfASURBDfNE/rm1BL7TkEB7er+Fqi8UYSZlMqva2GdhPArDN8bisfsIHYQOCT2rSZZqLo0XmwVEgxgAsOhtA7p0AKuJafAi+iRuFqEbusWSJ9k4zr66Wr4NR8bHF6bvsWyMY09yCabpeIFMguwLHpwL+2DYe/3ZbTnmw0cXTgTJLfRMHjSNE+00MMnh2DIfVVCej8kjIiBTSWd/gP9/V1CAt3TQY0LL3O8WWaMwvx3Qx6AdBP+BoBj+SOOdpmJIzh5vqQ6UsIKqp6pSg+Tf9oKwTc7FUP3wvFrsrnXWfwmZVmTmNeUuFBGGJ/mPm+kGuxkTrI35zWRe4uxo5OJbwMKdVU4wJmMXv8uALexaHiiAEc0LijAE/TbQ+HEilkgX0a9FpwE7/LvK7C5pLzrveTmR8FscEZjNJ03K3dDu5EQrpOpiKRA5Zx9imTajWZqwB1lIksHzXm8NFakWo7cxuDgiE3IAat9/9IJzLBSJRmrGvy8rvlKHJF6suTwOCGsYWjYxf5l33+Xt15pytbBYsHiMweAiT6l78S4LVvLwQc8wHY0ez0KxIxTipB8+xtTaFA913fbl7vt56oGOGfIXaXIqEXmD9WHXiRDyAZ6njxPl9tVe5lbZD2LULy6zUXNTP3/aVRdTBDMGukW9Uho2s/P3VlB/UmTsopeSTCNjT+fInzm33mlKyakt9pMOMh/hFGrAlg5FNZYSIF6NfSbo72CNg1GbbYVGiHXV2ZvgI8HI+z7c12O0Yi6uHfSFP9oMQKPdpZYVZQCHSusEBG7oQM+QfLAAwuMD9/HuBb8JNBPJR7No1OW9PQRxebWD9la+oWBzXc4usUzMFiI5fBiV2/I6vJ5F5UTz4Rs/MCLNcZ5l4RaET80PrCqM8bce0RInNFpnIc2tORtn7fAuB8YlfzXO0NM3ySwDVcMXZM3ypHBn9dGH+NKsboE41VtHqb0OJ5fePJTM1Tm7nt1YeCF8mY3xBQztnh7+NW/4xW0fKsoUz7WU/6sm3gOLwHVET+vO+/zMSo7hfsDeMvXCy6NAOsSPvOY0O6KCPelE188KdRjBhi3KAAwa3ZPCdnS0SIs0ID9uk2/pYZhtLFIqATVPe1J4uhXL1QMjqAOBAiReXEj+IdaoBFIqa7QK8R+2uN1lZVjv6eWeY3iRdmn3Jg++bd9r20qcQYaw64r9XUKcJiZfa3uNuHDsM/j5mY6TGiKRxo1hmCWbyJcWHKbVMTq0G4hZLMF1FxwM+3nq9riO3oJPz2RmuhULthZ9nGdRcczEe/ojaBFf/d/8ZRfytKDAYLWIM8vNB7O5nDlyDkDjFIhzU3cw/Ow3rFj+S/m1GOxx0fhnBZE9adiqW1jCmVrktQYZXqeKPMJI+vdelc1iFMmNfRUm64Em5MY5aJnyzARl62TuVV8OPHwj+bSGtc+8RrIsqVu2bwKZe1HTKL4iWdzg7jMICSfnzgUfz3UB9N+eisEJnR/5lLo77dyK26cr2qIJvaruam23G4rAjB0NUYEsKy5J11XMY2FVzbrkjSe8lv7h4gEcV4wVrrGMwPT7MO68Uap4Ml4taSwheJuuBWJ+uEJAU559DSmbLQwf2EYSkFgzClg7baa9Hx9h3dKTxpU47msCw9AWF+M8dPtSuW7PgdFG6o9rrnh/siMBwYiD9ZuwhxXaps28pxHVCsA+PlAmyTJc1FTC29/eItSYQ2TERHIyRAAY3MIeIHdqzz8pi9h6Mp+EIy15SLmGHZydncLxntGtTwmYTDdL3dPw7X+A8UHbX8yx+vIgu92XMircFah0JLQq7Mi4VpvLRWSvW7LRIuEwi2t5ZFHgaCUojHE1uW8aZu0LO7CpKaKlKrL3McjhK7cEyaW3sCcuDmTYbrSgZuiocsQxqS2+5LuzKVC57eKxNxmSDaK9E4E068jl3ouYz0Qen49k5N+ZW5fPgiWyKnQOOikxOKYfbP88Ld+X6iEactRkNHZnVuvE9Ag6WRT4nf8s2WMuO2+47rwuqHn8vTjRjXZOS8P/y0gC+RbR6N3Lm3xm+bWhezfAi3YRgxOfSvmid0glfFKcj9L7lKJDWv0Py3x3zlSKjeucGt9UjCmANtZ82xtEHialqNvnWkH2bS7HjndzvCCRkwbV7NlBZK5195mvNXz4Qcn1hGRl0Wr4J3JJflEL87SX69llihiahsNTRCojRSBumayb0TT+NzPAcNDrc6kv0dmr33EycbM9vpuGcCtVI5qYVJ4Gq9iHjp271m59oH8QvXfPDOPGlVlhbt088bDWDy8IY92wxFzuu7uGYpvIYtH7JMM9Lchtm5NTyy5d14YdufELBK1HGym575ngXkRDO1tMa4C2/eL3sfrZTPvPNRIzhIzs2vwTeIV5R7/FMGOLtYOYv8UPVhA4XFPbcH4W2+m5OgPZfTgnHuYmWo0qw8RT3zma20Fr12WcKkWTeXYu5/KK+bk53tiUa78OCedll/kF3Ygafhn2ylz4rm7m2h7AtrT2MB6r6EY8ZvtcIc03kHF8VjSjRd74XEawolBix8Pt/HQVFdqjH3Nq8yh1Zgv2dWD6Iw6rR0YHvDrkpF2m63IstyOdxpo5tcgnHr54hTUrNs98EfCV0uoRhs+zhooxM7tCEx1xBWAIpOGNvSV60H+5AwnNaERP2RGLAyCLkBinGCgwUckZ+CZ9/qLMx4pjaHFVItHRzvPIx7vMEjb15JIsq/U3wp9FAUDkBBAObreCU9+1b6tMTt3Mm+1x+u9jHmIZwxZwXM8nE6zVfML6YJU3ZCvIvRQCvjW6eTzQ7EWCHzOJB/B2xaMVDv4YFYK1KwO2K/WZMSyllAns/0G/P6YhFsgSsjFlX6w1nad9uKKP9vvtDTAME6tELka1+gsrWFDScmJ0O/fTQ8X1SfVz1joByB4rvmWWIHGhxd9wj0E00VwNH3r4jh3FTDLMC4/YXKdk3o8G9MhZBhZ6suJcOrCIT9gTWKa/Rk8bBTPOzr1KTlXdCX9NSkaBg4RKHrak5Vp1URbLxCQDl/LW02KYYSxTyg4lwQLES2QVncEnD4O7do8vxvRK/FqfTKTyhkQuFjAlPb1GqyNmjHmHEPAAA4YrzXumJgwJIPquQ0bQX2sJ55G096NP3QqlsfyxXmvXHsqkBzqWo4zBrt0EoW6WxRtl7Vs2BzHbm71usDPn0aZOBxKxRuOMEyj3xDJE8onBqaBilALgJ4UZSoPD2vEyBrNUYFUMIs1nYEXJC9V5h0uxNHZQDMtP+FigUHzzj1rSgUvEU9sS1mh8+w9nwWjhpvonOrIZ5OH4n8Q21Onyh0wWE/s+DEp4kawJ4CXTQuKZcH0544Jb4gfo9KnsL45gaz4LwhwG+i+pF1ClScREjrlckd3jol3QIC1TheVy0/LehSluFTRY3kPHV7s6ZKn+1ZHYicnQ+1J06LnILtvWRTlafppN+3xJfbLXSOrTiF3b/3oJiktHW4jaCrg6Ajk2ZJiXx2oIiUbMKqUqI0oajqD6ABJYaIniz2IykagNImZzS7NbM1fVeKGT56By0e7+vL4w0DIxAjAK6RB8HmcNGLzzXk5OYGIKPCAGA093iXiK05vDnHHIYVLIBmjiGYOZaWh5P5had2Y0UyuLCJVVaFfyYru/yTMjf1a9WRnOBodET/U73XggmV3Ldr38/OxmWckEWNNE66rRp1bw6AcNTW3SSkhqSiej+dzVAVG8sbcP62oFe+NDiKelo3s2JmSQFQFzHB9YW1vehvXjwi4690ykaP+1+czjpAk/QoN0+nD6MV5HQbT4KG73QGjsspvSVgy214420NfjM2lm1l2ZTaw3lvYW4Foi7qme7Ihaz4obX4ABJS1MPNNce3lbAI1sFshBs/OhKbCtisIbKU25TpZm1kPRNxouzQK8zz4i7UfeYX5XmB7yjiJuH/zu2TvZzfPAcuOjjRGJonP9osAawaOnglcA6EbRQdCPmZLkExJMpyyqwSPpOAY4lof63DhzzTC3AAKAWXa9jl9IQNmCeC+zpgSwrJrT+tQFAZhghwSadd3vN223laczAyCl0R9mLPahMMeiez/N435FjNYvjII7YTFSNqgF6mVfiy9wVukdX09DOaHHGWMUtvY6TwL3gPhPJcOCk4lKcczGiPwDf2v0Skus+agyXzdD1ozhVY0vi3iwVCbepES4fu2e14+8OuRIPqgEx6bjNy8zvS/UDsYgeKIhOzqSxSH/s9ie3fRuQjgAnpygX8zlthhYipb8kgRJh/eUSdlaSSteDf96hn86olaHnBqj/zAoWJU3vES+YQqbzHhYjSmc46EEt4AEmvn6IBjky2fYtVljp/ofohySxEAfG5lQVngEmF9VX6c34nWY7cNCEsmPo/8r93mBea3gQzcz8Yj9G+If9mhRPfPu1Sgq7cTy0RjSPF6RTqTKvjCItJsqDnh9O8OSjxl7ASYm49mvBqE8mW1dMJ1eCSmho0hLxypgzr1fWlzfPN6+gpQXWC8JUDZAGe40lYfHaknzkdA1G+EXlVfIy8JIqj0uTDDufj1Cc7tUWrkTMv32BdiS3s2i3EzxjPZrXWiIMuvsK9O3h2GlHJNgB+0Ed88HWtVsBBZufbuKGXhy65Og4ss8Wyu0tZR/aV5TguEdEpw7JSop7H640WGf6Y0/FMC4LtrB+c1ADb2OXL8d4otnxqGS5OzV6bwSt8GfLNH+hAofTl0IzEaVoyNvMlpRhImZynEUqi4kB7WkbzqYJKksAEIoeVtPaviP9ZTjXXQy1awCFHgs09fXfngehn4y9gRe2jRSiRZAudfdlC24MyWhwpwD+HWgQ+vdK5arzuHi29HmTSokAE882EYLZBlWXqGPsHU5XiCb0SiwZaqY1d+sC9RzO544teRbhT9k00z6Vz9nhmJrKUa+GwdL5WJG9d+3QDFBLeF7pyHbiv4mJGMxJNLd/KwjeMDUVsFpjyxvZhxMcVKJxRvsLieJ0N4gxDOB3j7UuuMT4IINl90DmCMtrKaq0ES9HH6FytzfwyJ4r9KTN9bU8t8NCXJOOr7wFdSboABSYtwc+cO7XfmEOGIlb40zulhQVMSA91myqqp9+ZR5RGYednmw9+wSgybowhuo+RLgicJLZIXZjuS1bW8Ew1EpwcEFGYu+X+sfoa30j+LilctQqihv2FX1KIFB8uWNe15k/hFeKsr1qjuRQtdLilRvSORGnNcBJrdxREegukIRsWzBE0Eikgcf2Pp/BYQPjXjFEHd6mdysNevjdkQnn+xqNM3YTEAz+YmdkchbZvDEewBPNyRbsTVNkFtj5ko+lcwVFtaiIXb68fYQBXN6RFuFTJCtCdaA+r4pLfnEF6XDsTWguV1eqhrouFvE+ZnNdkvJwEX0SVy/B+u4thgyt21AEo0ocRKnFNTnJ/3OiQhtGcbCe45M5C4qoA3Trk9JlVBBk0ZkcV0PXBMvUs9WCpJErxHi3OSuKhukXA5lpP+XawApsfYLw65xzVZsiWLSjy8kVopevVXS5gM6tAKpa4OvjoRSzpFrme7hHH+XZc5L+3PfI+nLhwTeN32fXpOSuIE9YkkrwPhtMAaiHRJYbni/eMqwbdYl4QB/IfVgesRFYw2nzY3xN2SvjL8tvN/sx3ktr7bRUCJUCTuBm+1/0CZewRPOHjUgk7nutnLtoZMUDQ4en3HKTxclhAk4ExdxhXCe64iTi2xBHlomp5VGqBFk7tazf/+XAVxEwCX8dHmyX8Zf9u2C4t2EaYaKXItlnkrJWCL47Jsynx8DjJaEkCMZhGbH2o5F6dmbj4I9beTY9RaruYcK0cjSt005F2ORaOLfMNlvmH+Zlu25VggcpFEaPePiE5tD74wr9QlaMIVIEF71vOOLRSz/gIBGKxc7P1fE/z75TVMNyahNDvYmSMgi6yla11VFphQ216MvT0itvZLCFfs+AO5lcXAEMMnmo9TXKgIP24VGwb/if0nmzKGz09SAW8vgSI1XDhsbGEXxrNVqDrEhY8oxoPGdr7HsKXNGc8452qxZf7MUFUPuVKc23wk01jdp/Rie0xqzSWRxvrCvKk0f0upeenw+FYEiRADu8LfJlF7zdB0BakXb/1W/Ox1oX9GWhFTTITrSfWc4ORgIP8o2CWop5Qn5a9xGDHchL6M0DOyS5aaky4b092KlRBV+MqHUrGIgAS5aDCqgMynkG136bfa+qV+BfeGoDT9aY+sgpS9wXJNW190A2oseCR0hOXiqUlRTHdnA1Lpyq+tpPVZkIxrXsIuvYYjWVQwFCoJH3UXQh0I0/+XoEF59yciqBrPUaFW39glMumzwBD/GQbn+HRDXOT3NFyg2YZN+E5abYWBWX1n17JahuObqZzTEukqqmUWOX7PexVCuvoTN/LRgsJuR7scH36ocr40ITPfH8sf6t66PRNUBi41Clq7vjnoVarLNS8ZoAobkfzaYIH0zz+PcQsIkgQSbw2HsmUXaikboAr9RcUtQQ7Auzdp59n5j6o1nbviYNv/kQfX3nrl/oQKYXvazMJHiwk3bHBEHoDAaVOHkDyvYB2cXHXAYvbk8pa1iIRxRHVrrg+RwtADqmReXirbTOr1oG1VaNCrb8wvQJc7jUWTphBKC8e57zq/hnhKNIQljRch01x/uG6LFmcen/Zlk1gKD6QoQCzLTgtwup7xQiNYHGdIsRpwuT6ZKLebbve52RqTNu/qb4BBRa0eNQXpl/HIAxZG7RcCS+i+aJTXsyuBb08woERKHFwGEh18oc/HTMloDsdQpBZVyNXQIxWK5sbtdim4KQi2GNR9Q41VDMV9iIaPfI/iAe2l98dabgFHmU/39JgGcxkfPDHogO4H2I2vOjisb6vUEe3v4+qjziHq6ORLFas1IlVgZTtpVKolyblDbUMaWBfodvSrHn+umNdCVO76u7EK3K/D3sO/Hz/NsZc4mfT1PD/61qy4s0BA6uH1vbWgdcl5jQqpMZYJ8xejvFvTdjm7wVqXuRJiWLWT8CNaplnOPkRlV8MreEVwal3jiVIZilNl38+8mjnHUmmCxFqOuy0Nzjhl2a+x8edvGoeK7zqmNvEft9TtmfKaFStG5e3GUVevdCEFsAjce8JgDoGpro+0mh4UfyrHoNH5/PuoiMxnTcRGL639VW+efhGSbHXLADLGDudQDNO3J6U6q5tTb/e3uO1i8yr8VIAThKsqNxrQdSnEQYlUNnJel4FIWZ8n0XLyW4eplrWspWiVjlzDG3vGzBp2WiOIjgylmnxnJ4J6XQ9Ww/xdKZLWcdNsGJVE1vCi0KyZZvOIcSjTuGgBP4NNqzAaJ8rhMCIbxuc9gzpslumfVfS50LxScyQJNmvMDXibBAnUlpFHQSfuFqlj5EkGNNJdJzQxPpgpXnbOq4X/4F9thFk8NMBsAEwt9S/u2OrakHbdYGTsITz8bq/X6aE0Aaf2kqoyr1ZurHbsEzpc4qZ4iBNiOnQO6kNrGrWY20fgiyg/pqfd5CgV7Exi5clEotPVeYiSlBvpP+pR48OxyVNzuE19MDUwEKTCBohnzkCT5FnIXsC4lkO/GWLEj9AKe0GwlWfmDwBRqh+oxZHfw5U1JuSJlNHq3qBXZ2lMJNS1eNMUfEkUt142rQ4A4vqr/mz0nP5l7FDHsWnmKBeujebRO5VAhDfbs0r/uYj9Cmmn4Jm9KLjb4LkQk3ALAUVuIyT9pwgMDpJhxS/CifenwUHM4W1x9zqTjGDUZH0nWxLPIVyXL+qoNXV3GNsdrTUykok59/wnFyEjH/WVRdAaQYpRq2f4fgT1CvhA53xSF8LXzm/F3uO5IcnzfzZS9G1xN3OBfeSA5VT8EHJ4yhJmmlHrKpqzkyhtphP8vwqEWzPL2ZrHlgDV/dnwKljU6ty6ojppMdpc5r+Kux1D/w/V2f2IcjvKZTxsi1RmneCgDuXloiBrfMOpZs/dNPeq78PQ61tLymcJ5ILaM8Q+alLyUyO+MrdWzEVmgfNyPQHYjEujk+soV42XXB92NoBUjRN1qFXYPj3rikBZVpBNzLknrqGOtz3Jco8yr8ggF90g+Bc/ywBTidJHqh9cZ93fYR2DfffllNIbZodU1ODs1dju4qUks4JsHY+nJ/pwE+GpZUChqpF9C5+lRxPNFFnCHYPD5YF0HGjU0zNU1VSq8+Gg19VMiF4r9DqX1s2UUPnVlTdTnEwJzSOjEJY/Or7mADW13RZtNaeZRUQHc8WHwnySKAXMgTWwiQm7SUR0m8xrFR/J24TNQ/NHKBSnfBZ1TX6UWjyPM3l365+kRM0gYxPDR6BOXSSDk7WmAs5I7cT63rDkHmmHo0kJvBdDfP7QfaRL0EKFe7mscLUq33UJU6l6yL87nKt9uUQPKKSd+VKviABC6J6XwjgbeIj7aHePaKHl16Z3yLaaSn/xmNd0sNy0i4pSbVzxkdLIdUYRN1uE+wjrNukZw2umCAh+040LKrIDJp9kuf4CALxCKQXhCvfeAt1SNdxFe94t9+GYglO7SgugyYE8MkVlfJ/0nB+rntwKSDwPu6s8KCt87Cxl4cBoY2gvY6AgNw3p8e9yTPcGvrS/bU+CxCM7JCfOCiXmM48SyJekIMwzoM/3ldMVAX/DwcckrGha5BQA1wcjOmcFzEG9/fpdsG0orYQWO+cJXTGjZZDq3XJ+VxrYOYruUWgMv+cqGVujRzcpW4XEAcguUCs1ujJoBCwfSMEctrknRKAO9tL1s2zLBNo4if5bOINzBuaAGkNXUrvjmkwOgGQ6e5NSTDGd9/UAC+5v36nNUoiujFTIF5GUF7NrkSd35zBMo7ydmvxfwn9/kxfHmJ1Aq6gfcgOqPbLd8xj5kM+x1RZKLI5htDEN+502TzlZrebKW7qmD8uzTqa/pwensJyFp/L8P7e8lx5y5S9IBfqgt7D9XBFY3tzRUYdmlosYFRTs2ek0bHCiILHOj/0LGMLu91X1d/lDZtSxKk0Y5xjmrqa1D6YksLegPfBlTgofd/LmuJiSCBu7ocAerBbu2fEwoHV2edho41qc7WlfFJBzWD2zyjR9n17wsM1GdTvXXHeAIrfQdlpw4Kc+wLimKMgKbBLGMaJiEdeQm6p64laTxUdOyH9u2T48nuv2BKTf879c1j9m6Ggkk1YPAf+DvNVwzPIgEIwGfCY4j2IubXLdZPvhscmqznXDPbQ5A5XHUtJDzKL5MPWv8DnMKQV01ANEWmIt4XP3CKsijT5rGnfYSEw+EduBnI/MGrLTMvkw/q3zlTrOYqQ8klMynTTWVCrtlKoJWH0PyoW3BAuYEDxXdYqC4ijfGY+LpyYxz5WQsHO47dNO04hfNtIHxpSe46X+IrcU7WR6OuukY/96HAZCkSARkYQfcnm8nb5+fDrRwtWK4WkZDwRMcCM2P6txC2SMo8u38bYD00e+GhLsyNB6AFrSktTXuePezm16KoOhaDeL1i7bJYGR1WPR1ZUbaLNdBlgzsCg2gB3A8zcViB6hrxGo8kgmTLprvrwy3j92R0vYG326FU1LOwULY5mjNHv1DMF8Vts7RFGlLcqZ9lZVF/dI++lSaZzIF1Kqs0wwx9OuNk8KbMujY9/W9nTn1nkQ2hlAqUjuOY64sbZF3c+UzEXj+JvmussjyAIifhHTcFMNQm/ELf7CdlxzIPVJ7X3bPVkS+DEQKrNIdNQrpJS9bdxtoFH8wxWnq24Gip86y7dd/iDn06D3MrCz8AodeHBGaiyHuy6zOwxpA9x2r7MuXJniHkW1rj5q6NEthy7BhpDdSfIdcwTfJEeC94Vgptf1HNrMYdWPuJwWh+wu0yrHudoI58g4ZVAPgyToLS3sSU0AfS2OeREEh3IIawK/cb+FYihrvJtYNgW5xZXIJpyi5EBgm163SePuSsVlm/jtiAlCz2HTqGpYK9t8lIpwoggkRTKAIzfVw04D9656xZrIxX8Q9szljfHm1fK5Ew2XoZ5b2hhRmXcvnEdBCNbYbJbJo1QFrv6zY/MyTQQPlsT6076YW/nFLZLtGmLsXamElo6ENLqKVbqsjqvWVWKiKDEYLJuGgkLBmCje4UKmAEVuKu3WBnuWQ7LQr+GliFsX8iJieujbsDXksfBcSJPzxmHVhlIJDUMA2RsbNYnBfj2PiyJmmkZbuEhRZeDMOynv/5TN7BsZB+7fQGEmlpzA38u3Qpdog7ZKmKVM1k97uL9/vmRNAp9DUAq07OtV4Sq+6kyJ9jAxFq8iWKKVAEFlF8MhFgoqXpLrP9lmlt0GK8FHUGKnbYO7w3eK/qljPBItPPVN5KMClKK4/ZZGwME/isa0iYxf7+PEF4kpMlzyyTp10InRZmT6DgOasqU8br1XSkTLTa/hV4uT6DEcIaMJQ0ychjgCrPfxOdsCutXt0WQsB9E8GuXktNPXTqAM4kuvGYQ11Og/N/xCMhI6ICKT7xhwb45Eh0qGcg8AJSDPEXuodU5lHLeRsvzES3hash96hTF1AGAuQVZYg41AVR2jcPL/FQPWr66RpZT1vtzci/PPYLN0f00QceO8Cukw7DAg4jDb+arTwU+z59dvXnjfZvqLRv4WENlERKBN/N4Ny52dDhMwY+AsqATCxbraK/G6plzoLwAE1F5KKWB+0aqVYxopitlqkWjN7VIh4TbNL/nGzcRsTRQT2Ca9fdnfQrqqJgRHro4YJ8n8LaOVjKLBplcZ2V20hbFIXh5x3dyQRFaAQFzQTODV2UgQHgoau0PjzSQV/Im9GtIqjF4tkNZ4eCc8NHFtb5hGiYapxhHNZ+8JwLI28N/bJuItM7cK5KPMEzy2gfiernPeeaiqA0UJeEEeMVSU8sZSY/c8u6wC+6o90rL2Cu1xWYQzC7VmRxxCu5cu65AWPSI+fKCD1y8OjDEghn3rM90F5z4GRYj5UPMYU3e/mph6x/To1agshWqFKr9jrgKAFi892x+Wwf6DVrRerzH+HVelDneUKYP1FVrPvvILZxbRbHlgTiVVyoyT10kxjgp+rfOpAKYVvD2t9DK88b1BcllXJnMJ3c818amkzg84G6699iHNfrOqjkMsf/sE8SqqX/WLGncNMzZcxXrPG7HYNUK4XUhGLNiaXLAb2JwPl/DkYUhTMawmJOVDRyNfaDqRSnxuC8WNYWKvcElviXs8mSMl47LsUOAuyDuDXQKp8ebsRfSPQ3n52owLr++iqnE7T/1v4Ft/Kz9llX72F8eCTJesNRq90UOOzUex2p6IZG58UIs4f+RIsdQY4qNeOHK+EhakRZNWm6wkjh5w84Hh3umgsMeouKjkStMO0V5e+0Q6cf2zbCubuo1V3077SDuoAx78zhQKkIQZkkKi7Oe91g9SqTUo0JNK9yHakH3FzE5Dhl+jwgIixzoNiTK0/txd5QpGKtUilTe7p+W78zdufAqTy2pXMc1kbjuPR8z8CR98wLA0CKg52MNH+N3/6nqyhSM6ppzB+szq2E6jMD4prwnJ+oMKpy/j9YSIM9T+9teq/K+FLwiVbwv1DcBDeHtVTtQn/5faVGbaQmGtzfYgZyYGKsjDef0glDFoLrv7a5EteOX1wAxfLuUmx168xmtpGjhRC1Fkqmz7oSlGIBTkr9rIXbaEHqdADUpM5mM0PozPmQ9qA5Sl2Rcnkt22Xo99MhmbwoUHqdTXfWudYIK10MaYP2gETirhrRFLYIFpq4+rW5r8hFlTT/HKvLyy8BrYIWgSvDzxDmdTgwyg69z7YfcLqczHAmKWSIC+zh0idTwMIh05vq6rShTOlIT6EVNjQxP34AAAB+M/QvF1nR/7wi1v2hngmjCygaem7Y62DaLiFaJDMPhV8k6OmYAAE1ZO2NK2OaMwSmeOZx8LF78oBNGMFiFojY1D91vTPD956ahGZ9QdtU+jCp3m9ye3gbjY35uRc3Sxnw81byTCwKHc0XSyW6VaF5SqmRc4k1C3k9m+sZJrTYloTAzJde+urNNA8KGARYWN1wbhkyY3Y7jJ2wj+eU50UC7RJ/QZ2ZJDQ+LjaW41hMhIQHoptBdEA8FSMi6ArOXZ/vvejtMbAoRmgZHXhyM/Kh6fJ30+R+wF629xWu104/TnJgGnPtsftPCJsOWmGDqsmkVgaPQ8ZUMACmvoo5BZgnaf2Oi/ff/TtyRH3xzW/g4yesxb11n1PNkT85iODU8YSao/39REQDvm+cwqzN3NJ73/jnNCIuT0f9yR4A+4z86fCro0yUr684iXZqKxuVhCAByhtmNgN80jQ7+ALR8I14vgRCzTEHQsLwf0UinvSuGWpBDP/vRDEV68FlRjP7+wWinAGo5YB1mdOaUxuPeP3DPkV1pR+rc9F8/TXYAy4rT9qwNre+GgXeOMZsLTZi308IUmZPXQ/B8XiekbSW/XkOMK7jVBS8U0t/OMDFnUJfv2sQOZd2FWrrJdZUnX7ALZ0SLhW5JDdEjgW/VI7WSTl/bO8xX+R7mKx338+SHlqpgsL8TwaL//msRUnqTRPHTuFE8dJ2tqiw6LABwzKgnz7L4w2lDZq+jGkJWF+89nnpA3JhKf9+kZuDGhRmKdkTp1VvieJyh3xAifP7f/6wAW528CL7E+xbXZ5BEIxr/C5D3ui26ZkuRMCS8HZ9iUEtbXUe9iULnHGkVsJt9qpF/NF9PHKLS2ddAmtDU+p3DL1ntcHbzK5D2YrPMbIweyqw5B0EMNMgc1aWq2l1arEe87Q92oUUm1wYZ30TyytEhR+PeUD0KqrvJ2U2H3vTdB1IlPenDUP7Ma8H5D/HJKdIkrNOwkfpbmg++CMWSIAulzAkamR+ejq3PPixFXpPG/CTQTyUezaNTlvT0EcXm1g/ZWvqFgc13OLrFMzBYiOXwYldvyOryeReVE8+EbPzAizXGeZeEWhE/ND6wqjPG3HtESJzRaZyHNrTkbZ+3wLgfGJX81ztDTN8ksA1XDF2TN8qRwaCqeBZB1wCJdg7flum5s7zaPtS19UK9eUFMUFl4bLC0EQYTGx7mfbV9q/CueR4CLSXbF/fLj4QMncF9VXHJREmxfCBJEtqSoVI2XESpAG/MkMCiSKo3HlPsyh2Ask0yHSm+OzCQ9wLDmw3BdV/T/YiJV8VbnQgCqJyLFqtp+V0EeADrMXJT0Sdwg8LTutfQ0IAABJKfG4GhKGdwhVe1OQcqNSCZX5T7cf3OjeWofrkzNonFkZu6NofmX5yPSf3GKrWHqjdDJcR1yCWBBYLceq3BKKhX0mVbuMEvPJ7YnTaJsTLpIJBYehseIVytlY4sGPMjWovwAACiQ07H2EndKkFw1sh9x/0lYMttdqQaDZU+PN2GTX1mgfsxKIlQAXrTJjpJ8LimRv6o0AC1r7mjiWhy+AGIw21Tqt1NzZl8AydKmW3E7zEYOAeQfw4RhPqKqbRvAzqDCDtlGF6ry6k2AhdmB8nr6+lEoKUxkGn59AjZP78crfi4zZwNexkN9/6TeRQTY+4AAxDGy2f1SNSFnICKA2Av8HVdt9TrzbEtc/v3MGkIiRcFyW2vjCgid9tmee+7gIimBfdzsIlvbiSjf3PX5aeB9emJ4kG8p+0izTbFHlVcYXtNV5w0SEvWTUWaVPGdDmoTWDO4GOQ9zJXdUJVq0eDHS2vKIb7oE8JwE3QCqANDS0ZUMcGnYbzyQ9Tgjs+LDNcw+LQMTCQS74x3iWUBqpJ7u3qEJx/FarlyWd+5oWi6xif50wxbDnsavJHHubK2UpOcL1Ac10XrtVNCKsbTsRKcJUl+fUvCQTxlftTkzICgEbXNEcZ0vo3gZEsjoaou1ErQ84NUf+YFCxKm94iYEpiYIf1VlQHAIoeuW0035y5w8VYofbhfGItX69eA7q3zlYOuVBS8BKtQQjXiQ4wGfrv3vgZXaYVUDUyPZCCrjLsUgx7MgRsCia9HRbuiNWMlTaR6Oo3IhnWRpID/baRSFHjK4t/pisxxFoCMmtFaSBCxXyJ3uj7EOUgdwR+koEy+XtGNJDgKQ2hHH2pXubG7LW59VsXZ+4Wfrqv+hwy+rvrse6JoCbhAdhsN2b1QJtLe+3R/W0+Mm4BZ0hZDkF/gte4enSyxXx2GJYSitfXVli/0NlkQjpWSANYS5WRGDdjtiwe6bXTYjpX9nZ7vO56a35QNA/gGb+5FfhgnCnc0GpW7dOalsIR9De7btXyvSTy8RIpzOq2MF8/a7ks+015NBXXPInDakinzXbK/oJMM0xswQqOeYJk07JGGQVrik5D+0HRt6Nsim1YllTnLDe9SDpyfBol9yzmJqGk+0jXcHKKFSc06KJBesnQYIOBmaUMPf353U9BlpxyBlzofyCNhuDsGVf5JM7LBu0nxNnGTCLqUm8kiTSAADgCdXc6dG8n85LSZJuQhI4cEQOtXo8L4qzRmNkAEkKYY6JS23vQ6q4asbwsxlwalXkYhpqIaRdgnMTM+DMrFyicj6xTaWSatVIzqRGEEJ0oSMU5pF29cTwxQtlm76s62B79Ll8fndpkQ404Q+dVeRSHjio8L2lWhsUH+MbVv7MRaCvW6q0xf4yPGwA56uzWssRfHH8gw0W5uLtotcwtcNv1Do0s7RzLmJU+r8EBJTmT0Bqdr7gbKTb3irPF0xIHfvwhk9HA6KZY0E5xiHXBEC9QqN3XdnvPG6jC6Z8i6iP0SqMJchDXGk/Ef9iP8qSXPfoc2xbHfvNOXvvbqSa9LkkEPbi8wEVPAsVpmoZyqFxsNZHurA3Xbuy+cOslaxrY2LHIfjgrJW7wVco25SBGoEKYWn1J8UOL8i+ciNq5PwvHdib1RlHXhh7p+nqq3Bgm+wr/N/fgPnFrjxM92xHNJjGqs3vJ/S5t+9mqD9CPdOAcxD/tdOP1sOr/rQ9PiXydx7NM2/eYOOUJIC2GpGwNIBQ5df9l7pHJ6VYOlJzA/fPD+BgfTwD39FDZn9qRvLftt7bCwLrN1PSOTdzN4OfW/Ozhxpd8FQg4KXddJHy5S7qxVq0SzRDDfCWhtgHzH8NOsLj7QdHrWM+Kzn26XJlxsgsOjbq7L3chHj6uLw/aDQ+w36SAakL8s9Wwlbd1OCLcs+RqsvhfZOU0+UC1p8mWEgocRVyzuF+t0Zhz0JdobDfqBJ6gAFww6mn8A2vhHqhNkaTr5xIWnNxLbU7EGh/TGBcCaC5xM3WeXoDJPR8ehGEd5PaU/3HGXEE0kyZB3Ks2XadOnq0cgPqZ15alfRAclhxXHRN4I2+qccJTM4+5euEbPuH/6vRT8NjWFLgG+UMIb4uv1tmQIMvCkDuahYIFALHczBjIPCn4oB6BMi3ur9e6q1jwPA5ovzFq2RTvxEK59Cris19B1I/CGAllafhhQn/4kVl1hYqykhjOROwXtZJhBec8nfIteHuwfzXzDVkICPyAigCRsg/Ft0O1EpbBkBPIn8DMlhs9IB3PRIR+1q7TJvn0WelrPuiBiFTq1rwMkEKgA9hSt09x6Q0IVnEQ2o+f4AYi1O1LA3uXrzyTRBYIFe2C53jr8O+DgmmsZp9AC99YC0t6CUPKP/ezbXg0YRaEeKUqv/aRROhlWZF5WGhO3CqALd+Ylvq08RTMdTNI9H0FW5deHvjYAACvgMqCJNXjTqf4pRpKX7GXpCbEdOgd1IbWNWsxto/BFlB/TU+7yFAr2JjFul5r++yWD5rbv9MfXtVZx4pqkuRXb9msFG7grG8SC65qw/G8Zm3lWbPJvBs6baM8Q2yGbEzkfGW0h0rXLhGe888yrbz68QGnxLlmAhdzUgFVLhbJRlKbo0p/gtJt4k9xwj/063GKDnT3ghtiXwahnTMOFms0tagWJAvqC/2+QuzsBZSHfJaZaR+hweS8+q/G3WJsRY6e+KzjQvBnlZr/hsM7P4p1c/iFlvz81ON9nT5HsqCeJMsWJXyBzGdxE7JHqR/cJyLoM1mQR5pwEZuP8/IXEoyVBVE7+IWTcGiAWdT1D+gdGw9yMblUP83NEwLySqyLh2O+xMUcxWxne1RAwa1FlA2P5R5NaHJDXMbfmKM1xbOhaqnvEuevTNvdJnUZv71CFGFeEn3XrZM2wvLp+Bids+BNXmUnpxFyklLWPqY9FsHmjEWwj5xS33jpClDm/y9O0Jl58fd3j02UToI3yZLk1dZZ/LuCMV1KGBI+y+n3EEL8fGRGzbV0uACdXb+E/uQklKcNrrpST4/SOdGnsMNXGRXhoAHRyTQQa5IXDE+9kbsVPo2eaurq0y/OMLxypb7zd2EcrpkAfb7B6M/CInA64YKashtHw4PceWOaiYQkxPipPDBq/p1evMnzuS4CsIn8Mr/2pbxRpHT5sHMeV5LneY0OXzas0LuUds5u8lOgAoGX+UCi9CHoK2isPBcNgpXb8hHkaHye4AYmjToxM3u/aq+nDUSLpQ6iu2mekLuNgDK7f5IoaTrbwSmHso2GYFyZNKTeZHtPtWP/WPaYmCL8mMQ3YjbuY7ImeoNz4RiBTQCPI2MUUUt+sUUtkaVgz6EiQrZBWLMR7j1uJo8HBdZhf41Sg20Q6a+TIgv3gPFw9EpdqMLENH57isBJZ0xSOgf4UqFH+4OYjTSVX1MKpwzQ/0DxBuQAAsZV1+ONIuJtDKGKYoyApsEsYGmicQIrTxebxd0VCwar07vIZqjtttMoX98xunpJGtJWa0LGvLfjODp8haPF8BmE//a7kg2/Uj9eGmcXhGmmoWs4Z+LmU8MUHDQDx/HHnuIcnw4DLBFv25q70QeaWaZuKfcLR1R1KUyTJvJpyxdQi61G71x21tC3WzoJ4lKtOXuDOXgqoIdxHaduZ2mayeAh02wfdt+P/sZW+gbnL2Nm14OqTNnkkE3qQIprQS9YZJ/9yvFfVbalZyFfM1/LhnIF4WleGCfxLdvFuxBkF966qbpWl+U2EuYxho35AStAAAmnD/RTBsp1v4bYrCL/2NE8OwQqZc4WNiyw6nZRCkuJAUvbv7OTuZ6bZXmcPOOr+NUn7/6Go5sqNk2MOJYNRVgjGkBNLpe7Y8f4ESIq1+8wrME9pDGh9cm10FSvcB4+AeNbwCcxK1tZ1K/RyQlWbWrnyxCpvZFYAEPbfaVU+Mfxu53Cl9peABbf5wzBfU3FKkhvif1NxlCbwp0Rpqz1EvrkCOP31Q4vrut4Ujdhh0FRq0EfOXXsXmTuITdZJZyT2DX/i5x+7bOGgQg6kMW4t/Bqd3knYGQo0iyKuVveJCiAAAAE/SxEHaZ5NunQUZTzD9ZQOQv7TKd95APhPHxmDaYLFyqtEoNGJZDcCWe+IjhJ/UStZXwfpQNqGg67b3rQToL5u0QrU9rfjTEMfgiq6PgCpeBHeARrvW37lsNUW6aZ7bgh0aB/7V0f94vwdqFE2t8J5bW1PP9ep4ZRE9IgTN0myy2VQ/ZNMbSguaA+noPyCeEKHFnG2VRr7vlxCCkarJ/xmdqXnEeuDkEWcoNB2ihmKPhyHbkIX+eoeOxNeoQVu+vqdgkGQvwW4f2/QZCw1UnqJqp2GfZ3saWZiz2koybMDicrkivTcqPALBqdbHr3wn19+7ClnvrMrIlLeNUHYhvjDiimARl/DxIPqT5AuQanWRojbUFwgzfAEpShvnXShKREUNloEeoJCIW6/MXhBm/TfODkZuLnWXeo5h/dh3OXZWZT/S2hmGxevQzqf3/vr/v8dDxncyawXm5aWabfex2lEa2P5RyXD+yTSk6O4KaeZnRD7T9eGcZqkszIFLX7T9k3gzWwsb+MODXsL00HTVYrnbGnE/vFurk/ROKL5zgNL7DfJ0i6XRXA+wG9rHqUCsPMZbFviS261IOWHibN6gDCo57/WHtdcLHoDqGBoAADZOm9Dcl/O4TrAzJ7TU0CONWWMHCU1kHQMKh/fjtSmNYhiC9BLQcDGokvomVm1KWs60wDbi+7TohKAbeuQ3LRXWtPZ6xop1C7EyMI5h38HaMgsEgZMvvdgIkh/NVIuTIFtmpkBdSyXTBpCyI3zJ1K54/+swaR2dlVDlgglm7tlkn7dLx/0zmRmB9lz4jrBR+J+eo6D137+LFtzS4Kg3Tw5lBRwz8pLQp51VobPLT4yeUsuE6Vz+0v9O8u5ke6V9XJHCVdBvLawMKD2qZ47sfUVi3zHM7c28VoBT5/5/CTnqVrvUBRezBsXOR6tzTroFkobJJKLtqyJ3+bisiOOBo3+2ca8RPK6QMH7PrrYZGgxnVg/wIR4FNauMkpAfRF/R9H2YCnAsCya/+/Cda+Jdy0N/sP+bTIAC5VhQqaeu7V5MgxZScKbWwgvycsunAKwlq/DW1XTgfLRdkVTVqQraagEepc30mju7wOWuqCruqALJqMLs012kT4w9NJ/5G4XwD6QV61DEPCUciuFIiiIM/1bKSxmr5+jn0bfhe8KO/U/K17U3ovnuI91hLQvxqT1DYrbR7iMAui2hhsG96MkeQtjsnH5DfeJTPuTvKEmSGHCMOAD8BnHarJ/jBgdroTchF7Ko7yLOI0M98Ygtx+xTJ7Q1519PNgAFjKuvxxpFxN6ncXBK04Gw5DlCqINRPhQ7fqi3xXcVHTDr+JJsnQ3jBXhtGPicx3xINPtcjHuudZ8P/1jHRvHiJeMBBpjy/ceWI2zxalKXoVvw9XWrIm97evdZrenuWeVP26sxQulb1eUHLOjhIFGRJuU+VtsRWDqRg1RiXY7br9t7ngyy+djfCOH8GFc9jaSw1DwZesxIhyFuyQqVpdlw0b+XLrjYEWdlxApo538ePUFeCKQfDHRydLOHveDiTPWeACf2DD9vEkNqdu01ozklmnuaPWcwUo305y9gC/9dyeXGSvM8vy+B/5b6qA8pHhv30fiVhJFYWyAiPfWJCONe10z6cE1NDj0yt7wDV9QXSqQvwc+mR7p9dee5GYguU5H/E4NHzDl+v9srTeLmRpDU84UG8HyMeEoi9vJAHu2kj+NR/0eKMqj3Myd5Qjp6El4LFeFmket0Cp/ZVQ2aLgyy1HzhQ6Obom4L4IkRQbiBfJ5vJ59wMUTGXOuTCjCK/a+kXF99dkV0E9WVxhrhVfXWfB1cTJccbQxQUT4Ip2q5acn47YHbeZmjHER8++lEXt0VrbRlSwV//5AOHdoY2zIzOXlp0AYRxWS8OmGRREyyCrVSYO4zPTKt0iEYx8mLKWZvR7l1/hJmtIRmCX90KhyveiLRMYxFUtFfaalcVUsHYxD6JQpzPL0P2MB0djSJF1LwcvKUJb3jLkqZWeBpxWhAEVTpTOSJSLpjuPd3yv1z0v0n1Vz5HJZPM6yJRU+iMyCeKNU0FbroQ2zuIdeLdS6k9rnO78XPhdS6HWGaZQxMazuWYwn8yaMPJ37KHAMLvqWCwjUe135T5Y+m0NGuCNMcYa9ipFb80lPzdPVUdUJEUmC5hJsgLIVSkBzaU/FW2BEc8L8IULkoimatu4t7wfu7S0WSgEr/EexwTgjSwWt+4gm2TbWqUpl9xNe7Ku1dmG/YKKbOsOzXae9KRq/1dNs/W0qGqP8zF46T7yeJgsxlCmIT24K7bAAAn1VRSrvz2yONsC8o7hAiGvK4rdF8HZE44h/mMjcLl/v9VICuVd08c9AFuWwg7OsGSJtgOWK817piSCdyPPKgP46TNXl5S3WujHaNHgCGxscEcuGFIeEXUPW8B5ReqXcGteSS7pt5ScVDg73sl4Qb62GJiPbrpvb6tWwyrt/+VQCe9Qpizrao2Z93Z0iIdN4AR80H4zwndGYS0nNfoVXEfaKIVZm9+VnPfY84OqujDW31MShqGD7/oJPrUcRetbzL26O/5lDl+Ou01D52QpBcQPHJSWPemlzExy9K5w82TsKS2NuOJfGywidvKCOY/81oEKiuqM/TGvNCr3LXb1O5Dpu9U6IaZOjjI6xMnOK1ipHFBgh0MLKbUWwltE6KKffReLmAHKJO2Wa2Q0dllUSrfaQ40dogH/BcVsPiOdLvksccsPrh4JGIvKmh37QqY9XYCFuFBEfRnKvgQ0+8Qp5Idw2yiIkEgtERuu+rYy63jXUQpq+8w1AXn/hKh00bjU3ZRy0uE/9d5RcBoH512AEgv5oZ+E0H8Ufl4/TitqD/+FtdcAz5LDwLFTbMl4qx5lKrOV6gOlXtogl7zanxjkETmAJmaTwLSMS0My8dWL490TkQMRFQ6uk90mZ4wmaV6TRYfcByWU6Uoe59DEFyuWyCY04jlmyzMQNremByhNmFDRD2xwNnwgPRMgr8TIIzfbGLiOyK06t5taG8ssFLKTXVg886HT0NM/Z8mwYM6wPTASZCxC74xarLIyS23MfFLVyQAvItPwgKkhjn4gThxNK70ohVK3nN7D6o3EjYy2S/IkETwy373FEnQkgQaDBkX0QnrZUHOasG23DgEbVdCopqJvAVp1K52gwqK7vUTrQSxPKmRRH/K/qz6bIzxyXOuuJI+rGy/+k86Gf3vXKRKVlExKzzpohhm1FFrGQqp0rUX2vQqsmoc1vVq/DgN1Vcr0fHJO6Yytk2B3hR1qeHkg/nqH55SrFDb/RrBuQjjNab2CBVk/J1xou4Y6D4sm3ySH+QVux4YFgPCFPsou6jXoJxuOYtMb7F7P7dklwMhopIrOLHz+3qGfzqiVoecGqP/MChYlTe8RL5hCpvMeFiNKZzjoQS3gASa+fogGOTLZ9i1WWOn+h+iHJLEQB8bmVBWeASYX1VfpzfidZjtw0ISyY+j/yv3eYF5reBEpvthT6iuO2fd09Ut+VUzxAkdXwlp/qoKrlT+jwqcKkeZeI8moWD2yoZrI+tlpWz1TuPKEO7PF8EBBNcewxy+N1biLaXH+arksAHU1fwMfc2j8YiJjMZZ7zFBIzi2kUZQO7bWRCJW7BM6LvbewADqOfTwsvyaiBw4JgqTdHeTcz8hCrvx1FmTgqMtAZnB2Q3whMP3swjuJzmp0rzmO7xB1pzyyNM0ujO3zWW4+/aLgG1Fqnib6NanxHWpD4oo++CA/E2FGODs4p8lNfF+AQ9gjR4YzhkBQGdSuCzbmA+VXew4yQN7kLiL3jUcIf4U0n4CFfLbDqEp2KewilXKRm0yNS3TIRTnMSMcMUFhfD22Ud5vNL7wb5/iRoNCjmmlLK1HabZYKuU1b5A0NylfEus9uT0K8voVxkCKSzt53wnP1CTT6xbhZs1Onq1jzN+WNQ3iJ0ySVv+MrEwlDZ1Hxe186WbzS5bCdX5HYjQy1FgWBxUfMIHiBuK9f643J/d7TNRJTpiYaPccMxyLbgIbI85A8vZpoepnzqWEU/RRWe5dH8qdPhIAPCzzfSdkyZbBaLqE3NvRUASii8592dmhAGjFqGC34cFqKIwWuD+tybxoYXEOJ4I4s9DR7dKvsz+9q/0TbcVn9YsFQi5V7kr5FpM31ruKkuS2ZeIetYSz2nWcnmH2LnSLqsdB+pYFGvkujyPvSKWIdMUpPTBB0azVuftInMLyasJwHOV3BenXqZ43E7ma3FRPrygjGW/xw4LdqI87VZAMnrQ2b5wdPEAfThuK9cscNvAAEFuWT3ldaESOIbLhHlhJmpi59zFjYkDsgrCTjW9jg0C9UtmDzPfb81wzCUJTWVEBYE8J4skSfzs4ep/9U6Mebr+vw/oPO43lncFGuGoOpArVtd9psc9EDkAXtlU+zSrKn7Hc3mbqsbU31NeyYSy/BSKgbGCPnh7g2lYa3p4luPpvTbvT0uQlaNrwIgWn/VRdVjPUpthFDZ1a9alScUqFoBOUzGhxBHucx7pX69P24KPuLExUJHzzMWR+YHJ6Z4H+uBM2Y2Yat+uUGie59XnnHIoBIO10rWohSE1oRBxlYL+XIgeQE0Gc0btzOLAzICqgGb6+jJsSleJ7u230tClCk9huLMwcsAssDM/l0qYlv6j5OIBduynpPeWbzGJ0CVyXx8netwXSlykGil15Kka3kLyxPnF9BbE6f39YeO3rjZWFYFOkznCMPFY60GBM9/6pn7HYLM4fv+cX201d2pUpaoX9Y1qjBaVBElwgaBz22nqxQnzdeWIsjdEp1RAW7ceVX7MetS6C2yQrssRtKO06/495adHftr5kyw2IJSXRFidkn4jCvRft6XaYnmXngWIrK4f847zzaratiSpqiPRmYMl/AYjplzkMwYMMreqrUNl4fInlmaC15f7CXtWGA63Pcp1GrE2uCuN7wOWnLRI1gqbVsvW7rXfBcfhd1u+b0/UtZ5lodyjQyRqE2H9MO23MXFiJnVHznkmeFktyBHLYOLurHw3fTwFfw37vXuVUDTsI1w5lBlioA8UkGMFFOJFmnnbiwaatMUl9UnUmdOIUMIeCxmRV3gGTVmhRVKEuKHaRf7brzfMmnP9Q7OsETVWfpJqoXaNjh3tAoRklwKSHC7i+0g+JE+eodSKqQOrjwYh+ruqrSKkV9Jb+iO9bIMjd6KmOXMsiSpqS6usmmmZu545fnTTTAKGmRHXN2MTSO1cZTvACHZHv2771ad6FpeMi+5Q+kHyhMwczh0MN4XFHmsN9G5rnsP4eBktRIwpFMLf82JcTtTPgcBEyaevyPjo7xPVvJUzBTA/G435NPs3i5Ve9JVEZaUz6gpdnTwPvXXG9qgb2saySkGeGjKdPQ4ReFWBtfOAd/Jq8uTYs0YXHYbvk3u4xw78MquJ1xKyibzV6Lhh1NP4Bt5m2464qAhwI7GJv1xgf2ys09x3A6H9mxYXU54Ec5hElUDFZ2FQNfKLBScKLZYdAnEJz3wSzjjh78AnXUyzn+SBoGa+xbn7ZwKOGddQLzZ2vbnA9qyH1vGWl+cEzvN679X9DkD6MuOuy8nJvsIXiC59jbBpmXyldti0ht2pxDbCE6uWv1BODYlDu8XSnM9uGuSL5yHRiuhJoRjaXjxt6u9LFlDKfl8VEubS9ssqVr/BIqFioGMNUY3OCaBywk8cjcmcfVnsn/aiXr66R96MA+GKQ13UbaaEKu4TCL/lT3Ih7ZFOmOu7Bv59Kek3r9ourNRHcgpBfuAxoBs0Hcni673GLBKB7TdZ+fmDG17FRUBTFKmkmGN2uaxueAIdofdfbZiuQmdiyhypz45jrAOrkeiBnKhfJr7p4dqJb3nhXBhRlL8l09OL+UQwAuFnbTM5wmFP8wRdBd/S31Wwu8MXKJs6fAPoPSnHVaZhwnVY3Y231jKqo5igItgGy4um8Ni22+g/x8YHeZK6tnpdNMOWtrW/D5kRUpMQQGAya+3+7hZg7dKVuJSITO/Hj1JT3l5dngaI16ZhFi6iRPXqM02b+gi6cO2l08+ZerkJhQzIpeUl2veseslEy8vGAOAqcnljNvjzOetXctfgIVxSTkWJA+GXarRrDuI3dPfV5l4VhIkUfPMRbdX1dylT/JgOuhd8Eaxcu7Y+jxUo2SnpOuCZZ1vdG54r+V44V2av6Vp42GYih2JhcDGiRslvILE4Pz7rUPvLYQ2eGyESHZ06xpLjUPypbA8d6F5/GqUG3PucOjYgG8ec5j2IIvqtMi9kmjXUjhwCDwt7bmObtUAG87UPU45txUJHfCtE6SArXyIM2wNMiURy6RapI2Nk5dpo4cUiLXNrOdGIPt5u0iztgNce2JinV6dKFIGwUvPTmfgtUZp3goATYguvfO0wRi2D8A/x0iCXHFEHEzDodiMIN6pzRXLGH8QbK7mQPjZnV5iZnXkr8Be/AFTfSpWYKcUNEG3xnB2E/XZbZ37k2FE+g18gkV6n5a30AJhR3f2vhA77vLO/FqhJtaX/UuZGV6N7lLYx5fwQZcyS3b/T1d1+CGAGkWOC7AK6bNAVV6rMomTc75TO11f4MonxOZHRU1rk3hAs71O7v3CySY01cfWNwgaiby5Zcko0rOYl96ZMqp9vHdTorxfk8eyQkcEQaQxX52cbmlHVBo82sz5Nq4WiEwvRU1Qf1m+a/W8stg6A1xuxdqIk4v4vl5uFwyz0dCllv8C7D3JjiOnA4ShZLBnc6RhNbj4BO1MIgzx/lOpqWb/OLvEGDy26p5maNDWZBccRh3JaTCuNsFeJ2IJDOIVoeEYSegCM97K8qnTakothkpRRBQa+L+WIMGMNtWxoVUy5ATm7qx0lN8IOD6Yp+YXEmNTkD1vNP2Gt7zGi+qXkqvd52rw4nouFzOs9umilGjxQ5SIcoY6SqngvsCfYylMZE+CxmGbA2AoJrub1btOsWeKnPkhM6dZ9U5aRzuO4aud4kEoAsFG3y2/hswqo1vt0vmPGTi7Xwgdfb327YEinkNnzlHA1P8xJ+8GI3gK1k61VBjdrn63BGNyxXBwoZjUPZvHCireeuCHn7YChBNMAiTgdLhuCPPRbpfg1DdvTym6W/9iHOSKPteIQUzb98Z3yWBsbW8zskXFXSxsjT+0hf5dVAvGI7SKQSCdO0/inmgwHJAW6jFcfediFEvhaRV1pZ/EH4p/0nzfy8cYjAjUbGPHF+w4H1w+rCIVpREQW+FQ8fxGFPUwhR5BOfu7EhgBHonocl2EvDoFtgjKi6xtQPI5GoslnTTfGvWnPOGujZcTg0QJgsKocvVNlb8zSyvr1GNjWnbTi2FB1jV2r3ANkUB2BmM24kTQ9c3IWHasPxw/Muox/Z+TOnuPDbkK6kxwNSLRNs78CfPC/ZcWyYx6WkINgCzs30Qo0PtHHlPDnmjTyRt2VPcyG1DgXgNNsAdig8PY50U39KLxiHBxsibvBBaAdxoDmk/FPOBp30jt6qX7SbJJx+TsAAAAFpUR0eNgfJ4tbdG6zHy+MbD74mUCsbiS6IwqEvGJ+YxwwtULPMst682BlcJmGggWozI60g4AKDRvHD/HlhV3jajUZy7K75wDHqz3wri0gxJw5w4SVUM/TmzKz6gLvp5h2/SO0z4PVuZpx25UOgedyy3kEELL4ARqJGx9/z6HOz3rfDBVWJOGHTQmHEh6baPaVCPH9GbkfwKyN7zDofP8YzyeRPBnH0nwEM25ZwGQDtrwN5AY2IklGBbFQS9Xs7WYNs1a1romIla0hdylJmffhavjmre2vVqN64t5/EsTYbjVwhbekduYf/Qvjm0kLf23PP/OSR2pfZczv+wqd9nJ0FDOYE/LVJ3WwULgN99EkQpfx6mH/00U/BE2C1Adu3gkTbXHaSxxFv7vovmQEoIeVDB6kvINhZh+YtEQ5OxBs/AmL4jmKSiKVah+PDsi6hx3EFBgScKp63TiV4AAAAA=" alt="Agento's agent builder: system prompt, model, tools and permission mode in three resizable panes">
+        </figure>
+        <div class="sheet panel">
+          <div class="eyebrow">Design<span class="eyebrow__end"><a href="#">Architecture ↗</a></span></div>
+          <h3>A native app that behaves like one</h3>
+          <p>Three resizable panes per section, hairline borders, focus-aware selection, a status bar, and a command palette. No browser affordances, because it is not a browser.</p>
+          <p>One process, one SQLite file, and the Claude Code CLI spawned per run. The whole backend is Rust; the window is Tauri.</p>
+          <div class="compbar">
+            <span class="pill pill--plain">Tauri 2</span>
+            <span class="pill pill--plain">Rust</span>
+            <span class="pill pill--plain">React</span>
+            <span class="pill pill--plain">SQLite</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="sheet panel">
+        <div class="eyebrow">Frequently asked</div>
+        <div class="rows">
+          <a class="row" href="#"><span class="row__t">Does Agento send my transcripts anywhere?</span><span class="row__go">▸</span></a>
+          <a class="row" href="#"><span class="row__t">Do I need an Anthropic API key?</span><span class="row__go">▸</span></a>
+          <a class="row" href="#"><span class="row__t">Will it change anything in ~/.claude?</span><span class="row__go">▸</span></a>
+          <a class="row" href="#"><span class="row__t">Can I point other tools at it?</span><span class="row__go">▸</span></a>
+        </div>
+      </div>
+    </section>
+
+    <section class="closer">
+      <h2>Your sessions are already on disk.</h2>
+      <p>Agento just reads them. Install it, and the last six months of your Claude Code usage become a dashboard you can search.</p>
+      <div class="hero__cta">
+        <a class="btn btn--primary" href="#">Download 1.2.0 →</a>
+        <a class="btn btn--ghost" href="#">Star on GitHub</a>
+      </div>
+    </section>
+
+    <footer class="foot">
+      <span class="label">© 2026 Shaharia Lab · MIT</span>
+      <a href="#">Docs</a><a href="#">Blog</a><a href="#">Releases</a><a href="#">Issues</a><a href="#">Security</a>
+      <span class="label foot__end">runs entirely on your machine —</span>
+    </footer>
+  </div>
+</main>
+
+<!-- ================================ DOCS ================================= -->
+<main id="view-docs" hidden>
+  <div class="shell docs">
+    <aside class="sidebar">
+      <button class="searchbox">Search docs <kbd>/</kbd></button>
+      <div class="sidebar__group">
+        <span class="label">For users</span>
+        <a href="#" aria-current="page">Installation</a>
+        <a href="#">User Guide</a>
+        <a href="#">Troubleshooting</a>
+      </div>
+      <div class="sidebar__group">
+        <span class="label">For contributors</span>
+        <a href="#">Architecture</a>
+        <a href="#">Development</a>
+        <a href="#">Releasing</a>
+      </div>
+    </aside>
+
+    <article class="article">
+      <div class="crumbs"><span>Docs</span><span>/</span><span>Installation</span></div>
+      <h1>Installation</h1>
+      <p class="article__sub">Everything you need to get Agento running, keep it updated, and remove it again.</p>
+
+      <h2>Requirements</h2>
+      <p><b>The Claude Code CLI, installed and signed in.</b> Agento runs every agent by launching <code>claude</code> on your machine. If <code>claude</code> works in your terminal, Agento works. There is no Anthropic API key to enter — the app reuses the CLI's own sign-in.</p>
+      <div class="note">
+        <span class="note__k">Note</span>
+        <p>Agento tells you on launch if the CLI is missing, and where it looked. See <a class="link" href="#">Troubleshooting → The Claude Code CLI</a> if the banner appears when <code>claude</code> plainly works.</p>
+      </div>
+
+      <h2>Which file do I download</h2>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>Platform</th><th>File</th><th>Updates</th></tr></thead>
+          <tbody>
+            <tr><td>macOS — Apple Silicon</td><td><code>Agento_1.2.0_aarch64.dmg</code></td><td>In-app</td></tr>
+            <tr><td>macOS — Intel</td><td><code>Agento_1.2.0_x64.dmg</code></td><td>In-app</td></tr>
+            <tr><td>Windows x64</td><td><code>Agento_1.2.0_x64-setup.exe</code></td><td>In-app</td></tr>
+            <tr><td>Linux — any distro</td><td><code>Agento_1.2.0_amd64.AppImage</code></td><td>In-app</td></tr>
+            <tr><td>Linux — Debian / Ubuntu</td><td><code>Agento_1.2.0_amd64.deb</code></td><td>Notify only</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h2>macOS</h2>
+      <p>Open the <code>.dmg</code> and drag Agento to Applications. On first launch macOS may say the app cannot be verified, because these builds are signed but not notarised.</p>
+      <h3>If Gatekeeper blocks the first launch</h3>
+      <p>Right-click the app and choose <b>Open</b>, then confirm. If that does not offer an Open button, clear the quarantine attribute:</p>
+      <pre class="code"><span class="c"># removes the download quarantine flag</span>
+<span class="k">xattr</span> -dr com.apple.quarantine <span class="s">/Applications/Agento.app</span></pre>
+      <div class="note note--warn">
+        <span class="note__k">Careful</span>
+        <p>Run that only against a bundle you downloaded from the official releases page. It disables the check that would have warned you about a tampered download.</p>
+      </div>
+
+      <h2>Where your data lives</h2>
+      <p>One directory, one database file, and nothing outside it:</p>
+      <div class="rows" style="margin-bottom:18px">
+        <div class="row"><span class="badge">db</span><span class="row__m">~/.agento/<span class="q">agento.db</span></span><span class="row__r">Chats, agents, tasks, session cache</span></div>
+        <div class="row"><span class="badge">key</span><span class="row__m">~/.agento/<span class="q">api-signing-key.pk8</span></span><span class="row__r">Per-install keypair, mode 0600</span></div>
+        <div class="row"><span class="badge">yaml</span><span class="row__m">~/.agento/<span class="q">mcps.yaml</span></span><span class="row__r">External MCP servers, if you use any</span></div>
+      </div>
+      <p>Deleting that directory resets Agento completely. It never touches <code>~/.claude</code>, which stays Claude Code's.</p>
+
+      <div class="pager">
+        <a class="sheet sheet--flat" href="#">
+          <span class="label">← Previous</span>
+          <span class="t">Overview</span>
+        </a>
+        <a class="sheet sheet--flat r" href="#">
+          <span class="label">Next →</span>
+          <span class="t">User Guide</span>
+        </a>
+      </div>
+    </article>
+
+    <nav class="toc">
+      <span class="label">On this page</span>
+      <a href="#" aria-current="true">Requirements</a>
+      <a href="#">Which file do I download</a>
+      <a href="#">macOS</a>
+      <a href="#">Windows</a>
+      <a href="#">Linux</a>
+      <a href="#">Updates</a>
+      <a href="#">Where your data lives</a>
+      <a href="#">Uninstalling</a>
+    </nav>
+  </div>
+</main>
+
+<!-- ============================== BLOG INDEX ============================= -->
+<main id="view-blog" hidden>
+  <div class="shell blog">
+    <h1 class="blog__title">Notes from the build.</h1>
+    <p class="blog__sub">Release notes, ported subsystems, and the decisions that were harder than they looked.</p>
+
+    <a class="post post--feature" href="#">
+      <div class="post__meta">
+        <span class="pill">Latest</span>
+        <span class="post__date">29 August 2026 · 9 min</span>
+      </div>
+      <h3>Finding the Claude CLI where it actually is</h3>
+      <p>A GUI app does not inherit your shell's <code>PATH</code>. Launched from the Dock, Agento saw <code>/usr/bin:/bin:/usr/sbin:/sbin</code> and nothing your <code>.zshrc</code> exported — so it told users with a working <code>claude</code> that it was not installed. The fix is five ordered rules, and the third one is a login shell.</p>
+      <div class="post__tags">
+        <span class="pill pill--plain">Engineering</span>
+        <span class="pill pill--plain">Release 1.2.0</span>
+      </div>
+    </a>
+
+    <div class="posts">
+      <a class="post" href="#">
+        <span class="post__date">14 Aug 2026</span>
+        <div class="post__body">
+          <h3>An integration that hosted zero tools, silently</h3>
+          <p>A service row that named no tools was dropped entirely — so a config written before per-service lists hosted nothing, while the allowlist still advertised everything. Here is why the obvious fix is unsound.</p>
+          <div class="post__tags"><span class="pill pill--plain">Engineering</span><span class="pill pill--plain">Security</span></div>
+        </div>
+        <span class="post__go">→</span>
+      </a>
+      <a class="post" href="#">
+        <span class="post__date">02 Aug 2026</span>
+        <div class="post__body">
+          <h3>Porting a Go scheduler without changing when it fires</h3>
+          <p>gocron parks for the whole interval. A laptop lid closed for eight hours would replay 68 missed windows as 68 back-to-back agent runs. What we do instead, and the one test that catches it.</p>
+          <div class="post__tags"><span class="pill pill--plain">Engineering</span></div>
+        </div>
+        <span class="post__go">→</span>
+      </a>
+      <a class="post" href="#">
+        <span class="post__date">21 Jul 2026</span>
+        <div class="post__body">
+          <h3>Agento 1.1: the gateway learns to check itself</h3>
+          <p>Provider credentials can now be validated before you save them, the model catalog is fetched live, and a port collision tells you which port is free instead of failing silently at boot.</p>
+          <div class="post__tags"><span class="pill pill--plain">Release</span></div>
+        </div>
+        <span class="post__go">→</span>
+      </a>
+      <a class="post" href="#">
+        <span class="post__date">09 Jul 2026</span>
+        <div class="post__body">
+          <h3>Why every byte of the wire format is frozen</h3>
+          <p>Key order, float spelling, and the difference between <code>null</code> and <code>[]</code>. A tour of the goldens in <code>parity/</code> and the bugs they caught that no unit test would have.</p>
+          <div class="post__tags"><span class="pill pill--plain">Architecture</span></div>
+        </div>
+        <span class="post__go">→</span>
+      </a>
+    </div>
+  </div>
+</main>
+
+<!-- ============================== BLOG POST ============================== -->
+<main id="view-post" hidden>
+  <div class="shell">
+    <article class="entry">
+      <div class="entry__meta">
+        <span class="pill">Engineering</span>
+        <span class="post__date">29 August 2026 · 9 min read</span>
+      </div>
+      <h1>Finding the Claude CLI where it actually is</h1>
+      <p class="entry__lede">A user ran <code>claude --version</code>, got <code>2.1.231</code>, and Agento told them Claude Code was not installed. They were both right.</p>
+
+      <p>Agento does not ship the Claude Code CLI. It spawns it — every agent run is a subprocess, and the CLI's own sign-in is the credential. So the first thing the app does on launch is work out where <code>claude</code> lives, and the first thing it did wrong was assume the answer was on <code>PATH</code>.</p>
+
+      <h2>A GUI app has a different PATH than your terminal</h2>
+      <p>This is the part that surprises people, and it surprised us. When you launch an application from Finder, the Dock or Spotlight, it inherits launchd's environment, not your shell's. That is <code>/usr/bin:/bin:/usr/sbin:/sbin</code> and nothing else. Every line your <code>.zshrc</code> exported is invisible.</p>
+
+      <blockquote>The launch that matters — from the Dock, by a user who has never opened a terminal that day — is exactly the launch where a PATH scan finds nothing.</blockquote>
+
+      <p>Worse, there is an install shape that is not on any <code>PATH</code> at all. <code>claude migrate-installer</code> puts the binary in <code>~/.claude/local</code> and wires it up as a shell <em>alias</em>. No amount of scanning directories will find it, because there is no file to find under any name you would look for.</p>
+
+      <h2>Five rules, in order</h2>
+      <p>The resolution is now a single function with an explicit order, cached once per launch:</p>
+      <pre class="code"><span class="c">// first hit wins; the answer is cached for the process</span>
+<span class="k">1.</span> AGENTO_CLAUDE_EXECUTABLE        <span class="c">// explicit override, trusted</span>
+<span class="k">2.</span> claude_executable_path setting   <span class="c">// stored, trusted</span>
+<span class="k">3.</span> $SHELL -lic 'command -v claude'  <span class="c">// login shell — finds aliases</span>
+<span class="k">4.</span> the process PATH                 <span class="c">// works when launched from a terminal</span>
+<span class="k">5.</span> known install locations          <span class="c">// last resort, verified</span></pre>
+
+      <p>Rules three through five verify what they find: the path must be an executable file <em>and</em> answer <code>--version</code> with Claude Code's banner, so an unrelated <code>claude</code> on the <code>PATH</code> is skipped rather than spawned on every turn. Rules one and two are taken on trust, because a wrapper script is a documented reason to set them and refusing it would remove the escape hatch.</p>
+
+      <h2>The bounds are a startup budget, not a ceiling</h2>
+      <p>Both subprocesses run inside the app's setup block, before the window shows. That makes three seconds for the shell probe and two per <code>--version</code> the worst case a user waits for a window — not a generous limit. A pathological shell degrades to "found by a later rule", never to a window that does not open.</p>
+
+      <div class="byline">
+        <div class="byline__av">SA</div>
+        <div>
+          <div class="byline__n">Shaharia Azam</div>
+          <div class="byline__r">Maintainer, Agento</div>
+        </div>
+      </div>
+    </article>
+  </div>
+</main>
+
+<!-- =============================== TOKENS ================================ -->
+<main id="view-tokens" hidden>
+  <div class="shell tokens">
+    <div>
+      <div class="section__head"><h2>Colour</h2><span class="label">Both themes, one token set</span></div>
+      <div class="swatches">
+        <div class="sw"><div class="sw__chip" style="background:var(--paper)"></div><div class="sw__meta"><div class="sw__n">--paper</div><div class="sw__v">ground</div></div></div>
+        <div class="sw"><div class="sw__chip" style="background:var(--raised)"></div><div class="sw__meta"><div class="sw__n">--raised</div><div class="sw__v">sheets, inputs</div></div></div>
+        <div class="sw"><div class="sw__chip" style="background:var(--sunken)"></div><div class="sw__meta"><div class="sw__n">--sunken</div><div class="sw__v">table heads, hover</div></div></div>
+        <div class="sw"><div class="sw__chip" style="background:var(--ink)"></div><div class="sw__meta"><div class="sw__n">--ink</div><div class="sw__v">text · every border</div></div></div>
+        <div class="sw"><div class="sw__chip" style="background:var(--ink-soft)"></div><div class="sw__meta"><div class="sw__n">--ink-soft</div><div class="sw__v">secondary text</div></div></div>
+        <div class="sw"><div class="sw__chip" style="background:var(--blue)"></div><div class="sw__meta"><div class="sw__n">--blue</div><div class="sw__v">the only accent</div></div></div>
+        <div class="sw"><div class="sw__chip" style="background:var(--blue-tint)"></div><div class="sw__meta"><div class="sw__n">--blue-tint</div><div class="sw__v">pills, current page</div></div></div>
+        <div class="sw"><div class="sw__chip" style="background:var(--warn)"></div><div class="sw__meta"><div class="sw__n">--warn</div><div class="sw__v">callouts only</div></div></div>
+      </div>
+    </div>
+
+    <div>
+      <div class="section__head"><h2>Type</h2><span class="label">Three roles</span></div>
+      <div class="typescale">
+        <div><span class="label">Display / Instrument Serif</span><span class="serif" style="font-size:46px">Read the transcript</span></div>
+        <div><span class="label">Heading / Instrument Serif</span><span class="serif" style="font-size:31px">Where your data lives</span></div>
+        <div><span class="label">Body / Karla 16px</span><span>Agento reads the session files Claude Code already writes to your disk.</span></div>
+        <div><span class="label">Label / JetBrains Mono</span><span class="label">FOR CONTRIBUTORS · ⌘K · V1.2.0</span></div>
+        <div><span class="label">Code / JetBrains Mono</span><code style="font-family:var(--font-mono);font-size:13px">~/.agento/agento.db</code></div>
+      </div>
+    </div>
+
+    <div>
+      <div class="section__head"><h2>Components</h2><span class="label">Hard edge, solid offset</span></div>
+      <div class="compbar">
+        <a class="btn btn--primary" href="#">Primary →</a>
+        <a class="btn btn--ink" href="#">Inverted</a>
+        <a class="btn" href="#">Default</a>
+        <span class="pill">Tinted pill</span>
+        <span class="pill pill--plain">Outline pill</span>
+      </div>
+      <div class="split" style="margin-top:20px">
+        <div class="sheet panel"><span class="label">Solid — the primary path</span><h3>A sheet</h3><p>Border, radius 3px, and a 6px solid offset shadow. Never blurred, never translucent.</p></div>
+        <div class="sheet sheet--dashed panel"><span class="label">Dashed — the alternate path</span><h3>A dashed sheet</h3><p>Dashed means "the other way to do this", as in your reference. It is a semantic, not a decoration.</p></div>
+      </div>
+    </div>
+  </div>
+</main>
+
+<script>
+  var views = ["landing","docs","blog","post","tokens"];
+  function show(name) {
+    views.forEach(function (v) {
+      document.getElementById("view-" + v).hidden = (v !== name);
+    });
+    document.querySelectorAll(".review__tab[data-view]").forEach(function (b) {
+      b.setAttribute("aria-selected", String(b.dataset.view === name));
+    });
+    window.scrollTo(0, 0);
+  }
+  document.querySelectorAll(".review__tab[data-view]").forEach(function (b) {
+    b.addEventListener("click", function () { show(b.dataset.view); });
+  });
+  document.getElementById("navDocs").addEventListener("click", function (e) { e.preventDefault(); show("docs"); });
+  document.getElementById("navBlog").addEventListener("click", function (e) { e.preventDefault(); show("blog"); });
+  document.querySelectorAll(".post").forEach(function (p) {
+    p.addEventListener("click", function (e) { e.preventDefault(); show("post"); });
+  });
+
+  document.getElementById("bodyToggle").addEventListener("click", function (e) {
+    var root = document.documentElement;
+    var serif = root.getAttribute("data-body") === "serif";
+    root.setAttribute("data-body", serif ? "sans" : "serif");
+    e.currentTarget.textContent = serif ? "Body: sans" : "Body: serif";
+  });
+
+  document.getElementById("themeToggle").addEventListener("click", function () {
+    var root = document.documentElement;
+    var dark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    var cur = root.getAttribute("data-theme") || (dark ? "dark" : "light");
+    root.setAttribute("data-theme", cur === "dark" ? "light" : "dark");
+  });
+</script>

--- a/web/docs.manifest.mjs
+++ b/web/docs.manifest.mjs
@@ -1,0 +1,30 @@
+/**
+ * Which files in docs/ become pages, in what order, under what heading.
+ *
+ * Imported by both the sync script and astro.config.mjs, so the sidebar and
+ * the generated pages cannot disagree about what exists. A doc added to docs/
+ * and not listed here fails the build rather than silently never publishing.
+ */
+export const GROUPS = [
+  { id: 'users', label: 'For users' },
+  { id: 'contributors', label: 'For contributors' },
+];
+
+export const PAGES = [
+  {
+    file: 'README.md',
+    slug: 'index',
+    label: 'Overview',
+    group: null,
+    // The lead paragraph of docs/README.md sits under a table, so it makes a
+    // poor <meta> description. Only pages whose opening line does not stand
+    // alone need an override here.
+    description: 'Guides for using Agento and for working on it — installation, every section of the app, troubleshooting, architecture and the release process.',
+  },
+  { file: 'installation.md', slug: 'installation', label: 'Installation', group: 'users' },
+  { file: 'user-guide.md', slug: 'user-guide', label: 'User Guide', group: 'users' },
+  { file: 'troubleshooting.md', slug: 'troubleshooting', label: 'Troubleshooting', group: 'users' },
+  { file: 'architecture.md', slug: 'architecture', label: 'Architecture', group: 'contributors' },
+  { file: 'development.md', slug: 'development', label: 'Development', group: 'contributors' },
+  { file: 'releasing.md', slug: 'releasing', label: 'Releasing', group: 'contributors' },
+];

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,7272 @@
+{
+  "name": "agento-site",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agento-site",
+      "dependencies": {
+        "@astrojs/rss": "^4.0.19",
+        "@astrojs/sitemap": "^3.7.3",
+        "@astrojs/starlight": "^0.41.10",
+        "@fontsource-variable/jetbrains-mono": "^5.3.0",
+        "@fontsource-variable/newsreader": "^5.3.0",
+        "@fontsource/instrument-serif": "^5.3.0",
+        "@fontsource/karla": "^5.3.0",
+        "astro": "^7.2.9"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding/-/compiler-binding-0.4.0.tgz",
+      "integrity": "sha512-x2RjDUuWfwLNtc3mjAdSRInwqh/rqbLar9cm/5FOMbHvmYZB7yfKewzSclAxWjIZsypJDXv1lhaP2WG+P8TK3g==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@astrojs/compiler-binding-darwin-arm64": "0.4.0",
+        "@astrojs/compiler-binding-darwin-x64": "0.4.0",
+        "@astrojs/compiler-binding-linux-arm64-gnu": "0.4.0",
+        "@astrojs/compiler-binding-linux-arm64-musl": "0.4.0",
+        "@astrojs/compiler-binding-linux-x64-gnu": "0.4.0",
+        "@astrojs/compiler-binding-linux-x64-musl": "0.4.0",
+        "@astrojs/compiler-binding-wasm32-wasi": "0.4.0",
+        "@astrojs/compiler-binding-win32-arm64-msvc": "0.4.0",
+        "@astrojs/compiler-binding-win32-x64-msvc": "0.4.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-darwin-arm64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-arm64/-/compiler-binding-darwin-arm64-0.4.0.tgz",
+      "integrity": "sha512-ZVUwHundaQyFNjE6uoa0usaC0WOCitDCLS/4mdb4rOiJXwVUuKJBMxI5WMzXLWmamsXtK/Z//ifLXvV5Yeh4Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-darwin-x64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-x64/-/compiler-binding-darwin-x64-0.4.0.tgz",
+      "integrity": "sha512-FI6G8AY8u6fR1SI/QRR5yGMwtvZwP34CDmZpZ5HwJGa50UM1VISTLhqkhV4a476pmgd25X1Aur2dqw6hUnrlKA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-linux-arm64-gnu": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-gnu/-/compiler-binding-linux-arm64-gnu-0.4.0.tgz",
+      "integrity": "sha512-lB9gLFJK7m82EnjaU8nlRBEfcwGNeHidW3sSjODTUjMNaoewVuUz9fwwdY5M4jiSXIqWLH3yl6TX8FTDKA74Sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-linux-arm64-musl": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-musl/-/compiler-binding-linux-arm64-musl-0.4.0.tgz",
+      "integrity": "sha512-HPbvWqbxFxyaoQJhLxCaSjtYBx9KBo7JGVzEFZCmMl968a2PsSH0UfiODYgYPXofTOIsIH2aoCcrHXML0IA3ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-linux-x64-gnu": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-gnu/-/compiler-binding-linux-x64-gnu-0.4.0.tgz",
+      "integrity": "sha512-tQKolMxoJ/+0AmLWm1PmJ/i+z3i10ZU1bNuVjEDulCf48azEMtUNjTZgHJ5MPtpYRNc7dlETr8QujUfduzoC7Q==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-linux-x64-musl": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-musl/-/compiler-binding-linux-x64-musl-0.4.0.tgz",
+      "integrity": "sha512-5v5YymudsxMHp3NBLCS8BUlu5CRqeLtWD9cKS/4nIhIEHCbpz9okmVV6I0HWqmBAPhWYcDa3vw/vltYPrOQCTA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-wasm32-wasi": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-wasm32-wasi/-/compiler-binding-wasm32-wasi-0.4.0.tgz",
+      "integrity": "sha512-m/phuH3x3PREvv1OnkM44NoPh4MatUadix1fB1u5SvMLCyDTUZykDJbKnWf1cjnYmHdlB8HcjTjl6JrCqAIXcw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-win32-arm64-msvc": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-arm64-msvc/-/compiler-binding-win32-arm64-msvc-0.4.0.tgz",
+      "integrity": "sha512-B9zYf3okEY83kM8gydlpH2BHP00w4ifxPqlYlWrgTwuD6wnkrJDCwBlgy1q31cERjCJRXN1lrE2VmkLvFjv/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-win32-x64-msvc": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-x64-msvc/-/compiler-binding-win32-x64-msvc-0.4.0.tgz",
+      "integrity": "sha512-zB0Nrv0dGc0zZWPGDRmmETTPhDRqyZjAjk+gWMlVrJX5U89obpB3VUUE1ZiHxOCN5LQojeLK6O8L/dnoHolvNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-rs": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-rs/-/compiler-rs-0.4.0.tgz",
+      "integrity": "sha512-koVikeon1kreEy+/JzLQRy3vzHHQVOjycs4degg4vFufKApZOwMZvSSAEztYNhmcQVfNVsVZZI4cEge3cexAbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler-binding": "0.4.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/internal-helpers": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.4.tgz",
+      "integrity": "sha512-nozZSy/mKYLqe4YrqbKtdOszedAfXYCtw3wZ0d+CAjz4GqQ4L9rl1ltIL5BlgwmYVinJg/RZ0MgGuWOdlyRZlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
+        "js-yaml": "^4.3.0",
+        "picomatch": "^4.0.4",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5"
+      }
+    },
+    "node_modules/@astrojs/markdown-remark": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.4.tgz",
+      "integrity": "sha512-MvspGMynWKAjTe4/lTUdmBPHIFKNVLTCF6UlyWGogTGzNrTvjD+D4n48k7h8swxsEPKHK2TwxkZO7uoaCv1Pow==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.10.4",
+        "@astrojs/prism": "4.0.2",
+        "github-slugger": "^2.0.0",
+        "hast-util-from-html": "^2.0.3",
+        "hast-util-to-text": "^4.0.2",
+        "mdast-util-definitions": "^6.0.0",
+        "rehype-raw": "^7.0.0",
+        "rehype-stringify": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "remark-smartypants": "^3.0.2",
+        "unified": "^11.0.5",
+        "unist-util-remove-position": "^5.0.0",
+        "unist-util-visit": "^5.1.0",
+        "unist-util-visit-parents": "^6.0.2",
+        "vfile": "^6.0.3"
+      }
+    },
+    "node_modules/@astrojs/markdown-satteri": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.8.tgz",
+      "integrity": "sha512-n8ItpFTCmlDsVR5+rwDmehSf+jFCYLWmZiisZNGuF7xILqYhsVeBfcha4qgS2Seq3fAc9Tm58ZVrvqFQ6RQgRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.10.4",
+        "@astrojs/prism": "4.0.2",
+        "github-slugger": "^2.0.0",
+        "satteri": "^0.10.3"
+      }
+    },
+    "node_modules/@astrojs/markdown-satteri/node_modules/@bruits/satteri-darwin-arm64": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-arm64/-/satteri-darwin-arm64-0.10.5.tgz",
+      "integrity": "sha512-27KTVl4TJkVahMy/ohyA7qd4938G5UNneFUz/PsScYfpIhj0IVAS23mpcJXdPF44sa6nva198lmV/cKIb2YPyA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@astrojs/markdown-satteri/node_modules/@bruits/satteri-darwin-x64": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-x64/-/satteri-darwin-x64-0.10.5.tgz",
+      "integrity": "sha512-IjnLe3nKspq6qaeqGgjT7MT8VrTV74yWRlaag7ZdNsI8TDAYZ0iPxMCo+9KQZHUk5EyVB+reBI/PFWL5KuFw9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@astrojs/markdown-satteri/node_modules/@bruits/satteri-linux-arm64-gnu": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-gnu/-/satteri-linux-arm64-gnu-0.10.5.tgz",
+      "integrity": "sha512-glkYXZCJywjP13v67eAyAMSJdF+ncvEbYvgi/wOtffL9tQ27lr/zsyzUfgs+ovjJ9d8JNQKiXeiArJcX8PJL9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@astrojs/markdown-satteri/node_modules/@bruits/satteri-linux-arm64-musl": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-musl/-/satteri-linux-arm64-musl-0.10.5.tgz",
+      "integrity": "sha512-yWdgG1g17Nh2QyGVlFUxGRa3FEFwiMcpZEyMNWkbM3deC94cmVc+/i9OuyFpdKuWo3GkgoCtYVOoxk1uCnCZIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@astrojs/markdown-satteri/node_modules/@bruits/satteri-linux-x64-gnu": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-gnu/-/satteri-linux-x64-gnu-0.10.5.tgz",
+      "integrity": "sha512-FVaLoPT1fBgGl0J+AYebyyXJYBachGl8Oyyrf1lye4RTqCB4S0Gwkj1uM9RJyThUOvx5VUmAT1CnNh1SFHA+kw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@astrojs/markdown-satteri/node_modules/@bruits/satteri-linux-x64-musl": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-musl/-/satteri-linux-x64-musl-0.10.5.tgz",
+      "integrity": "sha512-EHpVAx2bqW3GINHTKkljtxVfQmVDGWIuwOYOP5YghTj+0PkBa2o8oKPRtQ9Kbsr1Fye8jtUcDjhwj2jMNugZKg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@astrojs/markdown-satteri/node_modules/@bruits/satteri-wasm32-wasi": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-wasm32-wasi/-/satteri-wasm32-wasi-0.10.5.tgz",
+      "integrity": "sha512-ypz8c/Zmipxp4IoeDa228Gstv6TLzVmNs3yC6wKCoNSOjx1iwpgzu87Y3hTkXFdwChVGU85qeUDuOIarGUZQLw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.2.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@astrojs/markdown-satteri/node_modules/@bruits/satteri-win32-arm64-msvc": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-arm64-msvc/-/satteri-win32-arm64-msvc-0.10.5.tgz",
+      "integrity": "sha512-siTV88nb0LRqNpkL2gXboqCwVdq95sLtzMHS1/3eONV2gLbB3NAK46wmSMvCO/yquBvI2lvaFIfd8P12ecsxBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@astrojs/markdown-satteri/node_modules/@bruits/satteri-win32-x64-msvc": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-x64-msvc/-/satteri-win32-x64-msvc-0.10.5.tgz",
+      "integrity": "sha512-C3IfPvfvMXmlzBxaMPKFS1XiuV9pu2mC7YqkPk7PSvTgPZ8gbdASIpHpztDLvTTQjqZ0z1Ol8tK5X+V6XXC0wQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@astrojs/markdown-satteri/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@astrojs/markdown-satteri/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@astrojs/markdown-satteri/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@astrojs/markdown-satteri/node_modules/satteri": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.10.5.tgz",
+      "integrity": "sha512-Ao1LKpAEa9Wdg0otgbVKViZHEq9ebdXe4DMrp3s9vQAU0HNIuHnFEuMuOcm0ZIXyV0Yzxj91NvhLpvXZJO/5ZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.5",
+        "@types/hast": "^3.0.5",
+        "@types/mdast": "^4.0.4",
+        "@types/unist": "^3.0.3"
+      },
+      "optionalDependencies": {
+        "@bruits/satteri-darwin-arm64": "0.10.5",
+        "@bruits/satteri-darwin-x64": "0.10.5",
+        "@bruits/satteri-linux-arm64-gnu": "0.10.5",
+        "@bruits/satteri-linux-arm64-musl": "0.10.5",
+        "@bruits/satteri-linux-x64-gnu": "0.10.5",
+        "@bruits/satteri-linux-x64-musl": "0.10.5",
+        "@bruits/satteri-wasm32-wasi": "0.10.5",
+        "@bruits/satteri-win32-arm64-msvc": "0.10.5",
+        "@bruits/satteri-win32-x64-msvc": "0.10.5"
+      }
+    },
+    "node_modules/@astrojs/mdx": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-7.0.8.tgz",
+      "integrity": "sha512-RNuwq2ccTSi7NX9YqlR0noaWoVdOrZuJvdfWXotAzdhMVB0b0zEMLnNU+xar7le0GwTMlTObD/QAu8jeHA/3nA==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.10.4",
+        "@astrojs/markdown-remark": "7.2.4",
+        "@mdx-js/mdx": "^3.1.1",
+        "acorn": "^8.16.0",
+        "es-module-lexer": "^2.0.0",
+        "estree-util-visit": "^2.0.0",
+        "hast-util-to-html": "^9.0.5",
+        "piccolore": "^0.1.3",
+        "rehype-raw": "^7.0.0",
+        "remark-gfm": "^4.0.1",
+        "remark-smartypants": "^3.0.2",
+        "source-map": "^0.7.6",
+        "unist-util-visit": "^5.1.0",
+        "vfile": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "@astrojs/markdown-satteri": "^0.3.1",
+        "astro": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@astrojs/markdown-satteri": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@astrojs/prism": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-4.0.2.tgz",
+      "integrity": "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==",
+      "license": "MIT",
+      "dependencies": {
+        "prismjs": "^1.30.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.19.tgz",
+      "integrity": "sha512-e+z5wYeYtffQdHQO8c2tkSd2JEBdAuRXJV4ZEU5IxkYeE6e39woDd7nw1PH1Kk2tEYNCYuKdylnnbhGmt61awA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.7",
+        "piccolore": "^0.1.3",
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.3.tgz",
+      "integrity": "sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@astrojs/starlight": {
+      "version": "0.41.10",
+      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.41.10.tgz",
+      "integrity": "sha512-xE+OO2zzJkHPzc+giuFj+1c0sYw3//goo31PEksguNTd3XpXvV7TaJ0TzQzBUSCxYtBwWjAPkJfqR2W4aMQdhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/markdown-satteri": "^0.3.5",
+        "@astrojs/mdx": "^7.0.5",
+        "@astrojs/sitemap": "^3.7.3",
+        "@pagefind/default-ui": "^1.3.0",
+        "@types/hast": "^3.0.4",
+        "@types/js-yaml": "^4.0.9",
+        "@types/mdast": "^4.0.4",
+        "astro-expressive-code": "^0.44.0",
+        "bcp-47": "^2.1.0",
+        "hast-util-from-html": "^2.0.3",
+        "hast-util-select": "^6.0.4",
+        "hast-util-to-string": "^3.0.1",
+        "hastscript": "^9.0.1",
+        "i18next": "^26.0.7",
+        "js-yaml": "^4.1.1",
+        "klona": "^2.0.6",
+        "magic-string": "^0.30.21",
+        "mdast-util-directive": "^3.1.0",
+        "mdast-util-to-markdown": "^2.1.2",
+        "mdast-util-to-string": "^4.0.0",
+        "pagefind": "^1.5.2",
+        "rehype": "^13.0.2",
+        "rehype-format": "^5.0.1",
+        "remark-directive": "^4.0.0",
+        "satteri": "^0.9.1",
+        "ultrahtml": "^1.6.0",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.1.0",
+        "vfile": "^6.0.3"
+      },
+      "peerDependencies": {
+        "@astrojs/markdown-remark": "^7.2.0",
+        "astro": "^7.0.2"
+      },
+      "peerDependenciesMeta": {
+        "@astrojs/markdown-remark": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@astrojs/telemetry": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.3.tgz",
+      "integrity": "sha512-C1TLn5sPJr0x4vk56piHWKbnqlEB8BKyte5Y45V02U+D7BGO5eMqZDH5aPjnkXQWJggvmsTXxH03QMZ9NgWLzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^4.4.0",
+        "dset": "^3.1.4",
+        "is-docker": "^4.0.0",
+        "package-manager-detector": "^1.6.0"
+      },
+      "engines": {
+        "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bruits/satteri-darwin-arm64": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-arm64/-/satteri-darwin-arm64-0.9.5.tgz",
+      "integrity": "sha512-iw4nZgx9v30lWo/MTngQqi1pI78KI0DnkSm+lVJGYdmPLgAyDNJigVhpG42/Iq55A6c1Ll8q66ljyyRiQUxwow==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@bruits/satteri-darwin-x64": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-x64/-/satteri-darwin-x64-0.9.5.tgz",
+      "integrity": "sha512-6T26Z5Kf3cFW2PSlk9p7zT7yVxvuBSiJvYyz9u8KjYwMTqZyIDOj2wDyNpxKV4+6yUVG7rddq2QwvG/8LJA2+Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@bruits/satteri-linux-arm64-gnu": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-gnu/-/satteri-linux-arm64-gnu-0.9.5.tgz",
+      "integrity": "sha512-u51id17uJwNEMK9nBlICsq6U31c+XVqQueVBkwRIzZG+gMpS8TOJctt5h5Wz33Z8xnMdTd+adtACVz0yHgGuOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@bruits/satteri-linux-arm64-musl": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-musl/-/satteri-linux-arm64-musl-0.9.5.tgz",
+      "integrity": "sha512-v39HxiwGC5Rqm01HksP6+5Y+xKLPlsuVFgIgpEAo+SiQ22c+mJVhS3u7Z6ePAKdhL5NJoK1xq70kLz3L13AhpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@bruits/satteri-linux-x64-gnu": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-gnu/-/satteri-linux-x64-gnu-0.9.5.tgz",
+      "integrity": "sha512-F3uO8uFp3pAP5ZGXttwvh57GS7s0lL953tnNdyI2gRyP4kOOkp6pyGojNJzCjkDvWI2Cvb9iNrKok3aqQPauAw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@bruits/satteri-linux-x64-musl": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-musl/-/satteri-linux-x64-musl-0.9.5.tgz",
+      "integrity": "sha512-bicEqglLlz++mWyADaZoP0JY20s4vDfLjaPYgQqC+NI4zZLTOOg1T4GB8aqtc822Pqji8SQBmSrTb7CrP8i08Q==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@bruits/satteri-wasm32-wasi": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-wasm32-wasi/-/satteri-wasm32-wasi-0.9.5.tgz",
+      "integrity": "sha512-zauAuMwfPnKPUkd4AFixRFpXdgKwP2mKgxrIIo2gJzW0/ZneF9dbHnLkojSpaBnCCp7VUL1hIi5WWZvB1CqmAQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@bruits/satteri-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@bruits/satteri-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@bruits/satteri-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@bruits/satteri-win32-arm64-msvc": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-arm64-msvc/-/satteri-win32-arm64-msvc-0.9.5.tgz",
+      "integrity": "sha512-SrfE7NEsgZjBvU3c+RR6oQRu0ToXY5uVJEbieXEF0YTctIV2zAVlbaMjWLts074QCgh3a+XHWkR/lWh2VH2LUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@bruits/satteri-win32-x64-msvc": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-x64-msvc/-/satteri-win32-x64-msvc-0.9.5.tgz",
+      "integrity": "sha512-5Kw9ZAtTGS8WHizyn+CJhjjfIQrw+7jcZodpmpXJjefnO15M8UexIi6JR2E5thyvsmHyhL6ZDDMUNR4bKJPd4g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@capsizecss/unpack": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.1.tgz",
+      "integrity": "sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fontkitten": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.3.tgz",
+      "integrity": "sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.7.0.tgz",
+      "integrity": "sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.4.3",
+        "fast-string-width": "^3.0.2",
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@ctrl/tinycolor": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-4.2.0.tgz",
+      "integrity": "sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@expressive-code/core": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@expressive-code/core/-/core-0.44.1.tgz",
+      "integrity": "sha512-3dDo9N8D7hYrLNNMMWFovg3+aDUtnQm7c7z0GZc1c0LEFVBc0Q6lKG+tVT28gDadOvsgOANfCn35fgpe97Pmgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ctrl/tinycolor": "^4.0.4",
+        "hast-util-select": "^6.0.2",
+        "hast-util-to-html": "^9.0.1",
+        "hast-util-to-text": "^4.0.1",
+        "hastscript": "^9.0.0",
+        "postcss": "^8.4.38",
+        "postcss-nested": "^6.0.1",
+        "unist-util-visit": "^5.0.0",
+        "unist-util-visit-parents": "^6.0.1"
+      }
+    },
+    "node_modules/@expressive-code/plugin-frames": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-frames/-/plugin-frames-0.44.1.tgz",
+      "integrity": "sha512-HC/bdRao9225ApcgO/e3jn8ZOhldKO7ob1O/Tcipvtv7Vb5nMphZhMtD9uuywpvxkPYBHJi3504WhrKg05Dwqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expressive-code/core": "^0.44.1"
+      }
+    },
+    "node_modules/@expressive-code/plugin-shiki": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-shiki/-/plugin-shiki-0.44.1.tgz",
+      "integrity": "sha512-YApiZt3buUzBwL5tqj8G+sYC5NjMjRCHgQwr9bmGl69rtcHy6fE9dooWUeKYB978fJT2BuxT5FeHcF47rA3SEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expressive-code/core": "^0.44.1",
+        "shiki": "^4.0.2"
+      }
+    },
+    "node_modules/@expressive-code/plugin-text-markers": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-text-markers/-/plugin-text-markers-0.44.1.tgz",
+      "integrity": "sha512-B3BsJoJ8CFMlcIX9f+X9tcI3C4zPDO601+YuLi9GheSTNro7ZfqSjLptMQKBHOWZvxnAtY5zvIX7iO/qtBhNBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expressive-code/core": "^0.44.1"
+      }
+    },
+    "node_modules/@fontsource-variable/jetbrains-mono": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/jetbrains-mono/-/jetbrains-mono-5.3.0.tgz",
+      "integrity": "sha512-F32xpS2NsGYoQi2ADSkKTgpJj7ozajsGgDJ8woTnqjmIB+dxDIqImjl4pXZVEExu8UFZ2ndhmX18EBS/hdz3Lw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/newsreader": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/newsreader/-/newsreader-5.3.0.tgz",
+      "integrity": "sha512-rrzYi43qMpbzwuFtf9OkWH8sxAPVPcQQQEwXpPtwaKYeJ8yVg5aLs5kawmo1f2Q1t1M38TLmEKCkGVDsYwgdFw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/instrument-serif": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/instrument-serif/-/instrument-serif-5.3.0.tgz",
+      "integrity": "sha512-mDiaIg0u67sYV59fie92Wz4sM8UiVlbL7fLxnFPCKkX15DMASEnQTREbaP5S5/3DCcsoAOcQ0sV9E4AeY4QqYQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/karla": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/karla/-/karla-5.3.0.tgz",
+      "integrity": "sha512-zHBkxMumwFE+K4RgHQAv2xH0O2lAX9y4zPun5JEFZyNQQclZ5Oz/XvByE3CB5+rnxKEV5BXlZShIEfz0VILDmQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.4.tgz",
+      "integrity": "sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.4.tgz",
+      "integrity": "sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.4.tgz",
+      "integrity": "sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.3.tgz",
+      "integrity": "sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.3.tgz",
+      "integrity": "sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.3.tgz",
+      "integrity": "sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.3.tgz",
+      "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.3.tgz",
+      "integrity": "sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.3.tgz",
+      "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.3.tgz",
+      "integrity": "sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.3.tgz",
+      "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.3.tgz",
+      "integrity": "sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.3.tgz",
+      "integrity": "sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.4.tgz",
+      "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.4.tgz",
+      "integrity": "sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.4.tgz",
+      "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.4.tgz",
+      "integrity": "sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.4.tgz",
+      "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.4.tgz",
+      "integrity": "sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.4.tgz",
+      "integrity": "sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.4.tgz",
+      "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.4.tgz",
+      "integrity": "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==",
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.4.tgz",
+      "integrity": "sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.4.tgz",
+      "integrity": "sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.4.tgz",
+      "integrity": "sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.4.tgz",
+      "integrity": "sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "license": "MIT"
+    },
+    "node_modules/@mdx-js/mdx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-3.1.1.tgz",
+      "integrity": "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdx": "^2.0.0",
+        "acorn": "^8.0.0",
+        "collapse-white-space": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "estree-util-scope": "^1.0.0",
+        "estree-walker": "^3.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "markdown-extensions": "^2.0.0",
+        "recma-build-jsx": "^1.0.0",
+        "recma-jsx": "^1.0.0",
+        "recma-stringify": "^1.0.0",
+        "rehype-recma": "^1.0.0",
+        "remark-mdx": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "source-map": "^0.7.0",
+        "unified": "^11.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.3.tgz",
+      "integrity": "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@oslojs/encoding": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+      "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+      "license": "MIT"
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.147.0.tgz",
+      "integrity": "sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/default-ui": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/default-ui/-/default-ui-1.5.2.tgz",
+      "integrity": "sha512-pm1LMnQg8N2B3n2TnjKlhaFihpz6zTiA4HiGQ6/slKO/+8K9CAU5kcjdSSPgpuk1PMuuN4hxLipUIifnrkl3Sg==",
+      "license": "MIT"
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
+      "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
+      "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
+      "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
+      "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
+      "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.6.tgz",
+      "integrity": "sha512-b+jTcARdTiFLI6jB4a5XjTm0RWd6KcRfQj/I2356fxUZemiho9zQLxo0RtCuMDAyKcLo6cEltkgbQp6d1+sjjQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.6.tgz",
+      "integrity": "sha512-lkWU8ZJaRk9q3CIEY1Tc7vIFALp3Xw5NfGJo2hQg5oIqNgxWi1zI+IiDEK3r70BF5Dzol1tcXsnzsRc8NLhG+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.6.tgz",
+      "integrity": "sha512-dgR56NYnvAszm7Ob1B2/Vn0e8bUQYZH2UjVaMMtMVOCKFSfjhfLmuA/9+O+F+ajUdG6B/bSssrKW6JJYASa8jA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.6.tgz",
+      "integrity": "sha512-vpVxFvUCFioJqug7OTvqptkc4yb8UX0AwfDmJpaR/0sWz+BUmqSVAf7c8JkUgnN8YLspb4a/N6NhTyMAmdyQ7Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.6.tgz",
+      "integrity": "sha512-h1wG6Y6K3JlRswxsI64qQJqBAy4vrLuHgRbc8CZMGSWTOFRY6ghMApM1NKzB2I0n5xV1fjkE18SuVl2QpLeNpA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.6.tgz",
+      "integrity": "sha512-tbCiqub0q2MVWJKgF5PoAlNWCtQydiOYSLIkd8sByqK/6MMYLJRcSXSYodqYtd0O+Fw7QaVmKKlS4oL94YRZ0w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.6.tgz",
+      "integrity": "sha512-oxK9+baEBPhZG5HB4URY+uU04zJWeZlH6Tb9rB5DK4DF9XR1uXNLXt5Q5ZsugTKayNCNLhkcwz/ye74hRI98dg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.6.tgz",
+      "integrity": "sha512-muWCk27FVBEZtv0MsK8gnfSmgczA8KQ0uRVJbTABKhkRfQc38aUrcb7fhi3BNiyseFmgcRsoMfQsSNJ+DbZdSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.6.tgz",
+      "integrity": "sha512-eWDoSfU7Co2qj3vgB3Dt4lj1mG6CoWbcJQkRMP3XJplyCMtuaq3LHvPFjS9QIPvMGWVadJC04Xiy0IdcVPtnwQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.6.tgz",
+      "integrity": "sha512-2bWNjRSIayvupRKxXUY2tWG9fYdoUlTqWywHRvE8Eq3GvuQ+f2HeIkve697fIt+IQs/PV8yFsdWuhp1aJ1PdnA==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.6.tgz",
+      "integrity": "sha512-KekI0gS0wLxe1UBSQSjenBVwou/JkcQPDzBPICGZjxUv9k3RteHDPBQaiOicZUFKRIH2wKEimGwVpnJsbPzu7w==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.6.tgz",
+      "integrity": "sha512-TvtPnfVr+HtyGiDmPK4VWmlNm7QhNNAcK5Q9A7aOXsI8545yCyaoMaicXrFZ72JzeYjaUVk7yT243zT0jzjFKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.6.tgz",
+      "integrity": "sha512-iOo0VEay2XFhaCcH0sps5XIimkSuOnNaZrf6+ZkoSOQBJPKNU48RkmJv0/lSpipexu5P+ouFgafe5IGr/DiQfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.6.tgz",
+      "integrity": "sha512-y5NTmmasMS455JlOCO4ZM9krIchv3Mvm1crL1iUPGOPgEzSkves9n0SdC5Sjz6+qWDFhd8/JpfWMH8NSWNHe+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.6.tgz",
+      "integrity": "sha512-np8iZSLfXlAD4kWhiyq/u0Yt8oZDtRQ8lGhQaCXo2rl37KNjeU0GjJuwr4P3oeZ++ROfofsKNBqR5LTO8aXyWQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "license": "MIT"
+    },
+    "node_modules/@shikijs/core": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.4.3.tgz",
+      "integrity": "sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.4.3",
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.4.3.tgz",
+      "integrity": "sha512-FbOjFJp9VLdo1Wevs10BBtVxiTWwNLqZh5Gkhjgda/ioL15YOgeSl9n+6XMa3qRlPQzfhFNe641SrynFHYG0nQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.4.3.tgz",
+      "integrity": "sha512-EcOQkxdxGQrc1Row/cC2c96/v1dbZqGnEVu1qTuT/MJmp6+cXCvQussowVmCv5Tqr3KuY3c7IbM6HTW3LJ1k9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.4.3.tgz",
+      "integrity": "sha512-ePic0yfAJGOF83D5wBHK/00EjK65oahBYxFk5epgq33WRv7X9UuxLEV8PtR0szC0z8dl7INIpIodB99JRFlR+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.4.3.tgz",
+      "integrity": "sha512-m0wBeLDQDeIxRdUmrCPdQqfuUamDwRL5isCfYbguKD6NiaKpVbsv+3J81DyIKgNW5h4WAIIr8T4EkgQrBBxvaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.4.3.tgz",
+      "integrity": "sha512-w8UHjeUnIR965KMWJHUPXOc2mNJUnK3vpVLYLvw5IYU2mnTTJ89E24OrJDBNiJDQ0qzb0tc4l7mrIXx5cFeIyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.4.3.tgz",
+      "integrity": "sha512-UEJxmRR++MAGR6hugn0vgVS2W/6lWAts84FFSrnlH9sP0LNol7E5+NQ792pH8liWUhyMyjhTgSUH3k7iD7tc5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdx": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.14.tgz",
+      "integrity": "sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/nlcst": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-2.0.3.tgz",
+      "integrity": "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.4.0.tgz",
+      "integrity": "sha512-1mEZtMKPM09vDmQt5y7YvmN2+DFTP7Tg0EWXdic8/C6VRnpb33e4ghisCIE3WZjsE2N8mf+QV1Zqh7ZFYLWInQ==",
+      "license": "ISC"
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/am-i-vibing": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/am-i-vibing/-/am-i-vibing-0.4.0.tgz",
+      "integrity": "sha512-MxT4XZL7pzLHpuvhDKdMaQHMGGkJDLluKBLsbstn+8wv9sWcFT6h+0ve9qkml95amVTZtZV83gQe2hY+ojgHLg==",
+      "license": "MIT",
+      "dependencies": {
+        "process-ancestry": "^0.1.0"
+      },
+      "bin": {
+        "am-i-vibing": "dist/cli.mjs"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/array-iterate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-2.0.1.tgz",
+      "integrity": "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
+      }
+    },
+    "node_modules/astro": {
+      "version": "7.2.9",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-7.2.9.tgz",
+      "integrity": "sha512-o5nZFo/bieF6rp4x9sQSLhI7GO7Bahpld38Y4LvX27nFoxNiuttjI+Hea81w5ksORLHgdPUlQpU9obPz5QRa8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler-rs": "^0.4.0",
+        "@astrojs/internal-helpers": "0.10.4",
+        "@astrojs/markdown-satteri": "0.3.8",
+        "@astrojs/telemetry": "3.3.3",
+        "@capsizecss/unpack": "^4.0.0",
+        "@clack/prompts": "^1.1.0",
+        "@oslojs/encoding": "^1.1.0",
+        "am-i-vibing": "^0.4.0",
+        "aria-query": "^5.3.2",
+        "axobject-query": "^4.1.0",
+        "ci-info": "^4.4.0",
+        "clsx": "^2.1.1",
+        "common-ancestor-path": "^2.0.0",
+        "cookie": "^2.0.1",
+        "devalue": "^5.8.1",
+        "diff": "^9.0.0",
+        "dset": "^3.1.4",
+        "es-module-lexer": "^2.0.0",
+        "esbuild": "^0.28.0",
+        "find-proc": "0.1.0",
+        "flattie": "^1.1.1",
+        "fontace": "~0.4.1",
+        "get-tsconfig": "5.0.0-beta.4",
+        "github-slugger": "^2.0.0",
+        "html-escaper": "3.0.3",
+        "http-cache-semantics": "^4.2.0",
+        "js-yaml": "^4.3.0",
+        "jsonc-parser": "^3.3.1",
+        "magic-string": "^1.0.0",
+        "magicast": "^0.5.2",
+        "mrmime": "^2.0.1",
+        "neotraverse": "^1.0.1",
+        "obug": "^2.1.1",
+        "p-limit": "^7.3.0",
+        "p-queue": "^9.1.0",
+        "package-manager-detector": "^1.6.0",
+        "piccolore": "^0.1.3",
+        "picomatch": "^4.0.4",
+        "semver": "^7.7.4",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "svgo": "^4.0.1",
+        "tinyclip": "^0.1.12",
+        "tinyexec": "^1.0.4",
+        "tinyglobby": "^0.2.15",
+        "ultrahtml": "^1.6.0",
+        "unifont": "~0.7.5",
+        "unstorage": "^1.17.5",
+        "vite": "^8.0.13",
+        "vitefu": "^1.1.2",
+        "xxhash-wasm": "^1.1.0",
+        "yargs-parser": "^22.0.0",
+        "zod": "^4.3.6"
+      },
+      "bin": {
+        "astro": "bin/astro.mjs"
+      },
+      "engines": {
+        "node": ">=22.12.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/astrodotbuild"
+      },
+      "optionalDependencies": {
+        "sharp": "^0.35.4"
+      },
+      "peerDependencies": {
+        "@astrojs/markdown-remark": "7.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@astrojs/markdown-remark": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/astro-expressive-code": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/astro-expressive-code/-/astro-expressive-code-0.44.1.tgz",
+      "integrity": "sha512-DT1LnCqbHasBKlvzJ3m6LR4VI94wwx3W9EV/YbP1te4rqjOHsvsezHYuqb5MeLWLftXms/1FA9QBbwCo43DnJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "rehype-expressive-code": "^0.44.1",
+        "url-extras": "^0.1.0"
+      },
+      "peerDependencies": {
+        "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta || ^7.0.0"
+      }
+    },
+    "node_modules/astro/node_modules/magic-string": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/bcp-47": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bcp-47/-/bcp-47-2.1.1.tgz",
+      "integrity": "sha512-KLw+H/gd2p4zly1X7Yh/qziuyae5/w/QFnvTng9eZL5fvszL7Whl3MBoWF8yxL7ksUjBfOD+OxkytiqbBpG+Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/bcp-47-match": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/bcp-47-match/-/bcp-47-match-2.0.3.tgz",
+      "integrity": "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/collapse-white-space": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
+      "integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/common-ancestor-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
+      "integrity": "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-2.0.1.tgz",
+      "integrity": "sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cookie-es": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+      "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
+      "license": "MIT"
+    },
+    "node_modules/crossws": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+      "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-6.0.0.tgz",
+      "integrity": "sha512-rZZVSLle8v0+EY8QAkDWrKhpgt6SA5OtHsgBnsj6ZaLb5dmDVOWUDtQitd9ydxxvEjhewNudS6eTVU7uOyzvXw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^7.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "nth-check": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-selector-parser": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-3.3.0.tgz",
+      "integrity": "sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-7.0.0.tgz",
+      "integrity": "sha512-wD5oz5xibMOPHzy13CyGmogB3phdvcDaB5t0W/Nr5Z2O/agcB8YwOz6e2Lsp10pNDzBoDO9nVa3RGs/2BttpHQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csso": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "~2.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/css-tree": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/mdn-data": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.2.tgz",
+      "integrity": "sha512-po4PAY5c53tw5XMocSnf8A/5OHhbbUftpr93aEN6BBoAdntUmK7vu7wOATqvt7cXO7m1Cl4gMVn6p7n6n4mj0w==",
+      "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/direction": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-2.0.1.tgz",
+      "integrity": "sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==",
+      "license": "MIT",
+      "bin": {
+        "direction": "cli.js"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dset": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "license": "MIT"
+    },
+    "node_modules/esast-util-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/esast-util-from-estree/-/esast-util-from-estree-2.0.0.tgz",
+      "integrity": "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/esast-util-from-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esast-util-from-js/-/esast-util-from-js-2.0.1.tgz",
+      "integrity": "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "acorn": "^8.0.0",
+        "esast-util-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-util-attach-comments": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz",
+      "integrity": "sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-build-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/estree-util-build-jsx/-/estree-util-build-jsx-3.0.1.tgz",
+      "integrity": "sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "estree-walker": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-scope": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-util-scope/-/estree-util-scope-1.0.1.tgz",
+      "integrity": "sha512-B0np3dcdxqILX5e9nEi5/Fr4K7gL4oYFVPV1zRa2e9wRCbQoZZNWOZFYyoInvXUPJXBXjss+QXlWLJChDEHDkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-to-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-to-js/-/estree-util-to-js-2.0.0.tgz",
+      "integrity": "sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "astring": "^1.8.0",
+        "source-map": "^0.7.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-visit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
+      "integrity": "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/expressive-code": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/expressive-code/-/expressive-code-0.44.1.tgz",
+      "integrity": "sha512-GakidxhapWDzpKLqEaFQ8wGk6gAqEtPQibu8+yPBfnDLgev5Vdsh1pasTxnrXL/mzIknyqeTwhMHTghdaiUrTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expressive-code/core": "^0.44.1",
+        "@expressive-code/plugin-frames": "^0.44.1",
+        "@expressive-code/plugin-shiki": "^0.44.1",
+        "@expressive-code/plugin-text-markers": "^0.44.1"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.1.tgz",
+      "integrity": "sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.11.1.tgz",
+      "integrity": "sha512-TBw6K/fxoQGGjCmZDw9w/ZwP3uDcnTM4YH/g+PFRWr8sbe5idXtxNN6vITh4+1ruCZaho6uBFurElsA7F0zzgw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.2",
+        "xml-naming": "^0.3.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/find-proc": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/find-proc/-/find-proc-0.1.0.tgz",
+      "integrity": "sha512-OaOpEYv2PiQ7SQ5LIrl+deA1XaWcxEjnpM6VuWXTUvn+teIXxeFTLDmu18/zDQpFmHN4o3oDBX+BT0AGwEhemg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/flattie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
+      "integrity": "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fontace": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.4.1.tgz",
+      "integrity": "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==",
+      "license": "MIT",
+      "dependencies": {
+        "fontkitten": "^1.0.2"
+      }
+    },
+    "node_modules/fontkitten": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fontkitten/-/fontkitten-1.0.3.tgz",
+      "integrity": "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==",
+      "license": "MIT",
+      "dependencies": {
+        "tiny-inflate": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "5.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-5.0.0-beta.4.tgz",
+      "integrity": "sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20.20.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "license": "ISC"
+    },
+    "node_modules/h3": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+      "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie-es": "^1.2.3",
+        "crossws": "^0.3.5",
+        "defu": "^6.1.6",
+        "destr": "^2.0.5",
+        "iron-webcrypto": "^1.2.1",
+        "node-mock-http": "^1.0.4",
+        "radix3": "^1.1.2",
+        "ufo": "^1.6.3",
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/hast-util-embedded": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-3.0.0.tgz",
+      "integrity": "sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-is-element": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-format": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-format/-/hast-util-format-1.1.0.tgz",
+      "integrity": "sha512-yY1UDz6bC9rDvCWHpx12aIBGRG7krurX0p0Fm6pT547LwDIZZiNr8a+IHDogorAdreULSEzP82Nlv5SZkHZcjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-minify-whitespace": "^1.0.0",
+        "hast-util-phrasing": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-whitespace-sensitive-tag-names": "^3.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-has-property": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
+      "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-body-ok-link": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-3.0.1.tgz",
+      "integrity": "sha512-0qpnzOBLztXHbHQenVB8uNuxTnm/QBFUOmdOSsEn7GnBtyY07+ENTWVFBAnXd/zEgd9/SUG3lRY7hSIBWRgGpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-minify-whitespace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-minify-whitespace/-/hast-util-minify-whitespace-1.0.1.tgz",
+      "integrity": "sha512-L96fPOVpnclQE0xzdWb/D12VT5FabA7SnZOUMtL1DbXmYiHJMXZvFkIZfiMmTCNJHUeO2K9UYNXoVyfz+QHuOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-phrasing": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-phrasing/-/hast-util-phrasing-3.0.1.tgz",
+      "integrity": "sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-has-property": "^3.0.0",
+        "hast-util-is-body-ok-link": "^3.0.0",
+        "hast-util-is-element": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "hast-util-to-parse5": "^8.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "parse5": "^7.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-select": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-select/-/hast-util-select-6.0.4.tgz",
+      "integrity": "sha512-RqGS1ZgI0MwxLaKLDxjprynNzINEkRHY2i8ln4DDjgv9ZhcYVIHN9rlpiYsqtFwrgpYU361SyWDQcGNIBVu3lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "bcp-47-match": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "css-selector-parser": "^3.0.0",
+        "devlop": "^1.0.0",
+        "direction": "^2.0.0",
+        "hast-util-has-property": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "nth-check": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-estree": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz",
+      "integrity": "sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-attach-comments": "^3.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/html-whitespace-sensitive-tag-names": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-whitespace-sensitive-tag-names/-/html-whitespace-sensitive-tag-names-3.0.1.tgz",
+      "integrity": "sha512-q+310vW8zmymYHALr1da4HyXUQ0zgiIwIicEfotYPWGN0OJVEN/58IJ3A4GBYcEq3LGAZqKb+ugvP0GNB9CEAA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/i18next": {
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.4.0.tgz",
+      "integrity": "sha512-rsmK5bFqsD1AetSFSIa43wtNR4WpvvH4p0tLEsTxkC7QTrfdFm06nbQ95bh8Og4wwaCnUEcm9DVYL2cgxitiQg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://www.locize.com/i18next"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "^5 || ^6 || ^7"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/iron-webcrypto": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+      "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/brc-dd"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-4.0.0.tgz",
+      "integrity": "sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unsafe": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.2.tgz",
+      "integrity": "sha512-HgbIHPBH0KHHCcjLfGsCvhtPTVxjaAZlXjwdz7/GQC40SjSe4sfQsar8J5VFo8JOSbarkpV0OLG95bbaNd9aAQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
+    },
+    "node_modules/klona": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
+      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/markdown-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-2.0.0.tgz",
+      "integrity": "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-definitions": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz",
+      "integrity": "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-directive": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-3.1.0.tgz",
+      "integrity": "sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
+      "integrity": "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-directive": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
+      "integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdx-expression": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz",
+      "integrity": "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-mdx-jsx": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz",
+      "integrity": "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdx-md": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
+      "integrity": "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
+      "integrity": "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.0.0",
+        "acorn-jsx": "^5.0.0",
+        "micromark-extension-mdx-expression": "^3.0.0",
+        "micromark-extension-mdx-jsx": "^3.0.0",
+        "micromark-extension-mdx-md": "^2.0.0",
+        "micromark-extension-mdxjs-esm": "^3.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs-esm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
+      "integrity": "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-mdx-expression": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz",
+      "integrity": "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-events-to-acorn": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz",
+      "integrity": "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      }
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/neotraverse": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-1.0.1.tgz",
+      "integrity": "sha512-WmmLty1YWwJl9yZi77v2dVIV6X2kuYV8YYBI/G3LWGKdGHmHUvL1z7FW0iDvEvGAwNEoc5x1tOOOyDnf5jJw/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/nlcst-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz",
+      "integrity": "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "license": "MIT"
+    },
+    "node_modules/node-mock-http": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.5.tgz",
+      "integrity": "sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw==",
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/ofetch": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+      "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
+      "license": "MIT",
+      "dependencies": {
+        "destr": "^2.0.5",
+        "node-fetch-native": "^1.6.7",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.12.tgz",
+      "integrity": "sha512-65S/5gk9YSsaRjcyf7Nfa6h/d3E8/1gslpXfI4W7Dxn/oap8IKRuNT5VXkLQ1YFKIEg4apRY4Pj6aiwFzrDdmw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.1.tgz",
+      "integrity": "sha512-0trZaiG7Y7kN/Egy9a8j47t9osC0Tch4PaIWd9yGF6bvmlk7muExRvGNYb8sXBwEKMoNKsbNN9P8EefuQekE4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.3.tgz",
+      "integrity": "sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+      "license": "MIT"
+    },
+    "node_modules/pagefind": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
+      "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.5.2",
+        "@pagefind/darwin-x64": "1.5.2",
+        "@pagefind/freebsd-x64": "1.5.2",
+        "@pagefind/linux-arm64": "1.5.2",
+        "@pagefind/linux-x64": "1.5.2",
+        "@pagefind/windows-arm64": "1.5.2",
+        "@pagefind/windows-x64": "1.5.2"
+      }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-latin": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
+      "integrity": "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0",
+        "@types/unist": "^3.0.0",
+        "nlcst-to-string": "^4.0.0",
+        "unist-util-modify-children": "^4.0.0",
+        "unist-util-visit-children": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/piccolore": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
+      "integrity": "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==",
+      "license": "ISC"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/process-ancestry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/process-ancestry/-/process-ancestry-0.1.0.tgz",
+      "integrity": "sha512-tGqJW/UnclpYASFcM6Xh8D8l/BMtaQ9+CSG0vlJSJTcdMM4lDRv4c6H0Pdcsfted+bVczdYSfk2fdukg2gQkZg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/radix3": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+      "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
+      "license": "MIT"
+    },
+    "node_modules/readdirp": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/recma-build-jsx": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
+      "integrity": "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-util-build-jsx": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/recma-jsx": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/recma-jsx/-/recma-jsx-1.0.1.tgz",
+      "integrity": "sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn-jsx": "^5.0.0",
+        "estree-util-to-js": "^2.0.0",
+        "recma-parse": "^1.0.0",
+        "recma-stringify": "^1.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/recma-parse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-parse/-/recma-parse-1.0.0.tgz",
+      "integrity": "sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "esast-util-from-js": "^2.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/recma-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-stringify/-/recma-stringify-1.0.0.tgz",
+      "integrity": "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-util-to-js": "^2.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
+    },
+    "node_modules/rehype": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz",
+      "integrity": "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "rehype-parse": "^9.0.0",
+        "rehype-stringify": "^10.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-expressive-code": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/rehype-expressive-code/-/rehype-expressive-code-0.44.1.tgz",
+      "integrity": "sha512-+VZgs7Evw4LXRN3owpoBNSTpYuW6GeOdjqcUT1TuY8o/4MGPtbd0EU7Bgrju7X8KrQ6SslOBAuGWJ5fV5TriJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expressive-code": "^0.44.1"
+      }
+    },
+    "node_modules/rehype-format": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-format/-/rehype-format-5.0.1.tgz",
+      "integrity": "sha512-zvmVru9uB0josBVpr946OR8ui7nJEdzZobwLOOqHb/OOD88W0Vk2SqLwoVOj0fM6IPCCO6TaV9CvQvJMWwukFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-format": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-parse": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+      "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-raw": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-raw": "^9.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-recma": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-recma/-/rehype-recma-1.0.0.tgz",
+      "integrity": "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "hast-util-to-estree": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-stringify": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+      "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-directive": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-4.0.0.tgz",
+      "integrity": "sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-directive": "^3.0.0",
+        "micromark-extension-directive": "^4.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-mdx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.1.tgz",
+      "integrity": "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-mdx": "^3.0.0",
+        "micromark-extension-mdxjs": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-smartypants": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.3.tgz",
+      "integrity": "sha512-gCaK+ndZ0hYezlqFegHFCVh2CQemsi0Npdh1qVM9bxlUFknjkbP6VmojWhddOCrbK0PbbacmYLWfTULRiT1eWA==",
+      "license": "MIT",
+      "dependencies": {
+        "retext": "^9.0.0",
+        "retext-smartypants": "^6.0.0",
+        "unified": "^11.0.4",
+        "unist-util-visit": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retext": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
+      "integrity": "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0",
+        "retext-latin": "^4.0.0",
+        "retext-stringify": "^4.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/retext-latin": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-4.0.0.tgz",
+      "integrity": "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0",
+        "parse-latin": "^7.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/retext-smartypants": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-6.2.0.tgz",
+      "integrity": "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0",
+        "nlcst-to-string": "^4.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/retext-stringify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-4.0.0.tgz",
+      "integrity": "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0",
+        "nlcst-to-string": "^4.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.6.tgz",
+      "integrity": "sha512-vMM4q3aixf46GiF1Kok8jDPFsEpXgFWGjUHXNkNHNm+Y2adXAG2dbX91jkti3i0ZRsOlcmbuzAz1poObSHCmUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.147.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm-eabi": "1.2.6",
+        "@rolldown/binding-android-arm64": "1.2.6",
+        "@rolldown/binding-darwin-arm64": "1.2.6",
+        "@rolldown/binding-darwin-x64": "1.2.6",
+        "@rolldown/binding-freebsd-x64": "1.2.6",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.6",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.6",
+        "@rolldown/binding-linux-arm64-musl": "1.2.6",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.6",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.6",
+        "@rolldown/binding-linux-x64-gnu": "1.2.6",
+        "@rolldown/binding-linux-x64-musl": "1.2.6",
+        "@rolldown/binding-openharmony-arm64": "1.2.6",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.6",
+        "@rolldown/binding-win32-x64-msvc": "1.2.6"
+      }
+    },
+    "node_modules/satteri": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.9.5.tgz",
+      "integrity": "sha512-ZuWVl+vnM64y+/TtX8Kosv2c00W+hLQiiwnEL6H0UKVVrxFqMw4D2CJHHQaouVd89OAhtBBfjWLqhKi3TVUV4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.5",
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
+        "@types/unist": "^3.0.3"
+      },
+      "optionalDependencies": {
+        "@bruits/satteri-darwin-arm64": "0.9.5",
+        "@bruits/satteri-darwin-x64": "0.9.5",
+        "@bruits/satteri-linux-arm64-gnu": "0.9.5",
+        "@bruits/satteri-linux-arm64-musl": "0.9.5",
+        "@bruits/satteri-linux-x64-gnu": "0.9.5",
+        "@bruits/satteri-linux-x64-musl": "0.9.5",
+        "@bruits/satteri-wasm32-wasi": "0.9.5",
+        "@bruits/satteri-win32-arm64-msvc": "0.9.5",
+        "@bruits/satteri-win32-x64-msvc": "0.9.5"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.4.tgz",
+      "integrity": "sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.5"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.4",
+        "@img/sharp-darwin-x64": "0.35.4",
+        "@img/sharp-freebsd-wasm32": "0.35.4",
+        "@img/sharp-libvips-darwin-arm64": "1.3.3",
+        "@img/sharp-libvips-darwin-x64": "1.3.3",
+        "@img/sharp-libvips-linux-arm": "1.3.3",
+        "@img/sharp-libvips-linux-arm64": "1.3.3",
+        "@img/sharp-libvips-linux-ppc64": "1.3.3",
+        "@img/sharp-libvips-linux-riscv64": "1.3.3",
+        "@img/sharp-libvips-linux-s390x": "1.3.3",
+        "@img/sharp-libvips-linux-x64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3",
+        "@img/sharp-linux-arm": "0.35.4",
+        "@img/sharp-linux-arm64": "0.35.4",
+        "@img/sharp-linux-ppc64": "0.35.4",
+        "@img/sharp-linux-riscv64": "0.35.4",
+        "@img/sharp-linux-s390x": "0.35.4",
+        "@img/sharp-linux-x64": "0.35.4",
+        "@img/sharp-linuxmusl-arm64": "0.35.4",
+        "@img/sharp-linuxmusl-x64": "0.35.4",
+        "@img/sharp-webcontainers-wasm32": "0.35.4",
+        "@img/sharp-win32-arm64": "0.35.4",
+        "@img/sharp-win32-ia32": "0.35.4",
+        "@img/sharp-win32-x64": "0.35.4"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/shiki": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.4.3.tgz",
+      "integrity": "sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.4.3",
+        "@shikijs/engine-javascript": "4.4.3",
+        "@shikijs/engine-oniguruma": "4.4.3",
+        "@shikijs/langs": "4.4.3",
+        "@shikijs/themes": "4.4.3",
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
+    },
+    "node_modules/sitemap": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^24.9.2",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/esm/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "license": "MIT"
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.2.tgz",
+      "integrity": "sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
+    },
+    "node_modules/svgo": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.1.0.tgz",
+      "integrity": "sha512-bkxnTg1kSU0guhIBmibA6UUhrQmPVA1XsQLN+ylCd+UWzbnLkySOcXpyk1mrl05f+pcaCx2eHb+sp6BgMZWX+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^11.1.0",
+        "css-select": "^6.0.0",
+        "css-tree": "^3.0.1",
+        "css-what": "^7.0.0",
+        "csso": "^5.0.5",
+        "picocolors": "^1.1.1",
+        "sax": "1.6.1"
+      },
+      "bin": {
+        "svgo": "bin/svgo.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
+    "node_modules/tinyclip": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.15.tgz",
+      "integrity": "sha512-uo33abH+Ays0xYaDysoBt494Hb3hsEczMpcC0MwFl773pazORx4fmvKhclhR1wonUbB6vvpRsvVMwnhfqeMc+A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^16.14.0 || >= 17.3.0"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "license": "MIT"
+    },
+    "node_modules/ultrahtml": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.7.0.tgz",
+      "integrity": "sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g==",
+      "license": "MIT"
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unifont": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.5.tgz",
+      "integrity": "sha512-ULe/Cs+ZIsq+dcFofNkhqielCrUJnb5mr+Yc4EBM2VlL+6OZR6+cjtI2mT1bJvRBrVncqHAbLURxmPLcCXzWMg==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.1.0",
+        "ohash": "^2.0.11",
+        "undici": "^8.0.0"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-modify-children": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-4.0.0.tgz",
+      "integrity": "sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "array-iterate": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
+      "integrity": "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-children": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-3.0.0.tgz",
+      "integrity": "sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unstorage": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
+      "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "^3.1.3",
+        "chokidar": "^5.0.0",
+        "destr": "^2.0.5",
+        "h3": "^1.15.10",
+        "lru-cache": "^11.2.7",
+        "node-fetch-native": "^1.6.7",
+        "ofetch": "^1.5.1",
+        "ufo": "^1.6.3"
+      },
+      "peerDependencies": {
+        "@azure/app-configuration": "^1.8.0",
+        "@azure/cosmos": "^4.2.0",
+        "@azure/data-tables": "^13.3.0",
+        "@azure/identity": "^4.6.0",
+        "@azure/keyvault-secrets": "^4.9.0",
+        "@azure/storage-blob": "^12.26.0",
+        "@capacitor/preferences": "^6 || ^7 || ^8",
+        "@deno/kv": ">=0.9.0",
+        "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+        "@planetscale/database": "^1.19.0",
+        "@upstash/redis": "^1.34.3",
+        "@vercel/blob": ">=0.27.1",
+        "@vercel/functions": "^2.2.12 || ^3.0.0",
+        "@vercel/kv": "^1 || ^2 || ^3",
+        "aws4fetch": "^1.0.20",
+        "db0": ">=0.2.1",
+        "idb-keyval": "^6.2.1",
+        "ioredis": "^5.4.2",
+        "uploadthing": "^7.4.4"
+      },
+      "peerDependenciesMeta": {
+        "@azure/app-configuration": {
+          "optional": true
+        },
+        "@azure/cosmos": {
+          "optional": true
+        },
+        "@azure/data-tables": {
+          "optional": true
+        },
+        "@azure/identity": {
+          "optional": true
+        },
+        "@azure/keyvault-secrets": {
+          "optional": true
+        },
+        "@azure/storage-blob": {
+          "optional": true
+        },
+        "@capacitor/preferences": {
+          "optional": true
+        },
+        "@deno/kv": {
+          "optional": true
+        },
+        "@netlify/blobs": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/blob": {
+          "optional": true
+        },
+        "@vercel/functions": {
+          "optional": true
+        },
+        "@vercel/kv": {
+          "optional": true
+        },
+        "aws4fetch": {
+          "optional": true
+        },
+        "db0": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        },
+        "uploadthing": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/url-extras": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/url-extras/-/url-extras-0.1.0.tgz",
+      "integrity": "sha512-8tzwTeXFPuX/5PHuCDQE5Dd9Ts4rwoq2t9aIT+HS4iAVpmj5l4Ao7Q+BuuFjvWRqrLswBhQDk8O96ZicgCqQqw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitefu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+      "license": "MIT",
+      "workspaces": [
+        "tests/deps/*",
+        "tests/projects/*",
+        "tests/projects/workspace/packages/*"
+      ],
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/xxhash-wasm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+      "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+      "license": "MIT"
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.2.tgz",
+      "integrity": "sha512-XkYXCol10+ba/6F/cueWV+TezUeOqXW0hdeJt5CdXjTYeAgAQg5N03RQdJ80mhfFE72+pblvYMW4wy2Qp4Qbrg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -5,9 +5,10 @@
   "scripts": {
     "sync": "node scripts/sync-docs.mjs && node scripts/fetch-release.mjs",
     "dev": "npm run sync && astro dev",
-    "build": "npm run sync && astro build",
+    "build": "npm run clean && npm run sync && astro build",
     "preview": "astro preview",
-    "check": "astro check"
+    "check": "astro check",
+    "clean": "node scripts/clean.mjs"
   },
   "dependencies": {
     "@astrojs/rss": "^4.0.19",

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "agento-site",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "sync": "node scripts/sync-docs.mjs && node scripts/fetch-release.mjs",
+    "dev": "npm run sync && astro dev",
+    "build": "npm run sync && astro build",
+    "preview": "astro preview",
+    "check": "astro check"
+  },
+  "dependencies": {
+    "@astrojs/rss": "^4.0.19",
+    "@astrojs/sitemap": "^3.7.3",
+    "@astrojs/starlight": "^0.41.10",
+    "@fontsource-variable/jetbrains-mono": "^5.3.0",
+    "@fontsource-variable/newsreader": "^5.3.0",
+    "@fontsource/instrument-serif": "^5.3.0",
+    "@fontsource/karla": "^5.3.0",
+    "astro": "^7.2.9"
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,8 @@
     "build": "npm run clean && npm run sync && astro build",
     "preview": "astro preview",
     "check": "astro check",
-    "clean": "node scripts/clean.mjs"
+    "clean": "node scripts/clean.mjs",
+    "check:links": "node scripts/check-links.mjs"
   },
   "dependencies": {
     "@astrojs/rss": "^4.0.19",

--- a/web/public/favicon.svg
+++ b/web/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="3" fill="#F0EEE6"/>
+  <rect x="1.25" y="1.25" width="29.5" height="29.5" rx="2.4" fill="none" stroke="#0B0C07" stroke-width="2.5"/>
+  <circle cx="16" cy="16" r="5.5" fill="#1DC1FF" stroke="#0B0C07" stroke-width="2.5"/>
+</svg>

--- a/web/scripts/check-links.mjs
+++ b/web/scripts/check-links.mjs
@@ -1,0 +1,89 @@
+/**
+ * Checks every internal link in the built site, including its fragment.
+ *
+ * This is a script rather than a link-checking action because the repository
+ * restricts Actions to an allowlist and requires SHA pinning; adding a
+ * third-party checker would mean widening that policy for a docs job. It also
+ * does the one thing that matters most here and that a generic checker does
+ * only with coaxing: `docs/` cross-links by heading anchor
+ * (`troubleshooting.md#the-claude-code-cli`), and renaming a heading breaks
+ * those silently — the markdown still renders, the link just lands nowhere.
+ *
+ * External links are deliberately not fetched. A docs job that fails because
+ * somebody else's site is down, or because GitHub rate-limited the runner, is a
+ * job people learn to ignore.
+ */
+import { readdir, readFile } from 'node:fs/promises';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { BASE } from '../site.config.mjs';
+
+const DIST = resolve(dirname(fileURLToPath(import.meta.url)), '../dist');
+
+async function htmlFiles(dir) {
+  const out = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'pagefind') continue; // generated search index
+      out.push(...(await htmlFiles(path)));
+    } else if (entry.name.endsWith('.html')) {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+/** `/agento/docs/installation/` -> the file that serves it. */
+function fileFor(href) {
+  const path = href.slice(BASE.length) || '/';
+  const rel = path.endsWith('/') ? `${path}index.html` : path;
+  return join(DIST, rel.replace(/^\//, ''));
+}
+
+const ids = new Map();
+async function idsOf(file) {
+  if (!ids.has(file)) {
+    let html;
+    try {
+      html = await readFile(file, 'utf8');
+    } catch {
+      ids.set(file, null);
+      return null;
+    }
+    ids.set(file, new Set([...html.matchAll(/\sid="([^"]+)"/g)].map((m) => m[1])));
+  }
+  return ids.get(file);
+}
+
+const files = await htmlFiles(DIST);
+const problems = [];
+
+for (const file of files) {
+  const html = await readFile(file, 'utf8');
+  const page = file.slice(DIST.length) || '/';
+  const hrefs = new Set([...html.matchAll(/href="([^"]+)"/g)].map((m) => m[1]));
+
+  for (const href of hrefs) {
+    if (!href.startsWith(BASE + '/') && href !== BASE) continue;
+    if (/\.(css|js|xml|json|svg|png|webp|woff2?)$/.test(href)) continue;
+
+    const [path, hash] = href.split('#');
+    const target = fileFor(path);
+    const targetIds = await idsOf(target);
+
+    if (targetIds === null) {
+      problems.push(`${page} -> ${href} (no page at ${target.slice(DIST.length)})`);
+      continue;
+    }
+    if (hash && !targetIds.has(hash)) {
+      problems.push(`${page} -> ${href} (page exists, no element with id="${hash}")`);
+    }
+  }
+}
+
+if (problems.length) {
+  console.error(`check-links: ${problems.length} broken:\n  ${problems.join('\n  ')}`);
+  process.exit(1);
+}
+console.log(`check-links: ${files.length} pages, every internal link and fragment resolves`);

--- a/web/scripts/clean.mjs
+++ b/web/scripts/clean.mjs
@@ -1,0 +1,19 @@
+/**
+ * Removes the build output and Astro's cache before each build.
+ *
+ * Not housekeeping. An incremental build was observed to emit a fresh
+ * `_astro/ec.<hash>.css` while leaving the previous hash in the generated HTML,
+ * so every page linked a stylesheet that 404ed and every code block on the site
+ * rendered unstyled — dark text on a dark ground, with no frame. It looks
+ * exactly like a theming bug, and it is not one; a clean build is always
+ * correct. This site builds in under two seconds, so the cache buys nothing
+ * worth that failure mode.
+ */
+import { rm } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+for (const dir of ['dist', '.astro', 'node_modules/.astro']) {
+  await rm(resolve(root, dir), { recursive: true, force: true });
+}

--- a/web/scripts/fetch-release.mjs
+++ b/web/scripts/fetch-release.mjs
@@ -1,0 +1,113 @@
+/**
+ * The latest release, resolved at build time.
+ *
+ * Nothing about a download may be hand-written. Asset filenames carry the
+ * version (`Agento_1.2.0_amd64.deb`), so GitHub's `releases/latest/download/…`
+ * redirect cannot address them and a link spelled out in a template rots the
+ * moment a release ships. This asks the API once per build and writes
+ * src/data/release.json, which the pages import.
+ *
+ * Two properties are deliberate:
+ *
+ *   - **It never fails the build.** No network, no token, a rate limit, a
+ *     repository with no releases yet — each falls back to the version in
+ *     src-tauri/tauri.conf.json and the `releases/latest` redirect, which is
+ *     always correct even when it cannot name a file. A docs site that cannot
+ *     build because GitHub is slow is worse than one showing a generic link.
+ *   - **It runs at build time, not in the visitor's browser.** A client-side
+ *     fetch would put a third-party request on every page view of a product
+ *     whose entire claim is that nothing leaves your machine, and would show
+ *     an empty download section to anyone the API rate-limits. The release
+ *     workflow rebuilds this site when a release is published, so the baked
+ *     answer is refreshed by the event that changes it.
+ */
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const OUT = resolve(here, '../src/data/release.json');
+const REPO_OUT = resolve(here, '../src/data/repo.json');
+const CONF = resolve(here, '../../src-tauri/tauri.conf.json');
+const REPO_API = 'https://api.github.com/repos/shaharia-lab/agento';
+const API = `${REPO_API}/releases/latest`;
+const RELEASES = 'https://github.com/shaharia-lab/agento/releases';
+
+/**
+ * Which download a file is. Ordered: the first pattern that matches wins, so
+ * `_x64-setup.exe` is claimed by Windows before any looser `x64` rule.
+ */
+const PLATFORMS = [
+  { id: 'macos-arm', os: 'macos', label: 'macOS', arch: 'Apple Silicon', kind: 'dmg', updates: 'in-app', test: /_aarch64\.dmg$/ },
+  { id: 'macos-x64', os: 'macos', label: 'macOS', arch: 'Intel', kind: 'dmg', updates: 'in-app', test: /_x64\.dmg$/ },
+  { id: 'win-x64', os: 'windows', label: 'Windows', arch: 'x64', kind: 'exe', updates: 'in-app', test: /_x64-setup\.exe$/ },
+  { id: 'linux-appimage-x64', os: 'linux', label: 'Linux', arch: 'x86_64', kind: 'AppImage', updates: 'in-app', test: /_amd64\.AppImage$/ },
+  { id: 'linux-appimage-arm', os: 'linux', label: 'Linux', arch: 'ARM64', kind: 'AppImage', updates: 'in-app', test: /_aarch64\.AppImage$/ },
+  { id: 'linux-deb-x64', os: 'linux', label: 'Debian / Ubuntu', arch: 'x86_64', kind: 'deb', updates: 'notify', test: /_amd64\.deb$/ },
+  { id: 'linux-deb-arm', os: 'linux', label: 'Debian / Ubuntu', arch: 'ARM64', kind: 'deb', updates: 'notify', test: /_arm64\.deb$/ },
+  { id: 'linux-rpm-x64', os: 'linux', label: 'Fedora / RHEL', arch: 'x86_64', kind: 'rpm', updates: 'notify', test: /\.x86_64\.rpm$/ },
+  { id: 'linux-rpm-arm', os: 'linux', label: 'Fedora / RHEL', arch: 'ARM64', kind: 'rpm', updates: 'notify', test: /\.(aarch64|arm64)\.rpm$/ },
+];
+
+async function fallback(reason) {
+  const version = JSON.parse(await readFile(CONF, 'utf8')).version;
+  console.warn(`fetch-release: ${reason} — falling back to v${version} with no per-platform files`);
+  return { version, tag: `v${version}`, url: `${RELEASES}/latest`, publishedAt: null, resolved: false, downloads: [] };
+}
+
+function headers() {
+  const h = { accept: 'application/vnd.github+json', 'user-agent': 'agento-site-build' };
+  if (process.env.GITHUB_TOKEN) h.authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  return h;
+}
+
+/** Star count for the call to action. A missing count renders no number. */
+async function repoStats() {
+  try {
+    const res = await fetch(REPO_API, { headers: headers(), signal: AbortSignal.timeout(10_000) });
+    if (!res.ok) throw new Error(`GitHub answered ${res.status}`);
+    const r = await res.json();
+    console.log(`fetch-release: repo has ${r.stargazers_count} stars`);
+    return { stars: r.stargazers_count, forks: r.forks_count, resolved: true };
+  } catch (err) {
+    console.warn(`fetch-release: could not read repo stats (${err.message})`);
+    return { stars: null, forks: null, resolved: false };
+  }
+}
+
+async function main() {
+  await mkdir(dirname(OUT), { recursive: true });
+  await writeFile(REPO_OUT, JSON.stringify(await repoStats(), null, 2) + '\n', 'utf8');
+
+  let data;
+  try {
+    const res = await fetch(API, { headers: headers(), signal: AbortSignal.timeout(10_000) });
+    if (!res.ok) throw new Error(`GitHub answered ${res.status}`);
+    const release = await res.json();
+
+    const downloads = PLATFORMS.map((p) => {
+      const asset = (release.assets ?? []).find((a) => p.test.test(a.name));
+      return asset
+        ? { ...p, test: undefined, file: asset.name, href: asset.browser_download_url, size: asset.size }
+        : null;
+    }).filter(Boolean);
+
+    if (!downloads.length) throw new Error(`release ${release.tag_name} carries no recognised installer`);
+
+    data = {
+      version: String(release.tag_name).replace(/^v/, ''),
+      tag: release.tag_name,
+      url: release.html_url,
+      publishedAt: release.published_at,
+      resolved: true,
+      downloads,
+    };
+    console.log(`fetch-release: ${data.tag}, ${downloads.length} installers`);
+  } catch (err) {
+    data = await fallback(err.message);
+  }
+
+  await writeFile(OUT, JSON.stringify(data, null, 2) + '\n', 'utf8');
+}
+
+await main();

--- a/web/scripts/sync-docs.mjs
+++ b/web/scripts/sync-docs.mjs
@@ -1,0 +1,167 @@
+/**
+ * docs/ is the single source. This copies it into the site.
+ *
+ * The markdown in `docs/` is written to be read on GitHub — relative `*.md`
+ * links, no frontmatter, an inline table of contents at the top of each file.
+ * None of that is wrong; it is just not what Starlight consumes. So rather
+ * than reshaping the source (which would degrade it for everyone reading the
+ * repository, and break README.md and CLAUDE.md's own pointers), this rewrites
+ * a copy at build time:
+ *
+ *   - the H1 becomes the frontmatter `title`, and is removed from the body,
+ *     because Starlight renders the title itself;
+ *   - the lead paragraph becomes `description` (used for <meta> and search);
+ *   - the inline TOC list is dropped, because Starlight renders one;
+ *   - `installation.md#updates` becomes `/agento/docs/installation/#updates`;
+ *   - a link that leaves docs/ (`../CLAUDE.md`) becomes a GitHub blob URL,
+ *     since those files have no page on this site;
+ *   - screenshots are copied to public/ and their links repointed.
+ *
+ * The output is generated and gitignored. Never edit it.
+ */
+import { mkdir, readdir, readFile, writeFile, rm, cp } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { BASE, REPO_BLOB } from '../site.config.mjs';
+import { PAGES } from '../docs.manifest.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const SRC = resolve(here, '../../docs');
+const OUT = resolve(here, '../src/content/docs/docs');
+const SHOTS_OUT = resolve(here, '../public/screenshots');
+
+const bySourceFile = new Map(PAGES.map((p) => [p.file, p]));
+
+/** `installation.md` -> `/agento/docs/installation/`; unknown files -> null. */
+function hrefFor(target) {
+  const [path, hash] = target.split('#');
+  const page = bySourceFile.get(path);
+  if (!page) return null;
+  const route = page.slug === 'index' ? `${BASE}/docs/` : `${BASE}/docs/${page.slug}/`;
+  return hash ? `${route}#${hash}` : route;
+}
+
+function rewriteLinks(body) {
+  return body.replace(/\]\(([^)\s]+)(\s+"[^"]*")?\)/g, (whole, target, title = '') => {
+    if (/^(https?:|mailto:|#)/.test(target)) return whole;
+
+    if (target.startsWith('screenshots/')) return `](${BASE}/${target}${title})`;
+
+    const inDocs = hrefFor(target);
+    if (inDocs) return `](${inDocs}${title})`;
+
+    // Anything else points outside docs/ — CLAUDE.md, README.md, parity/,
+    // source files. Real destinations, just not pages on this site.
+    const repoPath = target.replace(/^\.\//, '').replace(/^\.\.\//, '');
+    return `](${REPO_BLOB}/${repoPath}${title})`;
+  });
+}
+
+/** Strip the leading bullet TOC; Starlight renders its own. */
+function dropInlineToc(body) {
+  const lines = body.split('\n');
+  const start = lines.findIndex((l) => /^[-*] \[.+\]\(#.+\)$/.test(l.trim()));
+  if (start === -1) return body;
+  let end = start;
+  while (
+    end < lines.length &&
+    (/^[-*] \[.+\]\(#.+\)$/.test(lines[end].trim()) || lines[end].trim() === '')
+  ) {
+    end++;
+  }
+  const entries = lines.slice(start, end).filter((l) => l.trim()).length;
+  if (entries < 3) return body;
+  return [...lines.slice(0, start), ...lines.slice(end)].join('\n');
+}
+
+function plain(md) {
+  return md
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/[`*_]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** First whole sentence if it fits, otherwise a clean word boundary. */
+function summarise(text, max = 165) {
+  if (text.length <= max) return text;
+  const sentence = text.slice(0, max).match(/^.*?[.!?](?=\s|$)/);
+  if (sentence && sentence[0].length > 60) return sentence[0];
+  return text.slice(0, max).replace(/\s+\S*$/, '') + '\u2026';
+}
+
+function yaml(value) {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function transform(raw, page) {
+  const lines = raw.split('\n');
+  const h1 = lines.findIndex((l) => l.startsWith('# '));
+  const title = h1 === -1 ? page.label : lines[h1].slice(2).trim();
+  let body = h1 === -1 ? raw : lines.slice(h1 + 1).join('\n');
+
+  body = dropInlineToc(body);
+
+  const lead = body
+    .split('\n\n')
+    .map((b) => b.trim())
+    .find(
+      (b) =>
+        b &&
+        !b.startsWith('#') &&
+        !b.startsWith('---') &&
+        !b.startsWith('|') &&
+        !b.startsWith('>')
+    );
+  const description = page.description ?? (lead ? summarise(plain(lead)) : '');
+
+  const front = [
+    '---',
+    `title: ${yaml(title)}`,
+    description ? `description: ${yaml(description)}` : null,
+    `editUrl: ${yaml(`${REPO_BLOB}/docs/${page.file}`)}`,
+    '---',
+    '',
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  return front + rewriteLinks(body).replace(/^\n+/, '\n');
+}
+
+async function main() {
+  await rm(OUT, { recursive: true, force: true });
+  await mkdir(OUT, { recursive: true });
+
+  const present = new Set(await readdir(SRC));
+  let written = 0;
+
+  for (const page of PAGES) {
+    if (!present.has(page.file)) {
+      throw new Error(
+        `docs/${page.file} is listed in sync-docs.mjs but does not exist. ` +
+          `Update PAGES if the file was renamed or removed.`
+      );
+    }
+    const raw = await readFile(join(SRC, page.file), 'utf8');
+    await writeFile(join(OUT, `${page.slug}.md`), transform(raw, page), 'utf8');
+    written++;
+  }
+
+  // A doc added to docs/ and not listed here would silently never publish.
+  const unlisted = [...present].filter((f) => f.endsWith('.md') && !bySourceFile.has(f));
+  if (unlisted.length) {
+    throw new Error(
+      `docs/ contains ${unlisted.join(', ')}, which the site does not publish. ` +
+        `Add ${unlisted.length > 1 ? 'them' : 'it'} to PAGES in web/scripts/sync-docs.mjs.`
+    );
+  }
+
+  await rm(SHOTS_OUT, { recursive: true, force: true });
+  await cp(join(SRC, 'screenshots'), SHOTS_OUT, { recursive: true });
+  const shots = await readdir(join(SHOTS_OUT, 'light'));
+
+  console.log(`sync-docs: ${written} pages, ${shots.length} screenshots`);
+}
+
+await main();

--- a/web/site.config.mjs
+++ b/web/site.config.mjs
@@ -1,0 +1,20 @@
+/**
+ * One definition of where this site lives.
+ *
+ * The site is published to GitHub Pages at shaharia-lab.github.io/agento, so
+ * every internal URL carries a `/agento` prefix. Astro applies `base` to its
+ * own routing, but NOT to hrefs inside markdown — so the docs sync script and
+ * every hand-written link build their URLs through `url()` below rather than
+ * spelling the prefix out. Change the base here and nothing else moves.
+ */
+export const SITE = 'https://shaharia-lab.github.io';
+export const BASE = '/agento';
+
+export const REPO = 'https://github.com/shaharia-lab/agento';
+export const REPO_BLOB = `${REPO}/blob/main`;
+
+/** Join a site-absolute path onto the base. `url('/docs/')` → `/agento/docs/`. */
+export function url(path = '/') {
+  const p = path.startsWith('/') ? path : `/${path}`;
+  return `${BASE}${p}`.replace(/\/{2,}/g, '/');
+}

--- a/web/src/components/Faq.astro
+++ b/web/src/components/Faq.astro
@@ -1,0 +1,81 @@
+---
+/**
+ * The landing FAQ.
+ *
+ * These answer on the page rather than linking away. An earlier version was a
+ * list of links into the docs, which meant the one question somebody has
+ * before downloading — "does this send my transcripts anywhere?" — cost them a
+ * page load to answer, and the deep links were fragile besides: a heading
+ * rename breaks a fragment silently.
+ *
+ * Every answer is taken from docs/, and the `more` link goes to the section it
+ * came from. If you change one here, change it there too — or better, don't
+ * write anything here that the docs do not already say.
+ */
+import { url } from '../../site.config.mjs';
+
+const FAQ = [
+  {
+    q: 'Does Agento send my transcripts anywhere?',
+    a: `No. Everything is stored locally in ~/.agento, and your Claude Code transcripts in
+        ~/.claude are read but never modified. There is no account, no telemetry and no
+        analytics. The only outbound calls are the ones you asked for: agent runs, the
+        integrations you connected, the update check — which you can switch off — and, if
+        you turn it on, the providers the LLM Gateway forwards to.`,
+    more: { label: 'Privacy', href: url('/docs/user-guide/#privacy') },
+  },
+  {
+    q: 'Do I need an Anthropic API key?',
+    a: `No. Agento runs every agent by launching the Claude Code CLI on your machine and
+        reuses its sign-in. If claude works in your terminal, Agento works. The app tells
+        you on launch if it cannot find the CLI, and where it looked.`,
+    more: { label: 'Requirements', href: url('/docs/installation/#requirements') },
+  },
+  {
+    q: 'Will it change anything in ~/.claude?',
+    a: `Your session transcripts are read only. Agento does write Claude Code's own
+        settings.json and the settings profiles beside it — but only when you edit them
+        from the Settings section yourself. Everything Agento owns lives in ~/.agento, and
+        deleting that directory resets it completely.`,
+    more: { label: 'Where your data lives', href: url('/docs/installation/#where-your-data-lives') },
+  },
+  {
+    q: 'Can I point my other tools at it?',
+    a: `Yes. The LLM Gateway is an OpenAI- and Anthropic-compatible endpoint on loopback
+        that routes to whichever providers you configure, and records usage and cost per
+        request. It is off by default and costs one database read at startup when it is.`,
+    more: { label: 'LLM Gateway', href: url('/docs/user-guide/#llm-gateway') },
+  },
+  {
+    q: 'How are my integration credentials stored?',
+    a: `In plain text, in the local database. Their protection is your user account and
+        your disk permissions, so treat ~/.agento as sensitive. The API scrubs secrets
+        from every response and the app never displays one back to you, but the bytes at
+        rest are not encrypted.`,
+    more: { label: 'Privacy', href: url('/docs/user-guide/#privacy') },
+  },
+];
+---
+
+<section class="section">
+  <div class="sheet panel">
+    <div class="eyebrow">
+      Frequently asked
+      <span class="eyebrow__end"><a href={url('/docs/')}>All documentation ↗</a></span>
+    </div>
+    <div class="rows">
+      {FAQ.map((item, i) => (
+        <details class="faq" open={i === 0}>
+          <summary class="faq__q">
+            <span class="faq__chev" aria-hidden="true">▸</span>
+            <span>{item.q}</span>
+          </summary>
+          <div class="faq__a">
+            <p>{item.a}</p>
+            <a class="faq__more" href={item.more.href}>{item.more.label} ↗</a>
+          </div>
+        </details>
+      ))}
+    </div>
+  </div>
+</section>

--- a/web/src/components/Foot.astro
+++ b/web/src/components/Foot.astro
@@ -1,0 +1,13 @@
+---
+import { url, REPO } from '../../site.config.mjs';
+const year = new Date().getFullYear();
+---
+<footer class="foot">
+  <span class="label">© {year} Shaharia Lab · MIT</span>
+  <a href={url('/docs/')}>Docs</a>
+  <a href={url('/blog/')}>Blog</a>
+  <a href={`${REPO}/releases`}>Releases</a>
+  <a href={`${REPO}/issues`}>Issues</a>
+  <a href={`${REPO}/blob/main/SECURITY.md`}>Security</a>
+  <span class="label foot__end">runs entirely on your machine —</span>
+</footer>

--- a/web/src/components/Install.astro
+++ b/web/src/components/Install.astro
@@ -5,10 +5,12 @@
  * Three rules shape it, and they are all consequences of this being a static
  * page that cannot know who is asking:
  *
- *   1. **Every platform is rendered.** Detection happens in the browser, so
- *      anything hidden server-side is hidden from search engines, from people
- *      with JavaScript off, and from anyone the guess gets wrong. The script
- *      below only *reorders and marks* — it never hides.
+ *   1. **Every platform is rendered**, as a stacked <details>. Detection
+ *      happens in the browser, so nothing may be omitted server-side: a
+ *      <details> panel keeps its content in the DOM whether open or shut, which
+ *      is why collapsing is safe where dropping would not be. The script below
+ *      reorders, opens and marks — it never removes. With JavaScript off, the
+ *      first panel is open and the other two are one click away.
  *   2. **The OS is detected; the architecture is not.** Safari reports
  *      `MacIntel` on Apple Silicon, so there is no reliable way to tell an ARM
  *      Mac from an Intel one in JavaScript. Chromium exposes it through
@@ -78,7 +80,7 @@ const OSES = [
 
 <section class="section" id="install">
   <div class="section__head">
-    <h2>Three steps, about a minute.</h2>
+    <h2>Installed in about a minute.</h2>
     <span class="label">Install</span>
   </div>
 
@@ -92,17 +94,21 @@ const OSES = [
       Agento runs every agent through the CLI you already have and reuses its sign-in. There is no
       Anthropic API key to enter. If this prints a version, you are ready:
     </p>
-    <pre class="code"><span class="k">claude</span> --version</pre>
+    <pre class="codeblock"><span class="k">claude</span> --version</pre>
   </div>
 
   <div class="osgrid" id="osgrid">
-    {OSES.map((entry) => (
-      <div class="sheet oscard" data-os={entry.os}>
-        <div class="eyebrow">
+    {OSES.map((entry, i) => (
+      <details class="sheet oscard" data-os={entry.os} open={i === 0}>
+        <summary class="oscard__sum">
+          <span class="oscard__chev" aria-hidden="true">▸</span>
           {entry.label}
-          <span class="eyebrow__end oscard__rec" hidden>Recommended for you</span>
-        </div>
-
+          <span class="oscard__rec" hidden>Recommended for you</span>
+          <span class="oscard__files">
+            {entry.files.length} {entry.files.length === 1 ? 'file' : 'files'}
+          </span>
+        </summary>
+        <div class="oscard__body">
         {resolved && entry.files.length > 0 ? (
           <div class="rows">
             {entry.files.map((f: any) => (
@@ -122,13 +128,14 @@ const OSES = [
           {entry.steps.map((s) => (
             <li>
               <span>{s.t}</span>
-              {s.code && <pre class="code">{s.code}</pre>}
+              {s.code && <pre class="codeblock">{s.code}</pre>}
             </li>
           ))}
         </ol>
 
         <p class="oshint label">{entry.hint}</p>
-      </div>
+        </div>
+      </details>
     ))}
   </div>
 
@@ -157,10 +164,19 @@ const OSES = [
 
     const card = grid.querySelector(`.oscard[data-os="${os}"]`);
     if (!card) return;
+
     grid.prepend(card);
     card.classList.add('oscard--rec');
+    card.open = true;
     const flag = card.querySelector('.oscard__rec');
     if (flag) flag.hidden = false;
+
+    /* Collapse the others, so the section is one open panel rather than three
+       competing ones. They stay one click away, and their content stays in the
+       DOM either way — <details> hides, it does not remove. */
+    grid.querySelectorAll('.oscard').forEach((el) => {
+      if (el !== card) el.open = false;
+    });
 
     /* Architecture, only where the browser will actually tell us. Chromium
        answers 'arm'; Safari and Firefox do not expose it at all, so both Mac

--- a/web/src/components/Install.astro
+++ b/web/src/components/Install.astro
@@ -1,0 +1,180 @@
+---
+/**
+ * The install section.
+ *
+ * Three rules shape it, and they are all consequences of this being a static
+ * page that cannot know who is asking:
+ *
+ *   1. **Every platform is rendered.** Detection happens in the browser, so
+ *      anything hidden server-side is hidden from search engines, from people
+ *      with JavaScript off, and from anyone the guess gets wrong. The script
+ *      below only *reorders and marks* — it never hides.
+ *   2. **The OS is detected; the architecture is not.** Safari reports
+ *      `MacIntel` on Apple Silicon, so there is no reliable way to tell an ARM
+ *      Mac from an Intel one in JavaScript. Chromium exposes it through
+ *      `userAgentData.getHighEntropyValues`, which is used when present, and
+ *      both Mac downloads are always listed either way. Guessing wrong here
+ *      hands someone a binary that will not run.
+ *   3. **Filenames and links come from the release API**, never from a
+ *      template — asset names carry the version, so a hand-written one is
+ *      wrong the day after a release.
+ */
+import release from '../data/release.json';
+import { url } from '../../site.config.mjs';
+
+const { downloads, resolved } = release;
+const mb = (bytes: number) => `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+const pick = (id: string) => downloads.find((d: any) => d.id === id);
+
+const appimage = pick('linux-appimage-x64');
+const deb = pick('linux-deb-x64');
+const rpm = pick('linux-rpm-x64');
+
+const OSES = [
+  {
+    os: 'macos',
+    label: 'macOS',
+    hint: 'Apple menu → About This Mac tells you which chip you have.',
+    files: downloads.filter((d: any) => d.os === 'macos'),
+    steps: [
+      { t: 'Open the .dmg and drag Agento to Applications.', code: null },
+      {
+        t: 'If macOS says the app cannot be verified, right-click it and choose Open. If that gives you no Open button, clear the quarantine flag:',
+        code: 'xattr -dr com.apple.quarantine /Applications/Agento.app',
+      },
+    ],
+  },
+  {
+    os: 'windows',
+    label: 'Windows',
+    hint: 'Updates arrive in the app after the first install.',
+    files: downloads.filter((d: any) => d.os === 'windows'),
+    steps: [
+      { t: 'Run the installer.', code: null },
+      {
+        t: 'SmartScreen may warn that the publisher is unknown — choose More info, then Run anyway. These builds are signed by our own key rather than an EV certificate.',
+        code: null,
+      },
+    ],
+  },
+  {
+    os: 'linux',
+    label: 'Linux',
+    hint: 'The AppImage updates itself; .deb and .rpm are notify-only, because dpkg and rpm own their files.',
+    files: downloads.filter((d: any) => d.os === 'linux'),
+    steps: [
+      {
+        t: 'AppImage — works on any distribution, and updates in-app:',
+        code: appimage ? `chmod +x ${appimage.file}\n./${appimage.file}` : null,
+      },
+      {
+        t: 'Or install the native package:',
+        code: deb && rpm ? `sudo dpkg -i ${deb.file}      # Debian, Ubuntu\nsudo rpm -i  ${rpm.file}   # Fedora, RHEL` : null,
+      },
+    ],
+  },
+];
+---
+
+<section class="section" id="install">
+  <div class="section__head">
+    <h2>Three steps, about a minute.</h2>
+    <span class="label">Install</span>
+  </div>
+
+  <div class="sheet panel prereq">
+    <div class="eyebrow">
+      Before anything
+      <span class="eyebrow__end"><a href={url('/docs/installation/#requirements')}>Requirements ↗</a></span>
+    </div>
+    <h3>Have the Claude Code CLI, signed in</h3>
+    <p>
+      Agento runs every agent through the CLI you already have and reuses its sign-in. There is no
+      Anthropic API key to enter. If this prints a version, you are ready:
+    </p>
+    <pre class="code"><span class="k">claude</span> --version</pre>
+  </div>
+
+  <div class="osgrid" id="osgrid">
+    {OSES.map((entry) => (
+      <div class="sheet oscard" data-os={entry.os}>
+        <div class="eyebrow">
+          {entry.label}
+          <span class="eyebrow__end oscard__rec" hidden>Recommended for you</span>
+        </div>
+
+        {resolved && entry.files.length > 0 ? (
+          <div class="rows">
+            {entry.files.map((f: any) => (
+              <a class="row" href={f.href}>
+                <span class="badge">{f.kind}</span>
+                <span class="row__m">{f.file}</span>
+                <span class="row__r">{f.arch} · {mb(f.size)}</span>
+                <span class="row__go">↓</span>
+              </a>
+            ))}
+          </div>
+        ) : (
+          <p><a href={release.url}>Pick a file from the latest release ↗</a></p>
+        )}
+
+        <ol class="osteps">
+          {entry.steps.map((s) => (
+            <li>
+              <span>{s.t}</span>
+              {s.code && <pre class="code">{s.code}</pre>}
+            </li>
+          ))}
+        </ol>
+
+        <p class="oshint label">{entry.hint}</p>
+      </div>
+    ))}
+  </div>
+
+  <p class="osfoot">
+    <span class="label">Not your platform?</span>
+    <a href={release.url}>Every file in {release.tag} ↗</a>
+    <span class="label">·</span>
+    <a href={url('/docs/installation/')}>Full installation guide</a>
+  </p>
+</section>
+
+<script is:inline>
+  /* Promotes the visitor's platform to the front and marks it. It never hides
+     a card: a wrong guess, an unknown OS, or no JavaScript all leave the full
+     set visible and in their authored order. */
+  (async () => {
+    const grid = document.getElementById('osgrid');
+    if (!grid) return;
+
+    const ua = navigator.userAgent;
+    let os = null;
+    if (/Mac/i.test(ua)) os = 'macos';
+    else if (/Win/i.test(ua)) os = 'windows';
+    else if (/Linux|X11|CrOS/i.test(ua) && !/Android/i.test(ua)) os = 'linux';
+    if (!os) return;
+
+    const card = grid.querySelector(`.oscard[data-os="${os}"]`);
+    if (!card) return;
+    grid.prepend(card);
+    card.classList.add('oscard--rec');
+    const flag = card.querySelector('.oscard__rec');
+    if (flag) flag.hidden = false;
+
+    /* Architecture, only where the browser will actually tell us. Chromium
+       answers 'arm'; Safari and Firefox do not expose it at all, so both Mac
+       builds stay listed and nothing is emphasised. */
+    try {
+      const d = await navigator.userAgentData?.getHighEntropyValues(['architecture']);
+      if (!d?.architecture) return;
+      const arm = d.architecture === 'arm';
+      card.querySelectorAll('.row').forEach((row) => {
+        const isArm = /aarch64|arm64/i.test(row.querySelector('.row__m')?.textContent || '');
+        if (isArm === arm) row.classList.add('row--rec');
+      });
+    } catch {
+      /* No high-entropy hints available. The list stands as rendered. */
+    }
+  })();
+</script>

--- a/web/src/components/Masthead.astro
+++ b/web/src/components/Masthead.astro
@@ -18,7 +18,7 @@ const { current } = Astro.props;
       <a href={url('/docs/')} aria-current={current === 'docs' ? 'page' : undefined}>Docs</a>
       <a href={url('/blog/')} aria-current={current === 'blog' ? 'page' : undefined}>Blog</a>
       <a href={`${REPO}/releases`}>Releases</a>
-      <a class="navstar" href={REPO}><span aria-hidden="true">★</span> Star{stars && <span class="n">{stars}</span>}</a>
+      <a class="navbtn navstar" href={REPO}><span aria-hidden="true">★</span> Star{stars && <span class="n">{stars}</span>}</a>
       <ThemeToggle />
     </nav>
   </div>

--- a/web/src/components/Masthead.astro
+++ b/web/src/components/Masthead.astro
@@ -1,0 +1,25 @@
+---
+import { url, REPO } from '../../site.config.mjs';
+import ThemeToggle from './ThemeToggle.astro';
+import repo from '../data/repo.json';
+
+// Same threshold as StarCta: below it the number weakens the ask.
+const stars = repo.resolved && repo.stars !== null && repo.stars >= 250
+  ? new Intl.NumberFormat('en', { notation: 'compact' }).format(repo.stars)
+  : null;
+
+interface Props { current?: 'docs' | 'blog' }
+const { current } = Astro.props;
+---
+<header class="masthead">
+  <div class="masthead__in">
+    <a class="wordmark" href={url('/')}><span class="wordmark__dot"></span>Agento</a>
+    <nav class="nav">
+      <a href={url('/docs/')} aria-current={current === 'docs' ? 'page' : undefined}>Docs</a>
+      <a href={url('/blog/')} aria-current={current === 'blog' ? 'page' : undefined}>Blog</a>
+      <a href={`${REPO}/releases`}>Releases</a>
+      <a class="navstar" href={REPO}><span aria-hidden="true">★</span> Star{stars && <span class="n">{stars}</span>}</a>
+      <ThemeToggle />
+    </nav>
+  </div>
+</header>

--- a/web/src/components/StarCta.astro
+++ b/web/src/components/StarCta.astro
@@ -1,0 +1,29 @@
+---
+/**
+ * The star ask.
+ *
+ * The count is read at build time. It is only *shown* above a threshold —
+ * below it, a number is weaker than no number, and the ask reads better
+ * without one. Raise or drop SHOW_COUNT_ABOVE as the repository grows.
+ */
+import repo from '../data/repo.json';
+import { REPO } from '../../site.config.mjs';
+
+const SHOW_COUNT_ABOVE = 250;
+const showCount = repo.resolved && repo.stars !== null && repo.stars >= SHOW_COUNT_ABOVE;
+const stars = showCount ? new Intl.NumberFormat('en').format(repo.stars) : null;
+---
+
+<section class="starband sheet">
+  <div class="starband__t">
+    <div class="eyebrow">One click, and it helps more than you would think</div>
+    <h3>Star the repo</h3>
+    <p>
+      Stars are how the next Claude Code user finds Agento. It is the whole of our distribution —
+      there is no ad budget and nothing tracks you here.
+    </p>
+  </div>
+  <a class="btn btn--primary starband__btn" href={REPO}>
+    <span aria-hidden="true">★</span> Star on GitHub {stars && <span class="starband__n">{stars}</span>}
+  </a>
+</section>

--- a/web/src/components/ThemeToggle.astro
+++ b/web/src/components/ThemeToggle.astro
@@ -1,0 +1,31 @@
+---
+/**
+ * Theme switch for the pages Starlight does not render.
+ *
+ * It reads and writes the same `starlight-theme` localStorage key Starlight's
+ * own selector uses, so a choice made on the landing page survives into the
+ * docs and back. Diverging here would give one site two memories.
+ */
+---
+<button class="themetoggle" type="button" aria-label="Switch between light and dark">
+  <span class="themetoggle__t">Theme</span>
+</button>
+
+<script is:inline>
+  (() => {
+    const KEY = 'starlight-theme';
+    const root = document.documentElement;
+    const apply = (t) => {
+      if (t === 'dark' || t === 'light') root.setAttribute('data-theme', t);
+      else root.removeAttribute('data-theme');
+    };
+    apply(localStorage.getItem(KEY));
+    document.querySelector('.themetoggle')?.addEventListener('click', () => {
+      const dark = matchMedia('(prefers-color-scheme: dark)').matches;
+      const now = root.getAttribute('data-theme') || (dark ? 'dark' : 'light');
+      const next = now === 'dark' ? 'light' : 'dark';
+      localStorage.setItem(KEY, next);
+      apply(next);
+    });
+  })();
+</script>

--- a/web/src/components/ThemeToggle.astro
+++ b/web/src/components/ThemeToggle.astro
@@ -5,25 +5,41 @@
  * It reads and writes the same `starlight-theme` localStorage key Starlight's
  * own selector uses, so a choice made on the landing page survives into the
  * docs and back. Diverging here would give one site two memories.
+ *
+ * The label names the mode it switches to — "Dark" while you are in light —
+ * rather than saying "Theme", which tells you nothing about what a click does.
  */
 ---
-<button class="themetoggle" type="button" aria-label="Switch between light and dark">
-  <span class="themetoggle__t">Theme</span>
+<button class="navbtn themetoggle" type="button" aria-label="Switch between light and dark">
+  <span class="themetoggle__t">Dark</span>
 </button>
 
 <script is:inline>
   (() => {
     const KEY = 'starlight-theme';
     const root = document.documentElement;
+    const btn = document.querySelector('.themetoggle');
+    const now = () =>
+      root.getAttribute('data-theme') ||
+      (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+
+    /* The label names the mode the button switches *to*, which is what people
+       read it as. Set from the resolved theme rather than rendered, because on
+       the "system" setting the server cannot know which one that is. */
+    const relabel = () => {
+      const t = btn?.querySelector('.themetoggle__t');
+      if (t) t.textContent = now() === 'dark' ? 'Light' : 'Dark';
+    };
+
     const apply = (t) => {
       if (t === 'dark' || t === 'light') root.setAttribute('data-theme', t);
       else root.removeAttribute('data-theme');
+      relabel();
     };
+
     apply(localStorage.getItem(KEY));
-    document.querySelector('.themetoggle')?.addEventListener('click', () => {
-      const dark = matchMedia('(prefers-color-scheme: dark)').matches;
-      const now = root.getAttribute('data-theme') || (dark ? 'dark' : 'light');
-      const next = now === 'dark' ? 'light' : 'dark';
+    btn?.addEventListener('click', () => {
+      const next = now() === 'dark' ? 'light' : 'dark';
       localStorage.setItem(KEY, next);
       apply(next);
     });

--- a/web/src/content.config.ts
+++ b/web/src/content.config.ts
@@ -1,0 +1,24 @@
+import { defineCollection, z } from 'astro:content';
+import { glob } from 'astro/loaders';
+import { docsLoader } from '@astrojs/starlight/loaders';
+import { docsSchema } from '@astrojs/starlight/schema';
+
+export const collections = {
+  docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+
+  blog: defineCollection({
+    loader: glob({ base: './src/content/blog', pattern: '**/[^_]*.md' }),
+    schema: z.object({
+      title: z.string(),
+      // Shown under the title and used as the <meta> description and the RSS
+      // summary, so it has to read as a sentence rather than a label.
+      description: z.string(),
+      date: z.coerce.date(),
+      author: z.string().default('Shaharia Azam'),
+      tags: z.array(z.string()).default([]),
+      /** Pins one post to the top of the index. At most one may set it. */
+      featured: z.boolean().default(false),
+      draft: z.boolean().default(false),
+    }),
+  }),
+};

--- a/web/src/content/blog/finding-the-claude-cli.md
+++ b/web/src/content/blog/finding-the-claude-cli.md
@@ -1,0 +1,71 @@
+---
+title: Finding the Claude CLI where it actually is
+description: A user ran claude --version, got 2.1.231, and Agento told them Claude Code was not installed. They were both right.
+date: 2026-08-25
+tags: [Engineering, Release 1.2.0]
+featured: true
+---
+
+Agento does not ship the Claude Code CLI. It spawns it — every agent run is a
+subprocess, and the CLI's own sign-in is the credential. So the first thing the
+app does on launch is work out where `claude` lives, and the first thing it did
+wrong was assume the answer was on `PATH`.
+
+## A GUI app has a different PATH than your terminal
+
+This is the part that surprises people, and it surprised us. When you launch an
+application from Finder, the Dock or Spotlight, it inherits launchd's
+environment rather than your shell's. That is
+`/usr/bin:/bin:/usr/sbin:/sbin` and nothing else. Every line your `.zshrc`
+exported is invisible.
+
+> The launch that matters — from the Dock, by someone who has not opened a
+> terminal that day — is exactly the launch where scanning `PATH` finds
+> nothing.
+
+Worse, there is an install shape that is on no `PATH` at all.
+`claude migrate-installer` puts the binary in `~/.claude/local` and wires it up
+as a shell *alias*. No amount of scanning directories finds it, because there is
+no file to find under any name you would look for.
+
+## Five rules, in order
+
+Resolution is now a single function with an explicit order, cached once per
+launch:
+
+```text
+1. AGENTO_CLAUDE_EXECUTABLE        explicit override, trusted
+2. claude_executable_path setting  stored, trusted
+3. $SHELL -lic 'command -v claude' login shell — finds aliases
+4. the process PATH                works when launched from a terminal
+5. known install locations         last resort, verified
+```
+
+Rules three through five verify what they find: the path must be an executable
+file **and** answer `--version` with Claude Code's banner, so an unrelated
+`claude` on the `PATH` is skipped rather than spawned on every turn. Rules one
+and two are taken on trust — a wrapper script is a documented reason to set
+them, and refusing one would remove the escape hatch the setting exists to be.
+
+## The banner and the spawn had to become one answer
+
+The reported bug was really a pair. The startup banner said the CLI was
+missing, *and* agents genuinely could not run — because the fallback was the
+bare name `claude`, which fails to resolve for exactly the same reason the
+banner did. Two lookups that agreed on being wrong.
+
+They are one function now. If the banner is wrong, every run is wrong, and you
+find out at launch instead of at the first message.
+
+## The bounds are a startup budget, not a ceiling
+
+Both subprocesses run inside the app's setup block, before the window shows.
+That makes three seconds for the shell probe and two per `--version` the worst
+case a user waits for a window — not a generous limit. A pathological shell
+degrades to "found by a later rule", never to a window that does not open.
+
+Resolution happens once per launch, so saving the setting takes effect at the
+next start. Re-detecting live was considered and left out: a `OnceLock` filled
+by a background thread races the first caller, and the loser fills it *without*
+the stored override — which would mean a configured path being ignored on some
+launches and not others.

--- a/web/src/layouts/Page.astro
+++ b/web/src/layouts/Page.astro
@@ -1,0 +1,53 @@
+---
+/**
+ * The shell for every page Starlight does not own: the landing page and the
+ * blog. Starlight builds its own <head>, so anything that must be true of
+ * *both* halves of the site (fonts, tokens, the theme attribute) is imported
+ * here and passed to Starlight through `customCss` in astro.config.mjs.
+ */
+import '../styles/fonts.css';
+import '../styles/tokens.css';
+import '../styles/site.css';
+import Masthead from '../components/Masthead.astro';
+import Foot from '../components/Foot.astro';
+import { url } from '../../site.config.mjs';
+
+interface Props {
+  title: string;
+  description: string;
+  current?: 'docs' | 'blog';
+  ogType?: string;
+}
+const { title, description, current, ogType = 'website' } = Astro.props;
+const canonical = new URL(Astro.url.pathname, Astro.site).href;
+---
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{title}</title>
+    <meta name="description" content={description} />
+    <link rel="canonical" href={canonical} />
+    <link rel="icon" href={url('/favicon.svg')} type="image/svg+xml" />
+    <link rel="alternate" type="application/rss+xml" title="Agento — Notes from the build" href={url('/rss.xml')} />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:type" content={ogType} />
+    <meta property="og:url" content={canonical} />
+    <meta name="twitter:card" content="summary_large_image" />
+    <script is:inline>
+      // Applied before first paint so a dark-mode visitor never sees a flash
+      // of the paper ground.
+      (() => {
+        const t = localStorage.getItem('starlight-theme');
+        if (t === 'dark' || t === 'light') document.documentElement.setAttribute('data-theme', t);
+      })();
+    </script>
+  </head>
+  <body>
+    <Masthead current={current} />
+    <slot />
+    <div class="shell"><Foot /></div>
+  </body>
+</html>

--- a/web/src/pages/404.astro
+++ b/web/src/pages/404.astro
@@ -1,0 +1,43 @@
+---
+/**
+ * Authored as a site page rather than a docs entry: a Starlight 404 lands with
+ * the docs sidebar and reads as a documentation page that happens to be
+ * missing, and it also collides with Starlight's own catch-all route.
+ */
+import Page from '../layouts/Page.astro';
+import { url, REPO } from '../../site.config.mjs';
+---
+
+<Page title="Not found — Agento" description="That page does not exist here.">
+  <div class="shell notfound">
+    <span class="label">Error 404</span>
+    <h1>That page is not here.</h1>
+    <p>The address you followed does not match anything on this site.</p>
+
+    <div class="rows">
+      <a class="row" href={url('/docs/')}>
+        <span class="badge">docs</span>
+        <span class="row__t">Documentation</span>
+        <span class="row__r">Installation, the user guide, troubleshooting</span>
+        <span class="row__go">→</span>
+      </a>
+      <a class="row" href={url('/blog/')}>
+        <span class="badge">blog</span>
+        <span class="row__t">Notes from the build</span>
+        <span class="row__r">Release notes and engineering write-ups</span>
+        <span class="row__go">→</span>
+      </a>
+      <a class="row" href={`${REPO}/releases`}>
+        <span class="badge">dl</span>
+        <span class="row__t">Releases</span>
+        <span class="row__r">Every build, for every platform</span>
+        <span class="row__go">↗</span>
+      </a>
+    </div>
+
+    <p class="notfound__f">
+      If a link on this site sent you here, that is a bug —
+      <a href={`${REPO}/issues/new`}>tell us</a>.
+    </p>
+  </div>
+</Page>

--- a/web/src/pages/blog/[...slug].astro
+++ b/web/src/pages/blog/[...slug].astro
@@ -1,0 +1,52 @@
+---
+import { getCollection, render } from 'astro:content';
+import Page from '../../layouts/Page.astro';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog', ({ data }) => !data.draft);
+  return posts.map((post) => ({ params: { slug: post.id }, props: { post } }));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+
+const initials = post.data.author
+  .split(' ')
+  .map((w: string) => w[0])
+  .join('')
+  .slice(0, 2)
+  .toUpperCase();
+const date = post.data.date.toLocaleDateString('en-GB', {
+  day: 'numeric',
+  month: 'long',
+  year: 'numeric',
+});
+---
+
+<Page
+  title={`${post.data.title} — Agento`}
+  description={post.data.description}
+  current="blog"
+  ogType="article"
+>
+  <div class="shell">
+    <article class="entry">
+      <div class="entry__meta">
+        {post.data.tags[0] && <span class="pill">{post.data.tags[0]}</span>}
+        <span class="post__date">{date}</span>
+      </div>
+      <h1>{post.data.title}</h1>
+      <p class="entry__lede">{post.data.description}</p>
+
+      <Content />
+
+      <div class="byline">
+        <div class="byline__av">{initials}</div>
+        <div>
+          <div class="byline__n">{post.data.author}</div>
+          <div class="byline__r">Maintainer, Agento</div>
+        </div>
+      </div>
+    </article>
+  </div>
+</Page>

--- a/web/src/pages/blog/index.astro
+++ b/web/src/pages/blog/index.astro
@@ -1,0 +1,66 @@
+---
+import { getCollection } from 'astro:content';
+import Page from '../../layouts/Page.astro';
+import { url } from '../../../site.config.mjs';
+
+const posts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
+  (a, b) => b.data.date.valueOf() - a.data.date.valueOf()
+);
+const [featured, ...rest] = posts.some((p) => p.data.featured)
+  ? [posts.find((p) => p.data.featured)!, ...posts.filter((p) => !p.data.featured)]
+  : posts;
+
+const fmt = (d: Date, long = false) =>
+  d.toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: long ? 'long' : 'short',
+    year: 'numeric',
+  });
+---
+
+<Page
+  title="Notes from the build — Agento"
+  description="Release notes, ported subsystems, and the decisions that were harder than they looked."
+  current="blog"
+>
+  <div class="shell blog">
+    <h1 class="blog__title">Notes from the build.</h1>
+    <p class="blog__sub">
+      Release notes, ported subsystems, and the decisions that were harder than they looked.
+    </p>
+
+    {featured && (
+      <a class="post post--feature" href={url(`/blog/${featured.id}/`)}>
+        <div class="post__meta">
+          <span class="pill">Latest</span>
+          <span class="post__date">{fmt(featured.data.date, true)}</span>
+        </div>
+        <h3>{featured.data.title}</h3>
+        <p>{featured.data.description}</p>
+        <div class="post__tags">
+          {featured.data.tags.map((t) => <span class="pill pill--plain">{t}</span>)}
+        </div>
+      </a>
+    )}
+
+    {rest.length > 0 && (
+      <div class="posts">
+        {rest.map((post) => (
+          <a class="post" href={url(`/blog/${post.id}/`)}>
+            <span class="post__date">{fmt(post.data.date)}</span>
+            <div class="post__body">
+              <h3>{post.data.title}</h3>
+              <p>{post.data.description}</p>
+              <div class="post__tags">
+                {post.data.tags.map((t) => <span class="pill pill--plain">{t}</span>)}
+              </div>
+            </div>
+            <span class="post__go">→</span>
+          </a>
+        ))}
+      </div>
+    )}
+
+    {posts.length === 0 && <p class="blog__sub">Nothing published yet.</p>}
+  </div>
+</Page>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -10,6 +10,7 @@ import { url, REPO } from '../../site.config.mjs';
 import release from '../data/release.json';
 import Install from '../components/Install.astro';
 import StarCta from '../components/StarCta.astro';
+import Faq from '../components/Faq.astro';
 
 // Resolved at build time by scripts/fetch-release.mjs — version, tag and the
 // per-platform installer URLs. Nothing about a download is written by hand.
@@ -122,7 +123,7 @@ const RELEASE = release.url;
         <h2>Built for the desk, not the tab.</h2>
         <span class="label">Design</span>
       </div>
-      <div class="split">
+      <div class="split split--media">
         <figure class="shot" style="margin:0">
           <div class="shot__bar">
             <span class="shot__dot"></span><span class="shot__dot"></span><span class="shot__dot"></span>
@@ -145,17 +146,7 @@ const RELEASE = release.url;
       </div>
     </section>
 
-    <section class="section">
-      <div class="sheet panel">
-        <div class="eyebrow">Frequently asked</div>
-        <div class="rows">
-          <a class="row" href={url("/docs/troubleshooting/#privacy")}><span class="row__t">Does Agento send my transcripts anywhere?</span><span class="row__go">▸</span></a>
-          <a class="row" href={url("/docs/installation/#requirements")}><span class="row__t">Do I need an Anthropic API key?</span><span class="row__go">▸</span></a>
-          <a class="row" href={url("/docs/user-guide/#privacy")}><span class="row__t">Will it change anything in ~/.claude?</span><span class="row__go">▸</span></a>
-          <a class="row" href={url("/docs/user-guide/#llm-gateway")}><span class="row__t">Can I point other tools at it?</span><span class="row__go">▸</span></a>
-        </div>
-      </div>
-    </section>
+    <Faq />
 
     <StarCta />
 

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -1,0 +1,173 @@
+---
+/**
+ * The landing page. Everything here is hand-laid rather than generated: it is
+ * the one page whose job is persuasion, and it carries the design at full
+ * intensity — offset shadows, the display serif, the single blue call to
+ * action. Docs and blog step the same vocabulary down.
+ */
+import Page from '../layouts/Page.astro';
+import { url, REPO } from '../../site.config.mjs';
+import release from '../data/release.json';
+import Install from '../components/Install.astro';
+import StarCta from '../components/StarCta.astro';
+
+// Resolved at build time by scripts/fetch-release.mjs — version, tag and the
+// per-platform installer URLs. Nothing about a download is written by hand.
+const { version } = release;
+const RELEASE = release.url;
+
+---
+
+<Page
+  title="Agento — see what Claude Code really costs you"
+  description="A desktop app that reads the session files Claude Code already writes to your disk and turns them into cost analytics, searchable history and scheduled agents. No API key, no account, no telemetry."
+>
+
+  <div class="shell">
+    <section class="hero">
+      <div class="hero__eyebrow">
+        <span class="pill">v{version}</span>
+        <span class="pill pill--plain">macOS · Windows · Linux</span>
+        <span class="pill pill--plain">MIT licensed</span>
+      </div>
+      <h1 class="hero__title">See what Claude Code <em>really</em> costs you.</h1>
+      <p class="hero__lede">
+        Agento reads the session files Claude Code already writes to your disk and turns them into
+        cost analytics, productivity insights and a searchable, replayable history of every run.
+        Then it lets you build agents, schedule them, and connect them to your tools.
+      </p>
+      <div class="hero__cta">
+        <a class="btn btn--primary" href="#install">Download {version} →</a>
+        <a class="btn btn--ink" href={url("/docs/installation/")}>Read the docs</a>
+        <span class="hero__note">No API key. No account. No telemetry.</span>
+      </div>
+
+      <div class="stats">
+        <div class="stat">
+          <div class="stat__n">0</div>
+          <div class="stat__k label">Bytes sent anywhere</div>
+        </div>
+        <div class="stat">
+          <div class="stat__n">1</div>
+          <div class="stat__k label">SQLite file, on your disk</div>
+        </div>
+        <div class="stat">
+          <div class="stat__n">6</div>
+          <div class="stat__k label">Integrations built in</div>
+        </div>
+        <div class="stat">
+          <div class="stat__n">~60s</div>
+          <div class="stat__k label">Install to first session</div>
+        </div>
+      </div>
+
+      <figure class="shot">
+        <div class="shot__bar">
+          <span class="shot__dot"></span><span class="shot__dot"></span><span class="shot__dot"></span>
+          <span class="shot__name">Agento — Insights</span>
+        </div>
+        <img src={url("/screenshots/light/insights.png")} alt="Agento's Insights view: cost, autonomy, cache-hit and tool-error cards over Claude Code sessions">
+        <figcaption class="shot__cap">Every tool call attributed to a skill, MCP server or sub-agent.</figcaption>
+      </figure>
+    </section>
+
+    <section class="section">
+      <div class="section__head">
+        <h2>Two halves, one window.</h2>
+        <span class="label">What you get</span>
+      </div>
+      <div class="split">
+        <div class="sheet panel">
+          <div class="eyebrow">Looks backward</div>
+          <h3>Your history, made legible</h3>
+          <p>Agento never asks you to change how you work. It reads what Claude Code already wrote.</p>
+          <ul>
+            <li><b>Cost per session</b>, priced at the rate in effect when each message ran.</li>
+            <li><b>Full-text search</b> across every transcript, ranked, with snippets.</li>
+            <li><b>Session journey</b> — turn by turn, sub-agents nested under the task that spawned them.</li>
+          </ul>
+        </div>
+        <div class="sheet sheet--dashed panel">
+          <div class="eyebrow">Looks forward</div>
+          <h3>Agents that do the work</h3>
+          <p>Build one, give it tools, hand it a schedule, and read the job history in the morning.</p>
+          <ul>
+            <li><b>Agent builder</b> with system prompts, tool allowlists and permission modes.</li>
+            <li><b>Scheduled tasks</b> — cron, intervals, or a one-off at a fixed instant.</li>
+            <li><b>GitHub, Slack, Jira, Confluence, Telegram, Google</b> as in-process MCP servers.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section__head">
+        <h2>Every section, one keystroke away.</h2>
+        <span class="label">⌘K</span>
+      </div>
+      <div class="grid3">
+        <div class="sheet card"><span class="label">01 · Chats</span><h4>Talk to your agents</h4><p>Streaming turns, tool calls rendered inline, and a permission prompt you can actually answer.</p></div>
+        <div class="sheet card"><span class="label">02 · Agents</span><h4>Build and version them</h4><p>Prompt templates with variables, tool allowlists, and a Claude settings profile per agent.</p></div>
+        <div class="sheet card"><span class="label">03 · Tasks</span><h4>Put them on a clock</h4><p>Cron expressions validated at save time, so a schedule that can never fire is refused.</p></div>
+        <div class="sheet card"><span class="label">04 · Sessions</span><h4>Replay any run</h4><p>Ranked search over 1,000+ transcripts, then continue any one of them as a live chat.</p></div>
+        <div class="sheet card"><span class="label">05 · Analytics</span><h4>Where the money went</h4><p>Cost by model and project, cache-hit rate, and an activity heatmap in your own timezone.</p></div>
+        <div class="sheet card"><span class="label">06 · Gateway</span><h4>Route your other tools</h4><p>One OpenAI- and Anthropic-compatible endpoint on loopback, with usage and cost per request.</p></div>
+      </div>
+    </section>
+
+    <Install />
+
+    <section class="section">
+      <div class="section__head">
+        <h2>Built for the desk, not the tab.</h2>
+        <span class="label">Design</span>
+      </div>
+      <div class="split">
+        <figure class="shot" style="margin:0">
+          <div class="shot__bar">
+            <span class="shot__dot"></span><span class="shot__dot"></span><span class="shot__dot"></span>
+            <span class="shot__name">Agento — Agent builder</span>
+          </div>
+          <img src={url("/screenshots/light/agent-builder.png")} alt="Agento's agent builder: system prompt, model, tools and permission mode in three resizable panes">
+        </figure>
+        <div class="sheet panel">
+          <div class="eyebrow">Design<span class="eyebrow__end"><a href={url("/docs/architecture/")}>Architecture ↗</a></span></div>
+          <h3>A native app that behaves like one</h3>
+          <p>Three resizable panes per section, hairline borders, focus-aware selection, a status bar, and a command palette. No browser affordances, because it is not a browser.</p>
+          <p>One process, one SQLite file, and the Claude Code CLI spawned per run. The whole backend is Rust; the window is Tauri.</p>
+          <div class="compbar">
+            <span class="pill pill--plain">Tauri 2</span>
+            <span class="pill pill--plain">Rust</span>
+            <span class="pill pill--plain">React</span>
+            <span class="pill pill--plain">SQLite</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="sheet panel">
+        <div class="eyebrow">Frequently asked</div>
+        <div class="rows">
+          <a class="row" href={url("/docs/troubleshooting/#privacy")}><span class="row__t">Does Agento send my transcripts anywhere?</span><span class="row__go">▸</span></a>
+          <a class="row" href={url("/docs/installation/#requirements")}><span class="row__t">Do I need an Anthropic API key?</span><span class="row__go">▸</span></a>
+          <a class="row" href={url("/docs/user-guide/#privacy")}><span class="row__t">Will it change anything in ~/.claude?</span><span class="row__go">▸</span></a>
+          <a class="row" href={url("/docs/user-guide/#llm-gateway")}><span class="row__t">Can I point other tools at it?</span><span class="row__go">▸</span></a>
+        </div>
+      </div>
+    </section>
+
+    <StarCta />
+
+    <section class="closer">
+      <h2>Your sessions are already on disk.</h2>
+      <p>Agento just reads them. Install it, and the last six months of your Claude Code usage become a dashboard you can search.</p>
+      <div class="hero__cta">
+        <a class="btn btn--primary" href={RELEASE}>Download {version} →</a>
+        <a class="btn btn--ghost" href={REPO}>Star on GitHub</a>
+      </div>
+    </section>
+
+  </div>
+
+</Page>

--- a/web/src/pages/rss.xml.js
+++ b/web/src/pages/rss.xml.js
@@ -1,0 +1,23 @@
+import rss from '@astrojs/rss';
+import { getCollection } from 'astro:content';
+import { url } from '../../site.config.mjs';
+
+export async function GET(context) {
+  const posts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
+    (a, b) => b.data.date.valueOf() - a.data.date.valueOf()
+  );
+
+  return rss({
+    title: 'Agento — Notes from the build',
+    description: 'Release notes, ported subsystems, and the decisions that were harder than they looked.',
+    site: context.site,
+    items: posts.map((post) => ({
+      title: post.data.title,
+      description: post.data.description,
+      pubDate: post.data.date,
+      categories: post.data.tags,
+      author: post.data.author,
+      link: url(`/blog/${post.id}/`),
+    })),
+  });
+}

--- a/web/src/styles/fonts.css
+++ b/web/src/styles/fonts.css
@@ -1,0 +1,11 @@
+/* Fonts are self-hosted. Agento's whole claim is that nothing leaves your
+   machine; loading the marketing site's type from a third party would put a
+   request to Google on every page view, which is the wrong note to open on. */
+@import '@fontsource/instrument-serif/400.css';
+@import '@fontsource/instrument-serif/400-italic.css';
+@import '@fontsource-variable/newsreader/index.css';
+@import '@fontsource-variable/jetbrains-mono/index.css';
+@import '@fontsource/karla/400.css';
+@import '@fontsource/karla/500.css';
+@import '@fontsource/karla/600.css';
+@import '@fontsource/karla/700.css';

--- a/web/src/styles/site.css
+++ b/web/src/styles/site.css
@@ -113,7 +113,7 @@ img { max-width: 100%; display: block; }
 .btn:hover { transform: translate(2px, 2px); box-shadow: 2px 2px 0 var(--ink); }
 .btn:active { transform: translate(4px, 4px); box-shadow: 0 0 0 var(--ink); }
 .btn:focus-visible { outline: 3px solid var(--blue); outline-offset: 3px; }
-.btn--primary { background: var(--blue); color: #0B0C07; }
+.btn--primary { background: var(--blue); color: var(--on-accent); }
 .btn--ink { background: var(--ink); color: var(--paper); }
 @media (prefers-reduced-motion: reduce) {
   .btn { transition: none; }
@@ -146,23 +146,26 @@ img { max-width: 100%; display: block; }
 .nav a {
   font-family: var(--font-mono); font-size: 12px; font-weight: 500;
   letter-spacing: 0.06em; text-transform: uppercase;
-  text-decoration: none; padding-bottom: 2px;
-  border-bottom: 2px solid transparent;
+  text-decoration: none;
 }
-.nav a:hover { border-bottom-color: var(--blue); }
-.nav a[aria-current] { border-bottom-color: var(--ink); }
+/* The underline is for the plain nav links only. Scoped rather than left to
+   the cascade: `.nav a` outranks `.navstar`, so an unscoped
+   `border-bottom: transparent` here erases the star button's own border. */
+.nav a:not(.navstar) { padding-bottom: 2px; border-bottom: 2px solid transparent; }
+.nav a:not(.navstar):hover { border-bottom-color: var(--blue); }
+.nav a:not(.navstar)[aria-current] { border-bottom-color: var(--ink); }
 
 /* --- landing ------------------------------------------------------------- */
 .hero { padding: 64px 0 40px; }
 .hero__eyebrow { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 22px; }
 .hero__title {
   font-family: var(--font-display);
-  font-size: clamp(44px, 7vw, 82px);
-  line-height: 0.98;
+  font-size: clamp(44px, 8vw, 92px);
+  line-height: 0.97;
   letter-spacing: -0.02em;
   margin: 0 0 20px;
   text-wrap: balance;
-  max-width: 15ch;
+  max-width: 19ch;
 }
 .hero__title em { font-style: italic; color: var(--blue-deep); }
 .hero__lede {
@@ -220,6 +223,9 @@ img { max-width: 100%; display: block; }
 .section__head .label { margin-left: auto; }
 
 .split { display: grid; grid-template-columns: 1fr 1fr; gap: 22px; }
+/* A panel beside a screenshot sizes to its own text. Stretching it to match the
+   image's height leaves a third of the panel empty. */
+.split--media { align-items: start; }
 .panel { padding: 26px; }
 .panel h3 {
   font-family: var(--font-sub); font-weight: 600;
@@ -251,16 +257,20 @@ img { max-width: 100%; display: block; }
 .step h4 { font-family: var(--font-sub); font-weight: 600; font-size: 20px; margin: 14px 0 8px; }
 .step p { margin: 0 0 12px; font-size: 14.5px; color: var(--ink-soft); }
 
-.code {
+/* Namespaced deliberately. Expressive Code marks the content of every rendered
+   line with `class="code"` and its frame caption with `class="header"`, so a
+   bare `.code` or `.header` rule here reaches inside every fenced block on the
+   page — which is what turned one code block into five padded boxes. Keep new
+   class names in this file specific enough not to collide. */
+.codeblock {
   background: var(--code-bg); color: var(--code-fg);
   border: var(--bw) solid var(--code-border); border-radius: var(--radius);
   font-family: var(--font-mono); font-size: 12.5px; line-height: 1.7;
   padding: 14px 16px; overflow-x: auto; margin: 0;
 }
-.code .c { color: #8A8779; }
-.code .s { color: var(--blue); }
-.code .k { color: #FFFFFF; font-weight: 700; }
-:root[data-theme="dark"] .code .k, :root:not([data-theme="light"]) .code .k { color: var(--code-fg); }
+.codeblock .c { color: var(--code-comment); }
+.codeblock .s { color: var(--blue); }
+.codeblock .k { color: var(--code-key); font-weight: 700; }
 
 .closer {
   margin: 76px 0 0; padding: 46px 34px;
@@ -269,7 +279,7 @@ img { max-width: 100%; display: block; }
   box-shadow: var(--offset-sm);
 }
 .closer h2 { font-family: var(--font-display); font-weight: 400; font-size: 40px; margin: 0 0 12px; line-height: 1.05; }
-.closer p { margin: 0 0 24px; color: #C9C6BB; max-width: 52ch; }
+.closer p { margin: 0 0 24px; color: var(--on-ink-soft); max-width: 52ch; }
 .closer .btn { border-color: var(--paper); }
 .closer .btn--primary { border-color: var(--paper); box-shadow: 4px 4px 0 var(--paper); }
 .closer .btn--ghost { background: transparent; color: var(--paper); box-shadow: 4px 4px 0 var(--paper); }
@@ -332,7 +342,7 @@ img { max-width: 100%; display: block; }
   border-radius: 2px; padding: 1px 5px;
 }
 .article a.link { color: var(--blue-deep); text-decoration: none; border-bottom: 1.5px solid var(--blue); }
-.article .code { margin: 0 0 18px; }
+.article .codeblock { margin: 0 0 18px; }
 
 .table-wrap { overflow-x: auto; margin: 0 0 20px; border: var(--bw) solid var(--ink); border-radius: var(--radius); }
 table { border-collapse: collapse; width: 100%; background: var(--raised); font-size: 14.5px; }
@@ -395,13 +405,22 @@ td code { font-family: var(--font-mono); font-size: 12.5px; }
 .entry__lede { font-size: 20px; line-height: 1.5; color: var(--ink-soft); margin: 0 0 30px; padding-bottom: 26px; border-bottom: var(--bw-strong) solid var(--ink); }
 .entry p { margin: 0 0 17px; font-size: 17px; line-height: 1.68; }
 .entry h2 { font-family: var(--font-display); font-weight: 400; font-size: 32px; margin: 38px 0 12px; line-height: 1.12; }
-.entry .code { margin: 0 0 20px; }
+.entry .codeblock { margin: 0 0 20px; }
 .entry blockquote {
   margin: 26px 0; padding: 20px 24px;
   border: var(--bw) solid var(--ink); border-left: 6px solid var(--blue);
   border-radius: var(--radius); background: var(--raised);
-  font-family: var(--font-display); font-size: 25px; line-height: 1.3;
 }
+/* The size has to land on the paragraph. `.entry p` (0,1,1) outranks
+   `.entry blockquote` (0,1,1, but earlier), so a font-size on the container
+   alone left the pull quote rendering as body text. */
+.entry blockquote p {
+  margin: 0; color: var(--ink);
+  font-family: var(--font-display); font-weight: 400;
+  font-size: 25px; line-height: 1.3;
+}
+.entry blockquote p + p { margin-top: 12px; }
+.entry blockquote code { font-size: 0.8em; }
 .byline { display: flex; align-items: center; gap: 12px; margin-top: 34px; padding-top: 22px; border-top: var(--bw) solid var(--ink); }
 .byline__av { width: 40px; height: 40px; border-radius: 999px; border: var(--bw) solid var(--ink); background: var(--blue-tint); display: grid; place-items: center; font-family: var(--font-mono); font-weight: 700; font-size: 14px; }
 .byline__n { font-weight: 700; font-size: 15px; }
@@ -444,17 +463,38 @@ td code { font-family: var(--font-mono); font-size: 12.5px; }
 
 /* --- install ------------------------------------------------------------- */
 .prereq { margin-bottom: 22px; }
-.osgrid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; align-items: start; }
-.oscard { padding: 22px; }
-.oscard--rec { box-shadow: var(--offset), 0 0 0 3px var(--blue); }
-.oscard__rec { color: var(--blue-deep); font-weight: 700; }
+.osgrid { display: flex; flex-direction: column; gap: 12px; }
+.oscard { padding: 0; overflow: hidden; }
+.oscard__sum {
+  display: flex; align-items: center; gap: 14px;
+  padding: 15px 20px; cursor: pointer; list-style: none;
+  font-family: var(--font-sub); font-weight: 600; font-size: 20px;
+}
+.oscard__sum::-webkit-details-marker { display: none; }
+.oscard__sum:hover { background: var(--sunken); }
+.oscard__sum:focus-visible { outline: 3px solid var(--blue); outline-offset: -3px; }
+.oscard__files {
+  margin-left: auto; font-family: var(--font-mono); font-size: 11px;
+  letter-spacing: 0.06em; text-transform: uppercase; color: var(--ink-soft);
+}
+.oscard__chev { font-family: var(--font-mono); color: var(--ink-soft); transition: transform 140ms ease; }
+.oscard[open] .oscard__chev { transform: rotate(90deg); }
+.oscard__body { padding: 0 20px 20px; border-top: 1px dashed var(--ink-faint); padding-top: 18px; }
+.oscard--rec { box-shadow: 8px 8px 0 var(--blue); }
+.oscard__rec {
+  font-family: var(--font-mono); font-size: 10px; font-weight: 700;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  padding: 3px 9px; border: 1.5px solid var(--ink); border-radius: 999px;
+  background: var(--blue-tint); color: var(--ink);
+}
 .oscard .rows { margin-bottom: 16px; }
 .oscard .row__r { font-family: var(--font-mono); font-size: 11px; }
 .row--rec { border-color: var(--ink); background: var(--blue-tint); }
+@media (prefers-reduced-motion: reduce) { .oscard__chev { transition: none; } }
 
 .osteps { margin: 0 0 14px; padding-left: 18px; font-size: 14.5px; color: var(--ink-soft); }
 .osteps li { margin-bottom: 12px; }
-.osteps .code { margin-top: 8px; font-size: 11.5px; white-space: pre; }
+.osteps .codeblock { margin-top: 8px; font-size: 11.5px; white-space: pre; }
 .oshint { display: block; text-transform: none; letter-spacing: 0.01em; line-height: 1.5; }
 .osfoot { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; margin: 22px 0 0; }
 .osfoot a { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.06em;
@@ -475,23 +515,21 @@ td code { font-family: var(--font-mono); font-size: 12.5px; }
 }
 
 /* --- masthead star -------------------------------------------------------- */
-.navstar {
-  display: inline-flex; align-items: center; gap: 6px;
-  padding: 4px 10px; border: 1.5px solid var(--ink); border-radius: var(--radius);
-  background: var(--raised); text-decoration: none;
+.navbtn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+  height: 26px; padding: 0 10px;
+  border: 1.5px solid var(--ink); border-radius: var(--radius);
+  background: var(--raised); color: var(--ink);
+  font-family: var(--font-mono); font-size: 11px; font-weight: 500;
+  letter-spacing: 0.06em; text-transform: uppercase; line-height: 1;
+  text-decoration: none; cursor: pointer;
 }
+.navbtn:focus-visible { outline: 3px solid var(--blue); outline-offset: 2px; }
 .navstar:hover { background: var(--blue-tint); }
 .navstar .n { font-variant-numeric: tabular-nums; }
-
-.themetoggle {
-  border: 1.5px solid var(--ink); border-radius: var(--radius);
-  background: var(--raised); color: var(--ink); cursor: pointer;
-  font-family: var(--font-mono); font-size: 11px; font-weight: 500;
-  letter-spacing: 0.06em; text-transform: uppercase; padding: 4px 10px;
-}
+.themetoggle { min-width: 66px; }
 .themetoggle:hover { background: var(--sunken); }
 
-@media (max-width: 900px) { .osgrid { grid-template-columns: 1fr; } }
 
 /* --- 404 ----------------------------------------------------------------- */
 .notfound { padding: 80px 24px 90px; max-width: 720px; }
@@ -500,3 +538,42 @@ td code { font-family: var(--font-mono); font-size: 12.5px; }
 .notfound > p { color: var(--ink-soft); font-size: 18px; margin: 0 0 28px; }
 .notfound__f { margin-top: 26px; font-size: 14.5px; color: var(--ink-soft); }
 .notfound__f a { color: var(--blue-deep); border-bottom: 1.5px solid var(--blue); text-decoration: none; }
+
+/* --- faq ----------------------------------------------------------------- */
+.faq { border: 1px solid var(--ink-faint); border-radius: var(--radius); background: var(--raised); }
+.faq[open] { border-color: var(--ink); }
+.faq__q {
+  display: flex; align-items: baseline; gap: 12px;
+  padding: 12px 15px; cursor: pointer; list-style: none;
+  font-family: var(--font-sub); font-weight: 600; font-size: 16.5px;
+}
+.faq__q::-webkit-details-marker { display: none; }
+.faq__q:hover { background: var(--sunken); }
+.faq__q:focus-visible { outline: 3px solid var(--blue); outline-offset: -3px; }
+.faq__chev { font-family: var(--font-mono); color: var(--ink-faint); transition: transform 140ms ease; }
+.faq[open] .faq__chev { transform: rotate(90deg); }
+.faq__a { padding: 0 15px 14px 39px; }
+.faq__a p { margin: 0 0 10px; font-size: 15px; color: var(--ink-soft); max-width: 72ch; }
+.faq__more {
+  font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.06em;
+  text-transform: uppercase; text-decoration: none;
+  border-bottom: 1.5px solid var(--blue); color: var(--blue-deep);
+}
+@media (prefers-reduced-motion: reduce) { .faq__chev { transition: none; } }
+
+/* --- fenced code blocks --------------------------------------------------- */
+/* Expressive Code carries its own palette through `--ec-*` custom properties.
+   Rather than depend on those resolving, the ground is pinned to our own
+   tokens, so a fenced block in a post looks exactly like the hand-written
+   .codeblock elsewhere on the site: one solid inverted rectangle. Syntax
+   colours still come from Expressive Code's per-token inline styles. */
+.expressive-code .frame pre {
+  background: var(--code-bg);
+  border: var(--bw) solid var(--code-border);
+  border-radius: var(--radius);
+  padding: 14px 0;
+  margin: 0;
+}
+.expressive-code figure { margin: 0 0 20px; }
+.expressive-code .frame .header { display: none; }
+.expressive-code .ec-line .code { padding-inline: 16px; }

--- a/web/src/styles/site.css
+++ b/web/src/styles/site.css
@@ -1,0 +1,502 @@
+/* ==========================================================================
+   Agento site — components
+
+   Everything here reads colour through the tokens in tokens.css. The rules are
+   ordered shared primitives, then chrome, then per-surface (landing, blog).
+   Docs pages are Starlight's markup and are themed in starlight.css.
+   ========================================================================== */
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--font-body);
+  font-size: 16px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+a { color: inherit; }
+img { max-width: 100%; display: block; }
+
+/* --- shared primitives --------------------------------------------------- */
+.label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+.serif { font-family: var(--font-display); font-weight: 400; letter-spacing: -0.01em; }
+.sheet {
+  background: var(--raised);
+  border: var(--bw) solid var(--ink);
+  border-radius: var(--radius);
+  box-shadow: var(--offset);
+}
+.sheet--flat { box-shadow: none; }
+.sheet--dashed { border-style: dashed; box-shadow: none; background: transparent; }
+.rule { height: var(--bw); background: var(--ink); border: 0; margin: 0; }
+.rule--dashed { height: 0; background: none; border-top: 1.5px dashed var(--ink-faint); }
+
+/* The signature device: a mono label prefixed by an em rule, set into the
+   top-left of the panel it names. */
+.eyebrow {
+  display: flex; align-items: center; gap: 9px;
+  font-family: var(--font-mono);
+  font-size: 11px; font-weight: 500;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--ink-soft);
+  margin-bottom: 18px;
+}
+.eyebrow::before {
+  content: ""; width: 16px; height: 1.5px; background: var(--ink-soft); flex: none;
+}
+.eyebrow__end { margin-left: auto; letter-spacing: 0.04em; text-transform: none; }
+.eyebrow__end a { text-decoration: none; border-bottom: 1.5px solid var(--blue); }
+
+/* Hairline rows stacked inside a panel. The panel carries the shadow; rows
+   never do. */
+.rows { display: flex; flex-direction: column; gap: 8px; }
+.row {
+  display: flex; align-items: center; gap: 14px;
+  padding: 12px 15px;
+  border: 1px solid var(--ink-faint);
+  border-radius: var(--radius);
+  background: var(--raised);
+  text-decoration: none;
+}
+.row:hover { border-color: var(--ink); background: var(--sunken); }
+.row__t { font-family: var(--font-sub); font-weight: 600; font-size: 16.5px; }
+.row__m { font-family: var(--font-mono); font-size: 12.5px; }
+.row__m .q { color: var(--blue-deep); }
+.row__r { margin-left: auto; font-size: 14px; color: var(--ink-soft); text-align: right; }
+.row__go { color: var(--ink-faint); font-family: var(--font-mono); }
+.row:hover .row__go { color: var(--blue-deep); }
+
+.badge {
+  font-family: var(--font-mono); font-size: 10px; font-weight: 700;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  padding: 3px 7px; border-radius: var(--radius);
+  background: var(--sunken); border: 1px solid var(--ink-faint);
+  color: var(--ink-soft); flex: none;
+}
+
+.pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 3px 10px;
+  border: var(--bw) solid var(--ink);
+  border-radius: 999px;
+  background: var(--blue-tint);
+  font-family: var(--font-mono);
+  font-size: 11px; font-weight: 500;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  white-space: nowrap;
+}
+.pill--plain { background: transparent; }
+
+.btn {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 11px 20px;
+  border: var(--bw-strong) solid var(--ink);
+  border-radius: var(--radius);
+  background: var(--raised);
+  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 12px; font-weight: 700;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  text-decoration: none;
+  box-shadow: var(--offset-sm);
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+.btn:hover { transform: translate(2px, 2px); box-shadow: 2px 2px 0 var(--ink); }
+.btn:active { transform: translate(4px, 4px); box-shadow: 0 0 0 var(--ink); }
+.btn:focus-visible { outline: 3px solid var(--blue); outline-offset: 3px; }
+.btn--primary { background: var(--blue); color: #0B0C07; }
+.btn--ink { background: var(--ink); color: var(--paper); }
+@media (prefers-reduced-motion: reduce) {
+  .btn { transition: none; }
+  .btn:hover, .btn:active { transform: none; box-shadow: var(--offset-sm); }
+}
+
+/* --- site header --------------------------------------------------------- */
+.shell { max-width: var(--shell); margin: 0 auto; padding: 0 24px; }
+.masthead {
+  border-bottom: var(--bw-strong) solid var(--ink);
+  background: var(--paper);
+}
+.masthead__in {
+  display: flex; align-items: center; gap: 18px;
+  padding: 16px 24px;
+  max-width: var(--shell); margin: 0 auto;
+}
+.wordmark {
+  font-family: var(--font-display);
+  font-size: 26px; line-height: 1;
+  text-decoration: none;
+  display: flex; align-items: baseline; gap: 8px;
+}
+.wordmark__dot {
+  width: 9px; height: 9px; border-radius: 999px;
+  background: var(--blue); border: 1.5px solid var(--ink);
+  display: inline-block;
+}
+.nav { display: flex; gap: 20px; margin-left: auto; align-items: center; }
+.nav a {
+  font-family: var(--font-mono); font-size: 12px; font-weight: 500;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  text-decoration: none; padding-bottom: 2px;
+  border-bottom: 2px solid transparent;
+}
+.nav a:hover { border-bottom-color: var(--blue); }
+.nav a[aria-current] { border-bottom-color: var(--ink); }
+
+/* --- landing ------------------------------------------------------------- */
+.hero { padding: 64px 0 40px; }
+.hero__eyebrow { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 22px; }
+.hero__title {
+  font-family: var(--font-display);
+  font-size: clamp(44px, 7vw, 82px);
+  line-height: 0.98;
+  letter-spacing: -0.02em;
+  margin: 0 0 20px;
+  text-wrap: balance;
+  max-width: 15ch;
+}
+.hero__title em { font-style: italic; color: var(--blue-deep); }
+.hero__lede {
+  font-size: 19px; line-height: 1.55;
+  max-width: 54ch; color: var(--ink-soft);
+  margin: 0 0 30px;
+}
+.hero__cta { display: flex; flex-wrap: wrap; gap: 14px; align-items: center; }
+.hero__note { font-family: var(--font-mono); font-size: 11px; color: var(--ink-faint); letter-spacing: 0.04em; }
+
+.stats {
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  margin: 44px 0 0;
+  border: var(--bw) solid var(--ink);
+  border-radius: var(--radius);
+  background: var(--raised);
+  box-shadow: var(--offset);
+  overflow: hidden;
+}
+.stat { padding: 16px 18px; border-right: var(--bw) solid var(--ink); }
+.stat:last-child { border-right: 0; }
+.stat__n {
+  font-family: var(--font-mono); font-size: 21px; font-weight: 700;
+  font-variant-numeric: tabular-nums; line-height: 1.2;
+}
+.stat__k { margin-top: 3px; }
+
+.shot {
+  margin: 40px 0 0;
+  border: var(--bw-strong) solid var(--ink);
+  border-radius: var(--radius);
+  box-shadow: var(--offset);
+  background: var(--raised);
+  overflow: hidden;
+}
+.shot__bar {
+  display: flex; align-items: center; gap: 8px;
+  padding: 8px 12px;
+  border-bottom: var(--bw) solid var(--ink);
+  background: var(--sunken);
+}
+.shot__dot { width: 9px; height: 9px; border-radius: 999px; border: 1.2px solid var(--ink); background: var(--paper); }
+.shot__name { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink-soft); margin-left: 4px; }
+.shot__cap {
+  padding: 10px 14px; border-top: var(--bw) solid var(--ink);
+  font-family: var(--font-mono); font-size: 11px; color: var(--ink-soft);
+}
+
+.section { padding: 70px 0 0; }
+.section__head { display: flex; align-items: baseline; gap: 16px; margin-bottom: 26px; }
+.section__head h2 {
+  font-family: var(--font-display); font-weight: 400;
+  font-size: 38px; line-height: 1.05; letter-spacing: -0.01em; margin: 0;
+}
+.section__head .label { margin-left: auto; }
+
+.split { display: grid; grid-template-columns: 1fr 1fr; gap: 22px; }
+.panel { padding: 26px; }
+.panel h3 {
+  font-family: var(--font-sub); font-weight: 600;
+  font-size: 25px; line-height: 1.2; margin: 0 0 10px; letter-spacing: -0.01em;
+}
+.panel p { margin: 0 0 14px; color: var(--ink-soft); font-size: 15px; }
+.panel ul { margin: 0; padding-left: 18px; color: var(--ink-soft); font-size: 15px; }
+.panel li { margin-bottom: 6px; }
+.panel li b { color: var(--ink); font-weight: 600; }
+
+.grid3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.card { padding: 20px; }
+.card h4 {
+  font-family: var(--font-sub); font-weight: 600;
+  font-size: 19.5px; margin: 12px 0 8px; line-height: 1.25; letter-spacing: -0.01em;
+}
+.card p { margin: 0; font-size: 14.5px; color: var(--ink-soft); line-height: 1.55; }
+
+.steps { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0; border: var(--bw) solid var(--ink); border-radius: var(--radius); box-shadow: var(--offset); background: var(--raised); overflow: hidden; }
+.step { padding: 24px; border-right: var(--bw) solid var(--ink); }
+.step:last-child { border-right: 0; }
+.step__n {
+  font-family: var(--font-mono); font-size: 11px; font-weight: 700;
+  letter-spacing: 0.1em; color: var(--ink);
+  border: var(--bw) solid var(--ink); border-radius: 999px;
+  width: 26px; height: 26px; display: grid; place-items: center;
+  background: var(--blue-tint);
+}
+.step h4 { font-family: var(--font-sub); font-weight: 600; font-size: 20px; margin: 14px 0 8px; }
+.step p { margin: 0 0 12px; font-size: 14.5px; color: var(--ink-soft); }
+
+.code {
+  background: var(--code-bg); color: var(--code-fg);
+  border: var(--bw) solid var(--code-border); border-radius: var(--radius);
+  font-family: var(--font-mono); font-size: 12.5px; line-height: 1.7;
+  padding: 14px 16px; overflow-x: auto; margin: 0;
+}
+.code .c { color: #8A8779; }
+.code .s { color: var(--blue); }
+.code .k { color: #FFFFFF; font-weight: 700; }
+:root[data-theme="dark"] .code .k, :root:not([data-theme="light"]) .code .k { color: var(--code-fg); }
+
+.closer {
+  margin: 76px 0 0; padding: 46px 34px;
+  background: var(--ink); color: var(--paper);
+  border-radius: var(--radius);
+  box-shadow: var(--offset-sm);
+}
+.closer h2 { font-family: var(--font-display); font-weight: 400; font-size: 40px; margin: 0 0 12px; line-height: 1.05; }
+.closer p { margin: 0 0 24px; color: #C9C6BB; max-width: 52ch; }
+.closer .btn { border-color: var(--paper); }
+.closer .btn--primary { border-color: var(--paper); box-shadow: 4px 4px 0 var(--paper); }
+.closer .btn--ghost { background: transparent; color: var(--paper); box-shadow: 4px 4px 0 var(--paper); }
+
+.foot {
+  margin-top: 60px; border-top: 1.5px dashed var(--ink-faint);
+  padding: 22px 0 46px;
+  display: flex; flex-wrap: wrap; gap: 18px; align-items: center;
+}
+.foot .label { margin-right: auto; letter-spacing: 0.06em; }
+.foot__end { margin-left: auto; }
+.foot a { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; text-decoration: none; border-bottom: 1.5px solid var(--ink); }
+
+/* --- docs ---------------------------------------------------------------- */
+.docs { display: grid; grid-template-columns: 232px minmax(0,1fr) 190px; gap: 34px; padding: 34px 0 60px; align-items: start; }
+.sidebar { position: sticky; top: 78px; }
+.sidebar__group { margin-bottom: 22px; }
+.sidebar__group > .label { display: block; padding-bottom: 8px; border-bottom: var(--bw) solid var(--ink); margin-bottom: 8px; }
+.sidebar a {
+  display: block; padding: 5px 9px; text-decoration: none;
+  font-size: 14.5px; border-radius: 2px; border: 1.5px solid transparent;
+}
+.sidebar a:hover { background: var(--sunken); }
+.sidebar a[aria-current="page"] {
+  background: var(--blue-tint); border-color: var(--ink); font-weight: 600;
+}
+.searchbox {
+  display: flex; align-items: center; gap: 8px; width: 100%;
+  padding: 8px 10px; margin-bottom: 22px;
+  background: var(--raised); border: var(--bw) solid var(--ink); border-radius: var(--radius);
+  font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.06em;
+  text-transform: uppercase; color: var(--ink-soft); cursor: pointer;
+}
+.searchbox kbd {
+  margin-left: auto; font-family: var(--font-mono); font-size: 10px;
+  border: 1.2px solid var(--ink-faint); border-radius: 2px; padding: 1px 5px; color: var(--ink-soft);
+}
+
+.article { max-width: var(--measure); }
+.crumbs { display: flex; gap: 8px; align-items: center; margin-bottom: 14px; }
+.crumbs span { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--ink-faint); }
+.article h1 {
+  font-family: var(--font-display); font-weight: 400;
+  font-size: 52px; line-height: 1.02; letter-spacing: -0.02em;
+  margin: 0 0 10px;
+}
+.article__sub { font-size: 18px; color: var(--ink-soft); margin: 0 0 26px; max-width: 56ch; }
+.article h2 {
+  font-family: var(--font-display); font-weight: 400; font-size: 31px;
+  margin: 40px 0 12px; padding-bottom: 8px;
+  border-bottom: var(--bw) solid var(--ink); line-height: 1.15;
+}
+.article h3 { font-family: var(--font-sub); font-weight: 700; font-size: 19px; margin: 28px 0 8px; }
+.article p { margin: 0 0 15px; }
+.article ul { margin: 0 0 15px; padding-left: 20px; }
+.article li { margin-bottom: 6px; }
+.article code:not(.code code) {
+  font-family: var(--font-mono); font-size: 0.87em;
+  background: var(--sunken); border: 1px solid var(--ink-faint);
+  border-radius: 2px; padding: 1px 5px;
+}
+.article a.link { color: var(--blue-deep); text-decoration: none; border-bottom: 1.5px solid var(--blue); }
+.article .code { margin: 0 0 18px; }
+
+.table-wrap { overflow-x: auto; margin: 0 0 20px; border: var(--bw) solid var(--ink); border-radius: var(--radius); }
+table { border-collapse: collapse; width: 100%; background: var(--raised); font-size: 14.5px; }
+th, td { text-align: left; padding: 9px 12px; border-bottom: 1px solid var(--ink-faint); }
+th {
+  font-family: var(--font-mono); font-size: 10.5px; font-weight: 700;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  background: var(--sunken); border-bottom: var(--bw) solid var(--ink);
+}
+tr:last-child td { border-bottom: 0; }
+td code { font-family: var(--font-mono); font-size: 12.5px; }
+
+.note {
+  display: grid; grid-template-columns: auto 1fr; gap: 12px;
+  padding: 14px 16px; margin: 0 0 20px;
+  border: var(--bw) dashed var(--ink); border-radius: var(--radius);
+  background: transparent;
+}
+.note__k { font-family: var(--font-mono); font-size: 10.5px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink); white-space: nowrap; padding-top: 2px; }
+.note p { margin: 0; font-size: 14.5px; color: var(--ink-soft); }
+.note--warn { border-style: solid; border-color: var(--warn); }
+.note--warn .note__k { color: var(--warn); }
+
+.toc { position: sticky; top: 78px; }
+.toc > .label { display: block; padding-bottom: 8px; border-bottom: var(--bw) solid var(--ink); margin-bottom: 10px; }
+.toc a { display: block; font-size: 13.5px; padding: 4px 0 4px 10px; text-decoration: none; color: var(--ink-soft); border-left: 2px solid var(--ink-faint); }
+.toc a[aria-current] { color: var(--ink); border-left-color: var(--blue); border-left-width: 3px; font-weight: 600; }
+
+.pager { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 48px; }
+.pager a { text-decoration: none; padding: 16px 18px; display: block; }
+.pager .label { display: block; margin-bottom: 6px; }
+.pager .t { font-family: var(--font-display); font-size: 22px; }
+.pager .r { text-align: right; }
+
+/* --- blog ---------------------------------------------------------------- */
+.blog { padding: 46px 0 60px; }
+.blog__title { font-family: var(--font-display); font-weight: 400; font-size: 62px; line-height: 1; margin: 0 0 10px; letter-spacing: -0.02em; }
+.blog__sub { font-size: 18px; color: var(--ink-soft); margin: 0 0 38px; max-width: 50ch; }
+.posts { display: flex; flex-direction: column; gap: 0; border-top: var(--bw-strong) solid var(--ink); }
+.post {
+  display: grid; grid-template-columns: 130px 1fr auto; gap: 24px; align-items: start;
+  padding: 24px 4px; border-bottom: var(--bw) solid var(--ink);
+  text-decoration: none;
+}
+.post:hover { background: var(--sunken); }
+.post__date { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.06em; color: var(--ink-soft); padding-top: 7px; text-transform: uppercase; }
+.post__body h3 { font-family: var(--font-sub); font-weight: 600; font-size: 26px; line-height: 1.18; margin: 0 0 7px; letter-spacing: -0.01em; }
+.post__body p { margin: 0 0 10px; color: var(--ink-soft); font-size: 15px; max-width: 62ch; }
+.post__tags { display: flex; gap: 7px; flex-wrap: wrap; }
+.post__go { font-family: var(--font-mono); font-size: 15px; padding-top: 6px; color: var(--ink-faint); }
+.post:hover .post__go { color: var(--blue-deep); }
+.post--feature { grid-template-columns: 1fr; padding: 30px; margin-bottom: 26px; background: var(--raised); border: var(--bw-strong) solid var(--ink); border-radius: var(--radius); box-shadow: var(--offset); }
+.post--feature h3 { font-size: 40px; margin-bottom: 10px; max-width: 20ch; }
+.post--feature .post__meta { display: flex; gap: 12px; align-items: center; margin-bottom: 14px; }
+
+/* --- blog post ----------------------------------------------------------- */
+.entry { max-width: var(--measure); margin: 0 auto; padding: 46px 0 70px; }
+.entry__meta { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; margin-bottom: 20px; }
+.entry h1 { font-family: var(--font-display); font-weight: 400; font-size: 58px; line-height: 1.0; letter-spacing: -0.025em; margin: 0 0 16px; text-wrap: balance; }
+.entry__lede { font-size: 20px; line-height: 1.5; color: var(--ink-soft); margin: 0 0 30px; padding-bottom: 26px; border-bottom: var(--bw-strong) solid var(--ink); }
+.entry p { margin: 0 0 17px; font-size: 17px; line-height: 1.68; }
+.entry h2 { font-family: var(--font-display); font-weight: 400; font-size: 32px; margin: 38px 0 12px; line-height: 1.12; }
+.entry .code { margin: 0 0 20px; }
+.entry blockquote {
+  margin: 26px 0; padding: 20px 24px;
+  border: var(--bw) solid var(--ink); border-left: 6px solid var(--blue);
+  border-radius: var(--radius); background: var(--raised);
+  font-family: var(--font-display); font-size: 25px; line-height: 1.3;
+}
+.byline { display: flex; align-items: center; gap: 12px; margin-top: 34px; padding-top: 22px; border-top: var(--bw) solid var(--ink); }
+.byline__av { width: 40px; height: 40px; border-radius: 999px; border: var(--bw) solid var(--ink); background: var(--blue-tint); display: grid; place-items: center; font-family: var(--font-mono); font-weight: 700; font-size: 14px; }
+.byline__n { font-weight: 700; font-size: 15px; }
+.byline__r { font-size: 13.5px; color: var(--ink-soft); }
+
+/* --- tokens sheet -------------------------------------------------------- */
+.tokens { padding: 40px 0 70px; display: flex; flex-direction: column; gap: 34px; }
+.swatches { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px,1fr)); gap: 14px; }
+.sw { border: var(--bw) solid var(--ink); border-radius: var(--radius); overflow: hidden; }
+.sw__chip { height: 64px; border-bottom: var(--bw) solid var(--ink); }
+.sw__meta { padding: 8px 10px; background: var(--raised); }
+.sw__n { font-family: var(--font-mono); font-size: 11px; font-weight: 700; }
+.sw__v { font-family: var(--font-mono); font-size: 10.5px; color: var(--ink-soft); }
+.typescale > div { display: flex; align-items: baseline; gap: 18px; padding: 10px 0; border-bottom: 1px solid var(--ink-faint); }
+.typescale .label { width: 190px; flex: none; }
+.compbar { display: flex; flex-wrap: wrap; gap: 14px; align-items: center; }
+
+/* --- responsive ---------------------------------------------------------- */
+@media (max-width: 1000px) {
+  .docs { grid-template-columns: 200px minmax(0,1fr); }
+  .toc { display: none; }
+  .grid3 { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 760px) {
+  .stats { grid-template-columns: 1fr 1fr; }
+  .stat:nth-child(2) { border-right: 0; }
+  .stat:nth-child(1), .stat:nth-child(2) { border-bottom: var(--bw) solid var(--ink); }
+  .split, .grid3, .steps, .pager { grid-template-columns: 1fr; }
+  .step { border-right: 0; border-bottom: var(--bw) solid var(--ink); }
+  .step:last-child { border-bottom: 0; }
+  .docs { grid-template-columns: 1fr; }
+  .sidebar { position: static; }
+  .post { grid-template-columns: 1fr; gap: 8px; }
+  .nav { display: none; }
+}
+
+/* --- downloads ----------------------------------------------------------- */
+.dlgroup + .dlgroup { margin-top: 20px; }
+.dlgroup__os { display: block; margin-bottom: 8px; }
+
+/* --- install ------------------------------------------------------------- */
+.prereq { margin-bottom: 22px; }
+.osgrid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; align-items: start; }
+.oscard { padding: 22px; }
+.oscard--rec { box-shadow: var(--offset), 0 0 0 3px var(--blue); }
+.oscard__rec { color: var(--blue-deep); font-weight: 700; }
+.oscard .rows { margin-bottom: 16px; }
+.oscard .row__r { font-family: var(--font-mono); font-size: 11px; }
+.row--rec { border-color: var(--ink); background: var(--blue-tint); }
+
+.osteps { margin: 0 0 14px; padding-left: 18px; font-size: 14.5px; color: var(--ink-soft); }
+.osteps li { margin-bottom: 12px; }
+.osteps .code { margin-top: 8px; font-size: 11.5px; white-space: pre; }
+.oshint { display: block; text-transform: none; letter-spacing: 0.01em; line-height: 1.5; }
+.osfoot { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; margin: 22px 0 0; }
+.osfoot a { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.06em;
+  text-transform: uppercase; text-decoration: none; border-bottom: 1.5px solid var(--blue); }
+
+/* --- star call to action -------------------------------------------------- */
+.starband {
+  display: flex; flex-wrap: wrap; gap: 24px; align-items: center;
+  margin-top: 70px; padding: 30px 32px;
+}
+.starband__t { flex: 1 1 380px; }
+.starband h3 { font-family: var(--font-sub); font-weight: 600; font-size: 27px; margin: 0 0 8px; letter-spacing: -0.01em; }
+.starband p { margin: 0; color: var(--ink-soft); font-size: 15px; max-width: 58ch; }
+.starband__n {
+  font-variant-numeric: tabular-nums;
+  padding-left: 9px; margin-left: 3px;
+  border-left: 1.5px solid currentColor;
+}
+
+/* --- masthead star -------------------------------------------------------- */
+.navstar {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 4px 10px; border: 1.5px solid var(--ink); border-radius: var(--radius);
+  background: var(--raised); text-decoration: none;
+}
+.navstar:hover { background: var(--blue-tint); }
+.navstar .n { font-variant-numeric: tabular-nums; }
+
+.themetoggle {
+  border: 1.5px solid var(--ink); border-radius: var(--radius);
+  background: var(--raised); color: var(--ink); cursor: pointer;
+  font-family: var(--font-mono); font-size: 11px; font-weight: 500;
+  letter-spacing: 0.06em; text-transform: uppercase; padding: 4px 10px;
+}
+.themetoggle:hover { background: var(--sunken); }
+
+@media (max-width: 900px) { .osgrid { grid-template-columns: 1fr; } }
+
+/* --- 404 ----------------------------------------------------------------- */
+.notfound { padding: 80px 24px 90px; max-width: 720px; }
+.notfound h1 { font-family: var(--font-display); font-weight: 400; font-size: clamp(40px, 6vw, 62px);
+  line-height: 1.02; letter-spacing: -0.02em; margin: 14px 0 12px; }
+.notfound > p { color: var(--ink-soft); font-size: 18px; margin: 0 0 28px; }
+.notfound__f { margin-top: 26px; font-size: 14.5px; color: var(--ink-soft); }
+.notfound__f a { color: var(--blue-deep); border-bottom: 1.5px solid var(--blue); text-decoration: none; }

--- a/web/src/styles/starlight.css
+++ b/web/src/styles/starlight.css
@@ -1,0 +1,293 @@
+/* ==========================================================================
+   Agento site — Starlight
+
+   Docs pages are Starlight's markup, so the theme is applied by pointing its
+   own custom properties at our tokens and then restyling the handful of
+   surfaces that carry the design's signature: hard ink borders, the em-rule
+   eyebrow on sidebar groups, hairline rows, and serif headings.
+
+   Starlight defines its props inside `@layer starlight.base`. This file is
+   unlayered, so it wins on the cascade without needing specificity tricks —
+   which is why the whole mapping can sit on a single `:root` and still beat
+   Starlight's own `:root[data-theme='light']` block.
+
+   Starlight stamps data-theme on <html>, the same attribute tokens.css keys
+   its dark palette off, so its theme toggle drives our tokens for free.
+   ========================================================================== */
+
+:root {
+  --sl-font: var(--font-body);
+  --sl-font-mono: var(--font-mono);
+
+  --sl-color-bg: var(--paper);
+  --sl-color-bg-nav: var(--paper);
+  --sl-color-bg-sidebar: var(--paper);
+  --sl-color-bg-inline-code: var(--sunken);
+  --sl-color-bg-accent: var(--blue-tint);
+
+  --sl-color-text: var(--ink);
+  --sl-color-white: var(--ink);
+  --sl-color-black: var(--paper);
+  --sl-color-text-invert: var(--paper);
+  --sl-color-text-accent: var(--blue-deep);
+  --sl-color-accent: var(--blue-deep);
+  --sl-color-accent-low: var(--blue-tint);
+  --sl-color-accent-high: var(--blue-deep);
+
+  --sl-color-gray-1: var(--ink);
+  --sl-color-gray-2: var(--ink-soft);
+  --sl-color-gray-3: var(--ink-soft);
+  --sl-color-gray-4: var(--ink-faint);
+  --sl-color-gray-5: var(--ink-faint);
+  --sl-color-gray-6: var(--sunken);
+  --sl-color-gray-7: var(--raised);
+
+  --sl-color-hairline: var(--ink);
+  --sl-color-hairline-light: var(--ink-faint);
+  --sl-color-hairline-shade: var(--ink);
+
+  /* Nothing in this design is blurred. */
+  --sl-shadow-sm: none;
+  --sl-shadow-md: none;
+  --sl-shadow-lg: none;
+
+  --sl-content-width: 48rem;
+  --sl-sidebar-width: 15.5rem;
+  --sl-text-body: 1rem;
+  --sl-nav-height: 4rem;
+}
+
+/* --- header -------------------------------------------------------------- */
+.header {
+  border-bottom: var(--bw-strong) solid var(--ink);
+  background: var(--paper);
+  padding-inline: var(--sl-nav-pad-x, 1rem);
+}
+.site-title {
+  font-family: var(--font-display);
+  font-size: 26px;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  gap: 0.5rem;
+}
+header .social-icons a { color: var(--ink); }
+header .social-icons a:hover { color: var(--blue-deep); }
+
+/* --- sidebar ------------------------------------------------------------- */
+#starlight__sidebar { border-inline-end: var(--bw) solid var(--ink); }
+.sidebar-content { padding-top: 1.25rem; }
+
+/* Group headings take the em-rule eyebrow the whole site uses. */
+.sidebar-content summary,
+.sidebar-content > ul > li > details > summary > .group-label > span,
+.sidebar-content .top-level > li > span {
+  font-family: var(--font-mono) !important;
+  font-size: 11px !important;
+  font-weight: 500 !important;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+.sidebar-content > ul > li > details > summary .group-label span::before,
+.sidebar-content .top-level > li > span::before {
+  content: '';
+  display: inline-block;
+  width: 16px;
+  height: 1.5px;
+  margin-right: 9px;
+  margin-bottom: 4px;
+  background: var(--ink-soft);
+}
+.sidebar-content a {
+  border: 1.5px solid transparent;
+  border-radius: var(--radius);
+  padding: 0.3rem 0.55rem;
+  font-size: 0.95rem;
+}
+.sidebar-content a:hover { background: var(--sunken); color: var(--ink); }
+.sidebar-content a[aria-current='page'],
+.sidebar-content a[aria-current='page']:hover {
+  background: var(--blue-tint);
+  border-color: var(--ink);
+  color: var(--ink);
+  font-weight: 600;
+}
+
+/* --- search -------------------------------------------------------------- */
+site-search button[data-open-modal] {
+  border: var(--bw) solid var(--ink);
+  border-radius: var(--radius);
+  background: var(--raised);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+site-search kbd {
+  background: transparent;
+  border: 1.2px solid var(--ink-faint);
+  border-radius: 2px;
+  font-family: var(--font-mono);
+  color: var(--ink-soft);
+}
+dialog[aria-label='Search'] {
+  border: var(--bw-strong) solid var(--ink);
+  border-radius: var(--radius);
+  box-shadow: var(--offset);
+  background: var(--paper);
+}
+
+/* --- content ------------------------------------------------------------- */
+.content-panel { border-top: none; }
+.content-panel + .content-panel { border-top: var(--bw) solid var(--ink); }
+
+.sl-markdown-content h1,
+h1.page-title {
+  font-family: var(--font-display);
+  font-weight: 400;
+  letter-spacing: -0.02em;
+  line-height: 1.02;
+  font-size: clamp(2.4rem, 5vw, 3.25rem);
+}
+.sl-markdown-content h2 {
+  font-family: var(--font-display);
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  font-size: 1.95rem;
+  line-height: 1.15;
+  padding-bottom: 0.4rem;
+  border-bottom: var(--bw) solid var(--ink);
+}
+.sl-markdown-content h3 {
+  font-family: var(--font-sub);
+  font-weight: 700;
+  font-size: 1.2rem;
+}
+.sl-markdown-content h4,
+.sl-markdown-content h5 {
+  font-family: var(--font-sub);
+  font-weight: 600;
+}
+
+.sl-markdown-content a:not(:where(.not-content *)) {
+  color: var(--blue-deep);
+  text-decoration: none;
+  border-bottom: 1.5px solid var(--blue);
+}
+.sl-markdown-content a:hover:not(:where(.not-content *)) { background: var(--blue-tint); }
+
+.sl-markdown-content :not(pre) > code:not(:where(.not-content *)) {
+  border: 1px solid var(--ink-faint);
+  border-radius: 2px;
+  padding: 0.05em 0.35em;
+  font-size: 0.87em;
+}
+
+.sl-markdown-content blockquote:not(:where(.not-content *)) {
+  border-inline-start: 6px solid var(--blue);
+  border-block: var(--bw) solid var(--ink);
+  border-inline-end: var(--bw) solid var(--ink);
+  border-radius: var(--radius);
+  background: var(--raised);
+  padding: 1rem 1.25rem;
+}
+
+/* Tables get the hairline-row treatment, with a mono header. */
+.sl-markdown-content table:not(:where(.not-content *)) {
+  border: var(--bw) solid var(--ink);
+  border-radius: var(--radius);
+  border-collapse: collapse;
+  background: var(--raised);
+  overflow: hidden;
+}
+.sl-markdown-content th:not(:where(.not-content *)) {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: var(--sunken);
+  border-bottom: var(--bw) solid var(--ink);
+}
+.sl-markdown-content :is(th, td):not(:where(.not-content *)) {
+  border-bottom: 1px solid var(--ink-faint);
+  padding: 0.55rem 0.75rem;
+}
+.sl-markdown-content tr:last-child td:not(:where(.not-content *)) { border-bottom: 0; }
+
+/* Asides are the dashed callout from the design. */
+.starlight-aside {
+  border: var(--bw) dashed var(--ink);
+  border-inline-start-width: var(--bw);
+  border-radius: var(--radius);
+  background: transparent;
+  padding: 0.9rem 1rem;
+}
+.starlight-aside__title {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink);
+}
+.starlight-aside--caution,
+.starlight-aside--danger { border-style: solid; border-color: var(--warn); }
+.starlight-aside--caution .starlight-aside__title,
+.starlight-aside--danger .starlight-aside__title { color: var(--warn); }
+
+.expressive-code .frame pre {
+  border: var(--bw) solid var(--code-border) !important;
+  border-radius: var(--radius) !important;
+}
+
+/* --- right-hand table of contents ---------------------------------------- */
+#starlight__on-this-page,
+.right-sidebar-panel h2 {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  padding-bottom: 0.5rem;
+  border-bottom: var(--bw) solid var(--ink);
+}
+.right-sidebar-panel a {
+  border-inline-start: 2px solid var(--ink-faint);
+  padding-inline-start: 0.6rem;
+  color: var(--ink-soft);
+  text-decoration: none;
+}
+.right-sidebar-panel a[aria-current='true'] {
+  border-inline-start: 3px solid var(--blue);
+  color: var(--ink);
+  font-weight: 600;
+}
+
+/* --- pagination ---------------------------------------------------------- */
+.pagination-links > a {
+  border: var(--bw) solid var(--ink);
+  border-radius: var(--radius);
+  box-shadow: none;
+  background: var(--raised);
+}
+.pagination-links > a:hover { background: var(--sunken); }
+.pagination-links span:first-of-type {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+.pagination-links .link-title { font-family: var(--font-sub); font-weight: 600; }
+
+/* --- footer -------------------------------------------------------------- */
+footer .meta a {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}

--- a/web/src/styles/starlight.css
+++ b/web/src/styles/starlight.css
@@ -58,7 +58,11 @@
 }
 
 /* --- header -------------------------------------------------------------- */
-.header {
+/* `header.header`, not `.header`. Expressive Code gives every code frame a
+   <figcaption class="header">, so an unqualified rule here painted the title
+   bar of every shell block with the page background — a bare light strip
+   stacked on a dark code body. */
+header.header {
   border-bottom: var(--bw-strong) solid var(--ink);
   background: var(--paper);
   padding-inline: var(--sl-nav-pad-x, 1rem);
@@ -70,8 +74,15 @@
   letter-spacing: -0.01em;
   gap: 0.5rem;
 }
-header .social-icons a { color: var(--ink); }
-header .social-icons a:hover { color: var(--blue-deep); }
+header.header .social-icons a { color: var(--ink); }
+header.header .social-icons a:hover { color: var(--blue-deep); }
+
+/* A code frame is one solid block, matching the hand-written ones on the
+   landing page: no title bar, no window dots. The colours come from the
+   `frames` style overrides in astro.config.mjs; this removes the strip's
+   height, which no colour setting can. */
+.expressive-code .frame.is-terminal .header { display: none; }
+.expressive-code .frame.is-terminal pre { border-top: var(--bw) solid var(--code-border); }
 
 /* --- sidebar ------------------------------------------------------------- */
 #starlight__sidebar { border-inline-end: var(--bw) solid var(--ink); }
@@ -156,6 +167,12 @@ h1.page-title {
   letter-spacing: -0.01em;
   font-size: 1.95rem;
   line-height: 1.15;
+}
+/* The rule goes on the wrapper, not the heading. Starlight sets
+   `.sl-heading-wrapper > :first-child { display: inline }` so that the anchor
+   link sits on the last line — which makes a border on the h2 itself stop at
+   the end of the text rather than spanning the column. */
+.sl-markdown-content .sl-heading-wrapper.level-h2 {
   padding-bottom: 0.4rem;
   border-bottom: var(--bw) solid var(--ink);
 }
@@ -237,10 +254,15 @@ h1.page-title {
 .starlight-aside--caution .starlight-aside__title,
 .starlight-aside--danger .starlight-aside__title { color: var(--warn); }
 
+/* Same rule as site.css: the block's ground comes from our tokens rather than
+   from Expressive Code's own `--ec-*` palette. */
 .expressive-code .frame pre {
-  border: var(--bw) solid var(--code-border) !important;
-  border-radius: var(--radius) !important;
+  background: var(--code-bg);
+  border: var(--bw) solid var(--code-border);
+  border-radius: var(--radius);
+  padding: 14px 0;
 }
+.expressive-code .ec-line .code { padding-inline: 16px; }
 
 /* --- right-hand table of contents ---------------------------------------- */
 #starlight__on-this-page,

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -1,0 +1,86 @@
+/* ==========================================================================
+   Agento site — design tokens
+
+   Neo-brutalist editorial: bone paper, hard ink borders, solid offset shadows,
+   one electric accent. Light is the native state; dark inverts the ground and
+   the ink and keeps everything else.
+
+   Every colour is defined here on bare :root first, then redefined for the two
+   dark states. Nothing downstream may declare a colour inside a media query or
+   a [data-theme] block — a token defined only there never applies to a visitor
+   on the default "system" setting, which is most of them.
+   ========================================================================== */
+/* ==========================================================================
+   AGENTO — site design tokens
+   Neo-brutalist editorial: bone paper, hard ink borders, solid offset
+   shadows, one electric accent. Light is the native state; dark inverts the
+   ground and the ink and keeps everything else.
+   ========================================================================== */
+:root {
+  --paper:       #F0EEE6;
+  --raised:      #F7F5EE;
+  --sunken:      #E6E3D9;
+  --ink:         #0B0C07;
+  --ink-soft:    #5A574D;
+  --ink-faint:   #8A8779;
+  --blue:        #1DC1FF;
+  --blue-tint:   #C9E6F6;
+  --blue-deep:   #0B7FA8;
+  --code-bg:     #0B0C07;
+  --code-fg:     #EFECE2;
+  --code-border: #0B0C07;
+  --warn:        #E8A33D;
+
+  --bw: 1.5px;
+  --bw-strong: 2px;
+  --offset: 8px 8px 0 var(--ink);
+  --offset-sm: 5px 5px 0 var(--ink);
+  --radius: 2px;
+
+  --font-display: "Instrument Serif", "Iowan Old Style", Georgia, serif;
+  --font-sub: "Newsreader", "Iowan Old Style", Georgia, serif;
+  --font-serif-text: "Newsreader", "Iowan Old Style", Georgia, serif;
+  --font-sans-text: "Karla", "Helvetica Neue", Arial, sans-serif;
+  --font-body: var(--font-sans-text);
+  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+
+  --measure: 68ch;
+  --shell: 1120px;
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --paper:       #14150F;
+    --raised:      #1C1D16;
+    --sunken:      #0D0E09;
+    --ink:         #F1EEE5;
+    --ink-soft:    #A29F92;
+    --ink-faint:   #6E6C61;
+    --blue:        #1DC1FF;
+    --blue-tint:   #0E3A4C;
+    --blue-deep:   #7FDCFF;
+    --code-bg:     #0A0B06;
+    --code-fg:     #EFECE2;
+    --code-border: #F1EEE5;
+    --warn:        #E8A33D;
+  }
+}
+:root[data-theme="dark"] {
+  --paper:       #14150F;
+  --raised:      #1C1D16;
+  --sunken:      #0D0E09;
+  --ink:         #F1EEE5;
+  --ink-soft:    #A29F92;
+  --ink-faint:   #6E6C61;
+  --blue:        #1DC1FF;
+  --blue-tint:   #0E3A4C;
+  --blue-deep:   #7FDCFF;
+  --code-bg:     #0A0B06;
+  --code-fg:     #EFECE2;
+  --code-border: #F1EEE5;
+  --warn:        #E8A33D;
+}
+
+/* Review switch: the reference sets body copy in a serif. Both are wired so
+   the choice can be made by looking, not by arguing. */
+:root[data-body="serif"] { --font-body: var(--font-serif-text); }
+:root[data-body="serif"] body { font-size: 17.5px; line-height: 1.62; }

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -31,6 +31,16 @@
   --code-border: #0B0C07;
   --warn:        #E8A33D;
 
+  /* Text on the accent. The accent does not flip between themes, so neither
+     does this — it is a literal by nature, not by omission. */
+  --on-accent:   #0B0C07;
+  /* Muted text on an inverted ground (the closing panel), which is bone in
+     light and near-black in dark. Reading it off --ink-soft would be wrong in
+     both: that token is tuned against the page, not against its inverse. */
+  --on-ink-soft: #C9C6BB;
+  --code-comment:#8A8779;
+  --code-key:    #FFFFFF;
+
   --bw: 1.5px;
   --bw-strong: 2px;
   --offset: 8px 8px 0 var(--ink);
@@ -62,6 +72,10 @@
     --code-fg:     #EFECE2;
     --code-border: #F1EEE5;
     --warn:        #E8A33D;
+    --on-accent:   #0B0C07;
+    --on-ink-soft: #4A4840;
+    --code-comment:#8A8779;
+    --code-key:    #FFFFFF;
   }
 }
 :root[data-theme="dark"] {
@@ -78,6 +92,10 @@
   --code-fg:     #EFECE2;
   --code-border: #F1EEE5;
   --warn:        #E8A33D;
+  --on-accent:   #0B0C07;
+  --on-ink-soft: #4A4840;
+  --code-comment:#8A8779;
+  --code-key:    #FFFFFF;
 }
 
 /* Review switch: the reference sets body copy in a serif. Both are wired so

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "include": [".astro/types.d.ts", "**/*"],
+  "exclude": ["dist", "design"]
+}


### PR DESCRIPTION
Publishes `docs/` and a blog as a GitHub Pages site at `shaharia-lab.github.io/agento`.

## Before merging

**GitHub Pages is not enabled on this repository yet.** `pages.yml` runs on push to
`main`, and its deploy job will fail until Settings → Pages → Source is set to
**GitHub Actions**. `site-check.yml` (the PR job) does not deploy and runs fine
either way.

## The shape of it

**`docs/` stays the single source and is not modified.** `web/scripts/sync-docs.mjs`
rewrites a copy at build time, so browsing the files in the repository, `README.md`'s
links and `CLAUDE.md`'s own pointers all keep working:

- the H1 becomes the frontmatter `title`, and is removed from the body
- the inline table of contents is dropped, because Starlight renders one
- `installation.md#updates` becomes `/agento/docs/installation/#updates`
- a link that leaves `docs/` — `../CLAUDE.md`, `../parity/README.md` — becomes a
  GitHub blob URL, since those files have no page here
- a `.md` added to `docs/` and not listed in `web/docs.manifest.mjs` **fails the
  build**, rather than silently never publishing

The generated copy is gitignored. Never edit it.

**Nothing about a download is written by hand.** Asset filenames carry the version
(`Agento_1.2.0_amd64.deb`), so GitHub's `releases/latest/download/…` redirect cannot
address them and a hand-written link rots the day after a release.
`web/scripts/fetch-release.mjs` resolves the latest release from the API at build
time — this build picked up all nine v1.2.0 installers with their real URLs and
sizes. Two properties are deliberate:

- **it never fails the build** — no network, no token or a rate limit each fall back
  to the version in `tauri.conf.json` and the `releases/latest` link, which is always
  correct even when it cannot name a file;
- **it runs at build time, not in the visitor's browser** — a client-side fetch would
  put a third-party request on every page view and show an empty download list to
  anyone the API rate-limits.

`pages.yml` therefore also triggers on `release: published`, so the baked answer is
refreshed by the event that changes it.

**The install section detects the OS and does not guess the architecture.** Safari
reports `MacIntel` on Apple Silicon, so there is no reliable way to tell an ARM Mac
from an Intel one in JavaScript; it is read from
`userAgentData.getHighEntropyValues` where a browser offers it and guessed nowhere
else, with both Mac builds always listed. The script reorders and marks the detected
platform — it never hides a card, so no-JS, an unknown OS and a wrong guess all leave
the full set visible.

**Fonts are self-hosted.** Loading the site's type from Google would put a request to
a third party on every page view of a product whose whole claim is that nothing
leaves your machine.

## Also here

- Base path defined once in `web/site.config.mjs` and applied through `url()`. The
  `/agento` prefix is the known footgun of a project-pages site; nothing spells it out
  by hand.
- Pagefind search (offline, no Algolia account), RSS, sitemap.
- A site-page 404 rather than a Starlight one — landing on the docs sidebar reads as
  "this documentation page is missing" rather than "this address is wrong".
- `site-check.yml` builds every PR touching `docs/` or `web/` and link-checks the
  output **with fragments**. `docs/` cross-links by heading anchor, and renaming a
  heading breaks those silently today.
- One seed blog post, on the CLI-resolution work from #503.

## Design

The visual direction was approved from a static mockup before any of this was wired
up; `web/design/site-mockup.html` is that mockup, and `web/src/styles/` is extracted
from it rather than rewritten. Neo-brutalist editorial: bone paper, hard ink borders,
solid offset shadows, one electric accent, and a mono label layer. Light and dark are
both defined at token level.

## Not done

- Per-post OG images.
- A `/changelog` page built from the Releases API.
- Dark-mode screenshots — `docs/screenshots/` only has a `light/` set, so both themes
  currently show the light shots.
- `README.md` and `CLAUDE.md` pointers to the site, which are worth adding once the
  URL is actually live.

https://claude.ai/code/session_01RkWXjbmfNWNPMBry54a1tB
