### PR TITLE
feat(site): serve from myagento.app at the domain root

### DIFF
--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -32,7 +32,9 @@ const INK = '#0B0C07';
 
 export default defineConfig({
   site: SITE,
-  base: BASE,
+  // BASE is '' rather than '/' so the raw concatenations in scripts/ stay
+  // correct (see site.config.mjs); Astro wants a real path for the site root.
+  base: BASE || '/',
   trailingSlash: 'always',
   integrations: [
     starlight({

--- a/web/scripts/check-links.mjs
+++ b/web/scripts/check-links.mjs
@@ -34,7 +34,7 @@ async function htmlFiles(dir) {
   return out;
 }
 
-/** `/agento/docs/installation/` -> the file that serves it. */
+/** `/docs/installation/` -> the file that serves it. */
 function fileFor(href) {
   const path = href.slice(BASE.length) || '/';
   const rel = path.endsWith('/') ? `${path}index.html` : path;

--- a/web/scripts/sync-docs.mjs
+++ b/web/scripts/sync-docs.mjs
@@ -12,7 +12,7 @@
  *     because Starlight renders the title itself;
  *   - the lead paragraph becomes `description` (used for <meta> and search);
  *   - the inline TOC list is dropped, because Starlight renders one;
- *   - `installation.md#updates` becomes `/agento/docs/installation/#updates`;
+ *   - `installation.md#updates` becomes `/docs/installation/#updates`;
  *   - a link that leaves docs/ (`../CLAUDE.md`) becomes a GitHub blob URL,
  *     since those files have no page on this site;
  *   - screenshots are copied to public/ and their links repointed.
@@ -32,7 +32,7 @@ const SHOTS_OUT = resolve(here, '../public/screenshots');
 
 const bySourceFile = new Map(PAGES.map((p) => [p.file, p]));
 
-/** `installation.md` -> `/agento/docs/installation/`; unknown files -> null. */
+/** `installation.md` -> `/docs/installation/`; unknown files -> null. */
 function hrefFor(target) {
   const [path, hash] = target.split('#');
   const page = bySourceFile.get(path);

--- a/web/site.config.mjs
+++ b/web/site.config.mjs
@@ -1,19 +1,33 @@
 /**
  * One definition of where this site lives.
  *
- * The site is published to GitHub Pages at shaharia-lab.github.io/agento, so
- * every internal URL carries a `/agento` prefix. Astro applies `base` to its
- * own routing, but NOT to hrefs inside markdown — so the docs sync script and
- * every hand-written link build their URLs through `url()` below rather than
- * spelling the prefix out. Change the base here and nothing else moves.
+ * The site is published to GitHub Pages at its own domain, myagento.app, so
+ * pages sit at the root and internal URLs carry no path prefix. Astro applies
+ * `base` to its own routing, but NOT to hrefs inside markdown — so the docs
+ * sync script and every hand-written link build their URLs through `url()`
+ * below rather than spelling any prefix out. Change the base here and nothing
+ * else moves.
+ *
+ * BASE is the EMPTY STRING, not '/'. It is concatenated directly in a few
+ * places that do not go through `url()` — `${BASE}/docs/` in
+ * scripts/sync-docs.mjs, and `href.slice(BASE.length)` /
+ * `href.startsWith(BASE + '/')` in scripts/check-links.mjs. With '/' those
+ * become `//docs/`, an off-by-one slice, and a `'//'` prefix test that matches
+ * nothing, so the docs links break and the link checker silently stops
+ * checking. Astro wants '/' for the site root, and astro.config.mjs converts
+ * it there.
+ *
+ * The domain and the GitHub Pages custom-domain setting are managed in
+ * shaharia-lab/infrastructure (terraform/cloudflare + terraform/github-shaharia-lab),
+ * not in this repository; there is deliberately no CNAME file here.
  */
-export const SITE = 'https://shaharia-lab.github.io';
-export const BASE = '/agento';
+export const SITE = 'https://myagento.app';
+export const BASE = '';
 
 export const REPO = 'https://github.com/shaharia-lab/agento';
 export const REPO_BLOB = `${REPO}/blob/main`;
 
-/** Join a site-absolute path onto the base. `url('/docs/')` → `/agento/docs/`. */
+/** Join a site-absolute path onto the base. `url('/docs/')` → `/docs/`. */
 export function url(path = '/') {
   const p = path.startsWith('/') ? path : `/${path}`;
   return `${BASE}${p}`.replace(/\/{2,}/g, '/');


### PR DESCRIPTION
## What

The site now has its own domain. [shaharia-lab/infrastructure#400](https://github.com/shaharia-lab/infrastructure/pull/400) created the Cloudflare zone, pointed the apex and `www` at GitHub Pages, and set the Pages custom domain. The delegation has moved (`angelina`/`gabriel.ns.cloudflare.com`) and the apex resolves to GitHub's Pages IPs.

A custom domain serves the site at the **root**, so the `/agento` prefix every internal URL carried has to go — otherwise every link lands one level too deep.

- `SITE` → `https://myagento.app`
- `BASE` → `''`

## Why `BASE = ''` and not `'/'`

Most links go through `url()`, which collapses duplicate slashes, so either value would survive there. Four places don't go through it:

| Place | With `BASE = '/'` |
|---|---|
| `sync-docs.mjs` — `` `${BASE}/docs/` `` | `//docs/` |
| `sync-docs.mjs` — `` `${BASE}/${target}` `` | `//screenshots/...` |
| `check-links.mjs` — `href.slice(BASE.length)` | off by one |
| `check-links.mjs` — `href.startsWith(BASE + '/')` | tests `'//'`, matches **no** href |

That last one is the nasty one: the link checker would pass having checked nothing at all. Astro does want a real path for the site root, so `astro.config.mjs` converts with `base: BASE || '/'`.

The comments in both scripts that spelled out example URLs are updated to match.

There is deliberately still no `CNAME` file — the custom domain is a repo setting, managed in `terraform/github-shaharia-lab`.

## Verification

Ran a real build, not just inspection:

- `npm run build` → 11 pages, routes emitted at `/docs/...` rather than `/agento/docs/...`
- `npm run check:links` → `11 pages, every internal link and fragment resolves`
- `dist/` contains no `/agento/` `href` or `src`, and no `//` doubles
- `sitemap-0.xml` and `rss.xml` carry `https://myagento.app/`

## Note on ordering

GitHub hasn't issued the TLS certificate yet (`https_certificate: null` as of opening this). Since `.app` is HSTS-preloaded there's no plain-HTTP fallback, so the domain is unreachable in a browser until that lands — independent of this PR. `shaharia-lab.github.io/agento` keeps working throughout; GitHub redirects it to the custom domain.

https://claude.ai/code/session_01HVvF57zD9BD8U8EAZ8uA8B