### PR TITLE
fix(integrations): a rejected credential check disconnects, an unreachable one does not (#521)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2333,6 +2333,45 @@ writes a credential and must reload the hosted server, so
 `integrations::reload_after_forward` is the route predicate and the place to
 read why the list is one entry long.
 
+**A *rejected* credential check is a state change; an *unreachable* one is
+not** (#521). That route now has a second write, on the failure path:
+`native/integrations/check.rs`'s `CheckKind` — `Rejected` when the provider
+answered and refused the credential (a 401 or 403, or a refusal carried in a
+200 envelope: Slack's `ok:false`, Telegram's), `Unreachable` for everything
+else. On `Rejected`, `token_validate::clear_auth` empties the `auth` column and
+reloads, so `authenticated` goes false, `reload` hits its `!is_startable()`
+early return with the server already stopped, and `available-tools` drops the
+row's tools. On `Unreachable`, nothing moves at all.
+
+Four things about it are load-bearing:
+
+- **Both halves are the fix, and each is the other's inverse.** Without the
+  clear, replacing a working token with a rejected one left the badge reading
+  `Connected` about the *previous* authorisation while the hosted server went on
+  answering `tools/call` with the credential just refused — three correct
+  behaviours composing into a lie (`PUT` preserves a non-empty `auth` in SQL so
+  the token is never read into the process; `authenticated` is computed from
+  that column alone; the `PUT` reloads before any check can run). With a **flat**
+  clear, a provider that is briefly unreachable disconnects a working
+  integration — the same dishonesty pointing the other way. **A test that only
+  exercises the 401 passes against a flat clear**; the unreachable case needs its
+  own, over a row that *was* authorised, because a clear against a NULL `auth`
+  is unobservable.
+- **`Unreachable` is the default for anything unrecognised.** Misclassifying a
+  refusal leaves the old bug standing for one shape; misclassifying a transport
+  failure invents a new one.
+- **Each validator decides its own kind**, because only it can see the status or
+  the envelope. `CheckFailure::from_status` is the one place 401 and 403 are
+  grouped — `gateway_api/catalog.rs`'s reasoning verbatim, since some providers
+  report an exhausted quota as 403.
+- **Nothing else moves.** The 400 body is byte-identical on both classes — three
+  keys, `error` · `valid` · `validated`, and `REPORTS_VALIDATED` is untouched —
+  and `credentials` keeps the bytes the `PUT` stored, so re-running the check
+  after fixing the token restores the authorisation. A failed `clear_auth` is
+  logged and still answers the 400, and a row with nothing to clear is not
+  written at all. The UI tells the two classes apart by **re-reading the row**,
+  never by matching on the error string.
+
 **Shutdown is graceful, and it took one line's placement.** Go stops a server
 with `httpServer.Shutdown(context.Background())` and hands each tool handler the
 *HTTP request's* context, so a `tools/call` in flight when the server is torn

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2364,6 +2364,19 @@ Four things about it are load-bearing:
   the envelope. `CheckFailure::from_status` is the one place 401 and 403 are
   grouped — `gateway_api/catalog.rs`'s reasoning verbatim, since some providers
   report an exhausted quota as 403.
+- **A refusal only clears when it refused the credential `auth` attests, and
+  there is exactly one row where it does not.** A Slack integration in `oauth`
+  mode keeps its OAuth2 *token* in `auth` while `credentials` holds the client
+  pair — and `validateSlackTokenAuth` runs anyway, against
+  `credentials.bot_token`, which is **empty** in that mode, so Slack answers
+  `not_authed` about a credential that was never the authorisation. Clearing
+  there would destroy a working grant and force the whole flow again, on a check
+  that tested nothing. `token_validate::clears_on_refusal` reads `auth_mode` off
+  the **stored** blob through `integrations::auth_mode_of`'s three-literal
+  allowlist, so an absent or unrecognised mode still clears — matching
+  `resolveToken`'s own fallback to `bot_token`. `IntegrationsView` states the
+  same invariant beside its two auth buttons ("neither writes anything, so this
+  is a confusing answer rather than data loss"); keep both true together.
 - **Nothing else moves.** The 400 body is byte-identical on both classes — three
   keys, `error` · `valid` · `validated`, and `REPORTS_VALIDATED` is untouched —
   and `credentials` keeps the bytes the `PUT` stored, so re-running the check

--- a/src-tauri/src/native/integrations.rs
+++ b/src-tauri/src/native/integrations.rs
@@ -142,6 +142,10 @@
 /// job, and this module still never reads a credential — [`registry`] does,
 /// through a projection of its own that no response type can reach.
 pub mod base_url;
+/// What a failed credential check concluded — refused, or never answered (#521).
+/// Read by the five validators below and by [`token_validate`], which is the one
+/// caller that acts on the difference.
+pub mod check;
 pub mod confluence;
 pub mod github;
 pub mod google;

--- a/src-tauri/src/native/integrations.rs
+++ b/src-tauri/src/native/integrations.rs
@@ -327,7 +327,7 @@ fn auth_mode_sql() -> String {
 /// `auth_mode_sql`'s answer for a credential blob this process is already
 /// holding, for the two writes that build their response by hand instead of
 /// re-reading the row.
-fn auth_mode_of(credentials: &str) -> String {
+pub(crate) fn auth_mode_of(credentials: &str) -> String {
     serde_json::from_str::<serde_json::Value>(credentials)
         .ok()
         .as_ref()

--- a/src-tauri/src/native/integrations/check.rs
+++ b/src-tauri/src/native/integrations/check.rs
@@ -1,0 +1,100 @@
+//! What a remote credential check *concluded*, beyond the fact that it failed
+//! (#521).
+//!
+//! # Why a failure needs a kind at all
+//!
+//! `POST /api/integrations/{id}/auth/validate` reports a failure as one 400
+//! whatever went wrong, and that is the wire contract — it does not move. But
+//! three behaviours compose into a state that lies, and telling the two failure
+//! classes apart is what fixes it:
+//!
+//! - `PUT /api/integrations/{id}` overwrites `credentials` and deliberately
+//!   **preserves a non-empty `auth`** in SQL, so the stored token is never read
+//!   into this process;
+//! - `authenticated` is computed from `auth` alone, and
+//!   [`super::registry::HostingRow::is_startable`] is `enabled && authenticated`
+//!   — neither consults `credentials`;
+//! - the `PUT` reloads the MCP server *before* any check can run, because the
+//!   check is a separate route reading what was stored.
+//!
+//! So replacing a working token with a **rejected** one left the badge reading
+//! `Connected` about the previous authorisation while the hosted server answered
+//! `tools/call` on the credential the provider had just refused. The fix is to
+//! clear `auth` on that path — but only on that path: a **flat** clear would
+//! disconnect a working integration every time the provider was briefly
+//! unreachable, which is the same dishonesty pointing the other way.
+//!
+//! # The trichotomy, minus one
+//!
+//! `native/gateway_api/catalog.rs` already answers this exact question for the
+//! gateway's provider check, as `unauthorized` / `unreachable` / `unexpected`.
+//! Only the first of those is a state change here, and the other two are the
+//! same answer — *change nothing* — so this is the same distinction with the
+//! two harmless arms merged.
+//!
+//! **[`CheckKind::Unreachable`] is the safe default and every unrecognised
+//! outcome takes it.** Misclassifying a refusal as unreachable leaves the
+//! pre-existing bug standing for that one shape; misclassifying a transport
+//! failure as a refusal disconnects a working integration. Only the second is
+//! a new failure, so the doubt goes the other way.
+//!
+//! Grouping 401 **with** 403 is `catalog.rs`'s reasoning verbatim: some
+//! providers report an exhausted quota with 403, and both are the provider
+//! answering about the credential rather than failing to answer at all.
+
+/// Which of the two classes a failed credential check falls into.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CheckKind {
+    /// The provider answered and refused the credential — an HTTP 401 or 403,
+    /// or a refusal carried in a 200 envelope (Slack's `ok:false`, Telegram's).
+    ///
+    /// This is the only kind that changes stored state.
+    Rejected,
+    /// Everything else: a transport failure, a timeout, a 404 on the base URL,
+    /// a 5xx, a response that would not parse, a rate limit, or a credential
+    /// that never reached the network because its own site URL was refused.
+    ///
+    /// Nothing about the authorisation on file is known, so nothing moves.
+    Unreachable,
+}
+
+/// A failed remote check: what to say, and what class it was.
+///
+/// The message is the one that was already going on the wire — every
+/// per-validator sentence is a parity fixture and none of them move here. Only
+/// the kind is new.
+pub struct CheckFailure {
+    pub kind: CheckKind,
+    pub message: String,
+}
+
+impl CheckFailure {
+    /// The provider answered and refused the credential.
+    pub fn rejected(message: impl Into<String>) -> Self {
+        Self {
+            kind: CheckKind::Rejected,
+            message: message.into(),
+        }
+    }
+
+    /// Everything else — see [`CheckKind::Unreachable`].
+    pub fn unreachable(message: impl Into<String>) -> Self {
+        Self {
+            kind: CheckKind::Unreachable,
+            message: message.into(),
+        }
+    }
+
+    /// Whether an HTTP status is the provider refusing the credential.
+    ///
+    /// The one place the 401/403 pair is spelled, so the four validators that
+    /// classify on a status cannot drift apart — and so widening it is one
+    /// edit rather than four.
+    pub fn from_status(status: u16, message: impl Into<String>) -> Self {
+        if status == 401 || status == 403 {
+            Self::rejected(message)
+        } else {
+            Self::unreachable(message)
+        }
+    }
+}

--- a/src-tauri/src/native/integrations/confluence/validate.rs
+++ b/src-tauri/src/native/integrations/confluence/validate.rs
@@ -35,16 +35,19 @@
 //! dropping the decode would turn it into a success.
 
 use crate::claude::CancellationToken;
+use crate::native::integrations::check::CheckFailure;
 
 use super::client::{http_client, read_capped_at};
 
 /// Why a validation failed, and whether this port can spell Go's sentence.
 pub enum Refusal {
-    /// A sentence Go produces verbatim, safe to put on the wire.
-    Reproducible(String),
+    /// A sentence Go produces verbatim, safe to put on the wire — carrying the
+    /// outcome's kind (#521) as well as its wording.
+    Reproducible(CheckFailure),
     /// A wording this build does not reproduce. The caller answers a 500 with
     /// the reason in the log rather than inventing a sentence the user sees —
-    /// safe here because it can only arise before the network call.
+    /// safe here because it can only arise before the network call, which is
+    /// also why it needs no kind: nothing was asked, so nothing was refused.
     Unreproducible(String),
 }
 
@@ -87,7 +90,9 @@ pub async fn validate_credentials(
         if e.starts_with("invalid site URL: ") {
             Refusal::Unreproducible(e)
         } else {
-            Refusal::Reproducible(e)
+            // A site URL this build refuses outright never reached Atlassian,
+            // so it says nothing about the token.
+            Refusal::Reproducible(CheckFailure::unreachable(e))
         }
     })?;
 
@@ -99,7 +104,7 @@ pub async fn validate_credentials(
         .map_err(|e| Refusal::Unreproducible(format!("creating confluence request: {e}")))?;
 
     let request = http_client()
-        .ok_or_else(|| Refusal::Reproducible(failed.clone()))?
+        .ok_or_else(|| Refusal::Reproducible(CheckFailure::unreachable(failed.clone())))?
         .get(url)
         // `req.SetBasicAuth(email, apiToken)`.
         .basic_auth(email, Some(api_token))
@@ -108,30 +113,45 @@ pub async fn validate_credentials(
     // Go discards `client.Do`'s error rather than wrapping it: the URL is the
     // customer's site and the header is a credential.
     let response = tokio::select! {
-        () = ct.cancelled() => return Err(Refusal::Reproducible(failed.clone())),
-        result = request.send() => result.map_err(|_| Refusal::Reproducible(failed))?,
+        () = ct.cancelled() => {
+            return Err(Refusal::Reproducible(CheckFailure::unreachable(failed.clone())))
+        }
+        result = request.send() => {
+            result.map_err(|_| Refusal::Reproducible(CheckFailure::unreachable(failed)))?
+        }
     };
 
     let status = response.status().as_u16();
     let body = read_capped_at(ct, response, MAX_VALIDATE_BYTES)
         .await
-        .map_err(|e| Refusal::Reproducible(format!("reading confluence response: {e}")))?;
+        .map_err(|e| {
+            Refusal::Reproducible(CheckFailure::unreachable(format!(
+                "reading confluence response: {e}"
+            )))
+        })?;
 
+    // The only one of the five whose refusal is already singled out by status,
+    // so this arm *is* the rejection — Go's own 401/403 grouping, and the same
+    // grouping `CheckFailure::from_status` applies for the other four.
     if status == 401 || status == 403 {
-        return Err(Refusal::Reproducible(
-            "invalid credentials: check email and API token".to_string(),
-        ));
+        return Err(Refusal::Reproducible(CheckFailure::rejected(
+            "invalid credentials: check email and API token",
+        )));
     }
     if status != 200 {
-        return Err(Refusal::Reproducible(format!(
+        return Err(Refusal::Reproducible(CheckFailure::unreachable(format!(
             "confluence API returned status {status}: {body}"
-        )));
+        ))));
     }
 
     // `json.Unmarshal` into a struct: a bare `null` leaves it zeroed and
     // succeeds, and a JSON array is a type error to Go but decodes positionally
     // in serde — hence the `Option` and `GoStruct` this codebase uses for both.
     serde_json::from_str::<Option<crate::native::gojson::GoStruct<SpacesResponse>>>(&body)
-        .map_err(|e| Refusal::Reproducible(format!("parsing confluence response: {e}")))?;
+        .map_err(|e| {
+            Refusal::Reproducible(CheckFailure::unreachable(format!(
+                "parsing confluence response: {e}"
+            )))
+        })?;
     Ok(())
 }

--- a/src-tauri/src/native/integrations/github/validate.rs
+++ b/src-tauri/src/native/integrations/github/validate.rs
@@ -10,6 +10,7 @@
 //! attached.
 
 use crate::claude::CancellationToken;
+use crate::native::integrations::check::CheckFailure;
 
 use super::client::{api_base, http_client, read_capped};
 
@@ -25,13 +26,16 @@ struct User {
 }
 
 /// `ValidatePAT(ctx, token)` — the GitHub login on success.
-pub async fn validate_pat(ct: &CancellationToken, token: &str) -> Result<String, String> {
+///
+/// Like Jira's, the 401/403 pair does not change the *sentence* and does decide
+/// the [`CheckFailure`]: only those two are GitHub answering about the token.
+pub async fn validate_pat(ct: &CancellationToken, token: &str) -> Result<String, CheckFailure> {
     let failed = "calling GitHub /user: request failed".to_string();
     let url = reqwest::Url::parse(&format!("{}/user", api_base()))
-        .map_err(|e| format!("creating GitHub user request: {e}"))?;
+        .map_err(|e| CheckFailure::unreachable(format!("creating GitHub user request: {e}")))?;
 
     let request = http_client()
-        .ok_or_else(|| failed.clone())?
+        .ok_or_else(|| CheckFailure::unreachable(failed.clone()))?
         .get(url)
         .header("Authorization", format!("Bearer {token}"))
         .header("Accept", "application/vnd.github.v3+json");
@@ -39,8 +43,8 @@ pub async fn validate_pat(ct: &CancellationToken, token: &str) -> Result<String,
     // Go discards `client.Do`'s error rather than wrapping it — the request
     // carries the personal access token in a header.
     let response = tokio::select! {
-        () = ct.cancelled() => return Err(failed.clone()),
-        result = request.send() => result.map_err(|_| failed)?,
+        () = ct.cancelled() => return Err(CheckFailure::unreachable(failed.clone())),
+        result = request.send() => result.map_err(|_| CheckFailure::unreachable(failed))?,
     };
 
     let status = response.status().as_u16();
@@ -49,14 +53,17 @@ pub async fn validate_pat(ct: &CancellationToken, token: &str) -> Result<String,
     // parameter because the diff path uses a different one.
     let body = read_capped(ct, response, MAX_VALIDATE_BYTES)
         .await
-        .map_err(|e| format!("reading GitHub response: {e}"))?;
+        .map_err(|e| CheckFailure::unreachable(format!("reading GitHub response: {e}")))?;
 
     if status != 200 {
-        return Err(format!("github API error: status {status}: {body}"));
+        return Err(CheckFailure::from_status(
+            status,
+            format!("github API error: status {status}: {body}"),
+        ));
     }
 
     let user: User = serde_json::from_str::<Option<crate::native::gojson::GoStruct<User>>>(&body)
         .map(|wrapped| wrapped.map_or_else(User::default, |wrapped| wrapped.0))
-        .map_err(|e| format!("parsing GitHub user response: {e}"))?;
+        .map_err(|e| CheckFailure::unreachable(format!("parsing GitHub user response: {e}")))?;
     Ok(user.login)
 }

--- a/src-tauri/src/native/integrations/jira/validate.rs
+++ b/src-tauri/src/native/integrations/jira/validate.rs
@@ -18,6 +18,7 @@
 //! come from `client`.
 
 use crate::claude::CancellationToken;
+use crate::native::integrations::check::CheckFailure;
 
 use super::client::{http_client, read_capped};
 
@@ -40,20 +41,24 @@ struct Myself {
 
 /// `ValidateCredentials(ctx, siteURL, email, apiToken)` — the display name on
 /// success.
+///
+/// It does not single out 401/403 in its *message* (see above) and it does have
+/// to single them out in its [`CheckFailure`]: a 401 is Atlassian refusing the
+/// token, while a 404 or a 5xx says nothing about it. Same sentence either way.
 pub async fn validate_credentials(
     ct: &CancellationToken,
     site_url: &str,
     email: &str,
     api_token: &str,
-) -> Result<String, String> {
+) -> Result<String, CheckFailure> {
     let failed = "calling Jira /myself: request failed".to_string();
     let url = reqwest::Url::parse(&format!("{site_url}/rest/api/3/myself"))
         // `creating Jira myself request: %w` — `net/http`'s wording, so this
         // carries reqwest's.
-        .map_err(|e| format!("creating Jira myself request: {e}"))?;
+        .map_err(|e| CheckFailure::unreachable(format!("creating Jira myself request: {e}")))?;
 
     let request = http_client()
-        .ok_or_else(|| failed.clone())?
+        .ok_or_else(|| CheckFailure::unreachable(failed.clone()))?
         .get(url)
         .basic_auth(email, Some(api_token))
         .header("Accept", "application/json");
@@ -61,22 +66,25 @@ pub async fn validate_credentials(
     // Go discards `client.Do`'s error: the URL is the customer's site and the
     // header is a credential.
     let response = tokio::select! {
-        () = ct.cancelled() => return Err(failed.clone()),
-        result = request.send() => result.map_err(|_| failed)?,
+        () = ct.cancelled() => return Err(CheckFailure::unreachable(failed.clone())),
+        result = request.send() => result.map_err(|_| CheckFailure::unreachable(failed))?,
     };
 
     let status = response.status().as_u16();
     let body = read_capped(ct, response)
         .await
-        .map_err(|e| format!("reading Jira response: {e}"))?;
+        .map_err(|e| CheckFailure::unreachable(format!("reading Jira response: {e}")))?;
 
     if status != 200 {
-        return Err(format!("jira API error: status {status}: {body}"));
+        return Err(CheckFailure::from_status(
+            status,
+            format!("jira API error: status {status}: {body}"),
+        ));
     }
 
     let myself: Myself =
         serde_json::from_str::<Option<crate::native::gojson::GoStruct<Myself>>>(&body)
             .map(|wrapped| wrapped.map_or_else(Myself::default, |wrapped| wrapped.0))
-            .map_err(|e| format!("parsing Jira myself response: {e}"))?;
+            .map_err(|e| CheckFailure::unreachable(format!("parsing Jira myself response: {e}")))?;
     Ok(myself.display_name)
 }

--- a/src-tauri/src/native/integrations/registry.rs
+++ b/src-tauri/src/native/integrations/registry.rs
@@ -170,6 +170,16 @@ impl HostingRow {
         self.enabled && self.authenticated
     }
 
+    /// `cfg.IsAuthenticated()` on its own — whether the `auth` column holds
+    /// anything.
+    ///
+    /// The boolean, never the value: [`Self::auth`] stays private to this
+    /// module, and the one caller outside it ([`super::token_validate`]) only
+    /// needs to know whether there is an authorisation to clear (#521).
+    pub(crate) fn is_authenticated(&self) -> bool {
+        self.authenticated
+    }
+
     /// The services map a starter sees. A stored `null` is a nil Go map, which
     /// ranges zero times — an empty map is the same thing to every reader here.
     fn services(&self) -> BTreeMap<String, ServiceConfig> {

--- a/src-tauri/src/native/integrations/slack/validate.rs
+++ b/src-tauri/src/native/integrations/slack/validate.rs
@@ -21,6 +21,7 @@
 //! the alternative is a native handler that succeeds where Go fails.
 
 use crate::claude::CancellationToken;
+use crate::native::integrations::check::CheckFailure;
 
 use super::client::{api_base, http_client, read_capped};
 
@@ -58,23 +59,28 @@ struct AuthTest {
 }
 
 /// `ValidateToken(ctx, token)` — the team name on success.
-pub async fn validate_token(ct: &CancellationToken, token: &str) -> Result<String, String> {
+///
+/// The status is ignored and `ok` decides, so the refusal is `ok:false` — which
+/// is what an empty OAuth-mode bot token reaches, as `not_authed`. A **429** is
+/// deliberately *not* a refusal: Slack is declining to answer, not refusing the
+/// token.
+pub async fn validate_token(ct: &CancellationToken, token: &str) -> Result<String, CheckFailure> {
     let failed = "calling Slack auth.test: request failed".to_string();
     let url = reqwest::Url::parse(&format!("{}/auth.test", api_base()))
-        .map_err(|e| format!("creating Slack auth.test request: {e}"))?;
+        .map_err(|e| CheckFailure::unreachable(format!("creating Slack auth.test request: {e}")))?;
 
     // A POST with **no body** and `Content-Type: application/json` — Go builds
     // it with a nil body and sets the header anyway.
     let request = http_client()
-        .ok_or_else(|| failed.clone())?
+        .ok_or_else(|| CheckFailure::unreachable(failed.clone()))?
         .post(url)
         .header("Authorization", format!("Bearer {token}"))
         .header("Content-Type", "application/json");
 
     // Go discards `client.Do`'s error: the request carries the bot token.
     let response = tokio::select! {
-        () = ct.cancelled() => return Err(failed.clone()),
-        result = request.send() => result.map_err(|_| failed)?,
+        () = ct.cancelled() => return Err(CheckFailure::unreachable(failed.clone())),
+        result = request.send() => result.map_err(|_| CheckFailure::unreachable(failed))?,
     };
 
     // Checked before the body is read, and it returns without reading it.
@@ -84,22 +90,26 @@ pub async fn validate_token(ct: &CancellationToken, token: &str) -> Result<Strin
             .get("Retry-After")
             .and_then(|v| v.to_str().ok())
             .unwrap_or("");
-        return Err(format!(
+        return Err(CheckFailure::unreachable(format!(
             "slack rate limited, retry after {retry_after} seconds"
-        ));
+        )));
     }
 
     let body = read_capped(ct, response)
         .await
-        .map_err(|e| format!("reading Slack response: {e}"))?;
+        .map_err(|e| CheckFailure::unreachable(format!("reading Slack response: {e}")))?;
 
     let result: AuthTest =
         serde_json::from_str::<Option<crate::native::gojson::GoStruct<AuthTest>>>(&body)
             .map(|wrapped| wrapped.map_or_else(AuthTest::default, |wrapped| wrapped.0))
-            .map_err(|e| format!("parsing Slack response: {e}"))?;
+            .map_err(|e| CheckFailure::unreachable(format!("parsing Slack response: {e}")))?;
 
     if !result.ok {
-        return Err(format!("slack API error: {}", result.error));
+        // Slack refuses a bad token inside a 200 — this is the refusal.
+        return Err(CheckFailure::rejected(format!(
+            "slack API error: {}",
+            result.error
+        )));
     }
     Ok(result.team)
 }

--- a/src-tauri/src/native/integrations/telegram/validate.rs
+++ b/src-tauri/src/native/integrations/telegram/validate.rs
@@ -18,6 +18,7 @@
 //! in `callTelegram`.
 
 use crate::claude::CancellationToken;
+use crate::native::integrations::check::CheckFailure;
 
 use super::client::{api_base, http_client, read_capped, TelegramResponse};
 
@@ -46,24 +47,33 @@ struct BotUser {
 }
 
 /// `ValidateBotToken(ctx, token)` — the bot's username on success.
-pub async fn validate_bot_token(ct: &CancellationToken, token: &str) -> Result<String, String> {
+///
+/// The status is never looked at, so the *only* [`CheckFailure::rejected`] here
+/// is the envelope's `ok:false` — a refusal Telegram delivers with HTTP 200.
+/// Everything else is a transport or decode failure and changes nothing.
+pub async fn validate_bot_token(
+    ct: &CancellationToken,
+    token: &str,
+) -> Result<String, CheckFailure> {
     // Every failure between here and the response is this one sentence: Go
     // discards `client.Do`'s error rather than wrapping it, because the URL
     // carries the bot token and the error would print it.
     let failed = "calling Telegram getMe: request failed".to_string();
 
-    let url = endpoint(token).ok_or_else(|| failed.clone())?;
-    let request = http_client().ok_or_else(|| failed.clone())?.get(url);
+    let url = endpoint(token).ok_or_else(|| CheckFailure::unreachable(failed.clone()))?;
+    let request = http_client()
+        .ok_or_else(|| CheckFailure::unreachable(failed.clone()))?
+        .get(url);
 
     let response = tokio::select! {
-        () = ct.cancelled() => return Err(failed.clone()),
-        result = request.send() => result.map_err(|_| failed)?,
+        () = ct.cancelled() => return Err(CheckFailure::unreachable(failed.clone())),
+        result = request.send() => result.map_err(|_| CheckFailure::unreachable(failed))?,
     };
 
     let body = read_capped(ct, response)
         .await
         // `fmt.Errorf("reading Telegram response: %w", err)`.
-        .map_err(|e| format!("reading Telegram response: {e}"))?;
+        .map_err(|e| CheckFailure::unreachable(format!("reading Telegram response: {e}")))?;
 
     // `json.Unmarshal` into a struct: a bare `null` body leaves it zeroed and
     // returns no error, so Go falls through to the `!ok` branch with an empty
@@ -75,10 +85,14 @@ pub async fn validate_bot_token(ct: &CancellationToken, token: &str) -> Result<S
             // `encoding/json`'s wording is not reproducible, so this carries serde's —
             // the same pinned divergence `client::read_response` records. It cannot
             // leak the token: what is being parsed is Telegram's response.
-            .map_err(|e| format!("parsing Telegram response: {e}"))?;
+            .map_err(|e| CheckFailure::unreachable(format!("parsing Telegram response: {e}")))?;
 
     if !envelope.ok {
-        return Err(format!("telegram API error: {}", envelope.description));
+        // Telegram refuses a bad token inside a 200 — this is the refusal.
+        return Err(CheckFailure::rejected(format!(
+            "telegram API error: {}",
+            envelope.description
+        )));
     }
 
     // `json.Unmarshal(tgResp.Result, &bot)`. An *absent* `result` is `nil` to
@@ -89,7 +103,7 @@ pub async fn validate_bot_token(ct: &CancellationToken, token: &str) -> Result<S
     let bot: BotUser =
         serde_json::from_str::<Option<crate::native::gojson::GoStruct<BotUser>>>(envelope.result())
             .map(|wrapped| wrapped.map_or_else(BotUser::default, |wrapped| wrapped.0))
-            .map_err(|e| format!("parsing bot user: {e}"))?;
+            .map_err(|e| CheckFailure::unreachable(format!("parsing bot user: {e}")))?;
 
     Ok(bot.username)
 }

--- a/src-tauri/src/native/integrations/token_validate.rs
+++ b/src-tauri/src/native/integrations/token_validate.rs
@@ -46,6 +46,26 @@
 //! integration: %w` goes into the very same 400 body. So a failed write is
 //! answered with that 400, and nothing on this path returns `Fallback` once the
 //! network has been touched.
+//!
+//! # A rejected check is a state change; an unreachable one is not (#521)
+//!
+//! There are now **two** writes, and the second is on the failure path. When the
+//! provider *answers and refuses* the credential, [`clear_auth`] empties the
+//! `auth` column and the server is reloaded — so `authenticated` goes false,
+//! [`registry::reload`] hits its `!is_startable()` early return with the server
+//! already stopped, and `available-tools` drops the row's tools. When the check
+//! merely could not be completed, nothing moves at all.
+//!
+//! [`super::check`] carries the whole argument for why the distinction exists
+//! and why `Unreachable` is the default. Two rules local to this module:
+//!
+//! - **The clear must not turn a 400 into a 500.** The credential is refused
+//!   whichever way the write goes, so a failed `clear_auth` is logged and the
+//!   400 is answered anyway — the same reasoning as the reload's own swallowing.
+//! - **A row with nothing to clear is not written.** `updated_at` moving is
+//!   observable, and a check refused against a row that was never authorised has
+//!   changed nothing; the reload still runs, because it is what proves no handle
+//!   is left.
 
 use std::path::Path;
 
@@ -55,6 +75,7 @@ use crate::claude::CancellationToken;
 use crate::native::writes::WriteError;
 use crate::native::{goquote, Answer};
 
+use super::check::{CheckFailure, CheckKind};
 use super::registry;
 
 /// `map[string]any{"valid": …, "validated": …}` — a Go map, so the wire order
@@ -179,10 +200,41 @@ fn validate_token_auth(db_path: &Path, row: &registry::HostingRow) -> Result<(),
 
     // ── Nothing above has called out; nothing below may return Fallback ──────
     let ct = CancellationToken::new();
-    let stored = super::super::trigger::block_on_result(
-        "validating integration credentials",
-        call(integration_type, &ct, &creds, rewritten),
-    )?;
+    // `trigger::block_on_result`'s body, spelled here — including its
+    // no-runtime sentence verbatim — because that helper is fixed to
+    // `WriteError` and this call has to carry the outcome's *kind* alongside
+    // one.
+    let called = match tokio::runtime::Handle::try_current() {
+        Ok(handle) => handle.block_on(call(integration_type, &ct, &creds, rewritten)),
+        Err(_) => Err(CallFailure {
+            kind: CheckKind::Unreachable,
+            error: WriteError::Fallback(
+                "validating integration credentials: no tokio runtime on this thread".to_string(),
+            ),
+        }),
+    };
+
+    let stored = match called {
+        Ok(stored) => stored,
+        Err(failure) => {
+            // The provider answered and refused it: the stored authorisation is
+            // about a credential that is no longer in use, so it goes — and the
+            // reload is what stops the server hosting the refused one.
+            if failure.kind == CheckKind::Rejected {
+                if row.is_authenticated() {
+                    if let Err(e) = clear_auth(db_path, &row.id) {
+                        log::warn!(
+                            "could not clear the authorisation of an integration \
+                             whose credential was refused: id={:?} error={e}",
+                            row.id
+                        );
+                    }
+                }
+                registry::reload_blocking(db_path, &row.id);
+            }
+            return Err(failure.error);
+        }
+    };
 
     // Go's `saving validated integration: %w` arm, which lands in the *same*
     // 400 body as a failed validation — so this is the inherited behaviour,
@@ -197,16 +249,45 @@ fn validate_token_auth(db_path: &Path, row: &registry::HostingRow) -> Result<(),
     Ok(())
 }
 
+/// A failed remote call: the answer it earns, and which class it was.
+///
+/// The `error` is exactly what this function used to return, so the 400 body is
+/// byte-identical on both classes; `kind` is the new half, and it decides only
+/// whether the caller clears the stored authorisation.
+struct CallFailure {
+    kind: CheckKind,
+    error: WriteError,
+}
+
+impl CallFailure {
+    /// Wrap a validator's [`CheckFailure`] in the `ValidationError` Go builds
+    /// around it, keeping the kind. `field` and the message prefix are the
+    /// per-type wording and do not move.
+    fn validation(field: &str, prefix: &str, failure: CheckFailure) -> Self {
+        Self {
+            kind: failure.kind,
+            error: WriteError::Validation {
+                field: field.to_string(),
+                message: format!("{prefix}{}", failure.message),
+            },
+        }
+    }
+}
+
 /// The five remote calls, each returning the `auth` payload its own MCP server
 /// reads. The payloads are built with [`goquote::quote`] and not a JSON encoder
 /// — Go builds them with `fmt.Sprintf("%q")`, whose output differs from
 /// `encoding/json`'s on `&`, `<`, `>` and every control character.
+///
+/// Each validator decides its own [`CheckKind`], because only it can see the
+/// status or the envelope; this function does no classifying of its own beyond
+/// giving the two shapes that never touched the network the safe default.
 async fn call(
     integration_type: &str,
     ct: &CancellationToken,
     creds: &Credentials,
     rewritten: Option<String>,
-) -> Result<Stored, WriteError> {
+) -> Result<Stored, CallFailure> {
     let auth = match integration_type {
         "confluence" => {
             use super::confluence::validate::Refusal;
@@ -218,25 +299,27 @@ async fn call(
             )
             .await
             .map_err(|refusal| match refusal {
-                Refusal::Reproducible(message) => WriteError::Validation {
-                    field: "credentials".to_string(),
-                    message: format!("invalid credentials: {message}"),
-                },
+                Refusal::Reproducible(failure) => {
+                    CallFailure::validation("credentials", "invalid credentials: ", failure)
+                }
                 // A `url.Parse` refusal, whose wording is not reproducible. It
                 // can only arise **before** the request, so a 500 costs nothing
-                // — see `confluence::validate`'s header.
-                Refusal::Unreproducible(why) => WriteError::Fallback(format!(
-                    "confluence site URL needs net/url's own message: {why}"
-                )),
+                // — see `confluence::validate`'s header — and nothing was
+                // refused, so it changes no stored state either.
+                Refusal::Unreproducible(why) => CallFailure {
+                    kind: CheckKind::Unreachable,
+                    error: WriteError::Fallback(format!(
+                        "confluence site URL needs net/url's own message: {why}"
+                    )),
+                },
             })?;
             r#"{"validated":true}"#.to_string()
         }
         "telegram" => {
             let username = super::telegram::validate::validate_bot_token(ct, &creds.bot_token)
                 .await
-                .map_err(|e| WriteError::Validation {
-                    field: "credentials.bot_token".to_string(),
-                    message: format!("invalid bot token: {e}"),
+                .map_err(|e| {
+                    CallFailure::validation("credentials.bot_token", "invalid bot token: ", e)
                 })?;
             format!(
                 r#"{{"validated":true,"bot_username":{}}}"#,
@@ -251,10 +334,7 @@ async fn call(
                 &creds.api_token,
             )
             .await
-            .map_err(|e| WriteError::Validation {
-                field: "credentials".to_string(),
-                message: format!("invalid jira credentials: {e}"),
-            })?;
+            .map_err(|e| CallFailure::validation("credentials", "invalid jira credentials: ", e))?;
             format!(
                 r#"{{"validated":true,"display_name":{}}}"#,
                 goquote::quote(&display_name)
@@ -263,9 +343,12 @@ async fn call(
         "github" => {
             let username = super::github::validate::validate_pat(ct, &creds.personal_access_token)
                 .await
-                .map_err(|e| WriteError::Validation {
-                    field: "credentials.personal_access_token".to_string(),
-                    message: format!("invalid personal access token: {e}"),
+                .map_err(|e| {
+                    CallFailure::validation(
+                        "credentials.personal_access_token",
+                        "invalid personal access token: ",
+                        e,
+                    )
                 })?;
             format!(
                 r#"{{"validated":true,"username":{}}}"#,
@@ -277,9 +360,8 @@ async fn call(
         "slack" => {
             let team = super::slack::validate::validate_token(ct, &creds.bot_token)
                 .await
-                .map_err(|e| WriteError::Validation {
-                    field: "credentials.bot_token".to_string(),
-                    message: format!("invalid bot token: {e}"),
+                .map_err(|e| {
+                    CallFailure::validation("credentials.bot_token", "invalid bot token: ", e)
                 })?;
             format!(
                 r#"{{"validated":true,"team_name":{}}}"#,
@@ -288,9 +370,12 @@ async fn call(
         }
         // Unreachable: the caller filtered the type before anything was called.
         other => {
-            return Err(WriteError::Fallback(format!(
-                "no token validation for integration type {other:?}"
-            )))
+            return Err(CallFailure {
+                kind: CheckKind::Unreachable,
+                error: WriteError::Fallback(format!(
+                    "no token validation for integration type {other:?}"
+                )),
+            })
         }
     };
     Ok(Stored {
@@ -324,6 +409,32 @@ fn save(db_path: &Path, id: &str, stored: &Stored) -> Result<(), String> {
     }
     .map_err(|e| format!("{e}"))?;
 
+    tx.commit().map_err(|e| format!("{e}"))
+}
+
+/// Empty the `auth` column of a row whose credential the provider refused
+/// (#521) — the one write on a failure path, and the whole of the state change.
+///
+/// It is [`save`]'s shape with one column and no value: same immediate
+/// transaction, same `updated_at`. `credentials` is deliberately untouched, so
+/// the bytes the `PUT` stored survive and re-running the check after fixing the
+/// token restores the authorisation.
+///
+/// `NULL` rather than `''` because that is what the column holds before anything
+/// validates it, and what `native/integrations.rs`'s `PUT` normalises `''` and
+/// the literal `null` back to — the three are one state to
+/// `HOSTING_COLUMNS`'s `authenticated` expression, and writing the one the rest
+/// of the port writes keeps them from drifting into two.
+fn clear_auth(db_path: &Path, id: &str) -> Result<(), String> {
+    let mut conn = crate::native::db::open_read_write(db_path)?;
+    let tx = conn
+        .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+        .map_err(|e| format!("begin authorisation clear: {e}"))?;
+    tx.execute(
+        "UPDATE integrations SET auth = NULL, updated_at = ?1 WHERE id = ?2",
+        rusqlite::params![crate::native::gotime::now_go_text(), id],
+    )
+    .map_err(|e| format!("{e}"))?;
     tx.commit().map_err(|e| format!("{e}"))
 }
 
@@ -694,6 +805,178 @@ mod tests {
             "got {}",
             body_of(&answer)
         );
+    }
+
+    /// Give a seeded row an authorisation, the way a successful check would.
+    ///
+    /// `migrated` leaves `auth` NULL, which is the state of a row nothing has
+    /// validated — and every failure-path assertion below is about a row that
+    /// *had* one, because that is the state the bug produced a lie about.
+    fn authorise(db: &Path, id: &str) {
+        let conn = rusqlite::Connection::open(db).expect("open");
+        conn.execute(
+            "UPDATE integrations SET auth = ?1 WHERE id = ?2",
+            rusqlite::params![r#"{"validated":true}"#, id],
+        )
+        .expect("authorise");
+    }
+
+    /// #521: a provider that **answers and refuses** the credential clears the
+    /// stored authorisation and leaves nothing hosted.
+    ///
+    /// Both halves matter and neither implies the other. The column is what
+    /// `authenticated` — and therefore the badge, `is_startable` and
+    /// `available-tools` — is computed from; the handle is what would otherwise
+    /// go on answering `tools/call` with the token the provider just refused,
+    /// for the life of the process.
+    ///
+    /// The row is genuinely hosted first, so the second assertion is about a
+    /// listener that existed rather than one that never started.
+    #[tokio::test]
+    async fn a_rejected_check_clears_the_authorisation_and_stops_the_server() {
+        use crate::native::integrations::telegram::client::{api_base_lock, set_api_base};
+        let _guard = api_base_lock().await;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(
+            dir.path(),
+            "tg-521-rejected",
+            "telegram",
+            &format!(r#"{{"bot_token":"{TOKEN}"}}"#),
+        );
+        authorise(&db, "tg-521-rejected");
+        registry::reload(&db, "tg-521-rejected")
+            .await
+            .expect("host the row");
+        assert!(
+            registry::registry().is_hosted("tg-521-rejected"),
+            "the row has to be hosted before the check, or the assertion below \
+             would pass against a server that never started"
+        );
+
+        // `{"ok":false}` is how Telegram refuses a bad token — at HTTP 200.
+        let base = fake(
+            StatusCode::OK,
+            r#"{"ok":false,"description":"Unauthorized"}"#,
+        )
+        .await;
+        set_api_base(Some(base));
+        let db2 = db.clone();
+        let answer = tokio::task::spawn_blocking(move || serve(&db2, "tg-521-rejected")).await;
+        set_api_base(None);
+        let answer = answer.expect("join").expect("served");
+
+        // The wire is unmoved: the same three-key 400 as before #521.
+        assert_eq!(answer.status, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            body_of(&answer),
+            concat!(
+                r#"{"error":"validation error for \"credentials.bot_token\": "#,
+                "invalid bot token: telegram API error: Unauthorized",
+                r#"","valid":false,"validated":true}"#,
+                "\n",
+            )
+        );
+
+        let (auth, credentials, updated) = row(&db, "tg-521-rejected");
+        assert_eq!(auth, "", "a refused credential leaves no authorisation");
+        assert_eq!(
+            credentials,
+            format!(r#"{{"bot_token":"{TOKEN}"}}"#),
+            "only `auth` is cleared — the credential the PUT stored survives"
+        );
+        assert_ne!(
+            updated, "2026-01-01 00:00:00 +0000 UTC",
+            "the row changed, so `updated_at` moves"
+        );
+        assert!(
+            !registry::registry().is_hosted("tg-521-rejected"),
+            "the refused credential must stop being served"
+        );
+    }
+
+    /// #521's other half, and the one a flat clear would fail: a provider that
+    /// **could not be reached** says nothing about the credential, so the
+    /// authorisation, the row and the running server are left exactly as they
+    /// were.
+    ///
+    /// Its row is authorised on purpose. The pre-existing unreachable test seeds
+    /// a NULL `auth`, where a clear is unobservable — so it passes against a
+    /// flat clear and this one does not.
+    #[tokio::test]
+    async fn an_unreachable_provider_leaves_the_authorisation_standing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(
+            dir.path(),
+            "ji-521-unreachable",
+            "jira",
+            &format!(
+                r#"{{"site_url":"http://127.0.0.1:1","email":"a@b.c","api_token":"{TOKEN}"}}"#
+            ),
+        );
+        authorise(&db, "ji-521-unreachable");
+
+        let db2 = db.clone();
+        let answer = tokio::task::spawn_blocking(move || serve(&db2, "ji-521-unreachable"))
+            .await
+            .expect("join")
+            .expect("served");
+
+        assert_eq!(answer.status, StatusCode::BAD_REQUEST);
+        let (auth, _, updated) = row(&db, "ji-521-unreachable");
+        assert_eq!(
+            auth, r#"{"validated":true}"#,
+            "a provider that never answered must not disconnect a working integration"
+        );
+        assert_eq!(
+            updated, "2026-01-01 00:00:00 +0000 UTC",
+            "nothing is written on the unreachable path"
+        );
+    }
+
+    /// The status classification itself, over the two shapes that share one
+    /// sentence: GitHub reports a revoked token and a broken API the same way
+    /// (`github API error: status N: …`), so only the kind tells them apart.
+    ///
+    /// A 500 first — proving the second assertion is not simply "the clear never
+    /// runs" — then a 401 against the same row.
+    #[tokio::test]
+    async fn a_5xx_is_unreachable_where_a_401_is_a_refusal() {
+        use crate::native::integrations::github::client::{api_base_lock, set_api_base};
+        let _guard = api_base_lock().await;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(
+            dir.path(),
+            "gh-521",
+            "github",
+            &format!(r#"{{"auth_mode":"pat","personal_access_token":"{TOKEN}"}}"#),
+        );
+        authorise(&db, "gh-521");
+
+        for (status, expected_auth, why) in [
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                r#"{"validated":true}"#,
+                "a 5xx says nothing about the token",
+            ),
+            (
+                StatusCode::UNAUTHORIZED,
+                "",
+                "a 401 is GitHub refusing the token",
+            ),
+        ] {
+            let base = fake(status, r#"{"message":"nope"}"#).await;
+            set_api_base(Some(base));
+            let db2 = db.clone();
+            let answer = tokio::task::spawn_blocking(move || serve(&db2, "gh-521")).await;
+            set_api_base(None);
+            let answer = answer.expect("join").expect("served");
+            assert_eq!(answer.status, StatusCode::BAD_REQUEST, "{why}");
+
+            let (auth, _, _) = row(&db, "gh-521");
+            assert_eq!(auth, expected_auth, "{why}");
+        }
     }
 
     /// A stored blob that is present but not JSON is a 500 rather than being

--- a/src-tauri/src/native/integrations/token_validate.rs
+++ b/src-tauri/src/native/integrations/token_validate.rs
@@ -220,7 +220,7 @@ fn validate_token_auth(db_path: &Path, row: &registry::HostingRow) -> Result<(),
             // The provider answered and refused it: the stored authorisation is
             // about a credential that is no longer in use, so it goes — and the
             // reload is what stops the server hosting the refused one.
-            if failure.kind == CheckKind::Rejected {
+            if failure.kind == CheckKind::Rejected && clears_on_refusal(row) {
                 if row.is_authenticated() {
                     if let Err(e) = clear_auth(db_path, &row.id) {
                         log::warn!(
@@ -410,6 +410,31 @@ fn save(db_path: &Path, id: &str, stored: &Stored) -> Result<(), String> {
     .map_err(|e| format!("{e}"))?;
 
     tx.commit().map_err(|e| format!("{e}"))
+}
+
+/// Whether a refusal is about the credential `auth` actually attests.
+///
+/// **It is not, in exactly one shape, and clearing there would be the damage
+/// this issue exists to avoid rather than the fix.** A Slack row in `oauth`
+/// mode stores its OAuth2 *token* in `auth` while `credentials` holds the
+/// client pair — and `validateSlackTokenAuth` runs anyway, with
+/// `credentials.bot_token`, which is **empty** in that mode (see
+/// `slack::validate`'s header). Slack answers `not_authed`, which is a genuine
+/// refusal of a credential that was never the authorisation: clearing on it
+/// would destroy a working OAuth grant and force the user through the whole
+/// flow again, for a check that tested nothing.
+///
+/// `IntegrationsView` already says as much beside its two auth buttons — "one
+/// click on the other tab of a connected Slack row would otherwise check an
+/// OAuth blob with the bot-token action … neither writes anything, so this is a
+/// confusing answer rather than data loss". This keeps that true.
+///
+/// Read off the **stored** blob rather than any request, which is
+/// `native/integrations.rs`'s own rule for `auth_mode`, and through its
+/// three-literal allowlist — so an unrecognised or absent mode is `""` and
+/// clears, matching `resolveToken`'s own fallback to `bot_token`.
+fn clears_on_refusal(row: &registry::HostingRow) -> bool {
+    super::auth_mode_of(&row.credentials) != "oauth"
 }
 
 /// Empty the `auth` column of a row whose credential the provider refused
@@ -892,6 +917,54 @@ mod tests {
         assert!(
             !registry::registry().is_hosted("tg-521-rejected"),
             "the refused credential must stop being served"
+        );
+    }
+
+    /// The one refusal that must **not** clear: an OAuth-mode Slack row.
+    ///
+    /// `auth` there is the OAuth2 token the flow wrote, while this check reads
+    /// `credentials.bot_token` — empty in that mode — so Slack answers
+    /// `not_authed` about a credential that was never the authorisation.
+    /// Clearing on it would destroy a working grant and force a full
+    /// re-authorisation, which is precisely the harm the classification exists
+    /// to avoid.
+    #[tokio::test]
+    async fn an_oauth_rows_refusal_does_not_clear_the_token_the_flow_wrote() {
+        use crate::native::integrations::slack::client::{api_base_lock, set_api_base};
+        let _guard = api_base_lock().await;
+        let base = fake(StatusCode::OK, r#"{"ok":false,"error":"not_authed"}"#).await;
+        set_api_base(Some(base));
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(
+            dir.path(),
+            "sl-521-oauth",
+            "slack",
+            r#"{"auth_mode":"oauth","client_id":"cid","client_secret":"sec"}"#,
+        );
+        // What `oauth/flow.rs` writes: the grant itself, not a `validated` flag.
+        let conn = rusqlite::Connection::open(&db).expect("open");
+        conn.execute(
+            "UPDATE integrations SET auth = ?1 WHERE id = 'sl-521-oauth'",
+            [r#"{"access_token":"xoxb-from-the-flow","token_type":"Bearer"}"#],
+        )
+        .expect("store the grant");
+        drop(conn);
+
+        let db2 = db.clone();
+        let answer = tokio::task::spawn_blocking(move || serve(&db2, "sl-521-oauth")).await;
+        set_api_base(None);
+        let answer = answer.expect("join").expect("served");
+
+        assert_eq!(answer.status, StatusCode::BAD_REQUEST);
+        let (auth, _, updated) = row(&db, "sl-521-oauth");
+        assert_eq!(
+            auth, r#"{"access_token":"xoxb-from-the-flow","token_type":"Bearer"}"#,
+            "a refusal about an empty bot token must not destroy an OAuth grant"
+        );
+        assert_eq!(
+            updated, "2026-01-01 00:00:00 +0000 UTC",
+            "nothing is written"
         );
     }
 

--- a/src/views/IntegrationsView.tsx
+++ b/src/views/IntegrationsView.tsx
@@ -1019,18 +1019,34 @@ function IntegrationDetail({
       // failed — the new credential *is* stored, and saying otherwise would
       // send the user looking for a write that happened.
       //
-      // **A rejected check does not make the badge honest**, and the copy has
-      // to say so. `update` preserves a non-empty `auth` in SQL and
-      // `authenticated` is computed from that column, so a row that was already
-      // connected still reads `Connected` after its credential is replaced with
-      // a rejected one — and `reload_blocking` has restarted its MCP server on
-      // the new, bad token. The status the user can see is about the *previous*
-      // authorisation; only this sentence is about the credential they just
-      // saved.
+      // **A failed check now has two outcomes, and the copy has to pick the
+      // right one** (#521). A credential the provider *refused* clears the
+      // `auth` column and stops the hosted server, so the status is about to
+      // read *Not connected* and the old sentence — "any earlier authorisation
+      // is what the status above still reflects" — would be a fresh lie. A
+      // check that could not reach the provider changes nothing, and there that
+      // sentence is exactly right.
+      //
+      // **The row is what tells them apart, not the error string.** No wire
+      // field distinguishes the two (both are the same three-key 400), and
+      // matching on the message would be prose coupling that breaks the day a
+      // provider rewords its refusal. `authenticated` after the check is the
+      // fact itself. A read that fails leaves `stillAuthorised` false, which is
+      // the sentence that claims less.
+      let stillAuthorised = false;
+      if (checking) {
+        try {
+          stillAuthorised = (await api.get<Integration>(`/integrations/${item.id}`)).authenticated;
+        } catch {
+          // Nothing to add — the honest-either-way sentence is below.
+        }
+      }
       setError(
-        checking
-          ? `${describeError(err)} — the new credential was saved but not accepted, so any earlier authorisation is what the status above still reflects.`
-          : describeError(err)
+        !checking
+          ? describeError(err)
+          : stillAuthorised
+            ? `${describeError(err)} — the new credential was saved but not accepted, so any earlier authorisation is what the status above still reflects.`
+            : `${describeError(err)} — the new credential was saved but the provider refused it, so this integration is not connected and its tools are not being served.`
       );
     } finally {
       // Unconditional, and outside the `try`: the row changed even when the


### PR DESCRIPTION
Closes #521

## What

A failed token credential check is now classified into **rejected** — the provider answered and refused the credential — versus **unreachable**, and only the first changes stored state.

- **Rejected** (HTTP 401/403, or a refusal carried inside a 200 envelope: Slack's `ok:false`, Telegram's) → `token_validate::clear_auth` empties the `auth` column and reloads, so `authenticated` goes false, `reload` hits its `!is_startable()` early return with the server already stopped, and `available-tools` drops the row's tools.
- **Unreachable** (transport failure, timeout, 5xx, a 404 on the base URL, a rate limit, an unparseable body, a site URL this build refuses) → nothing moves. It is the default for anything unrecognised.

## Why

Three correct behaviours composed into a dishonest state: `PUT /api/integrations/{id}` preserves a non-empty `auth` in SQL so the token is never read into the process; `authenticated` is computed from that column alone and `is_startable` is `enabled && authenticated`; and the `PUT` reloads before any check can run. So replacing a working token with a rejected one left the badge reading `Connected` about the *previous* authorisation while the hosted MCP server answered `tools/call` with the credential just refused — a failure that surfaces far from its cause, mid agent run.

A **flat** clear is the same dishonesty pointing the other way, which is why the classification is the fix rather than the clear alone.

## How

- **New `src-tauri/src/native/integrations/check.rs`** — `CheckKind` / `CheckFailure`, mirroring `gateway_api/catalog.rs`'s `unauthorized`/`unreachable`/`unexpected` with the two harmless arms merged. `from_status` is the one place 401 and 403 are grouped.
- **The five validators** (`telegram`, `confluence`, `jira`, `slack`, `github`) return `Result<_, CheckFailure>`; each decides its own kind, because only it can see the status or the envelope. No sentence moves.
- **`token_validate.rs`** — `CallFailure` carries the kind beside the `WriteError`, and `clear_auth` is the one write on a failure path.
- **`IntegrationsView.tsx`** — the failure copy picks its sentence by **re-reading the row**, never by matching the error string, so "any earlier authorisation is what the status above still reflects" is printed only where it is still true.

### The carve-out review found

A Slack row in `oauth` mode keeps its OAuth2 grant in `auth` while `credentials` holds the client pair — and `validateSlackTokenAuth` runs anyway, against `credentials.bot_token`, which is **empty** in that mode. Slack answers `not_authed`: a genuine refusal of a credential that was never the authorisation. A flat clear there destroys a working grant and forces the whole OAuth flow again. `clears_on_refusal` gates on `auth_mode` read off the stored blob through `integrations::auth_mode_of`'s three-literal allowlist, which keeps `IntegrationsView`'s own "neither writes anything, so this is a confusing answer rather than data loss" true.

## Acceptance criteria

- [x] A rejected check leaves `GET /api/integrations/{id}` reporting `authenticated: false`.
- [x] The registry holds no handle for the id afterwards, and `available-tools` contains none of its tools.
- [x] An unreachable check leaves `auth`, `authenticated` and the running server exactly as they were.
- [x] The route still answers `400` with `error` · `valid` · `validated` in that order on **both** failure classes, and `200 {valid, validated}` unchanged on success (`REPORTS_VALIDATED` untouched).
- [x] Nothing is written on either failure path except the `auth` clear on the rejected one — `credentials` keeps the bytes the `PUT` stored.
- [x] The UI re-reads the row and shows the honest state; the "earlier authorisation" sentence appears only on the unreachable path.

## Tests

Four in `token_validate.rs`, each verified to fail on the corresponding revert:

| test | fails when |
|---|---|
| `a_rejected_check_clears_the_authorisation_and_stops_the_server` | the clear is removed (the row is genuinely hosted first, so the handle assertion is about a listener that existed) |
| `an_unreachable_provider_leaves_the_authorisation_standing` | the clear is made flat |
| `a_5xx_is_unreachable_where_a_401_is_a_refusal` | either direction |
| `an_oauth_rows_refusal_does_not_clear_the_token_the_flow_wrote` | the `auth_mode` gate is removed |

## Deviations from the issue's HOW

- The HOW says *Create: none*; `check.rs` is a new ~100-line module because five validators plus the route share the type, and putting it in `token_validate.rs` would have made each validator depend on the route module.
- `trigger::block_on_result` is fixed to `WriteError`, so `validate_token_auth` inlines its body (no-runtime sentence verbatim) rather than widening a shared helper for one caller.
- Two visibility bumps: `HostingRow::is_authenticated()` (the boolean, never the value) and `integrations::auth_mode_of` → `pub(crate)`.

## Out of scope

The `PUT` credential-wipe entry in `CLAUDE.md`'s known-bugs list (fixed separately by #515), the `REPORTS_VALIDATED` list that omits github and slack, and a third state on the wire.