### PR TITLE
feat: trigger rules apply their execution settings; most-specific rule selection for Slack channels (#565)

### DIFF
--- a/parity/README.md
+++ b/parity/README.md
@@ -105,8 +105,9 @@ It sits here rather than in the test file so that changing the rule is a change
 to a contract, exactly as `trigger_match_vectors.json` makes matching one.
 `select_rule::select_rule_for_channel` is the only reader.
 
-The last three were all authored *after* the Go tree was deleted, because none
-has a Go ancestor left to record from. `claude_sessions_search_golden.json`
+`claude_sessions_search_golden.json`, `session_detail_blocks_golden.json` and
+`journey_golden.json` were all authored *after* the Go tree was deleted, because
+none has a Go ancestor left to record from. `claude_sessions_search_golden.json`
 pins one search response — `match_snippet` and the `relevance` sort (#437) are
 Agento's own — recording where the field sits, that it is omitted where there is
 no index hit, and the ranked order. Two things it deliberately does **not** pin:

--- a/parity/README.md
+++ b/parity/README.md
@@ -91,10 +91,19 @@ git show 07b6212^:desktop/parity/
 git show 07b6212^:desktop/parity/github_parity_test.go
 ```
 
-Five files never had a generator and are hand-written beside the code:
+Six files never had a generator and are hand-written beside the code:
 `desktop_routes.json`, `session_metric_vectors.json`,
-`claude_sessions_search_golden.json`, `session_detail_blocks_golden.json` and
-`journey_golden.json`.
+`claude_sessions_search_golden.json`, `session_detail_blocks_golden.json`,
+`journey_golden.json` and `trigger_select_vectors.json`.
+
+`trigger_select_vectors.json` (#565) is the newest and the only one that pins a
+rule Go never had: which trigger rule owns a Slack channel. Every case is a
+*decision*, not a recording — most importantly that a **disabled**
+channel-specific rule means silence rather than a fall-through to the
+workspace-wide default, which is the clause a future reader will file as a bug.
+It sits here rather than in the test file so that changing the rule is a change
+to a contract, exactly as `trigger_match_vectors.json` makes matching one.
+`select_rule::select_rule_for_channel` is the only reader.
 
 The last three were all authored *after* the Go tree was deleted, because none
 has a Go ancestor left to record from. `claude_sessions_search_golden.json`
@@ -132,7 +141,8 @@ Two mechanisms, and the difference matters when files move:
 
 - **`include_str!` with a relative path** — `gojson.rs`, `gotime.rs`,
   `goquote.rs`, `migrate.rs`, `pricing.rs`, `pricing_seed.rs`,
-  `trigger/match_rule.rs`, `schedule/tests_vectors.rs`,
+  `trigger/match_rule.rs`, `trigger/select_rule.rs`,
+  `schedule/tests_vectors.rs`,
   `integrations/oauth/mod.rs`, `notifications/template.rs`,
   `analytics/tests_golden.rs`, `sessions/tests_db.rs`,
   `sessions/tests_search.rs`. These count directory levels and break if either

--- a/parity/trigger_select_vectors.json
+++ b/parity/trigger_select_vectors.json
@@ -1,0 +1,115 @@
+{
+  "cases": [
+    {
+      "name": "specific/enabled-beats-an-enabled-default",
+      "note": "the channel's own rule is more specific than a workspace-wide one, whatever the store order",
+      "channel_id": "C1",
+      "rules": [
+        { "id": "default", "enabled": true, "filter_chat_ids": null },
+        { "id": "specific", "enabled": true, "filter_chat_ids": ["C1"] }
+      ],
+      "selected": "specific"
+    },
+    {
+      "name": "specific/disabled-is-silence-even-with-an-enabled-default",
+      "note": "THE clause: a disabled channel-specific rule is the channel's off switch and does not fall through",
+      "channel_id": "C1",
+      "rules": [
+        { "id": "default", "enabled": true, "filter_chat_ids": null },
+        { "id": "specific", "enabled": false, "filter_chat_ids": ["C1"] }
+      ],
+      "selected": null
+    },
+    {
+      "name": "default/answers-a-channel-with-no-rule-of-its-own",
+      "note": "an empty filter_chat_ids is the workspace-wide default",
+      "channel_id": "C2",
+      "rules": [
+        { "id": "default", "enabled": true, "filter_chat_ids": null },
+        { "id": "specific", "enabled": true, "filter_chat_ids": ["C1"] }
+      ],
+      "selected": "default"
+    },
+    {
+      "name": "default/disabled-alone-is-silence",
+      "note": "no specific rule and the default is off, so nothing answers",
+      "channel_id": "C2",
+      "rules": [{ "id": "default", "enabled": false, "filter_chat_ids": null }],
+      "selected": null
+    },
+    {
+      "name": "specific/two-for-one-channel-take-the-earlier-created_at",
+      "note": "rules arrive oldest first, so the tie is the first of them",
+      "channel_id": "C1",
+      "rules": [
+        { "id": "older", "enabled": true, "filter_chat_ids": ["C1"] },
+        { "id": "newer", "enabled": true, "filter_chat_ids": ["C1"] }
+      ],
+      "selected": "older"
+    },
+    {
+      "name": "specific/a-disabled-one-is-not-walked-past-to-a-later-specific-one",
+      "note": "the off switch wins the tie too: the earlier rule owns the channel and it is off",
+      "channel_id": "C1",
+      "rules": [
+        { "id": "older", "enabled": false, "filter_chat_ids": ["C1"] },
+        { "id": "newer", "enabled": true, "filter_chat_ids": ["C1"] }
+      ],
+      "selected": null
+    },
+    {
+      "name": "default/two-take-the-earlier-created_at",
+      "note": "same tie-break as the specific rules",
+      "channel_id": "C9",
+      "rules": [
+        { "id": "older", "enabled": true, "filter_chat_ids": null },
+        { "id": "newer", "enabled": true, "filter_chat_ids": null }
+      ],
+      "selected": "older"
+    },
+    {
+      "name": "default/a-disabled-one-is-skipped-for-an-enabled-one",
+      "note": "unlike a specific rule, a disabled default is not an off switch — it is simply not a default",
+      "channel_id": "C9",
+      "rules": [
+        { "id": "off", "enabled": false, "filter_chat_ids": null },
+        { "id": "on", "enabled": true, "filter_chat_ids": null }
+      ],
+      "selected": "on"
+    },
+    {
+      "name": "specific/a-rule-for-another-channel-is-neither-specific-nor-a-default",
+      "note": "a non-empty filter_chat_ids that does not name this channel never answers for it",
+      "channel_id": "C2",
+      "rules": [{ "id": "elsewhere", "enabled": true, "filter_chat_ids": ["C1"] }],
+      "selected": null
+    },
+    {
+      "name": "specific/one-rule-may-name-several-channels",
+      "note": "membership, not equality — the same rule owns every channel it lists",
+      "channel_id": "C3",
+      "rules": [
+        { "id": "default", "enabled": true, "filter_chat_ids": null },
+        { "id": "team", "enabled": true, "filter_chat_ids": ["C2", "C3"] }
+      ],
+      "selected": "team"
+    },
+    {
+      "name": "specific/exact-string-compare",
+      "note": "a channel id is compared byte for byte, as Telegram's chat ids are",
+      "channel_id": "c1",
+      "rules": [
+        { "id": "default", "enabled": true, "filter_chat_ids": null },
+        { "id": "specific", "enabled": true, "filter_chat_ids": ["C1"] }
+      ],
+      "selected": "default"
+    },
+    {
+      "name": "no-rules/is-silence",
+      "note": "an integration with no rules answers nothing at all",
+      "channel_id": "C1",
+      "rules": [],
+      "selected": null
+    }
+  ]
+}

--- a/src-tauri/src/native/agent_run.rs
+++ b/src-tauri/src/native/agent_run.rs
@@ -112,16 +112,31 @@ pub async fn run_headless(
     collected
 }
 
-/// A `RunSpec` for a headless run of `agent`, with no session pinned.
+/// A `RunSpec` for a headless run of `agent`, with no session pinned and
+/// `settings` imposed over the agent's own choices.
 ///
 /// `buildRunOptions` sets neither session field, so the CLI generates its own id
 /// and the caller stores it afterwards.
+///
+/// **Empty is "no choice was recorded"** for every field of `settings`, so the
+/// zero value reproduces exactly what a headless run did before a caller could
+/// configure one: the agent's model, the agent's permission mode, and no
+/// working directory or settings profile. That is what the scheduler passes for
+/// the two fields a task does not carry.
 pub fn headless_spec(
     db_path: &std::path::Path,
     agent: crate::native::agents::Agent,
-    working_dir: String,
-    settings_profile_id: String,
+    settings: &ExecutionSettings,
 ) -> RunSpec {
+    // The caller's model wins over the agent's own, and it is written into
+    // `agent.model` rather than into the closure below: `build_options` reads
+    // the agent for any spec that has one, and this spec always has one, so the
+    // closure is the arm that never runs. `resume_spec` has to write both
+    // because a chat may have no agent.
+    let mut agent = agent;
+    if !settings.model.is_empty() {
+        agent.model = settings.model.clone();
+    }
     RunSpec {
         agent: Some(agent),
         // Never called: both callers synthesize an agent rather than passing
@@ -130,11 +145,12 @@ pub fn headless_spec(
         // tools where a nil one gets none.
         no_agent_model: Box::new(String::new),
         settings: Arc::new(runner::TurnSettings::from_db(db_path)),
-        working_dir,
-        settings_profile_id,
-        // A headless run carries no conversation-level choice, so the agent's
-        // own mode applies — `buildRunOptions` sets no permission mode either.
-        permission_mode: String::new(),
+        working_dir: settings.working_directory.clone(),
+        settings_profile_id: settings.settings_profile_id.clone(),
+        // A trigger rule may impose one (#565). Empty leaves the pre-#565
+        // answer: no conversation-level choice, so `build_options` applies the
+        // agent's own mode — `buildRunOptions` sets none either.
+        permission_mode: settings.permission_mode.clone(),
         resume_session_id: None,
         custom_session_id: String::new(),
     }
@@ -663,6 +679,60 @@ mod tests {
         assert_eq!(spec.settings_profile_id, "rule-profile");
         assert_eq!(spec.permission_mode, "bypass");
         assert_eq!((spec.no_agent_model)(), "rule-model");
+    }
+
+    /// The four settings reach a fresh headless run too, not only a resumed
+    /// one — which is what a trigger rule needs (#565). The model goes onto the
+    /// agent, because that is the arm `build_options` reads for a spec that has
+    /// one, and `headless_spec` always has one.
+    #[test]
+    fn headless_execution_settings_reach_the_spec() {
+        let agent = crate::native::agents::Agent {
+            name: "A".to_string(),
+            slug: "a".to_string(),
+            description: String::new(),
+            model: "agent-model".to_string(),
+            thinking: String::new(),
+            permission_mode: String::new(),
+            system_prompt: String::new(),
+            capabilities: Default::default(),
+            claude_config_dir: String::new(),
+        };
+
+        let spec = headless_spec(
+            std::path::Path::new(NO_DB),
+            agent.clone(),
+            &ExecutionSettings::default(),
+        );
+        assert_eq!(spec.working_dir, "");
+        assert_eq!(spec.settings_profile_id, "");
+        assert_eq!(
+            spec.permission_mode, "",
+            "no choice recorded, so `build_options` applies the agent's own"
+        );
+        assert_eq!(
+            spec.agent.as_ref().map(|a| a.model.as_str()),
+            Some("agent-model"),
+            "the zero value is exactly what a headless run did before #565"
+        );
+
+        let spec = headless_spec(
+            std::path::Path::new(NO_DB),
+            agent,
+            &ExecutionSettings {
+                model: "rule-model".to_string(),
+                working_directory: "/from/the/rule".to_string(),
+                settings_profile_id: "rule-profile".to_string(),
+                permission_mode: "plan".to_string(),
+            },
+        );
+        assert_eq!(spec.working_dir, "/from/the/rule");
+        assert_eq!(spec.settings_profile_id, "rule-profile");
+        assert_eq!(spec.permission_mode, "plan");
+        assert_eq!(
+            spec.agent.as_ref().map(|a| a.model.as_str()),
+            Some("rule-model")
+        );
     }
 
     /// The model override has to be written into **both** arms `build_options`

--- a/src-tauri/src/native/integrations.rs
+++ b/src-tauri/src/native/integrations.rs
@@ -296,7 +296,7 @@ pub struct TriggerRule {
 ///
 /// Four hours. High enough that no legitimate run is refused, low enough that a
 /// mistyped value cannot park a subprocess for a week.
-const RULE_MAX_TIMEOUT_MINUTES: i64 = 240;
+pub(crate) const RULE_MAX_TIMEOUT_MINUTES: i64 = 240;
 
 /// Every `auth_mode` a credential blob may legitimately carry.
 ///

--- a/src-tauri/src/native/schedule/executor.rs
+++ b/src-tauri/src/native/schedule/executor.rs
@@ -686,8 +686,14 @@ async fn run_agent(
     let spec = crate::native::agent_run::headless_spec(
         db_path,
         agent,
-        task.working_directory.clone(),
-        task.settings_profile_id.clone(),
+        // A task carries only these two of the four. Its model and permission
+        // mode have always been the agent's, and #565 gave the *rule* the other
+        // two rather than changing what a scheduled task does.
+        &crate::native::agent_run::ExecutionSettings {
+            working_directory: task.working_directory.clone(),
+            settings_profile_id: task.settings_profile_id.clone(),
+            ..Default::default()
+        },
     );
     let timeout = std::time::Duration::from_secs(
         u64::try_from(task.timeout_minutes.max(0)).unwrap_or(0) * 60,

--- a/src-tauri/src/native/trigger/dispatcher.rs
+++ b/src-tauri/src/native/trigger/dispatcher.rs
@@ -292,7 +292,7 @@ fn usable_permission_mode(stored: String) -> String {
 /// because it reads a stored row rather than a validated request, and an absurd
 /// value there would otherwise hold one of the ten concurrency slots for as long
 /// as it says.
-pub fn run_timeout(rule: &Rule) -> std::time::Duration {
+fn run_timeout(rule: &Rule) -> std::time::Duration {
     if rule.timeout_minutes <= 0 {
         return RUN_TIMEOUT;
     }
@@ -956,6 +956,50 @@ mod tests {
             run_timeout(&rule(100_000)),
             std::time::Duration::from_secs(240 * 60),
             "a stored row is clamped: the write path caps it, this reads what is there"
+        );
+    }
+
+    /// [`run_inputs`] is what the dispatcher calls, so this is where the two
+    /// halves of the wiring are pinned. [`run_timeout`]'s own mapping is tested
+    /// above; what a revert would break here is `run_inputs` *calling* it —
+    /// which no fake-CLI test can see, because the timeout is only observable
+    /// by outliving it and the smallest non-default rule timeout is a minute.
+    #[test]
+    fn run_inputs_carries_the_rules_settings_and_its_timeout() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path());
+        add_configured_rule(
+            &db,
+            "r",
+            true,
+            "[]",
+            "opus",
+            "/srv/repo",
+            "profile-7",
+            "plan",
+            1,
+            "2026-01-01 00:00:00 +0000 UTC",
+        );
+        let agent = resolve_agent(&db, "").expect("a synthesized agent");
+        let rules = load_rules(&db, "tg").expect("load");
+
+        let (spec, timeout) = run_inputs(&db, agent.clone(), &rules[0]);
+        assert_eq!(spec.working_dir, "/srv/repo");
+        assert_eq!(spec.settings_profile_id, "profile-7");
+        assert_eq!(spec.permission_mode, "plan");
+        assert_eq!(spec.agent.as_ref().map(|a| a.model.as_str()), Some("opus"));
+        assert_eq!(
+            timeout,
+            std::time::Duration::from_secs(60),
+            "the rule's one minute, not the flat five"
+        );
+
+        let mut unset = rules[0].clone();
+        unset.timeout_minutes = 0;
+        assert_eq!(
+            run_inputs(&db, agent, &unset).1,
+            RUN_TIMEOUT,
+            "and a rule that records none still gets the flat five"
         );
     }
 

--- a/src-tauri/src/native/trigger/dispatcher.rs
+++ b/src-tauri/src/native/trigger/dispatcher.rs
@@ -19,8 +19,8 @@
 //!   nothing back cannot tell a broken agent from an ignored message.
 //! - **There is no job history at all.** The run is recorded only as chat
 //!   messages on a `[Telegram] <rule>` session.
-//! - **The timeout is a flat five minutes**, not the task's own — triggers have
-//!   no configurable timeout.
+//! - **The timeout is the matched rule's own**, and five minutes when the rule
+//!   records none (#565) — see [`run_timeout`].
 //! - **Concurrency is bounded to 10**, not the scheduler's 3, and the bound is
 //!   Go's `sem` on the dispatcher rather than a per-run permit.
 
@@ -37,11 +37,13 @@ use crate::native::db;
 /// `maxConcurrentExecutions`, the buffer on `Dispatcher.sem`.
 ///
 /// **Ten, not the scheduler's three.** A busy group chat can fire several rules
-/// at once, and with the flat five-minute run timeout a limit set too low makes
-/// the sixth message wait up to five minutes before its "typing…" even appears.
+/// at once, and a limit set too low makes the sixth message wait a whole run —
+/// five minutes by default, and as much as a rule's own `timeout_minutes` since
+/// #565 — before its "typing…" even appears.
 const MAX_CONCURRENT: usize = 10;
 
-/// `context.WithTimeout(ctx, 5*time.Minute)` in `executeAndReply`.
+/// `context.WithTimeout(ctx, 5*time.Minute)` in `executeAndReply`, and since
+/// #565 the answer only for a rule that records no timeout of its own.
 const RUN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5 * 60);
 
 /// What Go replies with on every failure path.
@@ -151,7 +153,21 @@ pub struct Rule {
     pub id: String,
     pub name: String,
     pub agent_slug: String,
+    /// Whether the rule is on.
+    ///
+    /// A field rather than a `WHERE` clause because the two selectors disagree
+    /// about disabled rules: [`find_matching_rule`] skips one, and Slack's
+    /// [`super::select_rule::select_rule_for_channel`] has to *see* one, since
+    /// a disabled channel-specific rule is that channel's off switch.
+    pub enabled: bool,
     pub filters: RuleFilters,
+    /// Migration 39's four spec-reachable execution settings (#563), as
+    /// [`load_rules`] read them — with an unusable `permission_mode` already
+    /// dropped, see [`usable_permission_mode`].
+    pub settings: agent_run::ExecutionSettings,
+    /// Migration 39's fifth. `0` is "the dispatcher's own default", **not** a
+    /// run that times out instantly — see [`run_timeout`].
+    pub timeout_minutes: i64,
 }
 
 /// `findMatchingRule`: the first **enabled** rule that matches, in the order the
@@ -172,34 +188,61 @@ fn find_matching_rule(
     let chat_id = msg.chat.id.to_string();
     rules
         .into_iter()
+        // The `enabled` test used to be `load_rules`' SQL. It is here now, and
+        // the answer is the same one: the first enabled rule that matches, in
+        // store order.
+        .filter(|rule| rule.enabled)
         .find_map(|rule| match_rule(&rule.filters, &msg.text, &chat_id).map(|p| (rule, p)))
 }
 
-/// `ListRules`, filtered to the enabled ones as `findMatchingRule` does.
-fn load_rules(db_path: &Path, integration_id: &str) -> Result<Vec<Rule>, String> {
+/// `ListRules` for one integration, oldest first — **including disabled rules**.
+///
+/// The `enabled = 1` test used to live in this SQL and now lives in
+/// [`find_matching_rule`], which does not change Telegram's answer and does make
+/// this loader usable by both selectors. Slack's
+/// [`super::select_rule::select_rule_for_channel`] needs the disabled rows: a
+/// disabled channel-specific rule is how a channel is switched off, so a loader
+/// that hid it would silently turn that off switch into a fall-through to the
+/// workspace-wide default.
+///
+/// `ORDER BY created_at ASC` is load-bearing for both: it is what makes "the
+/// first match in store order" and "the earlier `created_at` wins a tie" the
+/// same sentence.
+pub fn load_rules(db_path: &Path, integration_id: &str) -> Result<Vec<Rule>, String> {
     let conn = crate::native::db::open_read_only(db_path)?;
     let mut stmt = conn
         .prepare(
-            "SELECT id, name, agent_slug, filter_prefix, filter_keywords, filter_chat_ids
+            "SELECT id, name, agent_slug, enabled, filter_prefix, filter_keywords,
+                    filter_chat_ids, model, working_directory, settings_profile_id,
+                    permission_mode, timeout_minutes
              FROM trigger_rules
-             WHERE integration_id = ?1 AND enabled = 1
+             WHERE integration_id = ?1
              ORDER BY created_at ASC",
         )
         .map_err(|e| format!("preparing trigger rules query: {e}"))?;
 
     let rows = stmt
         .query_map([integration_id], |row| {
-            let keywords: String = row.get(4)?;
-            let chat_ids: String = row.get(5)?;
+            let keywords: String = row.get(5)?;
+            let chat_ids: String = row.get(6)?;
+            let permission_mode: String = row.get(10)?;
             Ok(Rule {
                 id: row.get(0)?,
                 name: row.get(1)?,
                 agent_slug: row.get(2)?,
+                enabled: row.get(3)?,
                 filters: RuleFilters {
-                    prefix: row.get(3)?,
+                    prefix: row.get(4)?,
                     keywords: decode_list(&keywords),
                     chat_ids: decode_list(&chat_ids),
                 },
+                settings: agent_run::ExecutionSettings {
+                    model: row.get(7)?,
+                    working_directory: row.get(8)?,
+                    settings_profile_id: row.get(9)?,
+                    permission_mode: usable_permission_mode(permission_mode),
+                },
+                timeout_minutes: row.get(11)?,
             })
         })
         .map_err(|e| format!("querying trigger rules: {e}"))?;
@@ -220,6 +263,43 @@ fn decode_list(raw: &str) -> Vec<String> {
         .flatten()
         .map(|list| list.into_iter().map(Option::unwrap_or_default).collect())
         .unwrap_or_default()
+}
+
+/// A stored `permission_mode`, or empty when it is not one Agento knows.
+///
+/// `integrations::validate_rule_settings` rejects anything outside
+/// [`crate::native::chats::CHAT_PERMISSION_MODES`] at the write (#563), but the
+/// dispatcher reads *stored rows* — hand-edited, restored from a backup, or
+/// written before that validation existed. An unknown mode is not inert:
+/// `chat/runner.rs`' `match` routes everything it does not recognise into
+/// `with_bypass_permissions()`, so one typo would run the agent with permissions
+/// fully bypassed. Falling back to empty runs it on the agent's own configured
+/// mode, which is what a rule that sets nothing already does.
+fn usable_permission_mode(stored: String) -> String {
+    if crate::native::chats::is_valid_permission_mode(&stored) {
+        return stored;
+    }
+    log::warn!("ignoring unknown trigger rule permission mode {stored:?}");
+    String::new()
+}
+
+/// How long one run of `rule` may take.
+///
+/// `timeout_minutes = 0` is "no choice recorded" and means [`RUN_TIMEOUT`] — the
+/// flat five minutes every trigger run had before #565 — not a run that times
+/// out instantly. The write path already caps the column at
+/// [`crate::native::integrations::RULE_MAX_TIMEOUT_MINUTES`]; this clamps again
+/// because it reads a stored row rather than a validated request, and an absurd
+/// value there would otherwise hold one of the ten concurrency slots for as long
+/// as it says.
+pub fn run_timeout(rule: &Rule) -> std::time::Duration {
+    if rule.timeout_minutes <= 0 {
+        return RUN_TIMEOUT;
+    }
+    let minutes = rule
+        .timeout_minutes
+        .min(crate::native::integrations::RULE_MAX_TIMEOUT_MINUTES);
+    std::time::Duration::from_secs(u64::try_from(minutes).unwrap_or(0) * 60)
 }
 
 /// `executeAndReply`.
@@ -252,8 +332,10 @@ async fn execute_and_reply(
         }
     };
 
-    // Go creates the session with **no** working directory, model or settings
-    // profile — a trigger run is not configurable the way a task is.
+    // The chat is created with the rule's own working directory, model,
+    // settings profile and permission mode (#565). Go created it with none of
+    // them, because a trigger run was not configurable the way a task is;
+    // migration 39 gave the rule those columns and this is the reader.
     let created = {
         let (db, rule) = (db_path.to_path_buf(), rule.clone());
         db::blocking("telegram session", move || {
@@ -271,8 +353,8 @@ async fn execute_and_reply(
         }
     };
 
-    let spec = agent_run::headless_spec(db_path, agent, String::new(), String::new());
-    let result = agent_run::run_headless(&spec, prompt, RUN_TIMEOUT).await;
+    let spec = agent_run::headless_spec(db_path, agent, &rule.settings);
+    let result = agent_run::run_headless(&spec, prompt, run_timeout(rule)).await;
 
     let result = match result {
         Ok(result) => result,
@@ -378,10 +460,10 @@ fn create_trigger_session(db_path: &Path, rule: &Rule) -> Result<String, String>
         &tx,
         crate::native::chats::NewSessionParams {
             agent_slug: &rule.agent_slug,
-            working_directory: "",
-            model: "",
-            settings_profile_id: "",
-            permission_mode: "",
+            working_directory: &rule.settings.working_directory,
+            model: &rule.settings.model,
+            settings_profile_id: &rule.settings.settings_profile_id,
+            permission_mode: &rule.settings.permission_mode,
         },
     )
     .map_err(|e| e.message())?;
@@ -692,5 +774,213 @@ mod tests {
         let db = migrated(dir.path());
         let err = resolve_agent(&db, "nope").unwrap_err();
         assert_eq!(err, r#"agent "nope" not found"#);
+    }
+
+    /// A rule with migration 39's five columns set. Separate from [`add_rule`]
+    /// rather than an extension of it: the tests above pin Telegram's selection
+    /// and must keep seeding exactly the rows they seeded before #565.
+    #[allow(clippy::too_many_arguments)]
+    fn add_configured_rule(
+        db: &Path,
+        id: &str,
+        enabled: bool,
+        chat_ids: &str,
+        model: &str,
+        working_directory: &str,
+        settings_profile_id: &str,
+        permission_mode: &str,
+        timeout_minutes: i64,
+        created_at: &str,
+    ) {
+        let conn = rusqlite::Connection::open(db).expect("open");
+        conn.execute(
+            "INSERT INTO trigger_rules
+                (id, integration_id, name, agent_slug, enabled, filter_prefix,
+                 filter_keywords, filter_chat_ids, model, working_directory,
+                 settings_profile_id, permission_mode, timeout_minutes,
+                 created_at, updated_at)
+             VALUES (?1, 'tg', ?1, 'a', ?2, '', '[]', ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?9)",
+            rusqlite::params![
+                id,
+                enabled,
+                chat_ids,
+                model,
+                working_directory,
+                settings_profile_id,
+                permission_mode,
+                timeout_minutes,
+                created_at
+            ],
+        )
+        .expect("seed configured rule");
+    }
+
+    /// The five columns migration 39 added reach the loaded rule. Before #565
+    /// the projection did not name them and every run used the agent's defaults
+    /// in whatever directory the app happened to be started from.
+    #[test]
+    fn the_execution_settings_come_off_the_row() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path());
+        add_configured_rule(
+            &db,
+            "r",
+            true,
+            "[]",
+            "opus",
+            "/srv/repo",
+            "profile-7",
+            "plan",
+            30,
+            "2026-01-01 00:00:00 +0000 UTC",
+        );
+
+        let rules = load_rules(&db, "tg").expect("load");
+        let rule = rules.first().expect("one rule");
+        assert_eq!(rule.settings.model, "opus");
+        assert_eq!(rule.settings.working_directory, "/srv/repo");
+        assert_eq!(rule.settings.settings_profile_id, "profile-7");
+        assert_eq!(rule.settings.permission_mode, "plan");
+        assert_eq!(rule.timeout_minutes, 30);
+    }
+
+    /// `load_rules` returns disabled rules now, because Slack's selection is the
+    /// one that has to see them. Telegram's answer is unchanged — the
+    /// `enabled` test moved into `find_matching_rule`, which
+    /// `a_disabled_rule_is_never_considered` still pins.
+    #[test]
+    fn the_loader_returns_disabled_rules_and_the_telegram_selector_skips_them() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path());
+        add_rule(
+            &db,
+            "off",
+            false,
+            "",
+            "[]",
+            "[]",
+            "2026-01-01 00:00:00 +0000 UTC",
+        );
+
+        let rules = load_rules(&db, "tg").expect("load");
+        assert_eq!(rules.len(), 1, "the disabled row is loaded");
+        assert!(!rules[0].enabled);
+        assert!(
+            find_matching_rule(&db, "tg", &msg("hi", 1)).is_none(),
+            "and Telegram still ignores it"
+        );
+    }
+
+    /// An unknown mode is not inert: `build_options`' catch-all would run the
+    /// agent with permissions fully bypassed, so a stored value outside
+    /// `CHAT_PERMISSION_MODES` is dropped rather than forwarded.
+    #[test]
+    fn an_unusable_permission_mode_is_dropped_rather_than_escalating_to_bypass() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path());
+        add_configured_rule(
+            &db,
+            "r",
+            true,
+            "[]",
+            "",
+            "",
+            "",
+            "yolo",
+            0,
+            "2026-01-01 00:00:00 +0000 UTC",
+        );
+
+        let rules = load_rules(&db, "tg").expect("load");
+        assert_eq!(
+            rules[0].settings.permission_mode, "",
+            "\"yolo\" would reach `with_bypass_permissions()`; empty runs the agent's own mode"
+        );
+        for mode in crate::native::chats::CHAT_PERMISSION_MODES {
+            assert_eq!(usable_permission_mode(mode.to_string()), mode);
+        }
+    }
+
+    /// Zero is "no choice recorded", not a run that times out instantly, and a
+    /// stored row is clamped because it never went through the write path's
+    /// validation.
+    #[test]
+    fn the_run_timeout_is_the_rules_own_with_five_minutes_as_the_default() {
+        let rule = |minutes: i64| Rule {
+            id: "r".to_string(),
+            name: "r".to_string(),
+            agent_slug: "a".to_string(),
+            enabled: true,
+            filters: RuleFilters::default(),
+            settings: Default::default(),
+            timeout_minutes: minutes,
+        };
+
+        assert_eq!(run_timeout(&rule(0)), RUN_TIMEOUT);
+        assert_eq!(
+            run_timeout(&rule(-1)),
+            RUN_TIMEOUT,
+            "and so is a broken row"
+        );
+        assert_eq!(
+            run_timeout(&rule(1)),
+            std::time::Duration::from_secs(60),
+            "one minute is one minute"
+        );
+        assert_eq!(
+            run_timeout(&rule(crate::native::integrations::RULE_MAX_TIMEOUT_MINUTES)),
+            std::time::Duration::from_secs(240 * 60)
+        );
+        assert_eq!(
+            run_timeout(&rule(100_000)),
+            std::time::Duration::from_secs(240 * 60),
+            "a stored row is clamped: the write path caps it, this reads what is there"
+        );
+    }
+
+    /// The chat a run is recorded in carries the rule's settings, where it used
+    /// to carry four empty strings.
+    #[test]
+    fn the_chat_row_carries_the_rules_execution_settings() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = migrated(dir.path());
+        add_configured_rule(
+            &db,
+            "r",
+            true,
+            "[]",
+            "opus",
+            "/srv/repo",
+            "profile-7",
+            "dontAsk",
+            0,
+            "2026-01-01 00:00:00 +0000 UTC",
+        );
+        let rules = load_rules(&db, "tg").expect("load");
+
+        let id = create_trigger_session(&db, &rules[0]).expect("session");
+        let conn = rusqlite::Connection::open(&db).expect("open");
+        let row: (String, String, String, String, String) = conn
+            .query_row(
+                "SELECT title, working_directory, model, settings_profile_id, permission_mode
+                 FROM chat_sessions WHERE id = ?1",
+                [&id],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                    ))
+                },
+            )
+            .expect("the session row");
+
+        assert_eq!(row.0, "[Telegram] r", "the title is unchanged");
+        assert_eq!(row.1, "/srv/repo");
+        assert_eq!(row.2, "opus");
+        assert_eq!(row.3, "profile-7");
+        assert_eq!(row.4, "dontAsk");
     }
 }

--- a/src-tauri/src/native/trigger/dispatcher.rs
+++ b/src-tauri/src/native/trigger/dispatcher.rs
@@ -287,18 +287,30 @@ fn usable_permission_mode(stored: String) -> String {
 ///
 /// `timeout_minutes = 0` is "no choice recorded" and means [`RUN_TIMEOUT`] — the
 /// flat five minutes every trigger run had before #565 — not a run that times
-/// out instantly. The write path already caps the column at
-/// [`crate::native::integrations::RULE_MAX_TIMEOUT_MINUTES`]; this clamps again
-/// because it reads a stored row rather than a validated request, and an absurd
-/// value there would otherwise hold one of the ten concurrency slots for as long
-/// as it says.
+/// out instantly.
+///
+/// The write path **refuses** a value above
+/// [`crate::native::integrations::RULE_MAX_TIMEOUT_MINUTES`] with a 422 rather
+/// than clamping it, so a row holding one never came through
+/// `validate_rule_settings`: it was hand-edited, restored, or written before
+/// that validation existed. This clamps rather than refusing, because refusing
+/// here means an inbound message silently going unanswered, and an absurd value
+/// would otherwise hold one of the ten concurrency slots for as long as it says.
+/// It is [`usable_permission_mode`]'s premise with the opposite answer, and for
+/// the same reason both are stated: a clamped timeout is a run that still
+/// happens, where a bad mode is a run that must not.
 fn run_timeout(rule: &Rule) -> std::time::Duration {
     if rule.timeout_minutes <= 0 {
         return RUN_TIMEOUT;
     }
-    let minutes = rule
-        .timeout_minutes
-        .min(crate::native::integrations::RULE_MAX_TIMEOUT_MINUTES);
+    let max = crate::native::integrations::RULE_MAX_TIMEOUT_MINUTES;
+    let minutes = rule.timeout_minutes.min(max);
+    if minutes != rule.timeout_minutes {
+        log::warn!(
+            "clamping trigger rule timeout {} to {max} minutes",
+            rule.timeout_minutes
+        );
+    }
     std::time::Duration::from_secs(u64::try_from(minutes).unwrap_or(0) * 60)
 }
 

--- a/src-tauri/src/native/trigger/dispatcher.rs
+++ b/src-tauri/src/native/trigger/dispatcher.rs
@@ -302,6 +302,27 @@ pub fn run_timeout(rule: &Rule) -> std::time::Duration {
     std::time::Duration::from_secs(u64::try_from(minutes).unwrap_or(0) * 60)
 }
 
+/// Everything a matched rule decides about the run it is about to start: the
+/// spec, and how long it may take.
+///
+/// One function rather than two lines in [`execute_and_reply`] so that the
+/// fake-CLI suite (`tests/trigger_run.rs`) binds to the **shipped** call site.
+/// `execute_and_reply` cannot be driven from `tests/` at all — it sends a
+/// Telegram reply, and the base-URL seam that redirects one is `#[cfg(test)]` on
+/// the library, so an integration-test crate cannot reach it — and a test that
+/// re-spelled these two lines for itself would stay green if the dispatcher
+/// stopped passing the rule's settings, which is the whole of #565.
+pub fn run_inputs(
+    db_path: &Path,
+    agent: Agent,
+    rule: &Rule,
+) -> (crate::native::chat::runner::RunSpec, std::time::Duration) {
+    (
+        agent_run::headless_spec(db_path, agent, &rule.settings),
+        run_timeout(rule),
+    )
+}
+
 /// `executeAndReply`.
 async fn execute_and_reply(
     db_path: &Path,
@@ -353,8 +374,8 @@ async fn execute_and_reply(
         }
     };
 
-    let spec = agent_run::headless_spec(db_path, agent, &rule.settings);
-    let result = agent_run::run_headless(&spec, prompt, run_timeout(rule)).await;
+    let (spec, timeout) = run_inputs(db_path, agent, rule);
+    let result = agent_run::run_headless(&spec, prompt, timeout).await;
 
     let result = match result {
         Ok(result) => result,

--- a/src-tauri/src/native/trigger/mod.rs
+++ b/src-tauri/src/native/trigger/mod.rs
@@ -7,6 +7,7 @@ pub mod dispatcher;
 pub mod match_rule;
 pub mod receiver;
 pub mod registration;
+pub mod select_rule;
 pub mod telegram_api;
 
 use axum::http::Method;

--- a/src-tauri/src/native/trigger/select_rule.rs
+++ b/src-tauri/src/native/trigger/select_rule.rs
@@ -1,0 +1,149 @@
+//! Slack's rule selection: most specific first, with a per-channel off switch.
+//!
+//! **A second selection function, not a generalization of Telegram's.**
+//! `dispatcher::find_matching_rule` keeps first-enabled-in-store-order because
+//! changing it would change what an existing install already does; Slack has no
+//! stored behaviour to preserve and needs a rule Telegram does not have (#565).
+//!
+//! The two are also asked different questions. Telegram matches a *message* —
+//! prefix, keywords and chat id together, via `match_rule`. This picks the rule
+//! that owns a *channel*, before anything has been said in it; whether the
+//! message then matters is the caller's business (#568).
+
+use super::dispatcher::Rule;
+
+/// The rule that answers for `channel_id`, or `None` for silence.
+///
+/// `rules` is one integration's rules in `created_at` order, oldest first, and
+/// **including the disabled ones** — which is exactly what
+/// `dispatcher::load_rules` returns, and the reason it returns them.
+///
+/// In order of preference:
+///
+/// 1. A rule whose `filter_chat_ids` names the channel beats a rule with none,
+///    **whether that specific rule is enabled or disabled**.
+/// 2. Otherwise the enabled default: a rule with an empty `filter_chat_ids`.
+/// 3. Otherwise `None`.
+///
+/// # A disabled channel-specific rule means silence
+///
+/// This is the clause a reader will assume is a bug, so it is stated here: rule
+/// 1 does not skip disabled rules, so a disabled channel-specific rule stops the
+/// channel outright rather than falling through to the workspace-wide default.
+///
+/// That is the whole point of the ordering. A default rule makes **every**
+/// channel the app is in respond, so a channel needs an off switch, and
+/// "disable that channel's rule" is the gesture that reads naturally in the
+/// rules list — where the alternative would be a rule that exists only to say
+/// no. Skipping disabled rules here would make that gesture do the opposite of
+/// what it looks like: the channel would keep answering, on the default.
+///
+/// # Ties
+///
+/// Two rules naming one channel, or two defaults, resolve to the earlier
+/// `created_at` — which is simply the first of them in `rules`.
+pub fn select_rule_for_channel<'a>(rules: &'a [Rule], channel_id: &str) -> Option<&'a Rule> {
+    if let Some(specific) = rules
+        .iter()
+        .find(|rule| rule.filters.chat_ids.iter().any(|id| id == channel_id))
+    {
+        // Deliberately not `rules.iter().find(...).filter(|r| r.enabled)`: the
+        // search must not walk *past* a disabled specific rule to a later one.
+        return specific.enabled.then_some(specific);
+    }
+    rules
+        .iter()
+        .find(|rule| rule.enabled && rule.filters.chat_ids.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(serde::Deserialize)]
+    struct Vectors {
+        cases: Vec<Case>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct Case {
+        name: String,
+        #[allow(dead_code)]
+        note: String,
+        channel_id: String,
+        /// Oldest first, as `dispatcher::load_rules` returns them.
+        rules: Vec<VectorRule>,
+        /// The `id` of the rule that answers, or `null` for silence.
+        selected: Option<String>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct VectorRule {
+        id: String,
+        enabled: bool,
+        filter_chat_ids: Option<Vec<String>>,
+    }
+
+    fn rule(v: &VectorRule) -> Rule {
+        Rule {
+            id: v.id.clone(),
+            name: v.id.clone(),
+            agent_slug: "a".to_string(),
+            enabled: v.enabled,
+            filters: super::super::match_rule::RuleFilters {
+                chat_ids: v.filter_chat_ids.clone().unwrap_or_default(),
+                ..Default::default()
+            },
+            settings: Default::default(),
+            timeout_minutes: 0,
+        }
+    }
+
+    #[test]
+    fn every_case_selects_what_the_rule_says() {
+        let raw = include_str!("../../../../parity/trigger_select_vectors.json");
+        let vectors: Vectors = serde_json::from_str(raw).expect("vectors decode");
+        assert!(!vectors.cases.is_empty(), "the vector file is empty");
+
+        for case in &vectors.cases {
+            let rules: Vec<Rule> = case.rules.iter().map(rule).collect();
+            let got = select_rule_for_channel(&rules, &case.channel_id);
+            assert_eq!(
+                got.map(|r| r.id.as_str()),
+                case.selected.as_deref(),
+                "case {:?}",
+                case.name
+            );
+        }
+    }
+
+    /// The clause the doc comment warns about, spelled out on its own so a
+    /// change to it fails a test named for it rather than a numbered vector.
+    #[test]
+    fn a_disabled_channel_specific_rule_is_silence_not_a_fall_through() {
+        let rules = vec![
+            rule(&VectorRule {
+                id: "default".to_string(),
+                enabled: true,
+                filter_chat_ids: None,
+            }),
+            rule(&VectorRule {
+                id: "muted".to_string(),
+                enabled: false,
+                filter_chat_ids: Some(vec!["C-muted".to_string()]),
+            }),
+        ];
+
+        assert_eq!(
+            select_rule_for_channel(&rules, "C-muted").map(|r| r.id.as_str()),
+            None,
+            "the channel's own rule is off, so the channel is off — the enabled \
+             default must not answer for it"
+        );
+        assert_eq!(
+            select_rule_for_channel(&rules, "C-other").map(|r| r.id.as_str()),
+            Some("default"),
+            "and every other channel still gets the default"
+        );
+    }
+}

--- a/src-tauri/tests/trigger_run.rs
+++ b/src-tauri/tests/trigger_run.rs
@@ -128,7 +128,6 @@ fn flag_value<'a>(argv: &'a [String], flag: &str) -> Option<&'a str> {
 
 /// A migrated database with a Telegram integration and one rule carrying the
 /// five execution settings.
-#[allow(clippy::too_many_arguments)]
 fn migrated_with_rule(
     path: &Path,
     model: &str,

--- a/src-tauri/tests/trigger_run.rs
+++ b/src-tauri/tests/trigger_run.rs
@@ -1,0 +1,280 @@
+//! A trigger rule's execution settings, driven all the way to a real
+//! subprocess (#565).
+//!
+//! The chain under test is a stored `trigger_rules` row → `load_rules` →
+//! `ExecutionSettings` → `headless_spec` → `build_options` →
+//! `Options::build_args` → a command line and a working directory. Every unit
+//! test in `dispatcher.rs` can see the first two links and none of them can see
+//! the last: **the working directory is not on the command line at all** — it is
+//! `Command::current_dir`, so only the process itself can report it. So the
+//! fake CLI records `os.getcwd()` alongside its argv, and that recording is the
+//! assertion.
+//!
+//! It inherits `scheduled_run.rs`'s trap — the fake CLI never exits after the
+//! result — so a run that went through `claude::client::Session` rather than the
+//! one-shot `query` would hang here rather than fail. Each test wraps its await
+//! in a deadline that names it.
+
+use std::path::{Path, PathBuf};
+
+use agento_lib::native::trigger::dispatcher;
+
+/// `AGENTO_CLAUDE_EXECUTABLE` is process-wide, so the tests that set it are
+/// serialized against each other.
+fn env_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+fn python3() -> Option<String> {
+    for candidate in ["python3", "python"] {
+        if std::process::Command::new(candidate)
+            .arg("--version")
+            .output()
+            .is_ok_and(|out| out.status.success())
+        {
+            return Some(candidate.to_string());
+        }
+    }
+    None
+}
+
+fn json_str(path: &Path) -> String {
+    serde_json::to_string(&path.to_string_lossy()).expect("encode path")
+}
+
+fn spawn_log(dir: &Path) -> PathBuf {
+    dir.join("spawns.jsonl")
+}
+
+/// A CLI that records **its own argv and working directory**, acknowledges
+/// `initialize`, and answers the first user message.
+///
+/// `headless_resume.rs` records argv only, which is enough for a `--resume`
+/// flag. A working directory has no flag, so this one adds `os.getcwd()`.
+fn fake_cli(dir: &Path) -> PathBuf {
+    let script = format!(
+        r#"#!/usr/bin/env {python}
+import json, os, sys
+
+with open({spawn_log}, "a") as _log:
+    _log.write(json.dumps({{"argv": sys.argv, "cwd": os.getcwd()}}) + "\n")
+    _log.flush()
+
+def say(obj):
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+
+def ack(request_id):
+    say({{"type": "control_response",
+         "response": {{"subtype": "success", "request_id": request_id,
+                       "response": {{"models": [{{"value": "fake", "displayName": "Fake"}}],
+                                     "account": {{"apiProvider": "fake"}},
+                                     "output_style": "default"}}}}}})
+
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        msg = json.loads(line)
+    except Exception:
+        continue
+    req = msg.get("request") or {{}}
+    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack(req.get("request_id") or msg.get("request_id"))
+        continue
+    if msg.get("type") == "user":
+        say({{"type": "assistant", "session_id": "s-1",
+             "message": {{"role": "assistant",
+                          "content": [{{"type": "text", "text": "done"}}]}}}})
+        say({{"type": "result", "subtype": "success", "session_id": "s-1",
+             "is_error": False, "result": "done",
+             "usage": {{"input_tokens": 1, "output_tokens": 1}}}})
+        # **Deliberately no exit**, as `scheduled_run.rs` explains.
+        continue
+"#,
+        python = python3().unwrap_or_else(|| "python3".into()),
+        spawn_log = json_str(&spawn_log(dir)),
+    );
+    let path = dir.join("fake-claude");
+    std::fs::write(&path, script).expect("write fake CLI");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod fake CLI");
+    }
+    path
+}
+
+/// What the fake CLI recorded about the one time it was spawned.
+fn only_spawn(dir: &Path) -> (Vec<String>, String) {
+    let raw = std::fs::read_to_string(spawn_log(dir)).expect("the CLI was never spawned");
+    let lines: Vec<&str> = raw.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert_eq!(lines.len(), 1, "exactly one spawn");
+    let entry: serde_json::Value = serde_json::from_str(lines[0]).expect("spawn line");
+    (
+        serde_json::from_value(entry["argv"].clone()).expect("argv"),
+        entry["cwd"].as_str().expect("cwd").to_string(),
+    )
+}
+
+/// The value that follows `flag` on a command line, or `None`.
+fn flag_value<'a>(argv: &'a [String], flag: &str) -> Option<&'a str> {
+    let at = argv.iter().position(|a| a == flag)?;
+    argv.get(at + 1).map(String::as_str)
+}
+
+/// A migrated database with a Telegram integration and one rule carrying the
+/// five execution settings.
+#[allow(clippy::too_many_arguments)]
+fn migrated_with_rule(
+    path: &Path,
+    model: &str,
+    working_directory: &str,
+    permission_mode: &str,
+    timeout_minutes: i64,
+) {
+    let mut conn = rusqlite::Connection::open(path).expect("open");
+    agento_lib::native::migrate::apply(&mut conn).expect("migrate");
+    conn.execute(
+        "INSERT INTO integrations (id, name, type, enabled, credentials, services,
+                                   created_at, updated_at)
+         VALUES ('tg', 'T', 'telegram', 1, '{}', '{}',
+                 '2026-01-01 00:00:00 +0000 UTC', '2026-01-01 00:00:00 +0000 UTC')",
+        [],
+    )
+    .expect("seed integration");
+    conn.execute(
+        "INSERT INTO trigger_rules
+            (id, integration_id, name, agent_slug, enabled, filter_prefix,
+             filter_keywords, filter_chat_ids, model, working_directory,
+             settings_profile_id, permission_mode, timeout_minutes,
+             created_at, updated_at)
+         VALUES ('r', 'tg', 'r', 'a', 1, '', '[]', '[]', ?1, ?2, '', ?3, ?4,
+                 '2026-01-01 00:00:00 +0000 UTC', '2026-01-01 00:00:00 +0000 UTC')",
+        rusqlite::params![model, working_directory, permission_mode, timeout_minutes],
+    )
+    .expect("seed rule");
+}
+
+/// The agent the dispatcher would resolve for a rule that names one — built here
+/// rather than seeded, because `resolve_agent` is the dispatcher's business and
+/// what this file is about is what happens *after* it.
+fn agent() -> agento_lib::native::agents::Agent {
+    agento_lib::native::agents::Agent {
+        name: "A".to_string(),
+        slug: "a".to_string(),
+        description: String::new(),
+        model: "agent-model".to_string(),
+        thinking: String::new(),
+        permission_mode: String::new(),
+        system_prompt: String::new(),
+        capabilities: Default::default(),
+        claude_config_dir: String::new(),
+    }
+}
+
+/// Everything the dispatcher does between a matched rule and the subprocess.
+async fn run_the_rule(db: &Path) -> Result<agento_lib::native::agent_run::RunResult, String> {
+    let rules = dispatcher::load_rules(db, "tg").expect("load rules");
+    let rule = rules.first().expect("one rule");
+    let spec = agento_lib::native::agent_run::headless_spec(db, agent(), &rule.settings);
+    agento_lib::native::agent_run::run_headless(&spec, "hello", dispatcher::run_timeout(rule)).await
+}
+
+/// A rule's working directory, model and permission mode reach the process.
+///
+/// Before #565 the dispatcher passed two empty strings and no mode at all, so
+/// the CLI ran in whatever directory the app was started from, on the agent's
+/// model, with permissions bypassed.
+#[tokio::test]
+async fn a_rules_execution_settings_reach_the_spawned_cli() {
+    let Some(_) = python3() else {
+        eprintln!("no python3; skipping");
+        return;
+    };
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cwd = dir.path().join("repo");
+    std::fs::create_dir(&cwd).expect("mkdir repo");
+    // The directory a process reports may be a symlink resolution of the one it
+    // was given (`/tmp` is `/private/tmp` on macOS), so compare against the
+    // canonical form rather than the string handed to the rule.
+    let canonical = std::fs::canonicalize(&cwd).expect("canonicalize");
+
+    let db = dir.path().join("agento.db");
+    migrated_with_rule(
+        &db,
+        "rule-model",
+        cwd.to_str().expect("utf-8 path"),
+        "plan",
+        0,
+    );
+    let cli = fake_cli(dir.path());
+
+    let _env = env_lock().lock().await;
+    std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", &cli);
+    let result = tokio::time::timeout(std::time::Duration::from_secs(30), run_the_rule(&db))
+        .await
+        .expect("the run must finish, not hang: a `Session` here never sees stdout close")
+        .expect("the run answered");
+    assert_eq!(result.answer, "done");
+
+    let (argv, reported_cwd) = only_spawn(dir.path());
+    assert_eq!(
+        Path::new(&reported_cwd),
+        canonical,
+        "the rule's working_directory is the process's cwd, and nothing else can show it"
+    );
+    assert_eq!(
+        flag_value(&argv, "--model"),
+        Some("rule-model"),
+        "the rule's model beats the agent's own"
+    );
+    assert_eq!(
+        flag_value(&argv, "--permission-mode"),
+        Some("plan"),
+        "and its permission mode reaches build_options rather than the bypassing catch-all"
+    );
+    // `--allow-dangerously-skip-permissions` is on this line too, and that is
+    // not this change: `Options`' own default sets the flag, and only
+    // `with_default_permissions()` clears it — so `plan` and `dontAsk` have
+    // always carried it, for a chat as much as for a trigger run. What `plan`
+    // buys is the mode the CLI reads, which is the flag asserted above.
+}
+
+/// A rule that records nothing runs exactly as a trigger run did before #565:
+/// the agent's model, no working directory, and the bypassing catch-all that a
+/// headless run with no configured mode has always taken.
+#[tokio::test]
+async fn a_rule_that_configures_nothing_runs_as_it_always_did() {
+    let Some(_) = python3() else {
+        eprintln!("no python3; skipping");
+        return;
+    };
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = dir.path().join("agento.db");
+    migrated_with_rule(&db, "", "", "", 0);
+    let cli = fake_cli(dir.path());
+
+    let _env = env_lock().lock().await;
+    std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", &cli);
+    tokio::time::timeout(std::time::Duration::from_secs(30), run_the_rule(&db))
+        .await
+        .expect("the run must finish, not hang")
+        .expect("the run answered");
+
+    let (argv, reported_cwd) = only_spawn(dir.path());
+    assert_eq!(
+        Path::new(&reported_cwd),
+        std::fs::canonicalize(std::env::current_dir().expect("cwd")).expect("canonicalize"),
+        "an unset working directory leaves the process where the app is"
+    );
+    assert_eq!(flag_value(&argv, "--model"), Some("agent-model"));
+    assert_eq!(
+        flag_value(&argv, "--permission-mode"),
+        Some("bypassPermissions"),
+        "no mode on the rule and none on the agent is `build_options`' catch-all"
+    );
+}

