### PR TITLE
feat: headless resume — one turn on an existing chat, under its busy lock (#564)

### DIFF
--- a/src-tauri/src/native/agent_run.rs
+++ b/src-tauri/src/native/agent_run.rs
@@ -1,9 +1,11 @@
 //! Running an agent to completion with **no interactive permission handler and
 //! no SSE** — `agent.RunAgent` plus `collectRunResult`.
 //!
-//! Shared by the two callers that have no user watching: the scheduler (#275)
-//! and the Telegram trigger dispatcher (#319). Go shares it too — both call
-//! `agent.RunAgent` — and the reason to share it here is sharper than tidiness.
+//! Shared by every caller that has no user watching: the scheduler (#275), the
+//! Telegram trigger dispatcher (#319), and [`run_resumed`] (#564), which is the
+//! one that continues an *existing* chat rather than minting a fresh one. Go
+//! shares it too — both of its callers call `agent.RunAgent` — and the reason to
+//! share it here is sharper than tidiness.
 //!
 //! **The trap this file exists to hold in one place:** the run must go through
 //! [`crate::claude::client::query`], the *one-shot*, and never through
@@ -18,7 +20,9 @@
 
 use std::sync::Arc;
 
+use crate::native::chat::live;
 use crate::native::chat::runner::{self, RunSpec};
+use crate::native::db;
 
 /// What one run produced. `agent.AgentResult`, narrowed to the fields its two
 /// callers store — the thinking, cost and per-model breakdowns are collected
@@ -136,6 +140,301 @@ pub fn headless_spec(
     }
 }
 
