### PR TITLE
fix(integrations): an omitted credential is preserved, not wiped (#515)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2334,14 +2334,31 @@ reproduces Go's one real effect there — a column holding `''` or the literal
 four bytes `null` becomes SQL `NULL`, because `Save` writes `authJSON` only when
 `IsAuthenticated()`.
 
-**Three things about the `PUT` that read as bugs and are Go's behaviour**, all
+**Two things about the `PUT` that read as bugs and are Go's behaviour**, both
 pinned by `parity_writes::the_integration_id_write_answers_match_go` against a
 live server: it runs **no** credential validation (`validateIntegrationCredentials`
 is `Create`'s alone, so an empty name, an empty type and a `{}` blob are all
-200s); a request omitting `credentials` **wipes** them, because the store's
-upsert overwrites the column wholesale; and an omitted `services` is stored and
-returned as `null`, not `{}`, because `Update` skips the `make(...)` that
-`Create` does.
+200s); and an omitted `services` is stored and returned as `null`, not `{}`,
+because `Update` skips the `make(...)` that `Create` does.
+
+**There was a third, and #515 fixed it rather than reproducing it.** A request
+omitting `credentials` used to **wipe** them, because the store's upsert
+overwrote the column wholesale — and `GET` scrubs the column, so the
+read-then-write an edit form performs destroyed the secret. It is now
+three-valued, `gateway::config::update_provider`'s contract: **absent leaves
+the column out of the `SET` list** so the stored blob survives byte for byte,
+and **any present value replaces it**, so `{}` and `null` are an explicit
+clear. Two `UPDATE` statements, not one with a `CASE` — the difference is
+*which columns are assigned*, and a `CASE` would still bind the blob's
+parameter slot on the path that must not have one. The absent arm never reads
+the credential into this process, so the module-header rule is intact.
+
+Two consequences worth carrying: the read gained **`has_credentials`**, a
+SQL-computed boolean (`''`, `null` and `{}` all count as absent, trimmed of
+ASCII whitespace) sorting between `enabled` and `id` on a response whose key
+order is the contract; and the reload stays **outside** both arms, because it
+is the *replace* path that must reload — a revoked token otherwise keeps
+answering `tools/call` for the life of the process.
 
 **Do not open the live database with a bare `rusqlite::Connection::open`.** It
 opens `READWRITE|CREATE`, and against a WAL database another process holds, that
@@ -2514,16 +2531,21 @@ busy timeout.
   `internal/api/types.go` has no such field, so the REST API silently drops it
   even though `AgentConfig` and the validator both know about it. The service
   also only accepts `""`, `bypass` or `default`, rejecting `plan`/`dontAsk`.
