### PR TITLE
fix: resolve an empty working directory to the settings default (#559)

### DIFF
--- a/docs/internal/native-chat.md
+++ b/docs/internal/native-chat.md
@@ -214,6 +214,22 @@ model stays `""` (i.e. "set no model option") rather than becoming `resolve`'s
 `"sonnet"`: a database this process cannot open is not a user who never saved
 settings.
 
+**The CLI's cwd is always set; an empty `working_directory` resolves to the
+settings default** (#559). Four paths reach the spawn with `""` — `POST /api/chats`,
+a task, a trigger rule left on *agent default*, and a continued session — and
+`build_options` is the one hop all four share, so the resolution lives there:
+`TurnSettings::default_working_dir()` is `resolve`'s `default_working_dir`, so
+`AGENTO_WORKING_DIR`, else the stored setting, else `<temp>/agento/work`. It
+deliberately does **not** copy `default_model()`'s "unreadable row answers `""`":
+there is no "set no cwd" worth having, because that is inheriting the Agento
+process's own cwd (`src-tauri/` under `npm run app`), which is the bug. The
+directory is created when missing — nothing else creates `<temp>/agento/work` —
+and a failed create is a `warn` left to the spawn to report. The stored row keeps
+`""`; the Chats list reads `GET /settings` to show where such a chat runs. Since
+`with_cwd` travels with `with_setting_sources(["project"])`, those runs also gained
+the project setting source, pointed at the default directory
+(`runner::tests::an_empty_working_dir_runs_in_the_settings_default`).
+
 **An embedded raw value is compacted and HTML-escaped on the way out, and Go
 does it on the way *in*** (#298). `encoding/json` runs
 `compact(…, escapeHTML=true)` over a `Marshaler`'s output, so a nested

--- a/docs/internal/native-chat.md
+++ b/docs/internal/native-chat.md
@@ -223,8 +223,11 @@ a task, a trigger rule left on *agent default*, and a continued session — and
 deliberately does **not** copy `default_model()`'s "unreadable row answers `""`":
 there is no "set no cwd" worth having, because that is inheriting the Agento
 process's own cwd (`src-tauri/` under `npm run app`), which is the bug. The
-directory is created when missing — nothing else creates `<temp>/agento/work` —
-and a failed create is a `warn` left to the spawn to report. The stored row keeps
+**default** is created when missing — nothing else creates `<temp>/agento/work` —
+and a failed create is a `warn` left to the spawn to report. A directory the chat,
+task or rule **chose** is never created: a renamed repo or an unmounted drive still
+fails the spawn rather than becoming an empty folder a bypassing run acts in
+(`runner::tests::a_chosen_working_dir_that_is_missing_is_not_created`). The stored row keeps
 `""`; the Chats list reads `GET /settings` to show where such a chat runs. Since
 `with_cwd` travels with `with_setting_sources(["project"])`, those runs also gained
 the project setting source, pointed at the default directory

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -83,6 +83,13 @@ The working directory matters. It is the folder the agent can see and act in, th
 same way `claude` behaves when you run it from that folder. **Browse…** opens your
 system's file picker, falling back to a built-in one if that is unavailable.
 
+A chat or task that reaches Agento with no working directory — one created through
+the API, a scheduled task that names none, a Slack or Telegram rule left on *agent
+default* — runs in the **Settings → General** working directory, not in whatever
+folder Agento itself was started from. The Chats list shows that folder for such a
+chat. Conversations that already ran somewhere else keep their place in History;
+only new runs change.
+
 Your choices are remembered and filled in next time you start a chat. They start
 from **Settings → General** the first time.
 
@@ -892,7 +899,9 @@ instead, revoke that token by name in **Settings → Security**.
 
 ### General
 
-- **Working directory**: the default folder for new chats and tasks.
+- **Working directory**: the default folder for new chats and tasks, and the folder
+  any chat, task or rule without a working directory of its own runs in. Agento
+  creates it if it does not exist.
 - **Default model**: used when neither the chat nor the agent picks one.
 - **Public URL**: only relevant if you also run the server.
 - **Updates**: how Agento behaves when a new version exists. See

--- a/src-tauri/src/native/chat/runner.rs
+++ b/src-tauri/src/native/chat/runner.rs
@@ -184,6 +184,21 @@ impl TurnSettings {
             .default_model
     }
 
+    /// `settingsMgr.Get().DefaultWorkingDir`: `AGENTO_WORKING_DIR`, else the
+    /// stored setting, else `<temp>/agento/work` — `resolve`'s chain, not a
+    /// second copy of it (#559).
+    ///
+    /// Unlike [`Self::default_model`], a database this process cannot open
+    /// still answers a usable path: `resolve`'s own default is a temp
+    /// directory, not a value invented from the user's intent, and the
+    /// alternative — setting no cwd — is inheriting the app process's own.
+    pub(crate) fn default_working_dir(&self) -> String {
+        let row = self.stored().cloned().unwrap_or_default();
+        crate::native::settings::resolve(row)
+            .settings
+            .default_working_dir
+    }
+
     /// `config.ClaudeRunConfigDir`: `CLAUDE_CONFIG_DIR`, else the stored global
     /// setting, else the default.
     fn run_config_dir(&self) -> String {
@@ -285,11 +300,16 @@ pub async fn build_options(
 
     // A working dir also selects the project setting source, exactly as Go
     // does. Note `--settings` below can suppress it; that is Go's behaviour too.
-    if !spec.working_dir.is_empty() {
-        opts = opts
-            .with_cwd(spec.working_dir.clone())
-            .with_setting_sources(["project"]);
-    }
+    // An empty `working_dir` resolves to the settings default rather than
+    // inheriting the app process's cwd (#559) — `src-tauri/` under
+    // `npm run app`, and whatever the launcher chose for a release build.
+    let cwd = if spec.working_dir.is_empty() {
+        spec.settings.default_working_dir()
+    } else {
+        spec.working_dir.clone()
+    };
+    ensure_dir(&cwd);
+    opts = opts.with_cwd(cwd).with_setting_sources(["project"]);
 
     let config_dir = resolve_agent_config_dir(spec.agent.as_ref(), &spec.settings);
     if config_dir != crate::native::settings::default_claude_config_dir()
@@ -1049,6 +1069,21 @@ fn profile_file_path_in(config_dir: &str, index_dir: &str, profile_id: &str) -> 
     fallback
 }
 
+/// Create the run's working directory when it is missing (#559).
+///
+/// Nothing else creates `<temp>/agento/work`, so defaulting to it on a fresh
+/// install would turn an inherited-cwd run into a spawn failure. A failure here
+/// is a `warn` and nothing more: the directory may exist and merely be
+/// unreadable to `stat`, and one that is truly unusable is the spawn's to report.
+fn ensure_dir(dir: &str) {
+    if let Err(e) = std::fs::create_dir_all(dir) {
+        log::warn!(
+            "working directory not created dir={dir:?} error={:?}",
+            e.to_string()
+        );
+    }
+}
+
 /// Which `claude` binary to spawn.
 ///
 /// The SDK defaults to the bare name resolved on `PATH`, which is exactly what
@@ -1382,12 +1417,107 @@ mod tests {
         // And the fourth consumer, which an agent chat never reaches — asked
         // here so the count covers every field a turn can want.
         let _ = settings.default_model();
+        // And the working directory (#559), which `build_options` already
+        // resolved above — `spec_for` names none — asked again for the count.
+        let _ = settings.default_working_dir();
 
         assert_eq!(
             settings.loads(),
             1,
             "the settings row was read more than once for one turn"
         );
+    }
+
+    /// A migrated database whose settings row stores `dir` as the default
+    /// working directory.
+    fn settings_db_with_working_dir(dir: &str) -> tempfile::NamedTempFile {
+        let file = settings_db();
+        rusqlite::Connection::open(file.path())
+            .expect("open")
+            .execute(
+                "INSERT INTO user_settings (id, default_working_dir) VALUES (1, ?1)",
+                [dir],
+            )
+            .expect("seed settings");
+        file
+    }
+
+    /// What `resolve` answers for `stored` in this process: the developer's own
+    /// `AGENTO_WORKING_DIR` wins when exported, so the assertions below are
+    /// identities in that case and still literal in CI. The env rung itself is
+    /// pinned in `tests/chat_turn.rs`, under the lock that makes setting it safe.
+    fn expected_working_dir(stored: String) -> String {
+        crate::native::settings::env_value("AGENTO_WORKING_DIR").unwrap_or(stored)
+    }
+
+    /// #559: an empty `working_dir` is the settings default, never "no cwd" —
+    /// which inherited the Agento process's own. The directory is created before
+    /// the spawn, and the project setting source travels with the cwd, because
+    /// `with_cwd` and `with_setting_sources` are one decision.
+    #[tokio::test]
+    async fn an_empty_working_dir_runs_in_the_settings_default() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let stored = dir.path().join("not-yet").to_string_lossy().into_owned();
+        let file = settings_db_with_working_dir(&stored);
+        let mut spec = spec_for(Capabilities::default());
+        spec.settings = std::sync::Arc::new(TurnSettings::from_db(file.path()));
+
+        let (opts, _servers, _hosted) = build_options(&spec, no_op_handler())
+            .await
+            .expect("options");
+
+        let want = expected_working_dir(stored);
+        assert_eq!(opts.cwd, want);
+        assert!(
+            std::path::Path::new(&want).is_dir(),
+            "created before the spawn"
+        );
+        assert_eq!(opts.setting_sources, vec!["project".to_string()]);
+    }
+
+    /// The last rung: no stored value, or no row this process can read, is
+    /// `<temp>/agento/work` — `resolve`'s default, deliberately *not*
+    /// `default_model`'s "answer nothing on an unreadable row".
+    #[test]
+    fn with_nothing_stored_the_working_dir_is_the_temp_default() {
+        let temp_default = std::env::temp_dir()
+            .join("agento")
+            .join("work")
+            .to_string_lossy()
+            .into_owned();
+        let want = expected_working_dir(temp_default);
+        let empty = settings_db();
+
+        assert_eq!(TurnSettings::none().default_working_dir(), want);
+        assert_eq!(
+            TurnSettings::from_db(empty.path()).default_working_dir(),
+            want,
+            "an empty stored value"
+        );
+        assert_eq!(
+            TurnSettings::from_db("/nonexistent/agento/definitely-not-a-db").default_working_dir(),
+            want,
+            "an unreadable database"
+        );
+    }
+
+    /// A default that cannot be created is left to the spawn to report: the
+    /// turn is still built, on that directory, rather than refused.
+    #[tokio::test]
+    async fn a_default_that_cannot_be_created_does_not_refuse_the_turn() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let blocker = dir.path().join("a-file");
+        std::fs::write(&blocker, "").expect("write blocker");
+        let stored = blocker.join("work").to_string_lossy().into_owned();
+        let file = settings_db_with_working_dir(&stored);
+        let mut spec = spec_for(Capabilities::default());
+        spec.settings = std::sync::Arc::new(TurnSettings::from_db(file.path()));
+
+        let (opts, _servers, _hosted) = build_options(&spec, no_op_handler())
+            .await
+            .expect("a directory that cannot be created is not a refusal");
+
+        assert_eq!(opts.cwd, expected_working_dir(stored));
     }
 
     /// The zero case, which is the other half of the same rule: an absolute
@@ -1408,12 +1538,17 @@ mod tests {
         let mut spec = spec_for(Capabilities::default());
         spec.agent = Some(agent);
         spec.settings = std::sync::Arc::clone(&settings);
+        // A chat that names its own working directory, so the config dir is the
+        // only field left that could reach the row: an empty one resolves the
+        // settings default (#559), which is a read of its own.
+        spec.working_dir = dir.path().to_string_lossy().into_owned();
 
-        let (_opts, _servers, _hosted) = build_options(&spec, no_op_handler())
+        let (opts, _servers, _hosted) = build_options(&spec, no_op_handler())
             .await
             .expect("options");
 
         assert_eq!(settings.loads(), 0);
+        assert_eq!(opts.cwd, spec.working_dir, "a chosen directory is kept");
     }
 
     /// The precedence itself, unchanged: an absolute per-agent override wins,

--- a/src-tauri/src/native/chat/runner.rs
+++ b/src-tauri/src/native/chat/runner.rs
@@ -303,12 +303,18 @@ pub async fn build_options(
     // An empty `working_dir` resolves to the settings default rather than
     // inheriting the app process's cwd (#559) — `src-tauri/` under
     // `npm run app`, and whatever the launcher chose for a release build.
+    //
+    // Only the default is created. A directory the user chose that has since
+    // gone missing — a renamed repo, an unmounted drive — must fail the spawn
+    // as it always has, rather than become an empty folder a bypassing run
+    // then acts in and reports success from.
     let cwd = if spec.working_dir.is_empty() {
-        spec.settings.default_working_dir()
+        let default = spec.settings.default_working_dir();
+        ensure_dir(&default);
+        default
     } else {
         spec.working_dir.clone()
     };
-    ensure_dir(&cwd);
     opts = opts.with_cwd(cwd).with_setting_sources(["project"]);
 
     let config_dir = resolve_agent_config_dir(spec.agent.as_ref(), &spec.settings);
@@ -1518,6 +1524,24 @@ mod tests {
             .expect("a directory that cannot be created is not a refusal");
 
         assert_eq!(opts.cwd, expected_working_dir(stored));
+    }
+
+    /// The other side of creating the default: a directory the chat, task or
+    /// rule **chose** is never created. A renamed repo or an unmounted drive
+    /// must still fail the spawn, not become an empty folder the run acts in.
+    #[tokio::test]
+    async fn a_chosen_working_dir_that_is_missing_is_not_created() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let chosen = dir.path().join("renamed-repo");
+        let mut spec = spec_for(Capabilities::default());
+        spec.working_dir = chosen.to_string_lossy().into_owned();
+
+        let (opts, _servers, _hosted) = build_options(&spec, no_op_handler())
+            .await
+            .expect("options");
+
+        assert_eq!(opts.cwd, spec.working_dir, "the chosen directory is kept");
+        assert!(!chosen.exists(), "a chosen directory was created");
     }
 
     /// The zero case, which is the other half of the same rule: an absolute

--- a/src-tauri/tests/chat_turn.rs
+++ b/src-tauri/tests/chat_turn.rs
@@ -318,11 +318,14 @@ fn tool_use_input_survives_the_round_trip_byte_for_byte() {
 fn fake_cli(dir: &Path, emit: &str) -> PathBuf {
     let script = format!(
         r#"#!/usr/bin/env {python}
-import json, sys, threading, time
+import json, os, sys, threading, time
 
 LOG = {log}
 _log = open(LOG, "a")
 _lock = threading.Lock()
+
+with open({cwd}, "w") as _cwd:
+    _cwd.write(os.getcwd())
 
 def record(entry):
     with _lock:
@@ -361,6 +364,7 @@ for line in sys.stdin:
 "#,
         python = python3().unwrap_or_else(|| "python3".into()),
         log = serde_json::to_string(&stdin_log(dir).to_string_lossy()).unwrap(),
+        cwd = serde_json::to_string(&cwd_log(dir).to_string_lossy()).unwrap(),
         emit = emit,
     );
     let path = dir.join("fake-claude");
@@ -377,6 +381,11 @@ for line in sys.stdin:
 /// Where [`fake_cli`] records the lines it was sent.
 fn stdin_log(dir: &Path) -> PathBuf {
     dir.join("stdin.jsonl")
+}
+
+/// Where [`fake_cli`] records the directory it was started in (#559).
+fn cwd_log(dir: &Path) -> PathBuf {
+    dir.join("cwd")
 }
 
 /// Everything the SDK wrote to the CLI, decoded, in order.
@@ -474,6 +483,128 @@ async fn a_turn_forwards_the_cli_lines_verbatim_and_ends_on_the_final_result() {
         frames[0].1,
         r#"{"type":"assistant","message":{"content":[{"type":"text","text":"hi"},{"type":"tool_use","id":"t1","name":"Bash","input":{"z":1.50,"a":1}}]}}"#
     );
+}
+
+// ─── The working directory (#559) ─────────────────────────────────────────────
+
+/// A CLI that acknowledges `initialize` and answers the first message with a
+/// bare `result` — for tests whose subject is where it was started, not what it
+/// said.
+const RESULT_ONLY: &str = r#"
+    if msg.get("type") == "control_request" and req.get("subtype") == "initialize":
+        ack(req.get("request_id") or msg.get("request_id"))
+    elif msg.get("type") == "user":
+        raw('{"type":"result","subtype":"success","is_error":false,"result":"done","session_id":"sdk-cwd","usage":{"input_tokens":1,"output_tokens":1}}')
+"#;
+
+/// `file`'s settings row, with `default_working_dir` stored as `dir`.
+fn seed_default_working_dir(file: &tempfile::NamedTempFile, dir: &Path) {
+    rusqlite::Connection::open(file.path())
+        .expect("open")
+        .execute(
+            "INSERT INTO user_settings (id, default_working_dir) VALUES (1, ?1)",
+            [dir.to_string_lossy()],
+        )
+        .expect("seed settings");
+}
+
+/// Drive one turn with `AGENTO_WORKING_DIR` set to `env`, or unset for `None`.
+///
+/// Set and removed **inside** the env lock, for [`run_turn_on`]'s reason: every
+/// turn's `build_options` now reads the variable, so a value left behind would
+/// move every later test's CLI.
+async fn run_turn_with_working_dir_env(
+    cli: &Path,
+    file: &tempfile::NamedTempFile,
+    chat_id: &str,
+    env: Option<&Path>,
+) -> String {
+    let _env = env_lock().lock().await;
+    std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", cli);
+    std::env::remove_var("AGENTO_MCPS_FILE");
+    match env {
+        Some(dir) => std::env::set_var("AGENTO_WORKING_DIR", dir),
+        None => std::env::remove_var("AGENTO_WORKING_DIR"),
+    }
+
+    let response = agento_lib::native::chat::turn::run(
+        file.path().to_path_buf(),
+        chat_id.to_string(),
+        "where am I".to_string(),
+    )
+    .await
+    .expect("the turn should stream");
+    assert_eq!(response.status(), 200);
+    let collected = collect_with_timeout(response).await;
+    std::env::remove_var("AGENTO_WORKING_DIR");
+    String::from_utf8(collected.to_bytes().to_vec()).expect("utf8")
+}
+
+/// The directory the fake CLI was started in, canonicalised — macOS's temp dir
+/// is behind a symlink and `os.getcwd()` answers the resolved path.
+fn recorded_cwd(dir: &Path) -> PathBuf {
+    let raw = std::fs::read_to_string(cwd_log(dir)).expect("the CLI ran and recorded its cwd");
+    std::fs::canonicalize(raw).expect("recorded cwd exists")
+}
+
+/// #559: a chat whose `working_directory` is `""` runs the CLI in the stored
+/// settings default — not in this test process's cwd, which is what an empty
+/// value used to mean.
+///
+/// The default does not exist before the turn, because nothing else creates
+/// `<temp>/agento/work` on a fresh install and a missing cwd fails the spawn.
+#[tokio::test]
+async fn a_chat_with_no_working_directory_runs_in_the_settings_default() {
+    let Some(_) = python3() else {
+        eprintln!("skipping: no python3");
+        return;
+    };
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cli = fake_cli(dir.path(), RESULT_ONLY);
+    let stored = dir.path().join("stored-default").join("work");
+    let id = unique_id("default-cwd");
+    let file = migrated_with_chat(&id);
+    seed_default_working_dir(&file, &stored);
+
+    let body = run_turn_with_working_dir_env(&cli, &file, &id, None).await;
+    let names: Vec<String> = frames(&body).into_iter().map(|(e, _)| e).collect();
+    assert_eq!(names, vec!["result"], "body was: {body}");
+
+    assert!(stored.is_dir(), "the default directory was created");
+    assert_eq!(
+        recorded_cwd(dir.path()),
+        std::fs::canonicalize(&stored).expect("stored default"),
+        "the CLI ran outside the settings default"
+    );
+}
+
+/// The rung above it: `AGENTO_WORKING_DIR` beats the stored default, because
+/// the runner goes through `settings::resolve` rather than reading the column.
+#[tokio::test]
+async fn agento_working_dir_wins_over_the_stored_default() {
+    let Some(_) = python3() else {
+        eprintln!("skipping: no python3");
+        return;
+    };
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cli = fake_cli(dir.path(), RESULT_ONLY);
+    let stored = dir.path().join("stored-default");
+    let from_env = dir.path().join("from-env");
+    std::fs::create_dir_all(&from_env).expect("env dir");
+    let id = unique_id("env-cwd");
+    let file = migrated_with_chat(&id);
+    seed_default_working_dir(&file, &stored);
+
+    let body = run_turn_with_working_dir_env(&cli, &file, &id, Some(&from_env)).await;
+    let names: Vec<String> = frames(&body).into_iter().map(|(e, _)| e).collect();
+    assert_eq!(names, vec!["result"], "body was: {body}");
+
+    assert_eq!(
+        recorded_cwd(dir.path()),
+        std::fs::canonicalize(&from_env).expect("env dir"),
+        "AGENTO_WORKING_DIR must win over the stored default"
+    );
+    assert!(!stored.exists(), "the losing rung is never created");
 }
 
 /// The rule most likely to be got wrong: `result` means "turn done", not

--- a/src-tauri/tests/scheduled_run.rs
+++ b/src-tauri/tests/scheduled_run.rs
@@ -43,7 +43,10 @@ fn python3() -> Option<String> {
 fn fake_cli(dir: &Path, emit: &str) -> PathBuf {
     let script = format!(
         r#"#!/usr/bin/env {python}
-import json, sys
+import json, os, sys
+
+with open({cwd}, "w") as _cwd:
+    _cwd.write(os.getcwd())
 
 def say(obj):
     sys.stdout.write(json.dumps(obj) + "\n")
@@ -81,6 +84,7 @@ for line in sys.stdin:
         continue
 "#,
         python = python3().unwrap_or_else(|| "python3".into()),
+        cwd = serde_json::to_string(&dir.join("cwd").to_string_lossy()).unwrap(),
         emit = emit,
     );
     let path = dir.join("fake-claude");
@@ -228,6 +232,57 @@ async fn a_scheduled_run_records_a_successful_job_and_persists_its_chat() {
     assert_eq!(task.last_run_status, "success");
     assert!(task.last_run_at.is_some());
     assert_eq!(task.status, "active", "a cron task keeps running");
+}
+
+/// #559, the executor's half: a task with no `working_directory` runs the CLI
+/// in the settings default, not in whatever directory this process has.
+///
+/// The default is pointed at a directory that does **not** exist yet, because
+/// nothing else creates `<temp>/agento/work` on a fresh install — a spawn into
+/// a missing cwd would fail the run rather than merely misplace it.
+#[tokio::test]
+async fn a_task_with_no_working_directory_runs_in_the_settings_default() {
+    if python3().is_none() {
+        eprintln!("skipping: no python3 to script the fake CLI");
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = dir.path().join("agento.db");
+    let task_id = migrated_with_task(&db, "cron", true);
+    let default = dir.path().join("settings-default").join("work");
+    rusqlite::Connection::open(&db)
+        .expect("open")
+        .execute(
+            "INSERT INTO user_settings (id, default_working_dir) VALUES (1, ?1)",
+            [default.to_string_lossy()],
+        )
+        .expect("seed settings");
+
+    let cli = fake_cli(
+        dir.path(),
+        r#"        raw('{"type":"result","subtype":"success","is_error":false,"result":"done","session_id":"sdk-cwd","usage":{"input_tokens":1,"output_tokens":1}}')"#,
+    );
+
+    let _env = env_lock().lock().await;
+    std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", &cli);
+    // The stored rung is the subject; a developer's own export would win.
+    std::env::remove_var("AGENTO_WORKING_DIR");
+
+    let scheduler = agento_lib::native::schedule::runtime::detached(&db);
+    agento_lib::native::schedule::executor::execute_task(&scheduler, &task_id).await;
+
+    let jobs = job_rows(&db);
+    assert_eq!(jobs.len(), 1, "exactly one run: {jobs:?}");
+    assert_eq!(jobs[0].0, "success", "error was {:?}", jobs[0].1);
+    assert!(default.is_dir(), "the default directory was created");
+    let recorded = std::fs::read_to_string(dir.path().join("cwd")).expect("the CLI ran");
+    // Canonicalised on both sides: macOS's temp dir is behind a symlink, and
+    // `os.getcwd()` answers the resolved path.
+    assert_eq!(
+        std::fs::canonicalize(recorded).expect("recorded cwd"),
+        std::fs::canonicalize(&default).expect("default dir"),
+        "the task ran outside the settings default"
+    );
 }
 
 /// #541, end to end: a **paused** task, sitting **at** its `stop_after_count`,

--- a/src-tauri/tests/trigger_run.rs
+++ b/src-tauri/tests/trigger_run.rs
@@ -246,9 +246,10 @@ async fn a_rules_execution_settings_reach_the_spawned_cli() {
     // buys is the mode the CLI reads, which is the flag asserted above.
 }
 
-/// A rule that records nothing runs exactly as a trigger run did before #565:
-/// the agent's model, no working directory, and the bypassing catch-all that a
-/// headless run with no configured mode has always taken.
+/// A rule that records nothing runs as a trigger run did before #565 — the
+/// agent's model and the bypassing catch-all a headless run with no configured
+/// mode has always taken — with one deliberate exception: since #559 an unset
+/// working directory is the settings default, not the app process's own cwd.
 #[tokio::test]
 async fn a_rule_that_configures_nothing_runs_as_it_always_did() {
     let Some(_) = python3() else {
@@ -262,16 +263,25 @@ async fn a_rule_that_configures_nothing_runs_as_it_always_did() {
 
     let _env = env_lock().lock().await;
     std::env::set_var("AGENTO_CLAUDE_EXECUTABLE", &cli);
+    // No settings row, so the answer is `resolve`'s last rung — unless a
+    // developer's own export would win over it.
+    std::env::remove_var("AGENTO_WORKING_DIR");
     tokio::time::timeout(std::time::Duration::from_secs(30), run_the_rule(&db))
         .await
         .expect("the run must finish, not hang")
         .expect("the run answered");
 
     let (argv, reported_cwd) = only_spawn(dir.path());
+    let temp_default = std::env::temp_dir().join("agento").join("work");
     assert_eq!(
         Path::new(&reported_cwd),
+        std::fs::canonicalize(&temp_default).expect("the default was created"),
+        "an unset working directory is the settings default, not where the app is (#559)"
+    );
+    assert_ne!(
+        Path::new(&reported_cwd),
         std::fs::canonicalize(std::env::current_dir().expect("cwd")).expect("canonicalize"),
-        "an unset working directory leaves the process where the app is"
+        "the run must not inherit the app process's cwd"
     );
     assert_eq!(flag_value(&argv, "--model"), Some("agent-model"));
     assert_eq!(

--- a/src/views/ChatsView.tsx
+++ b/src/views/ChatsView.tsx
@@ -883,7 +883,9 @@ export function ChatsView({
                 <div className="pathwell mono">
                   {session.working_directory
                     ? tildePath(session.working_directory)
-                    : "Not set"}
+                    : defaultWorkingDir
+                      ? tildePath(defaultWorkingDir)
+                      : "Default working directory"}
                 </div>
               </InspGroup>
 

--- a/src/views/ChatsView.tsx
+++ b/src/views/ChatsView.tsx
@@ -20,6 +20,7 @@ import type {
   ChatSession,
   ClaudeMessage,
   ClaudeSessionDetail,
+  SettingsResponse,
 } from "../lib/types";
 import {
   Empty,
@@ -91,6 +92,14 @@ export function ChatsView({
     (signal) => api.get<Agent[]>("/agents", signal),
     []
   );
+  // Where a chat with no working directory of its own actually runs (#559):
+  // the runner resolves `""` to this, env override included, so the list shows
+  // it rather than implying the chat has no folder at all.
+  const settings = useResource<SettingsResponse | null>(
+    (signal) => api.get<SettingsResponse>("/settings", signal),
+    []
+  );
+  const defaultWorkingDir = settings.data?.settings.default_working_dir ?? "";
 
   const [selected, setSelected] = useState<string | null>(null);
   const [drafting, setDrafting] = useState(false);
@@ -500,7 +509,9 @@ export function ChatsView({
                     <div className="listrow__preview">
                       {c.working_directory
                         ? tildePath(c.working_directory)
-                        : c.model || "No working directory"}
+                        : defaultWorkingDir
+                          ? tildePath(defaultWorkingDir)
+                          : c.model || "Default working directory"}
                     </div>
                     <div className="listrow__meta">
                       {c.id === stream.chatId && (


### PR DESCRIPTION
Closes #559

## What
A chat, scheduled task or trigger rule with an empty `working_directory` no longer spawns the Claude CLI in the Agento process's own cwd (`src-tauri/` under `npm run app`, whatever the launcher chose in a release build). `runner::build_options` always sets the cwd, resolving `""` to the settings default.

## Why
The cwd selects the model's `CLAUDE.md`, `.claude/settings*.json`, skills and hooks, confines its file tools, and keys the transcript's project in History. Inheriting it meant a directory nobody chose. All four empty-cwd entry paths (API chat, task, trigger rule, continue) reach `build_options`, so the fix is one choke point rather than per-endpoint validation.

## How
- `TurnSettings::default_working_dir()` — beside `default_model()`, through the same `OnceLock` and `settings::resolve`: `AGENTO_WORKING_DIR` > stored `default_working_dir` > `<temp>/agento/work`. Unlike `default_model()`, an unreadable row still answers the temp default.
- `build_options`: `with_cwd(..)` + `with_setting_sources(["project"])` are unconditional. `ensure_dir` creates the **default** when missing (a failure only `warn`s); a directory the chat/task/rule **chose** is never created, so a renamed repo still fails the spawn instead of becoming an empty folder a bypassing run acts in.
- `ChatsView`: the list row and the inspector render the resolved default (`GET /settings`) instead of *No working directory* / *Not set*.
- Docs: `docs/internal/native-chat.md`, `docs/user-guide.md`.

## Acceptance criteria
- [x] Empty-`working_directory` chat spawns with cwd = resolved default — `chat_turn::a_chat_with_no_working_directory_runs_in_the_settings_default` (fake CLI records `os.getcwd()`).
- [x] Same for a scheduled task — `scheduled_run::a_task_with_no_working_directory_runs_in_the_settings_default`.
- [x] `AGENTO_WORKING_DIR` > stored > `<temp>/agento/work`, via `settings::resolve` — `chat_turn::agento_working_dir_wins_over_the_stored_default`, `runner::tests::an_empty_working_dir_runs_in_the_settings_default`, `runner::tests::with_nothing_stored_the_working_dir_is_the_temp_default`.
- [x] Default created when missing; a failed create does not fail the turn — the tests above + `a_default_that_cannot_be_created_does_not_refuse_the_turn`.
- [x] Chats list renders the resolved path.
- [x] `loads()` still 1 with model + working dir read — `a_turn_reads_the_settings_row_at_most_once`.

Revert check: restoring the old `if !working_dir.is_empty()` guard fails all six cwd tests; creating a chosen dir again fails `a_chosen_working_dir_that_is_missing_is_not_created`.

## Deviations from the refinement
- **`ensure_dir` only on the default branch** — the HOW snippet created any cwd; review round 1 caught that it would recreate a user's missing directory.
- **ChatsView adds one `GET /settings`** — the HOW suggested relabelling rather than fetching, but WHAT and the acceptance criterion require the resolved path; `/settings` returns `resolve()`, so env overrides match the runner.
- **Existing tests updated because they pinned the bug**: `trigger_run::a_rule_that_configures_nothing_runs_as_it_always_did` asserted the inherited process cwd; `an_absolute_per_agent_override_never_reads_the_settings_row` now names a working dir (an empty one reads settings now).
- Out of scope, as refined: no 422 for an empty `working_directory`, no write-back of the resolved value onto rows, no re-keying of existing History.