### PR TITLE
feat: run a task on demand, and say which button means what (#541)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3568,14 +3568,19 @@ omissions are the feature rather than shortcuts:
   its tenth run would make the feature hostile. `next_run_at` needs no mention:
   nothing on the run path writes it, so skipping the write-back leaves it alone
   by construction. `RunKind` is a type rather than a `bool` because it is read at
-  three call sites — `prepare`, `finish` and `record_failed_run` — and a `bool`
-  at any of them says nothing.
+  **four** call sites — `prepare`'s agent-resolution arm, both of `finish`'s
+  arms, and `record_failed_run` — each with its own `Manual`/`Scheduled` pair
+  over one fixture, because a guard dropped from any one of them ships with
+  every other test green.
 
 Everything else is identical, including the module's own rule that **every path
 ends in a `job_history` row**. That row's id is **minted by the route**, not by
 `create_initial_job_history`, so the `202` can name the row the run is about to
 write; a scheduled run passes a fresh v4 uuid, which is what that line generated
-before.
+before. **The row does not exist when the `202` is sent**, and not merely for a
+moment: `run_manual` waits for one of the three permits first, so with three
+240-minute runs in flight the id 404s until one ends. A consumer of it — #542 —
+has to treat "not there yet" as a state rather than an error.
 
 Two more properties are load-bearing. The **three-slot semaphore** is acquired
 inside `run_manual` rather than by the route, because waiting for a permit is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -400,7 +400,10 @@ src-tauri/src/
                  three rate writes (#306): add and correct are not one upsert
     agents.rs    GET /api/agents and /api/agents/{slug}
     chats.rs     GET /api/chats and /api/chats/{id}; compact() is Go's, byte for byte
-    tasks.rs     GET /api/tasks, /api/job-history and the three reads between them
+    tasks.rs     GET /api/tasks, /api/job-history and the three reads between
+                 them, the five task writes, and POST /api/tasks/{id}/run
+                 (#541) — the desktop-only route that fires a task on demand,
+                 and this module's whole `ROUTES` const
     gateway_api.rs the LLM gateway's control plane (#426) — fifteen
                  /api/gateway/* routes; under native/ because it IS the /api
                  seam, where gateway/'s listener is not. Two of them are
@@ -3548,6 +3551,47 @@ passes against a drain that never terminates on its own — the first version of
 that test did exactly that and went green against the hang. A real CLI in session
 mode stays alive; the fake has to as well.
 
+**A run can also be started by a request, and the difference is one function
+call** (#541). `POST /api/tasks/{id}/run` goes through
+`executor::run_manual`, which is `execute_task` minus two things — and both
+omissions are the feature rather than shortcuts:
+
+- **`due_task` is not consulted.** It refuses a `paused` task and auto-pauses
+  one past its `stop_after_count`/`stop_after_time`, in both cases returning
+  *silently*. Right for a timer nobody asked to fire; wrong here, where running
+  a paused task on demand is most of the point and a task at its limit is
+  exactly the one somebody wants to try again.
+- **`update_task_after_run` is skipped**, via `RunKind::Manual`. `run_count`,
+  `last_run_at`, `last_run_status` and the two auto-pause rules are what the
+  *schedule* has done; a manual run is a test of the configuration, and
+  consuming a `stop_after_count` budget or pausing the task because the test was
+  its tenth run would make the feature hostile. `next_run_at` needs no mention:
+  nothing on the run path writes it, so skipping the write-back leaves it alone
+  by construction. `RunKind` is a type rather than a `bool` because it is read at
+  three call sites — `prepare`, `finish` and `record_failed_run` — and a `bool`
+  at any of them says nothing.
+
+Everything else is identical, including the module's own rule that **every path
+ends in a `job_history` row**. That row's id is **minted by the route**, not by
+`create_initial_job_history`, so the `202` can name the row the run is about to
+write; a scheduled run passes a fresh v4 uuid, which is what that line generated
+before.
+
+Two more properties are load-bearing. The **three-slot semaphore** is acquired
+inside `run_manual` rather than by the route, because waiting for a permit is
+precisely what must not happen inside a request — `Endpoint::serve` is a sync
+`fn` on `spawn_blocking` and a run reaches 240 minutes, so the route spawns and
+answers. And the **`409`** comes from `Scheduler::in_flight`, a *refcounted*
+task-id map added for it: `jobs` holds timers, not runs, and the durable
+alternative — a `job_history` row still marked `running` — cannot be used,
+because a panic in `finish` leaves exactly such a row with nothing to finish it,
+so a crash would 409 that task for ever. **Both run paths mark and only the
+manual one refuses**, so a timer's behaviour is untouched while the route can
+still see a scheduled run; the check and the mark are one operation under one
+lock, or two simultaneous requests both pass and both start. A count rather than
+a set, because a scheduled run that outlives its own interval overlaps the next
+one and the first to finish would clear an entry the second still owns.
+
 **A task write can fail after storing a row, so the timers are swept.**
 `Scheduler::reconcile` runs every 60 seconds and brings the installed timers
 back in line with the stored rows. It is a sweep rather than a hook on any one
@@ -3839,15 +3883,19 @@ gateway must not be able to reconfigure which provider it spends with).
 
 Three things about it are decisions:
 
-- **The route table is `parity/desktop_routes.json`, and it now has two
+- **The route table is `parity/desktop_routes.json`, and it now has three
   owners.** #405 created that file for `/api/security/*` — routes with no Go
   ancestor, which could go in neither frozen Go table without destroying what
   those are. Its guarantee is *stronger* than theirs: they assert in one
   direction, so a route claimed and never recorded passes, while this is **set
   equality** against the modules' `ROUTES` consts. The claimed set is now the
-  **union** of `security::ROUTES` and `gateway_api::ROUTES`; a third owner
-  appends there, and forgetting to would quietly weaken the assertion back to
-  one direction. The issue's "resolve at implementation time" question — grow
+  **union** of `security::ROUTES`, `gateway_api::ROUTES` and — since #541 —
+  `tasks::ROUTES`, whose single row is `POST /api/tasks/{id}/run`; a fourth
+  owner appends there, and forgetting to would quietly weaken the assertion back
+  to one direction. Note the third owner is a module that is *mostly* Go's:
+  a route with no Go ancestor belongs here whatever else its module claims, and
+  adding it to the frozen `write_routes.json` instead would be a silent contract
+  break that no test catches. The issue's "resolve at implementation time" question — grow
   the Go tables, or fall back to Tauri commands — is answered by this file
   existing. A command would have been wrong anyway: `logs.rs` is a command
   because the app log belongs to the *process*; gateway config is API surface.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -306,6 +306,21 @@ Other options:
 The inspector shows the next run, the last run, the total number of runs and the
 last outcome.
 
+**Run now** runs the task immediately, whatever its schedule says. It works on a
+paused task too, and on one that has already reached its **Stop after** count —
+that is the point of it, since a task you cannot try is a task you cannot fix.
+The run lands in **Job history** like any other, with its output, timing, tokens
+and any error.
+
+A manual run **does not touch the schedule**: it does not move the next run, does
+not count towards **Stop after**, and never pauses the task. Only one run of a
+task happens at a time — pressing **Run now** while one is going says so and
+starts nothing.
+
+**Enable** / **Disable** is the other button, and it is the one that decides
+whether the schedule fires at all. It does the same thing as the **Enabled**
+switch in the form below.
+
 **Times are your local time.** They are stored in UTC and converted for display.
 
 **Agento has to be running.** A scheduled task fires from the app itself, so
@@ -315,7 +330,8 @@ nothing runs while it is closed.
 
 ## Job history
 
-Every scheduled run leaves a record: which task, when it started, how long it
+Every run leaves a record — scheduled or started with **Run now** — of which
+task, when it started, how long it
 took, whether it succeeded, the tokens and cost, and the output if you asked for
 it to be saved.
 

--- a/parity/desktop_routes.json
+++ b/parity/desktop_routes.json
@@ -26,6 +26,13 @@
   ],
   "routes": [
     {
+      "method": "POST",
+      "route": "/api/tasks/{id}/run",
+      "status": "native",
+      "owner": "#541",
+      "reason": "fires a configured task on demand -- the one thing the product could not do, since the only way to make a task run was to change its schedule type to run_immediately and so destroy the schedule being tested. Answers 202 with the job_history id the run will write rather than blocking for the run itself, which reaches 240 minutes; 409 when a run of that task is already in flight; and a PAUSED task is deliberately runnable, which is most of the point. It advances nothing the schedule owns -- not run_count, not next_run_at, not the stop_after_count budget"
+    },
+    {
       "method": "GET",
       "route": "/api/security/keys",
       "status": "native",

--- a/src-tauri/src/native/mod.rs
+++ b/src-tauri/src/native/mod.rs
@@ -462,6 +462,7 @@ mod tests {
         assert!(claims(&Method::POST, "/api/tasks"));
         assert!(claims(&Method::PUT, "/api/tasks/abc-123"));
         assert!(claims(&Method::POST, "/api/tasks/abc-123/pause"));
+        assert!(claims(&Method::POST, "/api/tasks/abc-123/run"));
         assert!(claims(&Method::POST, "/api/tasks/abc-123/resume"));
         assert!(claims(&Method::DELETE, "/api/tasks/abc-123"));
         assert!(claims(&Method::DELETE, "/api/job-history"));
@@ -827,14 +828,15 @@ mod tests {
             .map(|row| (row.method.clone(), row.route.clone()))
             .collect();
         //
-        // The file has **two owners** since #426, so the claimed set is the
-        // union of both modules' consts. A third owner appends here; leaving it
-        // out would silently weaken the assertion from set equality to "the
-        // owners I remembered", which is the one-directional property this test
-        // exists to escape.
+        // The file has **three owners** since #541, so the claimed set is the
+        // union of all three modules' consts. A fourth owner appends here;
+        // leaving it out would silently weaken the assertion from set equality
+        // to "the owners I remembered", which is the one-directional property
+        // this test exists to escape.
         let claimed: BTreeSet<(String, String)> = security::ROUTES
             .iter()
             .chain(gateway_api::ROUTES.iter())
+            .chain(tasks::ROUTES.iter())
             .map(|(method, route)| (method.to_string(), route.to_string()))
             .collect();
         assert_eq!(

--- a/src-tauri/src/native/schedule/executor.rs
+++ b/src-tauri/src/native/schedule/executor.rs
@@ -168,6 +168,46 @@ pub async fn run_manual(
         return;
     };
 
+    // **Re-read after the permit, and only for the row's existence.**
+    //
+    // This is the half of [`due_task`] a manual run keeps. The other half —
+    // `status != "active"` and the two auto-pause rules — is schedule policy
+    // and is deliberately skipped; *this* is not policy, it is the same check
+    // Go's own comment calls "a task that vanished between the fire and the
+    // read". And the window here is far wider than the timer's: the wait above
+    // is for one of three permits, which the runs holding them may keep for
+    // 240 minutes. `job_history.task_id` cascades from `scheduled_tasks`, so a
+    // run whose task was deleted meanwhile would spawn the agent, spend the
+    // tokens, and then fail to insert its job row — leaving nothing at all to
+    // explain it, which is the one outcome this module does not allow.
+    //
+    // It also picks up an edit that landed after the request, which is the
+    // `dirty` gate in the UI applied to the window that gate cannot cover.
+    let task = {
+        let (db_path, id) = (scheduler.db_path().to_path_buf(), task.id.clone());
+        match db::blocking("manual run re-read", move || tasks::get_task(&db_path, &id)).await {
+            Some(Ok(Some(fresh))) => fresh,
+            Some(Ok(None)) => {
+                log::info!(
+                    "manual run abandoned: the task no longer exists task_id={:?}",
+                    task.id
+                );
+                return;
+            }
+            // A read failure, or a panic in the section. Neither can be told
+            // apart from a deleted row well enough to run on the snapshot, and
+            // running on it is the outcome with no evidence.
+            Some(Err(e)) => {
+                log::error!(
+                    "manual run abandoned: could not re-read the task task_id={:?} error={e}",
+                    task.id
+                );
+                return;
+            }
+            None => return,
+        }
+    };
+
     log::info!(
         "executing task manually task_id={:?} task_name={:?} job_id={job_id:?}",
         task.id,

--- a/src-tauri/src/native/schedule/executor.rs
+++ b/src-tauri/src/native/schedule/executor.rs
@@ -68,6 +68,11 @@ impl RunKind {
     /// you could not try a task without spending it. `next_run_at` needs no
     /// mention here because nothing on the run path ever writes it; skipping
     /// the write-back leaves it alone by construction.
+    /// Read at **four** sites — `prepare`'s agent-resolution arm, both of
+    /// `finish`'s arms, and `record_failed_run` — each with a test that fails
+    /// when this answers `true` unconditionally. Four rather than three because
+    /// a failure can be recorded before, during or after the run, and a manual
+    /// run must spend nothing in any of them.
     fn advances_schedule(self) -> bool {
         matches!(self, Self::Scheduled)
     }
@@ -251,9 +256,12 @@ fn auto_pause(scheduler: &Arc<Scheduler>, mut task: ScheduledTask, reason: &str)
 async fn run_task(scheduler: &Arc<Scheduler>, task: ScheduledTask, run: Run) {
     let db_path = scheduler.db_path().to_path_buf();
 
+    // The two labels below say "task run" rather than "scheduled run": since
+    // #541 both sections serve a manual run too, and `db::blocking`'s label is
+    // what names the section in the log when one panics.
     let prepared = {
         let (scheduler, run) = (Arc::clone(scheduler), run.clone());
-        db::blocking("scheduled run preparation", move || {
+        db::blocking("task run preparation", move || {
             prepare(&scheduler, task, &run)
         })
         .await
@@ -282,7 +290,7 @@ async fn run_task(scheduler: &Arc<Scheduler>, task: ScheduledTask, run: Run) {
 
     let recorded = {
         let (scheduler, session) = (Arc::clone(scheduler), chat_session_id.clone());
-        db::blocking("scheduled run results", move || {
+        db::blocking("task run results", move || {
             finish(&scheduler, task, job, &session, &prompt, result, &run)
         })
         .await
@@ -1566,9 +1574,57 @@ mod tests {
         assert_eq!(stored.status, "paused");
     }
 
-    /// The third guarded site: the arm `finish` takes when the agent run itself
-    /// failed. Same shape, so a `kind` dropped from any one of the three is
-    /// caught rather than only from the one a single test happened to walk.
+    /// The site a *misconfigured* task reaches, which is the task somebody
+    /// presses **Run now** to diagnose: `prepare` finishes the running job row
+    /// and then decides whether the schedule moves.
+    ///
+    /// `at_its_limit`'s `agent_slug` is `no-such-agent`, so `resolve_agent`
+    /// fails after the session and the job row exist — the arm under test —
+    /// without needing a subprocess.
+    #[test]
+    fn the_preparation_section_honours_the_run_kind_too() {
+        for (kind, expected_count, expected_status) in [
+            (RunKind::Manual, 3, "active"),
+            (RunKind::Scheduled, 4, "paused"),
+        ] {
+            let file = at_its_limit();
+            let scheduler = test_scheduler(file.path());
+            let task = tasks::get_task(file.path(), "t1")
+                .expect("read")
+                .expect("row");
+            let run = Run {
+                kind,
+                job_id: "j-prep".to_string(),
+                started_at: Utc::now(),
+            };
+
+            // Matched rather than `expect_err`, which would need `Ready: Debug`
+            // — and `Ready` carries an `Agent`, whose system prompt has no
+            // business in a panic message.
+            match prepare(&scheduler, task, &run) {
+                Err(failed) => assert!(failed.message.contains("resolve agent"), "{kind:?}"),
+                Ok(_) => panic!("{kind:?}: the agent must not resolve"),
+            }
+
+            let stored = tasks::get_task(file.path(), "t1")
+                .expect("read")
+                .expect("row");
+            assert_eq!(stored.run_count, expected_count, "{kind:?}");
+            assert_eq!(stored.status, expected_status, "{kind:?}");
+            assert_eq!(
+                tasks::get_job_history(file.path(), "j-prep")
+                    .expect("read")
+                    .expect("row")
+                    .status,
+                "failed",
+                "{kind:?} still records the run"
+            );
+        }
+    }
+
+    /// The arm `finish` takes when the agent run itself failed. Same shape as
+    /// its siblings, so a `kind` dropped from any one of the four guarded sites
+    /// is caught rather than only from the one a single test happened to walk.
     #[test]
     fn the_finish_section_honours_the_run_kind_too() {
         for (kind, expected_count, expected_status) in [

--- a/src-tauri/src/native/schedule/executor.rs
+++ b/src-tauri/src/native/schedule/executor.rs
@@ -42,8 +42,57 @@ use crate::native::notifications;
 use crate::native::tasks::{self, JobHistory, ScheduledTask};
 use crate::native::template;
 
+/// Which caller started a run, and therefore what accounting it owns (#541).
+///
+/// The two differ in exactly one place — [`update_task_after_run`] — and the
+/// asymmetry is the whole of the manual-run feature's risk, so it travels as a
+/// type rather than as a `bool` nobody can read at a call site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunKind {
+    /// A timer fired. Advances `run_count` and `last_run_*`, and applies the
+    /// two auto-pause rules.
+    Scheduled,
+    /// `POST /api/tasks/{id}/run`. Produces an identical `job_history` row and
+    /// touches **none** of the schedule's own accounting.
+    Manual,
+}
+
+impl RunKind {
+    /// Whether this run advances the *schedule's* counters.
+    ///
+    /// `run_count`, `last_run_at`, `last_run_status` and the two auto-pause
+    /// rules are what a schedule has done, not what the agent has done. A
+    /// manual run is a test of the configuration: consuming a
+    /// `stop_after_count` budget or auto-pausing the task because the test
+    /// happened to be its tenth run would make the feature actively hostile —
+    /// you could not try a task without spending it. `next_run_at` needs no
+    /// mention here because nothing on the run path ever writes it; skipping
+    /// the write-back leaves it alone by construction.
+    fn advances_schedule(self) -> bool {
+        matches!(self, Self::Scheduled)
+    }
+}
+
+/// What describes *this* run rather than the task it is of: who started it,
+/// which `job_history` row it is, and when it began.
+///
+/// One value rather than three parameters because all three are threaded
+/// through the same three functions, and a `RunKind` sitting seventh in a
+/// positional list is exactly the argument that gets dropped by a later edit.
+#[derive(Clone)]
+struct Run {
+    kind: RunKind,
+    /// Minted by the *caller* — `POST /api/tasks/{id}/run` answers with it — so
+    /// the row a run writes is knowable before the run starts.
+    job_id: String,
+    started_at: chrono::DateTime<Utc>,
+}
+
 /// `executeTask`. The semaphore is the caller's; this is everything inside it.
 pub async fn execute_task(scheduler: &Arc<Scheduler>, task_id: &str) {
+    // Marked, never refused: the in-flight map exists so the *manual* route can
+    // answer 409, and a timer's fire must behave exactly as it did before #541.
+    let _in_flight = scheduler.mark_running(task_id);
     let due = {
         let (scheduler, task_id) = (Arc::clone(scheduler), task_id.to_string());
         db::blocking("scheduled run", move || due_task(&scheduler, &task_id)).await
@@ -67,7 +116,68 @@ pub async fn execute_task(scheduler: &Arc<Scheduler>, task_id: &str) {
         task.name,
         task.run_count + 1
     );
-    run_task(scheduler, task).await;
+    run_task(
+        scheduler,
+        task,
+        Run {
+            kind: RunKind::Scheduled,
+            job_id: uuid::Uuid::new_v4().to_string(),
+            started_at: Utc::now(),
+        },
+    )
+    .await;
+}
+
+/// One run started by `POST /api/tasks/{id}/run` (#541).
+///
+/// Everything a scheduled run does, minus the two things that belong to the
+/// schedule rather than to the run:
+///
+/// - **[`due_task`] is not consulted.** It refuses a `paused` task and
+///   auto-pauses one past its `stop_after_count`/`stop_after_time`, in both
+///   cases returning *silently* — no `job_history` row, nothing on screen. That
+///   is right for a timer, whose fire nobody asked for, and wrong here: running
+///   a paused task on demand is most of what this feature is for, and a task at
+///   its limit is exactly the one a user wants to try again. The task is read
+///   by the route, which is also what answers the `404`.
+/// - **The schedule's counters are not advanced**, via [`RunKind::Manual`].
+///
+/// `guard` is the in-flight entry the route claimed before spawning this, held
+/// here so it is released when the run ends however it ends; `permit` is the
+/// scheduler's own three-slot semaphore, acquired here rather than in the route
+/// because waiting for it is exactly what must not happen inside a request.
+pub async fn run_manual(
+    scheduler: Arc<Scheduler>,
+    task: ScheduledTask,
+    job_id: String,
+    guard: crate::native::schedule::runtime::RunGuard,
+) {
+    let _guard = guard;
+    let Ok(_permit) = scheduler.semaphore().acquire_owned().await else {
+        // The semaphore is never closed, so this is unreachable in practice;
+        // returning is what the timer path does with the same error.
+        log::warn!(
+            "manual run abandoned: the scheduler semaphore is closed task_id={:?}",
+            task.id
+        );
+        return;
+    };
+
+    log::info!(
+        "executing task manually task_id={:?} task_name={:?} job_id={job_id:?}",
+        task.id,
+        task.name
+    );
+    run_task(
+        &scheduler,
+        task,
+        Run {
+            kind: RunKind::Manual,
+            job_id,
+            started_at: Utc::now(),
+        },
+    )
+    .await;
 }
 
 /// The load-and-check half of `executeTask`: the row, its status, and the
@@ -138,14 +248,13 @@ fn auto_pause(scheduler: &Arc<Scheduler>, mut task: ScheduledTask, reason: &str)
 ///
 /// The notifications stay out here because [`publish`] already spawns and
 /// deliberately does not wait — see its own note.
-async fn run_task(scheduler: &Arc<Scheduler>, task: ScheduledTask) {
+async fn run_task(scheduler: &Arc<Scheduler>, task: ScheduledTask, run: Run) {
     let db_path = scheduler.db_path().to_path_buf();
-    let started_at = Utc::now();
 
     let prepared = {
-        let scheduler = Arc::clone(scheduler);
+        let (scheduler, run) = (Arc::clone(scheduler), run.clone());
         db::blocking("scheduled run preparation", move || {
-            prepare(&scheduler, task, started_at)
+            prepare(&scheduler, task, &run)
         })
         .await
     };
@@ -174,7 +283,7 @@ async fn run_task(scheduler: &Arc<Scheduler>, task: ScheduledTask) {
     let recorded = {
         let (scheduler, session) = (Arc::clone(scheduler), chat_session_id.clone());
         db::blocking("scheduled run results", move || {
-            finish(&scheduler, task, job, &session, &prompt, started_at, result)
+            finish(&scheduler, task, job, &session, &prompt, result, &run)
         })
         .await
     };
@@ -237,9 +346,10 @@ struct Failed {
 fn prepare(
     scheduler: &Arc<Scheduler>,
     mut task: ScheduledTask,
-    started_at: chrono::DateTime<Utc>,
+    run: &Run,
 ) -> Result<Ready, Box<Failed>> {
     let db_path = scheduler.db_path().to_path_buf();
+    let started_at = run.started_at;
 
     // `prepareTaskRun`. Both failures record a *complete* failed job row and
     // return — the run never reaches `createInitialJobHistory`, so there is no
@@ -252,7 +362,7 @@ fn prepare(
                 "failed to interpolate prompt task_id={:?} error={e}",
                 task.id
             );
-            record_failed_run(scheduler, &mut task, started_at, "", &message);
+            record_failed_run(scheduler, &mut task, "", &message, run);
             return Err(Box::new(Failed { task, message }));
         }
     };
@@ -265,13 +375,12 @@ fn prepare(
                 "failed to create chat session task_id={:?} error={e}",
                 task.id
             );
-            record_failed_run(scheduler, &mut task, started_at, "", &message);
+            record_failed_run(scheduler, &mut task, "", &message, run);
             return Err(Box::new(Failed { task, message }));
         }
     };
 
-    let mut job =
-        create_initial_job_history(&db_path, &task, started_at, &chat_session_id, &prompt);
+    let mut job = create_initial_job_history(&db_path, &task, &chat_session_id, &prompt, run);
 
     // `resolveAgentConfig`. From here on there *is* a running row, so every
     // failure finishes it rather than creating a second.
@@ -284,7 +393,9 @@ fn prepare(
                 task.id
             );
             finish_job_history(&db_path, &mut job, started_at, "failed", &message, None, "");
-            update_task_after_run(scheduler, &mut task, started_at, "failed");
+            if run.kind.advances_schedule() {
+                update_task_after_run(scheduler, &mut task, started_at, "failed");
+            }
             return Err(Box::new(Failed { task, message }));
         }
     };
@@ -314,17 +425,20 @@ fn finish(
     mut job: JobHistory,
     chat_session_id: &str,
     prompt: &str,
-    started_at: chrono::DateTime<Utc>,
     result: Result<RunResult, String>,
+    run: &Run,
 ) -> Recorded {
     let db_path = scheduler.db_path().to_path_buf();
+    let started_at = run.started_at;
 
     let result = match result {
         Ok(result) => result,
         Err(e) => {
             log::error!("task execution failed task_id={:?} error={e}", task.id);
             finish_job_history(&db_path, &mut job, started_at, "failed", &e, None, "");
-            update_task_after_run(scheduler, &mut task, started_at, "failed");
+            if run.kind.advances_schedule() {
+                update_task_after_run(scheduler, &mut task, started_at, "failed");
+            }
             return Recorded {
                 task,
                 job,
@@ -350,7 +464,9 @@ fn finish(
         Some(&result),
         response_text,
     );
-    update_task_after_run(scheduler, &mut task, started_at, "success");
+    if run.kind.advances_schedule() {
+        update_task_after_run(scheduler, &mut task, started_at, "success");
+    }
 
     Recorded {
         task,
@@ -407,17 +523,21 @@ fn create_task_session(db_path: &std::path::Path, task: &ScheduledTask) -> Resul
 fn create_initial_job_history(
     db_path: &std::path::Path,
     task: &ScheduledTask,
-    started_at: chrono::DateTime<Utc>,
     chat_session_id: &str,
     prompt: &str,
+    run: &Run,
 ) -> JobHistory {
     let job = JobHistory {
-        id: uuid::Uuid::new_v4().to_string(),
+        // Minted by the caller rather than here, so `POST /api/tasks/{id}/run`
+        // can answer with the id of the row this run is about to write. A
+        // scheduled run passes a fresh v4 uuid, which is what this line used to
+        // generate — the bytes are the same shape either way.
+        id: run.job_id.clone(),
         task_id: task.id.clone(),
         task_name: task.name.clone(),
         agent_slug: task.agent_slug.clone(),
         status: "running".to_string(),
-        started_at: crate::native::gotime::GoTime::from_utc(started_at),
+        started_at: crate::native::gotime::GoTime::from_utc(run.started_at),
         finished_at: None,
         duration_ms: 0,
         chat_session_id: chat_session_id.to_string(),
@@ -760,13 +880,17 @@ fn write_run_result(
 fn record_failed_run(
     scheduler: &Arc<Scheduler>,
     task: &mut ScheduledTask,
-    started_at: chrono::DateTime<Utc>,
     chat_session_id: &str,
     error_message: &str,
+    run: &Run,
 ) {
     let now = Utc::now();
+    let started_at = run.started_at;
     let job = JobHistory {
-        id: uuid::Uuid::new_v4().to_string(),
+        // The caller's id, for `create_initial_job_history`'s reason: this is
+        // the row a manual run answered with, and it must exist under that id
+        // even when the run failed before it started.
+        id: run.job_id.clone(),
         task_id: task.id.clone(),
         task_name: task.name.clone(),
         agent_slug: task.agent_slug.clone(),
@@ -792,7 +916,9 @@ fn record_failed_run(
             task.id
         );
     }
-    update_task_after_run(scheduler, task, started_at, "failed");
+    if run.kind.advances_schedule() {
+        update_task_after_run(scheduler, task, started_at, "failed");
+    }
 }
 
 /// Hand a notification to the blocking pool and **do not wait for it**.
@@ -992,8 +1118,17 @@ mod tests {
         let mut task = sample_task();
         task.id = "t1".to_string();
         let started_at = Utc::now();
-        let mut job =
-            create_initial_job_history(file.path(), &task, started_at, "chat-1", "the prompt");
+        let mut job = create_initial_job_history(
+            file.path(),
+            &task,
+            "chat-1",
+            "the prompt",
+            &Run {
+                kind: RunKind::Scheduled,
+                job_id: uuid::Uuid::new_v4().to_string(),
+                started_at,
+            },
+        );
         assert_eq!(job.status, "running");
 
         let stored = tasks::get_job_history(file.path(), &job.id)
@@ -1350,6 +1485,151 @@ mod tests {
             Utc::now() + chrono::Duration::hours(1),
         ));
         assert!(!should_auto_pause(&task));
+    }
+
+    /// #541: a manual run is a *test* of the configuration, so none of the
+    /// schedule's own accounting may move — and the task under test is at its
+    /// `stop_after_count` limit, which is the one a user most wants to try
+    /// again and the one a scheduled fire would auto-pause.
+    ///
+    /// The boundary is constructed rather than approached: `run_count` is set
+    /// **equal** to `stop_after_count`, because `>=` is what
+    /// [`write_run_result`] compares and a task merely near its limit passes
+    /// against a manual run that advances the counters exactly once.
+    #[test]
+    fn a_manual_run_leaves_run_count_the_pause_rule_and_the_row_untouched() {
+        let file = at_its_limit();
+        let scheduler = test_scheduler(file.path());
+        let mut task = tasks::get_task(file.path(), "t1")
+            .expect("read")
+            .expect("row");
+
+        record_failed_run(
+            &scheduler,
+            &mut task,
+            "",
+            "boom",
+            &Run {
+                kind: RunKind::Manual,
+                job_id: "job-manual".to_string(),
+                started_at: Utc::now(),
+            },
+        );
+
+        let stored = tasks::get_task(file.path(), "t1")
+            .expect("read")
+            .expect("row");
+        assert_eq!(stored.run_count, 3, "a manual run spends no budget");
+        assert_eq!(stored.status, "active", "and never auto-pauses the task");
+        assert!(
+            stored.last_run_at.is_none(),
+            "nor claims to be the last run"
+        );
+        assert!(stored.next_run_at.is_none(), "nor shifts the next fire");
+
+        // The other half of the rule: it is still a real run, so it leaves a
+        // job_history row — under the id the route answered with.
+        let job = tasks::get_job_history(file.path(), "job-manual")
+            .expect("read")
+            .expect("row");
+        assert_eq!(job.status, "failed");
+        assert_eq!(job.task_id, "t1");
+    }
+
+    /// The inverse of the test above, over the identical fixture and differing
+    /// only in [`RunKind`] — which is what makes that one a regression guard
+    /// rather than an assertion about a task nothing touched.
+    #[test]
+    fn a_scheduled_run_at_the_same_limit_does_advance_and_auto_pause() {
+        let file = at_its_limit();
+        let scheduler = test_scheduler(file.path());
+        let mut task = tasks::get_task(file.path(), "t1")
+            .expect("read")
+            .expect("row");
+
+        record_failed_run(
+            &scheduler,
+            &mut task,
+            "",
+            "boom",
+            &Run {
+                kind: RunKind::Scheduled,
+                job_id: "job-scheduled".to_string(),
+                started_at: Utc::now(),
+            },
+        );
+
+        let stored = tasks::get_task(file.path(), "t1")
+            .expect("read")
+            .expect("row");
+        assert_eq!(stored.run_count, 4);
+        assert_eq!(stored.status, "paused");
+    }
+
+    /// The third guarded site: the arm `finish` takes when the agent run itself
+    /// failed. Same shape, so a `kind` dropped from any one of the three is
+    /// caught rather than only from the one a single test happened to walk.
+    #[test]
+    fn the_finish_section_honours_the_run_kind_too() {
+        for (kind, expected_count, expected_status) in [
+            (RunKind::Manual, 3, "active"),
+            (RunKind::Scheduled, 4, "paused"),
+        ] {
+            let file = at_its_limit();
+            let scheduler = test_scheduler(file.path());
+            let task = tasks::get_task(file.path(), "t1")
+                .expect("read")
+                .expect("row");
+            let run = Run {
+                kind,
+                job_id: "j1".to_string(),
+                started_at: Utc::now(),
+            };
+            let job = create_initial_job_history(file.path(), &task, "", "p", &run);
+
+            finish(
+                &scheduler,
+                task,
+                job,
+                "",
+                "p",
+                Err("the agent failed".to_string()),
+                &run,
+            );
+
+            let stored = tasks::get_task(file.path(), "t1")
+                .expect("read")
+                .expect("row");
+            assert_eq!(stored.run_count, expected_count, "{kind:?}");
+            assert_eq!(stored.status, expected_status, "{kind:?}");
+            assert_eq!(
+                tasks::get_job_history(file.path(), "j1")
+                    .expect("read")
+                    .expect("row")
+                    .status,
+                "failed",
+                "{kind:?} still records the run"
+            );
+        }
+    }
+
+    /// A task sitting **exactly** on its `stop_after_count`, still `active`.
+    fn at_its_limit() -> tempfile::NamedTempFile {
+        let file = tempfile::NamedTempFile::new().expect("temp file");
+        let mut conn = rusqlite::Connection::open(file.path()).expect("open");
+        crate::native::migrate::apply(&mut conn).expect("migrate");
+        conn.execute(
+            "INSERT INTO scheduled_tasks
+                (id, name, prompt, agent_slug, schedule_type, schedule_config, status,
+                 run_count, stop_after_count, created_at, updated_at)
+             VALUES ('t1','T','p','no-such-agent','interval','{}','active',
+                     3, 3,
+                     '2026-01-01 00:00:00 +0000 UTC','2026-01-01 00:00:00 +0000 UTC')",
+            [],
+        )
+        .expect("seed");
+        drop(conn);
+        file
     }
 
     fn test_scheduler(db_path: &std::path::Path) -> Arc<Scheduler> {

--- a/src-tauri/src/native/schedule/runtime.rs
+++ b/src-tauri/src/native/schedule/runtime.rs
@@ -124,11 +124,113 @@ pub struct Scheduler {
     /// timer, exactly as Go's `executeTask` does — a job whose turn is waiting
     /// still advances its own schedule.
     semaphore: Arc<Semaphore>,
+    /// Task id → how many runs of it are in flight **right now**, in this
+    /// process (#541).
+    ///
+    /// The manual-run route needs to answer "is this task already running?" and
+    /// there was nothing here to ask: `jobs` holds *timers*, not runs, and a
+    /// task's timer exists whether or not it is executing. The durable
+    /// alternative — a `job_history` row still marked `running` — cannot be
+    /// used, because [`super::executor`]'s own header records that a panic in
+    /// `finish` leaves exactly such a row behind with nothing to finish it, so
+    /// a crash would 409 that task for ever.
+    ///
+    /// A **count**, not a set: a scheduled run that outlives its own interval
+    /// overlaps the next one (the semaphore bounds the overlap, it does not
+    /// prevent it), and a set would have the first to finish clear an entry the
+    /// second still owns.
+    ///
+    /// **Both run paths mark; only the manual one refuses.** Scheduled firing is
+    /// untouched by this map — [`Scheduler::mark_running`] always succeeds — so
+    /// nothing about the timer's behaviour changes, while
+    /// [`Scheduler::try_mark_running`] can still see a scheduled run and answer
+    /// the route's 409 honestly.
+    in_flight: Mutex<HashMap<String, usize>>,
+}
+
+/// A run's entry in [`Scheduler::in_flight`], removed when the run ends.
+///
+/// RAII rather than a matching `unmark` call, because a run has many exits —
+/// every early return in the executor, plus a panic inside `db::blocking`,
+/// which is caught by the blocking pool and would otherwise leak the entry and
+/// 409 that task until the app restarts.
+pub struct RunGuard {
+    scheduler: Arc<Scheduler>,
+    task_id: String,
+}
+
+impl Drop for RunGuard {
+    fn drop(&mut self) {
+        let mut in_flight = self
+            .scheduler
+            .in_flight
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        match in_flight.get_mut(&self.task_id) {
+            Some(count) if *count > 1 => *count -= 1,
+            _ => {
+                in_flight.remove(&self.task_id);
+            }
+        }
+    }
 }
 
 impl Scheduler {
     pub fn db_path(&self) -> &Path {
         &self.db_path
+    }
+
+    /// The three-slot execution semaphore, for a caller that is a request
+    /// rather than a timer (#541).
+    ///
+    /// A manual run takes a permit like any other, so a burst of them cannot
+    /// outnumber what the machine was sized for — and so it queues behind the
+    /// scheduled runs already using them rather than beside them.
+    pub fn semaphore(&self) -> Arc<Semaphore> {
+        Arc::clone(&self.semaphore)
+    }
+
+    /// Record that a run of `task_id` has started. Always succeeds.
+    ///
+    /// This is the *scheduled* path's marker: a timer's fire is never refused
+    /// by the in-flight map, it only becomes visible in it.
+    pub fn mark_running(self: &Arc<Self>, task_id: &str) -> RunGuard {
+        *self
+            .in_flight
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .entry(task_id.to_string())
+            .or_insert(0) += 1;
+        RunGuard {
+            scheduler: Arc::clone(self),
+            task_id: task_id.to_string(),
+        }
+    }
+
+    /// Record a run of `task_id`, or `None` when one is already in flight.
+    ///
+    /// The check and the mark are one operation under one lock, which is what
+    /// makes two simultaneous `POST /api/tasks/{id}/run` requests answer one
+    /// `202` and one `409` rather than starting two runs.
+    pub fn try_mark_running(self: &Arc<Self>, task_id: &str) -> Option<RunGuard> {
+        let mut in_flight = self.in_flight.lock().unwrap_or_else(|e| e.into_inner());
+        if in_flight.contains_key(task_id) {
+            return None;
+        }
+        in_flight.insert(task_id.to_string(), 1);
+        drop(in_flight);
+        Some(RunGuard {
+            scheduler: Arc::clone(self),
+            task_id: task_id.to_string(),
+        })
+    }
+
+    /// Whether a run of `task_id` is in flight in this process.
+    pub fn is_running(&self, task_id: &str) -> bool {
+        self.in_flight
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .contains_key(task_id)
     }
 
     /// `ScheduleTask`: add or replace a task's schedule.
@@ -452,6 +554,7 @@ pub fn start(db_path: PathBuf) {
         jobs: Mutex::new(HashMap::new()),
         swept: Mutex::new(HashMap::new()),
         semaphore: Arc::new(Semaphore::new(MAX_CONCURRENCY)),
+        in_flight: Mutex::new(HashMap::new()),
     });
     if RUNNING.set(Arc::clone(&scheduler)).is_err() {
         log::warn!("task scheduler already started; ignoring a second start");
@@ -526,6 +629,7 @@ pub fn detached(db_path: impl Into<PathBuf>) -> Arc<Scheduler> {
         jobs: Mutex::new(HashMap::new()),
         swept: Mutex::new(HashMap::new()),
         semaphore: Arc::new(Semaphore::new(MAX_CONCURRENCY)),
+        in_flight: Mutex::new(HashMap::new()),
     })
 }
 
@@ -640,6 +744,7 @@ mod tests {
             jobs: Mutex::new(HashMap::new()),
             swept: Mutex::new(HashMap::new()),
             semaphore: Arc::new(Semaphore::new(MAX_CONCURRENCY)),
+            in_flight: Mutex::new(HashMap::new()),
         });
         let task = ScheduledTask {
             id: "legacy".to_string(),

--- a/src-tauri/src/native/tasks.rs
+++ b/src-tauri/src/native/tasks.rs
@@ -2244,7 +2244,8 @@ fn resume_task(db_path: &Path, id: &str) -> Result<super::Answer, WriteError> {
 /// - **It answers within a request round-trip.** `Endpoint::serve` is a sync
 ///   `fn` on `spawn_blocking` and a run reaches 240 minutes, so the run is
 ///   spawned and the response is built here. `202 Accepted` carries the
-///   `job_history` id the run will write, so a caller can navigate to it.
+///   `job_history` id the run will write — see [`TaskRunStarted`] for why that
+///   row may not exist yet.
 /// - **It refuses a second concurrent run of the same task**, `409`, through
 ///   the scheduler's in-flight map — claimed *here*, under one lock, so two
 ///   simultaneous requests answer one `202` and one `409` rather than both
@@ -2317,10 +2318,17 @@ fn start_manual_run(
 
 /// The `202` body of `POST /api/tasks/{id}/run`.
 ///
-/// The job id is the row the run is about to write, not one that already
-/// exists: the row is created inside the run's own preparation, milliseconds
-/// later. Answering with it is what lets the UI point at the run it just
-/// started (#542) without polling for a row it has no way to recognise.
+/// **The job id names a row that does not exist yet**, and a caller has to
+/// tolerate that rather than assume a short window. The row is written by the
+/// run's own preparation, and the run first waits for one of the scheduler's
+/// three permits — so with three long runs already going (they reach 240
+/// minutes) `GET /api/job-history/{job_id}` answers 404 until one of them ends.
+/// That is a property of the queue, not a race to lose.
+///
+/// It is still worth answering with, because it is the only thing that makes
+/// the started run *identifiable*: the alternative is a caller diffing the
+/// history list and guessing which row is its own. Navigation on top of it
+/// (#542) has to treat "not there yet" as a state rather than an error.
 #[derive(Serialize)]
 struct TaskRunStarted<'a> {
     job_id: &'a str,

--- a/src-tauri/src/native/tasks.rs
+++ b/src-tauri/src/native/tasks.rs
@@ -387,6 +387,16 @@ fn page_offset(query: &str) -> i64 {
 
 // ─── The seam ─────────────────────────────────────────────────────────────────
 
+/// The routes here that exist **only** in the desktop build (#541).
+///
+/// The third owner of `parity/desktop_routes.json`, whose assertion is set
+/// equality over the union of every owner's const — so this list and that file
+/// move together or `the_desktop_only_routes_are_recorded_in_both_directions`
+/// fails. Everything else this module claims came from Go and is recorded in
+/// `read_routes.json` / `write_routes.json`, which are frozen records of Go's
+/// surface and cannot carry a route Go never had.
+pub const ROUTES: &[(&str, &str)] = &[("POST", "/api/tasks/{id}/run")];
+
 /// This module's entry in `native::ENDPOINTS`.
 pub const ENDPOINT: super::Endpoint = super::Endpoint {
     name: "tasks",
@@ -400,6 +410,7 @@ enum Route<'a> {
     Task(&'a str),
     TaskPause(&'a str),
     TaskResume(&'a str),
+    TaskRun(&'a str),
     TaskJobHistory(&'a str),
     JobHistoryList,
     JobHistory(&'a str),
@@ -422,7 +433,10 @@ fn claims(method: &Method, path: &str) -> bool {
         // again the same edit.
         Method::POST => matches!(
             route_of(path),
-            Some(Route::TaskList) | Some(Route::TaskPause(_)) | Some(Route::TaskResume(_))
+            Some(Route::TaskList)
+                | Some(Route::TaskPause(_))
+                | Some(Route::TaskResume(_))
+                | Some(Route::TaskRun(_))
         ),
         Method::PUT => matches!(route_of(path), Some(Route::Task(_))),
         Method::DELETE => matches!(
@@ -437,7 +451,7 @@ fn claims(method: &Method, path: &str) -> bool {
 ///
 /// The ids are single segments, so `/api/tasks/{id}/pause` and `/resume` cannot
 /// be swallowed by the `/api/tasks/{id}` arm, and an empty id is not a match
-/// because chi routes `/api/tasks/` to nothing. The three suffixed forms are
+/// because chi routes `/api/tasks/` to nothing. The four suffixed forms are
 /// checked before the bare one for the same reason.
 fn route_of(path: &str) -> Option<Route<'_>> {
     if path == "/api/tasks" {
@@ -458,6 +472,9 @@ fn route_of(path: &str) -> Option<Route<'_>> {
         }
         if let Some(id) = rest.strip_suffix("/resume") {
             return segment(id).map(Route::TaskResume);
+        }
+        if let Some(id) = rest.strip_suffix("/run") {
+            return segment(id).map(Route::TaskRun);
         }
         return segment(rest).map(Route::Task);
     }
@@ -482,6 +499,7 @@ fn serve(ctx: &super::Ctx, req: &super::Request) -> Result<super::Answer, String
         (Method::POST, Some(Route::TaskList)) => finish(create_task(db, req.body)),
         (Method::POST, Some(Route::TaskPause(id))) => finish(pause_task(db, id)),
         (Method::POST, Some(Route::TaskResume(id))) => finish(resume_task(db, id)),
+        (Method::POST, Some(Route::TaskRun(id))) => finish(run_task_now(id)),
         (Method::PUT, Some(Route::Task(id))) => finish(update_task(db, id, req.body)),
         (Method::GET, _) => serve_read(ctx, req),
         _ => Err(format!("{} {} is not ported", req.method, req.path)),
@@ -523,10 +541,10 @@ fn serve_read(ctx: &super::Ctx, req: &super::Request) -> Result<super::Answer, S
             None => return Err(format!("job history {id:?} not found")),
         },
 
-        // The two POST-only paths reach `serve_read` from nowhere — `serve`
+        // The three POST-only paths reach `serve_read` from nowhere — `serve`
         // routes them by method first — so this arm is the same "not a read"
         // answer the `None` arm gives.
-        Some(Route::TaskPause(_)) | Some(Route::TaskResume(_)) | None => {
+        Some(Route::TaskPause(_)) | Some(Route::TaskResume(_)) | Some(Route::TaskRun(_)) | None => {
             return Err(format!("{} is not a task read", req.path))
         }
     };
@@ -1512,6 +1530,7 @@ mod tests {
         assert!(claims(&Method::DELETE, "/api/tasks/t1"));
         assert!(claims(&Method::POST, "/api/tasks/t1/pause"));
         assert!(claims(&Method::POST, "/api/tasks/t1/resume"));
+        assert!(claims(&Method::POST, "/api/tasks/t1/run"));
 
         // Mounted paths this module must *not* answer for the wrong method —
         // chi would 405, and claiming one would turn that into a native error.
@@ -1520,7 +1539,88 @@ mod tests {
         assert!(!claims(&Method::POST, "/api/tasks/t1"));
         assert!(!claims(&Method::POST, "/api/job-history"));
         assert!(!claims(&Method::PUT, "/api/tasks/t1/pause"));
+        assert!(!claims(&Method::GET, "/api/tasks/t1/run"));
+        assert!(!claims(&Method::DELETE, "/api/tasks/t1/run"));
         assert!(!claims(&Method::PATCH, "/api/tasks/t1"));
+    }
+
+    /// #541. Driven through [`start_manual_run`] rather than [`run_task_now`],
+    /// because `running()` reads the process-wide `OnceLock` a test may not
+    /// install; `detached` is the same `Scheduler` without it.
+    #[tokio::test]
+    async fn a_manual_run_is_accepted_for_any_task_and_answers_with_its_job_id() {
+        crate::native::writes::testlog::install();
+        let file = migrated();
+        // An agent that resolves to nothing, so the spawned run fails at
+        // `resolve_agent` and never reaches a subprocess. What is under test is
+        // the route's answer, not the run.
+        let task = created(
+            &file,
+            r#"{"name":"n","prompt":"p","agent_slug":"no-such-agent"}"#,
+        );
+        // **Paused**, which is most of the point: the one control the product
+        // had made a task un-runnable, and this route has to ignore it.
+        pause_task(file.path(), &task.id).expect("pause");
+
+        let scheduler = crate::native::schedule::runtime::detached(file.path());
+        let answer = start_manual_run(&scheduler, &task.id).expect("run");
+        assert_eq!(answer.status, StatusCode::ACCEPTED);
+
+        let body: serde_json::Value =
+            serde_json::from_slice(&answer.body.expect("body")).expect("json");
+        assert_eq!(body["task_id"], serde_json::json!(task.id));
+        let job_id = body["job_id"].as_str().expect("job_id").to_string();
+        assert!(!job_id.is_empty());
+
+        crate::native::writes::testlog::assert_info_once(&format!(
+            r#"task run started id={:?} job_id={job_id:?}"#,
+            task.id
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_manual_run_of_an_unknown_task_is_404() {
+        let file = migrated();
+        let scheduler = crate::native::schedule::runtime::detached(file.path());
+        let err = start_manual_run(&scheduler, "nope").unwrap_err();
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+        assert_eq!(err.message(), r#"task "nope" not found"#);
+    }
+
+    /// The 409, driven off the in-flight map directly: holding the guard is
+    /// exactly the state a run in flight leaves behind, and it is the only way
+    /// to assert the refusal without racing a background run to finish.
+    #[tokio::test]
+    async fn a_second_manual_run_while_one_is_in_flight_is_409() {
+        let file = migrated();
+        let task = created(
+            &file,
+            r#"{"name":"n","prompt":"p","agent_slug":"no-such-agent"}"#,
+        );
+        let scheduler = crate::native::schedule::runtime::detached(file.path());
+
+        let guard = scheduler.mark_running(&task.id);
+        let err = start_manual_run(&scheduler, &task.id).unwrap_err();
+        assert_eq!(err.status(), StatusCode::CONFLICT);
+        assert_eq!(err.message(), "a run of this task is already in progress");
+        // A *different* task is unaffected — the map is per task, not a lock on
+        // the scheduler.
+        let other = created(
+            &file,
+            r#"{"name":"o","prompt":"p","agent_slug":"no-such-agent"}"#,
+        );
+        assert_eq!(
+            start_manual_run(&scheduler, &other.id).expect("run").status,
+            StatusCode::ACCEPTED
+        );
+
+        // And the refusal lifts when the run ends.
+        drop(guard);
+        assert!(!scheduler.is_running(&task.id));
+        assert_eq!(
+            start_manual_run(&scheduler, &task.id).expect("run").status,
+            StatusCode::ACCEPTED
+        );
     }
 
     /// #335: the two job-history deletes, which are all this module claims.
@@ -2128,6 +2228,103 @@ fn resume_task(db_path: &Path, id: &str) -> Result<super::Answer, WriteError> {
     log::info!("task resumed id={id:?}");
     super::schedule::runtime::schedule_if_running(&task, "resumed");
     encode_task(&task)
+}
+
+/// `POST /api/tasks/{id}/run` (#541): fire a task now, whatever its schedule
+/// says.
+///
+/// **This route has no Go ancestor.** Nothing in the product could run a
+/// configured task on demand; the only way to make one fire was to change its
+/// schedule type to `run_immediately`, i.e. destroy the schedule under test in
+/// order to test it once. See `ROUTES` for where it is recorded.
+///
+/// Four properties, each of which is the whole point of one of the issue's
+/// acceptance criteria:
+///
+/// - **It answers within a request round-trip.** `Endpoint::serve` is a sync
+///   `fn` on `spawn_blocking` and a run reaches 240 minutes, so the run is
+///   spawned and the response is built here. `202 Accepted` carries the
+///   `job_history` id the run will write, so a caller can navigate to it.
+/// - **It refuses a second concurrent run of the same task**, `409`, through
+///   the scheduler's in-flight map — claimed *here*, under one lock, so two
+///   simultaneous requests answer one `202` and one `409` rather than both
+///   passing a check and then both starting.
+/// - **A paused task is runnable**, and so is one past its `stop_after_count`.
+///   [`super::schedule::executor::run_manual`] deliberately does not go through
+///   `due_task`.
+/// - **It changes nothing about the schedule.** See [`RunKind::Manual`].
+fn run_task_now(id: &str) -> Result<super::Answer, WriteError> {
+    let Some(scheduler) = super::schedule::runtime::running() else {
+        // No scheduler means no database (`shell_owns_scheduler`), which is not
+        // a state a shipped build reaches — every other write here would have
+        // answered 500 for the same reason.
+        return Err(WriteError::Fallback(
+            "the task scheduler is not running".to_string(),
+        ));
+    };
+    start_manual_run(&scheduler, id)
+}
+
+/// [`run_task_now`] against a scheduler the caller supplies, so the tests can
+/// drive it without the process-wide `OnceLock`.
+///
+/// The task is read through **the scheduler's** database rather than the
+/// request context's. They are the same file in this process, and taking it
+/// from one place is what stops the `404` check and the run itself from ever
+/// disagreeing about which row is meant.
+fn start_manual_run(
+    scheduler: &std::sync::Arc<super::schedule::runtime::Scheduler>,
+    id: &str,
+) -> Result<super::Answer, WriteError> {
+    let Some(task) = get_task(scheduler.db_path(), id).map_err(WriteError::Fallback)? else {
+        return Err(WriteError::NotFound {
+            resource: "task".to_string(),
+            id: id.to_string(),
+        });
+    };
+
+    let Some(guard) = scheduler.try_mark_running(id) else {
+        return Err(WriteError::ConflictMessage(
+            "a run of this task is already in progress".to_string(),
+        ));
+    };
+
+    let job_id = uuid::Uuid::new_v4().to_string();
+    // Built before anything is spawned: the write-path rule is that nothing
+    // fallible may sit after the effect, and here the effect is a subprocess
+    // rather than a commit.
+    let body = super::gojson::to_vec(&TaskRunStarted {
+        job_id: &job_id,
+        task_id: id,
+    })
+    .map_err(|e| WriteError::Fallback(format!("encoding task run: {e}")))?;
+
+    let Ok(handle) = tokio::runtime::Handle::try_current() else {
+        return Err(WriteError::Fallback(
+            "no tokio runtime to start a manual task run on".to_string(),
+        ));
+    };
+    handle.spawn(super::schedule::executor::run_manual(
+        std::sync::Arc::clone(scheduler),
+        task,
+        job_id.clone(),
+        guard,
+    ));
+
+    log::info!("task run started id={id:?} job_id={job_id:?}");
+    Ok(super::Answer::json_status(StatusCode::ACCEPTED, body))
+}
+
+/// The `202` body of `POST /api/tasks/{id}/run`.
+///
+/// The job id is the row the run is about to write, not one that already
+/// exists: the row is created inside the run's own preparation, milliseconds
+/// later. Answering with it is what lets the UI point at the run it just
+/// started (#542) without polling for a row it has no way to recognise.
+#[derive(Serialize)]
+struct TaskRunStarted<'a> {
+    job_id: &'a str,
+    task_id: &'a str,
 }
 
 /// The read-modify-write both status actions share, in one transaction.

--- a/src-tauri/src/native/writes.rs
+++ b/src-tauri/src/native/writes.rs
@@ -54,6 +54,16 @@ pub enum WriteError {
     Validation { field: String, message: String },
     /// `service.ConflictError` → 409.
     Conflict { resource: String, id: String },
+    /// A 409 whose body is a fixed string rather than `ConflictError`'s
+    /// wording, for a conflict that is not "this already exists".
+    ///
+    /// [`Self::Conflict`] renders `<resource> with id "<id>" already exists`,
+    /// which is the only thing Go's service layer ever raised a 409 for.
+    /// `POST /api/tasks/{id}/run` (#541) has no Go ancestor and its conflict is
+    /// temporal — a run of that task is in flight — so the existence wording
+    /// would be a plain lie about a task that exists and is fine.
+    /// [`Self::NotFoundMessage`] is the same escape hatch one status up.
+    ConflictMessage(String),
     /// `service.NotFoundError` → 404, formatted as that error formats.
     NotFound { resource: String, id: String },
     /// A 404 whose body is a fixed string rather than the service error's
@@ -109,7 +119,7 @@ impl WriteError {
         match self {
             Self::InvalidBody | Self::BadRequest(_) => StatusCode::BAD_REQUEST,
             Self::Validation { .. } => StatusCode::UNPROCESSABLE_ENTITY,
-            Self::Conflict { .. } => StatusCode::CONFLICT,
+            Self::Conflict { .. } | Self::ConflictMessage(_) => StatusCode::CONFLICT,
             Self::NotFound { .. } | Self::NotFoundMessage(_) => StatusCode::NOT_FOUND,
             Self::Forbidden(_) => StatusCode::FORBIDDEN,
             Self::NotImplemented(_) => StatusCode::NOT_IMPLEMENTED,
@@ -139,6 +149,7 @@ impl WriteError {
             }
             // `service.NotFoundError.Error()`.
             Self::NotFound { resource, id } => format!("{resource} {:?} not found", id),
+            Self::ConflictMessage(m) => m.clone(),
             Self::NotFoundMessage(m) => m.clone(),
             Self::Forbidden(m) => m.clone(),
             Self::NotImplemented(m) => m.clone(),

--- a/src-tauri/tests/scheduled_run.rs
+++ b/src-tauri/tests/scheduled_run.rs
@@ -230,6 +230,102 @@ async fn a_scheduled_run_records_a_successful_job_and_persists_its_chat() {
     assert_eq!(task.status, "active", "a cron task keeps running");
 }
 
+/// #541, end to end: a **paused** task, sitting **at** its `stop_after_count`,
+/// run on demand.
+///
+/// Both halves of the acceptance criteria in one pass, because they pull
+/// against each other: the run must be as complete as a scheduled one (a
+/// `job_history` row with the answer and the token counts, a persisted chat)
+/// while changing nothing the schedule owns. The fixture is the state a timer
+/// refuses outright — `execute_task` on this row returns silently, which the
+/// first assertion pins — so nothing here can pass by accident on the scheduled
+/// path.
+#[tokio::test]
+async fn a_manual_run_fires_a_paused_task_at_its_limit_and_moves_no_counter() {
+    if python3().is_none() {
+        eprintln!("skipping: no python3 to script the fake CLI");
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = dir.path().join("agento.db");
+    let task_id = migrated_with_task(&db, "cron", true);
+    {
+        let conn = rusqlite::Connection::open(&db).expect("open");
+        conn.execute(
+            "UPDATE scheduled_tasks
+                SET status = 'paused', run_count = 2, stop_after_count = 2
+              WHERE id = ?1",
+            [&task_id],
+        )
+        .expect("park the task on its limit");
+    }
+
+    let cli = fake_cli(
+        dir.path(),
+        r#"        raw('{"type":"result","subtype":"success","is_error":false,"result":"tried it","session_id":"sdk-manual-1","usage":{"input_tokens":5,"output_tokens":6}}')"#,
+    );
+
+    let _env = env_lock().lock().await;
+    std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", &cli);
+
+    let scheduler = agento_lib::native::schedule::runtime::detached(&db);
+
+    // The timer path declines this row, silently and with no row — which is
+    // exactly the gap the manual route exists to fill.
+    agento_lib::native::schedule::executor::execute_task(&scheduler, &task_id).await;
+    assert!(
+        job_rows(&db).is_empty(),
+        "a paused task is not due; nothing may be recorded for it"
+    );
+
+    let guard = scheduler
+        .try_mark_running(&task_id)
+        .expect("nothing is in flight");
+    assert!(
+        scheduler.try_mark_running(&task_id).is_none(),
+        "and a second claim on the same task is refused, which is the route's 409"
+    );
+    agento_lib::native::schedule::executor::run_manual(
+        std::sync::Arc::clone(&scheduler),
+        agento_lib::native::tasks::get_task(&db, &task_id)
+            .expect("read")
+            .expect("row"),
+        "job-manual-1".to_string(),
+        guard,
+    )
+    .await;
+
+    // As useful as a scheduled run's: status, output and usage all present,
+    // under the id the route would have answered with.
+    let jobs = job_rows(&db);
+    assert_eq!(jobs.len(), 1, "the manual run is recorded: {jobs:?}");
+    let (status, error, response, input, output) = &jobs[0];
+    assert_eq!(status, "success", "error was {error:?}");
+    assert_eq!(response, "tried it");
+    assert_eq!((*input, *output), (5, 6));
+    {
+        let conn = rusqlite::Connection::open(&db).expect("open");
+        let id: String = conn
+            .query_row("SELECT id FROM job_history", [], |r| r.get(0))
+            .expect("the job row");
+        assert_eq!(id, "job-manual-1", "the route's id is the row's id");
+    }
+    assert_eq!(session_count(&db), 1, "and the chat is persisted");
+
+    // …and the schedule is exactly where it was.
+    let task = agento_lib::native::tasks::get_task(&db, &task_id)
+        .expect("read")
+        .expect("row");
+    assert_eq!(task.run_count, 2, "no budget spent");
+    assert_eq!(task.status, "paused", "still paused; nothing resumed it");
+    assert!(task.last_run_at.is_none(), "not the schedule's last run");
+    assert!(task.last_run_status.is_empty());
+    assert!(task.next_run_at.is_none(), "the next fire has not moved");
+
+    // The guard went with the run, so the task is runnable again.
+    assert!(!scheduler.is_running(&task_id));
+}
+
 #[tokio::test]
 async fn an_error_result_is_a_failed_job_with_gos_wording() {
     if python3().is_none() {

--- a/src-tauri/tests/scheduled_run.rs
+++ b/src-tauri/tests/scheduled_run.rs
@@ -326,6 +326,68 @@ async fn a_manual_run_fires_a_paused_task_at_its_limit_and_moves_no_counter() {
     assert!(!scheduler.is_running(&task_id));
 }
 
+/// #541: a task deleted while its manual run waited for a permit is not run.
+///
+/// The wait is for one of three slots that a 240-minute run can hold, so this
+/// window is not the timer's milliseconds — and `job_history.task_id` cascades
+/// from `scheduled_tasks`, so running anyway would spawn the agent and then
+/// fail to insert the row that explains it. `execute_task` gets this from
+/// `due_task`'s vanished-row arm; `run_manual` skips `due_task` and has to
+/// re-read for itself.
+#[tokio::test]
+async fn a_manual_run_whose_task_was_deleted_while_it_queued_does_not_run() {
+    if python3().is_none() {
+        eprintln!("skipping: no python3 to script the fake CLI");
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = dir.path().join("agento.db");
+    let task_id = migrated_with_task(&db, "cron", true);
+
+    let cli = fake_cli(
+        dir.path(),
+        r#"        raw('{"type":"result","subtype":"success","is_error":false,"result":"ran anyway","session_id":"sdk-ghost","usage":{}}')"#,
+    );
+
+    let _env = env_lock().lock().await;
+    std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", &cli);
+
+    let scheduler = agento_lib::native::schedule::runtime::detached(&db);
+    let task = agento_lib::native::tasks::get_task(&db, &task_id)
+        .expect("read")
+        .expect("row");
+    let guard = scheduler
+        .try_mark_running(&task_id)
+        .expect("nothing is in flight");
+
+    // The row goes after the route read it and before the run reaches the
+    // database — which is exactly what the permit wait makes reachable.
+    {
+        let conn = rusqlite::Connection::open(&db).expect("open");
+        conn.execute("DELETE FROM scheduled_tasks WHERE id = ?1", [&task_id])
+            .expect("delete");
+    }
+
+    agento_lib::native::schedule::executor::run_manual(
+        std::sync::Arc::clone(&scheduler),
+        task,
+        "job-ghost".to_string(),
+        guard,
+    )
+    .await;
+
+    assert!(
+        job_rows(&db).is_empty(),
+        "nothing ran, so there is nothing to record"
+    );
+    assert_eq!(
+        session_count(&db),
+        0,
+        "and no chat session was created for a task that is gone"
+    );
+    assert!(!scheduler.is_running(&task_id), "the guard was released");
+}
+
 #[tokio::test]
 async fn an_error_result_is_a_failed_job_with_gos_wording() {
     if python3().is_none() {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -214,6 +214,12 @@ export interface ScheduledTask {
   updated_at: string;
 }
 
+/** The `202` body of `POST /api/tasks/{id}/run` (#541). */
+export interface TaskRunStarted {
+  job_id: string;
+  task_id: string;
+}
+
 export interface JobHistory {
   id: string;
   task_id: string;

--- a/src/views/TasksView.tsx
+++ b/src/views/TasksView.tsx
@@ -178,7 +178,18 @@ export function TasksView({ inspectorOpen }: { inspectorOpen: boolean }) {
    * verb into it would widen that problem; a run also has to disable a
    * different button from the one a save disables.
    */
-  const [running, setRunning] = useState(false);
+  const [starting, setStarting] = useState(false);
+  /**
+   * The `job_history` id the last **Run now** answered with, held until that
+   * row reaches a terminal status (#541).
+   *
+   * `starting` covers the *request*, which returns in milliseconds; the run
+   * itself waits for one of the scheduler's three permits and can then take
+   * hours, so clearing on the response would put the button back to "Run now"
+   * while the run it started had not begun. The row may not exist yet either,
+   * which is why "unknown id" reads as in flight rather than as finished.
+   */
+  const [startedJobId, setStartedJobId] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string>();
   const [confirmDelete, setConfirmDelete] = useState(false);
 
@@ -218,6 +229,25 @@ export function TasksView({ inspectorOpen }: { inspectorOpen: boolean }) {
     [selectedId, creating]
   );
   usePoll(historyRes.reload, POLL_MS, !!selectedId && !creating);
+
+  const startedJob = useMemo(
+    () =>
+      startedJobId
+        ? (historyRes.data ?? []).find((j) => j.id === startedJobId)
+        : undefined,
+    [historyRes.data, startedJobId]
+  );
+  /** The started run has landed and finished, so the button is free again. */
+  useEffect(() => {
+    if (startedJob && startedJob.status !== "running") setStartedJobId(null);
+  }, [startedJob]);
+  /** Selecting another task drops the previous one's pending run. */
+  useEffect(() => {
+    setStartedJobId(null);
+  }, [selectedId]);
+
+  /** The request, or the run it started — either shuts the action strip. */
+  const runInFlight = starting || startedJobId !== null;
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -296,23 +326,26 @@ export function TasksView({ inspectorOpen }: { inspectorOpen: boolean }) {
    * mistaken for, now its own labelled control beside the one that means
    * *enabled*.
    *
-   * The route answers `202` as soon as the run is started, so there is nothing
-   * to await beyond that: the run itself lands in the history below (and in the
-   * Jobs section), which `historyRes` is already polling. It deliberately does
-   * not reload `tasksRes` — a manual run changes nothing about the task row,
-   * which is the whole point of it.
+   * The route answers `202` as soon as the run is *accepted*, which is not the
+   * same as started — so the id it answers with is kept, and the strip stays
+   * shut until that row turns up in the history below with a terminal status.
+   * `historyRes` is already polling, so nothing new has to be scheduled here.
+   *
+   * It deliberately does not reload `tasksRes` — a manual run changes nothing
+   * about the task row, which is the whole point of it.
    */
   async function runNow() {
     if (!draft?.id) return;
-    setRunning(true);
+    setStarting(true);
     setActionError(undefined);
     try {
-      await api.post<TaskRunStarted>(`/tasks/${draft.id}/run`);
+      const started = await api.post<TaskRunStarted>(`/tasks/${draft.id}/run`);
+      setStartedJobId(started?.job_id ?? null);
       historyRes.reload();
     } catch (err) {
       setActionError(describeError(err));
     } finally {
-      setRunning(false);
+      setStarting(false);
     }
   }
 
@@ -462,13 +495,14 @@ export function TasksView({ inspectorOpen }: { inspectorOpen: boolean }) {
                   <button
                     className="btn btn--primary"
                     onClick={save}
-                    disabled={busy || running || (!dirty && !creating)}
+                    disabled={busy || runInFlight || (!dirty && !creating)}
                   >
                     {/* Never the in-flight label: this view's `busy` is shared
                         with pause/resume and delete, so passing it here would
                         make the submit read "Saving…" while an unrelated
                         request runs. The disabled state already covers that
-                        case, and `running` joins it for the same reason. */}
+                        case, and `runInFlight` joins it for the same
+                        reason. */}
                     {submitLabel(creating, false)}
                   </button>
                   {!creating && (
@@ -483,23 +517,27 @@ export function TasksView({ inspectorOpen }: { inspectorOpen: boolean }) {
                           a `+`: both act on a record that already exists, which
                           is the rule in CLAUDE.md → *A form's actions are a
                           fixed grammar*. */}
-                      {/* Disabled while the draft is dirty, which `save`
-                          above is too. The run reads the stored *row* — the
-                          route never sees the draft — so running with unsaved
-                          edits would test the previous configuration and file a
-                          job_history row that reads as a test of what is on
-                          screen. Save is right there and already enabled. */}
+                      {/* Disabled while the draft is dirty — which is exactly
+                          when `save` above is enabled. The run reads the stored
+                          *row*; the route never sees the draft, so running with
+                          unsaved edits would test the previous configuration
+                          and file a job_history row that reads as a test of
+                          what is on screen. */}
                       <button
                         className="btn"
                         onClick={runNow}
-                        disabled={busy || running || dirty}
+                        disabled={busy || runInFlight || dirty}
                       >
-                        {running ? "Starting…" : "Run now"}
+                        {starting
+                          ? "Starting…"
+                          : startedJobId
+                            ? "Running…"
+                            : "Run now"}
                       </button>
                       <button
                         className="btn"
                         onClick={toggleStatus}
-                        disabled={busy || running}
+                        disabled={busy || runInFlight}
                       >
                         {draft.status === "active" ? "Disable" : "Enable"}
                       </button>
@@ -553,7 +591,14 @@ export function TasksView({ inspectorOpen }: { inspectorOpen: boolean }) {
                       label="Enabled"
                       help="Paused tasks keep their history but never fire."
                     >
-                      <Switch on={draft.status === "active"} onChange={toggleStatus} />
+                      {/* The same guard as the toolbar's twin above: both
+                          drive `toggleStatus`, so one of them staying live
+                          during a write would be the asymmetry, not a mercy. */}
+                      <Switch
+                        on={draft.status === "active"}
+                        onChange={toggleStatus}
+                        disabled={busy || runInFlight}
+                      />
                     </FormRow>
                   )}
                 </div>

--- a/src/views/TasksView.tsx
+++ b/src/views/TasksView.tsx
@@ -483,7 +483,17 @@ export function TasksView({ inspectorOpen }: { inspectorOpen: boolean }) {
                           a `+`: both act on a record that already exists, which
                           is the rule in CLAUDE.md → *A form's actions are a
                           fixed grammar*. */}
-                      <button className="btn" onClick={runNow} disabled={busy || running}>
+                      {/* Disabled while the draft is dirty, which `save`
+                          above is too. The run reads the stored *row* — the
+                          route never sees the draft — so running with unsaved
+                          edits would test the previous configuration and file a
+                          job_history row that reads as a test of what is on
+                          screen. Save is right there and already enabled. */}
+                      <button
+                        className="btn"
+                        onClick={runNow}
+                        disabled={busy || running || dirty}
+                      >
                         {running ? "Starting…" : "Run now"}
                       </button>
                       <button

--- a/src/views/TasksView.tsx
+++ b/src/views/TasksView.tsx
@@ -6,6 +6,7 @@ import type {
   ScheduleConfig,
   ScheduleType,
   ScheduledTask,
+  TaskRunStarted,
 } from "../lib/types";
 import { describeError, usePoll, useResource } from "../lib/hooks";
 import { DESTROY, partnerLabel, submitLabel } from "../lib/formVerbs";
@@ -169,6 +170,15 @@ export function TasksView({ inspectorOpen }: { inspectorOpen: boolean }) {
   const [draft, setDraft] = useState<ScheduledTask | null>(null);
   const [dirty, setDirty] = useState(false);
   const [busy, setBusy] = useState(false);
+  /**
+   * Starting a manual run, kept **separate from `busy`** (#541).
+   *
+   * `busy` is already shared by save, pause/resume and delete, which is why the
+   * submit button below cannot use it as an in-flight label. Folding a third
+   * verb into it would widen that problem; a run also has to disable a
+   * different button from the one a save disables.
+   */
+  const [running, setRunning] = useState(false);
   const [actionError, setActionError] = useState<string>();
   const [confirmDelete, setConfirmDelete] = useState(false);
 
@@ -279,6 +289,31 @@ export function TasksView({ inspectorOpen }: { inspectorOpen: boolean }) {
     }
     setDirty(false);
     setActionError(undefined);
+  }
+
+  /**
+   * `POST /api/tasks/{id}/run` (#541) — the verb the ▶ glyph used to be
+   * mistaken for, now its own labelled control beside the one that means
+   * *enabled*.
+   *
+   * The route answers `202` as soon as the run is started, so there is nothing
+   * to await beyond that: the run itself lands in the history below (and in the
+   * Jobs section), which `historyRes` is already polling. It deliberately does
+   * not reload `tasksRes` — a manual run changes nothing about the task row,
+   * which is the whole point of it.
+   */
+  async function runNow() {
+    if (!draft?.id) return;
+    setRunning(true);
+    setActionError(undefined);
+    try {
+      await api.post<TaskRunStarted>(`/tasks/${draft.id}/run`);
+      historyRes.reload();
+    } catch (err) {
+      setActionError(describeError(err));
+    } finally {
+      setRunning(false);
+    }
   }
 
   async function toggleStatus() {
@@ -427,27 +462,36 @@ export function TasksView({ inspectorOpen }: { inspectorOpen: boolean }) {
                   <button
                     className="btn btn--primary"
                     onClick={save}
-                    disabled={busy || (!dirty && !creating)}
+                    disabled={busy || running || (!dirty && !creating)}
                   >
                     {/* Never the in-flight label: this view's `busy` is shared
-                        with pause/resume, so passing it here would make the
-                        submit read "Saving…" while an unrelated request runs.
-                        The disabled state already covers that case. */}
+                        with pause/resume and delete, so passing it here would
+                        make the submit read "Saving…" while an unrelated
+                        request runs. The disabled state already covers that
+                        case, and `running` joins it for the same reason. */}
                     {submitLabel(creating, false)}
                   </button>
                   {!creating && (
                     <>
                       <div className="toolbar__sep" />
+                      {/* Two verbs, two words. This strip used to carry one
+                          ▶/⏸ icon button whose only affordance was a `title`,
+                          and ▶ is the universal *execute* glyph — so the one
+                          control that meant "enabled" was drawn as the one that
+                          means "run", and the run it was mistaken for did not
+                          exist anywhere in the product (#541). Neither carries
+                          a `+`: both act on a record that already exists, which
+                          is the rule in CLAUDE.md → *A form's actions are a
+                          fixed grammar*. */}
+                      <button className="btn" onClick={runNow} disabled={busy || running}>
+                        {running ? "Starting…" : "Run now"}
+                      </button>
                       <button
-                        className="iconbtn"
-                        title={draft.status === "active" ? "Pause" : "Resume"}
+                        className="btn"
                         onClick={toggleStatus}
-                        disabled={busy}
+                        disabled={busy || running}
                       >
-                        <Icon
-                          name={draft.status === "active" ? "pause" : "play"}
-                          size={14}
-                        />
+                        {draft.status === "active" ? "Disable" : "Enable"}
                       </button>
                       <button
                         className="iconbtn"


### PR DESCRIPTION
Closes #541

## What

Two problems on one control strip in the Tasks toolbar, fixed together.

**The ambiguity.** The strip carried a single `iconbtn` whose icon was ▶/⏸ and whose only affordance was a `title` tooltip. It toggled `status` between `active` and `paused` — but ▶ is the universal *execute* glyph, so the one control meaning "enabled" was drawn as the one meaning "run". It is now two labelled buttons: **Run now** and **Enable**/**Disable**. Neither carries a `+` (CLAUDE.md → *A form's actions are a fixed grammar*).

**The absence.** Nothing in the product could run a configured task on demand. The only way to make one fire was to change its schedule type to `run_immediately` — a one-time job at `now + 2s` — i.e. destroy the schedule you had just configured in order to test it once. `POST /api/tasks/{id}/run` is the new route.

## How

- **`native/tasks.rs`** claims `POST /api/tasks/{id}/run` and gains `pub const ROUTES`. The route has no Go ancestor, so it is recorded in `parity/desktop_routes.json` — **not** in the frozen `write_routes.json` — and `native/mod.rs`'s set-equality union gains `tasks::ROUTES` as its third owner.
- **The handler answers, it does not run.** `Endpoint::serve` is a sync `fn` on `spawn_blocking` and a run reaches 240 minutes, so it looks the task up, claims the in-flight slot, builds the body, spawns and returns `202`. The body carries the `job_history` id the run will write, so a caller can navigate to it (#542).
- **`executor::run_manual`** is `execute_task` minus exactly two things, both deliberate:
  - `due_task` is not consulted, so a **paused** task and one past its `stop_after_count` are both runnable — which is most of the point. (`due_task` refuses both *silently*, with no `job_history` row: right for a timer nobody asked to fire, wrong for a button somebody pressed.)
  - `update_task_after_run` is skipped, via `RunKind::Manual`. `run_count`, `last_run_at`, `last_run_status` and the two auto-pause rules belong to the *schedule*; a manual run is a test of the configuration and must not spend a user's budget or shift the next fire. `next_run_at` needs no special handling — nothing on the run path writes it.
  Everything else is identical, including the module's rule that **every path ends in a `job_history` row**.
- **The `409`** comes from a new refcounted `in_flight` map on `Scheduler`. `jobs` holds *timers*, not runs; and the durable alternative — a `job_history` row still marked `running` — cannot be used, because a panic in `finish` leaves exactly such a row with nothing to finish it, so a crash would 409 that task for ever. **Both run paths mark it and only the manual one refuses**, so scheduled firing is byte-for-byte unchanged. The check and the mark are one operation under one lock, so two simultaneous requests answer one `202` and one `409`.
- The **three-slot semaphore** is acquired inside `run_manual`, not by the route: waiting for a permit is precisely what must not happen inside a request.
- `WriteError::ConflictMessage` joins `NotFoundMessage` one status up — `Conflict` renders `<resource> with id "x" already exists`, which would be a plain lie about a task that exists and is fine.

## Tests

All three fail when `RunKind::advances_schedule` is forced to `true` (verified):

All four `advances_schedule` guard sites — `prepare`'s agent-resolution arm, both of `finish`'s arms, and `record_failed_run` — have a `Manual`/`Scheduled` pair over one fixture, and all of them fail when the guard is forced to `true` (verified):

- `the_preparation_section_honours_the_run_kind_too` — the arm a *misconfigured* task reaches, i.e. exactly the task **Run now** is pressed to diagnose.
- `a_manual_run_leaves_run_count_the_pause_rule_and_the_row_untouched` — over a task sitting **exactly on** its `stop_after_count` (the boundary is constructed, not approached), asserting the counters *and* that the job row still lands under the route's id.
- `a_scheduled_run_at_the_same_limit_does_advance_and_auto_pause` — the inverse over the identical fixture, differing only in `RunKind`, which is what makes the first a regression guard rather than an assertion about a task nothing touched.
- `the_finish_section_honours_the_run_kind_too` — the third guarded call site.
- `a_manual_run_fires_a_paused_task_at_its_limit_and_moves_no_counter` (`tests/scheduled_run.rs`, real scripted CLI) — end to end: `execute_task` on the same row records **nothing**, then the manual run produces a `job_history` row with the answer and the token counts plus a persisted chat, and every schedule counter is where it was.
- Route tests: `202` shape + job id + the `#335` log line, `404`, `409` (including that a *different* task is unaffected and that the refusal lifts when the guard drops), and the claims table.

- `a_manual_run_whose_task_was_deleted_while_it_queued_does_not_run` — `run_manual` re-reads the task after acquiring its permit. That wait is for one of three slots a 240-minute run can hold, and `job_history.task_id` cascades from `scheduled_tasks`, so a task deleted in that window would otherwise have spawned the agent and then failed to insert the row explaining it. This is `due_task`'s vanished-row half, which is not schedule policy; its status and auto-pause halves stay skipped.

The UI holds the returned `job_id` and keeps the action strip shut with a `Running…` label until that row reaches a terminal status, rather than until the `202` arrives — a *queued* run would otherwise leave the button reading **Run now** with a 409 waiting behind it. **Run now** is disabled while the draft is dirty, because the route reads the stored row and never the draft.

## Not in scope

Live-streaming a manual run's output into the Tasks view, navigating from the started run to its detail (#542), and cancelling an in-flight run.

## Docs

`CLAUDE.md` (the scheduler's manual-run path and its "does not advance the schedule" rule; the third owner of `desktop_routes.json`) and `docs/user-guide.md`.