+/// The per-run execution choices a headless caller may impose on a chat.
+///
+/// The four `trigger_rules` columns #563 added that reach a [`RunSpec`] — the
+/// fifth, `timeout_minutes`, is a [`std::time::Duration`] argument to
+/// [`run_resumed`] rather than a spec field, because nothing about a `RunSpec`
+/// is time-bounded.
+///
+/// **Empty means "no choice was recorded"** for every field, exactly as it does
+/// on `chat_sessions.permission_mode` and on a trigger rule — so a rule that
+/// sets nothing runs the chat on the chat's own settings, and a rule that sets
+/// one field overrides only that one.
+#[derive(Debug, Default, Clone)]
+pub struct ExecutionSettings {
+    /// Overrides the agent's model (or, for a chat with no agent, the chat's).
+    pub model: String,
+    pub working_directory: String,
+    pub settings_profile_id: String,
+    /// One of [`crate::native::chats::CHAT_PERMISSION_MODES`]. The catch-all in
+    /// `build_options` turns an unknown mode into a fully bypassing run, so a
+    /// caller validates before it gets here.
+    pub permission_mode: String,
+}
+
+/// A [`RunSpec`] that **continues** `row`'s CLI session, with `settings`
+/// applied over the chat's own.
+///
+/// The counterpart to [`headless_spec`], and the differences are the whole
+/// point:
+///
+/// - `resume_session_id` is the chat's `sdk_session_id`, which is what makes the
+///   turn a continuation rather than a fresh conversation (`runner.rs` prefers
+///   it over `custom_session_id`).
+/// - `custom_session_id` stays **empty**, including for a chat that has never
+///   run. Pinning the chat's own id there — which the interactive turn does —
+///   would file the transcript under an id the write-back then has no reason to
+///   store; instead the CLI mints one and [`run_resumed`] records it, the way
+///   both existing headless callers do.
+///
+/// It takes `db_path` and `agent` that the [`RunSpec`] needs and a `ChatRow`
+/// does not carry: the settings row is read lazily through
+/// [`runner::TurnSettings`], and the agent is the other half of what
+/// [`runner::load`] returns.
+pub fn resume_spec(
+    db_path: &std::path::Path,
+    row: &crate::native::chat::runner::ChatRow,
+    agent: Option<crate::native::agents::Agent>,
+    settings: &ExecutionSettings,
+) -> RunSpec {
+    let turn_settings = Arc::new(runner::TurnSettings::from_db(db_path));
+
+    // The caller's model wins, then the chat's own, then — inside the closure —
+    // the user's default. `build_options` reads the agent's `model` field for an
+    // agent chat and this closure only for a chat with none, so an override has
+    // to be written into both arms or it applies to half the chats.
+    let mut agent = agent;
+    if let Some(agent) = agent.as_mut() {
+        if !settings.model.is_empty() {
+            agent.model = settings.model.clone();
+        }
+    }
+    let no_agent_model = match pick(&settings.model, &row.model) {
+        model if model.is_empty() => {
+            let settings = Arc::clone(&turn_settings);
+            Box::new(move || settings.default_model()) as Box<dyn Fn() -> String + Send + Sync>
+        }
+        model => Box::new(move || model.clone()),
+    };
+
+    RunSpec {
+        agent,
+        no_agent_model,
+        settings: turn_settings,
+        working_dir: pick(&settings.working_directory, &row.working_dir),
+        settings_profile_id: pick(&settings.settings_profile_id, &row.settings_profile_id),
+        permission_mode: pick(&settings.permission_mode, &row.permission_mode),
+        // `None` for a chat that has never run, which falls through to the
+        // empty `custom_session_id` below and leaves the CLI to mint an id.
+        resume_session_id: Some(row.sdk_session_id.clone()).filter(|s| !s.is_empty()),
+        custom_session_id: String::new(),
+    }
+}
+
+/// `override` when it is set, otherwise `fallback`. Empty is "no choice".
+fn pick(overridden: &str, fallback: &str) -> String {
+    if overridden.is_empty() {
+        fallback.to_string()
+    } else {
+        overridden.to_string()
+    }
+}
+
+/// Run **one turn on an existing chat**, resuming its CLI session, and write
+/// what it produced back onto the chat.
+///
+/// # It takes the chat's busy lock, and it is the first headless run that does
+///
+/// `live::registry().try_lock` had exactly one caller, the interactive turn.
+/// That was safe only because the scheduler and the trigger dispatcher mint a
+/// **fresh** chat per run, so no headless run could ever collide with a UI one.
+/// Resuming an existing chat removes that guarantee: a `POST
+/// /api/chats/{id}/messages` and an inbound turn would otherwise spawn two CLI
+/// processes against one row, each reading the other's stale `sdk_session_id`.
+/// So the lock is taken **before** anything is spawned and a held one is
+/// answered with [`live::CHAT_BUSY`] — the same string the chat route's 409
+/// carries, so an inbound worker can queue on it rather than fail.
+///
+/// The release is a guard's `Drop` rather than paired calls, because a leaked
+/// lock wedges the chat for the life of the process and the error, timeout and
+/// panic paths are exactly the ones a paired release is dropped from.
+///
+/// # Token totals are **incremented**, unlike every other headless write-back
+///
+/// `schedule/executor.rs` and `trigger/dispatcher.rs` both *replace* the four
+/// totals, which is correct for them: they own a chat nothing else ever wrote
+/// to. A resumed chat is shared — a user can answer in the UI between two
+/// inbound turns — so replacing would silently erase the UI turns' usage. This
+/// increments, the way `chat/persist.rs` does for the interactive turn. **Do not
+/// unify this statement with the executor's.**
+pub async fn run_resumed(
+    db_path: &std::path::Path,
+    chat_id: &str,
+    prompt: &str,
+    settings: &ExecutionSettings,
+    timeout: std::time::Duration,
+) -> Result<RunResult, String> {
+    if !live::registry().try_lock(chat_id) {
+        return Err(live::CHAT_BUSY.to_string());
+    }
+    let _guard = BusyGuard {
+        id: chat_id.to_string(),
+    };
+
+    let loaded = {
+        let (db, id) = (db_path.to_path_buf(), chat_id.to_string());
+        db::blocking("headless resume chat lookup", move || {
+            runner::load(&db, &id)
+        })
+        .await
+        .unwrap_or_else(|| Err("the chat lookup task failed".to_string()))?
+    };
+    let Some((row, agent)) = loaded else {
+        return Err(format!("chat {chat_id:?} not found"));
+    };
+
+    let spec = resume_spec(db_path, &row, agent, settings);
+    let result = run_headless(&spec, prompt, timeout).await;
+
+    let result = match result {
+        Ok(result) => result,
+        Err(e) => {
+            // The user turn is stored with no answer, `saveSessionMessages`'
+            // shape — so a failed inbound turn is visible in the chat rather
+            // than vanishing. Nothing else is touched: the totals and the
+            // `sdk_session_id` stay as they were, which is what lets the next
+            // attempt resume the same CLI session.
+            let (db, id, prompt) = (db_path.to_path_buf(), row.id.clone(), prompt.to_string());
+            db::blocking("headless resume failed turn", move || {
+                let conn = match crate::native::db::open_read_write(&db) {
+                    Ok(conn) => conn,
+                    Err(e) => {
+                        log::warn!("failed to store user message: {e}");
+                        return;
+                    }
+                };
+                if let Err(e) = append_message(&conn, &id, "user", &prompt) {
+                    log::warn!("failed to store user message: {e}");
+                }
+            })
+            .await;
+            return Err(e);
+        }
+    };
+
+    {
+        let (db, id, prior, run, prompt) = (
+            db_path.to_path_buf(),
+            row.id.clone(),
+            row.sdk_session_id.clone(),
+            result.clone(),
+            prompt.to_string(),
+        );
+        db::blocking("headless resume write-back", move || {
+            save_resumed_results(&db, &id, &prior, &run, &prompt)
+        })
+        .await;
+    }
+
+    Ok(result)
+}
+
+/// Releases the chat's busy lock on **every** exit path — the error and timeout
+/// ones included, which is why it is a `Drop` and not a pair of calls.
+///
+/// Unlike the interactive turn's guard, releasing here cannot be early: nothing
+/// is put in the `sessions` map (a headless run has no `/stop`, `/input` or
+/// `/permission` to serve), and the write-back has already run.
+struct BusyGuard {
+    id: String,
+}
+
+impl Drop for BusyGuard {
+    fn drop(&mut self) {
+        live::registry().release(&self.id);
+    }
+}
+
+/// The write-back: the totals onto the chat row, then the two messages.
+///
+/// `write_session_results`' three-independent-statements shape (see
+/// `schedule/executor.rs` for why one transaction would be a wider blast radius
+/// than the code being ported has), with the two divergences [`run_resumed`]
+/// documents: the totals are **incremented**, and `sdk_session_id` is written
+/// only when the run reported one — `prior_sdk_session_id` being what the chat
+/// carried before the run, and what it keeps when the run reported none.
+fn save_resumed_results(
+    db_path: &std::path::Path,
+    chat_id: &str,
+    prior_sdk_session_id: &str,
+    result: &RunResult,
+    prompt: &str,
+) {
+    let conn = match crate::native::db::open_read_write(db_path) {
+        Ok(conn) => conn,
+        Err(e) => {
+            log::warn!("failed to update chat session after a resumed run: {e}");
+            return;
+        }
+    };
+
+    // Only overwrite the CLI session id when the turn returned one — the
+    // reasoning at `chat/persist.rs`: blanking it would make the next turn start
+    // a new CLI session instead of resuming this one.
+    let sdk_session_id = if result.session_id.is_empty() {
+        prior_sdk_session_id
+    } else {
+        result.session_id.as_str()
+    };
+    if let Err(e) = conn.execute(
+        "UPDATE chat_sessions SET
+            sdk_session_id = ?1,
+            total_input_tokens = total_input_tokens + ?2,
+            total_output_tokens = total_output_tokens + ?3,
+            total_cache_creation_tokens = total_cache_creation_tokens + ?4,
+            total_cache_read_tokens = total_cache_read_tokens + ?5,
+            updated_at = ?6
+         WHERE id = ?7",
+        rusqlite::params![
+            sdk_session_id,
+            result.input_tokens,
+            result.output_tokens,
+            result.cache_creation_tokens,
+            result.cache_read_tokens,
+            crate::native::gotime::now_go_text(),
+            chat_id,
+        ],
+    ) {
+        log::warn!("failed to update chat session after a resumed run: {e}");
+    }
+
+    // Each insert logged on its own, as `saveSessionMessages` does: a failed
+    // user insert must not skip the assistant one, because the answer has
+    // already gone out to whoever asked.
+    if let Err(e) = append_message(&conn, chat_id, "user", prompt) {
+        log::warn!("failed to store user message: {e}");
+    }
+    if !result.answer.is_empty() {
+        if let Err(e) = append_message(&conn, chat_id, "assistant", &result.answer) {
+            log::warn!("failed to store assistant message: {e}");
+        }
+    }
+}
+
+/// `AppendMessage`, the dispatcher's spelling of it.
+fn append_message(
+    conn: &rusqlite::Connection,
+    chat_session_id: &str,
+    role: &str,
+    content: &str,
+) -> Result<(), String> {
+    // `id` is `INTEGER PRIMARY KEY AUTOINCREMENT`, so it is not in the column
+    // list; `blocks` defaults to `[]`, which every reader JSON-decodes.
+    conn.execute(
+        "INSERT INTO chat_messages (session_id, role, content, blocks, timestamp)
+         VALUES (?1, ?2, ?3, '[]', ?4)",
+        rusqlite::params![
+            chat_session_id,
+            role,
+            content,
+            crate::native::gotime::now_go_text()
+        ],
+    )
+    .map_err(|e| format!("storing {role} message: {e}"))?;
+    Ok(())
+}
+
 /// What `context.DeadlineExceeded` reaches Go's caller as, and therefore what
 /// lands in `job_history.error_message` for a run that ran out of time.
 pub const DEADLINE_EXCEEDED: &str = "context deadline exceeded";
