### PR TITLE
fix: re-root claude_cli's absolute candidates under a test-only root (#535)

### DIFF
--- a/docs/internal/src-tauri.md
+++ b/docs/internal/src-tauri.md
@@ -479,3 +479,14 @@ answer is cached, and **revalidated before every spawn** (#533, below).
     between two reads would report one rule's path beside another rule's name.
   There is no filesystem watcher and no background re-detection timer. Saving
   the setting still takes effect at the next start, which the Settings help says.
+- **`AGENTO_CLI_CANDIDATE_ROOT` is a test hook, not an override** (#535). Rule
+  5's three absolute directories (`/opt/homebrew/bin`, `/usr/local/bin`,
+  `/opt/local/bin`) are the one part of the walk `HOME`, `PATH` and `SHELL`
+  cannot redirect, so the `claude_cli_*` integration suites were hermetic only
+  on a machine with no Claude Code in any of them. Under the `test-hooks` Cargo
+  feature those directories are re-rooted under that variable. The feature is
+  off in every shipped build — only the package's self dev-dependency turns it
+  on, so it reaches `cargo test` and never `cargo build` — and with it off
+  `candidate_root()` is `None` and the variable is not read at all: **the
+  shipped walk is unchanged**. `claude_cli::tests` pins that the feature is
+  enabled nowhere but the dev-dependency.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -12,6 +12,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 name = "agento"
 version = "1.2.0"
 dependencies = [
+ "agento",
  "axum",
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -419,7 +419,18 @@ lto = false
 codegen-units = 16
 opt-level = 0
 
+[features]
+# Off in every shipped build. Enabled only by the self dev-dependency below, so
+# it reaches test and bench targets and nothing else. See
+# `claude_cli::candidates` (#535).
+test-hooks = []
+
 [dev-dependencies]
 tempfile = "3.27.0"
 # Collecting a streamed SSE body in the turn tests.
 http-body-util = "0.1"
+# The package itself, with `test-hooks` on: the supported way to compile the
+# library differently for `cargo test` without touching `cargo build`. An
+# integration test links the library built without `cfg(test)`, so a
+# `#[cfg(test)]` branch would be compiled out for exactly the suites that need it.
+agento = { path = ".", features = ["test-hooks"] }

--- a/src-tauri/src/claude_cli.rs
+++ b/src-tauri/src/claude_cli.rs
@@ -525,13 +525,31 @@ pub fn resolve(stored_override: Option<&str>) -> Option<Resolution> {
 /// `home` is optional because the absolute entries do not need it: an
 /// environment with no `HOME` still gets Homebrew and `/usr/local/bin` checked.
 fn candidates(home: Option<&Path>) -> Vec<PathBuf> {
+    candidates_under(candidate_root().as_deref(), home)
+}
+
+/// [`candidates`] with the absolute entries re-rooted under `root`. Split out so
+/// the re-rooting is testable without writing a process-wide variable that every
+/// other unit test calling [`candidates`] would read concurrently.
+fn candidates_under(root: Option<&Path>, home: Option<&Path>) -> Vec<PathBuf> {
     let name = cli_name();
     let mut dirs: Vec<PathBuf> = Vec::new();
 
     // Homebrew (Apple silicon, then Intel) and the system npm prefix. Absent
     // from launchd's PATH, present in every macOS user's shell.
+    //
+    // These are the one part of the walk that no environment variable can
+    // redirect, which made the integration suites hermetic only on a machine
+    // with no Claude Code in any of them (#535). Under the `test-hooks`
+    // feature — off in every shipped build — they are re-rooted, so a suite
+    // can own all five rules. The shipped walk is unchanged.
     for abs in ["/opt/homebrew/bin", "/usr/local/bin", "/opt/local/bin"] {
-        dirs.push(PathBuf::from(abs));
+        // `trim_start_matches`, not `&abs[1..]`: an entry that ever lost its
+        // leading slash must not turn the join into an absolute overwrite.
+        dirs.push(root.map_or_else(
+            || PathBuf::from(abs),
+            |root| root.join(abs.trim_start_matches('/')),
+        ));
     }
 
     let Some(home) = home else {
@@ -575,6 +593,21 @@ fn candidates(home: Option<&Path>) -> Vec<PathBuf> {
     ));
 
     dirs.into_iter().map(|d| d.join(name)).collect()
+}
+
+/// Where the integration suites re-root rule 5's absolute directories. Exists
+/// only under the `test-hooks` feature, which nothing but the package's own
+/// dev-dependency enables (#535).
+#[cfg(feature = "test-hooks")]
+fn candidate_root() -> Option<PathBuf> {
+    std::env::var_os("AGENTO_CLI_CANDIDATE_ROOT").map(PathBuf::from)
+}
+
+/// A shipped build: no root, and the variable is not read at all, so it is not
+/// a lever a user can reach.
+#[cfg(not(feature = "test-hooks"))]
+fn candidate_root() -> Option<PathBuf> {
+    None
 }
 
 /// The subdirectories of `parent`, each with `suffix` appended, newest name
@@ -957,6 +990,63 @@ mod tests {
                 format!("/usr/local/bin/{name}"),
                 format!("/opt/local/bin/{name}"),
             ]
+        );
+    }
+
+    /// A root moves the three absolute entries under it, in the same order, and
+    /// touches nothing else — so a suite that sets it owns rule 5 without
+    /// changing what rule 5 scans relative to `HOME` (#535). Driven through
+    /// `candidates_under` rather than the variable, which every other test here
+    /// calling `candidates` would otherwise read concurrently.
+    #[test]
+    fn a_candidate_root_re_roots_only_the_absolute_locations() {
+        let root = Path::new("/tmp/suite-root");
+        let home = Path::new("/home/u");
+        let shipped = candidates_under(None, Some(home));
+        let rooted = candidates_under(Some(root), Some(home));
+        let name = cli_name();
+        assert_eq!(
+            rooted[..3],
+            [
+                root.join("opt/homebrew/bin").join(name),
+                root.join("usr/local/bin").join(name),
+                root.join("opt/local/bin").join(name),
+            ]
+        );
+        assert_eq!(rooted[3..], shipped[3..], "the home-relative entries moved");
+        assert_eq!(rooted[3], home.join(".local/bin").join(name));
+    }
+
+    /// The shipped walk is unchanged only while `test-hooks` stays off in every
+    /// build a user installs, and the one thing that can quietly break that is
+    /// the manifest: the feature added to `default`, or enabled on a normal
+    /// dependency edge. A `cargo test` build always has the feature on, so the
+    /// gate is pinned where it is decided rather than by a test that could only
+    /// ever run with it off.
+    #[test]
+    fn test_hooks_is_enabled_by_nothing_but_the_dev_dependency() {
+        let manifest = include_str!("../Cargo.toml");
+        let mut section = "";
+        let mut mentions = Vec::new();
+        for line in manifest.lines() {
+            let line = line.split('#').next().unwrap_or("").trim();
+            if line.starts_with('[') {
+                section = line;
+            } else if line.contains("test-hooks") {
+                mentions.push((section, line));
+            }
+        }
+        assert_eq!(
+            mentions,
+            [
+                ("[features]", "test-hooks = []"),
+                (
+                    "[dev-dependencies]",
+                    r#"agento = { path = ".", features = ["test-hooks"] }"#
+                ),
+            ],
+            "`test-hooks` must be declared, off by default, and enabled only by \
+             the self dev-dependency — anywhere else it reaches a shipped build"
         );
     }
 

--- a/src-tauri/tests/claude_cli_detection.rs
+++ b/src-tauri/tests/claude_cli_detection.rs
@@ -81,6 +81,24 @@ fn the_resolver_walks_its_order_under_a_gui_launchs_environment() {
     assert_eq!(found.source, Source::Candidate);
     assert_eq!(found.path, aliased.to_string_lossy());
 
+    // ── The absolute entries are really re-rooted, not vacuously absent. ─────
+    // On a machine with nothing in `/opt/homebrew/bin` every stage here passes
+    // whether or not `AGENTO_CLI_CANDIDATE_ROOT` is honoured, so a renamed
+    // variable or a feature that stopped reaching this build would go unseen.
+    // A CLI under the root's Homebrew directory outranks `~/.claude/local`,
+    // because the absolute entries are tried first.
+    let homebrew = tmp.path().join("opt/homebrew/bin");
+    std::fs::create_dir_all(&homebrew).expect("rooted homebrew dir");
+    let rooted = write_cli(&homebrew, "claude", "2.1.231 (Claude Code)", 0);
+    let found = resolve(None).expect("the re-rooted Homebrew install is found");
+    assert_eq!(found.source, Source::Candidate);
+    assert_eq!(
+        found.path,
+        rooted.to_string_lossy(),
+        "rule 5's absolute directories were not re-rooted under the tempdir"
+    );
+    std::fs::remove_file(&rooted).expect("remove the rooted CLI");
+
     // ── A program named `claude` that is not Claude Code is not the CLI. ─────
     // Left unchecked it reads as a healthy install *and* gets spawned for every
     // turn, failing with something that looks nothing like a missing dependency.

--- a/src-tauri/tests/claude_cli_detection.rs
+++ b/src-tauri/tests/claude_cli_detection.rs
@@ -51,11 +51,14 @@ fn the_resolver_walks_its_order_under_a_gui_launchs_environment() {
 
     // SAFETY: this binary holds exactly one test, so nothing else is reading
     // the environment concurrently — which is why the module is written that
-    // way. See the header.
+    // way. See the header. `AGENTO_CLI_CANDIDATE_ROOT` re-roots rule 5's
+    // absolute directories under the tempdir (`test-hooks`, #535), or a real
+    // install in `/usr/local/bin` would answer the "nothing anywhere" case.
     unsafe {
         std::env::set_var("HOME", &home);
         std::env::set_var("PATH", LAUNCHD_PATH);
         std::env::set_var("SHELL", &shell);
+        std::env::set_var("AGENTO_CLI_CANDIDATE_ROOT", tmp.path());
         std::env::remove_var("AGENTO_CLAUDE_EXECUTABLE");
     }
 

--- a/src-tauri/tests/claude_cli_offload.rs
+++ b/src-tauri/tests/claude_cli_offload.rs
@@ -100,11 +100,14 @@ async fn re_resolving_the_cli_does_not_stall_the_runtime() {
     // SAFETY: one test in this binary, so nothing else reads the environment
     // concurrently. `AGENTO_CLAUDE_EXECUTABLE` must stay **unset** — it is rule
     // 1 and returns before any walk, so setting it would make this test pass
-    // against the very thing it is written to catch.
+    // against the very thing it is written to catch. `AGENTO_CLI_CANDIDATE_ROOT`
+    // re-roots rule 5's absolute directories under the tempdir (`test-hooks`,
+    // #535), or a real install in `/usr/local/bin` ends the walk with a CLI.
     unsafe {
         std::env::set_var("HOME", &home);
         std::env::set_var("PATH", tmp.path().join("no-such-bin"));
         std::env::set_var("SHELL", &shell);
+        std::env::set_var("AGENTO_CLI_CANDIDATE_ROOT", tmp.path());
         std::env::remove_var("AGENTO_CLAUDE_EXECUTABLE");
     }
 

--- a/src-tauri/tests/claude_cli_refresh.rs
+++ b/src-tauri/tests/claude_cli_refresh.rs
@@ -75,11 +75,14 @@ fn a_cli_that_stops_being_spawnable_is_resolved_again_without_a_restart() {
     // SAFETY: this binary holds exactly one test, so nothing else is reading
     // the environment concurrently — which is why the module is written that
     // way. See the header. `PATH` points at nothing so rule 4 contributes
-    // nothing, and the walk is decided by the candidate list alone.
+    // nothing, and the walk is decided by the candidate list alone — which is
+    // only this test's list because `AGENTO_CLI_CANDIDATE_ROOT` re-roots its
+    // absolute directories under the tempdir (`test-hooks`, #535).
     unsafe {
         std::env::set_var("HOME", &home);
         std::env::set_var("PATH", tmp.path().join("no-such-bin"));
         std::env::set_var("SHELL", &shell);
+        std::env::set_var("AGENTO_CLI_CANDIDATE_ROOT", tmp.path());
         std::env::remove_var("AGENTO_CLAUDE_EXECUTABLE");
     }
 


### PR DESCRIPTION
Closes #535

## What
The three `claude_cli` integration suites are now hermetic on a machine that has Claude Code installed in `/usr/local/bin`, `/opt/homebrew/bin` or `/opt/local/bin`. The shipped binary is unchanged.

## Why
`claude_cli::candidates` scans those three absolute directories first. The suites build their environment by overriding `HOME`, `PATH` and `SHELL`, and none of those variables reaches an absolute path. So on a contributor's machine a real `claude` there was accepted where a fixture expected nothing, and all three suites went red on a clean checkout.

## How
- **`src-tauri/Cargo.toml`**: adds a `test-hooks` feature, off by default. Only the package's self dev-dependency (`agento = { path = ".", features = ["test-hooks"] }`) enables it, so it reaches `cargo test` and never `cargo build` or `tauri build` (edition 2021, feature resolver 2).
- **`src-tauri/src/claude_cli.rs`**: `candidates(home)` now delegates to `candidates_under(candidate_root(), home)`, and the three absolute entries are joined under the root when one is set.
  - With the feature on, `candidate_root()` reads `AGENTO_CLI_CANDIDATE_ROOT`.
  - With it off, it is `None` and the variable is never read.
- **The three suites** set `AGENTO_CLI_CANDIDATE_ROOT` to their tempdir.
- **`claude_cli_detection.rs`** gains one positive stage. It puts a fake CLI under `<root>/opt/homebrew/bin` and asserts that fake is what gets resolved, so the hook cannot silently stop working on a CI machine that has no real install.
- **`docs/internal/src-tauri.md`** names the variable as a test hook, not an override.
- **`Cargo.lock`** gains one `"agento"` line in the package's own dependency list. The version field is untouched, and the version guards read `Cargo.toml`.

### Deviations from the HOW
- **`candidates_under` is split out.** The re-rooting unit test calls it directly instead of setting a process-wide variable, which other concurrent unit tests that call `candidates` would also read.
- **Acceptance criterion 2 (the feature-off walk is unchanged, pinned by a unit test)** is pinned at the manifest. Every `cargo test` build has `test-hooks` on, so a `cfg(not(feature))` test could never run in CI.
  - `test_hooks_is_enabled_by_nothing_but_the_dev_dependency` asserts the feature is declared `test-hooks = []` and enabled only by the dev-dependency.
  - `the_absolute_locations_are_scanned_even_with_no_home` still pins the bare three-path list when no root is set.
  - The `cfg(not)` arm is compiled and linted by `cargo clippy --lib`, which is the Windows job's command.

## Verification
- **Reproduction** (the criterion CI cannot automate): I ran the suites in an `ubuntu:24.04` container with an executable fake `claude` answering `2.1.231 (Claude Code)` bind-mounted at **both** `/usr/local/bin/claude` and `/opt/homebrew/bin/claude`.
  - `origin/main` binaries: all three suites **fail**.
    - `claude_cli_detection.rs:79`
    - `claude_cli_refresh.rs:91`
    - `claude_cli_offload.rs:116`
  - This branch's binaries: all three suites **pass**.
- **Shipped build**: `cargo build --profile ci` (feature off) succeeds, and `strings` finds 0 occurrences of `AGENTO_CLI_CANDIDATE_ROOT` in the binary. A feature-on test binary has 2.
- **Local gates**:
  - `cargo fmt --check`
  - `cargo clippy --all-targets -- -D warnings`
  - `cargo clippy --lib -- -D warnings`
  - full `cargo test`, all green
- No test is skipped. Every assertion that ran before still runs.
- `cargo test` compiled the `agento` crate once per profile, with no double compile.