--- a/src-tauri/tests/trigger_run.rs
+++ b/src-tauri/tests/trigger_run.rs
@@ -180,8 +180,11 @@ fn agent() -> agento_lib::native::agents::Agent {
 async fn run_the_rule(db: &Path) -> Result<agento_lib::native::agent_run::RunResult, String> {
     let rules = dispatcher::load_rules(db, "tg").expect("load rules");
     let rule = rules.first().expect("one rule");
-    let spec = agento_lib::native::agent_run::headless_spec(db, agent(), &rule.settings);
-    agento_lib::native::agent_run::run_headless(&spec, "hello", dispatcher::run_timeout(rule)).await
+    // `dispatcher::run_inputs`, not a re-spelling of it: this is the function
+    // `execute_and_reply` calls, so a dispatcher that stopped passing the rule's
+    // settings fails here rather than staying green.
+    let (spec, timeout) = dispatcher::run_inputs(db, agent(), rule);
+    agento_lib::native::agent_run::run_headless(&spec, "hello", timeout).await
 }
 
 /// A rule's working directory, model and permission mode reach the process.


### PR DESCRIPTION
Closes #565.

## What

A trigger run now runs **where, how and for how long its rule says**, and Slack
gains a second rule-selection function whose semantics are most-specific-first
with a per-channel off switch.

- `native/trigger/dispatcher.rs` — `Rule` carries migration 39's five columns
  (#563). `create_trigger_session` writes four of them onto the chat row instead
  of the four empty strings; `headless_spec` receives them as an
  `ExecutionSettings`; `run_timeout(rule)` replaces the flat `RUN_TIMEOUT`.
- `native/trigger/select_rule.rs` (new) — `select_rule_for_channel(rules, channel_id)`,
  a pure function over one integration's rules in `created_at` order.
- `parity/trigger_select_vectors.json` (new, 12 cases) pins the selection the way
  `trigger_match_vectors.json` pins matching.
- `native/agent_run.rs` — `headless_spec` takes `&ExecutionSettings` (the type
  #564 introduced) rather than two positional strings. The zero value reproduces
  the pre-#565 answer exactly.
- `native/schedule/executor.rs` — adapted to the new signature; a scheduled
  task's behaviour is unchanged (its model and permission mode were, and remain,
  the agent's).

## Why

Decisions 3 and 4 of #562. #563 gave a rule the columns; nothing read them.

**A disabled channel-specific rule means silence** — it does not fall through to
the workspace default. That is the clause a reader will file as a bug, so it is
stated in the function's doc, in a test named for it, and in the vector file. A
workspace-wide default makes every channel the app is in respond; "disable that
channel's rule" is the gesture that reads naturally in the rules list, and
skipping disabled rules would make it do the opposite of what it looks like.

## How

Two reads are defensive, because the dispatcher reads *stored rows* rather than
validated requests:

- `timeout_minutes` is clamped again at `RULE_MAX_TIMEOUT_MINUTES` (240), and
  `<= 0` means `RUN_TIMEOUT` — not a run that times out instantly.
- a `permission_mode` outside `chats::CHAT_PERMISSION_MODES` is **dropped**, not
  forwarded: `chat/runner.rs`' `match` routes anything it does not recognise into
  `with_bypass_permissions()`, so one typo in a hand-edited row would otherwise
  run the agent with permissions fully bypassed.

**Telegram is unchanged.** `find_matching_rule` answers exactly what it answered
before and `parity/trigger_match_vectors.json` is untouched. Its `enabled` test
moved out of `load_rules`' SQL into `find_matching_rule` so that one loader can
serve both selectors — without that, `select_rule_for_channel` could never see a
disabled rule and the off switch would be unreachable.

## Tests

- `trigger/select_rule.rs` — the 12 vectors, plus
  `a_disabled_channel_specific_rule_is_silence_not_a_fall_through`.
- `trigger/dispatcher.rs` — five new: settings off the row, the loader returning
  disabled rows while Telegram still skips them, the dropped permission mode, the
  timeout mapping and clamp, and the chat row carrying the rule's settings.
- `agent_run.rs` — `headless_execution_settings_reach_the_spec`.
- `src-tauri/tests/trigger_run.rs` (new) — a fake CLI that records **`os.getcwd()`
  as well as argv**, because a working directory is `Command::current_dir` and is
  not on the command line at all. Asserts cwd, `--model` and `--permission-mode`
  on a real spawn, and that an unconfigured rule runs exactly as it did before.

Every reverted behaviour was checked to fail a test, by mutation, including both
halves of the wiring: `dispatcher::run_inputs` returns the spec **and** the
deadline, and `run_inputs_carries_the_rules_settings_and_its_timeout` seeds
`timeout_minutes = 1` and asserts `Duration::from_secs(60)` — which costs no wall
clock, because the deadline is handed back as a value rather than spent. The one
line no test reaches is `execute_and_reply`'s pass-through of that `Duration`:
`execute_and_reply` sends a Telegram reply and the base-URL seam that redirects
one (`integrations::telegram::client::set_api_base`) is `#[cfg(test)]` on the
library, so an integration-test crate cannot drive it. `run_inputs`' doc says so.

## Acceptance

- [x] Vectors: specific enabled beats default; specific disabled → `None`; no
      specific → enabled default; disabled default only → `None`; two specific →
      the earlier `created_at`.
- [x] `parity/trigger_match_vectors.json` and every Telegram dispatcher test
      byte-identical and green.
- [x] A rule with `working_directory` set runs the CLI in that directory
      (fake-CLI test records cwd).
- [x] `timeout_minutes: 1` → 60s, `0` → the five-minute default.
- [x] `permission_mode: "plan"` reaches the spawn as `--permission-mode plan`.
- [x] The chat row created for a run carries the rule's four settings.

**Out of scope**, as the issue says: nothing calls `select_rule_for_channel` yet
(#568), and no UI (#569).


---

**Reported to the maintainer rather than filed** (automated review, `ticket`): a
rule may now hold one of `MAX_CONCURRENT`'s ten dispatcher permits for up to 240
minutes, where every run used to be capped at five. That is a direct consequence
of what this issue asked for and of #563's 240-minute cap, so it is out of scope
here — but `handle_update` takes the permit before `process`, and updates queue
unboundedly behind it, so it may be worth bounding or shedding that queue.
