### PR TITLE
feat: Slack Socket Mode worker — connect, ack, dedup, reconnect with backoff, stored status (#567)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -18,6 +18,7 @@ dependencies = [
  "chrono-tz",
  "ferrox-providers",
  "form_urlencoded",
+ "futures-util",
  "http-body-util",
  "iana-time-zone",
  "jsonwebtoken",
@@ -49,6 +50,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "tokio-tungstenite",
  "tokio-util",
  "tracing",
  "uuid",
@@ -892,6 +894,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "dbus"
@@ -4169,6 +4177,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5071,6 +5090,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5314,6 +5349,24 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.20",
+]
 
 [[package]]
 name = "typeid"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -230,6 +230,42 @@ rmcp = { version = "3.1.2", default-features = false, features = [
 # rather than reached through `rmcp`, which does not re-export it. Already in
 # the tree via `tokio-stream` and `rmcp`; adds no package.
 tokio-util = { version = "0.7", default-features = false }
+
+# Slack Socket Mode's transport (#567). A desktop app has no public URL, so the
+# only way a Slack event reaches Agento is a websocket Agento itself opens —
+# and there was no websocket client anywhere in the tree, `reqwest` having no
+# such feature enabled and none of the six integrations needing one.
+#
+# **`default-features = false` with `rustls-tls-native-roots`, for `reqwest`'s
+# reason above and not a new one.** The default feature set turns on
+# `native-tls`, which links the platform's OpenSSL/Schannel — the release
+# workflow builds five target triples with no C toolchain arranged, which is
+# why `rusqlite` is `bundled` and why `reqwest` is rustls. `rustls-tls-native-
+# roots` also keeps the **platform** trust store rather than a compiled-in
+# Mozilla snapshot, so a TLS-inspecting corporate proxy whose CA exists only in
+# the system store intercepts `wss://wss-primary.slack.com` the way it already
+# intercepts `https://slack.com/api`: bundled roots would give a user whose
+# Slack tools work an inbound worker that answers `connect failed` with nothing
+# to point at the cause. It resolves to `ring`, which rustls, `lettre` and
+# `jsonwebtoken` already pull, so no second crypto provider enters the tree.
+#
+# `connect` is what `connect_async` needs and is the only client entry point
+# used; the `stream` feature it implies is what carries a TLS stream. The
+# transitive cost is small because the TLS half is already here: **four** crates
+# enter the lockfile, 596 -> 600 packages — `tokio-tungstenite`, `tungstenite`,
+# and the two `tungstenite` needs for the RFC 6455 handshake, `sha1` and
+# `data-encoding`. `rustls`, `rustls-pki-types`, `rustls-native-certs`,
+# `tokio-rustls`, `ring`, `http`, `bytes`, `futures-core`, `utf8` and `log` were
+# all in the tree already, every one of them by way of `reqwest`.
+tokio-tungstenite = { version = "0.30.0", default-features = false, features = [
+    "connect",
+    "rustls-tls-native-roots",
+] }
+# `SinkExt::send`, for writing the Socket Mode acknowledgement frame. The
+# websocket is a `Sink` as well as a `Stream`, and `tokio_stream::StreamExt`
+# covers only the reading half. Already in the tree via `rmcp` and
+# `tokio-tungstenite`; adds no package.
+futures-util = { version = "0.3", default-features = false }
 # Not used directly — declared so the feature is. `rmcp` instruments itself with
 # `tracing`, this app logs through `tauri-plugin-log` over the `log` crate, and
 # nothing installs a `tracing` subscriber, so every protocol-layer event was

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -249,6 +249,13 @@ tokio-util = { version = "0.7", default-features = false }
 # to point at the cause. It resolves to `ring`, which rustls, `lettre` and
 # `jsonwebtoken` already pull, so no second crypto provider enters the tree.
 #
+# **That covers a *transparent* proxy and not a configured one.** `reqwest`
+# reads `HTTPS_PROXY` and the system proxy settings; `connect_async` does no
+# proxy handling at all, so behind an explicit proxy `apps.connections.open`
+# succeeds and the socket does not — the asymmetry above, pointing the other
+# way. Reported on #567's PR rather than fixed there; `socket.rs` says so at the
+# connect.
+#
 # `connect` is what `connect_async` needs and is the only client entry point
 # used; the `stream` feature it implies is what carries a TLS stream. The
 # transitive cost is small because the TLS half is already here: **four** crates
@@ -265,7 +272,16 @@ tokio-tungstenite = { version = "0.30.0", default-features = false, features = [
 # websocket is a `Sink` as well as a `Stream`, and `tokio_stream::StreamExt`
 # covers only the reading half. Already in the tree via `rmcp` and
 # `tokio-tungstenite`; adds no package.
-futures-util = { version = "0.3", default-features = false }
+#
+# **`sink` is named explicitly and it is load-bearing.** `SinkExt` is gated on
+# it, and `sink` is in neither `default` nor `std` — so with features left off
+# this compiles only because `tokio-tungstenite` happens to ask for `sink` too
+# and Cargo unifies the two. That is a build that breaks on somebody else's
+# dependency bump, with nothing at this declaration to explain why.
+futures-util = { version = "0.3", default-features = false, features = [
+    "sink",
+    "std",
+] }
 # Not used directly — declared so the feature is. `rmcp` instruments itself with
 # `tracing`, this app logs through `tauri-plugin-log` over the `log` crate, and
 # nothing installs a `tracing` subscriber, so every protocol-layer event was

--- a/src-tauri/src/native/integrations/registry.rs
+++ b/src-tauri/src/native/integrations/registry.rs
@@ -425,7 +425,16 @@ pub async fn start_all(db_path: &Path) -> Result<(), String> {
     // `connecting` a moment later; a row that gets no worker is left saying
     // nothing, which is what the column's default means. See
     // `slack::socket::clear_all_inbound_status_blocking`.
-    super::slack::socket::clear_all_inbound_status_blocking(db_path);
+    // Through `db::blocking` like every other database touch in this module:
+    // `start_all` is spawned onto the runtime at boot, and this is a *write*
+    // against a five-second `busy_timeout` at the one moment the scanner's batch
+    // writer is most likely to hold the lock. The read below is a WAL read and
+    // never waits on a writer, which is why it is not the same question.
+    let clear_db = db_path.to_path_buf();
+    crate::native::db::blocking("slack inbound clear at boot", move || {
+        super::slack::socket::clear_all_inbound_status_blocking(&clear_db);
+    })
+    .await;
     let rows = list_for_hosting(db_path)?;
     for row in rows {
         if !row.is_startable() {

--- a/src-tauri/src/native/integrations/registry.rs
+++ b/src-tauri/src/native/integrations/registry.rs
@@ -330,10 +330,13 @@ impl Registry {
 
     /// `Stop`: idempotent, and an unknown id is a silent no-op with no error.
     ///
-    /// Dropping the handle is what stops the listener, and it is done **inside**
-    /// the lock: the drop only sends a oneshot, so there is nothing to await and
-    /// nothing to deadlock on, and releasing first would leave a window in which
-    /// the map says the server is gone while the port is still open.
+    /// Removing the handle from the map is what makes the server unreachable and
+    /// it is done **inside** the lock; *dropping* it is what stops the listener,
+    /// and that happens after the guard is released. The drop only sends a
+    /// oneshot, so there is nothing to await and nothing to gain from holding
+    /// the lock across it — and the window it leaves is one in which the
+    /// listener is closing and the map already says it is gone, which is the
+    /// direction that is safe.
     ///
     /// The generation bump is what makes a concurrent start notice. It happens
     /// whether or not anything was removed, because a `DELETE` racing a `reload`
@@ -343,16 +346,12 @@ impl Registry {
         let mut state = self.lock();
         *state.generations.entry(id.to_string()).or_default() += 1;
         let removed = state.servers.remove(id);
-        // Removed under the same lock, for the reason above — after this the
-        // map cannot hand the worker to anyone. *Dropping* it is what closes
-        // the socket, and that happens a line later, outside the guard: the
-        // drop only sends a oneshot, so there is nothing to await and nothing
-        // to gain from holding the lock across it. The window it leaves is one
-        // in which the socket is closing and the map already says so, which is
-        // the direction that is safe.
-        // Retired under the same lock. A stop is the end of that worker's right
-        // to report, whether or not a replacement follows.
+        // The epoch first: a stop ends that worker's right to report, whether or
+        // not a replacement follows, and retiring it under the same lock is what
+        // makes that true for a status write already queued.
         Self::take_socket_epoch(&mut state, id);
+        // The socket worker on exactly the terms the doc comment gives for the
+        // server — out of the map here, dropped below.
         let removed_socket = state.sockets.remove(id);
         drop(state);
         drop(removed_socket);

--- a/src-tauri/src/native/integrations/registry.rs
+++ b/src-tauri/src/native/integrations/registry.rs
@@ -512,10 +512,19 @@ async fn start_one(db_path: &Path, row: &HostingRow, generation: u64) -> Result<
         return Ok(());
     }
     log::info!(
-        "integration MCP server started: id={:?} type={:?} url={url} socket={hosted_socket}",
+        "integration MCP server started: id={:?} type={:?} url={url}",
         row.id,
         row.integration_type
     );
+    // A separate statement rather than a field on the line above, and that is
+    // not style. CodeQL reads `url` there as tainted by a stored credential —
+    // an alert that has been open against `main` for as long as the line has
+    // existed — and *editing* the line re-reports it as introduced by whatever
+    // change touched it. #567 has no business either fixing or inheriting that,
+    // so the line is left byte-for-byte as it was.
+    if hosted_socket {
+        log::info!("slack socket mode worker hosted: id={:?}", row.id);
+    }
     Ok(())
 }
 

--- a/src-tauri/src/native/integrations/registry.rs
+++ b/src-tauri/src/native/integrations/registry.rs
@@ -407,7 +407,14 @@ impl Registry {
                 // order — see `slack::socket::status_writer`.
                 let epoch = Self::take_socket_epoch(&mut state, id);
                 socket.accept(epoch);
-                state.sockets.insert(id.to_string(), socket);
+                // Displaced under the lock, dropped outside it — the discipline
+                // `stop` and the arm below already follow. Two concurrent
+                // reloads were always safe here because `insert` returns the
+                // old handle, but dropping it *inside* the guard is a shutdown
+                // fired while holding a lock the shutdown path may want.
+                let displaced = state.sockets.insert(id.to_string(), socket);
+                drop(state);
+                drop(displaced);
                 Recorded::WithSocket
             }
             // A Slack row whose inbound switch was turned off still reloads, and
@@ -433,12 +440,40 @@ impl Registry {
         *epoch
     }
 
-    /// Retire whatever socket worker is recorded for `id`, answering the epoch
-    /// that is now current.
+    /// Retire whatever socket worker is recorded for `id`, **unless the caller's
+    /// start has been superseded**, answering the epoch that is now current.
     ///
-    /// The caller quotes it to `slack::socket::clear_status`, which is what
-    /// stops a clear about a decision that has since been superseded from
-    /// blanking the row under a worker that is running.
+    /// `generation` is the value the caller read before the row read that
+    /// justified its start — the same value [`Registry::put_if_current`] checks,
+    /// and it has to be checked here for the same reason. A start that fails is
+    /// still a start that may have lost: a user saving a bad Slack blob and then
+    /// a good one gives two overlapping reloads, and the first one's *failure*
+    /// arrives after the second one's worker has been accepted. Retiring
+    /// unconditionally there would drop a live worker and hand its caller an
+    /// epoch with which to blank the row — leaving Slack inbound silently dead
+    /// with an empty status, which is the outage the column exists to prevent.
+    ///
+    /// `None` means the caller lost and must touch nothing. `Some(epoch)` is
+    /// quoted to `slack::socket::clear_status`, which re-checks it once more
+    /// across its own await.
+    pub fn retire_socket_if_current(&self, id: &str, generation: u64) -> Option<u64> {
+        let mut state = self.lock();
+        if state.generations.get(id).copied().unwrap_or_default() != generation {
+            return None;
+        }
+        let epoch = Self::take_socket_epoch(&mut state, id);
+        let stale = state.sockets.remove(id);
+        drop(state);
+        drop(stale);
+        Some(epoch)
+    }
+
+    /// [`Registry::retire_socket_if_current`] with no generation to check.
+    ///
+    /// **No production caller, and there should not be one**: every start in
+    /// this module has a generation, and skipping it is finding #3 of #567's
+    /// review. It exists for `tests/slack_socket.rs`, which drives workers with
+    /// no registry lifecycle at all and needs a current epoch to grant.
     pub fn retire_socket(&self, id: &str) -> u64 {
         let mut state = self.lock();
         let epoch = Self::take_socket_epoch(&mut state, id);
@@ -549,8 +584,9 @@ pub async fn reload(db_path: &Path, id: &str) -> Result<(), String> {
         // same reason as in `start_one`, the status it left behind is the
         // registry's to clear.
         if row.integration_type == "slack" {
-            let epoch = registry().retire_socket(&row.id);
-            super::slack::socket::clear_status(db_path, &row.id, epoch).await;
+            if let Some(epoch) = registry().retire_socket_if_current(&row.id, generation) {
+                super::slack::socket::clear_status(db_path, &row.id, epoch).await;
+            }
         }
         return Ok(());
     }
@@ -575,8 +611,12 @@ async fn start_one(db_path: &Path, row: &HostingRow, generation: u64) -> Result<
         Ok(server) => server,
         Err(e) => {
             if row.integration_type == "slack" {
-                let epoch = registry().retire_socket(&row.id);
-                super::slack::socket::clear_status(db_path, &row.id, epoch).await;
+                // Only if this start is still the current one — a failure that
+                // arrives after a concurrent reload's worker was accepted must
+                // not drop it. See `retire_socket_if_current`.
+                if let Some(epoch) = registry().retire_socket_if_current(&row.id, generation) {
+                    super::slack::socket::clear_status(db_path, &row.id, epoch).await;
+                }
             }
             return Err(e);
         }
@@ -2040,6 +2080,60 @@ mod tests {
                 "{integration_type} has a service group naming no tools"
             );
         }
+    }
+
+    /// A start that *fails* still clears the status of the worker it replaced.
+    ///
+    /// `reload` stops the previous worker before it tries to start the next one,
+    /// so a start that then fails leaves a row with no worker — and returning
+    /// the `Err` without clearing would leave the dead worker's `connected`
+    /// standing until the next boot. That path is the one every other no-worker
+    /// branch of `start_one` is careful about, and it is the one reached by an
+    /// `Err`, so it is easy to write and easy to forget.
+    ///
+    /// The row here is *startable* — enabled and authenticated — but its blob
+    /// carries no usable token, which is what `resolve_slack_token` refuses.
+    #[tokio::test]
+    async fn a_start_that_fails_still_clears_the_status_it_replaced() {
+        let file = db();
+        insert(
+            &file,
+            "sl-broken",
+            "slack",
+            true,
+            Some(r#"{"validated":true}"#),
+            // `auth_mode` says bot token and there is none: startable by the
+            // registry's test, refused by the Slack starter.
+            r#"{"auth_mode":"bot_token","bot_token":"","app_token":"xapp-1-A000-1111-secret"}"#,
+            SLACK_SERVICES,
+        );
+        set_inbound(&file, "sl-broken", true);
+        crate::native::integrations::slack::socket::write_status_blocking(
+            file.path(),
+            "sl-broken",
+            crate::native::integrations::slack::socket::STATUS_CONNECTED,
+            "",
+        );
+
+        reload(file.path(), "sl-broken")
+            .await
+            .expect_err("the start must fail");
+
+        let (status, error): (String, String) = Connection::open(file.path())
+            .expect("open")
+            .query_row(
+                "SELECT inbound_status, inbound_error FROM integrations WHERE id = 'sl-broken'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("read the inbound state");
+        assert_eq!(
+            (status, error),
+            (String::new(), String::new()),
+            "a failed start must not leave the previous worker's `connected` standing"
+        );
+        assert!(!registry().is_socket_running("sl-broken"));
+        registry().stop("sl-broken");
     }
 
     /// A socket worker the registry **refused** never takes the epoch from the

--- a/src-tauri/src/native/integrations/registry.rs
+++ b/src-tauri/src/native/integrations/registry.rs
@@ -131,6 +131,7 @@ use rusqlite::OptionalExtension;
 
 use crate::claude::InProcessMcpServer;
 
+use super::slack::socket::SocketWorker;
 use super::{decode_services, ServiceConfig};
 
 /// One integration row, **credentials included**.
@@ -221,10 +222,9 @@ impl HostingRow {
     /// JSON string is escaped in the blob, so the decoded token is not always a
     /// slice of it, and every other credential accessor in this module hands
     /// back an owned value for the same reason.
-    /// `allow(dead_code)` for [`Self::inbound_enabled`]'s reason: #567's worker
-    /// is the caller, and the accessor is what that change reads rather than
+    /// #567's socket worker is the caller, through
+    /// [`start_socket_worker`], and this accessor is what it reads rather than
     /// reaching into the blob itself.
-    #[allow(dead_code)]
     pub(crate) fn app_token(&self) -> Option<String> {
         serde_json::from_str::<serde_json::Value>(&self.credentials)
             .ok()?
@@ -271,6 +271,16 @@ pub struct Registry {
 #[derive(Default)]
 struct State {
     servers: HashMap<String, InProcessMcpServer>,
+    /// The Slack Socket Mode workers, keyed the same way (#567).
+    ///
+    /// A second map rather than a second field on the value, because the two
+    /// handles are independent: every hosted type has a server, and only a
+    /// Slack row with `inbound_enabled` and an `xapp-` token has a worker. They
+    /// share one generation, so [`Registry::stop`] and
+    /// [`Registry::put_if_current`] move both at once and a stop racing a
+    /// reload can no more leave a socket holding a credential than it can leave
+    /// a bound port.
+    sockets: HashMap<String, SocketWorker>,
     /// Bumped by every [`Registry::stop`], and never reset.
     ///
     /// This is what closes the window `reload` opens by design: a start records
@@ -315,7 +325,14 @@ impl Registry {
         let mut state = self.lock();
         *state.generations.entry(id.to_string()).or_default() += 1;
         let removed = state.servers.remove(id);
+        // Removed inside the same lock and dropped with it, for the reason
+        // above: dropping a [`SocketWorker`] only sends a oneshot, so there is
+        // nothing to await, and releasing first would leave a window in which
+        // the map says the worker is gone while the socket is still open
+        // holding the app token.
+        let removed_socket = state.sockets.remove(id);
         drop(state);
+        drop(removed_socket);
         if removed.is_some() {
             log::info!("integration MCP server stopped: id={id:?}");
         }
@@ -341,12 +358,35 @@ impl Registry {
     /// Returns whether the handle was kept. A refused handle is dropped here,
     /// which fires its shutdown oneshot — so the listener the caller started
     /// goes away rather than outliving the row it was built from.
-    fn put_if_current(&self, id: &str, generation: u64, server: InProcessMcpServer) -> bool {
+    ///
+    /// The socket worker is recorded in the **same** critical section as the
+    /// server, so the pair a `start_one` built is kept or dropped together. Two
+    /// calls would leave a `stop` landing between them able to keep one half.
+    fn put_if_current(
+        &self,
+        id: &str,
+        generation: u64,
+        server: InProcessMcpServer,
+        socket: Option<SocketWorker>,
+    ) -> bool {
         let mut state = self.lock();
         if state.generations.get(id).copied().unwrap_or_default() != generation {
             return false;
         }
         state.servers.insert(id.to_string(), server);
+        match socket {
+            Some(socket) => {
+                state.sockets.insert(id.to_string(), socket);
+            }
+            // A Slack row whose inbound switch was turned off still reloads, and
+            // the reload must retire the previous worker rather than leave it
+            // running against a row that no longer wants it.
+            None => {
+                let stale = state.sockets.remove(id);
+                drop(state);
+                drop(stale);
+            }
+        }
         true
     }
 
@@ -354,6 +394,14 @@ impl Registry {
     /// this; it exists so the lifecycle can be asserted.
     pub fn is_hosted(&self, id: &str) -> bool {
         self.lock().servers.contains_key(id)
+    }
+
+    /// Whether a Slack Socket Mode worker is running for this integration.
+    /// Nothing on the wire reads this either — `inbound_status` is what the UI
+    /// sees, and it is the worker's to write. This exists so the lifecycle can
+    /// be asserted (#567).
+    pub fn is_socket_running(&self, id: &str) -> bool {
+        self.lock().sockets.contains_key(id)
     }
 }
 
@@ -376,7 +424,7 @@ pub async fn start_all(db_path: &Path) -> Result<(), String> {
             continue;
         }
         let generation = generations.get(&row.id).copied().unwrap_or_default();
-        if let Err(e) = start_one(&row, generation).await {
+        if let Err(e) = start_one(db_path, &row, generation).await {
             log::warn!(
                 "failed to start integration server: id={:?} type={:?} error={e}",
                 row.id,
@@ -408,7 +456,7 @@ pub async fn reload(db_path: &Path, id: &str) -> Result<(), String> {
     if !row.is_startable() {
         return Ok(()); // disabled or not authenticated
     }
-    start_one(&row, generation).await
+    start_one(db_path, &row, generation).await
 }
 
 /// `startOne`: resolve the type's starter, run it, record the handle.
@@ -417,10 +465,12 @@ pub async fn reload(db_path: &Path, id: &str) -> Result<(), String> {
 /// decided to start: a mismatch means the integration was stopped or deleted
 /// while the server was being built, and the handle is dropped rather than
 /// recorded — which stops the listener it just bound.
-async fn start_one(row: &HostingRow, generation: u64) -> Result<(), String> {
+async fn start_one(db_path: &Path, row: &HostingRow, generation: u64) -> Result<(), String> {
     let server = start_for_type(row).await?;
     let url = server.url().to_string();
-    if !registry().put_if_current(&row.id, generation, server) {
+    let socket = start_socket_worker(db_path, row);
+    let hosted_socket = socket.is_some();
+    if !registry().put_if_current(&row.id, generation, server, socket) {
         log::info!(
             "integration MCP server discarded before it was recorded, \
              the integration was stopped while it started: id={:?} type={:?}",
@@ -430,11 +480,45 @@ async fn start_one(row: &HostingRow, generation: u64) -> Result<(), String> {
         return Ok(());
     }
     log::info!(
-        "integration MCP server started: id={:?} type={:?} url={url}",
+        "integration MCP server started: id={:?} type={:?} url={url} socket={hosted_socket}",
         row.id,
         row.integration_type
     );
     Ok(())
+}
+
+/// The Slack Socket Mode worker for this row, when the row asks for one (#567).
+///
+/// Three conditions, and each is a different absence: the type must be `slack`,
+/// migration 39's switch must be on, and the credentials blob must actually hold
+/// an `xapp-` token. The last is not redundant with the 422 on `PUT
+/// /api/integrations/{id}/inbound` — a later `PUT /api/integrations/{id}` can
+/// replace the blob with one that has no `app_token`, which is exactly why that
+/// write clears `inbound_enabled`; this is the second line, because a row stored
+/// before that clearing existed still has to start cleanly rather than open a
+/// socket with an empty bearer.
+///
+/// **Started here rather than in `start_for_type`**, which returns one
+/// `InProcessMcpServer` and is the starter table for the six hosted types. The
+/// worker is not a seventh type — it is a second handle on one of them.
+fn start_socket_worker(db_path: &Path, row: &HostingRow) -> Option<SocketWorker> {
+    if row.integration_type != "slack" || !row.inbound_enabled {
+        return None;
+    }
+    let Some(app_token) = row.app_token() else {
+        log::warn!(
+            "slack inbound is enabled but no app token is stored, \
+             not starting the socket worker: id={:?}",
+            row.id
+        );
+        return None;
+    };
+    Some(super::slack::socket::start(
+        db_path,
+        &row.id,
+        &app_token,
+        super::slack::socket::SocketOptions::default(),
+    ))
 }
 
 /// The starter table. Go builds a `map[string]ServerStarter` at wiring time;
@@ -1387,6 +1471,127 @@ mod tests {
 
     const GITHUB_SERVICES: &str = r#"{"repos":{"enabled":true,"tools":["list_repos","get_repo"]}}"#;
 
+    const SLACK_SERVICES: &str =
+        r#"{"messaging":{"enabled":true,"tools":["send_message","list_channels"]}}"#;
+    const SLACK_APP_TOKEN: &str = "xapp-1-A000-1111-secret";
+
+    fn slack_credentials(app_token: Option<&str>) -> String {
+        match app_token {
+            Some(token) => format!(
+                r#"{{"auth_mode":"bot_token","bot_token":"xoxb-test","app_token":"{token}"}}"#
+            ),
+            None => r#"{"auth_mode":"bot_token","bot_token":"xoxb-test"}"#.to_string(),
+        }
+    }
+
+    fn set_inbound(file: &tempfile::NamedTempFile, id: &str, enabled: bool) {
+        Connection::open(file.path())
+            .expect("open")
+            .execute(
+                "UPDATE integrations SET inbound_enabled = ?1 WHERE id = ?2",
+                rusqlite::params![i64::from(enabled), id],
+            )
+            .expect("set the switch");
+    }
+
+    /// A Slack row carries **two** handles or one, and the switch plus the
+    /// stored token is what decides which — over the same `start_all` / `reload`
+    /// / `stop` path the MCP server already travels (#567).
+    ///
+    /// The three negative cases are the point. A socket started for a row with
+    /// the switch off would ignore `PUT /api/integrations/{id}/inbound`
+    /// entirely; one started for a row with no `app_token` would open a
+    /// connection with an empty bearer and report `error` forever; and a socket
+    /// left running by a reload that turned the switch off is a socket holding a
+    /// credential for a state the user has just left — the same failure the
+    /// generation counter exists to prevent for listeners.
+    #[tokio::test]
+    async fn a_slack_socket_worker_follows_the_switch_and_the_stored_token() {
+        // Pointed at a local fake, never at slack.com: the worker's first act is
+        // an `apps.connections.open`, and a test that reached the real one would
+        // pass offline for the wrong reason.
+        let _guard = super::super::slack::client::api_base_lock().await;
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        tokio::spawn(async move {
+            let app = axum::Router::new().fallback(|| async {
+                // What Slack answers for a token it will not accept.
+                (
+                    axum::http::StatusCode::OK,
+                    r#"{"ok":false,"error":"invalid_auth"}"#,
+                )
+            });
+            let _ = axum::serve(listener, app).await;
+        });
+        super::super::slack::client::set_api_base(Some(format!("http://{addr}")));
+
+        let file = db();
+        // Inbound on, token stored: both handles.
+        insert(
+            &file,
+            "sl-on",
+            "slack",
+            true,
+            Some(r#"{"validated":true}"#),
+            &slack_credentials(Some(SLACK_APP_TOKEN)),
+            SLACK_SERVICES,
+        );
+        // Inbound off: server only.
+        insert(
+            &file,
+            "sl-off",
+            "slack",
+            true,
+            Some(r#"{"validated":true}"#),
+            &slack_credentials(Some(SLACK_APP_TOKEN)),
+            SLACK_SERVICES,
+        );
+        // Inbound on but nothing to authenticate with: server only.
+        insert(
+            &file,
+            "sl-tokenless",
+            "slack",
+            true,
+            Some(r#"{"validated":true}"#),
+            &slack_credentials(None),
+            SLACK_SERVICES,
+        );
+        set_inbound(&file, "sl-on", true);
+        set_inbound(&file, "sl-tokenless", true);
+
+        start_all(file.path()).await.expect("start_all");
+        for id in ["sl-on", "sl-off", "sl-tokenless"] {
+            assert!(registry().is_hosted(id), "{id} must be hosted");
+        }
+        assert!(registry().is_socket_running("sl-on"));
+        assert!(!registry().is_socket_running("sl-off"));
+        assert!(!registry().is_socket_running("sl-tokenless"));
+
+        // Turning the switch off and reloading retires the worker without
+        // touching the hosted server.
+        set_inbound(&file, "sl-on", false);
+        reload(file.path(), "sl-on").await.expect("reload");
+        assert!(registry().is_hosted("sl-on"));
+        assert!(
+            !registry().is_socket_running("sl-on"),
+            "a reload with the switch off must retire the worker"
+        );
+
+        // And back on again.
+        set_inbound(&file, "sl-on", true);
+        reload(file.path(), "sl-on").await.expect("reload");
+        assert!(registry().is_socket_running("sl-on"));
+
+        for id in ["sl-on", "sl-off", "sl-tokenless"] {
+            registry().stop(id);
+            assert!(!registry().is_hosted(id));
+            assert!(!registry().is_socket_running(id));
+        }
+        super::super::slack::client::set_api_base(None);
+    }
+
     fn github_credentials() -> String {
         format!(r#"{{"auth_mode":"pat","personal_access_token":"{PAT}"}}"#)
     }
@@ -1673,7 +1878,7 @@ mod tests {
             .await
             .expect("a server to race with");
         assert!(
-            !registry().put_if_current("gh-race", generation, server),
+            !registry().put_if_current("gh-race", generation, server, None),
             "a handle whose generation has moved must be refused"
         );
         assert!(!registry().is_hosted("gh-race"));
@@ -1683,7 +1888,7 @@ mod tests {
         let server = start_filtered_server(file.path(), "gh-race", &[])
             .await
             .expect("server");
-        assert!(registry().put_if_current("gh-race", generation, server));
+        assert!(registry().put_if_current("gh-race", generation, server, None));
         assert!(registry().is_hosted("gh-race"));
         registry().stop("gh-race");
     }

--- a/src-tauri/src/native/integrations/registry.rs
+++ b/src-tauri/src/native/integrations/registry.rs
@@ -475,11 +475,7 @@ pub async fn reload(db_path: &Path, id: &str) -> Result<(), String> {
         // same reason as in `start_one`, the status it left behind is the
         // registry's to clear.
         if row.integration_type == "slack" {
-            let (path, id) = (db_path.to_path_buf(), row.id.clone());
-            crate::native::db::blocking("slack inbound clear", move || {
-                super::slack::socket::clear_status_blocking(&path, &id);
-            })
-            .await;
+            super::slack::socket::clear_status(db_path, &row.id).await;
         }
         return Ok(());
     }
@@ -504,11 +500,7 @@ async fn start_one(db_path: &Path, row: &HostingRow, generation: u64) -> Result<
     // compare-and-swap cannot break the tie, because both write the identical
     // `"connected"`. Here the clear is simply ordered before the start.
     if row.integration_type == "slack" && !hosted_socket {
-        let (path, id) = (db_path.to_path_buf(), row.id.clone());
-        crate::native::db::blocking("slack inbound clear", move || {
-            super::slack::socket::clear_status_blocking(&path, &id);
-        })
-        .await;
+        super::slack::socket::clear_status(db_path, &row.id).await;
     }
     if !registry().put_if_current(&row.id, generation, server, socket) {
         log::info!(

--- a/src-tauri/src/native/integrations/registry.rs
+++ b/src-tauri/src/native/integrations/registry.rs
@@ -277,6 +277,16 @@ struct State {
     /// reload can no more leave a socket holding a credential than it can leave
     /// a bound port.
     sockets: HashMap<String, SocketWorker>,
+    /// Which worker's status writes still count, per integration (#567).
+    ///
+    /// Separate from [`Self::generations`] and not merged into it: the
+    /// generation is bumped by every `stop`, including one for a row that has no
+    /// socket at all, and it is read *before* a start to be quoted back
+    /// afterwards. This is the opposite shape — taken at the moment a handle is
+    /// accepted or retired, and never read speculatively. See
+    /// `slack::socket::status_writer` for why the grant has to happen exactly
+    /// here.
+    socket_epochs: HashMap<String, u64>,
     /// Bumped by every [`Registry::stop`], and never reset.
     ///
     /// This is what closes the window `reload` opens by design: a start records
@@ -299,6 +309,18 @@ pub fn registry() -> &'static Registry {
     REGISTRY.get_or_init(|| Registry {
         state: Mutex::new(State::default()),
     })
+}
+
+/// What [`Registry::put_if_current`] did with a start.
+enum Recorded {
+    /// The integration was stopped while the server was being built; both
+    /// handles were dropped rather than recorded.
+    Refused,
+    /// Recorded, with a socket worker that is now the current one.
+    WithSocket,
+    /// Recorded, with no socket worker — so any previous one has been retired,
+    /// and `epoch` is what the caller quotes to `slack::socket::clear_status`.
+    WithoutSocket { epoch: u64 },
 }
 
 impl Registry {
@@ -328,6 +350,9 @@ impl Registry {
         // to gain from holding the lock across it. The window it leaves is one
         // in which the socket is closing and the map already says so, which is
         // the direction that is safe.
+        // Retired under the same lock. A stop is the end of that worker's right
+        // to report, whether or not a replacement follows.
+        Self::take_socket_epoch(&mut state, id);
         let removed_socket = state.sockets.remove(id);
         drop(state);
         drop(removed_socket);
@@ -366,15 +391,24 @@ impl Registry {
         generation: u64,
         server: InProcessMcpServer,
         socket: Option<SocketWorker>,
-    ) -> bool {
+    ) -> Recorded {
         let mut state = self.lock();
         if state.generations.get(id).copied().unwrap_or_default() != generation {
-            return false;
+            // The refused socket is dropped with `socket` at the end of this
+            // arm, still holding `NOT_ACCEPTED`, so it never writes a status.
+            return Recorded::Refused;
         }
         state.servers.insert(id.to_string(), server);
         match socket {
             Some(socket) => {
+                // **Granted here and nowhere else.** This is the one critical
+                // section that decides which worker won, so taking the epoch in
+                // it is what makes epoch order and acceptance order the same
+                // order — see `slack::socket::status_writer`.
+                let epoch = Self::take_socket_epoch(&mut state, id);
+                socket.accept(epoch);
                 state.sockets.insert(id.to_string(), socket);
+                Recorded::WithSocket
             }
             // A Slack row whose inbound switch was turned off still reloads, and
             // the reload must retire the previous worker rather than leave it
@@ -382,12 +416,52 @@ impl Registry {
             // lock and dropped outside it, exactly as [`Registry::stop`] does
             // and for the same reason.
             None => {
+                let epoch = Self::take_socket_epoch(&mut state, id);
                 let stale = state.sockets.remove(id);
                 drop(state);
                 drop(stale);
+                Recorded::WithoutSocket { epoch }
             }
         }
-        true
+    }
+
+    /// Take the next status epoch for `id`, retiring whatever held the last one.
+    /// Callers must already hold the state lock.
+    fn take_socket_epoch(state: &mut State, id: &str) -> u64 {
+        let epoch = state.socket_epochs.entry(id.to_string()).or_default();
+        *epoch += 1;
+        *epoch
+    }
+
+    /// Retire whatever socket worker is recorded for `id`, answering the epoch
+    /// that is now current.
+    ///
+    /// The caller quotes it to `slack::socket::clear_status`, which is what
+    /// stops a clear about a decision that has since been superseded from
+    /// blanking the row under a worker that is running.
+    pub fn retire_socket(&self, id: &str) -> u64 {
+        let mut state = self.lock();
+        let epoch = Self::take_socket_epoch(&mut state, id);
+        let stale = state.sockets.remove(id);
+        drop(state);
+        drop(stale);
+        epoch
+    }
+
+    /// Whether `epoch` is the one currently granted for `id`.
+    ///
+    /// [`slack::socket::NOT_ACCEPTED`](super::slack::socket::NOT_ACCEPTED) never
+    /// matches, because epochs are handed out from one upwards — so a worker
+    /// that was built and then refused writes nothing, ever.
+    pub fn socket_epoch_is_current(&self, id: &str, epoch: u64) -> bool {
+        epoch != super::slack::socket::NOT_ACCEPTED
+            && self
+                .lock()
+                .socket_epochs
+                .get(id)
+                .copied()
+                .unwrap_or_default()
+                == epoch
     }
 
     /// Whether an integration is hosted right now. Nothing on the wire reads
@@ -475,7 +549,8 @@ pub async fn reload(db_path: &Path, id: &str) -> Result<(), String> {
         // same reason as in `start_one`, the status it left behind is the
         // registry's to clear.
         if row.integration_type == "slack" {
-            super::slack::socket::clear_status(db_path, &row.id).await;
+            let epoch = registry().retire_socket(&row.id);
+            super::slack::socket::clear_status(db_path, &row.id, epoch).await;
         }
         return Ok(());
     }
@@ -489,27 +564,47 @@ pub async fn reload(db_path: &Path, id: &str) -> Result<(), String> {
 /// while the server was being built, and the handle is dropped rather than
 /// recorded — which stops the listener it just bound.
 async fn start_one(db_path: &Path, row: &HostingRow, generation: u64) -> Result<(), String> {
-    let server = start_for_type(row).await?;
+    // **The error arm clears too, and that is not symmetry for its own sake.**
+    // `reload` has already stopped the previous worker by the time this runs, so
+    // a start that fails here — `resolve_slack_token` refusing a blob whose
+    // usable token has gone, an in-process server failing to bind — leaves a row
+    // with no worker. Returning the `Err` without clearing would leave the dead
+    // worker's `connected` standing until the next boot, which is the same lie
+    // every other no-worker path in this function is careful to avoid.
+    let server = match start_for_type(row).await {
+        Ok(server) => server,
+        Err(e) => {
+            if row.integration_type == "slack" {
+                let epoch = registry().retire_socket(&row.id);
+                super::slack::socket::clear_status(db_path, &row.id, epoch).await;
+            }
+            return Err(e);
+        }
+    };
     let url = server.url().to_string();
     let socket = start_socket_worker(db_path, row);
     let hosted_socket = socket.is_some();
-    // A Slack row that is not getting a worker must not keep the previous
-    // worker's status. **This is the registry's to do and not the worker's**:
-    // a `reload` is a stop followed immediately by a start, so a retiring worker
-    // clearing its own row would race the replacement's `connecting` — and a
-    // compare-and-swap cannot break the tie, because both write the identical
-    // `"connected"`. Here the clear is simply ordered before the start.
-    if row.integration_type == "slack" && !hosted_socket {
-        super::slack::socket::clear_status(db_path, &row.id).await;
-    }
-    if !registry().put_if_current(&row.id, generation, server, socket) {
-        log::info!(
-            "integration MCP server discarded before it was recorded, \
-             the integration was stopped while it started: id={:?} type={:?}",
-            row.id,
-            row.integration_type
-        );
-        return Ok(());
+    match registry().put_if_current(&row.id, generation, server, socket) {
+        Recorded::Refused => {
+            log::info!(
+                "integration MCP server discarded before it was recorded, \
+                 the integration was stopped while it started: id={:?} type={:?}",
+                row.id,
+                row.integration_type
+            );
+            return Ok(());
+        }
+        // A Slack row that is not getting a worker must not keep the previous
+        // worker's status. **This is the registry's to do and not the
+        // worker's**: a `reload` is a stop followed immediately by a start, so a
+        // retiring worker clearing its own row would race the replacement's
+        // `connecting` — and a compare-and-swap cannot break the tie, because
+        // both write the identical `"connected"`. Here the clear is ordered
+        // after the decision, and quotes the epoch that decision took.
+        Recorded::WithoutSocket { epoch } if row.integration_type == "slack" => {
+            super::slack::socket::clear_status(db_path, &row.id, epoch).await;
+        }
+        Recorded::WithoutSocket { .. } | Recorded::WithSocket => {}
     }
     log::info!(
         "integration MCP server started: id={:?} type={:?} url={url}",
@@ -1947,10 +2042,109 @@ mod tests {
         }
     }
 
+    /// A socket worker the registry **refused** never takes the epoch from the
+    /// one it accepted.
+    ///
+    /// This is the failure that made the epoch the registry's rather than the
+    /// worker's. A worker is built before the decision — `start_for_type` is
+    /// `async` and can be slow — so with the epoch claimed at spawn, two
+    /// overlapping `reload`s whose starts finish out of order would have the
+    /// *refused* worker holding the later epoch. `status_writer` would then
+    /// discard every status the accepted worker ever posted, freezing the row on
+    /// whatever it last held — a `connected` with nothing connected, which is
+    /// the exact outage the column exists to make visible. Granting the epoch
+    /// inside `put_if_current` is what makes epoch order and acceptance order
+    /// the same order.
+    #[tokio::test]
+    async fn a_refused_socket_never_takes_the_epoch_from_the_accepted_one() {
+        let file = db();
+        insert(
+            &file,
+            "gh-epoch",
+            "github",
+            true,
+            Some(r#"{"ok":true}"#),
+            &github_credentials(),
+            GITHUB_SERVICES,
+        );
+
+        let worker = |id: &str| {
+            crate::native::integrations::slack::socket::start(
+                file.path(),
+                id,
+                SLACK_APP_TOKEN,
+                // Pointed at a port nothing is listening on: this test is about
+                // the epoch, and the worker must not reach the network for it.
+                crate::native::integrations::slack::socket::SocketOptions {
+                    api_base: "http://127.0.0.1:1".to_string(),
+                    ..Default::default()
+                },
+            )
+        };
+
+        // The accepted start: it reads the generation, then records.
+        let accepted_generation = registry().generation("gh-epoch");
+        let accepted = worker("gh-epoch");
+        let server = start_filtered_server(file.path(), "gh-epoch", &[])
+            .await
+            .expect("a server for the accepted start");
+        assert!(matches!(
+            registry().put_if_current("gh-epoch", accepted_generation, server, Some(accepted)),
+            Recorded::WithSocket
+        ));
+        assert!(registry().is_socket_running("gh-epoch"));
+
+        // The slower start, which read an older generation and is refused. It
+        // was *built* after the accepted one, so a spawn-time claim would have
+        // given it the newer epoch.
+        let stale_generation = accepted_generation.wrapping_sub(1);
+        let refused = worker("gh-epoch");
+        let server = start_filtered_server(file.path(), "gh-epoch", &[])
+            .await
+            .expect("a server for the refused start");
+        assert!(matches!(
+            registry().put_if_current("gh-epoch", stale_generation, server, Some(refused)),
+            Recorded::Refused
+        ));
+
+        // The accepted worker is still the one that may report. Asserting it
+        // through `socket_epoch_is_current` rather than the map, because being
+        // *recorded* was never the thing at risk — being *heard* was.
+        assert!(
+            registry().is_socket_running("gh-epoch"),
+            "the refused start must not have displaced the accepted worker"
+        );
+        let epoch_now = {
+            let state = registry().lock();
+            state.socket_epochs.get("gh-epoch").copied().unwrap_or(0)
+        };
+        assert_eq!(
+            epoch_now, 1,
+            "exactly one epoch was granted, to the accepted worker"
+        );
+        assert!(registry().socket_epoch_is_current("gh-epoch", 1));
+        assert!(
+            !registry().socket_epoch_is_current(
+                "gh-epoch",
+                crate::native::integrations::slack::socket::NOT_ACCEPTED
+            ),
+            "a worker that was never accepted matches nothing"
+        );
+
+        // And a retire moves it on, which is what a clear quotes.
+        let retired = registry().retire_socket("gh-epoch");
+        assert_eq!(retired, 2);
+        assert!(!registry().socket_epoch_is_current("gh-epoch", 1));
+        assert!(registry().socket_epoch_is_current("gh-epoch", 2));
+        assert!(!registry().is_socket_running("gh-epoch"));
+        registry().stop("gh-epoch");
+    }
+
     /// The race `reload` opens by design, and the guard that closes it: a
     /// `DELETE` between the row read and the handle being recorded must not
     /// leave a bound port holding the credential of a row that is gone.
     #[tokio::test]
+
     async fn a_stop_between_the_read_and_the_put_discards_the_server() {
         let file = db();
         insert(
@@ -1974,7 +2168,10 @@ mod tests {
             .await
             .expect("a server to race with");
         assert!(
-            !registry().put_if_current("gh-race", generation, server, None),
+            matches!(
+                registry().put_if_current("gh-race", generation, server, None),
+                Recorded::Refused
+            ),
             "a handle whose generation has moved must be refused"
         );
         assert!(!registry().is_hosted("gh-race"));
@@ -1984,7 +2181,10 @@ mod tests {
         let server = start_filtered_server(file.path(), "gh-race", &[])
             .await
             .expect("server");
-        assert!(registry().put_if_current("gh-race", generation, server, None));
+        assert!(!matches!(
+            registry().put_if_current("gh-race", generation, server, None),
+            Recorded::Refused
+        ));
         assert!(registry().is_hosted("gh-race"));
         registry().stop("gh-race");
     }

--- a/src-tauri/src/native/integrations/registry.rs
+++ b/src-tauri/src/native/integrations/registry.rs
@@ -172,12 +172,8 @@ pub(crate) struct HostingRow {
     /// second `SELECT` naming `credentials`, which the module header exists to
     /// prevent.
     ///
-    /// `allow(dead_code)` because the worker that reads it lands in #567 and
-    /// the projection has to carry the column first — the same standing
-    /// exemption `WhatsAppCredentials::phone` carries, and for the same reason:
-    /// deleting the field to silence the lint is what makes the next change
-    /// reintroduce it wrongly.
-    #[allow(dead_code)]
+    /// Read by [`start_socket_worker`] since #567, which is what took the
+    /// standing `allow(dead_code)` off it.
     pub(crate) inbound_enabled: bool,
 }
 
@@ -325,11 +321,13 @@ impl Registry {
         let mut state = self.lock();
         *state.generations.entry(id.to_string()).or_default() += 1;
         let removed = state.servers.remove(id);
-        // Removed inside the same lock and dropped with it, for the reason
-        // above: dropping a [`SocketWorker`] only sends a oneshot, so there is
-        // nothing to await, and releasing first would leave a window in which
-        // the map says the worker is gone while the socket is still open
-        // holding the app token.
+        // Removed under the same lock, for the reason above — after this the
+        // map cannot hand the worker to anyone. *Dropping* it is what closes
+        // the socket, and that happens a line later, outside the guard: the
+        // drop only sends a oneshot, so there is nothing to await and nothing
+        // to gain from holding the lock across it. The window it leaves is one
+        // in which the socket is closing and the map already says so, which is
+        // the direction that is safe.
         let removed_socket = state.sockets.remove(id);
         drop(state);
         drop(removed_socket);
@@ -380,7 +378,9 @@ impl Registry {
             }
             // A Slack row whose inbound switch was turned off still reloads, and
             // the reload must retire the previous worker rather than leave it
-            // running against a row that no longer wants it.
+            // running against a row that no longer wants it. Removed under the
+            // lock and dropped outside it, exactly as [`Registry::stop`] does
+            // and for the same reason.
             None => {
                 let stale = state.sockets.remove(id);
                 drop(state);
@@ -418,6 +418,14 @@ pub async fn start_all(db_path: &Path) -> Result<(), String> {
     // recorded here, so the start that follows is refused instead of orphaning
     // a listener for a row that has just gone.
     let generations = registry().generations();
+    // **Before any worker exists**, so nothing races it. A fresh process hosts
+    // no sockets, so every `inbound_status` in the database is about a
+    // connection that no longer exists — including the `connected` a crash left
+    // behind, which nothing else would ever correct. Each worker writes
+    // `connecting` a moment later; a row that gets no worker is left saying
+    // nothing, which is what the column's default means. See
+    // `slack::socket::clear_all_inbound_status_blocking`.
+    super::slack::socket::clear_all_inbound_status_blocking(db_path);
     let rows = list_for_hosting(db_path)?;
     for row in rows {
         if !row.is_startable() {
@@ -451,10 +459,20 @@ pub async fn reload(db_path: &Path, id: &str) -> Result<(), String> {
     let generation = registry().generation(id);
 
     let Some(row) = get_for_hosting(db_path, id)? else {
-        return Ok(()); // deleted — nothing to start
+        return Ok(()); // deleted — the row is gone, and its status with it
     };
     if !row.is_startable() {
-        return Ok(()); // disabled or not authenticated
+        // Disabled or not authenticated, so no worker will run — and for the
+        // same reason as in `start_one`, the status it left behind is the
+        // registry's to clear.
+        if row.integration_type == "slack" {
+            let (path, id) = (db_path.to_path_buf(), row.id.clone());
+            crate::native::db::blocking("slack inbound clear", move || {
+                super::slack::socket::clear_status_blocking(&path, &id);
+            })
+            .await;
+        }
+        return Ok(());
     }
     start_one(db_path, &row, generation).await
 }
@@ -470,6 +488,19 @@ async fn start_one(db_path: &Path, row: &HostingRow, generation: u64) -> Result<
     let url = server.url().to_string();
     let socket = start_socket_worker(db_path, row);
     let hosted_socket = socket.is_some();
+    // A Slack row that is not getting a worker must not keep the previous
+    // worker's status. **This is the registry's to do and not the worker's**:
+    // a `reload` is a stop followed immediately by a start, so a retiring worker
+    // clearing its own row would race the replacement's `connecting` — and a
+    // compare-and-swap cannot break the tie, because both write the identical
+    // `"connected"`. Here the clear is simply ordered before the start.
+    if row.integration_type == "slack" && !hosted_socket {
+        let (path, id) = (db_path.to_path_buf(), row.id.clone());
+        crate::native::db::blocking("slack inbound clear", move || {
+            super::slack::socket::clear_status_blocking(&path, &id);
+        })
+        .await;
+    }
     if !registry().put_if_current(&row.id, generation, server, socket) {
         log::info!(
             "integration MCP server discarded before it was recorded, \
@@ -1569,14 +1600,69 @@ mod tests {
         assert!(!registry().is_socket_running("sl-off"));
         assert!(!registry().is_socket_running("sl-tokenless"));
 
+        // A status left behind by a worker that is no longer running is the
+        // registry's to clear, because it is the only thing that can tell a stop
+        // from a replacement — see `slack::socket::clear_status_blocking`.
+        let status_of = |id: &str| -> (String, String) {
+            Connection::open(file.path())
+                .expect("open")
+                .query_row(
+                    "SELECT inbound_status, inbound_error FROM integrations WHERE id = ?1",
+                    [id],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+                .expect("read the inbound state")
+        };
+        assert_eq!(
+            status_of("sl-off"),
+            (String::new(), String::new()),
+            "a row with the switch off must not carry an inbound status"
+        );
+
         // Turning the switch off and reloading retires the worker without
-        // touching the hosted server.
+        // touching the hosted server, and takes the status with it.
+        crate::native::integrations::slack::socket::write_status_blocking(
+            file.path(),
+            "sl-on",
+            crate::native::integrations::slack::socket::STATUS_CONNECTED,
+            "",
+        );
         set_inbound(&file, "sl-on", false);
         reload(file.path(), "sl-on").await.expect("reload");
         assert!(registry().is_hosted("sl-on"));
         assert!(
             !registry().is_socket_running("sl-on"),
             "a reload with the switch off must retire the worker"
+        );
+        assert_eq!(
+            status_of("sl-on"),
+            (String::new(), String::new()),
+            "and must not leave `connected` in a row whose worker is gone"
+        );
+
+        // The same for a row that stops being startable at all: disabling the
+        // integration is a second way to end up with no worker.
+        set_inbound(&file, "sl-off", true);
+        reload(file.path(), "sl-off").await.expect("reload");
+        assert!(registry().is_socket_running("sl-off"));
+        Connection::open(file.path())
+            .expect("open")
+            .execute(
+                "UPDATE integrations SET enabled = 0 WHERE id = 'sl-off'",
+                [],
+            )
+            .expect("disable");
+        crate::native::integrations::slack::socket::write_status_blocking(
+            file.path(),
+            "sl-off",
+            crate::native::integrations::slack::socket::STATUS_CONNECTED,
+            "",
+        );
+        reload(file.path(), "sl-off").await.expect("reload");
+        assert_eq!(
+            status_of("sl-off"),
+            (String::new(), String::new()),
+            "a disabled integration must not keep reporting `connected`"
         );
 
         // And back on again.

--- a/src-tauri/src/native/integrations/slack/CLAUDE.md
+++ b/src-tauri/src/native/integrations/slack/CLAUDE.md
@@ -142,9 +142,17 @@ default logs at `debug`.
   the row when they decline to start a worker, ordered before the start rather
   than racing it, and `start_all` clears every Slack row once at boot, before any
   worker exists, which is what corrects a `connected` a crash left behind. The
-  worker's own half is `stopped`: once its handle is dropped, `status_writer`
-  writes nothing more, so a transition queued just before a reload cannot
-  overwrite the replacement's.
+  worker's own half is two checks, and it needs both: `stopped` — set in
+  `SocketWorker::drop` before the shutdown oneshot — is the cheap early exit, and
+  an **epoch re-read inside `status_lock`** is what holds when the drop lands
+  between the check and the write. A `db::blocking` write can sit for the whole
+  five-second `busy_timeout`, which is ample time for a replacement to write
+  `connected` underneath it, and the row would then be stuck on the old worker's
+  last value because a socket that connects and stays connected has no next
+  transition. `status_lock` is global and held across the write, so the two
+  writes are ordered whichever way they arrive and the stale one is a no-op.
+  `clear_status_blocking` deliberately does not take it: the registry clears only
+  where it has already decided no worker will run.
 - **The backoff is re-anchored on the wall clock**, `schedule::runtime`'s rule
   for gocron's reason: `tokio::time::sleep` measures process time, and on a
   suspended machine that is not elapsed wall-clock time, so one long sleep holds

--- a/src-tauri/src/native/integrations/slack/CLAUDE.md
+++ b/src-tauri/src/native/integrations/slack/CLAUDE.md
@@ -151,11 +151,24 @@ default logs at `debug`.
   last value because a socket that connects and stays connected has no next
   transition. `status_lock` is global and held across the write, so the two
   writes are ordered whichever way they arrive and the stale one is a no-op.
-  The registry's own clear takes the same lock **and bumps the epoch**
-  (`clear_status`), because a worker retiring with no replacement claims no new
-  epoch — so without the bump `is_current` still answers `true` for a write of
-  its own already inside `db::blocking`, and the clear could be overwritten by it.
-  Only the boot clear skips both, and only because no worker exists yet.
+- **The epoch is granted by the registry inside `put_if_current`, never taken by
+  the worker**, and that placement is the whole of its correctness. A worker is
+  *built* before the decision — `start_for_type` is `async` and can be slow — and
+  may then be refused on the generation. A worker that claimed its own epoch at
+  spawn could therefore hold a **later** one than the worker that went on to be
+  accepted; `status_writer` would discard every status the accepted worker posted
+  for the rest of the process, freezing the row on whatever it last held.
+  Granting it in the one critical section that decides acceptance makes epoch
+  order and acceptance order the same order by construction. `NOT_ACCEPTED`
+  matches nothing, so a refused worker is silent. `Registry::stop` and the
+  no-worker arm of `put_if_current` retire the epoch under the same lock and hand
+  it to `clear_status`, which refuses to write if something has been accepted
+  since. Only the boot clear skips all of it, because no worker exists yet.
+  `a_refused_socket_never_takes_the_epoch_from_the_accepted_one` is the guard.
+- **`tests/slack_socket.rs` drives workers with no registry, so it grants the
+  epoch itself** (`accepted_worker`), and **every test uses its own integration
+  id** — the epoch map is keyed by id, which is unique in a shipped build and
+  emphatically not across the tests in one binary.
 - **The backoff is re-anchored on the wall clock**, `schedule::runtime`'s rule
   for gocron's reason: `tokio::time::sleep` measures process time, and on a
   suspended machine that is not elapsed wall-clock time, so one long sleep holds

--- a/src-tauri/src/native/integrations/slack/CLAUDE.md
+++ b/src-tauri/src/native/integrations/slack/CLAUDE.md
@@ -169,12 +169,15 @@ default logs at `debug`.
   Granting it in the one critical section that decides acceptance makes epoch
   order and acceptance order the same order by construction. `NOT_ACCEPTED`
   matches nothing, so a refused worker is silent. `Registry::stop` and the
-  no-worker arm of `put_if_current` retire the epoch under the same lock; the one
-  that *hands* it to `clear_status` is **`retire_socket_if_current`**, and the
-  generation check in its name is load-bearing — a start that fails is still a
-  start that may have lost, so retiring unconditionally there would drop a
-  concurrent reload's live worker and then blank its row. `None` means the caller
-  lost and touches nothing. Only the boot clear skips all of it, because no
+  no-worker arm of `put_if_current` retire the epoch under the same lock. Two of
+  those *hand* it on to `clear_status` — that arm, and
+  **`retire_socket_if_current`**; `Registry::stop` discards its own, because a
+  stop is either a delete (the row goes too) or a `reload` that clears on
+  whichever no-worker branch it reaches. The generation check in
+  `retire_socket_if_current`'s name is load-bearing: a start that *fails* is
+  still a start that may have lost, so retiring unconditionally there would drop
+  a concurrent reload's live worker and then blank its row. `None` means the
+  caller lost and touches nothing. Only the boot clear skips all of it, because no
   worker exists yet.
   `a_refused_socket_never_takes_the_epoch_from_the_accepted_one` is the guard.
 - **`tests/slack_socket.rs` drives workers with no registry, so it grants the

--- a/src-tauri/src/native/integrations/slack/CLAUDE.md
+++ b/src-tauri/src/native/integrations/slack/CLAUDE.md
@@ -108,12 +108,13 @@ default logs at `debug`.
   `slack_processed_events` inside an immediate transaction with the row count
   deciding who won, plus the same best-effort 48-hour sweep. A failed claim is
   `false` — never run the agent against a database that could not record it.
-- **A stream that ends without a close frame is a failure, not a polite
-  reconnect.** Only an explicit `disconnect` envelope or a `Close` frame is
-  `Requested`. Calling a dropped TCP connection polite would reset the
-  consecutive-failure counter, so a flapping gateway would be retried every base
-  wait forever, with `inbound_status` never reaching `error` and nothing telling
-  the user anything is wrong.
+- **Only an explicit `disconnect` envelope is a polite reconnect.** A stream
+  that ends without a close frame is a failure, and so is a `Close` frame that no
+  `disconnect` preceded — Slack's own reconnect sends `disconnect` first, so
+  reaching either means the gateway went away on us. Calling those polite would
+  reset the consecutive-failure counter, so a gateway that keeps dropping or
+  keeps closing would be retried every base wait forever, with `inbound_status`
+  never reaching `error` and nothing telling the user anything is wrong.
 - **A session that stayed up resets the counter even though it failed.** The
   counter is about a gateway that will not have us, not about a laptop lid:
   without this a socket that runs for hours and dies on a suspend adds one to a

--- a/src-tauri/src/native/integrations/slack/CLAUDE.md
+++ b/src-tauri/src/native/integrations/slack/CLAUDE.md
@@ -109,10 +109,42 @@ default logs at `debug`.
   deciding who won, plus the same best-effort 48-hour sweep. A failed claim is
   `false` — never run the agent against a database that could not record it.
 - **A stream that ends without a close frame is a failure, not a polite
-  reconnect.** Only an explicit `disconnect` envelope or a `Close` frame resets
-  the consecutive-failure counter. Calling a dropped TCP connection `Requested`
-  would retry a flapping gateway every second forever, with `inbound_status`
-  never reaching `error` and nothing telling the user anything is wrong.
+  reconnect.** Only an explicit `disconnect` envelope or a `Close` frame is
+  `Requested`. Calling a dropped TCP connection polite would reset the
+  consecutive-failure counter, so a flapping gateway would be retried every base
+  wait forever, with `inbound_status` never reaching `error` and nothing telling
+  the user anything is wrong.
+- **A session that stayed up resets the counter even though it failed.** The
+  counter is about a gateway that will not have us, not about a laptop lid:
+  without this a socket that runs for hours and dies on a suspend adds one to a
+  number that never comes back down, so an integration that has worked all week
+  reads `error` on its fifth lifetime drop and reconnects only once a minute
+  after. The bar is `max_backoff`, which is the one value that cannot produce a
+  hot loop — an attempt that outlived the longest wait the schedule would ever
+  impose costs at most one base wait to retry, whatever it does next.
+- **A read with no deadline is how an outage becomes invisible.** A half-open
+  connection — a suspended laptop, a rebinding NAT — delivers no FIN and no RST,
+  so `next()` never completes and the worker parks with the row still reading
+  `connected`. `idle_timeout` is what turns that into a reconnect. Slack's own
+  pings are traffic, so a healthy connection never approaches it.
+- **No database write is ever awaited on the task that reads the socket.**
+  `db::open_read_write` carries a five-second `busy_timeout`, so one write meeting
+  the session scanner's batch writer would leave the *next* envelope unread and
+  unacknowledged for that whole window — past the seconds Slack waits before
+  redelivering. The dedup claim lives inside `dispatch`'s `tokio::spawn`, and
+  every status transition is *posted* to `status_writer`, a single consumer so
+  the writes stay ordered: a `connected` overtaking the `reconnecting` that
+  followed it would leave the row lying about a socket that is down.
+- **Clearing the status is the registry's, and writing it is the worker's.** A
+  worker cannot tell a stop from a replacement — a `reload` is a stop followed
+  immediately by a start — and a compare-and-swap cannot break that tie, because
+  both workers write the identical `connected`. So `start_one` and `reload` clear
+  the row when they decline to start a worker, ordered before the start rather
+  than racing it, and `start_all` clears every Slack row once at boot, before any
+  worker exists, which is what corrects a `connected` a crash left behind. The
+  worker's own half is `stopped`: once its handle is dropped, `status_writer`
+  writes nothing more, so a transition queued just before a reload cannot
+  overwrite the replacement's.
 - **The backoff is re-anchored on the wall clock**, `schedule::runtime`'s rule
   for gocron's reason: `tokio::time::sleep` measures process time, and on a
   suspended machine that is not elapsed wall-clock time, so one long sleep holds

--- a/src-tauri/src/native/integrations/slack/CLAUDE.md
+++ b/src-tauri/src/native/integrations/slack/CLAUDE.md
@@ -74,3 +74,67 @@ gone. `reload_after_auth` fires on the write itself.
 It is **best-effort**: a user who closes the dialog before the flow completes is
 still served only at the next boot. #318 owns the OAuth flow itself and is where
 that stops being true.
+
+## Socket Mode: the inbound worker (#567)
+
+`slack/socket.rs` is one tokio task per Slack row that has migration 39's
+`inbound_enabled` set **and** an `xapp-` token in its credentials blob. A
+desktop app has no public URL, so an Events API webhook is not available to it
+and this is the only way a Slack event arrives. What an `app_mention` *does* is
+#568's and reaches the worker as `SocketOptions::handler`; until then the
+default logs at `debug`.
+
+- **Two handles per row, one generation.** `integrations::registry`'s `State`
+  gained a `sockets` map beside `servers`, and `stop` / `put_if_current` move
+  both inside one critical section. Two calls would let a `stop` landing between
+  them keep one half, which for the socket half is a live connection holding the
+  app token of a row the user has just changed. The worker is **not** a seventh
+  entry in `start_for_type`'s starter table: it is a second handle on one of the
+  six, and `start_socket_worker` is where the three conditions are read.
+- **The stored-token check is not redundant with the 422 on `PUT
+  /api/integrations/{id}/inbound`.** That refusal guards the moment the switch
+  goes on; a later `PUT /api/integrations/{id}` can replace the blob with one
+  that has no `app_token`, which is why `clears_inbound` exists — and a row
+  stored before that clearing did still has to start cleanly rather than open a
+  socket with an empty bearer.
+- **The ack comes before everything.** Slack redelivers anything it does not see
+  acknowledged within seconds, so `{"envelope_id": …}` is written to the socket
+  before the dedup claim, before the handler and before any database touch. The
+  handler then runs on `tokio::spawn` under **the trigger dispatcher's**
+  semaphore, which is why `dispatcher::semaphore` is `pub(crate)` rather than
+  this module opening a second bound of ten on the same `claude` subprocesses.
+- **Acknowledged is not processed**, so dedup is separate: `claim_event` is
+  `trigger::receiver::claim_update`'s shape exactly, `INSERT OR IGNORE` into
+  `slack_processed_events` inside an immediate transaction with the row count
+  deciding who won, plus the same best-effort 48-hour sweep. A failed claim is
+  `false` — never run the agent against a database that could not record it.
+- **A stream that ends without a close frame is a failure, not a polite
+  reconnect.** Only an explicit `disconnect` envelope or a `Close` frame resets
+  the consecutive-failure counter. Calling a dropped TCP connection `Requested`
+  would retry a flapping gateway every second forever, with `inbound_status`
+  never reaching `error` and nothing telling the user anything is wrong.
+- **The backoff is re-anchored on the wall clock**, `schedule::runtime`'s rule
+  for gocron's reason: `tokio::time::sleep` measures process time, and on a
+  suspended machine that is not elapsed wall-clock time, so one long sleep holds
+  the socket down for the length of a shut lid *after* the lid opens.
+  `sleep_until` sleeps in one-second slices and re-reads `Utc::now()`. The
+  jitter is additive and bounded at a quarter of the step, deliberately: a
+  jitter wide enough to reorder two adjacent steps would make "the second
+  attempt waits longer than the first" true only most of the time.
+- **A fresh `apps.connections.open` on every attempt** — the `wss://` URL it
+  returns is single-use. `ok` decides there too, not the HTTP status, the same
+  way it does for the seven tools.
+- **`error` is a report, not a stop.** After `failure_threshold` consecutive
+  failures the status reads `error` and the worker keeps retrying, so an expired
+  token the user then fixes reconnects without a restart. A refusal from
+  `apps.connections.open` **never** clears the stored credential: that is
+  `token_validate::clear_auth`'s decision, on a route a person asked for.
+- **The status write touches two columns and no more.** `inbound_status` and
+  `inbound_error`, never `updated_at` and never the switch — #566 left that
+  contract, and a worker reconnecting hourly would otherwise keep moving the
+  record's timestamp for something the user did not do.
+- **`SocketOptions` is a struct rather than a `#[cfg(test)]` override**, because
+  `tests/slack_socket.rs` is a separate binary and a `cfg(test)` seam in the
+  library is invisible to it. `SocketOptions::default` reads
+  `client::api_base()`, so an in-crate `registry` test still drives the whole
+  start path through the existing seam.

--- a/src-tauri/src/native/integrations/slack/CLAUDE.md
+++ b/src-tauri/src/native/integrations/slack/CLAUDE.md
@@ -150,8 +150,15 @@ default logs at `debug`.
   five-second `busy_timeout`, which is ample time for a replacement to write
   `connected` underneath it, and the row would then be stuck on the old worker's
   last value because a socket that connects and stays connected has no next
-  transition. `status_lock` is global and held across the write, so the two
-  writes are ordered whichever way they arrive and the stale one is a no-op.
+  transition. `status_lock` is held across the write, so the two writes are
+  ordered whichever way they arrive and the stale one is a no-op. It is keyed
+  **per integration id**, not one lock for the process: what needs ordering is
+  the writes to one row, and a global lock additionally makes one integration's
+  slow write — `busy_timeout` allows five seconds of slow — delay every other
+  integration's reporting. That is not theoretical; a global lock is what made
+  `tests/slack_socket.rs` flake, because two of its tests hold a write lock for a
+  second and a half on purpose and every other worker's status queued behind
+  them.
 - **The epoch is granted by the registry inside `put_if_current`, never taken by
   the worker**, and that placement is the whole of its correctness. A worker is
   *built* before the decision — `start_for_type` is `async` and can be slow — and
@@ -162,9 +169,13 @@ default logs at `debug`.
   Granting it in the one critical section that decides acceptance makes epoch
   order and acceptance order the same order by construction. `NOT_ACCEPTED`
   matches nothing, so a refused worker is silent. `Registry::stop` and the
-  no-worker arm of `put_if_current` retire the epoch under the same lock and hand
-  it to `clear_status`, which refuses to write if something has been accepted
-  since. Only the boot clear skips all of it, because no worker exists yet.
+  no-worker arm of `put_if_current` retire the epoch under the same lock; the one
+  that *hands* it to `clear_status` is **`retire_socket_if_current`**, and the
+  generation check in its name is load-bearing — a start that fails is still a
+  start that may have lost, so retiring unconditionally there would drop a
+  concurrent reload's live worker and then blank its row. `None` means the caller
+  lost and touches nothing. Only the boot clear skips all of it, because no
+  worker exists yet.
   `a_refused_socket_never_takes_the_epoch_from_the_accepted_one` is the guard.
 - **`tests/slack_socket.rs` drives workers with no registry, so it grants the
   epoch itself** (`accepted_worker`), and **every test uses its own integration

--- a/src-tauri/src/native/integrations/slack/CLAUDE.md
+++ b/src-tauri/src/native/integrations/slack/CLAUDE.md
@@ -151,8 +151,11 @@ default logs at `debug`.
   last value because a socket that connects and stays connected has no next
   transition. `status_lock` is global and held across the write, so the two
   writes are ordered whichever way they arrive and the stale one is a no-op.
-  `clear_status_blocking` deliberately does not take it: the registry clears only
-  where it has already decided no worker will run.
+  The registry's own clear takes the same lock **and bumps the epoch**
+  (`clear_status`), because a worker retiring with no replacement claims no new
+  epoch — so without the bump `is_current` still answers `true` for a write of
+  its own already inside `db::blocking`, and the clear could be overwritten by it.
+  Only the boot clear skips both, and only because no worker exists yet.
 - **The backoff is re-anchored on the wall clock**, `schedule::runtime`'s rule
   for gocron's reason: `tokio::time::sleep` measures process time, and on a
   suspended machine that is not elapsed wall-clock time, so one long sleep holds

--- a/src-tauri/src/native/integrations/slack/mod.rs
+++ b/src-tauri/src/native/integrations/slack/mod.rs
@@ -58,6 +58,7 @@
 
 pub mod client;
 pub mod messaging;
+pub mod socket;
 pub mod validate;
 
 #[cfg(test)]

--- a/src-tauri/src/native/integrations/slack/socket.rs
+++ b/src-tauri/src/native/integrations/slack/socket.rs
@@ -331,12 +331,14 @@ fn status_lock() -> &'static tokio::sync::Mutex<()> {
     LOCK.get_or_init(Default::default)
 }
 
-/// Take the next epoch for this integration. The caller is now the current
-/// worker, and every earlier one is stale.
+/// The map key: a NUL between the two parts, which no path and no integration
+/// id contains, so no pair can spell another pair's key.
 fn epoch_key(db_path: &Path, integration_id: &str) -> String {
     format!("{}\u{0}{integration_id}", db_path.display())
 }
 
+/// Take the next epoch for this row. The caller is now the current worker, and
+/// every earlier one is stale.
 fn claim_epoch(db_path: &Path, integration_id: &str) -> u64 {
     let mut epochs = epochs().lock().unwrap_or_else(|e| e.into_inner());
     let epoch = epochs
@@ -906,18 +908,39 @@ pub fn write_status_blocking(db_path: &Path, integration_id: &str, status: &str,
 /// the one place that knows whether a socket is going away or being replaced —
 /// it is the code that decides — so it owns the clear, ordered against the start
 /// rather than racing it.
+/// **Callers other than [`clear_status`] must already hold [`status_lock`].**
+/// The one exception is boot, where no worker exists to order against.
 pub fn clear_status_blocking(db_path: &Path, integration_id: &str) {
-    // Deliberately **not** behind [`status_lock`]. The registry clears only
-    // where it has already decided no worker will run — `start_one` and `reload`
-    // do it before the start that might follow — so there is no concurrent
-    // writer to order against, and taking an async lock from a `_blocking`
-    // helper would mean this could not be called from `db::blocking` at all.
     run_status_write(
         db_path,
         "UPDATE integrations SET inbound_status = '', inbound_error = '' WHERE id = ?1",
         rusqlite::params![integration_id],
         integration_id,
     );
+}
+
+/// Clear one row's inbound state, ordered against any status write already in
+/// flight.
+///
+/// **Both halves are load-bearing, and the epoch is the half that is easy to
+/// miss.** A `status_writer` that has already passed its `stopped` and
+/// `is_current` checks is sitting inside `db::blocking` for as long as the
+/// five-second `busy_timeout` allows — and a worker that retires *without a
+/// replacement* claims no new epoch, so `is_current` still answers `true` for
+/// it. Bumping the epoch here is what retires that writer; holding the lock
+/// across the bump and the clear is what makes a writer that got there first
+/// finish before the clear rather than after it. Either one alone leaves the row
+/// able to end up reading `connected` with no worker running, which nothing
+/// would ever correct — a socket that connects and stays connected has no next
+/// transition.
+pub async fn clear_status(db_path: &Path, integration_id: &str) {
+    let _guard = status_lock().lock().await;
+    claim_epoch(db_path, integration_id);
+    let (path, id) = (db_path.to_path_buf(), integration_id.to_string());
+    db::blocking("slack inbound clear", move || {
+        clear_status_blocking(&path, &id);
+    })
+    .await;
 }
 
 /// Clear the inbound state of **every** Slack row. Boot only.

--- a/src-tauri/src/native/integrations/slack/socket.rs
+++ b/src-tauri/src/native/integrations/slack/socket.rs
@@ -249,6 +249,10 @@ pub fn start(
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
     let (status_tx, status_rx) = tokio::sync::mpsc::unbounded_channel::<StatusMsg>();
     let stopped = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    // Taken here, not in the spawned writer: a worker is the current one from
+    // the moment it is started, and a writer that claimed lazily could be
+    // scheduled after its own replacement's.
+    let epoch = claim_epoch(db_path, integration_id);
     let task = Worker {
         db_path: db_path.to_path_buf(),
         integration_id: integration_id.to_string(),
@@ -261,6 +265,7 @@ pub fn start(
     tokio::spawn(status_writer(
         db_path.to_path_buf(),
         id.clone(),
+        epoch,
         Arc::clone(&stopped),
         status_rx,
     ));
@@ -285,6 +290,70 @@ struct Worker {
     /// worker never awaits a database write, because the thread that would wait
     /// is the one reading the socket.
     status: tokio::sync::mpsc::UnboundedSender<StatusMsg>,
+}
+
+/// Which worker's status writes still count, per row.
+///
+/// Bumped by [`claim_epoch`] on every [`start`], so a worker that has been
+/// replaced can tell. A plain `std` mutex: the section is a map lookup, and
+/// nothing awaits inside it.
+///
+/// **Keyed by the database as well as the id**, because that pair is what
+/// identifies the row a worker writes to. In a shipped build there is one
+/// database and the distinction never arises; in `cargo test` it is the whole
+/// difference between workers that replace each other and workers that merely
+/// share a name, and the test binaries run in one process.
+fn epochs() -> &'static std::sync::Mutex<std::collections::HashMap<String, u64>> {
+    static EPOCHS: std::sync::OnceLock<std::sync::Mutex<std::collections::HashMap<String, u64>>> =
+        std::sync::OnceLock::new();
+    EPOCHS.get_or_init(Default::default)
+}
+
+/// Serializes every status write in the process, **and the epoch check that
+/// guards it**.
+///
+/// The two have to be one critical section or the check proves nothing: a
+/// retiring worker's [`StatusMsg`] can pass a `stopped` test and then sit inside
+/// a `db::blocking` write for as long as the five-second `busy_timeout` allows,
+/// which is ample time for its replacement to write `connected` underneath it.
+/// The row would then be stuck on the old worker's last value, because on a
+/// socket that connects and stays connected there is no next transition to
+/// correct it. Holding this across the write makes the two writes ordered, and
+/// re-reading the epoch inside it makes a stale one a no-op whichever order they
+/// arrive in.
+///
+/// Global rather than per-integration because a status transition happens a
+/// handful of times per connection lifetime and a machine has one or two Slack
+/// integrations; a map of mutexes would be more code for a queue that is
+/// essentially always empty. Nothing on the socket's read path waits here.
+fn status_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(Default::default)
+}
+
+/// Take the next epoch for this integration. The caller is now the current
+/// worker, and every earlier one is stale.
+fn epoch_key(db_path: &Path, integration_id: &str) -> String {
+    format!("{}\u{0}{integration_id}", db_path.display())
+}
+
+fn claim_epoch(db_path: &Path, integration_id: &str) -> u64 {
+    let mut epochs = epochs().lock().unwrap_or_else(|e| e.into_inner());
+    let epoch = epochs
+        .entry(epoch_key(db_path, integration_id))
+        .or_default();
+    *epoch += 1;
+    *epoch
+}
+
+fn is_current(db_path: &Path, integration_id: &str, epoch: u64) -> bool {
+    epochs()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(&epoch_key(db_path, integration_id))
+        .copied()
+        .unwrap_or_default()
+        == epoch
 }
 
 /// One thing to record about the connection.
@@ -318,11 +387,19 @@ struct StatusMsg {
 async fn status_writer(
     db_path: PathBuf,
     integration_id: String,
+    epoch: u64,
     stopped: Arc<std::sync::atomic::AtomicBool>,
     mut rx: tokio::sync::mpsc::UnboundedReceiver<StatusMsg>,
 ) {
     while let Some(StatusMsg { status, error }) = rx.recv().await {
         if stopped.load(std::sync::atomic::Ordering::SeqCst) {
+            continue;
+        }
+        let _guard = status_lock().lock().await;
+        // Re-read *inside* the lock. `stopped` above is the cheap early exit for
+        // the ordinary case; this is the one that holds when the drop lands
+        // between the two.
+        if !is_current(&db_path, &integration_id, epoch) {
             continue;
         }
         let (path, id) = (db_path.clone(), integration_id.clone());
@@ -830,6 +907,11 @@ pub fn write_status_blocking(db_path: &Path, integration_id: &str, status: &str,
 /// it is the code that decides — so it owns the clear, ordered against the start
 /// rather than racing it.
 pub fn clear_status_blocking(db_path: &Path, integration_id: &str) {
+    // Deliberately **not** behind [`status_lock`]. The registry clears only
+    // where it has already decided no worker will run — `start_one` and `reload`
+    // do it before the start that might follow — so there is no concurrent
+    // writer to order against, and taking an async lock from a `_blocking`
+    // helper would mean this could not be called from `db::blocking` at all.
     run_status_write(
         db_path,
         "UPDATE integrations SET inbound_status = '', inbound_error = '' WHERE id = ?1",
@@ -974,6 +1056,43 @@ mod tests {
                 "the cap plus its jitter is the ceiling: {waits:?}"
             );
         }
+    }
+
+    /// Starting a worker makes every earlier one for that integration stale,
+    /// and leaves other integrations alone.
+    ///
+    /// This is the half of the retiring-worker race that can be asserted
+    /// directly. The interleaving it defends against — a status write already
+    /// inside `db::blocking` when its replacement starts — is driven by
+    /// `a_stopped_worker_writes_no_more_status` over a real socket; what is
+    /// pinned here is that the epoch actually distinguishes the two workers,
+    /// which is what makes the check inside `status_lock` mean anything.
+    #[test]
+    fn starting_a_worker_makes_every_earlier_one_for_that_integration_stale() {
+        let one = std::path::Path::new("/tmp/epoch-test/one.db");
+        let two = std::path::Path::new("/tmp/epoch-test/two.db");
+
+        let a = claim_epoch(one, "s1");
+        assert!(is_current(one, "s1", a));
+
+        let b = claim_epoch(one, "s1");
+        assert_ne!(a, b, "each start takes its own epoch");
+        assert!(!is_current(one, "s1", a), "the replaced worker is stale");
+        assert!(is_current(one, "s1", b));
+
+        // A different integration's starts do not move this one.
+        let other = claim_epoch(one, "s2");
+        assert!(is_current(one, "s1", b));
+        assert!(is_current(one, "s2", other));
+
+        // Neither does the same id against a different database — the pair is
+        // the identity, and two suites' `s1` are not the same row.
+        let elsewhere = claim_epoch(two, "s1");
+        assert!(is_current(one, "s1", b));
+        assert!(is_current(two, "s1", elsewhere));
+
+        // An id nothing ever claimed is at epoch 0, so no live worker matches.
+        assert!(!is_current(one, "never", b));
     }
 
     /// A boot clears every Slack row's inbound state and nothing else's.

--- a/src-tauri/src/native/integrations/slack/socket.rs
+++ b/src-tauri/src/native/integrations/slack/socket.rs
@@ -1,0 +1,874 @@
+//! Slack Socket Mode: one long-lived websocket per enabled Slack integration
+//! (#567, epic #562).
+//!
+//! A desktop app has no public URL, so an Events API webhook is not available to
+//! it at all — Socket Mode is the only way a Slack event reaches Agento. This
+//! module is the transport half: open the connection, acknowledge, de-duplicate,
+//! reconnect, and keep `inbound_status`/`inbound_error` current. What an
+//! `app_mention` *does* is #568's, and arrives here as [`SocketOptions::handler`];
+//! the default is a no-op that logs at `debug`.
+//!
+//! # The rules, and why each is a rule
+//!
+//! - **Acknowledge before anything else.** Slack expects `{"envelope_id": …}`
+//!   within seconds and redelivers the envelope otherwise, so the ack is written
+//!   to the socket before the claim, before the handler, and before any database
+//!   touch. The handler then runs on `tokio::spawn` under the trigger
+//!   dispatcher's semaphore, which is why that semaphore is `pub(crate)` rather
+//!   than this module opening a second bound on the same agent runs.
+//! - **De-duplicate by `event_id`.** An unacknowledged envelope is redelivered,
+//!   and a reconnect can replay one, so "acknowledged" is not "processed".
+//!   [`claim_event`] is `trigger::receiver::claim_update`'s shape exactly —
+//!   `INSERT OR IGNORE` inside an immediate transaction, the row count deciding
+//!   who won, plus the same best-effort 48-hour sweep.
+//! - **Back off on the wall clock, not on `tokio::time`.** A capped doubling
+//!   schedule re-anchored against `Utc::now()`, for the reason
+//!   `schedule::runtime`'s `advance_past_now` re-anchors: a suspended laptop
+//!   does not advance a `tokio::time::sleep` on every platform, and a reconnect
+//!   that waits out a shut lid is an integration that is silently down long
+//!   after the machine is back.
+//! - **A fresh `apps.connections.open` on every attempt.** The `wss://` URL it
+//!   returns is single-use; reconnecting to the previous one fails.
+//! - **The status is a stored value, not a log line.** `inbound_status` walks
+//!   `connecting` → `connected` → `reconnecting` → `error`, with
+//!   `inbound_error` carrying the last reason, so the UI can show an outage
+//!   rather than the user discovering it by being ignored. That is the
+//!   gateway's `BindFailed` reasoning (`gateway/registry.rs`), applied to a
+//!   value the UI already reads.
+//! - **`error` still retries.** It is the *reported* state after
+//!   [`SocketOptions::failure_threshold`] consecutive failures, not a stop: an
+//!   expired token that the user then fixes must reconnect without a restart. A
+//!   401 from `apps.connections.open` is reported and **never** clears the
+//!   stored credential — that is `token_validate::clear_auth`'s decision to
+//!   make, on a route a person asked for.
+//! - **Nothing blocking on the runtime.** Every database touch goes through
+//!   [`db::blocking`]; `a_socket_workers_contended_write_lock_does_not_stall_the_runtime`
+//!   in `tests/slack_socket.rs` is the copy of that rule for this task.
+//! - **The `xapp-` token is read once and captured into the task.** It is never
+//!   logged, never formatted into an error, and this module derives no `Debug`
+//!   that could carry it.
+
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use futures_util::SinkExt;
+use tokio_stream::StreamExt;
+use tokio_tungstenite::tungstenite::Message;
+
+use crate::native::db;
+
+/// `inbound_status` while an attempt is in flight and nothing has succeeded yet.
+pub const STATUS_CONNECTING: &str = "connecting";
+/// `inbound_status` for a live socket.
+pub const STATUS_CONNECTED: &str = "connected";
+/// `inbound_status` between a drop and the next successful connect.
+pub const STATUS_RECONNECTING: &str = "reconnecting";
+/// `inbound_status` after [`SocketOptions::failure_threshold`] consecutive
+/// failures. **Still retrying** — see the module header.
+pub const STATUS_ERROR: &str = "error";
+
+/// The first backoff wait.
+const DEFAULT_BASE_BACKOFF: Duration = Duration::from_secs(1);
+/// The ceiling the doubling stops at.
+const DEFAULT_MAX_BACKOFF: Duration = Duration::from_secs(60);
+/// Consecutive failed attempts before the status is reported as `error`.
+const DEFAULT_FAILURE_THRESHOLD: u32 = 5;
+/// How long `apps.connections.open` may take. Shorter than the Slack client's
+/// sixty seconds: this call is on the reconnect path, and a request that hangs
+/// is a worker that is not backing off.
+const OPEN_TIMEOUT: Duration = Duration::from_secs(30);
+/// The largest chunk of a backoff wait spent inside one `tokio::time::sleep`.
+/// See [`sleep_until`] — the point is to re-read the wall clock often.
+const SLEEP_CHUNK: Duration = Duration::from_secs(1);
+/// How long the sweep keeps a processed `event_id`. `claim_update`'s horizon.
+const DEDUP_HORIZON_HOURS: i64 = 48;
+
+/// One `app_mention` event, as much of it as the transport can see.
+///
+/// Deliberately not the raw payload: #568 decides what an `app_mention` does,
+/// and giving it the fields Slack always sends keeps the parse in one place.
+/// No `Debug` is derived on the worker's own state, but this carries no
+/// credential and a handler will want to log it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppMention {
+    /// The integration whose socket delivered it.
+    pub integration_id: String,
+    /// `event.channel`.
+    pub channel: String,
+    /// `event.user`.
+    pub user: String,
+    /// `event.text`, with the leading `<@bot>` mention left in.
+    pub text: String,
+    /// `event.ts` — the message's own timestamp, and its id within the channel.
+    pub ts: String,
+    /// `event.thread_ts`, empty when the mention is not in a thread.
+    pub thread_ts: String,
+    /// The envelope's `payload.event_id`, which is what dedup claims.
+    pub event_id: String,
+}
+
+/// What runs after the ack. Returns a future so a handler may await — #568's
+/// does, since it starts an agent run.
+pub type EventHandler =
+    Arc<dyn Fn(AppMention) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
+
+/// Everything about a worker that a test needs to move and production does not.
+///
+/// A plain struct rather than a `#[cfg(test)]` override like
+/// [`client::API_BASE`](super::client): `tests/slack_socket.rs` is a separate
+/// binary, so a `cfg(test)` seam inside the library is invisible to it, and the
+/// alternative — an environment variable, as `AGENTO_CLAUDE_EXECUTABLE` is —
+/// would be process-wide state for something each worker can simply be handed.
+/// Production builds exactly one of these, [`SocketOptions::default`].
+#[derive(Clone)]
+pub struct SocketOptions {
+    /// Where `apps.connections.open` lives. Slack's own base by default.
+    pub api_base: String,
+    /// The first backoff wait; each consecutive failure doubles it.
+    pub base_backoff: Duration,
+    /// The ceiling the doubling stops at.
+    pub max_backoff: Duration,
+    /// Consecutive failures before the status is reported as `error`.
+    pub failure_threshold: u32,
+    /// What an `app_mention` does. The default logs at `debug` and returns.
+    pub handler: EventHandler,
+}
+
+impl Default for SocketOptions {
+    fn default() -> Self {
+        Self {
+            api_base: default_api_base(),
+            base_backoff: DEFAULT_BASE_BACKOFF,
+            max_backoff: DEFAULT_MAX_BACKOFF,
+            failure_threshold: DEFAULT_FAILURE_THRESHOLD,
+            handler: default_handler(),
+        }
+    }
+}
+
+/// Slack's own base, and in an in-crate test whatever
+/// [`client::API_BASE`](super::client) has been pointed at — so a `registry`
+/// test can drive the whole start path, which builds its options with
+/// [`SocketOptions::default`], without reaching the real `slack.com`.
+fn default_api_base() -> String {
+    super::client::api_base()
+}
+
+/// #568 replaces this. Until then an `app_mention` is observed and dropped, at
+/// `debug` so a user who turns inbound on can see the transport working without
+/// anything acting on their messages.
+fn default_handler() -> EventHandler {
+    Arc::new(|mention: AppMention| {
+        Box::pin(async move {
+            log::debug!(
+                "slack socket: app_mention integration_id={:?} channel={:?} event_id={:?}",
+                mention.integration_id,
+                mention.channel,
+                mention.event_id
+            );
+        })
+    })
+}
+
+/// A running Socket Mode worker. **Dropping it stops the worker**, which is the
+/// discipline the whole `integrations::registry` is built on: the handle *is*
+/// the cancel, so there is no second map of cancel functions to keep in step.
+///
+/// The stop is prompt at every point of the loop — the connect, the read and the
+/// backoff wait all select on the same oneshot — so a `stop` landing mid-connect
+/// abandons the attempt rather than leaving a socket holding a credential.
+pub struct SocketWorker {
+    /// `Option` only so `Drop` can take it; always `Some` while alive.
+    shutdown: Option<tokio::sync::oneshot::Sender<()>>,
+    integration_id: String,
+}
+
+impl Drop for SocketWorker {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+        log::info!(
+            "slack socket worker stopped: integration_id={:?}",
+            self.integration_id
+        );
+    }
+}
+
+/// Start a worker. Returns as soon as the task is spawned — the connect happens
+/// inside it.
+///
+/// **Returning before the first connect is the point.** The caller is
+/// `registry::start_one`, which has to record the handle under the generation it
+/// read; awaiting a connection first would hold that decision open for however
+/// long Slack takes, and a `stop` in that window would have nothing to drop.
+pub fn start(
+    db_path: &Path,
+    integration_id: &str,
+    app_token: &str,
+    options: SocketOptions,
+) -> SocketWorker {
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let task = Worker {
+        db_path: db_path.to_path_buf(),
+        integration_id: integration_id.to_string(),
+        // Read once from `HostingRow` and captured here. It does not leave.
+        app_token: app_token.to_string(),
+        options,
+    };
+    let id = integration_id.to_string();
+    tokio::spawn(async move { task.run(shutdown_rx).await });
+    log::info!("slack socket worker started: integration_id={id:?}");
+    SocketWorker {
+        shutdown: Some(shutdown_tx),
+        integration_id: id,
+    }
+}
+
+/// The task's own state. Derives nothing: [`Self::app_token`] is a secret and a
+/// `{self:?}` in a log line is the same leak with a longer fuse — the rule
+/// `registry::HostingRow` already states for the blob this came out of.
+struct Worker {
+    db_path: PathBuf,
+    integration_id: String,
+    app_token: String,
+    options: SocketOptions,
+}
+
+/// Why an inner session ended. Both reconnect; they differ only in what the
+/// status says while the next attempt runs.
+enum SessionEnd {
+    /// Slack asked us to reconnect (a `disconnect` envelope), or the socket
+    /// closed cleanly. Not a failure — the consecutive counter resets.
+    Requested,
+    /// The socket died. The reason is user-visible.
+    Failed(String),
+}
+
+impl Worker {
+    async fn run(self, mut shutdown: tokio::sync::oneshot::Receiver<()>) {
+        // Consecutive *failed* attempts. Reset by any established connection,
+        // which is what makes a nightly `disconnect` — Slack rotates its
+        // gateways — cost one base wait rather than an ever-growing one.
+        let mut failures: u32 = 0;
+        self.write_status(STATUS_CONNECTING, "").await;
+
+        loop {
+            let outcome = tokio::select! {
+                biased;
+                _ = &mut shutdown => return,
+                outcome = self.session() => outcome,
+            };
+
+            match outcome {
+                Ok(SessionEnd::Requested) => {
+                    failures = 0;
+                    self.write_status(STATUS_RECONNECTING, "").await;
+                }
+                Ok(SessionEnd::Failed(reason)) | Err(reason) => {
+                    failures = failures.saturating_add(1);
+                    let status = if failures >= self.options.failure_threshold {
+                        STATUS_ERROR
+                    } else {
+                        STATUS_RECONNECTING
+                    };
+                    log::warn!(
+                        "slack socket: integration_id={:?} attempt={failures} status={status}: {reason}",
+                        self.integration_id
+                    );
+                    self.write_status(status, &reason).await;
+                }
+            }
+
+            let wait = backoff_for(
+                failures,
+                self.options.base_backoff,
+                self.options.max_backoff,
+                jitter_ratio(),
+            );
+            let deadline = Utc::now() + chrono::Duration::from_std(wait).unwrap_or_default();
+            if sleep_until(deadline, &mut shutdown).await.is_break() {
+                return;
+            }
+        }
+    }
+
+    /// One attempt: open a connection and pump it until it ends.
+    async fn session(&self) -> Result<SessionEnd, String> {
+        let url = self.open_connection().await?;
+        let (mut socket, _) =
+            tokio::time::timeout(OPEN_TIMEOUT, tokio_tungstenite::connect_async(url.as_str()))
+                .await
+                .map_err(|_| "opening the socket mode connection timed out".to_string())?
+                .map_err(|e| format!("opening the socket mode connection: {e}"))?;
+
+        self.write_status(STATUS_CONNECTED, "").await;
+
+        while let Some(frame) = socket.next().await {
+            let frame = match frame {
+                Ok(frame) => frame,
+                Err(e) => return Ok(SessionEnd::Failed(format!("reading the socket: {e}"))),
+            };
+            let text = match frame {
+                Message::Text(text) => text.to_string(),
+                Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => continue,
+                // Slack sends no binary frames; one is not a reason to drop the
+                // connection, only to say nothing was understood.
+                Message::Binary(_) => continue,
+                Message::Close(_) => return Ok(SessionEnd::Requested),
+            };
+
+            let Some(envelope) = Envelope::parse(&text) else {
+                log::warn!(
+                    "slack socket: integration_id={:?}: an envelope did not parse",
+                    self.integration_id
+                );
+                continue;
+            };
+
+            // **The ack comes first, before the claim and before the handler.**
+            // Slack redelivers anything unacknowledged within seconds, and the
+            // handler starts an agent run — orders of magnitude longer.
+            if let Some(envelope_id) = envelope.envelope_id.as_deref() {
+                let ack = format!(
+                    "{{\"envelope_id\":{}}}",
+                    serde_json::Value::String(envelope_id.to_string())
+                );
+                if let Err(e) = socket.send(Message::text(ack)).await {
+                    return Ok(SessionEnd::Failed(format!(
+                        "acknowledging an envelope: {e}"
+                    )));
+                }
+            }
+
+            if envelope.kind == "disconnect" {
+                log::info!(
+                    "slack socket: integration_id={:?}: slack asked for a reconnect ({})",
+                    self.integration_id,
+                    envelope.reason
+                );
+                return Ok(SessionEnd::Requested);
+            }
+
+            if let Some(mention) = envelope.app_mention(&self.integration_id) {
+                self.dispatch(mention).await;
+            }
+        }
+
+        // **The stream ending without a close frame is a failure, not a polite
+        // reconnect.** It is what a dropped TCP connection looks like from
+        // here, and calling it `Requested` would reset the consecutive-failure
+        // counter — so a gateway that keeps dropping us would be retried every
+        // second forever, with `inbound_status` never reaching `error` and
+        // nothing telling the user anything is wrong.
+        Ok(SessionEnd::Failed(
+            "the connection closed without a disconnect".to_string(),
+        ))
+    }
+
+    /// Claim the event, then run the handler under the trigger dispatcher's
+    /// semaphore.
+    ///
+    /// Spawned rather than awaited: the socket has to go back to reading, or the
+    /// next envelope waits out an agent run and Slack redelivers it.
+    async fn dispatch(&self, mention: AppMention) {
+        let db_path = self.db_path.clone();
+        let integration_id = self.integration_id.clone();
+        let event_id = mention.event_id.clone();
+        let claimed = db::blocking("slack event claim", move || {
+            claim_event(&db_path, &integration_id, &event_id)
+        })
+        .await
+        .unwrap_or(false);
+        if !claimed {
+            log::debug!(
+                "slack socket: integration_id={:?}: event_id={:?} already processed",
+                self.integration_id,
+                mention.event_id
+            );
+            return;
+        }
+
+        let handler = Arc::clone(&self.options.handler);
+        let integration_id = self.integration_id.clone();
+        tokio::spawn(async move {
+            let Ok(_permit) = crate::native::trigger::dispatcher::semaphore()
+                .acquire()
+                .await
+            else {
+                log::warn!(
+                    "dispatcher stopped, dropping slack app_mention integration_id={integration_id:?}"
+                );
+                return;
+            };
+            handler(mention).await;
+        });
+    }
+
+    /// `apps.connections.open` with the app-level token, answering the
+    /// single-use `wss://` URL it hands back.
+    ///
+    /// Slack's own convention, which the six ported tools already follow:
+    /// **`ok` decides, not the HTTP status.** No message here interpolates the
+    /// token; what a failure names is Slack's `error` code or the transport's.
+    async fn open_connection(&self) -> Result<String, String> {
+        let client = super::client::http_client()
+            .ok_or_else(|| "the slack http client could not be built".to_string())?;
+        let url = format!("{}/apps.connections.open", self.options.api_base);
+        let response = tokio::time::timeout(
+            OPEN_TIMEOUT,
+            client
+                .post(&url)
+                .bearer_auth(&self.app_token)
+                .header(
+                    reqwest::header::CONTENT_TYPE,
+                    "application/x-www-form-urlencoded",
+                )
+                .send(),
+        )
+        .await
+        .map_err(|_| "apps.connections.open timed out".to_string())?
+        .map_err(|e| format!("apps.connections.open: {e}"))?;
+
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .map_err(|e| format!("reading apps.connections.open: {e}"))?;
+        let parsed: serde_json::Value = serde_json::from_str(&body)
+            .map_err(|_| format!("apps.connections.open answered {status}, not JSON"))?;
+
+        // **`ok` decides, not the HTTP status** — Slack's own convention, and the
+        // one a port gets backwards, as `slack/CLAUDE.md` records for the seven
+        // tools. A 500 carrying `{"ok":true}` is a success here too.
+        if parsed.get("ok").and_then(serde_json::Value::as_bool) != Some(true) {
+            let reason = parsed
+                .get("error")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("unknown_error");
+            return Err(format!(
+                "apps.connections.open refused the app token: {reason}"
+            ));
+        }
+        parsed
+            .get("url")
+            .and_then(serde_json::Value::as_str)
+            .filter(|url| !url.is_empty())
+            .map(str::to_string)
+            .ok_or_else(|| "apps.connections.open returned no url".to_string())
+    }
+
+    /// Write `inbound_status`/`inbound_error`, and **nothing else**.
+    ///
+    /// `updated_at` is deliberately not bumped: a worker rewriting its state on
+    /// every reconnection would keep moving the record's timestamp for something
+    /// the user did not do. `integrations/CLAUDE.md` states that as the contract
+    /// #566 left for this worker.
+    async fn write_status(&self, status: &'static str, error: &str) {
+        let db_path = self.db_path.clone();
+        let id = self.integration_id.clone();
+        let error = error.to_string();
+        db::blocking("slack inbound status", move || {
+            write_status_blocking(&db_path, &id, status, &error);
+        })
+        .await;
+    }
+}
+
+/// The parsed shape of a Socket Mode envelope. Only the fields the transport
+/// acts on; the payload is re-read for the event itself.
+struct Envelope {
+    kind: String,
+    envelope_id: Option<String>,
+    reason: String,
+    payload: serde_json::Value,
+}
+
+impl Envelope {
+    fn parse(text: &str) -> Option<Self> {
+        let value: serde_json::Value = serde_json::from_str(text).ok()?;
+        Some(Self {
+            kind: value
+                .get("type")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            envelope_id: value
+                .get("envelope_id")
+                .and_then(serde_json::Value::as_str)
+                .filter(|id| !id.is_empty())
+                .map(str::to_string),
+            reason: value
+                .get("reason")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            payload: value
+                .get("payload")
+                .cloned()
+                .unwrap_or(serde_json::Value::Null),
+        })
+    }
+
+    /// The envelope's `app_mention`, or `None` for every other event.
+    ///
+    /// **Every other Slack event type is out of scope** (#567's *Out of Scope*),
+    /// and silently: a workspace sends dozens of event types Agento subscribes
+    /// to by accident, and each one is still acknowledged above — dropping it
+    /// here rather than at the ack is what keeps Slack from redelivering it.
+    fn app_mention(&self, integration_id: &str) -> Option<AppMention> {
+        if self.kind != "events_api" {
+            return None;
+        }
+        let event = self.payload.get("event")?;
+        if event.get("type").and_then(serde_json::Value::as_str)? != "app_mention" {
+            return None;
+        }
+        let text_field = |value: &serde_json::Value, key: &str| {
+            value
+                .get(key)
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_string()
+        };
+        let event_id = self
+            .payload
+            .get("event_id")
+            .and_then(serde_json::Value::as_str)
+            .filter(|id| !id.is_empty())?
+            .to_string();
+        Some(AppMention {
+            integration_id: integration_id.to_string(),
+            channel: text_field(event, "channel"),
+            user: text_field(event, "user"),
+            text: text_field(event, "text"),
+            ts: text_field(event, "ts"),
+            thread_ts: text_field(event, "thread_ts"),
+            event_id,
+        })
+    }
+}
+
+/// `true` when this event is new and has now been claimed.
+///
+/// `trigger::receiver::claim_update`'s shape, with a TEXT `event_id` instead of
+/// an integer `update_id`. The claim is atomic — `INSERT OR IGNORE` inside an
+/// immediate transaction, the row count deciding who won — because an envelope
+/// redelivered while the first delivery's handler is still running would
+/// otherwise start the agent twice, and Socket Mode redelivers anything it does
+/// not see acknowledged.
+///
+/// A failure to record is `false`: do not run the agent against a database that
+/// could not record the run.
+pub fn claim_event(db_path: &Path, integration_id: &str, event_id: &str) -> bool {
+    let claim = || -> Result<bool, String> {
+        let mut conn = db::open_read_write(db_path)?;
+        let tx = conn
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+            .map_err(|e| format!("begin slack event claim: {e}"))?;
+        let now = crate::native::gotime::now_go_text();
+        let inserted = tx
+            .execute(
+                "INSERT OR IGNORE INTO slack_processed_events
+                    (integration_id, event_id, processed_at)
+                 VALUES (?1, ?2, ?3)",
+                rusqlite::params![integration_id, event_id, now],
+            )
+            .map_err(|e| format!("marking a slack event as processed: {e}"))?;
+
+        // The same best-effort 48-hour sweep `claim_update` does, and ignored
+        // the same way: a full table is a slow claim, never a wrong one.
+        let cutoff = crate::native::gotime::go_string_from_millis(
+            (Utc::now() - chrono::Duration::hours(DEDUP_HORIZON_HOURS)).timestamp_millis(),
+        );
+        let _ = tx.execute(
+            "DELETE FROM slack_processed_events WHERE processed_at < ?1",
+            [&cutoff],
+        );
+
+        tx.commit()
+            .map_err(|e| format!("commit slack event claim: {e}"))?;
+        Ok(inserted > 0)
+    };
+    match claim() {
+        Ok(claimed) => claimed,
+        Err(e) => {
+            log::error!(
+                "failed to claim slack event integration_id={integration_id:?} \
+                 event_id={event_id:?} error={e}"
+            );
+            false
+        }
+    }
+}
+
+/// `UPDATE integrations SET inbound_status, inbound_error`. Public so a test can
+/// read the contract back; nothing on the wire calls it.
+pub fn write_status_blocking(db_path: &Path, integration_id: &str, status: &str, error: &str) {
+    let write = || -> Result<(), String> {
+        let conn = db::open_read_write(db_path)?;
+        conn.execute(
+            "UPDATE integrations SET inbound_status = ?1, inbound_error = ?2 WHERE id = ?3",
+            rusqlite::params![status, error, integration_id],
+        )
+        .map_err(|e| format!("saving the inbound status: {e}"))?;
+        Ok(())
+    };
+    if let Err(e) = write() {
+        log::error!(
+            "failed to record the slack inbound status integration_id={integration_id:?} \
+             status={status:?} error={e}"
+        );
+    }
+}
+
+/// The wait before attempt `failures + 1`: `base * 2^failures`, capped, plus up
+/// to a quarter of itself as jitter.
+///
+/// `failures == 0` is the reconnect after a *successful* session and gets the
+/// base wait; every consecutive failure doubles it. The jitter is additive and
+/// bounded above by `ratio < 0.25 * step`, which is what keeps the schedule
+/// **strictly increasing** below the cap — two workers reconnecting in lockstep
+/// is what jitter is for, and a jitter wide enough to reorder two steps would
+/// make "the second attempt waits longer than the first" untrue.
+fn backoff_for(failures: u32, base: Duration, max: Duration, ratio: f64) -> Duration {
+    let step = base
+        .checked_mul(1u32.checked_shl(failures.min(31)).unwrap_or(u32::MAX))
+        .unwrap_or(max)
+        .min(max);
+    let jitter = step.mul_f64(ratio.clamp(0.0, 1.0) * 0.25);
+    step.saturating_add(jitter)
+}
+
+/// A cheap, dependency-free source of jitter in `[0, 1)`.
+///
+/// `rand` is in the lockfile (via `rmcp`) but not a direct dependency, and this
+/// needs no distribution guarantees at all — only that two processes waking at
+/// the same instant do not pick the same wait. The nanosecond field of the wall
+/// clock is exactly that.
+fn jitter_ratio() -> f64 {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(0);
+    f64::from(nanos) / 1_000_000_000.0
+}
+
+/// Wait until a **wall-clock** instant, or until the worker is stopped.
+///
+/// `tokio::time::sleep` measures elapsed process time, and on a suspended
+/// machine that is not elapsed wall-clock time — the same difference
+/// `schedule::runtime` re-anchors against with `advance_past_now`, quoting
+/// gocron's own "the machine went to sleep, and woke up some time later". A
+/// single long sleep would therefore hold the socket down for the length of a
+/// shut lid *after* the lid opens. Sleeping in [`SLEEP_CHUNK`] slices and
+/// re-reading `Utc::now()` each time bounds that error at one chunk.
+///
+/// `Break` means the worker was stopped and must return.
+async fn sleep_until(
+    deadline: DateTime<Utc>,
+    shutdown: &mut tokio::sync::oneshot::Receiver<()>,
+) -> std::ops::ControlFlow<()> {
+    loop {
+        let remaining = deadline - Utc::now();
+        if remaining <= chrono::Duration::zero() {
+            return std::ops::ControlFlow::Continue(());
+        }
+        let chunk = remaining.to_std().unwrap_or(SLEEP_CHUNK).min(SLEEP_CHUNK);
+        tokio::select! {
+            biased;
+            _ = &mut *shutdown => return std::ops::ControlFlow::Break(()),
+            () = tokio::time::sleep(chunk) => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn db() -> tempfile::NamedTempFile {
+        let file = tempfile::NamedTempFile::new().expect("temp file");
+        let mut conn = rusqlite::Connection::open(file.path()).expect("open");
+        crate::native::migrate::apply(&mut conn).expect("migrate");
+        file
+    }
+
+    /// The property the reconnect test in `tests/slack_socket.rs` observes over
+    /// a socket, asserted here over the schedule itself — deterministically, at
+    /// every jitter value rather than the one the clock happened to produce.
+    ///
+    /// A wider jitter would break it: at `± step` two adjacent steps overlap,
+    /// and "the second attempt waits longer than the first" becomes true only
+    /// most of the time, which is the shape of a test that passes in CI and
+    /// fails on someone's laptop.
+    #[test]
+    fn the_backoff_doubles_to_a_cap_and_never_goes_backwards() {
+        let base = Duration::from_secs(1);
+        let max = Duration::from_secs(60);
+        for ratio in [0.0, 0.25, 0.5, 0.999] {
+            let waits: Vec<Duration> = (0..10).map(|n| backoff_for(n, base, max, ratio)).collect();
+            for pair in waits.windows(2) {
+                assert!(
+                    pair[1] >= pair[0],
+                    "the schedule went backwards at ratio {ratio}: {waits:?}"
+                );
+            }
+            assert!(
+                waits[1] > waits[0],
+                "the second wait must be strictly longer than the first at ratio {ratio}: {waits:?}"
+            );
+            assert!(
+                *waits.last().expect("ten waits") <= max.mul_f64(1.25),
+                "the cap plus its jitter is the ceiling: {waits:?}"
+            );
+        }
+    }
+
+    /// The cap is a cap: a very large failure count must neither overflow nor
+    /// wrap back to a short wait, which is how a shift-based doubling fails.
+    #[test]
+    fn a_runaway_failure_count_still_waits_the_cap_and_no_more() {
+        let max = Duration::from_secs(60);
+        for failures in [31u32, 32, 64, u32::MAX] {
+            let wait = backoff_for(failures, Duration::from_secs(1), max, 0.0);
+            assert_eq!(wait, max, "failures={failures} left the cap");
+        }
+    }
+
+    /// `INSERT OR IGNORE` claims once. The second call is the redelivery Socket
+    /// Mode makes when it does not see an ack, and it must not reach a handler.
+    #[test]
+    fn an_event_is_claimed_once_per_integration() {
+        let file = db();
+        assert!(
+            claim_event(file.path(), "int-1", "Ev1"),
+            "the first delivery"
+        );
+        assert!(!claim_event(file.path(), "int-1", "Ev1"), "a redelivery");
+        assert!(
+            claim_event(file.path(), "int-2", "Ev1"),
+            "another integration is a different event"
+        );
+    }
+
+    /// The status write touches two columns and no others. `updated_at` is the
+    /// one that matters: a worker that reconnects hourly would otherwise keep
+    /// moving the record's timestamp for something the user did not do.
+    #[test]
+    fn a_status_write_moves_neither_updated_at_nor_the_switch() {
+        let file = db();
+        let conn = rusqlite::Connection::open(file.path()).expect("open");
+        conn.execute(
+            "INSERT INTO integrations
+                (id, name, type, enabled, credentials, services, created_at, updated_at,
+                 inbound_enabled, inbound_status, inbound_error)
+             VALUES ('s1', 'S', 'slack', 1, '{}', '{}', 'then', 'then', 1, '', '')",
+            [],
+        )
+        .expect("seed");
+        drop(conn);
+
+        write_status_blocking(file.path(), "s1", STATUS_ERROR, "invalid_auth");
+
+        let conn = rusqlite::Connection::open(file.path()).expect("reopen");
+        let (status, error, updated, enabled): (String, String, String, i64) = conn
+            .query_row(
+                "SELECT inbound_status, inbound_error, updated_at, inbound_enabled
+                 FROM integrations WHERE id = 's1'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .expect("read back");
+        assert_eq!(status, STATUS_ERROR);
+        assert_eq!(error, "invalid_auth");
+        assert_eq!(updated, "then", "the status write must not bump updated_at");
+        assert_eq!(enabled, 1, "the status write must not touch the switch");
+    }
+
+    /// Only `app_mention` inside an `events_api` envelope becomes work, and an
+    /// event with no `event_id` is not dispatched at all — dedup has nothing to
+    /// claim for it, so it would run again on every redelivery.
+    #[test]
+    fn only_an_app_mention_carrying_an_event_id_becomes_work() {
+        let mention = Envelope::parse(
+            r#"{"type":"events_api","envelope_id":"e1","payload":{"event_id":"Ev1",
+                "event":{"type":"app_mention","channel":"C1","user":"U1","text":"hi",
+                         "ts":"1.1","thread_ts":"1.0"}}}"#,
+        )
+        .expect("parse")
+        .app_mention("int-1")
+        .expect("an app_mention");
+        assert_eq!(mention.event_id, "Ev1");
+        assert_eq!(mention.channel, "C1");
+        assert_eq!(mention.thread_ts, "1.0");
+
+        let not_work = [
+            // A different event type.
+            r#"{"type":"events_api","payload":{"event_id":"Ev2","event":{"type":"message"}}}"#,
+            // An app_mention with no event_id to claim.
+            r#"{"type":"events_api","payload":{"event":{"type":"app_mention"}}}"#,
+            // A control envelope.
+            r#"{"type":"hello"}"#,
+            r#"{"type":"disconnect","reason":"refresh_requested"}"#,
+        ];
+        for text in not_work {
+            assert!(
+                Envelope::parse(text)
+                    .expect("parse")
+                    .app_mention("int-1")
+                    .is_none(),
+                "{text} must not become work"
+            );
+        }
+    }
+
+    /// A `thread_ts` that Slack omits is the empty string, not a missing field
+    /// that drops the whole mention — a top-level mention is the common case.
+    #[test]
+    fn a_mention_outside_a_thread_carries_an_empty_thread_ts() {
+        let mention = Envelope::parse(
+            r#"{"type":"events_api","envelope_id":"e1","payload":{"event_id":"Ev1",
+                "event":{"type":"app_mention","channel":"C1","user":"U1","text":"hi","ts":"1.1"}}}"#,
+        )
+        .expect("parse")
+        .app_mention("int-1")
+        .expect("an app_mention");
+        assert_eq!(mention.thread_ts, "");
+    }
+
+    /// An envelope id is JSON-encoded rather than interpolated. Slack's ids are
+    /// UUIDs, but the ack is a document and building it with `format!` on a
+    /// value from the network is how a quote in it becomes a broken frame.
+    #[test]
+    fn an_envelope_id_is_json_encoded_into_the_ack() {
+        let ack = format!(
+            "{{\"envelope_id\":{}}}",
+            serde_json::Value::String("a\"b".to_string())
+        );
+        assert_eq!(ack, r#"{"envelope_id":"a\"b"}"#);
+        let parsed: serde_json::Value = serde_json::from_str(&ack).expect("valid json");
+        assert_eq!(parsed["envelope_id"], "a\"b");
+    }
+
+    /// The default handler is what ships until #568, and the thing it must not
+    /// do is anything: no database touch, no reply, no panic.
+    #[tokio::test]
+    async fn the_default_handler_does_nothing_at_all() {
+        let handler = default_handler();
+        handler(AppMention {
+            integration_id: "int-1".into(),
+            channel: "C1".into(),
+            user: "U1".into(),
+            text: "hi".into(),
+            ts: "1.1".into(),
+            thread_ts: String::new(),
+            event_id: "Ev1".into(),
+        })
+        .await;
+    }
+}

--- a/src-tauri/src/native/integrations/slack/socket.rs
+++ b/src-tauri/src/native/integrations/slack/socket.rs
@@ -316,8 +316,8 @@ struct Worker {
     status: tokio::sync::mpsc::UnboundedSender<StatusMsg>,
 }
 
-/// Serializes every status write in the process, **and the epoch check that
-/// guards it**.
+/// Serializes the status writes **of one integration**, and the epoch check that
+/// guards them.
 ///
 /// The two have to be one critical section or the check proves nothing: a
 /// retiring worker's [`StatusMsg`] can pass a `stopped` test and then sit inside
@@ -329,13 +329,29 @@ struct Worker {
 /// re-reading the epoch inside it makes a stale one a no-op whichever order they
 /// arrive in.
 ///
-/// Global rather than per-integration because a status transition happens a
-/// handful of times per connection lifetime and a machine has one or two Slack
-/// integrations; a map of mutexes would be more code for a queue that is
-/// essentially always empty. Nothing on the socket's read path waits here.
-fn status_lock() -> &'static tokio::sync::Mutex<()> {
-    static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
-    LOCK.get_or_init(Default::default)
+/// **Per integration, not one lock for the process.** What needs ordering is the
+/// writes to *one row*; a single global lock would additionally make one
+/// integration's slow write — and `busy_timeout` allows five seconds of slow —
+/// delay every other integration's status reporting, which is the column being
+/// wrong about a socket that is fine. It is also what made
+/// `tests/slack_socket.rs` flake: eleven workers share that binary, two of them
+/// hold a write lock for a second and a half on purpose, and a global lock
+/// propagated those stalls to every other test's status writes.
+///
+/// The map grows with the number of distinct integration ids the process has
+/// ever hosted, which is the same bound the registry's own maps carry. Nothing
+/// on the socket's read path waits here.
+fn status_lock(integration_id: &str) -> Arc<tokio::sync::Mutex<()>> {
+    static LOCKS: std::sync::OnceLock<
+        std::sync::Mutex<std::collections::HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
+    > = std::sync::OnceLock::new();
+    LOCKS
+        .get_or_init(Default::default)
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .entry(integration_id.to_string())
+        .or_default()
+        .clone()
 }
 
 /// One thing to record about the connection.
@@ -390,7 +406,8 @@ async fn status_writer(
         if stopped.load(std::sync::atomic::Ordering::SeqCst) {
             continue;
         }
-        let _guard = status_lock().lock().await;
+        let lock = status_lock(&integration_id);
+        let _guard = lock.lock().await;
         // Re-read *inside* the lock. `stopped` above is the cheap early exit for
         // the ordinary case; this is the one that holds when the drop lands
         // between the two.
@@ -913,7 +930,8 @@ pub fn write_status_blocking(db_path: &Path, integration_id: &str, status: &str,
 /// the one place that knows whether a socket is going away or being replaced —
 /// it is the code that decides — so it owns the clear, ordered against the start
 /// rather than racing it.
-/// **Callers other than [`clear_status`] must already hold [`status_lock`].**
+/// **Callers other than [`clear_status`] must already hold this row's
+/// [`status_lock`].**
 /// The one exception is boot, where no worker exists to order against.
 pub fn clear_status_blocking(db_path: &Path, integration_id: &str) {
     run_status_write(
@@ -939,7 +957,8 @@ pub fn clear_status_blocking(db_path: &Path, integration_id: &str) {
 /// would ever correct — a socket that connects and stays connected has no next
 /// transition.
 pub async fn clear_status(db_path: &Path, integration_id: &str, epoch: u64) {
-    let _guard = status_lock().lock().await;
+    let lock = status_lock(integration_id);
+    let _guard = lock.lock().await;
     // The registry took `epoch` when it retired the worker, under its own lock.
     // If something has been accepted since, that acceptance took a later one and
     // this clear is about a decision that has been superseded — writing it would

--- a/src-tauri/src/native/integrations/slack/socket.rs
+++ b/src-tauri/src/native/integrations/slack/socket.rs
@@ -651,11 +651,7 @@ impl Worker {
             // Slack redelivers anything unacknowledged within seconds, and the
             // handler starts an agent run — orders of magnitude longer.
             if let Some(envelope_id) = envelope.envelope_id.as_deref() {
-                let ack = format!(
-                    "{{\"envelope_id\":{}}}",
-                    serde_json::Value::String(envelope_id.to_string())
-                );
-                if let Err(e) = socket.send(Message::text(ack)).await {
+                if let Err(e) = socket.send(Message::text(ack_frame(envelope_id))).await {
                     return SessionEnd::Failed(format!("acknowledging an envelope: {e}"));
                 }
             }
@@ -776,6 +772,20 @@ impl Worker {
             .map(str::to_string)
             .ok_or_else(|| "apps.connections.open returned no url".to_string())
     }
+}
+
+/// The acknowledgement for one envelope.
+///
+/// **JSON-encoded rather than interpolated**, because the id comes off the
+/// network: `format!`ing a quote straight into a document is how a frame Slack
+/// cannot parse gets sent, and an unparsed ack is a redelivery. Its own function
+/// so the test that pins the escaping calls the same code the socket sends —
+/// a test that re-typed the expression would pass against a reverted fix.
+fn ack_frame(envelope_id: &str) -> String {
+    format!(
+        "{{\"envelope_id\":{}}}",
+        serde_json::Value::String(envelope_id.to_string())
+    )
 }
 
 /// The parsed shape of a Socket Mode envelope. Only the fields the transport
@@ -1278,16 +1288,21 @@ mod tests {
 
     /// An envelope id is JSON-encoded rather than interpolated. Slack's ids are
     /// UUIDs, but the ack is a document and building it with `format!` on a
-    /// value from the network is how a quote in it becomes a broken frame.
+    /// value from the network is how a quote in it becomes a broken frame — and
+    /// a frame Slack cannot parse is an unacknowledged envelope, so it comes
+    /// back.
+    ///
+    /// Calls [`ack_frame`] rather than re-typing it, which is the difference
+    /// between a regression guard and a copy that agrees with itself.
     #[test]
     fn an_envelope_id_is_json_encoded_into_the_ack() {
-        let ack = format!(
-            "{{\"envelope_id\":{}}}",
-            serde_json::Value::String("a\"b".to_string())
-        );
+        let ack = ack_frame("a\"b");
         assert_eq!(ack, r#"{"envelope_id":"a\"b"}"#);
         let parsed: serde_json::Value = serde_json::from_str(&ack).expect("valid json");
         assert_eq!(parsed["envelope_id"], "a\"b");
+
+        // And the ordinary case is still exactly what Slack expects.
+        assert_eq!(ack_frame("Env0001"), r#"{"envelope_id":"Env0001"}"#);
     }
 
     /// The default handler is what ships until #568, and the thing it must not

--- a/src-tauri/src/native/integrations/slack/socket.rs
+++ b/src-tauri/src/native/integrations/slack/socket.rs
@@ -29,6 +29,10 @@
 //!   after the machine is back.
 //! - **A fresh `apps.connections.open` on every attempt.** The `wss://` URL it
 //!   returns is single-use; reconnecting to the previous one fails.
+//! - **A read has a deadline.** A half-open connection delivers no FIN and no
+//!   RST, so a read without one parks the worker forever with the row still
+//!   reading `connected` — the silent outage the stored status exists to
+//!   prevent. [`SocketOptions::idle_timeout`] turns it into a reconnect.
 //! - **The status is a stored value, not a log line.** `inbound_status` walks
 //!   `connecting` → `connected` → `reconnecting` → `error`, with
 //!   `inbound_error` carrying the last reason, so the UI can show an outage
@@ -41,9 +45,19 @@
 //!   401 from `apps.connections.open` is reported and **never** clears the
 //!   stored credential — that is `token_validate::clear_auth`'s decision to
 //!   make, on a route a person asked for.
-//! - **Nothing blocking on the runtime.** Every database touch goes through
-//!   [`db::blocking`]; `a_socket_workers_contended_write_lock_does_not_stall_the_runtime`
-//!   in `tests/slack_socket.rs` is the copy of that rule for this task.
+//! - **Nothing blocking on the runtime, and nothing blocking on the socket
+//!   either.** Every database touch goes through [`db::blocking`], which keeps
+//!   it off a runtime worker — and no write is ever *awaited* on the task that
+//!   reads the socket, which is a second rule with a second reason: the
+//!   five-second `busy_timeout` that makes an inline write a stalled runtime
+//!   also makes it an unacknowledged envelope. The claim is inside
+//!   [`Worker::dispatch`]'s spawn and the status goes through
+//!   [`status_writer`]. `a_socket_workers_contended_write_lock_does_not_stall_the_runtime`
+//!   and `a_stalled_claim_does_not_hold_up_the_next_envelope` in
+//!   `tests/slack_socket.rs` are the two halves.
+//! - **Clearing the status belongs to `integrations::registry`, not here.** A
+//!   worker cannot tell a stop from a replacement; see
+//!   [`clear_status_blocking`].
 //! - **The `xapp-` token is read once and captured into the task.** It is never
 //!   logged, never formatted into an error, and this module derives no `Debug`
 //!   that could carry it.
@@ -77,6 +91,15 @@ const DEFAULT_BASE_BACKOFF: Duration = Duration::from_secs(1);
 const DEFAULT_MAX_BACKOFF: Duration = Duration::from_secs(60);
 /// Consecutive failed attempts before the status is reported as `error`.
 const DEFAULT_FAILURE_THRESHOLD: u32 = 5;
+/// How long a live socket may deliver nothing before it is treated as dead.
+///
+/// Slack's gateway pings a Socket Mode connection well inside this, and
+/// `tungstenite` answers a ping itself while the frame still arrives here as
+/// traffic — so a healthy connection never approaches it. Generous rather than
+/// tight because the cost of being wrong is asymmetric: a reconnect too early
+/// is a fresh `apps.connections.open`, a reconnect too late is an integration
+/// that looks connected and answers nothing.
+const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(90);
 /// How long `apps.connections.open` may take. Shorter than the Slack client's
 /// sixty seconds: this call is on the reconnect path, and a request that hangs
 /// is a worker that is not backing off.
@@ -134,6 +157,9 @@ pub struct SocketOptions {
     pub max_backoff: Duration,
     /// Consecutive failures before the status is reported as `error`.
     pub failure_threshold: u32,
+    /// How long a live socket may deliver nothing at all before it is treated
+    /// as dead. Slack's own pings count as traffic.
+    pub idle_timeout: Duration,
     /// What an `app_mention` does. The default logs at `debug` and returns.
     pub handler: EventHandler,
 }
@@ -145,6 +171,7 @@ impl Default for SocketOptions {
             base_backoff: DEFAULT_BASE_BACKOFF,
             max_backoff: DEFAULT_MAX_BACKOFF,
             failure_threshold: DEFAULT_FAILURE_THRESHOLD,
+            idle_timeout: DEFAULT_IDLE_TIMEOUT,
             handler: default_handler(),
         }
     }
@@ -184,11 +211,18 @@ fn default_handler() -> EventHandler {
 pub struct SocketWorker {
     /// `Option` only so `Drop` can take it; always `Some` while alive.
     shutdown: Option<tokio::sync::oneshot::Sender<()>>,
+    /// Set before the shutdown is sent, and read by [`status_writer`] — see
+    /// there for why a stopped worker must write nothing more.
+    stopped: Arc<std::sync::atomic::AtomicBool>,
     integration_id: String,
 }
 
 impl Drop for SocketWorker {
     fn drop(&mut self) {
+        // **Before** the oneshot, so there is no instant in which the worker
+        // knows it is stopping and the writer does not.
+        self.stopped
+            .store(true, std::sync::atomic::Ordering::SeqCst);
         if let Some(tx) = self.shutdown.take() {
             let _ = tx.send(());
         }
@@ -213,18 +247,28 @@ pub fn start(
     options: SocketOptions,
 ) -> SocketWorker {
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let (status_tx, status_rx) = tokio::sync::mpsc::unbounded_channel::<StatusMsg>();
+    let stopped = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let task = Worker {
         db_path: db_path.to_path_buf(),
         integration_id: integration_id.to_string(),
         // Read once from `HostingRow` and captured here. It does not leave.
         app_token: app_token.to_string(),
         options,
+        status: status_tx,
     };
     let id = integration_id.to_string();
+    tokio::spawn(status_writer(
+        db_path.to_path_buf(),
+        id.clone(),
+        Arc::clone(&stopped),
+        status_rx,
+    ));
     tokio::spawn(async move { task.run(shutdown_rx).await });
     log::info!("slack socket worker started: integration_id={id:?}");
     SocketWorker {
         shutdown: Some(shutdown_tx),
+        stopped,
         integration_id: id,
     }
 }
@@ -237,25 +281,102 @@ struct Worker {
     integration_id: String,
     app_token: String,
     options: SocketOptions,
+    /// Where every status transition is *posted*. See [`status_writer`] — the
+    /// worker never awaits a database write, because the thread that would wait
+    /// is the one reading the socket.
+    status: tokio::sync::mpsc::UnboundedSender<StatusMsg>,
+}
+
+/// One thing to record about the connection.
+struct StatusMsg {
+    status: &'static str,
+    error: String,
+}
+
+/// The one place `inbound_status` is written, and the reason the worker posts
+/// rather than writes.
+///
+/// **Every database touch this module makes would otherwise be on the task that
+/// reads the socket**, and `db::open_read_write` carries a five-second
+/// `busy_timeout` — so awaiting one under a lock held by the session scanner's
+/// batch writer leaves the next envelope unread and unacknowledged for that
+/// whole window, past the seconds Slack waits before redelivering. Posting to a
+/// channel takes the wait off that task; `db::blocking` here keeps it off a
+/// runtime worker as well.
+///
+/// One consumer, so the writes stay **ordered**: a `connected` overtaking the
+/// `reconnecting` that followed it would leave the row lying about a socket that
+/// is down, which is the failure this column exists to prevent. The channel is
+/// unbounded because a transition is rare and dropping one is worse than
+/// queueing it, and the loop ends by draining when the worker drops its sender.
+///
+/// **`stopped` is checked per message, not once.** A `reload` is a stop followed
+/// immediately by a start, and a transition posted just before the stop is still
+/// in this queue; writing it would overwrite the *new* worker's status with the
+/// old worker's last words, and nothing would rewrite it until the next
+/// transition — which on a socket that connects and stays connected is never.
+async fn status_writer(
+    db_path: PathBuf,
+    integration_id: String,
+    stopped: Arc<std::sync::atomic::AtomicBool>,
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<StatusMsg>,
+) {
+    while let Some(StatusMsg { status, error }) = rx.recv().await {
+        if stopped.load(std::sync::atomic::Ordering::SeqCst) {
+            continue;
+        }
+        let (path, id) = (db_path.clone(), integration_id.clone());
+        db::blocking("slack inbound status", move || {
+            write_status_blocking(&path, &id, status, &error);
+        })
+        .await;
+    }
 }
 
 /// Why an inner session ended. Both reconnect; they differ only in what the
 /// status says while the next attempt runs.
 enum SessionEnd {
-    /// Slack asked us to reconnect (a `disconnect` envelope), or the socket
-    /// closed cleanly. Not a failure — the consecutive counter resets.
+    /// Slack asked us to reconnect (a `disconnect` envelope, or a close frame).
+    /// Not a failure — the consecutive counter resets.
     Requested,
     /// The socket died. The reason is user-visible.
     Failed(String),
 }
 
+/// One attempt's result: how it ended, and how long it was actually connected.
+struct SessionOutcome {
+    end: SessionEnd,
+    /// `None` when the attempt never reached an open socket at all — an
+    /// `apps.connections.open` refusal, or a handshake that failed.
+    connected_for: Option<Duration>,
+}
+
+impl SessionOutcome {
+    fn failed(reason: impl Into<String>) -> Self {
+        Self {
+            end: SessionEnd::Failed(reason.into()),
+            connected_for: None,
+        }
+    }
+}
+
+/// Whether the worker's handle has been dropped, without waiting for it.
+///
+/// `Err(Empty)` is the only "still running" answer: the sender is dropped only
+/// by [`SocketWorker::drop`], which always sends first, so both `Ok` and
+/// `Err(Closed)` mean the handle is gone.
+fn is_stopped(shutdown: &mut tokio::sync::oneshot::Receiver<()>) -> bool {
+    !matches!(
+        shutdown.try_recv(),
+        Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+    )
+}
+
 impl Worker {
     async fn run(self, mut shutdown: tokio::sync::oneshot::Receiver<()>) {
-        // Consecutive *failed* attempts. Reset by any established connection,
-        // which is what makes a nightly `disconnect` — Slack rotates its
-        // gateways — cost one base wait rather than an ever-growing one.
+        // Consecutive *failed* attempts, and what was last written about them.
         let mut failures: u32 = 0;
-        self.write_status(STATUS_CONNECTING, "").await;
+        self.post_status(STATUS_CONNECTING, String::new());
 
         loop {
             let outcome = tokio::select! {
@@ -264,13 +385,34 @@ impl Worker {
                 outcome = self.session() => outcome,
             };
 
-            match outcome {
-                Ok(SessionEnd::Requested) => {
+            // **A session that stayed up is not evidence of a problem.** The
+            // counter is about a gateway that will not have us, not about a
+            // laptop lid: without this a socket that runs for hours and dies on
+            // a suspend adds one to a counter that never comes back down, so an
+            // integration that has worked all week reads `error` on its fifth
+            // lifetime drop and reconnects only once a minute thereafter.
+            //
+            // `max_backoff` is the bar, and it is the one value that cannot
+            // produce a hot loop: an attempt that outlived the longest wait this
+            // schedule would ever impose costs at most one base wait to retry,
+            // whatever it does next. A gateway that accepts and closes
+            // immediately keeps escalating, which is the case the counter is
+            // for.
+            let healthy = outcome
+                .connected_for
+                .is_some_and(|held| held >= self.options.max_backoff);
+
+            let (status, reason) = match outcome.end {
+                SessionEnd::Requested => {
                     failures = 0;
-                    self.write_status(STATUS_RECONNECTING, "").await;
+                    (STATUS_RECONNECTING, String::new())
                 }
-                Ok(SessionEnd::Failed(reason)) | Err(reason) => {
-                    failures = failures.saturating_add(1);
+                SessionEnd::Failed(reason) => {
+                    failures = if healthy {
+                        0
+                    } else {
+                        failures.saturating_add(1)
+                    };
                     let status = if failures >= self.options.failure_threshold {
                         STATUS_ERROR
                     } else {
@@ -280,9 +422,19 @@ impl Worker {
                         "slack socket: integration_id={:?} attempt={failures} status={status}: {reason}",
                         self.integration_id
                     );
-                    self.write_status(status, &reason).await;
+                    (status, reason)
                 }
+            };
+
+            // **Do not report anything once stopped.** A `reload` is a stop
+            // followed by a start, so a retiring worker writing here would
+            // overwrite the new worker's `connecting`/`connected` with its own
+            // last words, and nothing would rewrite it until the next
+            // transition — which on a healthy socket is never.
+            if is_stopped(&mut shutdown) {
+                return;
             }
+            self.post_status(status, reason);
 
             let wait = backoff_for(
                 failures,
@@ -297,29 +449,93 @@ impl Worker {
         }
     }
 
+    /// Record a transition. **Never awaited** — see [`status_writer`].
+    fn post_status(&self, status: &'static str, error: String) {
+        let _ = self.status.send(StatusMsg { status, error });
+    }
+
     /// One attempt: open a connection and pump it until it ends.
-    async fn session(&self) -> Result<SessionEnd, String> {
-        let url = self.open_connection().await?;
-        let (mut socket, _) =
-            tokio::time::timeout(OPEN_TIMEOUT, tokio_tungstenite::connect_async(url.as_str()))
-                .await
-                .map_err(|_| "opening the socket mode connection timed out".to_string())?
-                .map_err(|e| format!("opening the socket mode connection: {e}"))?;
+    async fn session(&self) -> SessionOutcome {
+        let url = match self.open_connection().await {
+            Ok(url) => url,
+            Err(e) => return SessionOutcome::failed(e),
+        };
+        // `connect_async` does **no** proxy handling, where `reqwest` reads
+        // `HTTPS_PROXY` and the system settings — so behind an explicitly
+        // configured proxy the call above succeeds and this does not. Reported
+        // on #567's PR rather than widened into it; the `tokio-tungstenite`
+        // paragraph in `Cargo.toml` says the same thing.
+        let opened = match tokio::time::timeout(
+            OPEN_TIMEOUT,
+            tokio_tungstenite::connect_async(url.as_str()),
+        )
+        .await
+        {
+            Err(_) => {
+                return SessionOutcome::failed("opening the socket mode connection timed out")
+            }
+            Ok(Err(e)) => {
+                return SessionOutcome::failed(format!("opening the socket mode connection: {e}"))
+            }
+            Ok(Ok((socket, _))) => socket,
+        };
+        let mut socket = opened;
+        let opened_at = std::time::Instant::now();
 
-        self.write_status(STATUS_CONNECTED, "").await;
+        self.post_status(STATUS_CONNECTED, String::new());
 
-        while let Some(frame) = socket.next().await {
-            let frame = match frame {
-                Ok(frame) => frame,
-                Err(e) => return Ok(SessionEnd::Failed(format!("reading the socket: {e}"))),
+        let end = self.pump(&mut socket).await;
+        SessionOutcome {
+            end,
+            connected_for: Some(opened_at.elapsed()),
+        }
+    }
+
+    /// Read the socket until it ends, acknowledging and dispatching as it goes.
+    async fn pump<S>(&self, socket: &mut S) -> SessionEnd
+    where
+        S: futures_util::Sink<Message, Error = tokio_tungstenite::tungstenite::Error>
+            + tokio_stream::Stream<Item = Result<Message, tokio_tungstenite::tungstenite::Error>>
+            + Unpin,
+    {
+        loop {
+            // **A read with no deadline is how an outage becomes invisible.**
+            // A half-open connection — a suspended laptop, a NAT rebinding, an
+            // address change — delivers no FIN and no RST, so `next()` simply
+            // never completes and the worker parks with `inbound_status` still
+            // reading `connected`. That is exactly the silent failure the
+            // stored status exists to prevent. Slack's own pings are traffic and
+            // reset this, so a healthy connection never reaches it.
+            let frame = match tokio::time::timeout(self.options.idle_timeout, socket.next()).await {
+                Err(_) => {
+                    return SessionEnd::Failed(format!(
+                        "no traffic from slack for {:?}",
+                        self.options.idle_timeout
+                    ))
+                }
+                // **The stream ending without a close frame is a failure, not a
+                // polite reconnect.** It is what a dropped TCP connection looks
+                // like from here, and calling it `Requested` would reset the
+                // consecutive-failure counter — so a gateway that keeps dropping
+                // us would be retried every base wait forever, with
+                // `inbound_status` never reaching `error`.
+                Ok(None) => {
+                    return SessionEnd::Failed(
+                        "the connection closed without a disconnect".to_string(),
+                    )
+                }
+                Ok(Some(Err(e))) => return SessionEnd::Failed(format!("reading the socket: {e}")),
+                Ok(Some(Ok(frame))) => frame,
             };
+
             let text = match frame {
                 Message::Text(text) => text.to_string(),
-                Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => continue,
                 // Slack sends no binary frames; one is not a reason to drop the
                 // connection, only to say nothing was understood.
-                Message::Binary(_) => continue,
-                Message::Close(_) => return Ok(SessionEnd::Requested),
+                Message::Ping(_) | Message::Pong(_) | Message::Frame(_) | Message::Binary(_) => {
+                    continue
+                }
+                Message::Close(_) => return SessionEnd::Requested,
             };
 
             let Some(envelope) = Envelope::parse(&text) else {
@@ -339,9 +555,7 @@ impl Worker {
                     serde_json::Value::String(envelope_id.to_string())
                 );
                 if let Err(e) = socket.send(Message::text(ack)).await {
-                    return Ok(SessionEnd::Failed(format!(
-                        "acknowledging an envelope: {e}"
-                    )));
+                    return SessionEnd::Failed(format!("acknowledging an envelope: {e}"));
                 }
             }
 
@@ -351,57 +565,57 @@ impl Worker {
                     self.integration_id,
                     envelope.reason
                 );
-                return Ok(SessionEnd::Requested);
+                return SessionEnd::Requested;
             }
 
             if let Some(mention) = envelope.app_mention(&self.integration_id) {
-                self.dispatch(mention).await;
+                self.dispatch(mention);
             }
         }
-
-        // **The stream ending without a close frame is a failure, not a polite
-        // reconnect.** It is what a dropped TCP connection looks like from
-        // here, and calling it `Requested` would reset the consecutive-failure
-        // counter — so a gateway that keeps dropping us would be retried every
-        // second forever, with `inbound_status` never reaching `error` and
-        // nothing telling the user anything is wrong.
-        Ok(SessionEnd::Failed(
-            "the connection closed without a disconnect".to_string(),
-        ))
     }
 
     /// Claim the event, then run the handler under the trigger dispatcher's
     /// semaphore.
     ///
-    /// Spawned rather than awaited: the socket has to go back to reading, or the
-    /// next envelope waits out an agent run and Slack redelivers it.
-    async fn dispatch(&self, mention: AppMention) {
+    /// **Nothing here is awaited by the caller, and the claim is inside the
+    /// spawn rather than before it.** The read loop has to go straight back to
+    /// `next()`: `db::open_read_write` carries a five-second `busy_timeout`, so
+    /// a claim awaited on the loop would, under a lock held by the session
+    /// scanner's batch writer, leave the *next* envelope unread and
+    /// unacknowledged for that whole window — which is precisely the window the
+    /// ack-first rule exists to stay inside. The claim itself is unaffected:
+    /// `INSERT OR IGNORE` decides who won whenever it runs.
+    fn dispatch(&self, mention: AppMention) {
         let db_path = self.db_path.clone();
         let integration_id = self.integration_id.clone();
-        let event_id = mention.event_id.clone();
-        let claimed = db::blocking("slack event claim", move || {
-            claim_event(&db_path, &integration_id, &event_id)
-        })
-        .await
-        .unwrap_or(false);
-        if !claimed {
-            log::debug!(
-                "slack socket: integration_id={:?}: event_id={:?} already processed",
-                self.integration_id,
-                mention.event_id
-            );
-            return;
-        }
-
         let handler = Arc::clone(&self.options.handler);
-        let integration_id = self.integration_id.clone();
         tokio::spawn(async move {
+            let (claim_db, claim_id, event_id) = (
+                db_path.clone(),
+                integration_id.clone(),
+                mention.event_id.clone(),
+            );
+            let claimed = db::blocking("slack event claim", move || {
+                claim_event(&claim_db, &claim_id, &event_id)
+            })
+            .await
+            .unwrap_or(false);
+            if !claimed {
+                log::debug!(
+                    "slack socket: integration_id={integration_id:?}: event_id={:?} \
+                     already processed",
+                    mention.event_id
+                );
+                return;
+            }
+
             let Ok(_permit) = crate::native::trigger::dispatcher::semaphore()
                 .acquire()
                 .await
             else {
                 log::warn!(
-                    "dispatcher stopped, dropping slack app_mention integration_id={integration_id:?}"
+                    "dispatcher stopped, dropping slack app_mention \
+                     integration_id={integration_id:?}"
                 );
                 return;
             };
@@ -460,22 +674,6 @@ impl Worker {
             .filter(|url| !url.is_empty())
             .map(str::to_string)
             .ok_or_else(|| "apps.connections.open returned no url".to_string())
-    }
-
-    /// Write `inbound_status`/`inbound_error`, and **nothing else**.
-    ///
-    /// `updated_at` is deliberately not bumped: a worker rewriting its state on
-    /// every reconnection would keep moving the record's timestamp for something
-    /// the user did not do. `integrations/CLAUDE.md` states that as the contract
-    /// #566 left for this worker.
-    async fn write_status(&self, status: &'static str, error: &str) {
-        let db_path = self.db_path.clone();
-        let id = self.integration_id.clone();
-        let error = error.to_string();
-        db::blocking("slack inbound status", move || {
-            write_status_blocking(&db_path, &id, status, &error);
-        })
-        .await;
     }
 }
 
@@ -606,23 +804,72 @@ pub fn claim_event(db_path: &Path, integration_id: &str, event_id: &str) -> bool
     }
 }
 
-/// `UPDATE integrations SET inbound_status, inbound_error`. Public so a test can
-/// read the contract back; nothing on the wire calls it.
+/// `UPDATE integrations SET inbound_status, inbound_error`, and **nothing else**.
+///
+/// `updated_at` is deliberately not bumped: a worker rewriting its state on
+/// every reconnection would keep moving the record's timestamp for something the
+/// user did not do. `integrations/CLAUDE.md` states that as the contract #566
+/// left for this worker.
 pub fn write_status_blocking(db_path: &Path, integration_id: &str, status: &str, error: &str) {
+    run_status_write(
+        db_path,
+        "UPDATE integrations SET inbound_status = ?1, inbound_error = ?2 WHERE id = ?3",
+        rusqlite::params![status, error, integration_id],
+        integration_id,
+    );
+}
+
+/// Clear `inbound_status`/`inbound_error` for one integration.
+///
+/// **The registry calls this, not the worker, and that is the whole point.** A
+/// worker cannot tell a stop from a replacement: a `reload` is a stop followed
+/// immediately by a start, so a retiring worker clearing its own row would race
+/// the new worker's `connecting`, and a compare-and-swap on the value cannot
+/// help because both workers write the identical `"connected"`. The registry is
+/// the one place that knows whether a socket is going away or being replaced —
+/// it is the code that decides — so it owns the clear, ordered against the start
+/// rather than racing it.
+pub fn clear_status_blocking(db_path: &Path, integration_id: &str) {
+    run_status_write(
+        db_path,
+        "UPDATE integrations SET inbound_status = '', inbound_error = '' WHERE id = ?1",
+        rusqlite::params![integration_id],
+        integration_id,
+    );
+}
+
+/// Clear the inbound state of **every** Slack row. Boot only.
+///
+/// A fresh process has no workers, so any status left in the database is about a
+/// connection that no longer exists — including one a crash left reading
+/// `connected`, which nothing else would ever correct. Run once at the top of
+/// `start_all`, before any worker exists to race it; each worker then writes
+/// `connecting` as it starts.
+///
+/// This does erase a stored `error` across a restart, where #566's rule is not
+/// to erase the reason the user is looking at. The difference is that something
+/// is about to re-report it: a row whose token is still bad is answered by its
+/// own worker within a second or two, and a row that gets no worker genuinely
+/// has nothing to say.
+pub fn clear_all_inbound_status_blocking(db_path: &Path) {
+    run_status_write(
+        db_path,
+        "UPDATE integrations SET inbound_status = '', inbound_error = ''
+         WHERE type = 'slack' AND (inbound_status != '' OR inbound_error != '')",
+        rusqlite::params![],
+        "*",
+    );
+}
+
+fn run_status_write(db_path: &Path, sql: &str, params: impl rusqlite::Params, what: &str) {
     let write = || -> Result<(), String> {
         let conn = db::open_read_write(db_path)?;
-        conn.execute(
-            "UPDATE integrations SET inbound_status = ?1, inbound_error = ?2 WHERE id = ?3",
-            rusqlite::params![status, error, integration_id],
-        )
-        .map_err(|e| format!("saving the inbound status: {e}"))?;
+        conn.execute(sql, params)
+            .map_err(|e| format!("writing the inbound status: {e}"))?;
         Ok(())
     };
     if let Err(e) = write() {
-        log::error!(
-            "failed to record the slack inbound status integration_id={integration_id:?} \
-             status={status:?} error={e}"
-        );
+        log::error!("failed to write the slack inbound status integration_id={what:?} error={e}");
     }
 }
 
@@ -727,6 +974,59 @@ mod tests {
                 "the cap plus its jitter is the ceiling: {waits:?}"
             );
         }
+    }
+
+    /// A boot clears every Slack row's inbound state and nothing else's.
+    ///
+    /// A fresh process hosts no sockets, so a `connected` left by a crash is
+    /// about a connection that does not exist and nothing else would ever
+    /// correct it. The `type` scope is the part worth pinning: an `app_token`
+    /// can be stored on any row (no validator rejects an unknown key), so a
+    /// clear that forgot to scope by type would blank a column another
+    /// integration's own inbound half might one day own.
+    #[test]
+    fn a_boot_clears_every_slack_rows_inbound_state_and_no_others() {
+        let file = db();
+        let conn = rusqlite::Connection::open(file.path()).expect("open");
+        for (id, kind) in [("s1", "slack"), ("s2", "slack"), ("t1", "telegram")] {
+            conn.execute(
+                "INSERT INTO integrations
+                    (id, name, type, enabled, credentials, services, created_at, updated_at,
+                     inbound_enabled, inbound_status, inbound_error)
+                 VALUES (?1, ?1, ?2, 1, '{}', '{}', 'then', 'then', 1, 'connected', 'boom')",
+                rusqlite::params![id, kind],
+            )
+            .expect("seed");
+        }
+        drop(conn);
+
+        clear_all_inbound_status_blocking(file.path());
+
+        let conn = rusqlite::Connection::open(file.path()).expect("reopen");
+        let read = |id: &str| -> (String, String, String) {
+            conn.query_row(
+                "SELECT inbound_status, inbound_error, updated_at FROM integrations WHERE id = ?1",
+                [id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("read back")
+        };
+        for id in ["s1", "s2"] {
+            assert_eq!(
+                read(id),
+                (String::new(), String::new(), "then".to_string()),
+                "{id} must be cleared, and its updated_at left alone"
+            );
+        }
+        assert_eq!(
+            read("t1"),
+            (
+                "connected".to_string(),
+                "boom".to_string(),
+                "then".to_string()
+            ),
+            "a non-slack row is not this clear's business"
+        );
     }
 
     /// The cap is a cap: a very large failure count must neither overflow nor

--- a/src-tauri/src/native/integrations/slack/socket.rs
+++ b/src-tauri/src/native/integrations/slack/socket.rs
@@ -55,9 +55,10 @@
 //!   [`status_writer`]. `a_socket_workers_contended_write_lock_does_not_stall_the_runtime`
 //!   and `a_stalled_claim_does_not_hold_up_the_next_envelope` in
 //!   `tests/slack_socket.rs` are the two halves.
-//! - **Clearing the status belongs to `integrations::registry`, not here.** A
-//!   worker cannot tell a stop from a replacement; see
-//!   [`clear_status_blocking`].
+//! - **Clearing the status belongs to `integrations::registry`, and so does
+//!   deciding which worker may report it.** A worker cannot tell a stop from a
+//!   replacement, and it cannot know whether the registry accepted it — see
+//!   [`clear_status_blocking`] and [`status_writer`].
 //! - **The `xapp-` token is read once and captured into the task.** It is never
 //!   logged, never formatted into an error, and this module derives no `Debug`
 //!   that could carry it.
@@ -109,6 +110,10 @@ const OPEN_TIMEOUT: Duration = Duration::from_secs(30);
 const SLEEP_CHUNK: Duration = Duration::from_secs(1);
 /// How long the sweep keeps a processed `event_id`. `claim_update`'s horizon.
 const DEDUP_HORIZON_HOURS: i64 = 48;
+/// The epoch a worker holds until the registry accepts it — see
+/// [`status_writer`]. Epochs are handed out from one upwards, so this matches
+/// nothing and a worker that is built and then refused never writes a status.
+pub(crate) const NOT_ACCEPTED: u64 = 0;
 
 /// One `app_mention` event, as much of it as the transport can see.
 ///
@@ -214,7 +219,26 @@ pub struct SocketWorker {
     /// Set before the shutdown is sent, and read by [`status_writer`] — see
     /// there for why a stopped worker must write nothing more.
     stopped: Arc<std::sync::atomic::AtomicBool>,
+    /// [`NOT_ACCEPTED`] until [`SocketWorker::accept`] is called under the
+    /// registry's lock. See [`status_writer`] for why it is granted there and
+    /// not taken here.
+    epoch: Arc<std::sync::atomic::AtomicU64>,
     integration_id: String,
+}
+
+impl SocketWorker {
+    /// Grant the epoch the registry just took for this id, inside the same
+    /// critical section that recorded the handle.
+    ///
+    /// **`integrations::registry` is the only production caller**, and the
+    /// grant must stay where the acceptance is decided — see [`status_writer`].
+    /// It is `pub` rather than `pub(crate)` because `tests/slack_socket.rs`
+    /// drives a worker without a registry and has to do for itself what the
+    /// registry would do for it; a worker that is never accepted reports
+    /// nothing, which is the correct production behaviour and a silent test.
+    pub fn accept(&self, epoch: u64) {
+        self.epoch.store(epoch, std::sync::atomic::Ordering::SeqCst);
+    }
 }
 
 impl Drop for SocketWorker {
@@ -249,10 +273,9 @@ pub fn start(
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
     let (status_tx, status_rx) = tokio::sync::mpsc::unbounded_channel::<StatusMsg>();
     let stopped = Arc::new(std::sync::atomic::AtomicBool::new(false));
-    // Taken here, not in the spawned writer: a worker is the current one from
-    // the moment it is started, and a writer that claimed lazily could be
-    // scheduled after its own replacement's.
-    let epoch = claim_epoch(db_path, integration_id);
+    // Not claimed here. The registry grants it when it accepts the handle —
+    // see [`status_writer`] for why the two cannot be the same moment.
+    let epoch = Arc::new(std::sync::atomic::AtomicU64::new(NOT_ACCEPTED));
     let task = Worker {
         db_path: db_path.to_path_buf(),
         integration_id: integration_id.to_string(),
@@ -265,7 +288,7 @@ pub fn start(
     tokio::spawn(status_writer(
         db_path.to_path_buf(),
         id.clone(),
-        epoch,
+        Arc::clone(&epoch),
         Arc::clone(&stopped),
         status_rx,
     ));
@@ -274,6 +297,7 @@ pub fn start(
     SocketWorker {
         shutdown: Some(shutdown_tx),
         stopped,
+        epoch,
         integration_id: id,
     }
 }
@@ -290,23 +314,6 @@ struct Worker {
     /// worker never awaits a database write, because the thread that would wait
     /// is the one reading the socket.
     status: tokio::sync::mpsc::UnboundedSender<StatusMsg>,
-}
-
-/// Which worker's status writes still count, per row.
-///
-/// Bumped by [`claim_epoch`] on every [`start`], so a worker that has been
-/// replaced can tell. A plain `std` mutex: the section is a map lookup, and
-/// nothing awaits inside it.
-///
-/// **Keyed by the database as well as the id**, because that pair is what
-/// identifies the row a worker writes to. In a shipped build there is one
-/// database and the distinction never arises; in `cargo test` it is the whole
-/// difference between workers that replace each other and workers that merely
-/// share a name, and the test binaries run in one process.
-fn epochs() -> &'static std::sync::Mutex<std::collections::HashMap<String, u64>> {
-    static EPOCHS: std::sync::OnceLock<std::sync::Mutex<std::collections::HashMap<String, u64>>> =
-        std::sync::OnceLock::new();
-    EPOCHS.get_or_init(Default::default)
 }
 
 /// Serializes every status write in the process, **and the epoch check that
@@ -329,33 +336,6 @@ fn epochs() -> &'static std::sync::Mutex<std::collections::HashMap<String, u64>>
 fn status_lock() -> &'static tokio::sync::Mutex<()> {
     static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
     LOCK.get_or_init(Default::default)
-}
-
-/// The map key: a NUL between the two parts, which no path and no integration
-/// id contains, so no pair can spell another pair's key.
-fn epoch_key(db_path: &Path, integration_id: &str) -> String {
-    format!("{}\u{0}{integration_id}", db_path.display())
-}
-
-/// Take the next epoch for this row. The caller is now the current worker, and
-/// every earlier one is stale.
-fn claim_epoch(db_path: &Path, integration_id: &str) -> u64 {
-    let mut epochs = epochs().lock().unwrap_or_else(|e| e.into_inner());
-    let epoch = epochs
-        .entry(epoch_key(db_path, integration_id))
-        .or_default();
-    *epoch += 1;
-    *epoch
-}
-
-fn is_current(db_path: &Path, integration_id: &str, epoch: u64) -> bool {
-    epochs()
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-        .get(&epoch_key(db_path, integration_id))
-        .copied()
-        .unwrap_or_default()
-        == epoch
 }
 
 /// One thing to record about the connection.
@@ -386,10 +366,23 @@ struct StatusMsg {
 /// in this queue; writing it would overwrite the *new* worker's status with the
 /// old worker's last words, and nothing would rewrite it until the next
 /// transition — which on a socket that connects and stays connected is never.
+///
+/// **The epoch is granted by the registry, not taken here, and that is the whole
+/// of its correctness.** It says *this worker is the one the registry accepted*,
+/// and only the registry can know that: a worker is built before the decision —
+/// `start_for_type` is `async` and can be slow — and `put_if_current` may refuse
+/// it on the generation. A worker that took its own epoch at spawn could
+/// therefore take a **later** one than the worker that went on to be accepted,
+/// and then be refused; every status the accepted worker posted for the rest of
+/// the process would be discarded as stale, freezing the row on whatever it last
+/// held. So the epoch is granted inside the same critical section that records
+/// the handle, which makes epoch order and acceptance order the same order by
+/// construction. A worker that is never accepted keeps [`NOT_ACCEPTED`], which
+/// matches nothing.
 async fn status_writer(
     db_path: PathBuf,
     integration_id: String,
-    epoch: u64,
+    epoch: Arc<std::sync::atomic::AtomicU64>,
     stopped: Arc<std::sync::atomic::AtomicBool>,
     mut rx: tokio::sync::mpsc::UnboundedReceiver<StatusMsg>,
 ) {
@@ -401,7 +394,10 @@ async fn status_writer(
         // Re-read *inside* the lock. `stopped` above is the cheap early exit for
         // the ordinary case; this is the one that holds when the drop lands
         // between the two.
-        if !is_current(&db_path, &integration_id, epoch) {
+        if !super::super::registry::registry().socket_epoch_is_current(
+            &integration_id,
+            epoch.load(std::sync::atomic::Ordering::SeqCst),
+        ) {
             continue;
         }
         let (path, id) = (db_path.clone(), integration_id.clone());
@@ -415,7 +411,7 @@ async fn status_writer(
 /// Why an inner session ended. Both reconnect; they differ only in what the
 /// status says while the next attempt runs.
 enum SessionEnd {
-    /// Slack asked us to reconnect (a `disconnect` envelope, or a close frame).
+    /// Slack asked us to reconnect — a `disconnect` envelope, and only that.
     /// Not a failure — the consecutive counter resets.
     Requested,
     /// The socket died. The reason is user-visible.
@@ -614,7 +610,16 @@ impl Worker {
                 Message::Ping(_) | Message::Pong(_) | Message::Frame(_) | Message::Binary(_) => {
                     continue
                 }
-                Message::Close(_) => return SessionEnd::Requested,
+                // **A close frame with no `disconnect` before it is a
+                // failure.** Slack's own reconnect sends `disconnect` first and
+                // returns above, so reaching here means the gateway closed on
+                // us — and calling that `Requested` would reset the
+                // consecutive-failure counter, leaving a gateway that accepts
+                // and immediately closes in a one-second loop that never
+                // escalates to `error`. Same reasoning as the `Ok(None)` arm.
+                Message::Close(_) => {
+                    return SessionEnd::Failed("slack closed the connection".to_string())
+                }
             };
 
             let Some(envelope) = Envelope::parse(&text) else {
@@ -933,9 +938,15 @@ pub fn clear_status_blocking(db_path: &Path, integration_id: &str) {
 /// able to end up reading `connected` with no worker running, which nothing
 /// would ever correct — a socket that connects and stays connected has no next
 /// transition.
-pub async fn clear_status(db_path: &Path, integration_id: &str) {
+pub async fn clear_status(db_path: &Path, integration_id: &str, epoch: u64) {
     let _guard = status_lock().lock().await;
-    claim_epoch(db_path, integration_id);
+    // The registry took `epoch` when it retired the worker, under its own lock.
+    // If something has been accepted since, that acceptance took a later one and
+    // this clear is about a decision that has been superseded — writing it would
+    // blank the row under a worker that is running.
+    if !super::super::registry::registry().socket_epoch_is_current(integration_id, epoch) {
+        return;
+    }
     let (path, id) = (db_path.to_path_buf(), integration_id.to_string());
     db::blocking("slack inbound clear", move || {
         clear_status_blocking(&path, &id);
@@ -1079,43 +1090,6 @@ mod tests {
                 "the cap plus its jitter is the ceiling: {waits:?}"
             );
         }
-    }
-
-    /// Starting a worker makes every earlier one for that integration stale,
-    /// and leaves other integrations alone.
-    ///
-    /// This is the half of the retiring-worker race that can be asserted
-    /// directly. The interleaving it defends against — a status write already
-    /// inside `db::blocking` when its replacement starts — is driven by
-    /// `a_stopped_worker_writes_no_more_status` over a real socket; what is
-    /// pinned here is that the epoch actually distinguishes the two workers,
-    /// which is what makes the check inside `status_lock` mean anything.
-    #[test]
-    fn starting_a_worker_makes_every_earlier_one_for_that_integration_stale() {
-        let one = std::path::Path::new("/tmp/epoch-test/one.db");
-        let two = std::path::Path::new("/tmp/epoch-test/two.db");
-
-        let a = claim_epoch(one, "s1");
-        assert!(is_current(one, "s1", a));
-
-        let b = claim_epoch(one, "s1");
-        assert_ne!(a, b, "each start takes its own epoch");
-        assert!(!is_current(one, "s1", a), "the replaced worker is stale");
-        assert!(is_current(one, "s1", b));
-
-        // A different integration's starts do not move this one.
-        let other = claim_epoch(one, "s2");
-        assert!(is_current(one, "s1", b));
-        assert!(is_current(one, "s2", other));
-
-        // Neither does the same id against a different database — the pair is
-        // the identity, and two suites' `s1` are not the same row.
-        let elsewhere = claim_epoch(two, "s1");
-        assert!(is_current(one, "s1", b));
-        assert!(is_current(two, "s1", elsewhere));
-
-        // An id nothing ever claimed is at epoch 0, so no live worker matches.
-        assert!(!is_current(one, "never", b));
     }
 
     /// A boot clears every Slack row's inbound state and nothing else's.

--- a/src-tauri/src/native/trigger/dispatcher.rs
+++ b/src-tauri/src/native/trigger/dispatcher.rs
@@ -49,7 +49,13 @@ const RUN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5 * 60);
 /// What Go replies with on every failure path.
 const ERROR_REPLY: &str = "Sorry, something went wrong.";
 
-fn semaphore() -> &'static Semaphore {
+/// `pub(crate)` rather than module-private since #567: Slack's Socket Mode
+/// worker runs its handler under **this** bound, not a second one. Two
+/// semaphores would each be ten, so a workspace busy on both transports could
+/// have twenty agent runs in flight against a limit that says ten — and the
+/// limit is about `claude` subprocesses, which do not care which transport
+/// asked for them.
+pub(crate) fn semaphore() -> &'static Semaphore {
     static SEM: std::sync::OnceLock<Semaphore> = std::sync::OnceLock::new();
     SEM.get_or_init(|| Semaphore::new(MAX_CONCURRENT))
 }

--- a/src-tauri/tests/gateway_engine.rs
+++ b/src-tauri/tests/gateway_engine.rs
@@ -1383,7 +1383,8 @@ async fn free_port() -> u16 {
 
 // ── Startup ordering ─────────────────────────────────────────────────────────
 
-/// The gateway may not start before the credential system it verifies against.
+/// The gateway and the Slack socket worker may not start before the credential
+/// system they verify against, or the database they write to.
 ///
 /// **This is a source assertion, and deliberately so.** The property is about
 /// the order of three calls in one `setup` closure that also creates a database,
@@ -1420,6 +1421,44 @@ fn a_gateway_start_requires_an_installed_keypair() {
         revoked < gateway,
         "the gateway must not be started before the revoked-token set is loaded, \
          or it accepts a revoked token for the length of that window"
+    );
+
+    // #567 put a **second** thing this process opens at boot on the far side of
+    // that install: `integrations::registry::start_all` now starts a Slack
+    // Socket Mode worker per enabled row, and a worker is a listener in every
+    // way that matters here — it is spawned rather than awaited, it holds a
+    // credential, and it begins accepting inbound work the moment it connects.
+    //
+    // Its own hard requirement is `migrate::apply`: the worker's first act is a
+    // `db::blocking` write of `inbound_status`, which is migration 39's column,
+    // so a start above the migrations writes to a schema that does not have it
+    // and reports nothing for the rest of the launch. The credential ordering is
+    // the same rule the gateway follows, kept for the same reason — every
+    // listener this process opens at boot, the gateway's inbound HTTP and
+    // Slack's inbound websocket alike, is on one side of the install, so the
+    // question is answered once rather than argued per listener.
+    let migrate = source
+        .find("migrate::apply")
+        .expect("lib.rs must apply the migrations");
+    let integrations = source
+        .find("integrations::registry::start_all")
+        .expect("lib.rs must start the integrations");
+
+    assert!(
+        migrate < integrations,
+        "the slack socket worker must not be started before the migrations have \
+         run, or its first `inbound_status` write lands on a schema without the \
+         column and the integration reports nothing all launch"
+    );
+    assert!(
+        install < integrations,
+        "the slack socket worker must not be started before the signing keypair \
+         is installed"
+    );
+    assert!(
+        revoked < integrations,
+        "the slack socket worker must not be started before the revoked-token \
+         set is loaded"
     );
 }
 

--- a/src-tauri/tests/slack_socket.rs
+++ b/src-tauri/tests/slack_socket.rs
@@ -1,0 +1,812 @@
+//! The Slack Socket Mode worker, against a fake Slack (#567).
+//!
+//! The fake is two halves of one thing: an `axum` route answering
+//! `apps.connections.open` with a `ws://` URL, and a raw `TcpListener` speaking
+//! websocket through `tokio-tungstenite`'s server side. Both are in-process, for
+//! the reason `tests/gateway_engine.rs` gives for its own fake — there is no
+//! executable to fork, so there is no `python3` to skip on — and, unlike the
+//! three suites that drive a fake Claude CLI, nothing here reaches for
+//! `std::os::unix::fs::PermissionsExt`, so this file is not a new reason
+//! `src-tauri/tests/` cannot compile on Windows.
+//!
+//! **Every await has a deadline.** A worker that never connects and a fake that
+//! never answers look identical to a test that simply waits, so each wait is a
+//! `tokio::time::timeout` whose message names the hang.
+
+use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use agento_lib::native::integrations::slack::socket::{
+    self, AppMention, SocketOptions, STATUS_CONNECTED, STATUS_ERROR, STATUS_RECONNECTING,
+};
+use agento_lib::native::{db, migrate};
+use futures_util::{SinkExt, StreamExt};
+use tokio_tungstenite::tungstenite::Message;
+
+/// The app-level token every fixture stores. Its presence in a captured log is
+/// the leak `a_full_connect_drop_reconnect_cycle_names_nothing_secret` looks for.
+const APP_TOKEN: &str = "xapp-1-A0000000000-1111111111111-secretsecretsecret";
+
+/// Short enough that a three-attempt reconnect test finishes in about two
+/// seconds, long enough that the gaps are unambiguous against scheduler noise.
+const BASE_BACKOFF: Duration = Duration::from_millis(250);
+
+/// What the fake does with one accepted websocket connection, in order.
+#[derive(Clone, Debug)]
+enum Step {
+    /// Send one text frame.
+    Send(String),
+    /// Wait until the worker has acknowledged `n` envelopes in total.
+    AwaitAcks(usize),
+    /// Sleep, holding the connection open.
+    Hold(Duration),
+    /// Drop the TCP connection with no closing handshake — a network drop.
+    Drop,
+}
+
+/// One accepted connection's script. The fake serves them in order; running off
+/// the end holds the connection open forever, which is what a healthy Slack
+/// gateway does.
+type Session = Vec<Step>;
+
+/// A fake Slack: `apps.connections.open` plus the websocket it points at.
+///
+/// Dropping it stops both listeners.
+struct FakeSlack {
+    api_base: String,
+    /// One entry per `apps.connections.open`, at the moment it was answered.
+    opens: Arc<Mutex<Vec<Instant>>>,
+    /// Every `envelope_id` the worker acknowledged, in arrival order.
+    acks: Arc<Mutex<Vec<String>>>,
+    /// Fires on every ack, so a test can wait for one instead of sleeping.
+    acked: Arc<tokio::sync::Notify>,
+    /// Websocket connections currently open. `max_live` is what proves a reload
+    /// left exactly one.
+    live: Arc<AtomicUsize>,
+    max_live: Arc<AtomicUsize>,
+    /// Fires whenever a websocket connection ends, however it ended.
+    closed: Arc<tokio::sync::Notify>,
+    _shutdown: tokio::sync::oneshot::Sender<()>,
+    _ws_shutdown: tokio::sync::oneshot::Sender<()>,
+}
+
+impl FakeSlack {
+    fn opens(&self) -> Vec<Instant> {
+        self.opens.lock().expect("opens lock").clone()
+    }
+
+    fn acks(&self) -> Vec<String> {
+        self.acks.lock().expect("acks lock").clone()
+    }
+}
+
+/// Bind the fake and hand back its base URL.
+///
+/// `refusals` is answered *before* the sessions: each entry is the Slack `error`
+/// code `apps.connections.open` reports with `{"ok":false}`, which is how the
+/// failure-threshold and 401 cases are driven without a socket at all.
+async fn fake_slack(refusals: Vec<String>, sessions: Vec<Session>) -> FakeSlack {
+    let opens: Arc<Mutex<Vec<Instant>>> = Arc::new(Mutex::new(Vec::new()));
+    let acks: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let acked = Arc::new(tokio::sync::Notify::new());
+    let closed = Arc::new(tokio::sync::Notify::new());
+    let live = Arc::new(AtomicUsize::new(0));
+    let max_live = Arc::new(AtomicUsize::new(0));
+    let script: Arc<Mutex<VecDeque<Session>>> = Arc::new(Mutex::new(sessions.into()));
+    let refusals: Arc<Mutex<VecDeque<String>>> = Arc::new(Mutex::new(refusals.into()));
+
+    // The websocket half.
+    let ws_listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind the fake socket mode gateway");
+    let ws_addr = ws_listener.local_addr().expect("ws addr");
+    let (ws_tx, mut ws_rx) = tokio::sync::oneshot::channel::<()>();
+    {
+        let (acks, acked, closed, live, max_live, script) = (
+            Arc::clone(&acks),
+            Arc::clone(&acked),
+            Arc::clone(&closed),
+            Arc::clone(&live),
+            Arc::clone(&max_live),
+            Arc::clone(&script),
+        );
+        tokio::spawn(async move {
+            loop {
+                let stream = tokio::select! {
+                    _ = &mut ws_rx => return,
+                    accepted = ws_listener.accept() => match accepted {
+                        Ok((stream, _)) => stream,
+                        Err(_) => return,
+                    },
+                };
+                let session = script.lock().expect("script lock").pop_front();
+                let (acks, acked, closed, live, max_live) = (
+                    Arc::clone(&acks),
+                    Arc::clone(&acked),
+                    Arc::clone(&closed),
+                    Arc::clone(&live),
+                    Arc::clone(&max_live),
+                );
+                tokio::spawn(async move {
+                    let now = live.fetch_add(1, Ordering::SeqCst) + 1;
+                    max_live.fetch_max(now, Ordering::SeqCst);
+                    serve_session(stream, session.unwrap_or_default(), &acks, &acked).await;
+                    live.fetch_sub(1, Ordering::SeqCst);
+                    closed.notify_waiters();
+                });
+            }
+        });
+    }
+
+    // The `apps.connections.open` half.
+    let ws_url = format!("ws://{ws_addr}/link");
+    let http_opens = Arc::clone(&opens);
+    let app = axum::Router::new().route(
+        "/apps.connections.open",
+        axum::routing::post(move || {
+            let (opens, refusals, ws_url) = (
+                Arc::clone(&http_opens),
+                Arc::clone(&refusals),
+                ws_url.clone(),
+            );
+            async move {
+                opens.lock().expect("opens lock").push(Instant::now());
+                match refusals.lock().expect("refusals lock").pop_front() {
+                    Some(error) => axum::Json(serde_json::json!({"ok": false, "error": error})),
+                    // The URL is single-use in Slack's own protocol, which is
+                    // why the worker asks again on every attempt; the fake hands
+                    // back the same one because what is under test is that it
+                    // *asked*, not that Slack rotated it.
+                    None => axum::Json(serde_json::json!({"ok": true, "url": ws_url})),
+                }
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind the fake slack api");
+    let api_base = format!("http://{}", listener.local_addr().expect("api addr"));
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                let _ = rx.await;
+            })
+            .await;
+    });
+
+    FakeSlack {
+        api_base,
+        opens,
+        acks,
+        acked,
+        live,
+        max_live,
+        closed,
+        _shutdown: tx,
+        _ws_shutdown: ws_tx,
+    }
+}
+
+/// Run one connection's script while recording every ack the worker sends.
+///
+/// The script and the read loop are separate tasks and the session ends when
+/// **either** finishes — which is the part that makes `live` mean what the
+/// reload and stop tests read it as. A session that ended only when its script
+/// ran out would still be counted as live for the whole of a `Hold` after the
+/// worker had already gone, so "the socket closed" and "the script is still
+/// sleeping" would be indistinguishable.
+async fn serve_session(
+    stream: tokio::net::TcpStream,
+    session: Session,
+    acks: &Arc<Mutex<Vec<String>>>,
+    acked: &Arc<tokio::sync::Notify>,
+) {
+    let Ok(ws) = tokio_tungstenite::accept_async(stream).await else {
+        return;
+    };
+    let (mut sink, mut source) = ws.split();
+    let ack_count = Arc::new(AtomicUsize::new(0));
+
+    let mut reader = {
+        let (acks, acked, ack_count) =
+            (Arc::clone(acks), Arc::clone(acked), Arc::clone(&ack_count));
+        tokio::spawn(async move {
+            while let Some(Ok(frame)) = source.next().await {
+                if let Message::Text(text) = frame {
+                    let value: serde_json::Value =
+                        serde_json::from_str(&text).expect("an ack is valid json");
+                    let id = value["envelope_id"]
+                        .as_str()
+                        .expect("an ack carries an envelope_id")
+                        .to_string();
+                    acks.lock().expect("acks lock").push(id);
+                    ack_count.fetch_add(1, Ordering::SeqCst);
+                    acked.notify_waiters();
+                }
+            }
+        })
+    };
+
+    let mut script = tokio::spawn(async move {
+        for step in session {
+            match step {
+                Step::Send(text) => {
+                    if sink.send(Message::text(text)).await.is_err() {
+                        return;
+                    }
+                }
+                Step::AwaitAcks(n) => {
+                    let deadline = Instant::now() + Duration::from_secs(5);
+                    while ack_count.load(Ordering::SeqCst) < n && Instant::now() < deadline {
+                        tokio::time::sleep(Duration::from_millis(5)).await;
+                    }
+                }
+                Step::Hold(d) => tokio::time::sleep(d).await,
+                // Returning drops `sink`, which closes the TCP connection with
+                // no closing handshake — what a network drop looks like from
+                // the worker's side, and the case the reconnect schedule is
+                // about.
+                Step::Drop => return,
+            }
+        }
+        // Running off the end holds the connection open, as a healthy gateway
+        // does, until the worker goes away.
+        std::future::pending::<()>().await;
+    });
+
+    tokio::select! {
+        _ = &mut reader => script.abort(),
+        _ = &mut script => reader.abort(),
+    }
+}
+
+/// A migrated database with one Slack integration, inbound on.
+fn fixture_db(dir: &Path) -> PathBuf {
+    let db_path = dir.join("agento.db");
+    let mut conn = db::ensure_database(&db_path).expect("create");
+    migrate::apply(&mut conn).expect("migrations");
+    conn.execute(
+        "INSERT INTO integrations
+            (id, name, type, enabled, credentials, services, created_at, updated_at,
+             inbound_enabled, inbound_status, inbound_error)
+         VALUES ('s1', 'Slack', 'slack', 1, ?1, '{}', 'then', 'then', 1, '', '')",
+        rusqlite::params![format!(r#"{{"app_token":"{APP_TOKEN}"}}"#)],
+    )
+    .expect("seed the integration");
+    db_path
+}
+
+fn inbound_state(db_path: &Path) -> (String, String) {
+    let conn = db::open_read_only(db_path).expect("open");
+    conn.query_row(
+        "SELECT inbound_status, inbound_error FROM integrations WHERE id = 's1'",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )
+    .expect("read the inbound state")
+}
+
+/// Poll the stored status until it is one of `wanted`, or fail naming what it
+/// was. A status is written from a `db::blocking` task, so it lands a moment
+/// after the transition it reports.
+async fn await_status(db_path: &Path, wanted: &[&str], what: &str) -> (String, String) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut last = (String::new(), String::new());
+    while Instant::now() < deadline {
+        last = inbound_state(db_path);
+        if wanted.contains(&last.0.as_str()) {
+            return last;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("{what}: inbound_status never reached {wanted:?}, it is {last:?}");
+}
+
+fn options(fake: &FakeSlack, handler: socket::EventHandler) -> SocketOptions {
+    SocketOptions {
+        api_base: fake.api_base.clone(),
+        base_backoff: BASE_BACKOFF,
+        max_backoff: Duration::from_secs(5),
+        failure_threshold: 2,
+        handler,
+    }
+}
+
+/// A handler that records every mention it is given and, optionally, holds for
+/// `hold` before recording — long enough that an ack arriving in the meantime
+/// cannot have been waiting behind it.
+fn recording_handler(seen: &Arc<Mutex<Vec<AppMention>>>, hold: Duration) -> socket::EventHandler {
+    let seen = Arc::clone(seen);
+    Arc::new(move |mention: AppMention| {
+        let seen = Arc::clone(&seen);
+        Box::pin(async move {
+            tokio::time::sleep(hold).await;
+            seen.lock().expect("seen lock").push(mention);
+        })
+    })
+}
+
+fn events_api(envelope_id: &str, event_id: &str) -> String {
+    serde_json::json!({
+        "type": "events_api",
+        "envelope_id": envelope_id,
+        "payload": {
+            "event_id": event_id,
+            "event": {
+                "type": "app_mention",
+                "channel": "C1",
+                "user": "U1",
+                "text": "<@B1> hello",
+                "ts": "1700000000.000100",
+            },
+        },
+    })
+    .to_string()
+}
+
+/// The worker opens exactly the URL `apps.connections.open` returned, and
+/// **acknowledges before the handler runs**.
+///
+/// The ordering is the whole point and it is asserted the only way that is not a
+/// race: the handler holds for a second, and the ack has to arrive at the fake
+/// inside a fraction of that. An implementation that acknowledged after the
+/// handler could not produce it. Recording two timestamps and comparing them
+/// would pass against such an implementation whenever the scheduler happened to
+/// run the ack first.
+#[tokio::test]
+async fn an_envelope_is_acknowledged_before_its_handler_runs() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = fixture_db(dir.path());
+    let fake = fake_slack(
+        vec![],
+        vec![vec![
+            Step::Send(events_api("env-1", "Ev1")),
+            Step::Hold(Duration::from_secs(5)),
+        ]],
+    )
+    .await;
+
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let handler = recording_handler(&seen, Duration::from_secs(1));
+    let _worker = socket::start(&db_path, "s1", APP_TOKEN, options(&fake, handler));
+
+    tokio::time::timeout(Duration::from_secs(5), fake.acked.notified())
+        .await
+        .expect("the envelope must be acknowledged, and long before the handler finishes");
+    assert!(
+        seen.lock().expect("seen lock").is_empty(),
+        "the handler must still be running when the ack has already arrived"
+    );
+    assert_eq!(fake.acks(), vec!["env-1".to_string()]);
+    assert_eq!(fake.opens().len(), 1, "one apps.connections.open");
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while seen.lock().expect("seen lock").is_empty() && Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    let seen = seen.lock().expect("seen lock").clone();
+    assert_eq!(seen.len(), 1, "the handler ran once");
+    assert_eq!(seen[0].event_id, "Ev1");
+    assert_eq!(seen[0].channel, "C1");
+    assert_eq!(seen[0].integration_id, "s1");
+
+    let (status, error) = await_status(&db_path, &[STATUS_CONNECTED], "after a connect").await;
+    assert_eq!(status, STATUS_CONNECTED);
+    assert_eq!(error, "", "a healthy connection carries no error");
+}
+
+/// A repeated `event_id` is acknowledged twice and reaches the handler once.
+///
+/// **Both halves matter.** Acknowledging only the first would make Slack
+/// redeliver the second forever; running the handler twice would answer the same
+/// mention twice, which is the failure a user actually sees.
+#[tokio::test]
+async fn a_repeated_event_id_is_acknowledged_twice_and_handled_once() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = fixture_db(dir.path());
+    let fake = fake_slack(
+        vec![],
+        vec![vec![
+            Step::Send(events_api("env-1", "Ev1")),
+            Step::AwaitAcks(1),
+            Step::Send(events_api("env-2", "Ev1")),
+            Step::Hold(Duration::from_secs(5)),
+        ]],
+    )
+    .await;
+
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let handler = recording_handler(&seen, Duration::ZERO);
+    let _worker = socket::start(&db_path, "s1", APP_TOKEN, options(&fake, handler));
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while fake.acks().len() < 2 && Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert_eq!(
+        fake.acks(),
+        vec!["env-1".to_string(), "env-2".to_string()],
+        "every envelope is acknowledged, duplicate or not"
+    );
+
+    // Give a second delivery every chance to reach the handler before saying it
+    // did not.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    let seen = seen.lock().expect("seen lock").clone();
+    assert_eq!(
+        seen.len(),
+        1,
+        "the duplicate event_id must reach the handler once, got {seen:?}"
+    );
+}
+
+/// A `disconnect` envelope and a dropped socket each produce a fresh
+/// `apps.connections.open`, and **the wait after the second failure is strictly
+/// longer than the wait after the first**.
+///
+/// The schedule is what makes a flapping gateway survivable, and the property
+/// that would silently regress is monotonicity: a backoff that resets on every
+/// attempt reconnects in a tight loop, which reads as "it reconnects" to any
+/// test that only counts attempts.
+#[tokio::test]
+async fn a_disconnect_and_a_drop_each_reconnect_with_a_growing_wait() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = fixture_db(dir.path());
+    let fake = fake_slack(
+        vec![],
+        vec![
+            // Slack asking politely. Not a failure: the counter resets.
+            vec![Step::Send(
+                serde_json::json!({"type": "disconnect", "reason": "refresh_requested"})
+                    .to_string(),
+            )],
+            // Then two network drops, whose waits must grow.
+            vec![Step::Drop],
+            vec![Step::Drop],
+            vec![Step::Hold(Duration::from_secs(10))],
+        ],
+    )
+    .await;
+
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let handler = recording_handler(&seen, Duration::ZERO);
+    let _worker = socket::start(&db_path, "s1", APP_TOKEN, options(&fake, handler));
+
+    let deadline = Instant::now() + Duration::from_secs(20);
+    while fake.opens().len() < 4 && Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    let opens = fake.opens();
+    assert_eq!(
+        opens.len(),
+        4,
+        "a disconnect and two drops each ask apps.connections.open again"
+    );
+
+    let after_disconnect = opens[1].duration_since(opens[0]);
+    let after_first_drop = opens[2].duration_since(opens[1]);
+    let after_second_drop = opens[3].duration_since(opens[2]);
+    assert!(
+        after_second_drop > after_first_drop,
+        "the wait after the second consecutive failure must be strictly longer \
+         than after the first: {after_first_drop:?} then {after_second_drop:?}"
+    );
+    assert!(
+        after_disconnect < after_first_drop,
+        "a disconnect is not a failure, so it must not have advanced the schedule: \
+         {after_disconnect:?} then {after_first_drop:?}"
+    );
+}
+
+/// `inbound_status` reads `connected`, then `reconnecting` with the reason in
+/// `inbound_error` after a drop, then `error` once the failures pile up — and
+/// `error` is a report, not a stop, so the worker is still trying.
+#[tokio::test]
+async fn the_stored_status_walks_connected_reconnecting_and_error() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = fixture_db(dir.path());
+    // One good connection, then nothing but refusals: enough to cross the
+    // threshold of two and stay there.
+    let fake = fake_slack(
+        vec![],
+        vec![vec![Step::Hold(Duration::from_millis(150)), Step::Drop]],
+    )
+    .await;
+
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let handler = recording_handler(&seen, Duration::ZERO);
+    let _worker = socket::start(&db_path, "s1", APP_TOKEN, options(&fake, handler));
+
+    await_status(&db_path, &[STATUS_CONNECTED], "after the first connect").await;
+    let (_, error) = await_status(&db_path, &[STATUS_RECONNECTING], "after the drop").await;
+    assert!(
+        !error.is_empty(),
+        "a reconnecting status must carry the reason it is reconnecting"
+    );
+
+    // Every later attempt reconnects to a gateway with no script left, which
+    // holds the connection open — so the failures that carry it to `error` come
+    // from the sessions after the script is exhausted only if they fail. Drive
+    // it instead with a worker whose every attempt is refused.
+    drop(_worker);
+    let refusing = fake_slack(vec!["invalid_auth".into(), "invalid_auth".into()], vec![]).await;
+    let handler = recording_handler(&seen, Duration::ZERO);
+    let worker = socket::start(&db_path, "s1", APP_TOKEN, options(&refusing, handler));
+
+    let (_, error) = await_status(&db_path, &[STATUS_ERROR], "after the failure threshold").await;
+    assert!(
+        error.contains("invalid_auth"),
+        "the error column must name what Slack said, got {error:?}"
+    );
+    assert!(
+        !error.contains("xapp-"),
+        "a stored error must not carry the app token, got {error:?}"
+    );
+
+    // `error` still retries: a third attempt happens after it.
+    let before = refusing.opens().len();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while refusing.opens().len() <= before && Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        refusing.opens().len() > before,
+        "`error` is a reported state, not a stop — the worker must keep trying"
+    );
+    drop(worker);
+}
+
+/// Dropping the handle closes the socket promptly, and nothing survives it.
+///
+/// One second is the bar because that is what a `PUT
+/// /api/integrations/{id}/inbound` turning inbound off has to feel like — and
+/// because a socket that outlives its handle is a socket still holding the app
+/// token of a row the user has just changed.
+#[tokio::test]
+async fn dropping_the_handle_closes_the_socket_within_a_second() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = fixture_db(dir.path());
+    let fake = fake_slack(vec![], vec![vec![Step::Hold(Duration::from_secs(30))]]).await;
+
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let handler = recording_handler(&seen, Duration::ZERO);
+    let worker = socket::start(&db_path, "s1", APP_TOKEN, options(&fake, handler));
+    await_status(&db_path, &[STATUS_CONNECTED], "before the stop").await;
+    assert_eq!(fake.live.load(Ordering::SeqCst), 1);
+
+    let closed = fake.closed.notified();
+    drop(worker);
+    tokio::time::timeout(Duration::from_secs(1), closed)
+        .await
+        .expect("the socket must close within a second of the handle being dropped");
+    assert_eq!(
+        fake.live.load(Ordering::SeqCst),
+        0,
+        "no connection may survive the handle"
+    );
+
+    // And nothing reconnects afterwards: the task is gone, not merely idle.
+    let opens = fake.opens().len();
+    tokio::time::sleep(BASE_BACKOFF * 6).await;
+    assert_eq!(
+        fake.opens().len(),
+        opens,
+        "a dropped worker must not ask apps.connections.open again"
+    );
+}
+
+/// A stop landing while a worker is connecting, immediately followed by a
+/// start — what `Registry::reload` does — leaves **one** live connection, never
+/// two.
+///
+/// Two would mean two sockets holding the same app token, which is the failure
+/// the registry's generation counter exists to prevent for MCP listeners and
+/// which the socket map now shares.
+#[tokio::test]
+async fn a_reload_mid_connect_leaves_exactly_one_live_connection() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = fixture_db(dir.path());
+    let fake = fake_slack(
+        vec![],
+        vec![
+            vec![Step::Hold(Duration::from_secs(30))],
+            vec![Step::Hold(Duration::from_secs(30))],
+        ],
+    )
+    .await;
+
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    for _ in 0..5 {
+        let handler = recording_handler(&seen, Duration::ZERO);
+        let worker = socket::start(&db_path, "s1", APP_TOKEN, options(&fake, handler));
+        // Long enough to be inside `apps.connections.open` or the handshake,
+        // short enough that most iterations land mid-connect.
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        drop(worker);
+    }
+    let handler = recording_handler(&seen, Duration::ZERO);
+    let worker = socket::start(&db_path, "s1", APP_TOKEN, options(&fake, handler));
+    await_status(&db_path, &[STATUS_CONNECTED], "after the last start").await;
+
+    // Give any abandoned attempt every chance to finish its handshake.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert_eq!(
+        fake.live.load(Ordering::SeqCst),
+        1,
+        "exactly one connection may be live after a run of reloads"
+    );
+    assert_eq!(
+        fake.max_live.load(Ordering::SeqCst),
+        1,
+        "two connections were live at once, so a stop left a socket behind"
+    );
+    drop(worker);
+}
+
+/// A full connect → drop → reconnect cycle puts no `xapp-` token anywhere it can
+/// be read back.
+///
+/// The token is the one value in this module that must never be logged, and the
+/// paths that would leak it are the ones a happy-path test never walks: an error
+/// message built by `format!` from a failing request, or a `Debug` of a struct
+/// that happens to hold it. So the cycle here is deliberately the failing one,
+/// and both the stored `inbound_error` and every message the worker produced are
+/// searched.
+#[tokio::test]
+async fn a_full_connect_drop_reconnect_cycle_names_nothing_secret() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = fixture_db(dir.path());
+    let fake = fake_slack(
+        vec!["invalid_auth".into()],
+        vec![vec![Step::Hold(Duration::from_millis(100)), Step::Drop]],
+    )
+    .await;
+
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let handler = recording_handler(&seen, Duration::ZERO);
+    let worker = socket::start(&db_path, "s1", APP_TOKEN, options(&fake, handler));
+
+    await_status(&db_path, &[STATUS_CONNECTED], "after the retry succeeded").await;
+    await_status(
+        &db_path,
+        &[STATUS_RECONNECTING, STATUS_ERROR],
+        "after the drop",
+    )
+    .await;
+    drop(worker);
+
+    let (status, error) = inbound_state(&db_path);
+    for value in [&status, &error] {
+        assert!(
+            !value.contains("xapp-") && !value.contains(APP_TOKEN),
+            "the stored inbound state names the app token: {value:?}"
+        );
+    }
+
+    // The whole row, not just the two columns — a token that reached
+    // `credentials` is expected, one that reached anything else is not.
+    let conn = db::open_read_only(&db_path).expect("open");
+    let (name, credentials): (String, String) = conn
+        .query_row(
+            "SELECT name, credentials FROM integrations WHERE id = 's1'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("read the row");
+    assert!(!name.contains("xapp-"));
+    assert!(
+        credentials.contains(APP_TOKEN),
+        "the credentials blob is where the token belongs and it must be untouched"
+    );
+}
+
+/// A contended write lock must not stall the runtime (#366, #425, #567).
+///
+/// The fifth copy of this rule, and the first for a task driven by a socket
+/// rather than a request or a timer. `db::open_read_write` sets a five-second
+/// `busy_timeout`, so the worker's status write or its dedup claim meeting a
+/// lock held by the session scanner's batch writer parks its thread for up to
+/// that long. This task is not on `proxy.rs`'s blocking pool at all — nothing
+/// spawned from `integrations::registry::start_all` is — so an inline write
+/// would park a *runtime worker*, which on a four-core box is shared with the
+/// proxy, every SSE stream and the scheduler.
+///
+/// The shape is the established one and each part is load-bearing: **one worker
+/// thread**, so a single parked worker is the whole runtime; **a plain OS
+/// thread** holds the lock, so the contention comes from outside the runtime
+/// exactly as the scanner's batch writer does; and **`last` is seeded before the
+/// spawn**, because a starved ticker is never polled and seeding it on the first
+/// poll would start the clock after the stall and measure nothing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn a_socket_workers_contended_write_lock_does_not_stall_the_runtime() {
+    use std::sync::atomic::AtomicU64;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = fixture_db(dir.path());
+    let fake = fake_slack(
+        vec![],
+        vec![vec![
+            Step::Send(events_api("env-1", "Ev1")),
+            Step::Hold(Duration::from_secs(10)),
+        ]],
+    )
+    .await;
+
+    /// Long enough that a parked worker is unmistakable, short enough to stay
+    /// well inside the 5 s `busy_timeout` so the writes still succeed.
+    const HOLD: Duration = Duration::from_millis(1_500);
+
+    // The file must already be WAL. Left in the default rollback journal,
+    // `open_read_write`'s own `PRAGMA journal_mode=WAL` is a *mode change*
+    // needing an exclusive lock and fails in about a millisecond instead of
+    // waiting on `busy_timeout` — which would make this measure the wrong thing.
+    db::open_read_write(&db_path).expect("convert to WAL");
+
+    let (holding_tx, holding_rx) = std::sync::mpsc::channel();
+    let lock_db = db_path.clone();
+    let holder = std::thread::spawn(move || {
+        let mut conn = rusqlite::Connection::open(&lock_db).expect("open");
+        let tx = conn
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+            .expect("begin immediate");
+        holding_tx.send(()).expect("signal");
+        std::thread::sleep(HOLD);
+        tx.rollback().expect("rollback");
+    });
+    holding_rx.recv().expect("the writer took the lock");
+
+    let worst_gap_ms = Arc::new(AtomicU64::new(0));
+    let ticks = Arc::new(AtomicU64::new(0));
+    let ticker = {
+        let (worst_gap_ms, ticks, mut last) = (
+            Arc::clone(&worst_gap_ms),
+            Arc::clone(&ticks),
+            Instant::now(),
+        );
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                let now = Instant::now();
+                let gap = u64::try_from(now.duration_since(last).as_millis()).unwrap_or(u64::MAX);
+                worst_gap_ms.fetch_max(gap, Ordering::Relaxed);
+                ticks.fetch_add(1, Ordering::Relaxed);
+                last = now;
+            }
+        })
+    };
+
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let handler = recording_handler(&seen, Duration::ZERO);
+    let worker = socket::start(&db_path, "s1", APP_TOKEN, options(&fake, handler));
+
+    // The envelope has to be acknowledged while the lock is held: the ack is on
+    // the socket's own task, and the claim behind it is the write that must not
+    // park it.
+    tokio::time::timeout(Duration::from_secs(5), fake.acked.notified())
+        .await
+        .expect("the envelope must be acknowledged even while the database is locked");
+
+    holder.join().expect("the writer finished");
+    ticker.abort();
+    drop(worker);
+
+    let worst = worst_gap_ms.load(Ordering::Relaxed);
+    assert!(
+        worst < 500,
+        "the runtime stalled for {worst} ms while the write lock was held \
+         (the hold is {} ms; anything near it means the worker wrote inline)",
+        HOLD.as_millis()
+    );
+    // The gap alone would also read as healthy if the ticker had simply been
+    // cancelled early, so assert it really ran throughout.
+    let ticks = ticks.load(Ordering::Relaxed);
+    assert!(
+        ticks > 50,
+        "the ticker only advanced {ticks} times across a {} ms hold",
+        HOLD.as_millis()
+    );
+}

--- a/src-tauri/tests/slack_socket.rs
+++ b/src-tauri/tests/slack_socket.rs
@@ -582,9 +582,12 @@ async fn the_stored_status_walks_connected_reconnecting_and_error() {
     let db_path = fixture_db(dir.path(), "status-walk");
     // One good connection, then nothing but refusals: enough to cross the
     // threshold of two and stay there.
+    // Two seconds for the reason spelled out in
+    // `a_full_connect_drop_reconnect_cycle_names_nothing_secret`: the drop must
+    // not beat the `connected` write it is meant to follow.
     let fake = fake_slack(
         vec![],
-        vec![vec![Step::Hold(Duration::from_millis(150)), Step::Drop]],
+        vec![vec![Step::Hold(Duration::from_secs(2)), Step::Drop]],
     )
     .await;
 
@@ -943,9 +946,17 @@ async fn a_reload_mid_connect_leaves_exactly_one_live_connection() {
 async fn a_full_connect_drop_reconnect_cycle_names_nothing_secret() {
     let dir = tempfile::tempdir().expect("tempdir");
     let db_path = fixture_db(dir.path(), "secret");
+    // **The hold has to outlast the `connected` write, not merely the connect.**
+    // A status transition is posted to `status_writer` and written from
+    // `db::blocking`, so it lands some way after the socket opened. With a short
+    // hold the drop can beat it, and the first `connected` this test observes is
+    // then the one written by the *reconnect* — after which the fake's script is
+    // exhausted, the connection is held open forever, and no further transition
+    // ever comes. Two seconds is far longer than that write can take and costs
+    // nothing, because what follows it is polled rather than slept through.
     let fake = fake_slack(
         vec!["invalid_auth".into()],
-        vec![vec![Step::Hold(Duration::from_millis(100)), Step::Drop]],
+        vec![vec![Step::Hold(Duration::from_secs(2)), Step::Drop]],
     )
     .await;
 

--- a/src-tauri/tests/slack_socket.rs
+++ b/src-tauri/tests/slack_socket.rs
@@ -19,6 +19,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use agento_lib::native::integrations::registry;
 use agento_lib::native::integrations::slack::socket::{
     self, AppMention, SocketOptions, STATUS_CONNECTED, STATUS_ERROR, STATUS_RECONNECTING,
 };
@@ -296,7 +297,13 @@ fn captured_logs() -> Vec<String> {
 }
 
 /// A migrated database with one Slack integration, inbound on.
-fn fixture_db(dir: &Path) -> PathBuf {
+///
+/// **Every test passes its own id.** `integrations::registry`'s status-epoch map
+/// is keyed by integration id, which is unique in a shipped build and emphatically
+/// not across the tests in one binary — a shared `"s1"` has each test's
+/// `accepted_worker` retiring every other test's worker, and the symptom is a
+/// status column that simply never moves.
+fn fixture_db(dir: &Path, integration_id: &str) -> PathBuf {
     let db_path = dir.join("agento.db");
     let mut conn = db::ensure_database(&db_path).expect("create");
     migrate::apply(&mut conn).expect("migrations");
@@ -304,18 +311,18 @@ fn fixture_db(dir: &Path) -> PathBuf {
         "INSERT INTO integrations
             (id, name, type, enabled, credentials, services, created_at, updated_at,
              inbound_enabled, inbound_status, inbound_error)
-         VALUES ('s1', 'Slack', 'slack', 1, ?1, '{}', 'then', 'then', 1, '', '')",
-        rusqlite::params![format!(r#"{{"app_token":"{APP_TOKEN}"}}"#)],
+         VALUES (?1, 'Slack', 'slack', 1, ?2, '{}', 'then', 'then', 1, '', '')",
+        rusqlite::params![integration_id, format!(r#"{{"app_token":"{APP_TOKEN}"}}"#)],
     )
     .expect("seed the integration");
     db_path
 }
 
-fn inbound_state(db_path: &Path) -> (String, String) {
+fn inbound_state(db_path: &Path, integration_id: &str) -> (String, String) {
     let conn = db::open_read_only(db_path).expect("open");
     conn.query_row(
-        "SELECT inbound_status, inbound_error FROM integrations WHERE id = 's1'",
-        [],
+        "SELECT inbound_status, inbound_error FROM integrations WHERE id = ?1",
+        [integration_id],
         |row| Ok((row.get(0)?, row.get(1)?)),
     )
     .expect("read the inbound state")
@@ -324,17 +331,41 @@ fn inbound_state(db_path: &Path) -> (String, String) {
 /// Poll the stored status until it is one of `wanted`, or fail naming what it
 /// was. A status is written from a `db::blocking` task, so it lands a moment
 /// after the transition it reports.
-async fn await_status(db_path: &Path, wanted: &[&str], what: &str) -> (String, String) {
+async fn await_status(
+    db_path: &Path,
+    integration_id: &str,
+    wanted: &[&str],
+    what: &str,
+) -> (String, String) {
     let deadline = Instant::now() + Duration::from_secs(10);
     let mut last = (String::new(), String::new());
     while Instant::now() < deadline {
-        last = inbound_state(db_path);
+        last = inbound_state(db_path, integration_id);
         if wanted.contains(&last.0.as_str()) {
             return last;
         }
         tokio::time::sleep(Duration::from_millis(20)).await;
     }
     panic!("{what}: inbound_status never reached {wanted:?}, it is {last:?}");
+}
+
+/// Start a worker **and grant it the epoch**, which is what
+/// `integrations::registry` does for it in production.
+///
+/// A worker the registry never accepted reports nothing — that is the guard
+/// that stops a start which loses the acceptance race from overwriting the
+/// winner's status, and it is deliberately the default. These tests drive
+/// `socket::start` with no registry at all, so they stand in for it:
+/// `retire_socket` answers the epoch that is now current, exactly as
+/// `put_if_current` takes one.
+fn accepted_worker(
+    db_path: &Path,
+    integration_id: &str,
+    options: SocketOptions,
+) -> socket::SocketWorker {
+    let worker = socket::start(db_path, integration_id, APP_TOKEN, options);
+    worker.accept(registry::registry().retire_socket(integration_id));
+    worker
 }
 
 fn options(fake: &FakeSlack, handler: socket::EventHandler) -> SocketOptions {
@@ -394,7 +425,7 @@ fn events_api(envelope_id: &str, event_id: &str) -> String {
 #[tokio::test]
 async fn an_envelope_is_acknowledged_before_its_handler_runs() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let db_path = fixture_db(dir.path());
+    let db_path = fixture_db(dir.path(), "ack-first");
     let fake = fake_slack(
         vec![],
         vec![vec![
@@ -406,7 +437,7 @@ async fn an_envelope_is_acknowledged_before_its_handler_runs() {
 
     let seen = Arc::new(Mutex::new(Vec::new()));
     let handler = recording_handler(&seen, Duration::from_secs(1));
-    let _worker = socket::start(&db_path, "s1", APP_TOKEN, options(&fake, handler));
+    let _worker = accepted_worker(&db_path, "ack-first", options(&fake, handler));
 
     tokio::time::timeout(Duration::from_secs(5), fake.acked.notified())
         .await
@@ -426,9 +457,15 @@ async fn an_envelope_is_acknowledged_before_its_handler_runs() {
     assert_eq!(seen.len(), 1, "the handler ran once");
     assert_eq!(seen[0].event_id, "Ev1");
     assert_eq!(seen[0].channel, "C1");
-    assert_eq!(seen[0].integration_id, "s1");
+    assert_eq!(seen[0].integration_id, "ack-first");
 
-    let (status, error) = await_status(&db_path, &[STATUS_CONNECTED], "after a connect").await;
+    let (status, error) = await_status(
+        &db_path,
+        "ack-first",
+        &[STATUS_CONNECTED],
+        "after a connect",
+    )
+    .await;
     assert_eq!(status, STATUS_CONNECTED);
     assert_eq!(error, "", "a healthy connection carries no error");
 }
@@ -441,7 +478,7 @@ async fn an_envelope_is_acknowledged_before_its_handler_runs() {
 #[tokio::test]
 async fn a_repeated_event_id_is_acknowledged_twice_and_handled_once() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let db_path = fixture_db(dir.path());
+    let db_path = fixture_db(dir.path(), "dedup");
     let fake = fake_slack(
         vec![],
         vec![vec![
@@ -455,7 +492,7 @@ async fn a_repeated_event_id_is_acknowledged_twice_and_handled_once() {
 
     let seen = Arc::new(Mutex::new(Vec::new()));
     let handler = recording_handler(&seen, Duration::ZERO);
-    let _worker = socket::start(&db_path, "s1", APP_TOKEN, options(&fake, handler));
+    let _worker = accepted_worker(&db_path, "dedup", options(&fake, handler));
 
     let deadline = Instant::now() + Duration::from_secs(10);
     while fake.acks().len() < 2 && Instant::now() < deadline {
@@ -489,7 +526,7 @@ async fn a_repeated_event_id_is_acknowledged_twice_and_handled_once() {
 #[tokio::test]
 async fn a_disconnect_and_a_drop_each_reconnect_with_a_growing_wait() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let db_path = fixture_db(dir.path());
+    let db_path = fixture_db(dir.path(), "backoff");
     let fake = fake_slack(
         vec![],
         vec![
@@ -508,7 +545,7 @@ async fn a_disconnect_and_a_drop_each_reconnect_with_a_growing_wait() {
 
     let seen = Arc::new(Mutex::new(Vec::new()));
     let handler = recording_handler(&seen, Duration::ZERO);
-    let _worker = socket::start(&db_path, "s1", APP_TOKEN, options(&fake, handler));
+    let _worker = accepted_worker(&db_path, "backoff", options(&fake, handler));
 
     let deadline = Instant::now() + Duration::from_secs(20);
     while fake.opens().len() < 4 && Instant::now() < deadline {
@@ -542,7 +579,7 @@ async fn a_disconnect_and_a_drop_each_reconnect_with_a_growing_wait() {
 #[tokio::test]
 async fn the_stored_status_walks_connected_reconnecting_and_error() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let db_path = fixture_db(dir.path());
+    let db_path = fixture_db(dir.path(), "status-walk");
     // One good connection, then nothing but refusals: enough to cross the
     // threshold of two and stay there.
     let fake = fake_slack(
@@ -553,10 +590,22 @@ async fn the_stored_status_walks_connected_reconnecting_and_error() {
 
     let seen = Arc::new(Mutex::new(Vec::new()));
     let handler = recording_handler(&seen, Duration::ZERO);
-    let _worker = socket::start(&db_path, "s1", APP_TOKEN, options(&fake, handler));
+    let _worker = accepted_worker(&db_path, "status-walk", options(&fake, handler));
 
-    await_status(&db_path, &[STATUS_CONNECTED], "after the first connect").await;
-    let (_, error) = await_status(&db_path, &[STATUS_RECONNECTING], "after the drop").await;
+    await_status(
+        &db_path,
+        "status-walk",
+        &[STATUS_CONNECTED],
+        "after the first connect",
+    )
+    .await;
+    let (_, error) = await_status(
+        &db_path,
+        "status-walk",
+        &[STATUS_RECONNECTING],
+        "after the drop",
+    )
+    .await;
     assert!(
         !error.is_empty(),
         "a reconnecting status must carry the reason it is reconnecting"
@@ -569,9 +618,15 @@ async fn the_stored_status_walks_connected_reconnecting_and_error() {
     drop(_worker);
     let refusing = fake_slack(vec!["invalid_auth".into(), "invalid_auth".into()], vec![]).await;
     let handler = recording_handler(&seen, Duration::ZERO);
-    let worker = socket::start(&db_path, "s1", APP_TOKEN, options(&refusing, handler));
+    let worker = accepted_worker(&db_path, "status-walk", options(&refusing, handler));
 
-    let (_, error) = await_status(&db_path, &[STATUS_ERROR], "after the failure threshold").await;
+    let (_, error) = await_status(
+        &db_path,
+        "status-walk",
+        &[STATUS_ERROR],
+        "after the failure threshold",
+    )
+    .await;
     assert!(
         error.contains("invalid_auth"),
         "the error column must name what Slack said, got {error:?}"
@@ -603,13 +658,13 @@ async fn the_stored_status_walks_connected_reconnecting_and_error() {
 #[tokio::test]
 async fn dropping_the_handle_closes_the_socket_within_a_second() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let db_path = fixture_db(dir.path());
+    let db_path = fixture_db(dir.path(), "stop");
     let fake = fake_slack(vec![], vec![vec![Step::Hold(Duration::from_secs(30))]]).await;
 
     let seen = Arc::new(Mutex::new(Vec::new()));
     let handler = recording_handler(&seen, Duration::ZERO);
-    let worker = socket::start(&db_path, "s1", APP_TOKEN, options(&fake, handler));
-    await_status(&db_path, &[STATUS_CONNECTED], "before the stop").await;
+    let worker = accepted_worker(&db_path, "stop", options(&fake, handler));
+    await_status(&db_path, "stop", &[STATUS_CONNECTED], "before the stop").await;
     assert_eq!(fake.live.load(Ordering::SeqCst), 1);
 
     let closed = fake.closed.notified();
@@ -646,7 +701,7 @@ async fn dropping_the_handle_closes_the_socket_within_a_second() {
 #[tokio::test]
 async fn a_stopped_worker_writes_no_more_status() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let db_path = fixture_db(dir.path());
+    let db_path = fixture_db(dir.path(), "stopped-silent");
 
     // A gateway that refuses, so the old worker has a stream of `reconnecting`
     // transitions queued and in flight at the moment it is stopped.
@@ -660,14 +715,14 @@ async fn a_stopped_worker_writes_no_more_status() {
     )
     .await;
     let seen = Arc::new(Mutex::new(Vec::new()));
-    let old = socket::start(
+    let old = accepted_worker(
         &db_path,
-        "s1",
-        APP_TOKEN,
+        "stopped-silent",
         options(&refusing, recording_handler(&seen, Duration::ZERO)),
     );
     await_status(
         &db_path,
+        "stopped-silent",
         &[STATUS_RECONNECTING, STATUS_ERROR],
         "the old worker",
     )
@@ -677,19 +732,24 @@ async fn a_stopped_worker_writes_no_more_status() {
     // does.
     drop(old);
     let healthy = fake_slack(vec![], vec![vec![Step::Hold(Duration::from_secs(30))]]).await;
-    let new = socket::start(
+    let new = accepted_worker(
         &db_path,
-        "s1",
-        APP_TOKEN,
+        "stopped-silent",
         options(&healthy, recording_handler(&seen, Duration::ZERO)),
     );
-    await_status(&db_path, &[STATUS_CONNECTED], "the new worker").await;
+    await_status(
+        &db_path,
+        "stopped-silent",
+        &[STATUS_CONNECTED],
+        "the new worker",
+    )
+    .await;
 
     // Long enough for anything the old worker had queued to have been written.
     for _ in 0..10 {
         tokio::time::sleep(Duration::from_millis(50)).await;
         assert_eq!(
-            inbound_state(&db_path).0,
+            inbound_state(&db_path, "stopped-silent").0,
             STATUS_CONNECTED,
             "a stopped worker overwrote its replacement's status"
         );
@@ -707,18 +767,25 @@ async fn a_stopped_worker_writes_no_more_status() {
 #[tokio::test]
 async fn a_socket_that_goes_silent_is_treated_as_dead() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let db_path = fixture_db(dir.path());
+    let db_path = fixture_db(dir.path(), "idle");
     // Accepts, says nothing, and never closes.
     let fake = fake_slack(vec![], vec![vec![Step::Hold(Duration::from_secs(60))]]).await;
 
     let seen = Arc::new(Mutex::new(Vec::new()));
     let mut opts = options(&fake, recording_handler(&seen, Duration::ZERO));
     opts.idle_timeout = Duration::from_millis(400);
-    let worker = socket::start(&db_path, "s1", APP_TOKEN, opts);
+    let worker = accepted_worker(&db_path, "idle", opts);
 
-    await_status(&db_path, &[STATUS_CONNECTED], "the silent socket connects").await;
+    await_status(
+        &db_path,
+        "idle",
+        &[STATUS_CONNECTED],
+        "the silent socket connects",
+    )
+    .await;
     let (_, error) = await_status(
         &db_path,
+        "idle",
         &[STATUS_RECONNECTING, STATUS_ERROR],
         "the silent socket must not stay `connected`",
     )
@@ -748,7 +815,7 @@ async fn a_socket_that_goes_silent_is_treated_as_dead() {
 #[tokio::test]
 async fn a_stalled_claim_does_not_hold_up_the_next_envelope() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let db_path = fixture_db(dir.path());
+    let db_path = fixture_db(dir.path(), "stalled-claim");
     let fake = fake_slack(
         vec![],
         vec![vec![
@@ -779,10 +846,9 @@ async fn a_stalled_claim_does_not_hold_up_the_next_envelope() {
 
     let started = Instant::now();
     let seen = Arc::new(Mutex::new(Vec::new()));
-    let worker = socket::start(
+    let worker = accepted_worker(
         &db_path,
-        "s1",
-        APP_TOKEN,
+        "stalled-claim",
         options(&fake, recording_handler(&seen, Duration::ZERO)),
     );
 
@@ -816,7 +882,7 @@ async fn a_stalled_claim_does_not_hold_up_the_next_envelope() {
 #[tokio::test]
 async fn a_reload_mid_connect_leaves_exactly_one_live_connection() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let db_path = fixture_db(dir.path());
+    let db_path = fixture_db(dir.path(), "reload");
     let fake = fake_slack(
         vec![],
         vec![
@@ -829,15 +895,21 @@ async fn a_reload_mid_connect_leaves_exactly_one_live_connection() {
     let seen = Arc::new(Mutex::new(Vec::new()));
     for _ in 0..5 {
         let handler = recording_handler(&seen, Duration::ZERO);
-        let worker = socket::start(&db_path, "s1", APP_TOKEN, options(&fake, handler));
+        let worker = accepted_worker(&db_path, "reload", options(&fake, handler));
         // Long enough to be inside `apps.connections.open` or the handshake,
         // short enough that most iterations land mid-connect.
         tokio::time::sleep(Duration::from_millis(5)).await;
         drop(worker);
     }
     let handler = recording_handler(&seen, Duration::ZERO);
-    let worker = socket::start(&db_path, "s1", APP_TOKEN, options(&fake, handler));
-    await_status(&db_path, &[STATUS_CONNECTED], "after the last start").await;
+    let worker = accepted_worker(&db_path, "reload", options(&fake, handler));
+    await_status(
+        &db_path,
+        "reload",
+        &[STATUS_CONNECTED],
+        "after the last start",
+    )
+    .await;
 
     // Sampled rather than checked once, and deliberately **not** as a peak.
     //
@@ -870,7 +942,7 @@ async fn a_reload_mid_connect_leaves_exactly_one_live_connection() {
 #[tokio::test]
 async fn a_full_connect_drop_reconnect_cycle_names_nothing_secret() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let db_path = fixture_db(dir.path());
+    let db_path = fixture_db(dir.path(), "secret");
     let fake = fake_slack(
         vec!["invalid_auth".into()],
         vec![vec![Step::Hold(Duration::from_millis(100)), Step::Drop]],
@@ -880,11 +952,18 @@ async fn a_full_connect_drop_reconnect_cycle_names_nothing_secret() {
     capture_logs();
     let seen = Arc::new(Mutex::new(Vec::new()));
     let handler = recording_handler(&seen, Duration::ZERO);
-    let worker = socket::start(&db_path, "s1", APP_TOKEN, options(&fake, handler));
+    let worker = accepted_worker(&db_path, "secret", options(&fake, handler));
 
-    await_status(&db_path, &[STATUS_CONNECTED], "after the retry succeeded").await;
     await_status(
         &db_path,
+        "secret",
+        &[STATUS_CONNECTED],
+        "after the retry succeeded",
+    )
+    .await;
+    await_status(
+        &db_path,
+        "secret",
         &[STATUS_RECONNECTING, STATUS_ERROR],
         "after the drop",
     )
@@ -911,7 +990,7 @@ async fn a_full_connect_drop_reconnect_cycle_names_nothing_secret() {
         );
     }
 
-    let (status, error) = inbound_state(&db_path);
+    let (status, error) = inbound_state(&db_path, "secret");
     for value in [&status, &error] {
         assert!(
             !value.contains("xapp-") && !value.contains(APP_TOKEN),
@@ -924,7 +1003,7 @@ async fn a_full_connect_drop_reconnect_cycle_names_nothing_secret() {
     let conn = db::open_read_only(&db_path).expect("open");
     let (name, credentials): (String, String) = conn
         .query_row(
-            "SELECT name, credentials FROM integrations WHERE id = 's1'",
+            "SELECT name, credentials FROM integrations WHERE id = 'secret'",
             [],
             |row| Ok((row.get(0)?, row.get(1)?)),
         )
@@ -958,7 +1037,7 @@ async fn a_socket_workers_contended_write_lock_does_not_stall_the_runtime() {
     use std::sync::atomic::AtomicU64;
 
     let dir = tempfile::tempdir().expect("tempdir");
-    let db_path = fixture_db(dir.path());
+    let db_path = fixture_db(dir.path(), "contended");
     let fake = fake_slack(
         vec![],
         vec![vec![
@@ -1013,7 +1092,7 @@ async fn a_socket_workers_contended_write_lock_does_not_stall_the_runtime() {
 
     let seen = Arc::new(Mutex::new(Vec::new()));
     let handler = recording_handler(&seen, Duration::ZERO);
-    let worker = socket::start(&db_path, "s1", APP_TOKEN, options(&fake, handler));
+    let worker = accepted_worker(&db_path, "contended", options(&fake, handler));
 
     // The envelope has to be acknowledged while the lock is held: the ack is on
     // the socket's own task, and the claim behind it is the write that must not

--- a/src-tauri/tests/slack_socket.rs
+++ b/src-tauri/tests/slack_socket.rs
@@ -895,7 +895,16 @@ async fn a_full_connect_drop_reconnect_cycle_names_nothing_secret() {
     // binary actually produced. The refusal scripted above is what walks the
     // `format!`-an-error path, which is where the token would surface; the two
     // database columns below cannot see that class of leak at all.
-    for record in captured_logs() {
+    let records = captured_logs();
+    // **The emptiness check is the load-bearing half.** `set_boxed_logger`
+    // refuses a second install and this swallows that, so a capture that never
+    // started would satisfy "no record names the token" for the wrong reason —
+    // the exact shape of a green assertion over zero cases.
+    assert!(
+        !records.is_empty(),
+        "the collector captured nothing, so the leak check proves nothing"
+    );
+    for record in records {
         assert!(
             !record.contains("xapp-") && !record.contains(APP_TOKEN),
             "a log record names the app token: {record:?}"

--- a/src-tauri/tests/slack_socket.rs
+++ b/src-tauri/tests/slack_socket.rs
@@ -582,9 +582,10 @@ async fn the_stored_status_walks_connected_reconnecting_and_error() {
     let db_path = fixture_db(dir.path(), "status-walk");
     // One good connection, then nothing but refusals: enough to cross the
     // threshold of two and stay there.
-    // Two seconds for the reason spelled out in
-    // `a_full_connect_drop_reconnect_cycle_names_nothing_secret`: the drop must
-    // not beat the `connected` write it is meant to follow.
+    // **The hold has to outlast the `connected` write, not merely the connect.**
+    // A transition is posted to `status_writer` and written from `db::blocking`,
+    // so it lands some way after the socket opened; with a short hold the drop
+    // can beat it and the first `connected` this test sees is the *reconnect's*.
     let fake = fake_slack(
         vec![],
         vec![vec![Step::Hold(Duration::from_secs(2)), Step::Drop]],
@@ -946,17 +947,9 @@ async fn a_reload_mid_connect_leaves_exactly_one_live_connection() {
 async fn a_full_connect_drop_reconnect_cycle_names_nothing_secret() {
     let dir = tempfile::tempdir().expect("tempdir");
     let db_path = fixture_db(dir.path(), "secret");
-    // **The hold has to outlast the `connected` write, not merely the connect.**
-    // A status transition is posted to `status_writer` and written from
-    // `db::blocking`, so it lands some way after the socket opened. With a short
-    // hold the drop can beat it, and the first `connected` this test observes is
-    // then the one written by the *reconnect* — after which the fake's script is
-    // exhausted, the connection is held open forever, and no further transition
-    // ever comes. Two seconds is far longer than that write can take and costs
-    // nothing, because what follows it is polled rather than slept through.
     let fake = fake_slack(
         vec!["invalid_auth".into()],
-        vec![vec![Step::Hold(Duration::from_secs(2)), Step::Drop]],
+        vec![vec![Step::Hold(Duration::from_millis(200)), Step::Drop]],
     )
     .await;
 
@@ -965,20 +958,25 @@ async fn a_full_connect_drop_reconnect_cycle_names_nothing_secret() {
     let handler = recording_handler(&seen, Duration::ZERO);
     let worker = accepted_worker(&db_path, "secret", options(&fake, handler));
 
-    await_status(
-        &db_path,
-        "secret",
-        &[STATUS_CONNECTED],
-        "after the retry succeeded",
-    )
-    .await;
-    await_status(
-        &db_path,
-        "secret",
-        &[STATUS_RECONNECTING, STATUS_ERROR],
-        "after the drop",
-    )
-    .await;
+    // **Waited on `opens`, not on a status.** This test exists for the `xapp-`
+    // sweep and needs the *cycle* — refusal, connect, drop, reconnect — to have
+    // happened, which is exactly what a third `apps.connections.open` proves.
+    // `inbound_status` is the wrong thing to wait on here: `reconnecting` and
+    // `error` are transient, overwritten by the next `connected` a backoff
+    // later, and a poll that lands either side of that window sees a value that
+    // never changes again. The status walk has its own test
+    // (`the_stored_status_walks_connected_reconnecting_and_error`) which is
+    // scripted so the walk is the last thing that happens.
+    let deadline = Instant::now() + Duration::from_secs(20);
+    while fake.opens().len() < 3 && Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        fake.opens().len() >= 3,
+        "the full refusal -> connect -> drop -> reconnect cycle must have run, \
+         got {} calls to apps.connections.open",
+        fake.opens().len()
+    );
     drop(worker);
 
     // The `grep -r 'xapp-'` half of the acceptance criteria, over the log this

--- a/src-tauri/tests/slack_socket.rs
+++ b/src-tauri/tests/slack_socket.rs
@@ -63,10 +63,8 @@ struct FakeSlack {
     acks: Arc<Mutex<Vec<String>>>,
     /// Fires on every ack, so a test can wait for one instead of sleeping.
     acked: Arc<tokio::sync::Notify>,
-    /// Websocket connections currently open. `max_live` is what proves a reload
-    /// left exactly one.
+    /// Websocket connections currently open.
     live: Arc<AtomicUsize>,
-    max_live: Arc<AtomicUsize>,
     /// Fires whenever a websocket connection ends, however it ended.
     closed: Arc<tokio::sync::Notify>,
     _shutdown: tokio::sync::oneshot::Sender<()>,
@@ -94,7 +92,6 @@ async fn fake_slack(refusals: Vec<String>, sessions: Vec<Session>) -> FakeSlack 
     let acked = Arc::new(tokio::sync::Notify::new());
     let closed = Arc::new(tokio::sync::Notify::new());
     let live = Arc::new(AtomicUsize::new(0));
-    let max_live = Arc::new(AtomicUsize::new(0));
     let script: Arc<Mutex<VecDeque<Session>>> = Arc::new(Mutex::new(sessions.into()));
     let refusals: Arc<Mutex<VecDeque<String>>> = Arc::new(Mutex::new(refusals.into()));
 
@@ -105,12 +102,11 @@ async fn fake_slack(refusals: Vec<String>, sessions: Vec<Session>) -> FakeSlack 
     let ws_addr = ws_listener.local_addr().expect("ws addr");
     let (ws_tx, mut ws_rx) = tokio::sync::oneshot::channel::<()>();
     {
-        let (acks, acked, closed, live, max_live, script) = (
+        let (acks, acked, closed, live, script) = (
             Arc::clone(&acks),
             Arc::clone(&acked),
             Arc::clone(&closed),
             Arc::clone(&live),
-            Arc::clone(&max_live),
             Arc::clone(&script),
         );
         tokio::spawn(async move {
@@ -123,16 +119,14 @@ async fn fake_slack(refusals: Vec<String>, sessions: Vec<Session>) -> FakeSlack 
                     },
                 };
                 let session = script.lock().expect("script lock").pop_front();
-                let (acks, acked, closed, live, max_live) = (
+                let (acks, acked, closed, live) = (
                     Arc::clone(&acks),
                     Arc::clone(&acked),
                     Arc::clone(&closed),
                     Arc::clone(&live),
-                    Arc::clone(&max_live),
                 );
                 tokio::spawn(async move {
-                    let now = live.fetch_add(1, Ordering::SeqCst) + 1;
-                    max_live.fetch_max(now, Ordering::SeqCst);
+                    live.fetch_add(1, Ordering::SeqCst);
                     serve_session(stream, session.unwrap_or_default(), &acks, &acked).await;
                     live.fetch_sub(1, Ordering::SeqCst);
                     closed.notify_waiters();
@@ -184,7 +178,6 @@ async fn fake_slack(refusals: Vec<String>, sessions: Vec<Session>) -> FakeSlack 
         acks,
         acked,
         live,
-        max_live,
         closed,
         _shutdown: tx,
         _ws_shutdown: ws_tx,
@@ -264,6 +257,44 @@ async fn serve_session(
     }
 }
 
+/// Every log record this binary has produced, so the token can be searched for
+/// where it is most likely to end up.
+///
+/// A collecting `log::Log` rather than a `grep` over a file: #567 asks for
+/// `grep -r 'xapp-'` over a captured log, and the only capture available to a
+/// test binary is the logger itself. Installed once — `set_boxed_logger` is
+/// process-wide and refuses a second call — and at `Trace`, because a token in
+/// a `debug!` is the same leak as one in an `error!`.
+static RECORDS: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+struct Collector;
+
+impl log::Log for Collector {
+    fn enabled(&self, _: &log::Metadata<'_>) -> bool {
+        true
+    }
+    fn log(&self, record: &log::Record<'_>) {
+        RECORDS.lock().expect("records lock").push(format!(
+            "{} {}",
+            record.target(),
+            record.args()
+        ));
+    }
+    fn flush(&self) {}
+}
+
+fn capture_logs() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        let _ = log::set_boxed_logger(Box::new(Collector));
+        log::set_max_level(log::LevelFilter::Trace);
+    });
+}
+
+fn captured_logs() -> Vec<String> {
+    RECORDS.lock().expect("records lock").clone()
+}
+
 /// A migrated database with one Slack integration, inbound on.
 fn fixture_db(dir: &Path) -> PathBuf {
     let db_path = dir.join("agento.db");
@@ -312,6 +343,9 @@ fn options(fake: &FakeSlack, handler: socket::EventHandler) -> SocketOptions {
         base_backoff: BASE_BACKOFF,
         max_backoff: Duration::from_secs(5),
         failure_threshold: 2,
+        // Long enough that no other test in this file can trip it; the one that
+        // is about the idle timeout sets its own.
+        idle_timeout: Duration::from_secs(60),
         handler,
     }
 }
@@ -599,6 +633,179 @@ async fn dropping_the_handle_closes_the_socket_within_a_second() {
     );
 }
 
+/// A stopped worker writes nothing more, so a replacement's status stands.
+///
+/// A `reload` is a stop followed immediately by a start, and the retiring
+/// worker's queue can still hold a transition posted a moment before the stop.
+/// Writing it would overwrite the *new* worker's status with the old worker's
+/// last words, and nothing would rewrite it until the next transition — which on
+/// a socket that connects and stays connected is never. Clearing the row on a
+/// genuine stop is the registry's, not the worker's, and
+/// `a_slack_socket_worker_follows_the_switch_and_the_stored_token` covers it
+/// there; this covers the half the worker owns.
+#[tokio::test]
+async fn a_stopped_worker_writes_no_more_status() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = fixture_db(dir.path());
+
+    // A gateway that refuses, so the old worker has a stream of `reconnecting`
+    // transitions queued and in flight at the moment it is stopped.
+    let refusing = fake_slack(
+        vec![
+            "invalid_auth".into(),
+            "invalid_auth".into(),
+            "invalid_auth".into(),
+        ],
+        vec![],
+    )
+    .await;
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let old = socket::start(
+        &db_path,
+        "s1",
+        APP_TOKEN,
+        options(&refusing, recording_handler(&seen, Duration::ZERO)),
+    );
+    await_status(
+        &db_path,
+        &[STATUS_RECONNECTING, STATUS_ERROR],
+        "the old worker",
+    )
+    .await;
+
+    // Stop it and stand a healthy worker up in its place, exactly as a reload
+    // does.
+    drop(old);
+    let healthy = fake_slack(vec![], vec![vec![Step::Hold(Duration::from_secs(30))]]).await;
+    let new = socket::start(
+        &db_path,
+        "s1",
+        APP_TOKEN,
+        options(&healthy, recording_handler(&seen, Duration::ZERO)),
+    );
+    await_status(&db_path, &[STATUS_CONNECTED], "the new worker").await;
+
+    // Long enough for anything the old worker had queued to have been written.
+    for _ in 0..10 {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            inbound_state(&db_path).0,
+            STATUS_CONNECTED,
+            "a stopped worker overwrote its replacement's status"
+        );
+    }
+    drop(new);
+}
+
+/// A socket that goes silent is treated as dead rather than reported as
+/// `connected` forever.
+///
+/// This is the failure the whole stored-status design exists to make visible: a
+/// half-open connection — a suspended laptop, a rebinding NAT — delivers no FIN
+/// and no RST, so a read with no deadline simply never returns. Nothing else in
+/// this file can see it, because every other fake either speaks or closes.
+#[tokio::test]
+async fn a_socket_that_goes_silent_is_treated_as_dead() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = fixture_db(dir.path());
+    // Accepts, says nothing, and never closes.
+    let fake = fake_slack(vec![], vec![vec![Step::Hold(Duration::from_secs(60))]]).await;
+
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let mut opts = options(&fake, recording_handler(&seen, Duration::ZERO));
+    opts.idle_timeout = Duration::from_millis(400);
+    let worker = socket::start(&db_path, "s1", APP_TOKEN, opts);
+
+    await_status(&db_path, &[STATUS_CONNECTED], "the silent socket connects").await;
+    let (_, error) = await_status(
+        &db_path,
+        &[STATUS_RECONNECTING, STATUS_ERROR],
+        "the silent socket must not stay `connected`",
+    )
+    .await;
+    assert!(
+        error.contains("no traffic"),
+        "the stored reason must say why: {error:?}"
+    );
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while fake.opens().len() < 2 && Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        fake.opens().len() >= 2,
+        "and the worker must reconnect rather than merely report"
+    );
+    drop(worker);
+}
+
+/// A stalled database does not stall the socket: a second envelope is read and
+/// acknowledged while the first one's dedup claim is still waiting on a lock.
+///
+/// The claim is a `db::open_read_write` with a five-second `busy_timeout`, so
+/// awaiting it on the read loop would leave envelope two unacknowledged for that
+/// whole window — past the seconds Slack waits before redelivering. A test that
+/// sends one envelope cannot see this, which is why this one sends two.
+#[tokio::test]
+async fn a_stalled_claim_does_not_hold_up_the_next_envelope() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = fixture_db(dir.path());
+    let fake = fake_slack(
+        vec![],
+        vec![vec![
+            Step::Send(events_api("env-1", "Ev1")),
+            Step::Send(events_api("env-2", "Ev2")),
+            Step::Hold(Duration::from_secs(10)),
+        ]],
+    )
+    .await;
+
+    /// Well inside the 5 s `busy_timeout`, so the claims still succeed, and far
+    /// outside the fraction of a second two acks should take.
+    const HOLD: Duration = Duration::from_millis(1_500);
+
+    db::open_read_write(&db_path).expect("convert to WAL");
+    let (holding_tx, holding_rx) = std::sync::mpsc::channel();
+    let lock_db = db_path.clone();
+    let holder = std::thread::spawn(move || {
+        let mut conn = rusqlite::Connection::open(&lock_db).expect("open");
+        let tx = conn
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+            .expect("begin immediate");
+        holding_tx.send(()).expect("signal");
+        std::thread::sleep(HOLD);
+        tx.rollback().expect("rollback");
+    });
+    holding_rx.recv().expect("the writer took the lock");
+
+    let started = Instant::now();
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let worker = socket::start(
+        &db_path,
+        "s1",
+        APP_TOKEN,
+        options(&fake, recording_handler(&seen, Duration::ZERO)),
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while fake.acks().len() < 2 && Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    let took = started.elapsed();
+    assert_eq!(
+        fake.acks(),
+        vec!["env-1".to_string(), "env-2".to_string()],
+        "both envelopes must be acknowledged while the database is locked"
+    );
+    assert!(
+        took < HOLD,
+        "the second ack waited {took:?}, which is the length of the lock hold \
+         ({HOLD:?}) — the claim is being awaited on the read loop"
+    );
+
+    holder.join().expect("the writer finished");
+    drop(worker);
+}
+
 /// A stop landing while a worker is connecting, immediately followed by a
 /// start — what `Registry::reload` does — leaves **one** live connection, never
 /// two.
@@ -632,18 +839,22 @@ async fn a_reload_mid_connect_leaves_exactly_one_live_connection() {
     let worker = socket::start(&db_path, "s1", APP_TOKEN, options(&fake, handler));
     await_status(&db_path, &[STATUS_CONNECTED], "after the last start").await;
 
-    // Give any abandoned attempt every chance to finish its handshake.
-    tokio::time::sleep(Duration::from_millis(300)).await;
-    assert_eq!(
-        fake.live.load(Ordering::SeqCst),
-        1,
-        "exactly one connection may be live after a run of reloads"
-    );
-    assert_eq!(
-        fake.max_live.load(Ordering::SeqCst),
-        1,
-        "two connections were live at once, so a stop left a socket behind"
-    );
+    // Sampled rather than checked once, and deliberately **not** as a peak.
+    //
+    // A worker dropped mid-handshake can legitimately show up at the fake a
+    // moment later and close immediately, so a `max_live == 1` assertion is a
+    // race by construction. What is not a race, and is the actual bug, is a
+    // connection that a stop left running: that one never goes away, so it is
+    // visible in every sample of the settled state.
+    for _ in 0..10 {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            fake.live.load(Ordering::SeqCst),
+            1,
+            "exactly one connection may be live after a run of reloads — \
+             more means a stop left a socket behind"
+        );
+    }
     drop(worker);
 }
 
@@ -654,8 +865,8 @@ async fn a_reload_mid_connect_leaves_exactly_one_live_connection() {
 /// paths that would leak it are the ones a happy-path test never walks: an error
 /// message built by `format!` from a failing request, or a `Debug` of a struct
 /// that happens to hold it. So the cycle here is deliberately the failing one,
-/// and both the stored `inbound_error` and every message the worker produced are
-/// searched.
+/// and every log record this binary produced is searched alongside the row the
+/// worker writes to.
 #[tokio::test]
 async fn a_full_connect_drop_reconnect_cycle_names_nothing_secret() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -666,6 +877,7 @@ async fn a_full_connect_drop_reconnect_cycle_names_nothing_secret() {
     )
     .await;
 
+    capture_logs();
     let seen = Arc::new(Mutex::new(Vec::new()));
     let handler = recording_handler(&seen, Duration::ZERO);
     let worker = socket::start(&db_path, "s1", APP_TOKEN, options(&fake, handler));
@@ -678,6 +890,17 @@ async fn a_full_connect_drop_reconnect_cycle_names_nothing_secret() {
     )
     .await;
     drop(worker);
+
+    // The `grep -r 'xapp-'` half of the acceptance criteria, over the log this
+    // binary actually produced. The refusal scripted above is what walks the
+    // `format!`-an-error path, which is where the token would surface; the two
+    // database columns below cannot see that class of leak at all.
+    for record in captured_logs() {
+        assert!(
+            !record.contains("xapp-") && !record.contains(APP_TOKEN),
+            "a log record names the app token: {record:?}"
+        );
+    }
 
     let (status, error) = inbound_state(&db_path);
     for value in [&status, &error] {


### PR DESCRIPTION
Closes #567

## What

One tokio task per Slack integration that has `inbound_enabled` **and** an `xapp-` token in its credentials blob: `apps.connections.open` → the returned `wss://` → **acknowledge by `envelope_id` before anything else** → de-duplicate by `event_id` → hand `app_mention` to a handler → honour `disconnect` → reconnect after any drop with capped, wall-clock-anchored backoff → keep `inbound_status`/`inbound_error` current.

The handler is a no-op logging at `debug`; #568 supplies the real one through `SocketOptions::handler`.

## Why

Decisions 11 and 12 of epic #562. A desktop app has no public URL, so an Events API webhook is not available to it — Socket Mode is the only way a Slack event reaches Agento. There was no long-lived outbound connection anywhere in the tree and no websocket crate in the lockfile, so the dependency, the lifecycle and the failure reporting are all first-of-their-kind here.

## How

- **`tokio-tungstenite` 0.30**, `default-features = false` + `rustls-tls-native-roots`, argued in `Cargo.toml` the way the `rmcp` paragraph is. Four crates enter the lockfile, 596 → 600 (`tokio-tungstenite`, `tungstenite`, `sha1`, `data-encoding`); the TLS half was already there via `reqwest`. Platform trust store rather than bundled roots, for the corporate-proxy reason already recorded for `reqwest`. `futures-util` is declared for `SinkExt` and adds no package.
- **Lifecycle in `integrations/registry.rs`.** `State` gains a `sockets` map beside `servers`, moved together under one lock by `stop`/`put_if_current` so a stop racing a reload cannot keep one half. The worker is not a seventh entry in `start_for_type`'s starter table — it is a second handle on one of the six.
- **Nothing awaits a database write on the task that reads the socket.** The dedup claim lives inside `dispatch`'s `tokio::spawn`; every status transition is *posted* to a single `status_writer`, which keeps the writes ordered. `db::blocking` keeps them off a runtime worker; this keeps them off the socket.
- **The handler runs under the trigger dispatcher's semaphore**, which is why `dispatcher::semaphore` is now `pub(crate)` — two semaphores of ten would be twenty agent runs against a limit that says ten.
- **Dedup** is `trigger::receiver::claim_update`'s shape exactly, against `slack_processed_events`, plus the same 48-hour sweep.
- **Backoff** doubles from 1 s to a 60 s cap with bounded jitter, re-anchored on the wall clock the way `schedule::runtime` does, and a session that stayed up longer than `max_backoff` resets the failure counter — a lid close is not evidence of a bad gateway.
- **A read has a deadline** (`idle_timeout`, 90 s). A half-open connection delivers no FIN and no RST, so without one the worker parks forever with the row still reading `connected` — the silent outage the stored status exists to prevent.
- **Clearing the status is the registry's, writing it is the worker's.** A worker cannot tell a stop from a replacement, and a compare-and-swap cannot break the tie because both write the identical `connected`. `start_all` clears every Slack row once at boot; `start_one`/`reload` clear when they decline to start a worker; `clear_status` bumps an epoch under the write lock so an in-flight write cannot land after it.
- **No secret anywhere.** The token is read once from `HostingRow::app_token`, captured into the task, and never logged, formatted into an error, or carried by a `Debug`.

## Tests

`src-tauri/tests/slack_socket.rs` (11) against an in-process fake Slack — an `axum` `apps.connections.open` plus a real websocket server. Pure Rust, no `PermissionsExt`, so it is not a new reason `tests/` cannot compile on Windows. Plus 8 unit tests in `socket.rs` and an extended registry lifecycle test.

Acceptance criteria → test:
- ack before the handler → `an_envelope_is_acknowledged_before_its_handler_runs`
- duplicate `event_id` handled once → `a_repeated_event_id_is_acknowledged_twice_and_handled_once`
- `disconnect` + drop reconnect, second wait strictly longer → `a_disconnect_and_a_drop_each_reconnect_with_a_growing_wait`
- stop closes within a second, nothing survives → `dropping_the_handle_closes_the_socket_within_a_second`
- reload mid-connect leaves one connection → `a_reload_mid_connect_leaves_exactly_one_live_connection`
- the status walk → `the_stored_status_walks_connected_reconnecting_and_error`
- `grep xapp-` over a captured log → `a_full_connect_drop_reconnect_cycle_names_nothing_secret`
- the contended write lock → `a_socket_workers_contended_write_lock_does_not_stall_the_runtime`
- the boot-order source assertion → `a_gateway_start_requires_an_installed_keypair`, extended

## Deviations from the issue's HOW, and why

- **`State` needed a second map.** The HOW said the handle lives in the registry using the existing generation counter; `put_if_current` took exactly one `InProcessMcpServer`, so it now takes the pair and records both in one critical section.
- **`SocketOptions` is a public struct rather than a `#[cfg(test)]` seam.** `tests/` is a separate binary and cannot see a `cfg(test)` override. `SocketOptions::default()` still reads `client::api_base()`, so in-crate registry tests drive the whole start path through the existing seam.
- **The clear moved out of the worker.** The HOW implied the worker owns all four status transitions. It cannot own the clear — see above.
- **A fifth copy of the contended-write-lock test, not a fourth.** There are already three by that name plus one differently named that calls itself the fourth.

## Left for the maintainer

- **`connect_async` does no proxy handling where `reqwest` does**, so behind an *explicitly configured* proxy `apps.connections.open` succeeds and the socket does not. Documented at both sites; no issue filed, because filing one is not this workflow's call.
- **A pre-existing CodeQL alert on `main`** — `rust/cleartext-logging` at `registry.rs`'s "MCP server started" line, `url` tainted by `google_oauth_token`. Untouched here: editing that line makes CodeQL report the alert as introduced by this PR, so the addition is logged separately.
