### PR TITLE
feat(site): ask before measuring — Consent Mode v2 and a cookie banner

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -818,6 +818,16 @@ reference, along with any `OTEL_*` environment variables pinning them.
   `~/.agento` as sensitive.
 - Your Claude Code transcripts in `~/.claude` are read only, never modified.
 
+**The website is a separate thing, and it is not the app.** myagento.app loads
+Google Analytics through Google Tag Manager to count visits. Nothing above
+changes: the app has no analytics, and the site cannot see anything the app
+does — it is a static site on GitHub Pages that has never met your database.
+
+Consent is asked for on your first visit and **denied until you accept**, in
+every country rather than only where a regulator requires the question. Refuse
+and nothing is loaded. The choice is remembered in your browser's local storage
+and can be changed at any time from the **Cookies** link in the site footer.
+
 ---
 
 ## Getting help

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -2,7 +2,7 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 import sitemap from '@astrojs/sitemap';
-import { SITE, BASE, REPO, OG_IMAGE, abs, gtmId, gtmSnippet } from './site.config.mjs';
+import { SITE, BASE, REPO, OG_IMAGE, abs, url, gtmId, gtmSnippet, consentDefaultSnippet, consentBannerSnippet } from './site.config.mjs';
 import { GROUPS, PAGES } from './docs.manifest.mjs';
 
 /**
@@ -35,9 +35,18 @@ const starlightHead = [
 
 // Analytics, on the same terms as the other half: absent entirely when no
 // container id was supplied to the build. See gtmId() in site.config.mjs.
+// Consent Mode's defaults have to reach the dataLayer before the container
+// does, so these push in order: default, container, banner. Starlight has no
+// body extension point, which is why the banner is a script rather than
+// markup — see consentBannerSnippet() in site.config.mjs.
 const gtm = gtmId();
 if (gtm) {
+  starlightHead.push({ tag: 'script', content: consentDefaultSnippet() });
   starlightHead.push({ tag: 'script', content: gtmSnippet(gtm) });
+  starlightHead.push({
+    tag: 'script',
+    content: consentBannerSnippet(url('/docs/user-guide/#privacy')),
+  });
 }
 
 /** The sidebar is derived from the manifest, so it cannot drift from the pages. */
