### PR TITLE
feat: say so when the CLI drops a hosted tool list (#556)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -288,6 +288,32 @@ redirect to a local address, allow it and retry.
 Three things have to line up: the integration is connected, the service is
 enabled inside it, and the tool is ticked on the agent.
 
+### "…tools were hosted but the Claude CLI did not offer them to the model"
+
+Agento started the server and registered its tools, and the Claude Code CLI then
+gave the model none of them. The chat shows this as a notice on the turn; a
+scheduled task records it on the run's row in **Tasks → History**, which still
+reads `success` because the run itself completed. Everything else in the app
+reports the server as connected, which is why this message exists at all.
+
+The tools are genuinely unavailable to the model for that turn, so it will say
+the tool does not exist. Nothing on the Agento side can be reconfigured to fix
+it — it is the CLI that dropped the list — but two things narrow it down:
+
+- **The app log names the server and the missing tools**, on a line beginning
+  `mcp tools not offered to the model`. See [Reading the logs](#reading-the-logs).
+- **The reason is in the CLI's own debug log, which Agento never sees.** Run one
+  turn by hand with `--debug-file` and grep it:
+
+  ```bash
+  claude -p --debug-file /tmp/cli.debug "hello"
+  grep -i mcp /tmp/cli.debug
+  ```
+
+  A line like `tools/list failed (Invalid result for tools/list: …)` names the
+  field the CLI rejected. Upgrading the Claude Code CLI, or updating Agento, is
+  usually the fix — this is what a version skew between the two looks like.
+
 ### WhatsApp is listed but unusable
 
 Agento does not support WhatsApp. An integration created by an older version is

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -292,7 +292,7 @@ enabled inside it, and the tool is ticked on the agent.
 
 Agento started the server and registered its tools, and the Claude Code CLI then
 gave the model none of them. The chat shows this as a notice on the turn; a
-scheduled task records it on the run's row in **Tasks → History**, which still
+scheduled task records it on the run's row in **Job History**, which still
 reads `success` because the run itself completed. Everything else in the app
 reports the server as connected, which is why this message exists at all.
 

--- a/src-tauri/src/native/agent_run.rs
+++ b/src-tauri/src/native/agent_run.rs
@@ -164,9 +164,7 @@ async fn collect_run_result(
                     crate::native::chat::runner::report_tools_offered(hosted_tools, system)
                 {
                     if dropped.whole_server {
-                        tools_not_offered.push(crate::native::chat::runner::tools_dropped_message(
-                            &dropped.server,
-                        ));
+                        tools_not_offered.push(dropped.message());
                     }
                 }
             }

--- a/src-tauri/src/native/agent_run.rs
+++ b/src-tauri/src/native/agent_run.rs
@@ -31,6 +31,12 @@ pub struct RunResult {
     pub output_tokens: i64,
     pub cache_creation_tokens: i64,
     pub cache_read_tokens: i64,
+    /// One sentence per MCP server whose hosted tools the CLI never handed the
+    /// model (#556). A scheduled run has nobody reading the app log, so this
+    /// travels out to `job_history` — see
+    /// [`crate::native::schedule::executor`]. Empty is the normal case, and a
+    /// non-empty one never fails the run.
+    pub tools_not_offered: Vec<String>,
 }
 
 /// `agent.RunAgent`: build the options, spawn the CLI, drain it, answer the
@@ -67,7 +73,7 @@ pub async fn run_headless(
     // The refusal this port has that Go does not — an agent whose tools cannot
     // be hosted here. The caller decides what to do with it; both callers
     // record it rather than dropping it.
-    let (options, tool_servers) =
+    let (options, tool_servers, hosted_tools) =
         tokio::time::timeout_at(deadline, runner::build_options(spec, None))
             .await
             .map_err(|_| DEADLINE_EXCEEDED.to_string())?
@@ -90,9 +96,10 @@ pub async fn run_headless(
         }
     };
 
-    let collected = tokio::time::timeout_at(deadline, collect_run_result(&mut stream))
-        .await
-        .unwrap_or_else(|_| Err(DEADLINE_EXCEEDED.to_string()));
+    let collected =
+        tokio::time::timeout_at(deadline, collect_run_result(&mut stream, &hosted_tools))
+            .await
+            .unwrap_or_else(|_| Err(DEADLINE_EXCEEDED.to_string()));
 
     stream.close();
     // The in-process tool listeners outlive the subprocess and stop when
@@ -140,11 +147,30 @@ pub const DEADLINE_EXCEEDED: &str = "context deadline exceeded";
 /// and returning early would race the scanner against a half-written file.
 async fn collect_run_result(
     stream: &mut crate::claude::client::Stream,
+    hosted_tools: &[crate::native::chat::runner::HostedTools],
 ) -> Result<RunResult, String> {
     let mut result: Option<RunResult> = None;
     let mut result_err: Option<String> = None;
+    let mut tools_not_offered: Vec<String> = Vec::new();
 
     while let Some(event) = stream.next_event().await {
+        // The `init` frame says what the model was actually given, which is the
+        // only place a dropped tool list is visible (#556). A scheduled run has
+        // no stream to put a synthetic frame on, so the finding travels out on
+        // the result and reaches the `job_history` row instead.
+        if let Some(system) = event.system.as_ref() {
+            if system.subtype == crate::claude::messages::system_subtype::INIT {
+                for dropped in
+                    crate::native::chat::runner::report_tools_offered(hosted_tools, system)
+                {
+                    if dropped.whole_server {
+                        tools_not_offered.push(crate::native::chat::runner::tools_dropped_message(
+                            &dropped.server,
+                        ));
+                    }
+                }
+            }
+        }
         let Some(r) = event.result.as_ref() else {
             continue;
         };
@@ -158,6 +184,7 @@ async fn collect_run_result(
                 output_tokens: r.usage.output_tokens,
                 cache_creation_tokens: r.usage.cache_creation_input_tokens,
                 cache_read_tokens: r.usage.cache_read_input_tokens,
+                tools_not_offered: Vec::new(),
             });
         }
     }
@@ -165,7 +192,12 @@ async fn collect_run_result(
     if let Some(err) = result_err {
         return Err(err);
     }
-    result.ok_or_else(|| "agent finished without returning a result".to_string())
+    // Attached after the loop, so it is carried by whichever `result` frame
+    // turned out to be the last one — `init` always precedes them all.
+    let mut result =
+        result.ok_or_else(|| "agent finished without returning a result".to_string())?;
+    result.tools_not_offered = tools_not_offered;
+    Ok(result)
 }
 
 /// `buildResultError`, message for message.

--- a/src-tauri/src/native/chat/CLAUDE.md
+++ b/src-tauri/src/native/chat/CLAUDE.md
@@ -107,9 +107,13 @@ every turn is worse than silence. **The agreeing case emits nothing at all** —
 no line, no frame. And a mismatch is a **warning, never a refusal**: the turn
 runs and answers, for `start_local_tools`' own reason. Only a *whole* server's
 tools vanishing from a server the CLI called `connected` reaches the user, as a
-`tools_not_offered` frame here and as text on the `job_history` row for a
-headless run (`agent_run::collect_run_result` → `executor::finish`), because a
-scheduled run has nobody reading the log. The reason behind a miss is in the
+`tools_not_offered` frame here — rendered by `useChatStream`'s own case as the
+amber `banner`, never the red `banner--error`, because the turn answered — and
+as text on the `job_history` row for a headless run
+(`agent_run::collect_run_result` → `executor::finish`), because a scheduled run
+has nobody reading the log. **That row is the first `success` row that can
+carry `error_message`**, so `JobsView` titles the group off the status rather
+than off the column being non-empty. The reason behind a miss is in the
 CLI's own `--debug-file` log, which Agento never sees; `docs/troubleshooting.md`
 carries the hand-run that gets it.
 

--- a/src-tauri/src/native/chat/CLAUDE.md
+++ b/src-tauri/src/native/chat/CLAUDE.md
@@ -113,7 +113,11 @@ as text on the `job_history` row for a headless run
 (`agent_run::collect_run_result` → `executor::finish`), because a scheduled run
 has nobody reading the log. **That row is the first `success` row that can
 carry `error_message`**, so `JobsView` titles the group off the status rather
-than off the column being non-empty. The reason behind a miss is in the
+than off the column being non-empty. **The sentence names the server's *label*,
+not its `mcpServers` key** — for an integration that key is a v4 UUID the user
+has never seen — which is why it is `ToolsDropped::message()` rather than a
+function taking a name: with two callers and a free function, one of them passed
+the wrong field. The reason behind a miss is in the
 CLI's own `--debug-file` log, which Agento never sees; `docs/troubleshooting.md`
 carries the hand-run that gets it.
 

--- a/src-tauri/src/native/chat/CLAUDE.md
+++ b/src-tauri/src/native/chat/CLAUDE.md
@@ -11,8 +11,9 @@
 ## Things that will bite
 
 - **Chat SSE is a POST response**, so `EventSource` cannot be used. Events are
-  the raw Claude CLI JSON lines passed through verbatim, plus two synthetic
-  ones Agento adds (`user_input_required`, `permission_request`).
+  the raw Claude CLI JSON lines passed through verbatim, plus three synthetic
+  ones Agento adds (`user_input_required`, `permission_request`,
+  `tools_not_offered`).
 - **`AskUserQuestion` is answered by *denying* the tool** with the user's text
   in `Message` — that is how the answer reaches the model. Not a bug.
 - **A continued chat's inherited history is the transcript's, and it is a fixed
@@ -88,6 +89,29 @@ Covered with it: `wrap_permission_handler`'s allowlist (a tool the agent does no
 name is denied **without a prompt** — the absence is the assertion), the
 `AskUserQuestion` bypass of that allowlist, and the `permission_request` frame
 with its allow and deny answers.
