### PR TITLE
feat: make every session title a control, not dead text (#536)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,7 +245,14 @@ src/
                  `GET /claude-sessions/{id}`, which reads the whole transcript
                  back to learn one boolean; while it is unknown the item is
                  disabled and labelled neutrally, because "unknown" is not
-                 "not a favourite". Carries `styles/sessionlink.css` itself,
+                 "not a favourite". `findSessionById` is that read, and the
+                 hand-off in `SessionsView` resolves through it too — the by-id
+                 route is only the fallback for a session with no list row,
+                 because `SessionDetail` fetches the transcript itself on mount
+                 and taking it first reads every message twice. A caller must
+                 **not** pass `decoded_path` as `projectPath`: analytics ranks
+                 on it and the sessions list keys on `project_path` literally,
+                 so "Copy project path" would copy a string nothing filters on. Carries `styles/sessionlink.css` itself,
                  the `components/charts.tsx` shape, since its consumers are in
                  sections that do not import `styles/sessions.css`
     settings/LogsPane.tsx      Settings → Logs: tail, follow, filter, save a copy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,8 +252,9 @@ src/
                  and taking it first reads every message twice. A caller must
                  **not** pass `decoded_path` as `projectPath`: analytics ranks
                  on it and the sessions list keys on `project_path` literally,
-                 so "Copy project path" would copy a string nothing filters on. Carries `styles/sessionlink.css` itself,
-                 the `components/charts.tsx` shape, since its consumers are in
+                 so "Copy project path" would copy a string nothing filters
+                 on. Carries `styles/sessionlink.css` itself, the
+                 `components/charts.tsx` shape, since its consumers are in
                  sections that do not import `styles/sessions.css`
     settings/LogsPane.tsx      Settings → Logs: tail, follow, filter, save a copy
     settings/SecurityPane.tsx  Settings → Security: the public key, and issuing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,11 @@ src/
                  not a router, and query state, filters and scroll positions do
                  not belong in it. `App` clears the target on any navigation
                  that carries none, or a consumed chat id would be re-applied on
-                 every later visit to that section
+                 every later visit to that section. **There are two destinations
+                 now, and the rule is unchanged**: `chatId` (#485) and
+                 `sessionId` (#536), one optional id each. A second destination
+                 adds one field here and nothing else — the *number* of fields
+                 is not the rule, one-id-per-destination is
     icons.tsx    16px / 1.5-stroke icon set
     tauri.ts     window + menu bridge; degrades to a plain browser tab
     clipboard.ts copyText, with the execCommand fallback WebKitGTK needs
@@ -226,6 +230,24 @@ src/
                  charts.tsx shape. See *Conventions* for what it does and does
                  not take
   views/         one file per section
+    sessions/SessionLink.tsx   a session rendered as a control, wherever one is
+                 *named* (#536) — left-click hands off to the Sessions section
+                 through `NavTarget.sessionId`, right-click opens the row menu.
+                 `sessionMenuItems` is the **single** definition of those five
+                 entries: `SessionsView`'s own rows build their menu from it
+                 too, so a second hand-written array cannot drift. What an entry
+                 *does* stays with the caller — the list patches its loaded page
+                 and reloads its facets, which a link elsewhere has neither of.
+                 The favourite is the one item whose label is a function of the
+                 row, so an id-only caller hydrates it lazily on right-click
+                 through the **list** (`?q=<id>`, `add_search`'s LIKE half
+                 covers `session_id`) and never through
+                 `GET /claude-sessions/{id}`, which reads the whole transcript
+                 back to learn one boolean; while it is unknown the item is
+                 disabled and labelled neutrally, because "unknown" is not
+                 "not a favourite". Carries `styles/sessionlink.css` itself,
+                 the `components/charts.tsx` shape, since its consumers are in
+                 sections that do not import `styles/sessions.css`
     settings/LogsPane.tsx      Settings → Logs: tail, follow, filter, save a copy
     settings/SecurityPane.tsx  Settings → Security: the public key, and issuing
                  and revoking scoped API tokens (#405)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -412,7 +412,13 @@ export default function App() {
             )}
             {view === "tasks" && <TasksView inspectorOpen={inspectorOpen} />}
             {view === "jobs" && <JobsView inspectorOpen={inspectorOpen} />}
-            {view === "sessions" && <SessionsView inspectorOpen={inspectorOpen} />}
+            {view === "sessions" && (
+              <SessionsView
+                inspectorOpen={inspectorOpen}
+                openSessionId={navTarget?.sessionId}
+                openSessionNonce={navNonce}
+              />
+            )}
             {(view === "tokens" || view === "usage" || view === "insights") && (
               <AnalyticsView mode={view} inspectorOpen={inspectorOpen} />
             )}

--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -105,6 +105,8 @@ export const VIEW_TITLES: Record<ViewId, string> = {
 export interface NavTarget {
   /** A chat `chats` should preselect on arrival (#485). */
   chatId?: string;
+  /** A session `sessions` should open the transcript of on arrival (#536). */
+  sessionId?: string;
 }
 
 export type NavigateFn = (id: ViewId, target?: NavTarget) => void;

--- a/src/styles/sessionlink.css
+++ b/src/styles/sessionlink.css
@@ -1,0 +1,29 @@
+/* A session rendered as a control, wherever one is named (#536).
+   Imported by `views/sessions/SessionLink.tsx` itself — the
+   `components/charts.tsx` / `SaveBar.tsx` shape — because its consumers sit in
+   sections that do not import `styles/sessions.css`. */
+
+.sess-link {
+  display: block;
+  max-width: 100%;
+  padding: 0;
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  /* `base.css` already gives every `button` `cursor: default`,
+     `user-select: none` and `font: inherit`, which is what makes this read like
+     the list's own rows rather than like a web link. */
+  color: inherit;
+}
+
+.sess-link:hover {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+.sess-link__error {
+  margin-top: var(--sp-2);
+  font-size: var(--text-xs);
+  color: var(--red);
+}

--- a/src/styles/sessionlink.css
+++ b/src/styles/sessionlink.css
@@ -23,7 +23,11 @@
 }
 
 .sess-link__error {
+  display: block;
   margin-top: var(--sp-2);
   font-size: var(--text-xs);
   color: var(--red);
+  /* The link itself is nowrap-and-ellipsis; a failure has to be readable, and
+     its container may be narrow. */
+  white-space: normal;
 }

--- a/src/styles/sessionlink.css
+++ b/src/styles/sessionlink.css
@@ -31,3 +31,8 @@
      its container may be narrow. */
   white-space: normal;
 }
+
+.sess-link__dismiss {
+  color: var(--red);
+  text-decoration: underline;
+}

--- a/src/styles/sessionlink.css
+++ b/src/styles/sessionlink.css
@@ -28,11 +28,16 @@
   font-size: var(--text-xs);
   color: var(--red);
   /* The link itself is nowrap-and-ellipsis; a failure has to be readable, and
-     its container may be narrow. */
+     both containers it renders in are narrow and clipping — `describeError`
+     can carry an unbreakable token (a project path has no spaces), so it needs
+     the same break `.resumed__note` needed. */
   white-space: normal;
+  overflow-wrap: anywhere;
 }
 
 .sess-link__dismiss {
-  color: var(--red);
+  /* `base.css` clears a button's font, colour, background and border, but not
+     its padding — which is why `.sess-link` zeroes it too. */
+  padding: 0;
   text-decoration: underline;
 }

--- a/src/views/ChatsView.tsx
+++ b/src/views/ChatsView.tsx
@@ -892,7 +892,9 @@ function ResumedHistory({
         <span className="truncate" title={projectPath || sessionId}>
           Continued from {projectPath ? tildePath(projectPath) : "a Claude session"}
         </span>
-        <span className="resumed__id mono truncate">
+        {/* No `truncate` here: `SessionLink` truncates itself, and this
+            container clipping would hide the failure line it renders. */}
+        <span className="resumed__id mono">
           <SessionLink sessionId={sessionId} project={projectPath} />
         </span>
       </div>

--- a/src/views/ChatsView.tsx
+++ b/src/views/ChatsView.tsx
@@ -892,10 +892,12 @@ function ResumedHistory({
         <span className="truncate" title={projectPath || sessionId}>
           Continued from {projectPath ? tildePath(projectPath) : "a Claude session"}
         </span>
-        {/* No `truncate` here: `SessionLink` truncates itself, and this
-            container clipping would hide the failure line it renders. */}
+        {/* No `truncate` here: `SessionLink` ellipsises the id itself, and
+            this container's `nowrap` would put the failure line it renders on
+            one clipped line. It is still bounded by `.resumed__id`'s
+            `max-width`, so the message wraps rather than escaping the banner. */}
         <span className="resumed__id mono">
-          <SessionLink sessionId={sessionId} project={projectPath} />
+          <SessionLink sessionId={sessionId} projectPath={projectPath} />
         </span>
       </div>
 

--- a/src/views/ChatsView.tsx
+++ b/src/views/ChatsView.tsx
@@ -37,6 +37,7 @@ import { saveNewChatPrefs, type NewChatPrefs } from "../lib/newChatPrefs";
 import { Composer } from "./chat/Composer";
 import { Transcript } from "./chat/Transcript";
 import { useChatStream } from "./chat/useChatStream";
+import { SessionLink } from "./sessions/SessionLink";
 import { SessionTranscript } from "./sessions/SessionTranscript";
 import "../styles/chats.css";
 
@@ -891,7 +892,9 @@ function ResumedHistory({
         <span className="truncate" title={projectPath || sessionId}>
           Continued from {projectPath ? tildePath(projectPath) : "a Claude session"}
         </span>
-        <span className="resumed__id mono truncate">{sessionId}</span>
+        <span className="resumed__id mono truncate">
+          <SessionLink sessionId={sessionId} project={projectPath} />
+        </span>
       </div>
 
       {loading ? (

--- a/src/views/SessionsView.tsx
+++ b/src/views/SessionsView.tsx
@@ -10,6 +10,7 @@ import { api, qs } from "../lib/api";
 import { CopyButton } from "../components/CopyButton";
 import type {
   ClaudeProject,
+  ClaudeSessionDetail,
   ClaudeSessionSummary,
   SessionCost,
   SessionFacets,
@@ -45,6 +46,7 @@ import {
   Splitter,
 } from "../components/ui";
 import { SessionDetail } from "./sessions/SessionDetail";
+import { sessionMenuItems } from "./sessions/SessionLink";
 import "../styles/sessions.css";
 
 /**
@@ -587,7 +589,17 @@ function DraftMatchCount({ params }: { params: FilterParams }) {
   );
 }
 
-export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
+export function SessionsView({
+  inspectorOpen,
+  openSessionId,
+  openSessionNonce,
+}: {
+  inspectorOpen: boolean;
+  /** A session handed off from another section, to open on arrival (#536). */
+  openSessionId?: string;
+  /** `App`'s nav nonce, so the *same* hand-off twice still fires. */
+  openSessionNonce?: number;
+}) {
   const [query, setQuery] = useState("");
   const q = useDebounced(query, 250);
   const [filters, setFilters] = useState<Filters>(INITIAL_FILTERS);
@@ -794,6 +806,19 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
     setLastSelected(s);
   }, []);
 
+  /**
+   * The loaded rows, readable from an effect that must not *depend* on them —
+   * the hand-off below fires on a nonce, and adding `items` to its deps would
+   * re-open the handed-off session on every later page load.
+   */
+  const itemsRef = useRef(items);
+  useEffect(() => {
+    itemsRef.current = items;
+  }, [items]);
+
+  /** Why a hand-off did not open, when it did not. */
+  const [handoffError, setHandoffError] = useState<string>();
+
   const openSession = useMemo(() => {
     if (!openId) return undefined;
     return (
@@ -825,9 +850,56 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
   // current one is not among the loaded rows.
   useEffect(() => {
     if (!items.length) return;
+    // ...except while a transcript is open. That session is legitimately
+    // absent from the page — handed off from another section (#536), or simply
+    // filtered out while it was being read — and stealing the selection here
+    // also drops the `lastSelected` fallback `openSession` resolves through,
+    // leaving the pane with nothing to render.
+    if (selectedId && selectedId === openId) return;
     if (items.some((s) => s.session_id === selectedId)) return;
     select(items[0]);
-  }, [items, selectedId, select]);
+  }, [items, selectedId, openId, select]);
+
+  /**
+   * A hand-off from another section: open the named session's transcript.
+   *
+   * Keyed on the **nonce**, not on `items`. The page is usually still loading
+   * on arrival, so waiting for the row would leave a blank pane, and re-running
+   * on every later page change would re-open a session the user had already
+   * navigated away from. `App` clears `navTarget` on any navigation carrying
+   * none, so a stale id cannot be re-applied on a later visit.
+   *
+   * The row comes from the loaded page when it happens to be there, else from
+   * the by-id route — `ClaudeSessionDetail` **extends** `ClaudeSessionSummary`,
+   * so the answer is a row `SessionDetail` can render.
+   */
+  useEffect(() => {
+    const id = openSessionId;
+    if (!id) return;
+    setHandoffError(undefined);
+    const known = itemsRef.current.find((s) => s.session_id === id);
+    if (known) {
+      select(known);
+      setOpenId(id);
+      return;
+    }
+    let cancelled = false;
+    api
+      .get<ClaudeSessionDetail>(`/claude-sessions/${id}`)
+      .then((row) => {
+        if (cancelled) return;
+        select(row);
+        setOpenId(id);
+      })
+      .catch((err) => {
+        // A hand-off that silently does nothing is the bug #485 was filed for,
+        // so the list says why it is still showing the list.
+        if (!cancelled) setHandoffError(describeError(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [openSessionId, openSessionNonce, select]);
 
   /* --- Row actions -------------------------------------------------------- */
 
@@ -941,38 +1013,24 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
     [menu, items]
   );
 
+  // The five entries come from `sessionMenuItems`, shared with `SessionLink`
+  // (#536): this view and every surface that merely *names* a session must
+  // offer the same menu, and a second hand-written array is what drifts. What
+  // each entry does stays here — the list patches its loaded page and reloads
+  // its facets, which a link rendered elsewhere has neither of.
   const menuItems = useMemo<ContextMenuItem[]>(() => {
     const s = menuSession;
     if (!s) return [];
-    return [
-      {
-        label: "View session",
-        icon: "chat",
-        onSelect: () => setOpenId(s.session_id),
-      },
-      {
-        label: s.is_favorite ? "Remove favourite" : "Add to favourites",
-        icon: "star",
-        disabled: busy !== undefined,
-        onSelect: () => toggleFavorite(s),
-      },
-      {
-        label: "Continue in chat",
-        icon: "play",
-        disabled: busy !== undefined,
-        onSelect: () => continueInChat(s),
-      },
-      {
-        label: "Copy session ID",
-        icon: "copy",
-        onSelect: () => copyValue("session ID", s.session_id),
-      },
-      {
-        label: "Copy project path",
-        icon: "copy",
-        onSelect: () => copyValue("project path", s.project_path),
-      },
-    ];
+    return sessionMenuItems({
+      sessionId: s.session_id,
+      projectPath: s.project_path,
+      isFavorite: !!s.is_favorite,
+      busy: busy !== undefined,
+      onView: () => setOpenId(s.session_id),
+      onToggleFavorite: () => toggleFavorite(s),
+      onContinue: () => continueInChat(s),
+      onCopy: copyValue,
+    });
   }, [menuSession, busy, toggleFavorite, continueInChat, copyValue]);
 
   /* --- Derived view data --------------------------------------------------- */
@@ -1601,6 +1659,24 @@ export function SessionsView({ inspectorOpen }: { inspectorOpen: boolean }) {
             </table>
           </div>
         )}
+
+        {/* A hand-off (#536) that could not resolve its session says so, rather
+            than dropping the user on an unexplained list. */}
+        {handoffError ? (
+          <div className="sess-err">
+            <Icon name="alert" size={13} />
+            <span className="sess-err__msg">
+              That session could not be opened: {handoffError}
+            </span>
+            <div className="spacer" />
+            <button
+              className="btn btn--ghost"
+              onClick={() => setHandoffError(undefined)}
+            >
+              Dismiss
+            </button>
+          </div>
+        ) : null}
 
         {(page.error && items.length > 0) || refreshError ? (
           <div className="sess-err">

--- a/src/views/SessionsView.tsx
+++ b/src/views/SessionsView.tsx
@@ -46,7 +46,7 @@ import {
   Splitter,
 } from "../components/ui";
 import { SessionDetail } from "./sessions/SessionDetail";
-import { sessionMenuItems } from "./sessions/SessionLink";
+import { findSessionById, sessionMenuItems } from "./sessions/SessionLink";
 import "../styles/sessions.css";
 
 /**
@@ -869,9 +869,14 @@ export function SessionsView({
    * navigated away from. `App` clears `navTarget` on any navigation carrying
    * none, so a stale id cannot be re-applied on a later visit.
    *
-   * The row comes from the loaded page when it happens to be there, else from
-   * the by-id route — `ClaudeSessionDetail` **extends** `ClaudeSessionSummary`,
-   * so the answer is a row `SessionDetail` can render.
+   * The row comes from the loaded page when it happens to be there — which on
+   * a real arrival it is not, since this view is mounted conditionally and so
+   * remounts with an empty page — then from `findSessionById`, the same cheap
+   * list read `SessionLink` hydrates through. `GET /claude-sessions/{id}` is
+   * only the **fallback**, for a session with no list row at all (outside the
+   * indexed config dirs, or in a hidden project): it answers the transcript as
+   * well as the row, and `SessionDetail` fetches that for itself on mount, so
+   * taking it first reads every message twice.
    */
   useEffect(() => {
     const id = openSessionId;
@@ -883,9 +888,16 @@ export function SessionsView({
       setOpenId(id);
       return;
     }
+    // Aborted as well as flagged: `StrictMode` runs this twice in development,
+    // and the fallback read is the expensive one.
+    const ctl = new AbortController();
     let cancelled = false;
-    api
-      .get<ClaudeSessionDetail>(`/claude-sessions/${id}`)
+    findSessionById(id, ctl.signal)
+      .then(
+        (hit) =>
+          hit ??
+          api.get<ClaudeSessionDetail>(`/claude-sessions/${id}`, ctl.signal)
+      )
       .then((row) => {
         if (cancelled) return;
         select(row);
@@ -898,6 +910,7 @@ export function SessionsView({
       });
     return () => {
       cancelled = true;
+      ctl.abort();
     };
   }, [openSessionId, openSessionNonce, select]);
 

--- a/src/views/analytics/UsageMode.tsx
+++ b/src/views/analytics/UsageMode.tsx
@@ -1,6 +1,7 @@
 import { compactNumber, integer, percent, usd, duration } from "../../lib/format";
 import type { AnalyticsReport, SessionRanking } from "../../lib/types";
 import { AreaChart, BarChart, Heatmap, type Point } from "../../components/charts";
+import { SessionLink } from "../sessions/SessionLink";
 import {
   Card,
   CardEmpty,
@@ -219,12 +220,12 @@ function TopSessions({
                 <td className="num" style={{ color: "var(--fg-quaternary)" }}>
                   {i + 1}
                 </td>
-                <td
-                  className="truncate"
-                  style={{ maxWidth: 320 }}
-                  title={r.title || r.session_id}
-                >
-                  {r.title || r.session_id}
+                <td className="truncate" style={{ maxWidth: 320 }}>
+                  <SessionLink
+                    sessionId={r.session_id}
+                    title={r.title}
+                    project={r.project}
+                  />
                 </td>
                 <td
                   className="truncate"

--- a/src/views/analytics/UsageMode.tsx
+++ b/src/views/analytics/UsageMode.tsx
@@ -221,11 +221,11 @@ function TopSessions({
                   {i + 1}
                 </td>
                 <td className="truncate" style={{ maxWidth: 320 }}>
-                  <SessionLink
-                    sessionId={r.session_id}
-                    title={r.title}
-                    project={r.project}
-                  />
+                  {/* No `projectPath`: `SessionRanking.project` is analytics'
+                      `decoded_path`, which is not the sessions list's
+                      `project_path` — so "Copy project path" waits for the
+                      hydrated row rather than copying the wrong string. */}
+                  <SessionLink sessionId={r.session_id} title={r.title} />
                 </td>
                 <td
                   className="truncate"

--- a/src/views/sessions/SessionLink.tsx
+++ b/src/views/sessions/SessionLink.tsx
@@ -1,0 +1,240 @@
+/**
+ * A session, rendered as a control wherever one is *named* (#536).
+ *
+ * Session affordances used to live only in `views/SessionsView.tsx`, so a
+ * session named anywhere else — the three *Top sessions* rankings, a continued
+ * chat's provenance banner — was inert text and the one action those panels
+ * exist for (go and look at that session) was the one thing they could not do.
+ *
+ * Two things are shared from here, and the split matters:
+ *
+ * - **`sessionMenuItems` is the menu**, and it is the single definition of it.
+ *   `SessionsView`'s own rows build their menu from this function too, so the
+ *   five entries cannot drift into two lists that agree only by inspection.
+ *   What each entry *does* is the caller's, because the list view patches its
+ *   loaded page and reloads its facets where this component has neither.
+ * - **`SessionLink` is the control** — the button, the right-click, and the
+ *   four id-only actions a surface that knows nothing but an id can perform.
+ *
+ * Opening is a **hand-off, not a second detail renderer**: `navigate("sessions",
+ * { sessionId })` lands the user in the section that owns sessions, so the back
+ * button, the inspector and every row action they find there are the real ones.
+ *
+ * The stylesheet is imported here rather than declared in `styles/sessions.css`
+ * — the `components/charts.tsx` / `SaveBar.tsx` shape — because the consumers
+ * are in sections that do not import that sheet, so a rule there would reach
+ * them only for as long as `App.tsx` happens to import `SessionsView`
+ * statically.
+ */
+import { useCallback, useMemo, useState } from "react";
+import { api, qs } from "../../lib/api";
+import { copyText } from "../../lib/clipboard";
+import { describeError } from "../../lib/hooks";
+import { useNavigate } from "../../lib/nav";
+import type { ClaudeSessionSummary, SessionPage } from "../../lib/types";
+import { ContextMenu, type ContextMenuItem } from "../../components/ui";
+import "../../styles/sessionlink.css";
+
+export interface SessionMenuSpec {
+  sessionId: string;
+  /**
+   * The row's `project_path`. Absent where the calling surface has no path for
+   * the session — "Copy project path" is then disabled rather than copying an
+   * empty string, which reads exactly like a successful copy.
+   */
+  projectPath?: string;
+  /**
+   * `undefined` means **not yet known**, which is not the same as "not a
+   * favourite": offering *Add to favourites* for something already starred is
+   * a wrong label on a destructive-ish toggle. The item is then disabled and
+   * labelled neutrally.
+   */
+  isFavorite?: boolean;
+  /** Any of this session's actions already in flight. */
+  busy: boolean;
+  onView(): void;
+  onToggleFavorite(): void;
+  onContinue(): void;
+  onCopy(what: string, value: string): void;
+}
+
+/**
+ * The five entries a session's context menu has, everywhere it has one.
+ *
+ * One definition rather than one per surface: a second hand-written array is
+ * what drifts, and the labels here are load-bearing (the favourite item's
+ * *label* is a function of the row, so a copy goes stale silently).
+ */
+export function sessionMenuItems(spec: SessionMenuSpec): ContextMenuItem[] {
+  return [
+    {
+      label: "View session",
+      icon: "chat",
+      onSelect: spec.onView,
+    },
+    {
+      label:
+        spec.isFavorite === undefined
+          ? "Favourite"
+          : spec.isFavorite
+          ? "Remove favourite"
+          : "Add to favourites",
+      icon: "star",
+      disabled: spec.busy || spec.isFavorite === undefined,
+      onSelect: spec.onToggleFavorite,
+    },
+    {
+      label: "Continue in chat",
+      icon: "play",
+      disabled: spec.busy,
+      onSelect: spec.onContinue,
+    },
+    {
+      label: "Copy session ID",
+      icon: "copy",
+      onSelect: () => spec.onCopy("session ID", spec.sessionId),
+    },
+    {
+      label: "Copy project path",
+      icon: "copy",
+      disabled: !spec.projectPath,
+      onSelect: () => spec.onCopy("project path", spec.projectPath ?? ""),
+    },
+  ];
+}
+
+export function SessionLink({
+  sessionId,
+  title,
+  project,
+}: {
+  sessionId: string;
+  /** What to show. Falls back to the id, which is what the rankings do. */
+  title?: string;
+  /**
+   * A *display* path from the calling surface. Analytics ranks on
+   * `decoded_path` while the sessions list keys on `project_path` literally —
+   * a documented divergence — so the hydrated row's own `project_path` wins
+   * for "Copy project path" as soon as it lands.
+   */
+  project?: string;
+}) {
+  const navigate = useNavigate();
+  const [at, setAt] = useState<{ x: number; y: number }>();
+  const [row, setRow] = useState<ClaudeSessionSummary>();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string>();
+
+  const open = useCallback(
+    () => navigate("sessions", { sessionId }),
+    [navigate, sessionId]
+  );
+
+  /**
+   * Resolve the row lazily, on right-click, purely for the favourite's label.
+   *
+   * Through the **list** rather than `GET /claude-sessions/{id}`: that route
+   * reads the transcript back and answers with every message in it, which is
+   * megabytes to learn one boolean, while `add_search`'s LIKE half covers
+   * `session_id` so this is a cheap summary read. A miss is not an error — the
+   * session may have left the corpus — and every id-only item still works.
+   */
+  const hydrate = useCallback(async () => {
+    try {
+      const page = await api.get<SessionPage>(
+        `/claude-sessions${qs({ q: sessionId, limit: 5 })}`
+      );
+      const hit = (page.items ?? []).find((s) => s.session_id === sessionId);
+      if (hit) setRow(hit);
+    } catch {
+      // Deliberately silent: the menu is usable without it.
+    }
+  }, [sessionId]);
+
+  const toggleFavorite = useCallback(async () => {
+    if (!row) return;
+    const next = !row.is_favorite;
+    setBusy(true);
+    setError(undefined);
+    try {
+      await api.patch<void>(`/claude-sessions/${sessionId}`, {
+        is_favorite: next,
+      });
+      setRow({ ...row, is_favorite: next });
+    } catch (err) {
+      setError(describeError(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [row, sessionId]);
+
+  /**
+   * Create the resuming chat and **go to it** — #485's rule. Reporting the new
+   * id in place is what made a success and a 404 look identical.
+   */
+  const continueInChat = useCallback(async () => {
+    setBusy(true);
+    setError(undefined);
+    try {
+      const res = await api.post<{ chat_id: string }>(
+        `/claude-sessions/${sessionId}/continue`
+      );
+      if (!res?.chat_id) throw new Error("the server returned no chat id");
+      navigate("chats", { chatId: res.chat_id });
+    } catch (err) {
+      setError(describeError(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [navigate, sessionId]);
+
+  /** Only a failure is reported; the menu closing is the acknowledgement. */
+  const copyValue = useCallback(async (what: string, value: string) => {
+    if (await copyText(value)) return;
+    setError(`Could not copy the ${what} to the clipboard.`);
+  }, []);
+
+  const items = useMemo(
+    () =>
+      sessionMenuItems({
+        sessionId,
+        projectPath: row?.project_path || project || undefined,
+        isFavorite: row ? !!row.is_favorite : undefined,
+        busy,
+        onView: open,
+        onToggleFavorite: toggleFavorite,
+        onContinue: continueInChat,
+        onCopy: copyValue,
+      }),
+    [sessionId, row, project, busy, open, toggleFavorite, continueInChat, copyValue]
+  );
+
+  const label = title || sessionId;
+
+  return (
+    <>
+      <button
+        type="button"
+        className="sess-link"
+        title={label}
+        onClick={open}
+        // `stopPropagation` as well as `preventDefault`: this button sits inside
+        // rows and banners that may have menus of their own, and a session's
+        // menu must win over its container's.
+        onContextMenu={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          setError(undefined);
+          setAt({ x: e.clientX, y: e.clientY });
+          if (!row) void hydrate();
+        }}
+      >
+        {label}
+      </button>
+      {error && <div className="sess-link__error">{error}</div>}
+      {at && (
+        <ContextMenu at={at} items={items} onClose={() => setAt(undefined)} />
+      )}
+    </>
+  );
+}

--- a/src/views/sessions/SessionLink.tsx
+++ b/src/views/sessions/SessionLink.tsx
@@ -35,6 +35,30 @@ import type { ClaudeSessionSummary, SessionPage } from "../../lib/types";
 import { ContextMenu, type ContextMenuItem } from "../../components/ui";
 import "../../styles/sessionlink.css";
 
+/**
+ * The cheap row read: the **list**, scoped to one id.
+ *
+ * `GET /claude-sessions/{id}` answers a `ClaudeSessionDetail` — the summary
+ * plus every message in the transcript — and `SessionDetail` fetches that for
+ * itself the moment it mounts, so reaching for it merely to *obtain a row*
+ * reads the whole transcript twice. `add_search`'s LIKE half covers
+ * `LOWER(c.session_id)`, so a `q` of the whole id is a cheap summary read
+ * instead.
+ *
+ * A miss is not an error: the session may be outside the indexed config dirs,
+ * or in a hidden project. Callers decide what that means for them.
+ */
+export async function findSessionById(
+  id: string,
+  signal?: AbortSignal
+): Promise<ClaudeSessionSummary | undefined> {
+  const page = await api.get<SessionPage>(
+    `/claude-sessions${qs({ q: id, limit: 5 })}`,
+    signal
+  );
+  return (page.items ?? []).find((s) => s.session_id === id);
+}
+
 export interface SessionMenuSpec {
   sessionId: string;
   /**
@@ -106,18 +130,23 @@ export function sessionMenuItems(spec: SessionMenuSpec): ContextMenuItem[] {
 export function SessionLink({
   sessionId,
   title,
-  project,
+  projectPath,
 }: {
   sessionId: string;
   /** What to show. Falls back to the id, which is what the rankings do. */
   title?: string;
   /**
-   * A *display* path from the calling surface. Analytics ranks on
-   * `decoded_path` while the sessions list keys on `project_path` literally —
-   * a documented divergence — so the hydrated row's own `project_path` wins
-   * for "Copy project path" as soon as it lands.
+   * A genuine `project_path`, where the calling surface has one.
+   *
+   * It must **not** be filled with anything path-shaped: analytics ranks on
+   * `decoded_path`, which is the dash-encoded name for some sessions and a
+   * real path for others — a documented divergence — so "Copy project path"
+   * would copy a string the sessions list does not key on, and *which* string
+   * would depend on whether the hydration round-trip beat the click. A caller
+   * with no true path passes nothing and the item stays disabled until the
+   * row lands.
    */
-  project?: string;
+  projectPath?: string;
 }) {
   const navigate = useNavigate();
   const [at, setAt] = useState<{ x: number; y: number }>();
@@ -131,20 +160,15 @@ export function SessionLink({
   );
 
   /**
-   * Resolve the row lazily, on right-click, purely for the favourite's label.
+   * Resolve the row lazily, on right-click — for the favourite's label, and
+   * for a `project_path` that is actually one (see the prop's own note).
    *
-   * Through the **list** rather than `GET /claude-sessions/{id}`: that route
-   * reads the transcript back and answers with every message in it, which is
-   * megabytes to learn one boolean, while `add_search`'s LIKE half covers
-   * `session_id` so this is a cheap summary read. A miss is not an error — the
-   * session may have left the corpus — and every id-only item still works.
+   * A failure is deliberately silent: every id-only item still works without
+   * it, and the two that need the row are disabled until it lands.
    */
   const hydrate = useCallback(async () => {
     try {
-      const page = await api.get<SessionPage>(
-        `/claude-sessions${qs({ q: sessionId, limit: 5 })}`
-      );
-      const hit = (page.items ?? []).find((s) => s.session_id === sessionId);
+      const hit = await findSessionById(sessionId);
       if (hit) setRow(hit);
     } catch {
       // Deliberately silent: the menu is usable without it.
@@ -198,7 +222,7 @@ export function SessionLink({
     () =>
       sessionMenuItems({
         sessionId,
-        projectPath: row?.project_path || project || undefined,
+        projectPath: row?.project_path || projectPath || undefined,
         isFavorite: row ? !!row.is_favorite : undefined,
         busy,
         onView: open,
@@ -206,7 +230,16 @@ export function SessionLink({
         onContinue: continueInChat,
         onCopy: copyValue,
       }),
-    [sessionId, row, project, busy, open, toggleFavorite, continueInChat, copyValue]
+    [
+      sessionId,
+      row,
+      projectPath,
+      busy,
+      open,
+      toggleFavorite,
+      continueInChat,
+      copyValue,
+    ]
   );
 
   const label = title || sessionId;
@@ -233,8 +266,21 @@ export function SessionLink({
       </button>
       {/* A `span`, not a `div`: this component is used inside phrasing content
           (the Chats banner's `.resumed__id`), where a block element is invalid
-          nesting. `display: block` in the stylesheet does the layout. */}
-      {error && <span className="sess-link__error">{error}</span>}
+          nesting. `display: block` in the stylesheet does the layout.
+          It carries its own dismissal, as both of `SessionsView`'s equivalents
+          do — nothing else clears it, and it renders in dense cells. */}
+      {error && (
+        <span className="sess-link__error">
+          {error}{" "}
+          <button
+            type="button"
+            className="sess-link__dismiss"
+            onClick={() => setError(undefined)}
+          >
+            Dismiss
+          </button>
+        </span>
+      )}
       {at && (
         <ContextMenu at={at} items={items} onClose={() => setAt(undefined)} />
       )}

--- a/src/views/sessions/SessionLink.tsx
+++ b/src/views/sessions/SessionLink.tsx
@@ -231,7 +231,10 @@ export function SessionLink({
       >
         {label}
       </button>
-      {error && <div className="sess-link__error">{error}</div>}
+      {/* A `span`, not a `div`: this component is used inside phrasing content
+          (the Chats banner's `.resumed__id`), where a block element is invalid
+          nesting. `display: block` in the stylesheet does the layout. */}
+      {error && <span className="sess-link__error">{error}</span>}
       {at && (
         <ContextMenu at={at} items={items} onClose={() => setAt(undefined)} />
       )}


### PR DESCRIPTION
Closes #536

## What

A session named anywhere in the app now behaves like a session: left-click the title opens its detail view, right-click gives the same five-item menu a Sessions list row has (View session · Add/Remove favourite · Continue in chat · Copy session ID · Copy project path).

## How

- **`src/views/sessions/SessionLink.tsx`** (new) — three exports, and the split matters:
  - `sessionMenuItems` is the **single** definition of the five entries. `SessionsView`'s own rows build their menu from it too, so there is no second hand-written array to drift. What each entry *does* stays with the caller — the list patches its loaded page and reloads its facets, which a link elsewhere has neither of.
  - `findSessionById` is the **cheap row read**: the list scoped to one id (`?q=<id>&limit=5`, matched exactly). `GET /claude-sessions/{id}` answers the summary *plus every message*, and `SessionDetail` fetches that for itself on mount — so using it merely to obtain a row reads the transcript twice. It is the fallback only, for a session with no list row (outside the indexed config dirs, or in a hidden project).
  - `SessionLink` is the control. Left-click is a **hand-off**, `navigate("sessions", { sessionId })`, not a second detail renderer.
- **`src/styles/sessionlink.css`** (new) — imported by the component itself, the `components/charts.tsx` / `SaveBar.tsx` shape, because its consumers are in sections that do not import `styles/sessions.css`.
- **`src/lib/nav.ts`** — `NavTarget` gains one optional `sessionId` beside `chatId`. One id per destination; the rule is unchanged.
- **`src/App.tsx`** — threads `openSessionId` + the existing `navNonce` into `SessionsView`, mirroring `ChatsView`.
- **`src/views/SessionsView.tsx`** — resolves the hand-off in one effect keyed on the **nonce**, not on `items` (the page is still loading on arrival, and an `items` dep would re-open the session on every later page change). Also **guards the auto-select effect** (`selectedId === openId`), which otherwise steals the selection to `items[0]` and drops the `lastSelected` fallback the open pane resolves through.
- **`src/views/analytics/UsageMode.tsx`** — `TopSessions`' title cell.
- **`src/views/ChatsView.tsx`** — the `.resumed__id` line in the "continued from" banner.

### Two decisions the issue left open

1. **Favourite where the row is unknown** — hydrated lazily on right-click through the list, as recommended. While unknown the item is disabled and labelled neutrally `Favourite`, because "unknown" is not "not a favourite"; a miss is silent, and every id-only item still works.
2. **The Chats "continued from" banner is in scope** — kept, as recommended. It is a genuine session reference.

### Beyond the HOW

- The HOW prescribed `GET /claude-sessions/{id}` for the hand-off's row. That reads the transcript twice (see above) and its "take it from the loaded page" fast path can never fire, because `App.tsx` mounts `SessionsView` conditionally so it remounts with an empty page on every arrival. The hand-off goes through `findSessionById` instead, with by-id as the fallback.
- `SessionLink` takes a `projectPath`, not a display `project`. Analytics' `SessionRanking.project` is `decoded_path`, which the sessions list does not key on — passing it made "Copy project path" copy the wrong string, and *which* string depended on whether hydration beat the click. The analytics call site passes none and the item waits for the hydrated row.
- A hand-off whose read fails renders a dismissible `.sess-err` strip instead of dropping the user on an unexplained list — #485's rule that a hand-off must not silently do nothing.

## Verification

`npm run build` (tsc --noEmit + vite) clean; `pre-commit run --all-files` clean; CI green. No Rust changed.

There is **no TypeScript test harness in this repo**, so this change ships with no automated regression guard — reverting it would fail nothing. The acceptance criteria are behavioural; they were verified by build plus a full read of the effect ordering (nonce re-fire, no-target early return, auto-select guard, abort/cancel on StrictMode double-invoke).
