### PR TITLE
feat: compare the selected analytics period with the previous one (#539)

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -422,6 +422,36 @@ threshold. That is expected, and it happens in the background.
 Three views over the same indexed history. All of them take a date range, and
 group by hour, day, week, month or year depending on how wide that range is.
 
+### Comparing with the period before
+
+Token usage and General usage have a **Compare** box in the toolbar. Tick it and
+every headline figure gains its change against the *previous period* — the window
+immediately before the one you are looking at, of exactly the same length. On
+`30d` that is the 30 days before your 30 days; the project filter and the
+timezone are the same on both sides.
+
+Three things worth knowing about what it shows:
+
+- **The current window's last day is usually still in progress**, so the newest
+  figures are structurally a little low. The comparison does not try to correct
+  for that; it compares whole window against whole window.
+- **A change needs something to divide by.** Where the previous period had none
+  of something, the tile says *no baseline* rather than inventing a percentage.
+- **Cost is only compared when both windows are fully priced.** If either one
+  contains tokens from a model with no published rate, its total is a floor
+  rather than a figure, and the difference between two floors is not a change in
+  spend — so the cost tile says *no cost delta* instead.
+
+On the two time-series charts the previous period is drawn as a dashed grey
+line over the same axes, sharing one scale with the current one so the heights
+are directly comparable. It is lined up from the most recent bucket backwards,
+because two windows of the same length do not always contain the same number of
+buckets.
+
+The box is off by default and remembered per install. It is unavailable on
+**All time**, which is not a window of any particular length and so has nothing
+before it.
+
 ### Token usage
 
 Where the tokens and the money go.
@@ -453,8 +483,8 @@ That is intentional and the chart says so.
 Beta, and the most opinionated view.
 
 Headline numbers: sessions, average autonomy score, average turns, cache hit
-rate, and total cost. Each compared against the previous period, so you can see
-the direction.
+rate, and total cost. Unlike Token usage and General usage, this view has no
+period comparison yet — the numbers are for the selected range only.
 
 Below that, **tool call attribution**: every tool call broken down by the skill,
 plugin, MCP server, sub-agent and reasoning effort responsible. This is how you

--- a/src/components/charts.tsx
+++ b/src/components/charts.tsx
@@ -152,6 +152,7 @@ function Scale({
   );
 }
 
+
 /* --- Area chart ---------------------------------------------------------- */
 
 export function AreaChart({
@@ -198,12 +199,17 @@ export function AreaChart({
     : undefined;
   const offset = points.length - (cmp?.length ?? 0);
 
-  const peak = Math.max(
-    points.reduce((m, p) => Math.max(m, p.value), 0),
-    cmp?.reduce((m, p) => Math.max(m, p.value), 0) ?? 0
-  );
+  // Two peaks, and they are for two different things. `peak` is the *current*
+  // window's own, because that is what the caption and the aria-label name —
+  // reporting the combined maximum there would attribute a figure to a period
+  // it never occurred in. `scaleTo` is the combined one, because the two lines
+  // have to share a y-maximum or a smaller series draws above a larger one,
+  // which is a false crossover rather than a comparison.
+  const peak = points.reduce((m, p) => Math.max(m, p.value), 0);
+  const comparePeak = cmp?.reduce((m, p) => Math.max(m, p.value), 0) ?? 0;
+  const scaleTo = Math.max(peak, comparePeak);
   // A flat-zero series still has to draw a baseline rather than divide by zero.
-  const max = peak > 0 ? peak * 1.15 : 1;
+  const max = scaleTo > 0 ? scaleTo * 1.15 : 1;
   const step = points.length > 1 ? W / (points.length - 1) : 0;
   const y = (v: number) => {
     const at = H - (v / max) * H;
@@ -235,7 +241,11 @@ export function AreaChart({
       <Scale
         max={peak}
         format={format}
-        note={cmp ? `dashed = ${compareLabel}` : undefined}
+        note={
+          cmp
+            ? `${compareLabel} peak ${format(comparePeak)}, dashed`
+            : undefined
+        }
       />
       <svg
         className="a-chart__plot"
@@ -245,7 +255,7 @@ export function AreaChart({
         role="img"
         aria-label={
           cmp
-            ? `${points.length} buckets against the ${compareLabel}, peak ${format(peak)}`
+            ? `${points.length} buckets, peak ${format(peak)}, against the ${compareLabel}, peak ${format(comparePeak)}`
             : `${points.length} buckets, peak ${format(peak)}`
         }
       >

--- a/src/components/charts.tsx
+++ b/src/components/charts.tsx
@@ -199,15 +199,20 @@ export function AreaChart({
     : undefined;
   const offset = points.length - (cmp?.length ?? 0);
 
-  // Two peaks, and they are for two different things. `peak` is the *current*
-  // window's own, because that is what the caption and the aria-label name —
-  // reporting the combined maximum there would attribute a figure to a period
-  // it never occurred in. `scaleTo` is the combined one, because the two lines
-  // have to share a y-maximum or a smaller series draws above a larger one,
-  // which is a false crossover rather than a comparison.
+  // Two maxima, and they are for two different things. `peak` is the *current*
+  // window's own, and it is the only one named anywhere: it is exact, because
+  // the caller's trim removes zero buckets only. `scaleTo` also bounds the
+  // comparison, because the two lines have to share a y-maximum or a smaller
+  // series draws above a larger one, which is a false crossover rather than a
+  // comparison — but it is deliberately **not** captioned. `cmp` is a truncated,
+  // window-aligned slice of the comparison, so its maximum describes the drawn
+  // span rather than the period, and a number captioned "previous period peak"
+  // would attribute a figure to a window that may never have had it.
   const peak = points.reduce((m, p) => Math.max(m, p.value), 0);
-  const comparePeak = cmp?.reduce((m, p) => Math.max(m, p.value), 0) ?? 0;
-  const scaleTo = Math.max(peak, comparePeak);
+  const scaleTo = Math.max(
+    peak,
+    cmp?.reduce((m, p) => Math.max(m, p.value), 0) ?? 0
+  );
   // A flat-zero series still has to draw a baseline rather than divide by zero.
   const max = scaleTo > 0 ? scaleTo * 1.15 : 1;
   const step = points.length > 1 ? W / (points.length - 1) : 0;
@@ -241,11 +246,7 @@ export function AreaChart({
       <Scale
         max={peak}
         format={format}
-        note={
-          cmp
-            ? `${compareLabel} peak ${format(comparePeak)}, dashed`
-            : undefined
-        }
+        note={cmp ? `dashed = ${compareLabel}` : undefined}
       />
       <svg
         className="a-chart__plot"
@@ -255,7 +256,7 @@ export function AreaChart({
         role="img"
         aria-label={
           cmp
-            ? `${points.length} buckets, peak ${format(peak)}, against the ${compareLabel}, peak ${format(comparePeak)}`
+            ? `${points.length} buckets, peak ${format(peak)}, with the ${compareLabel} overlaid`
             : `${points.length} buckets, peak ${format(peak)}`
         }
       >

--- a/src/components/charts.tsx
+++ b/src/components/charts.tsx
@@ -71,23 +71,47 @@ function Grid() {
   );
 }
 
-/** Hit targets carrying the native tooltip — one invisible column per bucket. */
-function Hits({ points }: { points: Point[] }) {
+/**
+ * Hit targets carrying the native tooltip — one invisible column per bucket.
+ *
+ * There is one column per *current* bucket whether or not a comparison series
+ * is drawn: the comparison is an overlay on this axis, not a second axis, so a
+ * second row of hit targets would put two tooltips over one column. When
+ * `compare` is given, its aligned value is appended to the same `<title>`.
+ */
+function Hits({
+  points,
+  compare,
+  offset = 0,
+  compareText,
+}: {
+  points: Point[];
+  compare?: Point[];
+  /** Index in `points` the aligned comparison series starts at. */
+  offset?: number;
+  compareText?: (p: Point) => string;
+}) {
   const w = W / Math.max(1, points.length);
   return (
     <>
-      {points.map((p, i) => (
-        <rect
-          key={i}
-          className="a-chart__hit"
-          x={i * w}
-          y={0}
-          width={w}
-          height={H}
-        >
-          <title>{p.hint ?? `${p.label} — ${p.value}`}</title>
-        </rect>
-      ))}
+      {points.map((p, i) => {
+        const base = p.hint ?? `${p.label} — ${p.value}`;
+        const other = compare?.[i - offset];
+        return (
+          <rect
+            key={i}
+            className="a-chart__hit"
+            x={i * w}
+            y={0}
+            width={w}
+            height={H}
+          >
+            <title>
+              {other && compareText ? `${base} · ${compareText(other)}` : base}
+            </title>
+          </rect>
+        );
+      })}
     </>
   );
 }
@@ -111,19 +135,53 @@ function Axis({ points }: { points: Point[] }) {
   );
 }
 
-function Scale({ max, format }: { max: number; format(n: number): string }) {
-  return <div className="a-chart__scale">Peak {format(max)}</div>;
+function Scale({
+  max,
+  format,
+  note,
+}: {
+  max: number;
+  format(n: number): string;
+  note?: string;
+}) {
+  return (
+    <div className="a-chart__scale">
+      Peak {format(max)}
+      {note && ` · ${note}`}
+    </div>
+  );
 }
 
 /* --- Area chart ---------------------------------------------------------- */
 
 export function AreaChart({
   points,
+  compare,
+  compareLabel = "previous period",
   height = 180,
   format,
   emptyText = "No data in this period",
 }: {
   points: Point[];
+  /**
+   * An optional second series drawn as a stroke-only dashed line over the same
+   * axes (#539) — typically the same metric over the window immediately before
+   * this one.
+   *
+   * **It shares one y-maximum with `points`, and that is the load-bearing part**:
+   * two independently scaled lines would put a smaller series above a larger one,
+   * which is a false crossover rather than a comparison.
+   *
+   * **Alignment is from the last element backwards**, truncated to the shorter
+   * of the two. Two windows of equal *duration* can still produce different
+   * bucket counts — a weekly walk starting on a different weekday, unequal month
+   * lengths, an hourly walk across a DST transition — so zipping from index 0
+   * would slide the whole overlay by a bucket, and joining on the date key
+   * cannot work at all when the two windows share no dates by construction.
+   */
+  compare?: Point[];
+  /** How the comparison series is named in the caption and the tooltips. */
+  compareLabel?: string;
   height?: number;
   format(n: number): string;
   emptyText?: string;
@@ -132,15 +190,29 @@ export function AreaChart({
 
   if (!points.length) return <CardEmpty text={emptyText} />;
 
-  const peak = points.reduce((m, p) => Math.max(m, p.value), 0);
+  // Aligned from the last element backwards; a comparison longer than the
+  // current series loses its *oldest* buckets, which are the ones with no
+  // counterpart on this axis.
+  const cmp = compare?.length
+    ? compare.slice(Math.max(0, compare.length - points.length))
+    : undefined;
+  const offset = points.length - (cmp?.length ?? 0);
+
+  const peak = Math.max(
+    points.reduce((m, p) => Math.max(m, p.value), 0),
+    cmp?.reduce((m, p) => Math.max(m, p.value), 0) ?? 0
+  );
   // A flat-zero series still has to draw a baseline rather than divide by zero.
   const max = peak > 0 ? peak * 1.15 : 1;
   const step = points.length > 1 ? W / (points.length - 1) : 0;
+  const y = (v: number) => {
+    const at = H - (v / max) * H;
+    return isFinite(at) ? at : H;
+  };
 
   const coords = points.map((p, i) => {
     const x = points.length > 1 ? i * step : W / 2;
-    const y = H - (p.value / max) * H;
-    return `${x},${isFinite(y) ? y : H}`;
+    return `${x},${y(p.value)}`;
   });
 
   const line =
@@ -149,16 +221,33 @@ export function AreaChart({
       : `M0,${coords[0].split(",")[1]} L${W},${coords[0].split(",")[1]}`;
   const area = `${line} L${W},${H} L0,${H} Z`;
 
+  // A single comparison bucket against a multi-bucket axis has no segment to
+  // draw — one point is not a line. Its value still reaches the tooltip.
+  const compareLine =
+    cmp && cmp.length > 1
+      ? cmp.map((p, j) => `${j ? "L" : "M"}${(offset + j) * step},${y(p.value)}`).join(" ")
+      : cmp && cmp.length === 1 && points.length === 1
+        ? `M0,${y(cmp[0].value)} L${W},${y(cmp[0].value)}`
+        : undefined;
+
   return (
     <div className="a-chart">
-      <Scale max={peak} format={format} />
+      <Scale
+        max={peak}
+        format={format}
+        note={cmp ? `dashed = ${compareLabel}` : undefined}
+      />
       <svg
         className="a-chart__plot"
         viewBox={`0 0 ${W} ${H}`}
         preserveAspectRatio="none"
         style={{ height }}
         role="img"
-        aria-label={`${points.length} buckets, peak ${format(peak)}`}
+        aria-label={
+          cmp
+            ? `${points.length} buckets against the ${compareLabel}, peak ${format(peak)}`
+            : `${points.length} buckets, peak ${format(peak)}`
+        }
       >
         <defs>
           <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
@@ -169,6 +258,13 @@ export function AreaChart({
 
         <Grid />
         <path d={area} fill={`url(#${gradientId})`} />
+        {compareLine && (
+          <path
+            className="a-chart__compare"
+            d={compareLine}
+            vectorEffect="non-scaling-stroke"
+          />
+        )}
         <path
           d={line}
           fill="none"
@@ -178,7 +274,12 @@ export function AreaChart({
           strokeLinecap="round"
           vectorEffect="non-scaling-stroke"
         />
-        <Hits points={points} />
+        <Hits
+          points={points}
+          compare={cmp}
+          offset={offset}
+          compareText={(p) => `${compareLabel}: ${format(p.value)}`}
+        />
       </svg>
       <Axis points={points} />
     </div>

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -98,14 +98,27 @@ export function Switch({
 export function Checkbox({
   on,
   onChange,
+  disabled,
 }: {
   on: boolean;
   onChange(v: boolean): void;
+  /**
+   * A box the current state cannot support (#539) — `Switch`'s `disabled`, one
+   * control over. Opt-in and defaulted to `undefined`, so the three call sites
+   * that pass nothing emit exactly the button they always did.
+   *
+   * Note it carries **no `title`**, for `Switch`'s reason: a disabled button
+   * receives no mouse events, so a tooltip on one never shows. Why the box is
+   * shut has to live in something beside it — a wrapping `<label>` still gets
+   * the hover.
+   */
+  disabled?: boolean;
 }) {
   return (
     <button
       role="checkbox"
       aria-checked={on}
+      disabled={disabled}
       className={`checkbox ${on ? "checkbox--on" : ""}`}
       onClick={() => onChange(!on)}
     >

--- a/src/lib/analyticsPrefs.ts
+++ b/src/lib/analyticsPrefs.ts
@@ -1,0 +1,87 @@
+/* ============================================================================
+   What the analytics toolbar was last set to (#539).
+
+   Same reasoning as `newChatPrefs.ts` and `inspectorPrefs.ts`: "compare this
+   window against the one before it" is *how I like to read the dashboard*,
+   which belongs to this install rather than to the account. There is no wire
+   field for it, and adding one would make a presentation toggle a synced
+   preference — and would put a second request behind a `user_settings` write.
+
+   Two rules the shape depends on, both inherited:
+
+   * **Every key is optional on read.** A blob written by an older build keeps
+     the keys it has and takes the shipped default for the rest, so a second
+     toggle added later needs no migration.
+   * **The key and the shipped defaults are pinned** through `lib/typeAssert.ts`
+     — the localStorage key is a string nothing else validates, so respelling it
+     silently resets every user's saved state, and there is no TypeScript test
+     harness here that would notice.
+   ========================================================================== */
+
+import type { Eq, Expect } from "./typeAssert";
+
+/**
+ * The toolbar toggles and what they ship as.
+ *
+ * `compare` ships **off**: it costs a second `/claude-analytics` request per
+ * query change, and an install that never asks for a comparison must not pay
+ * for one.
+ */
+export const DEFAULT_ANALYTICS_PREFS = {
+  compare: false,
+} as const;
+
+/** The stored blob's key. */
+const KEY = "agento.analytics";
+
+/**
+ * The key and the shipped defaults, pinned.
+ *
+ * `KEY` is what a stored blob is found under, so respelling it is
+ * indistinguishable from a user who never set the toggle. `DEFAULT_ANALYTICS_PREFS`
+ * is what an install ships with, and flipping it would turn the second request
+ * on for everyone. Neither has a test to catch it, so the pin is the guard: an
+ * edit to either now fails `tsc`, i.e. fails CI.
+ */
+export type PinAnalyticsPrefsKey = Expect<Eq<typeof KEY, "agento.analytics">>;
+export type PinAnalyticsPrefs = Expect<
+  Eq<typeof DEFAULT_ANALYTICS_PREFS, { readonly compare: false }>
+>;
+
+export type AnalyticsPrefs = { -readonly [K in keyof typeof DEFAULT_ANALYTICS_PREFS]: boolean };
+
+/**
+ * The stored toolbar state, defaulted per key.
+ *
+ * Reads defensively rather than trusting the blob — localStorage is shared with
+ * anything else on this origin and survives every upgrade, so a `JSON.parse` of
+ * a corrupted value would take the whole view down at first render. A key whose
+ * value is not a boolean is treated as absent, which is the same fallback a
+ * missing key gets.
+ */
+export function loadAnalyticsPrefs(): AnalyticsPrefs {
+  const prefs: AnalyticsPrefs = { ...DEFAULT_ANALYTICS_PREFS };
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return prefs;
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return prefs;
+    const stored = parsed as Record<string, unknown>;
+    for (const id of Object.keys(prefs) as (keyof AnalyticsPrefs)[]) {
+      const value = stored[id];
+      if (typeof value === "boolean") prefs[id] = value;
+    }
+    return prefs;
+  } catch {
+    return { ...DEFAULT_ANALYTICS_PREFS };
+  }
+}
+
+/** Remember the toolbar. A private-mode or quota failure costs the memory, not the view. */
+export function saveAnalyticsPrefs(prefs: AnalyticsPrefs): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(prefs));
+  } catch {
+    // Nothing to do: the toggle still worked for this session.
+  }
+}

--- a/src/styles/charts.css
+++ b/src/styles/charts.css
@@ -56,6 +56,21 @@
   fill-opacity: 0.06;
 }
 
+/* The period-over-period comparison line (#539). Stroke only — no gradient
+   fill — and muted and dashed, so the current period stays the subject and the
+   previous one reads as the reference it is. The dash length is in screen units
+   rather than viewBox units because `preserveAspectRatio="none"` stretches the
+   plot: `vector-effect: non-scaling-stroke` on the path is what keeps the
+   pattern even across every card width. */
+.a-chart__compare {
+  fill: none;
+  stroke: var(--fg-quaternary);
+  stroke-width: 1.2;
+  stroke-dasharray: 3 3;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+}
+
 /* --- Heatmap ------------------------------------------------------------- */
 
 .a-heat {

--- a/src/styles/controls.css
+++ b/src/styles/controls.css
@@ -376,6 +376,14 @@ textarea.field-area:focus {
   box-shadow: inset 0 0 0 1px var(--accent);
   color: #fff;
 }
+/* A box the current state cannot support (#539) — `.switch:disabled`'s rule,
+   for the same reason: it reads as unavailable rather than as off, and the two
+   are different states. The stored preference is shown unchanged, so a toggle
+   that is on stays on while the range it cannot apply to is selected. */
+.checkbox:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
 
 /* --- Badges / pills ------------------------------------------------------ */
 .badge {

--- a/src/views/AnalyticsView.tsx
+++ b/src/views/AnalyticsView.tsx
@@ -37,6 +37,23 @@ import "../styles/analytics.css";
 
 type Mode = "tokens" | "usage" | "insights";
 
+/**
+ * A report, tagged with the query string it was fetched for (#539).
+ *
+ * `useResource` never clears `data` on a dependency change — it only calls
+ * `setData` on success — which is deliberate and is what lets a failed refresh
+ * keep showing the last good figures. It also means that while a range or
+ * project change is in flight the two analytics resources resolve
+ * independently, so for a moment whichever landed first would be differenced
+ * against the *other* window's data and every tile would show a percentage
+ * describing neither. Tagging is what makes that detectable: a delta is
+ * rendered only when both halves carry the query they are being read as.
+ */
+interface Keyed {
+  key: string;
+  report: AnalyticsReport;
+}
+
 export function AnalyticsView({
   mode,
   inspectorOpen,
@@ -77,10 +94,12 @@ export function AnalyticsView({
   const ready = range !== "custom" || Boolean(period.from && period.to);
   const wantsReport = mode !== "insights";
 
-  const report = useResource<AnalyticsReport | undefined>(
+  const report = useResource<Keyed | undefined>(
     (signal) =>
       ready && wantsReport
-        ? api.get<AnalyticsReport>(`/claude-analytics${query}`, signal)
+        ? api
+            .get<AnalyticsReport>(`/claude-analytics${query}`, signal)
+            .then((r) => ({ key: query, report: r }))
         : Promise.resolve(undefined),
     [query, ready, wantsReport]
   );
@@ -98,10 +117,12 @@ export function AnalyticsView({
     tz: TZ,
   });
 
-  const previous = useResource<AnalyticsReport | undefined>(
+  const previous = useResource<Keyed | undefined>(
     (signal) =>
       wantsCompare
-        ? api.get<AnalyticsReport>(`/claude-analytics${compareQuery}`, signal)
+        ? api
+            .get<AnalyticsReport>(`/claude-analytics${compareQuery}`, signal)
+            .then((r) => ({ key: compareQuery, report: r }))
         : Promise.resolve(undefined),
     [compareQuery, wantsCompare]
   );
@@ -130,14 +151,24 @@ export function AnalyticsView({
   const sessionCount =
     mode === "insights"
       ? insights.data?.total_sessions
-      : report.data?.summary.total_sessions;
+      : report.data?.report.summary.total_sessions;
 
   // A failed comparison must not take the view down with it: the primary report
   // is what the section is for, so the deltas are dropped and one banner says
-  // why. `useResource` keeps the last good `data` on error, so the check is on
-  // `error` rather than on `data` being absent — otherwise a stale comparison
-  // from a previous window would go on being differenced against this one.
-  const comparison = wantsCompare && !previous.error ? previous.data : undefined;
+  // why.
+  //
+  // Both halves are checked against the query they were fetched for, which is
+  // what stops a report from one window being differenced against another's
+  // while a change is in flight or after one of the two failed holding stale
+  // data. A delta is a claim about a *pair*, so it is only made when the pair
+  // is known to be one.
+  const comparison =
+    wantsCompare &&
+    !previous.error &&
+    report.data?.key === query &&
+    previous.data?.key === compareQuery
+      ? previous.data.report
+      : undefined;
 
   return (
     <div className="panes">
@@ -252,7 +283,7 @@ export function AnalyticsView({
           <div className={`dash scroll a-dash ${loading ? "a-dash--stale" : ""}`}>
             <Body
               mode={mode}
-              report={report.data}
+              report={report.data?.report}
               previous={comparison}
               insights={insights.data}
               project={project}
@@ -275,7 +306,7 @@ export function AnalyticsView({
                 to={period.to}
                 comparedWith={wantsCompare ? previousWindow : undefined}
                 project={project}
-                report={report.data}
+                report={report.data?.report}
                 insights={insights.data}
               />
             </div>

--- a/src/views/AnalyticsView.tsx
+++ b/src/views/AnalyticsView.tsx
@@ -3,12 +3,14 @@ import { api, qs } from "../lib/api";
 import { useResource } from "../lib/hooks";
 import { Icon } from "../lib/icons";
 import { integer, percent, usd } from "../lib/format";
+import { loadAnalyticsPrefs, saveAnalyticsPrefs } from "../lib/analyticsPrefs";
 import type {
   AnalyticsReport,
   ClaudeProject,
   InsightsSummary,
 } from "../lib/types";
 import {
+  Checkbox,
   Dropdown,
   Empty,
   InspGroup,
@@ -22,8 +24,10 @@ import {
   computePeriod,
   granularityLabel,
   list,
+  previousPeriod,
   projectLabel,
   share,
+  type Period,
   type RangeKey,
 } from "./analytics/shared";
 import { TokensMode } from "./analytics/TokensMode";
@@ -44,10 +48,19 @@ export function AnalyticsView({
   const [customFrom, setCustomFrom] = useState("");
   const [customTo, setCustomTo] = useState("");
   const [project, setProject] = useState("");
+  const [compare, setCompare] = useState(() => loadAnalyticsPrefs().compare);
 
   const period = useMemo(
     () => computePeriod(range, customFrom, customTo),
     [range, customFrom, customTo]
+  );
+
+  // The window immediately before this one, of the same length. `undefined`
+  // means there is nothing well-defined to compare against — All time, or a
+  // custom range that is not filled in — and the toggle is shut for it.
+  const previousWindow = useMemo(
+    () => previousPeriod(range, period),
+    [range, period]
   );
 
   // The two analytics endpoints share a query: range, project and — always —
@@ -70,6 +83,27 @@ export function AnalyticsView({
         ? api.get<AnalyticsReport>(`/claude-analytics${query}`, signal)
         : Promise.resolve(undefined),
     [query, ready, wantsReport]
+  );
+
+  // The comparison window, fetched only while the toggle is on and only for the
+  // two modes that render one — so an install that never asks for a comparison
+  // issues exactly the one request it always did. `qs` drops an undefined
+  // `from`/`to`, which the server would answer with its own 31-day default, so
+  // the fetch is gated on `previousWindow` rather than on the query string.
+  const wantsCompare = compare && wantsReport && ready && previousWindow !== undefined;
+  const compareQuery = qs({
+    from: previousWindow?.from,
+    to: previousWindow?.to,
+    project: project || undefined,
+    tz: TZ,
+  });
+
+  const previous = useResource<AnalyticsReport | undefined>(
+    (signal) =>
+      wantsCompare
+        ? api.get<AnalyticsReport>(`/claude-analytics${compareQuery}`, signal)
+        : Promise.resolve(undefined),
+    [compareQuery, wantsCompare]
   );
 
   const insights = useResource<InsightsSummary | undefined>(
@@ -97,6 +131,13 @@ export function AnalyticsView({
     mode === "insights"
       ? insights.data?.total_sessions
       : report.data?.summary.total_sessions;
+
+  // A failed comparison must not take the view down with it: the primary report
+  // is what the section is for, so the deltas are dropped and one banner says
+  // why. `useResource` keeps the last good `data` on error, so the check is on
+  // `error` rather than on `data` being absent — otherwise a stale comparison
+  // from a previous window would go on being differenced against this one.
+  const comparison = wantsCompare && !previous.error ? previous.data : undefined;
 
   return (
     <div className="panes">
@@ -136,6 +177,29 @@ export function AnalyticsView({
             projects={list(projects.data)}
           />
 
+          {wantsReport && (
+            <CompareToggle
+              on={compare}
+              // Disabled rather than silently ignored: "All time" is a floor
+              // chosen by the app, not a duration the user picked, so there is
+              // no preceding window of the same length to shift onto, and a
+              // half-filled custom range has no bounds to shift at all. The
+              // stored preference is left exactly as it is — a gate must never
+              // rewrite the value it gates (#474) — so switching back to 30d
+              // restores the comparison.
+              disabled={previousWindow === undefined}
+              disabledReason={
+                range === "all"
+                  ? "All time is not a window of any particular length, so it has nothing before it to compare against."
+                  : "Pick both dates to compare this range with the one before it."
+              }
+              onChange={(v) => {
+                setCompare(v);
+                saveAnalyticsPrefs({ compare: v });
+              }}
+            />
+          )}
+
           <div className="spacer" />
           <span className="toolbar__sub tnum">
             {sessionCount === undefined
@@ -159,6 +223,16 @@ export function AnalyticsView({
           </div>
         )}
 
+        {wantsCompare && previous.error && (
+          <div className="banner a-banner--error">
+            <Icon name="alert" size={14} />
+            <span>
+              Comparison unavailable — showing this period on its own.{" "}
+              {previous.error}
+            </span>
+          </div>
+        )}
+
         {!ready ? (
           <div className="a-state">{period.label}</div>
         ) : error && !hasData ? (
@@ -179,6 +253,7 @@ export function AnalyticsView({
             <Body
               mode={mode}
               report={report.data}
+              previous={comparison}
               insights={insights.data}
               project={project}
             />
@@ -198,6 +273,7 @@ export function AnalyticsView({
                 days={period.days}
                 from={period.from}
                 to={period.to}
+                comparedWith={wantsCompare ? previousWindow : undefined}
                 project={project}
                 report={report.data}
                 insights={insights.data}
@@ -215,11 +291,14 @@ export function AnalyticsView({
 function Body({
   mode,
   report,
+  previous,
   insights,
   project,
 }: {
   mode: Mode;
   report: AnalyticsReport | undefined;
+  /** The preceding window, when the comparison toggle is on and it loaded. */
+  previous: AnalyticsReport | undefined;
   insights: InsightsSummary | undefined;
   project: string;
 }) {
@@ -241,9 +320,54 @@ function Body({
   }
 
   return mode === "tokens" ? (
-    <TokensMode report={report} />
+    <TokensMode report={report} previous={previous} />
   ) : (
-    <UsageMode report={report} />
+    <UsageMode report={report} previous={previous} />
+  );
+}
+
+/* --- Compare toggle ------------------------------------------------------ */
+
+/**
+ * "Compare with previous period" (#539).
+ *
+ * The explanation lives on the wrapping `<label>` rather than on the box,
+ * because a disabled `<button>` receives no mouse events and a `title` on one
+ * never shows — the trap `Switch` already documents. The label is also the
+ * second hit target, so the word is clickable when the box is not shut.
+ */
+function CompareToggle({
+  on,
+  disabled,
+  disabledReason,
+  onChange,
+}: {
+  on: boolean;
+  disabled: boolean;
+  /** Why the box is shut — there is more than one reason it can be. */
+  disabledReason: string;
+  onChange(v: boolean): void;
+}) {
+  return (
+    <label
+      className="row"
+      style={{ gap: "var(--sp-3)", cursor: "default" }}
+      title={
+        disabled
+          ? disabledReason
+          : "Show each figure against the window immediately before this one."
+      }
+    >
+      <Checkbox
+        on={on}
+        disabled={disabled}
+        onChange={(v) => {
+          if (disabled) return;
+          onChange(v);
+        }}
+      />
+      <span className="toolbar__sub">Compare</span>
+    </label>
   );
 }
 
@@ -299,6 +423,7 @@ function Inspector({
   days,
   from,
   to,
+  comparedWith,
   project,
   report,
   insights,
@@ -308,6 +433,8 @@ function Inspector({
   days: number;
   from?: string;
   to?: string;
+  /** The window the figures are being differenced against, if any. */
+  comparedWith?: Period;
   project: string;
   report: AnalyticsReport | undefined;
   insights: InsightsSummary | undefined;
@@ -333,6 +460,17 @@ function Inspector({
         <InspRow label="Project">
           {project ? projectLabel(project) : "All projects"}
         </InspRow>
+        {comparedWith && (
+          <>
+            <InspRow label="Compared with">{comparedWith.label}</InspRow>
+            <InspRow label="From">
+              <span className="tnum">{isoDay(comparedWith.from)}</span>
+            </InspRow>
+            <InspRow label="To">
+              <span className="tnum">{isoDay(comparedWith.to, -1)}</span>
+            </InspRow>
+          </>
+        )}
       </InspGroup>
 
       {mode !== "insights" && report && (

--- a/src/views/AnalyticsView.tsx
+++ b/src/views/AnalyticsView.tsx
@@ -241,7 +241,15 @@ export function AnalyticsView({
           <button
             className="iconbtn"
             title="Refresh"
-            onClick={() => active.reload()}
+            // Both resources, or Refresh pairs a freshly read current window
+            // against whatever the comparison happened to hold — and the key
+            // check above cannot see it, because neither query moved. A
+            // `/claude-analytics` read is itself what drives `ensure_scan`, so
+            // this is the one action most likely to change both windows.
+            onClick={() => {
+              active.reload();
+              if (wantsCompare) previous.reload();
+            }}
           >
             <Icon name="refresh" size={14} />
           </button>

--- a/src/views/analytics/TokensMode.tsx
+++ b/src/views/analytics/TokensMode.tsx
@@ -9,7 +9,7 @@ import {
   DeltaNote,
   Tile,
   Tokens,
-  alignedTo,
+  alignedPair,
   bucketLabel,
   granularityLabel,
   list,
@@ -57,8 +57,12 @@ export function TokensMode({
     s.total_cache_read_tokens +
     s.total_cache_creation_tokens;
 
-  const raw = list(report.time_series);
-  const series = trimEmpty(raw, (p) => p.total_tokens);
+  // One call, so the two series cannot be windowed on different predicates.
+  const { series, compare: compareSeries } = alignedPair(
+    list(report.time_series),
+    previous ? list(previous.time_series) : undefined,
+    (p) => p.total_tokens
+  );
   const tokenPoints: Point[] = series.map((p) => ({
     label: bucketLabel(p.date, g),
     value: p.total_tokens,
@@ -67,16 +71,13 @@ export function TokensMode({
     } session${p.sessions === 1 ? "" : "s"}`,
   }));
 
-  // Windowed by the *current* series' trim bounds, never by its own zeros —
-  // see `alignedTo`, which is where that distinction is argued.
-  const comparePoints: Point[] | undefined = previous
-    ? alignedTo(raw, list(previous.time_series), (p) => p.total_tokens).map(
-        (p) => ({
+  const comparePoints: Point[] | undefined =
+    previous && compareSeries
+      ? compareSeries.map((p) => ({
           label: bucketLabel(p.date, previous.granularity),
           value: p.total_tokens,
-        })
-      )
-    : undefined;
+        }))
+      : undefined;
 
   const cache = trimEmpty(
     list(report.cache_efficiency),

--- a/src/views/analytics/TokensMode.tsx
+++ b/src/views/analytics/TokensMode.tsx
@@ -9,6 +9,7 @@ import {
   DeltaNote,
   Tile,
   Tokens,
+  alignedTo,
   bucketLabel,
   granularityLabel,
   list,
@@ -56,7 +57,8 @@ export function TokensMode({
     s.total_cache_read_tokens +
     s.total_cache_creation_tokens;
 
-  const series = trimEmpty(list(report.time_series), (p) => p.total_tokens);
+  const raw = list(report.time_series);
+  const series = trimEmpty(raw, (p) => p.total_tokens);
   const tokenPoints: Point[] = series.map((p) => ({
     label: bucketLabel(p.date, g),
     value: p.total_tokens,
@@ -65,13 +67,15 @@ export function TokensMode({
     } session${p.sessions === 1 ? "" : "s"}`,
   }));
 
-  // Trimmed on the same rule as the current series, so the two are like for
-  // like; `AreaChart` then aligns them from the last bucket backwards.
+  // Windowed by the *current* series' trim bounds, never by its own zeros —
+  // see `alignedTo`, which is where that distinction is argued.
   const comparePoints: Point[] | undefined = previous
-    ? trimEmpty(list(previous.time_series), (p) => p.total_tokens).map((p) => ({
-        label: bucketLabel(p.date, previous.granularity),
-        value: p.total_tokens,
-      }))
+    ? alignedTo(raw, list(previous.time_series), (p) => p.total_tokens).map(
+        (p) => ({
+          label: bucketLabel(p.date, previous.granularity),
+          value: p.total_tokens,
+        })
+      )
     : undefined;
 
   const cache = trimEmpty(

--- a/src/views/analytics/TokensMode.tsx
+++ b/src/views/analytics/TokensMode.tsx
@@ -5,6 +5,8 @@ import { AreaChart, RateChart, type Point } from "../../components/charts";
 import {
   Card,
   CardEmpty,
+  Delta,
+  DeltaNote,
   Tile,
   Tokens,
   bucketLabel,
@@ -28,9 +30,23 @@ const COMPOSITION = [
   { key: "Cache write", color: "var(--amber)", field: "total_cache_creation_tokens" },
 ] as const;
 
-export function TokensMode({ report }: { report: AnalyticsReport }) {
+export function TokensMode({
+  report,
+  previous,
+}: {
+  report: AnalyticsReport;
+  /** The preceding window, when the comparison toggle is on and it loaded. */
+  previous?: AnalyticsReport;
+}) {
   const s = report.summary;
   const g = report.granularity;
+  const was = previous?.summary;
+
+  /** A tile's delta slot, or nothing at all when there is no comparison. */
+  const vs = (current: number, before: number | undefined, format = compactNumber) =>
+    before === undefined ? undefined : (
+      <Delta current={current} previous={before} format={format} />
+    );
 
   // `total_tokens` is conversation-only (input + output); the cost is computed
   // over all four classes, so the composition bar needs its own denominator.
@@ -49,6 +65,15 @@ export function TokensMode({ report }: { report: AnalyticsReport }) {
     } session${p.sessions === 1 ? "" : "s"}`,
   }));
 
+  // Trimmed on the same rule as the current series, so the two are like for
+  // like; `AreaChart` then aligns them from the last bucket backwards.
+  const comparePoints: Point[] | undefined = previous
+    ? trimEmpty(list(previous.time_series), (p) => p.total_tokens).map((p) => ({
+        label: bucketLabel(p.date, previous.granularity),
+        value: p.total_tokens,
+      }))
+    : undefined;
+
   const cache = trimEmpty(
     list(report.cache_efficiency),
     (p) => p.total_input_tokens
@@ -65,6 +90,13 @@ export function TokensMode({ report }: { report: AnalyticsReport }) {
   const projects = list(report.project_breakdown);
   const unpriced = s.unknown_pricing_tokens > 0;
 
+  // A cost delta is only honest when *both* windows are fully priced: a model
+  // that lost its rate between them makes an unchanged spend read as a fall, and
+  // one that gained a rate makes it read as a rise. Neither is what happened, so
+  // the figure is withheld and the reason is put in its place.
+  const costComparable =
+    was !== undefined && !unpriced && was.unknown_pricing_tokens === 0;
+
   return (
     <>
       <div className="tiles">
@@ -73,12 +105,14 @@ export function TokensMode({ report }: { report: AnalyticsReport }) {
           label="Total sessions"
           value={integer(s.total_sessions)}
           note={`${integer(s.unique_projects)} projects`}
+          delta={vs(s.total_sessions, was?.total_sessions, integer)}
         />
         <Tile
           icon="zap"
           label="Conversation tokens"
           value={compactNumber(s.total_tokens)}
           note="input + output"
+          delta={vs(s.total_tokens, was?.total_tokens)}
           title={`${integer(s.total_tokens)} tokens`}
         />
         <Tile
@@ -86,6 +120,7 @@ export function TokensMode({ report }: { report: AnalyticsReport }) {
           label="Input"
           value={compactNumber(s.total_input_tokens)}
           note={percent(share(s.total_input_tokens, billable))}
+          delta={vs(s.total_input_tokens, was?.total_input_tokens)}
           title={`${integer(s.total_input_tokens)} tokens`}
         />
         <Tile
@@ -93,6 +128,7 @@ export function TokensMode({ report }: { report: AnalyticsReport }) {
           label="Output"
           value={compactNumber(s.total_output_tokens)}
           note={percent(share(s.total_output_tokens, billable))}
+          delta={vs(s.total_output_tokens, was?.total_output_tokens)}
           title={`${integer(s.total_output_tokens)} tokens`}
         />
         <Tile
@@ -100,6 +136,7 @@ export function TokensMode({ report }: { report: AnalyticsReport }) {
           label="Cache read"
           value={compactNumber(s.total_cache_read_tokens)}
           note={percent(share(s.total_cache_read_tokens, billable))}
+          delta={vs(s.total_cache_read_tokens, was?.total_cache_read_tokens)}
           title={`${integer(s.total_cache_read_tokens)} tokens`}
         />
         <Tile
@@ -107,6 +144,10 @@ export function TokensMode({ report }: { report: AnalyticsReport }) {
           label="Cache write"
           value={compactNumber(s.total_cache_creation_tokens)}
           note={percent(share(s.total_cache_creation_tokens, billable))}
+          delta={vs(
+            s.total_cache_creation_tokens,
+            was?.total_cache_creation_tokens
+          )}
           title={`${integer(s.total_cache_creation_tokens)} tokens`}
         />
         <Tile
@@ -114,6 +155,7 @@ export function TokensMode({ report }: { report: AnalyticsReport }) {
           label="Avg / session"
           value={compactNumber(s.avg_tokens_per_session)}
           note="conversation tokens"
+          delta={vs(s.avg_tokens_per_session, was?.avg_tokens_per_session)}
         />
         <Tile
           icon="dollar"
@@ -121,6 +163,20 @@ export function TokensMode({ report }: { report: AnalyticsReport }) {
           value={usd(s.estimated_cost_usd)}
           tone="var(--green)"
           note={unpriced ? "excludes unpriced models" : "all token types"}
+          delta={
+            was === undefined ? undefined : costComparable ? (
+              <Delta
+                current={s.estimated_cost_usd}
+                previous={was.estimated_cost_usd}
+                format={usd}
+              />
+            ) : (
+              <DeltaNote
+                text="no cost delta"
+                title="One of the two windows contains tokens with no published rate, so each total is a floor rather than a figure — the difference between two floors is not a change in spend."
+              />
+            )
+          }
         />
       </div>
 
@@ -178,7 +234,11 @@ export function TokensMode({ report }: { report: AnalyticsReport }) {
           title="Tokens over time"
           badge={granularityLabel(report.granularity)}
         >
-          <AreaChart points={tokenPoints} format={compactNumber} />
+          <AreaChart
+            points={tokenPoints}
+            compare={comparePoints}
+            format={compactNumber}
+          />
         </Card>
         <Card
           title="Cache efficiency"

--- a/src/views/analytics/UsageMode.tsx
+++ b/src/views/analytics/UsageMode.tsx
@@ -5,6 +5,7 @@ import { SessionLink } from "../sessions/SessionLink";
 import {
   Card,
   CardEmpty,
+  Delta,
   Tile,
   Tokens,
   bucketLabel,
@@ -20,9 +21,17 @@ import {
    Usage mode — when the work happened, not what it cost.
    ========================================================================== */
 
-export function UsageMode({ report }: { report: AnalyticsReport }) {
+export function UsageMode({
+  report,
+  previous,
+}: {
+  report: AnalyticsReport;
+  /** The preceding window, when the comparison toggle is on and it loaded. */
+  previous?: AnalyticsReport;
+}) {
   const s = report.summary;
   const g = report.granularity;
+  const was = previous?.summary;
 
   const series = trimEmpty(list(report.time_series), (p) => p.sessions);
   const activeBuckets = series.filter((p) => p.sessions > 0).length;
@@ -35,9 +44,36 @@ export function UsageMode({ report }: { report: AnalyticsReport }) {
     } · ${compactNumber(p.total_tokens)} tokens`,
   }));
 
+  // Trimmed on the same rule as the current series, so the two are like for
+  // like; `AreaChart` then aligns them from the last bucket backwards.
+  const compareSeries = previous
+    ? trimEmpty(list(previous.time_series), (p) => p.sessions).map((p) => ({
+        date: p.date,
+        sessions: p.sessions,
+      }))
+    : undefined;
+  const compareGranularity = previous?.granularity ?? g;
+  const comparePoints: Point[] | undefined = compareSeries?.map((p) => ({
+    label: bucketLabel(p.date, compareGranularity),
+    value: p.sessions,
+  }));
+
   // Averaging over buckets is only meaningful when the buckets are days.
   const avgPerDay =
     g === "daily" && activeBuckets > 0 ? s.total_sessions / activeBuckets : 0;
+
+  // The same figure over the previous window, computed the same way — and only
+  // when *both* windows bucket daily, since an average over weekly buckets is
+  // not the same quantity and differencing the two would be nonsense.
+  const compareActiveBuckets =
+    compareSeries?.filter((p) => p.sessions > 0).length ?? 0;
+  const comparableAvgPerDay =
+    was !== undefined &&
+    g === "daily" &&
+    compareGranularity === "daily" &&
+    compareActiveBuckets > 0
+      ? was.total_sessions / compareActiveBuckets
+      : undefined;
 
   const perModel = list(report.sessions_per_model);
   const topModel = perModel.reduce<{ model: string; sessions: number } | undefined>(
@@ -75,6 +111,15 @@ export function UsageMode({ report }: { report: AnalyticsReport }) {
           icon="grid"
           label="Total sessions"
           value={integer(s.total_sessions)}
+          delta={
+            was === undefined ? undefined : (
+              <Delta
+                current={s.total_sessions}
+                previous={was.total_sessions}
+                format={integer}
+              />
+            )
+          }
         />
         <Tile
           icon="clock"
@@ -84,6 +129,15 @@ export function UsageMode({ report }: { report: AnalyticsReport }) {
             g === "daily"
               ? `over ${activeBuckets} active day${activeBuckets === 1 ? "" : "s"}`
               : `buckets are ${g}`
+          }
+          delta={
+            comparableAvgPerDay === undefined ? undefined : (
+              <Delta
+                current={avgPerDay}
+                previous={comparableAvgPerDay}
+                format={(n) => n.toFixed(1)}
+              />
+            )
           }
         />
         <Tile
@@ -101,12 +155,25 @@ export function UsageMode({ report }: { report: AnalyticsReport }) {
           icon="folder"
           label="Unique projects"
           value={integer(s.unique_projects)}
+          delta={
+            was === undefined ? undefined : (
+              <Delta
+                current={s.unique_projects}
+                previous={was.unique_projects}
+                format={integer}
+              />
+            )
+          }
         />
       </div>
 
       <div className="a-grid a-grid--wide">
         <Card title="Sessions over time" badge={granularityLabel(g)}>
-          <AreaChart points={sessionPoints} format={integer} />
+          <AreaChart
+            points={sessionPoints}
+            compare={comparePoints}
+            format={integer}
+          />
         </Card>
         <Card title="Sessions by model" table>
           {perModel.length ? (

--- a/src/views/analytics/UsageMode.tsx
+++ b/src/views/analytics/UsageMode.tsx
@@ -8,13 +8,12 @@ import {
   Delta,
   Tile,
   Tokens,
-  alignedTo,
+  alignedPair,
   bucketLabel,
   granularityLabel,
   list,
   projectLabel,
   share,
-  trimEmpty,
   widthPct,
 } from "./shared";
 
@@ -34,8 +33,12 @@ export function UsageMode({
   const g = report.granularity;
   const was = previous?.summary;
 
-  const raw = list(report.time_series);
-  const series = trimEmpty(raw, (p) => p.sessions);
+  // One call, so the two series cannot be windowed on different predicates.
+  const { series, compare: compareSeries } = alignedPair(
+    list(report.time_series),
+    previous ? list(previous.time_series) : undefined,
+    (p) => p.sessions
+  );
   const activeBuckets = series.filter((p) => p.sessions > 0).length;
 
   const sessionPoints: Point[] = series.map((p) => ({
@@ -48,11 +51,6 @@ export function UsageMode({
 
   // Trimmed on the same rule as the current series, so the two are like for
   // like; `AreaChart` then aligns them from the last bucket backwards.
-  // Windowed by the *current* series' trim bounds, never by its own zeros —
-  // see `alignedTo`, which is where that distinction is argued.
-  const compareSeries = previous
-    ? alignedTo(raw, list(previous.time_series), (p) => p.sessions)
-    : undefined;
   const compareGranularity = previous?.granularity ?? g;
   const comparePoints: Point[] | undefined = compareSeries?.map((p) => ({
     label: bucketLabel(p.date, compareGranularity),
@@ -66,8 +64,16 @@ export function UsageMode({
   // The same figure over the previous window, computed the same way — and only
   // when *both* windows bucket daily, since an average over weekly buckets is
   // not the same quantity and differencing the two would be nonsense.
-  const compareActiveBuckets =
-    compareSeries?.filter((p) => p.sessions > 0).length ?? 0;
+  //
+  // Counted over `previous.time_series` itself, **never over `compareSeries`**:
+  // that one is a positional subset windowed to the current series' span, so
+  // wherever the current window was idle it has dropped active previous buckets
+  // — and `was.total_sessions` is the whole previous window's total, so the two
+  // would be over different spans. `activeBuckets` above has no such problem,
+  // because trimming only ever removes zero buckets.
+  const compareActiveBuckets = previous
+    ? list(previous.time_series).filter((p) => p.sessions > 0).length
+    : 0;
   const comparableAvgPerDay =
     was !== undefined &&
     g === "daily" &&

--- a/src/views/analytics/UsageMode.tsx
+++ b/src/views/analytics/UsageMode.tsx
@@ -8,6 +8,7 @@ import {
   Delta,
   Tile,
   Tokens,
+  alignedTo,
   bucketLabel,
   granularityLabel,
   list,
@@ -33,7 +34,8 @@ export function UsageMode({
   const g = report.granularity;
   const was = previous?.summary;
 
-  const series = trimEmpty(list(report.time_series), (p) => p.sessions);
+  const raw = list(report.time_series);
+  const series = trimEmpty(raw, (p) => p.sessions);
   const activeBuckets = series.filter((p) => p.sessions > 0).length;
 
   const sessionPoints: Point[] = series.map((p) => ({
@@ -46,11 +48,10 @@ export function UsageMode({
 
   // Trimmed on the same rule as the current series, so the two are like for
   // like; `AreaChart` then aligns them from the last bucket backwards.
+  // Windowed by the *current* series' trim bounds, never by its own zeros —
+  // see `alignedTo`, which is where that distinction is argued.
   const compareSeries = previous
-    ? trimEmpty(list(previous.time_series), (p) => p.sessions).map((p) => ({
-        date: p.date,
-        sessions: p.sessions,
-      }))
+    ? alignedTo(raw, list(previous.time_series), (p) => p.sessions)
     : undefined;
   const compareGranularity = previous?.granularity ?? g;
   const comparePoints: Point[] | undefined = compareSeries?.map((p) => ({

--- a/src/views/analytics/shared.tsx
+++ b/src/views/analytics/shared.tsx
@@ -1,7 +1,8 @@
 import { Icon, type IconName } from "../../lib/icons";
 import { CardEmpty } from "../../components/charts";
-import { compactNumber, integer, tildePath } from "../../lib/format";
+import { compactNumber, integer, percent, tildePath } from "../../lib/format";
 import type { AnalyticsReport, TopEntry } from "../../lib/types";
+import type { Eq, Expect } from "../../lib/typeAssert";
 
 /**
  * `CardEmpty` moved to `components/charts.tsx` with the charts that fall back to
@@ -104,6 +105,47 @@ export function computePeriod(
   };
 }
 
+/**
+ * The window immediately before `p`, of exactly the same length (#539).
+ *
+ * `undefined` when there is no well-defined predecessor: **All time**, whose
+ * window is an arbitrary floor rather than a duration anybody chose, and a
+ * half-filled or inverted custom range, which has no bounds to shift.
+ *
+ * Two things about the shape:
+ *
+ * * **It takes the `RangeKey`, not just the `Period`.** A `Period` does not
+ *   carry which preset produced it — `days` is 0 for All time *and* for an
+ *   invalid custom range — and the only other discriminator is `label`, which
+ *   is rendered text. Keying behaviour on rendered text is exactly what
+ *   `lib/inspectorPrefs.ts` exists to warn about.
+ * * **It shifts epoch milliseconds, never calendar units.** `to − from` is the
+ *   window's real length including any DST transition inside it, so the shifted
+ *   window is the same number of *hours* as the one it is compared with. A
+ *   calendar shift ("the previous 30 days" as `AddDate(0,0,-30)`) would produce
+ *   a window an hour longer or shorter twice a year.
+ *
+ * The current window's `from` is the shifted window's exclusive end, matching
+ * the convention `computePeriod` already uses for `to`.
+ */
+export function previousPeriod(key: RangeKey, p: Period): Period | undefined {
+  if (key === "all") return undefined;
+  if (!p.from || !p.to) return undefined;
+
+  const from = Date.parse(p.from);
+  const to = Date.parse(p.to);
+  if (!isFinite(from) || !isFinite(to) || to <= from) return undefined;
+
+  const len = to - from;
+  const days = Math.round(len / DAY_MS);
+  return {
+    from: new Date(from - len).toISOString(),
+    to: new Date(from).toISOString(),
+    days,
+    label: days > 0 ? `Previous ${days} days` : "Previous period",
+  };
+}
+
 export const RANGE_OPTIONS: { value: RangeKey; label: string }[] = [
   { value: "7d", label: "7d" },
   { value: "30d", label: "30d" },
@@ -129,6 +171,40 @@ export function widthPct(part: number, total: number): string {
 /** Go marshals an empty slice as null, so every array arrives possibly-null. */
 export function list<T>(v: T[] | null | undefined): T[] {
   return v ?? [];
+}
+
+export interface Delta {
+  /** Signed percentage change against the previous window. */
+  pct: number;
+  dir: "up" | "down" | "flat";
+}
+
+/**
+ * The direction spelling, pinned (`lib/typeAssert.ts`).
+ *
+ * `Delta.dir` is this module's public surface — it chooses the glyph, the sign
+ * and the optional colour class — and there is no TypeScript test harness here,
+ * so an added or respelled variant is caught by `tsc` or by nothing.
+ */
+export type PinDeltaDirections = Expect<Eq<Delta["dir"], "up" | "down" | "flat">>;
+
+/**
+ * `current` against `previous`, as a signed percentage (#539).
+ *
+ * `undefined` when there is no baseline to divide by — a previous value of zero
+ * or below, or either side non-finite. That is a *render* decision rather than a
+ * number: "+∞%" and "NaN%" are both worse than saying there was nothing to
+ * compare against, and the caller knows which of the two no-baseline cases it is
+ * in (nothing then and something now, or nothing either way).
+ *
+ * `flat` is anything that rounds to `0.0%` at `percent()`'s own precision, so
+ * the arrow never disagrees with the figure beside it.
+ */
+export function delta(current: number, previous: number): Delta | undefined {
+  if (!isFinite(current) || !isFinite(previous) || previous <= 0) return undefined;
+  const pct = ((current - previous) / previous) * 100;
+  if (!isFinite(pct)) return undefined;
+  return { pct, dir: pct >= 0.05 ? "up" : pct <= -0.05 ? "down" : "flat" };
 }
 
 /** `{ tool }` on every endpoint checked, but the wire type allows `name`. */
@@ -197,6 +273,7 @@ export function Tile({
   label,
   value,
   note,
+  delta,
   tone,
   title,
 }: {
@@ -204,6 +281,15 @@ export function Tile({
   label: string;
   value: string;
   note?: string;
+  /**
+   * The comparison annotation, which *replaces* the note when present (#539).
+   * One slot, because there is one line under the value — a caller wanting both
+   * would be asking the tile to grow, which is a different change.
+   *
+   * A caller passing nothing takes the note branch and emits exactly the markup
+   * it always did, which is what keeps the toggle-off rendering byte-identical.
+   */
+  delta?: React.ReactNode;
   tone?: string;
   title?: string;
 }) {
@@ -216,11 +302,93 @@ export function Tile({
       <div className="tile__value" style={tone ? { color: tone } : undefined}>
         {value}
       </div>
-      {note && (
-        <div className="tile__delta" style={{ color: "var(--fg-quaternary)" }}>
-          {note}
-        </div>
-      )}
+      {/* `||`, not `??`: a call site that spells "no delta" as `x && <Delta/>`
+          yields `false` rather than `undefined`, and that must still fall
+          through to the note rather than blanking the line. */}
+      {delta ||
+        (note && (
+          <div className="tile__delta" style={{ color: "var(--fg-quaternary)" }}>
+            {note}
+          </div>
+        ))}
+    </div>
+  );
+}
+
+/**
+ * A tile's period-over-period change (#539).
+ *
+ * **Neutral by default, and deliberately so.** `.tile__delta--up` /
+ * `--down` are green and red, and that polarity is wrong for most of what this
+ * dashboard reports: spending 20% more is not "good", and using 20% fewer
+ * tokens is not "bad" — both are just what happened. So the direction is carried
+ * by an arrow and a signed figure, and colour is left to the metrics whose
+ * polarity the product itself states. None of the tiles in Tokens or Usage mode
+ * is one, so nothing sets `polarity` today; the prop exists because the *first*
+ * such tile must not have to re-argue this at its call site.
+ *
+ * The previous absolute value goes in the `title`, because a percentage with no
+ * baseline is unreadable: "+400%" over two sessions and over two thousand are
+ * very different facts.
+ */
+export function Delta({
+  current,
+  previous,
+  format = compactNumber,
+  polarity = "neutral",
+}: {
+  current: number;
+  previous: number;
+  /** How the previous absolute value is spelled in the tooltip. */
+  format?: (n: number) => string;
+  /** `up-is-good` colours a rise green; `down-is-good` colours a fall green. */
+  polarity?: "neutral" | "up-is-good" | "down-is-good";
+}) {
+  const d = delta(current, previous);
+  const was = `Previous period: ${format(previous)}`;
+
+  // No baseline. "New" and "—" are different facts and only the caller's data
+  // can tell them apart, so both are spelled here rather than collapsed.
+  if (!d) {
+    return (
+      <div className="tile__delta" style={{ color: "var(--fg-quaternary)" }} title={was}>
+        {previous <= 0 && current > 0 ? "new — no baseline" : "no baseline"}
+      </div>
+    );
+  }
+
+  const good =
+    polarity === "neutral" || d.dir === "flat"
+      ? undefined
+      : (polarity === "up-is-good") === (d.dir === "up");
+  const tone =
+    good === undefined ? "" : good ? " tile__delta--up" : " tile__delta--down";
+
+  // `flat` gets its own glyph and no sign: an up arrow over "0.0%" reads as a
+  // rise the figure beside it does not show.
+  const icon = d.dir === "up" ? "arrowUp" : d.dir === "down" ? "arrowDown" : "minus";
+
+  return (
+    <div className={`tile__delta${tone}`} title={was}>
+      <Icon name={icon} size={12} />
+      <span className="tnum">
+        {d.dir === "up" ? "+" : ""}
+        {percent(d.pct)}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * The delta slot carrying a sentence instead of a figure — used where a
+ * comparison exists but would not be honest, which today is the cost tile
+ * against a window holding unpriced tokens (#539).
+ */
+export function DeltaNote({ text, title }: { text: string; title?: string }) {
+  return (
+    <div className="tile__delta" style={{ color: "var(--amber)" }} title={title}>
+      <Icon name="alert" size={12} />
+      <span>{text}</span>
     </div>
   );
 }

--- a/src/views/analytics/shared.tsx
+++ b/src/views/analytics/shared.tsx
@@ -271,9 +271,10 @@ export function trimEmpty<T>(points: T[], value: (p: T) => number): T[] {
 }
 
 /**
- * `previous`, windowed to the span `trimEmpty` selects from `current` (#539).
+ * The trimmed current series and the comparison series windowed to match it
+ * (#539).
  *
- * **Trimming the comparison series on its own rule is the bug this exists to
+ * **Trimming the comparison on its own rule is the bug this exists to
  * prevent**, and it is not obvious: the rule really is the same, but the
  * *result* is data-dependent, and it is the result the overlay's alignment
  * depends on. `AreaChart` lines the two series up from their last elements, on
@@ -288,24 +289,40 @@ export function trimEmpty<T>(points: T[], value: (p: T) => number): T[] {
  * its own zeros. Both arrays are first aligned at their ends — equal-duration
  * windows can still hold different bucket counts across a DST transition or
  * unequal month lengths — and then the current series' `[start, end)` is applied
- * to both. Positions with no counterpart can only be a leading run (the shift
- * is monotonic and the end is aligned), so what comes back is contiguous and
- * still end-aligned; `AreaChart`'s own truncation stays the residual safety net
- * it was written to be.
+ * to both. Positions with no counterpart can only be a leading run (the shift is
+ * monotonic and the end is aligned), so what comes back is contiguous and still
+ * end-aligned; `AreaChart`'s own truncation stays the residual safety net it was
+ * written to be.
+ *
+ * **Both series come back from one call because they must share one `value`
+ * predicate.** Two calls is two chances to pass different ones, and a
+ * disagreement there misaligns the overlay silently — which is the failure this
+ * function is for.
+ *
+ * **What comes back is a positional subset, so never derive a whole-window
+ * aggregate from it.** `trimEmpty` only ever removes zero buckets, so a count or
+ * an average over the current series is still the whole window's; `alignedPair`
+ * drops *non-zero* comparison buckets wherever the current window was idle, so
+ * the same count over the comparison is not. Aggregate over
+ * `previous.time_series` itself.
  */
-export function alignedTo<T, U>(
+export function alignedPair<T, U>(
   current: T[],
-  previous: U[],
+  previous: U[] | undefined,
   value: (p: T) => number
-): U[] {
+): { series: T[]; compare: U[] | undefined } {
   const { start, end } = trimBounds(current, value);
+  const series =
+    start === 0 && end === current.length ? current : current.slice(start, end);
+  if (!previous) return { series, compare: undefined };
+
   const shift = current.length - previous.length;
-  const out: U[] = [];
+  const compare: U[] = [];
   for (let i = start; i < end; i++) {
     const j = i - shift;
-    if (j >= 0 && j < previous.length) out.push(previous[j]);
+    if (j >= 0 && j < previous.length) compare.push(previous[j]);
   }
-  return out;
+  return { series, compare };
 }
 
 /** Project paths are absolute on the wire; folded/unresolved ones are not. */

--- a/src/views/analytics/shared.tsx
+++ b/src/views/analytics/shared.tsx
@@ -248,17 +248,64 @@ export function granularityLabel(g: Granularity): string {
   return g.charAt(0).toUpperCase() + g.slice(1);
 }
 
+/** The span `trimEmpty` keeps, as `[start, end)` into the original array. */
+function trimBounds<T>(
+  points: T[],
+  value: (p: T) => number
+): { start: number; end: number } {
+  let start = 0;
+  let end = points.length;
+  while (start < end && value(points[start]) <= 0) start++;
+  while (end > start && value(points[end - 1]) <= 0) end--;
+  return { start, end };
+}
+
 /**
  * Trim all-zero buckets from both ends. "All time" asks for a window far wider
  * than the data, and without this the real activity is squeezed into a corner.
  * Interior zeros are kept — a quiet week is signal.
  */
 export function trimEmpty<T>(points: T[], value: (p: T) => number): T[] {
-  let start = 0;
-  let end = points.length;
-  while (start < end && value(points[start]) <= 0) start++;
-  while (end > start && value(points[end - 1]) <= 0) end--;
+  const { start, end } = trimBounds(points, value);
   return start === 0 && end === points.length ? points : points.slice(start, end);
+}
+
+/**
+ * `previous`, windowed to the span `trimEmpty` selects from `current` (#539).
+ *
+ * **Trimming the comparison series on its own rule is the bug this exists to
+ * prevent**, and it is not obvious: the rule really is the same, but the
+ * *result* is data-dependent, and it is the result the overlay's alignment
+ * depends on. `AreaChart` lines the two series up from their last elements, on
+ * the reasoning that the server emits every bucket from `from` to `to`
+ * inclusive so the last element of each is the last bucket of its window. Trim
+ * each independently and that stops being true: a previous window that went
+ * quiet for its last ten days loses ten trailing buckets the current one keeps,
+ * and its busiest stretch is drawn under the current window's most recent days
+ * — with the tooltip stating the pairing as fact.
+ *
+ * So the comparison is windowed by *position within its own window*, never by
+ * its own zeros. Both arrays are first aligned at their ends — equal-duration
+ * windows can still hold different bucket counts across a DST transition or
+ * unequal month lengths — and then the current series' `[start, end)` is applied
+ * to both. Positions with no counterpart can only be a leading run (the shift
+ * is monotonic and the end is aligned), so what comes back is contiguous and
+ * still end-aligned; `AreaChart`'s own truncation stays the residual safety net
+ * it was written to be.
+ */
+export function alignedTo<T, U>(
+  current: T[],
+  previous: U[],
+  value: (p: T) => number
+): U[] {
+  const { start, end } = trimBounds(current, value);
+  const shift = current.length - previous.length;
+  const out: U[] = [];
+  for (let i = start; i < end; i++) {
+    const j = i - shift;
+    if (j >= 0 && j < previous.length) out.push(previous[j]);
+  }
+  return out;
 }
 
 /** Project paths are absolute on the wire; folded/unresolved ones are not. */

--- a/src/views/analytics/shared.tsx
+++ b/src/views/analytics/shared.tsx
@@ -142,7 +142,10 @@ export function previousPeriod(key: RangeKey, p: Period): Period | undefined {
     from: new Date(from - len).toISOString(),
     to: new Date(from).toISOString(),
     days,
-    label: days > 0 ? `Previous ${days} days` : "Previous period",
+    label:
+      days > 0
+        ? `Previous ${days} day${days === 1 ? "" : "s"}`
+        : "Previous period",
   };
 }
 
@@ -437,7 +440,10 @@ export function Delta({
       <Icon name={icon} size={12} />
       <span className="tnum">
         {d.dir === "up" ? "+" : ""}
-        {percent(d.pct)}
+        {/* `flat` covers the band that rounds to zero, and it includes small
+            negatives — so the figure is taken through zero rather than
+            through `pct`, which would render the literal text "-0.0%". */}
+        {percent(d.dir === "flat" ? 0 : d.pct)}
       </span>
     </div>
   );


### PR DESCRIPTION
Closes #539

## What

An opt-in **Compare** box in the Token Usage and General Usage toolbars. With it on, the view issues a second `/claude-analytics` request for the window immediately before the current one — of exactly the same length, with the same `project` and `tz` — and renders:

- a signed percentage delta under every token / session / project tile;
- the previous period as a dashed muted line over the two "…over time" charts, sharing one y-maximum with the current series;
- the compared window in the inspector's **Range** group.

Off by default, remembered per install in `localStorage`, and unavailable on **All time**, which is not a window of any particular length and so has nothing before it.

## Why

The dashboard answered "what did I use in this window" and had no way to answer "is that more or less than usual" — the question a usage and cost dashboard is opened for. Comparing two periods meant changing the range, memorising the figures and changing it back.

## How

Entirely client-side. `/api/claude-analytics` is pinned by a frozen parity golden, and **nothing under `src-tauri/` or `parity/` is touched**.

Four rules the shape depends on, each of them a way to be misleading:

- **A comparison with no baseline is not a percentage.** `delta()` answers `undefined` for a previous value of zero or below, so the tile reads "new — no baseline" or "no baseline" rather than `Infinity` or `NaN`.
- **Cost is only compared when both windows are fully priced.** An unpriced model makes a total a floor, and the difference between two floors is not a change in spend — so the cost tile carries a note instead of a figure.
- **The two chart series share one y-maximum.** Independently scaled lines put a smaller series above a larger one, which is a false crossover rather than a comparison. The *caption* still names only the current window's own exact peak — a figure computed over a merged or truncated set must not be attributed to a period.
- **The overlay aligns by position within each window, from the last bucket backwards.** `alignedPair` windows the comparison by the current series' trim bounds rather than by its own zeros; trimming both "on the same rule" is data-dependent and silently shifts the overlay. Two windows of equal duration can still hold different bucket counts (DST, unequal month lengths), and they share no date keys by construction.

Two more properties worth knowing:

- **Deltas are neutral, not green/red.** More cost is not "good" and fewer tokens are not "bad". `Delta` carries a `polarity` prop for the first metric whose direction the product itself states; none of these tiles is one.
- **A delta is a claim about a pair.** `useResource` never clears `data` on a dependency change, so both reports are tagged with the query they were fetched for and a delta is rendered only when both tags match — otherwise a change in flight would pair figures describing neither window. Refresh reloads both for the same reason.

Two shared primitives are widened **opt-in**, and both unset paths emit exactly the markup they did before: `Tile` gains a `delta` slot that falls through to `note`, and `Checkbox` gains `disabled` (carrying no `title`, for `Switch`'s reason — a disabled `button` receives no mouse events, so the explanation lives on the wrapping `<label>`).

## Verification

- `npm run build` (`tsc --noEmit` + `vite build`) clean; CI green on every check including *Typecheck, lint and build* and *Windows unit tests*.
- **CSS proved additive the documented way** — build both sides, split `dist/assets/*.css` into one rule per `}`, diff as a sorted set *and* as an ordered selector list: **2 rules added** (`.a-chart__compare`, `.checkbox:disabled`, each declared nowhere else), **0 removed, 0 reordered**.
- The alignment maths was simulated over 30- and 90-bucket windows for all three count relationships (equal, 29-vs-30, 31-vs-30): contiguous, end-aligned, oldest-first truncation.
- `previousPeriod`/`delta` edge cases and the `localStorage` key and shipped defaults are pinned at the type level through `lib/typeAssert.ts` — the repo has no TypeScript test harness, so that plus `tsc` is the whole frontend gate.

## Not verified

**Not exercised against a running app.** No Agento instance was up on this machine and starting one would have run the scheduler against a real data directory. The visual claims — the dashed stroke's weight in both themes, the tile layout with a delta in the note slot — are unverified by eye.

## Review status

Three automated review rounds ran; seven findings were raised and **all seven are fixed** (see the commit log — each commit names what it fixed and why). Round 3 still returned REQUEST CHANGES on its last finding, so the automated APPROVE gate was not met within its three rounds and **this was not auto-merged**. The head commit fixes that finding and its two nits, but no review has run against it.

## Out of scope

The **Insights** view and the **LLM Gateway → Usage** view, both named as follow-ups in the issue; calendar-aware comparison; any change to `GET /api/claude-analytics`.
