### PR TITLE
fix(ui): one word for one connection state, one verb for one delete (#518)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -553,6 +553,47 @@ enforcement. Note `.savebar` is declared in `styles/integrations.css` **and**
 `styles/settings.css` and is available everywhere only because `App.tsx` imports
 both views statically.
 
+**Destroying a stored record is `Delete`, everywhere, and `Remove` means
+something else** (#518). One gesture had three words — Integrations said
+`Remove`, Tasks and Settings profiles said `Delete`, Agents said `Delete
+agent`. `formVerbs.ts`'s `DESTROY` / `DESTROYING` is the spelling and the
+compile-time pin; `Delete` won because it was already the majority and because
+`Remove` reads as *detach without destroying*, which is not what
+`DELETE /api/integrations/{id}` does — the row and its stored credentials go.
+
+- **The verb is the same in all three places**: the danger button, the
+  icon-button `title`, and the confirmation. Not `Delete agent` — the record's
+  kind is already on screen, and a per-view suffix is how a fourth word starts.
+- **A confirmation is `Delete <name>? <what goes with it>.`** — the verb, the
+  record's own name, and one clause naming the collateral (`Its run history
+  goes with it.`). Not `Delete this task and its history?`, which names no row,
+  and not a bare `Delete rule?`.
+- **`Remove` survives for detaching, and only that**: taking a row out of a
+  list nothing has stored yet (a gateway alias's fallback target), or
+  unregistering something from a third party while the record it belongs to
+  stays (the Telegram webhook). If the record is gone afterwards, it is
+  `Delete`.
+
+**One connection state gets one word, and it is `Connected`** (#518).
+`Integration.authenticated` renders in four places visible at once — the
+sidebar row's preview, the detail toolbar badge, the Authorisation section's
+Status row and the inspector's State row — and each was written at its call
+site, so one row read `GitHub · Not connected` in the sidebar and `Not
+authenticated` in the inspector. Two words for one boolean reads as two states.
+
+`connectionState()` in `views/integrations/catalog.ts` is the only place either
+word is spelled, pinned the same way, and `IntegrationsView.tsx`'s
+`ConnectionBadge` carries the label **and** its `badge--green`/`badge--amber`
+tone together — a site that took the label and picked its own tone would be the
+same defect in a different column. `Connected` rather than `Authenticated`
+because it is the word the surrounding screen already speaks (the sidebar's
+`Connected` group, `Nothing connected yet.`, `Not connected yet — …`) and
+because it is the *user's* word rather than the wire's: `authenticated` is a
+column whose meaning is under review (#513), and copy spelled after a column
+has to be re-read every time the column moves. The Authorisation section keeps
+its heading and its `Authorise` / `Validate credentials` buttons, which name
+the **action**; only the state had two names.
+
 **The window's origin has to be in the capability's scope, or every IPC
 command is denied — silently.** This is the single most expensive thing to
 re-discover in this shell, because it fails *only in release builds* and it

--- a/src/lib/formVerbs.ts
+++ b/src/lib/formVerbs.ts
@@ -1,5 +1,5 @@
 /* ============================================================================
-   The words on a form's two action buttons (#516).
+   The words on a view's action buttons (#516, #518).
 
    Agento had three dialects for one gesture. Tasks said `Discard` + `Create`,
    Agents said `Discard` + `Create agent`, the gateway said `Cancel` + `Save`,
@@ -27,6 +27,19 @@
    The `+` icon rule cannot be expressed here, because it is the *absence* of an
    `<Icon name="plus" />` beside these labels. It is written down in `CLAUDE.md`
    under *Conventions*, with the rest of the grammar.
+
+   #518 added the third verb — the destructive one — for the same reason and by
+   the same mechanism. One gesture had three words: Integrations said `Remove`,
+   Tasks and Settings profiles said `Delete`, Agents said `Delete agent`.
+   `Delete` wins on both counts a tie needs: it was already the majority, and
+   `Remove` reads as *detach without destroying*, which is not what
+   `DELETE /api/integrations/{id}` does — the row and its stored credentials go.
+
+   What `Remove` still means, and why it survives in two places: taking a row
+   out of a list that is not stored yet (a gateway alias's fallback target) and
+   unregistering something from a third party while the record it belongs to
+   stays (the Telegram webhook). Both really are detaching, so both keep the
+   word this module deliberately does not lend them.
    ========================================================================== */
 
 import type { Eq, Expect } from "./typeAssert";
@@ -43,6 +56,10 @@ export const SUBMIT_SAVING = "Saving…";
 export const PARTNER_DISCARD = "Discard";
 /** The partner, once the record exists: restore what is stored. */
 export const PARTNER_REVERT = "Revert";
+/** Destroying a stored record — button, icon-button title and confirmation. */
+export const DESTROY = "Delete";
+/** The same, while the delete is in flight. */
+export const DESTROYING = "Deleting…";
 
 /**
  * What the primary button reads, given the two states that decide it.
@@ -75,3 +92,5 @@ export type PinSubmitCreating = Expect<Eq<typeof SUBMIT_CREATING, "Creating…">
 export type PinSubmitSaving = Expect<Eq<typeof SUBMIT_SAVING, "Saving…">>;
 export type PinPartnerDiscard = Expect<Eq<typeof PARTNER_DISCARD, "Discard">>;
 export type PinPartnerRevert = Expect<Eq<typeof PARTNER_REVERT, "Revert">>;
+export type PinDestroy = Expect<Eq<typeof DESTROY, "Delete">>;
+export type PinDestroying = Expect<Eq<typeof DESTROYING, "Deleting…">>;

--- a/src/views/AgentsView.tsx
+++ b/src/views/AgentsView.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../lib/api";
 import { describeError, useResource } from "../lib/hooks";
-import { partnerLabel, submitLabel } from "../lib/formVerbs";
+import { DESTROY, DESTROYING, partnerLabel, submitLabel } from "../lib/formVerbs";
 import { initials, toneFor } from "../lib/format";
 import { Icon } from "../lib/icons";
 import type {
@@ -398,7 +398,7 @@ export function AgentsView({ inspectorOpen }: { inspectorOpen: boolean }) {
               {!creating && (
                 <button
                   className="iconbtn"
-                  title="Delete agent"
+                  title={DESTROY}
                   onClick={() => setConfirmDelete(true)}
                 >
                   <Icon name="trash" size={14} />
@@ -412,8 +412,8 @@ export function AgentsView({ inspectorOpen }: { inspectorOpen: boolean }) {
                   <Icon name="alert" size={15} />
                 </span>
                 <span style={{ flex: 1 }}>
-                  Delete <strong>{baseline.name}</strong>? Its configuration is
-                  removed for good.
+                  {DESTROY} <strong>{baseline.name}</strong>? Its configuration
+                  goes with it.
                 </span>
                 <button className="btn" onClick={() => setConfirmDelete(false)}>
                   Cancel
@@ -423,7 +423,7 @@ export function AgentsView({ inspectorOpen }: { inspectorOpen: boolean }) {
                   disabled={busyDelete}
                   onClick={remove}
                 >
-                  {busyDelete ? "Deleting…" : "Delete"}
+                  {busyDelete ? DESTROYING : DESTROY}
                 </button>
               </div>
             )}

--- a/src/views/IntegrationsView.tsx
+++ b/src/views/IntegrationsView.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } fro
 import { api } from "../lib/api";
 import { describeError, useResource } from "../lib/hooks";
 import { dateTime, relativeTime } from "../lib/format";
-import { partnerLabel, submitLabel, SUBMIT_CREATE } from "../lib/formVerbs";
+import { DESTROY, partnerLabel, submitLabel, SUBMIT_CREATE } from "../lib/formVerbs";
 import { Icon } from "../lib/icons";
 import { openExternal } from "../lib/tauri";
 import {
@@ -25,6 +25,7 @@ import type {
   WebhookStatus,
 } from "../lib/types";
 import {
+  connectionState,
   modeFor,
   PROVIDERS,
   providerFor,
@@ -158,6 +159,20 @@ function countTools(services: Services | null | undefined): number {
     (n, s) => n + (s.enabled ? (s.tools?.length ?? 0) : 0),
     0
   );
+}
+
+/**
+ * The connection-state badge, wherever it appears (#518).
+ *
+ * Three badges rendered one boolean and two of them disagreed about the word.
+ * A component rather than three calls to `connectionState`, because the class
+ * name and the label have to move together: the amber/green pair *is* the
+ * state, and a site that took the label and picked its own tone would be the
+ * same defect in a different column.
+ */
+function ConnectionBadge({ authenticated }: { authenticated: boolean }) {
+  const state = connectionState(authenticated);
+  return <span className={`badge badge--${state.tone}`}>{state.label}</span>;
 }
 
 /* ============================================================================
@@ -355,7 +370,13 @@ function IntegrationRow({
         </div>
         <div className="listrow__preview">
           {provider?.label ?? item.type} ·{" "}
-          {item.authenticated ? `${countTools(item.services)} tools` : "Not connected"}
+          {/* The positive case says something the badges cannot — how many
+              tools this row grants — so only the negative label comes from the
+              helper. It is still the helper's: this line is what a user scans
+              first, and it is where the two words were most visibly two. */}
+          {item.authenticated
+            ? `${countTools(item.services)} tools`
+            : connectionState(false).label}
         </div>
       </div>
     </button>
@@ -1111,27 +1132,23 @@ function IntegrationDetail({
           <Icon name={provider.icon} size={13} />
         </div>
         <div className="toolbar__title">{item.name}</div>
-        {item.authenticated ? (
-          <span className="badge badge--green">Connected</span>
-        ) : (
-          <span className="badge badge--amber">Not connected</span>
-        )}
+        <ConnectionBadge authenticated={item.authenticated} />
         {!item.enabled && <span className="badge">Disabled</span>}
         <div className="spacer" />
         {confirmDelete ? (
           <span className="confirm">
-            Remove {item.name}?
+            {DESTROY} {item.name}? Its stored credentials go with it.
             <button className="btn btn--ghost" onClick={() => setConfirmDelete(false)}>
               Cancel
             </button>
             <button className="btn btn--danger" onClick={remove} disabled={busy}>
-              Remove
+              {DESTROY}
             </button>
           </span>
         ) : (
           <button className="btn btn--danger" onClick={() => setConfirmDelete(true)}>
             <Icon name="trash" size={13} />
-            Remove
+            {DESTROY}
           </button>
         )}
       </div>
@@ -1371,11 +1388,11 @@ function AuthSection({
         <div className="formrow__label">Status</div>
         <div className="formrow__control">
           <div className="row" style={{ gap: "var(--sp-4)", alignItems: "center" }}>
-            {item.authenticated ? (
-              <span className="badge badge--green">Authenticated</span>
-            ) : (
-              <span className="badge badge--amber">Not authenticated</span>
-            )}
+            {/* The same word the sidebar, the toolbar and the inspector use.
+                The section is still called Authorisation and its buttons still
+                say Authorise, because those name the *action*; only the state
+                had two names. */}
+            <ConnectionBadge authenticated={item.authenticated} />
             {isOAuth ? (
               <button
                 className="btn"
@@ -1582,7 +1599,7 @@ function TriggerRules({ integrationId }: { integrationId: string }) {
               </div>
               {confirmDelete === r.id ? (
                 <span className="confirm">
-                  Delete rule?
+                  {DESTROY} {r.name || "Untitled rule"}?
                   <button className="btn btn--ghost" onClick={() => setConfirmDelete(undefined)}>
                     Cancel
                   </button>
@@ -1596,7 +1613,7 @@ function TriggerRules({ integrationId }: { integrationId: string }) {
                       })
                     }
                   >
-                    Delete
+                    {DESTROY}
                   </button>
                 </span>
               ) : (
@@ -1635,7 +1652,7 @@ function TriggerRules({ integrationId }: { integrationId: string }) {
                   </button>
                   <button
                     className="iconbtn"
-                    title="Delete"
+                    title={DESTROY}
                     onClick={() => setConfirmDelete(r.id)}
                   >
                     <Icon name="trash" size={13} />
@@ -1905,11 +1922,7 @@ function ConnectedInspector({
     <>
       <InspGroup title="Status">
         <InspRow label="State">
-          {item.authenticated ? (
-            <span className="badge badge--green">Connected</span>
-          ) : (
-            <span className="badge badge--amber">Not authenticated</span>
-          )}
+          <ConnectionBadge authenticated={item.authenticated} />
         </InspRow>
         <InspRow label="Enabled">{item.enabled ? "Yes" : "No"}</InspRow>
         <InspRow label="Provider">{provider?.label ?? item.type}</InspRow>

--- a/src/views/IntegrationsView.tsx
+++ b/src/views/IntegrationsView.tsx
@@ -27,6 +27,7 @@ import type {
 import {
   connectionState,
   modeFor,
+  NOT_CONNECTED,
   PROVIDERS,
   providerFor,
   unavailableCopy,
@@ -370,13 +371,11 @@ function IntegrationRow({
         </div>
         <div className="listrow__preview">
           {provider?.label ?? item.type} ·{" "}
-          {/* The positive case says something the badges cannot — how many
-              tools this row grants — so only the negative label comes from the
-              helper. It is still the helper's: this line is what a user scans
-              first, and it is where the two words were most visibly two. */}
-          {item.authenticated
-            ? `${countTools(item.services)} tools`
-            : connectionState(false).label}
+          {/* The positive case says something no badge can — how many tools
+              this row grants — so this line takes the negative label alone,
+              from the constant the badge's own helper returns. It is where the
+              two words were most visibly two: it is what a user scans first. */}
+          {item.authenticated ? `${countTools(item.services)} tools` : NOT_CONNECTED}
         </div>
       </div>
     </button>

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -9,6 +9,7 @@ import {
 import { api, ApiError, qs } from "../lib/api";
 import { describeError, useResource, type Resource } from "../lib/hooks";
 import { dateTime, relativeTime, tildePath, usd } from "../lib/format";
+import { DESTROY } from "../lib/formVerbs";
 import { Icon, type IconName } from "../lib/icons";
 import { Checkbox, Dropdown, Empty, FormRow, Switch } from "../components/ui";
 import { openExternal } from "../lib/tauri";
@@ -856,7 +857,7 @@ function ProfilesSection() {
               ) : confirmDelete === p.id ? (
                 <>
                   <span className="confirm" style={{ flex: 1 }}>
-                    Delete “{p.name}”? The settings file is removed.
+                    {DESTROY} {p.name}? Its settings file goes with it.
                   </span>
                   <button className="btn btn--ghost" onClick={() => setConfirmDelete(undefined)}>
                     Cancel
@@ -871,7 +872,7 @@ function ProfilesSection() {
                       })
                     }
                   >
-                    Delete
+                    {DESTROY}
                   </button>
                 </>
               ) : (
@@ -921,7 +922,7 @@ function ProfilesSection() {
                   </button>
                   <button
                     className="iconbtn"
-                    title="Delete"
+                    title={DESTROY}
                     disabled={p.is_default}
                     onClick={() => setConfirmDelete(p.id)}
                   >

--- a/src/views/TasksView.tsx
+++ b/src/views/TasksView.tsx
@@ -8,7 +8,7 @@ import type {
   ScheduledTask,
 } from "../lib/types";
 import { describeError, usePoll, useResource } from "../lib/hooks";
-import { partnerLabel, submitLabel } from "../lib/formVerbs";
+import { DESTROY, partnerLabel, submitLabel } from "../lib/formVerbs";
 import { dateTime, duration, relativeTime, toneFor } from "../lib/format";
 import { Icon } from "../lib/icons";
 import { DirField, useDirPicker } from "../components/DirField";
@@ -404,7 +404,9 @@ export function TasksView({ inspectorOpen }: { inspectorOpen: boolean }) {
 
               {confirmDelete ? (
                 <div className="confirm">
-                  <span className="confirm__text">Delete this task and its history?</span>
+                  <span className="confirm__text">
+                    {DESTROY} {draft.name || "Untitled task"}? Its run history goes with it.
+                  </span>
                   <button
                     className="btn btn--ghost"
                     onClick={() => setConfirmDelete(false)}
@@ -412,7 +414,7 @@ export function TasksView({ inspectorOpen }: { inspectorOpen: boolean }) {
                     Cancel
                   </button>
                   <button className="btn btn--danger" onClick={remove} disabled={busy}>
-                    Delete
+                    {DESTROY}
                   </button>
                 </div>
               ) : (
@@ -449,7 +451,7 @@ export function TasksView({ inspectorOpen }: { inspectorOpen: boolean }) {
                       </button>
                       <button
                         className="iconbtn"
-                        title="Delete"
+                        title={DESTROY}
                         onClick={() => setConfirmDelete(true)}
                       >
                         <Icon name="trash" size={14} />

--- a/src/views/gateway/ModelsView.tsx
+++ b/src/views/gateway/ModelsView.tsx
@@ -11,7 +11,7 @@ import {
 } from "../../components/ui";
 import { Icon } from "../../lib/icons";
 import { describeError, useResource } from "../../lib/hooks";
-import { partnerLabel, submitLabel } from "../../lib/formVerbs";
+import { DESTROY, partnerLabel, submitLabel } from "../../lib/formVerbs";
 import type { ViewId } from "../../lib/nav";
 import type {
   GatewayModelAlias,
@@ -449,7 +449,7 @@ function AliasForm({
         {!creating &&
           (confirmDelete ? (
             <span className="confirm">
-              Delete {alias.alias}?
+              {DESTROY} {alias.alias}? Every request naming it stops routing.
               <button
                 className="btn btn--ghost"
                 onClick={() => setConfirmDelete(false)}
@@ -457,7 +457,7 @@ function AliasForm({
                 Cancel
               </button>
               <button className="btn btn--danger" onClick={remove} disabled={busy}>
-                Delete
+                {DESTROY}
               </button>
             </span>
           ) : (
@@ -466,7 +466,7 @@ function AliasForm({
               onClick={() => setConfirmDelete(true)}
             >
               <Icon name="trash" size={13} />
-              Delete
+              {DESTROY}
             </button>
           ))}
       </div>

--- a/src/views/gateway/ProvidersView.tsx
+++ b/src/views/gateway/ProvidersView.tsx
@@ -4,7 +4,7 @@ import { BrandMark } from "../../components/BrandMark";
 import { Dropdown, Empty, FormRow, Search, Splitter, Switch } from "../../components/ui";
 import { Icon } from "../../lib/icons";
 import { describeError, useResource } from "../../lib/hooks";
-import { partnerLabel, submitLabel } from "../../lib/formVerbs";
+import { DESTROY, partnerLabel, submitLabel } from "../../lib/formVerbs";
 import type {
   GatewayProviderRequest,
   GatewayProviderSummary,
@@ -430,7 +430,7 @@ function ProviderForm({
       // reads as nonsense on a delete. The status is what carries the meaning.
       setError(
         err instanceof ApiError && err.status === 409
-          ? `A model alias still routes to ${provider.name}. Remove or re-point it first.`
+          ? `A model alias still routes to ${provider.name}. Delete or re-point it first.`
           : describeError(err)
       );
       setConfirmDelete(false);
@@ -454,7 +454,7 @@ function ProviderForm({
         {!creating &&
           (confirmDelete ? (
             <span className="confirm">
-              Remove {provider.name}?
+              {DESTROY} {provider.name}? Its stored key goes with it.
               <button
                 className="btn btn--ghost"
                 onClick={() => setConfirmDelete(false)}
@@ -462,7 +462,7 @@ function ProviderForm({
                 Cancel
               </button>
               <button className="btn btn--danger" onClick={remove} disabled={busy}>
-                Remove
+                {DESTROY}
               </button>
             </span>
           ) : (
@@ -471,7 +471,7 @@ function ProviderForm({
               onClick={() => setConfirmDelete(true)}
             >
               <Icon name="trash" size={13} />
-              Remove
+              {DESTROY}
             </button>
           ))}
       </div>

--- a/src/views/integrations/catalog.ts
+++ b/src/views/integrations/catalog.ts
@@ -16,6 +16,7 @@
 
 import type { IconName } from "../../lib/icons";
 import type { Tone } from "../../lib/format";
+import type { Eq, Expect } from "../../lib/typeAssert";
 
 export interface CredField {
   key: string;
@@ -441,6 +442,62 @@ export function unavailableCopy(type: string): { title: string; text: string } {
     text: "This integration was created by a newer version of Agento than this app knows about.",
   };
 }
+
+/* --- One connection state, one word (#518) --------------------------------
+   `Integration.authenticated` renders in four places that are on screen at the
+   same time — the sidebar row's preview line, the detail toolbar badge, the
+   Authorisation section's Status row and the inspector's State row — and each
+   was written at its own call site, so one row read `GitHub · Not connected` in
+   the sidebar and `Not authenticated` in the inspector two inches apart. Two
+   words for one boolean reads as two states, and the reporter went looking for
+   a second thing to fix.
+
+   `Connected` is the word, in both directions. It is the one the surrounding
+   screen already speaks — the sidebar's own `Connected` group heading, the
+   `Nothing connected yet.` empty state, the connect screen's `Not connected
+   yet — …` — and it is the user's word rather than the wire's. That last part
+   matters beyond taste: `authenticated` is a *wire* field whose meaning is
+   under review (#513), so copy spelled after the column would have to be
+   re-read every time the column moves. This is the only place it is spelled,
+   so if #513 changes what the boolean means, one function changes.
+
+   The tone travels with the label because both badge sites need it and
+   `format.ts`'s `Tone` is emphatically not a status→tone map — it hashes a key
+   to pick a stable *tile* colour. Status colour is an explicit `badge--green` /
+   `badge--amber` class, so the union here is written out rather than imported.
+   ------------------------------------------------------------------------ */
+
+/** What a verified integration is called. */
+export const CONNECTED = "Connected";
+/** What an unverified one is called — the same word, negated. */
+export const NOT_CONNECTED = "Not connected";
+
+export interface ConnectionState {
+  label: string;
+  tone: "green" | "amber";
+}
+
+/**
+ * The one description of an integration's connection state.
+ *
+ * Takes the boolean rather than the row: it is the only input, and passing the
+ * wire type would put `lib/types.ts` into a module that otherwise describes
+ * only what this app knows about providers.
+ */
+export function connectionState(authenticated: boolean): ConnectionState {
+  return authenticated
+    ? { label: CONNECTED, tone: "green" }
+    : { label: NOT_CONNECTED, tone: "amber" };
+}
+
+/**
+ * Respell either word and these stop compiling, which fails `npm run build`
+ * and therefore CI — the frontend has no test harness, so this is the guard.
+ * Exported so `noUnusedLocals` does not delete it; see `lib/typeAssert.ts` for
+ * why `Eq` and not `extends`.
+ */
+export type PinConnected = Expect<Eq<typeof CONNECTED, "Connected">>;
+export type PinNotConnected = Expect<Eq<typeof NOT_CONNECTED, "Not connected">>;
 
 /**
  * The mode a stored integration is using.

--- a/src/views/integrations/catalog.ts
+++ b/src/views/integrations/catalog.ts
@@ -5,7 +5,10 @@
    service grants — /integrations/available-tools only reports tools already
    turned on, so it cannot drive a connect form for something not yet created.
    The shapes therefore live here: the credential fields each provider needs,
-   and the tool names its MCP server hosts.
+   and the tool names its MCP server hosts. Since #518 it also owns the one
+   spelling of an integration's connection state — same question ("what does
+   this app say about an integration?"), and `unavailableCopy` below was
+   already the precedent for answering it here rather than at a call site.
 
    WhatsApp is deliberately absent, and this is the list that decides it.
    `type` is a free-form string on the wire, so nothing upstream stops one


### PR DESCRIPTION
Closes #518

## What

Two vocabularies, each with one word too many.

**One connection state had two words, on screen at once.** `Integration.authenticated` renders in four places — the sidebar row's preview line, the detail toolbar badge, the Authorisation section's Status row and the inspector's State row — and each was written at its own call site, so one row read `GitHub · Not connected` in the sidebar and `Not authenticated` in the inspector two inches away. `connectionState()` in `src/views/integrations/catalog.ts` is now the only place either word is spelled, and `ConnectionBadge` in `IntegrationsView.tsx` carries the label together with its `badge--green` / `badge--amber` tone.

**One destructive gesture had three verbs.** Integrations said `Remove`, Tasks and Settings profiles said `Delete`, Agents said `Delete agent`. `src/lib/formVerbs.ts` gains `DESTROY` / `DESTROYING`, swept through the danger button, the icon-button `title` and the confirmation in Integrations (the row and its trigger rules), Tasks, Agents, Settings profiles and the LLM gateway's providers and aliases. The confirmations are one shape now: `Delete <name>? <what goes with it>.`

## Why

`Connected` rather than `Authenticated`: it is the word the surrounding screen already speaks (the sidebar's own `Connected` group, `Nothing connected yet.`, `Not connected yet — …`), and it is the user's word rather than the wire's. That second part is load-bearing — `authenticated` is a column whose meaning is under review in #513, and copy spelled after a column has to be re-read every time the column moves. This way #513 changes one function instead of four strings. The Authorisation section keeps its heading and its `Authorise` / `Validate credentials` buttons; those name the **action**, and only the state had two names.

`Delete` rather than `Remove`: it was already the majority, and `Remove` reads as *detach without destroying*, which is not what `DELETE /api/integrations/{id}` does — the row and its stored credentials go. `Remove` survives in exactly the two places it is honest: taking a row out of a list nothing has stored yet (a gateway alias's fallback target), and unregistering the Telegram webhook while its integration stays.

## How

- `src/views/integrations/catalog.ts` — `CONNECTED` / `NOT_CONNECTED`, `connectionState(authenticated: boolean)` returning `{ label, tone }`, and the `Eq`/`Expect` pins. It takes the boolean rather than the row, so no wire type enters the module.
- `src/views/IntegrationsView.tsx` — `ConnectionBadge` at the three badge sites; the row preview takes `NOT_CONNECTED` alone, because its positive case says something no badge can (the tool count).
- `src/lib/formVerbs.ts` — `DESTROY` / `DESTROYING` and their pins; the module header now covers all three verbs and records what `Remove` still means.
- `CLAUDE.md` → *Conventions* — both decisions, beside #516's form grammar.
- Verb sweep: `TasksView.tsx`, `AgentsView.tsx`, `SettingsView.tsx`, `gateway/ProvidersView.tsx`, `gateway/ModelsView.tsx`.

## Acceptance criteria

- [x] One integration in one state shows one word everywhere visible at once, positive and negative.
- [x] The word comes from one helper, not four literals.
- [x] One destructive verb across Integrations, Tasks, Agents and Settings profiles, button and confirmation.
- [x] The decision is written down in `CLAUDE.md`'s conventions.
- [x] No behavioural or wire change — the same boolean drives the same rendering decisions; no predicate, request or type moved.

## Verification

The frontend has no test harness, so `lib/typeAssert.ts`'s `Eq`/`Expect` is the guard, as it is for #516's verbs. Both pins were proven to be real guards rather than decoration by reverting each literal in turn and reading the failure: `NOT_CONNECTED` → `"Not authenticated"` fails `catalog.ts:500` with `TS2344`, `DESTROY` → `"Remove"` fails `formVerbs.ts:95` with `TS2344`. `npm run build` (`tsc --noEmit && vite build`) and `pre-commit run --all-files` are green.

**Deviations from the issue's HOW, both widenings of the sweep and neither of the change:**

- The gateway's `ProvidersView` and `ModelsView` are swept too. The issue named four views but also said "the Remove/Delete choice is repo-wide"; a convention stating one verb repo-wide while two `Remove`s remained on stored-record deletes would contradict itself on the day it was written.
- The confirmations gained a name and a consequence clause (`Delete this task and its history?` → `Delete <name>? Its run history goes with it.`), per the HOW's note to make them consistent in form and not only in verb.

**Deliberately left alone:** the sidebar's `Connected` **group heading**. It groups stored integrations rather than authenticated ones, so a `Not connected` row legitimately sits under it — a different concept sharing a word, and renaming it is a copy decision this issue did not ask for.

**Not verified visually.** The HOW asks for a `ui-verify` screenshot pass with one authenticated and one unauthenticated integration; producing that state needs real credentials written into a scratch instance, which this run could not do. Every changed site is a string inside JSX that `tsc` typechecks, and no predicate or layout moved.
