### PR TITLE
fix: give every outbound HTTP client a User-Agent (#514)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1640,6 +1640,24 @@ Five things it brought that #313 will want:
   reqwest decompresses in its service stack, so `bytes_stream()` yields
   decompressed bytes and `read_capped` caps what Go's `io.LimitReader` over a
   gunzipped `resp.Body` caps.
+- **`reqwest` sends no `User-Agent` where `net/http` sends one, and GitHub
+  answers 403 without it** (#514). Go's transport sets `Go-http-client/1.1`
+  unasked; `reqwest` sets nothing unless asked, and the port never asked — a
+  byte lost silently, because no response, stored value or parity vector records
+  it (`google_vectors.json` says outright that `User-Agent` is deliberately not
+  recorded). GitHub *requires* it, so **all twenty tools and `validate_pat`
+  403'd**, and the message names the credential rather than the header: the user
+  saw `validation error for "credentials.personal_access_token"` and regenerated
+  a PAT that was never the problem. **Every client comes from
+  `native::http::client_builder()`**, which pre-sets
+  `Agento/<CARGO_PKG_VERSION> (+https://myagento.app)` and touches nothing else
+  — the timeouts still differ per integration and GitHub keeps its second
+  no-redirect client. The version is `env!("CARGO_PKG_VERSION")` and **not**
+  `native::version::VERSION`, which answers `dev` in every unstamped build.
+  `no_client_is_built_outside_this_module` reads the crate's own sources so the
+  eighth client cannot omit it the way the first seven did; it found one the
+  issue's own table had missed, the OAuth token exchange in
+  `integrations/oauth/flow.rs`.
 - **The test seam is `#[cfg(test)]`, and should stay that way in #313.**
   `githubAPIBase` had to be *exported* on the Go side (`parity.go`) because
   `parity` is a different package; both Rust callers are in-crate, so

--- a/src-tauri/src/native/gateway_api/catalog.rs
+++ b/src-tauri/src/native/gateway_api/catalog.rs
@@ -110,7 +110,7 @@ fn client() -> Option<&'static reqwest::Client> {
     static CLIENT: std::sync::OnceLock<Option<reqwest::Client>> = std::sync::OnceLock::new();
     CLIENT
         .get_or_init(|| {
-            reqwest::Client::builder()
+            crate::native::http::client_builder()
                 .timeout(TIMEOUT)
                 .redirect(reqwest::redirect::Policy::none())
                 .build()
@@ -500,5 +500,23 @@ mod tests {
     #[test]
     fn a_base_with_a_dot_segment_is_refused_rather_than_followed() {
         assert!(Base::new("https://api.openai.com/v1/..").is_err());
+    }
+}
+
+/// The `User-Agent` this module's client puts on the wire (#514).
+///
+/// Read off a request a loopback server received, not off the builder: a
+/// `ClientBuilder`'s default headers cannot be inspected, and asserting that
+/// this file *calls* `client_builder` would only restate
+/// `native::http`'s own source guard.
+#[cfg(test)]
+mod user_agent {
+    #[tokio::test]
+    async fn the_gateway_catalog_client_sends_the_agento_user_agent() {
+        let client = super::client().expect("a usable HTTP client");
+        assert_eq!(
+            crate::native::http::testing::user_agent_seen_by_a_server(client).await,
+            crate::native::http::USER_AGENT,
+        );
     }
 }

--- a/src-tauri/src/native/http.rs
+++ b/src-tauri/src/native/http.rs
@@ -1,0 +1,374 @@
+//! The one place an outbound HTTP client is built.
+//!
+//! # Why this module exists at all
+//!
+//! Go's `net/http` sets `User-Agent: Go-http-client/1.1` on every request
+//! without being asked; `reqwest` sets **nothing** unless asked, and the port
+//! never asked. The header was lost silently, because it was written down on
+//! neither side — there is no response byte, no stored value and no parity
+//! vector that records it (`parity/google_vectors.json` says so explicitly:
+//! `X-Goog-Api-Client` and `User-Agent` are deliberately not recorded).
+//!
+//! GitHub *requires* the header and answers **403** without it, with a message
+//! that names the credential rather than the header:
+//!
+//! ```text
+//! Request forbidden by administrative rules. Please make sure your request has
+//! a User-Agent header
+//! ```
+//!
+//! So `validate_pat` reported `validation error for
+//! "credentials.personal_access_token"` for a perfectly good token, and since
+//! it shares `http_client()` with the tool path, all twenty GitHub tools 403'd
+//! the same way. The other five integrations were merely anonymous — they work
+//! today only because those APIs do not enforce a rule GitHub does.
+//!
+//! # The rule
+//!
+//! **Every `reqwest` client the app builds comes from [`client_builder`].**
+//! Not "every client that talks to GitHub" — the point of a single factory is
+//! that the eighth client cannot silently omit the header, which is exactly how
+//! the first seven came to. `no_client_is_built_outside_this_module` is the
+//! guard, and it reads the crate's own sources rather than trusting the rule to
+//! be remembered.
+//!
+//! What the factory does **not** do is unify anything else. Timeouts differ per
+//! integration on purpose (15s GitHub/Jira, 30s Confluence, 60s
+//! Slack/Telegram/Google), GitHub keeps its second no-redirect client, and the
+//! gateway catalog keeps `redirect::Policy::none()` because its credential
+//! rides a custom header `reqwest` does not strip across a redirect. Each call
+//! site adds its own; this adds one header and nothing else.
+
+/// `Agento/<crate version> (+https://myagento.app)`.
+///
+/// RFC 9110 `product/version` with an informational comment, and nothing else:
+/// no OS, no arch, no webview version. Those are fingerprinting surface on a
+/// desktop application and nothing downstream needs them — what a provider's
+/// abuse heuristic rewards is a stable product token with a contact URL.
+///
+/// **The version is [`env!`]`("CARGO_PKG_VERSION")`, not
+/// [`crate::native::version::VERSION`].** That one is
+/// `option_env!("AGENTO_BUILD_VERSION")` and answers `dev` in every unstamped
+/// build — deliberately and correctly for the About screen, and a shipped
+/// failure mode besides (every release through `desktop-v0.1.1` reported `dev`
+/// because nothing set the variable). `src-tauri/Cargo.toml`'s version is one
+/// of the five places the release commit bumps and CI enforces on every PR, so
+/// it is right in a shipped installer *and* right in a local build.
+///
+/// `concat!` keeps it a `&'static str`: no allocation, no lazy init, and the
+/// version is fixed at compile time rather than read back from anywhere.
+pub const USER_AGENT: &str = concat!(
+    "Agento/",
+    env!("CARGO_PKG_VERSION"),
+    " (+https://myagento.app)"
+);
+
+/// A [`reqwest::ClientBuilder`] with [`USER_AGENT`] already applied.
+///
+/// Note `.user_agent()` sets a **default** header, so an explicit per-request
+/// `.header(USER_AGENT, …)` would still win. Nothing in the tree sets one, and
+/// nothing should — a per-call override would put this module back to being
+/// advisory.
+pub fn client_builder() -> reqwest::ClientBuilder {
+    reqwest::Client::builder().user_agent(USER_AGENT)
+}
+
+/// A loopback recorder, for the per-integration tests that assert the header is
+/// on the wire rather than on the builder.
+///
+/// Reading `.user_agent()` back off a `ClientBuilder` is not possible and
+/// asserting that a call site *calls* [`client_builder`] would only restate the
+/// guard below. So each client's own module drives one real request through its
+/// own constructor and reads the header the server received.
+#[cfg(test)]
+pub(crate) mod testing {
+    /// Send one `GET` through `client` and answer with the `User-Agent` the
+    /// server saw — the empty string when none arrived.
+    pub(crate) async fn user_agent_seen_by_a_server(client: &reqwest::Client) -> String {
+        use std::sync::{Arc, Mutex};
+
+        let seen: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let recorder = seen.clone();
+
+        let app = axum::Router::new().fallback(move |headers: axum::http::HeaderMap| {
+            let recorder = recorder.clone();
+            async move {
+                *recorder.lock().expect("recorder lock") = Some(
+                    headers
+                        .get(axum::http::header::USER_AGENT)
+                        .and_then(|value| value.to_str().ok())
+                        .unwrap_or_default()
+                        .to_string(),
+                );
+                "ok"
+            }
+        });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind the recorder");
+        let url = format!("http://{}/", listener.local_addr().expect("addr"));
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+
+        client
+            .get(&url)
+            .send()
+            .await
+            .expect("the recorder answered")
+            .bytes()
+            .await
+            .expect("a body");
+
+        let seen = seen.lock().expect("recorder lock").clone();
+        seen.expect("the recorder saw no request at all")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The version in the header is the crate's, checked against the crate's
+    /// own version rather than against a literal — a release bump moves
+    /// `CARGO_PKG_VERSION` and this assertion moves with it, where a spelled-out
+    /// `1.2.0` would sit there being wrong for a whole release.
+    #[test]
+    fn the_user_agent_carries_the_crate_version() {
+        assert_eq!(
+            USER_AGENT,
+            format!(
+                "Agento/{} (+https://myagento.app)",
+                env!("CARGO_PKG_VERSION")
+            ),
+        );
+        assert!(
+            !env!("CARGO_PKG_VERSION").is_empty(),
+            "an empty crate version would make the assertion above vacuous"
+        );
+    }
+
+    /// A header value `reqwest` refuses is a client that fails to build, which
+    /// is `Option::None` at seven call sites and no outbound call anywhere.
+    #[test]
+    fn the_user_agent_is_a_legal_header_value() {
+        let value = reqwest::header::HeaderValue::from_str(USER_AGENT)
+            .expect("the User-Agent is not a legal header value");
+        assert_eq!(value.to_str().expect("visible ASCII"), USER_AGENT);
+    }
+
+    /// The shape a provider's heuristic reads: `product/version` plus a comment
+    /// carrying a contact URL, and no third token.
+    #[test]
+    fn the_user_agent_has_the_documented_shape() {
+        let (product, comment) = USER_AGENT
+            .split_once(' ')
+            .expect("a product token and a comment");
+        let version = product
+            .strip_prefix("Agento/")
+            .expect("the product token is `Agento/<version>`");
+        assert_eq!(comment, "(+https://myagento.app)");
+        assert_eq!(version.split('.').count(), 3, "a three-part version");
+        assert!(
+            version
+                .split('.')
+                .all(|part| !part.is_empty() && part.chars().all(|c| c.is_ascii_digit())),
+            "every version part is numeric: {version:?}"
+        );
+    }
+
+    /// Every outbound client is built here, and this is what keeps it true.
+    ///
+    /// The seven that existed before this module were each written
+    /// independently and each omitted the header; a rule that lives only in a
+    /// doc comment would be re-omitted by the eighth. So the crate's own
+    /// sources are read and any `reqwest::Client::builder()` or
+    /// `reqwest::Client::new()` outside this module fails the build.
+    ///
+    /// Test code is exempt two ways, and neither is a filename convention:
+    /// a `#[cfg(test)]` region within a file (`claude/mcp.rs`,
+    /// `claude/tool.rs`, `native/tools/mod.rs`), and a whole file whose parent
+    /// declares it `#[cfg(test)] mod …;` (the six `tests_vectors.rs`). The
+    /// second set is **derived from the declarations**, so naming a production
+    /// file `tests_something.rs` buys it no exemption. Those all drive loopback
+    /// fakes, where the header is the thing being asserted rather than
+    /// something to send.
+    ///
+    /// Comment lines are skipped, or this doc comment would report itself.
+    #[test]
+    fn no_client_is_built_outside_this_module() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let sources = rust_sources(&root);
+        let test_only = test_only_files(&root, &sources);
+        let mut offenders = Vec::new();
+
+        for path in &sources {
+            let relative = path
+                .strip_prefix(&root)
+                .expect("under src/")
+                .to_string_lossy()
+                .replace('\\', "/");
+            if relative == "native/http.rs" || test_only.contains(&relative) {
+                continue;
+            }
+            let source = std::fs::read_to_string(path).expect("a source file");
+            for (number, line) in source.lines().enumerate() {
+                let code = line.trim_start();
+                if code.starts_with("//") {
+                    continue;
+                }
+                if !line.contains("reqwest::Client::builder()")
+                    && !line.contains("reqwest::Client::new()")
+                {
+                    continue;
+                }
+                if in_test_code(&source, number) {
+                    continue;
+                }
+                offenders.push(format!("{}:{}", relative, number + 1));
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "these build a reqwest client outside native::http, so it sends no User-Agent \
+             and GitHub answers 403: {offenders:?}. Use `crate::native::http::client_builder()`."
+        );
+    }
+
+    /// The files some other file declares as `#[cfg(test)] mod <name>;` — the
+    /// whole file compiles only under `cargo test`, so nothing in it ever
+    /// reaches a user's machine.
+    fn test_only_files(
+        root: &std::path::Path,
+        sources: &[std::path::PathBuf],
+    ) -> std::collections::BTreeSet<String> {
+        let mut found = std::collections::BTreeSet::new();
+        for path in sources {
+            let source = std::fs::read_to_string(path).expect("a source file");
+            let dir = path.parent().expect("a parent dir").to_path_buf();
+            let mut lines = source.lines().peekable();
+            while let Some(line) = lines.next() {
+                if line.trim() != "#[cfg(test)]" {
+                    continue;
+                }
+                let Some(next) = lines.peek() else { continue };
+                let Some(name) = next
+                    .trim()
+                    .strip_prefix("mod ")
+                    .and_then(|rest| rest.strip_suffix(';'))
+                else {
+                    continue;
+                };
+                for candidate in [
+                    dir.join(format!("{name}.rs")),
+                    dir.join(name).join("mod.rs"),
+                ] {
+                    if let Ok(relative) = candidate.strip_prefix(root) {
+                        found.insert(relative.to_string_lossy().replace('\\', "/"));
+                    }
+                }
+            }
+        }
+        found
+    }
+
+    /// Every `.rs` file under `src-tauri/src`.
+    fn rust_sources(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
+        let mut found = Vec::new();
+        let mut stack = vec![dir.to_path_buf()];
+        while let Some(dir) = stack.pop() {
+            for entry in std::fs::read_dir(&dir).expect("readable source dir") {
+                let path = entry.expect("a dir entry").path();
+                if path.is_dir() {
+                    stack.push(path);
+                } else if path.extension().is_some_and(|ext| ext == "rs") {
+                    found.push(path);
+                }
+            }
+        }
+        found.sort();
+        found
+    }
+
+    /// Is line `number` (0-based) inside a `#[cfg(test)]` item?
+    ///
+    /// A brace count from the nearest preceding `#[cfg(test)]`, which is enough
+    /// for this crate: every test site in the tree is a `#[cfg(test)] mod` or a
+    /// `#[cfg(test)] fn`, and the guard only has to be right about *those* —
+    /// a false "not test code" is a loud, fixable assertion failure naming the
+    /// line, never a silent pass.
+    fn in_test_code(source: &str, number: usize) -> bool {
+        let mut depth = 0i32;
+        let mut inside = false;
+        for (index, line) in source.lines().enumerate() {
+            if index > number {
+                break;
+            }
+            if !inside && line.trim_start().starts_with("#[cfg(test)]") {
+                inside = true;
+                depth = 0;
+            }
+            if inside {
+                depth += line.matches('{').count() as i32;
+                depth -= line.matches('}').count() as i32;
+                if depth <= 0 && line.contains('}') {
+                    if index == number {
+                        return true;
+                    }
+                    inside = false;
+                }
+            }
+        }
+        inside
+    }
+
+    /// The guard's own reading of test code, pinned — a `in_test_code` that
+    /// answered `true` everywhere would make the guard above vacuous while
+    /// still passing.
+    #[test]
+    fn the_guard_tells_test_code_from_the_rest() {
+        let source = "fn a() {\n    reqwest::Client::new();\n}\n\
+                      #[cfg(test)]\nmod tests {\n    fn b() {\n        \
+                      reqwest::Client::new();\n    }\n}\n\
+                      fn c() {\n    reqwest::Client::new();\n}\n";
+        assert!(!in_test_code(source, 1), "line 2 is production code");
+        assert!(in_test_code(source, 6), "line 7 is inside #[cfg(test)]");
+        assert!(
+            !in_test_code(source, 10),
+            "line 11 is after the test module"
+        );
+    }
+
+    /// The exemption set is the other way the guard could go vacuous: one that
+    /// exempted every file would pass for ever while the header went missing
+    /// again. So it is pinned from both sides — the six vector files are in it,
+    /// and every file this fix actually touched is not.
+    #[test]
+    fn the_guards_exemptions_cover_the_vector_files_and_nothing_that_ships() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let exempt = test_only_files(&root, &rust_sources(&root));
+
+        for integration in [
+            "github",
+            "confluence",
+            "jira",
+            "slack",
+            "telegram",
+            "google",
+        ] {
+            assert!(
+                exempt.contains(&format!(
+                    "native/integrations/{integration}/tests_vectors.rs"
+                )),
+                "{integration}'s vector file is not recognised as test-only"
+            );
+            assert!(
+                !exempt.contains(&format!("native/integrations/{integration}/client.rs")),
+                "{integration}'s client is exempt from the guard, which makes it useless"
+            );
+        }
+        assert!(!exempt.contains("native/gateway_api/catalog.rs"));
+        assert!(!exempt.contains("native/integrations/oauth/flow.rs"));
+    }
+}

--- a/src-tauri/src/native/http.rs
+++ b/src-tauri/src/native/http.rs
@@ -293,34 +293,86 @@ mod tests {
 
     /// Is line `number` (0-based) inside a `#[cfg(test)]` item?
     ///
-    /// A brace count from the nearest preceding `#[cfg(test)]`, which is enough
-    /// for this crate: every test site in the tree is a `#[cfg(test)] mod` or a
-    /// `#[cfg(test)] fn`, and the guard only has to be right about *those* —
-    /// a false "not test code" is a loud, fixable assertion failure naming the
-    /// line, never a silent pass.
+    /// **An attribute covers exactly the one item after it**, and getting that
+    /// wrong is a hole rather than a false alarm — which is why it is spelled
+    /// out rather than approximated by "count braces from the last
+    /// `#[cfg(test)]`". Five of the client files open with
+    /// `#[cfg(test)]\nuse std::sync::RwLock;`, a *brace-less* item; a walk that
+    /// stayed "inside" until the next `}` then treated everything between that
+    /// `use` and the end of the next block as test code, and a production
+    /// client written there was exempted silently. Verified by putting one
+    /// there and watching the guard pass.
+    ///
+    /// So: the line after the attribute is the item. Braces balanced on it →
+    /// the item ended there. Otherwise track depth to zero.
     fn in_test_code(source: &str, number: usize) -> bool {
-        let mut depth = 0i32;
+        let mut pending = false;
         let mut inside = false;
+        let mut depth = 0i32;
+
         for (index, line) in source.lines().enumerate() {
-            if index > number {
-                break;
-            }
-            if !inside && line.trim_start().starts_with("#[cfg(test)]") {
-                inside = true;
-                depth = 0;
-            }
+            let delta = line.matches('{').count() as i32 - line.matches('}').count() as i32;
+
             if inside {
-                depth += line.matches('{').count() as i32;
-                depth -= line.matches('}').count() as i32;
-                if depth <= 0 && line.contains('}') {
-                    if index == number {
-                        return true;
-                    }
+                depth += delta;
+                if index == number {
+                    return true;
+                }
+                if depth <= 0 {
                     inside = false;
                 }
+                continue;
+            }
+            if pending {
+                pending = false;
+                if delta > 0 {
+                    inside = true;
+                    depth = delta;
+                }
+                // A stacked attribute (`#[cfg(test)]` then `#[allow(…)]`) is
+                // not the item, so keep waiting for one.
+                if line.trim_start().starts_with("#[") {
+                    pending = true;
+                    inside = false;
+                }
+                if index == number {
+                    return true;
+                }
+                continue;
+            }
+            if line.trim_start().starts_with("#[cfg(test)]") {
+                pending = true;
+                if index == number {
+                    return true;
+                }
+                continue;
+            }
+            if index == number {
+                return false;
             }
         }
-        inside
+        false
+    }
+
+    /// A `#[cfg(test)]` on a brace-less item covers that item and stops.
+    ///
+    /// This is the shape five client files actually open with, and the version
+    /// of `in_test_code` this replaced answered `true` for every line after it
+    /// until the next `}` — so a production client written in that window was
+    /// exempted from the guard with nothing to say so. Reverting the fix fails
+    /// here.
+    #[test]
+    fn a_cfg_test_use_does_not_exempt_the_code_after_it() {
+        let source = "#[cfg(test)]\nuse std::sync::RwLock;\n\
+                      fn leaked() {\n    reqwest::Client::new();\n}\n";
+        assert!(
+            in_test_code(source, 1),
+            "line 2 is the item the attribute covers"
+        );
+        assert!(
+            !in_test_code(source, 3),
+            "line 4 is production code: an attribute covers one item, not a region"
+        );
     }
 
     /// The guard's own reading of test code, pinned — a `in_test_code` that

--- a/src-tauri/src/native/integrations/confluence/client.rs
+++ b/src-tauri/src/native/integrations/confluence/client.rs
@@ -63,7 +63,7 @@ pub(super) fn http_client() -> Option<&'static reqwest::Client> {
     static CLIENT: OnceLock<Option<reqwest::Client>> = OnceLock::new();
     CLIENT
         .get_or_init(|| {
-            reqwest::Client::builder()
+            crate::native::http::client_builder()
                 .timeout(Duration::from_secs(30))
                 .build()
                 .ok()
@@ -468,5 +468,23 @@ mod tests {
             .await
             .expect("a 200 is a success however long the body is");
         assert_eq!(body.len(), MAX_RESPONSE_BYTES);
+    }
+}
+
+/// The `User-Agent` this module's client puts on the wire (#514).
+///
+/// Read off a request a loopback server received, not off the builder: a
+/// `ClientBuilder`'s default headers cannot be inspected, and asserting that
+/// this file *calls* `client_builder` would only restate
+/// `native::http`'s own source guard.
+#[cfg(test)]
+mod user_agent {
+    #[tokio::test]
+    async fn the_confluence_client_sends_the_agento_user_agent() {
+        let client = super::http_client().expect("a usable HTTP client");
+        assert_eq!(
+            crate::native::http::testing::user_agent_seen_by_a_server(client).await,
+            crate::native::http::USER_AGENT,
+        );
     }
 }

--- a/src-tauri/src/native/integrations/github/client.rs
+++ b/src-tauri/src/native/integrations/github/client.rs
@@ -133,7 +133,7 @@ pub(super) fn http_client() -> Option<&'static reqwest::Client> {
     static CLIENT: OnceLock<Option<reqwest::Client>> = OnceLock::new();
     CLIENT
         .get_or_init(|| {
-            reqwest::Client::builder()
+            crate::native::http::client_builder()
                 .timeout(Duration::from_secs(15))
                 .build()
                 .ok()
@@ -150,7 +150,7 @@ fn no_redirect_client() -> Option<&'static reqwest::Client> {
     static CLIENT: OnceLock<Option<reqwest::Client>> = OnceLock::new();
     CLIENT
         .get_or_init(|| {
-            reqwest::Client::builder()
+            crate::native::http::client_builder()
                 .timeout(Duration::from_secs(15))
                 .redirect(reqwest::redirect::Policy::none())
                 .build()
@@ -678,5 +678,34 @@ mod tests {
             .expect("a 200 is a success however long the body is");
         assert_eq!(body.len(), MAX_JSON_BYTES);
         set_api_base(None);
+    }
+}
+
+/// The `User-Agent` this module's client puts on the wire (#514).
+///
+/// Read off a request a loopback server received, not off the builder: a
+/// `ClientBuilder`'s default headers cannot be inspected, and asserting that
+/// this file *calls* `client_builder` would only restate
+/// `native::http`'s own source guard.
+#[cfg(test)]
+mod user_agent {
+    #[tokio::test]
+    async fn the_github_client_sends_the_agento_user_agent() {
+        let client = super::http_client().expect("a usable HTTP client");
+        assert_eq!(
+            crate::native::http::testing::user_agent_seen_by_a_server(client).await,
+            crate::native::http::USER_AGENT,
+        );
+    }
+
+    /// The no-redirect client is a *second* client, so it omits the header
+    /// independently — and it is the one `get_pull_diff` and `download_*` use.
+    #[tokio::test]
+    async fn the_no_redirect_client_sends_it_too() {
+        let client = super::no_redirect_client().expect("a usable HTTP client");
+        assert_eq!(
+            crate::native::http::testing::user_agent_seen_by_a_server(client).await,
+            crate::native::http::USER_AGENT,
+        );
     }
 }

--- a/src-tauri/src/native/integrations/github/tests_vectors.rs
+++ b/src-tauri/src/native/integrations/github/tests_vectors.rs
@@ -241,6 +241,12 @@ struct Recorded {
     authorization: String,
     accept: String,
     content_type: String,
+    /// Not a vector field — no golden records a `User-Agent`, and
+    /// `parity/google_vectors.json` says so in as many words. It is captured so
+    /// the twenty tools' real requests can be asserted to carry Agento's own
+    /// (#514), which is what the Go server got free from `net/http` and this
+    /// port did not.
+    user_agent: String,
     body: String,
 }
 
@@ -295,6 +301,7 @@ async fn serve_fake(
             authorization: header("authorization"),
             accept: header("accept"),
             content_type: header("content-type"),
+            user_agent: header("user-agent"),
             body: String::from_utf8_lossy(&body).into_owned(),
         });
         (fake.status, fake.location.clone(), fake.body.clone())
@@ -409,6 +416,16 @@ async fn every_call_matches_the_go_vectors() {
                     case.case
                 );
                 assert_eq!(got.body, want.body, "{}: request body", case.case);
+                // Every one of the twenty tools, not just the client that
+                // built the first request: GitHub answers 403 to a request
+                // without it, so this is the difference between the
+                // integration working and none of it working.
+                assert_eq!(
+                    got.user_agent,
+                    crate::native::http::USER_AGENT,
+                    "{}: User-Agent",
+                    case.case
+                );
             }
         }
     }

--- a/src-tauri/src/native/integrations/google/client.rs
+++ b/src-tauri/src/native/integrations/google/client.rs
@@ -447,7 +447,7 @@ fn http_client() -> Option<&'static reqwest::Client> {
             // for the reason `desktop/CLAUDE.md` gives: a handler with no client
             // timeout is what an unbounded graceful shutdown waits on. 60s
             // matches the longest any sibling uses.
-            reqwest::Client::builder()
+            crate::native::http::client_builder()
                 .timeout(Duration::from_secs(60))
                 .build()
                 .ok()
@@ -986,5 +986,23 @@ mod tests {
         );
 
         set_api_base(None);
+    }
+}
+
+/// The `User-Agent` this module's client puts on the wire (#514).
+///
+/// Read off a request a loopback server received, not off the builder: a
+/// `ClientBuilder`'s default headers cannot be inspected, and asserting that
+/// this file *calls* `client_builder` would only restate
+/// `native::http`'s own source guard.
+#[cfg(test)]
+mod user_agent {
+    #[tokio::test]
+    async fn the_google_client_sends_the_agento_user_agent() {
+        let client = super::http_client().expect("a usable HTTP client");
+        assert_eq!(
+            crate::native::http::testing::user_agent_seen_by_a_server(client).await,
+            crate::native::http::USER_AGENT,
+        );
     }
 }

--- a/src-tauri/src/native/integrations/jira/client.rs
+++ b/src-tauri/src/native/integrations/jira/client.rs
@@ -63,7 +63,7 @@ pub(super) fn http_client() -> Option<&'static reqwest::Client> {
     static CLIENT: OnceLock<Option<reqwest::Client>> = OnceLock::new();
     CLIENT
         .get_or_init(|| {
-            reqwest::Client::builder()
+            crate::native::http::client_builder()
                 .timeout(Duration::from_secs(15))
                 .build()
                 .ok()
@@ -370,5 +370,23 @@ mod tests {
             .await
             .expect("a 200 is a success however long the body is");
         assert_eq!(body.len(), MAX_RESPONSE_BYTES);
+    }
+}
+
+/// The `User-Agent` this module's client puts on the wire (#514).
+///
+/// Read off a request a loopback server received, not off the builder: a
+/// `ClientBuilder`'s default headers cannot be inspected, and asserting that
+/// this file *calls* `client_builder` would only restate
+/// `native::http`'s own source guard.
+#[cfg(test)]
+mod user_agent {
+    #[tokio::test]
+    async fn the_jira_client_sends_the_agento_user_agent() {
+        let client = super::http_client().expect("a usable HTTP client");
+        assert_eq!(
+            crate::native::http::testing::user_agent_seen_by_a_server(client).await,
+            crate::native::http::USER_AGENT,
+        );
     }
 }

--- a/src-tauri/src/native/integrations/oauth/flow.rs
+++ b/src-tauri/src/native/integrations/oauth/flow.rs
@@ -37,6 +37,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock};
 
+use crate::native::http;
 use crate::native::integrations::registry;
 use crate::native::writes::WriteError;
 
@@ -327,8 +328,32 @@ async fn handle_callback(
             .into_response();
     }
 
+    // Not in #514's own table of seven, and a production client all the same:
+    // this is the token exchange, an outbound HTTPS call carrying the
+    // `client_secret`. `reqwest::Client::new()` panics on an unusable trust
+    // store where every sibling constructor answers `Option` — inside a
+    // `tokio::spawn`ed callback server, which is a task that dies with nothing
+    // written to the flow state and a UI polling `auth/status` forever. Both
+    // are fixed by going through the factory.
+    let client = match http::client_builder().build() {
+        Ok(client) => client,
+        Err(e) => {
+            // The cause is never interpolated: a `reqwest` error's `Display`
+            // carries the URL it was built from, and this text is stored on the
+            // flow state and rendered by the UI.
+            log::warn!("OAuth flow id={:?}: no usable HTTP client: {e}", ctx.id);
+            fail_flow(&ctx.id, "oauth: no usable HTTP client".to_string());
+            ctx.finish();
+            return (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to exchange token\n",
+            )
+                .into_response();
+        }
+    };
+
     let token = match exchange::exchange(
-        &reqwest::Client::new(),
+        &client,
         &ctx.endpoint,
         &ctx.client_id,
         &ctx.client_secret,

--- a/src-tauri/src/native/integrations/slack/client.rs
+++ b/src-tauri/src/native/integrations/slack/client.rs
@@ -104,7 +104,7 @@ pub(super) fn http_client() -> Option<&'static reqwest::Client> {
     static CLIENT: OnceLock<Option<reqwest::Client>> = OnceLock::new();
     CLIENT
         .get_or_init(|| {
-            reqwest::Client::builder()
+            crate::native::http::client_builder()
                 .timeout(Duration::from_secs(60))
                 .build()
                 .ok()
@@ -517,4 +517,22 @@ mod tests {
     }
 
     use axum::http::StatusCode;
+}
+
+/// The `User-Agent` this module's client puts on the wire (#514).
+///
+/// Read off a request a loopback server received, not off the builder: a
+/// `ClientBuilder`'s default headers cannot be inspected, and asserting that
+/// this file *calls* `client_builder` would only restate
+/// `native::http`'s own source guard.
+#[cfg(test)]
+mod user_agent {
+    #[tokio::test]
+    async fn the_slack_client_sends_the_agento_user_agent() {
+        let client = super::http_client().expect("a usable HTTP client");
+        assert_eq!(
+            crate::native::http::testing::user_agent_seen_by_a_server(client).await,
+            crate::native::http::USER_AGENT,
+        );
+    }
 }

--- a/src-tauri/src/native/integrations/telegram/client.rs
+++ b/src-tauri/src/native/integrations/telegram/client.rs
@@ -90,7 +90,7 @@ pub(super) fn http_client() -> Option<&'static reqwest::Client> {
     static CLIENT: OnceLock<Option<reqwest::Client>> = OnceLock::new();
     CLIENT
         .get_or_init(|| {
-            reqwest::Client::builder()
+            crate::native::http::client_builder()
                 .timeout(Duration::from_secs(60))
                 .build()
                 .ok()
@@ -522,5 +522,23 @@ mod tests {
                 "{token} must be refused"
             );
         }
+    }
+}
+
+/// The `User-Agent` this module's client puts on the wire (#514).
+///
+/// Read off a request a loopback server received, not off the builder: a
+/// `ClientBuilder`'s default headers cannot be inspected, and asserting that
+/// this file *calls* `client_builder` would only restate
+/// `native::http`'s own source guard.
+#[cfg(test)]
+mod user_agent {
+    #[tokio::test]
+    async fn the_telegram_client_sends_the_agento_user_agent() {
+        let client = super::http_client().expect("a usable HTTP client");
+        assert_eq!(
+            crate::native::http::testing::user_agent_seen_by_a_server(client).await,
+            crate::native::http::USER_AGENT,
+        );
     }
 }

--- a/src-tauri/src/native/mod.rs
+++ b/src-tauri/src/native/mod.rs
@@ -37,6 +37,7 @@ pub mod goquote;
 pub mod gotime;
 pub mod gourl;
 pub mod health;
+pub mod http;
 pub mod insights;
 pub mod integration_credentials;
 pub mod integrations;


### PR DESCRIPTION
Closes #514

## What

`native/http.rs` is new and holds the single definition:

```rust
pub const USER_AGENT: &str = concat!("Agento/", env!("CARGO_PKG_VERSION"), " (+https://myagento.app)");
pub fn client_builder() -> reqwest::ClientBuilder { reqwest::Client::builder().user_agent(USER_AGENT) }
```

The seven constructors the issue names switch onto it, and nothing else about
them moves — the per-integration timeouts (15s GitHub/Jira, 30s Confluence, 60s
Slack/Telegram/Google), GitHub's second no-redirect client and the catalog's
`redirect::Policy::none()` are all untouched.

## Why

Go's `net/http` sets `User-Agent: Go-http-client/1.1` unasked; `reqwest` sets
nothing unless asked, and the port never asked. GitHub requires the header and
answers 403 without it, in a message that names the credential rather than the
header — so `validate_pat` reported a bad PAT for a good one, and since it
shares `http_client()` with the tool path, all twenty GitHub tools failed the
same way.

## One deviation from the HOW, flagged deliberately

The issue's table lists seven constructors. The source guard it also asks for
found an **eighth**: `native/integrations/oauth/flow.rs`, the OAuth token
exchange — a production `reqwest::Client::new()` on an outbound HTTPS call
carrying the `client_secret`. It is in neither the in-scope table nor the
out-of-scope list, so this is an omission from the table rather than a
deliberate exclusion, and the issue's own WHAT ("every `reqwest` client the app
builds") covers it. It is fixed here. `Client::new()` also *panics* on an
unusable trust store where every sibling answers `Option`, inside a spawned
callback task — so it now answers the flow's existing error path instead, with
the cause logged rather than interpolated into text the UI renders.

Recorded on the issue: https://github.com/shaharia-lab/agento/issues/514#issuecomment-5472483398

## Proof

- `no_client_is_built_outside_this_module` reads the crate's own sources and
  fails on any `reqwest::Client::builder()`/`::new()` outside this module.
  Exemptions are **derived**, not a filename convention: a `#[cfg(test)]`
  region, or a whole file some parent declares `#[cfg(test)] mod …;` (the six
  `tests_vectors.rs`). `the_guards_exemptions_cover_the_vector_files_and_nothing_that_ships`
  pins the exemption set from both sides so the guard cannot go vacuous.
- **Eight wire tests**, one per client (two for GitHub), each reading the header
  off a request a loopback recorder received — not off the builder, which cannot
  be inspected.
- `github/tests_vectors.rs` now records `user-agent` and asserts it on **every**
  one of the 40+ recorded calls. No golden field is added and no vector is
  regenerated: no `parity/` file carries request headers, and
  `google_vectors.json` says so explicitly.
- The version is asserted against `env!("CARGO_PKG_VERSION")`, never a literal.

**Reverting one call site fails two tests**, verified by doing it:

```
test native::integrations::slack::client::user_agent::the_slack_client_sends_the_agento_user_agent ... FAILED
test native::http::tests::no_client_is_built_outside_this_module ... FAILED
  these build a reqwest client outside native::http … ["native/integrations/slack/client.rs:107"]
```

### The second commit is the review of the first

Turning the guard on its own tree found a hole in it: **a `#[cfg(test)]`
attribute covers one item, not a region.** Five client files open with
`#[cfg(test)]\nuse std::sync::RwLock;` — a brace-less item — and the first
exemption walk counted braces from the attribute, so it stayed "inside" until
the next `}` and silently exempted any production client written in that window.
Proved by planting one there and watching the guard pass; it now fails with
`native/integrations/github/client.rs:39`.
`a_cfg_test_use_does_not_exempt_the_code_after_it` is the regression.

## Verified against real GitHub

With the exact string this ships:

```
$ curl -s -o /dev/null -w '%{http_code}\n' -A "" https://api.github.com/user
403
$ curl -s -o /dev/null -w '%{http_code}\n' -A "Agento/1.2.0 (+https://myagento.app)" \
    -H "Authorization: Bearer <invalid>" https://api.github.com/user
401
```

401 rather than 403 is the acceptance criterion: the request now reaches auth,
so a valid PAT validates and an invalid one reports 401.

## Acceptance criteria

- [x] The string is defined in exactly one place (`native/http.rs`); no integration spells it out.
- [x] The version is `env!("CARGO_PKG_VERSION")`, asserted against the crate version rather than a literal.
- [x] All seven clients (plus the eighth) send it, asserted off a loopback fake's received request.
- [x] A source-level guard fails the build on a client built outside `native::http`.
- [x] Real GitHub: 403 → 401 with the header.
- [x] Every existing parity vector passes unchanged.

## Local gates

`cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test`
(1489 lib + every integration suite, green), `npm run build`. CI green on the
head SHA: Typecheck/lint/build, Windows unit tests, and all five CodeQL analyses.