### PR TITLE
fix: scheduled task writes carry the five fields the form edits (#540)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4615,6 +4615,17 @@ these are now simply Agento's bugs, and fixing them is unblocked.
   until credentials were re-entered) is the thing a future session would
   otherwise restore. See *Wire-format traps* above for the contract that
   replaced it.
+- ~~**`POST`/`PUT /api/tasks` silently discard five fields the Tasks form can
+  edit** — `working_directory`, `model`, `settings_profile_id`,
+  `stop_after_count` and `stop_after_time`.~~ **Fixed by #540**, and struck
+  through rather than deleted for #515's reason: the note it replaced said
+  outright that accepting them "would store what Go discards", so a session
+  reading only `TaskRequest` could reasonably restore the drop. It must not —
+  the executor has always read all five, the `GET` has always returned them, and
+  the write hop was the only broken one. **The `PUT` is replace, not preserve**:
+  an omitted key resets its column, because the form posts the whole record and
+  none of the five is a write-only secret. `TaskRequest`'s own doc comment
+  carries the reasoning.
 - **An agent's `permission_mode` cannot be persisted.** `AgentRequest` has no
   such field, so the API silently drops it even though the config type and the
   validator both know about it.

--- a/src-tauri/src/native/gotime.rs
+++ b/src-tauri/src/native/gotime.rs
@@ -477,6 +477,54 @@ mod rfc3339_tests {
     use super::*;
     use chrono::Timelike;
 
+    /// The [`Deserialize`] impl parses through [`parse_rfc3339`], and **this is
+    /// the test that makes that a decision rather than a preference** (#540).
+    /// Swapping the impl body to `DateTime::parse_from_rfc3339` leaves the rest
+    /// of the suite entirely green — every `stop_after_time` fixture is a shape
+    /// both parsers accept — so without this the divergence the module header
+    /// says "would cost the same day twice" could be reintroduced by a
+    /// simplification with nothing red to stop it. Both directions are pinned,
+    /// because each fails differently: chrono's laxity accepts rows the wire
+    /// refuses, and chrono's strictness 400s input the wire takes.
+    #[test]
+    fn deserializing_a_gotime_uses_gos_grammar_and_not_chronos() {
+        let parsed = |json: &str| serde_json::from_str::<GoTime>(json);
+
+        // Go accepts, chrono rejects — the direction that turns into refusing
+        // a body `encoding/json` would have taken.
+        assert_eq!(
+            parsed(r#""2026-06-01T12:00:00,5Z""#)
+                .expect("a comma decimal separator")
+                .0
+                .nanosecond(),
+            500_000_000
+        );
+        assert_eq!(
+            parsed(r#""2026-06-01T5:04:05Z""#)
+                .expect("a one-digit hour")
+                .0
+                .hour(),
+            5
+        );
+        assert!(
+            parsed(r#""2026-06-01T12:00:00+24:00""#).is_ok(),
+            "the offset hour is unbounded to Go"
+        );
+
+        // Go rejects, chrono accepts — the direction that stores a row the
+        // wire would have refused.
+        assert!(parsed(r#""2026-06-01t12:00:00z""#).is_err());
+        assert!(
+            parsed(r#""2026-06-30T23:59:60Z""#).is_err(),
+            "a leap second is `second out of range` to Go"
+        );
+
+        // And the shape neither parser is asked about: a JSON value that is
+        // not a string at all.
+        assert!(parsed("1780000000").is_err());
+        assert!(parsed(r#"["2026-06-01T12:00:00Z"]"#).is_err());
+    }
+
     /// The five disagreements [`parse_rfc3339`] exists for, each measured
     /// against the pinned Go toolchain rather than reasoned about.
     #[test]

--- a/src-tauri/src/native/gotime.rs
+++ b/src-tauri/src/native/gotime.rs
@@ -12,7 +12,7 @@
 //! divergence again there would cost the same day twice.
 
 use chrono::{DateTime, FixedOffset, Utc};
-use serde::{Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// A timestamp that serializes exactly as Go's `time.Time` does.
 ///
@@ -242,6 +242,27 @@ impl Default for GoTime {
 impl Serialize for GoTime {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_str(&format_go_rfc3339(&self.0))
+    }
+}
+
+/// The inverse of [`Serialize`], for the request bodies that carry an instant.
+///
+/// `time.Time.UnmarshalJSON` reads a JSON string with the RFC 3339 layout, so
+/// this parses through [`parse_rfc3339`] — Go's own grammar — rather than
+/// `chrono::DateTime::parse_from_rfc3339`, which disagrees with it in five
+/// ways and would refuse three shapes `encoding/json` accepts. A value that
+/// does not parse is a decode error, which `writes::decode_body` renders as
+/// the same 400 every other mistyped field answers.
+///
+/// The offset is preserved, exactly as [`GoTime::parse`] preserves it; a write
+/// path that stores through `to_go_string_utc` is what normalizes to UTC, and
+/// that is the storage layer's business rather than the decoder's.
+impl<'de> Deserialize<'de> for GoTime {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let text = String::deserialize(deserializer)?;
+        parse_rfc3339(&text)
+            .map(GoTime)
+            .ok_or_else(|| serde::de::Error::custom(format!("parsing time {text:?}")))
     }
 }
 

--- a/src-tauri/src/native/schedule/executor.rs
+++ b/src-tauri/src/native/schedule/executor.rs
@@ -1143,6 +1143,50 @@ mod tests {
         assert_eq!(stored.status, "paused", "the second run hits the limit");
     }
 
+    /// The same limit, reached by a task the **API** created rather than one an
+    /// `INSERT` seeded (#540). The sibling above pins the executor's arithmetic
+    /// and says nothing about whether a `stop_after_count` can be configured at
+    /// all — which is exactly the hop that was dropping it, so a green sibling
+    /// was compatible with a budget the user could never set.
+    #[test]
+    fn a_stop_after_count_task_created_through_the_api_pauses_on_the_limit() {
+        let file = tempfile::NamedTempFile::new().expect("temp file");
+        let mut conn = rusqlite::Connection::open(file.path()).expect("open");
+        crate::native::migrate::apply(&mut conn).expect("migrate");
+        drop(conn);
+
+        tasks::create_task(
+            file.path(),
+            br#"{"name":"T","prompt":"p","schedule_type":"interval",
+                 "schedule_config":{"every_minutes":5},"stop_after_count":2}"#,
+        )
+        .expect("create");
+        let id = tasks::list_tasks(file.path()).expect("list")[0].id.clone();
+
+        let mut snapshot = tasks::get_task(file.path(), &id)
+            .expect("read")
+            .expect("row");
+        assert_eq!(snapshot.stop_after_count, 2, "the budget reached the row");
+
+        let scheduler = test_scheduler(file.path());
+        update_task_after_run(&scheduler, &mut snapshot, Utc::now(), "success");
+        assert_eq!(
+            tasks::get_task(file.path(), &id)
+                .expect("read")
+                .expect("row")
+                .status,
+            "active",
+            "the first run is inside the budget"
+        );
+
+        update_task_after_run(&scheduler, &mut snapshot, Utc::now(), "success");
+        let stored = tasks::get_task(file.path(), &id)
+            .expect("read")
+            .expect("row");
+        assert_eq!(stored.run_count, 2);
+        assert_eq!(stored.status, "paused", "the second run hits the limit");
+    }
+
     #[test]
     fn a_task_deleted_mid_run_is_not_recreated_by_the_write_back() {
         let file = tempfile::NamedTempFile::new().expect("temp file");

--- a/src-tauri/src/native/tasks.rs
+++ b/src-tauri/src/native/tasks.rs
@@ -1809,11 +1809,16 @@ struct TaskRequest {
 
 impl TaskRequest {
     /// The `storage.ScheduledTask` both handlers build from the request — the
-    /// fourteen fields they copy, and nothing else. The other seven are the
-    /// row's own: the minted `id`, the two stamps, and the four the scheduler
-    /// writes back after a run (`run_count`, `last_run_at`, `last_run_status`,
-    /// `next_run_at`), which `update_task` restores from the stored row rather
-    /// than from the body.
+    /// fourteen fields they copy, and nothing else.
+    ///
+    /// The other seven are the row's own, and they split three ways. `id` is
+    /// minted on a create and re-set from the URL on an update; `updated_at` is
+    /// restamped by every write. Four are taken from the **stored row** by
+    /// `update_task` — `created_at`, `run_count`, `last_run_at` and
+    /// `last_run_status` — which is what stops an edit resetting a task's
+    /// history. `next_run_at` is the exception in both directions: nothing in
+    /// this crate ever writes it, and an update **clears** it rather than
+    /// carrying it over. See `update_task`'s own doc comment.
     fn into_task(self) -> ScheduledTask {
         ScheduledTask {
             id: String::new(),

--- a/src-tauri/src/native/tasks.rs
+++ b/src-tauri/src/native/tasks.rs
@@ -963,22 +963,129 @@ mod tests {
         assert_eq!(stored, "{}");
     }
 
+    /// The inverse of `the_five_columns_the_request_cannot_reach_are_stored_at_
+    /// their_zero_values`, kept in that shape rather than deleted (#540) — the
+    /// way `a_full_length_positional_array` was inverted — so a later session
+    /// reading "Go discards these" cannot restore the drop without a red test.
     #[test]
-    fn the_five_columns_the_request_cannot_reach_are_stored_at_their_zero_values() {
-        // Go's handler copies nine fields out of the request and leaves the
-        // rest zero, so a body naming them changes nothing. Reproduced rather
-        // than "fixed" — accepting them here would store what Go discards.
+    fn the_five_columns_go_never_carried_now_reach_the_row() {
         let file = migrated();
         let task = created(
             &file,
             r#"{"name":"N","prompt":"p","working_directory":"/tmp","model":"opus",
-                "settings_profile_id":"prof","stop_after_count":9}"#,
+                "settings_profile_id":"prof","stop_after_count":9,
+                "stop_after_time":"2027-06-01T12:00:00Z"}"#,
         );
-        assert!(task.working_directory.is_empty());
-        assert!(task.model.is_empty());
-        assert!(task.settings_profile_id.is_empty());
-        assert_eq!(task.stop_after_count, 0);
-        assert!(task.stop_after_time.is_none());
+        assert_eq!(task.working_directory, "/tmp");
+        assert_eq!(task.model, "opus");
+        assert_eq!(task.settings_profile_id, "prof");
+        assert_eq!(task.stop_after_count, 9);
+        assert_eq!(
+            task.stop_after_time.map(|t| t.rfc3339_nano_utc()),
+            Some("2027-06-01T12:00:00Z".to_string()),
+        );
+    }
+
+    /// The whole hop the report was about: create with all five set, read them
+    /// back off the *stored row*, then `PUT` a change to each and re-read.
+    #[test]
+    fn the_five_fields_round_trip_through_create_read_and_update() {
+        let file = migrated();
+        let task = created(
+            &file,
+            r#"{"name":"N","prompt":"p","working_directory":"/w/one","model":"sonnet",
+                "settings_profile_id":"prof-a","stop_after_count":3,
+                "stop_after_time":"2027-06-01T12:00:00Z"}"#,
+        );
+
+        update_task(
+            file.path(),
+            &task.id,
+            br#"{"name":"N","prompt":"p","working_directory":"/w/two","model":"opus",
+                 "settings_profile_id":"prof-b","stop_after_count":7,
+                 "stop_after_time":"2028-01-02T03:04:05Z"}"#,
+        )
+        .expect("update");
+
+        let stored = get_task(file.path(), &task.id)
+            .expect("read")
+            .expect("task");
+        assert_eq!(stored.working_directory, "/w/two");
+        assert_eq!(stored.model, "opus");
+        assert_eq!(stored.settings_profile_id, "prof-b");
+        assert_eq!(stored.stop_after_count, 7);
+        assert_eq!(
+            stored.stop_after_time.map(|t| t.rfc3339_nano_utc()),
+            Some("2028-01-02T03:04:05Z".to_string()),
+        );
+    }
+
+    /// `stop_after_time` is the one genuinely nullable field of the five, so
+    /// absent and an explicit `null` must agree — and a value must come back
+    /// spelled exactly as it went in, since the read path is what the `full`
+    /// golden pins.
+    #[test]
+    fn stop_after_time_is_none_when_absent_or_null_and_byte_identical_otherwise() {
+        for body in [
+            r#"{"name":"N","prompt":"p"}"#,
+            r#"{"name":"N","prompt":"p","stop_after_time":null}"#,
+        ] {
+            let file = migrated();
+            assert!(created(&file, body).stop_after_time.is_none(), "for {body}");
+        }
+
+        let file = migrated();
+        let task = created(
+            &file,
+            r#"{"name":"N","prompt":"p","stop_after_time":"2027-06-01T12:00:00Z"}"#,
+        );
+        let encoded =
+            String::from_utf8(crate::native::gojson::to_vec(&task).expect("encode")).expect("utf8");
+        assert!(
+            encoded.contains(r#""stop_after_time":"2027-06-01T12:00:00Z""#),
+            "re-emitted as it arrived, in {encoded}"
+        );
+    }
+
+    /// An unparsable instant is a decode failure, not a silently dropped field
+    /// — the same 400 any other mistyped value on this body answers.
+    #[test]
+    fn an_unparsable_stop_after_time_is_a_400_rather_than_a_silent_none() {
+        let file = migrated();
+        let err = create_task(
+            file.path(),
+            br#"{"name":"N","prompt":"p","stop_after_time":"the first of June"}"#,
+        )
+        .unwrap_err();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        assert!(
+            list_tasks(file.path()).expect("list").is_empty(),
+            "a rejected create stores nothing"
+        );
+    }
+
+    /// The documented `PUT` semantics: replace, not preserve. An omitted key
+    /// resets its column, exactly as it does for `description` or `agent_slug`.
+    #[test]
+    fn an_omitted_field_on_update_resets_it_rather_than_preserving_it() {
+        let file = migrated();
+        let task = created(
+            &file,
+            r#"{"name":"N","prompt":"p","working_directory":"/w","model":"opus",
+                "settings_profile_id":"prof","stop_after_count":9,
+                "stop_after_time":"2027-06-01T12:00:00Z"}"#,
+        );
+
+        update_task(file.path(), &task.id, br#"{"name":"N","prompt":"p"}"#).expect("update");
+
+        let stored = get_task(file.path(), &task.id)
+            .expect("read")
+            .expect("task");
+        assert!(stored.working_directory.is_empty());
+        assert!(stored.model.is_empty());
+        assert!(stored.settings_profile_id.is_empty());
+        assert_eq!(stored.stop_after_count, 0);
+        assert!(stored.stop_after_time.is_none());
     }
 
     #[test]
@@ -1636,12 +1743,25 @@ pub fn update_job_history(db_path: &Path, job: &JobHistory) -> Result<(), String
 /// and two identical structs here would only be two places to forget an
 /// attribute.
 ///
-/// **Note what is absent**: `working_directory`, `model`, `settings_profile_id`,
-/// `stop_after_count` and `stop_after_time` are columns the table has and the
-/// request body does not, so both handlers build a `ScheduledTask` with those at
-/// their zero values. Reproduced rather than "fixed": a create that accepted a
-/// working directory here would store one Go's create discards, and an update
-/// that preserved the existing one would keep a value Go's update clears.
+/// **Five fields here have no Go ancestor, and that is deliberate** (#540).
+/// `working_directory`, `model`, `settings_profile_id`, `stop_after_count` and
+/// `stop_after_time` are columns the table has, the executor reads and the `GET`
+/// returns, and Go's two request types never carried — so both handlers built a
+/// `ScheduledTask` with them at their zero values and a form that posted them
+/// got a `200` and stored nothing. The port reproduced that while a second
+/// implementation shared the database; #391 deleted the Go tree, so the
+/// constraint is gone and this is simply Agento's bug. **Do not "restore
+/// parity" by taking them out again** — the Tasks form has edited all five
+/// since before the port, and dropping them is silent data loss.
+///
+/// **The `PUT` semantics are replace, for these five as for every other field
+/// on this route**: an omitted key resets the column to its zero value, because
+/// the only client posts the whole record back and a per-field preserve rule
+/// would make "clear my working directory" unexpressible. That is deliberately
+/// *not* `gateway::config::update_provider`'s three-valued absent/empty/present
+/// contract, nor the one #515 gave the integrations `PUT`: those exist because
+/// the field is a secret the caller cannot read back and therefore cannot
+/// resend, which is true of none of these five.
 #[derive(Debug, Default, Deserialize)]
 #[serde(default)]
 struct TaskRequest {
@@ -1666,11 +1786,32 @@ struct TaskRequest {
     timeout_minutes: i64,
     #[serde(deserialize_with = "super::gojson::null_is_zero_value")]
     save_output: bool,
+
+    // The five above the doc comment: Go's request types stopped here.
+    #[serde(deserialize_with = "super::gojson::null_is_zero_value")]
+    working_directory: String,
+    #[serde(deserialize_with = "super::gojson::null_is_zero_value")]
+    model: String,
+    #[serde(deserialize_with = "super::gojson::null_is_zero_value")]
+    settings_profile_id: String,
+    #[serde(deserialize_with = "super::gojson::null_is_zero_value")]
+    stop_after_count: i64,
+    /// The one genuinely nullable field, so a **plain** `Option` and no
+    /// `null_is_zero_value`: absent and explicit `null` both mean `None`, which
+    /// is what a bare `Option` already gives, and the column is `DATETIME NULL`
+    /// rather than a zero-valued `NOT NULL`. Note this is also the one field
+    /// where `deserialize_with` would change the shape rather than only the
+    /// value — see `CLAUDE.md` → *They are types rather than `deserialize_with`
+    /// functions*.
+    stop_after_time: Option<GoTime>,
 }
 
 impl TaskRequest {
     /// The `storage.ScheduledTask` both handlers build from the request — the
-    /// nine fields they copy, and nothing else.
+    /// fourteen fields they copy, and nothing else. The other six are the
+    /// row's own: the minted `id`, the two stamps, and the three the scheduler
+    /// writes back after a run (`run_count`, `last_run_*`, `next_run_at`), which
+    /// `update_task` restores from the stored row rather than from the body.
     fn into_task(self) -> ScheduledTask {
         ScheduledTask {
             id: String::new(),
@@ -1678,14 +1819,14 @@ impl TaskRequest {
             description: self.description,
             prompt: self.prompt,
             agent_slug: self.agent_slug,
-            working_directory: String::new(),
-            model: String::new(),
-            settings_profile_id: String::new(),
+            working_directory: self.working_directory,
+            model: self.model,
+            settings_profile_id: self.settings_profile_id,
             timeout_minutes: self.timeout_minutes,
             schedule_type: self.schedule_type,
             schedule_config: self.schedule_config.0,
-            stop_after_count: 0,
-            stop_after_time: None,
+            stop_after_count: self.stop_after_count,
+            stop_after_time: self.stop_after_time,
             save_output: self.save_output,
             status: self.status,
             run_count: 0,
@@ -1812,7 +1953,12 @@ fn validate_task(task: &mut ScheduledTask) -> Result<(), WriteError> {
 const DEFAULT_TIMEOUT_MINUTES: i64 = 30;
 
 /// `taskService.CreateTask`.
-fn create_task(db_path: &Path, body: &[u8]) -> Result<super::Answer, WriteError> {
+///
+/// `pub(crate)` for one caller outside this module: the scheduler's own
+/// `a_stop_after_count_task_created_through_the_api_pauses_on_the_limit`
+/// (#540), which has to build its task the way the app does rather than by
+/// `INSERT`, or it cannot see the write hop that was dropping the budget.
+pub(crate) fn create_task(db_path: &Path, body: &[u8]) -> Result<super::Answer, WriteError> {
     let req = decode_body::<TaskRequest>(body)?;
     let mut task = req.into_task();
     validate_task(&mut task)?;

--- a/src-tauri/src/native/tasks.rs
+++ b/src-tauri/src/native/tasks.rs
@@ -1787,7 +1787,8 @@ struct TaskRequest {
     #[serde(deserialize_with = "super::gojson::null_is_zero_value")]
     save_output: bool,
 
-    // The five above the doc comment: Go's request types stopped here.
+    // The five described in the doc comment above: Go's request types
+    // stopped at `save_output`.
     #[serde(deserialize_with = "super::gojson::null_is_zero_value")]
     working_directory: String,
     #[serde(deserialize_with = "super::gojson::null_is_zero_value")]
@@ -1808,10 +1809,11 @@ struct TaskRequest {
 
 impl TaskRequest {
     /// The `storage.ScheduledTask` both handlers build from the request — the
-    /// fourteen fields they copy, and nothing else. The other six are the
-    /// row's own: the minted `id`, the two stamps, and the three the scheduler
-    /// writes back after a run (`run_count`, `last_run_*`, `next_run_at`), which
-    /// `update_task` restores from the stored row rather than from the body.
+    /// fourteen fields they copy, and nothing else. The other seven are the
+    /// row's own: the minted `id`, the two stamps, and the four the scheduler
+    /// writes back after a run (`run_count`, `last_run_at`, `last_run_status`,
+    /// `next_run_at`), which `update_task` restores from the stored row rather
+    /// than from the body.
     fn into_task(self) -> ScheduledTask {
         ScheduledTask {
             id: String::new(),

--- a/src-tauri/src/native/writes.rs
+++ b/src-tauri/src/native/writes.rs
@@ -242,6 +242,7 @@ pub fn finish(result: Result<super::Answer, WriteError>) -> Result<super::Answer
 /// | `integrations::UpdateIntegrationRequest` | `services`' values | yes |
 /// | `notifications::NotificationSettings` | `provider`, `preferences`, `NotificationPreferences.scheduled_tasks` | yes |
 /// | `integrations::TriggerRuleRequest` | — (two `GoList<String>`) | n/a |
+/// | `tasks::TaskRequest` | `schedule_config` | yes |
 /// | `chats::CreateChatRequest`, `chats::PatchChatRequest` | — | n/a |
 /// | `chats::BulkDeleteRequest`, `tasks::BulkDeleteRequest` | — (`GoList<String>`) | n/a |
 /// | `pricing::RateRequest` | — (the bands are not expressible in a request) | n/a |


### PR DESCRIPTION
Closes #540

## What

`POST /api/tasks` and `PUT /api/tasks/{id}` accepted five fields the Tasks form lets the user edit and then threw them away — `working_directory`, `model`, `settings_profile_id`, `stop_after_count`, `stop_after_time`. The request answered `200`/`201` and the columns were stored at their zero values, so reopening a task showed `Stop after: 0`, an empty working directory, an empty model and no settings profile, with nothing to say the edit was discarded.

The columns already exist, the executor already reads every one of them, and the `GET` already returns them. The write hop was the only broken one.

## Why

`TaskRequest` was ported from Go's `CreateTaskRequest`/`UpdateTaskRequest`, which never carried these five, so `into_task` hardcoded the zero values — deliberately, and pinned by a test, because a second implementation shared the database and diverging would have made two installs behave differently. #391 deleted the Go tree, so that constraint is gone. This is the class `CLAUDE.md` → *Known bugs, and the reason not to fix them is gone* lists, and #515 is the precedent for the fix shape.

## How

- **`TaskRequest`** gains the five fields. Four take `gojson::null_is_zero_value`, the spelling their nine siblings already use. `stop_after_time` is the one genuinely nullable field, so it is a **plain `Option<GoTime>`** — absent and explicit `null` both mean `None`, which a bare `Option` already gives, and `deserialize_with` there would make the field required.
- **`GoTime` gains `Deserialize`** (it only had `Serialize`). It parses through `gotime::parse_rfc3339` — Go's own grammar, already the crate's one Go-RFC3339 parser — rather than `chrono::parse_from_rfc3339`, which disagrees with `time.Parse` in five ways and would refuse three shapes `encoding/json` accepts. An unparsable instant is a decode error, i.e. the same 400 any other mistyped field on this body answers.
- **`PUT` semantics: replace, not preserve**, documented in `TaskRequest`'s doc comment. An omitted key resets its column, exactly as it does for every other field on this route: the only client posts the whole record back, and a per-field preserve rule would make "clear my working directory" unexpressible. Deliberately *not* `gateway::config::update_provider`'s (and, since #515, the integrations `PUT`'s) three-valued contract — those exist because the field is a secret the caller cannot read back, which is true of none of these five.
- **The doc comment is rewritten** so the "note what is absent / accepting them would store what Go discards" paragraph becomes history, with a sentence saying why the divergence is deliberate — the next reader must not "restore parity".
- **`create_task` is `pub(crate)`** for one caller: the new executor test, which has to build its task the way the app does rather than by `INSERT`.

## Tests

- `the_five_columns_the_request_cannot_reach_are_stored_at_their_zero_values` → **inverted** to `the_five_columns_go_never_carried_now_reach_the_row`, the way `a_full_length_positional_array` was — so a session that later reads "Go discards these" cannot restore the drop without a red test.
- `the_five_fields_round_trip_through_create_read_and_update` — create with all five, `PUT` a change to each, re-read.
- `stop_after_time_is_none_when_absent_or_null_and_byte_identical_otherwise` — both null shapes, plus a re-emit assertion on the exact `"stop_after_time":"2027-06-01T12:00:00Z"` bytes the `full` golden spells.
- `an_unparsable_stop_after_time_is_a_400_rather_than_a_silent_none`.
- `an_omitted_field_on_update_resets_it_rather_than_preserving_it` — pins the documented `PUT` semantics.
- `a_stop_after_count_task_created_through_the_api_pauses_on_the_limit` (`schedule/executor.rs`) — the sibling of `a_stop_after_count_run_pauses_on_the_limit`, built through the API rather than by `INSERT`. The existing one pins the executor's arithmetic and says nothing about whether a budget can be configured at all, which is exactly the hop that was dropping it.

**Four of the six fail when the production change is reverted** (the three inverted/round-trip ones and the executor one), verified by reverting `into_task` and re-running. The other two guard the struct declaration and the documented `PUT` semantics rather than `into_task`.

## Acceptance

- [x] All five store and read back.
- [x] `stop_after_time` round-trips as RFC 3339; absent and `null` both `None`.
- [x] A `stop_after_count: 2` task created through the API pauses on its second run.
- [x] **No `parity/` golden moved** — this changes what a write accepts, not what a read emits; `git status` shows four files, none under `parity/`.
- [x] `CLAUDE.md` updated: struck-through *Known bugs* entry in the #515 style.

## Local gates

`npm run build` · `cargo fmt --check` · `cargo clippy --all-targets -- -D warnings` · `cargo test` (1508 lib + all integration binaries green) · `cargo build --profile ci`.

## Out of scope

The Limits UI presentation (#543), run-now (#541), and any validation of the five values beyond what the columns require.

---

## Review rounds

Three local review rounds; the diff grew two commits of fixes, both in scope.

- **Round 1** — `into_task`'s rewritten doc had an off-by-one field count and globbed `last_run_*`; `tasks::TaskRequest` was missing from `decode_body`'s write-body audit table (`writes.rs`), which is the enumeration #337's over-accept guarantee rests on. Both fixed in `9bc1971`.
- **Round 2** — the round-1 count fix put `next_run_at` among the fields `update_task` restores from the stored row, when it *clears* it and restores `created_at` instead, contradicting `update_task`'s own doc 200 lines below. And the new `Deserialize for GoTime` documented its parser choice as load-bearing while **no test pinned it**: every `stop_after_time` fixture is a shape both `gotime::parse_rfc3339` and chrono accept, so swapping the impl to chrono left all 1508 lib tests green. Both fixed in `1ba2b2d` — the doc now states the three-way split correctly, and `deserializing_a_gotime_uses_gos_grammar_and_not_chronos` pins both directions (Go-accepted/chrono-rejected must decode; chrono-accepted/Go-rejected must fail). Verified red against a chrono impl.
- **Round 3** — APPROVE, no findings. The reviewer independently re-measured the five Go/chrono disagreements against `go1.26.5` rather than trusting the comment.
