### PR TITLE
feat: Slack app_mention → chat run → threaded mrkdwn reply, with thread mapping and per-thread queue (#568)

### DIFF
--- a/src-tauri/src/native/integrations/registry.rs
+++ b/src-tauri/src/native/integrations/registry.rs
@@ -688,11 +688,29 @@ fn start_socket_worker(db_path: &Path, row: &HostingRow) -> Option<SocketWorker>
         );
         return None;
     };
+    // The bot token, not the app token: `xapp-` opens the socket and the
+    // workspace token posts the reply, and #568's handler needs both. Resolved
+    // through the same `resolve_slack_token` the hosted tools use, so the
+    // `auth` column's OAuth arm works on the inbound path too.
+    let bot_token = match resolve_slack_token(&row.id, &row.credentials, &row.auth) {
+        Ok(token) => token,
+        Err(e) => {
+            // A worker that cannot reply is silence with a live connection,
+            // which is worse than not starting: `inbound_status` is cleared by
+            // the caller on every branch that declines to start one, so the UI
+            // reports the same "not connected" it does for a missing app token.
+            log::warn!("not starting the slack socket worker, no usable bot token: {e}");
+            return None;
+        }
+    };
     Some(super::slack::socket::start(
         db_path,
         &row.id,
         &app_token,
-        super::slack::socket::SocketOptions::default(),
+        super::slack::socket::SocketOptions {
+            handler: super::slack::inbound::handler(db_path, &row.id, &bot_token),
+            ..super::slack::socket::SocketOptions::default()
+        },
     ))
 }
 

--- a/src-tauri/src/native/integrations/slack/CLAUDE.md
+++ b/src-tauri/src/native/integrations/slack/CLAUDE.md
@@ -244,7 +244,7 @@ declines to start one.
   turn is not one: taken in `socket.rs::dispatch`, as #567 had it, ten queued
   mentions in a single Slack thread hold every permit while one of them runs —
   and Telegram, which shares that semaphore, stops with them. `dispatch` no
-  longer acquires anything; `inbound::Inbound::run` does, immediately before
+  longer acquires anything; `inbound::Inbound::turn` does, immediately before
   `run_resumed`. The handler future still spans the whole turn (each job carries
   a `oneshot` the worker fires when it ends, however it ended), because a `debug`
   line saying a mention was seen and a reply appearing minutes later are two
@@ -288,7 +288,8 @@ declines to start one.
   words is posted by the app as itself, into a channel it is a member of by
   construction. The only raw `<`, `>` and `|` in the output are the ones this
   module writes around a link whose target it has checked is an `http`, `https`
-  or `mailto` URL. That check is the escape's second half, not tidiness: `<…>` is
+  or `mailto` URL — plus a restored blockquote marker, which is the one other
+  raw `>` it emits. That check is the escape's second half, not tidiness: `<…>` is
   Slack's markup for everything, so an unvetted link target is a hole straight
   back through the escape — `[](!channel)` would otherwise become `<!channel>`,
   and a channel member can ask for that in one sentence. Any other target keeps

--- a/src-tauri/src/native/integrations/slack/CLAUDE.md
+++ b/src-tauri/src/native/integrations/slack/CLAUDE.md
@@ -232,8 +232,13 @@ declines to start one.
   otherwise find no `inbound_threads` row — the row is written by the run it is
   queued behind — and be dropped as a mention in a thread Agento did not start.
   This is the one ordering constraint the FIFO exists for, and it is why
-  classification is split across `accept` (rule, mention strip) and `turn`
-  (mapping, start-or-resume).
+  classification is split across `accept` (the rule) and `turn` (the mapping, the
+  bot-id strip, start-or-resume). The order the queue preserves is **enqueue**
+  order, not arrival order: `socket.rs::dispatch` spawns a task per envelope and
+  each awaits its dedup claim before a handler runs, so two mentions posted a
+  millisecond apart can reach the queue either way round and nothing downstream
+  could put that back. What it guarantees is first-queued-first-answered, and no
+  overlap.
 - **The ten-slot bound is taken around the run, not around the handler.** It
   exists to bound `claude` subprocesses, and a mention waiting for its thread's
   turn is not one: taken in `socket.rs::dispatch`, as #567 had it, ten queued
@@ -282,7 +287,15 @@ declines to start one.
   mention. This is the first surface where an answer derived from a stranger's
   words is posted by the app as itself, into a channel it is a member of by
   construction. The only raw `<`, `>` and `|` in the output are the ones this
-  module writes building a `<url|text>` link; `gojson::to_vec_marshal` is not a
+  module writes around a link whose target it has checked is an `http`, `https`
+  or `mailto` URL. That check is the escape's second half, not tidiness: `<…>` is
+  Slack's markup for everything, so an unvetted link target is a hole straight
+  back through the escape — `[](!channel)` would otherwise become `<!channel>`,
+  and a channel member can ask for that in one sentence. Any other target keeps
+  its Markdown spelling and is posted as prose, which is what a reader wants for
+  the `[guide](./setup.md)` Slack could not link to anyway. A leading `&gt;` run
+  is put back to `>`, because Slack's blockquote is Markdown's and escaping is
+  the only thing that broke it. `gojson::to_vec_marshal` is not a
   substitute, since its `\u003c` is decoded straight back by Slack. The split
   counts `char`s, prefers a blank line then a line ending then the limit, and
   passes over a break inside a fenced block while any break outside one remains

--- a/src-tauri/src/native/integrations/slack/CLAUDE.md
+++ b/src-tauri/src/native/integrations/slack/CLAUDE.md
@@ -286,10 +286,11 @@ declines to start one.
   `<!here>` and `<!everyone>` in `text` as **broadcasts** and `<@U123>` as a
   mention. This is the first surface where an answer derived from a stranger's
   words is posted by the app as itself, into a channel it is a member of by
-  construction. The only raw `<`, `>` and `|` in the output are the ones this
-  module writes around a link whose target it has checked is an `http`, `https`
-  or `mailto` URL — plus a restored blockquote marker, which is the one other
-  raw `>` it emits. That check is the escape's second half, not tidiness: `<…>` is
+  construction. The only raw `<` in the output — and the only raw `>` other than
+  a restored blockquote marker — is the pair this module writes around a link
+  whose target it has checked is an `http`, `https` or `mailto` URL. `|` is not
+  escaped and need not be: it is markup only inside `<…>`, and `is_postable_url`
+  refuses a `|` in either half of a link rather than escaping one. That check is the escape's second half, not tidiness: `<…>` is
   Slack's markup for everything, so an unvetted link target is a hole straight
   back through the escape — `[](!channel)` would otherwise become `<!channel>`,
   and a channel member can ask for that in one sentence. Any other target keeps

--- a/src-tauri/src/native/integrations/slack/CLAUDE.md
+++ b/src-tauri/src/native/integrations/slack/CLAUDE.md
@@ -209,3 +209,72 @@ default logs at `debug`.
   library is invisible to it. `SocketOptions::default` reads
   `client::api_base()`, so an in-crate `registry` test still drives the whole
   start path through the existing seam.
+
+## The `app_mention` handler: event → run → threaded reply (#568)
+
+`slack/inbound.rs` is what `SocketOptions::handler` now points at, built per row
+by `registry::start_socket_worker` — which resolves the **bot** token there too,
+through the same `resolve_slack_token` the hosted tools use, because `xapp-`
+opens the socket and only the workspace token can post the answer. A row with no
+usable bot token does not get a worker: a live connection that cannot reply is
+silence, and the caller already clears `inbound_status` on every branch that
+declines to start one.
+
+- **A bot's own `app_mention` is dropped in `socket.rs`, at the decode.** Slack
+  delivers an `app_mention` for a mention inside a message the app itself
+  posted, so an answer that quotes the question answers itself in the same
+  thread, forever, one `claude` subprocess at a time. `bot_id` names the poster
+  and `subtype` covers `bot_message` and every authorless variant.
+  `a_bot_authored_app_mention_is_not_work` is the guard, and it lives beside the
+  decode rather than in the handler so nothing downstream has to remember.
+- **The thread mapping is read inside the per-thread worker, never at arrival.**
+  The second mention in a thread whose first mention is still running would
+  otherwise find no `inbound_threads` row — the row is written by the run it is
+  queued behind — and be dropped as a mention in a thread Agento did not start.
+  This is the one ordering constraint the FIFO exists for, and it is why
+  classification is split across `accept` (rule, mention strip) and `turn`
+  (mapping, start-or-resume).
+- **The handler future must not return before its turn is over.** #567 holds the
+  dispatcher's ten-slot permit for exactly as long as `handler(mention)` is
+  awaited, so a handler that returned at `enqueue` would leave the global bound
+  counting *queueing* rather than running. Each job therefore carries a
+  `oneshot` the worker fires when the turn ends, however it ended.
+- **Queue teardown is under the map lock.** A worker that found its channel
+  empty, released nothing and then removed its entry would lose a job queued in
+  between, so the drain re-checks the channel while holding the lock that hands
+  out senders and only removes the entry when it is still empty.
+- **Both start and resume go through `agent_run::run_resumed`.** A start creates
+  the chat first and then resumes it — no `sdk_session_id` yet, so `resume_spec`
+  passes no `--resume` — which makes the busy lock, the session-id write-back and
+  the *additive* usage accounting one implementation from the first turn on.
+- **The two failure sentences are `trigger::dispatcher`'s constants**, now
+  `pub(crate)`: `ERROR_REPLY` for a failed run and for a timeout (which arrives
+  as an `Err`, indistinguishable to a reader in Slack), `NO_RESPONSE_REPLY` for
+  an answer with no text. Two inbound transports spelling one failure differently
+  reads as a difference in what failed. `create_trigger_session` takes the title
+  for the same reason — `[Telegram] <rule>` and `[Slack] #channel: <60 chars>` are
+  the only difference between the two call sites.
+- **`auth.test` is called once per handler, not per event and not per
+  connection.** The bot user id is what the `<@Uxxx>` strip and the
+  empty-remainder rule both need; a failure to get it is a failed turn and
+  answers `ERROR_REPLY`, because a Slack that will not answer `auth.test` will
+  not accept `chat.postMessage` either. `conversations.info` (chat title) and
+  `chat.getPermalink` are best-effort on the start path only — the channel id and
+  an empty permalink are the fallbacks, and neither refuses the run.
+- **`mrkdwn.rs` escapes nothing.** Slack asks a client to send `&`, `<` and `>`
+  escaped; doing it here would be a lossy second pass over the model's own text
+  and cannot be applied inside a fenced block without changing the code the
+  answer is showing. The conversions are exactly #568's and no more, so the
+  consequence to know is that an answer literally containing `<@U123>` mentions
+  that user. The split counts `char`s, prefers a blank line then a line ending
+  then the limit, and passes over a break inside a fenced block while any break
+  outside one remains.
+
+**These tests are in the library, and they have to be.** Every assertion about a
+request Agento *sends* to Slack needs `client::API_BASE`, which is `#[cfg(test)]`
+on this crate so it cannot exist in a shipped binary — an integration-test crate
+cannot reach it, which is the same wall `trigger/dispatcher.rs` records and the
+reason `tests/trigger_run.rs` stops one function short of Telegram's reply. So
+`slack/inbound/tests.rs` carries `tests/slack_socket.rs`'s fake-server half and
+`tests/headless_resume.rs`'s fake-CLI half together, and inherits the fake CLI's
+trap — **no exit after the result** — with a named deadline on every await.

--- a/src-tauri/src/native/integrations/slack/CLAUDE.md
+++ b/src-tauri/src/native/integrations/slack/CLAUDE.md
@@ -234,11 +234,24 @@ declines to start one.
   This is the one ordering constraint the FIFO exists for, and it is why
   classification is split across `accept` (rule, mention strip) and `turn`
   (mapping, start-or-resume).
-- **The handler future must not return before its turn is over.** #567 holds the
-  dispatcher's ten-slot permit for exactly as long as `handler(mention)` is
-  awaited, so a handler that returned at `enqueue` would leave the global bound
-  counting *queueing* rather than running. Each job therefore carries a
-  `oneshot` the worker fires when the turn ends, however it ended.
+- **The ten-slot bound is taken around the run, not around the handler.** It
+  exists to bound `claude` subprocesses, and a mention waiting for its thread's
+  turn is not one: taken in `socket.rs::dispatch`, as #567 had it, ten queued
+  mentions in a single Slack thread hold every permit while one of them runs —
+  and Telegram, which shares that semaphore, stops with them. `dispatch` no
+  longer acquires anything; `inbound::Inbound::run` does, immediately before
+  `run_resumed`. The handler future still spans the whole turn (each job carries
+  a `oneshot` the worker fires when it ends, however it ended), because a `debug`
+  line saying a mention was seen and a reply appearing minutes later are two
+  different things to anyone reading a log — but that wait now costs a parked
+  task and no permit.
+- **`auth.test` is resolved after the mapping decision, not before it.** It is
+  the one Slack failure the handler cannot work around, and its answer is
+  `ERROR_REPLY` — so resolving it first would post that sentence into a thread
+  Agento never started, which is exactly what the ignore rule exists to prevent.
+  Reading the thread map likewise distinguishes *no row* from *could not read*:
+  `busy_timeout` is five seconds, and a database busy behind the session scanner
+  would otherwise make a resume look like a stranger's thread and answer nothing.
 - **Queue teardown is under the map lock.** A worker that found its channel
   empty, released nothing and then removed its entry would lose a job queued in
   between, so the drain re-checks the channel while holding the lock that hands
@@ -261,14 +274,19 @@ declines to start one.
   not accept `chat.postMessage` either. `conversations.info` (chat title) and
   `chat.getPermalink` are best-effort on the start path only — the channel id and
   an empty permalink are the fallbacks, and neither refuses the run.
-- **`mrkdwn.rs` escapes nothing.** Slack asks a client to send `&`, `<` and `>`
-  escaped; doing it here would be a lossy second pass over the model's own text
-  and cannot be applied inside a fenced block without changing the code the
-  answer is showing. The conversions are exactly #568's and no more, so the
-  consequence to know is that an answer literally containing `<@U123>` mentions
-  that user. The split counts `char`s, prefers a blank line then a line ending
-  then the limit, and passes over a break inside a fenced block while any break
-  outside one remains.
+- **`mrkdwn.rs` escapes `&`, `<` and `>` before it converts anything**, over the
+  whole answer including its fenced blocks. Slack renders those entities back as
+  themselves everywhere, so escaping costs the answer nothing — and not escaping
+  costs it a great deal, because `chat.postMessage` reads `<!channel>`,
+  `<!here>` and `<!everyone>` in `text` as **broadcasts** and `<@U123>` as a
+  mention. This is the first surface where an answer derived from a stranger's
+  words is posted by the app as itself, into a channel it is a member of by
+  construction. The only raw `<`, `>` and `|` in the output are the ones this
+  module writes building a `<url|text>` link; `gojson::to_vec_marshal` is not a
+  substitute, since its `\u003c` is decoded straight back by Slack. The split
+  counts `char`s, prefers a blank line then a line ending then the limit, and
+  passes over a break inside a fenced block while any break outside one remains
+  — a block that must be cut is cut, and the second chunk renders as prose.
 
 **These tests are in the library, and they have to be.** Every assertion about a
 request Agento *sends* to Slack needs `client::API_BASE`, which is `#[cfg(test)]`