@@ -230,5 +529,137 @@ mod tests {
 
         r.result = "the message".to_string();
         assert_eq!(build_result_error(&r), "agent error: the message");
+    }
+
+    /// A path that does not exist, so any eager settings read would show up as
+    /// an empty answer rather than as the row's own value — the trick
+    /// `turn.rs`'s own model test uses.
+    const NO_DB: &str = "/nonexistent/agento/definitely-not-a-db";
+
+    fn chat_row() -> crate::native::chat::runner::ChatRow {
+        crate::native::chat::runner::ChatRow {
+            id: "chat-1".to_string(),
+            title: "New Chat".to_string(),
+            agent_slug: String::new(),
+            sdk_session_id: String::new(),
+            working_dir: "/from/the/chat".to_string(),
+            model: "chat-model".to_string(),
+            settings_profile_id: "chat-profile".to_string(),
+            permission_mode: "plan".to_string(),
+        }
+    }
+
+    /// The one field that makes this a *resume*: it comes from the chat row, and
+    /// an empty one is `None` rather than `Some("")` — which is what sends a
+    /// never-run chat down `build_options`' third branch, where it supplies no
+    /// session flag at all.
+    #[test]
+    fn a_never_run_chat_pins_no_session_and_a_run_one_resumes_its_own() {
+        let mut row = chat_row();
+        let spec = resume_spec(
+            std::path::Path::new(NO_DB),
+            &row,
+            None,
+            &ExecutionSettings::default(),
+        );
+        assert_eq!(spec.resume_session_id, None);
+        assert_eq!(
+            spec.custom_session_id, "",
+            "the CLI mints the id and the write-back stores it; pinning the chat's own \
+             would file the transcript under an id nothing then records"
+        );
+
+        row.sdk_session_id = "sdk-7".to_string();
+        let spec = resume_spec(
+            std::path::Path::new(NO_DB),
+            &row,
+            None,
+            &ExecutionSettings::default(),
+        );
+        assert_eq!(spec.resume_session_id.as_deref(), Some("sdk-7"));
+        assert_eq!(spec.custom_session_id, "");
+    }
+
+    /// Empty means "no choice was recorded", so an unset caller runs the chat on
+    /// the chat's own settings.
+    #[test]
+    fn empty_execution_settings_leave_the_chats_own_choices_alone() {
+        let spec = resume_spec(
+            std::path::Path::new(NO_DB),
+            &chat_row(),
+            None,
+            &ExecutionSettings::default(),
+        );
+        assert_eq!(spec.working_dir, "/from/the/chat");
+        assert_eq!(spec.settings_profile_id, "chat-profile");
+        assert_eq!(spec.permission_mode, "plan");
+        assert_eq!(
+            (spec.no_agent_model)(),
+            "chat-model",
+            "and the chat's model, without opening the settings"
+        );
+    }
+
+    /// Each of the four overrides independently, which is what lets a rule set
+    /// one field and inherit the rest.
+    #[test]
+    fn each_execution_setting_overrides_the_chats_own() {
+        let settings = ExecutionSettings {
+            model: "rule-model".to_string(),
+            working_directory: "/from/the/rule".to_string(),
+            settings_profile_id: "rule-profile".to_string(),
+            permission_mode: "bypass".to_string(),
+        };
+        let spec = resume_spec(std::path::Path::new(NO_DB), &chat_row(), None, &settings);
+        assert_eq!(spec.working_dir, "/from/the/rule");
+        assert_eq!(spec.settings_profile_id, "rule-profile");
+        assert_eq!(spec.permission_mode, "bypass");
+        assert_eq!((spec.no_agent_model)(), "rule-model");
+    }
+
+    /// The model override has to be written into **both** arms `build_options`
+    /// reads: an agent chat takes `agent.model` and never consults the closure,
+    /// so setting only the closure would apply the rule's model to exactly the
+    /// chats that have no agent.
+    #[test]
+    fn the_model_override_reaches_an_agent_chat_too() {
+        let agent = crate::native::agents::Agent {
+            name: "A".to_string(),
+            slug: "a".to_string(),
+            description: String::new(),
+            model: "agent-model".to_string(),
+            thinking: String::new(),
+            permission_mode: String::new(),
+            system_prompt: String::new(),
+            capabilities: Default::default(),
+            claude_config_dir: String::new(),
+        };
+
+        let spec = resume_spec(
+            std::path::Path::new(NO_DB),
+            &chat_row(),
+            Some(agent.clone()),
+            &ExecutionSettings::default(),
+        );
+        assert_eq!(
+            spec.agent.as_ref().map(|a| a.model.as_str()),
+            Some("agent-model"),
+            "no override leaves the agent's own model, empty ones included"
+        );
+
+        let settings = ExecutionSettings {
+            model: "rule-model".to_string(),
+            ..Default::default()
+        };
+        let spec = resume_spec(
+            std::path::Path::new(NO_DB),
+            &chat_row(),
+            Some(agent),
+            &settings,
+        );
+        assert_eq!(
+            spec.agent.as_ref().map(|a| a.model.as_str()),
+            Some("rule-model")
+        );
     }
 }

