### PR TITLE
feat: Slack inbound honours a trigger rule's prefix and keywords (#582)

### DIFF
--- a/docs/internal/native-integrations-slack.md
+++ b/docs/internal/native-integrations-slack.md
@@ -284,6 +284,16 @@ declines to start one.
     would fire on every mention. `keywords_are_case_insensitive_and_never_see_the_bots_own_id`
     is that case. The prefix is matched on the stripped text for the same reason,
     which is also what makes `@bot /ask …` and `/ask @bot …` one message.
+  - **The filters gate a reply inside one of Agento's own threads too.** `accept`
+    has not read `inbound_threads` at that point and deliberately does not — the
+    mapping lookup belongs inside the per-thread worker, per the bullet above —
+    so a rule carrying a prefix asks for that prefix on every message in the
+    channel, follow-ups included. That is the reading of #582's *apply the
+    filters to app-mention events*, and it is the direction that runs less: the
+    alternative exempts anyone who can reply in a thread from the filter the
+    channel was given. Slack's `filterHelp` in `views/integrations/catalog.ts`
+    says so to the user, and
+    `a_prefixed_rule_gates_the_follow_up_in_its_own_thread_too` is the guard.
   - **`match_rule`'s own `chat_ids` clause is a no-op here, and is left in
     place.** Selection has already returned either a rule naming this channel or a
     rule naming none, and the matcher reads the second as "everything", so the two
@@ -310,9 +320,10 @@ declines to start one.
   rule and the filters all need; a failure to get it is a failed turn and answers
   `ERROR_REPLY`, because a Slack that will not answer `auth.test` will not accept
   `chat.postMessage` either. Moving the call into `accept` moves its cost rather
-  than doubling it — the `OnceCell` is per handler, and `turn` already awaited it. `conversations.info` (chat title) and
-  `chat.getPermalink` are best-effort on the start path only — the channel id and
-  an empty permalink are the fallbacks, and neither refuses the run.
+  than doubling it — the `OnceCell` is per handler, and `turn` already awaited it.
+  `conversations.info` (chat title) and `chat.getPermalink` are best-effort on the
+  start path only — the channel id and an empty permalink are the fallbacks, and
+  neither refuses the run.
 - **`mrkdwn.rs` escapes `&`, `<` and `>` before it converts anything**, over the
   whole answer including its fenced blocks. Slack renders those entities back as
   themselves everywhere, so escaping costs the answer nothing — and not escaping

--- a/docs/internal/native-integrations-slack.md
+++ b/docs/internal/native-integrations-slack.md
@@ -232,8 +232,8 @@ declines to start one.
   otherwise find no `inbound_threads` row — the row is written by the run it is
   queued behind — and be dropped as a mention in a thread Agento did not start.
   This is the one ordering constraint the FIFO exists for, and it is why
-  classification is split across `accept` (the rule) and `turn` (the mapping, the
-  bot-id strip, start-or-resume). The order the queue preserves is **enqueue**
+  classification is split across `accept` (the rule, the strip, the filters) and
+  `turn` (the mapping, start-or-resume). The order the queue preserves is **enqueue**
   order, not arrival order: `socket.rs::dispatch` spawns a task per envelope and
   each awaits its dedup claim before a handler runs, so two mentions posted a
   millisecond apart can reach the queue either way round and nothing downstream
@@ -250,13 +250,46 @@ declines to start one.
   line saying a mention was seen and a reply appearing minutes later are two
   different things to anyone reading a log — but that wait now costs a parked
   task and no permit.