--- a/src-tauri/src/native/integrations/slack/inbound.rs
+++ b/src-tauri/src/native/integrations/slack/inbound.rs
@@ -1,0 +1,603 @@
+//! What an `app_mention` does: the handler behind [`socket::SocketOptions::handler`]
+//! (#568).
+//!
+//! One mention becomes one agent turn on one chat, and its answer becomes one
+//! or more messages in the Slack thread the mention is in. Everything before
+//! this module is transport — #567 acknowledges the envelope, claims it against
+//! `slack_processed_events` and takes the trigger dispatcher's semaphore, so a
+//! handler runs already-deduplicated and already-bounded at ten concurrent runs
+//! across every inbound transport.
+//!
+//! ## The three decisions, in the order they are made
+//!
+//! 1. **Where the mention is.** A mention with no `thread_ts`, or whose
+//!    `thread_ts` equals its own `ts`, is **top-level** and starts a chat under
+//!    a new thread. A mention inside a thread is a **resume** when
+//!    `(integration, channel, thread_ts)` is in `inbound_threads`, and is
+//!    ignored at `debug` when it is not — Agento answers in threads it started
+//!    and nowhere else (epic #562, decision 1).
+//! 2. **Which rule.** [`select_rule_for_channel`] — most specific first, and a
+//!    *disabled* channel-specific rule is that channel's off switch rather than
+//!    a fall-through to the workspace default (#565). No rule at all is silence.
+//! 3. **Whether there is anything to say.** The bot's own `<@Uxxx>` is removed;
+//!    an empty remainder is ignored.
+//!
+//! The mapping lookup in (1) deliberately happens **inside the per-thread
+//! worker**, not when the event arrives. The second mention in a thread whose
+//! first mention is still running would otherwise look unmapped — the row is
+//! written by the run it is queued behind — and be dropped as a mention in a
+//! thread Agento did not start.
+//!
+//! ## The per-thread FIFO
+//!
+//! A `thread → queue` map with one worker task per key, torn down when its
+//! queue drains, so two mentions in one thread run in arrival order and never
+//! overlap. It is **in addition to** the chat's busy lock, not instead of it:
+//! `agent_run::run_resumed` takes `chat::live::try_lock`, which is what stops a
+//! Slack turn and a UI turn colliding on the same chat row (decision 9). The
+//! queue is what makes the *ordering* deterministic; the lock is what makes the
+//! collision safe.
+//!
+//! **Teardown is under the same lock that hands out senders.** A worker that
+//! found its queue empty, released nothing, and then removed its map entry
+//! would lose a job queued in between. So the drain re-checks the channel while
+//! holding the map lock and only removes the entry when it is still empty.
+//!
+//! ## Rules that are not obvious from the code
+//!
+//! - **Both paths run through [`agent_run::run_resumed`].** A start creates the
+//!   chat first and then resumes it — the chat has no `sdk_session_id` yet, so
+//!   `resume_spec` passes no `--resume` and the first turn is an ordinary
+//!   headless run whose session id is written back. One implementation means
+//!   the busy lock, the write-back and the *additive* usage accounting are the
+//!   same on the first turn and the fiftieth.
+//! - **The two failure sentences are the dispatcher's constants**, not
+//!   re-spellings. Telegram and Slack answering differently for the same failure
+//!   is the drift those `pub(crate)` consts exist to prevent.
+//! - **The bot user id comes from `auth.test` once**, cached for the life of the
+//!   handler rather than fetched per event. Without it neither the mention strip
+//!   nor the empty-remainder rule can be applied, so a failure to get it is a
+//!   failed turn and answers [`ERROR_REPLY`] — a Slack that will not answer
+//!   `auth.test` will not accept `chat.postMessage` either.
+//! - **No Slack-derived text reaches an `info` line, a path or a shell.** The
+//!   prompt is logged at `debug` and nowhere else; the channel and thread ids
+//!   are Slack's own opaque identifiers.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::mpsc;
+
+use crate::claude::CancellationToken;
+use crate::native::agent_run;
+use crate::native::db;
+use crate::native::trigger::dispatcher::{self, Rule, ERROR_REPLY, NO_RESPONSE_REPLY};
+use crate::native::trigger::select_rule::select_rule_for_channel;
+
+use crate::native::gourl::Values;
+
+use super::client::Client;
+use super::mrkdwn;
+use super::socket::{AppMention, EventHandler};
+
+/// `[Slack] #channel: <first 60 chars>` — the epic's chat title.
+const TITLE_PROMPT_CHARS: usize = 60;
+
+/// One thread's queue key. The integration is the handler's, so it is not here.
+type ThreadKey = (String, String);
+
+/// One mention, everything decided about it, waiting for its thread's turn.
+struct Job {
+    mention: AppMention,
+    /// The thread this belongs to: the mention's own `ts` when it is top-level.
+    thread_ts: String,
+    top_level: bool,
+    rule: Rule,
+    /// The message with the bot's own mention removed. Never empty.
+    prompt: String,
+    /// Dropped or signalled when this job is finished, however it finished.
+    ///
+    /// The handler future must not return before the turn it queued is over:
+    /// #567's dispatcher holds the ten-slot semaphore permit only for as long
+    /// as the handler is awaited, so a handler that returned at `enqueue` would
+    /// leave the global bound counting *queueing* rather than running, and a
+    /// workspace could have any number of `claude` subprocesses in flight.
+    done: tokio::sync::oneshot::Sender<()>,
+}
+
+/// The handler's state: one per Slack integration with inbound enabled.
+struct Inbound {
+    db_path: PathBuf,
+    integration_id: String,
+    client: Client,
+    bot_user_id: tokio::sync::OnceCell<String>,
+    queues: Mutex<HashMap<ThreadKey, mpsc::UnboundedSender<Job>>>,
+}
+
+/// The `app_mention` handler for one integration.
+///
+/// `bot_token` is the workspace token every reply is posted with — resolved by
+/// the registry through `resolve_slack_token`, so the `auth` column's OAuth arm
+/// works here exactly as it does for the hosted tools.
+pub fn handler(db_path: &Path, integration_id: &str, bot_token: &str) -> EventHandler {
+    let state = Arc::new(Inbound {
+        db_path: db_path.to_path_buf(),
+        integration_id: integration_id.to_string(),
+        client: Client::new(bot_token),
+        bot_user_id: tokio::sync::OnceCell::new(),
+        queues: Mutex::new(HashMap::new()),
+    });
+    Arc::new(move |mention: AppMention| {
+        let state = Arc::clone(&state);
+        Box::pin(async move { state.accept(mention).await })
+    })
+}
+
+impl Inbound {
+    /// Classify, select a rule, build the prompt, and queue — or drop.
+    async fn accept(self: Arc<Self>, mention: AppMention) {
+        let top_level = mention.thread_ts.is_empty() || mention.thread_ts == mention.ts;
+        let thread_ts = if top_level {
+            mention.ts.clone()
+        } else {
+            mention.thread_ts.clone()
+        };
+
+        let Some(rule) = self.rule_for(&mention.channel).await else {
+            log::debug!(
+                "slack mention ignored, no rule for the channel integration_id={:?} channel={:?}",
+                self.integration_id,
+                mention.channel
+            );
+            return;
+        };
+
+        let bot_user_id = match self.bot_user_id().await {
+            Some(id) => id,
+            None => {
+                // Nothing can be decided about the text without it, and the run
+                // is the thing the user is waiting for.
+                self.post(&mention.channel, &thread_ts, ERROR_REPLY).await;
+                return;
+            }
+        };
+        let prompt = strip_mention(&mention.text, bot_user_id);
+        if prompt.is_empty() {
+            log::debug!(
+                "slack mention ignored, nothing said to the bot integration_id={:?} channel={:?}",
+                self.integration_id,
+                mention.channel
+            );
+            return;
+        }
+
+        let (done, finished) = tokio::sync::oneshot::channel();
+        enqueue(
+            &self,
+            Job {
+                mention,
+                thread_ts,
+                top_level,
+                rule,
+                prompt,
+                done,
+            },
+        );
+        // An `Err` is the worker being torn down without answering, which is
+        // still the end of this handler's work.
+        let _ = finished.await;
+    }
+
+    /// The rule this channel runs under, or `None` for silence.
+    async fn rule_for(&self, channel: &str) -> Option<Rule> {
+        let (db_path, integration_id) = (self.db_path.clone(), self.integration_id.clone());
+        let loaded = db::blocking("slack rule match", move || {
+            dispatcher::load_rules(&db_path, &integration_id)
+        })
+        .await?;
+        let rules = match loaded {
+            Ok(rules) => rules,
+            Err(e) => {
+                log::warn!("failed to load slack trigger rules: {e}");
+                return None;
+            }
+        };
+        select_rule_for_channel(&rules, channel).cloned()
+    }
+
+    /// The bot's own user id, fetched from `auth.test` at most once.
+    async fn bot_user_id(&self) -> Option<&str> {
+        self.bot_user_id
+            .get_or_try_init(|| async {
+                let ct = CancellationToken::new();
+                let body = self
+                    .client
+                    .call_form(&ct, "auth.test", String::new())
+                    .await?;
+                let id = serde_json::from_str::<serde_json::Value>(&body)
+                    .ok()
+                    .and_then(|v| {
+                        v.get("user_id")
+                            .and_then(serde_json::Value::as_str)
+                            .map(str::to_string)
+                    })
+                    .filter(|id| !id.is_empty())
+                    .ok_or_else(|| "auth.test answered no user_id".to_string())?;
+                Ok::<String, String>(id)
+            })
+            .await
+            .map(String::as_str)
+            .map_err(|e| log::warn!("slack inbound cannot identify itself: {e}"))
+            .ok()
+    }
+
+    /// Run this thread's jobs in arrival order, then retire.
+    async fn drain(self: Arc<Self>, key: ThreadKey, mut rx: mpsc::UnboundedReceiver<Job>) {
+        loop {
+            let next = match rx.try_recv() {
+                Ok(job) => Some(job),
+                Err(_) => {
+                    // Re-check while holding the map lock: a job queued between
+                    // the check above and the removal below would otherwise be
+                    // handed to a worker that has already gone.
+                    let mut queues = self.queues.lock().expect("the slack inbound queue lock");
+                    let pending = rx.try_recv().ok();
+                    if pending.is_none() {
+                        queues.remove(&key);
+                    }
+                    drop(queues);
+                    pending
+                }
+            };
+            let Some(job) = next else { return };
+            self.run(job).await;
+        }
+    }
+
+    /// One turn: resolve the chat, run it, answer in the thread.
+    async fn run(&self, job: Job) {
+        self.turn(&job).await;
+        // Whatever happened, the caller waiting on this job is released.
+        let _ = job.done.send(());
+    }
+
+    async fn turn(&self, job: &Job) {
+        let mapped = self.thread_chat(job).await;
+        let (chat_id, kind) = match mapped {
+            Some(chat_id) => (chat_id, "resume"),
+            None if !job.top_level => {
+                log::debug!(
+                    "slack mention ignored, a thread Agento did not start integration_id={:?} \
+                     channel={:?} thread={:?}",
+                    self.integration_id,
+                    job.mention.channel,
+                    job.thread_ts
+                );
+                return;
+            }
+            None => match self.start_chat(job).await {
+                Some(chat_id) => (chat_id, "start"),
+                None => {
+                    self.post(&job.mention.channel, &job.thread_ts, ERROR_REPLY)
+                        .await;
+                    return;
+                }
+            },
+        };
+
+        log::info!(
+            "slack mention matched integration_id={:?} channel={:?} thread={:?} rule_id={:?} \
+             chat_id={:?} kind={kind}",
+            self.integration_id,
+            job.mention.channel,
+            job.thread_ts,
+            job.rule.id,
+            chat_id
+        );
+        // The one place a Slack message's own words are logged, and it is not
+        // `info`: everything above is Slack's opaque identifiers.
+        log::debug!(
+            "slack mention prompt chat_id={chat_id:?} prompt={:?}",
+            job.prompt
+        );
+
+        let result = agent_run::run_resumed(
+            &self.db_path,
+            &chat_id,
+            &job.prompt,
+            &job.rule.settings,
+            dispatcher::run_timeout(&job.rule),
+        )
+        .await;
+
+        let reply = reply_for(result, &chat_id);
+        self.post(&job.mention.channel, &job.thread_ts, &reply)
+            .await;
+        self.touch_thread(job).await;
+    }
+
+    /// The chat this thread is already mapped to, if any.
+    async fn thread_chat(&self, job: &Job) -> Option<String> {
+        let (db_path, integration_id) = (self.db_path.clone(), self.integration_id.clone());
+        let (channel, thread_ts) = (job.mention.channel.clone(), job.thread_ts.clone());
+        db::blocking("slack thread lookup", move || {
+            find_thread(&db_path, &integration_id, &channel, &thread_ts)
+        })
+        .await
+        .flatten()
+    }
+
+    /// Create the chat for a top-level mention and map the thread to it.
+    async fn start_chat(&self, job: &Job) -> Option<String> {
+        let title = format!(
+            "[Slack] #{}: {}",
+            self.channel_name(&job.mention.channel).await,
+            truncate_chars(&job.prompt, TITLE_PROMPT_CHARS)
+        );
+        let (db_path, rule) = (self.db_path.clone(), job.rule.clone());
+        let created = db::blocking("slack session", move || {
+            dispatcher::create_trigger_session(&db_path, &rule, &title)
+        })
+        .await?;
+        let chat_id = match created {
+            Ok(chat_id) => chat_id,
+            Err(e) => {
+                log::error!("failed to create chat session for a slack mention: {e}");
+                return None;
+            }
+        };
+
+        // Best-effort: the permalink is what #570 shows beside the chat, and a
+        // Slack that will not produce one is not a reason to refuse the run.
+        let permalink = self.permalink(&job.mention.channel, &job.thread_ts).await;
+        let (db_path, integration_id) = (self.db_path.clone(), self.integration_id.clone());
+        let (channel, thread_ts) = (job.mention.channel.clone(), job.thread_ts.clone());
+        let mapped = chat_id.clone();
+        if let Some(Err(e)) = db::blocking("slack thread map", move || {
+            insert_thread(
+                &db_path,
+                &integration_id,
+                &channel,
+                &thread_ts,
+                &mapped,
+                &permalink,
+            )
+        })
+        .await
+        {
+            // The run still happens; only the *next* mention in this thread is
+            // lost, so this is loud rather than fatal.
+            log::warn!("failed to map a slack thread to its chat: {e}");
+        }
+        Some(chat_id)
+    }
+
+    /// `last_event_at`, so a sweep can one day tell a live thread from a dead one.
+    async fn touch_thread(&self, job: &Job) {
+        let (db_path, integration_id) = (self.db_path.clone(), self.integration_id.clone());
+        let (channel, thread_ts) = (job.mention.channel.clone(), job.thread_ts.clone());
+        db::blocking("slack thread touch", move || {
+            touch_thread(&db_path, &integration_id, &channel, &thread_ts)
+        })
+        .await;
+    }
+
+    /// The channel's name for the chat title, falling back to its id.
+    async fn channel_name(&self, channel: &str) -> String {
+        let ct = CancellationToken::new();
+        let mut values = Values::new();
+        values.set("channel", channel);
+        let name = self
+            .client
+            .call_form(&ct, "conversations.info", values.encode())
+            .await
+            .ok()
+            .and_then(|body| serde_json::from_str::<serde_json::Value>(&body).ok())
+            .and_then(|value| {
+                value
+                    .get("channel")
+                    .and_then(|c| c.get("name"))
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string)
+            })
+            .filter(|name| !name.is_empty());
+        name.unwrap_or_else(|| channel.to_string())
+    }
+
+    /// `chat.getPermalink` for the thread's first message; `""` on any failure.
+    async fn permalink(&self, channel: &str, message_ts: &str) -> String {
+        let ct = CancellationToken::new();
+        let mut values = Values::new();
+        values.set("channel", channel);
+        values.set("message_ts", message_ts);
+        self.client
+            .call_form(&ct, "chat.getPermalink", values.encode())
+            .await
+            .ok()
+            .and_then(|body| serde_json::from_str::<serde_json::Value>(&body).ok())
+            .and_then(|value| {
+                value
+                    .get("permalink")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string)
+            })
+            .unwrap_or_default()
+    }
+
+    /// The reply, in the thread, as consecutive messages.
+    ///
+    /// Sent one at a time and in order: Slack orders a thread by arrival, so two
+    /// chunks in flight at once can render the answer backwards.
+    async fn post(&self, channel: &str, thread_ts: &str, text: &str) {
+        let ct = CancellationToken::new();
+        for (i, chunk) in mrkdwn::split(text, mrkdwn::MAX_MESSAGE_CHARS)
+            .into_iter()
+            .enumerate()
+        {
+            let payload = serde_json::json!({
+                "channel": channel,
+                "thread_ts": thread_ts,
+                "text": chunk,
+                "mrkdwn": true,
+            });
+            let body = match crate::native::gojson::to_vec_marshal(&payload) {
+                Ok(body) => body,
+                Err(e) => {
+                    log::error!("encoding a slack reply: {e}");
+                    return;
+                }
+            };
+            if let Err(e) = self.client.call_json(&ct, "chat.postMessage", body).await {
+                log::error!(
+                    "failed to send slack reply chunk {} channel={channel:?} error={e}",
+                    i + 1
+                );
+                return;
+            }
+        }
+    }
+}
+
+/// What a finished run answers with.
+///
+/// Silence is never an outcome, so every arm produces a sentence: a failed run
+/// and a timed-out one are one arm — `agent_run` reports a deadline as
+/// `Err(DEADLINE_EXCEEDED)`, so there is nothing to distinguish for a reader in
+/// Slack — and an answer with no text is the third.
+fn reply_for(result: Result<agent_run::RunResult, String>, chat_id: &str) -> String {
+    match result {
+        Ok(run) if run.answer.is_empty() => NO_RESPONSE_REPLY.to_string(),
+        Ok(run) => mrkdwn::to_mrkdwn(&run.answer),
+        Err(e) => {
+            log::error!("agent execution failed for slack chat_id={chat_id:?} error={e}");
+            ERROR_REPLY.to_string()
+        }
+    }
+}
+
+/// Hand `job` to its thread's worker, starting one when there is none.
+///
+/// A free function rather than a method because the worker task needs an owned
+/// `Arc` and the caller keeps its own.
+fn enqueue(state: &Arc<Inbound>, job: Job) {
+    let key = (job.mention.channel.clone(), job.thread_ts.clone());
+    let mut queues = state.queues.lock().expect("the slack inbound queue lock");
+    let job = match queues.get(&key) {
+        // A worker removes its entry under this same lock, so an entry that is
+        // present has a live receiver.
+        Some(tx) => match tx.send(job) {
+            Ok(()) => return,
+            Err(returned) => returned.0,
+        },
+        None => job,
+    };
+    let (tx, rx) = mpsc::unbounded_channel();
+    tx.send(job).expect("the receiver is alive on this line");
+    queues.insert(key.clone(), tx);
+    let worker = Arc::clone(state);
+    tokio::spawn(async move { worker.drain(key, rx).await });
+}
+
+/// `text` with every `<@bot>` (and `<@bot|label>`) removed, then trimmed.
+fn strip_mention(text: &str, bot_user_id: &str) -> String {
+    if bot_user_id.is_empty() {
+        return text.trim().to_string();
+    }
+    let open = format!("<@{bot_user_id}");
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(at) = rest.find(&open) {
+        let after = &rest[at + open.len()..];
+        // `<@U1>` and `<@U1|name>` are the bot; `<@U12>` is somebody else whose
+        // id merely starts the same way.
+        let Some(close) = after
+            .find('>')
+            .filter(|_| after.starts_with('>') || after.starts_with('|'))
+        else {
+            out.push_str(&rest[..at + open.len()]);
+            rest = after;
+            continue;
+        };
+        out.push_str(&rest[..at]);
+        rest = &after[close + 1..];
+    }
+    out.push_str(rest);
+    out.trim().to_string()
+}
+
+/// The first `limit` characters of `text`, never cutting one in half.
+fn truncate_chars(text: &str, limit: usize) -> &str {
+    match text.char_indices().nth(limit) {
+        Some((offset, _)) => &text[..offset],
+        None => text,
+    }
+}
+
+/// The chat this thread is mapped to.
+fn find_thread(
+    db_path: &Path,
+    integration_id: &str,
+    channel_id: &str,
+    thread_ts: &str,
+) -> Option<String> {
+    let conn = db::open_read_only(db_path)
+        .map_err(|e| log::warn!("reading the slack thread map: {e}"))
+        .ok()?;
+    conn.query_row(
+        "SELECT chat_id FROM inbound_threads
+         WHERE integration_id = ?1 AND channel_id = ?2 AND thread_ts = ?3",
+        rusqlite::params![integration_id, channel_id, thread_ts],
+        |row| row.get::<_, String>(0),
+    )
+    .ok()
+}
+
+fn insert_thread(
+    db_path: &Path,
+    integration_id: &str,
+    channel_id: &str,
+    thread_ts: &str,
+    chat_id: &str,
+    permalink: &str,
+) -> Result<(), String> {
+    let conn = db::open_read_write(db_path)?;
+    let now = crate::native::gotime::now_go_text();
+    conn.execute(
+        "INSERT INTO inbound_threads
+            (integration_id, channel_id, thread_ts, chat_id, permalink, created_at, last_event_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?6)",
+        rusqlite::params![
+            integration_id,
+            channel_id,
+            thread_ts,
+            chat_id,
+            permalink,
+            now
+        ],
+    )
+    .map_err(|e| format!("mapping slack thread {thread_ts:?}: {e}"))?;
+    Ok(())
+}
+
+fn touch_thread(db_path: &Path, integration_id: &str, channel_id: &str, thread_ts: &str) {
+    let Ok(conn) = db::open_read_write(db_path) else {
+        log::warn!("failed to open the database to touch a slack thread");
+        return;
+    };
+    if let Err(e) = conn.execute(
+        "UPDATE inbound_threads SET last_event_at = ?4
+         WHERE integration_id = ?1 AND channel_id = ?2 AND thread_ts = ?3",
+        rusqlite::params![
+            integration_id,
+            channel_id,
+            thread_ts,
+            crate::native::gotime::now_go_text()
+        ],
+    ) {
+        log::warn!("failed to record a slack thread's last event: {e}");
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src-tauri/src/native/integrations/slack/inbound.rs
+++ b/src-tauri/src/native/integrations/slack/inbound.rs
@@ -58,7 +58,13 @@
 //!   handler rather than fetched per event. Without it neither the mention strip
 //!   nor the empty-remainder rule can be applied, so a failure to get it is a
 //!   failed turn and answers [`ERROR_REPLY`] — a Slack that will not answer
-//!   `auth.test` will not accept `chat.postMessage` either.
+//!   `auth.test` will not accept `chat.postMessage` either. It is fetched
+//!   **after** the thread has been established as Agento's, because that reply
+//!   would otherwise land in a stranger's thread.
+//! - **The dispatcher's ten-slot semaphore is taken around the run**, not around
+//!   the handler. It bounds `claude` subprocesses, and a mention waiting for its
+//!   thread's turn is not one: taken at the handler, ten queued mentions in one
+//!   Slack thread hold every permit while one runs, and Telegram stops too.
 //! - **No Slack-derived text reaches an `info` line, a path or a shell.** The
 //!   prompt is logged at `debug` and nowhere else; the channel and thread ids
 //!   are Slack's own opaque identifiers.
@@ -94,15 +100,14 @@ struct Job {
     thread_ts: String,
     top_level: bool,
     rule: Rule,
-    /// The message with the bot's own mention removed. Never empty.
-    prompt: String,
     /// Dropped or signalled when this job is finished, however it finished.
     ///
-    /// The handler future must not return before the turn it queued is over:
-    /// #567's dispatcher holds the ten-slot semaphore permit only for as long
-    /// as the handler is awaited, so a handler that returned at `enqueue` would
-    /// leave the global bound counting *queueing* rather than running, and a
-    /// workspace could have any number of `claude` subprocesses in flight.
+    /// The handler future is the whole turn, not the enqueue: a `debug` line
+    /// saying a mention was seen and a reply appearing minutes later are two
+    /// different things for anyone reading a log, and #567's `dispatch` has
+    /// nothing left to do while this runs. It costs a parked task and no
+    /// semaphore permit — the ten-slot bound is taken in [`Inbound::run`],
+    /// around the run itself.
     done: tokio::sync::oneshot::Sender<()>,
 }
 
@@ -135,7 +140,7 @@ pub fn handler(db_path: &Path, integration_id: &str, bot_token: &str) -> EventHa
 }
 
 impl Inbound {
-    /// Classify, select a rule, build the prompt, and queue — or drop.
+    /// Classify, select a rule, and queue — or drop.
     async fn accept(self: Arc<Self>, mention: AppMention) {
         let top_level = mention.thread_ts.is_empty() || mention.thread_ts == mention.ts;
         let thread_ts = if top_level {
@@ -153,25 +158,6 @@ impl Inbound {
             return;
         };
 
-        let bot_user_id = match self.bot_user_id().await {
-            Some(id) => id,
-            None => {
-                // Nothing can be decided about the text without it, and the run
-                // is the thing the user is waiting for.
-                self.post(&mention.channel, &thread_ts, ERROR_REPLY).await;
-                return;
-            }
-        };
-        let prompt = strip_mention(&mention.text, bot_user_id);
-        if prompt.is_empty() {
-            log::debug!(
-                "slack mention ignored, nothing said to the bot integration_id={:?} channel={:?}",
-                self.integration_id,
-                mention.channel
-            );
-            return;
-        }
-
         let (done, finished) = tokio::sync::oneshot::channel();
         enqueue(
             &self,
@@ -180,7 +166,6 @@ impl Inbound {
                 thread_ts,
                 top_level,
                 rule,
-                prompt,
                 done,
             },
         );
@@ -263,20 +248,53 @@ impl Inbound {
     }
 
     async fn turn(&self, job: &Job) {
-        let mapped = self.thread_chat(job).await;
-        let (chat_id, kind) = match mapped {
-            Some(chat_id) => (chat_id, "resume"),
-            None if !job.top_level => {
-                log::debug!(
-                    "slack mention ignored, a thread Agento did not start integration_id={:?} \
-                     channel={:?} thread={:?}",
-                    self.integration_id,
-                    job.mention.channel,
-                    job.thread_ts
-                );
+        // Which thread this is has to be decided before anything is said, so a
+        // failure below cannot answer into a thread Agento did not start.
+        let mapped = match self.thread_chat(job).await {
+            Ok(mapped) => mapped,
+            Err(e) => {
+                // Not the same as "no row": a database this process could not
+                // read is a failed turn, and answering `debug`-and-silence here
+                // would drop a resume the moment the scanner held a write lock.
+                log::error!("reading the slack thread map: {e}");
+                if job.top_level {
+                    self.post(&job.mention.channel, &job.thread_ts, ERROR_REPLY)
+                        .await;
+                }
                 return;
             }
-            None => match self.start_chat(job).await {
+        };
+        if mapped.is_none() && !job.top_level {
+            log::debug!(
+                "slack mention ignored, a thread Agento did not start integration_id={:?} \
+                 channel={:?} thread={:?}",
+                self.integration_id,
+                job.mention.channel,
+                job.thread_ts
+            );
+            return;
+        }
+
+        // Only now, with the thread established as Agento's, is there anywhere
+        // a failure sentence may be posted.
+        let Some(bot_user_id) = self.bot_user_id().await else {
+            self.post(&job.mention.channel, &job.thread_ts, ERROR_REPLY)
+                .await;
+            return;
+        };
+        let prompt = strip_mention(&job.mention.text, bot_user_id);
+        if prompt.is_empty() {
+            log::debug!(
+                "slack mention ignored, nothing said to the bot integration_id={:?} channel={:?}",
+                self.integration_id,
+                job.mention.channel
+            );
+            return;
+        }
+
+        let (chat_id, kind) = match mapped {
+            Some(chat_id) => (chat_id, "resume"),
+            None => match self.start_chat(job, &prompt).await {
                 Some(chat_id) => (chat_id, "start"),
                 None => {
                     self.post(&job.mention.channel, &job.thread_ts, ERROR_REPLY)
@@ -297,15 +315,21 @@ impl Inbound {
         );
         // The one place a Slack message's own words are logged, and it is not
         // `info`: everything above is Slack's opaque identifiers.
-        log::debug!(
-            "slack mention prompt chat_id={chat_id:?} prompt={:?}",
-            job.prompt
-        );
+        log::debug!("slack mention prompt chat_id={chat_id:?} prompt={prompt:?}");
 
+        // **The ten-slot bound is taken here, around the run.** #567 took it
+        // around the handler, which counted a mention *waiting for its thread's
+        // turn* against a limit that is about `claude` subprocesses: ten queued
+        // mentions in one Slack thread would hold every permit while one ran,
+        // stalling Telegram and every other channel for the length of the chain.
+        let Ok(_permit) = dispatcher::semaphore().acquire().await else {
+            log::warn!("dispatcher stopped, dropping a slack turn chat_id={chat_id:?}");
+            return;
+        };
         let result = agent_run::run_resumed(
             &self.db_path,
             &chat_id,
-            &job.prompt,
+            &prompt,
             &job.rule.settings,
             dispatcher::run_timeout(&job.rule),
         )
@@ -317,23 +341,28 @@ impl Inbound {
         self.touch_thread(job).await;
     }
 
-    /// The chat this thread is already mapped to, if any.
-    async fn thread_chat(&self, job: &Job) -> Option<String> {
+    /// The chat this thread is already mapped to.
+    ///
+    /// `Ok(None)` is "no such thread" and `Err` is "the map could not be read",
+    /// and the two must not be confused: `open_read_write` carries a five-second
+    /// `busy_timeout`, so a database busy behind the session scanner would
+    /// otherwise make a resume look like a mention in somebody else's thread.
+    async fn thread_chat(&self, job: &Job) -> Result<Option<String>, String> {
         let (db_path, integration_id) = (self.db_path.clone(), self.integration_id.clone());
         let (channel, thread_ts) = (job.mention.channel.clone(), job.thread_ts.clone());
         db::blocking("slack thread lookup", move || {
             find_thread(&db_path, &integration_id, &channel, &thread_ts)
         })
         .await
-        .flatten()
+        .unwrap_or_else(|| Err("the slack thread lookup task failed".to_string()))
     }
 
     /// Create the chat for a top-level mention and map the thread to it.
-    async fn start_chat(&self, job: &Job) -> Option<String> {
+    async fn start_chat(&self, job: &Job, prompt: &str) -> Option<String> {
         let title = format!(
             "[Slack] #{}: {}",
             self.channel_name(&job.mention.channel).await,
-            truncate_chars(&job.prompt, TITLE_PROMPT_CHARS)
+            truncate_chars(prompt, TITLE_PROMPT_CHARS)
         );
         let (db_path, rule) = (self.db_path.clone(), job.rule.clone());
         let created = db::blocking("slack session", move || {
@@ -534,23 +563,24 @@ fn truncate_chars(text: &str, limit: usize) -> &str {
     }
 }
 
-/// The chat this thread is mapped to.
+/// The chat this thread is mapped to, distinguishing "no row" from "no answer".
 fn find_thread(
     db_path: &Path,
     integration_id: &str,
     channel_id: &str,
     thread_ts: &str,
-) -> Option<String> {
-    let conn = db::open_read_only(db_path)
-        .map_err(|e| log::warn!("reading the slack thread map: {e}"))
-        .ok()?;
-    conn.query_row(
+) -> Result<Option<String>, String> {
+    let conn = db::open_read_only(db_path)?;
+    match conn.query_row(
         "SELECT chat_id FROM inbound_threads
          WHERE integration_id = ?1 AND channel_id = ?2 AND thread_ts = ?3",
         rusqlite::params![integration_id, channel_id, thread_ts],
         |row| row.get::<_, String>(0),
-    )
-    .ok()
+    ) {
+        Ok(chat_id) => Ok(Some(chat_id)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(format!("reading the slack thread map: {e}")),
+    }
 }
 
 fn insert_thread(

--- a/src-tauri/src/native/integrations/slack/inbound.rs
+++ b/src-tauri/src/native/integrations/slack/inbound.rs
@@ -113,7 +113,7 @@ struct Job {
     /// saying a mention was seen and a reply appearing minutes later are two
     /// different things for anyone reading a log, and #567's `dispatch` has
     /// nothing left to do while this runs. It costs a parked task and no
-    /// semaphore permit — the ten-slot bound is taken in [`Inbound::run`],
+    /// semaphore permit — the ten-slot bound is taken in [`Inbound::turn`],
     /// around the run itself.
     done: tokio::sync::oneshot::Sender<()>,
 }

--- a/src-tauri/src/native/integrations/slack/inbound.rs
+++ b/src-tauri/src/native/integrations/slack/inbound.rs
@@ -351,7 +351,7 @@ impl Inbound {
     /// The chat this thread is already mapped to.
     ///
     /// `Ok(None)` is "no such thread" and `Err` is "the map could not be read",
-    /// and the two must not be confused: `open_read_write` carries a five-second
+    /// and the two must not be confused: `open_read_only` carries a five-second
     /// `busy_timeout`, so a database busy behind the session scanner would
     /// otherwise make a resume look like a mention in somebody else's thread.
     async fn thread_chat(&self, job: &Job) -> Result<Option<String>, String> {

--- a/src-tauri/src/native/integrations/slack/inbound.rs
+++ b/src-tauri/src/native/integrations/slack/inbound.rs
@@ -31,8 +31,15 @@
 //! ## The per-thread FIFO
 //!
 //! A `thread → queue` map with one worker task per key, torn down when its
-//! queue drains, so two mentions in one thread run in arrival order and never
-//! overlap. It is **in addition to** the chat's busy lock, not instead of it:
+//! queue drains, so two mentions in one thread run **in the order they were
+//! queued** and never overlap. Queued, not *arrived*: #567 spawns a task per
+//! envelope and each awaits its dedup claim before the handler is called at
+//! all, so two mentions posted a millisecond apart can reach [`enqueue`] either
+//! way round and nothing downstream could put that back. What the queue
+//! guarantees — and what the acceptance criterion is about — is that whichever
+//! arrives first at the queue is answered first, and that the second never runs
+//! while the first is running. It is **in addition to** the chat's busy lock,
+//! not instead of it:
 //! `agent_run::run_resumed` takes `chat::live::try_lock`, which is what stops a
 //! Slack turn and a UI turn colliding on the same chat row (decision 9). The
 //! queue is what makes the *ordering* deterministic; the lock is what makes the

--- a/src-tauri/src/native/integrations/slack/inbound/tests.rs
+++ b/src-tauri/src/native/integrations/slack/inbound/tests.rs
@@ -45,11 +45,17 @@ struct Call {
 }
 
 #[derive(Clone, Default)]
-struct FakeSlack(Arc<Mutex<Vec<Call>>>);
+struct FakeSlack {
+    calls: Arc<Mutex<Vec<Call>>>,
+    /// Cleared to make `auth.test` refuse, which is the one Slack failure the
+    /// handler cannot work around: without the bot user id it can neither strip
+    /// the mention nor apply the empty-remainder rule.
+    auth_works: Arc<std::sync::atomic::AtomicBool>,
+}
 
 impl FakeSlack {
     fn calls(&self) -> Vec<Call> {
-        self.0.lock().expect("the fake's lock").clone()
+        self.calls.lock().expect("the fake's lock").clone()
     }
 
     /// The `text` of every `chat.postMessage`, in the order Slack received them.
@@ -74,11 +80,14 @@ impl FakeSlack {
 
 async fn serve(State(state): State<FakeSlack>, uri: Uri, body: String) -> axum::response::Response {
     let method = uri.path().trim_start_matches('/').to_string();
-    state.0.lock().expect("the fake's lock").push(Call {
+    state.calls.lock().expect("the fake's lock").push(Call {
         method: method.clone(),
         body,
     });
     let reply = match method.as_str() {
+        "auth.test" if !state.auth_works.load(std::sync::atomic::Ordering::Relaxed) => {
+            serde_json::json!({"ok": false, "error": "invalid_auth"})
+        }
         "auth.test" => serde_json::json!({"ok": true, "user_id": BOT_USER, "team": "T"}),
         "conversations.info" => {
             serde_json::json!({"ok": true, "channel": {"id": CHANNEL, "name": "general"}})
@@ -94,7 +103,10 @@ async fn serve(State(state): State<FakeSlack>, uri: Uri, body: String) -> axum::
 
 /// Points every Slack request at a recording fake for as long as the guard lives.
 async fn fake_slack() -> FakeSlack {
-    let state = FakeSlack::default();
+    let state = FakeSlack {
+        calls: Arc::default(),
+        auth_works: Arc::new(std::sync::atomic::AtomicBool::new(true)),
+    };
     let app = axum::Router::new()
         .fallback(serve)
         .with_state(state.clone());
@@ -437,7 +449,10 @@ fn the_prompt_is_logged_at_debug_and_nowhere_else() {
         let tail = &rest[at..];
         let end = tail.find(");").map_or(tail.len(), |offset| offset + 2);
         let call = &tail[..end];
-        if call.contains("job.prompt") || call.contains("mention.text") {
+        // The word, not one binding: the message's own text is carried by
+        // whatever is called `prompt` here and by `mention.text`, and a guard
+        // that named today's binding would go quiet on a rename.
+        if call.contains("prompt") || call.contains("mention.text") {
             carrying.push(call.to_string());
         }
         rest = &tail[end..];
@@ -813,5 +828,86 @@ async fn a_disabled_channel_rule_silences_that_channel_only() {
         slack.posted(),
         vec![("1700000000.000200".to_string(), "answered".to_string())],
         "and every other channel still runs on the workspace default"
+    );
+}
+
+/// Review round 1, finding 4: the one Slack failure the handler cannot work
+/// around must not answer into a thread Agento never started.
+///
+/// `auth.test` is resolved **after** the mapping decision for exactly this
+/// reason. A stranger's thread gets nothing; a thread of Agento's own gets the
+/// failure sentence, because silence there is the outcome that is never allowed.
+#[tokio::test]
+async fn an_auth_failure_answers_only_in_a_thread_agento_started() {
+    let _base = api_base_lock().await;
+    let slack = fake_slack().await;
+    slack
+        .auth_works
+        .store(false, std::sync::atomic::Ordering::Relaxed);
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = migrated(dir.path(), "s-auth");
+    seed_rule(
+        &db,
+        "s-auth",
+        "r",
+        true,
+        "[]",
+        "",
+        "",
+        "2026-01-01 00:00:00 +0000 UTC",
+    );
+    let handler = super::handler(&db, "s-auth", "xoxb-t");
+
+    finish(handler(mention(
+        "<@U0BOT> hello",
+        "1700000000.000300",
+        "1700000000.000100",
+        "s-auth",
+    )))
+    .await;
+    assert!(
+        slack.posted().is_empty(),
+        "a mention in an unmapped thread produces no reply, whatever else failed"
+    );
+
+    finish(handler(mention(
+        "<@U0BOT> hello",
+        "1700000000.000400",
+        "",
+        "s-auth",
+    )))
+    .await;
+    set_api_base(None);
+    assert_eq!(
+        slack.posted(),
+        vec![("1700000000.000400".to_string(), ERROR_REPLY.to_string())],
+        "and a top-level mention, whose thread is Agento's own, is told"
+    );
+    assert!(
+        threads(&db).is_empty(),
+        "no chat is started for a mention that cannot be read"
+    );
+}
+
+/// Review round 1, finding 2: the dispatcher's ten permits bound `claude`
+/// subprocesses, so they are taken around the **run** and not around the
+/// handler.
+///
+/// Structural rather than behavioural on purpose: the semaphore is a process
+/// global shared with every other transport, so a test that drained it to
+/// observe the difference would stall unrelated tests in this binary. What can
+/// be pinned deterministically is *where* it is taken, and moving it back is a
+/// one-line change that nothing else would notice — ten mentions queued in one
+/// Slack thread would silently hold every permit while one of them ran.
+#[test]
+fn the_global_bound_is_taken_around_the_run_and_not_around_the_wait() {
+    assert!(
+        include_str!("../inbound.rs").contains("dispatcher::semaphore().acquire()"),
+        "the run must take the dispatcher's permit"
+    );
+    assert!(
+        !include_str!("../socket.rs").contains("semaphore()"),
+        "and the transport must not: a mention waiting for its thread's turn is \
+         not a `claude` subprocess"
     );
 }

--- a/src-tauri/src/native/integrations/slack/inbound/tests.rs
+++ b/src-tauri/src/native/integrations/slack/inbound/tests.rs
@@ -929,8 +929,73 @@ fn the_global_bound_is_taken_around_the_run_and_not_around_the_wait() {
          not while a mention waits for its thread's turn"
     );
     assert!(
-        !include_str!("../socket.rs").contains("semaphore().acquire"),
+        !include_str!("../socket.rs").contains("semaphore()"),
         "and the transport must not take it: a mention waiting for its thread's \
          turn is not a `claude` subprocess"
+    );
+}
+
+/// #568's acceptance criterion 5, through the code that actually sends: a long
+/// answer arrives as consecutive messages in one thread.
+///
+/// `mrkdwn::split` has its own table, but `post`'s loop runs at one chunk in
+/// every other test here — so posting the answer whole, or firing the chunks
+/// concurrently (which `post`'s own doc says renders a thread backwards), would
+/// leave the whole suite green.
+#[tokio::test]
+async fn a_long_answer_arrives_as_consecutive_messages_in_one_thread() {
+    if python3().is_none() {
+        eprintln!("no python3; skipping");
+        return;
+    }
+    let _base = api_base_lock().await;
+    let slack = fake_slack().await;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = migrated(dir.path(), "s-long");
+    seed_rule(
+        &db,
+        "s-long",
+        "r",
+        true,
+        "[]",
+        "",
+        "",
+        "2026-01-01 00:00:00 +0000 UTC",
+    );
+    let answer = "x".repeat(10_000);
+    let cli = fake_cli(dir.path(), &answer, "sess", false, 0);
+
+    let _env = env_lock().lock().await;
+    std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", &cli);
+    let handler = super::handler(&db, "s-long", "xoxb-t");
+    finish(handler(mention(
+        "<@U0BOT> at length",
+        "1700000000.000100",
+        "",
+        "s-long",
+    )))
+    .await;
+    std::env::remove_var("AGENTO_CLAUDE_EXECUTABLE");
+    set_api_base(None);
+
+    let posted = slack.posted();
+    assert_eq!(
+        posted.len(),
+        3,
+        "10000 characters over a 4000 limit is three"
+    );
+    assert!(
+        posted
+            .iter()
+            .all(|(thread, _)| thread == "1700000000.000100"),
+        "every chunk in the same thread"
+    );
+    assert_eq!(
+        posted
+            .iter()
+            .map(|(_, text)| text.as_str())
+            .collect::<String>(),
+        answer,
+        "in order, and losing nothing"
     );
 }

--- a/src-tauri/src/native/integrations/slack/inbound/tests.rs
+++ b/src-tauri/src/native/integrations/slack/inbound/tests.rs
@@ -417,10 +417,10 @@ fn only_the_bots_own_mention_is_stripped() {
 #[test]
 fn every_run_outcome_has_a_sentence() {
     let answered = RunResult {
-        answer: "## Title\n\n[a](b)".to_string(),
+        answer: "## Title\n\n[a](https://b)".to_string(),
         ..RunResult::default()
     };
-    assert_eq!(reply_for(Ok(answered), "c"), "*Title*\n\n<b|a>");
+    assert_eq!(reply_for(Ok(answered), "c"), "*Title*\n\n<https://b|a>");
     assert_eq!(reply_for(Ok(RunResult::default()), "c"), NO_RESPONSE_REPLY);
     assert_eq!(reply_for(Err("boom".to_string()), "c"), ERROR_REPLY);
     assert_eq!(
@@ -498,7 +498,13 @@ async fn a_top_level_mention_starts_a_chat_and_answers_in_its_thread() {
         cwd.to_str().expect("utf-8 path"),
         "2026-01-01 00:00:00 +0000 UTC",
     );
-    let cli = fake_cli(dir.path(), "## Title\n\nsee [a](b)", "sess", false, 0);
+    let cli = fake_cli(
+        dir.path(),
+        "## Title\n\nsee [a](https://b)",
+        "sess",
+        false,
+        0,
+    );
 
     let _env = env_lock().lock().await;
     std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", &cli);
@@ -532,7 +538,7 @@ async fn a_top_level_mention_starts_a_chat_and_answers_in_its_thread() {
             ("user".to_string(), "summarise the day".to_string()),
             (
                 "assistant".to_string(),
-                "## Title\n\nsee [a](b)".to_string()
+                "## Title\n\nsee [a](https://b)".to_string()
             ),
         ],
         "the chat holds what was said, as Markdown; only Slack sees mrkdwn"
@@ -542,7 +548,7 @@ async fn a_top_level_mention_starts_a_chat_and_answers_in_its_thread() {
         slack.posted(),
         vec![(
             "1700000000.000100".to_string(),
-            "*Title*\n\nsee <b|a>".to_string()
+            "*Title*\n\nsee <https://b|a>".to_string()
         )],
         "one reply, in the thread, converted"
     );
@@ -901,13 +907,30 @@ async fn an_auth_failure_answers_only_in_a_thread_agento_started() {
 /// Slack thread would silently hold every permit while one of them ran.
 #[test]
 fn the_global_bound_is_taken_around_the_run_and_not_around_the_wait() {
+    let flat = include_str!("../inbound.rs")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    let acquire = flat
+        .find("dispatcher::semaphore().acquire()")
+        .expect("the run must take the dispatcher's permit");
+    let prompt_line = flat
+        .find("\"slack mention prompt")
+        .expect("the turn logs its prompt before it runs");
+    let run = flat
+        .find("agent_run::run_resumed(")
+        .expect("the turn calls run_resumed");
+    // Presence alone would stay green if the acquire moved back to `accept`,
+    // which is the regression this test is named for. Its *position* is the
+    // claim: after the chat has been resolved, immediately before the run.
     assert!(
-        include_str!("../inbound.rs").contains("dispatcher::semaphore().acquire()"),
-        "the run must take the dispatcher's permit"
+        prompt_line < acquire && acquire < run,
+        "the permit must be taken between resolving the chat and running it, \
+         not while a mention waits for its thread's turn"
     );
     assert!(
-        !include_str!("../socket.rs").contains("semaphore()"),
-        "and the transport must not: a mention waiting for its thread's turn is \
-         not a `claude` subprocess"
+        !include_str!("../socket.rs").contains("semaphore().acquire"),
+        "and the transport must not take it: a mention waiting for its thread's \
+         turn is not a `claude` subprocess"
     );
 }

--- a/src-tauri/src/native/integrations/slack/inbound/tests.rs
+++ b/src-tauri/src/native/integrations/slack/inbound/tests.rs
@@ -1,0 +1,817 @@
+//! The `app_mention` handler, end to end (#568).
+//!
+//! **These live in the library, not in `src-tauri/tests/`, and they have to.**
+//! Every assertion here is about a request Agento *sends to Slack* — the
+//! threaded reply, its `thread_ts`, the permalink — and the seam that points a
+//! Slack request at a fake is `client::API_BASE`, which is `#[cfg(test)]` on
+//! this crate precisely so it cannot exist in a shipped binary. An
+//! integration-test crate cannot reach it. `trigger/dispatcher.rs` records the
+//! same constraint at the same wall, which is why `tests/trigger_run.rs` stops
+//! one function short of Telegram's reply.
+//!
+//! So this file is `tests/slack_socket.rs`'s fake-server half and
+//! `tests/headless_resume.rs`'s fake-CLI half, in one place: an axum fake Slack
+//! that records every call, and a Python CLI that records its argv, refuses to
+//! overlap with itself and answers a different sentence each time it is
+//! spawned.
+//!
+//! Two process-global seams are taken in a fixed order everywhere below —
+//! `api_base_lock` and then the `AGENTO_CLAUDE_EXECUTABLE` lock — because other
+//! suites in this binary take the first one alone.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use axum::extract::State;
+use axum::http::Uri;
+
+use crate::native::agent_run::RunResult;
+use crate::native::integrations::slack::client::{api_base_lock, set_api_base};
+use crate::native::integrations::slack::socket::AppMention;
+
+use super::{reply_for, strip_mention, ERROR_REPLY, NO_RESPONSE_REPLY};
+
+const BOT_USER: &str = "U0BOT";
+const CHANNEL: &str = "C1";
+
+// ─── The fake Slack ──────────────────────────────────────────────────────────
+
+/// One request the fake answered: which method, and the body it carried.
+#[derive(Clone, Debug)]
+struct Call {
+    method: String,
+    body: String,
+}
+
+#[derive(Clone, Default)]
+struct FakeSlack(Arc<Mutex<Vec<Call>>>);
+
+impl FakeSlack {
+    fn calls(&self) -> Vec<Call> {
+        self.0.lock().expect("the fake's lock").clone()
+    }
+
+    /// The `text` of every `chat.postMessage`, in the order Slack received them.
+    fn posted(&self) -> Vec<(String, String)> {
+        self.calls()
+            .iter()
+            .filter(|call| call.method == "chat.postMessage")
+            .map(|call| {
+                let payload: serde_json::Value =
+                    serde_json::from_str(&call.body).expect("a JSON post body");
+                (
+                    payload["thread_ts"]
+                        .as_str()
+                        .unwrap_or_default()
+                        .to_string(),
+                    payload["text"].as_str().unwrap_or_default().to_string(),
+                )
+            })
+            .collect()
+    }
+}
+
+async fn serve(State(state): State<FakeSlack>, uri: Uri, body: String) -> axum::response::Response {
+    let method = uri.path().trim_start_matches('/').to_string();
+    state.0.lock().expect("the fake's lock").push(Call {
+        method: method.clone(),
+        body,
+    });
+    let reply = match method.as_str() {
+        "auth.test" => serde_json::json!({"ok": true, "user_id": BOT_USER, "team": "T"}),
+        "conversations.info" => {
+            serde_json::json!({"ok": true, "channel": {"id": CHANNEL, "name": "general"}})
+        }
+        "chat.getPermalink" => {
+            serde_json::json!({"ok": true, "permalink": "https://slack.example/p/1"})
+        }
+        "chat.postMessage" => serde_json::json!({"ok": true, "ts": "1700000000.000200"}),
+        _ => serde_json::json!({"ok": false, "error": "unknown_method"}),
+    };
+    axum::response::IntoResponse::into_response(axum::Json(reply))
+}
+
+/// Points every Slack request at a recording fake for as long as the guard lives.
+async fn fake_slack() -> FakeSlack {
+    let state = FakeSlack::default();
+    let app = axum::Router::new()
+        .fallback(serve)
+        .with_state(state.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind the fake slack");
+    let base = format!("http://{}", listener.local_addr().expect("addr"));
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    set_api_base(Some(base));
+    state
+}
+
+// ─── The fake CLI ────────────────────────────────────────────────────────────
+
+/// `AGENTO_CLAUDE_EXECUTABLE` is process-wide, so the tests that set it are
+/// serialized against each other.
+fn env_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+fn python3() -> Option<String> {
+    for candidate in ["python3", "python"] {
+        if std::process::Command::new(candidate)
+            .arg("--version")
+            .output()
+            .is_ok_and(|out| out.status.success())
+        {
+            return Some(candidate.to_string());
+        }
+    }
+    None
+}
+
+fn json_str(path: &Path) -> String {
+    serde_json::to_string(&path.to_string_lossy()).expect("encode path")
+}
+
+fn argv_log(dir: &Path) -> PathBuf {
+    dir.join("argv.jsonl")
+}
+/// Exists while a fake CLI is answering. Two at once is the bug.
+fn busy_marker(dir: &Path) -> PathBuf {
+    dir.join("busy")
+}
+/// Written if a fake CLI ever found [`busy_marker`] already there.
+fn overlap_marker(dir: &Path) -> PathBuf {
+    dir.join("overlap")
+}
+
+/// A CLI that records its argv, refuses to overlap with itself, holds for
+/// `hold_ms`, and answers `answer` with `{n}` replaced by how many times it has
+/// been asked.
+///
+/// It inherits `tests/scheduled_run.rs`'s trap deliberately — **no exit after
+/// the result** — so a run that went through `claude::client::Session` rather
+/// than the one-shot `query` hangs rather than passing, which is what the
+/// deadline around every await below is for.
+fn fake_cli(dir: &Path, answer: &str, session: &str, is_error: bool, hold_ms: u64) -> PathBuf {
+    let script = format!(
+        r#"#!/usr/bin/env {python}
+import json, os, sys, time
+
+with open({argv_log}, "a") as _argv:
+    _argv.write(json.dumps({{"argv": sys.argv, "cwd": os.getcwd()}}) + "\n")
+    _argv.flush()
+
+ANSWER = {answer}
+SESSION = {session}
+IS_ERROR = {is_error}
+HOLD = {hold}
+BUSY = {busy}
+OVERLAP = {overlap}
+COUNTER = {counter}
+
+def say(obj):
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+
+def ack(request_id):
+    say({{"type": "control_response",
+         "response": {{"subtype": "success", "request_id": request_id,
+                       "response": {{"models": [{{"value": "fake", "displayName": "Fake"}}],
+                                     "account": {{"apiProvider": "fake"}},
+                                     "output_style": "default"}}}}}})
+
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        msg = json.loads(line)
+    except Exception:
+        continue
+    req = msg.get("request") or {{}}
+    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack(req.get("request_id") or msg.get("request_id"))
+        continue
+    if msg.get("type") == "user":
+        try:
+            n = int(open(COUNTER).read()) + 1
+        except Exception:
+            n = 1
+        open(COUNTER, "w").write(str(n))
+        if os.path.exists(BUSY):
+            open(OVERLAP, "w").close()
+        open(BUSY, "w").close()
+        time.sleep(HOLD / 1000.0)
+        os.remove(BUSY)
+        say({{"type": "result", "subtype": "success", "is_error": IS_ERROR,
+             "result": ANSWER.replace("{{n}}", str(n)),
+             "session_id": SESSION + "-" + str(n),
+             "usage": {{"input_tokens": 1, "output_tokens": 2,
+                       "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}}}})
+        # Deliberately no exit; see the doc comment.
+        continue
+"#,
+        python = python3().unwrap_or_else(|| "python3".into()),
+        argv_log = json_str(&argv_log(dir)),
+        answer = serde_json::to_string(answer).expect("encode answer"),
+        session = serde_json::to_string(session).expect("encode session"),
+        is_error = if is_error { "True" } else { "False" },
+        hold = hold_ms,
+        busy = json_str(&busy_marker(dir)),
+        overlap = json_str(&overlap_marker(dir)),
+        counter = json_str(&dir.join("counter")),
+    );
+    let path = dir.join("fake-claude");
+    std::fs::write(&path, script).expect("write the fake CLI");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod the fake CLI");
+    }
+    path
+}
+
+/// Every `(argv, cwd)` the fake CLI was invoked with, in order.
+///
+/// The working directory has no command-line flag — it is `Command::current_dir`
+/// — so the process reporting its own is the only way to see it.
+fn spawns(dir: &Path) -> Vec<(Vec<String>, String)> {
+    let Ok(raw) = std::fs::read_to_string(argv_log(dir)) else {
+        return Vec::new();
+    };
+    raw.lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            let entry: serde_json::Value = serde_json::from_str(line).expect("a spawn line");
+            (
+                serde_json::from_value(entry["argv"].clone()).expect("argv"),
+                entry["cwd"].as_str().expect("cwd").to_string(),
+            )
+        })
+        .collect()
+}
+
+fn flag<'a>(argv: &'a [String], name: &str) -> Option<&'a str> {
+    let at = argv.iter().position(|arg| arg == name)?;
+    argv.get(at + 1).map(String::as_str)
+}
+
+// ─── The database ────────────────────────────────────────────────────────────
+
+/// One Slack integration, with inbound on, and no trigger rules yet.
+fn migrated(dir: &Path, integration_id: &str) -> PathBuf {
+    let db_path = dir.join("agento.db");
+    let mut conn = rusqlite::Connection::open(&db_path).expect("open");
+    crate::native::migrate::apply(&mut conn).expect("migrate");
+    conn.execute(
+        "INSERT INTO integrations
+            (id, name, type, enabled, credentials, services, created_at, updated_at,
+             inbound_enabled, inbound_status, inbound_error)
+         VALUES (?1, 'Slack', 'slack', 1, '{\"bot_token\":\"xoxb-t\"}', '{}',
+                 '2026-01-01 00:00:00 +0000 UTC', '2026-01-01 00:00:00 +0000 UTC', 1, '', '')",
+        [integration_id],
+    )
+    .expect("seed the integration");
+    db_path
+}
+
+/// A trigger rule, oldest-first by the `created_at` this is called with.
+#[allow(clippy::too_many_arguments)] // one parameter per stored column, by design
+fn seed_rule(
+    db_path: &Path,
+    integration_id: &str,
+    id: &str,
+    enabled: bool,
+    channels: &str,
+    model: &str,
+    working_directory: &str,
+    created_at: &str,
+) {
+    let conn = rusqlite::Connection::open(db_path).expect("open");
+    conn.execute(
+        "INSERT INTO trigger_rules
+            (id, integration_id, name, agent_slug, enabled, filter_prefix, filter_keywords,
+             filter_chat_ids, model, working_directory, settings_profile_id, permission_mode,
+             timeout_minutes, created_at, updated_at)
+         VALUES (?1, ?2, ?1, '', ?3, '', '[]', ?4, ?5, ?6, '', 'plan', 0, ?7, ?7)",
+        rusqlite::params![
+            id,
+            integration_id,
+            enabled,
+            channels,
+            model,
+            working_directory,
+            created_at
+        ],
+    )
+    .expect("seed a rule");
+}
+
+fn messages(db_path: &Path, chat_id: &str) -> Vec<(String, String)> {
+    let conn = rusqlite::Connection::open(db_path).expect("open");
+    let mut stmt = conn
+        .prepare("SELECT role, content FROM chat_messages WHERE session_id = ?1 ORDER BY id")
+        .expect("prepare");
+    let rows = stmt
+        .query_map([chat_id], |row| Ok((row.get(0)?, row.get(1)?)))
+        .expect("query");
+    rows.map(|row| row.expect("a row")).collect()
+}
+
+/// `(chat_id, permalink)` for every mapped thread.
+fn threads(db_path: &Path) -> Vec<(String, String, String)> {
+    let conn = rusqlite::Connection::open(db_path).expect("open");
+    let mut stmt = conn
+        .prepare("SELECT thread_ts, chat_id, permalink FROM inbound_threads ORDER BY rowid")
+        .expect("prepare");
+    let rows = stmt
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+        .expect("query");
+    rows.map(|row| row.expect("a row")).collect()
+}
+
+fn chat_title(db_path: &Path, chat_id: &str) -> String {
+    let conn = rusqlite::Connection::open(db_path).expect("open");
+    conn.query_row(
+        "SELECT title FROM chat_sessions WHERE id = ?1",
+        [chat_id],
+        |row| row.get(0),
+    )
+    .expect("the chat exists")
+}
+
+// ─── Driving ─────────────────────────────────────────────────────────────────
+
+fn mention(text: &str, ts: &str, thread_ts: &str, integration_id: &str) -> AppMention {
+    AppMention {
+        integration_id: integration_id.to_string(),
+        channel: CHANNEL.to_string(),
+        user: "U1".to_string(),
+        text: text.to_string(),
+        ts: ts.to_string(),
+        thread_ts: thread_ts.to_string(),
+        event_id: format!("Ev{ts}"),
+    }
+}
+
+/// The deadline every await below carries, naming the trap it catches.
+async fn finish(future: impl std::future::Future<Output = ()>) {
+    tokio::time::timeout(Duration::from_secs(45), future)
+        .await
+        .expect("the handler must finish, not hang: a `Session` here never sees stdout close");
+}
+
+/// Wait for `path` to appear, or give up. Never blocks the runtime thread: the
+/// task it is waiting on is running on it.
+async fn wait_for(path: &Path) {
+    for _ in 0..2000 {
+        if path.exists() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    panic!("{} never appeared", path.display());
+}
+
+// ─── The pure parts ──────────────────────────────────────────────────────────
+
+/// The bot's own mention goes; everyone else's stays.
+#[test]
+fn only_the_bots_own_mention_is_stripped() {
+    for (text, want) in [
+        ("<@U0BOT> hello", "hello"),
+        ("<@U0BOT|agento> hello", "hello"),
+        ("hey <@U0BOT> what is up", "hey  what is up"),
+        ("<@U0BOT>", ""),
+        ("   <@U0BOT>   \n ", ""),
+        // Somebody else, and somebody whose id merely starts the same way.
+        ("<@U1> hello", "<@U1> hello"),
+        ("<@U0BOTX> hello", "<@U0BOTX> hello"),
+        ("<@U0BOT> tell <@U9> about it", "tell <@U9> about it"),
+        // Nothing to strip is the text, trimmed.
+        ("  plain  ", "plain"),
+    ] {
+        assert_eq!(strip_mention(text, BOT_USER), want, "stripping {text:?}");
+    }
+}
+
+/// Every ending has a sentence, and a timeout has the same one as a failure —
+/// `agent_run` reports a deadline as an `Err`, and #568's acceptance asks for
+/// `ERROR_REPLY` on both.
+#[test]
+fn every_run_outcome_has_a_sentence() {
+    let answered = RunResult {
+        answer: "## Title\n\n[a](b)".to_string(),
+        ..RunResult::default()
+    };
+    assert_eq!(reply_for(Ok(answered), "c"), "*Title*\n\n<b|a>");
+    assert_eq!(reply_for(Ok(RunResult::default()), "c"), NO_RESPONSE_REPLY);
+    assert_eq!(reply_for(Err("boom".to_string()), "c"), ERROR_REPLY);
+    assert_eq!(
+        reply_for(
+            Err(crate::native::agent_run::DEADLINE_EXCEEDED.to_string()),
+            "c"
+        ),
+        ERROR_REPLY,
+        "a timeout is a failure with the same sentence"
+    );
+}
+
+/// #568's last acceptance criterion, as a property of this file rather than of
+/// one run: the message a stranger wrote is logged in exactly one place, and
+/// that place is `debug`.
+#[test]
+fn the_prompt_is_logged_at_debug_and_nowhere_else() {
+    // Whitespace-collapsed so the assertion survives rustfmt wrapping a call
+    // across lines, which is what it does to the one line that matches.
+    let source = include_str!("../inbound.rs");
+    let flat = source.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    let mut carrying = Vec::new();
+    let mut rest = flat.as_str();
+    while let Some(at) = rest.find("log::") {
+        let tail = &rest[at..];
+        let end = tail.find(");").map_or(tail.len(), |offset| offset + 2);
+        let call = &tail[..end];
+        if call.contains("job.prompt") || call.contains("mention.text") {
+            carrying.push(call.to_string());
+        }
+        rest = &tail[end..];
+    }
+
+    assert_eq!(
+        carrying.len(),
+        1,
+        "exactly one log line may carry the message's own words: {carrying:?}"
+    );
+    assert!(
+        carrying[0].starts_with("log::debug!"),
+        "and it must be `debug`: {}",
+        carrying[0]
+    );
+}
+
+// ─── End to end ──────────────────────────────────────────────────────────────
+
+/// The first acceptance criterion, all of it: the chat carries the rule's
+/// execution settings, the thread is mapped with its permalink, and the reply
+/// lands in a thread hanging off the message that started it.
+#[tokio::test]
+async fn a_top_level_mention_starts_a_chat_and_answers_in_its_thread() {
+    if python3().is_none() {
+        eprintln!("no python3; skipping");
+        return;
+    }
+    let _base = api_base_lock().await;
+    let slack = fake_slack().await;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cwd = dir.path().join("repo");
+    std::fs::create_dir(&cwd).expect("mkdir repo");
+    let canonical = std::fs::canonicalize(&cwd).expect("canonicalize");
+    let db = migrated(dir.path(), "s-start");
+    seed_rule(
+        &db,
+        "s-start",
+        "r",
+        true,
+        "[]",
+        "rule-model",
+        cwd.to_str().expect("utf-8 path"),
+        "2026-01-01 00:00:00 +0000 UTC",
+    );
+    let cli = fake_cli(dir.path(), "## Title\n\nsee [a](b)", "sess", false, 0);
+
+    let _env = env_lock().lock().await;
+    std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", &cli);
+    let handler = super::handler(&db, "s-start", "xoxb-t");
+    finish(handler(mention(
+        "<@U0BOT> summarise the day",
+        "1700000000.000100",
+        "",
+        "s-start",
+    )))
+    .await;
+    std::env::remove_var("AGENTO_CLAUDE_EXECUTABLE");
+    set_api_base(None);
+
+    let mapped = threads(&db);
+    assert_eq!(mapped.len(), 1, "one thread, mapped");
+    let (thread_ts, chat_id, permalink) = mapped[0].clone();
+    assert_eq!(
+        thread_ts, "1700000000.000100",
+        "a top-level mention's own ts is the thread"
+    );
+    assert_eq!(permalink, "https://slack.example/p/1");
+    assert_eq!(
+        chat_title(&db, &chat_id),
+        "[Slack] #general: summarise the day",
+        "the channel's name, and the prompt with the bot's mention already gone"
+    );
+    assert_eq!(
+        messages(&db, &chat_id),
+        vec![
+            ("user".to_string(), "summarise the day".to_string()),
+            (
+                "assistant".to_string(),
+                "## Title\n\nsee [a](b)".to_string()
+            ),
+        ],
+        "the chat holds what was said, as Markdown; only Slack sees mrkdwn"
+    );
+
+    assert_eq!(
+        slack.posted(),
+        vec![(
+            "1700000000.000100".to_string(),
+            "*Title*\n\nsee <b|a>".to_string()
+        )],
+        "one reply, in the thread, converted"
+    );
+
+    let argv = spawns(dir.path());
+    assert_eq!(argv.len(), 1, "one CLI process");
+    assert_eq!(flag(&argv[0].0, "--model"), Some("rule-model"));
+    assert_eq!(flag(&argv[0].0, "--permission-mode"), Some("plan"));
+    assert_eq!(flag(&argv[0].0, "--resume"), None, "nothing to resume yet");
+    assert_eq!(
+        Path::new(&argv[0].1),
+        canonical,
+        "and the rule's working directory is the process's own"
+    );
+}
+
+/// Acceptance criteria 2 and 4 together, because they are the same run: the
+/// second mention arrives while the first is still in the CLI, and it must
+/// resume the same chat, in order, without a second process for it.
+#[tokio::test]
+async fn a_second_mention_in_the_thread_queues_and_resumes_the_same_chat() {
+    if python3().is_none() {
+        eprintln!("no python3; skipping");
+        return;
+    }
+    let _base = api_base_lock().await;
+    let slack = fake_slack().await;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = migrated(dir.path(), "s-resume");
+    seed_rule(
+        &db,
+        "s-resume",
+        "r",
+        true,
+        "[]",
+        "",
+        "",
+        "2026-01-01 00:00:00 +0000 UTC",
+    );
+    // Long enough that the second mention provably arrives mid-run.
+    let cli = fake_cli(dir.path(), "answer {n}", "sess", false, 1200);
+
+    let _env = env_lock().lock().await;
+    std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", &cli);
+    let handler = super::handler(&db, "s-resume", "xoxb-t");
+
+    let first = tokio::spawn({
+        let handler = Arc::clone(&handler);
+        async move {
+            handler(mention(
+                "<@U0BOT> first",
+                "1700000000.000100",
+                "",
+                "s-resume",
+            ))
+            .await;
+        }
+    });
+    // Only once the first run is inside the CLI is the second one provably a
+    // *concurrent* mention rather than a sequential one.
+    wait_for(&busy_marker(dir.path())).await;
+    let second = tokio::spawn({
+        let handler = Arc::clone(&handler);
+        async move {
+            handler(mention(
+                "<@U0BOT> second",
+                "1700000000.000300",
+                "1700000000.000100",
+                "s-resume",
+            ))
+            .await;
+        }
+    });
+    finish(async move {
+        first.await.expect("the first handler");
+        second.await.expect("the second handler");
+    })
+    .await;
+    std::env::remove_var("AGENTO_CLAUDE_EXECUTABLE");
+    set_api_base(None);
+
+    assert!(
+        !overlap_marker(dir.path()).exists(),
+        "two turns on one thread must never have two CLI processes answering at once"
+    );
+    let mapped = threads(&db);
+    assert_eq!(mapped.len(), 1, "one thread, one chat — the second resumed");
+    let chat_id = mapped[0].1.clone();
+
+    assert_eq!(
+        slack.posted(),
+        vec![
+            ("1700000000.000100".to_string(), "answer 1".to_string()),
+            ("1700000000.000100".to_string(), "answer 2".to_string()),
+        ],
+        "both replies in the same thread, in arrival order"
+    );
+    assert_eq!(
+        messages(&db, &chat_id)
+            .iter()
+            .map(|(role, content)| format!("{role}:{content}"))
+            .collect::<Vec<_>>(),
+        vec![
+            "user:first".to_string(),
+            "assistant:answer 1".to_string(),
+            "user:second".to_string(),
+            "assistant:answer 2".to_string(),
+        ],
+        "one chat holds both turns"
+    );
+
+    let argv = spawns(dir.path());
+    assert_eq!(argv.len(), 2, "two runs, one after the other");
+    assert_eq!(flag(&argv[0].0, "--resume"), None);
+    assert_eq!(
+        flag(&argv[1].0, "--resume"),
+        Some("sess-1"),
+        "the second turn resumes the session id the first one minted"
+    );
+}
+
+/// Acceptance criterion 3's two handler-side ignores. A mention from a bot is
+/// the third, and it never reaches this module — `Envelope::app_mention` drops
+/// it, where `a_bot_authored_app_mention_is_not_work` pins it.
+#[tokio::test]
+async fn an_unmapped_thread_and_an_empty_remainder_produce_nothing() {
+    let _base = api_base_lock().await;
+    let slack = fake_slack().await;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = migrated(dir.path(), "s-ignore");
+    seed_rule(
+        &db,
+        "s-ignore",
+        "r",
+        true,
+        "[]",
+        "",
+        "",
+        "2026-01-01 00:00:00 +0000 UTC",
+    );
+    // No `AGENTO_CLAUDE_EXECUTABLE` at all: a run reaching the CLI here would
+    // fail loudly rather than quietly answering.
+    let handler = super::handler(&db, "s-ignore", "xoxb-t");
+
+    finish(handler(mention(
+        "<@U0BOT> hello",
+        "1700000000.000300",
+        "1700000000.000100",
+        "s-ignore",
+    )))
+    .await;
+    finish(handler(mention(
+        "  <@U0BOT>  ",
+        "1700000000.000400",
+        "",
+        "s-ignore",
+    )))
+    .await;
+    set_api_base(None);
+
+    assert!(threads(&db).is_empty(), "no thread was mapped");
+    assert!(
+        slack.posted().is_empty(),
+        "and nothing was said in the channel"
+    );
+    let conn = rusqlite::Connection::open(&db).expect("open");
+    let chats: i64 = conn
+        .query_row("SELECT count(*) FROM chat_sessions", [], |row| row.get(0))
+        .expect("count");
+    assert_eq!(chats, 0, "no chat was created");
+}
+
+/// A failing run still answers, and the chat still holds what was asked — the
+/// failure is visible in Slack *and* in the app.
+#[tokio::test]
+async fn a_failed_run_answers_the_failure_sentence_and_keeps_the_question() {
+    if python3().is_none() {
+        eprintln!("no python3; skipping");
+        return;
+    }
+    let _base = api_base_lock().await;
+    let slack = fake_slack().await;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = migrated(dir.path(), "s-fail");
+    seed_rule(
+        &db,
+        "s-fail",
+        "r",
+        true,
+        "[]",
+        "",
+        "",
+        "2026-01-01 00:00:00 +0000 UTC",
+    );
+    let cli = fake_cli(dir.path(), "not reached", "sess", true, 0);
+
+    let _env = env_lock().lock().await;
+    std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", &cli);
+    let handler = super::handler(&db, "s-fail", "xoxb-t");
+    finish(handler(mention(
+        "<@U0BOT> break",
+        "1700000000.000100",
+        "",
+        "s-fail",
+    )))
+    .await;
+    std::env::remove_var("AGENTO_CLAUDE_EXECUTABLE");
+    set_api_base(None);
+
+    assert_eq!(
+        slack.posted(),
+        vec![("1700000000.000100".to_string(), ERROR_REPLY.to_string())]
+    );
+    let chat_id = threads(&db)[0].1.clone();
+    assert_eq!(
+        messages(&db, &chat_id),
+        vec![("user".to_string(), "break".to_string())],
+        "the question is stored with no answer, so the failure is visible in the app too"
+    );
+}
+
+/// #565's selection rule, as the user experiences it: turning a channel's own
+/// rule off silences that channel and leaves every other channel answering.
+#[tokio::test]
+async fn a_disabled_channel_rule_silences_that_channel_only() {
+    if python3().is_none() {
+        eprintln!("no python3; skipping");
+        return;
+    }
+    let _base = api_base_lock().await;
+    let slack = fake_slack().await;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = migrated(dir.path(), "s-off");
+    // Oldest first, as `load_rules` returns them: the workspace default, then
+    // the channel-specific rule that is switched off.
+    seed_rule(
+        &db,
+        "s-off",
+        "default",
+        true,
+        "[]",
+        "",
+        "",
+        "2026-01-01 00:00:00 +0000 UTC",
+    );
+    seed_rule(
+        &db,
+        "s-off",
+        "silenced",
+        false,
+        r#"["C1"]"#,
+        "",
+        "",
+        "2026-02-01 00:00:00 +0000 UTC",
+    );
+    let cli = fake_cli(dir.path(), "answered", "sess", false, 0);
+
+    let _env = env_lock().lock().await;
+    std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", &cli);
+    let handler = super::handler(&db, "s-off", "xoxb-t");
+
+    // `CHANNEL` is the silenced one.
+    finish(handler(mention(
+        "<@U0BOT> hello",
+        "1700000000.000100",
+        "",
+        "s-off",
+    )))
+    .await;
+    assert!(
+        slack.posted().is_empty(),
+        "a disabled channel-specific rule is that channel's off switch, not a \
+         fall-through to the workspace default"
+    );
+
+    let mut elsewhere = mention("<@U0BOT> hello", "1700000000.000200", "", "s-off");
+    elsewhere.channel = "C2".to_string();
+    finish(handler(elsewhere)).await;
+    std::env::remove_var("AGENTO_CLAUDE_EXECUTABLE");
+    set_api_base(None);
+
+    assert_eq!(
+        slack.posted(),
+        vec![("1700000000.000200".to_string(), "answered".to_string())],
+        "and every other channel still runs on the workspace default"
+    );
+}

--- a/src-tauri/src/native/integrations/slack/mod.rs
+++ b/src-tauri/src/native/integrations/slack/mod.rs
@@ -57,7 +57,9 @@
 //! every hosted type.
 
 pub mod client;
+pub mod inbound;
 pub mod messaging;
+pub mod mrkdwn;
 pub mod socket;
 pub mod validate;
 

--- a/src-tauri/src/native/integrations/slack/mrkdwn.rs
+++ b/src-tauri/src/native/integrations/slack/mrkdwn.rs
@@ -1,0 +1,382 @@
+//! Markdown → Slack mrkdwn, and the split that fits it into one message (#568).
+//!
+//! The model answers in Markdown and Slack renders *mrkdwn*, which is a
+//! different language with the same punctuation: `*one asterisk*` is bold,
+//! there are no headings at all, and a link is `<url|text>` rather than
+//! `[text](url)`. Posting the raw answer therefore renders `**bold**` literally
+//! and shows every URL twice, which is what the Telegram reply path does today
+//! (`trigger/telegram_api.rs` sends with no `parse_mode`) and is not a bar worth
+//! matching for a surface a team reads all day.
+//!
+//! Two pure functions, because everything that makes this hard is decidable
+//! from the text alone:
+//!
+//! - [`to_mrkdwn`] converts. It is **line-based and fence-aware**: a fenced code
+//!   block is copied out byte for byte, so an answer explaining `**` or showing
+//!   a Markdown link keeps saying what it said.
+//! - [`split`] cuts a long answer into consecutive messages at [`MAX_MESSAGE_CHARS`].
+//!
+//! ## What is deliberately *not* done
+//!
+//! **Nothing is HTML-escaped.** Slack asks a client to send `&`, `<` and `>` as
+//! `&amp;`, `&lt;` and `&gt;`, and doing so here would be a second, lossy pass
+//! over text the model wrote — it would mangle every `->` in prose, and it
+//! cannot be applied inside a fenced block without changing the code the answer
+//! is showing. The conversions this module performs are exactly the ones #568
+//! specifies and no more, so a byte the model wrote either survives or is one of
+//! those conversions. The consequence to know: an answer that literally contains
+//! `<@U123>` will mention that user.
+//!
+//! **The limit is counted in `char`s, not bytes and not grapheme clusters.**
+//! Slack's own limit is characters, and [`split`] never cuts inside one —
+//! `a_non_ascii_answer_is_never_cut_mid_character` is the guard.
+
+/// Where [`split`] cuts, from #568.
+///
+/// Slack's hard limit on `text` is larger, but a message anywhere near it is
+/// truncated in the client with a *See more* link, and 4000 is the number the
+/// epic settled on.
+pub const MAX_MESSAGE_CHARS: usize = 4000;
+
+/// The answer as Slack mrkdwn.
+pub fn to_mrkdwn(markdown: &str) -> String {
+    let mut out = String::with_capacity(markdown.len());
+    let mut in_fence = false;
+    let mut first = true;
+    for line in markdown.split('\n') {
+        if !first {
+            out.push('\n');
+        }
+        first = false;
+
+        if is_fence(line) {
+            in_fence = !in_fence;
+            out.push_str(line);
+            continue;
+        }
+        if in_fence {
+            // Verbatim, including any `**` and any `[text](url)`: inside a fence
+            // those are the answer's subject, not its formatting.
+            out.push_str(line);
+            continue;
+        }
+        match heading_text(line) {
+            // Slack has no headings, so the epic's answer is a bold line. An
+            // empty heading (`##` alone) would become a bare `**`, which Slack
+            // renders as two literal asterisks, so it stays a blank line.
+            Some(text) if !text.is_empty() => {
+                out.push('*');
+                out.push_str(&inline(text));
+                out.push('*');
+            }
+            Some(_) => {}
+            None => out.push_str(&inline(line)),
+        }
+    }
+    out
+}
+
+/// ```` ``` ```` or longer, at the start of a line, opening or closing a block.
+fn is_fence(line: &str) -> bool {
+    line.trim_start().starts_with("```")
+}
+
+/// The text of an ATX heading (`#` … `######`), or `None` for any other line.
+fn heading_text(line: &str) -> Option<&str> {
+    let trimmed = line.trim_start();
+    let hashes = trimmed.len() - trimmed.trim_start_matches('#').len();
+    if hashes == 0 || hashes > 6 {
+        return None;
+    }
+    let rest = &trimmed[hashes..];
+    // `#hashtag` is not a heading; `#` alone on a line is.
+    if rest.is_empty() {
+        return Some("");
+    }
+    rest.strip_prefix(' ').map(str::trim)
+}
+
+/// The inline conversions, on one line that is not a heading and not fenced.
+///
+/// Written as one scan rather than three passes because each rule has to see
+/// the others' delimiters: a `**` inside a code span is not bold, and a `[` in
+/// a code span does not open a link.
+fn inline(line: &str) -> String {
+    let bytes = line.as_bytes();
+    let mut out = String::with_capacity(line.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            // A code span is copied out with its delimiters, whatever it holds.
+            b'`' => {
+                let run = bytes[i..].iter().take_while(|b| **b == b'`').count();
+                let fence = &line[i..i + run];
+                match line[i + run..].find(fence) {
+                    Some(offset) => {
+                        let end = i + run + offset + run;
+                        out.push_str(&line[i..end]);
+                        i = end;
+                    }
+                    // An unclosed span is not a span: emit the backticks and
+                    // carry on converting the rest of the line.
+                    None => {
+                        out.push_str(fence);
+                        i += run;
+                    }
+                }
+            }
+            b'*' if bytes[i..].starts_with(b"**") => {
+                out.push('*');
+                i += 2;
+            }
+            // `![alt](url)` differs from `[alt](url)` only in the `!`, and Slack
+            // has no image syntax, so both become the same link.
+            b'!' if bytes.get(i + 1) == Some(&b'[') => i += 1,
+            b'[' => match link_at(line, i) {
+                Some((text, url, end)) => {
+                    out.push('<');
+                    out.push_str(url);
+                    if !text.is_empty() {
+                        out.push('|');
+                        out.push_str(text);
+                    }
+                    out.push('>');
+                    i = end;
+                }
+                None => {
+                    out.push('[');
+                    i += 1;
+                }
+            },
+            _ => {
+                let ch = line[i..].chars().next().expect("a char at a boundary");
+                out.push(ch);
+                i += ch.len_utf8();
+            }
+        }
+    }
+    out
+}
+
+/// `(text, url, end)` for the `[text](url)` starting at `open`, or `None`.
+///
+/// Deliberately non-recursive and non-nesting: the label may not contain `]`
+/// and the target may not contain `)`, which is every link the model writes and
+/// keeps a malformed one from swallowing the rest of the line.
+fn link_at(line: &str, open: usize) -> Option<(&str, &str, usize)> {
+    let after = &line[open + 1..];
+    let close = after.find(']')?;
+    if !after[close + 1..].starts_with('(') {
+        return None;
+    }
+    let target = &after[close + 2..];
+    let paren = target.find(')')?;
+    let url = &target[..paren];
+    if url.is_empty() {
+        return None;
+    }
+    let end = open + 1 + close + 2 + paren + 1;
+    Some((&after[..close], url, end))
+}
+
+/// `text` as consecutive messages of at most `limit` characters each.
+///
+/// Never empty: a caller with nothing to say has a sentence to send instead, so
+/// an empty input answers one empty chunk rather than none.
+///
+/// The break is chosen in the order #568 specifies — a blank line, then a line
+/// ending, then a hard cut — and a candidate **inside a fenced code block is
+/// passed over** while any candidate outside one remains, so a code block
+/// survives the split whole wherever the arithmetic allows it.
+pub fn split(text: &str, limit: usize) -> Vec<String> {
+    assert!(limit > 0, "a message limit of zero would never terminate");
+    let mut chunks = Vec::new();
+    let mut rest = text;
+    loop {
+        if rest.chars().count() <= limit {
+            chunks.push(rest.to_string());
+            return chunks;
+        }
+        let window = &rest[..char_boundary(rest, limit)];
+        let (end, resume) = next_break(window);
+        chunks.push(rest[..end].to_string());
+        rest = &rest[resume..];
+    }
+}
+
+/// The byte offset just past `chars` characters of `text`.
+fn char_boundary(text: &str, chars: usize) -> usize {
+    text.char_indices()
+        .nth(chars)
+        .map_or(text.len(), |(offset, _)| offset)
+}
+
+/// `(chunk_end, resume_at)` for the best break inside `window`.
+fn next_break(window: &str) -> (usize, usize) {
+    let mut paragraph = None;
+    let mut line = None;
+    let mut fenced_paragraph = None;
+    let mut fenced_line = None;
+    let mut in_fence = false;
+    let mut at = 0;
+
+    while let Some(offset) = window[at..].find('\n') {
+        let newline = at + offset;
+        if is_fence(&window[at..newline]) {
+            in_fence = !in_fence;
+        }
+        // A run of newlines is one paragraph break: the chunk ends at the first
+        // and the next resumes past the last, so the blank line is not repeated.
+        let after = newline + 1;
+        let resumed =
+            after + window[after..].len() - window[after..].trim_start_matches('\n').len();
+        let blank = resumed > after;
+        if newline > 0 {
+            let slot = match (in_fence, blank) {
+                (false, true) => &mut paragraph,
+                (false, false) => &mut line,
+                (true, true) => &mut fenced_paragraph,
+                (true, false) => &mut fenced_line,
+            };
+            *slot = Some((newline, if blank { resumed } else { after }));
+        }
+        at = after;
+    }
+
+    paragraph
+        .or(line)
+        .or(fenced_paragraph)
+        .or(fenced_line)
+        // Nothing to break on: a hard cut on a character boundary, which is what
+        // the window already is.
+        .unwrap_or((window.len(), window.len()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The four conversions #568 names, plus the ones that must *not* happen.
+    #[test]
+    fn every_conversion_is_the_one_slack_renders() {
+        for (markdown, want) in [
+            ("## Title", "*Title*"),
+            ("# H1", "*H1*"),
+            ("###### H6", "*H6*"),
+            ("####### not a heading", "####### not a heading"),
+            ("#hashtag", "#hashtag"),
+            ("**bold**", "*bold*"),
+            ("a **bold** word", "a *bold* word"),
+            ("[a](b)", "<b|a>"),
+            (
+                "see [the docs](https://x/y?a=1&b=2)",
+                "see <https://x/y?a=1&b=2|the docs>",
+            ),
+            ("![alt](u)", "<u|alt>"),
+            ("[](u)", "<u>"),
+            // Lists survive: Slack renders `- ` as a bullet already.
+            ("- one\n- two", "- one\n- two"),
+            // Malformed links stay text rather than eating the line.
+            ("[unclosed", "[unclosed"),
+            ("[a] (b)", "[a] (b)"),
+            ("[a]()", "[a]()"),
+            // A code span is its own subject.
+            ("use `**this**` here", "use `**this**` here"),
+            ("`[a](b)`", "`[a](b)`"),
+            ("an unclosed ` **span**", "an unclosed ` *span*"),
+            // Headings convert their own inline content.
+            ("## [a](b)", "*<b|a>*"),
+            ("##", ""),
+            ("", ""),
+        ] {
+            assert_eq!(to_mrkdwn(markdown), want, "converting {markdown:?}");
+        }
+    }
+
+    /// The whole point of tracking fences: an answer *about* Markdown.
+    #[test]
+    fn a_fenced_block_is_copied_out_byte_for_byte() {
+        let markdown =
+            "Before **bold**\n\n```md\n## Heading\n**bold** and [a](b)\n```\n\nAfter [x](y)";
+        assert_eq!(
+            to_mrkdwn(markdown),
+            "Before *bold*\n\n```md\n## Heading\n**bold** and [a](b)\n```\n\nAfter <y|x>"
+        );
+    }
+
+    /// #568's acceptance criterion, in the units it is written in.
+    #[test]
+    fn a_ten_thousand_character_answer_is_three_messages_in_order() {
+        let answer = "x".repeat(10_000);
+        let chunks = split(&answer, MAX_MESSAGE_CHARS);
+        assert_eq!(chunks.len(), 3, "10000 / 4000 rounds up to three");
+        assert_eq!(
+            chunks.iter().map(String::len).collect::<Vec<_>>(),
+            vec![4000, 4000, 2000]
+        );
+        assert_eq!(chunks.concat(), answer, "in order, and losing nothing");
+    }
+
+    #[test]
+    fn a_short_answer_is_one_message_and_an_empty_one_is_still_a_message() {
+        assert_eq!(split("hello", MAX_MESSAGE_CHARS), vec!["hello".to_string()]);
+        assert_eq!(split("", MAX_MESSAGE_CHARS), vec![String::new()]);
+    }
+
+    /// A blank line beats a line ending, and a line ending beats a hard cut.
+    #[test]
+    fn the_break_prefers_a_paragraph_then_a_line_then_the_limit() {
+        assert_eq!(
+            split("aaa\nbbb\n\nccc\nddd", 12),
+            vec!["aaa\nbbb".to_string(), "ccc\nddd".to_string()],
+            "the blank line is the break, and is not repeated"
+        );
+        assert_eq!(
+            split("aaa\nbbb\nccc", 8),
+            vec!["aaa\nbbb".to_string(), "ccc".to_string()],
+            "no blank line, so the last line ending inside the window"
+        );
+        assert_eq!(
+            split("aaaaaaaaaa", 4),
+            vec!["aaaa".to_string(), "aaaa".to_string(), "aa".to_string()],
+            "nothing to break on, so the limit itself"
+        );
+    }
+
+    /// The risk this pins: a `char` is one to four bytes and slicing is by byte.
+    #[test]
+    fn a_non_ascii_answer_is_never_cut_mid_character() {
+        let answer = "日本語のテキスト".repeat(500);
+        let chunks = split(&answer, 100);
+        assert!(chunks.len() > 1, "the fixture is long enough to be split");
+        for chunk in &chunks {
+            assert!(
+                chunk.chars().count() <= 100,
+                "each chunk respects the limit"
+            );
+        }
+        assert_eq!(chunks.concat(), answer, "and the bytes are all still there");
+    }
+
+    /// A break inside a fence is taken only when there is no other.
+    #[test]
+    fn a_fenced_block_is_not_split_when_a_break_outside_it_exists() {
+        let text = "intro\n```\none\ntwo\nthree\n```";
+        let chunks = split(text, 25);
+        assert_eq!(
+            chunks[0], "intro",
+            "the line ending before the fence beats the ones inside it"
+        );
+        assert_eq!(chunks[1], "```\none\ntwo\nthree\n```");
+
+        // With no candidate outside, the fence is cut rather than the limit
+        // being exceeded.
+        let only_fence = "```\naaaa\nbbbb\ncccc\ndddd\n```";
+        let chunks = split(only_fence, 14);
+        assert!(chunks.len() > 1);
+        assert_eq!(
+            chunks.concat().replace('\n', ""),
+            only_fence.replace('\n', "")
+        );
+    }
+}

--- a/src-tauri/src/native/integrations/slack/mrkdwn.rs
+++ b/src-tauri/src/native/integrations/slack/mrkdwn.rs
@@ -16,16 +16,23 @@
 //!   a Markdown link keeps saying what it said.
 //! - [`split`] cuts a long answer into consecutive messages at [`MAX_MESSAGE_CHARS`].
 //!
-//! ## What is deliberately *not* done
+//! ## Escaping comes first, and it is not cosmetic
 //!
-//! **Nothing is HTML-escaped.** Slack asks a client to send `&`, `<` and `>` as
-//! `&amp;`, `&lt;` and `&gt;`, and doing so here would be a second, lossy pass
-//! over text the model wrote — it would mangle every `->` in prose, and it
-//! cannot be applied inside a fenced block without changing the code the answer
-//! is showing. The conversions this module performs are exactly the ones #568
-//! specifies and no more, so a byte the model wrote either survives or is one of
-//! those conversions. The consequence to know: an answer that literally contains
-//! `<@U123>` will mention that user.
+//! Slack asks a client to send `&`, `<` and `>` as `&amp;`, `&lt;` and `&gt;`,
+//! and renders them back as themselves — in prose and inside a code block
+//! alike, so escaping costs the answer nothing. Not escaping costs it a great
+//! deal: `chat.postMessage` parses `<!channel>`, `<!here>` and `<!everyone>` in
+//! `text` as **broadcasts**, and `<@U123>` as a mention. This is the first
+//! surface where an agent's answer — derived from text a stranger in a Slack
+//! channel wrote — is posted by the app as itself, into a channel the app is a
+//! member of by construction. An answer talked into saying `<!channel>` would
+//! notify everyone in it.
+//!
+//! So [`to_mrkdwn`] escapes the whole answer **before** converting anything,
+//! and the only raw `<`, `>` and `|` in its output are the ones it writes
+//! itself, building a `<url|text>` link. `gojson::to_vec_marshal` is not this:
+//! it escapes `<` to `\u003c` at the JSON layer and Slack decodes that straight
+//! back to `<`.
 //!
 //! **The limit is counted in `char`s, not bytes and not grapheme clusters.**
 //! Slack's own limit is characters, and [`split`] never cuts inside one —
@@ -40,6 +47,12 @@ pub const MAX_MESSAGE_CHARS: usize = 4000;
 
 /// The answer as Slack mrkdwn.
 pub fn to_mrkdwn(markdown: &str) -> String {
+    // Before anything else, and over the whole answer including its fenced
+    // blocks: what Slack renders from `&lt;` is `<`, so nothing is lost, and
+    // what it renders from an unescaped `<!channel>` is a notification to a
+    // whole channel. See the module header.
+    let escaped = escape(markdown);
+    let markdown = escaped.as_str();
     let mut out = String::with_capacity(markdown.len());
     let mut in_fence = false;
     let mut first = true;
@@ -74,6 +87,14 @@ pub fn to_mrkdwn(markdown: &str) -> String {
         }
     }
     out
+}
+
+/// The three characters Slack reads as markup, as the entities it renders back.
+fn escape(text: &str) -> String {
+    // `&` first, or the `&` of an entity this function just wrote is escaped again.
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
 }
 
 /// ```` ``` ```` or longer, at the start of a line, opening or closing a block.
@@ -130,8 +151,10 @@ fn inline(line: &str) -> String {
                 i += 2;
             }
             // `![alt](url)` differs from `[alt](url)` only in the `!`, and Slack
-            // has no image syntax, so both become the same link.
-            b'!' if bytes.get(i + 1) == Some(&b'[') => i += 1,
+            // has no image syntax, so both become the same link. Only a `!` in
+            // front of a *well-formed* link is dropped: `![unclosed` is prose,
+            // and silently losing its `!` would be a conversion nobody asked for.
+            b'!' if bytes.get(i + 1) == Some(&b'[') && link_at(line, i + 1).is_some() => i += 1,
             b'[' => match link_at(line, i) {
                 Some((text, url, end)) => {
                     out.push('<');
@@ -270,7 +293,7 @@ mod tests {
             ("[a](b)", "<b|a>"),
             (
                 "see [the docs](https://x/y?a=1&b=2)",
-                "see <https://x/y?a=1&b=2|the docs>",
+                "see <https://x/y?a=1&amp;b=2|the docs>",
             ),
             ("![alt](u)", "<u|alt>"),
             ("[](u)", "<u>"),
@@ -278,6 +301,9 @@ mod tests {
             ("- one\n- two", "- one\n- two"),
             // Malformed links stay text rather than eating the line.
             ("[unclosed", "[unclosed"),
+            // A `!` that is not an image reference is prose, and keeps its `!`.
+            ("![unclosed", "![unclosed"),
+            ("![a] (b)", "![a] (b)"),
             ("[a] (b)", "[a] (b)"),
             ("[a]()", "[a]()"),
             // A code span is its own subject.
@@ -288,6 +314,30 @@ mod tests {
             ("## [a](b)", "*<b|a>*"),
             ("##", ""),
             ("", ""),
+        ] {
+            assert_eq!(to_mrkdwn(markdown), want, "converting {markdown:?}");
+        }
+    }
+
+    /// The reason escaping is not cosmetic: an answer talked into emitting a
+    /// broadcast must not produce one, and the only raw angle brackets in the
+    /// output are the ones this module writes itself.
+    #[test]
+    fn slacks_own_markup_never_survives_the_answer() {
+        for (markdown, want) in [
+            ("<!channel>", "&lt;!channel&gt;"),
+            ("<!here> deploy now", "&lt;!here&gt; deploy now"),
+            ("ping <@U123>", "ping &lt;@U123&gt;"),
+            ("a < b && c > d", "a &lt; b &amp;&amp; c &gt; d"),
+            (
+                "<https://x|already a link>",
+                "&lt;https://x|already a link&gt;",
+            ),
+            // Inside a fence too: Slack renders `&lt;` as `<` in a code block,
+            // so the code still reads as written and cannot notify anybody.
+            ("```\n<!channel>\n```", "```\n&lt;!channel&gt;\n```"),
+            // Escaped once, never twice.
+            ("&amp;", "&amp;amp;"),
         ] {
             assert_eq!(to_mrkdwn(markdown), want, "converting {markdown:?}");
         }

--- a/src-tauri/src/native/integrations/slack/mrkdwn.rs
+++ b/src-tauri/src/native/integrations/slack/mrkdwn.rs
@@ -29,14 +29,20 @@
 //! notify everyone in it.
 //!
 //! So [`to_mrkdwn`] escapes the whole answer **before** converting anything, and
-//! the only raw `<` and `|` in its output — and the only raw `>` outside a
-//! restored blockquote marker, below — are the ones it writes itself around a
-//! link whose target it has checked is an `http`, `https` or `mailto` URL. That check is not decoration: `<…>` is Slack's markup for *everything*,
-//! so a link target it did not vet is a hole straight back through the escape —
-//! `[](!channel)` would otherwise become `<!channel>`, and a channel member can
-//! ask for that in one sentence. A target that is not such a URL keeps its
-//! Markdown spelling and is posted as prose, which is also what a reader wants
-//! for the `[guide](./setup.md)` Slack could not link to anyway.
+//! the only raw `<` it then writes — and the only raw `>` outside a restored
+//! blockquote marker, below — is the pair it puts around a link whose target it
+//! has checked is an `http`, `https` or `mailto` URL. That check is not
+//! decoration: `<…>` is Slack's markup for *everything*, so a link target it did
+//! not vet is a hole straight back through the escape — `[](!channel)` would
+//! otherwise become `<!channel>`, and a channel member can ask for that in one
+//! sentence. A target that is not such a URL keeps its Markdown spelling and is
+//! posted as prose, which is also what a reader wants for the
+//! `[guide](./setup.md)` Slack could not link to anyway.
+//!
+//! `|` is **not** escaped, and does not need to be: outside `<…>` it is an
+//! ordinary character to Slack. Inside is where it separates a link's target
+//! from its label, and [`is_postable_url`] is what keeps it out of there,
+//! refusing a `|` in either half rather than escaping one.
 //! `gojson::to_vec_marshal` is not a substitute for any of this: it escapes `<`
 //! to `\u003c` at the JSON layer and Slack decodes that straight back to `<`.
 //!

--- a/src-tauri/src/native/integrations/slack/mrkdwn.rs
+++ b/src-tauri/src/native/integrations/slack/mrkdwn.rs
@@ -28,11 +28,22 @@
 //! member of by construction. An answer talked into saying `<!channel>` would
 //! notify everyone in it.
 //!
-//! So [`to_mrkdwn`] escapes the whole answer **before** converting anything,
-//! and the only raw `<`, `>` and `|` in its output are the ones it writes
-//! itself, building a `<url|text>` link. `gojson::to_vec_marshal` is not this:
-//! it escapes `<` to `\u003c` at the JSON layer and Slack decodes that straight
-//! back to `<`.
+//! So [`to_mrkdwn`] escapes the whole answer **before** converting anything, and
+//! the only raw `<`, `>` and `|` in its output are the three it writes itself
+//! around a link whose target it has checked is an `http`, `https` or `mailto`
+//! URL. That check is not decoration: `<…>` is Slack's markup for *everything*,
+//! so a link target it did not vet is a hole straight back through the escape —
+//! `[](!channel)` would otherwise become `<!channel>`, and a channel member can
+//! ask for that in one sentence. A target that is not such a URL keeps its
+//! Markdown spelling and is posted as prose, which is also what a reader wants
+//! for the `[guide](./setup.md)` Slack could not link to anyway.
+//! `gojson::to_vec_marshal` is not a substitute for any of this: it escapes `<`
+//! to `\u003c` at the JSON layer and Slack decodes that straight back to `<`.
+//!
+//! One thing escaping does cost: a Markdown blockquote. `> quoted` escapes to
+//! `&gt; quoted`, which Slack renders as literal text, so a leading run of them
+//! is restored — Slack's own blockquote is `>` too, and it is the one line-level
+//! marker the answer would otherwise lose.
 //!
 //! **The limit is counted in `char`s, not bytes and not grapheme clusters.**
 //! Slack's own limit is characters, and [`split`] never cuts inside one —
@@ -73,6 +84,8 @@ pub fn to_mrkdwn(markdown: &str) -> String {
             out.push_str(line);
             continue;
         }
+        let restored = restore_blockquote(line);
+        let line = restored.as_str();
         match heading_text(line) {
             // Slack has no headings, so the epic's answer is a bold line. An
             // empty heading (`##` alone) would become a bare `**`, which Slack
@@ -95,6 +108,24 @@ fn escape(text: &str) -> String {
     text.replace('&', "&amp;")
         .replace('<', "&lt;")
         .replace('>', "&gt;")
+}
+
+/// A line's leading run of escaped `&gt;` put back as `>`.
+///
+/// Slack's blockquote marker is Markdown's, so escaping is the only thing that
+/// broke it. Only the leading run: a `>` mid-sentence is prose and stays
+/// escaped, which is the whole point of escaping it.
+fn restore_blockquote(line: &str) -> String {
+    let mut markers = 0;
+    let mut rest = line;
+    while let Some(after) = rest.strip_prefix("&gt;") {
+        markers += 1;
+        rest = after;
+    }
+    if markers == 0 {
+        return line.to_string();
+    }
+    format!("{}{rest}", ">".repeat(markers))
 }
 
 /// ```` ``` ```` or longer, at the start of a line, opening or closing a block.
@@ -181,6 +212,26 @@ fn inline(line: &str) -> String {
     out
 }
 
+/// Whether `url` may be written between the raw `<` and `>` of a Slack link.
+///
+/// **This is the escape's second half, not a tidiness check.** `<…>` is Slack's
+/// markup for everything — `<!channel>` is a broadcast, `<@U1>` a mention,
+/// `<#C0|general>` a channel link — so a link target copied out unvetted
+/// reintroduces every form [`escape`] just removed, through a `[](…)` a channel
+/// member can ask the agent for in one sentence. An `http`, `https` or `mailto`
+/// URL is the only target Slack would render as a link anyway; everything else
+/// keeps its Markdown spelling and is posted as prose. `|` is refused in either
+/// half for the same reason: it is the separator.
+fn is_postable_url(url: &str, text: &str) -> bool {
+    if url.contains('|') || text.contains('|') {
+        return false;
+    }
+    let lower = url.to_ascii_lowercase();
+    ["http://", "https://", "mailto:"]
+        .iter()
+        .any(|scheme| lower.starts_with(scheme))
+}
+
 /// `(text, url, end)` for the `[text](url)` starting at `open`, or `None`.
 ///
 /// Deliberately non-recursive and non-nesting: the label may not contain `]`
@@ -195,11 +246,12 @@ fn link_at(line: &str, open: usize) -> Option<(&str, &str, usize)> {
     let target = &after[close + 2..];
     let paren = target.find(')')?;
     let url = &target[..paren];
-    if url.is_empty() {
+    let text = &after[..close];
+    if url.is_empty() || !is_postable_url(url, text) {
         return None;
     }
     let end = open + 1 + close + 2 + paren + 1;
-    Some((&after[..close], url, end))
+    Some((text, url, end))
 }
 
 /// `text` as consecutive messages of at most `limit` characters each.
@@ -290,13 +342,19 @@ mod tests {
             ("#hashtag", "#hashtag"),
             ("**bold**", "*bold*"),
             ("a **bold** word", "a *bold* word"),
-            ("[a](b)", "<b|a>"),
+            ("[a](https://b)", "<https://b|a>"),
+            // A target Slack would not render as a link keeps its Markdown
+            // spelling, which is also what stops `[](!channel)` below.
+            ("[a](b)", "[a](b)"),
+            ("[guide](./setup.md)", "[guide](./setup.md)"),
+            ("[m](mailto:a@b.c)", "<mailto:a@b.c|m>"),
+            ("[a](HTTPS://B)", "<HTTPS://B|a>"),
             (
                 "see [the docs](https://x/y?a=1&b=2)",
                 "see <https://x/y?a=1&amp;b=2|the docs>",
             ),
-            ("![alt](u)", "<u|alt>"),
-            ("[](u)", "<u>"),
+            ("![alt](https://u)", "<https://u|alt>"),
+            ("[](https://u)", "<https://u>"),
             // Lists survive: Slack renders `- ` as a bullet already.
             ("- one\n- two", "- one\n- two"),
             // Malformed links stay text rather than eating the line.
@@ -304,6 +362,7 @@ mod tests {
             // A `!` that is not an image reference is prose, and keeps its `!`.
             ("![unclosed", "![unclosed"),
             ("![a] (b)", "![a] (b)"),
+            ("![](!channel)", "![](!channel)"),
             ("[a] (b)", "[a] (b)"),
             ("[a]()", "[a]()"),
             // A code span is its own subject.
@@ -311,7 +370,7 @@ mod tests {
             ("`[a](b)`", "`[a](b)`"),
             ("an unclosed ` **span**", "an unclosed ` *span*"),
             // Headings convert their own inline content.
-            ("## [a](b)", "*<b|a>*"),
+            ("## [a](https://b)", "*<https://b|a>*"),
             ("##", ""),
             ("", ""),
         ] {
@@ -338,6 +397,19 @@ mod tests {
             ("```\n<!channel>\n```", "```\n&lt;!channel&gt;\n```"),
             // Escaped once, never twice.
             ("&amp;", "&amp;amp;"),
+            // The second half of the escape: a link target is `<…>` markup too,
+            // and `[](!channel)` is a broadcast a channel member can ask for in
+            // one sentence.
+            ("[](!channel)", "[](!channel)"),
+            ("[x](!channel)", "[x](!channel)"),
+            ("[](!here)", "[](!here)"),
+            ("[](@U12345)", "[](@U12345)"),
+            ("[](#C0000|general)", "[](#C0000|general)"),
+            ("[a|b](https://x)", "[a|b](https://x)"),
+            // A blockquote is the one line marker escaping would have cost.
+            ("> quoted", "> quoted"),
+            (">>> quoted", ">>> quoted"),
+            ("a > b", "a &gt; b"),
         ] {
             assert_eq!(to_mrkdwn(markdown), want, "converting {markdown:?}");
         }
@@ -347,10 +419,10 @@ mod tests {
     #[test]
     fn a_fenced_block_is_copied_out_byte_for_byte() {
         let markdown =
-            "Before **bold**\n\n```md\n## Heading\n**bold** and [a](b)\n```\n\nAfter [x](y)";
+            "Before **bold**\n\n```md\n## Heading\n**bold** and [a](b)\n```\n\nAfter [x](https://y)";
         assert_eq!(
             to_mrkdwn(markdown),
-            "Before *bold*\n\n```md\n## Heading\n**bold** and [a](b)\n```\n\nAfter <y|x>"
+            "Before *bold*\n\n```md\n## Heading\n**bold** and [a](b)\n```\n\nAfter <https://y|x>"
         );
     }
 

--- a/src-tauri/src/native/integrations/slack/mrkdwn.rs
+++ b/src-tauri/src/native/integrations/slack/mrkdwn.rs
@@ -29,9 +29,9 @@
 //! notify everyone in it.
 //!
 //! So [`to_mrkdwn`] escapes the whole answer **before** converting anything, and
-//! the only raw `<`, `>` and `|` in its output are the three it writes itself
-//! around a link whose target it has checked is an `http`, `https` or `mailto`
-//! URL. That check is not decoration: `<…>` is Slack's markup for *everything*,
+//! the only raw `<` and `|` in its output — and the only raw `>` outside a
+//! restored blockquote marker, below — are the ones it writes itself around a
+//! link whose target it has checked is an `http`, `https` or `mailto` URL. That check is not decoration: `<…>` is Slack's markup for *everything*,
 //! so a link target it did not vet is a hole straight back through the escape —
 //! `[](!channel)` would otherwise become `<!channel>`, and a channel member can
 //! ask for that in one sentence. A target that is not such a URL keeps its
@@ -110,14 +110,20 @@ fn escape(text: &str) -> String {
         .replace('>', "&gt;")
 }
 
-/// A line's leading run of escaped `&gt;` put back as `>`.
+/// A line's leading run of escaped `&gt;` put back as a single `>`.
 ///
 /// Slack's blockquote marker is Markdown's, so escaping is the only thing that
-/// broke it. Only the leading run: a `>` mid-sentence is prose and stays
-/// escaped, which is the whole point of escaping it.
+/// broke it. Two deliberate narrowings:
+///
+/// - **Only the leading run.** A `>` mid-sentence is prose and stays escaped,
+///   which is the whole point of escaping it.
+/// - **However long the run, one marker comes back.** Markdown's `>>>` is a
+///   *nested* blockquote, which Slack does not have; Slack's own `>>>` quotes
+///   **the rest of the message**, so reproducing the run verbatim would turn a
+///   nested quote into a quote of everything after it.
 fn restore_blockquote(line: &str) -> String {
-    let mut markers = 0;
     let mut rest = line;
+    let mut markers = 0;
     while let Some(after) = rest.strip_prefix("&gt;") {
         markers += 1;
         rest = after;
@@ -125,7 +131,7 @@ fn restore_blockquote(line: &str) -> String {
     if markers == 0 {
         return line.to_string();
     }
-    format!("{}{rest}", ">".repeat(markers))
+    format!(">{rest}")
 }
 
 /// ```` ``` ```` or longer, at the start of a line, opening or closing a block.
@@ -408,7 +414,9 @@ mod tests {
             ("[a|b](https://x)", "[a|b](https://x)"),
             // A blockquote is the one line marker escaping would have cost.
             ("> quoted", "> quoted"),
-            (">>> quoted", ">>> quoted"),
+            // Markdown's nested quote is Slack's quote-everything-after, so one
+            // marker comes back however many went in.
+            (">>> quoted", "> quoted"),
             ("a > b", "a &gt; b"),
         ] {
             assert_eq!(to_mrkdwn(markdown), want, "converting {markdown:?}");

--- a/src-tauri/src/native/integrations/slack/socket.rs
+++ b/src-tauri/src/native/integrations/slack/socket.rs
@@ -14,7 +14,8 @@
 //!   within seconds and redelivers the envelope otherwise, so the ack is written
 //!   to the socket before the claim, before the handler, and before any database
 //!   touch. The handler then runs on `tokio::spawn` under the trigger
-//!   dispatcher's semaphore, which is why that semaphore is `pub(crate)` rather
+//!   dispatcher's semaphore — taken by the handler, around the run (#568) —
+//!   which is why that semaphore is `pub(crate)` rather
 //!   than this module opening a second bound on the same agent runs.
 //! - **De-duplicate by `event_id`.** An unacknowledged envelope is redelivered,
 //!   and a reconnect can replay one, so "acknowledged" is not "processed".
@@ -671,8 +672,7 @@ impl Worker {
         }
     }
 
-    /// Claim the event, then run the handler under the trigger dispatcher's
-    /// semaphore.
+    /// Claim the event, then run the handler.
     ///
     /// **Nothing here is awaited by the caller, and the claim is inside the
     /// spawn rather than before it.** The read loop has to go straight back to
@@ -706,16 +706,15 @@ impl Worker {
                 return;
             }
 
-            let Ok(_permit) = crate::native::trigger::dispatcher::semaphore()
-                .acquire()
-                .await
-            else {
-                log::warn!(
-                    "dispatcher stopped, dropping slack app_mention \
-                     integration_id={integration_id:?}"
-                );
-                return;
-            };
+            // **The ten-slot bound is the handler's to take, not this task's**
+            // (#568). `trigger::dispatcher::semaphore` is still the one bound
+            // and it is still where the run happens under it — but it is
+            // acquired in `inbound::Inbound::run`, around the run itself. Taken
+            // here it would count a mention *waiting for its Slack thread's
+            // turn* against a limit that is about `claude` subprocesses, and ten
+            // queued mentions in one thread would hold every permit while one
+            // ran, stalling Telegram and every other channel for the length of
+            // the chain.
             handler(mention).await;
         });
     }

--- a/src-tauri/src/native/integrations/slack/socket.rs
+++ b/src-tauri/src/native/integrations/slack/socket.rs
@@ -844,6 +844,19 @@ impl Envelope {
                 .unwrap_or_default()
                 .to_string()
         };
+        // A bot's own message is not work, and the app's own reply is a bot's
+        // own message: Slack delivers an `app_mention` for a mention inside a
+        // message the app itself posted, so without this a reply that quotes the
+        // bot answers itself, in the thread, forever. `bot_id` names the poster
+        // and `subtype` covers `bot_message` and the joins/leaves/edits that
+        // carry no author at all. Dropped here rather than at the ack, like
+        // every other event this transport does not act on.
+        if !text_field(event, "bot_id").is_empty() || !text_field(event, "subtype").is_empty() {
+            log::debug!(
+                "slack socket: ignoring an app_mention from a bot integration_id={integration_id:?}"
+            );
+            return None;
+        }
         let event_id = self
             .payload
             .get("event_id")
@@ -1268,6 +1281,33 @@ mod tests {
                     .app_mention("int-1")
                     .is_none(),
                 "{text} must not become work"
+            );
+        }
+    }
+
+    /// The app's own reply is a bot's own message, and a bot's own message is
+    /// not work (#568).
+    ///
+    /// This is the loop guard: Slack delivers an `app_mention` for a mention
+    /// inside a message the app itself posted, so an answer that quotes the
+    /// question would otherwise answer itself in the same thread, forever, one
+    /// `claude` subprocess at a time.
+    #[test]
+    fn a_bot_authored_app_mention_is_not_work() {
+        for text in [
+            r#"{"type":"events_api","envelope_id":"e1","payload":{"event_id":"Ev1",
+                "event":{"type":"app_mention","channel":"C1","bot_id":"B1",
+                         "text":"<@B1> hi","ts":"1.1"}}}"#,
+            r#"{"type":"events_api","envelope_id":"e1","payload":{"event_id":"Ev1",
+                "event":{"type":"app_mention","channel":"C1","subtype":"bot_message",
+                         "text":"<@B1> hi","ts":"1.1"}}}"#,
+        ] {
+            assert!(
+                Envelope::parse(text)
+                    .expect("parse")
+                    .app_mention("int-1")
+                    .is_none(),
+                "a bot's own app_mention must not become work: {text}"
             );
         }
     }

--- a/src-tauri/src/native/integrations/slack/socket.rs
+++ b/src-tauri/src/native/integrations/slack/socket.rs
@@ -709,7 +709,7 @@ impl Worker {
             // **The ten-slot bound is the handler's to take, not this task's**
             // (#568). `trigger::dispatcher::semaphore` is still the one bound
             // and it is still where the run happens under it — but it is
-            // acquired in `inbound::Inbound::run`, around the run itself. Taken
+            // acquired in `inbound::Inbound::turn`, around the run itself. Taken
             // here it would count a mention *waiting for its Slack thread's
             // turn* against a limit that is about `claude` subprocesses, and ten
             // queued mentions in one thread would hold every permit while one

--- a/src-tauri/src/native/trigger/dispatcher.rs
+++ b/src-tauri/src/native/trigger/dispatcher.rs
@@ -47,7 +47,18 @@ const MAX_CONCURRENT: usize = 10;
 const RUN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5 * 60);
 
 /// What Go replies with on every failure path.
-const ERROR_REPLY: &str = "Sorry, something went wrong.";
+///
+/// `pub(crate)` since #568: Slack's inbound handler answers with **this** string
+/// rather than one of its own. Two inbound transports spelling the same failure
+/// differently is drift a reader would take for a difference in what failed.
+pub(crate) const ERROR_REPLY: &str = "Sorry, something went wrong.";
+
+/// What a run that finished with nothing to say replies with.
+///
+/// An empty answer still gets a reply — silence would be indistinguishable from
+/// the bot being broken — and, like [`ERROR_REPLY`], it is one string for every
+/// inbound transport.
+pub(crate) const NO_RESPONSE_REPLY: &str = "No response generated.";
 
 /// `pub(crate)` rather than module-private since #567: Slack's Socket Mode
 /// worker runs its handler under **this** bound, not a second one. Two
@@ -305,7 +316,7 @@ fn usable_permission_mode(stored: String) -> String {
 /// It is [`usable_permission_mode`]'s premise with the opposite answer, and for
 /// the same reason both are stated: a clamped timeout is a run that still
 /// happens, where a bad mode is a run that must not.
-fn run_timeout(rule: &Rule) -> std::time::Duration {
+pub(crate) fn run_timeout(rule: &Rule) -> std::time::Duration {
     if rule.timeout_minutes <= 0 {
         return RUN_TIMEOUT;
     }
@@ -377,8 +388,9 @@ async fn execute_and_reply(
     // migration 39 gave the rule those columns and this is the reader.
     let created = {
         let (db, rule) = (db_path.to_path_buf(), rule.clone());
+        let title = format!("[Telegram] {}", rule.name);
         db::blocking("telegram session", move || {
-            create_trigger_session(&db, &rule)
+            create_trigger_session(&db, &rule, &title)
         })
         .await
         .unwrap_or_else(|| Err("the session task failed".to_string()))
@@ -432,10 +444,8 @@ async fn execute_and_reply(
         .await;
     }
 
-    // An empty answer still gets a reply — silence would be indistinguishable
-    // from the bot being broken.
     let reply = if result.answer.is_empty() {
-        "No response generated."
+        NO_RESPONSE_REPLY
     } else {
         &result.answer
     };
@@ -489,8 +499,18 @@ fn resolve_agent(db_path: &Path, agent_slug: &str) -> Result<Agent, String> {
     })
 }
 
-/// The `[Telegram] <rule>` chat a trigger run is recorded in.
-fn create_trigger_session(db_path: &Path, rule: &Rule) -> Result<String, String> {
+/// The chat a trigger run is recorded in, titled `title`.
+///
+/// The title is the caller's since #568: Telegram's is `[Telegram] <rule>` and
+/// Slack's is `[Slack] #channel: <the first 60 characters of the prompt>`, and
+/// everything else about creating the chat — the rule's five execution settings
+/// on the row, the immediate transaction, the title being a second write whose
+/// failure is a warning rather than a failed run — is the same for both.
+pub(crate) fn create_trigger_session(
+    db_path: &Path,
+    rule: &Rule,
+    title: &str,
+) -> Result<String, String> {
     let mut conn = crate::native::db::open_read_write(db_path)?;
     let tx = conn
         .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
@@ -511,7 +531,6 @@ fn create_trigger_session(db_path: &Path, rule: &Rule) -> Result<String, String>
 
     // Two writes, as Go has them: a failed title update is a warning, not a
     // failed run.
-    let title = format!("[Telegram] {}", rule.name);
     if let Err(e) = conn.execute(
         "UPDATE chat_sessions SET title = ?1, updated_at = ?2 WHERE id = ?3",
         rusqlite::params![title, crate::native::gotime::now_go_text(), session.id],
@@ -1041,7 +1060,7 @@ mod tests {
         );
         let rules = load_rules(&db, "tg").expect("load");
 
-        let id = create_trigger_session(&db, &rules[0]).expect("session");
+        let id = create_trigger_session(&db, &rules[0], "[Telegram] r").expect("session");
         let conn = rusqlite::Connection::open(&db).expect("open");
         let row: (String, String, String, String, String) = conn
             .query_row(


### PR DESCRIPTION
Closes #568

## What

The `app_mention` handler: from a Slack event to a running chat and a reply in the thread.

- **`slack/inbound.rs`** — classify (top-level / resume / ignore), select the rule with `select_rule_for_channel`, strip the bot's own `<@Uxxx>`, create-or-resume the chat, run through `agent_run::run_resumed`, answer in the thread, touch `last_event_at`. A per-thread FIFO (`thread → queue`, one worker per key, torn down on drain) keeps two mentions in one thread in order and non-overlapping; the chat's busy lock stays the collision guard.
- **`slack/mrkdwn.rs`** — Markdown → Slack mrkdwn and a `char`-safe split at 4000 characters preferring a blank line, then a line ending, then the limit.
- **`slack/socket.rs`** — a bot-authored `app_mention` is dropped at the decode (the loop guard: Slack delivers one for a mention inside a message the app itself posted), and the dispatcher's permit is no longer taken there.
- **`trigger/dispatcher.rs`** — `ERROR_REPLY` and a new `NO_RESPONSE_REPLY` are `pub(crate)` and shared; `run_timeout` is `pub(crate)`; `create_trigger_session` takes the chat title so Telegram and Slack differ in nothing else.
- **`integrations/registry.rs`** — `start_socket_worker` resolves the **bot** token too and hands the real handler to `SocketOptions`.

## Security: the reply is attacker-adjacent text posted by the app as itself

This is the first surface where an answer derived from what a stranger wrote in a Slack channel is posted by Agento, into a channel it is a member of by construction. `chat.postMessage` reads `<!channel>`, `<!here>` and `<!everyone>` in `text` as **broadcasts**. So `to_mrkdwn` escapes `&`, `<` and `>` over the whole answer before converting anything (Slack renders the entities back as themselves, in prose and in code blocks alike, so nothing is lost), and the only raw `<`, `>` and `|` it emits are around a link whose target it has checked is an `http`, `https` or `mailto` URL — `[](!channel)` would otherwise reintroduce the broadcast through the link arm. A leading `&gt;` run is restored to `>` because Slack's blockquote is Markdown's.

The dispatcher's ten permits are taken around the **run**, not around the handler: a mention waiting for its Slack thread's turn is not a `claude` subprocess, and holding a permit for the wait would let ten queued mentions in one thread stall Telegram and every other channel.

## How it is proved

17 new tests. `slack/inbound/tests.rs` is an axum fake Slack plus the scripted Python CLI: a top-level mention creating a chat with the rule's model / working directory / permission mode, a thread row with its permalink and one converted reply; a second mention arriving mid-run that queues, resumes with `--resume <sdk_session_id>` and never overlaps; the ignore cases; an `auth.test` failure that answers in Agento's own thread and stays silent in a stranger's; the failure sentence with the question still stored; a disabled channel-specific rule silencing only that channel. Plus `mrkdwn.rs`'s conversion, escaping and splitting tables (the 10 000-character case, a non-ASCII one, and the `<!channel>` / `[](!channel)` injections) and two structural guards — the prompt is logged at `debug` and nowhere else, and the semaphore is acquired between resolving the chat and running it.

Each was checked by mutation: dropping the bot filter, moving the prompt log to `info`, removing the queue reuse, replacing `select_rule_for_channel` with a first-enabled scan, and moving the semaphore acquire back above the run each turn the matching test red.

## Deviations from the HOW

- **The end-to-end suite is in the library, not `src-tauri/tests/`.** Every assertion is about a request Agento *sends* to Slack, and the seam that redirects one is `client::API_BASE`, `#[cfg(test)]` on this crate — the same wall `trigger/dispatcher.rs` records for Telegram.
- **`auth.test` is called once per handler**, lazily, rather than once per connection: a worker survives reconnects, so per-handler is strictly fewer calls and needs no change to the connect loop. It is resolved *after* the thread mapping decision, so its failure sentence cannot land in a thread Agento never started.
- **The chat title calls `conversations.info`** (best-effort, once per thread) so `[Slack] #general: …` is the channel's name rather than its id, as the epic's title format asks. The id is the fallback.
- **The FIFO preserves enqueue order, not arrival order** — `socket.rs::dispatch` spawns a task per envelope and each awaits its dedup claim before a handler runs, so nothing downstream could reconstruct arrival order. Stated as such in the module header and `slack/CLAUDE.md`.

## Left for the maintainer (not fixed here, found by the automated review)

1. A UI turn holding the chat's busy lock makes `run_resumed` answer `Err(CHAT_BUSY)` **before** it stores the user turn, so Slack replies "Sorry, something went wrong." and the question is stored nowhere. A re-queue on that exact string (which `live.rs` documents as recognisable for this reason) would survive it.
2. A fenced code block that must be cut across the 4000-character split does not have its fence re-opened in the next chunk, so chunk 2 renders as prose. #568 explicitly accepts the hard cut; the doc now states the consequence.
3. `post` returns on the first failed chunk, leaving a truncated answer with no marker.

Local gates: `npm run build`, `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test` (24 binaries, 0 failures), `cargo build --profile ci`, `scripts/check-claude-md-size.sh` — all green.