+
+**The `init` frame is read, not only forwarded (#556).** `handle_event`'s
+`system` arm diffs `SystemMessage::tools` — the list of tools the CLI actually
+gave the model, MCP ones already qualified `mcp__<server>__<tool>` — against
+what this turn hosted, and `runner::report_tools_offered` warns on the
+difference. The two hops disagreeing **is** the defect signal: #501's
+`report_hosted_tools` reads names off the *handle*, so it can say a server hosts
+nothing, and only this frame can say whether what we hosted reached the model.
+#555 is why it exists — every integration was dead for a CLI release while the
+log, `"status":"connected"` and the inspector's tool count all said otherwise.
+
+Three rules on it, each of which makes it worthless if broken. The diff is taken
+against what the runner **asked for after `--allowedTools`/`--disallowedTools`**
+(`runner::narrow_to_command_line`), because a narrowing allowlist that warned on
+every turn is worse than silence. **The agreeing case emits nothing at all** —
+no line, no frame. And a mismatch is a **warning, never a refusal**: the turn
+runs and answers, for `start_local_tools`' own reason. Only a *whole* server's
+tools vanishing from a server the CLI called `connected` reaches the user, as a
+`tools_not_offered` frame here and as text on the `job_history` row for a
+headless run (`agent_run::collect_run_result` → `executor::finish`), because a
+scheduled run has nobody reading the log. The reason behind a miss is in the
+CLI's own `--debug-file` log, which Agento never sees; `docs/troubleshooting.md`
+carries the hand-run that gets it.
 
 - **`result` is not terminal.** With an `AskUserQuestion` pending the same
   subprocess carries on, so one HTTP request spans several turns and several
@@ -183,8 +207,11 @@ sees. Two places that mattered:
   which is exactly why nothing noticed.
 
 **The rule lives on the field, not at the construction site**, at all four of
-them: the two SSE structs in `chat/turn.rs`, plus `chats::MessageBlock::input`
-and `sessions::detail::NormalizedBlock::input`. `MessageBlock` is why — it has
+them: the two SSE structs in `chat/turn.rs` that carry a raw value, plus
+`chats::MessageBlock::input` and `sessions::detail::NormalizedBlock::input`.
+(`ToolsNotOffered` is the third synthetic frame and carries none, so the rule
+does not reach it — it is still encoded through `gojson` like every frame this
+side constructs.) `MessageBlock` is why — it has
 *two* sinks, the column via `persist::append_message` and the wire via
 `GET /api/chats/{id}`, and it had two independent compaction points, one of which
 was simply missing. A third construction path would have been silently wrong the

--- a/src-tauri/src/native/chat/runner.rs
+++ b/src-tauri/src/native/chat/runner.rs
@@ -628,11 +628,14 @@ async fn start_integration_servers(
                     &spec.tools,
                 )
                 .await?;
-                hosted.push(report_hosted_tools(
-                    &spec.id,
-                    server.tool_names(),
-                    &spec.tools,
-                ));
+                let registered = report_hosted_tools(&spec.id, server.tool_names(), &spec.tools);
+                hosted.push(HostedTools {
+                    tools: crate::native::integrations::registry::allowed_tool_names(
+                        &spec.id,
+                        &registered,
+                    ),
+                    server: spec.id.clone(),
+                });
                 let registered = opts.with_mcp_server(&spec.id, server.config());
                 servers.push(server);
                 registered
@@ -687,11 +690,15 @@ async fn start_local_tools(
     let server = crate::native::tools::start_local_mcp_server()
         .await
         .map_err(|e| format!("starting local MCP server: {e}"))?;
-    hosted.push(report_hosted_tools(
+    let registered = report_hosted_tools(
         crate::native::tools::LOCAL_MCP_SERVER_NAME,
         server.tool_names(),
         local,
-    ));
+    );
+    hosted.push(HostedTools {
+        server: crate::native::tools::LOCAL_MCP_SERVER_NAME.to_string(),
+        tools: crate::native::tools::allowed_tool_names(registered.iter()),
+    });
     let opts = opts
         .with_mcp_server(crate::native::tools::LOCAL_MCP_SERVER_NAME, server.config())
         .map_err(|e| format!("registering the local MCP server: {e}"))?
@@ -722,20 +729,26 @@ async fn start_local_tools(
 /// value `{:?}`, after the effect — with one departure it does not cover:
 /// the mismatch line is at `warn`, because the seam's own split puts failures
 /// there and a tool the model cannot reach is one.
-fn report_hosted_tools(server_key: &str, hosted: &[String], requested: &[String]) -> HostedTools {
+///
+/// Since #556 it also **returns the overlap** — the requested names this server
+/// really registered — so that the set the log reports and the set the `init`
+/// frame is diffed against are one computation and cannot drift. The names come
+/// back **bare**: each caller qualifies them with its own `allowed_tool_names`,
+/// the function that already owns the `mcp__<key>__<tool>` rule and the one that
+/// built this server's entries in `--allowedTools`. A third copy of that format
+/// string here would desynchronise the two on any change to it, and the symptom
+/// would be a warning on every turn.
+fn report_hosted_tools(server_key: &str, hosted: &[String], requested: &[String]) -> Vec<String> {
     log::info!("mcp server started server={server_key:?} tools={hosted:?}");
-    let mut tools = Vec::new();
+    let mut registered = Vec::new();
     for tool in requested {
         if hosted.iter().any(|name| name == tool) {
-            tools.push(format!("mcp__{server_key}__{tool}"));
+            registered.push(tool.clone());
         } else {
             log::warn!("mcp tool not hosted server={server_key:?} tool={tool:?}");
         }
     }
-    HostedTools {
-        server: server_key.to_string(),
-        tools,
-    }
+    registered
 }
 
 /// What one MCP server this turn started actually put in front of the model —
@@ -2271,19 +2284,20 @@ mod tests {
     #[test]
     fn what_a_server_hosts_is_the_overlap_of_registered_and_requested() {
         crate::native::writes::testlog::install();
-        let hosted = report_hosted_tools(
+        let registered = report_hosted_tools(
             "556-overlap",
             &["a".to_string(), "b".to_string()],
             &["b".to_string(), "gone".to_string()],
         );
+        // `a` is hosted but never asked for; `gone` was asked for and is not
+        // hosted (and warns, through #501's own line).
+        assert_eq!(registered, vec!["b".to_string()]);
+        // Bare, so the caller's own `allowed_tool_names` — the function that
+        // also built `--allowedTools` — stays the only place the prefix is
+        // spelled.
         assert_eq!(
-            hosted,
-            HostedTools {
-                server: "556-overlap".to_string(),
-                // `a` is hosted but never asked for; `gone` was asked for and
-                // is not hosted (and warns, through #501's own line).
-                tools: vec!["mcp__556-overlap__b".to_string()],
-            }
+            crate::native::integrations::registry::allowed_tool_names("556-overlap", &registered),
+            vec!["mcp__556-overlap__b".to_string()]
         );
     }
 

--- a/src-tauri/src/native/chat/runner.rs
+++ b/src-tauri/src/native/chat/runner.rs
@@ -61,6 +61,7 @@
 
 use rusqlite::OptionalExtension;
 
+use crate::claude::messages::SystemMessage;
 use crate::claude::options::{permission_mode, Options};
 use crate::claude::permissions::PermissionHandler;
 use crate::claude::InProcessMcpServer;
@@ -251,14 +252,22 @@ pub struct RunSpec {
 /// that binds a port: a local tools server that failed to start is dropped on
 /// the way out, so a refusal leaves no listener behind.
 ///
-/// The second half of the pair is the **tool listeners** this turn owns: the
-/// local tools server for an agent that named a local tool, plus one per
-/// integration in its `capabilities.mcp`. The caller owns them, and dropping one
-/// stops its server — so they have to outlive the subprocess that dials them.
+/// The second element is the **tool listeners** this turn owns: the local tools
+/// server for an agent that named a local tool, plus one per integration in its
+/// `capabilities.mcp`. The caller owns them, and dropping one stops its server —
+/// so they have to outlive the subprocess that dials them.
+///
+/// The third is what those listeners *host*, per server, as [`HostedTools`] —
+/// the half the caller needs to check the CLI's own `init` frame against
+/// (#556). It is a separate value rather than something read back off the
+/// handles because [`InProcessMcpServer`] does not know the name the CLI
+/// prefixes its tools with: an integration's server is *built* as
+/// `github-<id>` and *registered* as `<id>`, and only the second is the tool
+/// prefix. See [`crate::native::integrations::registry::allowed_tool_names`].
 pub async fn build_options(
     spec: &RunSpec,
     permission_handler: Option<PermissionHandler>,
-) -> Result<(Options, Vec<InProcessMcpServer>), String> {
+) -> Result<(Options, Vec<InProcessMcpServer>, Vec<HostedTools>), String> {
     let caps = spec.agent.as_ref().map(|a| &a.capabilities);
     // Decided **before** anything binds a port. Everything below this line
     // either cannot fail or is dropped on the way out, so a refusal leaves no
@@ -373,11 +382,18 @@ pub async fn build_options(
     // it is part of the command line: built-ins first, then the local server's
     // qualified names.
     let mut allowed = allowed_tools(caps);
+    let mut hosted: Vec<HostedTools> = Vec::new();
     let local_tools;
-    (opts, local_tools) = start_local_tools(opts, caps, &mut allowed).await?;
+    (opts, local_tools) = start_local_tools(opts, caps, &mut allowed, &mut hosted).await?;
     let mut tool_servers: Vec<InProcessMcpServer> = local_tools.into_iter().collect();
-    opts =
-        start_integration_servers(opts, mcp_plan.as_ref(), &mut allowed, &mut tool_servers).await?;
+    opts = start_integration_servers(
+        opts,
+        mcp_plan.as_ref(),
+        &mut allowed,
+        &mut tool_servers,
+        &mut hosted,
+    )
+    .await?;
 
     if !allowed.is_empty() {
         opts = opts.with_allowed_tools(allowed.iter().cloned());
@@ -406,7 +422,11 @@ pub async fn build_options(
     if let Some(handler) = permission_handler {
         opts = opts.with_permission_handler(wrap_permission_handler(handler, allowed));
     }
-    Ok((opts, tool_servers))
+    // Read the narrowing off the command line rather than off the list that
+    // produced it: `--allowedTools` and `--disallowedTools` are what the CLI
+    // obeys, so they are what an absence has to be judged against.
+    narrow_to_command_line(&mut hosted, &opts);
+    Ok((opts, tool_servers, hosted))
 }
 
 /// Where one `capabilities.mcp` name resolved to.
@@ -583,6 +603,7 @@ async fn start_integration_servers(
     plan: Option<&McpPlan>,
     allowed: &mut Vec<String>,
     servers: &mut Vec<InProcessMcpServer>,
+    hosted: &mut Vec<HostedTools>,
 ) -> Result<Options, String> {
     let Some(plan) = plan else {
         return Ok(opts);
@@ -607,7 +628,11 @@ async fn start_integration_servers(
                     &spec.tools,
                 )
                 .await?;
-                report_hosted_tools(&spec.id, server.tool_names(), &spec.tools);
+                hosted.push(report_hosted_tools(
+                    &spec.id,
+                    server.tool_names(),
+                    &spec.tools,
+                ));
                 let registered = opts.with_mcp_server(&spec.id, server.config());
                 servers.push(server);
                 registered
@@ -650,6 +675,7 @@ async fn start_local_tools(
     opts: Options,
     caps: Option<&Capabilities>,
     allowed: &mut Vec<String>,
+    hosted: &mut Vec<HostedTools>,
 ) -> Result<(Options, Option<InProcessMcpServer>), String> {
     let Some(local) = caps.and_then(|c| c.local.as_deref()) else {
         return Ok((opts, None));
@@ -661,11 +687,11 @@ async fn start_local_tools(
     let server = crate::native::tools::start_local_mcp_server()
         .await
         .map_err(|e| format!("starting local MCP server: {e}"))?;
-    report_hosted_tools(
+    hosted.push(report_hosted_tools(
         crate::native::tools::LOCAL_MCP_SERVER_NAME,
         server.tool_names(),
         local,
-    );
+    ));
     let opts = opts
         .with_mcp_server(crate::native::tools::LOCAL_MCP_SERVER_NAME, server.config())
         .map_err(|e| format!("registering the local MCP server: {e}"))?
@@ -696,13 +722,125 @@ async fn start_local_tools(
 /// value `{:?}`, after the effect — with one departure it does not cover:
 /// the mismatch line is at `warn`, because the seam's own split puts failures
 /// there and a tool the model cannot reach is one.
-fn report_hosted_tools(server_key: &str, hosted: &[String], requested: &[String]) {
+fn report_hosted_tools(server_key: &str, hosted: &[String], requested: &[String]) -> HostedTools {
     log::info!("mcp server started server={server_key:?} tools={hosted:?}");
+    let mut tools = Vec::new();
     for tool in requested {
-        if !hosted.iter().any(|name| name == tool) {
+        if hosted.iter().any(|name| name == tool) {
+            tools.push(format!("mcp__{server_key}__{tool}"));
+        } else {
             log::warn!("mcp tool not hosted server={server_key:?} tool={tool:?}");
         }
     }
+    HostedTools {
+        server: server_key.to_string(),
+        tools,
+    }
+}
+
+/// What one MCP server this turn started actually put in front of the model —
+/// the intersection of what it hosts and what the agent asked for, qualified.
+///
+/// The intersection is the point and both halves are load-bearing. The local
+/// tools server hosts *every* local tool whatever the agent named, so "what it
+/// hosts" overstates it; an agent may name a tool the server no longer
+/// registers, so "what it asked for" overstates it the other way (that one
+/// already warns, in [`report_hosted_tools`]). Only the overlap is a name the
+/// CLI can be expected to hand the model.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostedTools {
+    /// The `mcpServers` key, which is the prefix the CLI puts on every one of
+    /// this server's tool names — the bare integration id, **not** the MCP
+    /// implementation name (`github-<id>`) the server was built under.
+    pub server: String,
+    /// Qualified `mcp__<server>__<tool>` names, in the agent's own order.
+    pub tools: Vec<String>,
+}
+
+/// One server whose tools the CLI did not hand the model (#556).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolsDropped {
+    /// The `mcpServers` key, as [`HostedTools::server`].
+    pub server: String,
+    /// The qualified names that are missing from `init.tools`.
+    pub missing: Vec<String>,
+    /// **Every** hosted tool is missing and the CLI reported this server
+    /// `connected` — the shape #555 had, and the only one that is worth
+    /// telling the user about rather than only the log. A partial miss can be
+    /// a filter we do not model; a connected server whose whole tool list
+    /// vanished cannot.
+    pub whole_server: bool,
+}
+
+/// Drop from `hosted` anything `--allowedTools` / `--disallowedTools` already
+/// keeps from the model, so a narrowing filter is never read as a defect.
+///
+/// An empty `allowed_tools` means the flag is not passed at all, which the CLI
+/// reads as "no restriction" — so it narrows nothing.
+fn narrow_to_command_line(hosted: &mut [HostedTools], opts: &Options) {
+    for entry in hosted.iter_mut() {
+        entry.tools.retain(|name| {
+            (opts.allowed_tools.is_empty() || opts.allowed_tools.iter().any(|a| a == name))
+                && !opts.disallowed_tools.iter().any(|d| d == name)
+        });
+    }
+}
+
+/// Compare the CLI's `system`/`init` frame against what this turn hosted, and
+/// say so when they disagree (#556).
+///
+/// [`report_hosted_tools`] closed the hop before this one: it reads the names
+/// off the *handle* rather than off the request, so a server hosting nothing is
+/// logged as hosting nothing. The hop it cannot see is the CLI's — whether the
+/// tools we hosted were **given to the model**. `init.tools` is that fact, on
+/// the wire at the start of every turn, with MCP tools already qualified as
+/// `mcp__<server>__<tool>`. The two disagreeing is the defect signal, and #555
+/// is why it needs one: every integration in the product was dead for at least
+/// one CLI release while the log, the `init` frame's own `"status":"connected"`
+/// and the inspector's tool count all reported success.
+///
+/// **A mismatch is a warning and never a refusal**, for
+/// [`start_local_tools`]' reason: a model that cannot call a tool is the
+/// kinder failure over a turn that will not start. The caller decides what to
+/// do with the returned entries; the `warn` lines are emitted here so the
+/// policy has one home and both callers get the same log.
+///
+/// Follows `writes::service_log_convention` — `message key=value`, every string
+/// value `{:?}` — at `warn`, as [`report_hosted_tools`]' own mismatch line does.
+pub fn report_tools_offered(hosted: &[HostedTools], init: &SystemMessage) -> Vec<ToolsDropped> {
+    let mut dropped = Vec::new();
+    for entry in hosted {
+        if entry.tools.is_empty() {
+            continue;
+        }
+        let missing: Vec<String> = entry
+            .tools
+            .iter()
+            .filter(|name| !init.tools.iter().any(|offered| offered == *name))
+            .cloned()
+            .collect();
+        if missing.is_empty() {
+            continue;
+        }
+        let server = &entry.server;
+        log::warn!("mcp tools not offered to the model server={server:?} tools={missing:?}");
+        let connected = init
+            .mcp_servers
+            .iter()
+            .any(|s| &s.name == server && s.status == "connected");
+        dropped.push(ToolsDropped {
+            server: entry.server.clone(),
+            whole_server: missing.len() == entry.tools.len() && connected,
+            missing,
+        });
+    }
+    dropped
+}
+
+/// What the user is told when a connected server's whole tool list never
+/// reached the model. The app log carries the names; this carries the fact.
+pub fn tools_dropped_message(server: &str) -> String {
+    format!("{server} tools were hosted but the Claude CLI did not offer them to the model; see the app log")
 }
 
 fn capability_count(list: Option<&crate::native::gojson::GoList<String>>) -> usize {
@@ -1045,7 +1183,7 @@ mod tests {
         let mut agent = agent_with(Capabilities::default());
         agent.model = "agent-model".into();
         let (spec, calls) = spec_with(Some(agent));
-        let (opts, servers) = build_options(&spec, no_op_handler())
+        let (opts, servers, _hosted) = build_options(&spec, no_op_handler())
             .await
             .expect("options");
         assert!(servers.is_empty(), "no agent named a local tool");
@@ -1069,7 +1207,7 @@ mod tests {
         let mut agent = agent_with(Capabilities::default());
         agent.model = String::new();
         let (spec, calls) = spec_with(Some(agent));
-        let (opts, servers) = build_options(&spec, no_op_handler())
+        let (opts, servers, _hosted) = build_options(&spec, no_op_handler())
             .await
             .expect("options");
         assert!(servers.is_empty(), "no agent named a local tool");
@@ -1107,7 +1245,7 @@ mod tests {
         ] {
             let (mut spec, _) = spec_with(Some(agent_with(Capabilities::default())));
             spec.permission_mode = chosen.to_string();
-            let (opts, _servers) = build_options(&spec, no_op_handler())
+            let (opts, _servers, _hosted) = build_options(&spec, no_op_handler())
                 .await
                 .expect("options");
             assert_eq!(
@@ -1131,7 +1269,7 @@ mod tests {
         agent.permission_mode = "plan".into();
 
         let (spec, _) = spec_with(Some(agent.clone()));
-        let (opts, _servers) = build_options(&spec, no_op_handler())
+        let (opts, _servers, _hosted) = build_options(&spec, no_op_handler())
             .await
             .expect("options");
         assert_eq!(
@@ -1141,7 +1279,7 @@ mod tests {
         );
 
         let (spec, _) = spec_with(Some(agent));
-        let (opts, _servers) = build_options(&spec, None).await.expect("options");
+        let (opts, _servers, _hosted) = build_options(&spec, None).await.expect("options");
         assert_eq!(
             opts.permission_mode,
             permission_mode::PLAN,
@@ -1174,7 +1312,7 @@ mod tests {
         // reads no index at all.
         spec.settings_profile_id = "work".into();
 
-        let (_opts, servers) = build_options(&spec, no_op_handler())
+        let (_opts, servers, _hosted) = build_options(&spec, no_op_handler())
             .await
             .expect("options");
         assert!(servers.is_empty(), "no agent named a local tool");
@@ -1209,7 +1347,7 @@ mod tests {
         spec.agent = Some(agent);
         spec.settings = std::sync::Arc::clone(&settings);
 
-        let (_opts, _servers) = build_options(&spec, no_op_handler())
+        let (_opts, _servers, _hosted) = build_options(&spec, no_op_handler())
             .await
             .expect("options");
 
@@ -1256,7 +1394,7 @@ mod tests {
     #[tokio::test]
     async fn a_chat_with_no_agent_resolves_its_model_once() {
         let (spec, calls) = spec_with(None);
-        let (opts, servers) = build_options(&spec, no_op_handler())
+        let (opts, servers, _hosted) = build_options(&spec, no_op_handler())
             .await
             .expect("options");
         assert!(servers.is_empty(), "no agent named a local tool");
@@ -1590,10 +1728,15 @@ mod tests {
             .expect("a plan");
         let mut allowed = allowed_tools(Some(&caps));
         let mut servers = Vec::new();
-        let opts =
-            start_integration_servers(Options::new(), Some(&plan), &mut allowed, &mut servers)
-                .await
-                .expect("started");
+        let opts = start_integration_servers(
+            Options::new(),
+            Some(&plan),
+            &mut allowed,
+            &mut servers,
+            &mut Vec::new(),
+        )
+        .await
+        .expect("started");
 
         let [server] = &servers[..] else {
             panic!("one integration, one listener");
@@ -1640,9 +1783,15 @@ mod tests {
 
         let mut allowed = Vec::new();
         let mut servers = Vec::new();
-        start_integration_servers(Options::new(), Some(&plan), &mut allowed, &mut servers)
-            .await
-            .expect("started");
+        start_integration_servers(
+            Options::new(),
+            Some(&plan),
+            &mut allowed,
+            &mut servers,
+            &mut Vec::new(),
+        )
+        .await
+        .expect("started");
         assert_eq!(
             allowed,
             vec![
@@ -1704,10 +1853,15 @@ mod tests {
             .expect("a plan");
         let mut allowed = Vec::new();
         let mut servers = Vec::new();
-        let opts =
-            start_integration_servers(Options::new(), Some(&plan), &mut allowed, &mut servers)
-                .await
-                .expect("started");
+        let opts = start_integration_servers(
+            Options::new(),
+            Some(&plan),
+            &mut allowed,
+            &mut servers,
+            &mut Vec::new(),
+        )
+        .await
+        .expect("started");
 
         assert_eq!(
             servers.len(),
@@ -1741,7 +1895,7 @@ mod tests {
             local: Some(vec!["current_time".into()].into()),
             mcp: None,
         });
-        let (opts, servers) = build_options(&spec, no_op_handler())
+        let (opts, servers, _hosted) = build_options(&spec, no_op_handler())
             .await
             .expect("a local tool is supplied natively now");
 
@@ -1772,7 +1926,7 @@ mod tests {
             local: Some(vec!["current_time".into()].into()),
             mcp: None,
         });
-        let (opts, _servers) = build_options(&spec, no_op_handler())
+        let (opts, _servers, _hosted) = build_options(&spec, no_op_handler())
             .await
             .expect("options");
         assert!(
@@ -1792,7 +1946,7 @@ mod tests {
             local: Some(vec!["current_time".into(), "gone".into()].into()),
             mcp: None,
         });
-        let (opts, _servers) = build_options(&spec, no_op_handler())
+        let (opts, _servers, _hosted) = build_options(&spec, no_op_handler())
             .await
             .expect("options");
 
@@ -1828,7 +1982,7 @@ mod tests {
             local: Some(vec!["current_time".into()].into()),
             mcp: None,
         });
-        let (_opts, _servers) = build_options(&spec, no_op_handler())
+        let (_opts, _servers, _hosted) = build_options(&spec, no_op_handler())
             .await
             .expect("options");
 
@@ -1858,7 +2012,7 @@ mod tests {
             local: Some(vec!["current_time".into(), "gone".into()].into()),
             mcp: None,
         });
-        let (opts, _servers) = build_options(&spec, no_op_handler())
+        let (opts, _servers, _hosted) = build_options(&spec, no_op_handler())
             .await
             .expect("options");
 
@@ -1888,7 +2042,7 @@ mod tests {
     #[tokio::test]
     async fn an_agent_naming_no_local_tools_binds_nothing() {
         let spec = spec_for(Capabilities::default());
-        let (opts, servers) = build_options(&spec, no_op_handler())
+        let (opts, servers, _hosted) = build_options(&spec, no_op_handler())
             .await
             .expect("options");
         assert!(servers.is_empty());
@@ -1908,7 +2062,7 @@ mod tests {
             local: Some(vec![].into()),
             mcp: None,
         });
-        let (opts, servers) = build_options(&spec, no_op_handler())
+        let (opts, servers, _hosted) = build_options(&spec, no_op_handler())
             .await
             .expect("options");
         assert!(servers.is_empty());
@@ -2081,5 +2235,205 @@ mod tests {
             )],
         );
         assert!(settings_file_from(&path, &path, "gone").is_none());
+    }
+
+    // #556: the CLI's `init` frame is the only account of what the model was
+    // actually given, and the two hops disagreeing is the defect signal. These
+    // pin the set arithmetic directly; `tests/chat_turn.rs` drives the same
+    // rule end to end through a scripted CLI.
+
+    /// The CLI's `init` frame, with the tools it says the model was given and
+    /// the servers it says are connected.
+    ///
+    /// Every test below uses a `556-`-prefixed server key nothing else in this
+    /// binary produces: the buffer `testlog` installs is process-wide and
+    /// `cargo test` runs a binary's tests in parallel, so a "nothing was
+    /// logged" assertion is only about this test when the needle is unique.
+    fn init_offering(tools: &[&str], connected: &[&str]) -> SystemMessage {
+        SystemMessage {
+            message_type: "system".to_string(),
+            subtype: crate::claude::messages::system_subtype::INIT.to_string(),
+            tools: tools.iter().map(|t| (*t).to_string()).collect(),
+            mcp_servers: connected
+                .iter()
+                .map(|name| crate::claude::messages::McpServerInit {
+                    name: (*name).to_string(),
+                    status: "connected".to_string(),
+                })
+                .collect(),
+            ..SystemMessage::default()
+        }
+    }
+
+    /// [`report_hosted_tools`] hands back the **overlap**, not either side of
+    /// it: the local tools server hosts every local tool whatever the agent
+    /// named, and an agent may name one the server does not host.
+    #[test]
+    fn what_a_server_hosts_is_the_overlap_of_registered_and_requested() {
+        crate::native::writes::testlog::install();
+        let hosted = report_hosted_tools(
+            "556-overlap",
+            &["a".to_string(), "b".to_string()],
+            &["b".to_string(), "gone".to_string()],
+        );
+        assert_eq!(
+            hosted,
+            HostedTools {
+                server: "556-overlap".to_string(),
+                // `a` is hosted but never asked for; `gone` was asked for and
+                // is not hosted (and warns, through #501's own line).
+                tools: vec!["mcp__556-overlap__b".to_string()],
+            }
+        );
+    }
+
+    /// The all-present case has to be **completely** silent, or the signal is
+    /// worth nothing: every turn would carry it.
+    #[test]
+    fn an_init_listing_every_hosted_tool_reports_nothing() {
+        crate::native::writes::testlog::install();
+        let hosted = [HostedTools {
+            server: "556-quiet".to_string(),
+            tools: vec!["mcp__556-quiet__one".to_string()],
+        }];
+        let init = init_offering(&["Read", "mcp__556-quiet__one"], &["556-quiet"]);
+        assert!(report_tools_offered(&hosted, &init).is_empty());
+        assert!(
+            crate::native::writes::testlog::matching("556-quiet").is_empty(),
+            "the agreeing case logs nothing at all"
+        );
+    }
+
+    /// #555's shape: the server says `connected`, and not one of its tools
+    /// reached the model.
+    #[test]
+    fn a_connected_server_that_offered_nothing_is_a_whole_server_miss() {
+        crate::native::writes::testlog::install();
+        let hosted = [HostedTools {
+            server: "556-gone".to_string(),
+            tools: vec![
+                "mcp__556-gone__one".to_string(),
+                "mcp__556-gone__two".to_string(),
+            ],
+        }];
+        let init = init_offering(&["Read"], &["556-gone"]);
+        assert_eq!(
+            report_tools_offered(&hosted, &init),
+            vec![ToolsDropped {
+                server: "556-gone".to_string(),
+                missing: vec![
+                    "mcp__556-gone__one".to_string(),
+                    "mcp__556-gone__two".to_string()
+                ],
+                whole_server: true,
+            }]
+        );
+        let logged = crate::native::writes::testlog::matching(
+            r#"mcp tools not offered to the model server="556-gone""#,
+        );
+        assert_eq!(logged.len(), 1, "one line per server: {logged:?}");
+        assert!(logged[0].starts_with("WARN "), "{}", logged[0]);
+    }
+
+    /// A partial miss names exactly the difference, and is **not** a whole
+    /// server miss — so it stays in the log rather than reaching the user.
+    #[test]
+    fn a_partial_miss_names_only_what_is_absent() {
+        crate::native::writes::testlog::install();
+        let hosted = [HostedTools {
+            server: "556-partial".to_string(),
+            tools: vec![
+                "mcp__556-partial__kept".to_string(),
+                "mcp__556-partial__lost".to_string(),
+            ],
+        }];
+        let init = init_offering(&["mcp__556-partial__kept"], &["556-partial"]);
+        assert_eq!(
+            report_tools_offered(&hosted, &init),
+            vec![ToolsDropped {
+                server: "556-partial".to_string(),
+                missing: vec!["mcp__556-partial__lost".to_string()],
+                whole_server: false,
+            }]
+        );
+    }
+
+    /// A server the CLI did **not** report `connected` still warns, but is not
+    /// a whole-server miss: the CLI has already said the server is not there,
+    /// so a second sentence about it would be the noisy half of the signal.
+    #[test]
+    fn a_server_that_never_connected_warns_without_telling_the_user() {
+        crate::native::writes::testlog::install();
+        let hosted = [HostedTools {
+            server: "556-unconnected".to_string(),
+            tools: vec!["mcp__556-unconnected__one".to_string()],
+        }];
+        let dropped = report_tools_offered(&hosted, &init_offering(&["Read"], &[]));
+        assert_eq!(dropped.len(), 1);
+        assert!(!dropped[0].whole_server);
+    }
+
+    /// The detail that decides correctness: `init.tools` reflects
+    /// `--allowedTools` too, so a filter this side asked for must never read as
+    /// the CLI dropping something. Getting this backwards would warn on every
+    /// turn of every narrowed agent, which is worse than silence.
+    #[test]
+    fn an_allowlist_that_narrows_is_not_a_mismatch() {
+        let mut hosted = vec![HostedTools {
+            server: "556-narrow".to_string(),
+            tools: vec![
+                "mcp__556-narrow__kept".to_string(),
+                "mcp__556-narrow__filtered".to_string(),
+            ],
+        }];
+        let opts = Options::new()
+            .with_allowed_tools(["Read".to_string(), "mcp__556-narrow__kept".to_string()]);
+        narrow_to_command_line(&mut hosted, &opts);
+        assert_eq!(hosted[0].tools, vec!["mcp__556-narrow__kept".to_string()]);
+
+        let init = init_offering(&["Read", "mcp__556-narrow__kept"], &["556-narrow"]);
+        assert!(
+            report_tools_offered(&hosted, &init).is_empty(),
+            "the tool we filtered out ourselves is not missing"
+        );
+    }
+
+    /// `--disallowedTools` narrows the same way, and an **empty** allowlist is
+    /// no flag at all — the CLI reads that as no restriction, so it must not
+    /// subtract everything.
+    #[test]
+    fn a_denylist_narrows_and_an_empty_allowlist_narrows_nothing() {
+        let entry = || HostedTools {
+            server: "556-deny".to_string(),
+            tools: vec![
+                "mcp__556-deny__kept".to_string(),
+                "mcp__556-deny__denied".to_string(),
+            ],
+        };
+
+        let mut hosted = vec![entry()];
+        narrow_to_command_line(&mut hosted, &Options::new());
+        assert_eq!(hosted[0], entry(), "no flag, no narrowing");
+
+        let mut hosted = vec![entry()];
+        narrow_to_command_line(
+            &mut hosted,
+            &Options::new().with_disallowed_tools(["mcp__556-deny__denied".to_string()]),
+        );
+        assert_eq!(hosted[0].tools, vec!["mcp__556-deny__kept".to_string()]);
+    }
+
+    /// A server that ended up hosting nothing the agent asked for is already
+    /// #501's business, and reporting it here too would double the noise on a
+    /// turn that is already logging a warning per name.
+    #[test]
+    fn a_server_hosting_nothing_the_agent_asked_for_is_not_reported_twice() {
+        let hosted = [HostedTools {
+            server: "556-empty".to_string(),
+            tools: Vec::new(),
+        }];
+        assert!(
+            report_tools_offered(&hosted, &init_offering(&["Read"], &["556-empty"])).is_empty()
+        );
     }
 }

--- a/src-tauri/src/native/chat/runner.rs
+++ b/src-tauri/src/native/chat/runner.rs
@@ -628,11 +628,14 @@ async fn start_integration_servers(
                     &spec.tools,
                 )
                 .await?;
-                let registered = report_hosted_tools(&spec.id, server.tool_names(), &spec.tools);
+                // Not `registered` — that name is taken eight lines down by
+                // the registered *options*, and the two would shadow.
+                let registered_tools =
+                    report_hosted_tools(&spec.id, server.tool_names(), &spec.tools);
                 hosted.push(HostedTools {
                     tools: crate::native::integrations::registry::allowed_tool_names(
                         &spec.id,
-                        &registered,
+                        &registered_tools,
                     ),
                     server: spec.id.clone(),
                 });
@@ -690,14 +693,14 @@ async fn start_local_tools(
     let server = crate::native::tools::start_local_mcp_server()
         .await
         .map_err(|e| format!("starting local MCP server: {e}"))?;
-    let registered = report_hosted_tools(
+    let registered_tools = report_hosted_tools(
         crate::native::tools::LOCAL_MCP_SERVER_NAME,
         server.tool_names(),
         local,
     );
     hosted.push(HostedTools {
         server: crate::native::tools::LOCAL_MCP_SERVER_NAME.to_string(),
-        tools: crate::native::tools::allowed_tool_names(registered.iter()),
+        tools: crate::native::tools::allowed_tool_names(registered_tools.iter()),
     });
     let opts = opts
         .with_mcp_server(crate::native::tools::LOCAL_MCP_SERVER_NAME, server.config())

--- a/src-tauri/src/native/chat/runner.rs
+++ b/src-tauri/src/native/chat/runner.rs
@@ -885,14 +885,23 @@ pub fn report_tools_offered(hosted: &[HostedTools], init: &SystemMessage) -> Vec
     dropped
 }
 
-/// What the user is told when a connected server's whole tool list never
-/// reached the model. The app log carries the names; this carries the fact.
-///
-/// Takes [`ToolsDropped::label`], never `server`: for the integrations #555
-/// actually killed, the key is a v4 UUID, and a sentence naming one tells the
-/// reader nothing they can act on.
-pub fn tools_dropped_message(label: &str) -> String {
-    format!("{label} tools were hosted but the Claude CLI did not offer them to the model; see the app log")
+impl ToolsDropped {
+    /// What the user is told when a connected server's whole tool list never
+    /// reached the model. The app log carries the names; this carries the fact.
+    ///
+    /// **A method rather than a free function taking a name**, because the two
+    /// callers had one each and one of them passed the wrong field: the sentence
+    /// must name [`Self::label`] and never [`Self::server`], since for the
+    /// integrations #555 actually killed the key is a v4 UUID that appears
+    /// nowhere in the product. With the choice made here there is no argument to
+    /// get wrong.
+    pub fn message(&self) -> String {
+        format!(
+            "{} tools were hosted but the Claude CLI did not offer them to the model; \
+             see the app log",
+            self.label
+        )
+    }
 }
 
 fn capability_count(list: Option<&crate::native::gojson::GoList<String>>) -> usize {
@@ -2540,7 +2549,9 @@ mod tests {
         assert_eq!(dropped.len(), 1);
         assert!(dropped[0].whole_server);
 
-        let message = tools_dropped_message(&dropped[0].label);
+        // `message()` is what *both* callers emit — the chat frame and the
+        // `job_history` notice — so this is the sentence, not a rehearsal of it.
+        let message = dropped[0].message();
         assert!(message.starts_with("github tools were hosted"), "{message}");
         assert!(
             !message.contains("0c2e6b64"),

--- a/src-tauri/src/native/chat/runner.rs
+++ b/src-tauri/src/native/chat/runner.rs
@@ -475,6 +475,11 @@ struct McpServerSpec {
     /// bare integration id; for an external server it is whatever the user
     /// called it in `mcps.yaml`.
     id: String,
+    /// The readable name for this server, for a sentence a user will read
+    /// (#556). For an external server it is the id — the user chose it. For an
+    /// integration it is the **type** (`github`), because the id is a v4 UUID
+    /// that appears nowhere in the product.
+    label: String,
     tools: Vec<String>,
     source: McpSource,
 }
@@ -534,23 +539,28 @@ fn mcp_plan(
         // `resolveServerConfig` asks the registry first and returns on a hit,
         // so a name in both is the yaml entry and the integrations are never
         // consulted for it.
+        let mut label = id.clone();
         let source = match registry.get(id) {
             Some(config) => McpSource::External(config.clone()),
             None => {
                 let db_path =
                     db_path.ok_or("no home directory to resolve the data dir".to_string())?;
-                if !crate::native::integrations::registry::can_host(db_path, id)? {
+                let Some(integration_type) =
+                    crate::native::integrations::registry::hostable_type(db_path, id)?
+                else {
                     return Err(format!(
                         "agent uses MCP server {id:?}, which is named by no mcps.yaml entry \
                          and is not an integration this build can host (#375)"
                     ));
-                }
+                };
+                label = integration_type;
                 needs_db = true;
                 McpSource::Integration
             }
         };
         servers.push(McpServerSpec {
             id: id.clone(),
+            label,
             tools: capability
                 .tools
                 .iter()
@@ -638,6 +648,7 @@ async fn start_integration_servers(
                         &registered_tools,
                     ),
                     server: spec.id.clone(),
+                    label: spec.label.clone(),
                 });
                 let registered = opts.with_mcp_server(&spec.id, server.config());
                 servers.push(server);
@@ -700,6 +711,8 @@ async fn start_local_tools(
     );
     hosted.push(HostedTools {
         server: crate::native::tools::LOCAL_MCP_SERVER_NAME.to_string(),
+        // Already a readable literal, so the key is the label.
+        label: crate::native::tools::LOCAL_MCP_SERVER_NAME.to_string(),
         tools: crate::native::tools::allowed_tool_names(registered_tools.iter()),
     });
     let opts = opts
@@ -769,6 +782,11 @@ pub struct HostedTools {
     /// this server's tool names — the bare integration id, **not** the MCP
     /// implementation name (`github-<id>`) the server was built under.
     pub server: String,
+    /// What to **call** this server in a sentence a user reads. Usually the
+    /// key; for an integration it is the type (`github`), because the key is a
+    /// v4 UUID that appears nowhere in the product. The log and the frame's
+    /// `server` field keep the key, which is what a grep and a bug report need.
+    pub label: String,
     /// Qualified `mcp__<server>__<tool>` names, in the agent's own order.
     pub tools: Vec<String>,
 }
@@ -778,6 +796,8 @@ pub struct HostedTools {
 pub struct ToolsDropped {
     /// The `mcpServers` key, as [`HostedTools::server`].
     pub server: String,
+    /// What to call it, as [`HostedTools::label`].
+    pub label: String,
     /// The qualified names that are missing from `init.tools`.
     pub missing: Vec<String>,
     /// **Every** hosted tool is missing and the CLI reported this server
@@ -824,6 +844,17 @@ fn narrow_to_command_line(hosted: &mut [HostedTools], opts: &Options) {
 /// Follows `writes::service_log_convention` — `message key=value`, every string
 /// value `{:?}` — at `warn`, as [`report_hosted_tools`]' own mismatch line does.
 pub fn report_tools_offered(hosted: &[HostedTools], init: &SystemMessage) -> Vec<ToolsDropped> {
+    // An `init` that lists **nothing at all** is not a CLI that gave the model
+    // no tools — it is a frame this side could not read. `SystemMessage` is
+    // `#[serde(default)]` with every field `lenient`, so a renamed or moved
+    // `tools` decodes as an empty `Vec` with no `decode_err` to show for it,
+    // and every hosted server would then read as a whole-server miss on every
+    // turn. A real turn always lists the built-ins beside the MCP names, which
+    // is why both of this module's dropped-tools fixtures keep `Read`. The
+    // failure this reports is worth having only while it is rare.
+    if init.tools.is_empty() {
+        return Vec::new();
+    }
     let mut dropped = Vec::new();
     for entry in hosted {
         if entry.tools.is_empty() {
@@ -846,6 +877,7 @@ pub fn report_tools_offered(hosted: &[HostedTools], init: &SystemMessage) -> Vec
             .any(|s| &s.name == server && s.status == "connected");
         dropped.push(ToolsDropped {
             server: entry.server.clone(),
+            label: entry.label.clone(),
             whole_server: missing.len() == entry.tools.len() && connected,
             missing,
         });
@@ -855,8 +887,12 @@ pub fn report_tools_offered(hosted: &[HostedTools], init: &SystemMessage) -> Vec
 
 /// What the user is told when a connected server's whole tool list never
 /// reached the model. The app log carries the names; this carries the fact.
-pub fn tools_dropped_message(server: &str) -> String {
-    format!("{server} tools were hosted but the Claude CLI did not offer them to the model; see the app log")
+///
+/// Takes [`ToolsDropped::label`], never `server`: for the integrations #555
+/// actually killed, the key is a v4 UUID, and a sentence naming one tells the
+/// reader nothing they can act on.
+pub fn tools_dropped_message(label: &str) -> String {
+    format!("{label} tools were hosted but the Claude CLI did not offer them to the model; see the app log")
 }
 
 fn capability_count(list: Option<&crate::native::gojson::GoList<String>>) -> usize {
@@ -2311,6 +2347,7 @@ mod tests {
         crate::native::writes::testlog::install();
         let hosted = [HostedTools {
             server: "556-quiet".to_string(),
+            label: "556-quiet".to_string(),
             tools: vec!["mcp__556-quiet__one".to_string()],
         }];
         let init = init_offering(&["Read", "mcp__556-quiet__one"], &["556-quiet"]);
@@ -2328,6 +2365,7 @@ mod tests {
         crate::native::writes::testlog::install();
         let hosted = [HostedTools {
             server: "556-gone".to_string(),
+            label: "GitHub".to_string(),
             tools: vec![
                 "mcp__556-gone__one".to_string(),
                 "mcp__556-gone__two".to_string(),
@@ -2338,6 +2376,7 @@ mod tests {
             report_tools_offered(&hosted, &init),
             vec![ToolsDropped {
                 server: "556-gone".to_string(),
+                label: "GitHub".to_string(),
                 missing: vec![
                     "mcp__556-gone__one".to_string(),
                     "mcp__556-gone__two".to_string()
@@ -2359,6 +2398,7 @@ mod tests {
         crate::native::writes::testlog::install();
         let hosted = [HostedTools {
             server: "556-partial".to_string(),
+            label: "556-partial".to_string(),
             tools: vec![
                 "mcp__556-partial__kept".to_string(),
                 "mcp__556-partial__lost".to_string(),
@@ -2369,6 +2409,7 @@ mod tests {
             report_tools_offered(&hosted, &init),
             vec![ToolsDropped {
                 server: "556-partial".to_string(),
+                label: "556-partial".to_string(),
                 missing: vec!["mcp__556-partial__lost".to_string()],
                 whole_server: false,
             }]
@@ -2383,6 +2424,7 @@ mod tests {
         crate::native::writes::testlog::install();
         let hosted = [HostedTools {
             server: "556-unconnected".to_string(),
+            label: "556-unconnected".to_string(),
             tools: vec!["mcp__556-unconnected__one".to_string()],
         }];
         let dropped = report_tools_offered(&hosted, &init_offering(&["Read"], &[]));
@@ -2398,6 +2440,7 @@ mod tests {
     fn an_allowlist_that_narrows_is_not_a_mismatch() {
         let mut hosted = vec![HostedTools {
             server: "556-narrow".to_string(),
+            label: "556-narrow".to_string(),
             tools: vec![
                 "mcp__556-narrow__kept".to_string(),
                 "mcp__556-narrow__filtered".to_string(),
@@ -2422,6 +2465,7 @@ mod tests {
     fn a_denylist_narrows_and_an_empty_allowlist_narrows_nothing() {
         let entry = || HostedTools {
             server: "556-deny".to_string(),
+            label: "556-deny".to_string(),
             tools: vec![
                 "mcp__556-deny__kept".to_string(),
                 "mcp__556-deny__denied".to_string(),
@@ -2440,6 +2484,75 @@ mod tests {
         assert_eq!(hosted[0].tools, vec!["mcp__556-deny__kept".to_string()]);
     }
 
+    /// An `init` frame listing **no** tools at all is a frame this side could
+    /// not read, not a CLI that gave the model nothing: `SystemMessage` is
+    /// `#[serde(default)]` with `lenient` fields, so a renamed `tools` key
+    /// decodes as an empty `Vec` with nothing to show for it. Reporting that
+    /// would put the banner on every turn of every agent, which is the one
+    /// failure mode that makes the whole signal worthless.
+    #[test]
+    fn an_init_that_lists_no_tools_at_all_is_not_read_as_a_miss() {
+        let hosted = [HostedTools {
+            server: "556-unreadable".to_string(),
+            label: "556-unreadable".to_string(),
+            tools: vec!["mcp__556-unreadable__one".to_string()],
+        }];
+        assert!(report_tools_offered(&hosted, &init_offering(&[], &["556-unreadable"])).is_empty());
+    }
+
+    /// The sentence a user reads names the **label**, never the key — and for
+    /// an integration the key is a v4 UUID (`native/integrations.rs`), which is
+    /// exactly the class of server #555 killed.
+    ///
+    /// Driven through `mcp_plan` and `start_integration_servers` rather than a
+    /// hand-built `HostedTools`, because the property under test is that the
+    /// label *arrives* — a literal would pass with the plumbing removed.
+    #[tokio::test]
+    async fn the_message_names_the_integration_type_and_never_its_uuid_key() {
+        crate::native::writes::testlog::install();
+        let id = "0c2e6b64-6b2a-4f1e-9f0a-1f2f3a4b5c6d";
+        let file = db_with_integration(id, "github");
+        let caps = caps_naming(id, Some(vec!["get_repo".into()]));
+        let plan = mcp_plan(Some(&caps), Some(file.path()), None)
+            .expect("hostable")
+            .expect("a plan");
+
+        let mut hosted = Vec::new();
+        start_integration_servers(
+            Options::new(),
+            Some(&plan),
+            &mut Vec::new(),
+            &mut Vec::new(),
+            &mut hosted,
+        )
+        .await
+        .expect("started");
+
+        assert_eq!(hosted.len(), 1);
+        assert_eq!(
+            hosted[0].server, id,
+            "the key stays the id the CLI prefixes"
+        );
+        assert_eq!(hosted[0].label, "github");
+
+        let init = init_offering(&["Read"], &[id]);
+        let dropped = report_tools_offered(&hosted, &init);
+        assert_eq!(dropped.len(), 1);
+        assert!(dropped[0].whole_server);
+
+        let message = tools_dropped_message(&dropped[0].label);
+        assert!(message.starts_with("github tools were hosted"), "{message}");
+        assert!(
+            !message.contains("0c2e6b64"),
+            "a user is never shown the key: {message}"
+        );
+        // …while the log line, which a bug report quotes, keeps the key.
+        assert!(!crate::native::writes::testlog::matching(&format!(
+            r#"mcp tools not offered to the model server="{id}""#
+        ))
+        .is_empty());
+    }
+
     /// A server that ended up hosting nothing the agent asked for is already
     /// #501's business, and reporting it here too would double the noise on a
     /// turn that is already logging a warning per name.
@@ -2447,6 +2560,7 @@ mod tests {
     fn a_server_hosting_nothing_the_agent_asked_for_is_not_reported_twice() {
         let hosted = [HostedTools {
             server: "556-empty".to_string(),
+            label: "556-empty".to_string(),
             tools: Vec::new(),
         }];
         assert!(

--- a/src-tauri/src/native/chat/turn.rs
+++ b/src-tauri/src/native/chat/turn.rs
@@ -67,6 +67,21 @@ struct UserInputRequired<'a> {
     input: &'a RawValue,
 }
 
+/// The synthetic event announcing that a hosted MCP server's tools never
+/// reached the model (#556).
+///
+/// Flat and self-contained: `server` is the `mcpServers` key, `tools` the
+/// qualified names that are missing, and `message` the sentence a user can act
+/// on without reading either. No embedded raw value, so none of the
+/// compaction/escaping rules the other two carry apply here — but it is still
+/// encoded through `gojson` like every frame this side constructs.
+#[derive(Serialize)]
+struct ToolsNotOffered {
+    server: String,
+    tools: Vec<String>,
+    message: String,
+}
+
 /// The synthetic event announcing a tool permission prompt.
 #[derive(Serialize)]
 struct PermissionRequest {
@@ -192,13 +207,14 @@ pub async fn run(
     // in its `capabilities.mcp` (#311) — and they are **not** an unused
     // binding: dropping one stops its listener, so the whole vector has to be
     // moved into the stream task and released only once the subprocess is gone.
-    let (options, tool_servers) = match runner::build_options(&spec, Some(handler)).await {
-        Ok(built) => built,
-        Err(e) => {
-            log::warn!("chat {chat_id:?}: cannot run this chat: {e}");
-            return Ok(error_json(StatusCode::INTERNAL_SERVER_ERROR, &e));
-        }
-    };
+    let (options, tool_servers, hosted_tools) =
+        match runner::build_options(&spec, Some(handler)).await {
+            Ok(built) => built,
+            Err(e) => {
+                log::warn!("chat {chat_id:?}: cannot run this chat: {e}");
+                return Ok(error_json(StatusCode::INTERNAL_SERVER_ERROR, &e));
+            }
+        };
 
     // The subprocess starts here, and these are the last two pre-stream
     // failures. Both are answered rather than streamed, and both leave nothing
@@ -248,7 +264,15 @@ pub async fn run(
     let is_first_message = row.title == "New Chat";
 
     tokio::spawn(async move {
-        let state = stream_events(&mut session, &chat_id, notify_rx, &body_tx, &answers).await;
+        let state = stream_events(
+            &mut session,
+            &chat_id,
+            notify_rx,
+            &body_tx,
+            &answers,
+            &hosted_tools,
+        )
+        .await;
 
         // Go's defer order: forget the live session — which also releases the
         // busy lock — then close the subprocess.
@@ -454,6 +478,7 @@ async fn stream_events(
     mut notify_rx: mpsc::Receiver<Notify>,
     out: &mpsc::Sender<Result<Vec<u8>, std::io::Error>>,
     answers: &Arc<Answers>,
+    hosted_tools: &[runner::HostedTools],
 ) -> TurnState {
     let mut state = TurnState::default();
     let mut pending_input: Option<Box<RawValue>> = None;
@@ -487,7 +512,7 @@ async fn stream_events(
                     // The client hung up; the commit still runs.
                     return state;
                 }
-                match handle_event(session, chat_id, &event, &mut state, &mut pending_input, out, answers).await {
+                match handle_event(session, chat_id, &event, &mut state, &mut pending_input, out, answers, hosted_tools).await {
                     Flow::Continue => {}
                     Flow::Stop => return state,
                 }
@@ -544,6 +569,7 @@ async fn forward_event(event: &Event, out: &mpsc::Sender<Result<Vec<u8>, std::io
         .is_ok()
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn handle_event(
     session: &Session,
     chat_id: &str,
@@ -552,8 +578,44 @@ async fn handle_event(
     pending_input: &mut Option<Box<RawValue>>,
     out: &mpsc::Sender<Result<Vec<u8>, std::io::Error>>,
     answers: &Arc<Answers>,
+    hosted_tools: &[runner::HostedTools],
 ) -> Flow {
     match event.event_type.as_str() {
+        // The CLI's own account of what the model was given. Read rather than
+        // only forwarded (#556): `report_hosted_tools` can say what this
+        // process hosts, and only this frame can say what reached the model.
+        "system" => {
+            let Some(system) = event.system.as_ref() else {
+                return Flow::Continue;
+            };
+            if system.subtype != crate::claude::messages::system_subtype::INIT {
+                return Flow::Continue;
+            }
+            for dropped in runner::report_tools_offered(hosted_tools, system) {
+                if !dropped.whole_server {
+                    // A partial miss is on the record in the log and no
+                    // further: a filter this side does not model would
+                    // otherwise put a scary sentence in front of a user on
+                    // every turn.
+                    continue;
+                }
+                let frame = ToolsNotOffered {
+                    message: runner::tools_dropped_message(&dropped.server),
+                    server: dropped.server,
+                    tools: dropped.missing,
+                };
+                match sse::json_frame("tools_not_offered", &frame) {
+                    Ok(bytes) => {
+                        if out.send(Ok(bytes)).await.is_err() {
+                            return Flow::Stop;
+                        }
+                    }
+                    Err(e) => log::error!("encoding tools_not_offered: {e}"),
+                }
+            }
+            // Never a refusal: the turn runs and answers as it would have.
+            Flow::Continue
+        }
         "assistant" => {
             if let Some(raw) = event.raw.as_ref() {
                 super::persist::append_assistant_blocks(&mut state.blocks, raw.get().as_bytes());

--- a/src-tauri/src/native/chat/turn.rs
+++ b/src-tauri/src/native/chat/turn.rs
@@ -600,7 +600,7 @@ async fn handle_event(
                     continue;
                 }
                 let frame = ToolsNotOffered {
-                    message: runner::tools_dropped_message(&dropped.server),
+                    message: runner::tools_dropped_message(&dropped.label),
                     server: dropped.server,
                     tools: dropped.missing,
                 };

--- a/src-tauri/src/native/chat/turn.rs
+++ b/src-tauri/src/native/chat/turn.rs
@@ -600,7 +600,7 @@ async fn handle_event(
                     continue;
                 }
                 let frame = ToolsNotOffered {
-                    message: runner::tools_dropped_message(&dropped.label),
+                    message: dropped.message(),
                     server: dropped.server,
                     tools: dropped.missing,
                 };

--- a/src-tauri/src/native/integrations/registry.rs
+++ b/src-tauri/src/native/integrations/registry.rs
@@ -1029,7 +1029,19 @@ fn type_of(db_path: &Path, id: &str) -> Result<Option<String>, String> {
 /// another route: they have already read the row for their own purposes, so they
 /// call it directly rather than reading anything a second time.
 pub fn can_host(db_path: &Path, id: &str) -> Result<bool, String> {
-    Ok(type_of(db_path, id)?.is_some_and(|integration_type| hosts_type(&integration_type)))
+    Ok(hostable_type(db_path, id)?.is_some())
+}
+
+/// [`can_host`], answering **which** type it is rather than only whether it is
+/// one — `Some` exactly when `can_host` is true.
+///
+/// The type is the only readable name this process has for an integration: the
+/// id is a v4 UUID (`native/integrations.rs`), the string a user never sees, and
+/// #556 puts a sentence about a broken server in front of them. It is one read
+/// either way, so the caller that needs the word takes this and the two that do
+/// not keep the boolean.
+pub fn hostable_type(db_path: &Path, id: &str) -> Result<Option<String>, String> {
+    Ok(type_of(db_path, id)?.filter(|integration_type| hosts_type(integration_type)))
 }
 
 /// `filterConfigTools`: keep only the requested tools, of only the enabled

--- a/src-tauri/src/native/schedule/CLAUDE.md
+++ b/src-tauri/src/native/schedule/CLAUDE.md
@@ -41,6 +41,15 @@ where a chat forwards, a scheduled run records a **failed** row reading
 Silence is the one outcome that is not allowed, because a job history with no row
 is indistinguishable from a task that was not due.
 
+**One consequence of that rule since #556: a `success` row may carry a non-empty
+`error_message`.** A run whose `system`/`init` frame shows the CLI never handed
+the model a hosted server's tools completed and answered — that is a notice, not
+a failure — but nobody reads the app log at 03:00 and that column is the row's
+only free text, so `finish` puts the sentence there and leaves the status alone.
+**Do not re-derive "non-empty `error_message` means failed"**: the failure signal
+is `Recorded::failure`, which `publish` keys on, and `JobsView` titles the block
+off the status for the same reason.
+
 **A chat picks its own permission mode (migration 30).** Everything below about
 `appendPermissionOpts` describes the state before it, and the two-branch rule it
 describes is still exactly what runs — but only when the chat has expressed no

--- a/src-tauri/src/native/schedule/executor.rs
+++ b/src-tauri/src/native/schedule/executor.rs
@@ -503,12 +503,17 @@ fn finish(
     } else {
         ""
     };
+    // A tools mismatch is not a failure — the run produced its answer and the
+    // status stays `success` — but a scheduled run has nobody reading the app
+    // log, and `error_message` is the only free-text column on the row. #556's
+    // rule: silence about a broken tool list is the outcome not allowed.
+    let notice = result.tools_not_offered.join("; ");
     finish_job_history(
         &db_path,
         &mut job,
         started_at,
         "success",
-        "",
+        &notice,
         Some(&result),
         response_text,
     );
@@ -1066,6 +1071,7 @@ mod tests {
             output_tokens: 22,
             cache_creation_tokens: 33,
             cache_read_tokens: 44,
+            tools_not_offered: Vec::new(),
         };
         let started_at = Utc::now();
         write_session_results(file.path(), &session_id, &result, "the prompt", started_at)

--- a/src-tauri/tests/chat_turn.rs
+++ b/src-tauri/tests/chat_turn.rs
@@ -1607,3 +1607,97 @@ async fn a_contended_write_lock_does_not_stall_the_runtime() {
         HOLD.as_millis()
     );
 }
+
+/// #556, the agreeing case: an `init` frame that lists everything the turn
+/// hosted produces **no** synthetic frame. Silence is the whole point — a
+/// warning that fired on every turn would be worth nothing.
+///
+/// Only the frame is asserted here, not the absence of a log line. The buffer
+/// `testlog` installs is process-wide and its sibling below hosts the same
+/// server under the same name, so a "nothing was logged" assertion would be a
+/// race between two tests rather than a property. `runner`'s own
+/// `an_init_listing_every_hosted_tool_reports_nothing` pins the quiet half
+/// against a server key nothing else produces.
+#[tokio::test]
+async fn an_init_that_lists_the_hosted_tools_adds_no_frame() {
+    let Some(_) = python3() else {
+        eprintln!("skipping: no python3");
+        return;
+    };
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cli = fake_cli(
+        dir.path(),
+        r#"
+    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack(req.get("request_id") or msg.get("request_id"))
+    elif msg.get("type") == "user":
+        say({"type": "system", "subtype": "init", "session_id": "s-1",
+             "tools": ["Read", "mcp__local-tools__current_time"],
+             "mcp_servers": [{"name": "local-tools", "status": "connected"}]})
+        raw('{"type":"result","subtype":"success","is_error":false,"result":"ok","session_id":"s-1","usage":{"input_tokens":1,"output_tokens":1}}')
+"#,
+    );
+
+    let id = unique_id("toolsok");
+    let file = migrated_with_local_tool_agent(&id);
+    let body = run_turn_on(&cli, &file, &id, "hello", None).await;
+    let frames = frames(&body);
+    let names: Vec<&str> = frames.iter().map(|(e, _)| e.as_str()).collect();
+    assert_eq!(names, vec!["system", "result"], "body was: {body}");
+}
+
+/// #556, #555's own shape: the CLI reports the server `connected` and hands the
+/// model none of its tools. The log warns, the client is told, and the turn
+/// still answers — a mismatch is never a refusal.
+#[tokio::test]
+async fn an_init_that_drops_a_connected_servers_tools_warns_and_says_so() {
+    let Some(_) = python3() else {
+        eprintln!("skipping: no python3");
+        return;
+    };
+    testlog::install();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cli = fake_cli(
+        dir.path(),
+        r#"
+    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack(req.get("request_id") or msg.get("request_id"))
+    elif msg.get("type") == "user":
+        say({"type": "system", "subtype": "init", "session_id": "s-1",
+             "tools": ["Read"],
+             "mcp_servers": [{"name": "local-tools", "status": "connected"}]})
+        raw('{"type":"result","subtype":"success","is_error":false,"result":"answered anyway","session_id":"s-1","usage":{"input_tokens":1,"output_tokens":1}}')
+"#,
+    );
+
+    let id = unique_id("toolsgone");
+    let file = migrated_with_local_tool_agent(&id);
+    let body = run_turn_on(&cli, &file, &id, "hello", None).await;
+    let frames = frames(&body);
+
+    let names: Vec<&str> = frames.iter().map(|(e, _)| e.as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["system", "tools_not_offered", "result"],
+        "the frame goes out on the `init` that carried the miss: {body}"
+    );
+
+    // Flat, `gojson`-encoded, keys in declaration order — the wire contract
+    // every synthetic frame follows.
+    assert_eq!(
+        frames[1].1,
+        r#"{"server":"local-tools","tools":["mcp__local-tools__current_time"],"message":"local-tools tools were hosted but the Claude CLI did not offer them to the model; see the app log"}"#
+    );
+
+    // Never a refusal: the turn produced its normal result.
+    assert!(frames[2].1.contains("answered anyway"), "{body}");
+
+    let logged = testlog::matching(r#"mcp tools not offered to the model server="local-tools""#);
+    assert!(!logged.is_empty(), "the miss is on the record in the log");
+    for line in &logged {
+        assert!(
+            line.starts_with("WARN "),
+            "a dropped tool list warns: {line}"
+        );
+    }
+}

--- a/src-tauri/tests/claude_cli_offload.rs
+++ b/src-tauri/tests/claude_cli_offload.rs
@@ -152,7 +152,7 @@ async fn re_resolving_the_cli_does_not_stall_the_runtime() {
     // revert this fails, and inline-awaited it would not.
     let built = tokio::spawn(async move {
         let spec = spec();
-        let (options, _servers) = build_options(&spec, None)
+        let (options, _servers, _hosted) = build_options(&spec, None)
             .await
             .expect("the turn's own option assembly");
         options.claude_executable

--- a/src-tauri/tests/mcp_e2e_probe.rs
+++ b/src-tauri/tests/mcp_e2e_probe.rs
@@ -98,7 +98,7 @@ async fn a_turn_lists_and_calls_a_tool_through_the_options_a_turn_builds() {
     let spec = spec();
     // `_servers` is the listener's lifetime — dropping it stops the server and
     // cancels every handler's token, so it has to outlive the stream.
-    let (options, _servers) = build_options(&spec, None)
+    let (options, _servers, _hosted) = build_options(&spec, None)
         .await
         .expect("the turn's own option assembly");
 

--- a/src-tauri/tests/scheduled_run.rs
+++ b/src-tauri/tests/scheduled_run.rs
@@ -679,3 +679,61 @@ async fn a_contended_write_lock_does_not_stall_the_runtime() {
     assert_eq!(jobs.len(), 1, "the run still recorded a job: {jobs:?}");
     assert_eq!(jobs[0].0, "success", "error was {:?}", jobs[0].1);
 }
+
+/// #556 on the path with nobody watching: a scheduled run whose `init` frame
+/// drops a hosted server's tools **completes normally** and says so on its
+/// `job_history` row.
+///
+/// The row is the only record a scheduled run leaves — nobody is reading the
+/// app log when a cron task fires at 03:00 — and `error_message` is its one
+/// free-text column, so the notice lands there while the status stays
+/// `success`. That pairing is deliberate: the run answered, and a mismatch is
+/// never a refusal.
+#[tokio::test]
+async fn a_run_whose_init_drops_the_tools_still_succeeds_and_records_it() {
+    if python3().is_none() {
+        eprintln!("skipping: no python3 to script the fake CLI");
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = dir.path().join("agento.db");
+    let task_id = migrated_with(
+        &db,
+        "what time is it?",
+        "clock",
+        30,
+        Some(r#"{"local":["current_time"]}"#),
+    );
+
+    let cli = fake_cli(
+        dir.path(),
+        r#"        say({"type": "system", "subtype": "init", "session_id": "sdk-run-2",
+             "tools": ["Read"],
+             "mcp_servers": [{"name": "local-tools", "status": "connected"}]})
+        raw('{"type":"result","subtype":"success","is_error":false,"result":"the summary","session_id":"sdk-run-2","usage":{"input_tokens":5,"output_tokens":6}}')"#,
+    );
+
+    let _env = env_lock().lock().await;
+    std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", &cli);
+
+    let scheduler = agento_lib::native::schedule::runtime::detached(&db);
+    agento_lib::native::schedule::executor::execute_task(&scheduler, &task_id).await;
+
+    let jobs = job_rows(&db);
+    assert_eq!(jobs.len(), 1, "exactly one run: {jobs:?}");
+    let (status, error, response, ..) = &jobs[0];
+    assert_eq!(status, "success", "a dropped tool list never fails the run");
+    assert_eq!(
+        response, "the summary",
+        "the run produced its normal answer"
+    );
+    assert_eq!(
+        error,
+        "local-tools tools were hosted but the Claude CLI did not offer them to the model; see the app log"
+    );
+
+    let task = agento_lib::native::tasks::get_task(&db, &task_id)
+        .expect("read")
+        .expect("row");
+    assert_eq!(task.last_run_status, "success");
+}

--- a/src/views/ChatsView.tsx
+++ b/src/views/ChatsView.tsx
@@ -716,6 +716,10 @@ export function ChatsView({
               />
             )}
 
+            {stream.notice && (
+              <NoticeBar text={stream.notice} onClose={stream.dismissNotice} />
+            )}
+
             {(stream.error || actionError) && (
               <ErrorBar
                 text={stream.error ?? actionError ?? ""}
@@ -926,6 +930,24 @@ function ResumedHistory({
       <div className="resumed__rule">
         <span>Continued here</span>
       </div>
+    </div>
+  );
+}
+
+/**
+ * A non-fatal warning about the turn in flight — the amber `banner`, not the
+ * red `banner--error`, because the turn is answering and only did so with
+ * fewer tools than were configured (#556).
+ */
+function NoticeBar({ text, onClose }: { text: string; onClose(): void }) {
+  return (
+    <div className="banner">
+      <Icon name="alert" size={13} />
+      <span className="truncate">{text}</span>
+      <div className="spacer" />
+      <button className="iconbtn" title="Dismiss" onClick={onClose}>
+        <Icon name="close" size={12} />
+      </button>
     </div>
   );
 }

--- a/src/views/ChatsView.tsx
+++ b/src/views/ChatsView.tsx
@@ -550,7 +550,13 @@ export function ChatsView({
               />
             </div>
 
-            {actionError && <ErrorBar text={actionError} onClose={() => setActionError(undefined)} />}
+            {actionError && (
+              <Bar
+                tone="error"
+                text={actionError}
+                onClose={() => setActionError(undefined)}
+              />
+            )}
 
             <Composer
               value={draft}
@@ -717,11 +723,12 @@ export function ChatsView({
             )}
 
             {stream.notice && (
-              <NoticeBar text={stream.notice} onClose={stream.dismissNotice} />
+              <Bar text={stream.notice} onClose={stream.dismissNotice} />
             )}
 
             {(stream.error || actionError) && (
-              <ErrorBar
+              <Bar
+                tone="error"
                 text={stream.error ?? actionError ?? ""}
                 onClose={() => {
                   stream.dismissError();
@@ -935,26 +942,26 @@ function ResumedHistory({
 }
 
 /**
- * A non-fatal warning about the turn in flight — the amber `banner`, not the
- * red `banner--error`, because the turn is answering and only did so with
- * fewer tools than were configured (#556).
+ * The dismissible bar above the composer. **One component, two tones** rather
+ * than two near-identical copies: `SaveBar`'s own lesson (#519) is that the
+ * class was shared and the JSX was copied, and the JSX is what drifted.
+ *
+ * The tone is opt-in and defaults to the amber `banner`, because the newer of
+ * the two callers is the non-fatal one — #556's dropped tool list, where the
+ * turn ran and answered and only did so without the tools that were
+ * configured. `banner--error` is for a turn that failed.
  */
-function NoticeBar({ text, onClose }: { text: string; onClose(): void }) {
+function Bar({
+  text,
+  tone,
+  onClose,
+}: {
+  text: string;
+  tone?: "error";
+  onClose(): void;
+}) {
   return (
-    <div className="banner">
-      <Icon name="alert" size={13} />
-      <span className="truncate">{text}</span>
-      <div className="spacer" />
-      <button className="iconbtn" title="Dismiss" onClick={onClose}>
-        <Icon name="close" size={12} />
-      </button>
-    </div>
-  );
-}
-
-function ErrorBar({ text, onClose }: { text: string; onClose(): void }) {
-  return (
-    <div className="banner banner--error">
+    <div className={tone === "error" ? "banner banner--error" : "banner"}>
       <Icon name="alert" size={13} />
       <span className="truncate">{text}</span>
       <div className="spacer" />

--- a/src/views/JobsView.tsx
+++ b/src/views/JobsView.tsx
@@ -522,7 +522,11 @@ export function JobsView({
                     </InspGroup>
                   )}
 
-                  {!job.response_text && !job.error_message && (
+                  {/* Keyed on the status for #556's reason: a `success` row
+                      can carry `error_message` now, and a saved-output-off run
+                      would otherwise lose this line entirely. */}
+                  {!job.response_text &&
+                    (job.status === "success" || !job.error_message) && (
                     <InspGroup title="Output">
                       <div className="runrow">
                         {job.status === "running"

--- a/src/views/JobsView.tsx
+++ b/src/views/JobsView.tsx
@@ -496,9 +496,21 @@ export function JobsView({
                     </InspGroup>
                   )}
 
+                  {/* A successful run can carry text here too since #556 —
+                      a hosted tool list the CLI never offered the model is a
+                      notice, not a failure — so the title and the red follow
+                      the status rather than the column being non-empty. */}
                   {job.error_message && (
-                    <InspGroup title="Error">
-                      <div className="logblock logblock--error">
+                    <InspGroup
+                      title={job.status === "success" ? "Notice" : "Error"}
+                    >
+                      <div
+                        className={
+                          job.status === "success"
+                            ? "logblock"
+                            : "logblock logblock--error"
+                        }
+                      >
                         {job.error_message}
                       </div>
                     </InspGroup>

--- a/src/views/chat/sse.ts
+++ b/src/views/chat/sse.ts
@@ -265,6 +265,18 @@ export function readPermission(payload: unknown): PermissionRequest {
   };
 }
 
+/* --- tools_not_offered --------------------------------------------------- */
+
+/**
+ * The synthetic frame Agento sends when a hosted MCP server's tools never
+ * reached the model (#556). The backend has already composed the sentence a
+ * user can act on; `server` and `tools` are on the frame for the log and the
+ * raw event stream, and are deliberately not repeated in the notice.
+ */
+export function readToolsNotOffered(payload: unknown): string | undefined {
+  return str(pick(payload, "message"));
+}
+
 /* --- error --------------------------------------------------------------- */
 
 export function readError(payload: unknown): string | undefined {

--- a/src/views/chat/useChatStream.ts
+++ b/src/views/chat/useChatStream.ts
@@ -225,7 +225,15 @@ export function useChatStream(
               // user needs to know is that the answer was produced without the
               // tools they configured (#556).
               const message = readToolsNotOffered(payload);
-              if (message) setNotice(message);
+              // One frame per dropped server, and #555's own shape was *every*
+              // integration going at once — so these accumulate rather than
+              // replace, joined the way the scheduled path joins them
+              // (`executor::finish`). Replacing would name the last server and
+              // silently lose the rest.
+              if (message)
+                setNotice((prev) =>
+                  prev && prev !== message ? `${prev}; ${message}` : message
+                );
               return;
             }
             case "error":

--- a/src/views/chat/useChatStream.ts
+++ b/src/views/chat/useChatStream.ts
@@ -20,6 +20,7 @@ import {
   readResult,
   readSystemInit,
   readThinkingTokens,
+  readToolsNotOffered,
   readToolProgress,
   readToolResults,
   type PermissionRequest,
@@ -62,6 +63,12 @@ export interface ChatStream {
   result: TurnResult | null;
   system: SystemInit | null;
   error: string | undefined;
+  /**
+   * A non-fatal warning about the turn — today only #556's dropped tool list.
+   * Separate from `error` because the turn ran and answered: an error bar over
+   * a good answer would misreport it.
+   */
+  notice: string | undefined;
   stopping: boolean;
   start(chatId: string, content: string): void;
   stop(): void;
@@ -69,6 +76,7 @@ export interface ChatStream {
   decide(allow: boolean): Promise<void>;
   reset(): void;
   dismissError(): void;
+  dismissNotice(): void;
 }
 
 export function useChatStream(
@@ -81,6 +89,7 @@ export function useChatStream(
   const [result, setResult] = useState<TurnResult | null>(null);
   const [system, setSystem] = useState<SystemInit | null>(null);
   const [error, setError] = useState<string>();
+  const [notice, setNotice] = useState<string>();
   const [stopping, setStopping] = useState(false);
 
   const abortRef = useRef<(() => void) | null>(null);
@@ -109,6 +118,7 @@ export function useChatStream(
       setResult(null);
       setPrompt(null);
       setError(undefined);
+      setNotice(undefined);
       setStopping(false);
       setChatId(id);
 
@@ -210,6 +220,14 @@ export function useChatStream(
             case "permission_request":
               setPrompt({ kind: "permission", request: readPermission(payload) });
               return;
+            case "tools_not_offered": {
+              // Not `setError`: the turn is running and will answer. What the
+              // user needs to know is that the answer was produced without the
+              // tools they configured (#556).
+              const message = readToolsNotOffered(payload);
+              if (message) setNotice(message);
+              return;
+            }
             case "error":
               setError(readError(payload) ?? "The stream failed.");
               return;
@@ -275,6 +293,7 @@ export function useChatStream(
     setResult(null);
     setSystem(null);
     setError(undefined);
+    setNotice(undefined);
   }, []);
 
   return {
@@ -285,6 +304,7 @@ export function useChatStream(
     result,
     system,
     error,
+    notice,
     stopping,
     start,
     stop,
@@ -292,6 +312,7 @@ export function useChatStream(
     decide,
     reset,
     dismissError: useCallback(() => setError(undefined), []),
+    dismissNotice: useCallback(() => setNotice(undefined), []),
   };
 }
 


### PR DESCRIPTION
Closes #556

## What

On the `system`/`init` event of every turn, diff `SystemMessage::tools` — the
list of tools the Claude Code CLI actually gave the model — against the
qualified names each MCP server the turn hosted put in front of it, and say so
when they disagree.

## Why

`report_hosted_tools` (#501) closed the hop before this one: it reads names off
the *handle* rather than off the request, so a server hosting nothing is logged
as hosting nothing. The hop it cannot see is the CLI's — whether what we hosted
reached the model. #555 is what that costs: every integration in the product was
dead for at least one CLI release while the log said
`mcp server started server=… tools=[…]`, `init` said `"status":"connected"`, and
the inspector showed a tool count. Only the model's prose disagreed.

## How

- **`runner.rs`** — `build_options` returns a third value, `Vec<HostedTools>`:
  per server, the **overlap** of what it registered and what the agent asked
  for, qualified. It is built at the two `report_hosted_tools` call sites (that
  function now returns the entry it just reported, so the reported and diffed
  sets are one computation), then narrowed by `narrow_to_command_line` against
  the assembled `--allowedTools` / `--disallowedTools`.

  It is deliberately **not** read back off `InProcessMcpServer`, which the
  issue suggested: the handle does not know the name the CLI prefixes tools
  with. An integration's server is *built* as `github-<id>` and *registered* as
  `<id>`, and only the second is the tool prefix — `registry::allowed_tool_names`
  says so at length. The doc comment on `build_options` records this.

- **`report_tools_offered`** is the shared policy, beside its #501 sibling: it
  emits the `warn` lines and hands each caller what it needs for its own
  user-visible surface. One function, two callers, no duplicated policy.

- **`turn.rs`** — a `"system"` arm on `handle_event`, and a third synthetic
  frame, `tools_not_offered` (flat, `gojson`-encoded, no embedded raw value).
  Returns `Flow::Continue` unconditionally.

- **`agent_run.rs` / `executor.rs`** — the same check in the headless loop; the
  finding travels out on `RunResult::tools_not_offered` and lands in
  `job_history.error_message`, with the status left at `success`. A scheduled
  run has nobody reading the log, and that row is the only record it leaves.

Three rules, each of which makes the signal worthless if broken, and each an
acceptance criterion:

- the diff is against what the runner **asked for after filtering** — a
  narrowing allowlist is not a defect;
- the **agreeing case emits nothing at all** — no line, no frame;
- a mismatch is a **warning, never a refusal** (`start_local_tools`' rule), and
  only a *whole* server's tools vanishing from a server the CLI called
  `connected` reaches the user. A partial miss stays in the log, because a
  filter this side does not model would otherwise put a scary sentence in front
  of a user on every turn.

## Tests

- `runner.rs` — eight unit tests over the set arithmetic: the overlap, the
  all-present silence, #555's whole-server shape, a partial miss naming exactly
  the difference, a server that never connected, **allowlist and denylist
  narrowing**, and an empty allowlist narrowing nothing. Each uses a `556-`
  prefixed server key, because the `testlog` buffer is process-wide and
  `cargo test` runs a binary's tests in parallel.
- `tests/chat_turn.rs` — two scripted-CLI turns against the real hosted
  `local-tools` server: an `init` listing its tool adds no frame; an `init`
  listing none of it emits the `warn`, the frame (asserted at the bytes) and
  still produces the turn's normal result.
- `tests/scheduled_run.rs` — a run whose `init` drops the tools completes with
  status `success` and the sentence on its `job_history` row.

**All three fail on the revert**, verified by hand: removing the frame emission
fails the chat test, passing `""` instead of the notice fails the scheduled
test, and making `narrow_to_command_line` a no-op fails both narrowing tests.

## Deviation from the HOW, one

The spec asks `tests/chat_turn.rs` to cover **three** cases (all present / none
present / some present). The partial case is not constructible there: the only
server an integration test can host is `local-tools`, which registers exactly
one tool (`current_time`), so "some but not all missing" has no shape — and an
integration server cannot be hosted from `tests/`, because `mcp_plan` resolves
names against the process-wide `paths::database_path()` rather than the test's
temp file (the same constraint `an_agent_whose_tools_this_build_cannot_host_is_a_recorded_failure`
already documents). The partial case is covered as a unit test in `runner.rs`,
where any hosted/requested/offered combination can be constructed; the two
reachable cases are covered end to end in `chat_turn.rs`.

## Out of scope, as the issue says

`--debug-file` is **not** wired into the mismatch path — `docs/troubleshooting.md`
documents the hand-run instead. No change to what is hosted or to
`--allowedTools` assembly. No retry, reconnect or refusal. No new UI surface.

## Docs

`src-tauri/src/native/chat/CLAUDE.md` (the synthetic-event contract goes from
two frames to three, plus the three rules above) and `docs/troubleshooting.md`
(what the message means, and the one-command hand-run that gets the CLI's own
reason).