### PR TITLE
fix(ui): one action grammar for every form, and no + on a submit (#516)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -525,6 +525,34 @@ drag across it means "select this row", so selectable cells would leave a word
 highlighted behind the view they opened. `::selection` is focus-aware over the
 existing `--bg-select*` tokens, matching `.window--focused`.
 
+**A form's actions are a fixed grammar, and the `+` is not part of it** (#516).
+Four rules, and each of them was broken by exactly one view before it was
+written down here:
+
+- **The primary verb follows existence**: `Create` while the record does not
+  exist yet, `Save` once it does — with the in-flight label following it
+  (`Creating…` / `Saving…`). Not `Create agent`, not `Save` for something that
+  was never stored.
+- **Its partner follows the same split**: `Discard` throws away a record that
+  was never stored, `Revert` restores one that was. Two words because they undo
+  two different things — a single `Cancel` claims to undo a save, which is why
+  the gateway's spelling of it went rather than spreading.
+- **A `+` icon marks a list-level *New X* / *Add X*** — an action that opens a
+  blank thing (`New task`, `New rule`, `New profile`, `Add fallback`). **Never a
+  submit.** `+ Create` on the Integrations connect screen is what this issue was
+  reported for: it reads as "add another one" rather than "save this form".
+- **Placement is one strip per view, used by both states.** Integrations was the
+  only view whose primary action *moved* — toolbar while creating, savebar while
+  editing. Which strip a view uses is its own choice (Tasks is the toolbar,
+  everything else is the `.savebar` at the foot of the form); moving between
+  them inside one view is not.
+
+`IntegrationsView.tsx`'s `SaveBar` is the grammar as code and the component to
+copy from; nothing forces a view to import it, so this paragraph is the
+enforcement. Note `.savebar` is declared in `styles/integrations.css` **and**
+`styles/settings.css` and is available everywhere only because `App.tsx` imports
+both views statically.
+
 **The window's origin has to be in the capability's scope, or every IPC
 command is denied — silently.** This is the single most expensive thing to
 re-discover in this shell, because it fails *only in release builds* and it

--- a/src/lib/formVerbs.ts
+++ b/src/lib/formVerbs.ts
@@ -1,0 +1,77 @@
+/* ============================================================================
+   The words on a form's two action buttons (#516).
+
+   Agento had three dialects for one gesture. Tasks said `Discard` + `Create`,
+   Agents said `Discard` + `Create agent`, the gateway said `Cancel` + `Save`,
+   and Integrations said `+ Create` with no partner at all — the plus icon that
+   was reported as confusing, because everywhere else in the app a `+` opens a
+   blank *new thing* rather than committing a form.
+
+   Two rules, and they are the whole module:
+
+   * **The submit follows existence.** `Create` while the record does not exist
+     yet, `Save` once it does — and the in-flight label follows it, so a form
+     never says "Saving…" for something that was never stored.
+   * **Its partner follows the same split.** `Discard` throws away a record
+     that was never stored; `Revert` restores one that was. Two words because
+     they undo two different things, which is why the gateway's single `Cancel`
+     went rather than spreading: it claimed to undo a save.
+
+   Why a module rather than a paragraph: the four views that speak this grammar
+   share no component, so the only thing that can hold them together is one
+   spelling of each literal plus a compile-time pin on it. There is no
+   TypeScript test harness here (`npm run build` is `tsc --noEmit && vite
+   build`, and that is the whole frontend gate), so `lib/typeAssert.ts`'s idiom
+   is what stands in for the test — respell a literal below and CI fails.
+
+   The `+` icon rule cannot be expressed here, because it is the *absence* of an
+   `<Icon name="plus" />` beside these labels. It is written down in `CLAUDE.md`
+   under *Conventions*, with the rest of the grammar.
+   ========================================================================== */
+
+import type { Eq, Expect } from "./typeAssert";
+
+/** The submit, while the record does not exist yet. */
+export const SUBMIT_CREATE = "Create";
+/** The submit, once the record exists. */
+export const SUBMIT_SAVE = "Save";
+/** The submit while a create is in flight. */
+export const SUBMIT_CREATING = "Creating…";
+/** The submit while a save is in flight. */
+export const SUBMIT_SAVING = "Saving…";
+/** The partner, while the record does not exist yet: throw the draft away. */
+export const PARTNER_DISCARD = "Discard";
+/** The partner, once the record exists: restore what is stored. */
+export const PARTNER_REVERT = "Revert";
+
+/**
+ * What the primary button reads, given the two states that decide it.
+ *
+ * `busy` is checked first deliberately: a form mid-request is neither
+ * saveable nor discardable, and the in-flight word is the only honest label
+ * for a button that is doing something.
+ */
+export function submitLabel(creating: boolean, busy: boolean): string {
+  if (busy) return creating ? SUBMIT_CREATING : SUBMIT_SAVING;
+  return creating ? SUBMIT_CREATE : SUBMIT_SAVE;
+}
+
+/** What the partner button reads. */
+export function partnerLabel(creating: boolean): string {
+  return creating ? PARTNER_DISCARD : PARTNER_REVERT;
+}
+
+/* --- The compile-time pin ------------------------------------------------- */
+
+/**
+ * Respell any literal above and these stop compiling, which fails `npm run
+ * build` and therefore CI. Exported so `noUnusedLocals` does not delete the
+ * guard for being unused — see `lib/typeAssert.ts` for why `Eq` and not
+ * `extends`.
+ */
+export type PinSubmitCreate = Expect<Eq<typeof SUBMIT_CREATE, "Create">>;
+export type PinSubmitSave = Expect<Eq<typeof SUBMIT_SAVE, "Save">>;
+export type PinSubmitCreating = Expect<Eq<typeof SUBMIT_CREATING, "Creating…">>;
+export type PinSubmitSaving = Expect<Eq<typeof SUBMIT_SAVING, "Saving…">>;
+export type PinPartnerDiscard = Expect<Eq<typeof PARTNER_DISCARD, "Discard">>;
+export type PinPartnerRevert = Expect<Eq<typeof PARTNER_REVERT, "Revert">>;

--- a/src/views/AgentsView.tsx
+++ b/src/views/AgentsView.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../lib/api";
 import { describeError, useResource } from "../lib/hooks";
+import { partnerLabel, submitLabel } from "../lib/formVerbs";
 import { initials, toneFor } from "../lib/format";
 import { Icon } from "../lib/icons";
 import type {
@@ -705,14 +706,14 @@ export function AgentsView({ inspectorOpen }: { inspectorOpen: boolean }) {
                 </div>
                 <div className="spacer" />
                 <button className="btn btn--lg" onClick={revert} disabled={saving}>
-                  {creating ? "Discard" : "Revert"}
+                  {partnerLabel(creating)}
                 </button>
                 <button
                   className="btn btn--lg btn--primary"
                   onClick={save}
                   disabled={saving || !draft.name.trim() || !dirty}
                 >
-                  {saving ? "Saving…" : creating ? "Create agent" : "Save"}
+                  {submitLabel(creating, saving)}
                 </button>
               </div>
             )}

--- a/src/views/IntegrationsView.tsx
+++ b/src/views/IntegrationsView.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../lib/api";
 import { describeError, useResource } from "../lib/hooks";
 import { dateTime, relativeTime } from "../lib/format";
+import { partnerLabel, submitLabel, SUBMIT_CREATE } from "../lib/formVerbs";
 import { Icon } from "../lib/icons";
 import { openExternal } from "../lib/tauri";
 import {
@@ -351,6 +352,65 @@ function ProviderRow({
   );
 }
 
+/* --- The action strip ---------------------------------------------------- */
+
+/**
+ * The one place either half of this view submits from — and the reason it is a
+ * component rather than two copies of the same JSX (#516).
+ *
+ * Integrations used to be the only view whose primary action *moved*: a
+ * `+ Create` in the top toolbar while connecting, a `Save` in the bottom
+ * savebar while editing. One strip rendered from both components is what makes
+ * a future divergence a deliberate edit rather than an oversight.
+ *
+ * **The grammar it encodes is repo-wide, not this view's** — see *Conventions*
+ * in `CLAUDE.md`, which is where it is written down for the views that do not
+ * import this file:
+ *
+ * - **Primary verb follows existence**: `Create` while the record does not
+ *   exist yet, `Save` once it does. The in-flight label follows it.
+ * - **Partner follows the same split**: `Discard` throws away a record that
+ *   was never stored, `Revert` restores one that was. Two words because they
+ *   undo two different things; a single "Cancel" would claim to undo a save.
+ * - **No `+` icon.** The `+` marks a list-level *New X* that opens a blank
+ *   thing; on a submit it reads as "add another one", which is the confusion
+ *   this issue was reported for.
+ *
+ * `message` is the savebar's own explanation of why the primary is disabled,
+ * so a form never leaves the user guessing at a greyed-out button.
+ */
+function SaveBar({
+  creating,
+  busy,
+  canSubmit,
+  message,
+  onDiscard,
+  onSubmit,
+}: {
+  creating: boolean;
+  busy: boolean;
+  canSubmit: boolean;
+  message: string;
+  onDiscard(): void;
+  onSubmit(): void;
+}) {
+  return (
+    <div className="savebar">
+      <span className="savebar__text">{message}</span>
+      <button className="btn" onClick={onDiscard} disabled={busy}>
+        {partnerLabel(creating)}
+      </button>
+      <button
+        className="btn btn--primary"
+        onClick={onSubmit}
+        disabled={!canSubmit || busy}
+      >
+        {submitLabel(creating, busy)}
+      </button>
+    </div>
+  );
+}
+
 /* --- Connect a new integration ------------------------------------------- */
 
 function ConnectForm({
@@ -417,6 +477,21 @@ function ConnectForm({
     }
   }
 
+  /**
+   * Throw away everything typed so far without leaving the screen — the
+   * connect form's half of the `Discard`/`Revert` pair. There is no stored
+   * record to restore, so "back" means the state this form opened in, and
+   * `values` is emptied outright because it is the one field that can hold a
+   * secret the user pasted by mistake.
+   */
+  function discard() {
+    setName(provider.label);
+    setModeValue(provider.modes[0].value);
+    setValues({});
+    setServices(emptyServices(provider, true));
+    setError(undefined);
+  }
+
   return (
     <>
       <div className="toolbar">
@@ -424,11 +499,6 @@ function ConnectForm({
           <Icon name={provider.icon} size={13} />
         </div>
         <div className="toolbar__title">Connect {provider.label}</div>
-        <div className="spacer" />
-        <button className="btn btn--primary" onClick={create} disabled={!ready || busy}>
-          <Icon name="plus" size={13} />
-          {busy ? "Creating…" : "Create"}
-        </button>
       </div>
 
       <div className="scroll" style={{ flex: 1, padding: "var(--sp-8)" }}>
@@ -516,6 +586,26 @@ function ConnectForm({
               <span>{error}</span>
             </div>
           )}
+
+          {/* Always rendered, where the edit screen shows its strip only once
+              something changed: nothing here has been stored, so there is no
+              state in which the primary action should be absent. */}
+          <SaveBar
+            creating
+            busy={busy}
+            canSubmit={ready}
+            message={
+              ready
+                ? // Interpolated rather than spelled out, so the sentence
+                  // cannot drift away from the button it names.
+                  `Not connected yet — ${provider.label} is added when you press ${SUBMIT_CREATE}.`
+                : name.trim() === ""
+                  ? "A name is required."
+                  : "Fill in every credential field."
+            }
+            onDiscard={discard}
+            onSubmit={create}
+          />
         </div>
       </div>
     </>
@@ -1021,9 +1111,12 @@ function IntegrationDetail({
           )}
 
           {changed && (
-            <div className="savebar">
-              <span className="savebar__text">
-                {canSave
+            <SaveBar
+              creating={false}
+              busy={busy}
+              canSubmit={canSave}
+              message={
+                canSave
                   ? "You have unsaved changes."
                   : name.trim() === ""
                     ? "A name is required."
@@ -1035,15 +1128,11 @@ function IntegrationDetail({
                       ? `Enter the credentials for ${mode.label} — switching the auth method replaces the stored ones.`
                       : item.has_credentials
                         ? "Fill in every credential field, or clear them to keep the stored ones."
-                        : "Fill in every credential field."}
-              </span>
-              <button className="btn" onClick={revert} disabled={busy}>
-                Revert
-              </button>
-              <button className="btn btn--primary" onClick={save} disabled={!canSave || busy}>
-                {busy ? "Saving…" : "Save"}
-              </button>
-            </div>
+                        : "Fill in every credential field."
+              }
+              onDiscard={revert}
+              onSubmit={save}
+            />
           )}
         </div>
       </div>

--- a/src/views/TasksView.tsx
+++ b/src/views/TasksView.tsx
@@ -8,6 +8,7 @@ import type {
   ScheduledTask,
 } from "../lib/types";
 import { describeError, usePoll, useResource } from "../lib/hooks";
+import { partnerLabel, submitLabel } from "../lib/formVerbs";
 import { dateTime, duration, relativeTime, toneFor } from "../lib/format";
 import { Icon } from "../lib/icons";
 import { DirField, useDirPicker } from "../components/DirField";
@@ -418,7 +419,7 @@ export function TasksView({ inspectorOpen }: { inspectorOpen: boolean }) {
                 <>
                   {(dirty || creating) && (
                     <button className="btn btn--ghost" onClick={revert} disabled={busy}>
-                      {creating ? "Discard" : "Revert"}
+                      {partnerLabel(creating)}
                     </button>
                   )}
                   <button
@@ -426,7 +427,7 @@ export function TasksView({ inspectorOpen }: { inspectorOpen: boolean }) {
                     onClick={save}
                     disabled={busy || (!dirty && !creating)}
                   >
-                    {creating ? "Create" : "Save"}
+                    {submitLabel(creating, busy)}
                   </button>
                   {!creating && (
                     <>

--- a/src/views/TasksView.tsx
+++ b/src/views/TasksView.tsx
@@ -427,7 +427,11 @@ export function TasksView({ inspectorOpen }: { inspectorOpen: boolean }) {
                     onClick={save}
                     disabled={busy || (!dirty && !creating)}
                   >
-                    {submitLabel(creating, busy)}
+                    {/* Never the in-flight label: this view's `busy` is shared
+                        with pause/resume, so passing it here would make the
+                        submit read "Saving…" while an unrelated request runs.
+                        The disabled state already covers that case. */}
+                    {submitLabel(creating, false)}
                   </button>
                   {!creating && (
                     <>

--- a/src/views/gateway/ModelsView.tsx
+++ b/src/views/gateway/ModelsView.tsx
@@ -542,15 +542,17 @@ function AliasForm({
                   ? "Add at least one target."
                   : "Every target needs a provider and a model id."}
           </span>
-          {/* `onCancel` is only passed while creating, and abandoning a draft
-              is what `Discard` names — see `lib/formVerbs.ts`. */}
+          {/* `onCancel` is passed only when `alias` is undefined, so it is
+              present exactly while `creating` — and abandoning a draft is what
+              `Discard` names, where `Revert` restores a stored row. See
+              `lib/formVerbs.ts`. */}
           {onCancel ? (
             <button className="btn" onClick={onCancel} disabled={busy}>
-              {partnerLabel(true)}
+              {partnerLabel(creating)}
             </button>
           ) : (
             <button className="btn" onClick={revert} disabled={busy}>
-              {partnerLabel(false)}
+              {partnerLabel(creating)}
             </button>
           )}
           <button

--- a/src/views/gateway/ModelsView.tsx
+++ b/src/views/gateway/ModelsView.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../components/ui";
 import { Icon } from "../../lib/icons";
 import { describeError, useResource } from "../../lib/hooks";
+import { partnerLabel, submitLabel } from "../../lib/formVerbs";
 import type { ViewId } from "../../lib/nav";
 import type {
   GatewayModelAlias,
@@ -541,13 +542,15 @@ function AliasForm({
                   ? "Add at least one target."
                   : "Every target needs a provider and a model id."}
           </span>
+          {/* `onCancel` is only passed while creating, and abandoning a draft
+              is what `Discard` names — see `lib/formVerbs.ts`. */}
           {onCancel ? (
             <button className="btn" onClick={onCancel} disabled={busy}>
-              Cancel
+              {partnerLabel(true)}
             </button>
           ) : (
             <button className="btn" onClick={revert} disabled={busy}>
-              Revert
+              {partnerLabel(false)}
             </button>
           )}
           <button
@@ -555,7 +558,7 @@ function AliasForm({
             onClick={save}
             disabled={!canSave || busy}
           >
-            {busy ? "Saving…" : "Save"}
+            {submitLabel(creating, busy)}
           </button>
         </div>
       )}

--- a/src/views/gateway/OverviewView.tsx
+++ b/src/views/gateway/OverviewView.tsx
@@ -265,7 +265,6 @@ export function GatewayOverviewView({
               >
                 <div className="row">
                   <button className="btn btn--primary" disabled={busy} onClick={mint}>
-                    <Icon name="plus" size={14} />
                     {busy ? "Creating…" : "Create gateway token"}
                   </button>
                 </div>

--- a/src/views/gateway/ProvidersView.tsx
+++ b/src/views/gateway/ProvidersView.tsx
@@ -4,6 +4,7 @@ import { BrandMark } from "../../components/BrandMark";
 import { Dropdown, Empty, FormRow, Search, Splitter, Switch } from "../../components/ui";
 import { Icon } from "../../lib/icons";
 import { describeError, useResource } from "../../lib/hooks";
+import { partnerLabel, submitLabel } from "../../lib/formVerbs";
 import type {
   GatewayProviderRequest,
   GatewayProviderSummary,
@@ -693,13 +694,15 @@ function ProviderForm({
                   ? "Enter the API key to save."
                   : "Check the credentials, or save anyway."}
           </span>
+          {/* `onCancel` is only passed while creating, and abandoning a draft
+              is what `Discard` names — see `lib/formVerbs.ts`. */}
           {onCancel ? (
             <button className="btn" onClick={onCancel} disabled={busy}>
-              Cancel
+              {partnerLabel(true)}
             </button>
           ) : (
             <button className="btn" onClick={revert} disabled={busy}>
-              Revert
+              {partnerLabel(false)}
             </button>
           )}
           {/*
@@ -727,7 +730,7 @@ function ProviderForm({
               }}
               disabled={busy}
             >
-              Save anyway
+              {`${submitLabel(creating, false)} anyway`}
             </button>
           )}
           <button
@@ -735,7 +738,7 @@ function ProviderForm({
             onClick={save}
             disabled={!canSave || busy}
           >
-            {busy ? "Saving…" : "Save"}
+            {submitLabel(creating, busy)}
           </button>
         </div>
       )}

--- a/src/views/gateway/ProvidersView.tsx
+++ b/src/views/gateway/ProvidersView.tsx
@@ -694,15 +694,17 @@ function ProviderForm({
                   ? "Enter the API key to save."
                   : "Check the credentials, or save anyway."}
           </span>
-          {/* `onCancel` is only passed while creating, and abandoning a draft
-              is what `Discard` names — see `lib/formVerbs.ts`. */}
+          {/* `onCancel` is passed only when `provider` is undefined, so it is
+              present exactly while `creating` — and abandoning a draft is what
+              `Discard` names, where `Revert` restores a stored row. See
+              `lib/formVerbs.ts`. */}
           {onCancel ? (
             <button className="btn" onClick={onCancel} disabled={busy}>
-              {partnerLabel(true)}
+              {partnerLabel(creating)}
             </button>
           ) : (
             <button className="btn" onClick={revert} disabled={busy}>
-              {partnerLabel(false)}
+              {partnerLabel(creating)}
             </button>
           )}
           {/*

--- a/src/views/settings/SecurityPane.tsx
+++ b/src/views/settings/SecurityPane.tsx
@@ -365,7 +365,6 @@ export function SecurityPane() {
                 })
               }
             >
-              <Icon name="plus" size={14} />
               Create token
             </button>
           </div>


### PR DESCRIPTION
Closes #516

## What

The Integrations connect screen submitted through a `+ Create` in the **top toolbar** while its edit screen saved from the **bottom savebar** — the only view in the app whose primary action moved between the two states of one record, and the only submit carrying a `+`, which everywhere else marks a list-level *New X* that opens a blank thing. It also had no partner: once a credential was typed there was no way back except selecting a different provider.

## How

- **`IntegrationsView.tsx`** — a local `SaveBar` rendered by *both* `ConnectForm` and `IntegrationDetail`, so the action cannot move again without a deliberate edit. The connect form gains `discard()`, which resets name, auth mode, typed credentials and service selection **in place** (it never leaves the screen — there is nowhere to go back to). Its strip is always rendered, where the edit screen's still appears only once something changed.
- **`src/lib/formVerbs.ts`** (new) — the four literals plus compile-time pins through `lib/typeAssert.ts`. `Create`/`Save` follow whether the record exists; `Discard`/`Revert` follow whether there is anything stored to restore. The in-flight label follows the primary.
- **The sweep that makes the rule true, rather than just declared**: Tasks and Agents call the shared verbs (`Create agent` → `Create`); the gateway's `Cancel` → `Discard` and its `Save` → `Create` while creating (with `Save anyway` → `Create anyway` to match); the `+` comes off the two other `Create …` submits, in `SecurityPane` and the gateway `OverviewView`.
- **`CLAUDE.md` → Conventions** — the grammar written down, which is what binds the views that do not import the component.

## Judgement calls

- **Savebar, not toolbar.** Both were allowed by the spec; the savebar is the majority placement (3 of 4 views) and already existed in `IntegrationDetail`, so converging there moved one component instead of two.
- **`Discard` + `Create`, not `Cancel` + `Save`.** All four views' create-partner already does the same thing — abandon a record that was never stored — so the choice was naming, not behaviour. `Create`/`Save` keeps the information that the record does not exist yet, which a uniform `Save` would throw away; `Cancel` reads as *leave this screen*, which the connect form's button explicitly does not do.
- **The two token buttons are in scope.** AC1 is repo-wide ("no submit button in the app carries a `+` icon"), and `Create token` / `Create gateway token` were the only other `+`-bearing submits. Every remaining `+` is a `New …`/`Add …`.

## Proof

There is no TypeScript test harness in this repo — `npm run build` is `tsc --noEmit && vite build` and that is the whole frontend gate — so the guard is the repo's own `Eq`/`Expect` idiom rather than a test file. **Reverting a label fails the build**, verified: respelling `PARTNER_DISCARD` back to `"Cancel"` gives `src/lib/formVerbs.ts(76,40): error TS2344: Type 'false' does not satisfy the constraint 'true'`.

`npm run build` green; `pre-commit run --all-files` green. No backend surface touched.

## Acceptance criteria

- [x] No submit carries a `+`; every remaining `+` is a list-level `New …`/`Add …`
- [x] Connect and edit put the primary action in the same place, and it does not move
- [x] The connect form offers a Discard that clears typed fields, including a typed credential, without leaving the screen
- [x] Disabled/enabled logic unchanged (`ready` is still the gate) and the in-flight label is shown
- [x] The verb pair is written down (`CLAUDE.md` + `lib/formVerbs.ts`) and Tasks/Agents/Gateway are changed to match

## Out of scope

Form *contents* and their order (#517). No change to any create or save request.