-- **`auth.test` is resolved after the mapping decision, not before it.** It is
-  the one Slack failure the handler cannot work around, and its answer is
-  `ERROR_REPLY` — so resolving it first would post that sentence into a thread
-  Agento never started, which is exactly what the ignore rule exists to prevent.
-  Reading the thread map likewise distinguishes *no row* from *could not read*:
-  `busy_timeout` is five seconds, and a database busy behind the session scanner
-  would otherwise make a resume look like a stranger's thread and answer nothing.
+- **`auth.test` is resolved in `accept`; its `ERROR_REPLY` is still posted in
+  `turn`.** The two used to be one step, and #582 separated them. The bot user id
+  is what the `<@Uxxx>` strip needs and the strip is what the filters read, so the
+  id has to be in hand *before* the filter decision, which is before the queue.
+  The sentence it fails with does not move: `accept` posts nothing at all, and the
+  `ERROR_REPLY` for an unresolvable id waits in `turn` until the mapping decision
+  has established the thread as Agento's — otherwise it lands in a thread Agento
+  never started, which is exactly what the ignore rule exists to prevent. A `Job`
+  therefore carries `prompt: Option<String>`, and `None` is that one failure
+  rather than a drop. Reading the thread map likewise distinguishes *no row* from
+  *could not read*: `busy_timeout` is five seconds, and a database busy behind the
+  session scanner would otherwise make a resume look like a stranger's thread and
+  answer nothing.
+- **Strip, then filter, then enqueue — and the filters read the stripped text
+  (#582).** The trigger-rule form has always shown Prefix and Keywords for every
+  provider, and until #582 the Slack path read neither: `filter_prefix` and
+  `filter_keywords` were loaded off the row by `dispatcher::load_rules` and
+  dropped. A control that is displayed, stored and ignored fails in the direction
+  of running *more* than was asked for, so `accept` now gates the **already
+  selected** rule through `trigger::match_rule::match_rule` — the same function
+  Telegram calls, unmodified, with `parity/trigger_match_vectors.json` still its
+  authority. Three consequences worth stating:
+  - **The filters are a gate on the selected rule, never a reason to look for
+    another one.** `select_rule_for_channel`'s most-specific-wins (#565) picks the
+    rule; a rule that then refuses the message means silence, not a fall-through
+    to the workspace default. `a_mention_the_channels_rule_refuses_never_falls_through_to_the_default`
+    is the guard.
+  - **Keywords are matched against the stripped text, which is a deliberate
+    divergence from Telegram.** `match_rule`'s header pins keywords to the *whole*
+    message because Go did; on Slack the whole message always begins with a
+    `<@Uxxx>` no user typed, so a keyword equal to a fragment of the bot's own id
+    would fire on every mention. `keywords_are_case_insensitive_and_never_see_the_bots_own_id`
+    is that case. The prefix is matched on the stripped text for the same reason,
+    which is also what makes `@bot /ask …` and `/ask @bot …` one message.
+  - **`match_rule`'s own `chat_ids` clause is a no-op here, and is left in
+    place.** Selection has already returned either a rule naming this channel or a
+    rule naming none, and the matcher reads the second as "everything", so the two
+    agree. `the_matchers_channel_check_agrees_with_the_rule_selection` asserts that
+    rather than the code routing around it — one matcher, called the same way from
+    both transports.
 - **Queue teardown is under the map lock.** A worker that found its channel
   empty, released nothing and then removed its entry would lose a job queued in
   between, so the drain re-checks the channel while holding the lock that hands
@@ -273,10 +306,11 @@ declines to start one.
   for the same reason — `[Telegram] <rule>` and `[Slack] #channel: <60 chars>` are
   the only difference between the two call sites.
 - **`auth.test` is called once per handler, not per event and not per
-  connection.** The bot user id is what the `<@Uxxx>` strip and the
-  empty-remainder rule both need; a failure to get it is a failed turn and
-  answers `ERROR_REPLY`, because a Slack that will not answer `auth.test` will
-  not accept `chat.postMessage` either. `conversations.info` (chat title) and
+  connection.** The bot user id is what the `<@Uxxx>` strip, the empty-remainder
+  rule and the filters all need; a failure to get it is a failed turn and answers
+  `ERROR_REPLY`, because a Slack that will not answer `auth.test` will not accept
+  `chat.postMessage` either. Moving the call into `accept` moves its cost rather
+  than doubling it — the `OnceCell` is per handler, and `turn` already awaited it. `conversations.info` (chat title) and
   `chat.getPermalink` are best-effort on the start path only — the channel id and
   an empty permalink are the fallbacks, and neither refuses the run.
 - **`mrkdwn.rs` escapes `&`, `<` and `>` before it converts anything**, over the

--- a/docs/internal/native-integrations-slack.md
+++ b/docs/internal/native-integrations-slack.md
@@ -271,7 +271,7 @@ declines to start one.
   of running *more* than was asked for, so `accept` now gates the **already
   selected** rule through `trigger::match_rule::match_rule` — the same function
   Telegram calls, unmodified, with `parity/trigger_match_vectors.json` still its
-  authority. Three consequences worth stating:
+  authority. Four consequences worth stating:
   - **The filters are a gate on the selected rule, never a reason to look for
     another one.** `select_rule_for_channel`'s most-specific-wins (#565) picks the
     rule; a rule that then refuses the message means silence, not a fall-through

--- a/src-tauri/src/native/integrations/slack/inbound.rs
+++ b/src-tauri/src/native/integrations/slack/inbound.rs
@@ -21,10 +21,20 @@
 //!    a fall-through to the workspace default (#565). No rule at all is silence.
 //! 3. **Whether the rule wants what was said.** The bot's own `<@Uxxx>` is
 //!    removed, an empty remainder is ignored, and what is left is put through
-//!    that rule's `filter_prefix` and `filter_keywords` (#582). All three are
-//!    decided in [`Inbound::accept`], before the queue, so a mention the rule
-//!    does not want costs no chat, no thread lookup and no run — and, like
-//!    every other drop here, says nothing in Slack.
+//!    that rule's `filter_prefix` and `filter_keywords` (#582). The strip, the
+//!    empty-remainder rule and the filters are all decided in
+//!    [`Inbound::accept`], before the queue, so a mention the rule does not want
+//!    costs no chat, no thread lookup and no run — and, like every other drop
+//!    here, says nothing in Slack.
+//!
+//! **(3) gates a reply inside a thread Agento started exactly as it gates the
+//! mention that started it.** `accept` has not read the thread map at that point
+//! and deliberately does not — see (1) — so a rule carrying a prefix wants that
+//! prefix on every message, follow-ups included. That is the reading of #582's
+//! *apply the filters to app-mention events*, and it is the safe direction: the
+//! alternative exempts anyone who can reply in the thread from the filter the
+//! channel was given. [`filtered_prompt`] states it again at the decision, and
+//! `a_prefixed_rule_gates_the_follow_up_in_its_own_thread_too` pins it.
 //!
 //! The mapping lookup in (1) deliberately happens **inside the per-thread
 //! worker**, not when the event arrives. The second mention in a thread whose
@@ -618,6 +628,13 @@ impl Dropped {
 ///   what the user wrote. On Slack it always begins with the bot's id, which no
 ///   keyword can sensibly target and which would make a keyword equal to a
 ///   fragment of that id fire on every mention.
+///
+/// It answers for **every** mention, a reply in one of Agento's own threads
+/// included: the thread map is read later, in [`Inbound::turn`], and reading it
+/// here would put the filter behind the very lookup the FIFO exists to delay. So
+/// a prefixed rule asks for its prefix on every message in the channel rather
+/// than only on the one that opens a thread — which is the direction that runs
+/// less, and the direction a user who wrote a prefix asked for.
 ///
 /// `match_rule` also re-checks `chat_ids`, which is a no-op here and asserted as
 /// one by [`tests`]: `select_rule_for_channel` has already returned either a

--- a/src-tauri/src/native/integrations/slack/inbound.rs
+++ b/src-tauri/src/native/integrations/slack/inbound.rs
@@ -19,8 +19,12 @@
 //! 2. **Which rule.** [`select_rule_for_channel`] — most specific first, and a
 //!    *disabled* channel-specific rule is that channel's off switch rather than
 //!    a fall-through to the workspace default (#565). No rule at all is silence.
-//! 3. **Whether there is anything to say.** The bot's own `<@Uxxx>` is removed;
-//!    an empty remainder is ignored.
+//! 3. **Whether the rule wants what was said.** The bot's own `<@Uxxx>` is
+//!    removed, an empty remainder is ignored, and what is left is put through
+//!    that rule's `filter_prefix` and `filter_keywords` (#582). All three are
+//!    decided in [`Inbound::accept`], before the queue, so a mention the rule
+//!    does not want costs no chat, no thread lookup and no run — and, like
+//!    every other drop here, says nothing in Slack.
 //!
 //! The mapping lookup in (1) deliberately happens **inside the per-thread
 //! worker**, not when the event arrives. The second mention in a thread whose
@@ -63,11 +67,12 @@
 //!   is the drift those `pub(crate)` consts exist to prevent.
 //! - **The bot user id comes from `auth.test` once**, cached for the life of the
 //!   handler rather than fetched per event. Without it neither the mention strip
-//!   nor the empty-remainder rule can be applied, so a failure to get it is a
-//!   failed turn and answers [`ERROR_REPLY`] — a Slack that will not answer
-//!   `auth.test` will not accept `chat.postMessage` either. It is fetched
-//!   **after** the thread has been established as Agento's, because that reply
-//!   would otherwise land in a stranger's thread.
+//!   nor the filters can be applied, so a failure to get it is a failed turn and
+//!   answers [`ERROR_REPLY`] — a Slack that will not answer `auth.test` will not
+//!   accept `chat.postMessage` either. It is fetched in [`Inbound::accept`],
+//!   because the filter decision is made there; **the failure sentence still
+//!   waits** for [`Inbound::turn`] to establish the thread as Agento's, which is
+//!   what stops it landing in a stranger's thread. `accept` itself never posts.
 //! - **The dispatcher's ten-slot semaphore is taken around the run**, not around
 //!   the handler. It bounds `claude` subprocesses, and a mention waiting for its
 //!   thread's turn is not one: taken at the handler, ten queued mentions in one
@@ -86,6 +91,7 @@ use crate::claude::CancellationToken;
 use crate::native::agent_run;
 use crate::native::db;
 use crate::native::trigger::dispatcher::{self, Rule, ERROR_REPLY, NO_RESPONSE_REPLY};
+use crate::native::trigger::match_rule::{match_rule, RuleFilters};
 use crate::native::trigger::select_rule::select_rule_for_channel;
 
 use crate::native::gourl::Values;
@@ -107,6 +113,16 @@ struct Job {
     thread_ts: String,
     top_level: bool,
     rule: Rule,
+    /// The words this mention runs with: the text with the bot's own `<@Uxxx>`
+    /// removed and the rule's filters already applied, so the text that was
+    /// filtered is exactly the text that runs.
+    ///
+    /// `None` is the one decision [`Inbound::accept`] cannot make — `auth.test`
+    /// would not say who the bot is, so there is nothing to strip the mention
+    /// with and nothing to filter. That is a failed turn rather than a drop, and
+    /// carrying it here keeps its [`ERROR_REPLY`] where it has always been: in
+    /// [`Inbound::turn`], after the thread is known to be Agento's.
+    prompt: Option<String>,
     /// Dropped or signalled when this job is finished, however it finished.
     ///
     /// The handler future is the whole turn, not the enqueue: a `debug` line
@@ -165,6 +181,32 @@ impl Inbound {
             return;
         };
 
+        // The strip and the filters both need the bot's own id, and the filter
+        // decision belongs before the queue: a mention this rule does not want
+        // must not take a thread's turn, read the thread map or start a chat.
+        let decided = self
+            .bot_user_id()
+            .await
+            .map(|bot| filtered_prompt(&rule.filters, &mention.text, bot, &mention.channel));
+        let prompt = match decided {
+            Some(Ok(matched)) => Some(matched),
+            Some(Err(dropped)) => {
+                // Slack's own opaque identifiers only: what the user wrote is
+                // not repeated here, and a drop is not news at `info`.
+                log::debug!(
+                    "slack mention ignored, {} integration_id={:?} channel={:?} rule_id={:?}",
+                    dropped.reason(),
+                    self.integration_id,
+                    mention.channel,
+                    rule.id
+                );
+                return;
+            }
+            // Not a drop: `turn` answers `ERROR_REPLY` for this, in a thread it
+            // has established as Agento's. See `Job::prompt`.
+            None => None,
+        };
+
         let (done, finished) = tokio::sync::oneshot::channel();
         enqueue(
             &self,
@@ -173,6 +215,7 @@ impl Inbound {
                 thread_ts,
                 top_level,
                 rule,
+                prompt,
                 done,
             },
         );
@@ -283,25 +326,17 @@ impl Inbound {
         }
 
         // Only now, with the thread established as Agento's, is there anywhere
-        // a failure sentence may be posted.
-        let Some(bot_user_id) = self.bot_user_id().await else {
+        // a failure sentence may be posted — which is why the one decision
+        // `accept` could not make is answered here rather than there.
+        let Some(prompt) = job.prompt.as_deref() else {
             self.post(&job.mention.channel, &job.thread_ts, ERROR_REPLY)
                 .await;
             return;
         };
-        let prompt = strip_mention(&job.mention.text, bot_user_id);
-        if prompt.is_empty() {
-            log::debug!(
-                "slack mention ignored, nothing said to the bot integration_id={:?} channel={:?}",
-                self.integration_id,
-                job.mention.channel
-            );
-            return;
-        }
 
         let (chat_id, kind) = match mapped {
             Some(chat_id) => (chat_id, "resume"),
-            None => match self.start_chat(job, &prompt).await {
+            None => match self.start_chat(job, prompt).await {
                 Some(chat_id) => (chat_id, "start"),
                 None => {
                     self.post(&job.mention.channel, &job.thread_ts, ERROR_REPLY)
@@ -336,7 +371,7 @@ impl Inbound {
         let result = agent_run::run_resumed(
             &self.db_path,
             &chat_id,
-            &prompt,
+            prompt,
             &job.rule.settings,
             dispatcher::run_timeout(&job.rule),
         )
@@ -533,6 +568,73 @@ fn enqueue(state: &Arc<Inbound>, job: Job) {
     queues.insert(key.clone(), tx);
     let worker = Arc::clone(state);
     tokio::spawn(async move { worker.drain(key, rx).await });
+}
+
+/// Why a mention produced no run and no reply.
+///
+/// Two reasons rather than one because they read differently in a log: nothing
+/// was said to the bot at all, or the rule was asked for something narrower
+/// than what was said.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Dropped {
+    /// Removing the bot's own `<@Uxxx>` left nothing.
+    NothingSaid,
+    /// The rule's `filter_prefix` or `filter_keywords` said no.
+    Filtered,
+}
+
+impl Dropped {
+    /// The clause a `debug` line reads with. No Slack-derived text, by
+    /// construction — these are two constants.
+    fn reason(self) -> &'static str {
+        match self {
+            Dropped::NothingSaid => "nothing said to the bot",
+            Dropped::Filtered => "the rule's filters did not match",
+        }
+    }
+}
+
+/// The prompt a mention runs with under `filters`, or why it runs with none.
+///
+/// This is the whole of #582: the form has always shown Prefix and Keywords for
+/// every provider, and until now the Slack path read neither — a filter that is
+/// displayed and stored and then ignored narrows nothing, and fails in the
+/// direction of running *more* than was asked for.
+///
+/// Three rules, and only the last is Slack-specific:
+///
+/// - **The filters see the stripped text, not the event text.** Every
+///   `app_mention` begins with a `<@Uxxx>` no user typed, so a prefix matched
+///   against the raw text could only ever match the bot's own id. Stripping
+///   first is also what makes `@bot /ask …` and `/ask @bot …` the same message.
+/// - **`match_rule` is reused exactly as Telegram calls it**, so a prefix folds
+///   the way Go's `EqualFold` folds, a bare `/ask` with nothing after it is not
+///   a match, and keywords are a case-insensitive OR. Nothing in
+///   `native::trigger::match_rule` is modified; `parity/trigger_match_vectors.json`
+///   stays Telegram's authority.
+/// - **Keywords are therefore matched against the stripped text, which is a
+///   deliberate divergence from Telegram.** `match_rule`'s header pins keywords
+///   to the *whole* message because Go did, and on Telegram the whole message is
+///   what the user wrote. On Slack it always begins with the bot's id, which no
+///   keyword can sensibly target and which would make a keyword equal to a
+///   fragment of that id fire on every mention.
+///
+/// `match_rule` also re-checks `chat_ids`, which is a no-op here and asserted as
+/// one by [`tests`]: `select_rule_for_channel` has already returned either a
+/// rule naming this channel or a rule naming none, and the matcher reads the
+/// second as "everything". The check is left in place rather than routed around
+/// so that this path and Telegram's run the same function.
+fn filtered_prompt(
+    filters: &RuleFilters,
+    text: &str,
+    bot_user_id: &str,
+    channel: &str,
+) -> Result<String, Dropped> {
+    let stripped = strip_mention(text, bot_user_id);
+    if stripped.is_empty() {
+        return Err(Dropped::NothingSaid);
+    }
+    match_rule(filters, &stripped, channel).ok_or(Dropped::Filtered)
 }
 
 /// `text` with every `<@bot>` (and `<@bot|label>`) removed, then trimmed.

--- a/src-tauri/src/native/integrations/slack/inbound/tests.rs
+++ b/src-tauri/src/native/integrations/slack/inbound/tests.rs
@@ -837,6 +837,113 @@ async fn a_second_mention_in_the_thread_queues_and_resumes_the_same_chat() {
     );
 }
 
+/// The prefix decides on a run, and it decides on **every** message in the
+/// channel — including a reply inside the thread that run opened.
+///
+/// Two things nothing else pins. First, the positive half of #582's criterion 1:
+/// the prefix-*stripped* remainder is what reaches the chat and the CLI, not the
+/// raw mention. Second, the follow-up rule stated in this module's header: a
+/// mention in one of Agento's own threads is filtered exactly like the one that
+/// started it, because `accept` decides before the thread map is read. A rule
+/// with a prefix therefore wants that prefix on every message, and the reply
+/// that omits it is silence — no run, no message on the chat, nothing posted.
+#[tokio::test]
+async fn a_prefixed_rule_gates_the_follow_up_in_its_own_thread_too() {
+    if python3().is_none() {
+        eprintln!("no python3; skipping");
+        return;
+    }
+    let _base = api_base_lock().await;
+    let slack = fake_slack().await;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = migrated(dir.path(), "s-prefix");
+    seed_filtered_rule(
+        &db,
+        "s-prefix",
+        "r",
+        true,
+        "[]",
+        "",
+        "",
+        "2026-01-01 00:00:00 +0000 UTC",
+        "/ask",
+        "[]",
+    );
+    let cli = fake_cli(dir.path(), "answer {n}", "sess", false, 0);
+
+    let _env = env_lock().lock().await;
+    std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", &cli);
+    let handler = super::handler(&db, "s-prefix", "xoxb-t");
+
+    // Awaited one at a time: this is about what each mention decides, and the
+    // concurrent case is `a_second_mention_in_the_thread_queues_and_resumes…`.
+    finish(handler(mention(
+        "<@U0BOT> /ask deploy staging",
+        "1700000000.000100",
+        "",
+        "s-prefix",
+    )))
+    .await;
+    finish(handler(mention(
+        "<@U0BOT> and the database?",
+        "1700000000.000200",
+        "1700000000.000100",
+        "s-prefix",
+    )))
+    .await;
+    finish(handler(mention(
+        "<@U0BOT> /ask and the database?",
+        "1700000000.000300",
+        "1700000000.000100",
+        "s-prefix",
+    )))
+    .await;
+    std::env::remove_var("AGENTO_CLAUDE_EXECUTABLE");
+    set_api_base(None);
+
+    let mapped = threads(&db);
+    assert_eq!(
+        mapped.len(),
+        1,
+        "one thread, opened by the mention that matched"
+    );
+    let chat_id = mapped[0].1.clone();
+
+    assert_eq!(
+        messages(&db, &chat_id)
+            .iter()
+            .map(|(role, content)| format!("{role}:{content}"))
+            .collect::<Vec<_>>(),
+        vec![
+            "user:deploy staging".to_string(),
+            "assistant:answer 1".to_string(),
+            "user:and the database?".to_string(),
+            "assistant:answer 2".to_string(),
+        ],
+        "the prompt is the prefix-stripped remainder, and the un-prefixed \
+         follow-up between the two never reached the chat at all"
+    );
+    assert_eq!(
+        slack.posted(),
+        vec![
+            ("1700000000.000100".to_string(), "answer 1".to_string()),
+            ("1700000000.000100".to_string(), "answer 2".to_string()),
+        ],
+        "two answers for three mentions: the one that failed the prefix said \
+         nothing at all"
+    );
+    assert_eq!(
+        spawns(dir.path()).len(),
+        2,
+        "and started no third `claude` run"
+    );
+    assert_eq!(
+        chat_title(&db, &chat_id),
+        "[Slack] #general: deploy staging",
+        "the title is built from the prompt that ran, not the raw mention"
+    );
+}
+
 /// Acceptance criterion 3's two handler-side ignores. A mention from a bot is
 /// the third, and it never reaches this module — `Envelope::app_mention` drops
 /// it, where `a_bot_authored_app_mention_is_not_work` pins it.

--- a/src-tauri/src/native/integrations/slack/inbound/tests.rs
+++ b/src-tauri/src/native/integrations/slack/inbound/tests.rs
@@ -1176,9 +1176,12 @@ async fn a_disabled_channel_rule_silences_that_channel_only() {
 /// Review round 1, finding 4: the one Slack failure the handler cannot work
 /// around must not answer into a thread Agento never started.
 ///
-/// `auth.test` is resolved **after** the mapping decision for exactly this
-/// reason. A stranger's thread gets nothing; a thread of Agento's own gets the
-/// failure sentence, because silence there is the outcome that is never allowed.
+/// #582 moved the *resolution* into `accept`, before the queue, because the
+/// filters cannot read a mention until the bot's own id has stripped it — but
+/// the `ERROR_REPLY` stayed in `turn`, behind the mapping decision, for exactly
+/// this reason. A stranger's thread gets nothing; a thread of Agento's own gets
+/// the failure sentence, because silence there is the outcome that is never
+/// allowed.
 #[tokio::test]
 async fn an_auth_failure_answers_only_in_a_thread_agento_started() {
     let _base = api_base_lock().await;

--- a/src-tauri/src/native/integrations/slack/inbound/tests.rs
+++ b/src-tauri/src/native/integrations/slack/inbound/tests.rs
@@ -30,7 +30,9 @@ use crate::native::agent_run::RunResult;
 use crate::native::integrations::slack::client::{api_base_lock, set_api_base};
 use crate::native::integrations::slack::socket::AppMention;
 
-use super::{reply_for, strip_mention, ERROR_REPLY, NO_RESPONSE_REPLY};
+use crate::native::trigger::match_rule::RuleFilters;
+
+use super::{filtered_prompt, reply_for, strip_mention, Dropped, ERROR_REPLY, NO_RESPONSE_REPLY};
 
 const BOT_USER: &str = "U0BOT";
 const CHANNEL: &str = "C1";
@@ -291,7 +293,7 @@ fn migrated(dir: &Path, integration_id: &str) -> PathBuf {
     db_path
 }
 
-/// A trigger rule, oldest-first by the `created_at` this is called with.
+/// A trigger rule with no message filters, oldest-first by `created_at`.
 #[allow(clippy::too_many_arguments)] // one parameter per stored column, by design
 fn seed_rule(
     db_path: &Path,
@@ -303,13 +305,42 @@ fn seed_rule(
     working_directory: &str,
     created_at: &str,
 ) {
+    seed_filtered_rule(
+        db_path,
+        integration_id,
+        id,
+        enabled,
+        channels,
+        model,
+        working_directory,
+        created_at,
+        "",
+        "[]",
+    );
+}
+
+/// The same, with `filter_prefix` and `filter_keywords` as they are stored — the
+/// prefix bare, the keywords a JSON array (#582).
+#[allow(clippy::too_many_arguments)] // one parameter per stored column, by design
+fn seed_filtered_rule(
+    db_path: &Path,
+    integration_id: &str,
+    id: &str,
+    enabled: bool,
+    channels: &str,
+    model: &str,
+    working_directory: &str,
+    created_at: &str,
+    prefix: &str,
+    keywords: &str,
+) {
     let conn = rusqlite::Connection::open(db_path).expect("open");
     conn.execute(
         "INSERT INTO trigger_rules
             (id, integration_id, name, agent_slug, enabled, filter_prefix, filter_keywords,
              filter_chat_ids, model, working_directory, settings_profile_id, permission_mode,
              timeout_minutes, created_at, updated_at)
-         VALUES (?1, ?2, ?1, '', ?3, '', '[]', ?4, ?5, ?6, '', 'plan', 0, ?7, ?7)",
+         VALUES (?1, ?2, ?1, '', ?3, ?8, ?9, ?4, ?5, ?6, '', 'plan', 0, ?7, ?7)",
         rusqlite::params![
             id,
             integration_id,
@@ -317,7 +348,9 @@ fn seed_rule(
             channels,
             model,
             working_directory,
-            created_at
+            created_at,
+            prefix,
+            keywords
         ],
     )
     .expect("seed a rule");
@@ -409,6 +442,140 @@ fn only_the_bots_own_mention_is_stripped() {
     ] {
         assert_eq!(strip_mention(text, BOT_USER), want, "stripping {text:?}");
     }
+}
+
+/// Only the filters, which is all [`filtered_prompt`] reads of a rule.
+fn filters(prefix: &str, keywords: &[&str], channels: &[&str]) -> RuleFilters {
+    RuleFilters {
+        prefix: prefix.to_string(),
+        keywords: keywords.iter().map(|k| k.to_string()).collect(),
+        chat_ids: channels.iter().map(|c| c.to_string()).collect(),
+    }
+}
+
+/// #582's first criterion: the prefix decides, and what follows it is the run.
+#[test]
+fn a_prefix_gates_the_mention_and_the_remainder_is_the_prompt() {
+    let ask = filters("/ask", &[], &[]);
+    assert_eq!(
+        filtered_prompt(&ask, "<@U0BOT> /ask what is the status", BOT_USER, CHANNEL),
+        Ok("what is the status".to_string())
+    );
+    assert_eq!(
+        filtered_prompt(&ask, "<@U0BOT> what is the status", BOT_USER, CHANNEL),
+        Err(Dropped::Filtered),
+        "a mention that does not carry the prefix runs nothing"
+    );
+}
+
+/// …and it decides on the *stripped* text, so where the `@mention` sits in the
+/// message cannot change the answer. Slack puts it wherever the user typed it.
+#[test]
+fn the_prefix_is_matched_wherever_the_mention_was_typed() {
+    let ask = filters("/ask", &[], &[]);
+    for text in [
+        "<@U0BOT> /ask deploy the thing",
+        "/ask <@U0BOT> deploy the thing",
+        "/ask deploy the thing <@U0BOT>",
+        "<@U0BOT|agento> /ask deploy the thing",
+    ] {
+        assert_eq!(
+            filtered_prompt(&ask, text, BOT_USER, CHANNEL),
+            Ok("deploy the thing".to_string()),
+            "matching {text:?}"
+        );
+    }
+}
+
+/// Keywords are a case-insensitive OR — and they read the stripped text, which
+/// is the one place this path deliberately differs from Telegram's.
+#[test]
+fn keywords_are_case_insensitive_and_never_see_the_bots_own_id() {
+    let deploy = filters("", &["deploy"], &[]);
+    assert_eq!(
+        filtered_prompt(&deploy, "<@U0BOT> please Deploy staging", BOT_USER, CHANNEL),
+        Ok("please Deploy staging".to_string())
+    );
+    assert_eq!(
+        filtered_prompt(&deploy, "<@U0BOT> please ship staging", BOT_USER, CHANNEL),
+        Err(Dropped::Filtered)
+    );
+
+    // The divergence, as the case that would prove it broken: `match_rule`
+    // matches keywords against the whole message because Go did, and on Slack
+    // the whole message always begins with `<@U0BOT>`. A keyword that only
+    // occurs inside that id was never typed by anybody and must not fire.
+    let bot_shaped = filters("", &["u0bot"], &[]);
+    assert_eq!(
+        filtered_prompt(&bot_shaped, "<@U0BOT> hello", BOT_USER, CHANNEL),
+        Err(Dropped::Filtered),
+        "the bot's own id is not part of what the user said"
+    );
+}
+
+/// #582's fourth criterion, and the one that says an upgrade changes nothing
+/// for a rule that sets no filters: every mention in a matched channel runs.
+#[test]
+fn no_filters_runs_every_mention_in_the_channel() {
+    assert_eq!(
+        filtered_prompt(
+            &RuleFilters::default(),
+            "<@U0BOT> anything at all",
+            BOT_USER,
+            CHANNEL
+        ),
+        Ok("anything at all".to_string())
+    );
+}
+
+/// The two shapes of "there is nothing to run", told apart because they read
+/// differently in a log: a bare prefix, and a mention with no words after it.
+#[test]
+fn a_bare_prefix_and_a_bare_mention_both_run_nothing() {
+    let ask = filters("/ask", &[], &[]);
+    assert_eq!(
+        filtered_prompt(&ask, "<@U0BOT> /ask", BOT_USER, CHANNEL),
+        Err(Dropped::Filtered),
+        "an empty prompt is not a match — `match_rule`'s own rule"
+    );
+    assert_eq!(
+        filtered_prompt(&ask, "<@U0BOT>   \n ", BOT_USER, CHANNEL),
+        Err(Dropped::NothingSaid),
+        "nothing was said, so the prefix never came into it"
+    );
+    assert_eq!(
+        filtered_prompt(&RuleFilters::default(), "<@U0BOT>", BOT_USER, CHANNEL),
+        Err(Dropped::NothingSaid),
+        "and that is true with no filters at all"
+    );
+}
+
+/// `match_rule` re-checks `chat_ids`, which `select_rule_for_channel` has
+/// already decided. Asserted rather than special-cased: both shapes that
+/// selection can hand over say yes, so the two agree and this path can keep
+/// calling the same function Telegram calls.
+#[test]
+fn the_matchers_channel_check_agrees_with_the_rule_selection() {
+    let named = filters("", &[], &[CHANNEL]);
+    assert_eq!(
+        filtered_prompt(&named, "<@U0BOT> hello", BOT_USER, CHANNEL),
+        Ok("hello".to_string()),
+        "a rule naming this channel is the first thing selection can return"
+    );
+    assert_eq!(
+        filtered_prompt(&RuleFilters::default(), "<@U0BOT> hello", BOT_USER, CHANNEL),
+        Ok("hello".to_string()),
+        "and a rule naming none is the second — the matcher reads it as every \
+         channel"
+    );
+
+    // The shape selection cannot hand over, for completeness: it is the only
+    // one the clause would refuse, which is why leaving it in costs nothing.
+    let elsewhere = filters("", &[], &["C-other"]);
+    assert_eq!(
+        filtered_prompt(&elsewhere, "<@U0BOT> hello", BOT_USER, CHANNEL),
+        Err(Dropped::Filtered)
+    );
 }
 
 /// Every ending has a sentence, and a timeout has the same one as a failure —
@@ -719,6 +886,65 @@ async fn an_unmapped_thread_and_an_empty_remainder_produce_nothing() {
         .query_row("SELECT count(*) FROM chat_sessions", [], |row| row.get(0))
         .expect("count");
     assert_eq!(chats, 0, "no chat was created");
+}
+
+/// #582's fifth criterion, end to end: a mention that matches the channel and
+/// fails that rule's filters is dropped outright. It must **not** fall through
+/// to the workspace-wide default, which would make a prefix widen what runs
+/// instead of narrowing it.
+#[tokio::test]
+async fn a_mention_the_channels_rule_refuses_never_falls_through_to_the_default() {
+    let _base = api_base_lock().await;
+    let slack = fake_slack().await;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = migrated(dir.path(), "s-filter");
+    // The channel's own rule wants `/ask`; the workspace default wants nothing
+    // and would answer every mention if selection ever reached it.
+    seed_filtered_rule(
+        &db,
+        "s-filter",
+        "channel",
+        true,
+        &format!("[\"{CHANNEL}\"]"),
+        "",
+        "",
+        "2026-01-01 00:00:00 +0000 UTC",
+        "/ask",
+        "[]",
+    );
+    seed_rule(
+        &db,
+        "s-filter",
+        "default",
+        true,
+        "[]",
+        "",
+        "",
+        "2026-01-02 00:00:00 +0000 UTC",
+    );
+    // No `AGENTO_CLAUDE_EXECUTABLE` at all: anything that reached a run would
+    // fail loudly and answer `ERROR_REPLY`, so silence here is silence.
+    let handler = super::handler(&db, "s-filter", "xoxb-t");
+
+    finish(handler(mention(
+        "<@U0BOT> what is the status",
+        "1700000000.000100",
+        "",
+        "s-filter",
+    )))
+    .await;
+    set_api_base(None);
+
+    assert!(
+        slack.posted().is_empty(),
+        "a filtered mention says nothing at all"
+    );
+    assert!(threads(&db).is_empty(), "and maps no thread");
+    let conn = rusqlite::Connection::open(&db).expect("open");
+    let chats: i64 = conn
+        .query_row("SELECT count(*) FROM chat_sessions", [], |row| row.get(0))
+        .expect("count");
+    assert_eq!(chats, 0, "and starts no chat under the default rule either");
 }
 
 /// A failing run still answers, and the chat still holds what was asked — the

--- a/src-tauri/src/native/integrations/slack/inbound/tests.rs
+++ b/src-tauri/src/native/integrations/slack/inbound/tests.rs
@@ -841,8 +841,11 @@ async fn a_second_mention_in_the_thread_queues_and_resumes_the_same_chat() {
 /// channel — including a reply inside the thread that run opened.
 ///
 /// Two things nothing else pins. First, the positive half of #582's criterion 1:
-/// the prefix-*stripped* remainder is what reaches the chat and the CLI, not the
-/// raw mention. Second, the follow-up rule stated in this module's header: a
+/// the prefix-*stripped* remainder is what reaches the chat and the chat title,
+/// not the raw mention — and the mention that fails the prefix reaches no CLI at
+/// all. (The prompt travels to the CLI on stdin, which `spawns` does not record;
+/// the chat's own message row is the observable, and it is written by the run.)
+/// Second, the follow-up rule stated in this module's header: a
 /// mention in one of Agento's own threads is filtered exactly like the one that
 /// started it, because `accept` decides before the thread map is read. A rule
 /// with a prefix therefore wants that prefix on every message, and the reply

--- a/src/views/IntegrationsView.tsx
+++ b/src/views/IntegrationsView.tsx
@@ -1588,6 +1588,8 @@ const TRIGGER_TARGETS_FALLBACK: TriggerTargets = {
   placeholder: "IDs, comma separated (blank = any)",
   help: "Conversation ids, comma-separated; empty = every conversation.",
   noun: "chat",
+  filterHelp:
+    "The prefix must start the message and a keyword may appear anywhere in it. Leave both empty to answer every message.",
 };
 
 /** The longest run a rule may ask for, matching the write's own bound. */
@@ -2053,6 +2055,7 @@ function RuleForm({
           />
         </label>
       </div>
+      <div className="formrow__help">{targets.filterHelp}</div>
 
       <div className="row" style={{ gap: "var(--sp-3)" }}>
         <label className="field field--sm" style={{ flex: 1 }}>

--- a/src/views/integrations/catalog.ts
+++ b/src/views/integrations/catalog.ts
@@ -67,6 +67,20 @@ export interface TriggerTargets {
   help: string;
   /** The singular noun a row's `N x filter(s)` summary is built from. */
   noun: string;
+  /**
+   * What Prefix and Keywords are matched against on this provider.
+   *
+   * Required rather than optional: the two inputs are shown for every provider
+   * that supports triggers, and #582 was the case where they were shown, stored
+   * and then ignored — a filter that looks like a safety measure and is not one.
+   * Making the wording mandatory means a provider cannot gain the inputs without
+   * someone writing down what they do there.
+   *
+   * The two answers genuinely differ. Telegram matches the message as sent;
+   * Slack matches what is left once the `@mention` is removed, because every
+   * `app_mention` begins with a bot id no user typed.
+   */
+  filterHelp: string;
 }
 
 export interface Provider {
@@ -218,6 +232,8 @@ export const PROVIDERS: Provider[] = [
       placeholder: "C0123ABCDEF, C0456GHIJKL (blank = any channel)",
       help: "Slack channel ids, comma-separated; empty = every channel the app is in.",
       noun: "channel",
+      filterHelp:
+        "Checked after the @mention is removed: the prefix must start what is left, a keyword may appear anywhere in it. Leave both empty to answer every mention in a matched channel.",
     },
     extraField: {
       key: "app_token",
@@ -360,6 +376,8 @@ export const PROVIDERS: Provider[] = [
       placeholder: "Chat IDs, comma separated (blank = any chat)",
       help: "Telegram chat ids, comma-separated; empty = every chat the bot is in.",
       noun: "chat",
+      filterHelp:
+        "Checked against the message as sent: the prefix must start it, a keyword may appear anywhere in it. Leave both empty to answer every message.",
     },
   },
   {

--- a/src/views/integrations/catalog.ts
+++ b/src/views/integrations/catalog.ts
@@ -233,7 +233,7 @@ export const PROVIDERS: Provider[] = [
       help: "Slack channel ids, comma-separated; empty = every channel the app is in.",
       noun: "channel",
       filterHelp:
-        "Checked after the @mention is removed: the prefix must start what is left, a keyword may appear anywhere in it. Leave both empty to answer every mention in a matched channel.",
+        "Checked after the @mention is removed: the prefix must start what is left, a keyword may appear anywhere in it. Replies inside a thread Agento started are checked too. Leave both empty to answer every mention in a matched channel.",
     },
     extraField: {
       key: "app_token",


### PR DESCRIPTION
Closes #582

## What

Slack's inbound path now honours a trigger rule's `filter_prefix` and `filter_keywords` against the mention text with the bot's own `<@Uxxx>` removed. The two inputs the form has always shown for every provider now mean what they say on Slack.

## Why

The form renders Prefix and Keywords for every provider, and the Slack path read neither — both were loaded off the row by `dispatcher::load_rules` and dropped. A filter that is displayed, stored and then ignored is worse than no filter: it looks like a safety measure, and it fails in the direction of running *more* than was asked for.

## How

- **`slack/inbound.rs`** — `accept` resolves the bot user id, strips the mention and gates the **already selected** rule through `trigger::match_rule::match_rule`, before the queue. `Job` carries the resolved `prompt`, so the text that was filtered is exactly the text that runs and `turn` no longer re-derives one.
  - The filters are a gate on the rule `select_rule_for_channel` picked (#565), never a reason to fall through to a broader one.
  - **Keywords are matched against the stripped text**, a deliberate divergence from Telegram: `match_rule`'s header pins keywords to the whole message because Go did, and on Slack the whole message always begins with a bot id no user typed. Stated at the call site.
  - `match_rule`'s own `chat_ids` clause is a no-op here (selection has already returned a rule naming this channel, or one naming none) and is left in place rather than routed around — asserted by a test.
- **`native/trigger/match_rule.rs`** — untouched. `parity/trigger_match_vectors.json` stays Telegram's authority.
- **`src/views/integrations/catalog.ts` / `IntegrationsView.tsx`** — `TriggerTargets` gains a required `filterHelp`, rendered under the Prefix/Keywords row (the pattern `targets.help` already sets for the chat-ids row). Required rather than optional so a provider cannot gain the inputs without someone writing down what they match against there.
- **`docs/internal/native-integrations-slack.md`** — the strip → filter → enqueue ordering, the keywords divergence, and the `auth.test`/`ERROR_REPLY` split.

## Deviations from the issue's HOW, and why

1. **`auth.test` failing is still `ERROR_REPLY`, not a silent drop.** The HOW folded the unavailable-bot-id case into the same drop as an empty remainder. That would change an error-path behaviour the issue did not ask about and that `inbound.rs`' module header specifies. `Job::prompt` is an `Option` instead: `None` is that one failure, and `turn` answers it exactly where it did before, after the thread is known to be Agento's. `accept` itself posts nothing, so moving the *fetch* earlier is safe.
2. **The ordering note went to `docs/internal/native-integrations-slack.md`, not `src-tauri/src/native/integrations/slack/CLAUDE.md`.** That file cannot exist: since #580/#583 the repository may contain exactly one `CLAUDE.md`, at the root, and `scripts/check-claude-md-size.sh` fails CI otherwise.
3. **No `docs/user-guide.md` change.** The HOW asks for the *Slack Socket Mode → Who can run an agent this way* interim mitigation to be corrected. That section is #581's and **#581 is still open**, so nothing on `main` says prefix and keywords do not apply on Slack — there is nothing to correct. **#581 should have that sentence updated before it merges**; flagged rather than edited, since it is another PR's text.

## Acceptance criteria

- [x] `filter_prefix = "/ask"`: `@bot /ask what is the status` runs with prompt `what is the status`; `@bot what is the status` starts nothing and posts nothing
- [x] Prefix matching sees the stripped text — `@bot /ask …`, `/ask @bot …` and `/ask … @bot` are one message
- [x] `filter_keywords = ["deploy"]`: `Deploy` (any case) runs, a mention without it does not
- [x] Empty prefix and empty keywords behave exactly as today
- [x] A mention that matches the channel but fails the filters does not fall through to a broader rule; the drop is logged at `debug` with no Slack-derived text
- [x] A bare `@bot /ask` starts nothing
- [x] Telegram unchanged: `parity/trigger_match_vectors.json` and `native::trigger::match_rule` pass untouched
- [x] Unit tests cover prefix hit/miss, keyword hit/miss, both empty, prefix-only text and a mention in the middle

## Tests

Seven new tests in `slack/inbound/tests.rs` — five unit tests over `filtered_prompt` (the call site itself, not a re-spelling of it) and two end-to-end tests: one proving no fall-through to the workspace default, one proving the prefix-stripped remainder is what reaches the chat and the title *and* that a follow-up in Agento's own thread is gated the same way.

**Revert-proof, measured:** stubbing `filtered_prompt`'s `match_rule` call out fails all seven (`7 failed; 12 passed`).

## A decision the issue did not pose

The filter is decided in `accept`, before the thread map is read, so **a reply inside a thread Agento started is gated exactly like the mention that opened it** — a rule with `Prefix: /ask` wants `/ask` on every follow-up too.

Kept deliberately: #582's WHAT says "apply prefix and keyword filtering to Slack app-mention events", unqualified, and it is the direction that runs *less*. Stated in `inbound.rs`'s module header, at `filtered_prompt`, in the area doc and in Slack's `filterHelp`, and pinned by `a_prefixed_rule_gates_the_follow_up_in_its_own_thread_too`. Exempting mapped threads is the other defensible answer and would be a behaviour change, not a doc change.

## Review

Four automated review rounds, every finding applied: 3 → 2 → 1 → **APPROVE with no findings**. Round 1 surfaced the follow-up-gating decision above; rounds 2–3 were documentation accuracy (a contradicting caveat on the still-open #581, a stale consequence count, two doc sentences this change had falsified).

## Local gates

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo clippy --lib -- -D warnings` (the Windows arms), `cargo test` (1601 lib + every integration suite, 0 failed), `npm run build`, `scripts/check-claude-md-size.sh`, `web/scripts/sync-docs.mjs` — all green.
