### PR TITLE
fix(tests): stop oauth::flow tests wiping each other's flow state (#527)

### DIFF
--- a/src-tauri/src/native/integrations/oauth/flow.rs
+++ b/src-tauri/src/native/integrations/oauth/flow.rs
@@ -510,21 +510,36 @@ pub fn status(db_path: &std::path::Path, id: &str) -> Result<bool, WriteError> {
 }
 
 #[cfg(test)]
-pub(super) fn reset_flows_for_test() {
-    lock_flows().clear();
-}
-
-#[cfg(test)]
 mod tests {
+    //! # The ids are the isolation, and nothing here may clear the flow map
+    //!
+    //! [`flows()`] is process-global — it mirrors `integrationService.oauthFlows`,
+    //! which is one map per server — and `cargo test` runs this module's tests in
+    //! parallel inside one process. So **every test uses a flow id unique within
+    //! this module**: `no-oauth`, `unknown-probe`, `bound-port`, `denied`,
+    //! `settled`, `waiting`, `denied-then-timed-out`, `stored`, `tok`, `present`
+    //! (plus `nope` and `gone`, which are looked up and never inserted). Two
+    //! tests therefore never touch the same entry. Distinct ids rather than a
+    //! mutex, because the global is the thing under test.
+    //!
+    //! **A new test needs a new id, not a reset.** A `#[cfg(test)]` helper
+    //! calling `lock_flows().clear()` opened six of these tests until [#527];
+    //! clearing the *whole* map deletes every other test's entry, so the unique
+    //! ids bought nothing and the module failed roughly one run in eight. Two
+    //! windows are real, which is why it was never the same
+    //! test twice: a clear between a test's insert and its read makes
+    //! `.expect("state")` panic, and one between the insert and
+    //! [`fail_flow_if_in_flight`] — which *inserts* when the id is absent — leaves
+    //! a wrong entry and fails an assertion instead. Nothing needs the map empty;
+    //! each test needs only its own key absent, which a unique id already
+    //! guarantees.
+    //!
+    //! [#527]: https://github.com/shaharia-lab/agento/issues/527
+
     use super::*;
 
     /// A fresh database with one integration, under an id **unique to the
-    /// caller**.
-    ///
-    /// The flow map is process-global — it mirrors `integrationService.oauthFlows`,
-    /// which is one map per server — so two tests sharing an id share a flow,
-    /// and `cargo test` runs them in parallel. Distinct ids rather than a mutex,
-    /// because the global is the thing under test.
+    /// caller** — see the module doc for why that is the isolation.
     fn migrated(
         dir: &std::path::Path,
         id: &str,
@@ -573,7 +588,6 @@ mod tests {
 
     #[tokio::test]
     async fn starting_a_flow_answers_a_url_carrying_the_port_it_bound() {
-        reset_flows_for_test();
         let dir = tempfile::tempdir().expect("tempdir");
         let db = migrated(
             dir.path(),
@@ -611,7 +625,6 @@ mod tests {
 
     #[tokio::test]
     async fn a_failed_flow_is_remembered_as_a_500_rather_than_reported_as_unauthenticated() {
-        reset_flows_for_test();
         let dir = tempfile::tempdir().expect("tempdir");
         let db = migrated(
             dir.path(),
@@ -641,7 +654,6 @@ mod tests {
     /// stored and the MCP server running.
     #[test]
     fn the_deadline_cannot_overwrite_a_flow_that_already_succeeded() {
-        reset_flows_for_test();
         lock_flows().insert(
             "settled".to_string(),
             FlowState {
@@ -660,7 +672,6 @@ mod tests {
 
     #[test]
     fn the_deadline_does_fail_a_flow_still_in_flight() {
-        reset_flows_for_test();
         lock_flows().insert("waiting".to_string(), FlowState::default());
 
         fail_flow_if_in_flight("waiting");
@@ -673,7 +684,6 @@ mod tests {
     #[test]
     fn a_failed_flow_is_not_re_failed_by_the_deadline() {
         // Also finished — the first reason is the useful one to keep.
-        reset_flows_for_test();
         lock_flows().insert(
             "denied-then-timed-out".to_string(),
             FlowState {
@@ -697,7 +707,6 @@ mod tests {
 
     #[test]
     fn with_no_flow_the_status_is_the_stored_token() {
-        reset_flows_for_test();
         let dir = tempfile::tempdir().expect("tempdir");
         let db = migrated(dir.path(), "stored", "google", r#"{"client_id":"c"}"#);
         assert!(!status(&db, "stored").expect("status"), "auth is empty");


### PR DESCRIPTION
Closes #527

## What

`native::integrations::oauth::flow::tests` failed intermittently — measured here at **6 failures in 40 runs on unmodified `main` @ `e047d76`**. This deletes the cause: the `#[cfg(test)]` helper `reset_flows_for_test`, which called `lock_flows().clear()` on the process-global flow map, plus its six call sites. Test-only; no production code is touched and the ten existing assertions are unchanged in substance.

## Why

`flows()` is a process-global `OnceLock<Mutex<HashMap<String, FlowState>>>` — deliberately, mirroring `integrationService.oauthFlows`, one map per server. The module already picks the right isolation for that and its fixture doc said so: *distinct ids rather than a mutex, because the global is the thing under test*. Every id in the module is in fact unique.

`reset_flows_for_test` defeated it by clearing the **whole** map rather than the caller's entry, so six tests each began by deleting the other five's state. Under the default parallel harness: test A inserts `waiting`, test B clears, A reads `None`, `.expect("state")` panics.

## How

1. Delete `reset_flows_for_test` and its six call sites (each was the first statement of its test, so nothing else moved).
2. Lift the isolation rule from the `migrated` fixture doc to a `mod tests` doc comment — the better home now that three tests never call `migrated` at all. It names every id in use and states the rule as a rule: **a new test needs a new id, not a reset.**

### Every call site needs its own key absent, not the map empty

Confirmed per site before deleting, which is the one risk in a subtraction like this:

| test | id | why the reset was unnecessary |
|---|---|---|
| `starting_a_flow_answers_a_url_carrying_the_port_it_bound` | `bound-port` | `start` **inserts** the key itself (`flow.rs:174`) |
| `a_failed_flow_is_remembered_as_a_500_…` | `denied` | same — `start` inserts |
| `the_deadline_cannot_overwrite_a_flow_that_already_succeeded` | `settled` | inserts its key outright as the next statement |
| `the_deadline_does_fail_a_flow_still_in_flight` | `waiting` | same |
| `a_failed_flow_is_not_re_failed_by_the_deadline` | `denied-then-timed-out` | same |
| `with_no_flow_the_status_is_the_stored_token` | `stored` | the one that *reads* as depending on emptiness, and does not: it asserts `status` falls through to the stored token **for its own id**, and no other test ever writes `stored` |

## Verification

Measured on this machine, `cargo build --tests` first so the loop measures the race and not compile noise, driven off exit status:

| | result |
|---|---|
| unmodified `main` @ `e047d76`, 40 runs | **6 failures** (15%) |
| this branch, 50 runs | **50/50 green** |

The baseline also confirms the mechanism is subtler than "the entry disappears". Three different tests were seen failing, and `a_failed_flow_is_not_re_failed_by_the_deadline` failed on its **assertion** (`flow.rs:688`), not on `.expect` — a clear landing between a test's insert and its `fail_flow_if_in_flight` call leaves a *wrong* entry rather than no entry, because that function inserts when the id is absent. Both windows are recorded in the new doc comment.

Full local gates green: `npm run build`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (1498 lib tests, exit 0), `cargo build --profile ci`.

## Acceptance criteria

- [x] 50 consecutive runs green under the default multi-threaded harness
- [x] `grep -rn reset_flows_for_test src tests` returns nothing (0 hits — the doc comment describes the removed helper without naming it, so the criterion holds literally; `git log` and the `#527` link keep it findable)
- [x] Every flow id is unique within the module, and the module says so where a test author reaches it before adding a test
- [x] The ten test functions keep their assertions unchanged in substance
- [x] No new dependency, no test mutex, no `--test-threads=1`, no `serial_test`
- [x] `cargo clippy --all-targets -- -D warnings` clean

## Out of scope

The OAuth flow's own behaviour and the process-global `flows()` map itself — it mirrors the server's one-map-per-process shape and is not the defect. No mechanical guard against a future duplicate id was added; that was considered and declined during refinement, and the doc comment is the mitigation.

