### PR TITLE
feat: a task run leads somewhere — to the run, and to its session (#542)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,12 +273,17 @@ src/
                  **A caller that only has an id must resolve the row before
                  offering the control** (#542, the Jobs inspector): a
                  `job_history` row stores a session id whether or not that
-                 session was ever scanned, so handing the id straight over
-                 offers a button that lands on Sessions with nothing to open.
-                 Resolve through `findSessionById` — never `GET
-                 /claude-sessions/{id}` merely to decide whether a button is
-                 enabled — and treat a *failed lookup* as its own state, not as
-                 an absence
+                 session still exists, so handing the id straight over offers a
+                 button that lands on Sessions with nothing to open. Resolve
+                 through `findSessionById` **and fall back to `GET
+                 /claude-sessions/{id}` on a miss** — `SessionsView`'s own
+                 hand-off order, and the *list* is not the authority: it reads
+                 `claude_session_cache`, which a scan only refreshes once it is
+                 an hour old (`scan.rs`'s `CACHE_TTL`), while the by-id route
+                 re-reads the transcript off disk. Concluding "absent" from the
+                 list alone withholds the control for exactly the sessions a run
+                 has *just* produced. Only that route's **404** is an absence; a
+                 failed lookup is its own state
     settings/LogsPane.tsx      Settings → Logs: tail, follow, filter, save a copy
     settings/SecurityPane.tsx  Settings → Security: the public key, and issuing
                  and revoking scoped API tokens (#405)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,10 +195,11 @@ src/
                  further destination adds one field here and nothing else — the
                  *number* of fields is not the rule, one-id-per-destination is.
                  **Consuming one is keyed on the nonce, never on the loaded
-                 list**, and the destination's "always keep something selected"
-                 effect has to exempt the handed-off id: the row is
-                 *legitimately* absent from the page, and every one of the three
-                 destinations pages
+                 list**, and where the destination's list is a *page* its
+                 "always keep something selected" effect has to exempt the
+                 handed-off id, which is legitimately absent from it (Sessions
+                 and Jobs; `GET /api/chats` has no limit, so Chats guards with a
+                 one-shot ref instead)
     icons.tsx    16px / 1.5-stroke icon set
     tauri.ts     window + menu bridge; degrades to a plain browser tab
     clipboard.ts copyText, with the execCommand fallback WebKitGTK needs
@@ -283,7 +284,13 @@ src/
                  re-reads the transcript off disk. Concluding "absent" from the
                  list alone withholds the control for exactly the sessions a run
                  has *just* produced. Only that route's **404** is an absence; a
-                 failed lookup is its own state
+                 failed lookup is its own state. And **`job_history.chat_session_id`
+                 is a `chat_sessions.id`, not a transcript id** — the executor
+                 mints a chat row per run and passes no `custom_session_id`, so
+                 the CLI's own id lands on `chat_sessions.sdk_session_id` and
+                 nowhere else. A run's Claude session is reached *through* the
+                 chat; naming the job's column directly resolves to nothing, for
+                 every run
     settings/LogsPane.tsx      Settings → Logs: tail, follow, filter, save a copy
     settings/SecurityPane.tsx  Settings → Security: the public key, and issuing
                  and revoking scoped API tokens (#405)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,19 +180,25 @@ src/
                  hand-off (#485): `NavTarget`, `NavProvider` and `useNavigate`.
                  **Two mechanisms, and which one to use is decided by where the
                  caller is rendered.** A view `App.tsx` renders directly takes
-                 `onNavigate={navigate}` as a prop (the three gateway views);
-                 the context is for a caller several levels down, where the prop
-                 would have to be threaded through every parent — the Sessions
-                 inspector and `SessionDetail`. `NavTarget` is a view id plus
+                 `onNavigate={navigate}` as a prop (the three gateway views
+                 and `TasksView`, #542); the context is for a caller several
+                 levels down, where the prop would have to be threaded through
+                 every parent — the Sessions inspector and `SessionDetail`.
+                 `NavTarget` is a view id plus
                  *one optional row id*, and it must stay that: it is a hand-off,
                  not a router, and query state, filters and scroll positions do
                  not belong in it. `App` clears the target on any navigation
                  that carries none, or a consumed chat id would be re-applied on
-                 every later visit to that section. **There are two destinations
-                 now, and the rule is unchanged**: `chatId` (#485) and
-                 `sessionId` (#536), one optional id each. A second destination
-                 adds one field here and nothing else — the *number* of fields
-                 is not the rule, one-id-per-destination is
+                 every later visit to that section. **There are three
+                 destinations now, and the rule is unchanged**: `chatId` (#485),
+                 `sessionId` (#536) and `jobId` (#542), one optional id each. A
+                 further destination adds one field here and nothing else — the
+                 *number* of fields is not the rule, one-id-per-destination is.
+                 **Consuming one is keyed on the nonce, never on the loaded
+                 list**, and the destination's "always keep something selected"
+                 effect has to exempt the handed-off id: the row is
+                 *legitimately* absent from the page, and every one of the three
+                 destinations pages
     icons.tsx    16px / 1.5-stroke icon set
     tauri.ts     window + menu bridge; degrades to a plain browser tab
     clipboard.ts copyText, with the execCommand fallback WebKitGTK needs
@@ -263,7 +269,16 @@ src/
                  so "Copy project path" would copy a string nothing filters
                  on. Carries `styles/sessionlink.css` itself, the
                  `components/charts.tsx` shape, since its consumers are in
-                 sections that do not import `styles/sessions.css`
+                 sections that do not import `styles/sessions.css`.
+                 **A caller that only has an id must resolve the row before
+                 offering the control** (#542, the Jobs inspector): a
+                 `job_history` row stores a session id whether or not that
+                 session was ever scanned, so handing the id straight over
+                 offers a button that lands on Sessions with nothing to open.
+                 Resolve through `findSessionById` — never `GET
+                 /claude-sessions/{id}` merely to decide whether a button is
+                 enabled — and treat a *failed lookup* as its own state, not as
+                 an absence
     settings/LogsPane.tsx      Settings → Logs: tail, follow, filter, save a copy
     settings/SecurityPane.tsx  Settings → Security: the public key, and issuing
                  and revoking scoped API tokens (#405)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -410,8 +410,16 @@ export default function App() {
             {view === "integrations" && (
               <IntegrationsView inspectorOpen={inspectorOpen} />
             )}
-            {view === "tasks" && <TasksView inspectorOpen={inspectorOpen} />}
-            {view === "jobs" && <JobsView inspectorOpen={inspectorOpen} />}
+            {view === "tasks" && (
+              <TasksView inspectorOpen={inspectorOpen} onNavigate={navigate} />
+            )}
+            {view === "jobs" && (
+              <JobsView
+                inspectorOpen={inspectorOpen}
+                openJobId={navTarget?.jobId}
+                openJobNonce={navNonce}
+              />
+            )}
             {view === "sessions" && (
               <SessionsView
                 inspectorOpen={inspectorOpen}

--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -100,13 +100,16 @@ export const VIEW_TITLES: Record<ViewId, string> = {
  *
  * Deliberately one optional row id per destination: this is a hand-off, not a
  * router, and it must not grow query state, filters or scroll positions. A
- * second destination adds a second optional field here, and nothing else.
+ * further destination adds one more optional field here, and nothing else —
+ * **one id per destination is the rule, not the number of fields**.
  */
 export interface NavTarget {
   /** A chat `chats` should preselect on arrival (#485). */
   chatId?: string;
   /** A session `sessions` should open the transcript of on arrival (#536). */
   sessionId?: string;
+  /** A run `jobs` should select and scroll to on arrival (#542). */
+  jobId?: string;
 }
 
 export type NavigateFn = (id: ViewId, target?: NavTarget) => void;

--- a/src/styles/tasks.css
+++ b/src/styles/tasks.css
@@ -102,6 +102,25 @@
   min-height: 18px;
 }
 
+/* The clickable variant, added by #542. A modifier rather than a rule on
+   `.runrow` itself: JobsView renders the same class as a plain text container
+   for "No output was saved for this run.", which is not a control and must not
+   look like one. `base.css` already resets a button's font, colour,
+   background, border and outline, so this is a box reset and nothing else. */
+.runrow--link {
+  width: 100%;
+  padding: 0;
+  text-align: left;
+}
+
+.runrow--link:hover {
+  color: var(--fg-primary);
+}
+
+.runrow--link:hover .runrow__val {
+  color: var(--fg-secondary);
+}
+
 .runrow__when {
   flex: 1;
   min-width: 0;

--- a/src/views/JobsView.tsx
+++ b/src/views/JobsView.tsx
@@ -7,7 +7,12 @@ import {
   useState,
 } from "react";
 import { ApiError, api, qs } from "../lib/api";
-import type { ClaudeSessionSummary, JobHistory, JobStatus } from "../lib/types";
+import type {
+  ChatDetailResponse,
+  ClaudeSessionSummary,
+  JobHistory,
+  JobStatus,
+} from "../lib/types";
 import { describeError, usePoll, useResource } from "../lib/hooks";
 import {
   compactNumber,
@@ -517,7 +522,7 @@ export function JobsView({
 
                   {job.chat_session_id && (
                     <InspGroup title="Session">
-                      <RunSession sessionId={job.chat_session_id} />
+                      <RunSession chatId={job.chat_session_id} />
                     </InspGroup>
                   )}
                 </>
@@ -533,84 +538,134 @@ export function JobsView({
 /* --- The run's Claude session --------------------------------------------- */
 
 /**
- * The conversation a run produced, as a control rather than a string (#542).
+ * The Claude session a run produced, as a control rather than a string (#542).
  *
- * `job_history` stores the session **id** and nothing else, and an id is not a
- * promise that the session is there to open: the scan may not have reached the
- * transcript yet, or its project may be hidden. Handing the id straight to
- * `SessionLink` would offer a button that lands the user in the Sessions
- * section with nothing to show, so the row is resolved first and the control is
- * only offered once it is known to exist — `sessionMenuItems`' own rule that
- * "unknown" is not "absent", one level up.
+ * **`job_history.chat_session_id` is a `chat_sessions.id`, not a transcript
+ * id**, and that is the one thing to know before touching this. The executor
+ * creates a chat row per run (`schedule/executor.rs`'s `create_task_session`,
+ * a fresh v4 uuid) and stores *that* on the job; the run itself passes no
+ * `custom_session_id`, so the CLI mints its own, and `write_session_results`
+ * puts it on `chat_sessions.sdk_session_id` and nowhere else. Handing the job's
+ * column to `SessionLink` therefore names a session that cannot exist — the
+ * issue's own premise, and it misses for **every** run rather than for an
+ * unlucky one. So the chat is read first and its `sdk_session_id` is the
+ * session.
  *
- * The lookup is `findSessionById` — the cheap list read scoped to the id —
+ * Then the row is resolved before the control is offered, because an id is not
+ * a promise the transcript is there: `findSessionById` — the cheap list read —
  * with `GET /claude-sessions/{id}` as the fallback **on a miss only**, which is
- * `SessionsView`'s own hand-off resolution and is here for the same reason.
- * The list reads `claude_session_cache`, and a scan is only forced once the
- * cache is an hour old (`native/scan.rs`'s `CACHE_TTL`), so the session a run
- * *just* produced is normally not in it — while the by-id route re-reads the
- * transcript off disk and answers for a session the scanner has never reached.
- * Concluding "absent" from the list alone would therefore withhold the control
- * for exactly the freshest runs, which are the ones somebody clicks in *Recent
- * runs*. The order is what keeps that affordable: the by-id read answers the
- * summary *plus every message*, so it is never paid for a session the list can
- * already see, and only a **404** from it is a real absence.
+ * `SessionsView`'s own hand-off order. The list reads `claude_session_cache`,
+ * refreshed only once it is an hour old (`scan.rs`'s `CACHE_TTL`), so the
+ * session a run *just* produced is normally not in it, while the by-id route
+ * re-reads the transcript off disk. Concluding "absent" from the list alone
+ * would withhold the control for exactly the freshest runs. The order is what
+ * keeps that affordable: the by-id read answers the summary *plus every
+ * message*, so it is never paid for a session the list can already see.
+ *
+ * Nothing here reports an absence it cannot demonstrate. A 404 is one, an empty
+ * `sdk_session_id` is one, and a failed request is not — reporting a transient
+ * error as "no session" states something untrue about the user's data.
  */
-function RunSession({ sessionId }: { sessionId: string }) {
+function RunSession({ chatId }: { chatId: string }) {
   type Resolved =
     | { kind: "pending" }
-    | { kind: "found"; row: ClaudeSessionSummary }
-    | { kind: "absent" }
+    | { kind: "found"; sessionId: string; row: ClaudeSessionSummary }
+    /** Nothing to open, and `reason` says how that is known. */
+    | { kind: "none"; reason: string; id?: string }
     | { kind: "failed"; message: string };
 
   const [resolved, setResolved] = useState<Resolved>({ kind: "pending" });
 
   useEffect(() => {
-    // Aborted as well as flagged: `StrictMode` runs this twice in development.
+    // Aborted as well as flagged: `StrictMode` runs this twice in development,
+    // and the by-id read is the expensive one.
     const ctl = new AbortController();
     let cancelled = false;
     setResolved({ kind: "pending" });
-    findSessionById(sessionId, ctl.signal)
-      .then(
-        (hit) =>
-          hit ??
-          // Typed as the summary because that is all this needs; the route
-          // answers a `ClaudeSessionDetail`, which is that plus the transcript.
-          api.get<ClaudeSessionSummary>(
-            `/claude-sessions/${sessionId}`,
-            ctl.signal
-          )
-      )
-      .then((row) => {
+
+    void (async () => {
+      try {
+        let chat: ChatDetailResponse;
+        try {
+          chat = await api.get<ChatDetailResponse>(`/chats/${chatId}`, ctl.signal);
+        } catch (err) {
+          if (err instanceof ApiError && err.status === 404) {
+            if (!cancelled) {
+              setResolved({
+                kind: "none",
+                reason:
+                  "The conversation this run was recorded against has been deleted.",
+              });
+            }
+            return;
+          }
+          throw err;
+        }
+
+        const sessionId = chat.session?.sdk_session_id ?? "";
         if (cancelled) return;
-        setResolved({ kind: "found", row });
-      })
-      .catch((err) => {
-        if (cancelled) return;
-        // Only the by-id route's 404 says the session is not there. Anything
-        // else is a failed *lookup*, which is not evidence the session is gone
-        // — reporting a transient error as an absence states something untrue
-        // about the user's data.
-        setResolved(
-          err instanceof ApiError && err.status === 404
-            ? { kind: "absent" }
-            : { kind: "failed", message: describeError(err) }
-        );
-      });
+        if (!sessionId) {
+          // Written only by `write_session_results`, so it is empty for a run
+          // that failed before the CLI reported a session — and for one still
+          // going.
+          setResolved({
+            kind: "none",
+            reason: "This run never reported a Claude session.",
+          });
+          return;
+        }
+
+        let row: ClaudeSessionSummary;
+        try {
+          row =
+            (await findSessionById(sessionId, ctl.signal)) ??
+            // Typed as the summary because that is all this needs; the route
+            // answers a `ClaudeSessionDetail`, which is that plus the
+            // transcript.
+            (await api.get<ClaudeSessionSummary>(
+              `/claude-sessions/${sessionId}`,
+              ctl.signal
+            ));
+        } catch (err) {
+          if (err instanceof ApiError && err.status === 404) {
+            if (!cancelled) {
+              setResolved({
+                kind: "none",
+                id: sessionId,
+                // Deliberately two causes rather than one assertion: the by-id
+                // route only looks under the *indexed* config dirs, and an
+                // agent may carry a `claude_config_dir` of its own, so a
+                // transcript outside that set 404s while still being on disk.
+                reason:
+                  "This session is not under any indexed Claude config directory — it may have been deleted, or written somewhere the app does not index.",
+              });
+            }
+            return;
+          }
+          throw err;
+        }
+
+        if (!cancelled) setResolved({ kind: "found", sessionId, row });
+      } catch (err) {
+        if (!cancelled)
+          setResolved({ kind: "failed", message: describeError(err) });
+      }
+    })();
+
     return () => {
       cancelled = true;
       ctl.abort();
     };
-  }, [sessionId]);
+  }, [chatId]);
 
   if (resolved.kind === "found") {
     return (
-      // No `title`: the id is what this pane has always shown, and losing it
+      // No `title`: an id is what this pane has always shown, and losing it
       // would take the one string somebody debugging a run copies out of here.
       // `project_path` comes from the resolved row — never anything merely
       // path-shaped, per `SessionLink`'s own note on that prop.
       <SessionLink
-        sessionId={sessionId}
+        sessionId={resolved.sessionId}
         projectPath={resolved.row.project_path || undefined}
       />
     );
@@ -618,13 +673,15 @@ function RunSession({ sessionId }: { sessionId: string }) {
 
   return (
     <>
-      <div className="logblock">{sessionId}</div>
+      {resolved.kind === "none" && resolved.id && (
+        <div className="logblock">{resolved.id}</div>
+      )}
       <div className="runrow">
         {resolved.kind === "pending"
-          ? "Looking for this session…"
+          ? "Looking for this run's session…"
           : resolved.kind === "failed"
-          ? `Couldn't look this session up — ${resolved.message}`
-          : "This run's session is no longer on disk, so there is nothing to open."}
+          ? `Couldn't look this run's session up — ${resolved.message}`
+          : resolved.reason}
       </div>
     </>
   );

--- a/src/views/JobsView.tsx
+++ b/src/views/JobsView.tsx
@@ -444,10 +444,10 @@ export function JobsView({
                 // so the pane says which of the two it is rather than reading
                 // as "nothing selected" or spinning forever.
                 <div className="statepane">
-                  {focusedId && detail.error
-                    ? `Couldn't load this run — ${detail.error}`
-                    : focusedId && detail.loading
+                  {focusedId && detail.loading
                     ? "Loading run…"
+                    : focusedId && detail.error
+                    ? `Couldn't load this run — ${detail.error}`
                     : "Nothing selected"}
                 </div>
               ) : (
@@ -522,7 +522,10 @@ export function JobsView({
 
                   {job.chat_session_id && (
                     <InspGroup title="Session">
-                      <RunSession chatId={job.chat_session_id} />
+                      <RunSession
+                        chatId={job.chat_session_id}
+                        runStatus={job.status}
+                      />
                     </InspGroup>
                   )}
                 </>
@@ -566,7 +569,23 @@ export function JobsView({
  * `sdk_session_id` is one, and a failed request is not — reporting a transient
  * error as "no session" states something untrue about the user's data.
  */
-function RunSession({ chatId }: { chatId: string }) {
+function RunSession({
+  chatId,
+  runStatus,
+}: {
+  chatId: string;
+  /**
+   * The run's own status, which is a **dependency and not decoration**.
+   *
+   * `sdk_session_id` is inserted as `''` and written only by
+   * `write_session_results`, after the run finishes — so a run still going has
+   * no session yet, and with `chatId` alone in the deps (it is fixed for the
+   * row's life) the lookup would never re-run when it ends. The pane would go
+   * on denying the session while the Output group beside it, which polls,
+   * showed the finished answer.
+   */
+  runStatus: JobStatus;
+}) {
   type Resolved =
     | { kind: "pending" }
     | { kind: "found"; sessionId: string; row: ClaudeSessionSummary }
@@ -607,10 +626,18 @@ function RunSession({ chatId }: { chatId: string }) {
         if (!sessionId) {
           // Written only by `write_session_results`, so it is empty for a run
           // that failed before the CLI reported a session — and for one still
-          // going.
+          // going, which is why `runStatus` decides the wording and is in the
+          // deps. Re-resolving on completion is also the case the by-id
+          // fallback exists for: a just-finished session is not in
+          // `claude_session_cache` for up to an hour.
           setResolved({
             kind: "none",
-            reason: "This run never reported a Claude session.",
+            reason:
+              runStatus === "running"
+                ? // *Not yet*, not *never* — the same distinction the Output
+                  // group makes two blocks up with "Still running…".
+                  "This run has not reported a Claude session yet."
+                : "This run never reported a Claude session.",
           });
           return;
         }
@@ -656,7 +683,7 @@ function RunSession({ chatId }: { chatId: string }) {
       cancelled = true;
       ctl.abort();
     };
-  }, [chatId]);
+  }, [chatId, runStatus]);
 
   if (resolved.kind === "found") {
     return (

--- a/src/views/JobsView.tsx
+++ b/src/views/JobsView.tsx
@@ -6,7 +6,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { api, qs } from "../lib/api";
+import { ApiError, api, qs } from "../lib/api";
 import type { ClaudeSessionSummary, JobHistory, JobStatus } from "../lib/types";
 import { describeError, usePoll, useResource } from "../lib/hooks";
 import {
@@ -543,13 +543,18 @@ export function JobsView({
  * only offered once it is known to exist — `sessionMenuItems`' own rule that
  * "unknown" is not "absent", one level up.
  *
- * The lookup is `findSessionById`, the cheap list read scoped to the id, and
- * deliberately **not** `GET /claude-sessions/{id}`: that answers the summary
- * *plus every message*, which is a whole transcript read to decide whether one
- * button is enabled — and it would run again for every run the user clicks.
- * The cost of that choice is stated below rather than hidden: a session the
- * list cannot see reads as absent even where the by-id route could still open
- * it, which is why the copy names both causes instead of asserting one.
+ * The lookup is `findSessionById` — the cheap list read scoped to the id —
+ * with `GET /claude-sessions/{id}` as the fallback **on a miss only**, which is
+ * `SessionsView`'s own hand-off resolution and is here for the same reason.
+ * The list reads `claude_session_cache`, and a scan is only forced once the
+ * cache is an hour old (`native/scan.rs`'s `CACHE_TTL`), so the session a run
+ * *just* produced is normally not in it — while the by-id route re-reads the
+ * transcript off disk and answers for a session the scanner has never reached.
+ * Concluding "absent" from the list alone would therefore withhold the control
+ * for exactly the freshest runs, which are the ones somebody clicks in *Recent
+ * runs*. The order is what keeps that affordable: the by-id read answers the
+ * summary *plus every message*, so it is never paid for a session the list can
+ * already see, and only a **404** from it is a real absence.
  */
 function RunSession({ sessionId }: { sessionId: string }) {
   type Resolved =
@@ -566,15 +571,31 @@ function RunSession({ sessionId }: { sessionId: string }) {
     let cancelled = false;
     setResolved({ kind: "pending" });
     findSessionById(sessionId, ctl.signal)
-      .then((hit) => {
+      .then(
+        (hit) =>
+          hit ??
+          // Typed as the summary because that is all this needs; the route
+          // answers a `ClaudeSessionDetail`, which is that plus the transcript.
+          api.get<ClaudeSessionSummary>(
+            `/claude-sessions/${sessionId}`,
+            ctl.signal
+          )
+      )
+      .then((row) => {
         if (cancelled) return;
-        setResolved(hit ? { kind: "found", row: hit } : { kind: "absent" });
+        setResolved({ kind: "found", row });
       })
       .catch((err) => {
-        // A failed lookup is not evidence the session is gone, so it is its own
-        // state: reporting it as absent would state something untrue about the
-        // user's data on what may be a transient error.
-        if (!cancelled) setResolved({ kind: "failed", message: describeError(err) });
+        if (cancelled) return;
+        // Only the by-id route's 404 says the session is not there. Anything
+        // else is a failed *lookup*, which is not evidence the session is gone
+        // — reporting a transient error as an absence states something untrue
+        // about the user's data.
+        setResolved(
+          err instanceof ApiError && err.status === 404
+            ? { kind: "absent" }
+            : { kind: "failed", message: describeError(err) }
+        );
       });
     return () => {
       cancelled = true;
@@ -603,7 +624,7 @@ function RunSession({ sessionId }: { sessionId: string }) {
           ? "Looking for this session…"
           : resolved.kind === "failed"
           ? `Couldn't look this session up — ${resolved.message}`
-          : "Not in the indexed sessions, so there is nothing to open — it may not have been scanned yet, or its project is hidden."}
+          : "This run's session is no longer on disk, so there is nothing to open."}
       </div>
     </>
   );

--- a/src/views/JobsView.tsx
+++ b/src/views/JobsView.tsx
@@ -523,6 +523,13 @@ export function JobsView({
                   {job.chat_session_id && (
                     <InspGroup title="Session">
                       <RunSession
+                        // Remount on a different run rather than re-resolving
+                        // in place: `resolved` is state and its reset lives in
+                        // an effect, which React flushes after paint, so
+                        // without this the group shows the *previous* run's
+                        // answer for one frame — the same staleness `job`
+                        // itself is guarded against above.
+                        key={job.chat_session_id}
                         chatId={job.chat_session_id}
                         runStatus={job.status}
                       />
@@ -698,11 +705,15 @@ function RunSession({
     );
   }
 
+  // An id on every branch, not just the ones that got as far as a session id:
+  // this pane has always shown one, and it is the string somebody debugging a
+  // run copies out of here. Where there is no session id there is still the
+  // chat the run was recorded against, which is what `job_history` stores.
   return (
     <>
-      {resolved.kind === "none" && resolved.id && (
-        <div className="logblock">{resolved.id}</div>
-      )}
+      <div className="logblock">
+        {resolved.kind === "none" && resolved.id ? resolved.id : chatId}
+      </div>
       <div className="runrow">
         {resolved.kind === "pending"
           ? "Looking for this run's session…"

--- a/src/views/JobsView.tsx
+++ b/src/views/JobsView.tsx
@@ -1,6 +1,13 @@
-import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { api, qs } from "../lib/api";
-import type { JobHistory, JobStatus } from "../lib/types";
+import type { ClaudeSessionSummary, JobHistory, JobStatus } from "../lib/types";
 import { describeError, usePoll, useResource } from "../lib/hooks";
 import {
   compactNumber,
@@ -13,6 +20,7 @@ import {
 import { Icon } from "../lib/icons";
 import { Empty, InspGroup, InspRow, Search, Segmented, Splitter } from "../components/ui";
 import { StatusBadge } from "./TasksView";
+import { SessionLink, findSessionById } from "./sessions/SessionLink";
 import "../styles/tasks.css";
 
 const PAGE = 50;
@@ -44,7 +52,17 @@ function runDuration(j: JobHistory): string {
   return isFinite(started) ? duration(Date.now() - started) : "—";
 }
 
-export function JobsView({ inspectorOpen }: { inspectorOpen: boolean }) {
+export function JobsView({
+  inspectorOpen,
+  openJobId,
+  openJobNonce = 0,
+}: {
+  inspectorOpen: boolean;
+  /** A run handed off from a task's *Recent runs*, to select on arrival (#542). */
+  openJobId?: string;
+  /** `App`'s nav nonce, so the *same* hand-off twice still fires. */
+  openJobNonce?: number;
+}) {
   // The first page is a live resource so polling only ever re-fetches it;
   // later pages are appended once and left alone.
   const head = useResource<JobHistory[] | null>(
@@ -64,6 +82,12 @@ export function JobsView({ inspectorOpen }: { inspectorOpen: boolean }) {
   const [confirming, setConfirming] = useState(false);
   const [busy, setBusy] = useState(false);
   const [actionError, setActionError] = useState<string>();
+  /**
+   * The handed-off run, once applied — kept so the "keep the inspector pointed
+   * at something that still exists" effect below can tell it apart from a
+   * selection that has genuinely gone stale.
+   */
+  const [openId, setOpenId] = useState<string | null>(null);
 
   const rows = useMemo(() => {
     // A new run arriving shifts the offset window, so the same record can come
@@ -107,6 +131,14 @@ export function JobsView({ inspectorOpen }: { inspectorOpen: boolean }) {
 
   // Keep the inspector pointed at something that still exists.
   useEffect(() => {
+    // ...except a handed-off run, which is *legitimately* absent from the
+    // loaded page: this list pages 50 at a time and the run a user clicks in a
+    // task's Recent runs is usually older than the first page, or excluded by
+    // whatever search and filter were left set. Without this guard the arrival
+    // is silently replaced by `filtered[0]` — the same steal #536 had to fix in
+    // `SessionsView`. `detail` fetches by id, so the inspector renders the run
+    // whether or not a row for it exists.
+    if (focusedId && focusedId === openId) return;
     if (filtered.length === 0) {
       if (focusedId !== null) setFocusedId(null);
       return;
@@ -115,7 +147,7 @@ export function JobsView({ inspectorOpen }: { inspectorOpen: boolean }) {
       setFocusedId(filtered[0].id);
       setSelected(new Set([filtered[0].id]));
     }
-  }, [filtered, focusedId]);
+  }, [filtered, focusedId, openId]);
 
   // The list rows already carry the whole record, but the detail endpoint is
   // the authority — and it picks up a running job's output as it lands.
@@ -126,10 +158,68 @@ export function JobsView({ inspectorOpen }: { inspectorOpen: boolean }) {
   );
 
   const focusedRow = focusedId ? rows.find((j) => j.id === focusedId) ?? null : null;
-  const job = detail.data ?? focusedRow;
+  // `useResource` keeps the previous `data` when a fetch fails, so the detail is
+  // taken only when it is about the run currently focused. Without that check a
+  // run whose detail 404s — which is exactly what a hand-off to a deleted run
+  // does (#542) — renders the *previously* selected run's output under the new
+  // selection, which is worse than reporting nothing.
+  const detailRow =
+    detail.data && detail.data.id === focusedId ? detail.data : null;
+  const job = detailRow ?? focusedRow;
 
   // A running job's output and timing land after the row was first read.
   usePoll(detail.reload, POLL_MS, job?.status === "running");
+
+  /**
+   * A hand-off from a task's *Recent runs* (#542): select that run.
+   *
+   * Keyed on the **nonce**, never on `rows` — this view is mounted
+   * conditionally, so it remounts with an empty page on every arrival and a
+   * "is the row already loaded?" fast path would be dead by construction,
+   * while re-running on each later page load would yank the user back to a run
+   * they had already navigated away from. `App` clears `navTarget` on any
+   * navigation carrying none, so a consumed id is not re-applied on a later
+   * visit.
+   *
+   * Nothing is fetched here: `detail` already reads
+   * `GET /job-history/{id}` for whatever is focused, and that route answers a
+   * real 404 for a run that has been deleted. Paging forward until the run
+   * appears was the alternative and is unbounded — it re-reads the whole table
+   * for a run from last month.
+   */
+  const seenOpenNonce = useRef(0);
+  /** The handed-off row still waiting to be scrolled to, if any. */
+  const scrollTo = useRef<string | null>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (openJobNonce === seenOpenNonce.current) return;
+    seenOpenNonce.current = openJobNonce;
+    if (!openJobId) return;
+    setConfirming(false);
+    setOpenId(openJobId);
+    setFocusedId(openJobId);
+    setSelected(new Set([openJobId]));
+    // Cleared once the row has actually been scrolled to, or by the user
+    // picking a different one — a flag that outlived either would jump the
+    // list the next time that row happened to render.
+    scrollTo.current = openJobId;
+  }, [openJobId, openJobNonce]);
+
+  /**
+   * Scroll the handed-off row into view once it exists.
+   *
+   * `data-job-id` + `querySelector` + `{ block: "nearest" }` is the idiom the
+   * shared menus already use (`components/ui.tsx`); a ref per row would have to
+   * be keyed on a value that changes with every page.
+   */
+  useEffect(() => {
+    const id = scrollTo.current;
+    if (!id) return;
+    const row = listRef.current?.querySelector(`[data-job-id="${CSS.escape(id)}"]`);
+    if (!row) return;
+    scrollTo.current = null;
+    row.scrollIntoView({ block: "nearest" });
+  }, [groups]);
 
   async function loadMore() {
     setLoadingMore(true);
@@ -150,6 +240,9 @@ export function JobsView({ inspectorOpen }: { inspectorOpen: boolean }) {
 
   function onRowClick(e: React.MouseEvent, j: JobHistory) {
     setConfirming(false);
+    // The user has chosen where to look; a hand-off still waiting for its row
+    // to appear must not move the list out from under them later.
+    scrollTo.current = null;
     if (e.metaKey || e.ctrlKey) {
       setSelected((prev) => {
         const next = new Set(prev);
@@ -270,7 +363,7 @@ export function JobsView({ inspectorOpen }: { inspectorOpen: boolean }) {
             }
           />
         ) : (
-          <div className="scroll" style={{ flex: 1, minHeight: 0 }}>
+          <div className="scroll" style={{ flex: 1, minHeight: 0 }} ref={listRef}>
             <table className="table table--striped">
               <thead>
                 <tr>
@@ -297,6 +390,7 @@ export function JobsView({ inspectorOpen }: { inspectorOpen: boolean }) {
                     {items.map((j) => (
                       <tr
                         key={j.id}
+                        data-job-id={j.id}
                         className={selected.has(j.id) ? "is-selected" : ""}
                         onClick={(e) => onRowClick(e, j)}
                       >
@@ -340,7 +434,17 @@ export function JobsView({ inspectorOpen }: { inspectorOpen: boolean }) {
             <div className="inspector__head">Run</div>
             <div className="inspector__scroll scroll">
               {!job ? (
-                <div className="statepane">Nothing selected</div>
+                // A handed-off run that no longer exists answers a real 404
+                // from `GET /job-history/{id}` and has no row to fall back on,
+                // so the pane says which of the two it is rather than reading
+                // as "nothing selected" or spinning forever.
+                <div className="statepane">
+                  {focusedId && detail.error
+                    ? `Couldn't load this run — ${detail.error}`
+                    : focusedId && detail.loading
+                    ? "Loading run…"
+                    : "Nothing selected"}
+                </div>
               ) : (
                 <>
                   <InspGroup title="Overview">
@@ -413,7 +517,7 @@ export function JobsView({ inspectorOpen }: { inspectorOpen: boolean }) {
 
                   {job.chat_session_id && (
                     <InspGroup title="Session">
-                      <div className="logblock">{job.chat_session_id}</div>
+                      <RunSession sessionId={job.chat_session_id} />
                     </InspGroup>
                   )}
                 </>
@@ -423,5 +527,84 @@ export function JobsView({ inspectorOpen }: { inspectorOpen: boolean }) {
         </>
       )}
     </div>
+  );
+}
+
+/* --- The run's Claude session --------------------------------------------- */
+
+/**
+ * The conversation a run produced, as a control rather than a string (#542).
+ *
+ * `job_history` stores the session **id** and nothing else, and an id is not a
+ * promise that the session is there to open: the scan may not have reached the
+ * transcript yet, or its project may be hidden. Handing the id straight to
+ * `SessionLink` would offer a button that lands the user in the Sessions
+ * section with nothing to show, so the row is resolved first and the control is
+ * only offered once it is known to exist — `sessionMenuItems`' own rule that
+ * "unknown" is not "absent", one level up.
+ *
+ * The lookup is `findSessionById`, the cheap list read scoped to the id, and
+ * deliberately **not** `GET /claude-sessions/{id}`: that answers the summary
+ * *plus every message*, which is a whole transcript read to decide whether one
+ * button is enabled — and it would run again for every run the user clicks.
+ * The cost of that choice is stated below rather than hidden: a session the
+ * list cannot see reads as absent even where the by-id route could still open
+ * it, which is why the copy names both causes instead of asserting one.
+ */
+function RunSession({ sessionId }: { sessionId: string }) {
+  type Resolved =
+    | { kind: "pending" }
+    | { kind: "found"; row: ClaudeSessionSummary }
+    | { kind: "absent" }
+    | { kind: "failed"; message: string };
+
+  const [resolved, setResolved] = useState<Resolved>({ kind: "pending" });
+
+  useEffect(() => {
+    // Aborted as well as flagged: `StrictMode` runs this twice in development.
+    const ctl = new AbortController();
+    let cancelled = false;
+    setResolved({ kind: "pending" });
+    findSessionById(sessionId, ctl.signal)
+      .then((hit) => {
+        if (cancelled) return;
+        setResolved(hit ? { kind: "found", row: hit } : { kind: "absent" });
+      })
+      .catch((err) => {
+        // A failed lookup is not evidence the session is gone, so it is its own
+        // state: reporting it as absent would state something untrue about the
+        // user's data on what may be a transient error.
+        if (!cancelled) setResolved({ kind: "failed", message: describeError(err) });
+      });
+    return () => {
+      cancelled = true;
+      ctl.abort();
+    };
+  }, [sessionId]);
+
+  if (resolved.kind === "found") {
+    return (
+      // No `title`: the id is what this pane has always shown, and losing it
+      // would take the one string somebody debugging a run copies out of here.
+      // `project_path` comes from the resolved row — never anything merely
+      // path-shaped, per `SessionLink`'s own note on that prop.
+      <SessionLink
+        sessionId={sessionId}
+        projectPath={resolved.row.project_path || undefined}
+      />
+    );
+  }
+
+  return (
+    <>
+      <div className="logblock">{sessionId}</div>
+      <div className="runrow">
+        {resolved.kind === "pending"
+          ? "Looking for this session…"
+          : resolved.kind === "failed"
+          ? `Couldn't look this session up — ${resolved.message}`
+          : "Not in the indexed sessions, so there is nothing to open — it may not have been scanned yet, or its project is hidden."}
+      </div>
+    </>
   );
 }

--- a/src/views/TasksView.tsx
+++ b/src/views/TasksView.tsx
@@ -12,6 +12,7 @@ import { describeError, usePoll, useResource } from "../lib/hooks";
 import { DESTROY, partnerLabel, submitLabel } from "../lib/formVerbs";
 import { dateTime, duration, relativeTime, toneFor } from "../lib/format";
 import { Icon } from "../lib/icons";
+import type { NavigateFn } from "../lib/nav";
 import { DirField, useDirPicker } from "../components/DirField";
 import {
   Dropdown,
@@ -148,7 +149,20 @@ function blankTask(agentSlug: string): ScheduledTask {
 
 /* --- View ----------------------------------------------------------------- */
 
-export function TasksView({ inspectorOpen }: { inspectorOpen: boolean }) {
+export function TasksView({
+  inspectorOpen,
+  onNavigate,
+}: {
+  inspectorOpen: boolean;
+  /**
+   * The cross-view hand-off, as a prop rather than `useNavigate` (#542).
+   *
+   * `App` renders this view directly, so there is nothing to thread a callback
+   * through — which is the whole of `nav.ts`'s prop-versus-context rule, and
+   * the same reason the three gateway views take one.
+   */
+  onNavigate: NavigateFn;
+}) {
   const picker = useDirPicker();
   const tasksRes = useResource<ScheduledTask[] | null>(
     (signal) => api.get("/tasks", signal),
@@ -772,6 +786,7 @@ export function TasksView({ inspectorOpen }: { inspectorOpen: boolean }) {
                       error={historyRes.error}
                       runs={historyRes.data ?? []}
                       onRetry={historyRes.reload}
+                      onOpen={(jobId) => onNavigate("jobs", { jobId })}
                     />
                   </InspGroup>
                 </>
@@ -828,16 +843,33 @@ function TaskRow({
 
 /* --- Recent runs (inspector) ---------------------------------------------- */
 
+/**
+ * The task's last few runs — and, since #542, the way to one of them.
+ *
+ * A run *is* a record with a detail view: the Jobs section renders its output,
+ * error, timing, token counts and the Claude session it produced. Until this
+ * was a control the only route there was to leave the task, open Job History
+ * and hunt for the run by timestamp, which is the one thing anybody wants from
+ * a scheduled task that failed last night.
+ *
+ * The rows stay in `base.css`'s text-selection denylist — `button` is on that
+ * list already, so making the row a real button is what keeps a drag across it
+ * from leaving a word highlighted behind the view it just opened (#469). Do
+ * not add a per-view `user-select` here.
+ */
 function RecentRuns({
   loading,
   error,
   runs,
   onRetry,
+  onOpen,
 }: {
   loading: boolean;
   error: string | undefined;
   runs: JobHistory[];
   onRetry(): void;
+  /** Hand this run over to the Jobs section. */
+  onOpen(jobId: string): void;
 }) {
   if (loading) return <div className="runrow">Loading…</div>;
   if (error) {
@@ -857,13 +889,19 @@ function RecentRuns({
   return (
     <div className="runlist">
       {runs.slice(0, 8).map((j) => (
-        <div className="runrow" key={j.id} title={dateTime(j.started_at)}>
+        <button
+          type="button"
+          className="runrow runrow--link"
+          key={j.id}
+          title={`${dateTime(j.started_at)} — open this run`}
+          onClick={() => onOpen(j.id)}
+        >
           <span className={`dot ${statusDot(j.status)}`} />
           <span className="runrow__when">{relativeTime(j.started_at)}</span>
           <span className="runrow__val">
             {j.status === "running" ? "running" : duration(j.duration_ms)}
           </span>
-        </div>
+        </button>
       ))}
     </div>
   );


### PR DESCRIPTION
Closes #542

## What

Two hops that dead-ended a task run:

1. **Task → run.** *Recent runs* rows in the Tasks inspector are controls; clicking one opens that run in the Jobs section, selected and scrolled to.
2. **Run → session.** The run's Claude session renders as a `SessionLink` — or, when there is nothing to open, as a stated reason for which of the four ways that is.

## How

`NavTarget` gains one field, `jobId` — the third destination, rule unchanged: one optional row id each, no query state, no filters, no scroll positions. `TasksView` takes `onNavigate` as a prop (it is rendered directly by `App.tsx`).

Three things are substance rather than wiring:

- **The handed-off run is legitimately absent from the loaded page.** The list pages 50 at a time, so the "keep the inspector pointed at something that still exists" effect would silently replace the arrival with `filtered[0]` — the steal #536 had to fix in `SessionsView`. Exempted for the handed-off id alone, keyed on the nav **nonce**, never on the loaded list. Nothing new is fetched: `detail` already reads `GET /job-history/{id}`, which answers a real 404; paging forward until the run appears is unbounded and was rejected for that.
- **`job_history.chat_session_id` is a `chat_sessions.id`, not a transcript id** — see the deviation below. The Claude session is reached *through* the chat's `sdk_session_id`.
- **An id is not a promise the transcript is there.** Resolved via `findSessionById` (the cheap `?q=<id>` list read) with `GET /claude-sessions/{id}` as the fallback **on a miss only** — `SessionsView`'s own hand-off order. The list reads `claude_session_cache`, refreshed only once it is an hour old (`scan.rs`'s `CACHE_TTL`), so the session a run *just* produced is normally not in it while the by-id route re-reads it off disk. Only that route's **404** is an absence; a failed request is its own state, because reporting a transient error as "no session" states something untrue about the user's data.

Also guards `job` against `useResource` keeping the previous `data` on a failed fetch — for a hand-off to a deleted run that rendered the *previously* selected run's output under the new selection.

Rows stay in `base.css`'s selection denylist (`button` is already on it), so no per-view `user-select` (#469).

## Deviation from the HOW — the second hop names the wrong column

The issue's WHY states: *"a run **is** backed by a real Claude session: `job_history.chat_session_id` is written by the executor"*, and its HOW follows from that — render that column as a `SessionLink`.

The column is written by the executor and it is **not** a transcript id. The chain, all in source:

| step | file | what |
|---|---|---|
| 1 | `schedule/executor.rs` `create_task_session` | inserts a **`chat_sessions`** row via `chats::insert_session` and returns its id |
| 2 | `native/chats.rs` `insert_session` | that id is `Uuid::new_v4()` |
| 3 | `schedule/executor.rs` | it is passed to `create_initial_job_history` — this is `chat_session_id` |
| 4 | `native/agent_run.rs` `headless_spec` | `custom_session_id: String::new()`, so `--session-id` is never passed and the CLI mints its own |
| 5 | `schedule/executor.rs` `write_session_results` | the CLI's id is written to `chat_sessions.sdk_session_id` — and nowhere else |

So `findSessionById(<chat id>)` misses and `GET /claude-sessions/<chat id>` 404s for **every** run. Implemented as specified, the control would never once have been offered.

`RunSession` therefore reads `GET /chats/{id}` first and takes `sdk_session_id` from it. The acceptance criterion is unchanged and met; only the route to the id is.

## Acceptance criteria

- [x] Clicking a row in a task's *Recent runs* opens Jobs with that run selected and scrolled into view
- [x] Works for a run **not** in the Jobs list's loaded page — `detail` fetches by id and the keeper effect is exempted
- [x] `NavTarget` gains `jobId` and nothing else
- [x] Run rows remain in the text-selection denylist
- [ ] *The Claude session a run produced opens in one click* — implemented, **not exercised at runtime**; see below
- [ ] *A run with no resolvable session shows a stated reason* — implemented, **not exercised at runtime**; see below

One smaller deviation, stated rather than left silent: the issue asks for a **disabled control** with a reason, and this renders **plain text** with the reason beside it. The substance is the same ("never a link that 404s") and the text is the more honest shape — a disabled button hides its reason in a tooltip, and there are four different reasons here.

## Verification, and what it does not cover

Green: `npm run build` (tsc + vite), `pre-commit run --all-files`, `cargo fmt --check`. No Rust changed.

**The two runtime criteria are deliberately left unticked.** The issue's testing strategy names manual verification through `ui-verify`, and this machine cannot supply the fixture: `job_history` is **empty** on the real database, so there is no run to click and no session to resolve — and exercising it would mean creating and firing a scheduled task against the user's own data, which the repo's own rule (`CLAUDE.md` → *Verify against the live instance*, GET only) forbids. `CLAUDE.md`'s "an *identical* over an empty result set is not evidence" applies to a green tick here just as much.

What replaced it is source-level verification of the exact claim the runtime check would have caught — the five-step id chain in the table above, read at each call site. That is what found the defect the second review round raised, and it is stated rather than converted into a tick.


---

## Review

Four rounds of automated review, ending in **APPROVE**. Each round found a defect the previous one's fix had not reached, and each is fixed here:

1. Concluding "absent" from the `claude_session_cache` list read alone, which withheld the link for the freshest runs (`CACHE_TTL` is an hour). Fixed with the by-id fallback.
2. The second hop named `job_history.chat_session_id`, a **chat** id, so it could never resolve for any run. Fixed by reaching the session through the chat's `sdk_session_id` — this is the issue's own premise being wrong, documented above.
3. A **running** run was told its session "never" existed, permanently, because the lookup's only dependency was an id fixed for the row's life. Fixed by making the run's status a dependency and wording the live case as *not yet*. Plus `loading`-before-`error` in the run pane.
4. APPROVE, with two optional nits, both applied: a `key` so switching runs remounts the session group rather than showing the previous run's answer for a frame, and an id on every branch rather than only where a session id was reached.

**One thing is worth a second opinion even so**, and it is a product call rather than a defect: a run produces **both** a chat row (prompt + answer, always resolvable, one `navigate("chats", { chatId })` away with no new field) and a Claude transcript (richer, but absent while the run is still going). This links the transcript, because that is what the acceptance criterion names. Swapping it is a small change if you would rather have the chat.