--- a/src-tauri/src/native/agent_run.rs
+++ b/src-tauri/src/native/agent_run.rs
@@ -250,6 +250,16 @@ fn pick(overridden: &str, fallback: &str) -> String {
 /// lock wedges the chat for the life of the process and the error, timeout and
 /// panic paths are exactly the ones a paired release is dropped from.
 ///
+/// **It fences the two runs, not the two writes, and the residual window is
+/// deliberate.** The interactive turn releases the lock when its *stream* ends,
+/// before `chat/persist::commit` lands — Go's own ordering, reproduced on
+/// purpose and argued in [`live`]'s module header. So a `run_resumed` starting
+/// in that window loads an `sdk_session_id` the UI turn is still about to write.
+/// Two CLI processes on one chat, which is the outcome this lock exists to
+/// prevent, remains impossible; a resume from one turn earlier does not.
+/// Narrowing it means changing when the interactive turn releases, which is a
+/// divergence from that ordering and belongs to whoever decides to take it.
+///
 /// # Token totals are **incremented**, unlike every other headless write-back
 ///
 /// `schedule/executor.rs` and `trigger/dispatcher.rs` both *replace* the four
@@ -297,16 +307,14 @@ pub async fn run_resumed(
             // attempt resume the same CLI session.
             let (db, id, prompt) = (db_path.to_path_buf(), row.id.clone(), prompt.to_string());
             db::blocking("headless resume failed turn", move || {
-                let conn = match crate::native::db::open_read_write(&db) {
+                let conn = match db::open_read_write(&db) {
                     Ok(conn) => conn,
                     Err(e) => {
                         log::warn!("failed to store user message: {e}");
                         return;
                     }
                 };
-                if let Err(e) = append_message(&conn, &id, "user", &prompt) {
-                    log::warn!("failed to store user message: {e}");
-                }
+                save_messages(&conn, &id, &prompt, "");
             })
             .await;
             return Err(e);
@@ -354,6 +362,13 @@ impl Drop for BusyGuard {
 /// documents: the totals are **incremented**, and `sdk_session_id` is written
 /// only when the run reported one — `prior_sdk_session_id` being what the chat
 /// carried before the run, and what it keeps when the run reported none.
+///
+/// **`title` is not written here.** `chat/persist.rs` derives one from the first
+/// user message because a UI chat is created before anyone has typed; a chat
+/// this function runs against was created by its caller, which knows the origin
+/// and titles the row then (`[Task] <name>` for the scheduler, `[Telegram] …`
+/// for the dispatcher). Deriving one here would rename a chat the caller had
+/// already named.
 fn save_resumed_results(
     db_path: &std::path::Path,
     chat_id: &str,
@@ -361,7 +376,7 @@ fn save_resumed_results(
     result: &RunResult,
     prompt: &str,
 ) {
-    let conn = match crate::native::db::open_read_write(db_path) {
+    let conn = match db::open_read_write(db_path) {
         Ok(conn) => conn,
         Err(e) => {
             log::warn!("failed to update chat session after a resumed run: {e}");
@@ -399,14 +414,31 @@ fn save_resumed_results(
         log::warn!("failed to update chat session after a resumed run: {e}");
     }
 
-    // Each insert logged on its own, as `saveSessionMessages` does: a failed
-    // user insert must not skip the assistant one, because the answer has
-    // already gone out to whoever asked.
-    if let Err(e) = append_message(&conn, chat_id, "user", prompt) {
+    save_messages(&conn, chat_id, prompt, &result.answer);
+}
+
+/// `saveSessionMessages`: the user turn, then the assistant turn when there is
+/// one.
+///
+/// **The user turn is stored even when there is no answer** — the trigger
+/// dispatcher's shape, which #564 asks for by name, and *not*
+/// `chat/persist.rs`'s. That file guards both inserts on a non-empty answer
+/// because "an interrupted stream must not leave an orphaned user message …
+/// the two would diverge on the next resume", and this is the first headless
+/// path where the next resume is real. The dispatcher's shape still wins: an
+/// inbound message the user can see was asked, with no reply, is the outcome
+/// that surface needs, and the CLI reconciles its own transcript on the next
+/// `--resume` rather than being driven from `chat_messages`.
+///
+/// Each insert is logged on its own, as `saveSessionMessages` does: a failed
+/// user insert must not skip the assistant one, because the answer has already
+/// gone out to whoever asked.
+fn save_messages(conn: &rusqlite::Connection, chat_id: &str, prompt: &str, answer: &str) {
+    if let Err(e) = append_message(conn, chat_id, "user", prompt) {
         log::warn!("failed to store user message: {e}");
     }
-    if !result.answer.is_empty() {
-        if let Err(e) = append_message(&conn, chat_id, "assistant", &result.answer) {
+    if !answer.is_empty() {
+        if let Err(e) = append_message(conn, chat_id, "assistant", answer) {
             log::warn!("failed to store assistant message: {e}");
         }
     }

--- a/src-tauri/src/native/agent_run.rs
+++ b/src-tauri/src/native/agent_run.rs
@@ -305,6 +305,12 @@ pub async fn run_resumed(
             // than vanishing. Nothing else is touched: the totals and the
             // `sdk_session_id` stay as they were, which is what lets the next
             // attempt resume the same CLI session.
+            //
+            // A `None` here is a panic inside the section, and it costs the
+            // stored question and nothing else — the run has already failed and
+            // the caller is answered with its error either way. Best-effort in
+            // Go too, so it is ignored, as the dispatcher's two `save_messages`
+            // calls are.
             let (db, id, prompt) = (db_path.to_path_buf(), row.id.clone(), prompt.to_string());
             db::blocking("headless resume failed turn", move || {
                 let conn = match db::open_read_write(&db) {
@@ -321,6 +327,16 @@ pub async fn run_resumed(
         }
     };
 
+    // A `None` here is a panic between [`save_resumed_results`]' three
+    // untransacted writes — `db::blocking` says outright that what a half-done
+    // section left behind is the caller's problem. What it can leave is the
+    // `UPDATE` applied and neither message stored: `sdk_session_id` and the
+    // totals advanced for a turn `chat_messages` has no record of, so the chat
+    // reads as empty while the next `--resume` continues a session that did
+    // happen. It is a panic rather than a rusqlite failure — every statement in
+    // there logs and carries on — and the run itself succeeded, so the caller is
+    // still answered `Ok` and posts the reply it got. `db::blocking` logs it
+    // under the label; there is nothing better to do here than say so.
     {
         let (db, id, prior, run, prompt) = (
             db_path.to_path_buf(),

--- a/src-tauri/src/native/chat/CLAUDE.md
+++ b/src-tauri/src/native/chat/CLAUDE.md
@@ -16,6 +16,17 @@
   `tools_not_offered`).
 - **`AskUserQuestion` is answered by *denying* the tool** with the user's text
   in `Message` — that is how the answer reaches the model. Not a bug.
+- **The busy lock has two callers, and they answer with one string** (#564).
+  `live::try_lock` was the interactive turn's alone while every headless run
+  minted a fresh chat; `agent_run::run_resumed` runs a turn on an *existing*
+  chat, so a UI send and an inbound one can now collide on one row — two CLI
+  processes each reading the other's stale `sdk_session_id`. Both refuse with
+  `live::CHAT_BUSY`, the chat route's own 409 body, because an inbound worker
+  queues on exactly that string. `run_resumed` also **increments** the four
+  token totals where `schedule/executor.rs` and `trigger/dispatcher.rs` replace
+  them; replacing on a chat the user has also typed into erases the UI turns'
+  usage. Both divergences are stated at `run_resumed` and pinned by
+  `tests/headless_resume.rs` — do not unify that write-back with the executor's.
 - **A continued chat's inherited history is the transcript's, and it is a fixed
   prefix** (#490, migration 37). "Continue in chat" records
   `continued_from_session_id` / `continued_from_project_path` /

--- a/src-tauri/src/native/chat/CLAUDE.md
+++ b/src-tauri/src/native/chat/CLAUDE.md
@@ -22,7 +22,12 @@
   chat, so a UI send and an inbound one can now collide on one row — two CLI
   processes each reading the other's stale `sdk_session_id`. Both refuse with
   `live::CHAT_BUSY`, the chat route's own 409 body, because an inbound worker
-  queues on exactly that string. `run_resumed` also **increments** the four
+  queues on exactly that string. It fences the two *runs*, not the two *writes*:
+  the interactive turn still releases when its stream ends, before
+  `persist::commit` lands (Go's ordering, argued in `live.rs`'s header), so a
+  resume starting in that window reads an `sdk_session_id` the UI turn is about
+  to write. Two CLI processes on one chat stay impossible; a resume from one
+  turn earlier does not. `run_resumed` also **increments** the four
   token totals where `schedule/executor.rs` and `trigger/dispatcher.rs` replace
   them; replacing on a chat the user has also typed into erases the UI turns'
   usage. Both divergences are stated at `run_resumed` and pinned by

--- a/src-tauri/src/native/chat/live.rs
+++ b/src-tauri/src/native/chat/live.rs
@@ -77,6 +77,9 @@ impl LiveSessions {
     /// not the end of a scope but the end of the stream, and tying it to a
     /// guard's `Drop` would move it *after* the commit, which is the one thing
     /// this must not do (see the module header).
+    ///
+    /// Every refusal spells itself [`CHAT_BUSY`], so a caller that wants to
+    /// *queue* rather than fail can recognise one.
     pub fn try_lock(&self, id: &str) -> bool {
         let mut inner = self.lock();
         if inner.in_flight.contains(id) {
@@ -124,6 +127,16 @@ impl LiveSessions {
         self.inner.lock().unwrap_or_else(|e| e.into_inner())
     }
 }
+
+/// What a refused [`LiveSessions::try_lock`] is answered with — Go's own
+/// `handleSendMessage` string, and the body of the 409 the chat route returns.
+///
+/// It is a constant rather than a literal at each site because it is now the
+/// answer on **two** paths that are not each other's neighbours: the interactive
+/// turn's 409 (`turn.rs`) and the headless resume's `Err`
+/// ([`crate::native::agent_run::run_resumed`]). An inbound worker queues on
+/// exactly this string, so the two must not drift apart.
+pub const CHAT_BUSY: &str = "session is busy, wait for the current message to complete";
 
 /// The one registry. A chat turn is process state, so this is a process global —
 /// the same reason Go hangs it off the single `api.Server`.

--- a/src-tauri/src/native/chat/turn.rs
+++ b/src-tauri/src/native/chat/turn.rs
@@ -42,7 +42,7 @@ use crate::claude::permissions::{PermissionContext, PermissionResult};
 use crate::claude::session::Session;
 
 use super::error_json;
-use super::live::{registry, LiveSession};
+use super::live::{registry, LiveSession, CHAT_BUSY};
 use super::runner::{self, RunSpec};
 use super::sse;
 
@@ -133,10 +133,7 @@ pub async fn run(
     // would read a stale sdk_session_id and start a new CLI session instead of
     // resuming the right one.
     if !registry().try_lock(&chat_id) {
-        return Ok(error_json(
-            StatusCode::CONFLICT,
-            "session is busy, wait for the current message to complete",
-        ));
+        return Ok(error_json(StatusCode::CONFLICT, CHAT_BUSY));
     }
     // From here every early return must release the lock, or the chat is
     // wedged until the process restarts.

--- a/src-tauri/tests/headless_resume.rs
+++ b/src-tauri/tests/headless_resume.rs
@@ -1,0 +1,561 @@
+//! One headless turn on an **existing** chat, driven against a scripted fake
+//! CLI (#564).
+//!
+//! `tests/scheduled_run.rs` answers "does a scheduled task run?"; this file
+//! answers the two questions resuming adds, neither of which any unit test can
+//! see:
+//!
+//! - **Does the second turn actually resume the first?** The whole mechanism is
+//!   one `--resume <id>` on a command line the code under test never returns, so
+//!   the only honest assertion is the argv the subprocess was invoked with.
+//! - **Do a UI turn and a headless turn exclude each other?** The busy lock is a
+//!   process global reached from two unrelated call sites, and a missing
+//!   `try_lock` is invisible until two CLI processes are writing one chat row.
+//!
+//! It inherits `scheduled_run.rs`'s **trap**: the fake CLI never exits after the
+//! result. A run that went through `claude::client::Session` rather than the
+//! one-shot `query` would never see its event channel close and would sit until
+//! its timeout, so every test here would hang instead of failing cleanly — which
+//! is why the one that would hang longest wraps its own await in a deadline that
+//! names the trap.
+
+use std::path::{Path, PathBuf};
+
+use agento_lib::native::agent_run::{self, ExecutionSettings};
+
+/// `AGENTO_CLAUDE_EXECUTABLE` is process-wide, so the tests that set it are
+/// serialized against each other.
+fn env_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+fn python3() -> Option<String> {
+    for candidate in ["python3", "python"] {
+        if std::process::Command::new(candidate)
+            .arg("--version")
+            .output()
+            .is_ok_and(|out| out.status.success())
+        {
+            return Some(candidate.to_string());
+        }
+    }
+    None
+}
+
+/// A chat id unique to the calling test.
+///
+/// The live-session registry is a **process global** — a chat turn is process
+/// state — and cargo runs these tests in parallel in one binary, so a shared id
+/// would make one test see another's busy lock. That is a collision, not a
+/// finding.
+fn unique_id(label: &str) -> String {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    static NEXT: AtomicU32 = AtomicU32::new(0);
+    format!("{label}-{}", NEXT.fetch_add(1, Ordering::Relaxed))
+}
+
+fn argv_log(dir: &Path) -> PathBuf {
+    dir.join("argv.jsonl")
+}
+
+/// The file the gated fake CLI touches once it has read the user message, and
+/// the one it then waits for before answering.
+fn gate_started(dir: &Path) -> PathBuf {
+    dir.join("gate.started")
+}
+fn gate_release(dir: &Path) -> PathBuf {
+    dir.join("gate.release")
+}
+
+/// A CLI that records **its own argv** on start, acknowledges `initialize`, and
+/// emits `emit` verbatim on the first user message.
+///
+/// The argv line is what the `--resume` assertions read: the chain under test is
+/// a `RunSpec` field reaching `Options::build_args` reaching a command line, and
+/// inspecting an `Options` in the test would skip the last two links.
+///
+/// `gated` makes it touch `gate.started` and then block until `gate.release`
+/// appears, which is how a test gets a run that is provably *in flight*.
+fn fake_cli(dir: &Path, emit: &str, gated: bool) -> PathBuf {
+    let script = format!(
+        r#"#!/usr/bin/env {python}
+import json, os, sys, time
+
+with open({argv_log}, "a") as _argv:
+    _argv.write(json.dumps(sys.argv) + "\n")
+    _argv.flush()
+
+GATED = {gated}
+STARTED = {started}
+RELEASE = {release}
+
+def say(obj):
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+
+def raw(line):
+    sys.stdout.write(line + "\n")
+    sys.stdout.flush()
+
+def ack(request_id):
+    say({{"type": "control_response",
+         "response": {{"subtype": "success", "request_id": request_id,
+                       "response": {{"models": [{{"value": "fake", "displayName": "Fake"}}],
+                                     "account": {{"apiProvider": "fake"}},
+                                     "output_style": "default"}}}}}})
+
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        msg = json.loads(line)
+    except Exception:
+        continue
+    req = msg.get("request") or {{}}
+    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack(req.get("request_id") or msg.get("request_id"))
+        continue
+    if msg.get("type") == "user":
+        if GATED:
+            open(STARTED, "w").close()
+            while not os.path.exists(RELEASE):
+                time.sleep(0.02)
+{emit}
+        # **Deliberately no exit**, as `scheduled_run.rs` explains: a real CLI in
+        # session mode stays alive for the next send, so a fake that exited here
+        # would close stdout, end the event stream for free, and pass against a
+        # drain that never terminates on its own.
+        continue
+"#,
+        python = python3().unwrap_or_else(|| "python3".into()),
+        argv_log = json_str(&argv_log(dir)),
+        gated = if gated { "True" } else { "False" },
+        started = json_str(&gate_started(dir)),
+        release = json_str(&gate_release(dir)),
+        emit = emit,
+    );
+    let path = dir.join("fake-claude");
+    std::fs::write(&path, script).expect("write fake CLI");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod fake CLI");
+    }
+    path
+}
+
+fn json_str(path: &Path) -> String {
+    serde_json::to_string(&path.to_string_lossy()).expect("encode path")
+}
+
+/// Every argv the fake CLI has been invoked with, in order.
+fn spawns(dir: &Path) -> Vec<Vec<String>> {
+    let Ok(raw) = std::fs::read_to_string(argv_log(dir)) else {
+        return Vec::new();
+    };
+    raw.lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).expect("argv line"))
+        .collect()
+}
+
+/// The value of `--resume` in one spawn, or `None` when the flag is absent.
+fn resumed_with(argv: &[String]) -> Option<&str> {
+    let at = argv.iter().position(|a| a == "--resume")?;
+    argv.get(at + 1).map(String::as_str)
+}
+
+/// A migrated database with one chat row, seeded as if some earlier turn had
+/// already run against it.
+fn migrated_with_chat(path: &Path, chat_id: &str, sdk_session_id: &str, totals: [i64; 4]) {
+    let mut conn = rusqlite::Connection::open(path).expect("open");
+    agento_lib::native::migrate::apply(&mut conn).expect("migrate");
+    conn.execute(
+        "INSERT INTO chat_sessions
+            (id, title, agent_slug, sdk_session_id, working_directory, model,
+             settings_profile_id, permission_mode, total_input_tokens, total_output_tokens,
+             total_cache_creation_tokens, total_cache_read_tokens, created_at, updated_at)
+         VALUES (?1, 'New Chat', '', ?2, '', '', '', '', ?3, ?4, ?5, ?6,
+                 '2026-01-01 00:00:00 +0000 UTC', '2026-01-01 00:00:00 +0000 UTC')",
+        rusqlite::params![
+            chat_id,
+            sdk_session_id,
+            totals[0],
+            totals[1],
+            totals[2],
+            totals[3],
+        ],
+    )
+    .expect("seed chat");
+}
+
+fn sdk_session_id(path: &Path, chat_id: &str) -> String {
+    let conn = rusqlite::Connection::open(path).expect("open");
+    conn.query_row(
+        "SELECT sdk_session_id FROM chat_sessions WHERE id = ?1",
+        [chat_id],
+        |r| r.get(0),
+    )
+    .expect("the session row")
+}
+
+fn totals(path: &Path, chat_id: &str) -> [i64; 4] {
+    let conn = rusqlite::Connection::open(path).expect("open");
+    conn.query_row(
+        "SELECT total_input_tokens, total_output_tokens, total_cache_creation_tokens,
+                total_cache_read_tokens
+         FROM chat_sessions WHERE id = ?1",
+        [chat_id],
+        |r| Ok([r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?]),
+    )
+    .expect("the session row")
+}
+
+fn messages(path: &Path, chat_id: &str) -> Vec<(String, String)> {
+    let conn = rusqlite::Connection::open(path).expect("open");
+    let mut stmt = conn
+        .prepare("SELECT role, content FROM chat_messages WHERE session_id = ?1 ORDER BY id")
+        .expect("prepare");
+    let rows = stmt
+        .query_map([chat_id], |r| Ok((r.get(0)?, r.get(1)?)))
+        .expect("query");
+    rows.map(|r| r.expect("row")).collect()
+}
+
+fn result_frame(answer: &str, session_id: &str, usage: [i64; 4]) -> String {
+    format!(
+        r#"        raw('{{"type":"result","subtype":"success","is_error":false,"result":"{answer}","session_id":"{session_id}","usage":{{"input_tokens":{},"output_tokens":{},"cache_creation_input_tokens":{},"cache_read_input_tokens":{}}}}}')"#,
+        usage[0], usage[1], usage[2], usage[3],
+    )
+}
+
+/// The first acceptance criterion, both halves: a chat that has never run gets a
+/// fresh CLI session and stores the id the CLI minted; the next turn on the same
+/// chat is spawned with `--resume <that id>`.
+///
+/// Also the trap test for this path. The fake never exits, so a `run_resumed`
+/// built on `Session` rather than the one-shot `query` would drain forever —
+/// hence the explicit deadline around the await, well under the run's own
+/// 10-minute timeout.
+#[tokio::test]
+async fn the_first_turn_mints_a_session_and_the_second_resumes_it() {
+    if python3().is_none() {
+        eprintln!("skipping: no python3 to script the fake CLI");
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = dir.path().join("agento.db");
+    let chat = unique_id("resume-chat");
+    migrated_with_chat(&db, &chat, "", [0; 4]);
+
+    let cli = fake_cli(
+        dir.path(),
+        &result_frame("the answer", "sdk-minted-1", [11, 22, 3, 4]),
+        false,
+    );
+
+    let _env = env_lock().lock().await;
+    std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", &cli);
+
+    let first = tokio::time::timeout(
+        std::time::Duration::from_secs(90),
+        agent_run::run_resumed(
+            &db,
+            &chat,
+            "first question",
+            &ExecutionSettings::default(),
+            std::time::Duration::from_secs(600),
+        ),
+    )
+    .await
+    .expect("the drain must terminate: a `Session` here would hang until the timeout")
+    .expect("the run");
+    assert_eq!(first.answer, "the answer");
+
+    let spawned = spawns(dir.path());
+    assert_eq!(spawned.len(), 1, "one spawn so far: {spawned:?}");
+    assert_eq!(
+        resumed_with(&spawned[0]),
+        None,
+        "a chat that has never run has no session to resume"
+    );
+    assert_eq!(
+        sdk_session_id(&db, &chat),
+        "sdk-minted-1",
+        "the CLI's own id is written back, which is what the next turn resumes"
+    );
+    assert_eq!(
+        messages(&db, &chat),
+        vec![
+            ("user".to_string(), "first question".to_string()),
+            ("assistant".to_string(), "the answer".to_string()),
+        ]
+    );
+
+    agent_run::run_resumed(
+        &db,
+        &chat,
+        "second question",
+        &ExecutionSettings::default(),
+        std::time::Duration::from_secs(600),
+    )
+    .await
+    .expect("the second run");
+
+    let spawned = spawns(dir.path());
+    assert_eq!(spawned.len(), 2, "two spawns: {spawned:?}");
+    assert_eq!(
+        resumed_with(&spawned[1]),
+        Some("sdk-minted-1"),
+        "the second turn continues the session the first minted"
+    );
+}
+
+/// The busy lock, in the direction a headless run is refused.
+///
+/// The assertion that matters is the second one: refusing *after* spawning would
+/// still leave two CLI processes on one chat, which is the whole hazard.
+#[tokio::test]
+async fn a_resumed_run_is_refused_while_the_chat_is_busy_and_spawns_nothing() {
+    if python3().is_none() {
+        eprintln!("skipping: no python3 to script the fake CLI");
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = dir.path().join("agento.db");
+    let chat = unique_id("busy-chat");
+    migrated_with_chat(&db, &chat, "sdk-prior", [0; 4]);
+
+    let cli = fake_cli(
+        dir.path(),
+        &result_frame("unreachable", "sdk-prior", [1, 1, 1, 1]),
+        false,
+    );
+
+    let _env = env_lock().lock().await;
+    std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", &cli);
+
+    assert!(
+        agento_lib::native::chat::live::registry().try_lock(&chat),
+        "the lock starts free"
+    );
+
+    let refused = agent_run::run_resumed(
+        &db,
+        &chat,
+        "while busy",
+        &ExecutionSettings::default(),
+        std::time::Duration::from_secs(60),
+    )
+    .await
+    .expect_err("a busy chat must refuse");
+    assert_eq!(refused, agento_lib::native::chat::live::CHAT_BUSY);
+    assert!(
+        spawns(dir.path()).is_empty(),
+        "the refusal happens before anything is spawned"
+    );
+
+    agento_lib::native::chat::live::registry().release(&chat);
+}
+
+/// The busy lock, in the other direction: a UI `POST /api/chats/{id}/messages`
+/// meets the existing 409 while a headless turn is running.
+///
+/// The gate is what makes "while running" real rather than hopeful — the CLI has
+/// read the prompt and is holding it, so the lock is provably held by a live
+/// subprocess rather than by a race that happened to land.
+#[tokio::test]
+async fn a_ui_turn_is_refused_while_a_resumed_run_holds_the_lock() {
+    if python3().is_none() {
+        eprintln!("skipping: no python3 to script the fake CLI");
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = dir.path().join("agento.db");
+    let chat = unique_id("collide-chat");
+    migrated_with_chat(&db, &chat, "sdk-prior", [0; 4]);
+
+    let cli = fake_cli(
+        dir.path(),
+        &result_frame("the answer", "sdk-prior", [1, 2, 3, 4]),
+        true,
+    );
+
+    let _env = env_lock().lock().await;
+    std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", &cli);
+
+    let running = tokio::spawn({
+        let (db, chat) = (db.clone(), chat.clone());
+        async move {
+            agent_run::run_resumed(
+                &db,
+                &chat,
+                "the headless turn",
+                &ExecutionSettings::default(),
+                std::time::Duration::from_secs(600),
+            )
+            .await
+        }
+    });
+
+    // The CLI has the prompt and is parked on the gate: the run is in flight.
+    let started = gate_started(dir.path());
+    for _ in 0..1500 {
+        if started.exists() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    assert!(started.exists(), "the fake CLI never reached the gate");
+
+    let response =
+        agento_lib::native::chat::turn::run(db.clone(), chat.clone(), "from the UI".into())
+            .await
+            .expect("the route answers");
+    assert_eq!(response.status(), axum::http::StatusCode::CONFLICT);
+    let body = {
+        use http_body_util::BodyExt;
+        let collected = response.into_body().collect().await.expect("body");
+        String::from_utf8(collected.to_bytes().to_vec()).expect("utf8")
+    };
+    assert!(
+        body.contains(agento_lib::native::chat::live::CHAT_BUSY),
+        "the UI gets the existing busy answer, not a second run: {body}"
+    );
+
+    std::fs::write(gate_release(dir.path()), b"go").expect("release the gate");
+    running.await.expect("the task").expect("the run");
+
+    assert_eq!(
+        spawns(dir.path()).len(),
+        1,
+        "the refused UI turn spawned nothing"
+    );
+    // The lock is free again, which is what the guard's `Drop` is for.
+    assert!(agento_lib::native::chat::live::registry().try_lock(&chat));
+    agento_lib::native::chat::live::registry().release(&chat);
+}
+
+/// A turn that produced no final text: the user message is stored, no assistant
+/// message is, and the chat keeps the session id it already had.
+///
+/// The result frame carries an **empty** `session_id`, which is what an
+/// interrupted turn reports — blanking the column there would make the next turn
+/// start a new CLI session instead of resuming this one.
+#[tokio::test]
+async fn a_turn_with_no_final_text_stores_the_user_message_and_keeps_the_session_id() {
+    if python3().is_none() {
+        eprintln!("skipping: no python3 to script the fake CLI");
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = dir.path().join("agento.db");
+    let chat = unique_id("empty-chat");
+    migrated_with_chat(&db, &chat, "sdk-prior", [0; 4]);
+
+    let cli = fake_cli(dir.path(), &result_frame("", "", [5, 6, 7, 8]), false);
+
+    let _env = env_lock().lock().await;
+    std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", &cli);
+
+    agent_run::run_resumed(
+        &db,
+        &chat,
+        "a question with no answer",
+        &ExecutionSettings::default(),
+        std::time::Duration::from_secs(600),
+    )
+    .await
+    .expect("the run");
+
+    assert_eq!(
+        messages(&db, &chat),
+        vec![("user".to_string(), "a question with no answer".to_string())],
+        "the user turn is stored even with no answer, and nothing else is"
+    );
+    assert_eq!(
+        sdk_session_id(&db, &chat),
+        "sdk-prior",
+        "an empty reported id leaves the previous one in place"
+    );
+}
+
+/// The divergence from both existing headless write-backs: the four totals are
+/// **incremented**, so a chat a user has also typed into keeps the UI turns'
+/// usage.
+///
+/// The row is seeded as if a UI turn had already run — replacing rather than
+/// incrementing would answer the run's own numbers instead of the sum, which is
+/// exactly what `executor.rs` and `dispatcher.rs` do and what this path must
+/// not.
+#[tokio::test]
+async fn token_totals_are_summed_across_a_ui_turn_and_a_headless_turn() {
+    if python3().is_none() {
+        eprintln!("skipping: no python3 to script the fake CLI");
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = dir.path().join("agento.db");
+    let chat = unique_id("totals-chat");
+    // What one UI turn left behind.
+    migrated_with_chat(&db, &chat, "sdk-prior", [11, 22, 3, 4]);
+
+    let cli = fake_cli(
+        dir.path(),
+        &result_frame("the answer", "sdk-prior", [5, 6, 7, 8]),
+        false,
+    );
+
+    let _env = env_lock().lock().await;
+    std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", &cli);
+
+    agent_run::run_resumed(
+        &db,
+        &chat,
+        "the headless turn",
+        &ExecutionSettings::default(),
+        std::time::Duration::from_secs(600),
+    )
+    .await
+    .expect("the run");
+
+    assert_eq!(
+        totals(&db, &chat),
+        [16, 28, 10, 12],
+        "the headless turn adds to the UI turn's usage rather than replacing it"
+    );
+}
+
+/// A chat id nothing owns: refused, and the lock it took is given back.
+///
+/// The second half is the one that matters — a leaked lock wedges the chat for
+/// the life of the process, and the missing-chat path is the earliest return
+/// there is.
+#[tokio::test]
+async fn a_missing_chat_is_an_error_and_releases_the_lock_it_took() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = dir.path().join("agento.db");
+    let chat = unique_id("missing-chat");
+    migrated_with_chat(&db, &chat, "", [0; 4]);
+
+    let absent = unique_id("nobody");
+    let err = agent_run::run_resumed(
+        &db,
+        &absent,
+        "hello",
+        &ExecutionSettings::default(),
+        std::time::Duration::from_secs(60),
+    )
+    .await
+    .expect_err("no such chat");
+    assert!(err.contains("not found"), "{err}");
+
+    assert!(
+        agento_lib::native::chat::live::registry().try_lock(&absent),
+        "the guard released the lock on the early return"
+    );
+    agento_lib::native::chat::live::registry().release(&absent);
+}

--- a/src-tauri/tests/headless_resume.rs
+++ b/src-tauri/tests/headless_resume.rs
@@ -529,6 +529,75 @@ async fn token_totals_are_summed_across_a_ui_turn_and_a_headless_turn() {
     );
 }
 
+/// A run that **spawned** and then failed: the user turn is stored with no
+/// answer, nothing else on the row moves, and the busy lock comes back.
+///
+/// The lock release is the point. The missing-chat test below returns before
+/// `run_headless` is ever called, so it says nothing about the guard surviving a
+/// run that got as far as a subprocess — and a lock leaked here wedges the chat
+/// for the life of the process, which is the risk #564 singles out. The gated
+/// fake CLI parks holding the prompt, so the failure is the run's own deadline
+/// rather than a spawn that never happened.
+#[tokio::test]
+async fn a_run_that_times_out_stores_the_question_alone_and_frees_the_lock() {
+    if python3().is_none() {
+        eprintln!("skipping: no python3 to script the fake CLI");
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = dir.path().join("agento.db");
+    let chat = unique_id("timeout-chat");
+    migrated_with_chat(&db, &chat, "sdk-prior", [11, 22, 3, 4]);
+
+    let cli = fake_cli(
+        dir.path(),
+        &result_frame("never sent", "sdk-later", [9, 9, 9, 9]),
+        true,
+    );
+
+    let _env = env_lock().lock().await;
+    std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", &cli);
+
+    // Generous enough that the deadline can only be reached in the drain — every
+    // earlier stage (`build_options`, the spawn) is inside it too, and reaching
+    // it there would leave `gate.started` absent and fail the assertion below.
+    let err = agent_run::run_resumed(
+        &db,
+        &chat,
+        "a question that times out",
+        &ExecutionSettings::default(),
+        std::time::Duration::from_secs(15),
+    )
+    .await
+    .expect_err("the run must time out");
+    assert_eq!(err, agento_lib::native::agent_run::DEADLINE_EXCEEDED);
+    assert!(
+        gate_started(dir.path()).exists(),
+        "the CLI had the prompt: this is a failure after a spawn, not before one"
+    );
+
+    assert_eq!(
+        messages(&db, &chat),
+        vec![("user".to_string(), "a question that times out".to_string())],
+        "the question is visible in the chat; no answer is invented"
+    );
+    assert_eq!(
+        sdk_session_id(&db, &chat),
+        "sdk-prior",
+        "a failed turn leaves the id in place so the next attempt resumes"
+    );
+    assert_eq!(totals(&db, &chat), [11, 22, 3, 4], "no usage was recorded");
+
+    assert!(
+        agento_lib::native::chat::live::registry().try_lock(&chat),
+        "the guard released the lock on the failure path"
+    );
+    agento_lib::native::chat::live::registry().release(&chat);
+
+    // Let the parked subprocess finish rather than leaving it holding the gate.
+    std::fs::write(gate_release(dir.path()), b"go").expect("release the gate");
+}
+
 /// A chat id nothing owns: refused, and the lock it took is given back.
 ///
 /// The second half is the one that matters — a leaked lock wedges the chat for


### PR DESCRIPTION
Closes #564

## What

`agent_run::resume_spec` and `agent_run::run_resumed`: one headless turn on an **existing** chat, continuing its CLI session, taken under that chat's busy lock, with the session id written back and token totals **incremented** rather than replaced.

No caller is added — this ships the capability and its tests (#568 is the caller).

## How

- **`ExecutionSettings`** (new, in `agent_run.rs`) — `model`, `working_directory`, `settings_profile_id`, `permission_mode`. The four of #563's five `trigger_rules` columns that reach a `RunSpec`; `timeout_minutes` is a `Duration` argument instead. Empty means "no choice was recorded", so a rule that sets one field inherits the rest from the chat.
- **`resume_spec`** — `resume_session_id` from `chat_sessions.sdk_session_id` (`None` when empty), `custom_session_id` deliberately empty so a never-run chat gets a CLI-minted id the write-back records. The model override is written into **both** arms `build_options` reads (`agent.model` and the `no_agent_model` closure), or it would apply only to chats with no agent.
- **`run_resumed`** — `live::registry().try_lock` **before** anything is spawned, released from a guard's `Drop` so the error and timeout paths cannot leak it. This is the first headless run to take that lock: the scheduler and the Telegram dispatcher mint a fresh chat per run, so resuming an existing one is what makes a UI `POST /api/chats/{id}/messages` and an inbound turn collide on a single row.
- **`live::CHAT_BUSY`** — the 409 body was a literal in `turn.rs`; it is now a constant used by both the route and this `Err`, because an inbound worker queues on exactly that string and the two must not drift.
- **The write-back** is `executor.rs`'s three independent statements with two divergences, each stated at the site so a later "simplification" does not undo them: the four totals are **incremented** the way `chat/persist.rs` does (replacing them on a mixed UI/inbound chat erases the UI turns' usage), and `sdk_session_id` is written only when the run reported one. Messages follow the dispatcher's `save_messages` shape — the user turn stored even with no answer. Every database touch goes through `db::blocking`.

## Deviation from the issue's HOW

The issue spells the helper `resume_spec(row: &ChatRow, settings: &ExecutionSettings)`. It also needs `db_path` (for the lazily-read `TurnSettings`) and the `Option<Agent>` that `runner::load` returns alongside the row — neither is on a `ChatRow`, and a `RunSpec` cannot be built without them. Semantics are unchanged; only the parameter list is wider.

## Tests

`src-tauri/tests/headless_resume.rs`, new, against a fake CLI that logs its own argv and — inheriting `scheduled_run.rs`'s trap — **never exits after the result**, so a `run_resumed` built on `Session` rather than the one-shot `query` would hang rather than pass. The longest test wraps its await in a deadline that names the trap.

- the first turn on a chat with an empty `sdk_session_id` spawns **without** `--resume` and stores the CLI's id; the second spawns **with** `--resume <that id>`
- a `run_resumed` on a busy chat returns `CHAT_BUSY` and spawns nothing
- a UI turn against a chat with a `run_resumed` provably in flight (the fake CLI parks on a gate file) gets the existing 409, and the lock is free afterwards
- a turn with no final text stores the user message only and keeps the previous `sdk_session_id`
- totals after a seeded UI turn plus a headless turn are the **sum**
- a missing chat errors and releases the lock it took

Plus unit tests for `resume_spec`: the two `resume_session_id` branches, empty settings falling through to the chat's own, each of the four overriding, and the model override reaching an agent chat.

**Revert-checked**: replacing the totals, dropping the `sdk_session_id` guard, removing the `try_lock` refusal and forcing `resume_session_id: None` each make the corresponding test fail.

## Gates

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (1538 lib + every integration suite), `npm run build`, `cargo build --profile ci`, `scripts/check-claude-md-size.sh` — all green locally.