### PR TITLE
fix: the Limits section says "no limit" instead of showing one (#543)

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -299,8 +299,9 @@ Other options:
 - **Model**: override the agent's model for this task.
 - **Timeout**: runs longer than this are cancelled and recorded as failed.
 - **Save output**: keep the agent's reply in the run history.
-- **Stop after**: end the task after N runs. `0` means never.
-- **Stop at**: an end date.
+- **Stop after**: **No limit**, or a **Run limit** of N runs.
+- **Stop at**: **No end date**, or an **End date**. Switching back to *No end
+  date* clears a date you already chose.
 - **Enabled**: pause without deleting.
 
 The inspector shows the next run, the last run, the total number of runs and the

--- a/src/views/TasksView.tsx
+++ b/src/views/TasksView.tsx
@@ -118,6 +118,26 @@ function fromLocalStamp(v: string): string {
   return isFinite(d.getTime()) ? d.toISOString() : "";
 }
 
+/* --- The two "no limit" defaults ------------------------------------------
+   Both limits are stored as their *unset* value — `stop_after_count: 0` and
+   `stop_after_time: null` — and `0` is the longer horizon, not the shorter
+   one, the same way round as the gateway's `usage_retention_days`. The form
+   therefore never shows either unset value: switching a limit *on* has to
+   seed something a user would plausibly have typed, or the control lands on
+   the number it exists to stop meaning. -------------------------------------- */
+
+/** What "Run limit" starts at. Any value ≥ 1 works; ten is a short leash. */
+const FIRST_STOP_AFTER_COUNT = 10;
+
+/** What "End date" starts at: a week out, truncated to the minute the picker
+ *  shows — so the stored instant and the displayed one agree from the start
+ *  rather than only after the first edit. */
+function firstStopAfterTime(): string {
+  const d = new Date(Date.now() + 7 * 86_400_000);
+  d.setSeconds(0, 0);
+  return d.toISOString();
+}
+
 /* --- New-task template ---------------------------------------------------- */
 
 function blankTask(agentSlug: string): ScheduledTask {
@@ -695,35 +715,105 @@ export function TasksView({
 
                 <div className="formsec">
                   <div className="formsec__title">Limits</div>
-                  <FormRow label="Stop after" help="0 keeps the task running forever.">
+                  {/* Both rows are a mode switch over one stored value, and
+                      the *unset* value is never rendered as a value: a `0` in
+                      a spinner reads as "zero runs" and an empty
+                      `datetime-local` paints the browser's own
+                      `dd/mm/yyyy, --:--` mask, each the inverse of the "no
+                      limit" it means. The segmented pair is also the clear
+                      control the picker never had — selecting "No end date"
+                      writes `null`, so an end date can be undone without
+                      recreating the task. The wire is untouched. */}
+                  <FormRow
+                    label="Stop after"
+                    help={
+                      draft.stop_after_count > 0
+                        ? "The task pauses itself once it has run this many times."
+                        : "The task keeps running until you pause it."
+                    }
+                  >
                     <div className="inline">
-                      <label className="field field--num">
-                        <input
-                          type="number"
-                          min={0}
-                          value={draft.stop_after_count}
-                          onChange={(e) =>
-                            edit({ stop_after_count: Number(e.target.value) || 0 })
-                          }
-                        />
-                      </label>
-                      <span className="inline__label">runs</span>
-                    </div>
-                  </FormRow>
-                  <FormRow label="Stop at" help="Leave empty for no end date.">
-                    <label className="field field--stamp">
-                      <input
-                        type="datetime-local"
-                        value={toLocalStamp(draft.stop_after_time)}
-                        onChange={(e) =>
+                      <Segmented
+                        value={draft.stop_after_count > 0 ? "count" : "none"}
+                        options={[
+                          { value: "none", label: "No limit" },
+                          { value: "count", label: "Run limit" },
+                        ]}
+                        onChange={(v) =>
                           edit({
-                            stop_after_time: e.target.value
-                              ? fromLocalStamp(e.target.value)
-                              : null,
+                            stop_after_count:
+                              v === "count" ? FIRST_STOP_AFTER_COUNT : 0,
                           })
                         }
                       />
-                    </label>
+                      {draft.stop_after_count > 0 && (
+                        <>
+                          <label className="field field--num">
+                            {/* The floor is 1, not 0: `0` is now reached
+                                through "No limit" alone, and letting the
+                                number fall to it would collapse the input the
+                                user is typing into. */}
+                            <input
+                              type="number"
+                              min={1}
+                              value={draft.stop_after_count}
+                              onChange={(e) =>
+                                edit({
+                                  stop_after_count: Math.max(
+                                    1,
+                                    Number(e.target.value) || 1
+                                  ),
+                                })
+                              }
+                            />
+                          </label>
+                          <span className="inline__label">runs</span>
+                        </>
+                      )}
+                    </div>
+                  </FormRow>
+                  <FormRow
+                    label="Stop at"
+                    help={
+                      draft.stop_after_time
+                        ? "Local time; stored as UTC."
+                        : "The task has no end date."
+                    }
+                  >
+                    <div className="inline">
+                      <Segmented
+                        value={draft.stop_after_time ? "date" : "none"}
+                        options={[
+                          { value: "none", label: "No end date" },
+                          { value: "date", label: "End date" },
+                        ]}
+                        onChange={(v) =>
+                          edit({
+                            stop_after_time:
+                              v === "date" ? firstStopAfterTime() : null,
+                          })
+                        }
+                      />
+                      {draft.stop_after_time && (
+                        <label className="field field--stamp">
+                          <input
+                            type="datetime-local"
+                            value={toLocalStamp(draft.stop_after_time)}
+                            onChange={(e) => {
+                              /* Both ways of ending up with nothing collapse
+                                 to `null`: an emptied picker, and a value
+                                 `fromLocalStamp` cannot parse — which answers
+                                 `""`, and `""` is not "no end date" to the
+                                 API. */
+                              const iso = e.target.value
+                                ? fromLocalStamp(e.target.value)
+                                : "";
+                              edit({ stop_after_time: iso || null });
+                            }}
+                          />
+                        </label>
+                      )}
+                    </div>
                   </FormRow>
                 </div>
               </div>

--- a/src/views/TasksView.tsx
+++ b/src/views/TasksView.tsx
@@ -760,7 +760,7 @@ export function TasksView({
                     help={
                       draft.stop_after_count > 0
                         ? "The task pauses itself once it has run this many times."
-                        : "The task keeps running until you pause it."
+                        : "The number of runs is not limited."
                     }
                   >
                     <div className="inline">
@@ -771,6 +771,14 @@ export function TasksView({
                           { value: "count", label: "Run limit" },
                         ]}
                         onChange={(v) => {
+                          /* `Segmented` fires on every click, including one on
+                             the option already selected — and both arms below
+                             write. Without this guard the ordinary gesture of
+                             re-clicking the mode you are already in would
+                             re-seed a typed count, or stash the unset value
+                             over the one the stash exists to remember. */
+                          if (v === (draft.stop_after_count > 0 ? "count" : "none"))
+                            return;
                           if (v === "none") {
                             lastLimits.current = {
                               ...stashFor(lastLimits.current, draft.id),
@@ -828,6 +836,8 @@ export function TasksView({
                           { value: "date", label: "End date" },
                         ]}
                         onChange={(v) => {
+                          // The same already-selected guard as the row above.
+                          if (v === (draft.stop_after_time ? "date" : "none")) return;
                           if (v === "none") {
                             lastLimits.current = {
                               ...stashFor(lastLimits.current, draft.id),

--- a/src/views/TasksView.tsx
+++ b/src/views/TasksView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../lib/api";
 import type {
   Agent,
@@ -126,8 +126,34 @@ function fromLocalStamp(v: string): string {
    seed something a user would plausibly have typed, or the control lands on
    the number it exists to stop meaning. -------------------------------------- */
 
-/** What "Run limit" starts at. Any value ≥ 1 works; ten is a short leash. */
+/** How many *further* runs "Run limit" starts at.
+ *
+ *  Ten more, not a flat ten: `should_auto_pause` is
+ *  `stop_after_count > 0 && run_count >= stop_after_count`, evaluated *before*
+ *  the run and answered by declining it **silently** — no `job_history` row,
+ *  nothing on screen. So seeding a bare `10` on a task with 42 runs behind it
+ *  would hand the user a value that stops their schedule for good the moment
+ *  they save, with no record saying why. */
 const FIRST_STOP_AFTER_COUNT = 10;
+
+/** What "Run limit" starts at for a task that has already run this often. */
+function firstStopAfterCount(runCount: number): number {
+  return FIRST_STOP_AFTER_COUNT + Math.max(0, runCount);
+}
+
+/** What each limit was last set to, so flicking a mode switch off and back on
+ *  restores it instead of re-seeding.
+ *
+ *  This is a **memory, never a source of truth** — the mode stays derived from
+ *  the stored value, so there is no second copy of it to fall out of step with
+ *  the draft. It carries the task id it belongs to, so a value stashed on one
+ *  task cannot surface on another. */
+type LimitStash = { id: string; count: number; time: string | null };
+
+/** The stash, but only when it belongs to this task. */
+function stashFor(s: LimitStash, id: string): LimitStash {
+  return s.id === id ? s : { id, count: 0, time: null };
+}
 
 /** What "End date" starts at: a week out, truncated to the minute the picker
  *  shows — so the stored instant and the displayed one agree from the start
@@ -226,6 +252,8 @@ export function TasksView({
   const [startedJobId, setStartedJobId] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string>();
   const [confirmDelete, setConfirmDelete] = useState(false);
+  /** See `LimitStash` — what the two Limits switches restore when flicked back on. */
+  const lastLimits = useRef<LimitStash>({ id: "", count: 0, time: null });
 
   const selected = selectedId ? tasks.find((t) => t.id === selectedId) ?? null : null;
 
@@ -307,6 +335,7 @@ export function TasksView({
     setConfirmDelete(false);
     setActionError(undefined);
     setDraft(blankTask(agents[0]?.slug ?? ""));
+    lastLimits.current = { id: "", count: 0, time: null };
     setDirty(true);
   }
 
@@ -351,6 +380,8 @@ export function TasksView({
     } else {
       setDraft(selected);
     }
+    // The stash remembers edits; a revert throws those edits away.
+    lastLimits.current = { id: "", count: 0, time: null };
     setDirty(false);
     setActionError(undefined);
   }
@@ -739,12 +770,21 @@ export function TasksView({
                           { value: "none", label: "No limit" },
                           { value: "count", label: "Run limit" },
                         ]}
-                        onChange={(v) =>
+                        onChange={(v) => {
+                          if (v === "none") {
+                            lastLimits.current = {
+                              ...stashFor(lastLimits.current, draft.id),
+                              count: draft.stop_after_count,
+                            };
+                            edit({ stop_after_count: 0 });
+                            return;
+                          }
+                          const kept = stashFor(lastLimits.current, draft.id).count;
                           edit({
                             stop_after_count:
-                              v === "count" ? FIRST_STOP_AFTER_COUNT : 0,
-                          })
-                        }
+                              kept > 0 ? kept : firstStopAfterCount(draft.run_count),
+                          });
+                        }}
                       />
                       {draft.stop_after_count > 0 && (
                         <>
@@ -787,12 +827,18 @@ export function TasksView({
                           { value: "none", label: "No end date" },
                           { value: "date", label: "End date" },
                         ]}
-                        onChange={(v) =>
-                          edit({
-                            stop_after_time:
-                              v === "date" ? firstStopAfterTime() : null,
-                          })
-                        }
+                        onChange={(v) => {
+                          if (v === "none") {
+                            lastLimits.current = {
+                              ...stashFor(lastLimits.current, draft.id),
+                              time: draft.stop_after_time ?? null,
+                            };
+                            edit({ stop_after_time: null });
+                            return;
+                          }
+                          const kept = stashFor(lastLimits.current, draft.id).time;
+                          edit({ stop_after_time: kept ?? firstStopAfterTime() });
+                        }}
                       />
                       {draft.stop_after_time && (
                         <label className="field field--stamp">
@@ -800,15 +846,19 @@ export function TasksView({
                             type="datetime-local"
                             value={toLocalStamp(draft.stop_after_time)}
                             onChange={(e) => {
-                              /* Both ways of ending up with nothing collapse
-                                 to `null`: an emptied picker, and a value
-                                 `fromLocalStamp` cannot parse — which answers
-                                 `""`, and `""` is not "no end date" to the
-                                 API. */
-                              const iso = e.target.value
-                                ? fromLocalStamp(e.target.value)
-                                : "";
-                              edit({ stop_after_time: iso || null });
+                              /* An empty value is an edit in progress, not a
+                                 clear. A `datetime-local` reports `""` for
+                                 anything that is not a *complete* datetime, so
+                                 backspacing one segment to retype it would
+                                 otherwise write `null`, unmount this input
+                                 under the user and lose the date — the same
+                                 collapse the count input is floored against.
+                                 "No end date" beside it is the clear, and the
+                                 only one. `fromLocalStamp`'s own unparseable
+                                 `""` folds in here too: `""` is not "no end
+                                 date" to the API. */
+                              const iso = fromLocalStamp(e.target.value);
+                              if (iso) edit({ stop_after_time: iso });
                             }}
                           />
                         </label>


### PR DESCRIPTION
Closes #543

## What

The Tasks *Limits* section rendered both of its "no limit" values as values. `stop_after_count: 0` sat in a number spinner, which reads as *zero runs* — the inverse of unlimited — and `stop_after_time: null` was an empty `datetime-local`, which the browser paints with its own `dd/mm/yyyy, --:--` mask. Neither was distinguishable from a configured value, and an end date once chosen could not be cleared at all.

Each row is now a `Segmented` mode switch over the same stored value — **No limit / Run limit**, **No end date / End date** — with the number input and the picker rendering only in the second branch, so neither unset value is ever on screen. The switch is also the clear control the picker never had.

## Why

Reported from the app: *"the stop at value in the Limits should be 'not set' or something but currently it's showing me a value ... how can we reset this"*. This is the inverted-default class `CLAUDE.md` already documents for the gateway's retention horizon — `0` is the **longest** horizon, not the shortest, so every label over it has to read the right way round.

## How

The mode is **derived from the stored value, never held in state**. `setDraft` has eight call sites in this view (the 10 s re-seed poll, `select`, `startCreate`, `revert`, save-success, `toggleStatus`), and a second copy of the mode would have to resync at every one or silently disagree with the draft. That choice has four consequences, each of which is a guard in the diff:

- **Nothing may write the unset value while the input is mounted.** A `datetime-local` reports `""` for anything that is not a *complete* datetime, so backspacing one segment to retype it would clear the value the render guard reads and unmount the control. An empty value is an edit in progress; the switch beside it is the clear. The count input has the same guard as a floor of 1.
- **`Segmented` fires `onChange` on every click, including the already-selected option** (`ui.tsx`, no short-circuit — eight of its ten consumers are idempotent and never notice). Both handlers early-return when the clicked value equals the derived mode.
- **Seeding "Run limit" is a schedule-stopping act.** `should_auto_pause` is `stop_after_count > 0 && run_count >= stop_after_count`, checked *before* the run and answered by declining it **silently** — no `job_history` row. A flat `10` on a task with 42 runs behind it would stop it for good, so it seeds ten *further* runs.
- **Flicking a switch off stashes what it had**, so flicking it back restores rather than re-seeds. The stash is a memory in a `useRef`, keyed by task id and dropped on Discard — never a source of truth.

## Acceptance criteria

- [x] An unconfigured task's Limits reads as "no limits" — no `0`, no date mask
- [x] A set end date can be cleared without deleting and recreating the task
- [x] Clearing sends `stop_after_time: null`, never `""`
- [x] Wire unchanged — no limit is still `stop_after_count: 0` / `stop_after_time: null`; `blankTask` untouched
- [x] Help text consistent with what is displayed
- [x] The `one_off` `run_at` picker is **not** given a clear control — it is required

## Verification

No TypeScript test harness exists in this repo, so beyond `npm run build` (`tsc --noEmit`) this was verified against the **real Tauri webview** via the repo's `ui-verify` skill, on a dev instance built from this branch. Full results in <https://github.com/shaharia-lab/agento/pull/549#issuecomment-5516016773|the round-1 comment> and the round-2 commit message; the request bodies were read off the app's own `fetch`, showing `"stop_after_time": null` on the clearing save and `"stop_after_count": 0` on the no-limit save. The verification task was deleted afterwards.

## Deviation from the HOW

The HOW recommended a *"Set an end date"* affordance plus a separate `×` clear for **Stop at**, and an *Unlimited / Stop after N runs* pair for **Stop after**. Both rows use the segmented pair instead, so the two limits read as one idea rather than two mechanisms, no new CSS or icon button is needed, and the mode switch doubles as the clear. Every acceptance criterion is met either way.

## Noted, deliberately out of scope

A **past** end date is accepted with no warning and then silently pauses the task on its first fire — `validate_task` never mentions `stop_after_time`. Pre-existing, not worsened here (a newly revealed picker seeds a week into the future), and not #543's scope.