### PR TITLE
docs(skills): driving an agent flow from the UI, and seeing whether a hosted MCP tool reaches the model

### DIFF
--- a/.claude/skills/local-verify/SKILL.md
+++ b/.claude/skills/local-verify/SKILL.md
@@ -245,6 +245,68 @@ handoff is confirmed on the real desktop. A capability fix is not proven by an
 error disappearing — `openExternal` swallows failures into a `console.warn`
 and returns normally, so "no error" is the *symptom*, not the fix.
 
+## Is a hosted MCP tool actually reaching the model?
+
+Agento's own log cannot answer this. `mcp server started server=… tools=[…]`
+says what *we* hosted, the CLI's `init` event says `"status":"connected"`, and
+both were true on 2026-09-07 while every integration tool was invisible to the
+model — the CLI had fetched the tool list and **discarded it as invalid**
+(SEP-2549 `ttlMs`/`cacheScope`, #555). Four probes, in order, each ~10 s:
+
+1. **Did the model get the tools?** In the turn's SSE capture, the
+   `system`/`init` frame's `tools` array must contain `mcp__<server>__<tool>`
+   names. If it does not, nothing downstream matters — the model answers
+   "no such tool" and `ToolSearch` (which searches only the tools it was
+   given) finds nothing.
+2. **What did the CLI say to itself?** The CLI writes a per-run debug log:
+   `claude -p --debug-file /tmp/cli.debug …`. `grep -i mcp /tmp/cli.debug`
+   shows the transport setup, `Connection established`, and — the line that
+   matters — `tools/list failed (Invalid result for tools/list: …)` with the
+   zod path of the offending field. Nothing in Agento's log carries this.
+3. **Reproduce with the exact options the runner built.** The per-turn MCP
+   server lives only as long as its turn, so start a slow turn (a long essay)
+   and read the CLI's argv off the live process — the `--mcp-config` document
+   carries the server URL and its bearer token:
+
+   ```bash
+   for pid in $(pgrep -f mcpServers); do
+     case "$(readlink /proc/$pid/exe)" in */claude/versions/*) P=$pid;; esac; done
+   tr '\0' '\n' < /proc/$P/cmdline > /tmp/argv.txt
+   CFG=$(grep '"mcpServers"' /tmp/argv.txt)
+   ```
+
+   `pgrep -f` also matches *your own shell* when the pattern appears in its
+   command line, which is why the loop checks `/proc/<pid>/exe`. Then hand-run
+   `claude -p --debug-file … --mcp-config "$CFG" --strict-mcp-config
+   --allowedTools <qualified names> -- "prompt"` — the `--` is required,
+   because `--allowedTools` is variadic and swallows the prompt otherwise.
+4. **Is the server itself right?** With `$CFG` in hand, drive the endpoint
+   directly and validate the bytes against the spec's own schema
+   (`~/Projects/modelcontextprotocol/schema/<revision>/schema.json`,
+   `CacheableResult` / `ListToolsResult`):
+
+   ```bash
+   URL=$(jq -r '.mcpServers[].url' <<<"$CFG"); TOK=$(jq -r '.mcpServers[].headers.Authorization' <<<"$CFG")
+   curl -s "$URL" -H "Authorization: $TOK" -H 'Content-Type: application/json' \
+     -H 'Accept: application/json, text/event-stream' \
+     -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+   ```
+
+   A response that *looks* fine is the trap: a missing field is invisible
+   without the schema. The client's protocol revision decides which fields are
+   mandatory — the CLI negotiates `2026-07-28`, and rmcp advertises it while
+   leaving that revision's required result fields to the handler.
+
+A control that discriminates "our server" from "the CLI": the same hand-run
+against a stdio server (`npx -y @modelcontextprotocol/server-everything`)
+lists `mcp__ev__*` in `init.tools` and calls `echo`. If that works and ours
+does not, the defect is in what we serve.
+
+`cargo test --test mcp_e2e_probe -j 4 -- --ignored --nocapture` is the
+committed version of probe 1 against the real CLI (one binary, so it is safe
+on this machine); it is `#[ignore]`d and CI never runs it, so a CLI upgrade
+can break every integration with the suite green.
+
 ## Engine-only probe (no app)
 
 `python3-gi` + WebKit2 4.1 is the same library Tauri embeds. An

--- a/.claude/skills/ui-verify/SKILL.md
+++ b/.claude/skills/ui-verify/SKILL.md
@@ -23,6 +23,12 @@ a blank pane in the app.
 .claude/skills/ui-verify/app.sh --status # what is up
 ```
 
+**An app started any other way cannot be driven.** `npm run app:alongside` on
+its own opens no inspector, and `app.sh --status` then answers `inspector DOWN`
+with the launch line to use. Stop that instance (`app.sh --stop`) and launch
+through `app.sh`; the binary is already built, so it is back in ~15 s. Do this
+before the first screenshot, not after the first failure.
+
 A cold start links a ~430 MB debug binary and takes minutes; a warm one is
 instant because the script reuses whatever is already listening. **Leave the
 app running between verifications** — relaunching per check is the single
@@ -63,6 +69,10 @@ shot|/tmp/tokens.png
 EOF
 ```
 
+Fields split on `|`, so a `||` inside a `wait` predicate is cut into three
+fields and fails with `Unexpected end of script`. Write a literal pipe as
+`\|` (`wait|a \|\| b|5000`), or use `??` where it means the same thing.
+
 Measured on this app: **six steps — two navigations, two waits, two
 screenshots — in 0.63 s wall and 50 ms of CPU.** A single `shot` is ~140 ms.
 That budget is why there is no excuse for skipping the visual check, and why
@@ -96,6 +106,70 @@ That budget is why there is no excuse for skipping the visual check, and why
   instead of looping inside the webview.
 - **`pkill -f "tauri dev"` kills the shell running the command**, because the
   pattern appears in that shell's own argv. `app.sh` writes it as `tauri[ ]dev`.
+
+## Flows that are known to work, with the selectors they need
+
+Each of these was driven end to end on 2026-09-07. `text=` is a prefix match
+on trimmed text, and this UI's checkboxes are `<button role="checkbox">`, so
+`input[type=checkbox]` finds nothing anywhere.
+
+**Create an agent** (Agents → the `+` above the list):
+
+```bash
+node ui.mjs click 'text=Agents'
+node ui.mjs click 'button[title="New Agent"]'        # capital A; "New agent" finds nothing
+node ui.mjs type 'input[placeholder="Release Notes Writer"]' 'My Agent'   # Name
+# the two textareas carry no placeholder: [0] is Description, [1] is System prompt
+node ui.mjs eval 'document.querySelectorAll("textarea")[1].id="sysprompt"; 1'
+node ui.mjs type '#sysprompt' 'You are …'
+# tick capabilities by label: each row is .agents-cap with .agents-cap__label
+node ui.mjs eval '[...document.querySelectorAll(".agents-cap")].filter(r=>["list_issues","get_issue"].includes(r.querySelector(".agents-cap__label").textContent.trim())).forEach(r=>r.querySelector("button[role=checkbox]").click()); 1'
+node ui.mjs click 'text=Create'
+node ui.mjs wait '/State\s*Saved/.test(document.querySelector(".pane-inspector").textContent)' 8000
+```
+
+`eval` runs in the page's global scope and the page lives on between calls, so
+a top-level `const t = …` in one `eval` makes the next one throw *"Can't create
+duplicate variable"*. Wrap anything that declares in an IIFE, `(()=>{…})()`.
+
+The slug is derived from the name (`My Agent` → `my-agent`); confirm the store
+with `curl …/api/agents/<slug>` rather than trusting the inspector alone.
+
+**Start a chat on an agent and send a message** (the "New conversation" pane):
+
+```bash
+node ui.mjs click 'text=New Chat'                       # the sidebar button
+node ui.mjs wait 'document.querySelector("button.select")!==null' 3000
+node ui.mjs click 'button.select'                       # the agent picker
+node ui.mjs click 'text=My Agent'                       # a .dropdown__item; "No agent — direct chat" is the first
+node ui.mjs type 'input[placeholder="Working directory (required)"]' '/tmp/agento/work'   # must exist
+node ui.mjs type 'textarea' 'your message'
+node ui.mjs key 'textarea' Enter --ctrl                 # Ctrl+Enter sends; the chat is created on send
+```
+
+Run those as one uninterrupted sequence: the draft pane is a piece of view
+state, and anything that selects a chat (a click in the list, `text=Chats`, a
+hand-off) replaces it — then `textarea` matches the *selected chat's*
+composer and the message lands there instead. Check
+`node ui.mjs text '.pane-inspector'` names the agent you meant before sending.
+
+**Wait for a turn to finish.** The inspector's Status row is the signal, and
+its text has no space between label and value:
+
+```bash
+node ui.mjs wait '/Status\s*Running/i.test(document.querySelector(".pane-inspector").textContent)' 10000
+node ui.mjs wait '/Status\s*Idle/i.test(document.querySelector(".pane-inspector").textContent)' 180000
+node ui.mjs shot /tmp/turn.png
+```
+
+A turn that calls tools takes 20–90 s. The status bar's `Idle` is *not* the
+same signal — it reads Idle before the first frame arrives, so waiting on it
+alone photographs an empty reply. Tool calls render as rows under the
+assistant name with a ✓ or ⚠ at the right; a denied built-in (the agent's
+allowlist working) is the ⚠.
+
+**Open an existing chat**: `.listrow` rows in the middle pane, most recent
+first — `click '.listrow'` is the newest, `'.listrow:nth-child(2)'` the next.
 
 ## When you need *real* OS input, not a DOM click
 

--- a/.claude/skills/ui-verify/ui.mjs
+++ b/.claude/skills/ui-verify/ui.mjs
@@ -281,7 +281,10 @@ try {
     });
     const steps = script.split("\n").map((l) => l.trim()).filter((l) => l && !l.startsWith("#"));
     for (const line of steps) {
-      const [cmd, ...args] = line.split("|");
+      // Fields split on `|`; a literal pipe is `\|` (a `||` in a wait
+      // predicate would otherwise be cut into three fields and fail with
+      // "Unexpected end of script").
+      const [cmd, ...args] = line.split(/(?<!\\)\|/).map((f) => f.replace(/\\\|/g, "|"));
       const out = await dispatch(cmd.trim(), args);
       console.log(`${cmd.trim()}: ${typeof out === "string" ? out : JSON.stringify(out)}`);
     }


### PR DESCRIPTION
Skill-only change, no product code. What was learned reproducing #555 through the app:

- **`ui-verify`**: a `\|` escape in `do` batches (a `||` inside a `wait` predicate used to be split into three fields), the launch caveat (an app started with `npm run app:alongside` has no inspector), the exact selectors for the Agents form, the New Chat composer and waiting on a turn, and the `eval` scope trap.
- **`local-verify`**: a four-step recipe for *"is a hosted MCP tool actually reaching the model?"* — `init.tools` off the SSE capture, the CLI's `--debug-file`, reproducing with the runner's own `--mcp-config` read off the live process, and validating the server's bytes against the spec schema. Agento's log and the CLI's `connected` were both true while every integration tool was invisible; only the first two steps could see it.

The fix for #555 and the detection in #556 are separate work.

https://claude.ai/code/session_01WVhRah4ZioKZyw6L7oBGcC