@@ -78,6 +87,7 @@ export default defineConfig({
         './src/styles/fonts.css',
         './src/styles/tokens.css',
         './src/styles/starlight.css',
+        './src/styles/consent.css',
       ],
       expressiveCode: {
         // One theme for both site themes: code blocks are always inverted
@@ -114,6 +124,9 @@ export default defineConfig({
       head: starlightHead,
       social: [{ icon: 'github', label: 'GitHub', href: REPO }],
       editLink: { baseUrl: `${REPO}/edit/main/` },
+      // The only component override on the site, and it adds one link — see
+      // the file for why the docs half needs its own.
+      components: { Footer: './src/components/starlight/Footer.astro' },
       sidebar,
       // The docs pages are generated from ../docs by scripts/sync-docs.mjs.
       // Editing them in src/content/ has no effect; the next build overwrites.

--- a/web/site.config.mjs
+++ b/web/site.config.mjs
@@ -85,6 +85,99 @@ export function gtmSnippet(id) {
   return `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','${id}');`;
 }
 
+/**
+ * The consent key, shared by the two snippets below and by the footer's
+ * "Cookie settings" link. One spelling, in one place.
+ */
+export const CONSENT_KEY = 'agento-consent';
+
+/**
+ * Google Consent Mode v2 defaults, emitted `is:inline` IMMEDIATELY BEFORE the
+ * GTM loader on both halves of the site. The order is the whole point: a
+ * default set after the container has loaded is a default the container never
+ * saw, and the tags inside it will already have fired.
+ *
+ * Everything is denied except `security_storage`, and denied *globally* rather
+ * than for the EEA alone. Consent Mode supports a `region` argument and this
+ * deliberately does not use it: a site whose own FAQ answers "there is no
+ * account, no telemetry and no analytics" should not be measuring the visitors
+ * whose regulator happens not to require asking. It also removes a whole class
+ * of bug, since the untested branch of a region rule is the one that runs for
+ * almost everybody.
+ *
+ * `wait_for_update` holds tags for 500ms so a returning visitor's stored grant
+ * lands before anything fires. The replay below is what usually beats it —
+ * reading localStorage is synchronous, so the update is pushed in the same
+ * task as the default and the wait never elapses. The 500ms is the fallback
+ * for the first visit, where the answer comes from a click.
+ *
+ * v2 is the current version and there is no v4: `ad_user_data` and
+ * `ad_personalization` are the two signals v2 added to v1, and both are here.
+ */
+export function consentDefaultSnippet() {
+  return `window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}gtag('consent','default',{ad_storage:'denied',ad_user_data:'denied',ad_personalization:'denied',analytics_storage:'denied',functionality_storage:'denied',personalization_storage:'denied',security_storage:'granted',wait_for_update:500});try{var c=localStorage.getItem('${CONSENT_KEY}');if(c==='granted'||c==='denied'){var v=c==='granted'?'granted':'denied';gtag('consent','update',{ad_storage:v,ad_user_data:v,ad_personalization:v,analytics_storage:v,functionality_storage:v,personalization_storage:v})}}catch(e){}`;
+}
+
+/**
+ * The banner itself: built in JavaScript rather than authored as markup, and
+ * that is a constraint rather than a preference. Starlight builds its own
+ * document and its only extension point is the head — which is why GTM's
+ * <noscript> half is omitted (see gtmSnippet). A banner authored in
+ * Page.astro would exist on the landing page and the blog and simply not on
+ * the docs, which is the worst of the three outcomes. One head snippet reaches
+ * both halves, and the banner needs JavaScript to do its job anyway.
+ *
+ * Four things here are requirements rather than choices:
+ *
+ * - **Accept and Reject are the same control.** Same size, same weight, same
+ *   colour, adjacent. Regulators have repeatedly treated a prominent Accept
+ *   beside a muted Reject as consent that was not freely given, and the design
+ *   system has an accent that would make styling one of them "primary" the
+ *   natural thing to do. Do not make Accept the primary button.
+ * - **Refusing is one click**, same as accepting. There is no "manage
+ *   preferences" step in between, because there is one purpose to consent to.
+ * - **The choice is withdrawable.** `window.agentoConsent.open()` reopens the
+ *   banner and the footer link calls it, so changing your mind costs what
+ *   giving consent cost.
+ * - **It is inserted first in <body>**, not last. Fixed to the bottom visually,
+ *   but early in the tab order — a keyboard visitor should not have to traverse
+ *   the whole page to reach the thing blocking their consent decision.
+ *
+ * Dismissing without choosing is not offered: there is no X, and Escape does
+ * not close it. An unanswered banner leaves the denied default in force, so
+ * nothing is measured either way — but a dismiss control that silently means
+ * "no" while looking like "later" is the pattern this is avoiding.
+ */
+export function consentBannerSnippet(privacyHref) {
+  return `(function(){
+var K='${CONSENT_KEY}',el=null;
+function set(v){try{localStorage.setItem(K,v)}catch(e){}
+  if(window.gtag){gtag('consent','update',{ad_storage:v,ad_user_data:v,ad_personalization:v,analytics_storage:v,functionality_storage:v,personalization_storage:v})}
+  if(el){el.remove();el=null}}
+function build(){
+  if(el)return;
+  el=document.createElement('div');
+  el.className='cc';el.setAttribute('role','dialog');
+  el.setAttribute('aria-labelledby','cc-t');el.tabIndex=-1;
+  el.innerHTML='<div class="cc__in"><div class="cc__x"><span class="cc__l" id="cc-t">Cookies</span>'+
+    '<p class="cc__p">This site uses Google Analytics to count visits, and nothing else. '+
+    'The app itself sends nothing anywhere — that is not what this is. '+
+    '<a class="cc__a" href="${privacyHref}">What Agento stores</a></p></div>'+
+    '<div class="cc__b"><button type="button" class="cc__btn" data-v="denied">Reject</button>'+
+    '<button type="button" class="cc__btn" data-v="granted">Accept</button></div></div>';
+  el.addEventListener('click',function(e){var b=e.target.closest('[data-v]');if(b)set(b.getAttribute('data-v'))});
+  document.body.insertBefore(el,document.body.firstChild);
+}
+window.agentoConsent={open:function(){build();el.focus()}};
+function start(){var c=null;try{c=localStorage.getItem(K)}catch(e){}
+  if(c!=='granted'&&c!=='denied')build();
+  document.addEventListener('click',function(e){
+    var t=e.target.closest('[data-cookie-settings]');
+    if(t){e.preventDefault();window.agentoConsent.open()}});}
+if(document.readyState==='loading')document.addEventListener('DOMContentLoaded',start);else start();
+})();`;
+}
+
 /** Join a site-absolute path onto the base. `url('/docs/')` → `/docs/`. */
 export function url(path = '/') {
   const p = path.startsWith('/') ? path : `/${path}`;

--- a/web/src/components/Foot.astro
+++ b/web/src/components/Foot.astro
@@ -1,5 +1,6 @@
 ---
-import { url, REPO } from '../../site.config.mjs';
+import { url, REPO, gtmId } from '../../site.config.mjs';
+const gtm = gtmId();
 const year = new Date().getFullYear();
 ---
 <footer class="foot">
@@ -9,5 +10,13 @@ const year = new Date().getFullYear();
   <a href={`${REPO}/releases`}>Releases</a>
   <a href={`${REPO}/issues`}>Issues</a>
   <a href={`${REPO}/blob/main/SECURITY.md`}>Security</a>
+  {/* Reopens the consent banner. It is a link rather than a button because it
+      sits in a row of links, and href="#" with preventDefault keeps it
+      keyboard-reachable; the handler is delegated, so it works on the docs
+      half too, where this component does not render but Starlight's own
+      footer can carry the same attribute. When no container id was supplied
+      to the build there is no banner and nothing listens — the link is then
+      inert, which is why it is not rendered at all in that case. */}
+  {gtm && <a href="#" data-cookie-settings>Cookies</a>}
   <span class="label foot__end">runs entirely on your machine —</span>
 </footer>

--- a/web/src/components/starlight/Footer.astro
+++ b/web/src/components/starlight/Footer.astro
@@ -1,0 +1,27 @@
+---
+/**
+ * Starlight's footer, plus one link.
+ *
+ * Withdrawing consent has to be as easy as giving it, and the site's own
+ * <Foot /> — which carries that link — renders on the landing page and the blog
+ * only. Starlight builds its own document, so without this override a visitor
+ * who accepted on the landing page and then read the docs would have no way
+ * back to the question from where they were standing.
+ *
+ * It is an override rather than a `social` entry or a config option because
+ * Starlight has neither for this. The click is handled by the delegated
+ * listener in consentBannerSnippet(), which is why the anchor carries an
+ * attribute rather than a handler.
+ */
+import Default from '@astrojs/starlight/components/Footer.astro';
+import { gtmId } from '../../../site.config.mjs';
+
+// No container id, no banner, so nothing would answer the click.
+const gtm = gtmId();
+---
+<Default><slot /></Default>
+{gtm && (
+  <p class="cc-foot">
+    <a href="#" data-cookie-settings>Cookies</a>
+  </p>
+)}

--- a/web/src/layouts/Page.astro
+++ b/web/src/layouts/Page.astro
@@ -8,9 +8,10 @@
 import '../styles/fonts.css';
 import '../styles/tokens.css';
 import '../styles/site.css';
+import '../styles/consent.css';
 import Masthead from '../components/Masthead.astro';
 import Foot from '../components/Foot.astro';
-import { url, abs, OG_IMAGE, SITE_NAME, gtmId, gtmSnippet } from '../../site.config.mjs';
+import { url, abs, OG_IMAGE, SITE_NAME, gtmId, gtmSnippet, consentDefaultSnippet, consentBannerSnippet } from '../../site.config.mjs';
 
 interface Props {
   title: string;
@@ -54,7 +55,12 @@ const gtm = gtmId();
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:image" content={ogImage} />
     <slot name="head" />
+    {/* Consent Mode's defaults must be in the dataLayer BEFORE the container
+        loads, so these three are one ordered group: default, container,
+        banner. Keep them adjacent and keep them in this order. */}
+    {gtm && <script is:inline set:html={consentDefaultSnippet()} />}
     {gtm && <script is:inline set:html={gtmSnippet(gtm)} />}
+    {gtm && <script is:inline set:html={consentBannerSnippet(url('/docs/user-guide/#privacy'))} />}
     <script is:inline>
       // Applied before first paint so a dark-mode visitor never sees a flash
       // of the paper ground.

--- a/web/src/styles/consent.css
+++ b/web/src/styles/consent.css
@@ -1,0 +1,117 @@
+/* ==========================================================================
+   The cookie consent banner.
+
+   Loaded by BOTH halves of the site — imported by src/layouts/Page.astro for
+   the landing page and the blog, and listed in `customCss` in astro.config.mjs
+   for Starlight — because the banner is injected by a head script that runs on
+   every page. It is its own file for that reason: site.css is the landing
+   half's alone, and a rule that has to be true everywhere cannot live there.
+
+   It is self-contained on purpose. `.btn` and `.sheet` are site.css's, so a
+   docs page has never heard of them; every rule here is written from the
+   design tokens directly.
+
+   Unlike the tag itself, this ships whether or not a container id was supplied
+   to the build: Astro bundles an imported stylesheet unconditionally, and ~1KB
+   of rules nothing matches is not the thing gtmId() is gating against. What it
+   gates is the network request and the measurement, neither of which is here.
+
+   The banner is `position: fixed`, which the design otherwise does not do —
+   "nothing else is fixed or sticky, the masthead scrolls away". A consent
+   decision that scrolls out of reach is the one exception worth making.
+   ========================================================================== */
+.cc {
+  position: fixed;
+  left: 0; right: 0; bottom: 0;
+  z-index: 100;
+  padding: 12px;
+  /* The strip is the ground, so a banner over a code block or a screenshot is
+     still readable; the sheet inside carries the border and the shadow. */
+  background: color-mix(in srgb, var(--paper) 92%, transparent);
+  backdrop-filter: none; /* no glass anywhere in this design */
+}
+.cc__in {
+  max-width: var(--shell);
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+  background: var(--raised);
+  border: var(--bw) solid var(--ink);
+  border-radius: var(--radius);
+  box-shadow: var(--offset-sm);
+  padding: 16px 18px;
+}
+.cc__x { flex: 1 1 380px; min-width: 0; }
+.cc__l {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: var(--text-label);
+  font-weight: 500;
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  margin-bottom: 5px;
+}
+.cc__p {
+  margin: 0;
+  font-size: var(--text-ui-sm);
+  line-height: 1.5;
+  color: var(--ink-soft);
+  max-width: 68ch;
+}
+.cc__a {
+  color: var(--accent-deep);
+  text-decoration: none;
+  border-bottom: var(--bw) solid var(--accent);
+  white-space: nowrap;
+}
+
+/* Accept and Reject are one control in two instances. Same padding, same
+   border, same ground, same order every time — see consentBannerSnippet() in
+   site.config.mjs for why this is not a styling preference. */
+.cc__b { display: flex; gap: 10px; flex: 0 0 auto; }
+.cc__btn {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: var(--tracking-button);
+  text-transform: uppercase;
+  color: var(--ink);
+  background: var(--raised);
+  border: var(--bw-strong) solid var(--ink);
+  border-radius: var(--radius);
+  padding: 10px 18px;
+  cursor: pointer;
+  box-shadow: var(--offset-sm);
+  transition: transform var(--dur-press) var(--ease), box-shadow var(--dur-press) var(--ease);
+}
+.cc__btn:hover { background: var(--sunken); transform: var(--press-1); box-shadow: 2px 2px 0 var(--ink); }
+.cc__btn:active { transform: var(--press-2); box-shadow: 0 0 0 var(--ink); }
+.cc__btn:focus-visible { outline: 3px solid var(--accent); outline-offset: 3px; }
+.cc:focus-visible { outline: none; }
+
+@media (max-width: 620px) {
+  .cc__in { gap: 14px; }
+  .cc__b { width: 100%; }
+  .cc__btn { flex: 1 1 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .cc__btn { transition: none; }
+  .cc__btn:hover, .cc__btn:active { transform: none; box-shadow: var(--offset-sm); }
+}
+
+/* The docs half's footer link (src/components/starlight/Footer.astro). The
+   landing half's lives in site.css with the rest of .foot. */
+.cc-foot { margin: 18px 0 0; }
+.cc-foot a {
+  font-family: var(--font-mono);
+  font-size: var(--text-label);
+  letter-spacing: var(--tracking-nav);
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  text-decoration: none;
+  border-bottom: var(--bw) solid var(--ink-faint);
+}
+.cc-foot a:hover { color: var(--accent-deep); border-bottom-color: var(--accent); }


### PR DESCRIPTION
**Stacked on #511** — targets `adopt-agento-code`, because the banner is styled from the design-system tokens that PR introduces. GitHub will retarget this to `main` when #511 merges. Review #511 first.

## Why this comes before the container id

GTM has been wired since #510 and has never had a container id: `gtmId()` reads `PUBLIC_GTM_ID`, only the Pages workflow passes it, and unset the build emits no analytics at all. **Turning it on is one repository variable** — but doing that while the site asks nobody anything would put Google Analytics on a page whose own FAQ answers *"there is no account, no telemetry and no analytics."* This is the half that has to land first.

Once this is merged, `GTM-WXHN2QMQ` goes live with:

```
gh variable set PUBLIC_GTM_ID --body GTM-WXHN2QMQ --repo shaharia-lab/agento
```

I have deliberately **not** run that — the ordering is the point, and it is your call when.

## What it does

Three scripts on every page of both halves, **in one order that is the whole point**: Consent Mode defaults → the container → the banner. A default set after the container has loaded is a default the container never saw, and the tags inside it will already have fired.

- **Denied by default, globally.** Consent Mode takes a `region` argument and this deliberately does not use it. A site making this product's claims should not be measuring the visitors whose regulator happens not to require the question — and it removes a class of bug, since the untested branch of a region rule is the one that runs for almost everybody.
- **Consent Mode v2** — `ad_user_data` and `ad_personalization` are what v2 added to v1, and both are in the default and in every update. (There is no v4; v2 is current.)
- **A returning visitor's choice is replayed synchronously**, in the same task as the default, so it is in the dataLayer *before* the container script runs — the 500ms `wait_for_update` never elapses and no banner is shown.

## The banner — four things that are requirements, not choices

- **Accept and Reject are the same control.** Same size, weight, colour, adjacent. A prominent Accept beside a muted Reject has repeatedly been treated as consent that was not freely given — and this design has an accent that makes styling one of them "primary" the natural mistake. Please keep them identical.
- **Refusing is one click.** No "manage preferences" step, because there is one purpose to consent to.
- **Withdrawable from both halves.** This is why Starlight gets its first component override: `<Foot />` is the landing half's alone, so a visitor who accepted on the landing page and then read the docs would have no way back to the question.
- **Inserted first in `<body>`**, not last — fixed to the bottom visually, early in the tab order.

Dismissing without choosing is not offered: no X, and Escape does not close it. An unanswered banner leaves the denied default in force, so nothing is measured either way — but a dismiss control that silently means "no" while looking like "later" is the pattern this is avoiding.

## Two decisions worth a second opinion

- **The banner is built in JavaScript**, not authored as markup. Starlight has no body extension point — the same constraint that made #510 drop GTM's `<noscript>` half. Markup in `Page.astro` would exist on the landing page and the blog and simply *not* on the docs.
- **`position: fixed`** is the one exception to the design's "nothing else is fixed or sticky, the masthead scrolls away". A consent decision that scrolls out of reach seemed worth it.

## Honesty

`docs/user-guide.md`'s Privacy section now says the site has analytics and the app still does not — the two being different things is exactly what a reader arriving from the banner needs told. The banner text makes the same distinction in one line.

## Verification

Driven in a headless browser against the real exported snippets, not a mock:

- banner is the first child of `<body>`; buttons render `Reject, Accept`
- one click stores the choice and pushes **exactly one** consent update, with all six signals at the chosen value
- returning visitor: grant replayed before the container script runs, `dataLayer` already 2 entries deep, no banner shown
- footer link reopens it on both halves
- both halves carry all three scripts in the right order; a build with **no** container id carries none of them
- `npm run build` clean, `npm run check:links` passes 11 pages
- rendered light and dark

https://claude.ai/code/session_01XKh5u5MYwqLtaEHRSmfKjX