### PR TITLE
docs(skills): tick agent tools inside their integration group, and what a Telegram end-to-end run needs

### DIFF
--- a/.claude/skills/local-verify/SKILL.md
+++ b/.claude/skills/local-verify/SKILL.md
@@ -297,6 +297,16 @@ model — the CLI had fetched the tool list and **discarded it as invalid**
    mandatory — the CLI negotiates `2026-07-28`, and rmcp advertises it while
    leaving that revision's required result fields to the handler.
 
+**Telegram end to end needs a bot that has been started.** A bot cannot message
+a user who never opened it, so before the agent can `send_message` back,
+open `t.me/<bot>` from the user's own Telegram Web, press **Start**, and send
+one message — that is the update `read_messages` finds and the chat id
+`send_message` needs. The first message typed right after the chat opens can
+be dropped by Telegram Web (verified 2026-09-07: `/start` landed, the message
+sent 2 s later did not), so check the chat shows it before reading. The token
+BotFather prints is the user's to paste into Integrations → Telegram; do not
+type it anywhere yourself.
+
 A control that discriminates "our server" from "the CLI": the same hand-run
 against a stdio server (`npx -y @modelcontextprotocol/server-everything`)
 lists `mcp__ev__*` in `init.tools` and calls `echo`. If that works and ours

--- a/.claude/skills/ui-verify/SKILL.md
+++ b/.claude/skills/ui-verify/SKILL.md
@@ -122,8 +122,12 @@ node ui.mjs type 'input[placeholder="Release Notes Writer"]' 'My Agent'   # Name
 # the two textareas carry no placeholder: [0] is Description, [1] is System prompt
 node ui.mjs eval 'document.querySelectorAll("textarea")[1].id="sysprompt"; 1'
 node ui.mjs type '#sysprompt' 'You are …'
-# tick capabilities by label: each row is .agents-cap with .agents-cap__label
-node ui.mjs eval '[...document.querySelectorAll(".agents-cap")].filter(r=>["list_issues","get_issue"].includes(r.querySelector(".agents-cap__label").textContent.trim())).forEach(r=>r.querySelector("button[role=checkbox]").click()); 1'
+# tick capabilities by label INSIDE one integration group: tool names repeat
+# across integrations (Slack and Telegram both have send_message and
+# read_messages), so a page-wide label match ticks both and the agent gets a
+# second integration nobody asked for. Each group is .agents-group, its name
+# is .agents-group__name, each row is .agents-cap with .agents-cap__label.
+node ui.mjs eval '(()=>{const g=[...document.querySelectorAll(".agents-group")].find(x=>x.querySelector(".agents-group__name")?.textContent.trim()==="GitHub");[...g.querySelectorAll(".agents-cap")].filter(r=>["list_issues","get_issue"].includes(r.querySelector(".agents-cap__label").textContent.trim())).forEach(r=>r.querySelector("button[role=checkbox]").click());return 1})()'
 node ui.mjs click 'text=Create'
 node ui.mjs wait '/State\s*Saved/.test(document.querySelector(".pane-inspector").textContent)' 8000
 ```
@@ -131,6 +135,10 @@ node ui.mjs wait '/State\s*Saved/.test(document.querySelector(".pane-inspector")
 `eval` runs in the page's global scope and the page lives on between calls, so
 a top-level `const t = …` in one `eval` makes the next one throw *"Can't create
 duplicate variable"*. Wrap anything that declares in an IIFE, `(()=>{…})()`.
+
+After Create, read the stored capabilities back (`curl …/api/agents/<slug> |
+jq .capabilities`) before starting a chat on the agent: a wrongly ticked write
+tool is a message sent somewhere real.
 
 The slug is derived from the name (`My Agent` → `my-agent`); confirm the store
 with `curl …/api/agents/<slug>` rather than trusting the inspector alone.


### PR DESCRIPTION
Skill-only, no product code. Two things learned running Telegram end to end from the UI: the agent form's tool names repeat across integrations (Slack and Telegram both have `send_message` / `read_messages`), so the recipe now ticks inside one `.agents-group` and reads the stored capabilities back before chatting; and the Telegram prerequisites (the bot must be started from the user's own account, the first message after opening the chat can be dropped, the token is the user's to paste).

https://claude.ai/code/session_01WVhRah4ZioKZyw6L7oBGcC