-- **`PUT /integrations/{id}` destroys credentials on a scrubbed round-trip.**
-  `integrationService.Update` explicitly preserves `Auth` ("unless the caller
-  provides a new one") but does **not** do the same for `Credentials`, which it
-  replaces wholesale — while `GET` scrubs them. So read-then-write wipes the
-  stored secrets. Reproduced live: a working Telegram token went from
-  `invalid bot token: … Unauthorized` (reaching Telegram) to
-  `credentials are empty` after one such PUT. The reference web frontend has
-  this flaw. **This UI refuses to save an integration with pending changes
-  until credentials are re-entered**, rather than silently wiping them —
-  do not "simplify" that away.
+- **`PUT /integrations/{id}` no longer destroys credentials on a scrubbed
+  round-trip, and this entry used to say the opposite** (#515). Go's
+  `integrationService.Update` preserved `Auth` ("unless the caller provides a
+  new one") and did **not** do the same for `Credentials`, which it replaced
+  wholesale while `GET` scrubbed them — reproduced live: a working Telegram
+  token went from `invalid bot token: … Unauthorized` (reaching Telegram) to
+  `credentials are empty` after one such PUT. **An omitted `credentials` key
+  now preserves the stored blob**, so a rename or a tool toggle is an ordinary
+  save. The UI's old workaround — refusing to save until the credentials were
+  re-entered, behind a warning in its own bottom section — is **gone with it**,
+  and must not be reintroduced: it existed to defend against this and now only
+  demands a token the user cannot read back. A stored secret renders as
+  `••• stored` behind an explicit *Replace*, beside **Name** on both the
+  connect and the edit screen, and an untouched field sends no `credentials`
+  key at all.
 - **Validation errors are 422**, conflicts 409 — not 400.
 - An invalid `sort` on the sessions list is silently accepted (falls back to
   `recent`); only a cursor/sort mismatch 400s.
@@ -3563,11 +3585,13 @@ Three things about it are decisions:
   existing. A command would have been wrong anyway: `logs.rs` is a command
   because the app log belongs to the *process*; gateway config is API surface.
 - **An omitted `api_key` preserves the stored one, and that is the whole point
-  of `config::update_provider`.** `PUT /api/integrations/{id}` wipes
+  of `config::update_provider`.** `PUT /api/integrations/{id}` used to wipe
   credentials the caller omits while `GET` scrubs them, so a read-then-write
-  round trip — exactly what an edit form does — destroys the secret. That is
-  reproduced there deliberately because it was Go's behaviour, and it must not
-  be inherited here. `api_key` is `Option<String>` with three meanings: absent
+  round trip — exactly what an edit form does — destroyed the secret. That was
+  reproduced there deliberately because it was Go's behaviour, and this surface
+  refused to inherit it; **#515 has since fixed the integrations side by
+  copying this one**, so the two now share a contract rather than disagreeing
+  about it. `api_key` is `Option<String>` with three meanings: absent
   leaves the column out of the `SET` list entirely, `Some("")` is a deliberate
   clear, `Some(k)` replaces. `a_scrubbed_read_written_straight_back_preserves_the_stored_key`
   drives the **real** `GET` body back through the `PUT`, and fails with `""` on
@@ -4282,12 +4306,13 @@ implementation existed and diverging from it would have made two installs
 behave differently on the same database. That constraint no longer exists —
 these are now simply Agento's bugs, and fixing them is unblocked.
 
-- **`PUT /api/integrations/{id}` wipes stored credentials on a scrubbed
-  round-trip.** `Update` preserves `Auth` but replaces `Credentials` wholesale,
-  while `GET` scrubs them — so read-then-write destroys the secret. The UI
-  works around it by refusing to save an integration with pending changes until
-  credentials are re-entered; **do not "simplify" that away** before the API is
-  fixed. This is data loss and the highest-value fix on this list.
+- ~~**`PUT /api/integrations/{id}` wipes stored credentials on a scrubbed
+  round-trip.**~~ **Fixed by #515** — the entry is kept struck through rather
+  than deleted, because it was the one this list called "data loss and the
+  highest-value fix", and the workaround it licensed (the UI refusing to save
+  until credentials were re-entered) is the thing a future session would
+  otherwise restore. See *Wire-format traps* above for the contract that
+  replaced it.
 - **An agent's `permission_mode` cannot be persisted.** `AgentRequest` has no
   such field, so the API silently drops it even though the config type and the
   validator both know about it.

--- a/src-tauri/src/native/integrations.rs
+++ b/src-tauri/src/native/integrations.rs
@@ -179,6 +179,19 @@ pub struct ScrubbedIntegration {
     pub authenticated: bool,
     pub created_at: GoTime,
     pub enabled: bool,
+    /// Whether a credential is stored — **not** the credential (#515).
+    ///
+    /// A wire addition with no Go ancestor, and the only way an edit form can
+    /// tell "a secret is stored" from "no secret" now that omitting the field
+    /// preserves it: without it the UI cannot know whether leaving the input
+    /// alone keeps something or keeps nothing. Computed in SQL by
+    /// [`has_credentials_sql`], the same discipline `authenticated` uses, so the
+    /// value itself never reaches this process.
+    ///
+    /// It sits here because the field order **is** the wire order and this one
+    /// is alphabetical (Go built the object from a map): `enabled` <
+    /// `has_credentials` < `id`.
+    pub has_credentials: bool,
     pub id: String,
     pub name: String,
     /// A nil Go map is `null` and an empty one is `{}`, and the stored column
@@ -240,26 +253,85 @@ pub struct TriggerRule {
 /// `credentials` is absent on purpose — see this module's header — and `auth`
 /// is collapsed to a boolean before it leaves SQLite. `ORDER BY name ASC` is
 /// the store's, and it has no tiebreak in Go either.
-const INTEGRATION_COLUMNS: &str = "SELECT id, name, type, enabled,
+/// A function rather than a `const` since #515, because it now interpolates
+/// [`has_credentials_sql`] — which `existing_for_update` needs too, and one
+/// predicate written out twice is one that drifts. Both callers already built
+/// their statement with `format!`.
+fn integration_columns() -> String {
+    format!(
+        "SELECT id, name, type, enabled,
             (auth IS NOT NULL AND auth != '' AND auth != 'null') AS authenticated,
+            {} AS has_credentials,
             services, created_at, updated_at
-     FROM integrations";
+     FROM integrations",
+        has_credentials_sql()
+    )
+}
+
+/// "This row stores a credential", decided in SQL so the blob is never selected.
+///
+/// Three shapes mean *no* credential and all three are reachable: `''` (what a
+/// pre-#515 `PUT` that omitted the key wrote, so every install has rows like
+/// this), the literal four bytes `null`, and `{}` — the column's own default,
+/// what `create`'s validator calls "credentials are empty", and what an
+/// explicit clear now stores.
+///
+/// Two differences from `authenticated`'s otherwise identical predicate, both
+/// deliberate. There is no `IS NOT NULL` arm, because `credentials` is
+/// `NOT NULL DEFAULT '{}'` where `auth` is nullable — an unreachable clause
+/// reads as a case somebody checked. And `TRIM` is here because `auth` is
+/// written by the OAuth flow, which only ever emits compact JSON, while
+/// `credentials` is stored **verbatim from the caller**: ` {} ` is a body this
+/// endpoint accepts, and untrimmed it would report a credential that is not
+/// there.
+///
+/// The trim set is spelled out rather than left to a bare `TRIM(X)`, which in
+/// SQLite removes **spaces only** while Rust's `str::trim` removes every
+/// Unicode whitespace character — so the two spellings disagreed on a stored
+/// `"\n"`, which is what [`tests::the_two_has_credentials_rules_agree`] caught.
+/// Both sides now trim exactly these four ASCII bytes and nothing else.
+/// (A function only because a `const` cannot interpolate the trim set, which
+/// appears three times.)
+fn has_credentials_sql() -> String {
+    // Space, tab, LF, CR — the same four `stores_a_credential` trims.
+    const WS: &str = "char(32) || char(9) || char(10) || char(13)";
+    format!(
+        "(TRIM(credentials, {WS}) != ''
+             AND TRIM(credentials, {WS}) != 'null'
+             AND TRIM(credentials, {WS}) != '{{}}')"
+    )
+}
+
+/// [`has_credentials_sql`] over bytes this process already holds, for the two
+/// writes that know what they just stored and must not re-read it.
+///
+/// Kept in step with the SQL by
+/// [`tests::the_two_has_credentials_rules_agree`], which runs both over the
+/// same shapes — a second spelling of a rule is a rule that drifts.
+fn stores_a_credential(raw: &str) -> bool {
+    // `str::trim`, deliberately not: it removes every Unicode whitespace
+    // character and SQLite's `TRIM(X, Y)` removes exactly the bytes in `Y`.
+    let raw = raw.trim_matches([' ', '\t', '\n', '\r']);
+    !raw.is_empty() && raw != "null" && raw != "{}"
+}
 
 fn scan_integration(row: &rusqlite::Row<'_>) -> rusqlite::Result<ScrubbedIntegration> {
     let enabled: i64 = row.get(3)?;
     let authenticated: i64 = row.get(4)?;
-    let services: String = row.get(5)?;
-    let created_at: String = row.get(6)?;
-    let updated_at: String = row.get(7)?;
+    let has_credentials: i64 = row.get(5)?;
+    let services: String = row.get(6)?;
+    let created_at: String = row.get(7)?;
+    let updated_at: String = row.get(8)?;
     Ok(ScrubbedIntegration {
         authenticated: authenticated != 0,
-        created_at: super::gotime::from_sql_text(&created_at, 6)?,
+        created_at: super::gotime::from_sql_text(&created_at, 7)?,
         enabled: enabled != 0,
+        has_credentials: has_credentials != 0,
         id: row.get(0)?,
         name: row.get(1)?,
         services: decode_services(&services),
         integration_type: row.get(2)?,
-        updated_at: super::gotime::from_sql_text(&updated_at, 7)?,
+        updated_at: super::gotime::from_sql_text(&updated_at, 8)?,
     })
 }
 
@@ -284,7 +356,7 @@ fn decode_services(raw: &str) -> Option<BTreeMap<String, ServiceConfig>> {
 /// an install with none answers `[]` rather than `null`.
 pub fn list(db_path: &Path) -> Result<Vec<ScrubbedIntegration>, String> {
     let conn = super::db::open_read_only(db_path)?;
-    let sql = format!("{INTEGRATION_COLUMNS}\n     ORDER BY name ASC");
+    let sql = format!("{}\n     ORDER BY name ASC", integration_columns());
     let mut stmt = conn
         .prepare(&sql)
         .map_err(|e| format!("preparing integration list: {e}"))?;
@@ -301,7 +373,7 @@ pub fn list(db_path: &Path) -> Result<Vec<ScrubbedIntegration>, String> {
 /// One integration, or `None` when no row has that id.
 pub fn get(db_path: &Path, id: &str) -> Result<Option<ScrubbedIntegration>, String> {
     let conn = super::db::open_read_only(db_path)?;
-    let sql = format!("{INTEGRATION_COLUMNS}\n     WHERE id = ?1");
+    let sql = format!("{}\n     WHERE id = ?1", integration_columns());
     conn.query_row(&sql, [id], scan_integration)
         .optional()
         .map_err(|e| format!("getting integration {id:?}: {e}"))
@@ -764,6 +836,9 @@ fn create(db_path: &Path, body: &[u8]) -> Result<super::Answer, WriteError> {
         authenticated: false,
         created_at: parse_written(&now)?,
         enabled: req.enabled,
+        // From the bytes just stored rather than a re-read: this is the one
+        // path that legitimately holds the blob, because the caller supplied it.
+        has_credentials: stores_a_credential(&credentials),
         id,
         name: req.name,
         services: Some(services),
@@ -818,12 +893,30 @@ struct UpdateIntegrationRequest {
 /// as are an empty `name` and an empty `type`. Adding the create-side checks
 /// here would refuse requests Go applies.
 ///
-/// Three things the store's upsert does that look like bugs and are the
+/// **`credentials` used to be overwritten wholesale, and since #515 it is
+/// not.** This is the one place the port deliberately diverges from the
+/// behaviour it inherited, because that behaviour was data loss: `GET` scrubs
+/// the column, so a read-then-write round trip — which is exactly what an edit
+/// form is — destroyed the stored secret, and the UI had to demand a re-typed
+/// token before it would save a rename. The field is now three-valued, the
+/// contract `gateway::config::update_provider` already uses for `api_key`:
+///
+/// - **absent** — the column is left out of the `SET` list entirely, so the
+///   stored blob survives byte for byte. This is what a scrubbed `GET`
+///   round-trips to.
+/// - **present** — stored verbatim, whatever it is. `{}` and `null` are
+///   therefore an explicit *clear*: they replace the secret with a blob that
+///   [`stores_a_credential`] reads as empty, which is what `create`'s own
+///   validator already calls "credentials are empty". There is no separate
+///   sentinel, because "replace with what you sent" needs none.
+///
+/// The absent arm never reads the stored credential into this process, so the
+/// module-header rule holds — it is the same discipline the `auth` rewrite
+/// below uses, one level up: *do not read what you only need to keep*.
+///
+/// Two things the store's upsert does that look like bugs and **are** the
 /// behaviour to reproduce:
 ///
-/// - **`credentials` is overwritten wholesale.** A `PUT` that omits the key
-///   stores `""` — it wipes the secret rather than preserving it. The frontend
-///   always sends the whole object; a hand-written request does not have to.
 /// - **`services` is not defaulted.** `Create` fills a nil map with `make(...)`
 ///   before saving; `Update` does not, so an omitted `services` is the literal
 ///   `null` in the column *and* `null` in the response, where a create would
@@ -851,11 +944,10 @@ fn update(db_path: &Path, id: &str, body: &[u8]) -> Result<super::Answer, WriteE
     let created_at = parse_stored(&existing.created_at)?;
 
     let now = super::gotime::now_go_text();
-    let credentials = req
-        .credentials
-        .as_ref()
-        .map(|c| c.get().to_string())
-        .unwrap_or_default();
+    // Three-valued, and `.unwrap_or_default()` here was the whole bug: it
+    // flattened "the caller sent nothing" into "the caller sent an empty
+    // string" and then wrote it.
+    let credentials = req.credentials.as_ref().map(|c| c.get());
     // `json.Marshal(cfg.Services)`: a nil map is `null`, an empty one is `{}`.
     let services_json = super::gojson::to_vec_marshal(&req.services)
         .map_err(|e| WriteError::Fallback(format!("marshaling services: {e}")))?;
@@ -873,8 +965,15 @@ fn update(db_path: &Path, id: &str, body: &[u8]) -> Result<super::Answer, WriteE
     // round trip does change is the two non-token spellings — a column holding
     // `''` or the literal four bytes `null` fails `IsAuthenticated`, so the
     // update writes SQL `NULL` in its place.
-    conn.execute(
-        "UPDATE integrations SET
+    //
+    // Two statements rather than one with a `CASE`, which is
+    // `gateway::config::update_provider`'s reasoning verbatim: the difference
+    // is *which columns are assigned*, and a
+    // `CASE WHEN ?4 IS NULL THEN credentials ELSE ?4 END` would still bind the
+    // blob's parameter slot on the path that must not have one.
+    match credentials {
+        Some(blob) => conn.execute(
+            "UPDATE integrations SET
             name = ?1, type = ?2, enabled = ?3,
             credentials = ?4, services = ?5, updated_at = ?6,
             auth = CASE
@@ -882,16 +981,35 @@ fn update(db_path: &Path, id: &str, body: &[u8]) -> Result<super::Answer, WriteE
                 ELSE NULL
             END
          WHERE id = ?7",
-        rusqlite::params![
-            &req.name,
-            &req.integration_type,
-            i64::from(req.enabled),
-            &credentials,
-            &services_json,
-            &now,
-            id,
-        ],
-    )
+            rusqlite::params![
+                &req.name,
+                &req.integration_type,
+                i64::from(req.enabled),
+                blob,
+                &services_json,
+                &now,
+                id,
+            ],
+        ),
+        None => conn.execute(
+            "UPDATE integrations SET
+            name = ?1, type = ?2, enabled = ?3,
+            services = ?4, updated_at = ?5,
+            auth = CASE
+                WHEN auth IS NOT NULL AND auth != '' AND auth != 'null' THEN auth
+                ELSE NULL
+            END
+         WHERE id = ?6",
+            rusqlite::params![
+                &req.name,
+                &req.integration_type,
+                i64::from(req.enabled),
+                &services_json,
+                &now,
+                id,
+            ],
+        ),
+    }
     .map_err(|e| WriteError::Fallback(format!("saving integration: {e}")))?;
     drop(conn);
 
@@ -905,6 +1023,12 @@ fn update(db_path: &Path, id: &str, body: &[u8]) -> Result<super::Answer, WriteE
         authenticated: existing.authenticated,
         created_at,
         enabled: req.enabled,
+        // What the row holds *now*: the blob just written when the caller sent
+        // one, and whatever was already there when it did not.
+        has_credentials: match credentials {
+            Some(blob) => stores_a_credential(blob),
+            None => existing.has_credentials,
+        },
         id: id.to_string(),
         name: req.name,
         services: req.services.map(unwrap_services),
@@ -948,11 +1072,14 @@ fn delete(db_path: &Path, id: &str) -> Result<super::Answer, WriteError> {
 ///
 /// `created_at` because the response carries it and the column keeps it;
 /// `authenticated` because the response reports it — computed in SQL, so this
-/// stays a read that cannot hold a secret; `type` because it decides whether
-/// this process may answer at all. Absent means 404.
+/// stays a read that cannot hold a secret; `has_credentials` for the same
+/// reason and on the same terms, because a `PUT` that omits the field now
+/// preserves the column and so has to report what is *already* there; `type`
+/// because it decides whether this process may answer at all. Absent means 404.
 struct ExistingIntegration {
     created_at: String,
     authenticated: bool,
+    has_credentials: bool,
     integration_type: String,
 }
 
@@ -961,17 +1088,23 @@ fn existing_for_update(
     id: &str,
 ) -> Result<Option<ExistingIntegration>, WriteError> {
     conn.query_row(
-        "SELECT created_at,
+        &format!(
+            "SELECT created_at,
                 (auth IS NOT NULL AND auth != '' AND auth != 'null') AS authenticated,
+                {} AS has_credentials,
                 type
          FROM integrations WHERE id = ?1",
+            has_credentials_sql()
+        ),
         [id],
         |row| {
             let authenticated: i64 = row.get(1)?;
+            let has_credentials: i64 = row.get(2)?;
             Ok(ExistingIntegration {
                 created_at: row.get(0)?,
                 authenticated: authenticated != 0,
-                integration_type: row.get(2)?,
+                has_credentials: has_credentials != 0,
+                integration_type: row.get(3)?,
             })
         },
     )
@@ -1356,9 +1489,57 @@ mod tests {
         for body in bodies {
             let json = String::from_utf8(body).expect("utf8");
             assert!(!json.contains(SECRET), "a secret reached the wire: {json}");
-            assert!(!json.contains("credentials"), "{json}");
+            // The **key**, quoted on both sides: since #515 every body carries
+            // `has_credentials`, which is a boolean about the column and
+            // contains the word. A bare substring check would either fail on
+            // that or, softened to a word, stop catching `"credentials":`.
+            assert!(!json.contains(r#""credentials""#), "{json}");
             assert!(!json.contains("bot_token"), "{json}");
             assert!(!json.contains(r#""auth""#), "{json}");
+        }
+    }
+
+    /// The same guarantee over the **write** bodies, which the read-side test
+    /// above cannot reach: `create` is the one path that legitimately holds the
+    /// blob, and `update` echoes a row whose credential it just preserved
+    /// without reading. Over the bytes, not over a struct field — a
+    /// field-level check only proves the fields the test already knows about.
+    #[test]
+    fn no_write_response_carries_a_credential_either() {
+        let file = migrated();
+        let created = create(
+            file.path(),
+            format!(
+                r#"{{"name":"N","type":"github",
+                     "credentials":{{"auth_mode":"pat","personal_access_token":"{SECRET}"}}}}"#
+            )
+            .as_bytes(),
+        )
+        .expect("create");
+        let id = serde_json::from_str::<serde_json::Value>(&body_of(&created)).expect("json")["id"]
+            .as_str()
+            .expect("an id")
+            .to_string();
+
+        let bodies = [
+            body_of(&created),
+            // The preserve arm…
+            body_of(&update(file.path(), &id, br#"{"name":"R","type":"github"}"#).expect("update")),
+            // …and the replace arm.
+            body_of(
+                &update(
+                    file.path(),
+                    &id,
+                    format!(r#"{{"name":"R","type":"github","credentials":{{"pat":"{SECRET}"}}}}"#)
+                        .as_bytes(),
+                )
+                .expect("update"),
+            ),
+        ];
+        for json in bodies {
+            assert!(!json.contains(SECRET), "a secret reached the wire: {json}");
+            assert!(!json.contains(r#""credentials""#), "{json}");
+            assert!(!json.contains("pat"), "{json}");
         }
     }
 
@@ -1458,6 +1639,11 @@ mod tests {
             String::from_utf8(body).expect("utf8"),
             concat!(
                 r#"{"authenticated":true,"created_at":"2026-08-01T10:00:00Z","enabled":true,"#,
+                // #515's addition, and its **position** is the assertion: it
+                // sorts between `enabled` and `id`, which is where the field
+                // sits in the struct. Declared anywhere else it would move a
+                // byte on a response whose key order is the contract.
+                r#""has_credentials":true,"#,
                 // `<` and `>` arrive escaped: `writeJSON` uses `json.Encoder`,
                 // which HTML-escapes by default.
                 r#""id":"zulu-int","name":"Zulu \u003cwork\u003e","services":{"messaging":"#,
@@ -1904,8 +2090,10 @@ mod tests {
             "{body}"
         );
         assert!(!body.contains("2026-01-02T00:00:00Z"), "{body}");
-        // No secret, on either the way in or the way out.
-        assert!(!body.contains("credentials"), "{body}");
+        // No secret, on either the way in or the way out. The key is quoted
+        // on both sides because `has_credentials` contains the word.
+        assert!(!body.contains(r#""credentials""#), "{body}");
+        assert!(body.contains(r#""has_credentials":true"#), "{body}");
         assert!(!body.contains("pat"), "{body}");
         assert!(!body.contains("KEEP-ME"), "{body}");
 
@@ -1928,17 +2116,235 @@ mod tests {
         );
     }
 
-    /// The store's upsert overwrites `credentials` wholesale, so a `PUT` that
-    /// omits the key **wipes the secret**. Not helpfully preserved: the write
-    /// has to be the one Go performs, or the two databases diverge on a column
-    /// nothing else can reconcile.
+    /// #515, and the inverse of what this test asserted until then: a `PUT`
+    /// that omits the key **preserves** the secret, byte for byte.
+    ///
+    /// It was `a_put_that_omits_credentials_wipes_them`, pinning the store's
+    /// wholesale overwrite on the reasoning that the write "has to be the one
+    /// Go performs, or the two databases diverge on a column nothing else can
+    /// reconcile". There is no second implementation to diverge from since
+    /// #391, and what the rule was protecting was a data-loss bug: `GET`
+    /// scrubs this column, so the read-then-write an edit form performs
+    /// destroyed the stored credential.
+    ///
+    /// The fixture blob is **multi-key, out of alphabetical order, with a
+    /// trailing-zero decimal and interior whitespace** for the same reason
+    /// `decode_body`'s own tests use one: a single-key blob is a fixed point of
+    /// every round trip that could rebuild it, so it would pass against a
+    /// preservation that went through a re-serialization.
     #[test]
-    fn a_put_that_omits_credentials_wipes_them() {
+    fn a_put_that_omits_credentials_preserves_them() {
+        let file = migrated();
+        let conn = Connection::open(file.path()).expect("open");
+        conn.execute(
+            "INSERT INTO integrations (id, name, type, enabled, credentials, auth, services,
+                                       created_at, updated_at)
+             VALUES ('int-1', 'Original', 'github', 1, ?1, '{\"token\":\"t\"}', '{}',
+                     '2026-01-01 00:00:00 +0000 UTC', '2026-01-02 00:00:00 +0000 UTC')",
+            [r#"{"zebra":"z", "pat":"KEEP-ME","rate":1.50}"#],
+        )
+        .expect("seed");
+        drop(conn);
+
+        let answer =
+            update(file.path(), "int-1", br#"{"name":"N","type":"github"}"#).expect("update");
+
+        assert_eq!(
+            stored(&file, "SELECT credentials FROM integrations"),
+            r#"{"zebra":"z", "pat":"KEEP-ME","rate":1.50}"#,
+            "an omitted credentials key must leave the column untouched"
+        );
+        // The rest of the row still moved, so this is preservation rather than
+        // a write that did not happen.
+        assert_eq!(stored(&file, "SELECT name FROM integrations"), "N");
+        // And the response says a credential is there, which is the only way an
+        // edit form can tell "leaving this alone keeps something" from
+        // "leaving this alone keeps nothing".
+        assert!(
+            body_of(&answer).contains(r#""has_credentials":true"#),
+            "{}",
+            body_of(&answer)
+        );
+    }
+
+    /// The other two arms of the three-valued field. Both are a `Some`, so both
+    /// are stored verbatim — there is no clear sentinel, because "replace with
+    /// what you sent" needs none, and both spellings read as empty.
+    #[test]
+    fn an_explicit_empty_credentials_clears_the_stored_one() {
+        for (body, want) in [
+            (
+                br#"{"name":"N","type":"github","credentials":{}}"#.as_slice(),
+                "{}",
+            ),
+            (
+                br#"{"name":"N","type":"github","credentials":null}"#.as_slice(),
+                "null",
+            ),
+        ] {
+            let file = migrated();
+            seed_full_integration(&file, "int-1", Some(r#"{"token":"t"}"#));
+
+            let answer = update(file.path(), "int-1", body).expect("update");
+
+            assert_eq!(
+                stored(&file, "SELECT credentials FROM integrations"),
+                want,
+                "an explicit {want} must replace the stored blob"
+            );
+            assert!(
+                body_of(&answer).contains(r#""has_credentials":false"#),
+                "{}",
+                body_of(&answer)
+            );
+        }
+    }
+
+    /// The integration twin of
+    /// `gateway::config::tests::a_scrubbed_read_written_straight_back_preserves_the_stored_key`,
+    /// and the shape that matters: it drives the **real** `GET` body back
+    /// through the `PUT` rather than a hand-written approximation of it, so it
+    /// fails if the read ever starts emitting a `credentials` key the write
+    /// would then honour as an empty blob.
+    ///
+    /// This is the user-facing bug in one test: open an integration, change its
+    /// name, save. It fails on the revert.
+    #[test]
+    fn a_scrubbed_read_written_straight_back_preserves_the_stored_credential() {
         let file = migrated();
         seed_full_integration(&file, "int-1", Some(r#"{"token":"t"}"#));
+        let before = stored(&file, "SELECT credentials FROM integrations");
+        assert!(before.contains(SECRET), "the fixture must seed a secret");
 
-        update(file.path(), "int-1", br#"{"name":"N","type":"github"}"#).expect("update");
-        assert_eq!(stored(&file, "SELECT credentials FROM integrations"), "");
+        // Exactly what the edit form has: the scrubbed read, with one field
+        // edited and nothing else touched.
+        let read = get(file.path(), "int-1").expect("get").expect("a row");
+        let mut round_trip: serde_json::Map<String, serde_json::Value> =
+            serde_json::from_slice(&super::super::gojson::to_vec(&read).expect("encode"))
+                .expect("decode");
+        assert!(
+            !round_trip.contains_key("credentials"),
+            "the read must not carry the column at all: {round_trip:?}"
+        );
+        round_trip.insert("name".into(), serde_json::json!("Renamed"));
+
+        update(
+            file.path(),
+            "int-1",
+            &serde_json::to_vec(&round_trip).expect("encode request"),
+        )
+        .expect("update");
+
+        assert_eq!(
+            stored(&file, "SELECT credentials FROM integrations"),
+            before,
+            "renaming an integration destroyed its credential"
+        );
+        assert_eq!(stored(&file, "SELECT name FROM integrations"), "Renamed");
+    }
+
+    /// The reload is **outside** the credentials branch, so neither arm can
+    /// skip it.
+    ///
+    /// This is the hazard #515's two-statement split introduces and nothing
+    /// else would report: a hosted MCP server closes over the credential it was
+    /// started with, so an update that persists a *replaced* token without
+    /// reloading leaves the revoked one answering `tools/call` for the life of
+    /// the process — a 200 saying the save worked. Moving `reload_blocking`
+    /// into the `Some` arm even *reads* like a tightening ("only reload when
+    /// the credential changed"), and it is the exact inverse: it is the replace
+    /// path that must reload.
+    ///
+    /// Asserted against the source because `reload_blocking` is
+    /// `block_on_detached` fire-and-forget with no observable effect on a
+    /// database this test could inspect — the same reason
+    /// `lib.rs`'s startup-ordering guards read their own file. It is a
+    /// structural claim, and structure is what the source shows.
+    #[test]
+    fn the_registry_reload_is_not_inside_either_credentials_arm() {
+        const SOURCE: &str = include_str!("integrations.rs");
+        let update_fn = SOURCE
+            .split_once("fn update(db_path: &Path, id: &str, body: &[u8])")
+            .expect("update is still spelled this way")
+            .1;
+        let body = &update_fn[..update_fn.find("fn delete(").expect("delete follows update")];
+
+        let branch = body
+            .find("match credentials {")
+            .expect("the three-valued branch");
+        let reload = body
+            .find("registry::reload_blocking(db_path, id);")
+            .expect("the reload");
+        assert!(
+            reload > branch,
+            "the reload must follow the branch, not precede it"
+        );
+        // Between them there must be the branch's own closing `.map_err(...)?`
+        // and the `drop(conn)` — i.e. the reload is at the function's top
+        // level. The cheap structural proxy: exactly one `reload_blocking`
+        // call, so it cannot have been duplicated into both arms either.
+        assert_eq!(
+            body.matches("registry::reload_blocking").count(),
+            1,
+            "one unconditional reload, not one per arm"
+        );
+        let between = &body[branch..reload];
+        assert!(
+            between.contains("drop(conn);"),
+            "the reload sits after the write completes, outside the match"
+        );
+    }
+
+    /// One rule, two spellings — [`has_credentials_sql`] and
+    /// [`stores_a_credential`] — because the write path knows the bytes it just
+    /// stored and must not re-read a column this module is not allowed to
+    /// select. Drift between them is a response that lies about whether a
+    /// secret is there, so it is asserted rather than assumed.
+    #[test]
+    fn the_two_has_credentials_rules_agree() {
+        let file = migrated();
+        let conn = Connection::open(file.path()).expect("open");
+        let shapes = [
+            "",
+            "null",
+            "{}",
+            " {} ",
+            "\n",
+            "\t{}\r\n",
+            // A NO-BREAK SPACE, which `str::trim` removes and SQLite's
+            // `TRIM(X, Y)` does not — so both sides must call this one a
+            // credential, and neither may quietly widen its trim set.
+            "\u{a0}",
+            r#"{"pat":"x"}"#,
+            r#"{"pat":""}"#,
+            "[]",
+            "0",
+        ];
+        for (n, shape) in shapes.iter().enumerate() {
+            conn.execute(
+                "INSERT INTO integrations (id, name, type, enabled, credentials, auth, services,
+                                           created_at, updated_at)
+                 VALUES (?1, 'n', 'github', 1, ?2, NULL, '{}',
+                         '2026-01-01 00:00:00 +0000 UTC', '2026-01-01 00:00:00 +0000 UTC')",
+                rusqlite::params![format!("row-{n}"), shape],
+            )
+            .expect("seed");
+            let in_sql: i64 = conn
+                .query_row(
+                    &format!(
+                        "SELECT {} FROM integrations WHERE id = ?1",
+                        has_credentials_sql()
+                    ),
+                    [format!("row-{n}")],
+                    |row| row.get(0),
+                )
+                .expect("query");
+            assert_eq!(
+                in_sql != 0,
+                stores_a_credential(shape),
+                "the two rules disagree about {shape:?}"
+            );
+        }
     }
 
     /// `Update` does **not** default a nil services map the way `Create` does,

--- a/src-tauri/src/native/integrations.rs
+++ b/src-tauri/src/native/integrations.rs
@@ -285,6 +285,12 @@ fn integration_columns() -> String {
 /// endpoint accepts, and untrimmed it would report a credential that is not
 /// there.
 ///
+/// The trim covers **exterior** whitespace only, so `{ }` still reads as a
+/// credential. That is an approximation and it is the deliberate one: deciding
+/// otherwise means parsing the blob, which is reading it, which this module may
+/// not do. Nothing the UI sends can reach it — `JSON.stringify` emits no
+/// interior space — and `authenticated` still reports the truth beside it.
+///
 /// The trim set is spelled out rather than left to a bare `TRIM(X)`, which in
 /// SQLite removes **spaces only** while Rust's `str::trim` removes every
 /// Unicode whitespace character — so the two spellings disagreed on a stored

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -123,6 +123,13 @@ export interface Integration {
   type: string;
   enabled: boolean;
   authenticated: boolean;
+  /**
+   * Whether a credential is stored — never the credential itself (#515).
+   * Computed in SQL, so the value never reaches this process, let alone the
+   * webview. It is what lets the edit form say "leaving this alone keeps the
+   * stored one" rather than demanding a re-typed token on every save.
+   */
+  has_credentials: boolean;
   services: Record<string, ServiceConfig>;
   created_at: string;
   updated_at: string;

--- a/src/styles/integrations.css
+++ b/src/styles/integrations.css
@@ -212,3 +212,18 @@
   font-size: var(--text-base);
   color: var(--fg-secondary);
 }
+
+/* --- A stored secret, in place of the input that would replace it --------- */
+
+/* The gateway's `.gw-storedkey` is the same row, and this is deliberately a
+   second declaration rather than a shared class: `gateway.css` is imported only
+   by the gateway views, so reaching for `.gw-` here would leave this row
+   styled by whichever other section happened to be bundled — an accident of the
+   build, not an import. Same reasoning as `charts.tsx` carrying its own sheet. */
+.int-storedsecret {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+  min-height: var(--control-h);
+  color: var(--fg-secondary);
+}

--- a/src/views/IntegrationsView.tsx
+++ b/src/views/IntegrationsView.tsx
@@ -61,6 +61,31 @@ function buildCredentials(
   return out;
 }
 
+/**
+ * The credentials blob for a *save*, or `undefined` when the user typed
+ * nothing (#515).
+ *
+ * `PUT /api/integrations/{id}` is three-valued: an absent `credentials` key
+ * leaves the stored blob alone, and any present value — `{}` included —
+ * replaces it. So "the user did not touch the credential fields" has to be
+ * spelled as *sending no key*, which is what `undefined` becomes when the
+ * request object is spread. Building the blob unconditionally is what used to
+ * make every save a wipe, and it is why the field had its own quarantined
+ * section behind a warning.
+ *
+ * This is `ProvidersView`'s `...(hasKey ? { api_key } : {})`, one level up:
+ * there the credential is one string, here it is a map, so "typed nothing" is
+ * "no field of the selected mode has a value".
+ */
+function credentialsToSave(
+  provider: Provider,
+  mode: AuthMode,
+  values: Record<string, string>
+): Record<string, string> | undefined {
+  const typed = mode.fields.some((f) => (values[f.key] ?? "").trim() !== "");
+  return typed ? buildCredentials(provider, mode, values) : undefined;
+}
+
 function credentialsComplete(mode: AuthMode, values: Record<string, string>): boolean {
   return mode.fields.every((f) => (values[f.key] ?? "").trim() !== "");
 }
@@ -623,29 +648,49 @@ function IntegrationDetail({
 
   const mode = provider.modes.find((m) => m.value === modeValue) ?? provider.modes[0];
   const needsCredentials = mode.fields.length > 0;
+  /**
+   * Whether the credential inputs are shown at all (#515). A stored secret
+   * renders as `••• stored` behind an explicit *Replace*, because Agento
+   * cannot show it back and no longer needs to: an untouched field sends no
+   * `credentials` key and the stored blob survives.
+   *
+   * It starts open when there is nothing stored, which is the one case where
+   * leaving the field alone keeps the integration unusable.
+   */
+  const [replacing, setReplacing] = useState(!item.has_credentials);
+  const typedCredentials = mode.fields.some((f) => (values[f.key] ?? "").trim() !== "");
 
   const changed =
     name !== item.name ||
     enabled !== item.enabled ||
     JSON.stringify(services) !== JSON.stringify(item.services ?? {}) ||
-    Object.values(values).some((v) => v.trim() !== "");
+    typedCredentials;
 
+  // A credential is required only when the user is actually supplying one:
+  // a half-filled mode would be saved as a blob with empty values, which is a
+  // broken credential rather than a preserved one. Not typing anything is now
+  // a complete, valid save — that is the whole point of #515.
   const canSave =
-    changed && name.trim() !== "" && (!needsCredentials || credentialsComplete(mode, values));
+    changed && name.trim() !== "" && (!typedCredentials || credentialsComplete(mode, values));
 
   async function save() {
     setBusy(true);
     setError(undefined);
     setNotice(undefined);
     try {
+      const credentials = credentialsToSave(provider, mode, values);
       await api.put<Integration>(`/integrations/${item.id}`, {
         name: name.trim(),
         type: item.type,
         enabled,
-        credentials: buildCredentials(provider, mode, values),
+        // Spread, never `credentials: undefined` — `JSON.stringify` drops an
+        // undefined value, but spelling it this way is what makes "send no
+        // key" the visible intent rather than a serializer side effect.
+        ...(credentials ? { credentials } : {}),
         services,
       });
       setValues({});
+      setReplacing(false);
       setNotice("Saved.");
       onChanged();
     } catch (err) {
@@ -672,6 +717,7 @@ function IntegrationDetail({
     setEnabled(item.enabled);
     setServices(item.services ?? {});
     setValues({});
+    setReplacing(!item.has_credentials);
     setError(undefined);
     setNotice(undefined);
   }
@@ -723,8 +769,12 @@ function IntegrationDetail({
 
           <div className="divider" />
 
+          {/* The connect screen's *Connection* block, and deliberately the
+              same shape: Name, then the auth method, then the credential —
+              rather than the quarantined bottom section this used to be. See
+              `credentialsToSave`. */}
           <div className="formsec">
-            <div className="formsec__title">Settings</div>
+            <div className="formsec__title">Connection</div>
             <div className="formrow">
               <div className="formrow__label">Name</div>
               <div className="formrow__control">
@@ -737,6 +787,48 @@ function IntegrationDetail({
                 </label>
               </div>
             </div>
+
+            {needsCredentials &&
+              (replacing ? (
+                <>
+                  {provider.modes.length > 1 && (
+                    <div className="formrow">
+                      <div className="formrow__label">Auth method</div>
+                      <div className="formrow__control">
+                        <Segmented
+                          value={modeValue}
+                          options={provider.modes.map((m) => ({
+                            value: m.value,
+                            label: m.label,
+                          }))}
+                          onChange={setModeValue}
+                        />
+                      </div>
+                    </div>
+                  )}
+                  <CredentialFields mode={mode} values={values} onChange={setValues} />
+                </>
+              ) : (
+                /* The auth method is part of the credential blob, so it is
+                   offered only alongside the fields that carry it: changing it
+                   on its own would send nothing and silently do nothing. */
+                <div className="formrow">
+                  <div className="formrow__label">{mode.label}</div>
+                  <div className="formrow__control">
+                    <div className="int-storedsecret">
+                      <span className="mono">••••••••••• stored</span>
+                      <button className="btn btn--ghost" onClick={() => setReplacing(true)}>
+                        Replace
+                      </button>
+                    </div>
+                    <div className="formrow__help">
+                      Agento cannot show a stored secret back to you, and does not need to —
+                      leave this alone and saving keeps it.
+                    </div>
+                  </div>
+                </div>
+              ))}
+
             <div className="formrow">
               <div className="formrow__label">Enabled</div>
               <div className="formrow__control">
@@ -756,44 +848,6 @@ function IntegrationDetail({
             <div className="formsec__title">Services and tools</div>
             <ServiceEditor provider={provider} services={services} onChange={setServices} />
           </div>
-
-          {needsCredentials && (
-            <>
-              <div className="divider" />
-              <div className="formsec">
-                <div className="formsec__title">Credentials</div>
-                {/* The API replaces credentials wholesale on every update and
-                    never sends the stored ones back, so a save that omitted
-                    them would silently wipe the integration's secrets. */}
-                <div className="msgline msgline--warn">
-                  <span className="msgline__icon">
-                    <Icon name="shield" size={13} />
-                  </span>
-                  <span>
-                    Agento never returns stored secrets, and saving replaces them. Re-enter
-                    the credentials below to save any change on this page — otherwise the
-                    stored ones would be cleared.
-                  </span>
-                </div>
-                {provider.modes.length > 1 && (
-                  <div className="formrow">
-                    <div className="formrow__label">Auth method</div>
-                    <div className="formrow__control">
-                      <Segmented
-                        value={modeValue}
-                        options={provider.modes.map((m) => ({
-                          value: m.value,
-                          label: m.label,
-                        }))}
-                        onChange={setModeValue}
-                      />
-                    </div>
-                  </div>
-                )}
-                <CredentialFields mode={mode} values={values} onChange={setValues} />
-              </div>
-            </>
-          )}
 
           {error && (
             <div className="msgline msgline--error">
@@ -817,9 +871,9 @@ function IntegrationDetail({
               <span className="savebar__text">
                 {canSave
                   ? "You have unsaved changes."
-                  : needsCredentials
-                    ? "Re-enter the credentials above to save."
-                    : "A name is required."}
+                  : name.trim() === ""
+                    ? "A name is required."
+                    : "Fill in every credential field, or clear them to keep the stored ones."}
               </span>
               <button className="btn" onClick={revert} disabled={busy}>
                 Revert

--- a/src/views/IntegrationsView.tsx
+++ b/src/views/IntegrationsView.tsx
@@ -82,12 +82,28 @@ function credentialsToSave(
   mode: AuthMode,
   values: Record<string, string>
 ): Record<string, string> | undefined {
-  const typed = mode.fields.some((f) => (values[f.key] ?? "").trim() !== "");
-  return typed ? buildCredentials(provider, mode, values) : undefined;
+  return hasTypedCredentials(mode, values)
+    ? buildCredentials(provider, mode, values)
+    : undefined;
 }
 
 function credentialsComplete(mode: AuthMode, values: Record<string, string>): boolean {
   return mode.fields.every((f) => (values[f.key] ?? "").trim() !== "");
+}
+
+/**
+ * Whether the user has supplied a credential at all — the predicate that
+ * decides both whether a save *sends* a `credentials` key and whether the form
+ * insists the blob be complete before it will.
+ *
+ * One function rather than the same `.some()` written at both sites: the two
+ * are only correct while they agree, and a gate that disagrees with what is
+ * actually sent is either a half-filled blob saved as a credential or a save
+ * button that never enables. This is the frontend half of the rule
+ * `the_two_has_credentials_rules_agree` pins on the backend.
+ */
+function hasTypedCredentials(mode: AuthMode, values: Record<string, string>): boolean {
+  return mode.fields.some((f) => (values[f.key] ?? "").trim() !== "");
 }
 
 function countTools(services: Services | null | undefined): number {
@@ -658,7 +674,7 @@ function IntegrationDetail({
    * leaving the field alone keeps the integration unusable.
    */
   const [replacing, setReplacing] = useState(!item.has_credentials);
-  const typedCredentials = mode.fields.some((f) => (values[f.key] ?? "").trim() !== "");
+  const typedCredentials = hasTypedCredentials(mode, values);
 
   const changed =
     name !== item.name ||
@@ -690,7 +706,14 @@ function IntegrationDetail({
         services,
       });
       setValues({});
-      setReplacing(false);
+      // Collapse to `••• stored` only when this save actually stored one.
+      // `IntegrationDetail` is keyed on the integration id, so `onChanged()`
+      // does not remount it and the `useState` seed below never re-runs — an
+      // unconditional `false` would leave a row with nothing stored showing
+      // the masked line, claiming a secret that is not there and hiding the
+      // one field that would fix it. `item` is still the pre-reload prop,
+      // which is exactly right on the path where no credential was sent.
+      setReplacing(credentials ? false : !item.has_credentials);
       setNotice("Saved.");
       onChanged();
     } catch (err) {
@@ -811,9 +834,17 @@ function IntegrationDetail({
               ) : (
                 /* The auth method is part of the credential blob, so it is
                    offered only alongside the fields that carry it: changing it
-                   on its own would send nothing and silently do nothing. */
+                   on its own would send nothing and silently do nothing.
+
+                   The label is deliberately **not** `mode.label`. `modeValue`
+                   seeds from `provider.modes[0]` and nothing reports the stored
+                   `auth_mode`, so on the one multi-mode provider (Slack) a row
+                   connected by OAuth would be captioned "Bot token". Before
+                   this section moved, that default sat on an *input* the user
+                   was about to fill; as a caption on a stored secret it is a
+                   statement of fact the app cannot make. */
                 <div className="formrow">
-                  <div className="formrow__label">{mode.label}</div>
+                  <div className="formrow__label">Credentials</div>
                   <div className="formrow__control">
                     <div className="int-storedsecret">
                       <span className="mono">••••••••••• stored</span>
@@ -873,7 +904,9 @@ function IntegrationDetail({
                   ? "You have unsaved changes."
                   : name.trim() === ""
                     ? "A name is required."
-                    : "Fill in every credential field, or clear them to keep the stored ones."}
+                    : item.has_credentials
+                      ? "Fill in every credential field, or clear them to keep the stored ones."
+                      : "Fill in every credential field."}
               </span>
               <button className="btn" onClick={revert} disabled={busy}>
                 Revert


### PR DESCRIPTION
Closes #515

## What

`PUT /api/integrations/{id}` now treats `credentials` as **three-valued**, the contract `PUT /api/gateway/providers/{id}` already uses for `api_key`:

- **absent** — the column is left out of the `SET` list entirely, so the stored blob survives byte for byte;
- **present** — stored verbatim, so `{}` and `null` are an explicit *clear*.

The read gains `has_credentials`, a SQL-computed boolean, so the edit form can tell "a secret is stored" from "no secret" without ever receiving one. With that, the *Credentials* section, its warning banner and the mandatory re-type are gone — the credential sits beside **Name** on both the connect and the edit screen, a stored secret renders `••••••••••• stored` behind an explicit **Replace**, and an untouched field sends no `credentials` key.

## Why

`GET` scrubs the column, so the read-then-write an edit form performs destroyed the stored secret. The UI compensated by quarantining the field and refusing to save a rename until the user re-typed a token they cannot read back from anywhere — which is what the reporter saw as the field "moving" between the two screens. `CLAUDE.md` listed this under *Known bugs* as "data loss and the highest-value fix on this list"; the reason it was reproduced rather than fixed (a second implementation to stay byte-identical with) went with the Go tree in #391.

## How

- `native/integrations.rs::update` — branch on `req.credentials`, which is already `Option<Box<RawValue>>` via `captured_raw`; the bug was the `.unwrap_or_default()` that flattened it. **Two `UPDATE` statements, not one with a `CASE`** — `update_provider`'s own reasoning: the difference is *which columns are assigned*, and a `CASE` would still bind the blob's parameter slot on the path that must not have one. The absent arm never reads the credential into this process, so the module-header rule holds.
- `has_credentials_sql()` — `''`, `null` and `{}` all count as absent. No `IS NOT NULL` arm (the column is `NOT NULL DEFAULT '{}'`, so it would be unreachable), and the trim set is spelled out rather than left to a bare `TRIM(X)`.
- `IntegrationsView.tsx` — `credentialsToSave()` returns `undefined` when nothing was typed, spread conditionally; `canSave` requires a complete credential only when one is being supplied.
- `CLAUDE.md` — all four places asserting the old behaviour, including the *Known bugs* entry that licensed the UI workaround.

## Deviations from the HOW

- **No `parity/` golden changed.** The HOW says to update "whatever the read golden pins for `GET /api/integrations`"; there is none — the byte assertions for this endpoint live in the module's own `the_integration_shape_is_the_map_go_marshals`, which now pins `has_credentials`'s **position** (between `enabled` and `id`) as well as its presence.
- **`has_credentials_sql` is a function, not a `const`**, because a `const` cannot interpolate the trim set, which appears three times.

## Tests

- `a_put_that_omits_credentials_wipes_them` → `a_put_that_omits_credentials_preserves_them`, inverted rather than deleted, with a multi-key blob (`{"zebra":"z", "pat":"KEEP-ME","rate":1.50}`) so a preservation that went through a re-serialization would fail.
- `a_scrubbed_read_written_straight_back_preserves_the_stored_credential` — drives the **real** `GET` body back through the `PUT`, the integration twin of the gateway's.
- `an_explicit_empty_credentials_clears_the_stored_one` — both `{}` and `null`.
- `the_two_has_credentials_rules_agree` — the SQL and the Rust spelling over the same shapes. **It found a real divergence:** SQLite's bare `TRIM` strips spaces only, Rust's `str::trim` strips every Unicode whitespace, so a stored `"\n"` disagreed. Both now trim exactly `[' ', '\t', '\n', '\r']`, and a NO-BREAK SPACE shape pins that neither widens.
- `the_registry_reload_is_not_inside_either_credentials_arm` — a source guard, because `reload_blocking` is fire-and-forget with no inspectable effect. Moving it into the `Some` arm *reads* like a tightening and is the exact inverse: it is the replace path that must reload, or a revoked token keeps answering `tools/call`.
- `no_write_response_carries_a_credential_either` — over the bytes, on create and on both update arms.

**Revert check:** restoring the `.unwrap_or_default()` fails `a_put_that_omits_credentials_preserves_them` and `a_scrubbed_read_written_straight_back_preserves_the_stored_credential`, and nothing else. Both are genuine regression guards.

Local gates: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (1494 lib + all integration suites), `npm run build` — all green.

## Note

<https://github.com/shaharia-lab/agento/pull/520> (#513) is open against the same four files. This branch is off `main` and does not include it; whichever lands second rebases.