### PR TITLE
fix: set the ttlMs/cacheScope a 2026-07-28 tools/list requires (#555)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
             exit 0
           fi
 
-          echo "::error::version strings disagree — tauri.conf.json=${conf} package.json=${pkg} package-lock.json=${lock} package-lock.json .packages['']=${lock_pkg} src-tauri/Cargo.toml=${cargo_toml}. Fix with: npm version ${conf} --no-git-tag-version (package.json + lockfile), and set src-tauri/tauri.conf.json and src-tauri/Cargo.toml by hand (then \`cargo update -p agento --offline\` for Cargo.lock). See docs/releasing.md step 1."
+          echo "::error::version strings disagree — tauri.conf.json=${conf} package.json=${pkg} package-lock.json=${lock} package-lock.json .packages['']=${lock_pkg} src-tauri/Cargo.toml=${cargo_toml}. Fix with: npm version ${conf} --no-git-tag-version (package.json + lockfile), and set src-tauri/tauri.conf.json and src-tauri/Cargo.toml by hand (then \`cargo update -p agento --offline\` for Cargo.lock). See docs/releasing.md step 2."
           exit 1
 
       # Every CLAUDE.md stays under 40k characters. Claude Code truncates a

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
           check "src-tauri/Cargo.toml"               "$cargo_toml_version"
 
           if [ "$fail" = 1 ]; then
-            echo "::error::Fix with: npm version ${tag_version} --no-git-tag-version (package.json + lockfile), set src-tauri/tauri.conf.json and src-tauri/Cargo.toml by hand, then \`cargo update -p agento --offline\` for Cargo.lock. Then re-tag. See docs/releasing.md step 1."
+            echo "::error::Fix with: npm version ${tag_version} --no-git-tag-version (package.json + lockfile), set src-tauri/tauri.conf.json and src-tauri/Cargo.toml by hand, then \`cargo update -p agento --offline\` for Cargo.lock. Then re-tag. See docs/releasing.md step 2."
             exit 1
           fi
           echo "ok: ${tag_version} in all five places"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ Where a new note goes:
   lockfile is the one with teeth — npm repairs that field on almost any command,
   so every checkout goes dirty on the first `npm run build` with a change nobody
   made, which reads as local work and comes back as soon as it is discarded. See
-  `docs/releasing.md` step 1.
+  `docs/releasing.md` step 2.
 - Tagging builds a **draft** release with `latest.json` staged as an asset.
   Nothing has shipped at that point — draft assets are not publicly
   downloadable. **Publishing the draft is the release act**: the

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -64,7 +64,25 @@ cannot download.
 
 ## Cutting a release
 
-1. **Bump the version in all five places**, and commit them together on `main`:
+1. **Run the MCP end-to-end probe**, which CI never does.
+
+   ```bash
+   cd src-tauri && cargo test --test mcp_e2e_probe -- --ignored --nocapture
+   ```
+
+   It is `#[ignore]`d because it needs the Claude Code CLI, a signed-in profile
+   and it spends tokens — so nothing runs it unless a human does, and it is the
+   **only** test that sees the model's side of a hosted tool: that the tool is
+   listed in the `init` event, and that a `tool_result` carries the text our
+   handler produced. Run it **before every tag**, and again **whenever the
+   Claude Code CLI version changes**, because the CLI is what negotiates the MCP
+   protocol revision and a revision bump can invalidate our answers without a
+   line of Agento changing. That is exactly how #555 happened: the CLI moved to
+   revision `2026-07-28`, which made `ttlMs`/`cacheScope` mandatory on a
+   `tools/list` result, every integration went dark, and the CLI went on
+   reporting the server `"connected"`. This probe would have caught it that day.
+
+2. **Bump the version in all five places**, and commit them together on `main`:
    `src-tauri/tauri.conf.json`, `package.json`, `package-lock.json` (which
    carries it twice), `src-tauri/Cargo.toml` and `src-tauri/Cargo.lock`.
 
@@ -80,7 +98,7 @@ cannot download.
    alone leaves it behind. `cargo update -p agento --offline` does the same job
    for `Cargo.lock` without touching any dependency.
 
-   **All five are enforced now**, by the guard job in step 2 and by CI on every
+   **All five are enforced now**, by the guard job in step 3 and by CI on every
    PR. `tauri.conf.json` is the one that decides what ships — the bundler bakes
    it into the installer and the updater compares against it — and the rest are
    checked because nothing else ever looks at them. That is not hypothetical:
@@ -91,25 +109,25 @@ cannot download.
    tree dirty with a change nobody made, which reads as local work, invites
    someone to discard it, and comes straight back.
 
-2. **Tag that commit** and push the tag.
+3. **Tag that commit** and push the tag.
 
    ```bash
    git tag v1.1.0
    git push origin v1.1.0
    ```
 
-3. **Wait for the build.** Five runners, one per target: Linux x86_64, Linux
+4. **Wait for the build.** Five runners, one per target: Linux x86_64, Linux
    aarch64, macOS Apple Silicon, macOS Intel, Windows x86_64. Tauri cannot
    cross-compile its bundles, which is why each needs its own runner.
 
-4. **Check the draft release.** Confirm every platform's installer is attached
+5. **Check the draft release.** Confirm every platform's installer is attached
    and `latest.json` is there. Download one and launch it if the change was
    risky.
 
-5. **Write the release notes** into the draft's body, before publishing. See
+6. **Write the release notes** into the draft's body, before publishing. See
    [Release notes](#release-notes) below.
 
-6. **Publish the draft.** That fires `promote`, which copies the staged manifest
+7. **Publish the draft.** That fires `promote`, which copies the staged manifest
    to `desktop-latest`. Installed apps start seeing the update within their next
    check.
 
@@ -165,7 +183,7 @@ exists:
 ## The two guards
 
 **The tag must equal `v` plus the version in `tauri.conf.json`** (and in the four
-other files listed in step 1). A guard job fails the build otherwise, before
+other files listed in step 2). A guard job fails the build otherwise, before
 anything is built.
 
 This is not tidiness. The installed app compares the version baked into it at

--- a/src-tauri/src/claude/CLAUDE.md
+++ b/src-tauri/src/claude/CLAUDE.md
@@ -142,6 +142,26 @@ Consequences, each load-bearing:
   model nothing. The practical cost is that `?` needs a `String`, so every
   fallible call carries `.map_err(|e| format!("…: {e}"))` — the same context
   `fmt.Errorf` supplies, and the same message the model gets.
+- **A hand-written `list` handler owns `ttlMs` and `cacheScope`** (#555).
+  Protocol revision `2026-07-28` (SEP-2549) makes both **required** on the
+  result of `tools/list`, `prompts/list`, `resources/list`, `resources/read` and
+  `resources/templates/list`; the Claude Code CLI validates against that schema
+  and **discards the whole tool list** when either is missing, while still
+  reporting the server `"status":"connected"` — so every integration goes dark
+  and nothing anywhere says why. `rmcp` advertises the revision in
+  `ProtocolVersion::KNOWN_VERSIONS`, so we have promised the contract, but keeps
+  both fields `Option` for older peers and `with_all_items` sets neither; the
+  macro handlers it fixed for this (rust-sdk #1120) are unreachable because the
+  `macros` feature is off. `ToolServer::list_tools` therefore sets `ttlMs: 0`
+  (the spec's "immediately stale" — the tool set is per turn and per integration
+  row) and `cacheScope: private` (nothing is shareable across authorization
+  contexts; every listener has its own bearer token), pinned on the wire by
+  `mcp::tests::a_tool_list_carries_the_cache_hints_the_cli_requires`. Agento
+  serves no prompts or resources; the first one it serves needs the same two
+  fields. The revision's other requirements are `rmcp`'s and already met —
+  `server/discover`, `resultType` on every result (stripped for pre-2026 peers),
+  the `Mcp-Method`/`Mcp-Name` request headers, `subscriptions/listen` in place of
+  the `GET` stream, and no `Mcp-Session-Id` (we are stateless already).
 - **A handler takes the call's `CancellationToken`.** Go threads `ctx` into
   every `http.NewRequestWithContext`, so a cancelled turn aborts the outbound
   call. Rust does not inherit that: `rmcp` spawns a handler detached and

--- a/src-tauri/src/claude/mcp.rs
+++ b/src-tauri/src/claude/mcp.rs
@@ -380,6 +380,57 @@ mod tests {
         assert_eq!(response.status(), 202, "a notification has no reply");
     }
 
+    /// The two fields SEP-2549 made mandatory on a `tools/list` result at
+    /// protocol revision 2026-07-28 (#555). The Claude Code CLI validates the
+    /// result against that schema and drops the entire tool list when either is
+    /// absent, while still reporting the server connected — so the whole of
+    /// Agento's tool hosting is dead and nothing anywhere says why.
+    ///
+    /// Asserted on the **bytes the client receives**, not on the Rust value:
+    /// both fields are `Option` in `rmcp` with `skip_serializing_if`, so a
+    /// value-level assertion passes on a `Some` that never reaches the wire,
+    /// and the wire is what the CLI validates. Driven over the real transport
+    /// because `RequestContext`'s `Peer` cannot be built outside `rmcp`, which
+    /// makes an HTTP round trip the only way to reach `ToolServer::list_tools`
+    /// at all.
+    #[tokio::test]
+    async fn a_tool_list_carries_the_cache_hints_the_cli_requires() {
+        let server = start_in_process_mcp_server("probe", echo_server())
+            .await
+            .unwrap();
+
+        let response = post(&server, r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#).await;
+        assert_eq!(response.status(), 200);
+        let body: serde_json::Value =
+            serde_json::from_str(&response.text().await.unwrap()).unwrap();
+        let result = &body["result"];
+
+        let ttl = result
+            .get("ttlMs")
+            .unwrap_or_else(|| panic!("`ttlMs` is required on a tools/list result: {result}"));
+        assert!(
+            ttl.as_u64().is_some(),
+            "`ttlMs` must be a non-negative number, got {ttl}"
+        );
+        let scope = result
+            .get("cacheScope")
+            .unwrap_or_else(|| panic!("`cacheScope` is required on a tools/list result: {result}"));
+        assert!(
+            matches!(scope.as_str(), Some("public") | Some("private")),
+            "`cacheScope` must be `public` or `private`, got {scope}"
+        );
+
+        // The values Agento chose, pinned so a change to them is deliberate:
+        // the tool set is per turn and per integration row, and every listener
+        // carries its own bearer token.
+        assert_eq!(result["ttlMs"], 0);
+        assert_eq!(result["cacheScope"], "private");
+        assert_eq!(
+            result["tools"][0]["name"], "echo",
+            "the hints travel with a real tool list, not instead of one"
+        );
+    }
+
     #[tokio::test]
     async fn a_tool_call_reaches_the_handler() {
         let server = start_in_process_mcp_server("probe", echo_server())

--- a/src-tauri/src/claude/tool.rs
+++ b/src-tauri/src/claude/tool.rs
@@ -111,8 +111,8 @@ use rmcp::handler::server::router::tool::{
 use rmcp::handler::server::tool::ToolCallContext;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{
-    CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, Implementation,
-    ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
+    CacheScope, CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock,
+    Implementation, ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
 };
 use rmcp::service::RequestContext;
 use rmcp::{ErrorData, RoleServer, ServerHandler};
@@ -402,7 +402,33 @@ impl ServerHandler for ToolServer {
         _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> std::result::Result<ListToolsResult, ErrorData> {
-        Ok(ListToolsResult::with_all_items(self.router.list_all()))
+        // SEP-2549: protocol revision 2026-07-28 makes `ttlMs` and `cacheScope`
+        // REQUIRED on a `tools/list` result, and the Claude Code CLI validates
+        // the result against that schema and discards the **whole tool list**
+        // when either is missing — silently, with the server still reported
+        // `"status":"connected"`, so the model simply answers that no such
+        // tools exist. `rmcp` advertises 2026-07-28 in
+        // `ProtocolVersion::KNOWN_VERSIONS` (so we have promised the contract)
+        // but leaves both fields `Option` for older peers, and
+        // `with_all_items` sets neither: a hand-written handler owns them. The
+        // macro handlers the SDK fixed in rust-sdk #1120 are unreachable here
+        // by design — #282 runs with the `macros` feature off because tools are
+        // chosen at runtime. Sending both to a legacy-revision peer is
+        // harmless, so there is no per-version branch.
+        //
+        // `ttlMs: 0` is the spec's "immediately stale", which is right: the
+        // tool set is per turn and per integration row. `private` is the scope
+        // the TypeScript SDK defaults to, and nothing here is shareable across
+        // authorization contexts anyway — every listener carries its own bearer
+        // token.
+        //
+        // The same two fields are required on `prompts/list`, `resources/list`,
+        // `resources/read` and `resources/templates/list`. Agento serves none of
+        // them; whichever one is served first has to set them here too.
+        // Pinned on the wire by `mcp::tests::a_tool_list_carries_the_cache_hints_the_cli_requires`.
+        Ok(ListToolsResult::with_all_items(self.router.list_all())
+            .with_ttl_ms(0)
+            .with_cache_scope(CacheScope::Private))
     }
 
     async fn call_tool(

--- a/src-tauri/src/claude/tool.rs
+++ b/src-tauri/src/claude/tool.rs
@@ -402,30 +402,17 @@ impl ServerHandler for ToolServer {
         _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> std::result::Result<ListToolsResult, ErrorData> {
-        // SEP-2549: protocol revision 2026-07-28 makes `ttlMs` and `cacheScope`
-        // REQUIRED on a `tools/list` result, and the Claude Code CLI validates
-        // the result against that schema and discards the **whole tool list**
-        // when either is missing — silently, with the server still reported
-        // `"status":"connected"`, so the model simply answers that no such
-        // tools exist. `rmcp` advertises 2026-07-28 in
-        // `ProtocolVersion::KNOWN_VERSIONS` (so we have promised the contract)
-        // but leaves both fields `Option` for older peers, and
-        // `with_all_items` sets neither: a hand-written handler owns them. The
-        // macro handlers the SDK fixed in rust-sdk #1120 are unreachable here
-        // by design — #282 runs with the `macros` feature off because tools are
-        // chosen at runtime. Sending both to a legacy-revision peer is
-        // harmless, so there is no per-version branch.
-        //
-        // `ttlMs: 0` is the spec's "immediately stale", which is right: the
-        // tool set is per turn and per integration row. `private` is the scope
-        // the TypeScript SDK defaults to, and nothing here is shareable across
-        // authorization contexts anyway — every listener carries its own bearer
-        // token.
-        //
-        // The same two fields are required on `prompts/list`, `resources/list`,
-        // `resources/read` and `resources/templates/list`. Agento serves none of
-        // them; whichever one is served first has to set them here too.
-        // Pinned on the wire by `mcp::tests::a_tool_list_carries_the_cache_hints_the_cli_requires`.
+        // SEP-2549: at protocol revision 2026-07-28 `ttlMs` and `cacheScope`
+        // are REQUIRED on a `tools/list` result, and the Claude Code CLI
+        // discards the **whole tool list** when either is missing — while still
+        // reporting the server `"status":"connected"`. `rmcp` advertises that
+        // revision but leaves both fields `Option`, so a hand-written handler
+        // owns them. `ttlMs: 0` is the spec's "immediately stale" (the tool set
+        // is per turn and per integration row) and `private` is right because
+        // every listener carries its own bearer token. Why in full, including
+        // what `prompts/list` and `resources/*` would need: `CLAUDE.md`,
+        // *Hosting a tool*. Pinned on the wire by
+        // `mcp::tests::a_tool_list_carries_the_cache_hints_the_cli_requires`.
         Ok(ListToolsResult::with_all_items(self.router.list_all())
             .with_ttl_ms(0)
             .with_cache_scope(CacheScope::Private))


### PR DESCRIPTION
Closes #555

## What

`ToolServer::list_tools` now returns a `ListToolsResult` carrying `ttlMs: 0` and `cacheScope: "private"`, plus a wire-level regression guard, plus the release-checklist step that would have caught this the day it broke.

## Why

The Claude Code CLI negotiates MCP protocol revision `2026-07-28`, where SEP-2549 makes `ttlMs` and `cacheScope` **required** on a `tools/list` result. The CLI validates the result against that schema and discards the **whole tool list** when either is missing — while still reporting the server `"status":"connected"` and while Agento logs `tools=[…]` beside it. Every hosted tool (all six integrations and the local `current_time` server) was invisible to the model, and nothing in the log, the chat or the inspector said why.

`rmcp` advertises the revision in `ProtocolVersion::KNOWN_VERSIONS`, so we have promised the contract, but keeps both fields `Option` for older peers and `with_all_items` sets neither. The SDK's own fix (rust-sdk #1120) touched only `rmcp-macros`, and #282 runs with `macros` off by design — so a hand-written list handler owns these two fields.

## How

- **`src-tauri/src/claude/tool.rs`** — `.with_ttl_ms(0).with_cache_scope(CacheScope::Private)` on the one hand-written list handler every integration and the local-tools server share. `0` is the spec's *immediately stale*, correct because the tool set is per turn and per integration row; `private` because every listener carries its own bearer token. Sending both to a legacy-revision peer is harmless, so there is no per-version branch.
- **`src-tauri/src/claude/mcp.rs`** — `a_tool_list_carries_the_cache_hints_the_cli_requires`: starts a real in-process server, POSTs `tools/list` over the real transport, and asserts on the **response bytes** — that `ttlMs` is present and a non-negative number, that `cacheScope` is in the enum, and that the hints travel with a real tool list.
- **`docs/releasing.md`** — new step 1: run `cargo test --test mcp_e2e_probe -- --ignored` before every tag and whenever the Claude Code CLI version changes. It is the only test that sees the model's side and CI never runs it.
- **`src-tauri/src/claude/CLAUDE.md`** — the rule under *Hosting a tool*, including what `prompts/list` and `resources/*` would need and which of the revision's requirements are `rmcp`'s.
- **`.github/workflows/{ci,release}.yml`, `CLAUDE.md`** — the version-guard error text and one note point at `docs/releasing.md` **step 2** now that the probe is step 1. Without this the message a maintainer reads when a release is already broken sends them to the wrong step.

## Verification

| | |
|---|---|
| `cargo test --test mcp_e2e_probe -- --ignored` (real CLI) | **passes** with the fix; **fails** with only the two builder calls reverted |
| `a_tool_list_carries_the_cache_hints_the_cli_requires` | passes; reverting the fix fails it with `\`ttlMs\` is required on a tools/list result: {"tools":[…]}` — the exact wire shape the CLI rejects |
| local gates | `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, full `cargo test` (1517 lib + all suites), `cargo build --profile ci`, `npm run build`, the CLAUDE.md size gate |

## Deviation from the issue's HOW

Acceptance criterion 1 asked for the guard in `claude/tool.rs`'s `mod tests`, driving `ToolServer::list_tools` directly. **That is not constructible**: `list_tools` takes a `RequestContext<RoleServer>`, whose `peer` can only be built by `Peer::new`, which is `pub(crate)` in `rmcp` 3.1.4. The guard therefore lives in `claude/mcp.rs` beside the existing `tools/list` test and asserts on the bytes a client actually receives — a stricter reading of the criterion's own intent. Recorded on the issue: shaharia-lab/agento#555 (comment).

The `rmcp` 3.1.4 → 3.2.0 bump named in the issue is **not** here: the issue puts it out of scope and requires the fix to be provably independent of it.