### PR TITLE
feat: a collapsible, reusable session inspector (#538)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,10 @@ src/
     tauri.ts     window + menu bridge; degrades to a plain browser tab
     clipboard.ts copyText, with the execCommand fallback WebKitGTK needs
     newChatPrefs.ts  what the New Chat bar was last set to (localStorage)
+    inspectorPrefs.ts  which inspector groups are open (#538) — keyed by a
+                 stable slug, never the rendered title (two of them carry a
+                 count), with the ids and the shipped defaults pinned through
+                 typeAssert.ts
     logs.ts      the log commands, and the line parser (target before level)
     snippet.ts   the U+0001/U+0002 highlight sentinels, mirrored once from
                  native/search/mod.rs, and snippetParts() (#438). They are
@@ -230,6 +234,10 @@ src/
                  charts.tsx shape. See *Conventions* for what it does and does
                  not take
   views/         one file per section
+    sessions/SessionInspector.tsx  the inspector's metadata groups (#538) —
+                 `{ session }` and no handlers, the five collapsible groups and
+                 the localStorage write-through; `sessions/sessionMetrics.ts`
+                 beside it is the totals and the mode tables the table shares
     sessions/SessionLink.tsx   a session rendered as a control, wherever one is
                  *named* (#536) — left-click hands off to the Sessions section
                  through `NavTarget.sessionId`, right-click opens the row menu.
@@ -615,6 +623,49 @@ itself — the `components/charts.tsx` shape. It used to be declared in
 views only because `App.tsx` imports those two statically, so a section that
 stopped being statically imported would have had unstyled savebars with nothing
 to say so.
+
+**`InspGroup` collapsing is opt-in, and it has to stay opt-in** (#538). Eight
+views render `InspGroup` — Sessions, Analytics, Chats, Integrations, Tasks,
+Agents, Jobs and the gateway Overview — so a `collapsible` that defaulted to on
+would silently change every inspector in the app, which is `SaveBar`'s icon and
+error tone one level down. A caller passing nothing takes an early return and
+emits the `<div className="insp-group__title">` it always did; only a caller
+passing `collapsible` gets the `<button …  aria-expanded>` and the chevron.
+Proved the way the `charts.tsx` and `SaveBar.tsx` moves were: build both sides
+and diff the emitted CSS, as a sorted set **and** as an ordered selector list —
+the change is exactly two added `.insp-group__title--toggle*` rules, declared
+nowhere else, with every pre-existing rule byte-identical and in place.
+
+Three properties of it worth keeping:
+
+- **It is controlled, not self-stateful.** The caller owns `open` and persists
+  it. A group that kept its own state would need a storage key threaded in
+  anyway, and two groups would then disagree about where the state is kept.
+- **The header is a real `button`**, so Tab reaches it and Enter/Space toggle it
+  with no keydown handler here, and `base.css` already resets a button's font,
+  colour, background, border and outline and puts it in the selection denylist
+  (#469) — which is why the CSS is a five-line box reset and **not** a
+  `cursor: pointer` or a `:focus-visible` rule. This shell draws an arrow over
+  its own controls, and the global focus ring already covers a button.
+- **The persisted key is a stable slug, never the rendered title.**
+  `lib/inspectorPrefs.ts` keys on `activity`/`tokens`/`subagents`/`cost`/`prs`
+  and pins both those ids and the shipped defaults through `lib/typeAssert.ts`,
+  because two of the session groups interpolate a count into their heading
+  (`Sub-agents · 12`) — a title-keyed blob would store a new key per session and
+  remember nothing, and a respelled id silently resets everyone's saved state.
+
+**The session inspector is `views/sessions/SessionInspector.tsx`** (#538), not a
+private function in `SessionsView.tsx`, for the reason `SaveBar` is a component:
+a shape only one file can reach is a shape the next caller copies. It takes
+`{ session }` and no handlers — the action strip is `.sess-strip`, which
+`SessionsView` renders *above* `.inspector__scroll` and which #486 deliberately
+put there. Note the detail page needs no second mount: `SessionDetail` fills
+`.pane-detail`, and the `inspectorOpen` `aside.pane-inspector` is its **sibling**
+inside the same `.panes`, so a session's Transcript and Journey tabs already
+show this pane from this code. `views/sessions/sessionMetrics.ts` holds the
+totals and the permission-mode tables that came out with it, because the table's
+Cost column and its row badges call them too and exporting them from the view
+would have made the view and the inspector import each other.
 
 **Destroying a stored record is `Delete`, everywhere, and `Remove` means
 something else** (#518). One gesture had three words — Integrations said

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -633,8 +633,9 @@ emits the `<div className="insp-group__title">` it always did; only a caller
 passing `collapsible` gets the `<button …  aria-expanded>` and the chevron.
 Proved the way the `charts.tsx` and `SaveBar.tsx` moves were: build both sides
 and diff the emitted CSS, as a sorted set **and** as an ordered selector list —
-the change is exactly two added `.insp-group__title--toggle*` rules, declared
-nowhere else, with every pre-existing rule byte-identical and in place.
+the change is exactly three added rules (`.insp-group__title--toggle`, its
+`:hover`, and `.insp-group__title--closed`), declared nowhere else, with every
+pre-existing rule byte-identical and in place.
 
 Three properties of it worth keeping:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -666,6 +666,13 @@ show this pane from this code. `views/sessions/sessionMetrics.ts` holds the
 totals and the permission-mode tables that came out with it, because the table's
 Cost column and its row badges call them too and exporting them from the view
 would have made the view and the inspector import each other.
+It carries `styles/sessions.css` itself — `SessionLink.tsx`'s shape, one
+directory over — because the `.sess-heading` / `.sess-preview` / `.sess-pr*`
+rules it renders are declared only there and reached it until #538 only because
+`SessionsView` happened to import that sheet. A caller outside this section
+would have rendered the Session heading and the whole Pull requests list
+unstyled, with nothing to say so; that is the savebar failure above, and a
+component sold as portable has to own its own styling or it is not.
 
 **Destroying a stored record is `Delete`, everywhere, and `Remove` means
 something else** (#518). One gesture had three words — Integrations said

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -904,17 +904,55 @@ export function Search({
 
 /* --- Inspector primitives ------------------------------------------------ */
 
+/**
+ * A titled group of inspector rows, optionally collapsible (#538).
+ *
+ * **Collapsing is opt-in and must stay that way.** Eight views render this, and
+ * a default-collapsible group would silently change every inspector in the app
+ * — the same reason `SaveBar`'s icon and error tone are opt-in. With
+ * `collapsible` unset the markup is byte-identical to what it has always been,
+ * which is what makes the widening provably a no-op for the other seven.
+ *
+ * It is **controlled**: the caller owns `open` and persists it. A self-stateful
+ * group would need its own storage key threaded in anyway, and the state has to
+ * live in one place or two groups disagree about where it is kept.
+ */
 export function InspGroup({
   title,
+  collapsible,
+  open = true,
+  onToggle,
   children,
 }: {
   title: string;
+  collapsible?: boolean;
+  open?: boolean;
+  onToggle?: () => void;
   children: React.ReactNode;
 }) {
+  if (!collapsible) {
+    return (
+      <div className="insp-group">
+        <div className="insp-group__title">{title}</div>
+        {children}
+      </div>
+    );
+  }
   return (
     <div className="insp-group">
-      <div className="insp-group__title">{title}</div>
-      {children}
+      {/* A real button, so Tab reaches it and Enter/Space toggle it without a
+          keydown handler of our own. `Icon` is `aria-hidden` already, so the
+          chevron is decorative and the accessible name is the title alone. */}
+      <button
+        type="button"
+        className="insp-group__title insp-group__title--toggle"
+        aria-expanded={open}
+        onClick={onToggle}
+      >
+        <span>{title}</span>
+        <Icon name={open ? "chevronD" : "chevronR"} size={12} />
+      </button>
+      {open && children}
     </div>
   );
 }

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -945,7 +945,9 @@ export function InspGroup({
           chevron is decorative and the accessible name is the title alone. */}
       <button
         type="button"
-        className="insp-group__title insp-group__title--toggle"
+        className={`insp-group__title insp-group__title--toggle${
+          open ? "" : " insp-group__title--closed"
+        }`}
         aria-expanded={open}
         onClick={onToggle}
       >

--- a/src/lib/inspectorPrefs.ts
+++ b/src/lib/inspectorPrefs.ts
@@ -1,0 +1,103 @@
+/* ============================================================================
+   Which inspector groups are open, remembered across launches (#538).
+
+   Same reasoning as `newChatPrefs.ts`: this is "how I like the pane", which
+   belongs to this install rather than to the account, so it lives in
+   localStorage and never in `user_settings` — there is no wire field for it and
+   adding one would make a presentation toggle a synced preference.
+
+   Two rules the shape depends on:
+
+   * **The key is a stable slug, never the rendered title.** Two of the groups
+     interpolate a count into their heading (`Sub-agents · 12`), so a
+     title-keyed blob would store a new key per session and remember nothing.
+   * **Every key is optional on read.** A blob written by an older build keeps
+     the keys it has and takes the shipped default for the rest, so adding a
+     seventh group later needs no migration.
+   ========================================================================== */
+
+import type { Eq, Expect } from "./typeAssert";
+
+/**
+ * The collapsible groups and what they ship as.
+ *
+ * `Activity` and `Cost` are the two figures the sessions list is read for, so
+ * they are open; the rest start collapsed, which is what puts both above the
+ * fold on the default window size. `Session` is not here — it is the pane's
+ * identity rather than data, and does not collapse.
+ */
+export const DEFAULT_OPEN = {
+  activity: true,
+  tokens: false,
+  subagents: false,
+  cost: true,
+  prs: false,
+} as const;
+
+/**
+ * The ids and the shipped defaults, pinned.
+ *
+ * These strings are the localStorage keys, so respelling one silently resets
+ * every user's saved state to the default. There is no TypeScript test harness
+ * here (see `lib/typeAssert.ts`), so the pin is the regression guard: an edit
+ * to either the id or the default now fails `tsc`, i.e. fails CI.
+ */
+export type PinDefaultOpen = Expect<
+  Eq<
+    typeof DEFAULT_OPEN,
+    {
+      readonly activity: true;
+      readonly tokens: false;
+      readonly subagents: false;
+      readonly cost: true;
+      readonly prs: false;
+    }
+  >
+>;
+
+/** A collapsible group's stable id. Derived from the defaults so the two cannot drift. */
+export type InspectorGroupId = keyof typeof DEFAULT_OPEN;
+
+export type PinGroupIds = Expect<
+  Eq<InspectorGroupId, "activity" | "tokens" | "subagents" | "cost" | "prs">
+>;
+
+export type InspectorPrefs = Record<InspectorGroupId, boolean>;
+
+const KEY = "agento.inspector";
+
+/**
+ * The stored open/closed state, defaulted per group.
+ *
+ * Reads defensively rather than trusting the blob — localStorage is shared with
+ * anything else on this origin and survives every upgrade, so a `JSON.parse` of
+ * a corrupted value would take the whole pane down at first render. A key whose
+ * value is not a boolean is treated as absent, which is the same fallback a
+ * missing key gets.
+ */
+export function loadInspectorPrefs(): InspectorPrefs {
+  const prefs: InspectorPrefs = { ...DEFAULT_OPEN };
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return prefs;
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return prefs;
+    const stored = parsed as Record<string, unknown>;
+    for (const id of Object.keys(prefs) as InspectorGroupId[]) {
+      const value = stored[id];
+      if (typeof value === "boolean") prefs[id] = value;
+    }
+    return prefs;
+  } catch {
+    return { ...DEFAULT_OPEN };
+  }
+}
+
+/** Remember the pane's shape. A private-mode or quota failure costs the memory, not the view. */
+export function saveInspectorPrefs(prefs: InspectorPrefs): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(prefs));
+  } catch {
+    // Nothing to do: the toggle still worked for this session.
+  }
+}

--- a/src/styles/views.css
+++ b/src/styles/views.css
@@ -660,6 +660,13 @@
   color: var(--fg-secondary);
 }
 
+/* Open, the header keeps `.insp-group__title`'s 4px gap to the rows below it.
+   Closed there are no rows, so that margin would make the group 4px taller than
+   its own header and widen the gap to the next group past the pane's own. */
+.insp-group__title--closed {
+  margin-bottom: 0;
+}
+
 /* Label/value pairs — right-aligned labels, the inspector convention. */
 .insp-row {
   display: grid;

--- a/src/styles/views.css
+++ b/src/styles/views.css
@@ -640,6 +640,26 @@
   margin-bottom: var(--sp-2);
 }
 
+/* The same header when the group collapses (#538, opt-in). `base.css` already
+   resets a button's font, colour, background, border and outline, and puts it
+   in the selection denylist, so the only thing left is the box: a block-level
+   strip the width of the pane with the chevron pushed to the far end. No
+   `cursor: pointer` — this shell draws an arrow over its own controls — and no
+   `:focus-visible` rule, because the global ring in `base.css` covers it. */
+.insp-group__title--toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  width: 100%;
+  padding: 0;
+  text-align: left;
+}
+
+.insp-group__title--toggle:hover {
+  color: var(--fg-secondary);
+}
+
 /* Label/value pairs — right-aligned labels, the inspector convention. */
 .insp-row {
   display: grid;

--- a/src/views/SessionsView.tsx
+++ b/src/views/SessionsView.tsx
@@ -1700,6 +1700,8 @@ export function SessionsView({
   );
 }
 
+/* --- Toolbar dropdown ----------------------------------------------------- */
+
 function projectLabel(options: ClaudeProject[], value: string): string {
   const hit = options.find((p) => p.decoded_path === value);
   return hit ? hit.decoded_path : value;

--- a/src/views/SessionsView.tsx
+++ b/src/views/SessionsView.tsx
@@ -7,22 +7,18 @@ import {
   useState,
 } from "react";
 import { api, qs } from "../lib/api";
-import { CopyButton } from "../components/CopyButton";
 import type {
   ClaudeProject,
   ClaudeSessionDetail,
   ClaudeSessionSummary,
-  SessionCost,
   SessionFacets,
   SessionPage,
   SessionScanStatus,
-  TokenUsage,
 } from "../lib/types";
 import { describeError, useDebounced, usePoll, useResource } from "../lib/hooks";
 import {
   compactNumber,
   dateTime,
-  duration,
   groupByRecency,
   integer,
   relativeTime,
@@ -32,20 +28,24 @@ import {
 import { Icon } from "../lib/icons";
 import { useNavigate } from "../lib/nav";
 import { snippetParts, snippetText } from "../lib/snippet";
-import { sessionAgentName } from "../lib/sessionAgent";
-import { openExternal } from "../lib/tauri";
 import { copyText } from "../lib/clipboard";
 import {
   ContextMenu,
   type ContextMenuItem,
   Dropdown,
   Empty,
-  InspGroup,
-  InspRow,
   Search,
   Splitter,
 } from "../components/ui";
 import { SessionDetail } from "./sessions/SessionDetail";
+import { SessionInspector } from "./sessions/SessionInspector";
+import {
+  modeBadge,
+  modeLabel,
+  tokensIn,
+  tokensOut,
+  totalCost,
+} from "./sessions/sessionMetrics";
 import { findSessionById, sessionMenuItems } from "./sessions/SessionLink";
 import "../styles/sessions.css";
 
@@ -333,107 +333,6 @@ interface Loaded {
 }
 
 const NO_ROWS: ClaudeSessionSummary[] = [];
-
-/* --- Totals -------------------------------------------------------------- */
-
-const ZERO_USAGE: TokenUsage = {
-  input_tokens: 0,
-  output_tokens: 0,
-  cache_creation_tokens: 0,
-  cache_creation_5m_tokens: 0,
-  cache_creation_1h_tokens: 0,
-  cache_read_tokens: 0,
-};
-
-const ZERO_COST: SessionCost = {
-  input_usd: 0,
-  output_usd: 0,
-  cache_read_usd: 0,
-  cache_write_usd: 0,
-  total_usd: 0,
-};
-
-function usageOf(u: TokenUsage | undefined | null): TokenUsage {
-  return u ?? ZERO_USAGE;
-}
-
-function costOf(c: SessionCost | undefined | null): SessionCost {
-  return c ?? ZERO_COST;
-}
-
-/**
- * Billable input/output, main thread plus sub-agents. Cache tokens are billed
- * separately and are deliberately not folded in here — `facets.total_tokens`
- * is exactly the sum of these two numbers over the filtered set.
- */
-function tokensIn(s: ClaudeSessionSummary): number {
-  return usageOf(s.usage).input_tokens + usageOf(s.subagent_usage).input_tokens;
-}
-
-function tokensOut(s: ClaudeSessionSummary): number {
-  return (
-    usageOf(s.usage).output_tokens + usageOf(s.subagent_usage).output_tokens
-  );
-}
-
-function totalCost(s: ClaudeSessionSummary): number {
-  return costOf(s.cost).total_usd + costOf(s.subagent_cost).total_usd;
-}
-
-function totalDuration(s: ClaudeSessionSummary): number {
-  return (s.active_duration_ms ?? 0) + (s.subagent_active_duration_ms ?? 0);
-}
-
-/* --- Presentation helpers ------------------------------------------------- */
-
-/**
- * The permission modes Claude Code writes, and how each reads.
- *
- * One table for the row badge and the Mode filter, so the option a user picks
- * is spelled exactly as the column they picked it from. An unknown value keeps
- * its raw text in both places rather than being dropped — the corpus predates
- * some of these names.
- */
-const MODE_LABELS: Record<string, string> = {
-  bypassPermissions: "Bypass",
-  plan: "Plan",
-  acceptEdits: "Accept",
-  dontAsk: "Don't ask",
-  default: "Default",
-};
-
-const MODE_TONES: Record<string, string> = {
-  bypassPermissions: "badge--amber",
-  plan: "badge--purple",
-  acceptEdits: "badge--teal",
-  dontAsk: "badge--teal",
-};
-
-/**
- * `permission_mode` is a free-form column — the scanner copies whatever the
- * transcript's `permission-mode` event carried, with no enum in between — so
- * every read of these tables goes through a `typeof` check rather than `??`.
- * A plain object inherits `toString`, `constructor` and `valueOf`, and `??`
- * does not catch a function: the value would reach JSX as a React child and as
- * a `className`. The `switch` these tables replaced was immune by construction.
- */
-function lookup(table: Record<string, string>, key: string): string | undefined {
-  const v = table[key];
-  return typeof v === "string" ? v : undefined;
-}
-
-function modeLabel(mode: string): string {
-  return lookup(MODE_LABELS, mode) ?? mode;
-}
-
-function modeBadge(s: ClaudeSessionSummary): { label: string; tone: string } | null {
-  // `omitempty` on the Go side, so the field is absent on a row that recorded
-  // no mode — which is not the same as one whose mode this table does not know.
-  const mode = s.permission_mode ?? "";
-  const label = lookup(MODE_LABELS, mode);
-  if (label) return { label, tone: lookup(MODE_TONES, mode) ?? "" };
-  return s.mode ? { label: s.mode, tone: "" } : null;
-}
 
 /**
  * The second line under a row's title: why this row matched.
@@ -1785,7 +1684,7 @@ export function SessionsView({
             )}
             <div className="inspector__scroll scroll">
               {selected ? (
-                <Inspector session={selected} />
+                <SessionInspector session={selected} />
               ) : (
                 <div className="sess-note">No session selected.</div>
               )}
@@ -1800,221 +1699,6 @@ export function SessionsView({
     </div>
   );
 }
-
-/* --- Inspector ------------------------------------------------------------ */
-
-/**
- * The metadata groups alone. The actions live in `.sess-strip` above the
- * scrolling pane this renders into, so nothing here takes a handler.
- */
-function Inspector({ session }: { session: ClaudeSessionSummary }) {
-  const usage = usageOf(session.usage);
-  const sub = usageOf(session.subagent_usage);
-  const cost = costOf(session.cost);
-  const subCost = costOf(session.subagent_cost);
-  const prs = session.prs ?? [];
-  const badge = modeBadge(session);
-  const agentName = sessionAgentName(session);
-
-  return (
-    <>
-      <InspGroup title="Session">
-        <div className="sess-heading">
-          {session.display_title || "Untitled session"}
-        </div>
-        {session.preview && (
-          <div className="sess-preview">{session.preview}</div>
-        )}
-        {/* Both of these are single values a user copies whole and neither
-            fits the pane, so the button carries the real string while the row
-            shows an abbreviated one (#469). */}
-        <InspRow label="ID">
-          <span className="row insp-row__copy">
-            <span className="mono truncate">{session.session_id}</span>
-            <CopyButton text={session.session_id} title="Copy session ID" />
-          </span>
-        </InspRow>
-        {session.custom_title && (
-          <InspRow label="Custom">{session.custom_title}</InspRow>
-        )}
-        {session.ai_title && session.ai_title !== session.display_title && (
-          <InspRow label="AI title">{session.ai_title}</InspRow>
-        )}
-        {session.native_title && (
-          <InspRow label="Native">{session.native_title}</InspRow>
-        )}
-        {/* Another name Claude Code recorded for the session, shown only when
-            it is not one of the titles above — the same suppression the AI
-            title gets, for the reasons in lib/sessionAgent.ts. It was labelled
-            "Agent" and sat beside Model and Config until it turned out never to
-            name an agent, so it belongs here with the other titles. */}
-        {agentName && <InspRow label="Named">{agentName}</InspRow>}
-        <InspRow label="Project">
-          <span className="row insp-row__copy">
-            <span className="truncate" title={session.project_path}>
-              {tildePath(session.project_path)}
-            </span>
-            <CopyButton
-              text={session.project_path}
-              title="Copy the project path"
-            />
-          </span>
-        </InspRow>
-        {session.cwd && session.cwd !== session.project_path && (
-          <InspRow label="Directory">{tildePath(session.cwd)}</InspRow>
-        )}
-        {session.relocated_cwd && (
-          <InspRow label="Relocated">{tildePath(session.relocated_cwd)}</InspRow>
-        )}
-        <InspRow label="Branch">{session.git_branch || "—"}</InspRow>
-        {session.worktree_name && (
-          <InspRow label="Worktree">
-            {session.worktree_name}
-            {session.worktree_branch ? ` · ${session.worktree_branch}` : ""}
-          </InspRow>
-        )}
-        {session.original_branch && (
-          <InspRow label="From">{session.original_branch}</InspRow>
-        )}
-        <InspRow label="Model">{session.model || "—"}</InspRow>
-        <InspRow label="Mode">
-          {badge ? (
-            <span className={`badge ${badge.tone}`}>{badge.label}</span>
-          ) : (
-            "—"
-          )}
-        </InspRow>
-        <InspRow label="Config">{session.config_dir ?? "Default"}</InspRow>
-      </InspGroup>
-
-      <InspGroup title="Activity">
-        <InspRow label="Started">{dateTime(session.start_time)}</InspRow>
-        <InspRow label="Last">{dateTime(session.last_activity)}</InspRow>
-        <InspRow label="Active">
-          <span className="tnum">{duration(session.active_duration_ms)}</span>
-        </InspRow>
-        <InspRow label="Sub-agents">
-          <span className="tnum">
-            {duration(session.subagent_active_duration_ms)}
-          </span>
-        </InspRow>
-        <InspRow label="Total">
-          <span className="tnum">{duration(totalDuration(session))}</span>
-        </InspRow>
-        <InspRow label="Messages">
-          <span className="tnum">{integer(session.message_count)}</span>
-        </InspRow>
-        <InspRow label="Events">
-          <span className="tnum">{integer(session.event_count)}</span>
-        </InspRow>
-        <InspRow label="Compactions">
-          <span className="tnum">{integer(session.compaction_count)}</span>
-        </InspRow>
-        {session.dropped_tokens > 0 && (
-          <InspRow label="Dropped">
-            <span className="tnum">{integer(session.dropped_tokens)}</span>
-          </InspRow>
-        )}
-      </InspGroup>
-
-      <InspGroup title="Tokens">
-        <InspRow label="Input">
-          <span className="tnum">{integer(usage.input_tokens)}</span>
-        </InspRow>
-        <InspRow label="Output">
-          <span className="tnum">{integer(usage.output_tokens)}</span>
-        </InspRow>
-        <InspRow label="Cache read">
-          <span className="tnum">{integer(usage.cache_read_tokens)}</span>
-        </InspRow>
-        <InspRow label="Cache write">
-          <span className="tnum">{integer(usage.cache_creation_tokens)}</span>
-        </InspRow>
-        <InspRow label="Billable">
-          <span className="tnum">
-            {integer(tokensIn(session))} in / {integer(tokensOut(session))} out
-          </span>
-        </InspRow>
-      </InspGroup>
-
-      <InspGroup title={`Sub-agents · ${integer(session.subagent_count)}`}>
-        <InspRow label="Input">
-          <span className="tnum">{integer(sub.input_tokens)}</span>
-        </InspRow>
-        <InspRow label="Output">
-          <span className="tnum">{integer(sub.output_tokens)}</span>
-        </InspRow>
-        <InspRow label="Cache read">
-          <span className="tnum">{integer(sub.cache_read_tokens)}</span>
-        </InspRow>
-        <InspRow label="Cache write">
-          <span className="tnum">{integer(sub.cache_creation_tokens)}</span>
-        </InspRow>
-        <InspRow label="Cost">
-          <span className="tnum">{usd(subCost.total_usd)}</span>
-        </InspRow>
-      </InspGroup>
-
-      <InspGroup title="Cost">
-        <InspRow label="Input">
-          <span className="tnum">{usd(cost.input_usd)}</span>
-        </InspRow>
-        <InspRow label="Output">
-          <span className="tnum">{usd(cost.output_usd)}</span>
-        </InspRow>
-        <InspRow label="Cache read">
-          <span className="tnum">{usd(cost.cache_read_usd)}</span>
-        </InspRow>
-        <InspRow label="Cache write">
-          <span className="tnum">{usd(cost.cache_write_usd)}</span>
-        </InspRow>
-        <InspRow label="Session">
-          <span className="tnum">{usd(cost.total_usd)}</span>
-        </InspRow>
-        <InspRow label="Sub-agents">
-          <span className="tnum">{usd(subCost.total_usd)}</span>
-        </InspRow>
-        <InspRow label="Total">
-          <span className="tnum" style={{ color: "var(--green)" }}>
-            {usd(totalCost(session))}
-          </span>
-        </InspRow>
-        {session.unpriced_models?.length ? (
-          <InspRow label="Unpriced">
-            <span title={session.unpriced_models.join(", ")}>
-              {session.unpriced_models.length} models ·{" "}
-              {compactNumber(session.unpriced_tokens ?? 0)} tokens
-            </span>
-          </InspRow>
-        ) : null}
-      </InspGroup>
-
-      {prs.length > 0 && (
-        <InspGroup title={`Pull requests · ${prs.length}`}>
-          <div className="sess-prs">
-            {prs.map((pr) => (
-              <div className="sess-pr" key={`${pr.pr_repository}#${pr.pr_number}`}>
-                <a
-                  href={pr.pr_url}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    openExternal(pr.pr_url);
-                  }}
-                >
-                  #{pr.pr_number}
-                </a>
-                <span className="sess-pr__repo">{pr.pr_repository}</span>
-              </div>
-            ))}
-          </div>
-        </InspGroup>
-      )}
-
-    </>
-  );
-}
-
-/* --- Toolbar dropdown ----------------------------------------------------- */
 
 function projectLabel(options: ClaudeProject[], value: string): string {
   const hit = options.find((p) => p.decoded_path === value);

--- a/src/views/sessions/SessionInspector.tsx
+++ b/src/views/sessions/SessionInspector.tsx
@@ -19,6 +19,14 @@
  *
  * The `Session` group is deliberately not collapsible: it is the pane's
  * identity, not one of its figures.
+ *
+ * It imports `styles/sessions.css` itself — the `SessionLink.tsx` /
+ * `components/charts.tsx` shape. The `.sess-heading`, `.sess-preview` and
+ * `.sess-pr*` rules it renders are declared only there, and until #538 that
+ * sheet reached them only because `SessionsView` happened to import it. A
+ * second caller outside this section would have rendered the Session heading
+ * and the whole Pull requests list unstyled, with nothing to say so — which is
+ * the savebar failure `CLAUDE.md` records, one directory over.
  */
 import { useCallback, useState } from "react";
 import { CopyButton } from "../../components/CopyButton";
@@ -48,6 +56,7 @@ import {
   totalDuration,
   usageOf,
 } from "./sessionMetrics";
+import "../../styles/sessions.css";
 
 export function SessionInspector({
   session,
@@ -56,13 +65,18 @@ export function SessionInspector({
 }) {
   const [open, setOpen] = useState(loadInspectorPrefs);
 
-  const toggle = useCallback((id: InspectorGroupId) => {
-    setOpen((prev) => {
-      const next = { ...prev, [id]: !prev[id] };
+  // The write is deliberately *outside* the updater: `main.tsx` renders under
+  // `StrictMode`, which double-invokes an updater, and a state updater has to
+  // be pure. Idempotent here, so this is correctness of the shape rather than a
+  // bug — but it is the shape the rest of this view already keeps.
+  const toggle = useCallback(
+    (id: InspectorGroupId) => {
+      const next = { ...open, [id]: !open[id] };
+      setOpen(next);
       saveInspectorPrefs(next);
-      return next;
-    });
-  }, []);
+    },
+    [open],
+  );
 
   const usage = usageOf(session.usage);
   const sub = usageOf(session.subagent_usage);

--- a/src/views/sessions/SessionInspector.tsx
+++ b/src/views/sessions/SessionInspector.tsx
@@ -1,0 +1,297 @@
+/**
+ * The session inspector — the metadata groups of the right-hand pane (#538).
+ *
+ * It was `function Inspector` inside `views/SessionsView.tsx`, private to a
+ * 2,000-line file even though it takes one prop and no handlers. It is a module
+ * now for the same reason `components/SaveBar.tsx` is: a shape only one file can
+ * reach is a shape the next caller copies instead of importing.
+ *
+ * **Actions are not here.** They live in `.sess-strip`, which `SessionsView`
+ * renders *above* the scrolling pane this component fills, because as the last
+ * group of a scrolling pane they were below the fold on any session with a full
+ * metadata block — the whole of #486. Collapsing the data groups is the other
+ * half of that same problem, and it does not move the strip.
+ *
+ * **The open/closed state is held here and written through to localStorage** on
+ * every toggle (`lib/inspectorPrefs.ts`), so it survives a reload and a trip
+ * out of the Sessions section — `App.tsx` renders each view conditionally, so
+ * this component remounts on every arrival and re-seeds from storage.
+ *
+ * The `Session` group is deliberately not collapsible: it is the pane's
+ * identity, not one of its figures.
+ */
+import { useCallback, useState } from "react";
+import { CopyButton } from "../../components/CopyButton";
+import { InspGroup, InspRow } from "../../components/ui";
+import {
+  compactNumber,
+  dateTime,
+  duration,
+  integer,
+  tildePath,
+  usd,
+} from "../../lib/format";
+import {
+  type InspectorGroupId,
+  loadInspectorPrefs,
+  saveInspectorPrefs,
+} from "../../lib/inspectorPrefs";
+import { sessionAgentName } from "../../lib/sessionAgent";
+import { openExternal } from "../../lib/tauri";
+import type { ClaudeSessionSummary } from "../../lib/types";
+import {
+  costOf,
+  modeBadge,
+  tokensIn,
+  tokensOut,
+  totalCost,
+  totalDuration,
+  usageOf,
+} from "./sessionMetrics";
+
+export function SessionInspector({
+  session,
+}: {
+  session: ClaudeSessionSummary;
+}) {
+  const [open, setOpen] = useState(loadInspectorPrefs);
+
+  const toggle = useCallback((id: InspectorGroupId) => {
+    setOpen((prev) => {
+      const next = { ...prev, [id]: !prev[id] };
+      saveInspectorPrefs(next);
+      return next;
+    });
+  }, []);
+
+  const usage = usageOf(session.usage);
+  const sub = usageOf(session.subagent_usage);
+  const cost = costOf(session.cost);
+  const subCost = costOf(session.subagent_cost);
+  const prs = session.prs ?? [];
+  const badge = modeBadge(session);
+  const agentName = sessionAgentName(session);
+
+  return (
+    <>
+      <InspGroup title="Session">
+        <div className="sess-heading">
+          {session.display_title || "Untitled session"}
+        </div>
+        {session.preview && (
+          <div className="sess-preview">{session.preview}</div>
+        )}
+        {/* Both of these are single values a user copies whole and neither
+            fits the pane, so the button carries the real string while the row
+            shows an abbreviated one (#469). */}
+        <InspRow label="ID">
+          <span className="row insp-row__copy">
+            <span className="mono truncate">{session.session_id}</span>
+            <CopyButton text={session.session_id} title="Copy session ID" />
+          </span>
+        </InspRow>
+        {session.custom_title && (
+          <InspRow label="Custom">{session.custom_title}</InspRow>
+        )}
+        {session.ai_title && session.ai_title !== session.display_title && (
+          <InspRow label="AI title">{session.ai_title}</InspRow>
+        )}
+        {session.native_title && (
+          <InspRow label="Native">{session.native_title}</InspRow>
+        )}
+        {/* Another name Claude Code recorded for the session, shown only when
+            it is not one of the titles above — the same suppression the AI
+            title gets, for the reasons in lib/sessionAgent.ts. It was labelled
+            "Agent" and sat beside Model and Config until it turned out never to
+            name an agent, so it belongs here with the other titles. */}
+        {agentName && <InspRow label="Named">{agentName}</InspRow>}
+        <InspRow label="Project">
+          <span className="row insp-row__copy">
+            <span className="truncate" title={session.project_path}>
+              {tildePath(session.project_path)}
+            </span>
+            <CopyButton
+              text={session.project_path}
+              title="Copy the project path"
+            />
+          </span>
+        </InspRow>
+        {session.cwd && session.cwd !== session.project_path && (
+          <InspRow label="Directory">{tildePath(session.cwd)}</InspRow>
+        )}
+        {session.relocated_cwd && (
+          <InspRow label="Relocated">{tildePath(session.relocated_cwd)}</InspRow>
+        )}
+        <InspRow label="Branch">{session.git_branch || "—"}</InspRow>
+        {session.worktree_name && (
+          <InspRow label="Worktree">
+            {session.worktree_name}
+            {session.worktree_branch ? ` · ${session.worktree_branch}` : ""}
+          </InspRow>
+        )}
+        {session.original_branch && (
+          <InspRow label="From">{session.original_branch}</InspRow>
+        )}
+        <InspRow label="Model">{session.model || "—"}</InspRow>
+        <InspRow label="Mode">
+          {badge ? (
+            <span className={`badge ${badge.tone}`}>{badge.label}</span>
+          ) : (
+            "—"
+          )}
+        </InspRow>
+        <InspRow label="Config">{session.config_dir ?? "Default"}</InspRow>
+      </InspGroup>
+
+      <InspGroup
+        title="Activity"
+        collapsible
+        open={open.activity}
+        onToggle={() => toggle("activity")}
+      >
+        <InspRow label="Started">{dateTime(session.start_time)}</InspRow>
+        <InspRow label="Last">{dateTime(session.last_activity)}</InspRow>
+        <InspRow label="Active">
+          <span className="tnum">{duration(session.active_duration_ms)}</span>
+        </InspRow>
+        <InspRow label="Sub-agents">
+          <span className="tnum">
+            {duration(session.subagent_active_duration_ms)}
+          </span>
+        </InspRow>
+        <InspRow label="Total">
+          <span className="tnum">{duration(totalDuration(session))}</span>
+        </InspRow>
+        <InspRow label="Messages">
+          <span className="tnum">{integer(session.message_count)}</span>
+        </InspRow>
+        <InspRow label="Events">
+          <span className="tnum">{integer(session.event_count)}</span>
+        </InspRow>
+        <InspRow label="Compactions">
+          <span className="tnum">{integer(session.compaction_count)}</span>
+        </InspRow>
+        {session.dropped_tokens > 0 && (
+          <InspRow label="Dropped">
+            <span className="tnum">{integer(session.dropped_tokens)}</span>
+          </InspRow>
+        )}
+      </InspGroup>
+
+      <InspGroup
+        title="Tokens"
+        collapsible
+        open={open.tokens}
+        onToggle={() => toggle("tokens")}
+      >
+        <InspRow label="Input">
+          <span className="tnum">{integer(usage.input_tokens)}</span>
+        </InspRow>
+        <InspRow label="Output">
+          <span className="tnum">{integer(usage.output_tokens)}</span>
+        </InspRow>
+        <InspRow label="Cache read">
+          <span className="tnum">{integer(usage.cache_read_tokens)}</span>
+        </InspRow>
+        <InspRow label="Cache write">
+          <span className="tnum">{integer(usage.cache_creation_tokens)}</span>
+        </InspRow>
+        <InspRow label="Billable">
+          <span className="tnum">
+            {integer(tokensIn(session))} in / {integer(tokensOut(session))} out
+          </span>
+        </InspRow>
+      </InspGroup>
+
+      {/* The count stays in the title of both of these, so a collapsed group
+          still carries every figure its header carried open. */}
+      <InspGroup
+        title={`Sub-agents · ${integer(session.subagent_count)}`}
+        collapsible
+        open={open.subagents}
+        onToggle={() => toggle("subagents")}
+      >
+        <InspRow label="Input">
+          <span className="tnum">{integer(sub.input_tokens)}</span>
+        </InspRow>
+        <InspRow label="Output">
+          <span className="tnum">{integer(sub.output_tokens)}</span>
+        </InspRow>
+        <InspRow label="Cache read">
+          <span className="tnum">{integer(sub.cache_read_tokens)}</span>
+        </InspRow>
+        <InspRow label="Cache write">
+          <span className="tnum">{integer(sub.cache_creation_tokens)}</span>
+        </InspRow>
+        <InspRow label="Cost">
+          <span className="tnum">{usd(subCost.total_usd)}</span>
+        </InspRow>
+      </InspGroup>
+
+      <InspGroup
+        title="Cost"
+        collapsible
+        open={open.cost}
+        onToggle={() => toggle("cost")}
+      >
+        <InspRow label="Input">
+          <span className="tnum">{usd(cost.input_usd)}</span>
+        </InspRow>
+        <InspRow label="Output">
+          <span className="tnum">{usd(cost.output_usd)}</span>
+        </InspRow>
+        <InspRow label="Cache read">
+          <span className="tnum">{usd(cost.cache_read_usd)}</span>
+        </InspRow>
+        <InspRow label="Cache write">
+          <span className="tnum">{usd(cost.cache_write_usd)}</span>
+        </InspRow>
+        <InspRow label="Session">
+          <span className="tnum">{usd(cost.total_usd)}</span>
+        </InspRow>
+        <InspRow label="Sub-agents">
+          <span className="tnum">{usd(subCost.total_usd)}</span>
+        </InspRow>
+        <InspRow label="Total">
+          <span className="tnum" style={{ color: "var(--green)" }}>
+            {usd(totalCost(session))}
+          </span>
+        </InspRow>
+        {session.unpriced_models?.length ? (
+          <InspRow label="Unpriced">
+            <span title={session.unpriced_models.join(", ")}>
+              {session.unpriced_models.length} models ·{" "}
+              {compactNumber(session.unpriced_tokens ?? 0)} tokens
+            </span>
+          </InspRow>
+        ) : null}
+      </InspGroup>
+
+      {prs.length > 0 && (
+        <InspGroup
+          title={`Pull requests · ${prs.length}`}
+          collapsible
+          open={open.prs}
+          onToggle={() => toggle("prs")}
+        >
+          <div className="sess-prs">
+            {prs.map((pr) => (
+              <div className="sess-pr" key={`${pr.pr_repository}#${pr.pr_number}`}>
+                <a
+                  href={pr.pr_url}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    openExternal(pr.pr_url);
+                  }}
+                >
+                  #{pr.pr_number}
+                </a>
+                <span className="sess-pr__repo">{pr.pr_repository}</span>
+              </div>
+            ))}
+          </div>
+        </InspGroup>
+      )}
+    </>
+  );
+}

--- a/src/views/sessions/sessionMetrics.ts
+++ b/src/views/sessions/sessionMetrics.ts
@@ -1,0 +1,123 @@
+/* ============================================================================
+   The session totals and the permission-mode tables.
+
+   Lifted out of `views/SessionsView.tsx` by #538, when the inspector became its
+   own component (`SessionInspector.tsx`) and these turned out to have callers on
+   both sides of the split — the table's Cost column and its row badges as much
+   as the inspector's groups. Exporting them from the view instead would have
+   made `SessionsView` and `SessionInspector` import each other, so they live
+   here, where neither owns the other.
+
+   Nothing here renders. It is arithmetic over a `ClaudeSessionSummary` plus the
+   two lookup tables, so a `SessionDetail` — which extends the summary — can use
+   every one of them unchanged.
+   ========================================================================== */
+
+import type {
+  ClaudeSessionSummary,
+  SessionCost,
+  TokenUsage,
+} from "../../lib/types";
+
+/* --- Totals -------------------------------------------------------------- */
+
+const ZERO_USAGE: TokenUsage = {
+  input_tokens: 0,
+  output_tokens: 0,
+  cache_creation_tokens: 0,
+  cache_creation_5m_tokens: 0,
+  cache_creation_1h_tokens: 0,
+  cache_read_tokens: 0,
+};
+
+const ZERO_COST: SessionCost = {
+  input_usd: 0,
+  output_usd: 0,
+  cache_read_usd: 0,
+  cache_write_usd: 0,
+  total_usd: 0,
+};
+
+export function usageOf(u: TokenUsage | undefined | null): TokenUsage {
+  return u ?? ZERO_USAGE;
+}
+
+export function costOf(c: SessionCost | undefined | null): SessionCost {
+  return c ?? ZERO_COST;
+}
+
+/**
+ * Billable input/output, main thread plus sub-agents. Cache tokens are billed
+ * separately and are deliberately not folded in here — `facets.total_tokens`
+ * is exactly the sum of these two numbers over the filtered set.
+ */
+export function tokensIn(s: ClaudeSessionSummary): number {
+  return usageOf(s.usage).input_tokens + usageOf(s.subagent_usage).input_tokens;
+}
+
+export function tokensOut(s: ClaudeSessionSummary): number {
+  return (
+    usageOf(s.usage).output_tokens + usageOf(s.subagent_usage).output_tokens
+  );
+}
+
+export function totalCost(s: ClaudeSessionSummary): number {
+  return costOf(s.cost).total_usd + costOf(s.subagent_cost).total_usd;
+}
+
+export function totalDuration(s: ClaudeSessionSummary): number {
+  return (s.active_duration_ms ?? 0) + (s.subagent_active_duration_ms ?? 0);
+}
+
+/* --- Presentation helpers ------------------------------------------------- */
+
+/**
+ * The permission modes Claude Code writes, and how each reads.
+ *
+ * One table for the row badge and the Mode filter, so the option a user picks
+ * is spelled exactly as the column they picked it from. An unknown value keeps
+ * its raw text in both places rather than being dropped — the corpus predates
+ * some of these names.
+ */
+const MODE_LABELS: Record<string, string> = {
+  bypassPermissions: "Bypass",
+  plan: "Plan",
+  acceptEdits: "Accept",
+  dontAsk: "Don't ask",
+  default: "Default",
+};
+
+const MODE_TONES: Record<string, string> = {
+  bypassPermissions: "badge--amber",
+  plan: "badge--purple",
+  acceptEdits: "badge--teal",
+  dontAsk: "badge--teal",
+};
+
+/**
+ * `permission_mode` is a free-form column — the scanner copies whatever the
+ * transcript's `permission-mode` event carried, with no enum in between — so
+ * every read of these tables goes through a `typeof` check rather than `??`.
+ * A plain object inherits `toString`, `constructor` and `valueOf`, and `??`
+ * does not catch a function: the value would reach JSX as a React child and as
+ * a `className`. The `switch` these tables replaced was immune by construction.
+ */
+function lookup(table: Record<string, string>, key: string): string | undefined {
+  const v = table[key];
+  return typeof v === "string" ? v : undefined;
+}
+
+export function modeLabel(mode: string): string {
+  return lookup(MODE_LABELS, mode) ?? mode;
+}
+
+export function modeBadge(
+  s: ClaudeSessionSummary,
+): { label: string; tone: string } | null {
+  // `omitempty` on the Go side, so the field is absent on a row that recorded
+  // no mode — which is not the same as one whose mode this table does not know.
+  const mode = s.permission_mode ?? "";
+  const label = lookup(MODE_LABELS, mode);
+  if (label) return { label, tone: lookup(MODE_TONES, mode) ?? "" };
+  return s.mode ? { label: s.mode, tone: "" } : null;
+}


### PR DESCRIPTION
Closes #538

## What

Two things, both presentation-only — no `/api` change, no new field, no wire change.

1. **Collapsible inspector groups.** `InspGroup` gains an **opt-in** `collapsible` / `open` / `onToggle`. The session inspector's five data groups use it; `Activity` and `Cost` ship open, `Tokens`, `Sub-agents` and `Pull requests` collapsed, and each group's state is persisted per group in `localStorage`. `Session` stays always-open — it is the pane's identity, not one of its figures.
2. **One session inspector.** The private `function Inspector` in `SessionsView.tsx` is now `src/views/sessions/SessionInspector.tsx`, taking `{ session }` and no handlers.

## Why

The right sidebar is a session's whole "glance" surface and it keeps growing: six stacked groups, most of them below the fold on any session with a full metadata block. #486 hit exactly this and pinned the action strip *outside* the scrolling pane; collapsing the data groups is the other half of the same problem, and it is what makes a seventh group an append rather than a layout decision. The extraction is what stops the next caller copying the JSX instead of importing it — `SaveBar`'s lesson from #519, one component over.

## How

**`InspGroup` is widened opt-in, and the no-op is proved rather than asserted.** Eight views render it, so a default-collapsible group would silently change every inspector in the app. A caller passing nothing takes an early return and emits the `<div className="insp-group__title">` it always did; only `collapsible` gets the `<button … aria-expanded>` and the chevron. It is **controlled**, not self-stateful — the persistence has to live in one place, and a self-stateful group would need a storage key threaded in anyway.

Proved the way the `charts.tsx` (#428) and `SaveBar.tsx` (#519) moves were: build `main@7b2fb70` and this head, split `dist/assets/*.css` into one rule per `}`, and diff **twice** — as a sorted set (what changed at all) and as an ordered selector list (cascade, which a sorted set cannot see). Result: **3 added, 0 removed, 0 reordered**, every pre-existing rule byte-identical and in place, and all three additions new modifiers declared nowhere else:

```
.insp-group__title--toggle{justify-content:space-between;align-items:center;gap:var(--sp-3);text-align:left;width:100%;padding:0;display:flex}
.insp-group__title--toggle:hover{color:var(--fg-secondary)}
.insp-group__title--closed{margin-bottom:0}
```

**The CSS is a box reset and nothing more, deliberately.** `base.css` already resets a `button`'s font, colour, background, border and outline, puts `button` in #469's selection denylist with `cursor: default`, and paints a global `:focus-visible` ring — so there is **no** `cursor: pointer` (this shell draws an arrow over its own controls) and no per-component focus rule. `--closed` exists because the header's 4px bottom margin has nothing under it when the group is collapsed.

**`lib/inspectorPrefs.ts`** is `newChatPrefs.ts`'s shape — `agento.*` key, `try/catch`, every field optional on read so a blob from an older build keeps what it has — plus one rule of its own: it keys on a **stable slug**, never the rendered title, because two of the groups interpolate a count into their heading (`Sub-agents · 12`) and a title-keyed blob would store a new key per session and remember nothing. The ids and the shipped defaults are pinned through `lib/typeAssert.ts`, since a respelled id silently resets every user's saved state and there is no test harness to catch it.

**`views/sessions/sessionMetrics.ts`** holds the totals and the permission-mode tables that came out with the component. The issue suggested re-exporting them from the view; that would have made `SessionsView` and `SessionInspector` import each other, so they live in a third module instead — every one of its exports has callers on both sides.

**`SessionInspector` imports `styles/sessions.css` itself**, the `SessionLink.tsx` / `charts.tsx` shape. The five `.sess-*` classes it renders are declared only there and reached it until now only because `SessionsView` happened to import that sheet; a caller outside this section would have rendered the Session heading and the whole Pull requests list unstyled with nothing to say so. It changes no emitted CSS — Vite dedupes.

### Deviations from the refined HOW, stated

- **Step 4 of the issue's original body was deliberately not done.** The refinement's own Context corrects it, and the correction checks out: `SessionDetail` fills `.pane-detail` and the `inspectorOpen` `aside.pane-inspector` is its **sibling** inside the same `.panes`, so a session's Transcript and Journey tabs already render this pane from this code. Mounting a second one would have shown two inspectors side by side.
- **A third file, `sessionMetrics.ts`**, rather than the HOW's "export from their current home" — see above.
- **No `cursor: pointer` and no `:focus-visible` rule**, both of which the HOW asked for; `base.css` supplies the second and forbids the first.

## Acceptance criteria

- [x] `InspGroup` collapses only behind the new prop; the other 7 views emit byte-identical markup (early return) and byte-identical CSS (the diff above).
- [x] First run: `Session`, `Activity`, `Cost` open; `Tokens`, `Sub-agents`, `Pull requests` collapsed.
- [x] Toggling persists across a reload and across leaving the Sessions section (`App.tsx` renders each view conditionally, so the component remounts and re-seeds from storage).
- [x] A stored blob missing keys falls back **per group**; an unparseable blob falls back wholesale.
- [x] A collapsed group keeps the count its title carried (`Sub-agents · N`, `Pull requests · N`).
- [x] The header is a real `<button type="button">` with `aria-expanded`, reachable by Tab, toggled by Enter/Space; the chevron is `aria-hidden` (`Icon` sets it).
- [x] `SessionInspector` renders identically to today — same groups, same order, same values, still `{ session }` and no handlers.
- [x] `npm run build` (`tsc --noEmit && vite build`) passes; no `/api` request or payload change.

## Verification

- `npm run build` green; CI green on every push.
- Emitted-CSS diff, both directions, as above.
- The extracted JSX diffed against the removed `function Inspector` — the only deltas are the signature, the state block and the `collapsible`/`open`/`onToggle` props.
- **Not done: visual verification in the real Tauri webview.** No instance was running and building one was not worth the run; the CSS claim is proved by the emitted diff and the markup claim by construction, but the collapsed/expanded look has not been seen on screen.
