### PR TITLE
fix(integrations): make Slack bot-token auth reachable and effective (#513)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,8 +329,10 @@ src-tauri/src/
       template.rs  html/template's escaper, and why the skeleton is Go's output
       smtp.rs      go-mail's TLS policy — `ssl_tls` is *STARTTLS*, not SMTPS
     integrations.rs GET /api/integrations, /{id}, /available-tools, /{id}/triggers —
-                 credentials are never selected and auth is a bool made in SQL;
-                 plus POST /api/integrations, the trigger-rule writes (#277) and
+                 auth is a bool made in SQL, and the credentials column is
+                 reduced in SQL too — to `has_credentials` (#515) and, through
+                 an allowlist, `auth_mode` (#513); plus POST
+                 /api/integrations, the trigger-rule writes (#277) and
                  PUT/DELETE /{id} (#311)
     integrations/registry.rs
                  Start/Reload/Stop for the MCP servers of HOSTED_TYPES. The one
@@ -2319,9 +2321,26 @@ survive here: `1.50` is `"1.5"` and `0x10` is `"16"` where Go keeps the raw text
 Integers, booleans and strings are exact. Pinned, not reconciled.
 
 **Reading a credential is this module's job and nobody else's.** The rule in
-`native/integrations.rs` — `credentials` is never selected, `auth` collapses to
-a boolean in SQL — still holds there, and `registry.rs` is where the exception
-lives: its own `HOSTING_COLUMNS` projection into a `HostingRow` that derives
+`native/integrations.rs` — a stored secret never exists in this process to be
+echoed, `auth` collapses to a boolean in SQL — still holds there. What has
+changed is that the `credentials` column is no longer simply unmentioned: two
+things are now derived from it, **both entirely inside SQLite**, and neither is
+a widening.
+
+`has_credentials` (#515) is a boolean — whether the column holds anything at
+all — which is what lets the edit form say "leaving this alone keeps the stored
+one" instead of demanding a re-typed token on every save. `auth_mode` (#513) is
+the discriminator the Integrations editor reopens on, rather than guessing it
+from the provider's first mode; `auth_mode_sql` compares the extracted value
+against a fixed list of three literals (`AUTH_MODES`), so a byte the module did
+not already know cannot cross the boundary whatever a `PUT` stored under that
+key — and `update` validates nothing, so that is not hypothetical. **Copy that
+shape, not a bare `json_extract`, if a third derivation is ever needed**: the
+rule these keep is that what leaves SQLite is a value from a set this side
+already enumerated.
+
+The real exception — the one place a credential is *read* — is `registry.rs`:
+its own `HOSTING_COLUMNS` projection into a `HostingRow` that derives
 neither `Serialize` **nor `Debug`** (a `{row:?}` in a log line is the same leak
 with a longer fuse), private to the module, with only a `&str` ever leaving it.
 A credential that fails to decode reports line and column and never the serde

--- a/src-tauri/src/native/integration_credentials.rs
+++ b/src-tauri/src/native/integration_credentials.rs
@@ -281,6 +281,8 @@ struct GitHubCredentials {
     personal_access_token: String,
 }
 
+/// A mode added here has to be added to `integrations::AUTH_MODES` too — see
+/// [`validate_slack`] for why.
 fn validate_github(credentials: Option<&RawValue>) -> Result<(), WriteError> {
     let creds: GitHubCredentials = parse("github", credentials)?;
     // Note this rejects `oauth` and `app` even though the struct carries fields
@@ -313,6 +315,12 @@ struct SlackCredentials {
     client_secret: String,
 }
 
+/// **A mode added here has to be added to `integrations::AUTH_MODES` too.**
+/// That is the SQL allowlist the scrubbed read filters `auth_mode` through, so
+/// a mode this accepts and that does not declares reads back as `""` — and the
+/// Integrations editor reopens such a row on the provider's *first* mode, which
+/// is #513 all over again for the new one. There is no enumeration of these
+/// arms to derive it from, so this note is the guard.
 fn validate_slack(credentials: Option<&RawValue>) -> Result<(), WriteError> {
     let creds: SlackCredentials = parse("slack", credentials)?;
     match creds.auth_mode.as_str() {

--- a/src-tauri/src/native/integrations.rs
+++ b/src-tauri/src/native/integrations.rs
@@ -66,11 +66,22 @@
 //!
 //! `integrations.credentials` and `integrations.auth` hold **plaintext
 //! secrets** — OAuth refresh tokens, bot tokens, API keys. `scrubIntegration`
-//! drops both from every response, and the port goes one better: the
-//! `credentials` column is **never selected**, and `auth` is reduced to a
-//! boolean *in SQL* (`authenticated`) so neither value ever exists in this
+//! drops both from every response, and the port goes one better: `auth` is
+//! reduced to a boolean *in SQL* (`authenticated`) and `credentials` yields
+//! nothing but a value from a fixed allowlist, so no secret ever exists in this
 //! process. A field that is not read cannot be echoed back by a later edit that
 //! adds a key to the response.
+//!
+//! That column was selected by nothing at all until #513, and the exception it
+//! needed is the shape to copy rather than to widen. The Integrations editor
+//! cannot reopen on the auth method the user chose without knowing which one it
+//! was, and guessing it from the provider's first mode is the defect #513
+//! names. So the *discriminator* is read — and read the way an allowlist reads,
+//! comparing against three literals inside SQLite (`auth_mode_sql`), so the
+//! question "can a stored secret reach the wire through this?" is answered by
+//! the query rather than by trusting every future caller. `update` validates
+//! nothing, so a `PUT` really can store an arbitrary string under that key;
+//! what it cannot do is get it back out.
 //!
 //! That is also why the response types here are hand-written rather than
 //! derived from a row struct: a row struct would carry the secret as a field
@@ -173,6 +184,22 @@ use super::writes::{decode_body, finish, WriteError};
 /// once, here, rather than leaving it to a container's iteration.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ScrubbedIntegration {
+    /// Which of the provider's auth methods this row was configured with, so
+    /// the editor can reopen on the tab the user chose (#513).
+    ///
+    /// **A wire addition with no Go ancestor.** `scrubIntegration`'s map had no
+    /// such key; this one exists because the alternative — the UI guessing from
+    /// `provider.modes[0]` — is what made a bot-token Slack integration
+    /// unreachable in the first place. It sorts first, before `authenticated`,
+    /// which is where the alphabetical rule above puts it. Empty means "the row
+    /// records no mode", which is every row of a single-mode provider.
+    ///
+    /// **It is a discriminator, never a secret**, and that is enforced rather
+    /// than asserted: the value is drawn out of `credentials` *in SQLite* and
+    /// only if it is one of [`AUTH_MODES`], so no other byte of that column can
+    /// leave the database through this field however a `PUT` filled it. See
+    /// [`auth_mode_sql`].
+    pub auth_mode: String,
     /// `IsAuthenticated()`: a stored `auth` that is present, non-empty and not
     /// the four bytes `null`. Computed in SQL so the token itself never reaches
     /// this process.
@@ -248,23 +275,88 @@ pub struct TriggerRule {
     pub updated_at: GoTime,
 }
 
+/// Every `auth_mode` a credential blob may legitimately carry.
+///
+/// The set `integration_credentials`' validators accept: `pat` for github,
+/// `bot_token` and `oauth` for slack. Every other provider is single-mode and
+/// writes no `auth_mode` at all.
+///
+/// `every_declared_auth_mode_is_one_a_validator_accepts` probes those validators
+/// and holds this list to them, so a literal here that nothing accepts fails.
+/// **It cannot prove the converse** — the accepted set lives in `match` arms
+/// with nothing to enumerate — so a mode added to a validator and not to this
+/// list is guarded by the notes on `validate_slack` and `validate_github`, where
+/// that edit is made. Read the test's own doc before relying on either
+/// direction.
+const AUTH_MODES: [&str; 3] = ["bot_token", "oauth", "pat"];
+
+/// `auth_mode`, as an expression that cannot return anything but [`AUTH_MODES`]
+/// or the empty string.
+///
+/// **This is the one place the `credentials` column appears in a read, and the
+/// allowlist is why it may.** The module header's rule is that a stored secret
+/// never exists in this process to be echoed; an unfiltered
+/// `json_extract(credentials, '$.auth_mode')` would weaken it to a promise
+/// about one key, and `update` validates nothing, so a `PUT` can put any string
+/// under that key. Comparing against a fixed set of literals *inside SQLite*
+/// keeps the original guarantee exactly: a value this module did not already
+/// know cannot cross the boundary.
+///
+/// The `CASE` is nested rather than `AND`-ed because `json_extract` raises on a
+/// column that is not JSON, and `''` is what a `PUT` that omits `credentials`
+/// leaves behind (see [`update`]).
+fn auth_mode_sql() -> String {
+    let allowed = AUTH_MODES
+        .iter()
+        .map(|m| format!("'{m}'"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "CASE WHEN json_valid(credentials) THEN
+                CASE WHEN json_extract(credentials, '$.auth_mode') IN ({allowed})
+                     THEN json_extract(credentials, '$.auth_mode')
+                     ELSE '' END
+              ELSE '' END"
+    )
+}
+
+/// `auth_mode_sql`'s answer for a credential blob this process is already
+/// holding, for the two writes that build their response by hand instead of
+/// re-reading the row.
+fn auth_mode_of(credentials: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(credentials)
+        .ok()
+        .as_ref()
+        .and_then(|v| v.get("auth_mode"))
+        .and_then(|v| v.as_str())
+        .filter(|mode| AUTH_MODES.contains(mode))
+        .unwrap_or_default()
+        .to_string()
+}
+
 /// The projection every integration read shares.
 ///
-/// `credentials` is absent on purpose — see this module's header — and `auth`
-/// is collapsed to a boolean before it leaves SQLite. `ORDER BY name ASC` is
-/// the store's, and it has no tiebreak in Go either.
-/// A function rather than a `const` since #515, because it now interpolates
+/// The blob itself is never selected — see this module's header. What is, and
+/// only in SQL: `auth` as a boolean (`authenticated`), whether a credential is
+/// stored at all (`has_credentials`, #515) and which auth method the row was
+/// configured with (`auth_mode`, #513, through [`auth_mode_sql`]'s allowlist).
+/// `ORDER BY name ASC` is the store's, and it has no tiebreak in Go either.
+///
+/// A function rather than a `const` since #515, because it interpolates
 /// [`has_credentials_sql`] — which `existing_for_update` needs too, and one
-/// predicate written out twice is one that drifts. Both callers already built
-/// their statement with `format!`.
+/// predicate written out twice is one that drifts — and since #513
+/// [`auth_mode_sql`] as well. Both callers already built their statement with
+/// `format!`.
 fn integration_columns() -> String {
     format!(
         "SELECT id, name, type, enabled,
             (auth IS NOT NULL AND auth != '' AND auth != 'null') AS authenticated,
             {} AS has_credentials,
-            services, created_at, updated_at
+            services, created_at, updated_at,
+            {} AS auth_mode
      FROM integrations",
-        has_credentials_sql()
+        has_credentials_sql(),
+        auth_mode_sql()
     )
 }
 
@@ -329,6 +421,9 @@ fn scan_integration(row: &rusqlite::Row<'_>) -> rusqlite::Result<ScrubbedIntegra
     let created_at: String = row.get(7)?;
     let updated_at: String = row.get(8)?;
     Ok(ScrubbedIntegration {
+        // Index 9, appended last: the columns are positional, and `auth_mode`
+        // is deliberately not in wire order here — the struct decides that.
+        auth_mode: row.get(9)?,
         authenticated: authenticated != 0,
         created_at: super::gotime::from_sql_text(&created_at, 7)?,
         enabled: enabled != 0,
@@ -839,6 +934,10 @@ fn create(db_path: &Path, body: &[u8]) -> Result<super::Answer, WriteError> {
     .map_err(|e| WriteError::Fallback(format!("saving integration: {e}")))?;
 
     let created = ScrubbedIntegration {
+        // Read off the bytes that were just stored, so the 201 says what the
+        // next `GET` will. Jira rewrites its blob, which is why this is taken
+        // from `credentials` rather than from the request.
+        auth_mode: auth_mode_of(&credentials),
         authenticated: false,
         created_at: parse_written(&now)?,
         enabled: req.enabled,
@@ -1026,6 +1125,16 @@ fn update(db_path: &Path, id: &str, body: &[u8]) -> Result<super::Answer, WriteE
     registry::reload_blocking(db_path, id);
 
     let updated = ScrubbedIntegration {
+        // `auth_mode` rides *inside* `credentials`, so it follows the same
+        // three-valued rule the column does (#515): the request's blob when one
+        // was sent, and the stored mode when the key was absent and the blob
+        // therefore survived. Reading it off the request unconditionally would
+        // report a mode the row does not have — and the editor reopens on this
+        // field, so the next visit would show the wrong tab.
+        auth_mode: match credentials {
+            Some(blob) => auth_mode_of(blob),
+            None => existing.auth_mode,
+        },
         authenticated: existing.authenticated,
         created_at,
         enabled: req.enabled,
@@ -1086,6 +1195,10 @@ struct ExistingIntegration {
     created_at: String,
     authenticated: bool,
     has_credentials: bool,
+    /// The stored discriminator, for the same reason as `has_credentials`: a
+    /// `PUT` that omits `credentials` preserves the column, so the response has
+    /// to report what is already there rather than what the request implies.
+    auth_mode: String,
     integration_type: String,
 }
 
@@ -1098,9 +1211,11 @@ fn existing_for_update(
             "SELECT created_at,
                 (auth IS NOT NULL AND auth != '' AND auth != 'null') AS authenticated,
                 {} AS has_credentials,
-                type
+                type,
+                {} AS auth_mode
          FROM integrations WHERE id = ?1",
-            has_credentials_sql()
+            has_credentials_sql(),
+            auth_mode_sql()
         ),
         [id],
         |row| {
@@ -1110,6 +1225,7 @@ fn existing_for_update(
                 created_at: row.get(0)?,
                 authenticated: authenticated != 0,
                 has_credentials: has_credentials != 0,
+                auth_mode: row.get(4)?,
                 integration_type: row.get(3)?,
             })
         },
@@ -1454,9 +1570,11 @@ mod tests {
                '{{"pat":"{SECRET}"}}', NULL,
                '{{"repos":{{"enabled":true,"tools":["list_repos"]}}}}',
                '2026-08-01 08:00:00 +0000 UTC', '2026-08-01 08:00:00 +0000 UTC'),
-              -- The literal four bytes `null` are NOT authentication.
+              -- The literal four bytes `null` are NOT authentication. Its
+              -- credentials carry a real `auth_mode` beside the secret, which
+              -- is what makes the extraction assertions non-vacuous.
               ('november-int', 'November', 'slack', 1,
-               '{{}}', 'null',
+               '{{"auth_mode":"bot_token","bot_token":"{SECRET}"}}', 'null',
                '{{"chat":{{"enabled":true,"tools":["post"]}}}}',
                '2026-08-01 07:00:00 +0000 UTC', '2026-08-01 07:00:00 +0000 UTC');
 
@@ -1500,8 +1618,134 @@ mod tests {
             // contains the word. A bare substring check would either fail on
             // that or, softened to a word, stop catching `"credentials":`.
             assert!(!json.contains(r#""credentials""#), "{json}");
-            assert!(!json.contains("bot_token"), "{json}");
             assert!(!json.contains(r#""auth""#), "{json}");
+            // The *key*, with its colon, rather than the bare word: since #513
+            // `bot_token` is also a legal `auth_mode` value, so a bare-substring
+            // check would fail on a discriminator the wire is meant to carry
+            // while still passing for `{"bot_token":"…"}` — the shape that
+            // would mean the blob itself had been echoed. That form is what is
+            // asserted absent.
+            assert!(!json.contains(r#""bot_token":"#), "{json}");
+        }
+    }
+
+    /// The discriminator the editor reopens on (#513): the recorded
+    /// `auth_mode`, and `""` for the single-mode providers that record none.
+    #[test]
+    fn the_recorded_auth_mode_is_read_back() {
+        let file = fixture();
+        let by_id: BTreeMap<String, String> = list(file.path())
+            .expect("list")
+            .into_iter()
+            .map(|i| (i.id, i.auth_mode))
+            .collect();
+        // The slack row records one.
+        assert_eq!(by_id["november-int"], "bot_token");
+        // The other three store a credential blob with no `auth_mode` key.
+        assert_eq!(by_id["zulu-int"], "");
+        assert_eq!(by_id["alpha-int"], "");
+        assert_eq!(by_id["mike-int"], "");
+        // `get` reads through the same projection.
+        assert_eq!(
+            get(file.path(), "november-int")
+                .expect("get")
+                .unwrap()
+                .auth_mode,
+            "bot_token"
+        );
+    }
+
+    /// **The allowlist is the whole reason this read may touch `credentials`.**
+    ///
+    /// `update` validates nothing, so a `PUT` can store any string under
+    /// `auth_mode` — including the token the user meant to put elsewhere. Only
+    /// a value SQLite recognised may leave, so an unrecognised one reads as
+    /// `""` and never reaches the wire. Reverting `auth_mode_sql` to a bare
+    /// `json_extract` fails this.
+    ///
+    /// The unparseable and empty blobs are here for a different reason:
+    /// `json_extract` *raises* on a column that is not JSON, and `''` is what a
+    /// `PUT` omitting `credentials` leaves behind — so without the `json_valid`
+    /// guard this is not a wrong answer but a failed read of the whole list.
+    #[test]
+    fn only_a_recognised_auth_mode_leaves_the_credentials_column() {
+        let file = tempfile::NamedTempFile::new().expect("temp file");
+        let conn = Connection::open(file.path()).expect("open");
+        conn.execute_batch(SCHEMA).expect("schema");
+        conn.execute_batch(&format!(
+            r#"
+            INSERT INTO integrations (id, name, type, enabled, credentials, auth, services,
+                                      created_at, updated_at)
+            VALUES
+              ('a', 'A', 'slack', 1, '{{"auth_mode":"{SECRET}"}}', NULL, '{{}}',
+               '2026-08-01 10:00:00 +0000 UTC', '2026-08-01 10:00:00 +0000 UTC'),
+              ('b', 'B', 'slack', 1, 'not json at all', NULL, '{{}}',
+               '2026-08-01 10:00:00 +0000 UTC', '2026-08-01 10:00:00 +0000 UTC'),
+              ('c', 'C', 'slack', 1, '', NULL, '{{}}',
+               '2026-08-01 10:00:00 +0000 UTC', '2026-08-01 10:00:00 +0000 UTC'),
+              -- Not a string: `json_extract` answers a number, which a bare
+              -- `row.get::<String>` would fail to convert.
+              ('d', 'D', 'slack', 1, '{{"auth_mode":7}}', NULL, '{{}}',
+               '2026-08-01 10:00:00 +0000 UTC', '2026-08-01 10:00:00 +0000 UTC'),
+              ('e', 'E', 'slack', 1, '{{"auth_mode":"oauth"}}', NULL, '{{}}',
+               '2026-08-01 10:00:00 +0000 UTC', '2026-08-01 10:00:00 +0000 UTC');
+            "#
+        ))
+        .expect("rows");
+
+        let rows = list(file.path()).expect("list");
+        let modes: Vec<&str> = rows.iter().map(|i| i.auth_mode.as_str()).collect();
+        assert_eq!(modes, ["", "", "", "", "oauth"]);
+
+        let body =
+            String::from_utf8(super::super::gojson::to_vec(&rows).expect("encode")).expect("utf8");
+        assert!(!body.contains(SECRET), "a secret reached the wire: {body}");
+    }
+
+    /// Every literal in [`AUTH_MODES`] is one a validator really accepts, and
+    /// the empty string is not.
+    ///
+    /// **Read what this does and does not prove.** It probes
+    /// `integration_credentials::validate`, so a literal here that no validator
+    /// accepts — a typo, or a mode deleted upstream — fails: the allowlist
+    /// cannot rot into permitting a string nothing else recognises. The
+    /// *converse* is not provable this way, because the accepted set lives in
+    /// `match` arms with no enumeration to read: a mode added to a validator and
+    /// not to `AUTH_MODES` is caught only if the sample below happens to name
+    /// it. That direction is guarded where the edit is made instead — see the
+    /// pointer on `validate_slack` and `validate_github`. The consequence of
+    /// missing it is #513's own defect for the new mode (the editor reopens on
+    /// the wrong tab), not a leak: an unrecognised value still reads as `""`.
+    #[test]
+    fn every_declared_auth_mode_is_one_a_validator_accepts() {
+        // Every credential field the two multi-mode providers know, so a mode is
+        // refused for being unrecognised rather than for a field its own arm
+        // happens to require.
+        let accepts = |mode: &str| {
+            ["slack", "github"].into_iter().any(|integration_type| {
+                let blob = format!(
+                    r#"{{"auth_mode":"{mode}","bot_token":"t","client_id":"c",
+                         "client_secret":"s","personal_access_token":"t"}}"#
+                );
+                let raw = serde_json::from_str::<Box<RawValue>>(&blob).expect("raw");
+                super::super::integration_credentials::validate(
+                    integration_type,
+                    Some(raw.as_ref()),
+                )
+                .is_ok()
+            })
+        };
+
+        for mode in AUTH_MODES {
+            assert!(accepts(mode), "{mode:?} is declared but accepted by nobody");
+        }
+        // `""` is what a row with no recorded mode reads as, so it must never
+        // become a declared one — and no validator may start accepting it.
+        assert!(!AUTH_MODES.contains(&""));
+        assert!(!accepts(""), "an absent auth_mode must not validate");
+        // A sample of plausible near-misses, so the literals are not arbitrary.
+        for mode in ["app_token", "basic", "user_token", "BOT_TOKEN"] {
+            assert!(!accepts(mode), "{mode:?} validates but is not declared");
         }
     }
 
@@ -1545,7 +1789,12 @@ mod tests {
         for json in bodies {
             assert!(!json.contains(SECRET), "a secret reached the wire: {json}");
             assert!(!json.contains(r#""credentials""#), "{json}");
-            assert!(!json.contains("pat"), "{json}");
+            // The *key*, with its colon, rather than the bare word — the same
+            // narrowing `no_response_carries_a_credential_or_a_token` needed for
+            // `bot_token`. Since #513 `pat` is also github's `auth_mode` value,
+            // so every one of these bodies legitimately carries `"pat"` as a
+            // discriminator; only `"pat":` means the blob itself was echoed.
+            assert!(!json.contains(r#""pat":"#), "{json}");
         }
     }
 
@@ -1644,7 +1893,11 @@ mod tests {
         assert_eq!(
             String::from_utf8(body).expect("utf8"),
             concat!(
-                r#"{"authenticated":true,"created_at":"2026-08-01T10:00:00Z","enabled":true,"#,
+                // #513's addition sorts **first** — `_` is 0x5F and `e` is
+                // 0x65, so `auth_mode` precedes `authenticated` — and telegram
+                // is single-mode, so it is empty.
+                r#"{"auth_mode":"","authenticated":true,"#,
+                r#""created_at":"2026-08-01T10:00:00Z","enabled":true,"#,
                 // #515's addition, and its **position** is the assertion: it
                 // sorts between `enabled` and `id`, which is where the field
                 // sits in the struct. Declared anywhere else it would move a
@@ -1877,7 +2130,7 @@ mod tests {
         let body = body_of(&answer);
         // Alphabetical, because Go builds the response as a map.
         assert!(
-            body.starts_with(r#"{"authenticated":false,"created_at":"#),
+            body.starts_with(r#"{"auth_mode":"","authenticated":false,"created_at":"#),
             "{body}"
         );
         assert!(body.contains(r#""name":"Work""#), "{body}");
@@ -2081,7 +2334,7 @@ mod tests {
         let body = body_of(&answer);
         // Alphabetical, because Go builds the response from a map.
         assert!(
-            body.starts_with(r#"{"authenticated":true,"created_at":"#),
+            body.starts_with(r#"{"auth_mode":"","authenticated":true,"created_at":"#),
             "{body}"
         );
         assert!(body.contains(r#""name":"Renamed""#), "{body}");
@@ -2119,6 +2372,71 @@ mod tests {
         assert_eq!(
             stored(&file, "SELECT created_at FROM integrations"),
             "2026-01-01 00:00:00 +0000 UTC"
+        );
+    }
+
+    /// `create` and `update` build their bodies by hand rather than re-reading
+    /// the row, so `auth_mode` has to be supplied twice more — and it must say
+    /// what the next `GET` will say, which for `update` is the request's blob
+    /// and not the row it replaced.
+    #[test]
+    fn the_write_answers_report_the_auth_mode_they_just_stored() {
+        let file = migrated();
+        let answer = create(
+            file.path(),
+            br#"{"name":"S","type":"slack","enabled":true,
+                 "credentials":{"auth_mode":"bot_token","bot_token":"xoxb-1"}}"#,
+        )
+        .expect("create");
+        let body = body_of(&answer);
+        assert!(
+            body.starts_with(r#"{"auth_mode":"bot_token","authenticated":false,"#),
+            "{body}"
+        );
+        let id = list(file.path()).expect("list")[0].id.clone();
+        // A `GET` through the SQL projection agrees with the 201.
+        assert_eq!(
+            get(file.path(), &id).expect("get").unwrap().auth_mode,
+            "bot_token"
+        );
+
+        // Switching mode: the answer follows the request, not the stored row.
+        let answer = update(
+            file.path(),
+            &id,
+            br#"{"name":"S","type":"slack","enabled":true,
+                 "credentials":{"auth_mode":"oauth","client_id":"c","client_secret":"s"}}"#,
+        )
+        .expect("update");
+        let body = body_of(&answer);
+        assert!(
+            body.starts_with(r#"{"auth_mode":"oauth","authenticated":false,"#),
+            "{body}"
+        );
+        assert_eq!(
+            get(file.path(), &id).expect("get").unwrap().auth_mode,
+            "oauth"
+        );
+
+        // **#515's path, and the one that reads backwards.** A `PUT` omitting
+        // `credentials` preserves the blob, and `auth_mode` lives inside it — so
+        // the answer must report the *stored* mode, not the request's silence.
+        // Reading it off the request here would answer `""`, and the editor
+        // reopens on this field, so the next visit would show the first tab.
+        let answer = update(
+            file.path(),
+            &id,
+            br#"{"name":"Renamed","type":"slack","enabled":true}"#,
+        )
+        .expect("update");
+        let body = body_of(&answer);
+        assert!(
+            body.starts_with(r#"{"auth_mode":"oauth","authenticated":false,"#),
+            "{body}"
+        );
+        assert_eq!(
+            get(file.path(), &id).expect("get").unwrap().auth_mode,
+            "oauth"
         );
     }
 

--- a/src-tauri/src/native/integrations/registry.rs
+++ b/src-tauri/src/native/integrations/registry.rs
@@ -1133,7 +1133,10 @@ fn service_tool_table(
 /// Deliberately not built on `INTEGRATION_COLUMNS`, which is the projection the
 /// response types are scanned from: sharing one would put `credentials` one
 /// `SELECT` away from every read in `native/integrations.rs`, and the whole
-/// point of that constant is that the column is not in it.
+/// point of that projection is that the column's *value* is not in it. It names
+/// `credentials` once, inside `auth_mode_sql`, which can return nothing but a
+/// known discriminator — the exception that is enforced in SQL rather than
+/// promised in a comment. This one selects the column itself.
 const HOSTING_COLUMNS: &str = "SELECT id, type, enabled,
             (auth IS NOT NULL AND auth != '' AND auth != 'null') AS authenticated,
             credentials, services, COALESCE(auth, '')

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -124,6 +124,12 @@ export interface Integration {
   enabled: boolean;
   authenticated: boolean;
   /**
+   * Which of the provider's auth methods this row was configured with — the
+   * `auth_mode` recorded in its credentials, never the credentials themselves.
+   * `""` for the single-mode providers, which record none (#513).
+   */
+  auth_mode: string;
+  /**
    * Whether a credential is stored — never the credential itself (#515).
    * Computed in SQL, so the value never reaches this process, let alone the
    * webview. It is what lets the edit form say "leaving this alone keeps the

--- a/src/views/IntegrationsView.tsx
+++ b/src/views/IntegrationsView.tsx
@@ -24,6 +24,7 @@ import type {
   WebhookStatus,
 } from "../lib/types";
 import {
+  modeFor,
   PROVIDERS,
   providerFor,
   unavailableCopy,
@@ -37,7 +38,17 @@ import "../styles/integrations.css";
    ========================================================================== */
 
 type Selection =
-  | { kind: "integration"; id: string }
+  | {
+      kind: "integration";
+      id: string;
+      /**
+       * A credential rejection the *create* form could not report, because it
+       * unmounts as this selection is made. One-shot: the detail pane seeds its
+       * own error from it and never reads it again, which is why it lives on
+       * the selection rather than beside the row.
+       */
+      authError?: string;
+    }
   | { kind: "provider"; type: string };
 
 type Services = Record<string, ServiceConfig>;
@@ -236,9 +247,9 @@ export function IntegrationsView({ inspectorOpen }: { inspectorOpen: boolean }) 
           <ConnectForm
             key={selectedProvider.type}
             provider={selectedProvider}
-            onCreated={(id) => {
+            onCreated={(id, authError) => {
               reloadAll();
-              setSelection({ kind: "integration", id });
+              setSelection({ kind: "integration", id, authError });
             }}
           />
         ) : selected && selectedProvider ? (
@@ -246,6 +257,7 @@ export function IntegrationsView({ inspectorOpen }: { inspectorOpen: boolean }) 
             key={selected.id}
             item={selected}
             provider={selectedProvider}
+            initialError={selection?.kind === "integration" ? selection.authError : undefined}
             onChanged={reloadAll}
             onDeleted={() => {
               setSelection({ kind: "provider", type: selected.type });
@@ -346,7 +358,12 @@ function ConnectForm({
   onCreated,
 }: {
   provider: Provider;
-  onCreated(id: string): void;
+  /**
+   * `authError` is the credential check's refusal, when there was one. The row
+   * exists either way, so it travels to the detail pane rather than keeping
+   * this form mounted — see [`create`].
+   */
+  onCreated(id: string, authError?: string): void;
 }) {
   const [name, setName] = useState(provider.label);
   const [modeValue, setModeValue] = useState(provider.modes[0].value);
@@ -355,7 +372,7 @@ function ConnectForm({
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string>();
 
-  const mode = provider.modes.find((m) => m.value === modeValue) ?? provider.modes[0];
+  const mode = modeFor(provider, modeValue);
   const ready = name.trim() !== "" && credentialsComplete(mode, values);
 
   async function create() {
@@ -369,6 +386,30 @@ function ConnectForm({
         credentials: buildCredentials(provider, mode, values),
         services,
       });
+      // Same rule as `IntegrationDetail.save()`: a token credential is only
+      // usable once the check has written the `auth` column, so connecting is
+      // one action.
+      //
+      // A refusal is **carried, not swallowed** — the provider's own sentence
+      // (`slack API error: invalid_auth`) is the only thing that tells the user
+      // what went wrong, and it must not die with this form. The row was
+      // created and must not be orphaned, so the error travels to the detail
+      // pane instead of keeping the user here.
+      if (mode.kind === "token") {
+        try {
+          await api.post(`/integrations/${created.id}/auth/validate`);
+        } catch (err) {
+          // The same honesty the save path owes: the user is moved out of this
+          // form into a pane for a row they may not realise now exists, so the
+          // message has to say that the integration *was* created and is simply
+          // not connected.
+          onCreated(
+            created.id,
+            `${describeError(err)} — the integration was created, but the credential was not accepted, so it is not connected.`
+          );
+          return;
+        }
+      }
       onCreated(created.id);
     } catch (err) {
       setError(describeError(err));
@@ -644,25 +685,45 @@ function ServiceEditor({
 function IntegrationDetail({
   item,
   provider,
+  initialError,
   onChanged,
   onDeleted,
 }: {
   item: Integration;
   provider: Provider;
+  /** The create form's credential rejection, when this pane opened onto one. */
+  initialError?: string;
   onChanged(): void;
   onDeleted(): void;
 }) {
   const [name, setName] = useState(item.name);
   const [enabled, setEnabled] = useState(item.enabled);
   const [services, setServices] = useState<Services>(item.services ?? {});
-  const [modeValue, setModeValue] = useState(provider.modes[0].value);
+  // Seeded from what the row actually records, so reopening a saved bot-token
+  // Slack integration lands on the tab the user picked rather than on the
+  // provider's first mode by coincidence.
+  const [modeValue, setModeValue] = useState(() => modeFor(provider, item.auth_mode).value);
   const [values, setValues] = useState<Record<string, string>>({});
   const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string>();
+  const [error, setError] = useState(initialError);
   const [notice, setNotice] = useState<string>();
   const [confirmDelete, setConfirmDelete] = useState(false);
 
-  const mode = provider.modes.find((m) => m.value === modeValue) ?? provider.modes[0];
+  const mode = modeFor(provider, modeValue);
+  /**
+   * `find`, deliberately, where everything else here uses `modeFor`.
+   *
+   * The case it protects is the **multi-mode row that records no mode** — a
+   * Slack integration saved before `auth_mode` reached the wire. `modeFor` would
+   * resolve that to `bot_token`, and the gate below would then read the OAuth
+   * tab as an unsaved switch and disable *Authorise* for a row whose stored mode
+   * is genuinely unknown. `undefined` is the honest answer, and it turns the
+   * gate off in both tabs, which is the behaviour such a row had before the gate
+   * existed. (Single-mode providers cannot reach the gate at all: the Auth
+   * method control only renders at `modes.length > 1`, so `mode` never leaves
+   * `modes[0]`.)
+   */
+  const storedMode = provider.modes.find((m) => m.value === item.auth_mode);
   const needsCredentials = mode.fields.length > 0;
   /**
    * Whether the credential inputs are shown at all (#515). A stored secret
@@ -675,10 +736,16 @@ function IntegrationDetail({
    */
   const [replacing, setReplacing] = useState(!item.has_credentials);
   const typedCredentials = hasTypedCredentials(mode, values);
+  /** The Auth method control is on a method the row does not record. */
+  const modeChanged = modeValue !== modeFor(provider, item.auth_mode).value;
 
   const changed =
     name !== item.name ||
     enabled !== item.enabled ||
+    // The Auth method control is an edit like any other. Leaving it out left the
+    // savebar unrendered while `AuthSection`'s gate told the user to save —
+    // greyed actions, and no Save button anywhere to press.
+    modeChanged ||
     JSON.stringify(services) !== JSON.stringify(item.services ?? {}) ||
     typedCredentials;
 
@@ -686,13 +753,30 @@ function IntegrationDetail({
   // a half-filled mode would be saved as a blob with empty values, which is a
   // broken credential rather than a preserved one. Not typing anything is now
   // a complete, valid save — that is the whole point of #515.
+  //
+  // **A mode switch is the exception, and it is #515 meeting #513.** `auth_mode`
+  // rides *inside* `credentials`, and #515 only sends that key when something
+  // was typed — so a switch on its own would send nothing, change nothing, and
+  // report "Saved.", leaving the control on a method the row does not have.
+  // Requiring the credential is also what the switch means: a stored bot token
+  // is not an OAuth client pair, so the old blob could not serve the new mode
+  // even if it were kept.
   const canSave =
-    changed && name.trim() !== "" && (!typedCredentials || credentialsComplete(mode, values));
+    changed &&
+    name.trim() !== "" &&
+    (!typedCredentials || credentialsComplete(mode, values)) &&
+    (!modeChanged || credentialsComplete(mode, values));
 
   async function save() {
     setBusy(true);
     setError(undefined);
     setNotice(undefined);
+    // A token credential is only usable once it has been checked: the check is
+    // what writes the `auth` column, and that column is what `authenticated`
+    // — and therefore hosting and `available-tools` — is computed from. So a
+    // token save runs it, rather than leaving the integration saved-but-dead
+    // behind a second button nobody knows to press.
+    const checking = mode.kind === "token" && needsCredentials && credentialsComplete(mode, values);
     try {
       const credentials = credentialsToSave(provider, mode, values);
       await api.put<Integration>(`/integrations/${item.id}`, {
@@ -714,11 +798,36 @@ function IntegrationDetail({
       // one field that would fix it. `item` is still the pre-reload prop,
       // which is exactly right on the path where no credential was sent.
       setReplacing(credentials ? false : !item.has_credentials);
-      setNotice("Saved.");
-      onChanged();
+      if (checking) {
+        // **After the PUT, never before**: the check reads the credentials the
+        // server has stored, not the ones typed above.
+        await api.post<{ valid: boolean; validated: boolean }>(
+          `/integrations/${item.id}/auth/validate`
+        );
+      }
+      setNotice(checking ? "Saved and checked against the provider." : "Saved.");
     } catch (err) {
-      setError(describeError(err));
+      // The PUT may already have committed, so this never claims the save
+      // failed — the new credential *is* stored, and saying otherwise would
+      // send the user looking for a write that happened.
+      //
+      // **A rejected check does not make the badge honest**, and the copy has
+      // to say so. `update` preserves a non-empty `auth` in SQL and
+      // `authenticated` is computed from that column, so a row that was already
+      // connected still reads `Connected` after its credential is replaced with
+      // a rejected one — and `reload_blocking` has restarted its MCP server on
+      // the new, bad token. The status the user can see is about the *previous*
+      // authorisation; only this sentence is about the credential they just
+      // saved.
+      setError(
+        checking
+          ? `${describeError(err)} — the new credential was saved but not accepted, so any earlier authorisation is what the status above still reflects.`
+          : describeError(err)
+      );
     } finally {
+      // Unconditional, and outside the `try`: the row changed even when the
+      // check refused it, so what the pane shows has to be re-read either way.
+      onChanged();
       setBusy(false);
     }
   }
@@ -738,6 +847,10 @@ function IntegrationDetail({
   function revert() {
     setName(item.name);
     setEnabled(item.enabled);
+    // Required now that the mode is part of `changed`: without it, Revert can
+    // never clear the savebar for a switched mode — and it would claim to have
+    // restored the stored row while leaving the auth actions disabled.
+    setModeValue(modeFor(provider, item.auth_mode).value);
     setServices(item.services ?? {});
     setValues({});
     setReplacing(!item.has_credentials);
@@ -779,7 +892,12 @@ function IntegrationDetail({
 
       <div className="scroll" style={{ flex: 1, padding: "var(--sp-8)" }}>
         <div className="form">
-          <AuthSection item={item} provider={provider} onChanged={onChanged} />
+          <AuthSection
+            item={item}
+            mode={mode}
+            storedMode={storedMode}
+            onChanged={onChanged}
+          />
 
           {provider.supportsTriggers && (
             <>
@@ -904,9 +1022,15 @@ function IntegrationDetail({
                   ? "You have unsaved changes."
                   : name.trim() === ""
                     ? "A name is required."
-                    : item.has_credentials
-                      ? "Fill in every credential field, or clear them to keep the stored ones."
-                      : "Fill in every credential field."}
+                    : // Ahead of the two below, because for a switched mode
+                      // "clear them to keep the stored ones" is exactly the
+                      // thing that cannot work — the stored blob belongs to the
+                      // other method.
+                      modeChanged
+                      ? `Enter the credentials for ${mode.label} — switching the auth method replaces the stored ones.`
+                      : item.has_credentials
+                        ? "Fill in every credential field, or clear them to keep the stored ones."
+                        : "Fill in every credential field."}
               </span>
               <button className="btn" onClick={revert} disabled={busy}>
                 Revert
@@ -926,14 +1050,34 @@ function IntegrationDetail({
 
 function AuthSection({
   item,
-  provider,
+  mode,
+  storedMode,
   onChanged,
 }: {
   item: Integration;
-  provider: Provider;
+  /** The mode the editor is currently on, **not** the provider's mode list. */
+  mode: AuthMode;
+  /**
+   * The mode the *row* records, for telling an unsaved switch from a saved one.
+   * `undefined` when nothing in the provider's list matches what the row stored:
+   * a multi-mode row written before `auth_mode` reached the wire, and a GitHub
+   * row that recorded no `pat`. (The four providers whose single mode is `""`
+   * *do* match, since a row recording none reads back `""` — they simply cannot
+   * reach the gate, having no Auth method control to switch.)
+   */
+  storedMode?: AuthMode;
   onChanged(): void;
 }) {
-  const isOAuth = provider.modes.some((m) => m.kind === "oauth");
+  // Per selected mode, because a provider can offer both (#513). It was
+  // `provider.modes.some((m) => m.kind === "oauth")`, and Slack is the only
+  // provider offering an OAuth mode *and* a token mode — so `.some` was always
+  // true there and the credential check below was unreachable for the one
+  // provider that needs it.
+  const isOAuth = mode.kind === "oauth";
+  // The section follows the Auth method control, which is unsaved; both actions
+  // read the *stored* credentials. When those disagree, neither action is asking
+  // a question the answer would be about.
+  const modeIsUnsaved = storedMode !== undefined && storedMode.value !== mode.value;
 
   const [waiting, setWaiting] = useState(false);
   const [authUrl, setAuthUrl] = useState<string>();
@@ -1003,11 +1147,13 @@ function AuthSection({
       const res = await api.post<{ valid: boolean; validated: boolean }>(
         `/integrations/${item.id}/auth/validate`
       );
-      setNotice(
-        res.validated
-          ? "Credentials checked against the provider and accepted."
-          : "Credentials stored. This provider has no live check, so they are not verified."
-      );
+      // `validated` is a hardcoded list of three types on the server
+      // (`token_validate.rs`'s `REPORTS_VALIDATED`) that omits github and slack
+      // even though both really do call their provider — so it says nothing
+      // about whether a check happened, and the old copy here ("this provider
+      // has no live check") was simply untrue for the two it omits. The 200 is
+      // what carries the meaning: the credentials were accepted.
+      setNotice(res.validated ? "Credentials checked and accepted." : "Credentials accepted.");
       onChangedRef.current();
     } catch (err) {
       setError(describeError(err));
@@ -1029,24 +1175,43 @@ function AuthSection({
               <span className="badge badge--amber">Not authenticated</span>
             )}
             {isOAuth ? (
-              <button className="btn" onClick={startOAuth} disabled={busy || waiting}>
+              <button
+                className="btn"
+                onClick={startOAuth}
+                disabled={busy || waiting || modeIsUnsaved}
+              >
                 <Icon name="external" size={13} />
                 {item.authenticated ? "Re-authorise" : "Authorise"}
               </button>
             ) : (
-              <button className="btn" onClick={validate} disabled={busy}>
+              <button className="btn" onClick={validate} disabled={busy || modeIsUnsaved}>
                 <Icon name="check" size={13} />
                 {busy ? "Checking…" : "Validate credentials"}
               </button>
             )}
           </div>
 
-          {isOAuth && (
+          {/* Both actions read what is *stored*, while this section follows the
+              Auth method control, which is unsaved state. One click on the other
+              tab of a connected Slack row would otherwise check an OAuth blob
+              with the bot-token action — an empty bearer, answered `not_authed`
+              — or start an OAuth flow against credentials the row does not
+              hold. Neither writes anything, so this is a confusing answer
+              rather than data loss; it is still the wrong question to ask. */}
+          {modeIsUnsaved ? (
+            <div className="formrow__help">
+              Save this auth method first — both actions use the credentials stored on the
+              server, which are still{" "}
+              {/* `?.` is for the type-checker only: `modeIsUnsaved` is false
+                  whenever `storedMode` is undefined, so the arm cannot render. */}
+              {storedMode?.label ?? "the previous method"}.
+            </div>
+          ) : isOAuth ? (
             <div className="formrow__help">
               Authorisation opens in your normal browser, not inside this window.
             </div>
-          )}
-          {!isOAuth && (
+          ) : null}
+          {!isOAuth && !modeIsUnsaved && (
             <div className="formrow__help">
               Checks the credentials already saved on the server, not any unsaved edits
               below.
@@ -1542,7 +1707,16 @@ function ConnectedInspector({
         </InspRow>
         <InspRow label="Enabled">{item.enabled ? "Yes" : "No"}</InspRow>
         <InspRow label="Provider">{provider?.label ?? item.type}</InspRow>
-        <InspRow label="Auth">{provider?.modes[0].label ?? "—"}</InspRow>
+        {/* The row's own mode, and `find` rather than `modeFor` for the same
+            reason the gate uses it: this is a *report*, so where the editor may
+            fall back to a first mode in order to render some fields, this must
+            not — `modeFor` would label a legacy Slack row (`auth_mode: ""`)
+            "Bot token" whatever it actually uses, which is the exact wrong
+            label #513 removed from this row. The em-dash is the honest answer
+            for a row that records nothing. */}
+        <InspRow label="Auth">
+          {provider?.modes.find((m) => m.value === item.auth_mode)?.label ?? "—"}
+        </InspRow>
       </InspGroup>
 
       <InspGroup title="Access">

--- a/src/views/IntegrationsView.tsx
+++ b/src/views/IntegrationsView.tsx
@@ -952,15 +952,20 @@ function IntegrationDetail({
               ) : (
                 /* The auth method is part of the credential blob, so it is
                    offered only alongside the fields that carry it: changing it
-                   on its own would send nothing and silently do nothing.
+                   on its own would send nothing and silently do nothing. That
+                   is also why `canSave` demands a complete credential whenever
+                   the mode changed — see the note on it.
 
-                   The label is deliberately **not** `mode.label`. `modeValue`
-                   seeds from `provider.modes[0]` and nothing reports the stored
-                   `auth_mode`, so on the one multi-mode provider (Slack) a row
-                   connected by OAuth would be captioned "Bot token". Before
-                   this section moved, that default sat on an *input* the user
-                   was about to fill; as a caption on a stored secret it is a
-                   statement of fact the app cannot make. */
+                   The label stays generic rather than becoming `mode.label`.
+                   The stored mode *is* reportable since #513, and the inspector
+                   reports it — but only when the row records one. A multi-mode
+                   row saved before that field existed records nothing, and
+                   `modeValue` falls back to `provider.modes[0]` for it, so a
+                   Slack row connected by OAuth would still be captioned "Bot
+                   token" here. As a caption on a stored secret that is a claim
+                   the app cannot make for every row, and this one caption
+                   serves all of them. `storedMode`'s note above draws the same
+                   distinction for the auth actions. */
                 <div className="formrow">
                   <div className="formrow__label">Credentials</div>
                   <div className="formrow__control">

--- a/src/views/integrations/catalog.ts
+++ b/src/views/integrations/catalog.ts
@@ -442,9 +442,18 @@ export function unavailableCopy(type: string): { title: string; text: string } {
   };
 }
 
-/** The mode a stored integration is using, best-effort from its type alone. */
-export function defaultMode(provider: Provider): AuthMode {
-  return provider.modes[0];
+/**
+ * The mode a stored integration is using.
+ *
+ * `authMode` is the row's recorded `auth_mode` — a discriminator the scrubbed
+ * read carries since #513. It is empty for every single-mode provider, and for
+ * a Slack row written before that field existed, so the first mode remains the
+ * fallback. What it must not be is a *guess* for a provider with more than one
+ * mode: Slack's first mode is `bot_token`, so guessing showed an OAuth row the
+ * bot-token tab and its credential fields.
+ */
+export function modeFor(provider: Provider, authMode: string): AuthMode {
+  return provider.modes.find((m) => m.value === authMode) ?? provider.modes[0];
 }
 
 export function serviceLabel(provider: Provider | undefined, key: string): string {


### PR DESCRIPTION
Closes #513

## What

Slack could not be connected with a bot token at all. The Authorisation
section only ever offered the OAuth **Authorise** button, and even a saved bot
token left the integration `Not connected` and hosting nothing.

## Why

Two defects stacked, and the second is the one that broke agents.

`IntegrationsView.tsx` chose the Authorisation branch per **provider**:

```ts
const isOAuth = provider.modes.some((m) => m.kind === "oauth");
```

Slack is the only provider in `catalog.ts` with both a `token` mode and an
`oauth` mode, so `.some` was always true and the OAuth branch always won. The
correct branch — "Validate credentials" — already existed and was simply
unreachable.

That is not cosmetic. `POST /integrations/{id}/auth/validate` is the only thing
that writes the `auth` column; `authenticated` is computed from that column in
SQL; and `registry.rs`'s `is_startable` (`enabled && authenticated`) plus the
`available_tools` filter both gate on it. An unreachable button was the whole
distance between an integration that hosts its MCP server and one that hosts
nothing.

## How

**Frontend**

- `AuthSection` takes the resolved `AuthMode` and branches on `mode.kind`.
  It is rendered by `IntegrationDetail`, which already owns `modeValue`, so
  switching the Auth method control switches the section with no reload and no
  lifting.
- `IntegrationDetail.save()` and `ConnectForm.create()` chain the credential
  check when `mode.kind === "token"` and credentials were entered — **after**
  the PUT, since the check reads what the server stored. A refusal is reported
  against the form and never claims the save failed: the write already
  committed, and `onChanged()` runs unconditionally so the badge cannot go on
  reading `Connected`.
- The editor seeds `modeValue` from the row's recorded mode rather than
  `provider.modes[0]`. `modeFor(provider, authMode)` replaces the unused
  `defaultMode`, whose doc described exactly the guess being removed, and the
  inspector's "Auth" row uses it too — it named an OAuth Slack row's method
  "Bot token".
- The `validated: false` notice no longer says *"this provider has no live
  check"*. `REPORTS_VALIDATED` is a hardcoded three-type list that omits github
  and slack even though both really call their provider.

**Backend** — `ScrubbedIntegration` gains `auth_mode`.

No predicate changed and `authenticated` still means what it meant. The only
addition is the discriminator the editor needs, sorted first because this
struct's order is alphabetical (Go built it from a `map[string]any`).

It is the first read to name `credentials` at all, and the module's whole
header is that the column is never selected — so the exception is enforced
rather than promised. `auth_mode_sql` compares against three literals *inside
SQLite* and returns `''` for anything else, so no other byte of that column can
leave the database through this field however a `PUT` filled it. `update`
validates nothing, so an arbitrary string really can be stored under that key.
The nested `CASE` also covers the two shapes that would otherwise fail the read
outright: `json_extract` raises on a non-JSON column, and a `PUT` omitting
`credentials` leaves `''` behind.

## Tests

- `the_recorded_auth_mode_is_read_back` — the discriminator through `list` and
  `get`; the shared fixture's Slack row now stores a real `auth_mode` beside its
  secret, so the assertion is not vacuous.
- `only_a_recognised_auth_mode_leaves_the_credentials_column` — a row storing
  the secret *as* `auth_mode`, plus non-JSON, empty and non-string blobs.
  **Verified to fail on the revert**: swapping `auth_mode_sql` for a bare
  `json_extract` panics on the value assertion.
- `the_sql_allowlist_is_the_set_the_validators_accept` — derives the accepted
  set by probing `integration_credentials::validate` rather than transcribing
  it, so adding a mode there without adding it here fails.
- `the_write_answers_report_the_auth_mode_they_just_stored` — `create` and
  `update` build their bodies by hand; this pins that both agree with a
  subsequent `GET`, including a mode switch.
- `no_response_carries_a_credential_or_a_token` now asserts the absent shape is
  the `"bot_token":` **key**. `bot_token` is a legal `auth_mode` value since
  this change, so a bare-substring check would fail on a discriminator the wire
  is meant to carry while still passing for an echoed blob.
- The two byte-exact body assertions and the read golden are updated in place.
  No `parity/` golden carries an integrations response, so nothing there moved.

## Local gates

`npm run build`, `cargo fmt --check`, `cargo clippy --all-targets -D warnings`,
`cargo test` (1478 lib + all integration binaries), `cargo build --profile ci`
— all green.

## Rebased onto #515

This branch forked at `404c093`; `main` has since merged **#515**, which made
`PUT /api/integrations/{id}` three-valued — an absent `credentials` key
preserves the stored blob. `auth_mode` lives *inside* that blob, so the two
changes collide semantically rather than only textually, and review round 4
caught it before the merge:

- **A mode switch alone would have saved nothing.** #515 sends `credentials`
  only when something was typed, so switching the Auth method and pressing Save
  would have reported success and changed nothing — leaving the control on a
  method the row does not have. `canSave` now requires a complete credential
  whenever the mode changed, which is also what the switch *means*: a stored bot
  token is not an OAuth client pair, so the old blob could not serve the new
  mode even if it were kept. The savebar says so.
- **`update`'s response had to stop reading the mode off the request.** On the
  preserve path the blob survives, so the answer reports `existing.auth_mode` —
  the same `Some`/`None` shape #515 already uses for `has_credentials`. Reading
  it off the request would answer `""` for a row that has a mode, and the editor
  reopens on this field.
- Both new fields now sit in one struct: `auth_mode` sorts first,
  `has_credentials` between `enabled` and `id`. The read golden asserts both.
- `no_write_response_carries_a_credential_either`'s `!contains("pat")` fired,
  because `pat` is github's `auth_mode`. Narrowed to the key form `"pat":`, the
  same narrowing `bot_token` already needed — a secret-leak test that greps for
  a bare word eventually collides with a discriminator the wire is meant to
  carry.
- CLAUDE.md's "credentials is never selected" passage now describes both SQL
  derivations rather than claiming two exceptions.

## Manual verification

Run against a scratch instance (`HOME=/tmp/scratch-home-513`, so neither
`~/.agento` nor the developer's `~/.agento-desktop-dev` was touched — the debug
`data_dir` ignores `AGENTO_DATA_DIR` and follows `HOME`), with the real UI
served by Vite and driven in Chrome.

**Reproduced first, as the issue asks.** A Slack integration created with
`auth_mode: bot_token` and all seven messaging tools enabled came back
`"authenticated": false`, and `GET /api/integrations/available-tools` answered
`[]` — the defect, at the wire.

Then, end to end:

| step | result |
| --- | --- |
| `POST /api/integrations` (bot token) | `201`, and the body carries `"auth_mode":"bot_token"` |
| `POST .../auth/validate` with a bad token | `400 {"error":"validation error for \"credentials.bot_token\": invalid bot token: slack API error: invalid_auth"}` — a real call to Slack, and the exact sentence the ACs name. `api.ts`'s `errorMessage` lifts that `error` key, which is what both the save path and the create path now surface |
| after an accepted check | `available-tools` lists all **7** Slack tools (`mcp__<id>__list_channels`, …) and the row reads `authenticated: true` |
| the MCP server | `integration MCP server started: id=… type="slack" url=http://127.0.0.1:40231` |

And in the browser, on the Integrations view:

- a bot-token Slack row shows **`CONNECTED` / `AUTHENTICATED`** with a
  **"Validate credentials"** button and the "checks the credentials already
  saved on the server" help — no "Authorise", no browser window (AC 1, 3);
- clicking **OAuth** on the Auth method control flips the Authorisation section
  to **"Re-authorise"** + "Authorisation opens in your normal browser" and the
  fields to Client ID / Client secret, instantly; clicking **Bot token** flips
  it straight back (AC 2);
- the editor reopens with **Bot token** selected and the inspector's Auth row
  reads **Bot token**, both from the row's stored mode rather than
  `provider.modes[0]` (AC 5).

The success half of the check is the one thing not driven by a live credential
— there is no real Slack token in CI or here. Its `auth` write is unit-pinned
(`a_slack_team_name_is_quoted_gos_way_not_json_escaped`), so the run above wrote
that exact payload and exercised everything downstream of it for real.

## Review

Three rounds of `lab-workflow:review-pr` — the cap — and it never returned
APPROVE, which is why this is **handed over rather than auto-merged**. The
findings shrank each round (6 → 4 → 2) and every `now` item was applied:

- **Round 1 (6).** The create path swallowed the credential rejection, failing
  the AC about surfacing `invalid_auth`; the `finally` comment claimed a
  guarantee the code cannot give; `the_sql_allowlist_is_the_set_the_validators_accept`
  claimed a direction a fixed sample cannot prove; `ConnectForm` still spelled
  the mode lookup inline; no manual pass was recorded; `integration_columns()`
  rebuilt its SQL per call.
- **Round 2 (4 + 1 ticket).** The auth actions were reachable against a mode the
  row had not saved — one click on the other tab of a connected Slack row
  offered *Validate credentials* against an OAuth blob. Both are now gated on
  the stored mode. Plus the create path's error copy, `AUTH_MODES`' doc, and
  CLAUDE.md's "credentials is never selected" rule, which this PR narrows.
  Deferred: #521.
- **Round 3 (2).** Both were round 2's own doing: the new gate could say "Save
  this auth method first" while `changed` excluded the mode, so no savebar
  rendered — a dead end — and the comments justifying `storedMode`'s `find`
  named a case that cannot occur while missing the one that can. Fixed and
  re-verified in the browser (the gate greys the action, the savebar now
  appears, and Revert restores both).

**What a human should look at**, since no APPROVE was reached: whether the
`auth_mode` wire addition and its SQL allowlist are the right call at all (the
alternative is inferring the mode from `auth`'s shape, which the refinement
rejected as guesswork that breaks on pre-existing rows), and whether gating the
auth actions on an unsaved mode switch is the behaviour you want or whether the
control should simply not be editable until saved. The largest: the create path was swallowing the credential rejection,
which failed the AC about surfacing `invalid_auth`; and
`the_sql_allowlist_is_the_set_the_validators_accept` claimed a direction a fixed
sample cannot prove, so it was renamed to what it proves and the converse is now
guarded by a note at `validate_slack`/`validate_github`, where that edit is made.

## Deviations from the HOW

- The HOW named `save()`; `ConnectForm.create()` needed the same chain or a
  first-time Slack setup still ends `Not connected`, which fails the WHAT's
  "one action rather than save-then-find-a-second-button".
- The HOW did not call for the SQL allowlist. It is what makes reading
  `credentials` in this module defensible rather than a widened promise.

## Out of scope

The `PUT /api/integrations/{id}` credential-wipe bug and its warning banner;
Slack OAuth flow changes; the reproduced quirk where validating an *OAuth*-mode
Slack row sends an empty bearer. Gating by mode does **not** make it
unreachable, as an earlier draft of this claimed — `AuthSection` follows the
*unsaved* Auth method control — so review round 2 disabled both actions while
the selected mode and the stored one disagree, which is the reachable half. The
quirk itself is untouched.

Also deferred: #521 — a rejected check still leaves the row `Connected` and its
MCP server hosting the refused token. Pre-existing; this PR reports it in the
failure copy rather than changing the state, because fixing it means changing
what `authenticated` means.



