### PR TITLE
fix: re-resolve the Claude Code CLI when the cached path stops being spawnable (#533)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3003,9 +3003,8 @@ either way is the easy mistake here.
 `claude_cli::executable()` and then the bare name — see *The one external
 dependency* for the whole order and why a `PATH` scan was never enough. The
 override is re-read per call rather than taken from the cache, and that is for
-the tests rather than the app: the cache is a `OnceLock`, so a test binary whose
-cases each point at a *different* scripted CLI would otherwise all run the
-first one's.
+the tests rather than the app: a test binary whose cases each point at a
+*different* scripted CLI would otherwise all run the first one's.
 
 ### The scan (#289)
 
@@ -3430,7 +3429,13 @@ option-building — `TurnSettings::stored` and `registry::can_host`, shared by a
 three callers, plus `runner::load`, which is the chat turn's alone. Every one is
 `open_read_only`, and a WAL reader does not wait on a writer, which is why they
 are left: the test's contention is a write lock, so it says nothing about them
-either way. A *write* added there would be a different matter. A panic *inside* a handed-off
+either way. A *write* added there would be a different matter. **So is a
+subprocess**, and #533 nearly added one: `runner::claude_executable` can now
+re-walk the CLI order, which spawns a login shell bounded at 3 s plus a
+`--version` bounded at 2 s through a `std::thread::sleep` poll loop — twice the
+hold this test was written to catch. It is `spawn_blocking`ed at that one call
+site for exactly this rule; the list above is "non-blocking reads", not
+"whatever option-building happens to do". A panic *inside* a handed-off
 section is the one thing `db::blocking` cannot make safe: the executor's `finish`
 may have written the session results and not the job row, leaving a `running`
 row nothing will finish, which is why the rule is "every path ends in a job
@@ -4363,7 +4368,7 @@ runtime, which is not a packaging change.
 (#503). `AGENTO_CLAUDE_EXECUTABLE` → the stored `claude_executable_path` setting
 (migration 38) → **`$SHELL -lic 'command -v claude'`** → the `PATH` this process
 was launched with → a list of known install locations. First hit wins; the
-answer is cached in a `OnceLock` for the process.
+answer is cached, and **revalidated before every spawn** (#533, below).
 
 - **The login-shell probe is not decoration, and it must not be "simplified"
   away.** A GUI application does not inherit the user's shell `PATH`: a macOS
@@ -4416,8 +4421,18 @@ answer is cached in a `OnceLock` for the process.
     on every turn. The slot is claimed under the write lock *before* the walk, so
     two concurrent turns produce one walk; the cooldown is keyed on the last
     **refresh**, not on when the resolution was made, so the first failure always
-    recovers however recently the process started. Inside the cooldown the stale
-    path is returned and the failure message is unchanged.
+    recovers however recently the process started. Inside the cooldown, whatever
+    the last walk concluded is returned untouched.
+  - **A walk that finds nothing overwrites the cache with nothing**, and that is
+    the deliberate half of the previous rule rather than an oversight in it. The
+    old path is not kept: `cached()` is what the banner reads, and a banner
+    claiming an install detection could not find is the #503 defect wearing a
+    different hat. The spawn falls back to the bare name and fails with
+    `binary not found: "claude"` — which is what a machine that never had the
+    CLI has always reported, so the failure a user sees is unchanged rather than
+    newly worded. The cost is that recovery from a *transient* break waits for
+    the next due walk instead of the next free `stat`, and a ≤10 s wait is the
+    right price for a banner that cannot lie.
   - **`cached()` reads the refreshed value**, so the banner and Settings report
     the recovery — #503's "the banner and the spawn are one answer", kept true
     through a refresh. `host_info` reads it **once** and splits, or a refresh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4394,11 +4394,36 @@ answer is cached in a `OnceLock` for the process.
   are *the worst case a user waits for a window*, not a generous ceiling. A
   pathological shell degrades to "found by a later rule", never to a window that
   does not open. Priming on a background thread was rejected: `cached()` would
-  race it, and the loser fills the `OnceLock` **without the stored override**,
+  race it, and the loser fills the cache **without the stored override**,
   so a configured path would be ignored on some launches and not others.
-- **Resolution is once per launch.** Saving the setting takes effect at the next
-  start, which the Settings help says. Re-detecting live was considered and left
-  out.
+- **The walk is once per launch; its answer is revalidated before every spawn**
+  (#533). Claude Code self-updates, and the native install is a symlink into a
+  versioned directory that the update swaps — so for the length of that swap the
+  resolved path dangles, `execve` answers `ENOENT`, and a `OnceLock` filled at
+  startup meant **every chat and every scheduled run failed until the app was
+  restarted**, naming a path that works perfectly in a terminal. `executable()`
+  therefore `stat`s the cached path (`is_executable_file`, which follows
+  symlinks and is exactly the check a dangling one fails) and re-runs the walk
+  when it no longer holds. Four rules, each of them an acceptance criterion:
+  - **The refresh is given the stored override the first walk was given**, held
+    beside the resolution in the cache rather than re-derived — losing it would
+    silently demote a user's configured path to whatever detection finds, which
+    is the same defect background priming was rejected over.
+  - **`AGENTO_CLAUDE_EXECUTABLE` is returned verbatim and is never stat-gated**,
+    because rule 1 is taken on trust by design.
+  - **Re-resolution is rate-limited** (`REFRESH_COOLDOWN`, 10 s), or a CLI that
+    is genuinely gone pays a login-shell probe plus a `--version` per candidate
+    on every turn. The slot is claimed under the write lock *before* the walk, so
+    two concurrent turns produce one walk; the cooldown is keyed on the last
+    **refresh**, not on when the resolution was made, so the first failure always
+    recovers however recently the process started. Inside the cooldown the stale
+    path is returned and the failure message is unchanged.
+  - **`cached()` reads the refreshed value**, so the banner and Settings report
+    the recovery — #503's "the banner and the spawn are one answer", kept true
+    through a refresh. `host_info` reads it **once** and splits, or a refresh
+    between two reads would report one rule's path beside another rule's name.
+  There is no filesystem watcher and no background re-detection timer. Saving
+  the setting still takes effect at the next start, which the Settings help says.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4409,7 +4409,7 @@ answer is cached, and **revalidated before every spawn** (#533, below).
   restarted**, naming a path that works perfectly in a terminal. `executable()`
   therefore `stat`s the cached path (`is_executable_file`, which follows
   symlinks and is exactly the check a dangling one fails) and re-runs the walk
-  when it no longer holds. Four rules, each of them an acceptance criterion:
+  when it no longer holds. Five rules, each of them an acceptance criterion:
   - **The refresh is given the stored override the first walk was given**, held
     beside the resolution in the cache rather than re-derived — losing it would
     silently demote a user's configured path to whatever detection finds, which

--- a/src-tauri/src/claude_cli.rs
+++ b/src-tauri/src/claude_cli.rs
@@ -177,7 +177,11 @@ const VERSION_TIMEOUT: Duration = Duration::from_secs(2);
 /// user retrying: someone who repairs their install and presses send again
 /// should not be told the CLI is missing for as long as they can be bothered to
 /// wait. It does **not** delay the first recovery — see [`refresh_due`].
-const REFRESH_COOLDOWN: Duration = Duration::from_secs(10);
+///
+/// `pub` for one reason: the integration test drives [`spawnable_at`] with an
+/// instant this far ahead rather than sleeping, so the two cannot drift if this
+/// number changes.
+pub const REFRESH_COOLDOWN: Duration = Duration::from_secs(10);
 
 /// The cached answer, and what is needed to produce it again.
 ///
@@ -244,8 +248,13 @@ fn cli_name() -> &'static str {
 /// semantics, and it is what stops a second caller resolving concurrently with
 /// a *different* `stored_override` and installing the losing answer.
 fn fill(stored_override: Option<&str>) -> Option<Resolution> {
-    if let Some(cached) = read_cache().as_ref() {
-        return cached.resolution.clone();
+    // An explicit scope, not an `if let`: the read guard must be dropped before
+    // the write lock is taken or this deadlocks itself, and leaving that to
+    // temporary-lifetime rules makes adding an `else` here a hang.
+    {
+        if let Some(cached) = read_cache().as_ref() {
+            return cached.resolution.clone();
+        }
     }
     let mut guard = write_cache();
     // Somebody may have filled it between dropping the read lock and taking
@@ -318,26 +327,46 @@ pub fn executable() -> String {
             return explicit;
         }
     }
-    spawnable()
+    spawnable_at(Instant::now())
         .map(|r| r.path)
         .unwrap_or_else(|| "claude".to_string())
 }
 
 /// The cached resolution, re-resolved if it has stopped being spawnable (#533).
 ///
-/// Three outcomes, and the second is the whole issue: the path still stats as
-/// an executable file and is returned untouched; it does not and the walk runs
-/// again; it does not and a walk has already run too recently, in which case
-/// the stale answer is returned and the spawn fails with the unchanged
-/// `claude: binary not found` message.
-fn spawnable() -> Option<Resolution> {
+/// Three outcomes, and the second is the whole issue:
+///
+/// 1. The path still stats as an executable file — returned untouched, which is
+///    every ordinary turn.
+/// 2. It does not, and no walk has run too recently — the order is walked again
+///    and **whatever it concludes is what the cache now holds**, including
+///    `None`. A walk that finds nothing must not leave the old path behind: the
+///    banner reads the same value, and a banner claiming an install that is not
+///    there is exactly the #503 defect. The spawn then falls back to the bare
+///    name and fails with `claude: binary not found: "claude"` — which is what
+///    a machine that never had the CLI has always reported, so the failure is
+///    unchanged rather than newly worded.
+/// 3. It does not, and a walk *has* run too recently — whatever that walk
+///    concluded is returned unchanged, and no probe is paid for.
+///
+/// `now` is a parameter so a test can place the cooldown boundary instead of
+/// sleeping through it; [`executable`] is the production entry point and passes
+/// the real clock.
+pub fn spawnable_at(now: Instant) -> Option<Resolution> {
     let (resolution, stored_override) = {
         // `fill` first, so a caller reached before `prime` still gets an
-        // answer — the ordering safety net `cached` documents.
-        let current = fill(None);
+        // answer — the ordering safety net `cached` documents. Then **one**
+        // guard for both fields: taking two would let a refresh land between
+        // them and pair one walk's path with another walk's override, which is
+        // the same defect `host_info`'s read-once split avoids.
+        fill(None);
         let guard = read_cache();
-        let stored = guard.as_ref().and_then(|c| c.stored_override.clone());
-        (current, stored)
+        match guard.as_ref() {
+            Some(cached) => (cached.resolution.clone(), cached.stored_override.clone()),
+            // `fill` has just populated it, so this is unreachable; answering
+            // "nothing resolved" beats an `expect` on a spawn path.
+            None => (None, None),
+        }
     };
 
     if let Some(found) = resolution.as_ref() {
@@ -356,8 +385,8 @@ fn spawnable() -> Option<Resolution> {
     {
         let mut guard = write_cache();
         match guard.as_mut() {
-            Some(cached) if refresh_due(cached.refreshed_at, Instant::now()) => {
-                cached.refreshed_at = Some(Instant::now());
+            Some(cached) if refresh_due(cached.refreshed_at, now) => {
+                cached.refreshed_at = Some(now);
             }
             _ => return resolution,
         }
@@ -370,9 +399,11 @@ fn spawnable() -> Option<Resolution> {
     {
         let mut guard = write_cache();
         if let Some(cached) = guard.as_mut() {
+            // Unconditional, `None` included — see outcome 2 above.
             cached.resolution = fresh.clone();
-            // From completion rather than from the claim, so a walk that took
-            // its full five seconds does not immediately allow another.
+            // The real clock rather than `now`, and from completion rather than
+            // from the claim, so a walk that took its full five seconds does
+            // not immediately allow another.
             cached.refreshed_at = Some(Instant::now());
         }
     }

--- a/src-tauri/src/claude_cli.rs
+++ b/src-tauri/src/claude_cli.rs
@@ -1,4 +1,5 @@
-//! Where the Claude Code CLI is, decided once per launch (#503).
+//! Where the Claude Code CLI is: resolved once per launch, revalidated before
+//! every spawn (#503, #533).
 //!
 //! Everything Agento ships is self-contained except this one binary: agents run
 //! by spawning `claude` as a subprocess ([`crate::claude`]), and that CLI is a
@@ -30,7 +31,7 @@
 //!
 //! # The order
 //!
-//! First hit wins, and the result is cached for the process:
+//! First hit wins, and the result is cached:
 //!
 //! 1. **`AGENTO_CLAUDE_EXECUTABLE`** — an explicit instruction, taken verbatim.
 //! 2. **The stored `claude_executable_path` setting** — the in-product escape
@@ -62,10 +63,49 @@
 //! banner reports exactly what a turn will spawn — a wrong value produces a
 //! spawn error naming the user's own path, which is a better diagnostic than a
 //! banner claiming nothing is installed.
+//!
+//! # How long the answer is trusted (#533)
+//!
+//! **The walk runs once; its answer is checked before every spawn.** Claude
+//! Code updates itself, and the native install is a symlink
+//! (`~/.local/bin/claude`) into a versioned directory
+//! (`~/.local/share/claude/versions/<version>`) that a self-update swaps. For
+//! the length of that swap the symlink is dangling, `execve` answers `ENOENT`,
+//! and the SDK reports [`crate::claude::Error::CliNotFound`]. The path was
+//! right when it was resolved; nothing was wrong with the order. What was wrong
+//! is that the answer was never revisited — so **every chat and every scheduled
+//! run failed for the rest of the process's life**, naming a path that works
+//! perfectly in a terminal.
+//!
+//! So [`executable`] revalidates: one `stat` (through [`is_executable_file`],
+//! which follows symlinks and is therefore exactly the check a dangling one
+//! fails), and only when that fails does the walk run again — with the stored
+//! override the first walk was given, never `None`. Three properties hold it
+//! together, and each is an acceptance criterion rather than an optimisation:
+//!
+//! - **The happy path costs one `stat` and no subprocess.** The `--version`
+//!   round trip is emphatically *not* on it: it is what makes the walk
+//!   expensive, and a path that stats clean is the path that was already
+//!   verified.
+//! - **Re-resolution is rate-limited** ([`REFRESH_COOLDOWN`]). A CLI that is
+//!   genuinely gone would otherwise pay a login-shell probe plus a `--version`
+//!   per candidate on *every* turn. The slot is claimed under the write lock
+//!   before the walk starts, so two concurrent turns produce one walk.
+//! - **The first failure always refreshes.** The cooldown gates *repeated*
+//!   attempts, so it is keyed on the last refresh rather than on when the
+//!   resolution was made — a CLI that vanishes two seconds after launch still
+//!   recovers on the very next turn.
+//!
+//! [`cached`] reads the same value, so the banner and Settings report the
+//! recovery rather than the stale path. That is #503's invariant — the banner
+//! and the spawn are one answer — kept true through a refresh.
+//!
+//! What this deliberately is **not**: a filesystem watcher, a background
+//! re-detection timer, or a `--version` check per turn.
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::sync::OnceLock;
+use std::sync::{PoisonError, RwLock};
 use std::time::{Duration, Instant};
 
 /// How the CLI was found. Reported to the frontend so a user debugging a
@@ -116,13 +156,77 @@ pub struct Resolution {
 /// five seconds total, after which resolution simply continues down the order.
 ///
 /// The alternative — priming on a background thread — was rejected: `cached()`
-/// would then race the spawned resolution, and the loser fills the `OnceLock`
+/// would then race the spawned resolution, and the loser fills the cache
 /// *without* the stored override, so a user's configured path would be silently
 /// ignored on some launches and not others. Deterministic and bounded beats
-/// fast and occasionally wrong.
+/// fast and occasionally wrong. (#533 keeps that true from the other side: the
+/// override is stored *beside* the resolution, so a refresh cannot lose it
+/// either.)
 #[cfg(unix)]
 const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
 const VERSION_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// The shortest interval between two walks of the order (#533).
+///
+/// It bounds what a *missing* CLI costs. Every re-resolution is a login-shell
+/// probe plus up to one `--version` per candidate — up to five seconds of
+/// subprocess — and with nothing installed there is no answer to find, so an
+/// ungated refresh would pay that on every turn and on every scheduled run.
+///
+/// Ten seconds rather than a minute because the other side of the trade is a
+/// user retrying: someone who repairs their install and presses send again
+/// should not be told the CLI is missing for as long as they can be bothered to
+/// wait. It does **not** delay the first recovery — see [`refresh_due`].
+const REFRESH_COOLDOWN: Duration = Duration::from_secs(10);
+
+/// The cached answer, and what is needed to produce it again.
+///
+/// `stored_override` is remembered rather than re-derived. Re-reading the
+/// setting here would mean opening a database connection from this module,
+/// which it does not do; *dropping* it would mean a refresh silently demoting a
+/// user's configured path to whatever detection finds — the exact defect the
+/// module header rejects background priming over.
+struct Cached {
+    resolution: Option<Resolution>,
+    stored_override: Option<String>,
+    /// When the last **refresh** finished, not when the resolution was made.
+    /// `None` until one has run, which is what makes the first failure recover
+    /// immediately however recently the process started.
+    refreshed_at: Option<Instant>,
+}
+
+/// A `RwLock` rather than a `OnceLock`, because the answer can now change.
+///
+/// Reads are on a hot path only in the sense that a chat turn takes one, and a
+/// chat turn also spawns a process — the lock is not the cost. Nothing holds it
+/// across a subprocess except the very first fill, which is
+/// [`OnceLock::get_or_init`]'s own behaviour and is what keeps two concurrent
+/// first callers from resolving twice with different overrides.
+static CACHE: RwLock<Option<Cached>> = RwLock::new(None);
+
+/// Is a refresh allowed yet?
+///
+/// `None` — nothing has refreshed since this process resolved — is always due,
+/// so the turn that first meets a broken path re-resolves whatever the clock
+/// says. Only the *second* and later attempts wait out [`REFRESH_COOLDOWN`].
+///
+/// Split out and given `now` as a parameter so a test can construct the
+/// boundary rather than race it.
+fn refresh_due(refreshed_at: Option<Instant>, now: Instant) -> bool {
+    refreshed_at.is_none_or(|t| now.saturating_duration_since(t) >= REFRESH_COOLDOWN)
+}
+
+/// A poisoned lock is read through rather than panicked on: every critical
+/// section here is a clone or an assignment, so there is no torn state to
+/// protect against, and a panic elsewhere must not take the CLI path down with
+/// it.
+fn read_cache() -> std::sync::RwLockReadGuard<'static, Option<Cached>> {
+    CACHE.read().unwrap_or_else(PoisonError::into_inner)
+}
+
+fn write_cache() -> std::sync::RwLockWriteGuard<'static, Option<Cached>> {
+    CACHE.write().unwrap_or_else(PoisonError::into_inner)
+}
 
 /// The binary's name on this platform.
 fn cli_name() -> &'static str {
@@ -133,27 +237,60 @@ fn cli_name() -> &'static str {
     }
 }
 
-static CACHE: OnceLock<Option<Resolution>> = OnceLock::new();
+/// Fill the cache if it is empty, and hand back whatever it holds.
+///
+/// The write lock is held across [`resolve`] deliberately, which is the one
+/// place in this module that happens: it is [`OnceLock::get_or_init`]'s
+/// semantics, and it is what stops a second caller resolving concurrently with
+/// a *different* `stored_override` and installing the losing answer.
+fn fill(stored_override: Option<&str>) -> Option<Resolution> {
+    if let Some(cached) = read_cache().as_ref() {
+        return cached.resolution.clone();
+    }
+    let mut guard = write_cache();
+    // Somebody may have filled it between dropping the read lock and taking
+    // this one.
+    if let Some(cached) = guard.as_ref() {
+        return cached.resolution.clone();
+    }
+    let resolution = resolve(stored_override);
+    *guard = Some(Cached {
+        resolution: resolution.clone(),
+        stored_override: stored_override.map(str::to_owned),
+        refreshed_at: None,
+    });
+    resolution
+}
 
-/// Resolve once and remember the answer for the life of the process.
+/// Resolve once and remember the answer, along with the override that produced
+/// it.
 ///
 /// Called from `lib.rs`'s setup **after the database is open**, so the stored
 /// override is in hand; every later reader gets that same answer through
 /// [`cached`]. Priming is what keeps the expensive branch — a login shell,
 /// sourcing the user's rc files — off both the banner's path and a chat turn's.
-pub fn prime(stored_override: Option<&str>) -> Option<&'static Resolution> {
-    CACHE.get_or_init(|| resolve(stored_override)).as_ref()
+///
+/// Returns an owned value rather than a `&'static`: the answer can change under
+/// a reader now (#533), so handing out a borrow into the cache would be a lie
+/// about its lifetime as well as impossible to write.
+pub fn prime(stored_override: Option<&str>) -> Option<Resolution> {
+    fill(stored_override)
 }
 
-/// The cached resolution.
+/// The cached resolution — what the startup banner and Settings report.
 ///
 /// Resolves on first call if `prime` has not run — which is the case in unit
 /// tests and would be the case for any caller reached before setup finishes.
 /// That fallback deliberately passes **no** stored override: it is a safety net
 /// for ordering, not a second way to read the setting, and `lib.rs` primes
 /// before the proxy is listening so nothing in the app reaches it first.
-pub fn cached() -> Option<&'static Resolution> {
-    CACHE.get_or_init(|| resolve(None)).as_ref()
+///
+/// It reads, and never refreshes. A refresh is a spawn's business, and a banner
+/// that started subprocesses would put a login-shell probe behind every
+/// `host_info` — but because [`executable`] writes its recovery back here, this
+/// still reports the *refreshed* path rather than the one that failed.
+pub fn cached() -> Option<Resolution> {
+    fill(None)
 }
 
 /// The binary to spawn: the cached resolution, or the bare name when nothing
@@ -166,19 +303,91 @@ pub fn cached() -> Option<&'static Resolution> {
 /// nothing.
 ///
 /// `AGENTO_CLAUDE_EXECUTABLE` is re-read here rather than taken from the cache,
-/// and that is load-bearing for the tests rather than for the app: the cache is
-/// a `OnceLock`, so a test binary whose cases each point at a *different*
-/// scripted CLI would otherwise all run the first one's. In the app the two are
-/// the same value, because [`resolve`] reads the same variable first.
+/// and that is load-bearing for the tests rather than for the app: a test
+/// binary whose cases each point at a *different* scripted CLI would otherwise
+/// all run the first one's. In the app the two are the same value, because
+/// [`resolve`] reads the same variable first. It is also returned **verbatim**,
+/// with no `stat` and no refresh — rule 1 is taken on trust by design, and a
+/// wrapper script that does not exist yet at the moment it is asked about is a
+/// spawn error naming the user's own path, which is the better diagnostic.
+///
+/// Everything else is revalidated first — see the module header.
 pub fn executable() -> String {
     if let Ok(explicit) = std::env::var("AGENTO_CLAUDE_EXECUTABLE") {
         if !explicit.is_empty() {
             return explicit;
         }
     }
-    cached()
-        .map(|r| r.path.clone())
+    spawnable()
+        .map(|r| r.path)
         .unwrap_or_else(|| "claude".to_string())
+}
+
+/// The cached resolution, re-resolved if it has stopped being spawnable (#533).
+///
+/// Three outcomes, and the second is the whole issue: the path still stats as
+/// an executable file and is returned untouched; it does not and the walk runs
+/// again; it does not and a walk has already run too recently, in which case
+/// the stale answer is returned and the spawn fails with the unchanged
+/// `claude: binary not found` message.
+fn spawnable() -> Option<Resolution> {
+    let (resolution, stored_override) = {
+        // `fill` first, so a caller reached before `prime` still gets an
+        // answer — the ordering safety net `cached` documents.
+        let current = fill(None);
+        let guard = read_cache();
+        let stored = guard.as_ref().and_then(|c| c.stored_override.clone());
+        (current, stored)
+    };
+
+    if let Some(found) = resolution.as_ref() {
+        // One `stat`, following symlinks: a self-update that has swapped the
+        // version directory out from under `~/.local/bin/claude` leaves exactly
+        // a dangling symlink, and that is what this sees. No `--version` here —
+        // that is the expensive half, and a path that stats clean is a path the
+        // walk already verified.
+        if is_executable_file(Path::new(&found.path)) {
+            return resolution;
+        }
+    }
+
+    // Claim the refresh slot before walking, so a second turn arriving while
+    // this one is probing waits out the cooldown instead of probing too.
+    {
+        let mut guard = write_cache();
+        match guard.as_mut() {
+            Some(cached) if refresh_due(cached.refreshed_at, Instant::now()) => {
+                cached.refreshed_at = Some(Instant::now());
+            }
+            _ => return resolution,
+        }
+    }
+
+    // Outside every lock: this spawns a login shell and up to one `--version`
+    // per candidate.
+    let fresh = resolve(stored_override.as_deref());
+
+    {
+        let mut guard = write_cache();
+        if let Some(cached) = guard.as_mut() {
+            cached.resolution = fresh.clone();
+            // From completion rather than from the claim, so a walk that took
+            // its full five seconds does not immediately allow another.
+            cached.refreshed_at = Some(Instant::now());
+        }
+    }
+
+    // The same line the startup banner logs, so a recovery reads as one in the
+    // log the user exports rather than as silence between two failures.
+    match fresh.as_ref() {
+        Some(found) => log::info!(
+            "claude cli re-resolved path={:?} source={}",
+            found.path,
+            found.source.as_str()
+        ),
+        None => log::warn!("claude cli: the resolved path is gone and detection found no other"),
+    }
+    fresh
 }
 
 /// The ordered walk. `stored_override` is the `claude_executable_path` setting,
@@ -784,6 +993,37 @@ mod tests {
             "the wait was not bounded: {:?}",
             started.elapsed()
         );
+    }
+
+    /// The cooldown gates *repeated* walks, never the first one (#533).
+    ///
+    /// Keying it on "how long since this process resolved" instead would leave
+    /// the one case the issue is about — a CLI that goes away shortly after
+    /// launch — unable to recover on the turn that meets it. The boundary is
+    /// constructed rather than raced: `now` is a parameter precisely so a test
+    /// can place an instant exactly [`REFRESH_COOLDOWN`] ago.
+    #[test]
+    fn the_first_refresh_is_always_due_and_the_next_one_waits() {
+        let now = Instant::now();
+        assert!(
+            refresh_due(None, now),
+            "a path that broke before any refresh must recover on the next spawn"
+        );
+
+        assert!(
+            !refresh_due(Some(now), now),
+            "a second turn arriving immediately must not walk the order again"
+        );
+
+        let just_short = now
+            .checked_sub(REFRESH_COOLDOWN - Duration::from_millis(1))
+            .expect("an instant inside the cooldown");
+        assert!(!refresh_due(Some(just_short), now));
+
+        // Exactly on the boundary is due — `>=`, so the cooldown is the wait
+        // and not one tick more than it.
+        let exactly = now.checked_sub(REFRESH_COOLDOWN).expect("the boundary");
+        assert!(refresh_due(Some(exactly), now), "the boundary is inclusive");
     }
 
     #[cfg(unix)]

--- a/src-tauri/src/claude_cli.rs
+++ b/src-tauri/src/claude_cli.rs
@@ -80,7 +80,7 @@
 //! So [`executable`] revalidates: one `stat` (through [`is_executable_file`],
 //! which follows symlinks and is therefore exactly the check a dangling one
 //! fails), and only when that fails does the walk run again — with the stored
-//! override the first walk was given, never `None`. Three properties hold it
+//! override the first walk was given, never `None`. Four properties hold it
 //! together, and each is an acceptance criterion rather than an optimisation:
 //!
 //! - **The happy path costs one `stat` and no subprocess.** The `--version`
@@ -95,6 +95,14 @@
 //!   attempts, so it is keyed on the last refresh rather than on when the
 //!   resolution was made — a CLI that vanishes two seconds after launch still
 //!   recovers on the very next turn.
+//! - **A walk that finds nothing overwrites the cache with nothing.** The old
+//!   path is not kept: [`cached`] is what the banner reads, and a banner
+//!   claiming an install detection could not find is the #503 defect wearing a
+//!   different hat. The spawn then falls back to the bare name and fails with
+//!   `binary not found: "claude"`, which is what a machine that never had the
+//!   CLI has always reported — so the failure a user sees is unchanged rather
+//!   than newly worded. The price is that a *transient* break recovers on the
+//!   next due walk instead of the next free `stat`.
 //!
 //! [`cached`] reads the same value, so the banner and Settings report the
 //! recovery rather than the stale path. That is #503's invariant — the banner

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -86,7 +86,9 @@ pub struct HostInfo {
     /// Resolved path to the Claude Code CLI, or null when it could not be
     /// found. **The same resolution a turn spawns** ([`claude_cli`]) — the two
     /// were separate lookups that happened to call one function, and a banner
-    /// that disagrees with the spawn is #503.
+    /// that disagrees with the spawn is #503. Re-read per call rather than
+    /// captured, so a turn that recovered from a CLI self-update (#533) is
+    /// reported here too.
     pub claude_cli: Option<String>,
     /// Which rule produced `claude_cli` — `env`, `setting`, `login-shell`,
     /// `path` or `candidate`. Null exactly when `claude_cli` is.
@@ -105,6 +107,7 @@ pub struct HostInfo {
 
 #[tauri::command]
 fn host_info(state: tauri::State<'_, AppPorts>) -> HostInfo {
+    let claude = claude_cli::cached();
     HostInfo {
         os: std::env::consts::OS.to_string(),
         arch: std::env::consts::ARCH.to_string(),
@@ -120,8 +123,12 @@ fn host_info(state: tauri::State<'_, AppPorts>) -> HostInfo {
             log::error!("minting the webview session token: {e}");
             String::new()
         }),
-        claude_cli: claude_cli::cached().map(|r| r.path.clone()),
-        claude_cli_source: claude_cli::cached().map(|r| r.source.as_str().to_string()),
+        // Read once and split, rather than twice: since #533 this is a lock
+        // read and a clone rather than a `OnceLock` peek, and — more to the
+        // point — a refresh between the two calls would report one rule's path
+        // beside another rule's name.
+        claude_cli: claude.as_ref().map(|r| r.path.clone()),
+        claude_cli_source: claude.as_ref().map(|r| r.source.as_str().to_string()),
         can_self_update: install_kind() != "package",
         install_kind: install_kind().to_string(),
     }

--- a/src-tauri/src/native/chat/runner.rs
+++ b/src-tauri/src/native/chat/runner.rs
@@ -332,7 +332,7 @@ pub async fn build_options(
             .with_bypass_permissions(),
     };
 
-    opts = opts.with_claude_executable(claude_executable());
+    opts = opts.with_claude_executable(claude_executable().await);
 
     // `resolveAgentConfig` branches on whether the **chat names an agent**, not
     // on whether that agent has a model: it returns the agent's config outright,
@@ -865,8 +865,29 @@ fn profile_file_path_in(config_dir: &str, index_dir: &str, profile_id: &str) -> 
 ///
 /// It delegates rather than reimplementing the order, so there is nothing here
 /// that can drift from what `host_info` reports.
-fn claude_executable() -> String {
-    crate::claude_cli::executable()
+///
+/// **Off the runtime, because since #533 this can walk the order again.** The
+/// happy path is one `stat` (20.9 µs measured) and would be fine inline — but a
+/// cached path that has stopped being spawnable re-resolves, and that spawns
+/// `$SHELL -lic` bounded by three seconds plus a `--version` bounded by two,
+/// through a `std::thread::sleep` poll loop. `build_options` is awaited on the
+/// runtime by both the chat turn and the scheduler's executor, so leaving it
+/// inline puts a 3 s stall on a worker — twice the hold
+/// `a_contended_write_lock_does_not_stall_the_runtime` was written to catch,
+/// and it would falsify the "what is still on the worker" list in `CLAUDE.md`,
+/// every entry of which is a non-blocking read. It is bounded (one walk per
+/// `REFRESH_COOLDOWN`, and only one thread walks) but bounded is not the bar
+/// #366 set.
+///
+/// A `JoinError` means the blocking pool dropped the task, which leaves the
+/// same answer `executable()` gives when it finds nothing.
+async fn claude_executable() -> String {
+    tokio::task::spawn_blocking(crate::claude_cli::executable)
+        .await
+        .unwrap_or_else(|e| {
+            log::warn!("claude cli: resolving off the runtime failed: {e}");
+            "claude".to_string()
+        })
 }
 
 /// The two template variables Agento substitutes into a system prompt.

--- a/src-tauri/tests/claude_cli_offload.rs
+++ b/src-tauri/tests/claude_cli_offload.rs
@@ -1,0 +1,193 @@
+//! Re-resolving the CLI must not park a runtime worker (#533, #366).
+//!
+//! The fourth copy of `a_contended_write_lock_does_not_stall_the_runtime`, and
+//! it is here rather than beside the other three for one reason: they all reach
+//! the runner through `AGENTO_CLAUDE_EXECUTABLE`, which is rule 1 and returns
+//! before any walk. A test that sets it cannot see this property at all.
+//!
+//! What is under test is `runner::claude_executable`'s `spawn_blocking`. Before
+//! #533 that function was a `OnceLock` read and inlining it was free; now it can
+//! walk the order again, which spawns `$SHELL -lic` bounded at three seconds
+//! plus a `--version` bounded at two, through a `std::thread::sleep` poll loop.
+//! `build_options` is awaited on the runtime by both the chat turn and the
+//! scheduler's executor, so inline that is a multi-second stall on a worker —
+//! and #533's own note that it is *bounded* is exactly the argument #366 refused.
+//!
+//! **One test per binary**, like `claude_cli_refresh.rs`: this primes the
+//! process-wide resolution cache, and a second test would run against the
+//! first's.
+//!
+//! Verified in both directions rather than assumed: reverting `runner.rs` to the
+//! inline `claude_cli::executable()` takes the longest gap from ~10 ms to the
+//! whole of `PROBE`.
+
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use agento_lib::native::agents::{Agent, Capabilities};
+use agento_lib::native::chat::runner::{build_options, RunSpec, TurnSettings};
+
+/// How long the fake login shell takes to answer. Long enough that a parked
+/// worker is unmistakable, and well inside `claude_cli`'s own 3 s `PROBE_TIMEOUT`
+/// so the walk completes rather than being killed.
+const PROBE: Duration = Duration::from_millis(1_500);
+
+/// No capabilities, so `build_options` starts no MCP server and opens no
+/// database — the only work left in it is resolving the executable, which is
+/// what this measures.
+fn spec() -> RunSpec {
+    RunSpec {
+        agent: Some(Agent {
+            name: "offload".into(),
+            slug: "offload".into(),
+            description: String::new(),
+            model: String::new(),
+            thinking: "disabled".into(),
+            permission_mode: String::new(),
+            system_prompt: String::new(),
+            capabilities: Capabilities {
+                built_in: None,
+                local: None,
+                mcp: None,
+            },
+            claude_config_dir: String::new(),
+        }),
+        no_agent_model: Box::new(String::new),
+        settings: Arc::new(TurnSettings::none()),
+        working_dir: String::new(),
+        settings_profile_id: String::new(),
+        permission_mode: String::new(),
+        resume_session_id: None,
+        custom_session_id: String::new(),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn re_resolving_the_cli_does_not_stall_the_runtime() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let home = tmp.path().join("home");
+    let installed = home.join(".local/bin");
+    std::fs::create_dir_all(&installed).expect("install dir");
+    let cli = write_script(
+        &installed,
+        "claude",
+        "echo '2.1.231 (Claude Code)'\nexit 0\n",
+    );
+
+    // A login shell that takes its time, which is what an rc file sourcing a
+    // version manager does on a real machine. `sleep` is resolved to an absolute
+    // path **now**, while `PATH` is still the real one: the override below
+    // empties it so that rule 4 contributes nothing, and a `sleep` the script
+    // cannot find fails silently and leaves this measuring an instant probe.
+    let sleep_bin = std::env::var_os("PATH")
+        .and_then(|path| {
+            std::env::split_paths(&path)
+                .map(|dir| dir.join("sleep"))
+                .find(|candidate| candidate.is_file())
+        })
+        .expect("a sleep binary on PATH");
+    let shell = write_script(
+        tmp.path(),
+        "slow-login-shell",
+        &format!("{} {}\nexit 1\n", sleep_bin.display(), PROBE.as_secs_f32()),
+    );
+
+    // SAFETY: one test in this binary, so nothing else reads the environment
+    // concurrently. `AGENTO_CLAUDE_EXECUTABLE` must stay **unset** — it is rule
+    // 1 and returns before any walk, so setting it would make this test pass
+    // against the very thing it is written to catch.
+    unsafe {
+        std::env::set_var("HOME", &home);
+        std::env::set_var("PATH", tmp.path().join("no-such-bin"));
+        std::env::set_var("SHELL", &shell);
+        std::env::remove_var("AGENTO_CLAUDE_EXECUTABLE");
+    }
+
+    // Prime off the runtime, so the startup walk is not what is being measured.
+    let primed = tokio::task::spawn_blocking(|| agento_lib::claude_cli::prime(None))
+        .await
+        .expect("prime")
+        .expect("the installed CLI is found");
+    assert_eq!(primed.path, cli.to_string_lossy());
+
+    // Now break it, so the next resolution walks the order — through the slow
+    // shell — instead of stopping at the `stat`.
+    std::fs::remove_file(&cli).expect("remove the CLI");
+
+    let worst_gap_ms = Arc::new(AtomicU64::new(0));
+    let ticks = Arc::new(AtomicU64::new(0));
+    let ticker = {
+        // `last` is seeded **before** the spawn: a starved task is never polled,
+        // so seeding it on the first poll starts the clock after the stall and
+        // the test passes against the defect.
+        let (worst_gap_ms, ticks, mut last) = (
+            Arc::clone(&worst_gap_ms),
+            Arc::clone(&ticks),
+            Instant::now(),
+        );
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                let now = Instant::now();
+                let gap = u64::try_from(now.duration_since(last).as_millis()).unwrap_or(u64::MAX);
+                worst_gap_ms.fetch_max(gap, Ordering::Relaxed);
+                ticks.fetch_add(1, Ordering::Relaxed);
+                last = now;
+            }
+        })
+    };
+
+    // **Spawned, not awaited inline**, and that is the difference between a
+    // regression test and a decoration. `block_on` drives the test body on the
+    // *calling* thread, so blocking there leaves the single worker free and the
+    // ticker keeps running — the inline revert passes such a test. Production
+    // reaches `build_options` from an axum handler and from the scheduler's
+    // executor, both of which are spawned tasks on a worker, so the task has to
+    // be spawned here to model it. Confirmed in both directions: with the
+    // revert this fails, and inline-awaited it would not.
+    let built = tokio::spawn(async move {
+        let spec = spec();
+        let (options, _servers) = build_options(&spec, None)
+            .await
+            .expect("the turn's own option assembly");
+        options.claude_executable
+    });
+    let claude_executable = built.await.expect("the option assembly task");
+    ticker.abort();
+
+    // The walk really did run — otherwise the measurement below is of nothing.
+    assert!(
+        agento_lib::claude_cli::cached().is_none(),
+        "the CLI was still found, so no walk was paid for and nothing was measured"
+    );
+    assert_eq!(
+        claude_executable, "claude",
+        "with nothing installed the spawn falls back to the bare name"
+    );
+
+    let worst = worst_gap_ms.load(Ordering::Relaxed);
+    assert!(
+        worst < 500,
+        "the runtime stalled for {worst} ms while the CLI was being re-resolved \
+         (the probe takes {} ms; anything near it means the walk blocked a worker)",
+        PROBE.as_millis()
+    );
+    let ticks = ticks.load(Ordering::Relaxed);
+    assert!(
+        ticks > 50,
+        "the ticker only advanced {ticks} times across a {} ms walk",
+        PROBE.as_millis()
+    );
+}
+
+fn write_script(dir: &Path, name: &str, body: &str) -> PathBuf {
+    let path = dir.join(name);
+    std::fs::write(&path, format!("#!/bin/sh\n{body}\n")).expect("write");
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+    path
+}

--- a/src-tauri/tests/claude_cli_refresh.rs
+++ b/src-tauri/tests/claude_cli_refresh.rs
@@ -1,0 +1,213 @@
+//! Recovering when the resolved Claude Code CLI stops being spawnable (#533).
+//!
+//! Claude Code updates itself, and the native install is a symlink into a
+//! versioned directory that a self-update swaps. For the length of that swap
+//! the symlink dangles, `execve` answers `ENOENT`, and — because the resolution
+//! used to be a `OnceLock` filled once at startup — **every chat and every
+//! scheduled run failed for the rest of the process's life**, naming a path
+//! that works perfectly in a terminal.
+//!
+//! **One test, and that is deliberate**, for the same reason
+//! `claude_cli_detection.rs` holds one: everything here turns on process-wide
+//! state. `PATH`, `HOME`, `SHELL` and `AGENTO_CLAUDE_EXECUTABLE` are shared by
+//! cargo's threaded runner, and so — the whole point of this suite — is the
+//! resolution cache itself, which can be primed exactly once. Two tests would
+//! not fail; they would *pass against each other's cache*, which is the one
+//! thing a suite about a stale cache cannot afford.
+//!
+//! **The walk counter is the assertion**, not a convenience. The properties
+//! being pinned are "the happy path spawns nothing" and "a missing CLI does not
+//! re-probe on every turn", and neither is visible in a return value. The fake
+//! `$SHELL` appends a line every time it runs, and rule 3 runs it once per walk
+//! that gets that far — so the file's length counts walks that reached the
+//! probe. Every phase below says which of those two facts it is reading, because
+//! a walk short-circuiting at rule 2 leaves the counter still and that is a
+//! *positive* result there, not an absent one.
+//!
+//! It is not `#[ignore]`d: it needs no corpus and no Claude Code install, only a
+//! tempdir and `/bin/sh`.
+
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+use agento_lib::claude_cli::{cached, executable, prime, Source};
+
+#[test]
+fn a_cli_that_stops_being_spawnable_is_resolved_again_without_a_restart() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let home = tmp.path().join("home");
+    let installed = home.join(".local/bin");
+    std::fs::create_dir_all(&installed).expect("install dir");
+
+    // What the native installer leaves: a symlink under `~/.local/bin` into a
+    // versioned directory. Resolving it is what a self-update breaks.
+    let versions = home.join(".local/share/claude/versions");
+    std::fs::create_dir_all(versions.join("2.1.231")).expect("version dir");
+    let real = write_cli(
+        &versions.join("2.1.231"),
+        "claude",
+        "2.1.231 (Claude Code)",
+        0,
+    );
+    let link = installed.join("claude");
+    std::os::unix::fs::symlink(&real, &link).expect("symlink");
+
+    // Every walk of the order runs the login shell exactly once (rule 3), so
+    // counting its invocations counts walks. It answers "no such command", which
+    // is an answer rather than an error, and resolution continues past it.
+    let counter = tmp.path().join("walks");
+    let shell = write_script(
+        tmp.path(),
+        "counting-shell",
+        &format!("echo walk >> {}\nexit 1\n", counter.display()),
+    );
+
+    // A path the user *named*, which does not exist yet. It is deliberately not
+    // Claude-Code-shaped: nothing in the detection branches could ever accept
+    // it, so seeing it come back later can only mean the override was
+    // remembered across the refresh.
+    let wrapper_dir = tmp.path().join("wrapper");
+    std::fs::create_dir_all(&wrapper_dir).expect("wrapper dir");
+    let wrapper = wrapper_dir.join("claude-wrapper");
+
+    // SAFETY: this binary holds exactly one test, so nothing else is reading
+    // the environment concurrently — which is why the module is written that
+    // way. See the header. `PATH` points at nothing so rule 4 contributes
+    // nothing, and the walk is decided by the candidate list alone.
+    unsafe {
+        std::env::set_var("HOME", &home);
+        std::env::set_var("PATH", tmp.path().join("no-such-bin"));
+        std::env::set_var("SHELL", &shell);
+        std::env::remove_var("AGENTO_CLAUDE_EXECUTABLE");
+    }
+
+    // ── Startup: one walk, and the override is stored beside its answer. ─────
+    // The wrapper does not exist yet, so rule 2 logs and falls through and the
+    // candidate list wins. What matters is that the override is *kept*.
+    let found = prime(Some(&wrapper.to_string_lossy())).expect("the installed CLI is found");
+    assert_eq!(found.source, Source::Candidate);
+    assert_eq!(found.path, link.to_string_lossy());
+    assert_eq!(walks(&counter), 1, "priming should walk the order once");
+
+    // ── The happy path costs one `stat` and no subprocess. ───────────────────
+    // Not a micro-optimisation: a `--version` round trip per turn would put two
+    // seconds of worst case in front of every message.
+    for _ in 0..3 {
+        assert_eq!(executable(), link.to_string_lossy());
+    }
+    assert_eq!(
+        walks(&counter),
+        1,
+        "a spawnable path must not re-walk the order"
+    );
+
+    // ── The self-update: the version directory goes, the symlink dangles. ────
+    // This is the reported failure verbatim. `~/.local/bin/claude` still exists
+    // as a directory entry and still looks fine to `ls -l`; it just resolves to
+    // nothing, so `execve` answers ENOENT.
+    std::fs::remove_dir_all(versions.join("2.1.231")).expect("swap the version out");
+    assert!(
+        std::fs::metadata(&link).is_err(),
+        "the symlink should dangle"
+    );
+
+    // Meanwhile the user's configured wrapper has appeared — the escape hatch
+    // they were told to use.
+    write_script(&wrapper_dir, "claude-wrapper", "echo 'my wrapper'");
+
+    // ── The next spawn recovers, on the same process. ────────────────────────
+    // Before #533 this returned the dangling path for the life of the app.
+    assert_eq!(
+        executable(),
+        wrapper.to_string_lossy(),
+        "a dangling path must be resolved again rather than spawned"
+    );
+
+    // And it walked with the override the *first* walk was given. Nothing in
+    // detection can produce this path — it does not answer `--version` like
+    // Claude Code and it is on no `PATH` and in no candidate directory — and
+    // `Source::Setting` can only come from rule 2. Passing `None` on the
+    // refresh, which is what losing the override would mean, fails both halves.
+    let after = cached().expect("a resolution after the recovery");
+    assert_eq!(
+        after.source,
+        Source::Setting,
+        "the refresh lost the stored override"
+    );
+    assert_eq!(after.path, wrapper.to_string_lossy());
+
+    // The counter has *not* moved, and that is the same fact from the other
+    // side: rule 2 hits before rule 3, so a walk that consults the override
+    // never reaches the login shell. A refresh that had dropped the override
+    // would have walked past it and shown up here.
+    assert_eq!(
+        walks(&counter),
+        1,
+        "the refresh probed the login shell, so it walked past the stored override"
+    );
+
+    // ── The banner reports the recovery, not the path that failed. ───────────
+    // `host_info` reads `cached()`, so this is the whole of #503's invariant —
+    // the banner and the spawn are one answer — carried through a refresh.
+    assert_eq!(
+        cached().expect("resolved").path,
+        executable(),
+        "the banner and the spawn disagree after a recovery"
+    );
+    assert_eq!(walks(&counter), 1, "reading the banner must not walk");
+
+    // ── A CLI that is genuinely gone does not re-probe on every turn. ────────
+    // Without the cooldown this is 3 s of login shell plus a `--version` per
+    // candidate, on every message and every scheduled run.
+    std::fs::remove_file(&wrapper).expect("remove the wrapper too");
+    for _ in 0..3 {
+        assert_eq!(
+            executable(),
+            wrapper.to_string_lossy(),
+            "the stale path is returned, so the spawn fails with the unchanged message"
+        );
+    }
+    // With nothing at the override's path any more, a walk would fall through
+    // rule 2 and reach the login shell — so the counter is exactly what says
+    // whether one ran.
+    assert_eq!(
+        walks(&counter),
+        1,
+        "a walk ran inside the cooldown; a missing CLI would re-probe on every turn"
+    );
+
+    // ── The environment override is verbatim, and never stat-gated. ──────────
+    // Rule 1 is taken on trust by design: a wrapper script is a documented
+    // reason to set it, and a spawn error naming the user's own path is a better
+    // diagnostic than silently resolving somewhere else.
+    unsafe { std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", "/nonexistent/wrapper/claude") }
+    assert_eq!(executable(), "/nonexistent/wrapper/claude");
+    assert_eq!(
+        walks(&counter),
+        1,
+        "the environment override must not trigger a walk"
+    );
+    unsafe { std::env::remove_var("AGENTO_CLAUDE_EXECUTABLE") }
+}
+
+/// How many times the fake login shell has run — i.e. how many times the order
+/// has been walked. A file that does not exist yet is zero walks.
+fn walks(counter: &Path) -> usize {
+    std::fs::read_to_string(counter)
+        .map(|s| s.lines().count())
+        .unwrap_or(0)
+}
+
+/// A fake CLI: prints `banner` to stdout and exits with `code`.
+fn write_cli(dir: &Path, name: &str, banner: &str, code: i32) -> PathBuf {
+    write_script(dir, name, &format!("echo '{banner}'\nexit {code}\n"))
+}
+
+fn write_script(dir: &Path, name: &str, body: &str) -> PathBuf {
+    let path = dir.join(name);
+    std::fs::write(&path, format!("#!/bin/sh\n{body}\n")).expect("write");
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+    path
+}

--- a/src-tauri/tests/claude_cli_refresh.rs
+++ b/src-tauri/tests/claude_cli_refresh.rs
@@ -32,7 +32,7 @@
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
-use agento_lib::claude_cli::{cached, executable, prime, Source};
+use agento_lib::claude_cli::{cached, executable, prime, spawnable_at, Source, REFRESH_COOLDOWN};
 
 #[test]
 fn a_cli_that_stops_being_spawnable_is_resolved_again_without_a_restart() {
@@ -166,7 +166,7 @@ fn a_cli_that_stops_being_spawnable_is_resolved_again_without_a_restart() {
         assert_eq!(
             executable(),
             wrapper.to_string_lossy(),
-            "the stale path is returned, so the spawn fails with the unchanged message"
+            "inside the cooldown the last walk's answer is returned untouched"
         );
     }
     // With nothing at the override's path any more, a walk would fall through
@@ -178,6 +178,33 @@ fn a_cli_that_stops_being_spawnable_is_resolved_again_without_a_restart() {
         "a walk ran inside the cooldown; a missing CLI would re-probe on every turn"
     );
 
+    // ── A walk that finds nothing is allowed to say so. ──────────────────────
+    // Past the cooldown the order is walked again, and this time there is no
+    // CLI anywhere. The old path is **not** kept: `cached()` is what the banner
+    // reads, and a banner claiming an install that is not there is the #503
+    // defect this module exists to prevent. The spawn falls back to the bare
+    // name, which is what a machine that never had the CLI has always reported
+    // — so the failure a user sees is unchanged rather than newly worded.
+    //
+    // The boundary is constructed rather than slept through: `spawnable_at`
+    // takes the clock, and `REFRESH_COOLDOWN` is read from the crate so the two
+    // cannot drift.
+    let past_cooldown = std::time::Instant::now() + REFRESH_COOLDOWN;
+    assert!(
+        spawnable_at(past_cooldown).is_none(),
+        "a walk with no CLI anywhere must resolve to nothing"
+    );
+    assert_eq!(walks(&counter), 2, "the cooldown never expired");
+    assert_eq!(
+        executable(),
+        "claude",
+        "a CLI that is genuinely gone must report the same failure it always did"
+    );
+    assert!(
+        cached().is_none(),
+        "the banner is claiming an install that detection could not find"
+    );
+
     // ── The environment override is verbatim, and never stat-gated. ──────────
     // Rule 1 is taken on trust by design: a wrapper script is a documented
     // reason to set it, and a spawn error naming the user's own path is a better
@@ -186,7 +213,7 @@ fn a_cli_that_stops_being_spawnable_is_resolved_again_without_a_restart() {
     assert_eq!(executable(), "/nonexistent/wrapper/claude");
     assert_eq!(
         walks(&counter),
-        1,
+        2,
         "the environment override must not trigger a walk"
     );
     unsafe { std::env::remove_var("AGENTO_CLAUDE_EXECUTABLE") }


### PR DESCRIPTION
Closes #533

## What

`claude_cli::executable()` resolved the CLI once into a process-wide `OnceLock` and never revisited it. Claude Code self-updates, and the native install is `~/.local/bin/claude` symlinked into `~/.local/share/claude/versions/<version>` — a swap the update performs. For the length of that swap the symlink dangles, `execve` answers `ENOENT`, and **every chat and every scheduled run failed for the rest of the process's life**, naming a path that works perfectly in a terminal.

The walk still runs once. Its *answer* is now revalidated before every spawn.

## How

- `src-tauri/src/claude_cli.rs` — `OnceLock<Option<Resolution>>` becomes `RwLock<Option<Cached>>`, holding the resolution, **the stored override it was produced with**, and when the last refresh finished. `executable()` `stat`s the cached path through the existing `is_executable_file` (which follows symlinks, so a dangling one is exactly what it catches) and re-walks the order when that fails. `prime`/`cached` return an owned `Option<Resolution>` — the value can change, so a `&'static` into the cache would be a lie about its lifetime.
- `src-tauri/src/lib.rs` — `host_info` reads `cached()` **once** and splits it, so a refresh landing between two reads cannot report one rule's path beside another rule's name.
- `CLAUDE.md` — *The one external dependency*: "Resolution is once per launch" becomes the walk-once / revalidate-per-spawn rule and its four sub-rules.

Five properties, each an acceptance criterion rather than an optimisation:

| | |
|---|---|
| the happy path | one `stat`, no subprocess — the `--version` round trip is the expensive half and a path that stats clean is one the walk already verified |
| the override | remembered *beside* the resolution, so a refresh cannot silently demote a user's configured path to whatever detection finds |
| `AGENTO_CLAUDE_EXECUTABLE` | verbatim, never stat-gated, never refreshed away — rule 1 is taken on trust by design |
| a CLI that is gone | rate-limited to one walk per `REFRESH_COOLDOWN` (10 s), claimed under the write lock so two concurrent turns produce one walk; inside the cooldown, whatever the last walk concluded is returned untouched |
| a walk that finds nothing | **overwrites the cache with nothing**, deliberately — `cached()` is what the banner reads, and a banner claiming an install detection could not find is the #503 defect wearing a different hat. The spawn falls back to the bare name and fails with `binary not found: "claude"`, which is what a machine that never had the CLI has always reported. The price, stated here because it is the most surprising consequence: a *transient* break recovers on the next due walk (≤10 s) rather than on the next free `stat` |

The cooldown is keyed on the last **refresh**, not on when the resolution was made, so the first failure always recovers however recently the process started.

Scheduled runs inherit this with no second implementation: `executor.rs` → `agent_run::run_headless` → `runner::build_options` → `runner::claude_executable()`, which is `claude_cli::executable()` and nothing else.

## Deviation from the HOW

The HOW offered an **optional** second layer — branching on `Error::CliNotFound` in `turn.rs`/`executor.rs` and retrying once. Not taken: it covers only the residual `ENOENT` a `stat` cannot see, it is in no acceptance criterion, and it would need a shared retry helper across two more files. The reported failure is precisely the shape `is_executable_file` catches.

## Tests

- `src-tauri/tests/claude_cli_refresh.rs` (new, one test, not `#[ignore]`d) — builds the real install shape (a symlink into a versioned directory), primes with a stored override, deletes the version directory, and asserts the next `executable()` recovers on the same process. The fake `$SHELL` appends a line per invocation, so the walk count is observable: the happy path adds none, and three calls inside the cooldown with nothing installed add none either. One test per binary deliberately — the cache is process-wide and primes exactly once.
- `claude_cli.rs::the_first_refresh_is_always_due_and_the_next_one_waits` — the cooldown boundary, constructed rather than raced (`refresh_due` takes `now` as a parameter).

**Verified against three reverts**, each failing the test:

| revert | fails on |
|---|---|
| revalidation always passes | `a dangling path must be resolved again rather than spawned` |
| no cooldown | the stale path is re-walked away, so a missing CLI re-probes per turn |
| refresh passes `None` instead of the override | the recovery lands on `"claude"` rather than the configured wrapper |

## Gates

`npm run build` · `cargo fmt --check` · `cargo clippy --all-targets -- -D warnings` · `cargo test --no-fail-fast` (1503 lib + every integration binary green) · `cargo build --profile ci`.


---

## Review

Three automated review rounds. Round 1 moved the refresh off the tokio worker (`spawn_blocking`) and corrected three stale `OnceLock` claims in `CLAUDE.md`. Round 2 found that hand-off pinned by **no** test — it passed on the revert — and the guard added for it (`tests/claude_cli_offload.rs`) needed two non-obvious things to be real: `build_options` **spawned** rather than awaited inline (`block_on` drives the test body on the calling thread, leaving the single worker free), and `sleep` resolved absolutely **before** `PATH` is emptied. Reverted it reports 0 ticks across the 1500 ms walk; kept, green. Round 3 re-proved that revert independently and found the code clean on every dimension; its one remaining item was a scope error in the deferred issue's own body, now fixed.

Deferred: #535 — all three `claude_cli` suites assume no Claude Code in `/usr/local/bin`, `/opt/homebrew/bin` or `/opt/local/bin`. Pre-existing, and fixing it means changing what rule 5 scans, which #533 puts out of scope.
